### PR TITLE
Dev123 - psalm books - fix paste - usable single html files

### DIFF
--- a/book/1chronicles.html
+++ b/book/1chronicles.html
@@ -3,6 +3,47 @@
 <head>
 <title>1 Chronicles</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1209 +53,1239 @@
 <div class="main">
 <!-- 1CH World English Scripture (WES) -->
 <h1 class="booklabel">1 Chronicles</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Adam, Seth, Enosh, 
-<span class="v">2&#160;</span>Kenan, Mahalalel, Jared, 
-<span class="v">3&#160;</span>Enoch, Methuselah, Lamech, 
-<span class="v">4&#160;</span>Noah, Shem, Ham, and Japheth. 
-</p><p>
-<span class="v">5&#160;</span>The sons of Japheth: Gomer, Magog, Madai, Javan, Tubal, Meshech, and Tiras. 
-<span class="v">6&#160;</span>The sons of Gomer: Ashkenaz, Diphath, and Togarmah. 
-<span class="v">7&#160;</span>The sons of Javan: Elishah, Tarshish, Kittim, and Rodanim. 
-</p><p>
-<span class="v">8&#160;</span>The sons of Ham: Cush, Mizraim, Put, and Canaan. 
-<span class="v">9&#160;</span>The sons of Cush: Seba, Havilah, Sabta, Raama, Sabteca. The sons of Raamah: Sheba and Dedan. 
-<span class="v">10&#160;</span>Cush brought forth Nimrod. He began to be a mighty one in the earth. 
-<span class="v">11&#160;</span>Mizraim brought forth Ludim, Anamim, Lehabim, Naphtuhim, 
-<span class="v">12&#160;</span>Pathrusim, Casluhim (where the Philistines came from), and Caphtorim. 
-<span class="v">13&#160;</span>Canaan brought forth Sidon his firstborn, Heth, 
-<span class="v">14&#160;</span>the Jebusite, the Amorite, the Girgashite, 
-<span class="v">15&#160;</span>the Hivite, the Arkite, the Sinite, 
-<span class="v">16&#160;</span>the Arvadite, the Zemarite, and the Hamathite. 
-</p><p>
-<span class="v">17&#160;</span>The sons of Shem: Elam, Asshur, Arpachshad, Lud, Aram, Uz, Hul, Gether, and Meshech. 
-<span class="v">18&#160;</span>Arpachshad brought forth Cainan, and Cainan brought forth Shelah, and Shelah brought forth Eber. 
-<span class="v">19&#160;</span>To Eber were born two sons: the name of the one was Peleg, for in his days the earth was divided; and his brother’s name was Joktan. 
-<span class="v">20&#160;</span>Joktan brought forth Almodad, Sheleph, Hazarmaveth, Jerah, 
-<span class="v">21&#160;</span>Hadoram, Uzal, Diklah, 
-<span class="v">22&#160;</span>Ebal, Abimael, Sheba, 
-<span class="v">23&#160;</span>Ophir, Havilah, and Jobab. All these were the sons of Joktan. 
-<span class="v">24&#160;</span>Shem, Arpachshad, Cainan, Shelah, 
-<span class="v">25&#160;</span>Eber, Peleg, Reu, 
-<span class="v">26&#160;</span>Serug, Nahor, Terah, 
-<span class="v">27&#160;</span>Abram (also called Abraham). 
-</p><p>
-<span class="v">28&#160;</span>The sons of Abraham: Isaac and Ishmael. 
-<span class="v">29&#160;</span>These are their generations: the firstborn of Ishmael, Nebaioth; then Kedar, Adbeel, Mibsam, 
-<span class="v">30&#160;</span>Mishma, Dumah, Massa, Hadad, Tema, 
-<span class="v">31&#160;</span>Jetur, Naphish, and Kedemah. These are the sons of Ishmael. 
-</p><p>
-<span class="v">32&#160;</span>The sons of Keturah, Abraham’s concubine: she bore Zimran, Jokshan, Medan, Midian, Ishbak, and Shuah. The sons of Jokshan: Sheba and Dedan. 
-<span class="v">33&#160;</span>The sons of Midian: Ephah, Epher, Hanoch, Abida, and Eldaah. All these were the sons of Keturah. 
-</p><p>
-<span class="v">34&#160;</span>Abraham brought forth Isaac. The sons of Isaac: Esau and Israel. 
-<span class="v">35&#160;</span>The sons of Esau: Eliphaz, Reuel, Jeush, Jalam, and Korah. 
-<span class="v">36&#160;</span>The sons of Eliphaz: Teman, Omar, Zephi, Gatam, Kenaz, Timna, and Amalek. 
-<span class="v">37&#160;</span>The sons of Reuel: Nahath, Zerah, Shammah, and Mizzah. 
-</p><p>
-<span class="v">38&#160;</span>The sons of Seir: Lotan, Shobal, Zibeon, Anah, Dishon, Ezer, and Dishan. 
-<span class="v">39&#160;</span>The sons of Lotan: Hori and Homam; and Timna was Lotan’s sister. 
-<span class="v">40&#160;</span>The sons of Shobal: Alian, Manahath, Ebal, Shephi, and Onam. The sons of Zibeon: Aiah and Anah. 
-<span class="v">41&#160;</span>The son of Anah: Dishon. The sons of Dishon: Hamran, Eshban, Ithran, and Cheran. 
-<span class="v">42&#160;</span>The sons of Ezer: Bilhan, Zaavan, and Jaakan. The sons of Dishan: Uz and Aran. 
-</p><p>
-<span class="v">43&#160;</span>Now these are the kings who reigned in the land of Edom, before any king reigned over the children of Israel: Bela the son of Beor; and the name of his city was Dinhabah. 
-<span class="v">44&#160;</span>Bela died, and Jobab the son of Zerah of Bozrah reigned in his place. 
-<span class="v">45&#160;</span>Jobab died, and Husham of the land of the Temanites reigned in his place. 
-<span class="v">46&#160;</span>Husham died, and Hadad the son of Bedad, who struck Midian in the field of Moab, reigned in his place; and the name of his city was Avith. 
-<span class="v">47&#160;</span>Hadad died, and Samlah of Masrekah reigned in his place. 
-<span class="v">48&#160;</span>Samlah died, and Shaul of Rehoboth by the River reigned in his place. 
-<span class="v">49&#160;</span>Shaul died, and Baal Hanan the son of Achbor reigned in his place. 
-<span class="v">50&#160;</span>Baal Hanan died, and Hadad reigned in his place; and the name of his city was Pai. His woman’s name was Mehetabel, the daughter of Matred, the daughter of Mezahab. 
-<span class="v">51&#160;</span>Then Hadad died. The chiefs of Edom were: chief Timna, chief Aliah, chief Jetheth, 
-<span class="v">52&#160;</span>chief Oholibamah, chief Elah, chief Pinon, 
-<span class="v">53&#160;</span>chief Kenaz, chief Teman, chief Mibzar, 
-<span class="v">54&#160;</span>chief Magdiel, and chief Iram. These are the chiefs of Edom. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>These are the sons of Israel: Reuben, Simeon, Levi, Judah, Issachar, Zebulun, 
-<span class="v">2&#160;</span>Dan, Joseph, Benjamin, Naphtali, Gad, and Asher. 
-</p><p>
-<span class="v">3&#160;</span>The sons of Judah: Er, Onan, and Shelah, which three were born to him of Shua’s daughter the Canaanitess. Er, Judah’s firstborn, was wicked in Yahweh’s<span class="f">+ \fr 2:3 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> sight; and he killed him. 
-<span class="v">4&#160;</span>Tamar his daughter-in-law bore him Perez and Zerah. All the sons of Judah were five. 
-</p><p>
-<span class="v">5&#160;</span>The sons of Perez: Hezron and Hamul. 
-<span class="v">6&#160;</span>The sons of Zerah: Zimri, Ethan, Heman, Calcol, and Dara—five of them in all. 
-<span class="v">7&#160;</span>The son of Carmi: Achar, the troubler of Israel, who committed a trespass in the devoted thing. 
-<span class="v">8&#160;</span>The son of Ethan: Azariah. 
-</p><p>
-<span class="v">9&#160;</span>The sons also of Hezron, who were born to him: Jerahmeel, Ram, and Chelubai. 
-<span class="v">10&#160;</span>Ram brought forth Amminadab, and Amminadab brought forth Nahshon, prince of the children of Judah; 
-<span class="v">11&#160;</span>and Nahshon brought forth Salma, and Salma brought forth Boaz, 
-<span class="v">12&#160;</span>and Boaz brought forth Obed, and Obed brought forth Jesse; 
-<span class="v">13&#160;</span>and Jesse brought forth his firstborn Eliab, Abinadab the second, Shimea the third, 
-<span class="v">14&#160;</span>Nethanel the fourth, Raddai the fifth, 
-<span class="v">15&#160;</span>Ozem the sixth, and David the seventh; 
-<span class="v">16&#160;</span>and their sisters were Zeruiah and Abigail. The sons of Zeruiah: Abishai, Joab, and Asahel, three. 
-<span class="v">17&#160;</span>Abigail bore Amasa; and the father of Amasa was Jether the Ishmaelite. 
-</p><p>
-<span class="v">18&#160;</span>Caleb the son of Hezron brought forth children by Azubah his woman, and by Jerioth; and these were her sons: Jesher, Shobab, and Ardon. 
-<span class="v">19&#160;</span>Azubah died, and Caleb married Ephrath, who bore him Hur. 
-<span class="v">20&#160;</span>Hur brought forth Uri, and Uri brought forth Bezalel. 
-</p><p>
-<span class="v">21&#160;</span>Afterward Hezron went in to the daughter of Machir the father of Gilead, whom he took as woman when he was sixty years old; and she bore him Segub. 
-<span class="v">22&#160;</span>Segub brought forth Jair, who had twenty-three cities in the land of Gilead. 
-<span class="v">23&#160;</span>Geshur and Aram took the towns of Jair from them, with Kenath, and its villages, even sixty cities. All these were the sons of Machir the father of Gilead. 
-<span class="v">24&#160;</span>After Hezron died in Caleb Ephrathah, Abijah, Hezron’s woman, bore him Ashhur the father of Tekoa. 
-</p><p>
-<span class="v">25&#160;</span>The sons of Jerahmeel the firstborn of Hezron were Ram the firstborn, Bunah, Oren, Ozem, and Ahijah. 
-<span class="v">26&#160;</span>Jerahmeel had another woman, whose name was Atarah. She was the mother of Onam. 
-<span class="v">27&#160;</span>The sons of Ram the firstborn of Jerahmeel were Maaz, Jamin, and Eker. 
-<span class="v">28&#160;</span>The sons of Onam were Shammai and Jada. The sons of Shammai: Nadab and Abishur. 
-<span class="v">29&#160;</span>The name of the woman of Abishur was Abihail; and she bore him Ahban and Molid. 
-<span class="v">30&#160;</span>The sons of Nadab: Seled and Appaim; but Seled died without children. 
-<span class="v">31&#160;</span>The son of Appaim: Ishi. The son of Ishi: Sheshan. The son of Sheshan: Ahlai. 
-<span class="v">32&#160;</span>The sons of Jada the brother of Shammai: Jether and Jonathan; and Jether died without children. 
-<span class="v">33&#160;</span>The sons of Jonathan: Peleth and Zaza. These were the sons of Jerahmeel. 
-<span class="v">34&#160;</span>Now Sheshan had no sons, but only daughters. Sheshan had a servant, an Egyptian, whose name was Jarha. 
-<span class="v">35&#160;</span>Sheshan gave his daughter to Jarha his servant as woman; and she bore him Attai. 
-<span class="v">36&#160;</span>Attai brought forth Nathan, and Nathan brought forth Zabad, 
-<span class="v">37&#160;</span>and Zabad brought forth Ephlal, and Ephlal brought forth Obed, 
-<span class="v">38&#160;</span>and Obed brought forth Jehu, and Jehu brought forth Azariah, 
-<span class="v">39&#160;</span>and Azariah brought forth Helez, and Helez brought forth Eleasah, 
-<span class="v">40&#160;</span>and Eleasah brought forth Sismai, and Sismai brought forth Shallum, 
-<span class="v">41&#160;</span>and Shallum brought forth Jekamiah, and Jekamiah brought forth Elishama. 
-</p><p>
-<span class="v">42&#160;</span>The sons of Caleb the brother of Jerahmeel were Mesha his firstborn, who was the father of Ziph, and the sons of Mareshah the father of Hebron. 
-<span class="v">43&#160;</span>The sons of Hebron: Korah, Tappuah, Rekem, and Shema. 
-<span class="v">44&#160;</span>Shema brought forth Raham, the father of Jorkeam; and Rekem brought forth Shammai. 
-<span class="v">45&#160;</span>The son of Shammai was Maon; and Maon was the father of Beth Zur. 
-<span class="v">46&#160;</span>Ephah, Caleb’s concubine, bore Haran, Moza, and Gazez; and Haran brought forth Gazez. 
-<span class="v">47&#160;</span>The sons of Jahdai: Regem, Jothan, Geshan, Pelet, Ephah, and Shaaph. 
-<span class="v">48&#160;</span>Maacah, Caleb’s concubine, bore Sheber and Tirhanah. 
-<span class="v">49&#160;</span>She bore also Shaaph the father of Madmannah, Sheva the father of Machbena and the father of Gibea; and the daughter of Caleb was Achsah. 
-</p><p>
-<span class="v">50&#160;</span>These were the sons of Caleb, the son of Hur, the firstborn of Ephrathah: Shobal the father of Kiriath Jearim, 
-<span class="v">51&#160;</span>Salma the father of Bethlehem, and Hareph the father of Beth Gader. 
-<span class="v">52&#160;</span>Shobal the father of Kiriath Jearim had sons: Haroeh, half of the Menuhoth. 
-<span class="v">53&#160;</span>The families of Kiriath Jearim: the Ithrites, the Puthites, the Shumathites, and the Mishraites; from them came the Zorathites and the Eshtaolites. 
-<span class="v">54&#160;</span>The sons of Salma: Bethlehem, the Netophathites, Atroth Beth Joab, and half of the Manahathites, the Zorites. 
-<span class="v">55&#160;</span>The families of scribes who lived at Jabez: the Tirathites, the Shimeathites, and the Sucathites. These are the Kenites who came from Hammath, the father of the house of Rechab. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now these were the sons of David, who were born to him in Hebron: the firstborn, Amnon, of Ahinoam the Jezreelitess; the second, Daniel, of Abigail the Carmelitess; 
-<span class="v">2&#160;</span>the third, Absalom the son of Maacah the daughter of Talmai king of Geshur; the fourth, Adonijah the son of Haggith; 
-<span class="v">3&#160;</span>the fifth, Shephatiah of Abital; the sixth, Ithream by Eglah his woman: 
-<span class="v">4&#160;</span>six were born to him in Hebron; and he reigned there seven years and six months. He reigned thirty-three years in Jerusalem; 
-<span class="v">5&#160;</span>and these were born to him in Jerusalem: Shimea, Shobab, Nathan, and Solomon, four, by Bathshua the daughter of Ammiel; 
-<span class="v">6&#160;</span>and Ibhar, Elishama, Eliphelet, 
-<span class="v">7&#160;</span>Nogah, Nepheg, Japhia, 
-<span class="v">8&#160;</span>Elishama, Eliada, and Eliphelet, nine. 
-<span class="v">9&#160;</span>All these were the sons of David, in addition to the sons of the concubines; and Tamar was their sister. 
-</p><p>
-<span class="v">10&#160;</span>Solomon’s son was Rehoboam, Abijah his son, Asa his son, Jehoshaphat his son, 
-<span class="v">11&#160;</span>Joram his son, Ahaziah his son, Joash his son, 
-<span class="v">12&#160;</span>Amaziah his son, Azariah his son, Jotham his son, 
-<span class="v">13&#160;</span>Ahaz his son, Hezekiah his son, Manasseh his son, 
-<span class="v">14&#160;</span>Amon his son, and Josiah his son. 
-<span class="v">15&#160;</span>The sons of Josiah: the firstborn Johanan, the second Jehoiakim, the third Zedekiah, and the fourth Shallum. 
-<span class="v">16&#160;</span>The sons of Jehoiakim: Jeconiah his son, and Zedekiah his son. 
-<span class="v">17&#160;</span>The sons of Jeconiah, the captive: Shealtiel his son, 
-<span class="v">18&#160;</span>Malchiram, Pedaiah, Shenazzar, Jekamiah, Hoshama, and Nedabiah. 
-<span class="v">19&#160;</span>The sons of Pedaiah: Zerubbabel and Shimei. The sons of Zerubbabel: Meshullam and Hananiah; and Shelomith was their sister; 
-<span class="v">20&#160;</span>and Hashubah, Ohel, Berechiah, Hasadiah, and Jushab Hesed, five. 
-<span class="v">21&#160;</span>The sons of Hananiah: Pelatiah and Jeshaiah; the sons of Rephaiah, the sons of Arnan, the sons of Obadiah, the sons of Shecaniah. 
-<span class="v">22&#160;</span>The son of Shecaniah: Shemaiah. The sons of Shemaiah: Hattush, Igal, Bariah, Neariah, and Shaphat, six. 
-<span class="v">23&#160;</span>The sons of Neariah: Elioenai, Hizkiah, and Azrikam, three. 
-<span class="v">24&#160;</span>The sons of Elioenai: Hodaviah, Eliashib, Pelaiah, Akkub, Johanan, Delaiah, and Anani, seven. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>The sons of Judah: Perez, Hezron, Carmi, Hur, and Shobal. 
-<span class="v">2&#160;</span>Reaiah the son of Shobal brought forth Jahath; and Jahath brought forth Ahumai and Lahad. These are the families of the Zorathites. 
-<span class="v">3&#160;</span>These were the sons of the father of Etam: Jezreel, Ishma, and Idbash. The name of their sister was Hazzelelponi. 
-<span class="v">4&#160;</span>Penuel was the father of Gedor and Ezer the father of Hushah. These are the sons of Hur, the firstborn of Ephrathah, the father of Bethlehem. 
-<span class="v">5&#160;</span>Ashhur the father of Tekoa had two women, Helah and Naarah. 
-<span class="v">6&#160;</span>Naarah bore him Ahuzzam, Hepher, Temeni, and Haahashtari. These were the sons of Naarah. 
-<span class="v">7&#160;</span>The sons of Helah were Zereth, Izhar, and Ethnan. 
-<span class="v">8&#160;</span>Hakkoz brought forth Anub, Zobebah, and the families of Aharhel the son of Harum. 
-</p><p>
-<span class="v">9&#160;</span>Jabez was more honorable than his brothers. His mother named him Jabez,<span class="f">+ \fr 4:9 \ft “Jabez” sounds similar to the Hebrew word for “pain”.</span> saying, “Because I bore him with sorrow.” 
-</p><p>
-<span class="v">10&#160;</span>Jabez called on the Elohim<span class="f">+ \fr 4:10 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> of Israel, saying, “Oh that you would bless me indeed, and enlarge my border! May your hand be with me, and may you keep me from evil, that I may not cause pain!” 
-</p><p>Elohim granted him that which he requested. 
-</p><p>
-<span class="v">11&#160;</span>Chelub the brother of Shuhah brought forth Mehir, who was the father of Eshton. 
-<span class="v">12&#160;</span>Eshton brought forth Beth Rapha, Paseah, and Tehinnah the father of Ir Nahash. These are the men of Recah. 
-<span class="v">13&#160;</span>The sons of Kenaz: Othniel and Seraiah. The sons of Othniel: Hathath.<span class="f">+ \fr 4:13 \ft Greek and Vulgate add “and Meonothai”</span> 
-<span class="v">14&#160;</span>Meonothai brought forth Ophrah: and Seraiah brought forth Joab the father of Ge Harashim, for they were craftsmen. 
-<span class="v">15&#160;</span>The sons of Caleb the son of Jephunneh: Iru, Elah, and Naam. The son of Elah: Kenaz. 
-<span class="v">16&#160;</span>The sons of Jehallelel: Ziph, Ziphah, Tiria, and Asarel. 
-<span class="v">17&#160;</span>The sons of Ezrah: Jether, Mered, Epher, and Jalon; and Mered’s woman bore Miriam, Shammai, and Ishbah the father of Eshtemoa. 
-<span class="v">18&#160;</span>His woman the Jewess bore Jered the father of Gedor, Heber the father of Soco, and Jekuthiel the father of Zanoah. These are the sons of Bithiah the daughter of Pharaoh, whom Mered took. 
-<span class="v">19&#160;</span>The sons of the woman of Hodiah, the sister of Naham, were the fathers of Keilah the Garmite and Eshtemoa the Maacathite. 
-<span class="v">20&#160;</span>The sons of Shimon: Amnon, Rinnah, Ben Hanan, and Tilon. The sons of Ishi: Zoheth, and Ben Zoheth. 
-<span class="v">21&#160;</span>The sons of Shelah the son of Judah: Er the father of Lecah, Laadah the father of Mareshah, and the families of the house of those who worked fine linen, of the house of Ashbea; 
-<span class="v">22&#160;</span>and Jokim, and the men of Cozeba, and Joash, and Saraph, who had dominion in Moab, and Jashubilehem. These records are ancient. 
-<span class="v">23&#160;</span>These were the potters, and the inhabitants of Netaim and Gederah; they lived there with the king for his work. 
-</p><p>
-<span class="v">24&#160;</span>The sons of Simeon: Nemuel, Jamin, Jarib, Zerah, Shaul; 
-<span class="v">25&#160;</span>Shallum his son, Mibsam his son, and Mishma his son. 
-<span class="v">26&#160;</span>The sons of Mishma: Hammuel his son, Zaccur his son, Shimei his son. 
-<span class="v">27&#160;</span>Shimei had sixteen sons and six daughters; but his brothers didn’t have many children, and all their family didn’t multiply like the children of Judah. 
-<span class="v">28&#160;</span>They lived at Beersheba, Moladah, Hazarshual, 
-<span class="v">29&#160;</span>at Bilhah, at Ezem, at Tolad, 
-<span class="v">30&#160;</span>at Bethuel, at Hormah, at Ziklag, 
-<span class="v">31&#160;</span>at Beth Marcaboth, Hazar Susim, at Beth Biri, and at Shaaraim. These were their cities until David’s reign. 
-<span class="v">32&#160;</span>Their villages were Etam, Ain, Rimmon, Tochen, and Ashan, five cities; 
-<span class="v">33&#160;</span>and all their villages that were around the same cities, as far as Baal. These were their settlements, and they kept their genealogy. 
-<span class="v">34&#160;</span>Meshobab, Jamlech, Joshah the son of Amaziah, 
-<span class="v">35&#160;</span>Joel, Jehu the son of Joshibiah, the son of Seraiah, the son of Asiel, 
-<span class="v">36&#160;</span>Elioenai, Jaakobah, Jeshohaiah, Asaiah, Adiel, Jesimiel, Benaiah, 
-<span class="v">37&#160;</span>and Ziza the son of Shiphi, the son of Allon, the son of Jedaiah, the son of Shimri, the son of Shemaiah—<span class="v">38&#160;</span>these mentioned by name were princes in their families. Their fathers’ houses increased greatly. 
-</p><p>
-<span class="v">39&#160;</span>They went to the entrance of Gedor, even to the east side of the valley, to seek pasture for their flocks. 
-<span class="v">40&#160;</span>They found rich, good pasture, and the land was wide, and quiet, and peaceful, for those who lived there before were descended from Ham. 
-<span class="v">41&#160;</span>These written by name came in the days of Hezekiah king of Judah, and struck their tents and the Meunim who were found there; and they destroyed them utterly to this day, and lived in their place, because there was pasture there for their flocks. 
-<span class="v">42&#160;</span>Some of them, even of the sons of Simeon, five hundred men, went to Mount Seir, having for their captains Pelatiah, Neariah, Rephaiah, and Uzziel, the sons of Ishi. 
-<span class="v">43&#160;</span>They struck the remnant of the Amalekites who escaped, and have lived there to this day. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>The sons of Reuben the firstborn of Israel (for he was the firstborn, but because he defiled his father’s couch, his birthright was given to the sons of Joseph the son of Israel; and the genealogy is not to be listed according to the birthright. 
-<span class="v">2&#160;</span>For Judah prevailed above his brothers, and from him came the prince; but the birthright was Joseph’s)—<span class="v">3&#160;</span>the sons of Reuben the firstborn of Israel: Hanoch, Pallu, Hezron, and Carmi. 
-<span class="v">4&#160;</span>The sons of Joel: Shemaiah his son, Gog his son, Shimei his son, 
-<span class="v">5&#160;</span>Micah his son, Reaiah his son, Baal his son, 
-<span class="v">6&#160;</span>and Beerah his son, whom Tilgath Pilneser king of Assyria carried away captive. He was prince of the Reubenites. 
-<span class="v">7&#160;</span>His brothers by their families, when the genealogy of their generations was listed: the chief, Jeiel, and Zechariah, 
-<span class="v">8&#160;</span>and Bela the son of Azaz, the son of Shema, the son of Joel, who lived in Aroer, even to Nebo and Baal Meon; 
-<span class="v">9&#160;</span>and he lived eastward even to the entrance of the wilderness from the river Euphrates, because their livestock were multiplied in the land of Gilead. 
-</p><p>
-<span class="v">10&#160;</span>In the days of Saul, they made war with the Hagrites, who fell by their hand; and they lived in their tents throughout all the land east of Gilead. 
-</p><p>
-<span class="v">11&#160;</span>The sons of Gad lived beside them in the land of Bashan to Salecah: 
-<span class="v">12&#160;</span>Joel the chief, Shapham the second, Janai, and Shaphat in Bashan. 
-<span class="v">13&#160;</span>Their brothers of their fathers’ houses: Michael, Meshullam, Sheba, Jorai, Jacan, Zia, and Eber, seven. 
-<span class="v">14&#160;</span>These were the sons of Abihail, the son of Huri, the son of Jaroah, the son of Gilead, the son of Michael, the son of Jeshishai, the son of Jahdo, the son of Buz; 
-<span class="v">15&#160;</span>Ahi the son of Abdiel, the son of Guni, chief of their fathers’ houses. 
-<span class="v">16&#160;</span>They lived in Gilead in Bashan and in its towns, and in all the pasture lands of Sharon as far as their borders. 
-<span class="v">17&#160;</span>All these were listed by genealogies in the days of Jotham king of Judah, and in the days of Jeroboam king of Israel. 
-</p><p>
-<span class="v">18&#160;</span>The sons of Reuben, the Gadites, and the half-tribe of Manasseh, of valiant men, men able to bear buckler and sword, able to shoot with bow, and skillful in war, were forty-four thousand seven hundred sixty that were able to go out to war. 
-<span class="v">19&#160;</span>They made war with the Hagrites, with Jetur, and Naphish, and Nodab. 
-<span class="v">20&#160;</span>They were helped against them, and the Hagrites were delivered into their hand, and all who were with them; for they cried to Elohim in the battle, and he answered them because they put their trust in him. 
-<span class="v">21&#160;</span>They took away their livestock: of their camels fifty thousand, and of sheep two hundred fifty thousand, and of donkeys two thousand, and of men one hundred thousand. 
-<span class="v">22&#160;</span>For many fell slain, because the war was of Elohim. They lived in their place until the captivity. 
-</p><p>
-<span class="v">23&#160;</span>The children of the half-tribe of Manasseh lived in the land. They increased from Bashan to Baal Hermon, Senir, and Mount Hermon. 
-<span class="v">24&#160;</span>These were the heads of their fathers’ houses: Epher, Ishi, Eliel, Azriel, Jeremiah, Hodaviah, and Jahdiel—mighty men of valor, famous men, heads of their fathers’ houses. 
-<span class="v">25&#160;</span>They trespassed against the Elohim of their fathers, and played the prostitute after the elohims of the peoples of the land whom Elohim destroyed before them. 
-<span class="v">26&#160;</span>So the Elohim of Israel stirred up the spirit of Pul king of Assyria, and the spirit of Tilgath Pilneser king of Assyria, and he carried away the Reubenites, the Gadites, and the half-tribe of Manasseh, and brought them to Halah, Habor, Hara, and to the river of Gozan, to this day. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>The sons of Levi: Gershon, Kohath, and Merari. 
-<span class="v">2&#160;</span>The sons of Kohath: Amram, Izhar, Hebron, and Uzziel. 
-<span class="v">3&#160;</span>The children of Amram: Aaron, Moses, and Miriam. The sons of Aaron: Nadab, Abihu, Eleazar, and Ithamar. 
-<span class="v">4&#160;</span>Eleazar brought forth Phinehas, Phinehas brought forth Abishua, 
-<span class="v">5&#160;</span>Abishua brought forth Bukki. Bukki brought forth Uzzi. 
-<span class="v">6&#160;</span>Uzzi brought forth Zerahiah. Zerahiah brought forth Meraioth. 
-<span class="v">7&#160;</span>Meraioth brought forth Amariah. Amariah brought forth Ahitub. 
-<span class="v">8&#160;</span>Ahitub brought forth Zadok. Zadok brought forth Ahimaaz. 
-<span class="v">9&#160;</span>Ahimaaz brought forth Azariah. Azariah brought forth Johanan. 
-<span class="v">10&#160;</span>Johanan brought forth Azariah, who executed the priest’s office in the house that Solomon built in Jerusalem. 
-<span class="v">11&#160;</span>Azariah brought forth Amariah. Amariah brought forth Ahitub. 
-<span class="v">12&#160;</span>Ahitub brought forth Zadok. Zadok brought forth Shallum. 
-<span class="v">13&#160;</span>Shallum brought forth Hilkiah. Hilkiah brought forth Azariah. 
-<span class="v">14&#160;</span>Azariah brought forth Seraiah. Seraiah brought forth Jehozadak. 
-<span class="v">15&#160;</span>Jehozadak went into captivity when Yahweh carried Judah and Jerusalem away by the hand of Nebuchadnezzar. 
-</p><p>
-<span class="v">16&#160;</span>The sons of Levi: Gershom, Kohath, and Merari. 
-<span class="v">17&#160;</span>These are the names of the sons of Gershom: Libni and Shimei. 
-<span class="v">18&#160;</span>The sons of Kohath were Amram, Izhar, Hebron, and Uzziel. 
-<span class="v">19&#160;</span>The sons of Merari: Mahli and Mushi. These are the families of the Levites according to their fathers’ households. 
-<span class="v">20&#160;</span>Of Gershom: Libni his son, Jahath his son, Zimmah his son, 
-<span class="v">21&#160;</span>Joah his son, Iddo his son, Zerah his son, and Jeatherai his son. 
-<span class="v">22&#160;</span>The sons of Kohath: Amminadab his son, Korah his son, Assir his son, 
-<span class="v">23&#160;</span>Elkanah his son, Ebiasaph his son, Assir his son, 
-<span class="v">24&#160;</span>Tahath his son, Uriel his son, Uzziah his son, and Shaul his son. 
-<span class="v">25&#160;</span>The sons of Elkanah: Amasai and Ahimoth. 
-<span class="v">26&#160;</span>As for Elkanah, the sons of Elkanah: Zophai his son, Nahath his son, 
-<span class="v">27&#160;</span>Eliab his son, Jeroham his son, and Elkanah his son. 
-<span class="v">28&#160;</span>The sons of Samuel: the firstborn, Joel, and the second, Abijah. 
-<span class="v">29&#160;</span>The sons of Merari: Mahli, Libni his son, Shimei his son, Uzzah his son, 
-<span class="v">30&#160;</span>Shimea his son, Haggiah his son, Asaiah his son. 
-</p><p>
-<span class="v">31&#160;</span>These are they whom David set over the service of song in Yahweh’s house after the ark came to rest there. 
-<span class="v">32&#160;</span>They ministered with song before the tabernacle of the Tent of Meeting until Solomon had built Yahweh’s house in Jerusalem. They performed the duties of their office according to their order. 
-<span class="v">33&#160;</span>These are those who served, and their sons. Of the sons of the Kohathites: Heman the singer, the son of Joel, the son of Samuel, 
-<span class="v">34&#160;</span>the son of Elkanah, the son of Jeroham, the son of Eliel, the son of Toah, 
-<span class="v">35&#160;</span>the son of Zuph, the son of Elkanah, the son of Mahath, the son of Amasai, 
-<span class="v">36&#160;</span>the son of Elkanah, the son of Joel, the son of Azariah, the son of Zephaniah, 
-<span class="v">37&#160;</span>the son of Tahath, the son of Assir, the son of Ebiasaph, the son of Korah, 
-<span class="v">38&#160;</span>the son of Izhar, the son of Kohath, the son of Levi, the son of Israel. 
-<span class="v">39&#160;</span>His brother Asaph, who stood on his right hand, even Asaph the son of Berechiah, the son of Shimea, 
-<span class="v">40&#160;</span>the son of Michael, the son of Baaseiah, the son of Malchijah, 
-<span class="v">41&#160;</span>the son of Ethni, the son of Zerah, the son of Adaiah, 
-<span class="v">42&#160;</span>the son of Ethan, the son of Zimmah, the son of Shimei, 
-<span class="v">43&#160;</span>the son of Jahath, the son of Gershom, the son of Levi. 
-<span class="v">44&#160;</span>On the left hand their brothers the sons of Merari: Ethan the son of Kishi, the son of Abdi, the son of Malluch, 
-<span class="v">45&#160;</span>the son of Hashabiah, the son of Amaziah, the son of Hilkiah, 
-<span class="v">46&#160;</span>the son of Amzi, the son of Bani, the son of Shemer, 
-<span class="v">47&#160;</span>the son of Mahli, the son of Mushi, the son of Merari, the son of Levi. 
-<span class="v">48&#160;</span>Their brothers the Levites were appointed for all the service of the tabernacle of Elohim’s house. 
-<span class="v">49&#160;</span>But Aaron and his sons offered on the altar of burnt offering, and on the altar of incense, for all the work of the most set-apart place, and to make atonement for Israel, according to all that Moses the servant of Elohim had commanded. 
-</p><p>
-<span class="v">50&#160;</span>These are the sons of Aaron: Eleazar his son, Phinehas his son, Abishua his son, 
-<span class="v">51&#160;</span>Bukki his son, Uzzi his son, Zerahiah his son, 
-<span class="v">52&#160;</span>Meraioth his son, Amariah his son, Ahitub his son, 
-<span class="v">53&#160;</span>Zadok his son, and Ahimaaz his son. 
-<span class="v">54&#160;</span>Now these are their dwelling places according to their encampments in their borders: to the sons of Aaron, of the families of the Kohathites (for theirs was the first lot), 
-<span class="v">55&#160;</span>to them they gave Hebron in the land of Judah, and its pasture lands around it; 
-<span class="v">56&#160;</span>but the fields of the city and its villages, they gave to Caleb the son of Jephunneh. 
-<span class="v">57&#160;</span>To the sons of Aaron they gave the cities of refuge, Hebron, Libnah also with its pasture lands, Jattir, Eshtemoa with its pasture lands, 
-<span class="v">58&#160;</span>Hilen with its pasture lands, Debir with its pasture lands, 
-<span class="v">59&#160;</span>Ashan with its pasture lands, and Beth Shemesh with its pasture lands; 
-<span class="v">60&#160;</span>and out of the tribe of Benjamin, Geba with its pasture lands, Allemeth with its pasture lands, and Anathoth with its pasture lands. All their cities throughout their families were thirteen cities. 
-</p><p>
-<span class="v">61&#160;</span>To the rest of the sons of Kohath were given by lot, out of the family of the tribe, out of the half-tribe, the half of Manasseh, ten cities. 
-<span class="v">62&#160;</span>To the sons of Gershom, according to their families, out of the tribe of Issachar, and out of the tribe of Asher, and out of the tribe of Naphtali, and out of the tribe of Manasseh in Bashan, thirteen cities. 
-<span class="v">63&#160;</span>To the sons of Merari were given by lot, according to their families, out of the tribe of Reuben, and out of the tribe of Gad, and out of the tribe of Zebulun, twelve cities. 
-<span class="v">64&#160;</span>The children of Israel gave to the Levites the cities with their pasture lands. 
-<span class="v">65&#160;</span>They gave by lot out of the tribe of the children of Judah, and out of the tribe of the children of Simeon, and out of the tribe of the children of Benjamin, these cities which are mentioned by name. 
-</p><p>
-<span class="v">66&#160;</span>Some of the families of the sons of Kohath had cities of their borders out of the tribe of Ephraim. 
-<span class="v">67&#160;</span>They gave to them the cities of refuge, Shechem in the hill country of Ephraim with its pasture lands and Gezer with its pasture lands, 
-<span class="v">68&#160;</span>Jokmeam with its pasture lands, Beth Horon with its pasture lands, 
-<span class="v">69&#160;</span>Aijalon with its pasture lands, Gath Rimmon with its pasture lands; 
-<span class="v">70&#160;</span>and out of the half-tribe of Manasseh, Aner with its pasture lands, and Bileam with its pasture lands, for the rest of the family of the sons of Kohath. 
-</p><p>
-<span class="v">71&#160;</span>To the sons of Gershom were given, out of the family of the half-tribe of Manasseh, Golan in Bashan with its pasture lands, and Ashtaroth with its pasture lands; 
-<span class="v">72&#160;</span>and out of the tribe of Issachar, Kedesh with its pasture lands, Daberath with its pasture lands, 
-<span class="v">73&#160;</span>Ramoth with its pasture lands, and Anem with its pasture lands; 
-<span class="v">74&#160;</span>and out of the tribe of Asher, Mashal with its pasture lands, Abdon with its pasture lands, 
-<span class="v">75&#160;</span>Hukok with its pasture lands, and Rehob with its pasture lands; 
-<span class="v">76&#160;</span>and out of the tribe of Naphtali, Kedesh in Galilee with its pasture lands, Hammon with its pasture lands, and Kiriathaim with its pasture lands. 
-</p><p>
-<span class="v">77&#160;</span>To the rest of the Levites, the sons of Merari, were given, out of the tribe of Zebulun, Rimmono with its pasture lands, and Tabor with its pasture lands; 
-<span class="v">78&#160;</span>and beyond the Jordan at Jericho, on the east side of the Jordan, were given them out of the tribe of Reuben: Bezer in the wilderness with its pasture lands, Jahzah with its pasture lands, 
-<span class="v">79&#160;</span>Kedemoth with its pasture lands, and Mephaath with its pasture lands; 
-<span class="v">80&#160;</span>and out of the tribe of Gad, Ramoth in Gilead with its pasture lands, Mahanaim with its pasture lands, 
-<span class="v">81&#160;</span>Heshbon with its pasture lands, and Jazer with its pasture lands. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Of the sons of Issachar: Tola, Puah, Jashub, and Shimron, four. 
-<span class="v">2&#160;</span>The sons of Tola: Uzzi, Rephaiah, Jeriel, Jahmai, Ibsam, and Shemuel, heads of their fathers’ houses, of Tola; mighty men of valor in their generations. Their number in the days of David was twenty-two thousand six hundred. 
-<span class="v">3&#160;</span>The son of Uzzi: Izrahiah. The sons of Izrahiah: Michael, Obadiah, Joel, and Isshiah, five; all of them chief men. 
-<span class="v">4&#160;</span>With them, by their generations, after their fathers’ houses, were bands of the army for war, thirty-six thousand; for they had many women and sons. 
-<span class="v">5&#160;</span>Their brothers among all the families of Issachar, mighty men of valor, listed in all by genealogy, were eighty-seven thousand. 
-</p><p>
-<span class="v">6&#160;</span>The sons of Benjamin: Bela, Becher, and Jediael, three. 
-<span class="v">7&#160;</span>The sons of Bela: Ezbon, Uzzi, Uzziel, Jerimoth, and Iri, five; heads of fathers’ houses, mighty men of valor; and they were listed by genealogy twenty-two thousand thirty-four. 
-<span class="v">8&#160;</span>The sons of Becher: Zemirah, Joash, Eliezer, Elioenai, Omri, Jeremoth, Abijah, Anathoth, and Alemeth. All these were the sons of Becher. 
-<span class="v">9&#160;</span>They were listed by genealogy, after their generations, heads of their fathers’ houses, mighty men of valor, twenty thousand two hundred. 
-<span class="v">10&#160;</span>The son of Jediael: Bilhan. The sons of Bilhan: Jeush, Benjamin, Ehud, Chenaanah, Zethan, Tarshish, and Ahishahar. 
-<span class="v">11&#160;</span>All these were sons of Jediael, according to the heads of their fathers’ households, mighty men of valor, seventeen thousand two hundred, who were able to go out in the army for war. 
-<span class="v">12&#160;</span>So were Shuppim, Huppim, the sons of Ir, Hushim, and the sons of Aher. 
-</p><p>
-<span class="v">13&#160;</span>The sons of Naphtali: Jahziel, Guni, Jezer, Shallum, and the sons of Bilhah. 
-</p><p>
-<span class="v">14&#160;</span>The sons of Manasseh: Asriel, whom his concubine the Aramitess bore. She bore Machir the father of Gilead. 
-<span class="v">15&#160;</span>Machir took a woman of Huppim and Shuppim, whose sister’s name was Maacah. The name of the second was Zelophehad; and Zelophehad had daughters. 
-<span class="v">16&#160;</span>Maacah the woman of Machir bore a son, and she named him Peresh. The name of his brother was Sheresh; and his sons were Ulam and Rakem. 
-<span class="v">17&#160;</span>The sons of Ulam: Bedan. These were the sons of Gilead the son of Machir, the son of Manasseh. 
-<span class="v">18&#160;</span>His sister Hammolecheth bore Ishhod, Abiezer, and Mahlah. 
-<span class="v">19&#160;</span>The sons of Shemida were Ahian, Shechem, Likhi, and Aniam. 
-</p><p>
-<span class="v">20&#160;</span>The sons of Ephraim: Shuthelah, Bered his son, Tahath his son, Eleadah his son, Tahath his son, 
-<span class="v">21&#160;</span>Zabad his son, Shuthelah his son, Ezer, and Elead, whom the men of Gath who were born in the land killed, because they came down to take away their livestock. 
-<span class="v">22&#160;</span>Ephraim their father mourned many days, and his brothers came to comfort him. 
-<span class="v">23&#160;</span>He went in to his woman, and she conceived and bore a son, and he named him Beriah,<span class="f">+ \fr 7:23 \ft “Beriah” is similar to the Hebrew word for “misfortune”.</span> because there was trouble with his house. 
-<span class="v">24&#160;</span>His daughter was Sheerah, who built Beth Horon the lower and the upper, and Uzzen Sheerah. 
-<span class="v">25&#160;</span>Rephah was his son, Resheph his son, Telah his son, Tahan his son, 
-<span class="v">26&#160;</span>Ladan his son, Ammihud his son, Elishama his son, 
-<span class="v">27&#160;</span>Nun his son, and Joshua his son. 
-<span class="v">28&#160;</span>Their possessions and settlements were Bethel and its towns, and eastward Naaran, and westward Gezer with its towns; Shechem also and its towns, to Azzah and its towns; 
-<span class="v">29&#160;</span>and by the borders of the children of Manasseh, Beth Shean and its towns, Taanach and its towns, Megiddo and its towns, and Dor and its towns. The children of Joseph the son of Israel lived in these. 
-</p><p>
-<span class="v">30&#160;</span>The sons of Asher: Imnah, Ishvah, Ishvi, and Beriah. Serah was their sister. 
-<span class="v">31&#160;</span>The sons of Beriah: Heber and Malchiel, who was the father of Birzaith. 
-<span class="v">32&#160;</span>Heber brought forth Japhlet, Shomer, Hotham, and Shua their sister. 
-<span class="v">33&#160;</span>The sons of Japhlet: Pasach, Bimhal, and Ashvath. These are the children of Japhlet. 
-<span class="v">34&#160;</span>The sons of Shemer: Ahi, Rohgah, Jehubbah, and Aram. 
-<span class="v">35&#160;</span>The sons of Helem his brother: Zophah, Imna, Shelesh, and Amal. 
-<span class="v">36&#160;</span>The sons of Zophah: Suah, Harnepher, Shual, Beri, Imrah, 
-<span class="v">37&#160;</span>Bezer, Hod, Shamma, Shilshah, Ithran, and Beera. 
-<span class="v">38&#160;</span>The sons of Jether: Jephunneh, Pispa, and Ara. 
-<span class="v">39&#160;</span>The sons of Ulla: Arah, Hanniel, and Rizia. 
-<span class="v">40&#160;</span>All these were the children of Asher, heads of the fathers’ houses, choice and mighty men of valor, chief of the princes. The number of them listed by genealogy for service in war was twenty-six thousand men. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Benjamin brought forth Bela his firstborn, Ashbel the second, Aharah the third, 
-<span class="v">2&#160;</span>Nohah the fourth, and Rapha the fifth. 
-<span class="v">3&#160;</span>Bela had sons: Addar, Gera, Abihud, 
-<span class="v">4&#160;</span>Abishua, Naaman, Ahoah, 
-<span class="v">5&#160;</span>Gera, Shephuphan, and Huram. 
-<span class="v">6&#160;</span>These are the sons of Ehud. These are the heads of fathers’ households of the inhabitants of Geba, who were carried captive to Manahath: 
-<span class="v">7&#160;</span>Naaman, Ahijah, and Gera, who carried them captive; and he brought forth Uzza and Ahihud. 
-</p><p>
-<span class="v">8&#160;</span>Shaharaim brought forth children in the field of Moab, after he had sent them away. Hushim and Baara were his women. 
-<span class="v">9&#160;</span>By Hodesh his woman, he brought forth Jobab, Zibia, Mesha, Malcam, 
-<span class="v">10&#160;</span>Jeuz, Shachia, and Mirmah. These were his sons, heads of fathers’ households. 
-<span class="v">11&#160;</span>By Hushim, he brought forth Abitub and Elpaal. 
-<span class="v">12&#160;</span>The sons of Elpaal: Eber, Misham, and Shemed, who built Ono and Lod, with its towns; 
-<span class="v">13&#160;</span>and Beriah and Shema, who were heads of fathers’ households of the inhabitants of Aijalon, who put to flight the inhabitants of Gath; 
-<span class="v">14&#160;</span>and Ahio, Shashak, Jeremoth, 
-<span class="v">15&#160;</span>Zebadiah, Arad, Eder, 
-<span class="v">16&#160;</span>Michael, Ishpah, Joha, the sons of Beriah, 
-<span class="v">17&#160;</span>Zebadiah, Meshullam, Hizki, Heber, 
-<span class="v">18&#160;</span>Ishmerai, Izliah, Jobab, the sons of Elpaal, 
-<span class="v">19&#160;</span>Jakim, Zichri, Zabdi, 
-<span class="v">20&#160;</span>Elienai, Zillethai, Eliel, 
-<span class="v">21&#160;</span>Adaiah, Beraiah, Shimrath, the sons of Shimei, 
-<span class="v">22&#160;</span>Ishpan, Eber, Eliel, 
-<span class="v">23&#160;</span>Abdon, Zichri, Hanan, 
-<span class="v">24&#160;</span>Hananiah, Elam, Anthothijah, 
-<span class="v">25&#160;</span>Iphdeiah, Penuel, the sons of Shashak, 
-<span class="v">26&#160;</span>Shamsherai, Shehariah, Athaliah, 
-<span class="v">27&#160;</span>Jaareshiah, Elijah, Zichri, and the sons of Jeroham. 
-<span class="v">28&#160;</span>These were heads of fathers’ households throughout their generations, chief men. These lived in Jerusalem. 
-</p><p>
-<span class="v">29&#160;</span>The father of Gibeon, whose woman’s name was Maacah, lived in Gibeon 
-<span class="v">30&#160;</span>with his firstborn son Abdon, Zur, Kish, Baal, Nadab, 
-<span class="v">31&#160;</span>Gedor, Ahio, Zecher, 
-<span class="v">32&#160;</span>and Mikloth, who brought forth Shimeah. They also lived with their families in Jerusalem, near their relatives. 
-<span class="v">33&#160;</span>Ner brought forth Kish. Kish brought forth Saul. Saul brought forth Jonathan, Malchishua, Abinadab, and Eshbaal. 
-<span class="v">34&#160;</span>The son of Jonathan was Merib-baal. Merib-baal brought forth Micah. 
-<span class="v">35&#160;</span>The sons of Micah: Pithon, Melech, Tarea, and Ahaz. 
-<span class="v">36&#160;</span>Ahaz brought forth Jehoaddah. Jehoaddah brought forth Alemeth, Azmaveth, and Zimri. Zimri brought forth Moza. 
-<span class="v">37&#160;</span>Moza brought forth Binea. Raphah was his son, Eleasah his son, and Azel his son. 
-<span class="v">38&#160;</span>Azel had six sons, whose names are these: Azrikam, Bocheru, Ishmael, Sheariah, Obadiah, and Hanan. All these were the sons of Azel. 
-<span class="v">39&#160;</span>The sons of Eshek his brother: Ulam his firstborn, Jeush the second, and Eliphelet the third. 
-<span class="v">40&#160;</span>The sons of Ulam were mighty men of valor, archers, and had many sons, and grandsons, one hundred fifty. All these were of the sons of Benjamin. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>So all Israel were listed by genealogies; and behold,<span class="f">+ \fr 9:1 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> they are written in the book of the kings of Israel. Judah was carried away captive to Babylon for their disobedience. 
-<span class="v">2&#160;</span>Now the first inhabitants who lived in their possessions in their cities were Israel, the priests, the Levites, and the temple servants. 
-<span class="v">3&#160;</span>In Jerusalem, there lived of the children of Judah, of the children of Benjamin, and of the children of Ephraim and Manasseh: 
-<span class="v">4&#160;</span>Uthai the son of Ammihud, the son of Omri, the son of Imri, the son of Bani, of the children of Perez the son of Judah. 
-<span class="v">5&#160;</span>Of the Shilonites: Asaiah the firstborn and his sons. 
-<span class="v">6&#160;</span>Of the sons of Zerah: Jeuel and their brothers, six hundred ninety. 
-<span class="v">7&#160;</span>Of the sons of Benjamin: Sallu the son of Meshullam, the son of Hodaviah, the son of Hassenuah; 
-<span class="v">8&#160;</span>and Ibneiah the son of Jeroham, and Elah the son of Uzzi, the son of Michri; and Meshullam the son of Shephatiah, the son of Reuel, the son of Ibnijah; 
-<span class="v">9&#160;</span>and their brothers, according to their generations, nine hundred fifty-six. All these men were heads of fathers’ households by their fathers’ houses. 
-</p><p>
-<span class="v">10&#160;</span>Of the priests: Jedaiah, Jehoiarib, Jachin, 
-<span class="v">11&#160;</span>and Azariah the son of Hilkiah, the son of Meshullam, the son of Zadok, the son of Meraioth, the son of Ahitub, the ruler of Elohim’s house; 
-<span class="v">12&#160;</span>and Adaiah the son of Jeroham, the son of Pashhur, the son of Malchijah; and Maasai the son of Adiel, the son of Jahzerah, the son of Meshullam, the son of Meshillemith, the son of Immer; 
-<span class="v">13&#160;</span>and their brothers, heads of their fathers’ houses, one thousand seven hundred sixty; they were very able men for the work of the service of Elohim’s house. 
-</p><p>
-<span class="v">14&#160;</span>Of the Levites: Shemaiah the son of Hasshub, the son of Azrikam, the son of Hashabiah, of the sons of Merari; 
-<span class="v">15&#160;</span>and Bakbakkar, Heresh, Galal, and Mattaniah the son of Mica, the son of Zichri, the son of Asaph, 
-<span class="v">16&#160;</span>and Obadiah the son of Shemaiah, the son of Galal, the son of Jeduthun; and Berechiah the son of Asa, the son of Elkanah, who lived in the villages of the Netophathites. 
-</p><p>
-<span class="v">17&#160;</span>The gatekeepers: Shallum, Akkub, Talmon, Ahiman, and their brothers (Shallum was the chief), 
-<span class="v">18&#160;</span>who previously served in the king’s gate eastward. They were the gatekeepers for the camp of the children of Levi. 
-<span class="v">19&#160;</span>Shallum was the son of Kore, the son of Ebiasaph, the son of Korah, and his brothers, of his father’s house, the Korahites, were over the work of the service, keepers of the thresholds of the tent. Their fathers had been over Yahweh’s camp, keepers of the entry. 
-<span class="v">20&#160;</span>Phinehas the son of Eleazar was ruler over them in time past, and Yahweh was with him. 
-<span class="v">21&#160;</span>Zechariah the son of Meshelemiah was gatekeeper of the door of the Tent of Meeting. 
-<span class="v">22&#160;</span>All these who were chosen to be gatekeepers in the thresholds were two hundred twelve. These were listed by genealogy in their villages, whom David and Samuel the seer ordained in their office of trust. 
-<span class="v">23&#160;</span>So they and their children had the oversight of the gates of Yahweh’s house, even the house of the tent, as guards. 
-<span class="v">24&#160;</span>On the four sides were the gatekeepers, toward the east, west, north, and south. 
-<span class="v">25&#160;</span>Their brothers, in their villages, were to come in every seven days from time to time to be with them, 
-<span class="v">26&#160;</span>for the four chief gatekeepers, who were Levites, were in an office of trust, and were over the rooms and over the treasuries in Elohim’s house. 
-<span class="v">27&#160;</span>They stayed around Elohim’s house, because that was their duty; and it was their duty to open it morning by morning. 
-</p><p>
-<span class="v">28&#160;</span>Certain of them were in charge of the vessels of service, for these were brought in by count, and these were taken out by count. 
-<span class="v">29&#160;</span>Some of them also were appointed over the furniture, and over all the vessels of the sanctuary, over the fine flour, the wine, the oil, the frankincense, and the spices. 
-</p><p>
-<span class="v">30&#160;</span>Some of the sons of the priests prepared the mixing of the spices. 
-<span class="v">31&#160;</span>Mattithiah, one of the Levites, who was the firstborn of Shallum the Korahite, had the office of trust over the things that were baked in pans. 
-<span class="v">32&#160;</span>Some of their brothers, of the sons of the Kohathites, were over the show bread, to prepare it every Sabbath. 
-</p><p>
-<span class="v">33&#160;</span>These are the singers, heads of fathers’ households of the Levites, who lived in the rooms and were free from other service, for they were employed in their work day and night. 
-<span class="v">34&#160;</span>These were heads of fathers’ households of the Levites, throughout their generations, chief men. They lived at Jerusalem. 
-</p><p>
-<span class="v">35&#160;</span>Jeiel the father of Gibeon, whose woman’s name was Maacah, lived in Gibeon. 
-<span class="v">36&#160;</span>His firstborn son was Abdon, then Zur, Kish, Baal, Ner, Nadab, 
-<span class="v">37&#160;</span>Gedor, Ahio, Zechariah, and Mikloth. 
-<span class="v">38&#160;</span>Mikloth brought forth Shimeam. They also lived with their relatives in Jerusalem, near their relatives. 
-<span class="v">39&#160;</span>Ner brought forth Kish. Kish brought forth Saul. Saul brought forth Jonathan, Malchishua, Abinadab, and Eshbaal. 
-<span class="v">40&#160;</span>The son of Jonathan was Merib-baal. Merib-baal brought forth Micah. 
-<span class="v">41&#160;</span>The sons of Micah: Pithon, Melech, Tahrea, and Ahaz. 
-<span class="v">42&#160;</span>Ahaz brought forth Jarah. Jarah brought forth Alemeth, Azmaveth, and Zimri. Zimri brought forth Moza. 
-<span class="v">43&#160;</span>Moza brought forth Binea, Rephaiah his son, Eleasah his son, and Azel his son. 
-<span class="v">44&#160;</span>Azel had six sons, whose names are Azrikam, Bocheru, Ishmael, Sheariah, Obadiah, and Hanan. These were the sons of Azel. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Now the Philistines fought against Israel; and the men of Israel fled from before the Philistines, and fell down slain on Mount Gilboa. 
-<span class="v">2&#160;</span>The Philistines followed hard after Saul and after his sons; and the Philistines killed Jonathan, Abinadab, and Malchishua, the sons of Saul. 
-<span class="v">3&#160;</span>The battle went hard against Saul, and the archers overtook him; and he was distressed by reason of the archers. 
-<span class="v">4&#160;</span>Then Saul said to his armor bearer, “Draw your sword, and thrust me through with it, lest these uncircumcised come and abuse me.” 
-</p><p>But his armor bearer would not, for he was terrified. Therefore Saul took his sword and fell on it. 
-<span class="v">5&#160;</span>When his armor bearer saw that Saul was dead, he likewise fell on his sword and died. 
-<span class="v">6&#160;</span>So Saul died with his three sons; and all his house died together. 
-<span class="v">7&#160;</span>When all the men of Israel who were in the valley saw that they fled, and that Saul and his sons were dead, they abandoned their cities, and fled; and the Philistines came and lived in them. 
-</p><p>
-<span class="v">8&#160;</span>On the next day, when the Philistines came to strip the slain, they found Saul and his sons fallen on Mount Gilboa. 
-<span class="v">9&#160;</span>They stripped him and took his head and his armor, then sent into the land of the Philistines all around to carry the news to their idols and to the people. 
-<span class="v">10&#160;</span>They put his armor in the house of their elohims, and fastened his head in the house of Dagon. 
-<span class="v">11&#160;</span>When all Jabesh Gilead heard all that the Philistines had done to Saul, 
-<span class="v">12&#160;</span>all the valiant men arose and took away the body of Saul and the bodies of his sons, and brought them to Jabesh, and buried their bones under the oak in Jabesh, and fasted seven days. 
-</p><p>
-<span class="v">13&#160;</span>So Saul died for his trespass which he committed against Yahweh, because of Yahweh’s word, which he didn’t keep, and also because he asked counsel of one who had a familiar spirit, to inquire, 
-<span class="v">14&#160;</span>and didn’t inquire of Yahweh. Therefore he killed him, and turned the kingdom over to David the son of Jesse. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Then all Israel gathered themselves to David to Hebron, saying, “Behold, we are your bone and your flesh. 
-<span class="v">2&#160;</span>In times past, even when Saul was king, it was you who led out and brought in Israel. Yahweh your Elohim said to you, ‘You shall be shepherd of my people Israel, and you shall be prince over my people Israel.’&#160;” 
-</p><p>
-<span class="v">3&#160;</span>So all the elders of Israel came to the king to Hebron; and David made a covenant with them in Hebron before Yahweh. They anointed David king over Israel, according to Yahweh’s word by Samuel. 
-</p><p>
-<span class="v">4&#160;</span>David and all Israel went to Jerusalem (also called Jebus); and the Jebusites, the inhabitants of the land, were there. 
-<span class="v">5&#160;</span>The inhabitants of Jebus said to David, “You will not come in here!” Nevertheless David took the stronghold of Zion. The same is David’s city. 
-<span class="v">6&#160;</span>David had said, “Whoever strikes the Jebusites first shall be chief and captain.” Joab the son of Zeruiah went up first, and was made chief. 
-<span class="v">7&#160;</span>David lived in the stronghold; therefore they called it David’s city. 
-<span class="v">8&#160;</span>He built the city all around, from Millo even around; and Joab repaired the rest of the city. 
-<span class="v">9&#160;</span>David grew greater and greater, for Yahweh of Armies was with him. 
-</p><p>
-<span class="v">10&#160;</span>Now these are the chief of the mighty men whom David had, who showed themselves strong with him in his kingdom, together with all Israel, to make him king, according to Yahweh’s word concerning Israel. 
-</p><p>
-<span class="v">11&#160;</span>This is the number of the mighty men whom David had: Jashobeam, the son of a Hachmonite, the chief of the thirty; he lifted up his spear against three hundred and killed them at one time. 
-<span class="v">12&#160;</span>After him was Eleazar the son of Dodo, the Ahohite, who was one of the three mighty men. 
-<span class="v">13&#160;</span>He was with David at Pasdammim, and there the Philistines were gathered together to battle, where there was a plot of ground full of barley; and the people fled from before the Philistines. 
-<span class="v">14&#160;</span>They stood in the middle of the plot, defended it, and killed the Philistines; and Yahweh saved them by a great victory. 
-</p><p>
-<span class="v">15&#160;</span>Three of the thirty chief men went down to the rock to David, into the cave of Adullam; and the army of the Philistines were encamped in the valley of Rephaim. 
-<span class="v">16&#160;</span>David was then in the stronghold, and the garrison of the Philistines was in Bethlehem at that time. 
-<span class="v">17&#160;</span>David longed, and said, “Oh, that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
-</p><p>
-<span class="v">18&#160;</span>The three broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate, took it, and brought it to David; but David would not drink any of it, but poured it out to Yahweh, 
-<span class="v">19&#160;</span>and said, “My Elohim forbid me, that I should do this! Shall I drink the blood of these men who have put their lives in jeopardy?” For they risked their lives to bring it. Therefore he would not drink it. The three mighty men did these things. 
-</p><p>
-<span class="v">20&#160;</span>Abishai, the brother of Joab, was chief of the three; for he lifted up his spear against three hundred and killed them, and had a name among the three. 
-<span class="v">21&#160;</span>Of the three, he was more honorable than the two, and was made their captain; however he wasn’t included in the three. 
-</p><p>
-<span class="v">22&#160;</span>Benaiah the son of Jehoiada, the son of a valiant man of Kabzeel, who had done mighty deeds, killed the two sons of Ariel of Moab. He also went down and killed a lion in the middle of a pit on a snowy day. 
-<span class="v">23&#160;</span>He killed an Egyptian, a man of great stature, five cubits<span class="f">+ \fr 11:23 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters. Therefore this Egyptian was bout 7 feet and 6 inches or 2.28 meters tall.</span> high. In the Egyptian’s hand was a spear like a weaver’s beam; and he went down to him with a staff, plucked the spear out of the Egyptian’s hand, and killed him with his own spear. 
-<span class="v">24&#160;</span>Benaiah the son of Jehoiada did these things and had a name among the three mighty men. 
-<span class="v">25&#160;</span>Behold, he was more honorable than the thirty, but he didn’t attain to the three; and David set him over his guard. 
-</p><p>
-<span class="v">26&#160;</span>The mighty men of the armies also include Asahel the brother of Joab, Elhanan the son of Dodo of Bethlehem, 
-<span class="v">27&#160;</span>Shammoth the Harorite, Helez the Pelonite, 
-<span class="v">28&#160;</span>Ira the son of Ikkesh the Tekoite, Abiezer the Anathothite, 
-<span class="v">29&#160;</span>Sibbecai the Hushathite, Ilai the Ahohite, 
-<span class="v">30&#160;</span>Maharai the Netophathite, Heled the son of Baanah the Netophathite, 
-<span class="v">31&#160;</span>Ithai the son of Ribai of Gibeah of the children of Benjamin, Benaiah the Pirathonite, 
-<span class="v">32&#160;</span>Hurai of the brooks of Gaash, Abiel the Arbathite, 
-<span class="v">33&#160;</span>Azmaveth the Baharumite, Eliahba the Shaalbonite, 
-<span class="v">34&#160;</span>the sons of Hashem the Gizonite, Jonathan the son of Shagee the Hararite, 
-<span class="v">35&#160;</span>Ahiam the son of Sacar the Hararite, Eliphal the son of Ur, 
-<span class="v">36&#160;</span>Hepher the Mecherathite, Ahijah the Pelonite, 
-<span class="v">37&#160;</span>Hezro the Carmelite, Naarai the son of Ezbai, 
-<span class="v">38&#160;</span>Joel the brother of Nathan, Mibhar the son of Hagri, 
-<span class="v">39&#160;</span>Zelek the Ammonite, Naharai the Berothite (the armor bearer of Joab the son of Zeruiah), 
-<span class="v">40&#160;</span>Ira the Ithrite, Gareb the Ithrite, 
-<span class="v">41&#160;</span>Uriah the Hittite, Zabad the son of Ahlai, 
-<span class="v">42&#160;</span>Adina the son of Shiza the Reubenite (a chief of the Reubenites), and thirty with him, 
-<span class="v">43&#160;</span>Hanan the son of Maacah, Joshaphat the Mithnite, 
-<span class="v">44&#160;</span>Uzzia the Ashterathite, Shama and Jeiel the sons of Hotham the Aroerite, 
-<span class="v">45&#160;</span>Jediael the son of Shimri, and Joha his brother, the Tizite, 
-<span class="v">46&#160;</span>Eliel the Mahavite, and Jeribai, and Joshaviah, the sons of Elnaam, and Ithmah the Moabite, 
-<span class="v">47&#160;</span>Eliel, Obed, and Jaasiel the Mezobaite. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Now these are those who came to David to Ziklag while he was a fugitive from Saul the son of Kish. They were among the mighty men, his helpers in war. 
-<span class="v">2&#160;</span>They were armed with bows, and could use both the right hand and the left in slinging stones and in shooting arrows from the bow. They were of Saul’s relatives of the tribe of Benjamin. 
-<span class="v">3&#160;</span>The chief was Ahiezer, then Joash, the sons of Shemaah the Gibeathite; Jeziel and Pelet, the sons of Azmaveth; Beracah; Jehu the Anathothite; 
-<span class="v">4&#160;</span>Ishmaiah the Gibeonite, a mighty man among the thirty and a leader of the thirty; Jeremiah; Jahaziel; Johanan; Jozabad the Gederathite; 
-<span class="v">5&#160;</span>Eluzai; Jerimoth; Bealiah; Shemariah; Shephatiah the Haruphite; 
-<span class="v">6&#160;</span>Elkanah, Isshiah, Azarel, Joezer, and Jashobeam, the Korahites; 
-<span class="v">7&#160;</span>and Joelah and Zebadiah, the sons of Jeroham of Gedor. 
-</p><p>
-<span class="v">8&#160;</span>Some Gadites joined David in the stronghold in the wilderness, mighty men of valor, men trained for war, who could handle shield and spear; whose faces were like the faces of lions, and they were as swift as the gazelles on the mountains: 
-<span class="v">9&#160;</span>Ezer the chief, Obadiah the second, Eliab the third, 
-<span class="v">10&#160;</span>Mishmannah the fourth, Jeremiah the fifth, 
-<span class="v">11&#160;</span>Attai the sixth, Eliel the seventh, 
-<span class="v">12&#160;</span>Johanan the eighth, Elzabad the ninth, 
-<span class="v">13&#160;</span>Jeremiah the tenth, and Machbannai the eleventh. 
-<span class="v">14&#160;</span>These of the sons of Gad were captains of the army. He who was least was equal to one hundred, and the greatest to one thousand. 
-<span class="v">15&#160;</span>These are those who went over the Jordan in the first month, when it had overflowed all its banks; and they put to flight all who lived in the valleys, both toward the east and toward the west. 
-</p><p>
-<span class="v">16&#160;</span>Some of the children of Benjamin and Judah came to the stronghold to David. 
-<span class="v">17&#160;</span>David went out to meet them, and answered them, “If you have come peaceably to me to help me, my heart will be united with you; but if you have come to betray me to my adversaries, since there is no wrong in my hands, may the Elohim of our fathers see this and rebuke it.” 
-<span class="v">18&#160;</span>Then the Spirit came on Amasai, who was chief of the thirty, and he said, “We are yours, David, and on your side, you son of Jesse. Peace, peace be to you, and peace be to your helpers; for your Elohim helps you.” Then David received them and made them captains of the band. 
-</p><p>
-<span class="v">19&#160;</span>Some of Manasseh also joined David when he came with the Philistines against Saul to battle, but they didn’t help them, for the lords of the Philistines sent him away after consultation, saying, “He will desert to his master Saul to the jeopardy of our heads.” 
-</p><p>
-<span class="v">20&#160;</span>As he went to Ziklag, some from Manasseh joined him: Adnah, Jozabad, Jediael, Michael, Jozabad, Elihu, and Zillethai, captains of thousands who were of Manasseh. 
-<span class="v">21&#160;</span>They helped David against the band of raiders, for they were all mighty men of valor and were captains in the army. 
-<span class="v">22&#160;</span>For from day to day men came to David to help him, until there was a great army, like Elohim’s army. 
-</p><p>
-<span class="v">23&#160;</span>These are the numbers of the heads of those who were armed for war, who came to David to Hebron to turn the kingdom of Saul to him, according to Yahweh’s word. 
-<span class="v">24&#160;</span>The children of Judah who bore shield and spear were six thousand eight hundred, armed for war. 
-<span class="v">25&#160;</span>Of the children of Simeon, mighty men of valor for the war: seven thousand one hundred. 
-<span class="v">26&#160;</span>Of the children of Levi: four thousand six hundred. 
-<span class="v">27&#160;</span>Jehoiada was the leader of the household of Aaron; and with him were three thousand seven hundred, 
-<span class="v">28&#160;</span>and Zadok, a young man mighty of valor, and of his father’s house twenty-two captains. 
-<span class="v">29&#160;</span>Of the children of Benjamin, Saul’s relatives: three thousand, for until then, the greatest part of them had kept their allegiance to Saul’s house. 
-<span class="v">30&#160;</span>Of the children of Ephraim: twenty thousand eight hundred, mighty men of valor, famous men in their fathers’ houses. 
-<span class="v">31&#160;</span>Of the half-tribe of Manasseh: eighteen thousand, who were mentioned by name, to come and make David king. 
-<span class="v">32&#160;</span>Of the children of Issachar, men who had understanding of the times, to know what Israel ought to do, their heads were two hundred; and all their brothers were at their command. 
-<span class="v">33&#160;</span>Of Zebulun, such as were able to go out in the army, who could set the battle in array with all kinds of instruments of war: fifty thousand who could command and were not of double heart. 
-<span class="v">34&#160;</span>Of Naphtali: one thousand captains, and with them with shield and spear thirty-seven thousand. 
-<span class="v">35&#160;</span>Of the Danites who could set the battle in array: twenty-eight thousand six hundred. 
-<span class="v">36&#160;</span>Of Asher, such as were able to go out in the army, who could set the battle in array: forty thousand. 
-<span class="v">37&#160;</span>On the other side of the Jordan, of the Reubenites, the Gadites, and of the half-tribe of Manasseh, with all kinds of instruments of war for the battle: one hundred twenty thousand. 
-</p><p>
-<span class="v">38&#160;</span>All these were men of war who could order the battle array, and came with a perfect heart to Hebron to make David king over all Israel; and all the rest also of Israel were of one heart to make David king. 
-<span class="v">39&#160;</span>They were there with David three days, eating and drinking; for their brothers had supplied provisions for them. 
-<span class="v">40&#160;</span>Moreover those who were near to them, as far as Issachar, Zebulun, and Naphtali, brought bread on donkeys, on camels, on mules, and on oxen: supplies of flour, cakes of figs, clusters of raisins, wine, oil, cattle, and sheep in abundance; for there was joy in Israel. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>David consulted with the captains of thousands and of hundreds, even with every leader. 
-<span class="v">2&#160;</span>David said to all the assembly of Israel, “If it seems good to you, and if it is of Yahweh our Elohim, let’s send word everywhere to our brothers who are left in all the land of Israel, with whom the priests and Levites are in their cities that have pasture lands, that they may gather themselves to us. 
-<span class="v">3&#160;</span>Also, let’s bring the ark of our Elohim back to us again, for we didn’t seek it in the days of Saul.” 
-</p><p>
-<span class="v">4&#160;</span>All the assembly said that they would do so, for the thing was right in the eyes of all the people. 
-<span class="v">5&#160;</span>So David assembled all Israel together, from the Shihor River of Egypt even to the entrance of Hamath, to bring Elohim’s ark from Kiriath Jearim. 
-</p><p>
-<span class="v">6&#160;</span>David went up with all Israel to Baalah, that is, to Kiriath Jearim, which belonged to Judah, to bring up from there Elohim Yahweh’s ark that sits above the cherubim, that is called by the Name. 
-<span class="v">7&#160;</span>They carried Elohim’s ark on a new cart, and brought it out of Abinadab’s house; and Uzza and Ahio drove the cart. 
-<span class="v">8&#160;</span>David and all Israel played before Elohim with all their might, even with songs, with harps, with stringed instruments, with tambourines, with cymbals, and with trumpets. 
-</p><p>
-<span class="v">9&#160;</span>When they came to Chidon’s threshing floor, Uzza put out his hand to hold the ark, for the oxen stumbled. 
-<span class="v">10&#160;</span>Yahweh’s anger burned against Uzza, and he struck him because he put his hand on the ark; and he died there before Elohim. 
-<span class="v">11&#160;</span>David was displeased, because Yahweh had broken out against Uzza. He called that place Perez Uzza, to this day. 
-<span class="v">12&#160;</span>David was afraid of Elohim that day, saying, “How can I bring Elohim’s ark home to me?” 
-<span class="v">13&#160;</span>So David didn’t move the ark with him into David’s city, but carried it aside into Obed-Edom the Gittite’s house. 
-<span class="v">14&#160;</span>Elohim’s ark remained with the family of Obed-Edom in his house three months; and Yahweh blessed Obed-Edom’s house and all that he had. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Hiram king of Tyre sent messengers to David with cedar trees, masons, and carpenters, to build him a house. 
-<span class="v">2&#160;</span>David perceived that Yahweh had established him king over Israel, for his kingdom was highly exalted, for his people Israel’s sake. 
-</p><p>
-<span class="v">3&#160;</span>David took more women in Jerusalem, and David brought forth more sons and daughters. 
-<span class="v">4&#160;</span>These are the names of the children whom he had in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
-<span class="v">5&#160;</span>Ibhar, Elishua, Elpelet, 
-<span class="v">6&#160;</span>Nogah, Nepheg, Japhia, 
-<span class="v">7&#160;</span>Elishama, Beeliada, and Eliphelet. 
-</p><p>
-<span class="v">8&#160;</span>When the Philistines heard that David was anointed king over all Israel, all the Philistines went up to seek David; and David heard of it, and went out against them. 
-<span class="v">9&#160;</span>Now the Philistines had come and made a raid in the valley of Rephaim. 
-<span class="v">10&#160;</span>David inquired of Elohim, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
-</p><p>Yahweh said to him, “Go up; for I will deliver them into your hand.” 
-</p><p>
-<span class="v">11&#160;</span>So they came up to Baal Perazim, and David defeated them there. David said, Elohim has broken my enemies by my hand, like waters breaking out. Therefore they called the name of that place Baal Perazim.<span class="f">+ \fr 14:11 \ft “Baal Perazim” means “The Lord who breaks out”.</span> 
-<span class="v">12&#160;</span>They left their elohims there; and David gave a command, and they were burned with fire. 
-</p><p>
-<span class="v">13&#160;</span>The Philistines made another raid in the valley. 
-<span class="v">14&#160;</span>David inquired again of Elohim; and Elohim said to him, “You shall not go up after them. Turn away from them, and come on them opposite the mulberry trees. 
-<span class="v">15&#160;</span>When you hear the sound of marching in the tops of the mulberry trees, then go out to battle; for Elohim has gone out before you to strike the army of the Philistines.” 
-</p><p>
-<span class="v">16&#160;</span>David did as Elohim commanded him; and they attacked the army of the Philistines from Gibeon even to Gezer. 
-<span class="v">17&#160;</span>The fame of David went out into all lands; and Yahweh brought the fear of him on all nations. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>David made himself houses in David’s city; and he prepared a place for Elohim’s ark, and pitched a tent for it. 
-<span class="v">2&#160;</span>Then David said, “No one ought to carry Elohim’s ark but the Levites. For Yahweh has chosen them to carry Elohim’s ark, and to minister to him forever.” 
-</p><p>
-<span class="v">3&#160;</span>David assembled all Israel at Jerusalem, to bring up Yahweh’s ark to its place, which he had prepared for it. 
-<span class="v">4&#160;</span>David gathered together the sons of Aaron and the Levites: 
-<span class="v">5&#160;</span>of the sons of Kohath, Uriel the chief, and his brothers one hundred twenty; 
-<span class="v">6&#160;</span>of the sons of Merari, Asaiah the chief, and his brothers two hundred twenty; 
-<span class="v">7&#160;</span>of the sons of Gershom, Joel the chief, and his brothers one hundred thirty; 
-<span class="v">8&#160;</span>of the sons of Elizaphan, Shemaiah the chief, and his brothers two hundred; 
-<span class="v">9&#160;</span>of the sons of Hebron, Eliel the chief, and his brothers eighty; 
-<span class="v">10&#160;</span>of the sons of Uzziel, Amminadab the chief, and his brothers one hundred twelve. 
-</p><p>
-<span class="v">11&#160;</span>David called for Zadok and Abiathar the priests, and for the Levites: for Uriel, Asaiah, Joel, Shemaiah, Eliel, and Amminadab, 
-<span class="v">12&#160;</span>and said to them, “You are the heads of the fathers’ households of the Levites. Sanctify yourselves, both you and your brothers, that you may bring the ark of Yahweh, the Elohim of Israel, up to the place that I have prepared for it. 
-<span class="v">13&#160;</span>For because you didn’t carry it at first, Yahweh our Elohim broke out in anger against us, because we didn’t seek him according to the ordinance.” 
-</p><p>
-<span class="v">14&#160;</span>So the priests and the Levites sanctified themselves to bring up the ark of Yahweh, the Elohim of Israel. 
-<span class="v">15&#160;</span>The children of the Levites bore Elohim’s ark on their shoulders with its poles, as Moses commanded according to Yahweh’s word. 
-</p><p>
-<span class="v">16&#160;</span>David spoke to the chief of the Levites to appoint their brothers as singers with instruments of music, stringed instruments, harps, and cymbals, sounding aloud and lifting up their voices with joy. 
-<span class="v">17&#160;</span>So the Levites appointed Heman the son of Joel; and of his brothers, Asaph the son of Berechiah; and of the sons of Merari their brothers, Ethan the son of Kushaiah; 
-<span class="v">18&#160;</span>and with them their brothers of the second rank: Zechariah, Ben, Jaaziel, Shemiramoth, Jehiel, Unni, Eliab, Benaiah, Maaseiah, Mattithiah, Eliphelehu, Mikneiah, Obed-Edom, and Jeiel, the doorkeepers. 
-<span class="v">19&#160;</span>So the singers, Heman, Asaph, and Ethan, were given cymbals of bronze to sound aloud; 
-<span class="v">20&#160;</span>and Zechariah, Aziel, Shemiramoth, Jehiel, Unni, Eliab, Maaseiah, and Benaiah, with stringed instruments set to Alamoth; 
-<span class="v">21&#160;</span>and Mattithiah, Eliphelehu, Mikneiah, Obed-Edom, Jeiel, and Azaziah, with harps tuned to the eight-stringed lyre, to lead. 
-<span class="v">22&#160;</span>Chenaniah, chief of the Levites, was over the singing. He taught the singers, because he was skillful. 
-<span class="v">23&#160;</span>Berechiah and Elkanah were doorkeepers for the ark. 
-<span class="v">24&#160;</span>Shebaniah, Joshaphat, Nethanel, Amasai, Zechariah, Benaiah, and Eliezer, the priests, blew the trumpets before Elohim’s ark; and Obed-Edom and Jehiah were doorkeepers for the ark. 
-</p><p>
-<span class="v">25&#160;</span>So David, the elders of Israel, and the captains over thousands went to bring the ark of Yahweh’s covenant up out of the house of Obed-Edom with joy. 
-<span class="v">26&#160;</span>When Elohim helped the Levites who bore the ark of Yahweh’s covenant, they sacrificed seven bulls and seven rams. 
-<span class="v">27&#160;</span>David was clothed with a robe of fine linen, as were all the Levites who bore the ark, the singers, and Chenaniah the choir master with the singers; and David had an ephod of linen on him. 
-<span class="v">28&#160;</span>Thus all Israel brought the ark of Yahweh’s covenant up with shouting, with sound of the cornet, with trumpets, and with cymbals, sounding aloud with stringed instruments and harps. 
-<span class="v">29&#160;</span>As the ark of Yahweh’s covenant came to David’s city, Michal the daughter of Saul looked out at the window, and saw king David dancing and playing; and she despised him in her heart. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>They brought in Elohim’s ark, and set it in the middle of the tent that David had pitched for it; and they offered burnt offerings and peace offerings before Elohim. 
-<span class="v">2&#160;</span>When David had finished offering the burnt offering and the peace offerings, he blessed the people in Yahweh’s name. 
-<span class="v">3&#160;</span>He gave to everyone of Israel, both man and woman, to everyone a loaf of bread, a portion of meat, and a cake of raisins. 
-</p><p>
-<span class="v">4&#160;</span>He appointed some of the Levites to minister before Yahweh’s ark, and to commemorate, to thank, and to praise Yahweh, the Elohim of Israel: 
-<span class="v">5&#160;</span>Asaph the chief, and second to him Zechariah, then Jeiel, Shemiramoth, Jehiel, Mattithiah, Eliab, Benaiah, Obed-Edom, and Jeiel, with stringed instruments and with harps; and Asaph with cymbals, sounding aloud; 
-<span class="v">6&#160;</span>with Benaiah and Jahaziel the priests with trumpets continually, before the ark of the covenant of Elohim. 
-</p><p>
-<span class="v">7&#160;</span>Then on that day David first ordained giving of thanks to Yahweh by the hand of Asaph and his brothers. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Oh give thanks to Yahweh. 
-</p><p class="q2">Call on his name. 
-</p><p class="q2">Make what he has done known among the peoples. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Sing to him. 
-</p><p class="q2">Sing praises to him. 
-</p><p class="q2">Tell of all his marvelous works. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Glory in his set-apart name. 
-</p><p class="q2">Let the heart of those who seek Yahweh rejoice. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Seek Yahweh and his strength. 
-</p><p class="q2">Seek his face forever more. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Remember his marvelous works that he has done, 
-</p><p class="q2">his wonders, and the judgments of his mouth, 
-</p><p class="q1">
-<span class="v">13&#160;</span>you offspring<span class="f">+ \fr 16:13 \ft or, seed</span> of Israel his servant, 
-</p><p class="q2">you children of Jacob, his chosen ones. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>He is Yahweh our Elohim. 
-</p><p class="q2">His judgments are in all the earth. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Remember his covenant forever, 
-</p><p class="q2">the word which he commanded to a thousand generations, 
-</p><p class="q2">
-<span class="v">16&#160;</span>the covenant which he made with Abraham, 
-</p><p class="q2">his oath to Isaac. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He confirmed it to Jacob for a statute, 
-</p><p class="q2">and to Israel for an everlasting covenant, 
-</p><p class="q1">
-<span class="v">18&#160;</span>saying, “I will give you the land of Canaan, 
-</p><p class="q2">The lot of your inheritance,” 
-</p><p class="q2">
-<span class="v">19&#160;</span>when you were but a few men in number, 
-</p><p class="q2">yes, very few, and foreigners in it. 
-</p><p class="q1">
-<span class="v">20&#160;</span>They went about from nation to nation, 
-</p><p class="q2">from one kingdom to another people. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He allowed no man to do them wrong. 
-</p><p class="q2">Yes, he reproved kings for their sakes, 
-</p><p class="q1">
-<span class="v">22&#160;</span>“Don’t touch my anointed ones! 
-</p><p class="q2">Do my prophets no harm!” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>Sing to Yahweh, all the earth! 
-</p><p class="q2">Display his salvation from day to day. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Declare his glory among the nations, 
-</p><p class="q2">and his marvelous works among all the peoples. 
-</p><p class="q1">
-<span class="v">25&#160;</span>For great is Yahweh, and greatly to be praised. 
-</p><p class="q2">He also is to be feared above all elohims. 
-</p><p class="q1">
-<span class="v">26&#160;</span>For all the elohims of the peoples are idols, 
-</p><p class="q2">but Yahweh made the heavens. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Honor and majesty are before him. 
-</p><p class="q2">Strength and gladness are in his place. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>Ascribe to Yahweh, you families of the peoples, 
-</p><p class="q2">ascribe to Yahweh glory and strength! 
-</p><p class="q1">
-<span class="v">29&#160;</span>Ascribe to Yahweh the glory due to his name. 
-</p><p class="q2">Bring an offering, and come before him. 
-</p><p class="q2">Worship Yahweh in set-apart array. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Tremble before him, all the earth. 
-</p><p class="q2">The world also is established that it can’t be moved. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Let the heavens be glad, 
-</p><p class="q2">and let the earth rejoice! 
-</p><p class="q2">Let them say among the nations, “Yahweh reigns!” 
-</p><p class="q1">
-<span class="v">32&#160;</span>Let the sea roar, and its fullness! 
-</p><p class="q2">Let the field exult, and all that is in it! 
-</p><p class="q1">
-<span class="v">33&#160;</span>Then the trees of the forest will sing for joy before Yahweh, 
-</p><p class="q2">for he comes to judge the earth. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Oh give thanks to Yahweh, for he is good, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">35&#160;</span>Say, “Save us, Elohim of our salvation! 
-</p><p class="q2">Gather us together and deliver us from the nations, 
-</p><p class="q2">to give thanks to your set-apart name, 
-</p><p class="q2">to triumph in your praise.” 
-</p><p class="q1">
-<span class="v">36&#160;</span>Blessed be Yahweh, the Elohim of Israel, 
-</p><p class="q2">from everlasting even to everlasting. 
-</p><p>All the people said, “Amen,” and praised Yahweh. 
-</p><p>
-<span class="v">37&#160;</span>So he left Asaph and his brothers there before the ark of Yahweh’s covenant, to minister before the ark continually, as every day’s work required; 
-<span class="v">38&#160;</span>and Obed-Edom with their sixty-eight relatives; Obed-Edom also the son of Jeduthun and Hosah to be doorkeepers; 
-<span class="v">39&#160;</span>and Zadok the priest and his brothers the priests, before Yahweh’s tabernacle in the high place that was at Gibeon, 
-<span class="v">40&#160;</span>to offer burnt offerings to Yahweh on the altar of burnt offering continually morning and evening, even according to all that is written in Yahweh’s law, which he commanded to Israel; 
-<span class="v">41&#160;</span>and with them Heman and Jeduthun and the rest who were chosen, who were mentioned by name, to give thanks to Yahweh, because his loving kindness endures forever; 
-<span class="v">42&#160;</span>and with them Heman and Jeduthun with trumpets and cymbals for those that should sound aloud, and with instruments for the songs of Elohim, and the sons of Jeduthun to be at the gate. 
-<span class="v">43&#160;</span>All the people departed, each man to his house; and David returned to bless his house. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>When David was living in his house, David said to Nathan the prophet, “Behold, I live in a cedar house, but the ark of Yahweh’s covenant is in a tent.” 
-</p><p>
-<span class="v">2&#160;</span>Nathan said to David, “Do all that is in your heart; for Elohim is with you.” 
-</p><p>
-<span class="v">3&#160;</span>That same night, the word of Elohim came to Nathan, saying, 
-<span class="v">4&#160;</span>“Go and tell David my servant, ‘Yahweh says, “You shall not build me a house to dwell in; 
-<span class="v">5&#160;</span>for I have not lived in a house since the day that I brought up Israel to this day, but have gone from tent to tent, and from one tent to another. 
-<span class="v">6&#160;</span>In all places in which I have walked with all Israel, did I speak a word with any of the judges of Israel, whom I commanded to be shepherd of my people, saying, ‘Why have you not built me a house of cedar?’&#160;”&#160;’ 
-</p><p>
-<span class="v">7&#160;</span>“Now therefore, you shall tell my servant David, ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people Israel. 
-<span class="v">8&#160;</span>I have been with you wherever you have gone, and have cut off all your enemies from before you. I will make you a name like the name of the great ones who are in the earth. 
-<span class="v">9&#160;</span>I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place, and be moved no more. The children of wickedness will not waste them any more, as at the first, 
-<span class="v">10&#160;</span>and from the day that I commanded judges to be over my people Israel. I will subdue all your enemies. Moreover I tell you that Yahweh will build you a house. 
-<span class="v">11&#160;</span>It will happen, when your days are fulfilled that you must go to be with your fathers, that I will set up your offspring after you, who will be of your sons; and I will establish his kingdom. 
-<span class="v">12&#160;</span>He will build me a house, and I will establish his throne forever. 
-<span class="v">13&#160;</span>I will be his father, and he will be my son. I will not take my loving kindness away from him, as I took it from him who was before you; 
-<span class="v">14&#160;</span>but I will settle him in my house and in my kingdom forever. His throne will be established forever.”&#160;’&#160;” 
-<span class="v">15&#160;</span>According to all these words, and according to all this vision, so Nathan spoke to David. 
-</p><p>
-<span class="v">16&#160;</span>Then David the king went in and sat before Yahweh; and he said, “Who am I, Yahweh Elohim, and what is my house, that you have brought me this far? 
-<span class="v">17&#160;</span>This was a small thing in your eyes, O Elohim, but you have spoken of your servant’s house for a great while to come, and have respected me according to the standard of a man of high degree, Yahweh Elohim. 
-<span class="v">18&#160;</span>What can David say yet more to you concerning the honor which is done to your servant? For you know your servant. 
-<span class="v">19&#160;</span>Yahweh, for your servant’s sake, and according to your own heart, you have done all this greatness, to make known all these great things. 
-<span class="v">20&#160;</span>Yahweh, there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
-<span class="v">21&#160;</span>What one nation in the earth is like your people Israel, whom Elohim went to redeem to himself for a people, to make you a name by great and awesome things, in driving out nations from before your people whom you redeemed out of Egypt? 
-<span class="v">22&#160;</span>For you made your people Israel your own people forever; and you, Yahweh, became their Elohim. 
-<span class="v">23&#160;</span>Now, Yahweh, let the word that you have spoken concerning your servant, and concerning his house, be established forever, and do as you have spoken. 
-<span class="v">24&#160;</span>Let your name be established and magnified forever, saying, ‘Yahweh of Armies is the Elohim of Israel, even an Elohim to Israel. The house of David your servant is established before you.’ 
-<span class="v">25&#160;</span>For you, my Elohim, have revealed to your servant that you will build him a house. Therefore your servant has found courage to pray before you. 
-<span class="v">26&#160;</span>Now, Yahweh, you are Elohim, and have promised this good thing to your servant. 
-<span class="v">27&#160;</span>Now it has pleased you to bless the house of your servant, that it may continue forever before you; for you, Yahweh, have blessed, and it is blessed forever.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>After this, David defeated the Philistines and subdued them, and took Gath and its towns out of the hand of the Philistines. 
-<span class="v">2&#160;</span>He defeated Moab; and the Moabites became servants to David and brought tribute. 
-</p><p>
-<span class="v">3&#160;</span>David defeated Hadadezer king of Zobah, toward Hamath, as he went to establish his dominion by the river Euphrates. 
-<span class="v">4&#160;</span>David took from him one thousand chariots, seven thousand horsemen, and twenty thousand footmen; and David hamstrung all the chariot horses, but reserved of them enough for one hundred chariots. 
-<span class="v">5&#160;</span>When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty-two thousand men of the Syrians. 
-<span class="v">6&#160;</span>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David and brought tribute. Yahweh gave victory to David wherever he went. 
-<span class="v">7&#160;</span>David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
-<span class="v">8&#160;</span>From Tibhath and from Cun, cities of Hadadezer, David took very much bronze, with which Solomon made the bronze sea, the pillars, and the vessels of bronze. 
-</p><p>
-<span class="v">9&#160;</span>When Tou king of Hamath heard that David had struck all the army of Hadadezer king of Zobah, 
-<span class="v">10&#160;</span>he sent Hadoram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him (for Hadadezer had wars with Tou); and he had with him all kinds of vessels of gold and silver and bronze. 
-<span class="v">11&#160;</span>King David also dedicated these to Yahweh, with the silver and the gold that he carried away from all the nations: from Edom, from Moab, from the children of Ammon, from the Philistines, and from Amalek. 
-</p><p>
-<span class="v">12&#160;</span>Moreover Abishai the son of Zeruiah struck eighteen thousand of the Edomites in the Valley of Salt. 
-<span class="v">13&#160;</span>He put garrisons in Edom; and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
-</p><p>
-<span class="v">14&#160;</span>David reigned over all Israel; and he executed justice and righteousness for all his people. 
-<span class="v">15&#160;</span>Joab the son of Zeruiah was over the army; Jehoshaphat the son of Ahilud was recorder; 
-<span class="v">16&#160;</span>Zadok the son of Ahitub and Abimelech the son of Abiathar were priests; Shavsha was scribe; 
-<span class="v">17&#160;</span>and Benaiah the son of Jehoiada was over the Cherethites and the Pelethites; and the sons of David were chief officials serving the king. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>After this, Nahash the king of the children of Ammon died, and his son reigned in his place. 
-<span class="v">2&#160;</span>David said, “I will show kindness to Hanun the son of Nahash, because his father showed kindness to me.” 
-</p><p>So David sent messengers to comfort him concerning his father. David’s servants came into the land of the children of Ammon to Hanun to comfort him. 
-<span class="v">3&#160;</span>But the princes of the children of Ammon said to Hanun, “Do you think that David honors your father, in that he has sent comforters to you? Haven’t his servants come to you to search, to overthrow, and to spy out the land?” 
-<span class="v">4&#160;</span>So Hanun took David’s servants, shaved them, and cut off their garments in the middle at their buttocks, and sent them away. 
-<span class="v">5&#160;</span>Then some people went and told David how the men were treated. He sent to meet them; for the men were greatly humiliated. The king said, “Stay at Jericho until your beards have grown, and then return.” 
-</p><p>
-<span class="v">6&#160;</span>When the children of Ammon saw that they had made themselves odious to David, Hanun and the children of Ammon sent one thousand talents<span class="f">+ \fr 19:6 \ft A talent is about 30 kilograms or 66 pounds, so 1000 talents is about 30 metric tons</span> of silver to hire chariots and horsemen out of Mesopotamia, out of Aram-maacah, and out of Zobah. 
-<span class="v">7&#160;</span>So they hired for themselves thirty-two thousand chariots, and the king of Maacah with his people, who came and encamped near Medeba. The children of Ammon gathered themselves together from their cities, and came to battle. 
-<span class="v">8&#160;</span>When David heard of it, he sent Joab with all the army of the mighty men. 
-<span class="v">9&#160;</span>The children of Ammon came out, and put the battle in array at the gate of the city; and the kings who had come were by themselves in the field. 
-</p><p>
-<span class="v">10&#160;</span>Now when Joab saw that the battle was set against him before and behind, he chose some of all the choice men of Israel, and put them in array against the Syrians. 
-<span class="v">11&#160;</span>The rest of the people he committed into the hand of Abishai his brother; and they put themselves in array against the children of Ammon. 
-<span class="v">12&#160;</span>He said, “If the Syrians are too strong for me, then you are to help me; but if the children of Ammon are too strong for you, then I will help you. 
-<span class="v">13&#160;</span>Be courageous, and let’s be strong for our people and for the cities of our Elohim. May Yahweh do that which seems good to him.” 
-</p><p>
-<span class="v">14&#160;</span>So Joab and the people who were with him came near to the front of the Syrians to the battle; and they fled before him. 
-<span class="v">15&#160;</span>When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai his brother, and entered into the city. Then Joab came to Jerusalem. 
-</p><p>
-<span class="v">16&#160;</span>When the Syrians saw that they were defeated by Israel, they sent messengers and called out the Syrians who were beyond the River,<span class="f">+ \fr 19:16 \ft or, the Euphrates River</span> with Shophach the captain of the army of Hadadezer leading them. 
-<span class="v">17&#160;</span>David was told that, so he gathered all Israel together, passed over the Jordan, came to them, and set the battle in array against them. So when David had put the battle in array against the Syrians, they fought with him. 
-<span class="v">18&#160;</span>The Syrians fled before Israel; and David killed of the Syrian men seven thousand charioteers and forty thousand footmen, and also killed Shophach the captain of the army. 
-<span class="v">19&#160;</span>When the servants of Hadadezer saw that they were defeated by Israel, they made peace with David and served him. The Syrians would not help the children of Ammon any more. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>At the time of the return of the year, at the time when kings go out, Joab led out the army and wasted the country of the children of Ammon, and came and besieged Rabbah. But David stayed at Jerusalem. Joab struck Rabbah, and overthrew it. 
-<span class="v">2&#160;</span>David took the crown of their king from off his head, and found it to weigh a talent of gold,<span class="f">+ \fr 20:2 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> and there were precious stones in it. It was set on David’s head, and he brought very much plunder out of the city. 
-<span class="v">3&#160;</span>He brought out the people who were in it, and had them cut with saws, with iron picks, and with axes. David did so to all the cities of the children of Ammon. Then David and all the people returned to Jerusalem. 
-</p><p>
-<span class="v">4&#160;</span>After this, war arose at Gezer with the Philistines. Then Sibbecai the Hushathite killed Sippai, of the sons of the giant; and they were subdued. 
-</p><p>
-<span class="v">5&#160;</span>Again there was war with the Philistines; and Elhanan the son of Jair killed Lahmi the brother of Goliath the Gittite, the staff of whose spear was like a weaver’s beam. 
-<span class="v">6&#160;</span>There was again war at Gath, where there was a man of great stature, who had twenty-four fingers and toes, six on each hand and six on each foot; and he also was born to the giant. 
-<span class="v">7&#160;</span>When he defied Israel, Jonathan the son of Shimea, David’s brother, killed him. 
-<span class="v">8&#160;</span>These were born to the giant in Gath; and they fell by the hand of David and by the hand of his servants. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Satan stood up against Israel, and moved David to take a census of Israel. 
-<span class="v">2&#160;</span>David said to Joab and to the princes of the people, “Go, count Israel from Beersheba even to Dan; and bring me word, that I may know how many there are.” 
-</p><p>
-<span class="v">3&#160;</span>Joab said, “May Yahweh make his people a hundred times as many as they are. But, my lord the king, aren’t they all my lord’s servants? Why does my lord require this thing? Why will he be a cause of guilt to Israel?” 
-</p><p>
-<span class="v">4&#160;</span>Nevertheless the king’s word prevailed against Joab. Therefore Joab departed and went throughout all Israel, then came to Jerusalem. 
-<span class="v">5&#160;</span>Joab gave the sum of the census of the people to David. All those of Israel were one million one hundred thousand men who drew a sword; and in Judah were four hundred seventy thousand men who drew a sword. 
-<span class="v">6&#160;</span>But he didn’t count Levi and Benjamin among them, for the king’s word was abominable to Joab. 
-</p><p>
-<span class="v">7&#160;</span>Elohim was displeased with this thing; therefore he struck Israel. 
-<span class="v">8&#160;</span>David said to Elohim, “I have sinned greatly, in that I have done this thing. But now put away, I beg you, the iniquity of your servant, for I have done very foolishly.” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh spoke to Gad, David’s seer, saying, 
-<span class="v">10&#160;</span>“Go and speak to David, saying, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>So Gad came to David and said to him, “Yahweh says, ‘Take your choice: 
-<span class="v">12&#160;</span>either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days of the sword of Yahweh, even pestilence in the land, and Yahweh’s angel destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>David said to Gad, “I am in distress. Let me fall, I pray, into Yahweh’s hand, for his mercies are very great. Don’t let me fall into man’s hand.” 
-</p><p>
-<span class="v">14&#160;</span>So Yahweh sent a pestilence on Israel, and seventy thousand men of Israel fell. 
-<span class="v">15&#160;</span>Elohim sent an angel to Jerusalem to destroy it. As he was about to destroy, Yahweh saw, and he relented of the disaster, and said to the destroying angel, “It is enough. Now withdraw your hand.” Yahweh’s angel was standing by the threshing floor of Ornan the Jebusite. 
-<span class="v">16&#160;</span>David lifted up his eyes, and saw Yahweh’s angel standing between earth and the sky, having a drawn sword in his hand stretched out over Jerusalem. 
-</p><p>Then David and the elders, clothed in sackcloth, fell on their faces. 
-<span class="v">17&#160;</span>David said to Elohim, “Isn’t it I who commanded the people to be counted? It is even I who have sinned and done very wickedly; but these sheep, what have they done? Please let your hand, O Yahweh my Elohim, be against me and against my father’s house; but not against your people, that they should be plagued.” 
-</p><p>
-<span class="v">18&#160;</span>Then Yahweh’s angel commanded Gad to tell David that David should go up and raise an altar to Yahweh on the threshing floor of Ornan the Jebusite. 
-<span class="v">19&#160;</span>David went up at the saying of Gad, which he spoke in Yahweh’s name. 
-</p><p>
-<span class="v">20&#160;</span>Ornan turned back and saw the angel; and his four sons who were with him hid themselves. Now Ornan was threshing wheat. 
-<span class="v">21&#160;</span>As David came to Ornan, Ornan looked and saw David, and went out of the threshing floor, and bowed himself to David with his face to the ground. 
-</p><p>
-<span class="v">22&#160;</span>Then David said to Ornan, “Sell me the place of this threshing floor, that I may build an altar to Yahweh on it. You shall sell it to me for the full price, that the plague may be stopped from afflicting the people.” 
-</p><p>
-<span class="v">23&#160;</span>Ornan said to David, “Take it for yourself, and let my lord the king do that which is good in his eyes. Behold, I give the oxen for burnt offerings, and the threshing instruments for wood, and the wheat for the meal offering. I give it all.” 
-</p><p>
-<span class="v">24&#160;</span>King David said to Ornan, “No, but I will most certainly buy it for the full price. For I will not take that which is yours for Yahweh, nor offer a burnt offering that costs me nothing.” 
-</p><p>
-<span class="v">25&#160;</span>So David gave to Ornan six hundred shekels<span class="f">+ \fr 21:25 \ft A shekel is about 10 grams or about 0.32 Troy ounces, so 600 shekels was about 6 kilograms or about 192 Troy ounces.</span> of gold by weight for the place. 
-<span class="v">26&#160;</span>David built an altar to Yahweh there, and offered burnt offerings and peace offerings, and called on Yahweh; and he answered him from the sky by fire on the altar of burnt offering. 
-</p><p>
-<span class="v">27&#160;</span>Then Yahweh commanded the angel, and he put his sword back into its sheath. 
-</p><p>
-<span class="v">28&#160;</span>At that time, when David saw that Yahweh had answered him in the threshing floor of Ornan the Jebusite, then he sacrificed there. 
-<span class="v">29&#160;</span>For Yahweh’s tabernacle, which Moses made in the wilderness, and the altar of burnt offering, were at that time in the high place at Gibeon. 
-<span class="v">30&#160;</span>But David couldn’t go before it to inquire of Elohim, for he was afraid because of the sword of Yahweh’s angel. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Then David said, “This is the house of Yahweh Elohim, and this is the altar of burnt offering for Israel.” 
-</p><p>
-<span class="v">2&#160;</span>David gave orders to gather together the foreigners who were in the land of Israel; and he set masons to cut dressed stones to build Elohim’s house. 
-<span class="v">3&#160;</span>David prepared iron in abundance for the nails for the doors of the gates and for the couplings, and bronze in abundance without weight, 
-<span class="v">4&#160;</span>and cedar trees without number, for the Sidonians and the people of Tyre brought cedar trees in abundance to David. 
-<span class="v">5&#160;</span>David said, “Solomon my son is young and tender, and the house that is to be built for Yahweh must be exceedingly magnificent, of fame and of glory throughout all countries. I will therefore make preparation for it.” So David prepared abundantly before his death. 
-<span class="v">6&#160;</span>Then he called for Solomon his son, and commanded him to build a house for Yahweh, the Elohim of Israel. 
-<span class="v">7&#160;</span>David said to Solomon his son, “As for me, it was in my heart to build a house to the name of Yahweh my Elohim. 
-<span class="v">8&#160;</span>But Yahweh’s word came to me, saying, ‘You have shed blood abundantly and have made great wars. You shall not build a house to my name, because you have shed much blood on the earth in my sight. 
-<span class="v">9&#160;</span>Behold, a son shall be born to you, who shall be a man of peace. I will give him rest from all his enemies all around; for his name shall be Solomon, and I will give peace and quietness to Israel in his days. 
-<span class="v">10&#160;</span>He shall build a house for my name; and he will be my son, and I will be his father; and I will establish the throne of his kingdom over Israel forever.’ 
-<span class="v">11&#160;</span>Now, my son, may Yahweh be with you and prosper you, and build the house of Yahweh your Elohim, as he has spoken concerning you. 
-<span class="v">12&#160;</span>May Yahweh give you discretion and understanding, and put you in charge of Israel, so that you may keep the law of Yahweh your Elohim. 
-<span class="v">13&#160;</span>Then you will prosper, if you observe to do the statutes and the ordinances which Yahweh gave Moses concerning Israel. Be strong and courageous. Don’t be afraid and don’t be dismayed. 
-<span class="v">14&#160;</span>Now, behold, in my affliction I have prepared for Yahweh’s house one hundred thousand talents<span class="f">+ \fr 22:14 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 100,000 talents is about 3 metric tons</span> of gold, one million talents<span class="f">+ \fr 22:14 \ft about 30,000 metric tons</span> of silver, and bronze and iron without weight; for it is in abundance. I have also prepared timber and stone; and you may add to them. 
-<span class="v">15&#160;</span>There are also workmen with you in abundance—cutters and workers of stone and timber, and all kinds of men who are skillful in every kind of work; 
-<span class="v">16&#160;</span>of the gold, the silver, the bronze, and the iron, there is no number. Arise and be doing, and may Yahweh be with you.” 
-</p><p>
-<span class="v">17&#160;</span>David also commanded all the princes of Israel to help Solomon his son, saying, 
-<span class="v">18&#160;</span>“Isn’t Yahweh your Elohim with you? Hasn’t he given you rest on every side? For he has delivered the inhabitants of the land into my hand; and the land is subdued before Yahweh and before his people. 
-<span class="v">19&#160;</span>Now set your heart and your soul to follow Yahweh your Elohim. Arise therefore, and build the sanctuary of Yahweh Elohim, to bring the ark of Yahweh’s covenant and the set-apart vessels of Elohim into the house that is to be built for Yahweh’s name.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Now David was old and full of days; and he made Solomon his son king over Israel. 
-<span class="v">2&#160;</span>He gathered together all the princes of Israel, with the priests and the Levites. 
-<span class="v">3&#160;</span>The Levites were counted from thirty years old and upward; and their number by their polls, man by man, was thirty-eight thousand. 
-<span class="v">4&#160;</span>David said, “Of these, twenty-four thousand were to oversee the work of Yahweh’s house, six thousand were officers and judges, 
-<span class="v">5&#160;</span>four thousand were doorkeepers, and four thousand praised Yahweh with the instruments which I made for giving praise.” 
-</p><p>
-<span class="v">6&#160;</span>David divided them into divisions according to the sons of Levi: Gershon, Kohath, and Merari. 
-</p><p>
-<span class="v">7&#160;</span>Of the Gershonites: Ladan and Shimei. 
-<span class="v">8&#160;</span>The sons of Ladan: Jehiel the chief, Zetham, and Joel, three. 
-<span class="v">9&#160;</span>The sons of Shimei: Shelomoth, Haziel, and Haran, three. These were the heads of the fathers’ households of Ladan. 
-<span class="v">10&#160;</span>The sons of Shimei: Jahath, Zina, Jeush, and Beriah. These four were the sons of Shimei. 
-<span class="v">11&#160;</span>Jahath was the chief, and Zizah the second; but Jeush and Beriah didn’t have many sons; therefore they became a fathers’ house in one reckoning. 
-</p><p>
-<span class="v">12&#160;</span>The sons of Kohath: Amram, Izhar, Hebron, and Uzziel, four. 
-<span class="v">13&#160;</span>The sons of Amram: Aaron and Moses; and Aaron was separated that he should sanctify the most set-apart things, he and his sons forever, to burn incense before Yahweh, to minister to him, and to bless in his name forever. 
-<span class="v">14&#160;</span>But as for Moses the man of Elohim, his sons were named among the tribe of Levi. 
-<span class="v">15&#160;</span>The sons of Moses: Gershom and Eliezer. 
-<span class="v">16&#160;</span>The sons of Gershom: Shebuel the chief. 
-<span class="v">17&#160;</span>The son of Eliezer was Rehabiah the chief; and Eliezer had no other sons, but the sons of Rehabiah were very many. 
-<span class="v">18&#160;</span>The son of Izhar: Shelomith the chief. 
-<span class="v">19&#160;</span>The sons of Hebron: Jeriah the chief, Amariah the second, Jahaziel the third, and Jekameam the fourth. 
-<span class="v">20&#160;</span>The sons of Uzziel: Micah the chief, and Isshiah the second. 
-</p><p>
-<span class="v">21&#160;</span>The sons of Merari: Mahli and Mushi. The sons of Mahli: Eleazar and Kish. 
-<span class="v">22&#160;</span>Eleazar died, and had no sons, but daughters only; and their relatives, the sons of Kish, took them as women. 
-<span class="v">23&#160;</span>The sons of Mushi: Mahli, Eder, and Jeremoth, three. 
-</p><p>
-<span class="v">24&#160;</span>These were the sons of Levi after their fathers’ houses, even the heads of the fathers’ houses of those who were counted individually, in the number of names by their polls, who did the work for the service of Yahweh’s house, from twenty years old and upward. 
-<span class="v">25&#160;</span>For David said, “Yahweh, the Elohim of Israel, has given rest to his people; and he dwells in Jerusalem forever. 
-<span class="v">26&#160;</span>Also the Levites will no longer need to carry the tabernacle and all its vessels for its service.” 
-<span class="v">27&#160;</span>For by the last words of David the sons of Levi were counted, from twenty years old and upward. 
-<span class="v">28&#160;</span>For their duty was to wait on the sons of Aaron for the service of Yahweh’s house—in the courts, in the rooms, and in the purifying of all set-apart things, even the work of the service of Elohim’s house; 
-<span class="v">29&#160;</span>for the show bread also, and for the fine flour for a meal offering, whether of unleavened wafers, or of that which is baked in the pan, or of that which is soaked, and for all measurements of quantity and size; 
-<span class="v">30&#160;</span>and to stand every morning to thank and praise Yahweh, and likewise in the evening; 
-<span class="v">31&#160;</span>and to offer all burnt offerings to Yahweh on the Sabbaths, on the new moons, and on the set feasts, in number according to the ordinance concerning them, continually before Yahweh; 
-<span class="v">32&#160;</span>and that they should keep the duty of the Tent of Meeting, the duty of the set-apart place, and the duty of the sons of Aaron their brothers for the service of Yahweh’s house. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>These were the divisions of the sons of Aaron. The sons of Aaron: Nadab, Abihu, Eleazar, and Ithamar. 
-<span class="v">2&#160;</span>But Nadab and Abihu died before their father, and had no children; therefore Eleazar and Ithamar served as priests. 
-<span class="v">3&#160;</span>David, with Zadok of the sons of Eleazar and Ahimelech of the sons of Ithamar, divided them according to their ordering in their service. 
-<span class="v">4&#160;</span>There were more chief men found of the sons of Eleazar than of the sons of Ithamar; and they were divided like this: of the sons of Eleazar there were sixteen, heads of fathers’ houses; and of the sons of Ithamar, according to their fathers’ houses, eight. 
-<span class="v">5&#160;</span>Thus they were divided impartially by drawing lots; for there were princes of the sanctuary and princes of Elohim, both of the sons of Eleazar, and of the sons of Ithamar. 
-<span class="v">6&#160;</span>Shemaiah the son of Nethanel the scribe, who was of the Levites, wrote them in the presence of the king, the princes, Zadok the priest, Ahimelech the son of Abiathar, and the heads of the fathers’ households of the priests and of the Levites; one fathers’ house being taken for Eleazar, and one taken for Ithamar. 
-</p><p>
-<span class="v">7&#160;</span>Now the first lot came out to Jehoiarib, the second to Jedaiah, 
-<span class="v">8&#160;</span>the third to Harim, the fourth to Seorim, 
-<span class="v">9&#160;</span>the fifth to Malchijah, the sixth to Mijamin, 
-<span class="v">10&#160;</span>the seventh to Hakkoz, the eighth to Abijah, 
-<span class="v">11&#160;</span>the ninth to Jeshua, the tenth to Shecaniah, 
-<span class="v">12&#160;</span>the eleventh to Eliashib, the twelfth to Jakim, 
-<span class="v">13&#160;</span>the thirteenth to Huppah, the fourteenth to Jeshebeab, 
-<span class="v">14&#160;</span>the fifteenth to Bilgah, the sixteenth to Immer, 
-<span class="v">15&#160;</span>the seventeenth to Hezir, the eighteenth to Happizzez, 
-<span class="v">16&#160;</span>the nineteenth to Pethahiah, the twentieth to Jehezkel, 
-<span class="v">17&#160;</span>the twenty-first to Jachin, the twenty-second to Gamul, 
-<span class="v">18&#160;</span>the twenty-third to Delaiah, and the twenty-fourth to Maaziah. 
-<span class="v">19&#160;</span>This was their ordering in their service, to come into Yahweh’s house according to the ordinance given to them by Aaron their father, as Yahweh, the Elohim of Israel, had commanded him. 
-</p><p>
-<span class="v">20&#160;</span>Of the rest of the sons of Levi: of the sons of Amram, Shubael; of the sons of Shubael, Jehdeiah. 
-<span class="v">21&#160;</span>Of Rehabiah: of the sons of Rehabiah, Isshiah the chief. 
-<span class="v">22&#160;</span>Of the Izharites, Shelomoth; of the sons of Shelomoth, Jahath. 
-<span class="v">23&#160;</span>The sons of Hebron: Jeriah, Amariah the second, Jahaziel the third, and Jekameam the fourth. 
-<span class="v">24&#160;</span>The sons of Uzziel: Micah; of the sons of Micah, Shamir. 
-<span class="v">25&#160;</span>The brother of Micah: Isshiah; of the sons of Isshiah, Zechariah. 
-<span class="v">26&#160;</span>The sons of Merari: Mahli and Mushi. The son of Jaaziah: Beno. 
-<span class="v">27&#160;</span>The sons of Merari by Jaaziah: Beno, Shoham, Zaccur, and Ibri. 
-<span class="v">28&#160;</span>Of Mahli: Eleazar, who had no sons. 
-<span class="v">29&#160;</span>Of Kish, the son of Kish: Jerahmeel. 
-<span class="v">30&#160;</span>The sons of Mushi: Mahli, Eder, and Jerimoth. These were the sons of the Levites after their fathers’ houses. 
-<span class="v">31&#160;</span>These likewise cast lots even as their brothers the sons of Aaron in the presence of David the king, Zadok, Ahimelech, and the heads of the fathers’ households of the priests and of the Levites, the fathers’ households of the chief even as those of his younger brother. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Moreover, David and the captains of the army set apart for the service certain of the sons of Asaph, of Heman, and of Jeduthun, who were to prophesy with harps, with stringed instruments, and with cymbals. The number of those who did the work according to their service was: 
-<span class="v">2&#160;</span>of the sons of Asaph: Zaccur, Joseph, Nethaniah, and Asharelah. The sons of Asaph were under the hand of Asaph, who prophesied at the order of the king. 
-<span class="v">3&#160;</span>Of Jeduthun, the sons of Jeduthun: Gedaliah, Zeri, Jeshaiah, Shimei, Hashabiah, and Mattithiah, six, under the hands of their father Jeduthun, who prophesied in giving thanks and praising Yahweh with the harp. 
-<span class="v">4&#160;</span>Of Heman, the sons of Heman: Bukkiah, Mattaniah, Uzziel, Shebuel, Jerimoth, Hananiah, Hanani, Eliathah, Giddalti, Romamti-Ezer, Joshbekashah, Mallothi, Hothir, and Mahazioth. 
-<span class="v">5&#160;</span>All these were the sons of Heman the king’s seer in the words of Elohim, to lift up the horn. Elohim gave to Heman fourteen sons and three daughters. 
-<span class="v">6&#160;</span>All these were under the hands of their father for song in Yahweh’s house, with cymbals, stringed instruments, and harps, for the service of Elohim’s house: Asaph, Jeduthun, and Heman being under the order of the king. 
-<span class="v">7&#160;</span>The number of them, with their brothers who were instructed in singing to Yahweh, even all who were skillful, was two hundred eighty-eight. 
-<span class="v">8&#160;</span>They cast lots for their offices, all alike, the small as well as the great, the teacher as well as the student. 
-</p><p>
-<span class="v">9&#160;</span>Now the first lot came out for Asaph to Joseph; the second to Gedaliah, he and his brothers and sons were twelve; 
-<span class="v">10&#160;</span>the third to Zaccur, his sons and his brothers, twelve; 
-<span class="v">11&#160;</span>the fourth to Izri, his sons and his brothers, twelve; 
-<span class="v">12&#160;</span>the fifth to Nethaniah, his sons and his brothers, twelve; 
-<span class="v">13&#160;</span>the sixth to Bukkiah, his sons and his brothers, twelve; 
-<span class="v">14&#160;</span>the seventh to Jesharelah, his sons and his brothers, twelve; 
-<span class="v">15&#160;</span>the eighth to Jeshaiah, his sons and his brothers, twelve; 
-<span class="v">16&#160;</span>the ninth to Mattaniah, his sons and his brothers, twelve; 
-<span class="v">17&#160;</span>the tenth to Shimei, his sons and his brothers, twelve; 
-<span class="v">18&#160;</span>the eleventh to Azarel, his sons and his brothers, twelve; 
-<span class="v">19&#160;</span>the twelfth to Hashabiah, his sons and his brothers, twelve; 
-<span class="v">20&#160;</span>for the thirteenth, Shubael, his sons and his brothers, twelve; 
-<span class="v">21&#160;</span>for the fourteenth, Mattithiah, his sons and his brothers, twelve; 
-<span class="v">22&#160;</span>for the fifteenth to Jeremoth, his sons and his brothers, twelve; 
-<span class="v">23&#160;</span>for the sixteenth to Hananiah, his sons and his brothers, twelve; 
-<span class="v">24&#160;</span>for the seventeenth to Joshbekashah, his sons and his brothers, twelve; 
-<span class="v">25&#160;</span>for the eighteenth to Hanani, his sons and his brothers, twelve; 
-<span class="v">26&#160;</span>for the nineteenth to Mallothi, his sons and his brothers, twelve; 
-<span class="v">27&#160;</span>for the twentieth to Eliathah, his sons and his brothers, twelve; 
-<span class="v">28&#160;</span>for the twenty-first to Hothir, his sons and his brothers, twelve; 
-<span class="v">29&#160;</span>for the twenty-second to Giddalti, his sons and his brothers, twelve; 
-<span class="v">30&#160;</span>for the twenty-third to Mahazioth, his sons and his brothers, twelve; 
-<span class="v">31&#160;</span>for the twenty-fourth to Romamti-Ezer, his sons and his brothers, twelve. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>For the divisions of the doorkeepers: of the Korahites, Meshelemiah the son of Kore, of the sons of Asaph. 
-<span class="v">2&#160;</span>Meshelemiah had sons: Zechariah the firstborn, Jediael the second, Zebadiah the third, Jathniel the fourth, 
-<span class="v">3&#160;</span>Elam the fifth, Jehohanan the sixth, and Eliehoenai the seventh. 
-<span class="v">4&#160;</span>Obed-Edom had sons: Shemaiah the firstborn, Jehozabad the second, Joah the third, Sacar the fourth, Nethanel the fifth, 
-<span class="v">5&#160;</span>Ammiel the sixth, Issachar the seventh, and Peullethai the eighth; for Elohim blessed him. 
-<span class="v">6&#160;</span>Sons were also born to Shemaiah his son, who ruled over the house of their father; for they were mighty men of valor. 
-<span class="v">7&#160;</span>The sons of Shemaiah: Othni, Rephael, Obed, and Elzabad, whose relatives were valiant men, Elihu, and Semachiah. 
-<span class="v">8&#160;</span>All these were of the sons of Obed-Edom with their sons and their brothers, able men in strength for the service: sixty-two of Obed-Edom. 
-<span class="v">9&#160;</span>Meshelemiah had sons and brothers, eighteen valiant men. 
-<span class="v">10&#160;</span>Also Hosah, of the children of Merari, had sons: Shimri the chief (for though he was not the firstborn, yet his father made him chief), 
-<span class="v">11&#160;</span>Hilkiah the second, Tebaliah the third, and Zechariah the fourth. All the sons and brothers of Hosah were thirteen. 
-</p><p>
-<span class="v">12&#160;</span>Of these were the divisions of the doorkeepers, even of the chief men, having offices like their brothers, to minister in Yahweh’s house. 
-<span class="v">13&#160;</span>They cast lots, the small as well as the great, according to their fathers’ houses, for every gate. 
-<span class="v">14&#160;</span>The lot eastward fell to Shelemiah. Then for Zechariah his son, a wise counselor, they cast lots; and his lot came out northward. 
-<span class="v">15&#160;</span>To Obed-Edom southward; and to his sons the storehouse. 
-<span class="v">16&#160;</span>To Shuppim and Hosah westward, by the gate of Shallecheth, at the causeway that goes up, watchman opposite watchman. 
-<span class="v">17&#160;</span>Eastward were six Levites, northward four a day, southward four a day, and for the storehouse two and two. 
-<span class="v">18&#160;</span>For Parbar westward, four at the causeway, and two at Parbar. 
-<span class="v">19&#160;</span>These were the divisions of the doorkeepers; of the sons of the Korahites, and of the sons of Merari. 
-</p><p>
-<span class="v">20&#160;</span>Of the Levites, Ahijah was over the treasures of Elohim’s house and over the treasures of the dedicated things. 
-<span class="v">21&#160;</span>The sons of Ladan, the sons of the Gershonites belonging to Ladan, the heads of the fathers’ households belonging to Ladan the Gershonite: Jehieli. 
-<span class="v">22&#160;</span>The sons of Jehieli: Zetham, and Joel his brother, over the treasures of Yahweh’s house. 
-<span class="v">23&#160;</span>Of the Amramites, of the Izharites, of the Hebronites, of the Uzzielites: 
-<span class="v">24&#160;</span>Shebuel the son of Gershom, the son of Moses, was ruler over the treasuries. 
-<span class="v">25&#160;</span>His brothers: of Eliezer, Rehabiah his son, and Jeshaiah his son, and Joram his son, and Zichri his son, and Shelomoth his son. 
-<span class="v">26&#160;</span>This Shelomoth and his brothers were over all the treasuries of the dedicated things, which David the king, and the heads of the fathers’ households, the captains over thousands and hundreds, and the captains of the army, had dedicated. 
-<span class="v">27&#160;</span>They dedicated some of the plunder won in battles to repair Yahweh’s house. 
-<span class="v">28&#160;</span>All that Samuel the seer, Saul the son of Kish, Abner the son of Ner, and Joab the son of Zeruiah had dedicated, whoever had dedicated anything, it was under the hand of Shelomoth and of his brothers. 
-</p><p>
-<span class="v">29&#160;</span>Of the Izharites, Chenaniah and his sons were appointed to the outward business over Israel, for officers and judges. 
-<span class="v">30&#160;</span>Of the Hebronites, Hashabiah and his brothers, one thousand seven hundred men of valor, had the oversight of Israel beyond the Jordan westward, for all the business of Yahweh and for the service of the king. 
-<span class="v">31&#160;</span>Of the Hebronites, Jerijah was the chief of the Hebronites, according to their generations by fathers’ households. They were sought for in the fortieth year of the reign of David, and mighty men of valor were found among them at Jazer of Gilead. 
-<span class="v">32&#160;</span>His relatives, men of valor, were two thousand seven hundred, heads of fathers’ households, whom King David made overseers over the Reubenites, the Gadites, and the half-tribe of the Manassites, for every matter pertaining to Elohim and for the affairs of the king. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Now the children of Israel after their number, the heads of fathers’ households and the captains of thousands and of hundreds, and their officers who served the king in any matter of the divisions which came in and went out month by month throughout all the months of the year—of every division were twenty-four thousand. 
-</p><p>
-<span class="v">2&#160;</span>Over the first division for the first month was Jashobeam the son of Zabdiel. In his division were twenty-four thousand. 
-<span class="v">3&#160;</span>He was of the children of Perez, the chief of all the captains of the army for the first month. 
-<span class="v">4&#160;</span>Over the division of the second month was Dodai the Ahohite and his division, and Mikloth the ruler; and in his division were twenty-four thousand. 
-<span class="v">5&#160;</span>The third captain of the army for the third month was Benaiah, the son of Jehoiada the chief priest. In his division were twenty-four thousand. 
-<span class="v">6&#160;</span>This is that Benaiah who was the mighty man of the thirty and over the thirty. Of his division was Ammizabad his son. 
-<span class="v">7&#160;</span>The fourth captain for the fourth month was Asahel the brother of Joab, and Zebadiah his son after him. In his division were twenty-four thousand. 
-<span class="v">8&#160;</span>The fifth captain for the fifth month was Shamhuth the Izrahite. In his division were twenty-four thousand. 
-<span class="v">9&#160;</span>The sixth captain for the sixth month was Ira the son of Ikkesh the Tekoite. In his division were twenty-four thousand. 
-<span class="v">10&#160;</span>The seventh captain for the seventh month was Helez the Pelonite, of the children of Ephraim. In his division were twenty-four thousand. 
-<span class="v">11&#160;</span>The eighth captain for the eighth month was Sibbecai the Hushathite, of the Zerahites. In his division were twenty-four thousand. 
-<span class="v">12&#160;</span>The ninth captain for the ninth month was Abiezer the Anathothite, of the Benjamites. In his division were twenty-four thousand. 
-<span class="v">13&#160;</span>The tenth captain for the tenth month was Maharai the Netophathite, of the Zerahites. In his division were twenty-four thousand. 
-<span class="v">14&#160;</span>The eleventh captain for the eleventh month was Benaiah the Pirathonite, of the children of Ephraim. In his division were twenty-four thousand. 
-<span class="v">15&#160;</span>The twelfth captain for the twelfth month was Heldai the Netophathite, of Othniel. In his division were twenty-four thousand. 
-</p><p>
-<span class="v">16&#160;</span>Furthermore over the tribes of Israel: of the Reubenites, Eliezer the son of Zichri was the ruler; of the Simeonites, Shephatiah the son of Maacah; 
-<span class="v">17&#160;</span>of Levi, Hashabiah the son of Kemuel; of Aaron, Zadok; 
-<span class="v">18&#160;</span>of Judah, Elihu, one of the brothers of David; of Issachar, Omri the son of Michael; 
-<span class="v">19&#160;</span>of Zebulun, Ishmaiah the son of Obadiah; of Naphtali, Jeremoth the son of Azriel; 
-<span class="v">20&#160;</span>of the children of Ephraim, Hoshea the son of Azaziah; of the half-tribe of Manasseh, Joel the son of Pedaiah; 
-<span class="v">21&#160;</span>of the half-tribe of Manasseh in Gilead, Iddo the son of Zechariah; of Benjamin, Jaasiel the son of Abner; 
-<span class="v">22&#160;</span>of Dan, Azarel the son of Jeroham. These were the captains of the tribes of Israel. 
-<span class="v">23&#160;</span>But David didn’t take the number of them from twenty years old and under, because Yahweh had said he would increase Israel like the stars of the sky. 
-<span class="v">24&#160;</span>Joab the son of Zeruiah began to take a census, but didn’t finish; and wrath came on Israel for this. The number wasn’t put into the account in the chronicles of King David. 
-</p><p>
-<span class="v">25&#160;</span>Over the king’s treasures was Azmaveth the son of Adiel. Over the treasures in the fields, in the cities, in the villages, and in the towers was Jonathan the son of Uzziah; 
-<span class="v">26&#160;</span>Over those who did the work of the field for tillage of the ground was Ezri the son of Chelub. 
-<span class="v">27&#160;</span>Over the vineyards was Shimei the Ramathite. Over the increase of the vineyards for the wine cellars was Zabdi the Shiphmite. 
-<span class="v">28&#160;</span>Over the olive trees and the sycamore trees that were in the lowland was Baal Hanan the Gederite. Over the cellars of oil was Joash. 
-<span class="v">29&#160;</span>Over the herds that fed in Sharon was Shitrai the Sharonite. Over the herds that were in the valleys was Shaphat the son of Adlai. 
-<span class="v">30&#160;</span>Over the camels was Obil the Ishmaelite. Over the donkeys was Jehdeiah the Meronothite. Over the flocks was Jaziz the Hagrite. 
-<span class="v">31&#160;</span>All these were the rulers of the property which was King David’s. 
-</p><p>
-<span class="v">32&#160;</span>Also Jonathan, David’s uncle, was a counselor, a man of understanding, and a scribe. Jehiel the son of Hachmoni was with the king’s sons. 
-<span class="v">33&#160;</span>Ahithophel was the king’s counselor. Hushai the Archite was the king’s friend. 
-<span class="v">34&#160;</span>After Ahithophel was Jehoiada the son of Benaiah, and Abiathar. Joab was the captain of the king’s army. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>David assembled all the princes of Israel, the princes of the tribes, the captains of the companies who served the king by division, the captains of thousands, the captains of hundreds, and the rulers over all the substance and possessions of the king and of his sons, with the officers and the mighty men, even all the mighty men of valor, to Jerusalem. 
-<span class="v">2&#160;</span>Then David the king stood up on his feet and said, “Hear me, my brothers and my people! As for me, it was in my heart to build a house of rest for the ark of Yahweh’s covenant, and for the footstool of our Elohim; and I had prepared for the building. 
-<span class="v">3&#160;</span>But Elohim said to me, ‘You shall not build a house for my name, because you are a man of war and have shed blood.’ 
-<span class="v">4&#160;</span>However Yahweh, the Elohim of Israel, chose me out of all the house of my father to be king over Israel forever. For he has chosen Judah to be prince; and in the house of Judah, the house of my father; and among the sons of my father he took pleasure in me to make me king over all Israel. 
-<span class="v">5&#160;</span>Of all my sons (for Yahweh has given me many sons), he has chosen Solomon my son to sit on the throne of Yahweh’s kingdom over Israel. 
-<span class="v">6&#160;</span>He said to me, ‘Solomon, your son, shall build my house and my courts; for I have chosen him to be my son, and I will be his father. 
-<span class="v">7&#160;</span>I will establish his kingdom forever if he continues to do my commandments and my ordinances, as it is today.’ 
-</p><p>
-<span class="v">8&#160;</span>Now therefore, in the sight of all Israel, Yahweh’s assembly, and in the audience of our Elohim, observe and seek out all the commandments of Yahweh your Elohim, that you may possess this good land, and leave it for an inheritance to your children after you forever. 
-</p><p>
-<span class="v">9&#160;</span>You, Solomon my son, know the Elohim of your father, and serve him with a perfect heart and with a willing mind; for Yahweh searches all hearts, and understands all the imaginations of the thoughts. If you seek him, he will be found by you; but if you forsake him, he will cast you off forever. 
-<span class="v">10&#160;</span>Take heed now, for Yahweh has chosen you to build a house for the sanctuary. Be strong, and do it.” 
-</p><p>
-<span class="v">11&#160;</span>Then David gave to Solomon his son the plans for the porch of the temple, for its houses, for its treasuries, for its upper rooms, for its inner rooms, for the place of the mercy seat; 
-<span class="v">12&#160;</span>and the plans of all that he had by the Spirit, for the courts of Yahweh’s house, for all the surrounding rooms, for the treasuries of Elohim’s house, and for the treasuries of the dedicated things; 
-<span class="v">13&#160;</span>also for the divisions of the priests and the Levites, for all the work of the service of Yahweh’s house, and for all the vessels of service in Yahweh’s house—<span class="v">14&#160;</span>of gold by weight for the gold for all vessels of every kind of service, for all the vessels of silver by weight, for all vessels of every kind of service; 
-<span class="v">15&#160;</span>by weight also for the lamp stands of gold, and for its lamps, of gold, by weight for every lamp stand and for its lamps; and for the lamp stands of silver, by weight for every lamp stand and for its lamps, according to the use of every lamp stand; 
-<span class="v">16&#160;</span>and the gold by weight for the tables of show bread, for every table; and silver for the tables of silver; 
-<span class="v">17&#160;</span>and the forks, the basins, and the cups, of pure gold; and for the golden bowls by weight for every bowl; and for the silver bowls by weight for every bowl; 
-<span class="v">18&#160;</span>and for the altar of incense, refined gold by weight; and gold for the plans for the chariot, and the cherubim that spread out and cover the ark of Yahweh’s covenant. 
-<span class="v">19&#160;</span>“All this”, David said, “I have been made to understand in writing from Yahweh’s hand, even all the works of this pattern.” 
-</p><p>
-<span class="v">20&#160;</span>David said to Solomon his son, “Be strong and courageous, and do it. Don’t be afraid, nor be dismayed, for Yahweh Elohim, even my Elohim, is with you. He will not fail you nor forsake you, until all the work for the service of Yahweh’s house is finished. 
-<span class="v">21&#160;</span>Behold, there are the divisions of the priests and the Levites for all the service of Elohim’s house. Every willing man who has skill for any kind of service shall be with you in all kinds of work. Also the captains and all the people will be entirely at your command.” 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>David the king said to all the assembly, “Solomon my son, whom alone Elohim has chosen, is yet young and tender, and the work is great; for the palace is not for man, but for Yahweh Elohim. 
-<span class="v">2&#160;</span>Now I have prepared with all my might for the house of my Elohim the gold for the things of gold, the silver for the things of silver, the bronze for the things of bronze, iron for the things of iron, and wood for the things of wood, also onyx stones, stones to be set, stones for inlaid work of various colors, all kinds of precious stones, and marble stones in abundance. 
-<span class="v">3&#160;</span>In addition, because I have set my affection on the house of my Elohim, since I have a treasure of my own of gold and silver, I give it to the house of my Elohim, over and above all that I have prepared for the set-apart house: 
-<span class="v">4&#160;</span>even three thousand talents of gold,<span class="f">+ \fr 29:4 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 3000 talents is about 90 metric tons</span> of the gold of Ophir, and seven thousand talents<span class="f">+ \fr 29:4 \ft about 210 metric tons</span> of refined silver, with which to overlay the walls of the houses; 
-<span class="v">5&#160;</span>of gold for the things of gold, and of silver for the things of silver, and for all kinds of work to be made by the hands of artisans. Who then offers willingly to consecrate himself today to Yahweh?” 
-</p><p>
-<span class="v">6&#160;</span>Then the princes of the fathers’ households, and the princes of the tribes of Israel, and the captains of thousands and of hundreds, with the rulers over the king’s work, offered willingly; 
-<span class="v">7&#160;</span>and they gave for the service of Elohim’s house of gold five thousand talents<span class="f">+ \fr 29:7 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 5000 talents is about 150 metric tons</span> and ten thousand darics,<span class="f">+ \fr 29:7 \ft a daric was a gold coin issued by a Persian king, weighing about 8.4 grams or about 0.27 troy ounces each.</span> of silver ten thousand talents, of bronze eighteen thousand talents, and of iron one hundred thousand talents. 
-<span class="v">8&#160;</span>People with whom precious stones were found gave them to the treasure of Yahweh’s house, under the hand of Jehiel the Gershonite. 
-<span class="v">9&#160;</span>Then the people rejoiced, because they offered willingly, because with a perfect heart they offered willingly to Yahweh; and David the king also rejoiced with great joy. 
-</p><p>
-<span class="v">10&#160;</span>Therefore David blessed Yahweh before all the assembly; and David said, “You are blessed, Yahweh, the Elohim of Israel our father, forever and ever. 
-<span class="v">11&#160;</span>Yours, Yahweh, is the greatness, the power, the glory, the victory, and the majesty! For all that is in the heavens and in the earth is yours. Yours is the kingdom, Yahweh, and you are exalted as head above all. 
-<span class="v">12&#160;</span>Both riches and honor come from you, and you rule over all! In your hand is power and might! It is in your hand to make great, and to give strength to all! 
-<span class="v">13&#160;</span>Now therefore, our Elohim, we thank you and praise your glorious name. 
-<span class="v">14&#160;</span>But who am I, and what is my people, that we should be able to offer so willingly as this? For all things come from you, and we have given you of your own. 
-<span class="v">15&#160;</span>For we are strangers before you and foreigners, as all our fathers were. Our days on the earth are as a shadow, and there is no remaining. 
-<span class="v">16&#160;</span>Yahweh our Elohim, all this store that we have prepared to build you a house for your set-apart name comes from your hand, and is all your own. 
-<span class="v">17&#160;</span>I know also, my Elohim, that you try the heart and have pleasure in uprightness. As for me, in the uprightness of my heart I have willingly offered all these things. Now I have seen with joy your people, who are present here, offer willingly to you. 
-<span class="v">18&#160;</span>Yahweh, the Elohim of Abraham, of Isaac, and of Israel, our fathers, keep this desire forever in the thoughts of the heart of your people, and prepare their heart for you; 
-<span class="v">19&#160;</span>and give to Solomon my son a perfect heart, to keep your commandments, your testimonies, and your statutes, and to do all these things, and to build the palace, for which I have made provision.” 
-</p><p>
-<span class="v">20&#160;</span>Then David said to all the assembly, “Now bless Yahweh your Elohim!” 
-</p><p>All the assembly blessed Yahweh, the Elohim of their fathers, and bowed down their heads and prostrated themselves before Yahweh and the king. 
-<span class="v">21&#160;</span>They sacrificed sacrifices to Yahweh and offered burnt offerings to Yahweh on the next day after that day, even one thousand bulls, one thousand rams, and one thousand lambs, with their drink offerings and sacrifices in abundance for all Israel, 
-<span class="v">22&#160;</span>and ate and drank before Yahweh on that day with great gladness. They made Solomon the son of David king the second time, and anointed him before Yahweh to be prince, and Zadok to be priest. 
-</p><p>
-<span class="v">23&#160;</span>Then Solomon sat on the throne of Yahweh as king instead of David his father, and prospered; and all Israel obeyed him. 
-<span class="v">24&#160;</span>All the princes, the mighty men, and also all of the sons of King David submitted themselves to Solomon the king. 
-<span class="v">25&#160;</span>Yahweh magnified Solomon exceedingly in the sight of all Israel, and gave to him such royal majesty as had not been on any king before him in Israel. 
-</p><p>
-<span class="v">26&#160;</span>Now David the son of Jesse reigned over all Israel. 
-<span class="v">27&#160;</span>The time that he reigned over Israel was forty years; he reigned seven years in Hebron, and he reigned thirty-three years in Jerusalem. 
-<span class="v">28&#160;</span>He died at a good old age, full of days, riches, and honor; and Solomon his son reigned in his place. 
-<span class="v">29&#160;</span>Now the acts of David the king, first and last, behold, they are written in the history of Samuel the seer, and in the history of Nathan the prophet, and in the history of Gad the seer, 
-<span class="v">30&#160;</span>with all his reign and his might, and the events that involved him, Israel, and all the kingdoms of the lands. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Adam, Seth, Enosh, 
+<sup>2&#160;</sup>Kenan, Mahalalel, Jared, 
+<sup>3&#160;</sup>Enoch, Methuselah, Lamech, 
+<sup>4&#160;</sup>Noah, Shem, Ham, and Japheth. 
+</div><div class="p">
+<sup>5&#160;</sup>The sons of Japheth: Gomer, Magog, Madai, Javan, Tubal, Meshech, and Tiras. 
+<sup>6&#160;</sup>The sons of Gomer: Ashkenaz, Diphath, and Togarmah. 
+<sup>7&#160;</sup>The sons of Javan: Elishah, Tarshish, Kittim, and Rodanim. 
+</div><div class="p">
+<sup>8&#160;</sup>The sons of Ham: Cush, Mizraim, Put, and Canaan. 
+<sup>9&#160;</sup>The sons of Cush: Seba, Havilah, Sabta, Raama, Sabteca. The sons of Raamah: Sheba and Dedan. 
+<sup>10&#160;</sup>Cush brought forth Nimrod. He began to be a mighty one in the earth. 
+<sup>11&#160;</sup>Mizraim brought forth Ludim, Anamim, Lehabim, Naphtuhim, 
+<sup>12&#160;</sup>Pathrusim, Casluhim (where the Philistines came from), and Caphtorim. 
+<sup>13&#160;</sup>Canaan brought forth Sidon his firstborn, Heth, 
+<sup>14&#160;</sup>the Jebusite, the Amorite, the Girgashite, 
+<sup>15&#160;</sup>the Hivite, the Arkite, the Sinite, 
+<sup>16&#160;</sup>the Arvadite, the Zemarite, and the Hamathite. 
+</div><div class="p">
+<sup>17&#160;</sup>The sons of Shem: Elam, Asshur, Arpachshad, Lud, Aram, Uz, Hul, Gether, and Meshech. 
+<sup>18&#160;</sup>Arpachshad brought forth Cainan, and Cainan brought forth Shelah, and Shelah brought forth Eber. 
+<sup>19&#160;</sup>To Eber were born two sons: the name of the one was Peleg, for in his days the earth was divided; and his brother’s name was Joktan. 
+<sup>20&#160;</sup>Joktan brought forth Almodad, Sheleph, Hazarmaveth, Jerah, 
+<sup>21&#160;</sup>Hadoram, Uzal, Diklah, 
+<sup>22&#160;</sup>Ebal, Abimael, Sheba, 
+<sup>23&#160;</sup>Ophir, Havilah, and Jobab. All these were the sons of Joktan. 
+<sup>24&#160;</sup>Shem, Arpachshad, Cainan, Shelah, 
+<sup>25&#160;</sup>Eber, Peleg, Reu, 
+<sup>26&#160;</sup>Serug, Nahor, Terah, 
+<sup>27&#160;</sup>Abram (also called Abraham). 
+</div><div class="p">
+<sup>28&#160;</sup>The sons of Abraham: Isaac and Ishmael. 
+<sup>29&#160;</sup>These are their generations: the firstborn of Ishmael, Nebaioth; then Kedar, Adbeel, Mibsam, 
+<sup>30&#160;</sup>Mishma, Dumah, Massa, Hadad, Tema, 
+<sup>31&#160;</sup>Jetur, Naphish, and Kedemah. These are the sons of Ishmael. 
+</div><div class="p">
+<sup>32&#160;</sup>The sons of Keturah, Abraham’s concubine: she bore Zimran, Jokshan, Medan, Midian, Ishbak, and Shuah. The sons of Jokshan: Sheba and Dedan. 
+<sup>33&#160;</sup>The sons of Midian: Ephah, Epher, Hanoch, Abida, and Eldaah. All these were the sons of Keturah. 
+</div><div class="p">
+<sup>34&#160;</sup>Abraham brought forth Isaac. The sons of Isaac: Esau and Israel. 
+<sup>35&#160;</sup>The sons of Esau: Eliphaz, Reuel, Jeush, Jalam, and Korah. 
+<sup>36&#160;</sup>The sons of Eliphaz: Teman, Omar, Zephi, Gatam, Kenaz, Timna, and Amalek. 
+<sup>37&#160;</sup>The sons of Reuel: Nahath, Zerah, Shammah, and Mizzah. 
+</div><div class="p">
+<sup>38&#160;</sup>The sons of Seir: Lotan, Shobal, Zibeon, Anah, Dishon, Ezer, and Dishan. 
+<sup>39&#160;</sup>The sons of Lotan: Hori and Homam; and Timna was Lotan’s sister. 
+<sup>40&#160;</sup>The sons of Shobal: Alian, Manahath, Ebal, Shephi, and Onam. The sons of Zibeon: Aiah and Anah. 
+<sup>41&#160;</sup>The son of Anah: Dishon. The sons of Dishon: Hamran, Eshban, Ithran, and Cheran. 
+<sup>42&#160;</sup>The sons of Ezer: Bilhan, Zaavan, and Jaakan. The sons of Dishan: Uz and Aran. 
+</div><div class="p">
+<sup>43&#160;</sup>Now these are the kings who reigned in the land of Edom, before any king reigned over the children of Israel: Bela the son of Beor; and the name of his city was Dinhabah. 
+<sup>44&#160;</sup>Bela died, and Jobab the son of Zerah of Bozrah reigned in his place. 
+<sup>45&#160;</sup>Jobab died, and Husham of the land of the Temanites reigned in his place. 
+<sup>46&#160;</sup>Husham died, and Hadad the son of Bedad, who struck Midian in the field of Moab, reigned in his place; and the name of his city was Avith. 
+<sup>47&#160;</sup>Hadad died, and Samlah of Masrekah reigned in his place. 
+<sup>48&#160;</sup>Samlah died, and Shaul of Rehoboth by the River reigned in his place. 
+<sup>49&#160;</sup>Shaul died, and Baal Hanan the son of Achbor reigned in his place. 
+<sup>50&#160;</sup>Baal Hanan died, and Hadad reigned in his place; and the name of his city was Pai. His woman’s name was Mehetabel, the daughter of Matred, the daughter of Mezahab. 
+<sup>51&#160;</sup>Then Hadad died. The chiefs of Edom were: chief Timna, chief Aliah, chief Jetheth, 
+<sup>52&#160;</sup>chief Oholibamah, chief Elah, chief Pinon, 
+<sup>53&#160;</sup>chief Kenaz, chief Teman, chief Mibzar, 
+<sup>54&#160;</sup>chief Magdiel, and chief Iram. These are the chiefs of Edom. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>These are the sons of Israel: Reuben, Simeon, Levi, Judah, Issachar, Zebulun, 
+<sup>2&#160;</sup>Dan, Joseph, Benjamin, Naphtali, Gad, and Asher. 
+</div><div class="p">
+<sup>3&#160;</sup>The sons of Judah: Er, Onan, and Shelah, which three were born to him of Shua’s daughter the Canaanitess. Er, Judah’s firstborn, was wicked in Yahweh’s sight; and he killed him. 
+<sup>4&#160;</sup>Tamar his daughter-in-law bore him Perez and Zerah. All the sons of Judah were five. 
+</div><div class="p">
+<sup>5&#160;</sup>The sons of Perez: Hezron and Hamul. 
+<sup>6&#160;</sup>The sons of Zerah: Zimri, Ethan, Heman, Calcol, and Dara—five of them in all. 
+<sup>7&#160;</sup>The son of Carmi: Achar, the troubler of Israel, who committed a trespass in the devoted thing. 
+<sup>8&#160;</sup>The son of Ethan: Azariah. 
+</div><div class="p">
+<sup>9&#160;</sup>The sons also of Hezron, who were born to him: Jerahmeel, Ram, and Chelubai. 
+<sup>10&#160;</sup>Ram brought forth Amminadab, and Amminadab brought forth Nahshon, prince of the children of Judah; 
+<sup>11&#160;</sup>and Nahshon brought forth Salma, and Salma brought forth Boaz, 
+<sup>12&#160;</sup>and Boaz brought forth Obed, and Obed brought forth Jesse; 
+<sup>13&#160;</sup>and Jesse brought forth his firstborn Eliab, Abinadab the second, Shimea the third, 
+<sup>14&#160;</sup>Nethanel the fourth, Raddai the fifth, 
+<sup>15&#160;</sup>Ozem the sixth, and David the seventh; 
+<sup>16&#160;</sup>and their sisters were Zeruiah and Abigail. The sons of Zeruiah: Abishai, Joab, and Asahel, three. 
+<sup>17&#160;</sup>Abigail bore Amasa; and the father of Amasa was Jether the Ishmaelite. 
+</div><div class="p">
+<sup>18&#160;</sup>Caleb the son of Hezron brought forth children by Azubah his woman, and by Jerioth; and these were her sons: Jesher, Shobab, and Ardon. 
+<sup>19&#160;</sup>Azubah died, and Caleb married Ephrath, who bore him Hur. 
+<sup>20&#160;</sup>Hur brought forth Uri, and Uri brought forth Bezalel. 
+</div><div class="p">
+<sup>21&#160;</sup>Afterward Hezron went in to the daughter of Machir the father of Gilead, whom he took as woman when he was sixty years old; and she bore him Segub. 
+<sup>22&#160;</sup>Segub brought forth Jair, who had twenty-three cities in the land of Gilead. 
+<sup>23&#160;</sup>Geshur and Aram took the towns of Jair from them, with Kenath, and its villages, even sixty cities. All these were the sons of Machir the father of Gilead. 
+<sup>24&#160;</sup>After Hezron died in Caleb Ephrathah, Abijah, Hezron’s woman, bore him Ashhur the father of Tekoa. 
+</div><div class="p">
+<sup>25&#160;</sup>The sons of Jerahmeel the firstborn of Hezron were Ram the firstborn, Bunah, Oren, Ozem, and Ahijah. 
+<sup>26&#160;</sup>Jerahmeel had another woman, whose name was Atarah. She was the mother of Onam. 
+<sup>27&#160;</sup>The sons of Ram the firstborn of Jerahmeel were Maaz, Jamin, and Eker. 
+<sup>28&#160;</sup>The sons of Onam were Shammai and Jada. The sons of Shammai: Nadab and Abishur. 
+<sup>29&#160;</sup>The name of the woman of Abishur was Abihail; and she bore him Ahban and Molid. 
+<sup>30&#160;</sup>The sons of Nadab: Seled and Appaim; but Seled died without children. 
+<sup>31&#160;</sup>The son of Appaim: Ishi. The son of Ishi: Sheshan. The son of Sheshan: Ahlai. 
+<sup>32&#160;</sup>The sons of Jada the brother of Shammai: Jether and Jonathan; and Jether died without children. 
+<sup>33&#160;</sup>The sons of Jonathan: Peleth and Zaza. These were the sons of Jerahmeel. 
+<sup>34&#160;</sup>Now Sheshan had no sons, but only daughters. Sheshan had a servant, an Egyptian, whose name was Jarha. 
+<sup>35&#160;</sup>Sheshan gave his daughter to Jarha his servant as woman; and she bore him Attai. 
+<sup>36&#160;</sup>Attai brought forth Nathan, and Nathan brought forth Zabad, 
+<sup>37&#160;</sup>and Zabad brought forth Ephlal, and Ephlal brought forth Obed, 
+<sup>38&#160;</sup>and Obed brought forth Jehu, and Jehu brought forth Azariah, 
+<sup>39&#160;</sup>and Azariah brought forth Helez, and Helez brought forth Eleasah, 
+<sup>40&#160;</sup>and Eleasah brought forth Sismai, and Sismai brought forth Shallum, 
+<sup>41&#160;</sup>and Shallum brought forth Jekamiah, and Jekamiah brought forth Elishama. 
+</div><div class="p">
+<sup>42&#160;</sup>The sons of Caleb the brother of Jerahmeel were Mesha his firstborn, who was the father of Ziph, and the sons of Mareshah the father of Hebron. 
+<sup>43&#160;</sup>The sons of Hebron: Korah, Tappuah, Rekem, and Shema. 
+<sup>44&#160;</sup>Shema brought forth Raham, the father of Jorkeam; and Rekem brought forth Shammai. 
+<sup>45&#160;</sup>The son of Shammai was Maon; and Maon was the father of Beth Zur. 
+<sup>46&#160;</sup>Ephah, Caleb’s concubine, bore Haran, Moza, and Gazez; and Haran brought forth Gazez. 
+<sup>47&#160;</sup>The sons of Jahdai: Regem, Jothan, Geshan, Pelet, Ephah, and Shaaph. 
+<sup>48&#160;</sup>Maacah, Caleb’s concubine, bore Sheber and Tirhanah. 
+<sup>49&#160;</sup>She bore also Shaaph the father of Madmannah, Sheva the father of Machbena and the father of Gibea; and the daughter of Caleb was Achsah. 
+</div><div class="p">
+<sup>50&#160;</sup>These were the sons of Caleb, the son of Hur, the firstborn of Ephrathah: Shobal the father of Kiriath Jearim, 
+<sup>51&#160;</sup>Salma the father of Bethlehem, and Hareph the father of Beth Gader. 
+<sup>52&#160;</sup>Shobal the father of Kiriath Jearim had sons: Haroeh, half of the Menuhoth. 
+<sup>53&#160;</sup>The families of Kiriath Jearim: the Ithrites, the Puthites, the Shumathites, and the Mishraites; from them came the Zorathites and the Eshtaolites. 
+<sup>54&#160;</sup>The sons of Salma: Bethlehem, the Netophathites, Atroth Beth Joab, and half of the Manahathites, the Zorites. 
+<sup>55&#160;</sup>The families of scribes who lived at Jabez: the Tirathites, the Shimeathites, and the Sucathites. These are the Kenites who came from Hammath, the father of the house of Rechab. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these were the sons of David, who were born to him in Hebron: the firstborn, Amnon, of Ahinoam the Jezreelitess; the second, Daniel, of Abigail the Carmelitess; 
+<sup>2&#160;</sup>the third, Absalom the son of Maacah the daughter of Talmai king of Geshur; the fourth, Adonijah the son of Haggith; 
+<sup>3&#160;</sup>the fifth, Shephatiah of Abital; the sixth, Ithream by Eglah his woman: 
+<sup>4&#160;</sup>six were born to him in Hebron; and he reigned there seven years and six months. He reigned thirty-three years in Jerusalem; 
+<sup>5&#160;</sup>and these were born to him in Jerusalem: Shimea, Shobab, Nathan, and Solomon, four, by Bathshua the daughter of Ammiel; 
+<sup>6&#160;</sup>and Ibhar, Elishama, Eliphelet, 
+<sup>7&#160;</sup>Nogah, Nepheg, Japhia, 
+<sup>8&#160;</sup>Elishama, Eliada, and Eliphelet, nine. 
+<sup>9&#160;</sup>All these were the sons of David, in addition to the sons of the concubines; and Tamar was their sister. 
+</div><div class="p">
+<sup>10&#160;</sup>Solomon’s son was Rehoboam, Abijah his son, Asa his son, Jehoshaphat his son, 
+<sup>11&#160;</sup>Joram his son, Ahaziah his son, Joash his son, 
+<sup>12&#160;</sup>Amaziah his son, Azariah his son, Jotham his son, 
+<sup>13&#160;</sup>Ahaz his son, Hezekiah his son, Manasseh his son, 
+<sup>14&#160;</sup>Amon his son, and Josiah his son. 
+<sup>15&#160;</sup>The sons of Josiah: the firstborn Johanan, the second Jehoiakim, the third Zedekiah, and the fourth Shallum. 
+<sup>16&#160;</sup>The sons of Jehoiakim: Jeconiah his son, and Zedekiah his son. 
+<sup>17&#160;</sup>The sons of Jeconiah, the captive: Shealtiel his son, 
+<sup>18&#160;</sup>Malchiram, Pedaiah, Shenazzar, Jekamiah, Hoshama, and Nedabiah. 
+<sup>19&#160;</sup>The sons of Pedaiah: Zerubbabel and Shimei. The sons of Zerubbabel: Meshullam and Hananiah; and Shelomith was their sister; 
+<sup>20&#160;</sup>and Hashubah, Ohel, Berechiah, Hasadiah, and Jushab Hesed, five. 
+<sup>21&#160;</sup>The sons of Hananiah: Pelatiah and Jeshaiah; the sons of Rephaiah, the sons of Arnan, the sons of Obadiah, the sons of Shecaniah. 
+<sup>22&#160;</sup>The son of Shecaniah: Shemaiah. The sons of Shemaiah: Hattush, Igal, Bariah, Neariah, and Shaphat, six. 
+<sup>23&#160;</sup>The sons of Neariah: Elioenai, Hizkiah, and Azrikam, three. 
+<sup>24&#160;</sup>The sons of Elioenai: Hodaviah, Eliashib, Pelaiah, Akkub, Johanan, Delaiah, and Anani, seven. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>The sons of Judah: Perez, Hezron, Carmi, Hur, and Shobal. 
+<sup>2&#160;</sup>Reaiah the son of Shobal brought forth Jahath; and Jahath brought forth Ahumai and Lahad. These are the families of the Zorathites. 
+<sup>3&#160;</sup>These were the sons of the father of Etam: Jezreel, Ishma, and Idbash. The name of their sister was Hazzelelponi. 
+<sup>4&#160;</sup>Penuel was the father of Gedor and Ezer the father of Hushah. These are the sons of Hur, the firstborn of Ephrathah, the father of Bethlehem. 
+<sup>5&#160;</sup>Ashhur the father of Tekoa had two women, Helah and Naarah. 
+<sup>6&#160;</sup>Naarah bore him Ahuzzam, Hepher, Temeni, and Haahashtari. These were the sons of Naarah. 
+<sup>7&#160;</sup>The sons of Helah were Zereth, Izhar, and Ethnan. 
+<sup>8&#160;</sup>Hakkoz brought forth Anub, Zobebah, and the families of Aharhel the son of Harum. 
+</div><div class="p">
+<sup>9&#160;</sup>Jabez was more honorable than his brothers. His mother named him Jabez, saying, “Because I bore him with sorrow.” 
+</div><div class="p">
+<sup>10&#160;</sup>Jabez called on the Elohim of Israel, saying, “Oh that you would bless me indeed, and enlarge my border! May your hand be with me, and may you keep me from evil, that I may not cause pain!” 
+</div><div class="p">Elohim granted him that which he requested. 
+</div><div class="p">
+<sup>11&#160;</sup>Chelub the brother of Shuhah brought forth Mehir, who was the father of Eshton. 
+<sup>12&#160;</sup>Eshton brought forth Beth Rapha, Paseah, and Tehinnah the father of Ir Nahash. These are the men of Recah. 
+<sup>13&#160;</sup>The sons of Kenaz: Othniel and Seraiah. The sons of Othniel: Hathath. 
+<sup>14&#160;</sup>Meonothai brought forth Ophrah: and Seraiah brought forth Joab the father of Ge Harashim, for they were craftsmen. 
+<sup>15&#160;</sup>The sons of Caleb the son of Jephunneh: Iru, Elah, and Naam. The son of Elah: Kenaz. 
+<sup>16&#160;</sup>The sons of Jehallelel: Ziph, Ziphah, Tiria, and Asarel. 
+<sup>17&#160;</sup>The sons of Ezrah: Jether, Mered, Epher, and Jalon; and Mered’s woman bore Miriam, Shammai, and Ishbah the father of Eshtemoa. 
+<sup>18&#160;</sup>His woman the Jewess bore Jered the father of Gedor, Heber the father of Soco, and Jekuthiel the father of Zanoah. These are the sons of Bithiah the daughter of Pharaoh, whom Mered took. 
+<sup>19&#160;</sup>The sons of the woman of Hodiah, the sister of Naham, were the fathers of Keilah the Garmite and Eshtemoa the Maacathite. 
+<sup>20&#160;</sup>The sons of Shimon: Amnon, Rinnah, Ben Hanan, and Tilon. The sons of Ishi: Zoheth, and Ben Zoheth. 
+<sup>21&#160;</sup>The sons of Shelah the son of Judah: Er the father of Lecah, Laadah the father of Mareshah, and the families of the house of those who worked fine linen, of the house of Ashbea; 
+<sup>22&#160;</sup>and Jokim, and the men of Cozeba, and Joash, and Saraph, who had dominion in Moab, and Jashubilehem. These records are ancient. 
+<sup>23&#160;</sup>These were the potters, and the inhabitants of Netaim and Gederah; they lived there with the king for his work. 
+</div><div class="p">
+<sup>24&#160;</sup>The sons of Simeon: Nemuel, Jamin, Jarib, Zerah, Shaul; 
+<sup>25&#160;</sup>Shallum his son, Mibsam his son, and Mishma his son. 
+<sup>26&#160;</sup>The sons of Mishma: Hammuel his son, Zaccur his son, Shimei his son. 
+<sup>27&#160;</sup>Shimei had sixteen sons and six daughters; but his brothers didn’t have many children, and all their family didn’t multiply like the children of Judah. 
+<sup>28&#160;</sup>They lived at Beersheba, Moladah, Hazarshual, 
+<sup>29&#160;</sup>at Bilhah, at Ezem, at Tolad, 
+<sup>30&#160;</sup>at Bethuel, at Hormah, at Ziklag, 
+<sup>31&#160;</sup>at Beth Marcaboth, Hazar Susim, at Beth Biri, and at Shaaraim. These were their cities until David’s reign. 
+<sup>32&#160;</sup>Their villages were Etam, Ain, Rimmon, Tochen, and Ashan, five cities; 
+<sup>33&#160;</sup>and all their villages that were around the same cities, as far as Baal. These were their settlements, and they kept their genealogy. 
+<sup>34&#160;</sup>Meshobab, Jamlech, Joshah the son of Amaziah, 
+<sup>35&#160;</sup>Joel, Jehu the son of Joshibiah, the son of Seraiah, the son of Asiel, 
+<sup>36&#160;</sup>Elioenai, Jaakobah, Jeshohaiah, Asaiah, Adiel, Jesimiel, Benaiah, 
+<sup>37&#160;</sup>and Ziza the son of Shiphi, the son of Allon, the son of Jedaiah, the son of Shimri, the son of Shemaiah—<sup>38&#160;</sup>these mentioned by name were princes in their families. Their fathers’ houses increased greatly. 
+</div><div class="p">
+<sup>39&#160;</sup>They went to the entrance of Gedor, even to the east side of the valley, to seek pasture for their flocks. 
+<sup>40&#160;</sup>They found rich, good pasture, and the land was wide, and quiet, and peaceful, for those who lived there before were descended from Ham. 
+<sup>41&#160;</sup>These written by name came in the days of Hezekiah king of Judah, and struck their tents and the Meunim who were found there; and they destroyed them utterly to this day, and lived in their place, because there was pasture there for their flocks. 
+<sup>42&#160;</sup>Some of them, even of the sons of Simeon, five hundred men, went to Mount Seir, having for their captains Pelatiah, Neariah, Rephaiah, and Uzziel, the sons of Ishi. 
+<sup>43&#160;</sup>They struck the remnant of the Amalekites who escaped, and have lived there to this day. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>The sons of Reuben the firstborn of Israel (for he was the firstborn, but because he defiled his father’s couch, his birthright was given to the sons of Joseph the son of Israel; and the genealogy is not to be listed according to the birthright. 
+<sup>2&#160;</sup>For Judah prevailed above his brothers, and from him came the prince; but the birthright was Joseph’s)—<sup>3&#160;</sup>the sons of Reuben the firstborn of Israel: Hanoch, Pallu, Hezron, and Carmi. 
+<sup>4&#160;</sup>The sons of Joel: Shemaiah his son, Gog his son, Shimei his son, 
+<sup>5&#160;</sup>Micah his son, Reaiah his son, Baal his son, 
+<sup>6&#160;</sup>and Beerah his son, whom Tilgath Pilneser king of Assyria carried away captive. He was prince of the Reubenites. 
+<sup>7&#160;</sup>His brothers by their families, when the genealogy of their generations was listed: the chief, Jeiel, and Zechariah, 
+<sup>8&#160;</sup>and Bela the son of Azaz, the son of Shema, the son of Joel, who lived in Aroer, even to Nebo and Baal Meon; 
+<sup>9&#160;</sup>and he lived eastward even to the entrance of the wilderness from the river Euphrates, because their livestock were multiplied in the land of Gilead. 
+</div><div class="p">
+<sup>10&#160;</sup>In the days of Saul, they made war with the Hagrites, who fell by their hand; and they lived in their tents throughout all the land east of Gilead. 
+</div><div class="p">
+<sup>11&#160;</sup>The sons of Gad lived beside them in the land of Bashan to Salecah: 
+<sup>12&#160;</sup>Joel the chief, Shapham the second, Janai, and Shaphat in Bashan. 
+<sup>13&#160;</sup>Their brothers of their fathers’ houses: Michael, Meshullam, Sheba, Jorai, Jacan, Zia, and Eber, seven. 
+<sup>14&#160;</sup>These were the sons of Abihail, the son of Huri, the son of Jaroah, the son of Gilead, the son of Michael, the son of Jeshishai, the son of Jahdo, the son of Buz; 
+<sup>15&#160;</sup>Ahi the son of Abdiel, the son of Guni, chief of their fathers’ houses. 
+<sup>16&#160;</sup>They lived in Gilead in Bashan and in its towns, and in all the pasture lands of Sharon as far as their borders. 
+<sup>17&#160;</sup>All these were listed by genealogies in the days of Jotham king of Judah, and in the days of Jeroboam king of Israel. 
+</div><div class="p">
+<sup>18&#160;</sup>The sons of Reuben, the Gadites, and the half-tribe of Manasseh, of valiant men, men able to bear buckler and sword, able to shoot with bow, and skillful in war, were forty-four thousand seven hundred sixty that were able to go out to war. 
+<sup>19&#160;</sup>They made war with the Hagrites, with Jetur, and Naphish, and Nodab. 
+<sup>20&#160;</sup>They were helped against them, and the Hagrites were delivered into their hand, and all who were with them; for they cried to Elohim in the battle, and he answered them because they put their trust in him. 
+<sup>21&#160;</sup>They took away their livestock: of their camels fifty thousand, and of sheep two hundred fifty thousand, and of donkeys two thousand, and of men one hundred thousand. 
+<sup>22&#160;</sup>For many fell slain, because the war was of Elohim. They lived in their place until the captivity. 
+</div><div class="p">
+<sup>23&#160;</sup>The children of the half-tribe of Manasseh lived in the land. They increased from Bashan to Baal Hermon, Senir, and Mount Hermon. 
+<sup>24&#160;</sup>These were the heads of their fathers’ houses: Epher, Ishi, Eliel, Azriel, Jeremiah, Hodaviah, and Jahdiel—mighty men of valor, famous men, heads of their fathers’ houses. 
+<sup>25&#160;</sup>They trespassed against the Elohim of their fathers, and played the prostitute after the elohims of the peoples of the land whom Elohim destroyed before them. 
+<sup>26&#160;</sup>So the Elohim of Israel stirred up the spirit of Pul king of Assyria, and the spirit of Tilgath Pilneser king of Assyria, and he carried away the Reubenites, the Gadites, and the half-tribe of Manasseh, and brought them to Halah, Habor, Hara, and to the river of Gozan, to this day. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>The sons of Levi: Gershon, Kohath, and Merari. 
+<sup>2&#160;</sup>The sons of Kohath: Amram, Izhar, Hebron, and Uzziel. 
+<sup>3&#160;</sup>The children of Amram: Aaron, Moses, and Miriam. The sons of Aaron: Nadab, Abihu, Eleazar, and Ithamar. 
+<sup>4&#160;</sup>Eleazar brought forth Phinehas, Phinehas brought forth Abishua, 
+<sup>5&#160;</sup>Abishua brought forth Bukki. Bukki brought forth Uzzi. 
+<sup>6&#160;</sup>Uzzi brought forth Zerahiah. Zerahiah brought forth Meraioth. 
+<sup>7&#160;</sup>Meraioth brought forth Amariah. Amariah brought forth Ahitub. 
+<sup>8&#160;</sup>Ahitub brought forth Zadok. Zadok brought forth Ahimaaz. 
+<sup>9&#160;</sup>Ahimaaz brought forth Azariah. Azariah brought forth Johanan. 
+<sup>10&#160;</sup>Johanan brought forth Azariah, who executed the priest’s office in the house that Solomon built in Jerusalem. 
+<sup>11&#160;</sup>Azariah brought forth Amariah. Amariah brought forth Ahitub. 
+<sup>12&#160;</sup>Ahitub brought forth Zadok. Zadok brought forth Shallum. 
+<sup>13&#160;</sup>Shallum brought forth Hilkiah. Hilkiah brought forth Azariah. 
+<sup>14&#160;</sup>Azariah brought forth Seraiah. Seraiah brought forth Jehozadak. 
+<sup>15&#160;</sup>Jehozadak went into captivity when Yahweh carried Judah and Jerusalem away by the hand of Nebuchadnezzar. 
+</div><div class="p">
+<sup>16&#160;</sup>The sons of Levi: Gershom, Kohath, and Merari. 
+<sup>17&#160;</sup>These are the names of the sons of Gershom: Libni and Shimei. 
+<sup>18&#160;</sup>The sons of Kohath were Amram, Izhar, Hebron, and Uzziel. 
+<sup>19&#160;</sup>The sons of Merari: Mahli and Mushi. These are the families of the Levites according to their fathers’ households. 
+<sup>20&#160;</sup>Of Gershom: Libni his son, Jahath his son, Zimmah his son, 
+<sup>21&#160;</sup>Joah his son, Iddo his son, Zerah his son, and Jeatherai his son. 
+<sup>22&#160;</sup>The sons of Kohath: Amminadab his son, Korah his son, Assir his son, 
+<sup>23&#160;</sup>Elkanah his son, Ebiasaph his son, Assir his son, 
+<sup>24&#160;</sup>Tahath his son, Uriel his son, Uzziah his son, and Shaul his son. 
+<sup>25&#160;</sup>The sons of Elkanah: Amasai and Ahimoth. 
+<sup>26&#160;</sup>As for Elkanah, the sons of Elkanah: Zophai his son, Nahath his son, 
+<sup>27&#160;</sup>Eliab his son, Jeroham his son, and Elkanah his son. 
+<sup>28&#160;</sup>The sons of Samuel: the firstborn, Joel, and the second, Abijah. 
+<sup>29&#160;</sup>The sons of Merari: Mahli, Libni his son, Shimei his son, Uzzah his son, 
+<sup>30&#160;</sup>Shimea his son, Haggiah his son, Asaiah his son. 
+</div><div class="p">
+<sup>31&#160;</sup>These are they whom David set over the service of song in Yahweh’s house after the ark came to rest there. 
+<sup>32&#160;</sup>They ministered with song before the tabernacle of the Tent of Meeting until Solomon had built Yahweh’s house in Jerusalem. They performed the duties of their office according to their order. 
+<sup>33&#160;</sup>These are those who served, and their sons. Of the sons of the Kohathites: Heman the singer, the son of Joel, the son of Samuel, 
+<sup>34&#160;</sup>the son of Elkanah, the son of Jeroham, the son of Eliel, the son of Toah, 
+<sup>35&#160;</sup>the son of Zuph, the son of Elkanah, the son of Mahath, the son of Amasai, 
+<sup>36&#160;</sup>the son of Elkanah, the son of Joel, the son of Azariah, the son of Zephaniah, 
+<sup>37&#160;</sup>the son of Tahath, the son of Assir, the son of Ebiasaph, the son of Korah, 
+<sup>38&#160;</sup>the son of Izhar, the son of Kohath, the son of Levi, the son of Israel. 
+<sup>39&#160;</sup>His brother Asaph, who stood on his right hand, even Asaph the son of Berechiah, the son of Shimea, 
+<sup>40&#160;</sup>the son of Michael, the son of Baaseiah, the son of Malchijah, 
+<sup>41&#160;</sup>the son of Ethni, the son of Zerah, the son of Adaiah, 
+<sup>42&#160;</sup>the son of Ethan, the son of Zimmah, the son of Shimei, 
+<sup>43&#160;</sup>the son of Jahath, the son of Gershom, the son of Levi. 
+<sup>44&#160;</sup>On the left hand their brothers the sons of Merari: Ethan the son of Kishi, the son of Abdi, the son of Malluch, 
+<sup>45&#160;</sup>the son of Hashabiah, the son of Amaziah, the son of Hilkiah, 
+<sup>46&#160;</sup>the son of Amzi, the son of Bani, the son of Shemer, 
+<sup>47&#160;</sup>the son of Mahli, the son of Mushi, the son of Merari, the son of Levi. 
+<sup>48&#160;</sup>Their brothers the Levites were appointed for all the service of the tabernacle of Elohim’s house. 
+<sup>49&#160;</sup>But Aaron and his sons offered on the altar of burnt offering, and on the altar of incense, for all the work of the most set-apart place, and to make atonement for Israel, according to all that Moses the servant of Elohim had commanded. 
+</div><div class="p">
+<sup>50&#160;</sup>These are the sons of Aaron: Eleazar his son, Phinehas his son, Abishua his son, 
+<sup>51&#160;</sup>Bukki his son, Uzzi his son, Zerahiah his son, 
+<sup>52&#160;</sup>Meraioth his son, Amariah his son, Ahitub his son, 
+<sup>53&#160;</sup>Zadok his son, and Ahimaaz his son. 
+<sup>54&#160;</sup>Now these are their dwelling places according to their encampments in their borders: to the sons of Aaron, of the families of the Kohathites (for theirs was the first lot), 
+<sup>55&#160;</sup>to them they gave Hebron in the land of Judah, and its pasture lands around it; 
+<sup>56&#160;</sup>but the fields of the city and its villages, they gave to Caleb the son of Jephunneh. 
+<sup>57&#160;</sup>To the sons of Aaron they gave the cities of refuge, Hebron, Libnah also with its pasture lands, Jattir, Eshtemoa with its pasture lands, 
+<sup>58&#160;</sup>Hilen with its pasture lands, Debir with its pasture lands, 
+<sup>59&#160;</sup>Ashan with its pasture lands, and Beth Shemesh with its pasture lands; 
+<sup>60&#160;</sup>and out of the tribe of Benjamin, Geba with its pasture lands, Allemeth with its pasture lands, and Anathoth with its pasture lands. All their cities throughout their families were thirteen cities. 
+</div><div class="p">
+<sup>61&#160;</sup>To the rest of the sons of Kohath were given by lot, out of the family of the tribe, out of the half-tribe, the half of Manasseh, ten cities. 
+<sup>62&#160;</sup>To the sons of Gershom, according to their families, out of the tribe of Issachar, and out of the tribe of Asher, and out of the tribe of Naphtali, and out of the tribe of Manasseh in Bashan, thirteen cities. 
+<sup>63&#160;</sup>To the sons of Merari were given by lot, according to their families, out of the tribe of Reuben, and out of the tribe of Gad, and out of the tribe of Zebulun, twelve cities. 
+<sup>64&#160;</sup>The children of Israel gave to the Levites the cities with their pasture lands. 
+<sup>65&#160;</sup>They gave by lot out of the tribe of the children of Judah, and out of the tribe of the children of Simeon, and out of the tribe of the children of Benjamin, these cities which are mentioned by name. 
+</div><div class="p">
+<sup>66&#160;</sup>Some of the families of the sons of Kohath had cities of their borders out of the tribe of Ephraim. 
+<sup>67&#160;</sup>They gave to them the cities of refuge, Shechem in the hill country of Ephraim with its pasture lands and Gezer with its pasture lands, 
+<sup>68&#160;</sup>Jokmeam with its pasture lands, Beth Horon with its pasture lands, 
+<sup>69&#160;</sup>Aijalon with its pasture lands, Gath Rimmon with its pasture lands; 
+<sup>70&#160;</sup>and out of the half-tribe of Manasseh, Aner with its pasture lands, and Bileam with its pasture lands, for the rest of the family of the sons of Kohath. 
+</div><div class="p">
+<sup>71&#160;</sup>To the sons of Gershom were given, out of the family of the half-tribe of Manasseh, Golan in Bashan with its pasture lands, and Ashtaroth with its pasture lands; 
+<sup>72&#160;</sup>and out of the tribe of Issachar, Kedesh with its pasture lands, Daberath with its pasture lands, 
+<sup>73&#160;</sup>Ramoth with its pasture lands, and Anem with its pasture lands; 
+<sup>74&#160;</sup>and out of the tribe of Asher, Mashal with its pasture lands, Abdon with its pasture lands, 
+<sup>75&#160;</sup>Hukok with its pasture lands, and Rehob with its pasture lands; 
+<sup>76&#160;</sup>and out of the tribe of Naphtali, Kedesh in Galilee with its pasture lands, Hammon with its pasture lands, and Kiriathaim with its pasture lands. 
+</div><div class="p">
+<sup>77&#160;</sup>To the rest of the Levites, the sons of Merari, were given, out of the tribe of Zebulun, Rimmono with its pasture lands, and Tabor with its pasture lands; 
+<sup>78&#160;</sup>and beyond the Jordan at Jericho, on the east side of the Jordan, were given them out of the tribe of Reuben: Bezer in the wilderness with its pasture lands, Jahzah with its pasture lands, 
+<sup>79&#160;</sup>Kedemoth with its pasture lands, and Mephaath with its pasture lands; 
+<sup>80&#160;</sup>and out of the tribe of Gad, Ramoth in Gilead with its pasture lands, Mahanaim with its pasture lands, 
+<sup>81&#160;</sup>Heshbon with its pasture lands, and Jazer with its pasture lands. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Of the sons of Issachar: Tola, Puah, Jashub, and Shimron, four. 
+<sup>2&#160;</sup>The sons of Tola: Uzzi, Rephaiah, Jeriel, Jahmai, Ibsam, and Shemuel, heads of their fathers’ houses, of Tola; mighty men of valor in their generations. Their number in the days of David was twenty-two thousand six hundred. 
+<sup>3&#160;</sup>The son of Uzzi: Izrahiah. The sons of Izrahiah: Michael, Obadiah, Joel, and Isshiah, five; all of them chief men. 
+<sup>4&#160;</sup>With them, by their generations, after their fathers’ houses, were bands of the army for war, thirty-six thousand; for they had many women and sons. 
+<sup>5&#160;</sup>Their brothers among all the families of Issachar, mighty men of valor, listed in all by genealogy, were eighty-seven thousand. 
+</div><div class="p">
+<sup>6&#160;</sup>The sons of Benjamin: Bela, Becher, and Jediael, three. 
+<sup>7&#160;</sup>The sons of Bela: Ezbon, Uzzi, Uzziel, Jerimoth, and Iri, five; heads of fathers’ houses, mighty men of valor; and they were listed by genealogy twenty-two thousand thirty-four. 
+<sup>8&#160;</sup>The sons of Becher: Zemirah, Joash, Eliezer, Elioenai, Omri, Jeremoth, Abijah, Anathoth, and Alemeth. All these were the sons of Becher. 
+<sup>9&#160;</sup>They were listed by genealogy, after their generations, heads of their fathers’ houses, mighty men of valor, twenty thousand two hundred. 
+<sup>10&#160;</sup>The son of Jediael: Bilhan. The sons of Bilhan: Jeush, Benjamin, Ehud, Chenaanah, Zethan, Tarshish, and Ahishahar. 
+<sup>11&#160;</sup>All these were sons of Jediael, according to the heads of their fathers’ households, mighty men of valor, seventeen thousand two hundred, who were able to go out in the army for war. 
+<sup>12&#160;</sup>So were Shuppim, Huppim, the sons of Ir, Hushim, and the sons of Aher. 
+</div><div class="p">
+<sup>13&#160;</sup>The sons of Naphtali: Jahziel, Guni, Jezer, Shallum, and the sons of Bilhah. 
+</div><div class="p">
+<sup>14&#160;</sup>The sons of Manasseh: Asriel, whom his concubine the Aramitess bore. She bore Machir the father of Gilead. 
+<sup>15&#160;</sup>Machir took a woman of Huppim and Shuppim, whose sister’s name was Maacah. The name of the second was Zelophehad; and Zelophehad had daughters. 
+<sup>16&#160;</sup>Maacah the woman of Machir bore a son, and she named him Peresh. The name of his brother was Sheresh; and his sons were Ulam and Rakem. 
+<sup>17&#160;</sup>The sons of Ulam: Bedan. These were the sons of Gilead the son of Machir, the son of Manasseh. 
+<sup>18&#160;</sup>His sister Hammolecheth bore Ishhod, Abiezer, and Mahlah. 
+<sup>19&#160;</sup>The sons of Shemida were Ahian, Shechem, Likhi, and Aniam. 
+</div><div class="p">
+<sup>20&#160;</sup>The sons of Ephraim: Shuthelah, Bered his son, Tahath his son, Eleadah his son, Tahath his son, 
+<sup>21&#160;</sup>Zabad his son, Shuthelah his son, Ezer, and Elead, whom the men of Gath who were born in the land killed, because they came down to take away their livestock. 
+<sup>22&#160;</sup>Ephraim their father mourned many days, and his brothers came to comfort him. 
+<sup>23&#160;</sup>He went in to his woman, and she conceived and bore a son, and he named him Beriah, because there was trouble with his house. 
+<sup>24&#160;</sup>His daughter was Sheerah, who built Beth Horon the lower and the upper, and Uzzen Sheerah. 
+<sup>25&#160;</sup>Rephah was his son, Resheph his son, Telah his son, Tahan his son, 
+<sup>26&#160;</sup>Ladan his son, Ammihud his son, Elishama his son, 
+<sup>27&#160;</sup>Nun his son, and Joshua his son. 
+<sup>28&#160;</sup>Their possessions and settlements were Bethel and its towns, and eastward Naaran, and westward Gezer with its towns; Shechem also and its towns, to Azzah and its towns; 
+<sup>29&#160;</sup>and by the borders of the children of Manasseh, Beth Shean and its towns, Taanach and its towns, Megiddo and its towns, and Dor and its towns. The children of Joseph the son of Israel lived in these. 
+</div><div class="p">
+<sup>30&#160;</sup>The sons of Asher: Imnah, Ishvah, Ishvi, and Beriah. Serah was their sister. 
+<sup>31&#160;</sup>The sons of Beriah: Heber and Malchiel, who was the father of Birzaith. 
+<sup>32&#160;</sup>Heber brought forth Japhlet, Shomer, Hotham, and Shua their sister. 
+<sup>33&#160;</sup>The sons of Japhlet: Pasach, Bimhal, and Ashvath. These are the children of Japhlet. 
+<sup>34&#160;</sup>The sons of Shemer: Ahi, Rohgah, Jehubbah, and Aram. 
+<sup>35&#160;</sup>The sons of Helem his brother: Zophah, Imna, Shelesh, and Amal. 
+<sup>36&#160;</sup>The sons of Zophah: Suah, Harnepher, Shual, Beri, Imrah, 
+<sup>37&#160;</sup>Bezer, Hod, Shamma, Shilshah, Ithran, and Beera. 
+<sup>38&#160;</sup>The sons of Jether: Jephunneh, Pispa, and Ara. 
+<sup>39&#160;</sup>The sons of Ulla: Arah, Hanniel, and Rizia. 
+<sup>40&#160;</sup>All these were the children of Asher, heads of the fathers’ houses, choice and mighty men of valor, chief of the princes. The number of them listed by genealogy for service in war was twenty-six thousand men. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Benjamin brought forth Bela his firstborn, Ashbel the second, Aharah the third, 
+<sup>2&#160;</sup>Nohah the fourth, and Rapha the fifth. 
+<sup>3&#160;</sup>Bela had sons: Addar, Gera, Abihud, 
+<sup>4&#160;</sup>Abishua, Naaman, Ahoah, 
+<sup>5&#160;</sup>Gera, Shephuphan, and Huram. 
+<sup>6&#160;</sup>These are the sons of Ehud. These are the heads of fathers’ households of the inhabitants of Geba, who were carried captive to Manahath: 
+<sup>7&#160;</sup>Naaman, Ahijah, and Gera, who carried them captive; and he brought forth Uzza and Ahihud. 
+</div><div class="p">
+<sup>8&#160;</sup>Shaharaim brought forth children in the field of Moab, after he had sent them away. Hushim and Baara were his women. 
+<sup>9&#160;</sup>By Hodesh his woman, he brought forth Jobab, Zibia, Mesha, Malcam, 
+<sup>10&#160;</sup>Jeuz, Shachia, and Mirmah. These were his sons, heads of fathers’ households. 
+<sup>11&#160;</sup>By Hushim, he brought forth Abitub and Elpaal. 
+<sup>12&#160;</sup>The sons of Elpaal: Eber, Misham, and Shemed, who built Ono and Lod, with its towns; 
+<sup>13&#160;</sup>and Beriah and Shema, who were heads of fathers’ households of the inhabitants of Aijalon, who put to flight the inhabitants of Gath; 
+<sup>14&#160;</sup>and Ahio, Shashak, Jeremoth, 
+<sup>15&#160;</sup>Zebadiah, Arad, Eder, 
+<sup>16&#160;</sup>Michael, Ishpah, Joha, the sons of Beriah, 
+<sup>17&#160;</sup>Zebadiah, Meshullam, Hizki, Heber, 
+<sup>18&#160;</sup>Ishmerai, Izliah, Jobab, the sons of Elpaal, 
+<sup>19&#160;</sup>Jakim, Zichri, Zabdi, 
+<sup>20&#160;</sup>Elienai, Zillethai, Eliel, 
+<sup>21&#160;</sup>Adaiah, Beraiah, Shimrath, the sons of Shimei, 
+<sup>22&#160;</sup>Ishpan, Eber, Eliel, 
+<sup>23&#160;</sup>Abdon, Zichri, Hanan, 
+<sup>24&#160;</sup>Hananiah, Elam, Anthothijah, 
+<sup>25&#160;</sup>Iphdeiah, Penuel, the sons of Shashak, 
+<sup>26&#160;</sup>Shamsherai, Shehariah, Athaliah, 
+<sup>27&#160;</sup>Jaareshiah, Elijah, Zichri, and the sons of Jeroham. 
+<sup>28&#160;</sup>These were heads of fathers’ households throughout their generations, chief men. These lived in Jerusalem. 
+</div><div class="p">
+<sup>29&#160;</sup>The father of Gibeon, whose woman’s name was Maacah, lived in Gibeon 
+<sup>30&#160;</sup>with his firstborn son Abdon, Zur, Kish, Baal, Nadab, 
+<sup>31&#160;</sup>Gedor, Ahio, Zecher, 
+<sup>32&#160;</sup>and Mikloth, who brought forth Shimeah. They also lived with their families in Jerusalem, near their relatives. 
+<sup>33&#160;</sup>Ner brought forth Kish. Kish brought forth Saul. Saul brought forth Jonathan, Malchishua, Abinadab, and Eshbaal. 
+<sup>34&#160;</sup>The son of Jonathan was Merib-baal. Merib-baal brought forth Micah. 
+<sup>35&#160;</sup>The sons of Micah: Pithon, Melech, Tarea, and Ahaz. 
+<sup>36&#160;</sup>Ahaz brought forth Jehoaddah. Jehoaddah brought forth Alemeth, Azmaveth, and Zimri. Zimri brought forth Moza. 
+<sup>37&#160;</sup>Moza brought forth Binea. Raphah was his son, Eleasah his son, and Azel his son. 
+<sup>38&#160;</sup>Azel had six sons, whose names are these: Azrikam, Bocheru, Ishmael, Sheariah, Obadiah, and Hanan. All these were the sons of Azel. 
+<sup>39&#160;</sup>The sons of Eshek his brother: Ulam his firstborn, Jeush the second, and Eliphelet the third. 
+<sup>40&#160;</sup>The sons of Ulam were mighty men of valor, archers, and had many sons, and grandsons, one hundred fifty. All these were of the sons of Benjamin. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>So all Israel were listed by genealogies; and behold, they are written in the book of the kings of Israel. Judah was carried away captive to Babylon for their disobedience. 
+<sup>2&#160;</sup>Now the first inhabitants who lived in their possessions in their cities were Israel, the priests, the Levites, and the temple servants. 
+<sup>3&#160;</sup>In Jerusalem, there lived of the children of Judah, of the children of Benjamin, and of the children of Ephraim and Manasseh: 
+<sup>4&#160;</sup>Uthai the son of Ammihud, the son of Omri, the son of Imri, the son of Bani, of the children of Perez the son of Judah. 
+<sup>5&#160;</sup>Of the Shilonites: Asaiah the firstborn and his sons. 
+<sup>6&#160;</sup>Of the sons of Zerah: Jeuel and their brothers, six hundred ninety. 
+<sup>7&#160;</sup>Of the sons of Benjamin: Sallu the son of Meshullam, the son of Hodaviah, the son of Hassenuah; 
+<sup>8&#160;</sup>and Ibneiah the son of Jeroham, and Elah the son of Uzzi, the son of Michri; and Meshullam the son of Shephatiah, the son of Reuel, the son of Ibnijah; 
+<sup>9&#160;</sup>and their brothers, according to their generations, nine hundred fifty-six. All these men were heads of fathers’ households by their fathers’ houses. 
+</div><div class="p">
+<sup>10&#160;</sup>Of the priests: Jedaiah, Jehoiarib, Jachin, 
+<sup>11&#160;</sup>and Azariah the son of Hilkiah, the son of Meshullam, the son of Zadok, the son of Meraioth, the son of Ahitub, the ruler of Elohim’s house; 
+<sup>12&#160;</sup>and Adaiah the son of Jeroham, the son of Pashhur, the son of Malchijah; and Maasai the son of Adiel, the son of Jahzerah, the son of Meshullam, the son of Meshillemith, the son of Immer; 
+<sup>13&#160;</sup>and their brothers, heads of their fathers’ houses, one thousand seven hundred sixty; they were very able men for the work of the service of Elohim’s house. 
+</div><div class="p">
+<sup>14&#160;</sup>Of the Levites: Shemaiah the son of Hasshub, the son of Azrikam, the son of Hashabiah, of the sons of Merari; 
+<sup>15&#160;</sup>and Bakbakkar, Heresh, Galal, and Mattaniah the son of Mica, the son of Zichri, the son of Asaph, 
+<sup>16&#160;</sup>and Obadiah the son of Shemaiah, the son of Galal, the son of Jeduthun; and Berechiah the son of Asa, the son of Elkanah, who lived in the villages of the Netophathites. 
+</div><div class="p">
+<sup>17&#160;</sup>The gatekeepers: Shallum, Akkub, Talmon, Ahiman, and their brothers (Shallum was the chief), 
+<sup>18&#160;</sup>who previously served in the king’s gate eastward. They were the gatekeepers for the camp of the children of Levi. 
+<sup>19&#160;</sup>Shallum was the son of Kore, the son of Ebiasaph, the son of Korah, and his brothers, of his father’s house, the Korahites, were over the work of the service, keepers of the thresholds of the tent. Their fathers had been over Yahweh’s camp, keepers of the entry. 
+<sup>20&#160;</sup>Phinehas the son of Eleazar was ruler over them in time past, and Yahweh was with him. 
+<sup>21&#160;</sup>Zechariah the son of Meshelemiah was gatekeeper of the door of the Tent of Meeting. 
+<sup>22&#160;</sup>All these who were chosen to be gatekeepers in the thresholds were two hundred twelve. These were listed by genealogy in their villages, whom David and Samuel the seer ordained in their office of trust. 
+<sup>23&#160;</sup>So they and their children had the oversight of the gates of Yahweh’s house, even the house of the tent, as guards. 
+<sup>24&#160;</sup>On the four sides were the gatekeepers, toward the east, west, north, and south. 
+<sup>25&#160;</sup>Their brothers, in their villages, were to come in every seven days from time to time to be with them, 
+<sup>26&#160;</sup>for the four chief gatekeepers, who were Levites, were in an office of trust, and were over the rooms and over the treasuries in Elohim’s house. 
+<sup>27&#160;</sup>They stayed around Elohim’s house, because that was their duty; and it was their duty to open it morning by morning. 
+</div><div class="p">
+<sup>28&#160;</sup>Certain of them were in charge of the vessels of service, for these were brought in by count, and these were taken out by count. 
+<sup>29&#160;</sup>Some of them also were appointed over the furniture, and over all the vessels of the sanctuary, over the fine flour, the wine, the oil, the frankincense, and the spices. 
+</div><div class="p">
+<sup>30&#160;</sup>Some of the sons of the priests prepared the mixing of the spices. 
+<sup>31&#160;</sup>Mattithiah, one of the Levites, who was the firstborn of Shallum the Korahite, had the office of trust over the things that were baked in pans. 
+<sup>32&#160;</sup>Some of their brothers, of the sons of the Kohathites, were over the show bread, to prepare it every Sabbath. 
+</div><div class="p">
+<sup>33&#160;</sup>These are the singers, heads of fathers’ households of the Levites, who lived in the rooms and were free from other service, for they were employed in their work day and night. 
+<sup>34&#160;</sup>These were heads of fathers’ households of the Levites, throughout their generations, chief men. They lived at Jerusalem. 
+</div><div class="p">
+<sup>35&#160;</sup>Jeiel the father of Gibeon, whose woman’s name was Maacah, lived in Gibeon. 
+<sup>36&#160;</sup>His firstborn son was Abdon, then Zur, Kish, Baal, Ner, Nadab, 
+<sup>37&#160;</sup>Gedor, Ahio, Zechariah, and Mikloth. 
+<sup>38&#160;</sup>Mikloth brought forth Shimeam. They also lived with their relatives in Jerusalem, near their relatives. 
+<sup>39&#160;</sup>Ner brought forth Kish. Kish brought forth Saul. Saul brought forth Jonathan, Malchishua, Abinadab, and Eshbaal. 
+<sup>40&#160;</sup>The son of Jonathan was Merib-baal. Merib-baal brought forth Micah. 
+<sup>41&#160;</sup>The sons of Micah: Pithon, Melech, Tahrea, and Ahaz. 
+<sup>42&#160;</sup>Ahaz brought forth Jarah. Jarah brought forth Alemeth, Azmaveth, and Zimri. Zimri brought forth Moza. 
+<sup>43&#160;</sup>Moza brought forth Binea, Rephaiah his son, Eleasah his son, and Azel his son. 
+<sup>44&#160;</sup>Azel had six sons, whose names are Azrikam, Bocheru, Ishmael, Sheariah, Obadiah, and Hanan. These were the sons of Azel. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the Philistines fought against Israel; and the men of Israel fled from before the Philistines, and fell down slain on Mount Gilboa. 
+<sup>2&#160;</sup>The Philistines followed hard after Saul and after his sons; and the Philistines killed Jonathan, Abinadab, and Malchishua, the sons of Saul. 
+<sup>3&#160;</sup>The battle went hard against Saul, and the archers overtook him; and he was distressed by reason of the archers. 
+<sup>4&#160;</sup>Then Saul said to his armor bearer, “Draw your sword, and thrust me through with it, lest these uncircumcised come and abuse me.” 
+</div><div class="p">But his armor bearer would not, for he was terrified. Therefore Saul took his sword and fell on it. 
+<sup>5&#160;</sup>When his armor bearer saw that Saul was dead, he likewise fell on his sword and died. 
+<sup>6&#160;</sup>So Saul died with his three sons; and all his house died together. 
+<sup>7&#160;</sup>When all the men of Israel who were in the valley saw that they fled, and that Saul and his sons were dead, they abandoned their cities, and fled; and the Philistines came and lived in them. 
+</div><div class="p">
+<sup>8&#160;</sup>On the next day, when the Philistines came to strip the slain, they found Saul and his sons fallen on Mount Gilboa. 
+<sup>9&#160;</sup>They stripped him and took his head and his armor, then sent into the land of the Philistines all around to carry the news to their idols and to the people. 
+<sup>10&#160;</sup>They put his armor in the house of their elohims, and fastened his head in the house of Dagon. 
+<sup>11&#160;</sup>When all Jabesh Gilead heard all that the Philistines had done to Saul, 
+<sup>12&#160;</sup>all the valiant men arose and took away the body of Saul and the bodies of his sons, and brought them to Jabesh, and buried their bones under the oak in Jabesh, and fasted seven days. 
+</div><div class="p">
+<sup>13&#160;</sup>So Saul died for his trespass which he committed against Yahweh, because of Yahweh’s word, which he didn’t keep, and also because he asked counsel of one who had a familiar spirit, to inquire, 
+<sup>14&#160;</sup>and didn’t inquire of Yahweh. Therefore he killed him, and turned the kingdom over to David the son of Jesse. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Then all Israel gathered themselves to David to Hebron, saying, “Behold, we are your bone and your flesh. 
+<sup>2&#160;</sup>In times past, even when Saul was king, it was you who led out and brought in Israel. Yahweh your Elohim said to you, ‘You shall be shepherd of my people Israel, and you shall be prince over my people Israel.’&#160;” 
+</div><div class="p">
+<sup>3&#160;</sup>So all the elders of Israel came to the king to Hebron; and David made a covenant with them in Hebron before Yahweh. They anointed David king over Israel, according to Yahweh’s word by Samuel. 
+</div><div class="p">
+<sup>4&#160;</sup>David and all Israel went to Jerusalem (also called Jebus); and the Jebusites, the inhabitants of the land, were there. 
+<sup>5&#160;</sup>The inhabitants of Jebus said to David, “You will not come in here!” Nevertheless David took the stronghold of Zion. The same is David’s city. 
+<sup>6&#160;</sup>David had said, “Whoever strikes the Jebusites first shall be chief and captain.” Joab the son of Zeruiah went up first, and was made chief. 
+<sup>7&#160;</sup>David lived in the stronghold; therefore they called it David’s city. 
+<sup>8&#160;</sup>He built the city all around, from Millo even around; and Joab repaired the rest of the city. 
+<sup>9&#160;</sup>David grew greater and greater, for Yahweh of Armies was with him. 
+</div><div class="p">
+<sup>10&#160;</sup>Now these are the chief of the mighty men whom David had, who showed themselves strong with him in his kingdom, together with all Israel, to make him king, according to Yahweh’s word concerning Israel. 
+</div><div class="p">
+<sup>11&#160;</sup>This is the number of the mighty men whom David had: Jashobeam, the son of a Hachmonite, the chief of the thirty; he lifted up his spear against three hundred and killed them at one time. 
+<sup>12&#160;</sup>After him was Eleazar the son of Dodo, the Ahohite, who was one of the three mighty men. 
+<sup>13&#160;</sup>He was with David at Pasdammim, and there the Philistines were gathered together to battle, where there was a plot of ground full of barley; and the people fled from before the Philistines. 
+<sup>14&#160;</sup>They stood in the middle of the plot, defended it, and killed the Philistines; and Yahweh saved them by a great victory. 
+</div><div class="p">
+<sup>15&#160;</sup>Three of the thirty chief men went down to the rock to David, into the cave of Adullam; and the army of the Philistines were encamped in the valley of Rephaim. 
+<sup>16&#160;</sup>David was then in the stronghold, and the garrison of the Philistines was in Bethlehem at that time. 
+<sup>17&#160;</sup>David longed, and said, “Oh, that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
+</div><div class="p">
+<sup>18&#160;</sup>The three broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate, took it, and brought it to David; but David would not drink any of it, but poured it out to Yahweh, 
+<sup>19&#160;</sup>and said, “My Elohim forbid me, that I should do this! Shall I drink the blood of these men who have put their lives in jeopardy?” For they risked their lives to bring it. Therefore he would not drink it. The three mighty men did these things. 
+</div><div class="p">
+<sup>20&#160;</sup>Abishai, the brother of Joab, was chief of the three; for he lifted up his spear against three hundred and killed them, and had a name among the three. 
+<sup>21&#160;</sup>Of the three, he was more honorable than the two, and was made their captain; however he wasn’t included in the three. 
+</div><div class="p">
+<sup>22&#160;</sup>Benaiah the son of Jehoiada, the son of a valiant man of Kabzeel, who had done mighty deeds, killed the two sons of Ariel of Moab. He also went down and killed a lion in the middle of a pit on a snowy day. 
+<sup>23&#160;</sup>He killed an Egyptian, a man of great stature, five cubits high. In the Egyptian’s hand was a spear like a weaver’s beam; and he went down to him with a staff, plucked the spear out of the Egyptian’s hand, and killed him with his own spear. 
+<sup>24&#160;</sup>Benaiah the son of Jehoiada did these things and had a name among the three mighty men. 
+<sup>25&#160;</sup>Behold, he was more honorable than the thirty, but he didn’t attain to the three; and David set him over his guard. 
+</div><div class="p">
+<sup>26&#160;</sup>The mighty men of the armies also include Asahel the brother of Joab, Elhanan the son of Dodo of Bethlehem, 
+<sup>27&#160;</sup>Shammoth the Harorite, Helez the Pelonite, 
+<sup>28&#160;</sup>Ira the son of Ikkesh the Tekoite, Abiezer the Anathothite, 
+<sup>29&#160;</sup>Sibbecai the Hushathite, Ilai the Ahohite, 
+<sup>30&#160;</sup>Maharai the Netophathite, Heled the son of Baanah the Netophathite, 
+<sup>31&#160;</sup>Ithai the son of Ribai of Gibeah of the children of Benjamin, Benaiah the Pirathonite, 
+<sup>32&#160;</sup>Hurai of the brooks of Gaash, Abiel the Arbathite, 
+<sup>33&#160;</sup>Azmaveth the Baharumite, Eliahba the Shaalbonite, 
+<sup>34&#160;</sup>the sons of Hashem the Gizonite, Jonathan the son of Shagee the Hararite, 
+<sup>35&#160;</sup>Ahiam the son of Sacar the Hararite, Eliphal the son of Ur, 
+<sup>36&#160;</sup>Hepher the Mecherathite, Ahijah the Pelonite, 
+<sup>37&#160;</sup>Hezro the Carmelite, Naarai the son of Ezbai, 
+<sup>38&#160;</sup>Joel the brother of Nathan, Mibhar the son of Hagri, 
+<sup>39&#160;</sup>Zelek the Ammonite, Naharai the Berothite (the armor bearer of Joab the son of Zeruiah), 
+<sup>40&#160;</sup>Ira the Ithrite, Gareb the Ithrite, 
+<sup>41&#160;</sup>Uriah the Hittite, Zabad the son of Ahlai, 
+<sup>42&#160;</sup>Adina the son of Shiza the Reubenite (a chief of the Reubenites), and thirty with him, 
+<sup>43&#160;</sup>Hanan the son of Maacah, Joshaphat the Mithnite, 
+<sup>44&#160;</sup>Uzzia the Ashterathite, Shama and Jeiel the sons of Hotham the Aroerite, 
+<sup>45&#160;</sup>Jediael the son of Shimri, and Joha his brother, the Tizite, 
+<sup>46&#160;</sup>Eliel the Mahavite, and Jeribai, and Joshaviah, the sons of Elnaam, and Ithmah the Moabite, 
+<sup>47&#160;</sup>Eliel, Obed, and Jaasiel the Mezobaite. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are those who came to David to Ziklag while he was a fugitive from Saul the son of Kish. They were among the mighty men, his helpers in war. 
+<sup>2&#160;</sup>They were armed with bows, and could use both the right hand and the left in slinging stones and in shooting arrows from the bow. They were of Saul’s relatives of the tribe of Benjamin. 
+<sup>3&#160;</sup>The chief was Ahiezer, then Joash, the sons of Shemaah the Gibeathite; Jeziel and Pelet, the sons of Azmaveth; Beracah; Jehu the Anathothite; 
+<sup>4&#160;</sup>Ishmaiah the Gibeonite, a mighty man among the thirty and a leader of the thirty; Jeremiah; Jahaziel; Johanan; Jozabad the Gederathite; 
+<sup>5&#160;</sup>Eluzai; Jerimoth; Bealiah; Shemariah; Shephatiah the Haruphite; 
+<sup>6&#160;</sup>Elkanah, Isshiah, Azarel, Joezer, and Jashobeam, the Korahites; 
+<sup>7&#160;</sup>and Joelah and Zebadiah, the sons of Jeroham of Gedor. 
+</div><div class="p">
+<sup>8&#160;</sup>Some Gadites joined David in the stronghold in the wilderness, mighty men of valor, men trained for war, who could handle shield and spear; whose faces were like the faces of lions, and they were as swift as the gazelles on the mountains: 
+<sup>9&#160;</sup>Ezer the chief, Obadiah the second, Eliab the third, 
+<sup>10&#160;</sup>Mishmannah the fourth, Jeremiah the fifth, 
+<sup>11&#160;</sup>Attai the sixth, Eliel the seventh, 
+<sup>12&#160;</sup>Johanan the eighth, Elzabad the ninth, 
+<sup>13&#160;</sup>Jeremiah the tenth, and Machbannai the eleventh. 
+<sup>14&#160;</sup>These of the sons of Gad were captains of the army. He who was least was equal to one hundred, and the greatest to one thousand. 
+<sup>15&#160;</sup>These are those who went over the Jordan in the first month, when it had overflowed all its banks; and they put to flight all who lived in the valleys, both toward the east and toward the west. 
+</div><div class="p">
+<sup>16&#160;</sup>Some of the children of Benjamin and Judah came to the stronghold to David. 
+<sup>17&#160;</sup>David went out to meet them, and answered them, “If you have come peaceably to me to help me, my heart will be united with you; but if you have come to betray me to my adversaries, since there is no wrong in my hands, may the Elohim of our fathers see this and rebuke it.” 
+<sup>18&#160;</sup>Then the Spirit came on Amasai, who was chief of the thirty, and he said, “We are yours, David, and on your side, you son of Jesse. Peace, peace be to you, and peace be to your helpers; for your Elohim helps you.” Then David received them and made them captains of the band. 
+</div><div class="p">
+<sup>19&#160;</sup>Some of Manasseh also joined David when he came with the Philistines against Saul to battle, but they didn’t help them, for the lords of the Philistines sent him away after consultation, saying, “He will desert to his master Saul to the jeopardy of our heads.” 
+</div><div class="p">
+<sup>20&#160;</sup>As he went to Ziklag, some from Manasseh joined him: Adnah, Jozabad, Jediael, Michael, Jozabad, Elihu, and Zillethai, captains of thousands who were of Manasseh. 
+<sup>21&#160;</sup>They helped David against the band of raiders, for they were all mighty men of valor and were captains in the army. 
+<sup>22&#160;</sup>For from day to day men came to David to help him, until there was a great army, like Elohim’s army. 
+</div><div class="p">
+<sup>23&#160;</sup>These are the numbers of the heads of those who were armed for war, who came to David to Hebron to turn the kingdom of Saul to him, according to Yahweh’s word. 
+<sup>24&#160;</sup>The children of Judah who bore shield and spear were six thousand eight hundred, armed for war. 
+<sup>25&#160;</sup>Of the children of Simeon, mighty men of valor for the war: seven thousand one hundred. 
+<sup>26&#160;</sup>Of the children of Levi: four thousand six hundred. 
+<sup>27&#160;</sup>Jehoiada was the leader of the household of Aaron; and with him were three thousand seven hundred, 
+<sup>28&#160;</sup>and Zadok, a young man mighty of valor, and of his father’s house twenty-two captains. 
+<sup>29&#160;</sup>Of the children of Benjamin, Saul’s relatives: three thousand, for until then, the greatest part of them had kept their allegiance to Saul’s house. 
+<sup>30&#160;</sup>Of the children of Ephraim: twenty thousand eight hundred, mighty men of valor, famous men in their fathers’ houses. 
+<sup>31&#160;</sup>Of the half-tribe of Manasseh: eighteen thousand, who were mentioned by name, to come and make David king. 
+<sup>32&#160;</sup>Of the children of Issachar, men who had understanding of the times, to know what Israel ought to do, their heads were two hundred; and all their brothers were at their command. 
+<sup>33&#160;</sup>Of Zebulun, such as were able to go out in the army, who could set the battle in array with all kinds of instruments of war: fifty thousand who could command and were not of double heart. 
+<sup>34&#160;</sup>Of Naphtali: one thousand captains, and with them with shield and spear thirty-seven thousand. 
+<sup>35&#160;</sup>Of the Danites who could set the battle in array: twenty-eight thousand six hundred. 
+<sup>36&#160;</sup>Of Asher, such as were able to go out in the army, who could set the battle in array: forty thousand. 
+<sup>37&#160;</sup>On the other side of the Jordan, of the Reubenites, the Gadites, and of the half-tribe of Manasseh, with all kinds of instruments of war for the battle: one hundred twenty thousand. 
+</div><div class="p">
+<sup>38&#160;</sup>All these were men of war who could order the battle array, and came with a perfect heart to Hebron to make David king over all Israel; and all the rest also of Israel were of one heart to make David king. 
+<sup>39&#160;</sup>They were there with David three days, eating and drinking; for their brothers had supplied provisions for them. 
+<sup>40&#160;</sup>Moreover those who were near to them, as far as Issachar, Zebulun, and Naphtali, brought bread on donkeys, on camels, on mules, and on oxen: supplies of flour, cakes of figs, clusters of raisins, wine, oil, cattle, and sheep in abundance; for there was joy in Israel. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>David consulted with the captains of thousands and of hundreds, even with every leader. 
+<sup>2&#160;</sup>David said to all the assembly of Israel, “If it seems good to you, and if it is of Yahweh our Elohim, let’s send word everywhere to our brothers who are left in all the land of Israel, with whom the priests and Levites are in their cities that have pasture lands, that they may gather themselves to us. 
+<sup>3&#160;</sup>Also, let’s bring the ark of our Elohim back to us again, for we didn’t seek it in the days of Saul.” 
+</div><div class="p">
+<sup>4&#160;</sup>All the assembly said that they would do so, for the thing was right in the eyes of all the people. 
+<sup>5&#160;</sup>So David assembled all Israel together, from the Shihor River of Egypt even to the entrance of Hamath, to bring Elohim’s ark from Kiriath Jearim. 
+</div><div class="p">
+<sup>6&#160;</sup>David went up with all Israel to Baalah, that is, to Kiriath Jearim, which belonged to Judah, to bring up from there Elohim Yahweh’s ark that sits above the cherubim, that is called by the Name. 
+<sup>7&#160;</sup>They carried Elohim’s ark on a new cart, and brought it out of Abinadab’s house; and Uzza and Ahio drove the cart. 
+<sup>8&#160;</sup>David and all Israel played before Elohim with all their might, even with songs, with harps, with stringed instruments, with tambourines, with cymbals, and with trumpets. 
+</div><div class="p">
+<sup>9&#160;</sup>When they came to Chidon’s threshing floor, Uzza put out his hand to hold the ark, for the oxen stumbled. 
+<sup>10&#160;</sup>Yahweh’s anger burned against Uzza, and he struck him because he put his hand on the ark; and he died there before Elohim. 
+<sup>11&#160;</sup>David was displeased, because Yahweh had broken out against Uzza. He called that place Perez Uzza, to this day. 
+<sup>12&#160;</sup>David was afraid of Elohim that day, saying, “How can I bring Elohim’s ark home to me?” 
+<sup>13&#160;</sup>So David didn’t move the ark with him into David’s city, but carried it aside into Obed-Edom the Gittite’s house. 
+<sup>14&#160;</sup>Elohim’s ark remained with the family of Obed-Edom in his house three months; and Yahweh blessed Obed-Edom’s house and all that he had. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Hiram king of Tyre sent messengers to David with cedar trees, masons, and carpenters, to build him a house. 
+<sup>2&#160;</sup>David perceived that Yahweh had established him king over Israel, for his kingdom was highly exalted, for his people Israel’s sake. 
+</div><div class="p">
+<sup>3&#160;</sup>David took more women in Jerusalem, and David brought forth more sons and daughters. 
+<sup>4&#160;</sup>These are the names of the children whom he had in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
+<sup>5&#160;</sup>Ibhar, Elishua, Elpelet, 
+<sup>6&#160;</sup>Nogah, Nepheg, Japhia, 
+<sup>7&#160;</sup>Elishama, Beeliada, and Eliphelet. 
+</div><div class="p">
+<sup>8&#160;</sup>When the Philistines heard that David was anointed king over all Israel, all the Philistines went up to seek David; and David heard of it, and went out against them. 
+<sup>9&#160;</sup>Now the Philistines had come and made a raid in the valley of Rephaim. 
+<sup>10&#160;</sup>David inquired of Elohim, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
+</div><div class="p">Yahweh said to him, “Go up; for I will deliver them into your hand.” 
+</div><div class="p">
+<sup>11&#160;</sup>So they came up to Baal Perazim, and David defeated them there. David said, Elohim has broken my enemies by my hand, like waters breaking out. Therefore they called the name of that place Baal Perazim. 
+<sup>12&#160;</sup>They left their elohims there; and David gave a command, and they were burned with fire. 
+</div><div class="p">
+<sup>13&#160;</sup>The Philistines made another raid in the valley. 
+<sup>14&#160;</sup>David inquired again of Elohim; and Elohim said to him, “You shall not go up after them. Turn away from them, and come on them opposite the mulberry trees. 
+<sup>15&#160;</sup>When you hear the sound of marching in the tops of the mulberry trees, then go out to battle; for Elohim has gone out before you to strike the army of the Philistines.” 
+</div><div class="p">
+<sup>16&#160;</sup>David did as Elohim commanded him; and they attacked the army of the Philistines from Gibeon even to Gezer. 
+<sup>17&#160;</sup>The fame of David went out into all lands; and Yahweh brought the fear of him on all nations. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>David made himself houses in David’s city; and he prepared a place for Elohim’s ark, and pitched a tent for it. 
+<sup>2&#160;</sup>Then David said, “No one ought to carry Elohim’s ark but the Levites. For Yahweh has chosen them to carry Elohim’s ark, and to minister to him forever.” 
+</div><div class="p">
+<sup>3&#160;</sup>David assembled all Israel at Jerusalem, to bring up Yahweh’s ark to its place, which he had prepared for it. 
+<sup>4&#160;</sup>David gathered together the sons of Aaron and the Levites: 
+<sup>5&#160;</sup>of the sons of Kohath, Uriel the chief, and his brothers one hundred twenty; 
+<sup>6&#160;</sup>of the sons of Merari, Asaiah the chief, and his brothers two hundred twenty; 
+<sup>7&#160;</sup>of the sons of Gershom, Joel the chief, and his brothers one hundred thirty; 
+<sup>8&#160;</sup>of the sons of Elizaphan, Shemaiah the chief, and his brothers two hundred; 
+<sup>9&#160;</sup>of the sons of Hebron, Eliel the chief, and his brothers eighty; 
+<sup>10&#160;</sup>of the sons of Uzziel, Amminadab the chief, and his brothers one hundred twelve. 
+</div><div class="p">
+<sup>11&#160;</sup>David called for Zadok and Abiathar the priests, and for the Levites: for Uriel, Asaiah, Joel, Shemaiah, Eliel, and Amminadab, 
+<sup>12&#160;</sup>and said to them, “You are the heads of the fathers’ households of the Levites. Sanctify yourselves, both you and your brothers, that you may bring the ark of Yahweh, the Elohim of Israel, up to the place that I have prepared for it. 
+<sup>13&#160;</sup>For because you didn’t carry it at first, Yahweh our Elohim broke out in anger against us, because we didn’t seek him according to the ordinance.” 
+</div><div class="p">
+<sup>14&#160;</sup>So the priests and the Levites sanctified themselves to bring up the ark of Yahweh, the Elohim of Israel. 
+<sup>15&#160;</sup>The children of the Levites bore Elohim’s ark on their shoulders with its poles, as Moses commanded according to Yahweh’s word. 
+</div><div class="p">
+<sup>16&#160;</sup>David spoke to the chief of the Levites to appoint their brothers as singers with instruments of music, stringed instruments, harps, and cymbals, sounding aloud and lifting up their voices with joy. 
+<sup>17&#160;</sup>So the Levites appointed Heman the son of Joel; and of his brothers, Asaph the son of Berechiah; and of the sons of Merari their brothers, Ethan the son of Kushaiah; 
+<sup>18&#160;</sup>and with them their brothers of the second rank: Zechariah, Ben, Jaaziel, Shemiramoth, Jehiel, Unni, Eliab, Benaiah, Maaseiah, Mattithiah, Eliphelehu, Mikneiah, Obed-Edom, and Jeiel, the doorkeepers. 
+<sup>19&#160;</sup>So the singers, Heman, Asaph, and Ethan, were given cymbals of bronze to sound aloud; 
+<sup>20&#160;</sup>and Zechariah, Aziel, Shemiramoth, Jehiel, Unni, Eliab, Maaseiah, and Benaiah, with stringed instruments set to Alamoth; 
+<sup>21&#160;</sup>and Mattithiah, Eliphelehu, Mikneiah, Obed-Edom, Jeiel, and Azaziah, with harps tuned to the eight-stringed lyre, to lead. 
+<sup>22&#160;</sup>Chenaniah, chief of the Levites, was over the singing. He taught the singers, because he was skillful. 
+<sup>23&#160;</sup>Berechiah and Elkanah were doorkeepers for the ark. 
+<sup>24&#160;</sup>Shebaniah, Joshaphat, Nethanel, Amasai, Zechariah, Benaiah, and Eliezer, the priests, blew the trumpets before Elohim’s ark; and Obed-Edom and Jehiah were doorkeepers for the ark. 
+</div><div class="p">
+<sup>25&#160;</sup>So David, the elders of Israel, and the captains over thousands went to bring the ark of Yahweh’s covenant up out of the house of Obed-Edom with joy. 
+<sup>26&#160;</sup>When Elohim helped the Levites who bore the ark of Yahweh’s covenant, they sacrificed seven bulls and seven rams. 
+<sup>27&#160;</sup>David was clothed with a robe of fine linen, as were all the Levites who bore the ark, the singers, and Chenaniah the choir master with the singers; and David had an ephod of linen on him. 
+<sup>28&#160;</sup>Thus all Israel brought the ark of Yahweh’s covenant up with shouting, with sound of the cornet, with trumpets, and with cymbals, sounding aloud with stringed instruments and harps. 
+<sup>29&#160;</sup>As the ark of Yahweh’s covenant came to David’s city, Michal the daughter of Saul looked out at the window, and saw king David dancing and playing; and she despised him in her heart. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>They brought in Elohim’s ark, and set it in the middle of the tent that David had pitched for it; and they offered burnt offerings and peace offerings before Elohim. 
+<sup>2&#160;</sup>When David had finished offering the burnt offering and the peace offerings, he blessed the people in Yahweh’s name. 
+<sup>3&#160;</sup>He gave to everyone of Israel, both man and woman, to everyone a loaf of bread, a portion of meat, and a cake of raisins. 
+</div><div class="p">
+<sup>4&#160;</sup>He appointed some of the Levites to minister before Yahweh’s ark, and to commemorate, to thank, and to praise Yahweh, the Elohim of Israel: 
+<sup>5&#160;</sup>Asaph the chief, and second to him Zechariah, then Jeiel, Shemiramoth, Jehiel, Mattithiah, Eliab, Benaiah, Obed-Edom, and Jeiel, with stringed instruments and with harps; and Asaph with cymbals, sounding aloud; 
+<sup>6&#160;</sup>with Benaiah and Jahaziel the priests with trumpets continually, before the ark of the covenant of Elohim. 
+</div><div class="p">
+<sup>7&#160;</sup>Then on that day David first ordained giving of thanks to Yahweh by the hand of Asaph and his brothers. 
+</div><div class="q1">
+<sup>8&#160;</sup>Oh give thanks to Yahweh. 
+</div><div class="q2">Call on his name. 
+</div><div class="q2">Make what he has done known among the peoples. 
+</div><div class="q1">
+<sup>9&#160;</sup>Sing to him. 
+</div><div class="q2">Sing praises to him. 
+</div><div class="q2">Tell of all his marvelous works. 
+</div><div class="q1">
+<sup>10&#160;</sup>Glory in his set-apart name. 
+</div><div class="q2">Let the heart of those who seek Yahweh rejoice. 
+</div><div class="q1">
+<sup>11&#160;</sup>Seek Yahweh and his strength. 
+</div><div class="q2">Seek his face forever more. 
+</div><div class="q1">
+<sup>12&#160;</sup>Remember his marvelous works that he has done, 
+</div><div class="q2">his wonders, and the judgments of his mouth, 
+</div><div class="q1">
+<sup>13&#160;</sup>you offspring of Israel his servant, 
+</div><div class="q2">you children of Jacob, his chosen ones. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>He is Yahweh our Elohim. 
+</div><div class="q2">His judgments are in all the earth. 
+</div><div class="q1">
+<sup>15&#160;</sup>Remember his covenant forever, 
+</div><div class="q2">the word which he commanded to a thousand generations, 
+</div><div class="q2">
+<sup>16&#160;</sup>the covenant which he made with Abraham, 
+</div><div class="q2">his oath to Isaac. 
+</div><div class="q1">
+<sup>17&#160;</sup>He confirmed it to Jacob for a statute, 
+</div><div class="q2">and to Israel for an everlasting covenant, 
+</div><div class="q1">
+<sup>18&#160;</sup>saying, “I will give you the land of Canaan, 
+</div><div class="q2">The lot of your inheritance,” 
+</div><div class="q2">
+<sup>19&#160;</sup>when you were but a few men in number, 
+</div><div class="q2">yes, very few, and foreigners in it. 
+</div><div class="q1">
+<sup>20&#160;</sup>They went about from nation to nation, 
+</div><div class="q2">from one kingdom to another people. 
+</div><div class="q1">
+<sup>21&#160;</sup>He allowed no man to do them wrong. 
+</div><div class="q2">Yes, he reproved kings for their sakes, 
+</div><div class="q1">
+<sup>22&#160;</sup>“Don’t touch my anointed ones! 
+</div><div class="q2">Do my prophets no harm!” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>Sing to Yahweh, all the earth! 
+</div><div class="q2">Display his salvation from day to day. 
+</div><div class="q1">
+<sup>24&#160;</sup>Declare his glory among the nations, 
+</div><div class="q2">and his marvelous works among all the peoples. 
+</div><div class="q1">
+<sup>25&#160;</sup>For great is Yahweh, and greatly to be praised. 
+</div><div class="q2">He also is to be feared above all elohims. 
+</div><div class="q1">
+<sup>26&#160;</sup>For all the elohims of the peoples are idols, 
+</div><div class="q2">but Yahweh made the heavens. 
+</div><div class="q1">
+<sup>27&#160;</sup>Honor and majesty are before him. 
+</div><div class="q2">Strength and gladness are in his place. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>Ascribe to Yahweh, you families of the peoples, 
+</div><div class="q2">ascribe to Yahweh glory and strength! 
+</div><div class="q1">
+<sup>29&#160;</sup>Ascribe to Yahweh the glory due to his name. 
+</div><div class="q2">Bring an offering, and come before him. 
+</div><div class="q2">Worship Yahweh in set-apart array. 
+</div><div class="q1">
+<sup>30&#160;</sup>Tremble before him, all the earth. 
+</div><div class="q2">The world also is established that it can’t be moved. 
+</div><div class="q1">
+<sup>31&#160;</sup>Let the heavens be glad, 
+</div><div class="q2">and let the earth rejoice! 
+</div><div class="q2">Let them say among the nations, “Yahweh reigns!” 
+</div><div class="q1">
+<sup>32&#160;</sup>Let the sea roar, and its fullness! 
+</div><div class="q2">Let the field exult, and all that is in it! 
+</div><div class="q1">
+<sup>33&#160;</sup>Then the trees of the forest will sing for joy before Yahweh, 
+</div><div class="q2">for he comes to judge the earth. 
+</div><div class="q1">
+<sup>34&#160;</sup>Oh give thanks to Yahweh, for he is good, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>35&#160;</sup>Say, “Save us, Elohim of our salvation! 
+</div><div class="q2">Gather us together and deliver us from the nations, 
+</div><div class="q2">to give thanks to your set-apart name, 
+</div><div class="q2">to triumph in your praise.” 
+</div><div class="q1">
+<sup>36&#160;</sup>Blessed be Yahweh, the Elohim of Israel, 
+</div><div class="q2">from everlasting even to everlasting. 
+</div><div class="p">All the people said, “Amen,” and praised Yahweh. 
+</div><div class="p">
+<sup>37&#160;</sup>So he left Asaph and his brothers there before the ark of Yahweh’s covenant, to minister before the ark continually, as every day’s work required; 
+<sup>38&#160;</sup>and Obed-Edom with their sixty-eight relatives; Obed-Edom also the son of Jeduthun and Hosah to be doorkeepers; 
+<sup>39&#160;</sup>and Zadok the priest and his brothers the priests, before Yahweh’s tabernacle in the high place that was at Gibeon, 
+<sup>40&#160;</sup>to offer burnt offerings to Yahweh on the altar of burnt offering continually morning and evening, even according to all that is written in Yahweh’s law, which he commanded to Israel; 
+<sup>41&#160;</sup>and with them Heman and Jeduthun and the rest who were chosen, who were mentioned by name, to give thanks to Yahweh, because his loving kindness endures forever; 
+<sup>42&#160;</sup>and with them Heman and Jeduthun with trumpets and cymbals for those that should sound aloud, and with instruments for the songs of Elohim, and the sons of Jeduthun to be at the gate. 
+<sup>43&#160;</sup>All the people departed, each man to his house; and David returned to bless his house. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>When David was living in his house, David said to Nathan the prophet, “Behold, I live in a cedar house, but the ark of Yahweh’s covenant is in a tent.” 
+</div><div class="p">
+<sup>2&#160;</sup>Nathan said to David, “Do all that is in your heart; for Elohim is with you.” 
+</div><div class="p">
+<sup>3&#160;</sup>That same night, the word of Elohim came to Nathan, saying, 
+<sup>4&#160;</sup>“Go and tell David my servant, ‘Yahweh says, “You shall not build me a house to dwell in; 
+<sup>5&#160;</sup>for I have not lived in a house since the day that I brought up Israel to this day, but have gone from tent to tent, and from one tent to another. 
+<sup>6&#160;</sup>In all places in which I have walked with all Israel, did I speak a word with any of the judges of Israel, whom I commanded to be shepherd of my people, saying, ‘Why have you not built me a house of cedar?’&#160;”&#160;’ 
+</div><div class="p">
+<sup>7&#160;</sup>“Now therefore, you shall tell my servant David, ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people Israel. 
+<sup>8&#160;</sup>I have been with you wherever you have gone, and have cut off all your enemies from before you. I will make you a name like the name of the great ones who are in the earth. 
+<sup>9&#160;</sup>I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place, and be moved no more. The children of wickedness will not waste them any more, as at the first, 
+<sup>10&#160;</sup>and from the day that I commanded judges to be over my people Israel. I will subdue all your enemies. Moreover I tell you that Yahweh will build you a house. 
+<sup>11&#160;</sup>It will happen, when your days are fulfilled that you must go to be with your fathers, that I will set up your offspring after you, who will be of your sons; and I will establish his kingdom. 
+<sup>12&#160;</sup>He will build me a house, and I will establish his throne forever. 
+<sup>13&#160;</sup>I will be his father, and he will be my son. I will not take my loving kindness away from him, as I took it from him who was before you; 
+<sup>14&#160;</sup>but I will settle him in my house and in my kingdom forever. His throne will be established forever.”&#160;’&#160;” 
+<sup>15&#160;</sup>According to all these words, and according to all this vision, so Nathan spoke to David. 
+</div><div class="p">
+<sup>16&#160;</sup>Then David the king went in and sat before Yahweh; and he said, “Who am I, Yahweh Elohim, and what is my house, that you have brought me this far? 
+<sup>17&#160;</sup>This was a small thing in your eyes, O Elohim, but you have spoken of your servant’s house for a great while to come, and have respected me according to the standard of a man of high degree, Yahweh Elohim. 
+<sup>18&#160;</sup>What can David say yet more to you concerning the honor which is done to your servant? For you know your servant. 
+<sup>19&#160;</sup>Yahweh, for your servant’s sake, and according to your own heart, you have done all this greatness, to make known all these great things. 
+<sup>20&#160;</sup>Yahweh, there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
+<sup>21&#160;</sup>What one nation in the earth is like your people Israel, whom Elohim went to redeem to himself for a people, to make you a name by great and awesome things, in driving out nations from before your people whom you redeemed out of Egypt? 
+<sup>22&#160;</sup>For you made your people Israel your own people forever; and you, Yahweh, became their Elohim. 
+<sup>23&#160;</sup>Now, Yahweh, let the word that you have spoken concerning your servant, and concerning his house, be established forever, and do as you have spoken. 
+<sup>24&#160;</sup>Let your name be established and magnified forever, saying, ‘Yahweh of Armies is the Elohim of Israel, even an Elohim to Israel. The house of David your servant is established before you.’ 
+<sup>25&#160;</sup>For you, my Elohim, have revealed to your servant that you will build him a house. Therefore your servant has found courage to pray before you. 
+<sup>26&#160;</sup>Now, Yahweh, you are Elohim, and have promised this good thing to your servant. 
+<sup>27&#160;</sup>Now it has pleased you to bless the house of your servant, that it may continue forever before you; for you, Yahweh, have blessed, and it is blessed forever.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, David defeated the Philistines and subdued them, and took Gath and its towns out of the hand of the Philistines. 
+<sup>2&#160;</sup>He defeated Moab; and the Moabites became servants to David and brought tribute. 
+</div><div class="p">
+<sup>3&#160;</sup>David defeated Hadadezer king of Zobah, toward Hamath, as he went to establish his dominion by the river Euphrates. 
+<sup>4&#160;</sup>David took from him one thousand chariots, seven thousand horsemen, and twenty thousand footmen; and David hamstrung all the chariot horses, but reserved of them enough for one hundred chariots. 
+<sup>5&#160;</sup>When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty-two thousand men of the Syrians. 
+<sup>6&#160;</sup>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David and brought tribute. Yahweh gave victory to David wherever he went. 
+<sup>7&#160;</sup>David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
+<sup>8&#160;</sup>From Tibhath and from Cun, cities of Hadadezer, David took very much bronze, with which Solomon made the bronze sea, the pillars, and the vessels of bronze. 
+</div><div class="p">
+<sup>9&#160;</sup>When Tou king of Hamath heard that David had struck all the army of Hadadezer king of Zobah, 
+<sup>10&#160;</sup>he sent Hadoram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him (for Hadadezer had wars with Tou); and he had with him all kinds of vessels of gold and silver and bronze. 
+<sup>11&#160;</sup>King David also dedicated these to Yahweh, with the silver and the gold that he carried away from all the nations: from Edom, from Moab, from the children of Ammon, from the Philistines, and from Amalek. 
+</div><div class="p">
+<sup>12&#160;</sup>Moreover Abishai the son of Zeruiah struck eighteen thousand of the Edomites in the Valley of Salt. 
+<sup>13&#160;</sup>He put garrisons in Edom; and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
+</div><div class="p">
+<sup>14&#160;</sup>David reigned over all Israel; and he executed justice and righteousness for all his people. 
+<sup>15&#160;</sup>Joab the son of Zeruiah was over the army; Jehoshaphat the son of Ahilud was recorder; 
+<sup>16&#160;</sup>Zadok the son of Ahitub and Abimelech the son of Abiathar were priests; Shavsha was scribe; 
+<sup>17&#160;</sup>and Benaiah the son of Jehoiada was over the Cherethites and the Pelethites; and the sons of David were chief officials serving the king. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, Nahash the king of the children of Ammon died, and his son reigned in his place. 
+<sup>2&#160;</sup>David said, “I will show kindness to Hanun the son of Nahash, because his father showed kindness to me.” 
+</div><div class="p">So David sent messengers to comfort him concerning his father. David’s servants came into the land of the children of Ammon to Hanun to comfort him. 
+<sup>3&#160;</sup>But the princes of the children of Ammon said to Hanun, “Do you think that David honors your father, in that he has sent comforters to you? Haven’t his servants come to you to search, to overthrow, and to spy out the land?” 
+<sup>4&#160;</sup>So Hanun took David’s servants, shaved them, and cut off their garments in the middle at their buttocks, and sent them away. 
+<sup>5&#160;</sup>Then some people went and told David how the men were treated. He sent to meet them; for the men were greatly humiliated. The king said, “Stay at Jericho until your beards have grown, and then return.” 
+</div><div class="p">
+<sup>6&#160;</sup>When the children of Ammon saw that they had made themselves odious to David, Hanun and the children of Ammon sent one thousand talents of silver to hire chariots and horsemen out of Mesopotamia, out of Aram-maacah, and out of Zobah. 
+<sup>7&#160;</sup>So they hired for themselves thirty-two thousand chariots, and the king of Maacah with his people, who came and encamped near Medeba. The children of Ammon gathered themselves together from their cities, and came to battle. 
+<sup>8&#160;</sup>When David heard of it, he sent Joab with all the army of the mighty men. 
+<sup>9&#160;</sup>The children of Ammon came out, and put the battle in array at the gate of the city; and the kings who had come were by themselves in the field. 
+</div><div class="p">
+<sup>10&#160;</sup>Now when Joab saw that the battle was set against him before and behind, he chose some of all the choice men of Israel, and put them in array against the Syrians. 
+<sup>11&#160;</sup>The rest of the people he committed into the hand of Abishai his brother; and they put themselves in array against the children of Ammon. 
+<sup>12&#160;</sup>He said, “If the Syrians are too strong for me, then you are to help me; but if the children of Ammon are too strong for you, then I will help you. 
+<sup>13&#160;</sup>Be courageous, and let’s be strong for our people and for the cities of our Elohim. May Yahweh do that which seems good to him.” 
+</div><div class="p">
+<sup>14&#160;</sup>So Joab and the people who were with him came near to the front of the Syrians to the battle; and they fled before him. 
+<sup>15&#160;</sup>When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai his brother, and entered into the city. Then Joab came to Jerusalem. 
+</div><div class="p">
+<sup>16&#160;</sup>When the Syrians saw that they were defeated by Israel, they sent messengers and called out the Syrians who were beyond the River, with Shophach the captain of the army of Hadadezer leading them. 
+<sup>17&#160;</sup>David was told that, so he gathered all Israel together, passed over the Jordan, came to them, and set the battle in array against them. So when David had put the battle in array against the Syrians, they fought with him. 
+<sup>18&#160;</sup>The Syrians fled before Israel; and David killed of the Syrian men seven thousand charioteers and forty thousand footmen, and also killed Shophach the captain of the army. 
+<sup>19&#160;</sup>When the servants of Hadadezer saw that they were defeated by Israel, they made peace with David and served him. The Syrians would not help the children of Ammon any more. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>At the time of the return of the year, at the time when kings go out, Joab led out the army and wasted the country of the children of Ammon, and came and besieged Rabbah. But David stayed at Jerusalem. Joab struck Rabbah, and overthrew it. 
+<sup>2&#160;</sup>David took the crown of their king from off his head, and found it to weigh a talent of gold, and there were precious stones in it. It was set on David’s head, and he brought very much plunder out of the city. 
+<sup>3&#160;</sup>He brought out the people who were in it, and had them cut with saws, with iron picks, and with axes. David did so to all the cities of the children of Ammon. Then David and all the people returned to Jerusalem. 
+</div><div class="p">
+<sup>4&#160;</sup>After this, war arose at Gezer with the Philistines. Then Sibbecai the Hushathite killed Sippai, of the sons of the giant; and they were subdued. 
+</div><div class="p">
+<sup>5&#160;</sup>Again there was war with the Philistines; and Elhanan the son of Jair killed Lahmi the brother of Goliath the Gittite, the staff of whose spear was like a weaver’s beam. 
+<sup>6&#160;</sup>There was again war at Gath, where there was a man of great stature, who had twenty-four fingers and toes, six on each hand and six on each foot; and he also was born to the giant. 
+<sup>7&#160;</sup>When he defied Israel, Jonathan the son of Shimea, David’s brother, killed him. 
+<sup>8&#160;</sup>These were born to the giant in Gath; and they fell by the hand of David and by the hand of his servants. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Satan stood up against Israel, and moved David to take a census of Israel. 
+<sup>2&#160;</sup>David said to Joab and to the princes of the people, “Go, count Israel from Beersheba even to Dan; and bring me word, that I may know how many there are.” 
+</div><div class="p">
+<sup>3&#160;</sup>Joab said, “May Yahweh make his people a hundred times as many as they are. But, my lord the king, aren’t they all my lord’s servants? Why does my lord require this thing? Why will he be a cause of guilt to Israel?” 
+</div><div class="p">
+<sup>4&#160;</sup>Nevertheless the king’s word prevailed against Joab. Therefore Joab departed and went throughout all Israel, then came to Jerusalem. 
+<sup>5&#160;</sup>Joab gave the sum of the census of the people to David. All those of Israel were one million one hundred thousand men who drew a sword; and in Judah were four hundred seventy thousand men who drew a sword. 
+<sup>6&#160;</sup>But he didn’t count Levi and Benjamin among them, for the king’s word was abominable to Joab. 
+</div><div class="p">
+<sup>7&#160;</sup>Elohim was displeased with this thing; therefore he struck Israel. 
+<sup>8&#160;</sup>David said to Elohim, “I have sinned greatly, in that I have done this thing. But now put away, I beg you, the iniquity of your servant, for I have done very foolishly.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh spoke to Gad, David’s seer, saying, 
+<sup>10&#160;</sup>“Go and speak to David, saying, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>So Gad came to David and said to him, “Yahweh says, ‘Take your choice: 
+<sup>12&#160;</sup>either three years of famine; or three months to be consumed before your foes, while the sword of your enemies overtakes you; or else three days of the sword of Yahweh, even pestilence in the land, and Yahweh’s angel destroying throughout all the borders of Israel. Now therefore consider what answer I shall return to him who sent me.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>David said to Gad, “I am in distress. Let me fall, I pray, into Yahweh’s hand, for his mercies are very great. Don’t let me fall into man’s hand.” 
+</div><div class="p">
+<sup>14&#160;</sup>So Yahweh sent a pestilence on Israel, and seventy thousand men of Israel fell. 
+<sup>15&#160;</sup>Elohim sent an angel to Jerusalem to destroy it. As he was about to destroy, Yahweh saw, and he relented of the disaster, and said to the destroying angel, “It is enough. Now withdraw your hand.” Yahweh’s angel was standing by the threshing floor of Ornan the Jebusite. 
+<sup>16&#160;</sup>David lifted up his eyes, and saw Yahweh’s angel standing between earth and the sky, having a drawn sword in his hand stretched out over Jerusalem. 
+</div><div class="p">Then David and the elders, clothed in sackcloth, fell on their faces. 
+<sup>17&#160;</sup>David said to Elohim, “Isn’t it I who commanded the people to be counted? It is even I who have sinned and done very wickedly; but these sheep, what have they done? Please let your hand, O Yahweh my Elohim, be against me and against my father’s house; but not against your people, that they should be plagued.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then Yahweh’s angel commanded Gad to tell David that David should go up and raise an altar to Yahweh on the threshing floor of Ornan the Jebusite. 
+<sup>19&#160;</sup>David went up at the saying of Gad, which he spoke in Yahweh’s name. 
+</div><div class="p">
+<sup>20&#160;</sup>Ornan turned back and saw the angel; and his four sons who were with him hid themselves. Now Ornan was threshing wheat. 
+<sup>21&#160;</sup>As David came to Ornan, Ornan looked and saw David, and went out of the threshing floor, and bowed himself to David with his face to the ground. 
+</div><div class="p">
+<sup>22&#160;</sup>Then David said to Ornan, “Sell me the place of this threshing floor, that I may build an altar to Yahweh on it. You shall sell it to me for the full price, that the plague may be stopped from afflicting the people.” 
+</div><div class="p">
+<sup>23&#160;</sup>Ornan said to David, “Take it for yourself, and let my lord the king do that which is good in his eyes. Behold, I give the oxen for burnt offerings, and the threshing instruments for wood, and the wheat for the meal offering. I give it all.” 
+</div><div class="p">
+<sup>24&#160;</sup>King David said to Ornan, “No, but I will most certainly buy it for the full price. For I will not take that which is yours for Yahweh, nor offer a burnt offering that costs me nothing.” 
+</div><div class="p">
+<sup>25&#160;</sup>So David gave to Ornan six hundred shekels of gold by weight for the place. 
+<sup>26&#160;</sup>David built an altar to Yahweh there, and offered burnt offerings and peace offerings, and called on Yahweh; and he answered him from the sky by fire on the altar of burnt offering. 
+</div><div class="p">
+<sup>27&#160;</sup>Then Yahweh commanded the angel, and he put his sword back into its sheath. 
+</div><div class="p">
+<sup>28&#160;</sup>At that time, when David saw that Yahweh had answered him in the threshing floor of Ornan the Jebusite, then he sacrificed there. 
+<sup>29&#160;</sup>For Yahweh’s tabernacle, which Moses made in the wilderness, and the altar of burnt offering, were at that time in the high place at Gibeon. 
+<sup>30&#160;</sup>But David couldn’t go before it to inquire of Elohim, for he was afraid because of the sword of Yahweh’s angel. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Then David said, “This is the house of Yahweh Elohim, and this is the altar of burnt offering for Israel.” 
+</div><div class="p">
+<sup>2&#160;</sup>David gave orders to gather together the foreigners who were in the land of Israel; and he set masons to cut dressed stones to build Elohim’s house. 
+<sup>3&#160;</sup>David prepared iron in abundance for the nails for the doors of the gates and for the couplings, and bronze in abundance without weight, 
+<sup>4&#160;</sup>and cedar trees without number, for the Sidonians and the people of Tyre brought cedar trees in abundance to David. 
+<sup>5&#160;</sup>David said, “Solomon my son is young and tender, and the house that is to be built for Yahweh must be exceedingly magnificent, of fame and of glory throughout all countries. I will therefore make preparation for it.” So David prepared abundantly before his death. 
+<sup>6&#160;</sup>Then he called for Solomon his son, and commanded him to build a house for Yahweh, the Elohim of Israel. 
+<sup>7&#160;</sup>David said to Solomon his son, “As for me, it was in my heart to build a house to the name of Yahweh my Elohim. 
+<sup>8&#160;</sup>But Yahweh’s word came to me, saying, ‘You have shed blood abundantly and have made great wars. You shall not build a house to my name, because you have shed much blood on the earth in my sight. 
+<sup>9&#160;</sup>Behold, a son shall be born to you, who shall be a man of peace. I will give him rest from all his enemies all around; for his name shall be Solomon, and I will give peace and quietness to Israel in his days. 
+<sup>10&#160;</sup>He shall build a house for my name; and he will be my son, and I will be his father; and I will establish the throne of his kingdom over Israel forever.’ 
+<sup>11&#160;</sup>Now, my son, may Yahweh be with you and prosper you, and build the house of Yahweh your Elohim, as he has spoken concerning you. 
+<sup>12&#160;</sup>May Yahweh give you discretion and understanding, and put you in charge of Israel, so that you may keep the law of Yahweh your Elohim. 
+<sup>13&#160;</sup>Then you will prosper, if you observe to do the statutes and the ordinances which Yahweh gave Moses concerning Israel. Be strong and courageous. Don’t be afraid and don’t be dismayed. 
+<sup>14&#160;</sup>Now, behold, in my affliction I have prepared for Yahweh’s house one hundred thousand talents of silver, and bronze and iron without weight; for it is in abundance. I have also prepared timber and stone; and you may add to them. 
+<sup>15&#160;</sup>There are also workmen with you in abundance—cutters and workers of stone and timber, and all kinds of men who are skillful in every kind of work; 
+<sup>16&#160;</sup>of the gold, the silver, the bronze, and the iron, there is no number. Arise and be doing, and may Yahweh be with you.” 
+</div><div class="p">
+<sup>17&#160;</sup>David also commanded all the princes of Israel to help Solomon his son, saying, 
+<sup>18&#160;</sup>“Isn’t Yahweh your Elohim with you? Hasn’t he given you rest on every side? For he has delivered the inhabitants of the land into my hand; and the land is subdued before Yahweh and before his people. 
+<sup>19&#160;</sup>Now set your heart and your soul to follow Yahweh your Elohim. Arise therefore, and build the sanctuary of Yahweh Elohim, to bring the ark of Yahweh’s covenant and the set-apart vessels of Elohim into the house that is to be built for Yahweh’s name.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Now David was old and full of days; and he made Solomon his son king over Israel. 
+<sup>2&#160;</sup>He gathered together all the princes of Israel, with the priests and the Levites. 
+<sup>3&#160;</sup>The Levites were counted from thirty years old and upward; and their number by their polls, man by man, was thirty-eight thousand. 
+<sup>4&#160;</sup>David said, “Of these, twenty-four thousand were to oversee the work of Yahweh’s house, six thousand were officers and judges, 
+<sup>5&#160;</sup>four thousand were doorkeepers, and four thousand praised Yahweh with the instruments which I made for giving praise.” 
+</div><div class="p">
+<sup>6&#160;</sup>David divided them into divisions according to the sons of Levi: Gershon, Kohath, and Merari. 
+</div><div class="p">
+<sup>7&#160;</sup>Of the Gershonites: Ladan and Shimei. 
+<sup>8&#160;</sup>The sons of Ladan: Jehiel the chief, Zetham, and Joel, three. 
+<sup>9&#160;</sup>The sons of Shimei: Shelomoth, Haziel, and Haran, three. These were the heads of the fathers’ households of Ladan. 
+<sup>10&#160;</sup>The sons of Shimei: Jahath, Zina, Jeush, and Beriah. These four were the sons of Shimei. 
+<sup>11&#160;</sup>Jahath was the chief, and Zizah the second; but Jeush and Beriah didn’t have many sons; therefore they became a fathers’ house in one reckoning. 
+</div><div class="p">
+<sup>12&#160;</sup>The sons of Kohath: Amram, Izhar, Hebron, and Uzziel, four. 
+<sup>13&#160;</sup>The sons of Amram: Aaron and Moses; and Aaron was separated that he should sanctify the most set-apart things, he and his sons forever, to burn incense before Yahweh, to minister to him, and to bless in his name forever. 
+<sup>14&#160;</sup>But as for Moses the man of Elohim, his sons were named among the tribe of Levi. 
+<sup>15&#160;</sup>The sons of Moses: Gershom and Eliezer. 
+<sup>16&#160;</sup>The sons of Gershom: Shebuel the chief. 
+<sup>17&#160;</sup>The son of Eliezer was Rehabiah the chief; and Eliezer had no other sons, but the sons of Rehabiah were very many. 
+<sup>18&#160;</sup>The son of Izhar: Shelomith the chief. 
+<sup>19&#160;</sup>The sons of Hebron: Jeriah the chief, Amariah the second, Jahaziel the third, and Jekameam the fourth. 
+<sup>20&#160;</sup>The sons of Uzziel: Micah the chief, and Isshiah the second. 
+</div><div class="p">
+<sup>21&#160;</sup>The sons of Merari: Mahli and Mushi. The sons of Mahli: Eleazar and Kish. 
+<sup>22&#160;</sup>Eleazar died, and had no sons, but daughters only; and their relatives, the sons of Kish, took them as women. 
+<sup>23&#160;</sup>The sons of Mushi: Mahli, Eder, and Jeremoth, three. 
+</div><div class="p">
+<sup>24&#160;</sup>These were the sons of Levi after their fathers’ houses, even the heads of the fathers’ houses of those who were counted individually, in the number of names by their polls, who did the work for the service of Yahweh’s house, from twenty years old and upward. 
+<sup>25&#160;</sup>For David said, “Yahweh, the Elohim of Israel, has given rest to his people; and he dwells in Jerusalem forever. 
+<sup>26&#160;</sup>Also the Levites will no longer need to carry the tabernacle and all its vessels for its service.” 
+<sup>27&#160;</sup>For by the last words of David the sons of Levi were counted, from twenty years old and upward. 
+<sup>28&#160;</sup>For their duty was to wait on the sons of Aaron for the service of Yahweh’s house—in the courts, in the rooms, and in the purifying of all set-apart things, even the work of the service of Elohim’s house; 
+<sup>29&#160;</sup>for the show bread also, and for the fine flour for a meal offering, whether of unleavened wafers, or of that which is baked in the pan, or of that which is soaked, and for all measurements of quantity and size; 
+<sup>30&#160;</sup>and to stand every morning to thank and praise Yahweh, and likewise in the evening; 
+<sup>31&#160;</sup>and to offer all burnt offerings to Yahweh on the Sabbaths, on the new moons, and on the set feasts, in number according to the ordinance concerning them, continually before Yahweh; 
+<sup>32&#160;</sup>and that they should keep the duty of the Tent of Meeting, the duty of the set-apart place, and the duty of the sons of Aaron their brothers for the service of Yahweh’s house. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>These were the divisions of the sons of Aaron. The sons of Aaron: Nadab, Abihu, Eleazar, and Ithamar. 
+<sup>2&#160;</sup>But Nadab and Abihu died before their father, and had no children; therefore Eleazar and Ithamar served as priests. 
+<sup>3&#160;</sup>David, with Zadok of the sons of Eleazar and Ahimelech of the sons of Ithamar, divided them according to their ordering in their service. 
+<sup>4&#160;</sup>There were more chief men found of the sons of Eleazar than of the sons of Ithamar; and they were divided like this: of the sons of Eleazar there were sixteen, heads of fathers’ houses; and of the sons of Ithamar, according to their fathers’ houses, eight. 
+<sup>5&#160;</sup>Thus they were divided impartially by drawing lots; for there were princes of the sanctuary and princes of Elohim, both of the sons of Eleazar, and of the sons of Ithamar. 
+<sup>6&#160;</sup>Shemaiah the son of Nethanel the scribe, who was of the Levites, wrote them in the presence of the king, the princes, Zadok the priest, Ahimelech the son of Abiathar, and the heads of the fathers’ households of the priests and of the Levites; one fathers’ house being taken for Eleazar, and one taken for Ithamar. 
+</div><div class="p">
+<sup>7&#160;</sup>Now the first lot came out to Jehoiarib, the second to Jedaiah, 
+<sup>8&#160;</sup>the third to Harim, the fourth to Seorim, 
+<sup>9&#160;</sup>the fifth to Malchijah, the sixth to Mijamin, 
+<sup>10&#160;</sup>the seventh to Hakkoz, the eighth to Abijah, 
+<sup>11&#160;</sup>the ninth to Jeshua, the tenth to Shecaniah, 
+<sup>12&#160;</sup>the eleventh to Eliashib, the twelfth to Jakim, 
+<sup>13&#160;</sup>the thirteenth to Huppah, the fourteenth to Jeshebeab, 
+<sup>14&#160;</sup>the fifteenth to Bilgah, the sixteenth to Immer, 
+<sup>15&#160;</sup>the seventeenth to Hezir, the eighteenth to Happizzez, 
+<sup>16&#160;</sup>the nineteenth to Pethahiah, the twentieth to Jehezkel, 
+<sup>17&#160;</sup>the twenty-first to Jachin, the twenty-second to Gamul, 
+<sup>18&#160;</sup>the twenty-third to Delaiah, and the twenty-fourth to Maaziah. 
+<sup>19&#160;</sup>This was their ordering in their service, to come into Yahweh’s house according to the ordinance given to them by Aaron their father, as Yahweh, the Elohim of Israel, had commanded him. 
+</div><div class="p">
+<sup>20&#160;</sup>Of the rest of the sons of Levi: of the sons of Amram, Shubael; of the sons of Shubael, Jehdeiah. 
+<sup>21&#160;</sup>Of Rehabiah: of the sons of Rehabiah, Isshiah the chief. 
+<sup>22&#160;</sup>Of the Izharites, Shelomoth; of the sons of Shelomoth, Jahath. 
+<sup>23&#160;</sup>The sons of Hebron: Jeriah, Amariah the second, Jahaziel the third, and Jekameam the fourth. 
+<sup>24&#160;</sup>The sons of Uzziel: Micah; of the sons of Micah, Shamir. 
+<sup>25&#160;</sup>The brother of Micah: Isshiah; of the sons of Isshiah, Zechariah. 
+<sup>26&#160;</sup>The sons of Merari: Mahli and Mushi. The son of Jaaziah: Beno. 
+<sup>27&#160;</sup>The sons of Merari by Jaaziah: Beno, Shoham, Zaccur, and Ibri. 
+<sup>28&#160;</sup>Of Mahli: Eleazar, who had no sons. 
+<sup>29&#160;</sup>Of Kish, the son of Kish: Jerahmeel. 
+<sup>30&#160;</sup>The sons of Mushi: Mahli, Eder, and Jerimoth. These were the sons of the Levites after their fathers’ houses. 
+<sup>31&#160;</sup>These likewise cast lots even as their brothers the sons of Aaron in the presence of David the king, Zadok, Ahimelech, and the heads of the fathers’ households of the priests and of the Levites, the fathers’ households of the chief even as those of his younger brother. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Moreover, David and the captains of the army set apart for the service certain of the sons of Asaph, of Heman, and of Jeduthun, who were to prophesy with harps, with stringed instruments, and with cymbals. The number of those who did the work according to their service was: 
+<sup>2&#160;</sup>of the sons of Asaph: Zaccur, Joseph, Nethaniah, and Asharelah. The sons of Asaph were under the hand of Asaph, who prophesied at the order of the king. 
+<sup>3&#160;</sup>Of Jeduthun, the sons of Jeduthun: Gedaliah, Zeri, Jeshaiah, Shimei, Hashabiah, and Mattithiah, six, under the hands of their father Jeduthun, who prophesied in giving thanks and praising Yahweh with the harp. 
+<sup>4&#160;</sup>Of Heman, the sons of Heman: Bukkiah, Mattaniah, Uzziel, Shebuel, Jerimoth, Hananiah, Hanani, Eliathah, Giddalti, Romamti-Ezer, Joshbekashah, Mallothi, Hothir, and Mahazioth. 
+<sup>5&#160;</sup>All these were the sons of Heman the king’s seer in the words of Elohim, to lift up the horn. Elohim gave to Heman fourteen sons and three daughters. 
+<sup>6&#160;</sup>All these were under the hands of their father for song in Yahweh’s house, with cymbals, stringed instruments, and harps, for the service of Elohim’s house: Asaph, Jeduthun, and Heman being under the order of the king. 
+<sup>7&#160;</sup>The number of them, with their brothers who were instructed in singing to Yahweh, even all who were skillful, was two hundred eighty-eight. 
+<sup>8&#160;</sup>They cast lots for their offices, all alike, the small as well as the great, the teacher as well as the student. 
+</div><div class="p">
+<sup>9&#160;</sup>Now the first lot came out for Asaph to Joseph; the second to Gedaliah, he and his brothers and sons were twelve; 
+<sup>10&#160;</sup>the third to Zaccur, his sons and his brothers, twelve; 
+<sup>11&#160;</sup>the fourth to Izri, his sons and his brothers, twelve; 
+<sup>12&#160;</sup>the fifth to Nethaniah, his sons and his brothers, twelve; 
+<sup>13&#160;</sup>the sixth to Bukkiah, his sons and his brothers, twelve; 
+<sup>14&#160;</sup>the seventh to Jesharelah, his sons and his brothers, twelve; 
+<sup>15&#160;</sup>the eighth to Jeshaiah, his sons and his brothers, twelve; 
+<sup>16&#160;</sup>the ninth to Mattaniah, his sons and his brothers, twelve; 
+<sup>17&#160;</sup>the tenth to Shimei, his sons and his brothers, twelve; 
+<sup>18&#160;</sup>the eleventh to Azarel, his sons and his brothers, twelve; 
+<sup>19&#160;</sup>the twelfth to Hashabiah, his sons and his brothers, twelve; 
+<sup>20&#160;</sup>for the thirteenth, Shubael, his sons and his brothers, twelve; 
+<sup>21&#160;</sup>for the fourteenth, Mattithiah, his sons and his brothers, twelve; 
+<sup>22&#160;</sup>for the fifteenth to Jeremoth, his sons and his brothers, twelve; 
+<sup>23&#160;</sup>for the sixteenth to Hananiah, his sons and his brothers, twelve; 
+<sup>24&#160;</sup>for the seventeenth to Joshbekashah, his sons and his brothers, twelve; 
+<sup>25&#160;</sup>for the eighteenth to Hanani, his sons and his brothers, twelve; 
+<sup>26&#160;</sup>for the nineteenth to Mallothi, his sons and his brothers, twelve; 
+<sup>27&#160;</sup>for the twentieth to Eliathah, his sons and his brothers, twelve; 
+<sup>28&#160;</sup>for the twenty-first to Hothir, his sons and his brothers, twelve; 
+<sup>29&#160;</sup>for the twenty-second to Giddalti, his sons and his brothers, twelve; 
+<sup>30&#160;</sup>for the twenty-third to Mahazioth, his sons and his brothers, twelve; 
+<sup>31&#160;</sup>for the twenty-fourth to Romamti-Ezer, his sons and his brothers, twelve. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>For the divisions of the doorkeepers: of the Korahites, Meshelemiah the son of Kore, of the sons of Asaph. 
+<sup>2&#160;</sup>Meshelemiah had sons: Zechariah the firstborn, Jediael the second, Zebadiah the third, Jathniel the fourth, 
+<sup>3&#160;</sup>Elam the fifth, Jehohanan the sixth, and Eliehoenai the seventh. 
+<sup>4&#160;</sup>Obed-Edom had sons: Shemaiah the firstborn, Jehozabad the second, Joah the third, Sacar the fourth, Nethanel the fifth, 
+<sup>5&#160;</sup>Ammiel the sixth, Issachar the seventh, and Peullethai the eighth; for Elohim blessed him. 
+<sup>6&#160;</sup>Sons were also born to Shemaiah his son, who ruled over the house of their father; for they were mighty men of valor. 
+<sup>7&#160;</sup>The sons of Shemaiah: Othni, Rephael, Obed, and Elzabad, whose relatives were valiant men, Elihu, and Semachiah. 
+<sup>8&#160;</sup>All these were of the sons of Obed-Edom with their sons and their brothers, able men in strength for the service: sixty-two of Obed-Edom. 
+<sup>9&#160;</sup>Meshelemiah had sons and brothers, eighteen valiant men. 
+<sup>10&#160;</sup>Also Hosah, of the children of Merari, had sons: Shimri the chief (for though he was not the firstborn, yet his father made him chief), 
+<sup>11&#160;</sup>Hilkiah the second, Tebaliah the third, and Zechariah the fourth. All the sons and brothers of Hosah were thirteen. 
+</div><div class="p">
+<sup>12&#160;</sup>Of these were the divisions of the doorkeepers, even of the chief men, having offices like their brothers, to minister in Yahweh’s house. 
+<sup>13&#160;</sup>They cast lots, the small as well as the great, according to their fathers’ houses, for every gate. 
+<sup>14&#160;</sup>The lot eastward fell to Shelemiah. Then for Zechariah his son, a wise counselor, they cast lots; and his lot came out northward. 
+<sup>15&#160;</sup>To Obed-Edom southward; and to his sons the storehouse. 
+<sup>16&#160;</sup>To Shuppim and Hosah westward, by the gate of Shallecheth, at the causeway that goes up, watchman opposite watchman. 
+<sup>17&#160;</sup>Eastward were six Levites, northward four a day, southward four a day, and for the storehouse two and two. 
+<sup>18&#160;</sup>For Parbar westward, four at the causeway, and two at Parbar. 
+<sup>19&#160;</sup>These were the divisions of the doorkeepers; of the sons of the Korahites, and of the sons of Merari. 
+</div><div class="p">
+<sup>20&#160;</sup>Of the Levites, Ahijah was over the treasures of Elohim’s house and over the treasures of the dedicated things. 
+<sup>21&#160;</sup>The sons of Ladan, the sons of the Gershonites belonging to Ladan, the heads of the fathers’ households belonging to Ladan the Gershonite: Jehieli. 
+<sup>22&#160;</sup>The sons of Jehieli: Zetham, and Joel his brother, over the treasures of Yahweh’s house. 
+<sup>23&#160;</sup>Of the Amramites, of the Izharites, of the Hebronites, of the Uzzielites: 
+<sup>24&#160;</sup>Shebuel the son of Gershom, the son of Moses, was ruler over the treasuries. 
+<sup>25&#160;</sup>His brothers: of Eliezer, Rehabiah his son, and Jeshaiah his son, and Joram his son, and Zichri his son, and Shelomoth his son. 
+<sup>26&#160;</sup>This Shelomoth and his brothers were over all the treasuries of the dedicated things, which David the king, and the heads of the fathers’ households, the captains over thousands and hundreds, and the captains of the army, had dedicated. 
+<sup>27&#160;</sup>They dedicated some of the plunder won in battles to repair Yahweh’s house. 
+<sup>28&#160;</sup>All that Samuel the seer, Saul the son of Kish, Abner the son of Ner, and Joab the son of Zeruiah had dedicated, whoever had dedicated anything, it was under the hand of Shelomoth and of his brothers. 
+</div><div class="p">
+<sup>29&#160;</sup>Of the Izharites, Chenaniah and his sons were appointed to the outward business over Israel, for officers and judges. 
+<sup>30&#160;</sup>Of the Hebronites, Hashabiah and his brothers, one thousand seven hundred men of valor, had the oversight of Israel beyond the Jordan westward, for all the business of Yahweh and for the service of the king. 
+<sup>31&#160;</sup>Of the Hebronites, Jerijah was the chief of the Hebronites, according to their generations by fathers’ households. They were sought for in the fortieth year of the reign of David, and mighty men of valor were found among them at Jazer of Gilead. 
+<sup>32&#160;</sup>His relatives, men of valor, were two thousand seven hundred, heads of fathers’ households, whom King David made overseers over the Reubenites, the Gadites, and the half-tribe of the Manassites, for every matter pertaining to Elohim and for the affairs of the king. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the children of Israel after their number, the heads of fathers’ households and the captains of thousands and of hundreds, and their officers who served the king in any matter of the divisions which came in and went out month by month throughout all the months of the year—of every division were twenty-four thousand. 
+</div><div class="p">
+<sup>2&#160;</sup>Over the first division for the first month was Jashobeam the son of Zabdiel. In his division were twenty-four thousand. 
+<sup>3&#160;</sup>He was of the children of Perez, the chief of all the captains of the army for the first month. 
+<sup>4&#160;</sup>Over the division of the second month was Dodai the Ahohite and his division, and Mikloth the ruler; and in his division were twenty-four thousand. 
+<sup>5&#160;</sup>The third captain of the army for the third month was Benaiah, the son of Jehoiada the chief priest. In his division were twenty-four thousand. 
+<sup>6&#160;</sup>This is that Benaiah who was the mighty man of the thirty and over the thirty. Of his division was Ammizabad his son. 
+<sup>7&#160;</sup>The fourth captain for the fourth month was Asahel the brother of Joab, and Zebadiah his son after him. In his division were twenty-four thousand. 
+<sup>8&#160;</sup>The fifth captain for the fifth month was Shamhuth the Izrahite. In his division were twenty-four thousand. 
+<sup>9&#160;</sup>The sixth captain for the sixth month was Ira the son of Ikkesh the Tekoite. In his division were twenty-four thousand. 
+<sup>10&#160;</sup>The seventh captain for the seventh month was Helez the Pelonite, of the children of Ephraim. In his division were twenty-four thousand. 
+<sup>11&#160;</sup>The eighth captain for the eighth month was Sibbecai the Hushathite, of the Zerahites. In his division were twenty-four thousand. 
+<sup>12&#160;</sup>The ninth captain for the ninth month was Abiezer the Anathothite, of the Benjamites. In his division were twenty-four thousand. 
+<sup>13&#160;</sup>The tenth captain for the tenth month was Maharai the Netophathite, of the Zerahites. In his division were twenty-four thousand. 
+<sup>14&#160;</sup>The eleventh captain for the eleventh month was Benaiah the Pirathonite, of the children of Ephraim. In his division were twenty-four thousand. 
+<sup>15&#160;</sup>The twelfth captain for the twelfth month was Heldai the Netophathite, of Othniel. In his division were twenty-four thousand. 
+</div><div class="p">
+<sup>16&#160;</sup>Furthermore over the tribes of Israel: of the Reubenites, Eliezer the son of Zichri was the ruler; of the Simeonites, Shephatiah the son of Maacah; 
+<sup>17&#160;</sup>of Levi, Hashabiah the son of Kemuel; of Aaron, Zadok; 
+<sup>18&#160;</sup>of Judah, Elihu, one of the brothers of David; of Issachar, Omri the son of Michael; 
+<sup>19&#160;</sup>of Zebulun, Ishmaiah the son of Obadiah; of Naphtali, Jeremoth the son of Azriel; 
+<sup>20&#160;</sup>of the children of Ephraim, Hoshea the son of Azaziah; of the half-tribe of Manasseh, Joel the son of Pedaiah; 
+<sup>21&#160;</sup>of the half-tribe of Manasseh in Gilead, Iddo the son of Zechariah; of Benjamin, Jaasiel the son of Abner; 
+<sup>22&#160;</sup>of Dan, Azarel the son of Jeroham. These were the captains of the tribes of Israel. 
+<sup>23&#160;</sup>But David didn’t take the number of them from twenty years old and under, because Yahweh had said he would increase Israel like the stars of the sky. 
+<sup>24&#160;</sup>Joab the son of Zeruiah began to take a census, but didn’t finish; and wrath came on Israel for this. The number wasn’t put into the account in the chronicles of King David. 
+</div><div class="p">
+<sup>25&#160;</sup>Over the king’s treasures was Azmaveth the son of Adiel. Over the treasures in the fields, in the cities, in the villages, and in the towers was Jonathan the son of Uzziah; 
+<sup>26&#160;</sup>Over those who did the work of the field for tillage of the ground was Ezri the son of Chelub. 
+<sup>27&#160;</sup>Over the vineyards was Shimei the Ramathite. Over the increase of the vineyards for the wine cellars was Zabdi the Shiphmite. 
+<sup>28&#160;</sup>Over the olive trees and the sycamore trees that were in the lowland was Baal Hanan the Gederite. Over the cellars of oil was Joash. 
+<sup>29&#160;</sup>Over the herds that fed in Sharon was Shitrai the Sharonite. Over the herds that were in the valleys was Shaphat the son of Adlai. 
+<sup>30&#160;</sup>Over the camels was Obil the Ishmaelite. Over the donkeys was Jehdeiah the Meronothite. Over the flocks was Jaziz the Hagrite. 
+<sup>31&#160;</sup>All these were the rulers of the property which was King David’s. 
+</div><div class="p">
+<sup>32&#160;</sup>Also Jonathan, David’s uncle, was a counselor, a man of understanding, and a scribe. Jehiel the son of Hachmoni was with the king’s sons. 
+<sup>33&#160;</sup>Ahithophel was the king’s counselor. Hushai the Archite was the king’s friend. 
+<sup>34&#160;</sup>After Ahithophel was Jehoiada the son of Benaiah, and Abiathar. Joab was the captain of the king’s army. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>David assembled all the princes of Israel, the princes of the tribes, the captains of the companies who served the king by division, the captains of thousands, the captains of hundreds, and the rulers over all the substance and possessions of the king and of his sons, with the officers and the mighty men, even all the mighty men of valor, to Jerusalem. 
+<sup>2&#160;</sup>Then David the king stood up on his feet and said, “Hear me, my brothers and my people! As for me, it was in my heart to build a house of rest for the ark of Yahweh’s covenant, and for the footstool of our Elohim; and I had prepared for the building. 
+<sup>3&#160;</sup>But Elohim said to me, ‘You shall not build a house for my name, because you are a man of war and have shed blood.’ 
+<sup>4&#160;</sup>However Yahweh, the Elohim of Israel, chose me out of all the house of my father to be king over Israel forever. For he has chosen Judah to be prince; and in the house of Judah, the house of my father; and among the sons of my father he took pleasure in me to make me king over all Israel. 
+<sup>5&#160;</sup>Of all my sons (for Yahweh has given me many sons), he has chosen Solomon my son to sit on the throne of Yahweh’s kingdom over Israel. 
+<sup>6&#160;</sup>He said to me, ‘Solomon, your son, shall build my house and my courts; for I have chosen him to be my son, and I will be his father. 
+<sup>7&#160;</sup>I will establish his kingdom forever if he continues to do my commandments and my ordinances, as it is today.’ 
+</div><div class="p">
+<sup>8&#160;</sup>Now therefore, in the sight of all Israel, Yahweh’s assembly, and in the audience of our Elohim, observe and seek out all the commandments of Yahweh your Elohim, that you may possess this good land, and leave it for an inheritance to your children after you forever. 
+</div><div class="p">
+<sup>9&#160;</sup>You, Solomon my son, know the Elohim of your father, and serve him with a perfect heart and with a willing mind; for Yahweh searches all hearts, and understands all the imaginations of the thoughts. If you seek him, he will be found by you; but if you forsake him, he will cast you off forever. 
+<sup>10&#160;</sup>Take heed now, for Yahweh has chosen you to build a house for the sanctuary. Be strong, and do it.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then David gave to Solomon his son the plans for the porch of the temple, for its houses, for its treasuries, for its upper rooms, for its inner rooms, for the place of the mercy seat; 
+<sup>12&#160;</sup>and the plans of all that he had by the Spirit, for the courts of Yahweh’s house, for all the surrounding rooms, for the treasuries of Elohim’s house, and for the treasuries of the dedicated things; 
+<sup>13&#160;</sup>also for the divisions of the priests and the Levites, for all the work of the service of Yahweh’s house, and for all the vessels of service in Yahweh’s house—<sup>14&#160;</sup>of gold by weight for the gold for all vessels of every kind of service, for all the vessels of silver by weight, for all vessels of every kind of service; 
+<sup>15&#160;</sup>by weight also for the lamp stands of gold, and for its lamps, of gold, by weight for every lamp stand and for its lamps; and for the lamp stands of silver, by weight for every lamp stand and for its lamps, according to the use of every lamp stand; 
+<sup>16&#160;</sup>and the gold by weight for the tables of show bread, for every table; and silver for the tables of silver; 
+<sup>17&#160;</sup>and the forks, the basins, and the cups, of pure gold; and for the golden bowls by weight for every bowl; and for the silver bowls by weight for every bowl; 
+<sup>18&#160;</sup>and for the altar of incense, refined gold by weight; and gold for the plans for the chariot, and the cherubim that spread out and cover the ark of Yahweh’s covenant. 
+<sup>19&#160;</sup>“All this”, David said, “I have been made to understand in writing from Yahweh’s hand, even all the works of this pattern.” 
+</div><div class="p">
+<sup>20&#160;</sup>David said to Solomon his son, “Be strong and courageous, and do it. Don’t be afraid, nor be dismayed, for Yahweh Elohim, even my Elohim, is with you. He will not fail you nor forsake you, until all the work for the service of Yahweh’s house is finished. 
+<sup>21&#160;</sup>Behold, there are the divisions of the priests and the Levites for all the service of Elohim’s house. Every willing man who has skill for any kind of service shall be with you in all kinds of work. Also the captains and all the people will be entirely at your command.” 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>David the king said to all the assembly, “Solomon my son, whom alone Elohim has chosen, is yet young and tender, and the work is great; for the palace is not for man, but for Yahweh Elohim. 
+<sup>2&#160;</sup>Now I have prepared with all my might for the house of my Elohim the gold for the things of gold, the silver for the things of silver, the bronze for the things of bronze, iron for the things of iron, and wood for the things of wood, also onyx stones, stones to be set, stones for inlaid work of various colors, all kinds of precious stones, and marble stones in abundance. 
+<sup>3&#160;</sup>In addition, because I have set my affection on the house of my Elohim, since I have a treasure of my own of gold and silver, I give it to the house of my Elohim, over and above all that I have prepared for the set-apart house: 
+<sup>4&#160;</sup>even three thousand talents of gold, of refined silver, with which to overlay the walls of the houses; 
+<sup>5&#160;</sup>of gold for the things of gold, and of silver for the things of silver, and for all kinds of work to be made by the hands of artisans. Who then offers willingly to consecrate himself today to Yahweh?” 
+</div><div class="p">
+<sup>6&#160;</sup>Then the princes of the fathers’ households, and the princes of the tribes of Israel, and the captains of thousands and of hundreds, with the rulers over the king’s work, offered willingly; 
+<sup>7&#160;</sup>and they gave for the service of Elohim’s house of gold five thousand talents of silver ten thousand talents, of bronze eighteen thousand talents, and of iron one hundred thousand talents. 
+<sup>8&#160;</sup>People with whom precious stones were found gave them to the treasure of Yahweh’s house, under the hand of Jehiel the Gershonite. 
+<sup>9&#160;</sup>Then the people rejoiced, because they offered willingly, because with a perfect heart they offered willingly to Yahweh; and David the king also rejoiced with great joy. 
+</div><div class="p">
+<sup>10&#160;</sup>Therefore David blessed Yahweh before all the assembly; and David said, “You are blessed, Yahweh, the Elohim of Israel our father, forever and ever. 
+<sup>11&#160;</sup>Yours, Yahweh, is the greatness, the power, the glory, the victory, and the majesty! For all that is in the heavens and in the earth is yours. Yours is the kingdom, Yahweh, and you are exalted as head above all. 
+<sup>12&#160;</sup>Both riches and honor come from you, and you rule over all! In your hand is power and might! It is in your hand to make great, and to give strength to all! 
+<sup>13&#160;</sup>Now therefore, our Elohim, we thank you and praise your glorious name. 
+<sup>14&#160;</sup>But who am I, and what is my people, that we should be able to offer so willingly as this? For all things come from you, and we have given you of your own. 
+<sup>15&#160;</sup>For we are strangers before you and foreigners, as all our fathers were. Our days on the earth are as a shadow, and there is no remaining. 
+<sup>16&#160;</sup>Yahweh our Elohim, all this store that we have prepared to build you a house for your set-apart name comes from your hand, and is all your own. 
+<sup>17&#160;</sup>I know also, my Elohim, that you try the heart and have pleasure in uprightness. As for me, in the uprightness of my heart I have willingly offered all these things. Now I have seen with joy your people, who are present here, offer willingly to you. 
+<sup>18&#160;</sup>Yahweh, the Elohim of Abraham, of Isaac, and of Israel, our fathers, keep this desire forever in the thoughts of the heart of your people, and prepare their heart for you; 
+<sup>19&#160;</sup>and give to Solomon my son a perfect heart, to keep your commandments, your testimonies, and your statutes, and to do all these things, and to build the palace, for which I have made provision.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then David said to all the assembly, “Now bless Yahweh your Elohim!” 
+</div><div class="p">All the assembly blessed Yahweh, the Elohim of their fathers, and bowed down their heads and prostrated themselves before Yahweh and the king. 
+<sup>21&#160;</sup>They sacrificed sacrifices to Yahweh and offered burnt offerings to Yahweh on the next day after that day, even one thousand bulls, one thousand rams, and one thousand lambs, with their drink offerings and sacrifices in abundance for all Israel, 
+<sup>22&#160;</sup>and ate and drank before Yahweh on that day with great gladness. They made Solomon the son of David king the second time, and anointed him before Yahweh to be prince, and Zadok to be priest. 
+</div><div class="p">
+<sup>23&#160;</sup>Then Solomon sat on the throne of Yahweh as king instead of David his father, and prospered; and all Israel obeyed him. 
+<sup>24&#160;</sup>All the princes, the mighty men, and also all of the sons of King David submitted themselves to Solomon the king. 
+<sup>25&#160;</sup>Yahweh magnified Solomon exceedingly in the sight of all Israel, and gave to him such royal majesty as had not been on any king before him in Israel. 
+</div><div class="p">
+<sup>26&#160;</sup>Now David the son of Jesse reigned over all Israel. 
+<sup>27&#160;</sup>The time that he reigned over Israel was forty years; he reigned seven years in Hebron, and he reigned thirty-three years in Jerusalem. 
+<sup>28&#160;</sup>He died at a good old age, full of days, riches, and honor; and Solomon his son reigned in his place. 
+<sup>29&#160;</sup>Now the acts of David the king, first and last, behold, they are written in the history of Samuel the seer, and in the history of Nathan the prophet, and in the history of Gad the seer, 
+<sup>30&#160;</sup>with all his reign and his might, and the events that involved him, Israel, and all the kingdoms of the lands. </div></div><script src="../main.js"></script></body></html>

--- a/book/1john.html
+++ b/book/1john.html
@@ -3,6 +3,47 @@
 <head>
 <title>1 John</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,143 +53,149 @@
 <div class="main">
 <!-- 1JN World English Scripture (WES) -->
 <h1 class="booklabel">1 John</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>That which was from the beginning, that which we have heard, that which we have seen with our eyes, that which we saw, and our hands touched, concerning the Word of life 
-<span class="v">2&#160;</span>(and the life was revealed, and we have seen, and testify, and declare to you the life, the eternal life, which was with the Father, and was revealed to us); 
-<span class="v">3&#160;</span>that which we have seen and heard we declare to you, that you also may have fellowship with us. Yes, and our fellowship is with the Father and with his Son, Yahushua Christ.<span class="f">+ \fr 1:3 \ft “Christ” means “Anointed One”.</span> 
-<span class="v">4&#160;</span>And we write these things to you, that our joy may be fulfilled. 
-</p><p>
-<span class="v">5&#160;</span>This is the message which we have heard from him and announce to you, that Elohim is light, and in him is no darkness at all. 
-<span class="v">6&#160;</span>If we say that we have fellowship with him and walk in the darkness, we lie and don’t tell the truth. 
-<span class="v">7&#160;</span>But if we walk in the light as he is in the light, we have fellowship with one another, and the blood of Yahushua Christ his Son, cleanses us from all sin. 
-<span class="v">8&#160;</span>If we say that we have no sin, we deceive ourselves, and the truth is not in us. 
-<span class="v">9&#160;</span>If we confess our sins, he is faithful and righteous to forgive us the sins and to cleanse us from all unrighteousness. 
-<span class="v">10&#160;</span>If we say that we haven’t sinned, we make him a liar, and his word is not in us. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>My little children, I write these things to you so that you may not sin. If anyone sins, we have a Counselor<span class="f">+ \fr 2:1 \ft Greek παρακλητον: Counselor, Helper, Intercessor, Advocate, and Comforter.</span> with the Father, Yahushua Christ, the righteous. 
-<span class="v">2&#160;</span>And he is the atoning sacrifice<span class="f">+ \fr 2:2 \ft “atoning sacrifice” is from the Greek “ιλασμος”, an appeasing, propitiating, or the means of appeasement or propitiation—the sacrifice that turns away Elohim’s wrath because of our sin. </span> for our sins, and not for ours only, but also for the whole world. 
-<span class="v">3&#160;</span>This is how we know that we know him: if we keep his commandments. 
-<span class="v">4&#160;</span>One who says, “I know him,” and doesn’t keep his commandments, is a liar, and the truth isn’t in him. 
-<span class="v">5&#160;</span>But Elohim’s love has most certainly been perfected in whoever keeps his word. This is how we know that we are in him: 
-<span class="v">6&#160;</span>he who says he remains in him ought himself also to walk just like he walked. 
-</p><p>
-<span class="v">7&#160;</span>Brothers, I write no new commandment to you, but an old commandment which you had from the beginning. The old commandment is the word which you heard from the beginning. 
-<span class="v">8&#160;</span>Again, I write a new commandment to you, which is true in him and in you, because the darkness is passing away and the true light already shines. 
-<span class="v">9&#160;</span>He who says he is in the light and hates his brother is in the darkness even until now. 
-<span class="v">10&#160;</span>He who loves his brother remains in the light, and there is no occasion for stumbling in him. 
-<span class="v">11&#160;</span>But he who hates his brother is in the darkness, and walks in the darkness, and doesn’t know where he is going, because the darkness has blinded his eyes. 
-</p><p>
-<span class="v">12&#160;</span>I write to you, little children, because your sins are forgiven you for his name’s sake. 
-</p><p>
-<span class="v">13&#160;</span>I write to you, fathers, because you know him who is from the beginning. 
-</p><p>I write to you, young men, because you have overcome the evil one. 
-</p><p>I write to you, little children, because you know the Father. 
-</p><p>
-<span class="v">14&#160;</span>I have written to you, fathers, because you know him who is from the beginning. 
-</p><p>I have written to you, young men, because you are strong, and the word of Elohim remains in you, and you have overcome the evil one. 
-</p><p>
-<span class="v">15&#160;</span>Don’t love the world or the things that are in the world. If anyone loves the world, the Father’s love isn’t in him. 
-<span class="v">16&#160;</span>For all that is in the world—the lust of the flesh, the lust of the eyes, and the pride of life—isn’t the Father’s, but is the world’s. 
-<span class="v">17&#160;</span>The world is passing away with its lusts, but he who does Elohim’s will remains forever. 
-</p><p>
-<span class="v">18&#160;</span>Little children, these are the end times, and as you heard that the Antichrist is coming, even now many antichrists have arisen. By this we know that it is the final hour. 
-<span class="v">19&#160;</span>They went out from us, but they didn’t belong to us; for if they had belonged to us, they would have continued with us. But they left, that they might be revealed that none of them belong to us. 
-<span class="v">20&#160;</span>You have an anointing from the Set-Apart One, and you all have knowledge.<span class="f">+ \fr 2:20 \ft Or, “know what is true”, or, “know all things”</span> 
-<span class="v">21&#160;</span>I have not written to you because you don’t know the truth, but because you know it, and because no lie is of the truth. 
-<span class="v">22&#160;</span>Who is the liar but he who denies that Yahushua is the Christ? This is the Antichrist, he who denies the Father and the Son. 
-<span class="v">23&#160;</span>Whoever denies the Son doesn’t have the Father. He who confesses the Son has the Father also. 
-</p><p>
-<span class="v">24&#160;</span>Therefore, as for you, let that remain in you which you heard from the beginning. If that which you heard from the beginning remains in you, you also will remain in the Son, and in the Father. 
-<span class="v">25&#160;</span>This is the promise which he promised us, the eternal life. 
-</p><p>
-<span class="v">26&#160;</span>These things I have written to you concerning those who would lead you astray. 
-<span class="v">27&#160;</span>As for you, the anointing which you received from him remains in you, and you don’t need for anyone to teach you. But as his anointing teaches you concerning all things, and is true, and is no lie, and even as it taught you, you will remain in him. 
-</p><p>
-<span class="v">28&#160;</span>Now, little children, remain in him, that when he appears, we may have boldness and not be ashamed before him at his coming. 
-<span class="v">29&#160;</span>If you know that he is righteous, you know that everyone who practices righteousness has been born of him. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>See how great a love the Father has given to us, that we should be called children of Elohim! For this cause the world doesn’t know us, because it didn’t know him. 
-<span class="v">2&#160;</span>Beloved, now we are children of Elohim. It is not yet revealed what we will be; but we know that when he is revealed, we will be like him, for we will see him just as he is. 
-<span class="v">3&#160;</span>Everyone who has this hope set on him purifies himself, even as he is pure. 
-</p><p>
-<span class="v">4&#160;</span>Everyone who sins also commits lawlessness. Sin is lawlessness. 
-<span class="v">5&#160;</span>You know that he was revealed to take away our sins, and no sin is in him. 
-<span class="v">6&#160;</span>Whoever remains in him doesn’t sin. Whoever sins hasn’t seen him and doesn’t know him. 
-</p><p>
-<span class="v">7&#160;</span>Little children, let no one lead you astray. He who does righteousness is righteous, even as he is righteous. 
-<span class="v">8&#160;</span>He who sins is of the devil, for the devil has been sinning from the beginning. To this end the Son of Elohim was revealed: that he might destroy the works of the devil. 
-<span class="v">9&#160;</span>Whoever is born of Elohim doesn’t commit sin, because his seed remains in him, and he can’t sin, because he is born of Elohim. 
-<span class="v">10&#160;</span>In this the children of Elohim are revealed, and the children of the devil. Whoever doesn’t do righteousness is not of Elohim, neither is he who doesn’t love his brother. 
-<span class="v">11&#160;</span>For this is the message which you heard from the beginning, that we should love one another—<span class="v">12&#160;</span>unlike Cain, who was of the evil one and killed his brother. Why did he kill him? Because his deeds were evil, and his brother’s righteous. 
-</p><p>
-<span class="v">13&#160;</span>Don’t be surprised, my brothers, if the world hates you. 
-<span class="v">14&#160;</span>We know that we have passed out of death into life, because we love the brothers. He who doesn’t love his brother remains in death. 
-<span class="v">15&#160;</span>Whoever hates his brother is a murderer, and you know that no murderer has eternal life remaining in him. 
-</p><p>
-<span class="v">16&#160;</span>By this we know love, because he laid down his life for us. And we ought to lay down our lives for the brothers. 
-<span class="v">17&#160;</span>But whoever has the world’s goods and sees his brother in need, then closes his heart of compassion against him, how does Elohim’s love remain in him? 
-</p><p>
-<span class="v">18&#160;</span>My little children, let’s not love in word only, or with the tongue only, but in deed and truth. 
-<span class="v">19&#160;</span>And by this we know that we are of the truth and persuade our hearts before him, 
-<span class="v">20&#160;</span>because if our heart condemns us, Elohim is greater than our heart, and knows all things. 
-<span class="v">21&#160;</span>Beloved, if our hearts don’t condemn us, we have boldness toward Elohim; 
-<span class="v">22&#160;</span>so whatever we ask, we receive from him, because we keep his commandments and do the things that are pleasing in his sight. 
-<span class="v">23&#160;</span>This is his commandment, that we should believe in the name of his Son, Yahushua Christ, and love one another, even as he commanded. 
-<span class="v">24&#160;</span>He who keeps his commandments remains in him, and he in him. By this we know that he remains in us, by the Spirit which he gave us. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Beloved, don’t believe every spirit, but test the spirits, whether they are of Elohim, because many false prophets have gone out into the world. 
-<span class="v">2&#160;</span>By this you know the Spirit of Elohim: every spirit who confesses that Yahushua Christ has come in the flesh is of Elohim, 
-<span class="v">3&#160;</span>and every spirit who doesn’t confess that Yahushua Christ has come in the flesh is not of Elohim; and this is the spirit of the Antichrist, of whom you have heard that it comes. Now it is in the world already. 
-<span class="v">4&#160;</span>You are of Elohim, little children, and have overcome them, because greater is he who is in you than he who is in the world. 
-<span class="v">5&#160;</span>They are of the world. Therefore they speak of the world, and the world hears them. 
-<span class="v">6&#160;</span>We are of Elohim. He who knows Elohim listens to us. He who is not of Elohim doesn’t listen to us. By this we know the spirit of truth, and the spirit of error. 
-</p><p>
-<span class="v">7&#160;</span>Beloved, let’s love one another, for love is of Elohim; and everyone who loves has been born of Elohim and knows Elohim. 
-<span class="v">8&#160;</span>He who doesn’t love doesn’t know Elohim, for Elohim is love. 
-<span class="v">9&#160;</span>By this Elohim’s love was revealed in us, that Elohim has sent his only born<span class="f">+ \fr 4:9 \ft The phrase “only born” is from the Greek word “μονογενη”, which is sometimes translated “only begotten” or “one and only”.</span> Son into the world that we might live through him. 
-<span class="v">10&#160;</span>In this is love, not that we loved Elohim, but that he loved us, and sent his Son as the atoning sacrifice<span class="f">+ \fr 4:10 \ft “atoning sacrifice” is from the Greek “ιλασμος”, an appeasing, propitiating, or the means of appeasement or propitiation—the sacrifice that turns away Elohim’s wrath because of our sin. </span> for our sins. 
-<span class="v">11&#160;</span>Beloved, if Elohim loved us in this way, we also ought to love one another. 
-<span class="v">12&#160;</span>No one has seen Elohim at any time. If we love one another, Elohim remains in us, and his love has been perfected in us. 
-</p><p>
-<span class="v">13&#160;</span>By this we know that we remain in him and he in us, because he has given us of his Spirit. 
-<span class="v">14&#160;</span>We have seen and testify that the Father has sent the Son as the Savior of the world. 
-<span class="v">15&#160;</span>Whoever confesses that Yahushua is the Son of Elohim, Elohim remains in him, and he in Elohim. 
-<span class="v">16&#160;</span>We know and have believed the love which Elohim has for us. Elohim is love, and he who remains in love remains in Elohim, and Elohim remains in him. 
-<span class="v">17&#160;</span>In this, love has been made perfect among us, that we may have boldness in the day of judgment, because as he is, even so we are in this world. 
-<span class="v">18&#160;</span>There is no fear in love; but perfect love casts out fear, because fear has punishment. He who fears is not made perfect in love. 
-<span class="v">19&#160;</span>We love him,<span class="f">+ \fr 4:19 \ft NU omits “him”.</span> because he first loved us. 
-<span class="v">20&#160;</span>If a man says, “I love Elohim,” and hates his brother, he is a liar; for he who doesn’t love his brother whom he has seen, how can he love Elohim whom he has not seen? 
-<span class="v">21&#160;</span>This commandment we have from him, that he who loves Elohim should also love his brother. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Whoever believes that Yahushua is the Christ has been born of Elohim. Whoever loves the Father also loves the child who is born of him. 
-<span class="v">2&#160;</span>By this we know that we love the children of Elohim, when we love Elohim and keep his commandments. 
-<span class="v">3&#160;</span>For this is loving Elohim, that we keep his commandments. His commandments are not grievous. 
-<span class="v">4&#160;</span>For whatever is born of Elohim overcomes the world. This is the victory that has overcome the world: your faith. 
-<span class="v">5&#160;</span>Who is he who overcomes the world, but he who believes that Yahushua is the Son of Elohim? 
-</p><p>
-<span class="v">6&#160;</span>This is he who came by water and blood, Yahushua Christ; not with the water only, but with the water and the blood. It is the Spirit who testifies, because the Spirit is the truth. 
-<span class="v">7&#160;</span>For there are three who testify:<span class="f">+ \fr 5:7 \ft Only a few recent manuscripts add “in heaven: the Father, the Word, and the Set-Apart Spirit; and these three are one. And there are three that testify on earth:”</span> 
-<span class="v">8&#160;</span>the Spirit, the water, and the blood; and the three agree as one. 
-<span class="v">9&#160;</span>If we receive the witness of men, the witness of Elohim is greater; for this is Elohim’s testimony which he has testified concerning his Son. 
-<span class="v">10&#160;</span>He who believes in the Son of Elohim has the testimony in himself. He who doesn’t believe Elohim has made him a liar, because he has not believed in the testimony that Elohim has given concerning his Son. 
-<span class="v">11&#160;</span>The testimony is this: that Elohim gave to us eternal life, and this life is in his Son. 
-<span class="v">12&#160;</span>He who has the Son has the life. He who doesn’t have Elohim’s Son doesn’t have the life. 
-</p><p>
-<span class="v">13&#160;</span>These things I have written to you who believe in the name of the Son of Elohim, that you may know that you have eternal life, and that you may continue to believe in the name of the Son of Elohim. 
-</p><p>
-<span class="v">14&#160;</span>This is the boldness which we have toward him, that if we ask anything according to his will, he listens to us. 
-<span class="v">15&#160;</span>And if we know that he listens to us, whatever we ask, we know that we have the petitions which we have asked of him. 
-</p><p>
-<span class="v">16&#160;</span>If anyone sees his brother sinning a sin not leading to death, he shall ask, and Elohim will give him life for those who sin not leading to death. There is sin leading to death. I don’t say that he should make a request concerning this. 
-<span class="v">17&#160;</span>All unrighteousness is sin, and there is sin not leading to death. 
-</p><p>
-<span class="v">18&#160;</span>We know that whoever is born of Elohim doesn’t sin, but he who was born of Elohim keeps himself, and the evil one doesn’t touch him. 
-<span class="v">19&#160;</span>We know that we are of Elohim, and the whole world lies in the power of the evil one. 
-<span class="v">20&#160;</span>We know that the Son of Elohim has come and has given us an understanding, that we know him who is true; and we are in him who is true, in his Son Yahushua Christ. This is the true Elohim and eternal life. 
-</p><p>
-<span class="v">21&#160;</span>Little children, keep yourselves from idols. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>That which was from the beginning, that which we have heard, that which we have seen with our eyes, that which we saw, and our hands touched, concerning the Word of life 
+<sup>2&#160;</sup>(and the life was revealed, and we have seen, and testify, and declare to you the life, the eternal life, which was with the Father, and was revealed to us); 
+<sup>3&#160;</sup>that which we have seen and heard we declare to you, that you also may have fellowship with us. Yes, and our fellowship is with the Father and with his Son, Yahushua Christ. 
+<sup>4&#160;</sup>And we write these things to you, that our joy may be fulfilled. 
+</div><div class="p">
+<sup>5&#160;</sup>This is the message which we have heard from him and announce to you, that Elohim is light, and in him is no darkness at all. 
+<sup>6&#160;</sup>If we say that we have fellowship with him and walk in the darkness, we lie and don’t tell the truth. 
+<sup>7&#160;</sup>But if we walk in the light as he is in the light, we have fellowship with one another, and the blood of Yahushua Christ his Son, cleanses us from all sin. 
+<sup>8&#160;</sup>If we say that we have no sin, we deceive ourselves, and the truth is not in us. 
+<sup>9&#160;</sup>If we confess our sins, he is faithful and righteous to forgive us the sins and to cleanse us from all unrighteousness. 
+<sup>10&#160;</sup>If we say that we haven’t sinned, we make him a liar, and his word is not in us. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>My little children, I write these things to you so that you may not sin. If anyone sins, we have a Counselor with the Father, Yahushua Christ, the righteous. 
+<sup>2&#160;</sup>And he is the atoning sacrifice for our sins, and not for ours only, but also for the whole world. 
+<sup>3&#160;</sup>This is how we know that we know him: if we keep his commandments. 
+<sup>4&#160;</sup>One who says, “I know him,” and doesn’t keep his commandments, is a liar, and the truth isn’t in him. 
+<sup>5&#160;</sup>But Elohim’s love has most certainly been perfected in whoever keeps his word. This is how we know that we are in him: 
+<sup>6&#160;</sup>he who says he remains in him ought himself also to walk just like he walked. 
+</div><div class="p">
+<sup>7&#160;</sup>Brothers, I write no new commandment to you, but an old commandment which you had from the beginning. The old commandment is the word which you heard from the beginning. 
+<sup>8&#160;</sup>Again, I write a new commandment to you, which is true in him and in you, because the darkness is passing away and the true light already shines. 
+<sup>9&#160;</sup>He who says he is in the light and hates his brother is in the darkness even until now. 
+<sup>10&#160;</sup>He who loves his brother remains in the light, and there is no occasion for stumbling in him. 
+<sup>11&#160;</sup>But he who hates his brother is in the darkness, and walks in the darkness, and doesn’t know where he is going, because the darkness has blinded his eyes. 
+</div><div class="p">
+<sup>12&#160;</sup>I write to you, little children, because your sins are forgiven you for his name’s sake. 
+</div><div class="p">
+<sup>13&#160;</sup>I write to you, fathers, because you know him who is from the beginning. 
+</div><div class="p">I write to you, young men, because you have overcome the evil one. 
+</div><div class="p">I write to you, little children, because you know the Father. 
+</div><div class="p">
+<sup>14&#160;</sup>I have written to you, fathers, because you know him who is from the beginning. 
+</div><div class="p">I have written to you, young men, because you are strong, and the word of Elohim remains in you, and you have overcome the evil one. 
+</div><div class="p">
+<sup>15&#160;</sup>Don’t love the world or the things that are in the world. If anyone loves the world, the Father’s love isn’t in him. 
+<sup>16&#160;</sup>For all that is in the world—the lust of the flesh, the lust of the eyes, and the pride of life—isn’t the Father’s, but is the world’s. 
+<sup>17&#160;</sup>The world is passing away with its lusts, but he who does Elohim’s will remains forever. 
+</div><div class="p">
+<sup>18&#160;</sup>Little children, these are the end times, and as you heard that the Antichrist is coming, even now many antichrists have arisen. By this we know that it is the final hour. 
+<sup>19&#160;</sup>They went out from us, but they didn’t belong to us; for if they had belonged to us, they would have continued with us. But they left, that they might be revealed that none of them belong to us. 
+<sup>20&#160;</sup>You have an anointing from the Set-Apart One, and you all have knowledge. 
+<sup>21&#160;</sup>I have not written to you because you don’t know the truth, but because you know it, and because no lie is of the truth. 
+<sup>22&#160;</sup>Who is the liar but he who denies that Yahushua is the Christ? This is the Antichrist, he who denies the Father and the Son. 
+<sup>23&#160;</sup>Whoever denies the Son doesn’t have the Father. He who confesses the Son has the Father also. 
+</div><div class="p">
+<sup>24&#160;</sup>Therefore, as for you, let that remain in you which you heard from the beginning. If that which you heard from the beginning remains in you, you also will remain in the Son, and in the Father. 
+<sup>25&#160;</sup>This is the promise which he promised us, the eternal life. 
+</div><div class="p">
+<sup>26&#160;</sup>These things I have written to you concerning those who would lead you astray. 
+<sup>27&#160;</sup>As for you, the anointing which you received from him remains in you, and you don’t need for anyone to teach you. But as his anointing teaches you concerning all things, and is true, and is no lie, and even as it taught you, you will remain in him. 
+</div><div class="p">
+<sup>28&#160;</sup>Now, little children, remain in him, that when he appears, we may have boldness and not be ashamed before him at his coming. 
+<sup>29&#160;</sup>If you know that he is righteous, you know that everyone who practices righteousness has been born of him. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>See how great a love the Father has given to us, that we should be called children of Elohim! For this cause the world doesn’t know us, because it didn’t know him. 
+<sup>2&#160;</sup>Beloved, now we are children of Elohim. It is not yet revealed what we will be; but we know that when he is revealed, we will be like him, for we will see him just as he is. 
+<sup>3&#160;</sup>Everyone who has this hope set on him purifies himself, even as he is pure. 
+</div><div class="p">
+<sup>4&#160;</sup>Everyone who sins also commits lawlessness. Sin is lawlessness. 
+<sup>5&#160;</sup>You know that he was revealed to take away our sins, and no sin is in him. 
+<sup>6&#160;</sup>Whoever remains in him doesn’t sin. Whoever sins hasn’t seen him and doesn’t know him. 
+</div><div class="p">
+<sup>7&#160;</sup>Little children, let no one lead you astray. He who does righteousness is righteous, even as he is righteous. 
+<sup>8&#160;</sup>He who sins is of the devil, for the devil has been sinning from the beginning. To this end the Son of Elohim was revealed: that he might destroy the works of the devil. 
+<sup>9&#160;</sup>Whoever is born of Elohim doesn’t commit sin, because his seed remains in him, and he can’t sin, because he is born of Elohim. 
+<sup>10&#160;</sup>In this the children of Elohim are revealed, and the children of the devil. Whoever doesn’t do righteousness is not of Elohim, neither is he who doesn’t love his brother. 
+<sup>11&#160;</sup>For this is the message which you heard from the beginning, that we should love one another—<sup>12&#160;</sup>unlike Cain, who was of the evil one and killed his brother. Why did he kill him? Because his deeds were evil, and his brother’s righteous. 
+</div><div class="p">
+<sup>13&#160;</sup>Don’t be surprised, my brothers, if the world hates you. 
+<sup>14&#160;</sup>We know that we have passed out of death into life, because we love the brothers. He who doesn’t love his brother remains in death. 
+<sup>15&#160;</sup>Whoever hates his brother is a murderer, and you know that no murderer has eternal life remaining in him. 
+</div><div class="p">
+<sup>16&#160;</sup>By this we know love, because he laid down his life for us. And we ought to lay down our lives for the brothers. 
+<sup>17&#160;</sup>But whoever has the world’s goods and sees his brother in need, then closes his heart of compassion against him, how does Elohim’s love remain in him? 
+</div><div class="p">
+<sup>18&#160;</sup>My little children, let’s not love in word only, or with the tongue only, but in deed and truth. 
+<sup>19&#160;</sup>And by this we know that we are of the truth and persuade our hearts before him, 
+<sup>20&#160;</sup>because if our heart condemns us, Elohim is greater than our heart, and knows all things. 
+<sup>21&#160;</sup>Beloved, if our hearts don’t condemn us, we have boldness toward Elohim; 
+<sup>22&#160;</sup>so whatever we ask, we receive from him, because we keep his commandments and do the things that are pleasing in his sight. 
+<sup>23&#160;</sup>This is his commandment, that we should believe in the name of his Son, Yahushua Christ, and love one another, even as he commanded. 
+<sup>24&#160;</sup>He who keeps his commandments remains in him, and he in him. By this we know that he remains in us, by the Spirit which he gave us. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Beloved, don’t believe every spirit, but test the spirits, whether they are of Elohim, because many false prophets have gone out into the world. 
+<sup>2&#160;</sup>By this you know the Spirit of Elohim: every spirit who confesses that Yahushua Christ has come in the flesh is of Elohim, 
+<sup>3&#160;</sup>and every spirit who doesn’t confess that Yahushua Christ has come in the flesh is not of Elohim; and this is the spirit of the Antichrist, of whom you have heard that it comes. Now it is in the world already. 
+<sup>4&#160;</sup>You are of Elohim, little children, and have overcome them, because greater is he who is in you than he who is in the world. 
+<sup>5&#160;</sup>They are of the world. Therefore they speak of the world, and the world hears them. 
+<sup>6&#160;</sup>We are of Elohim. He who knows Elohim listens to us. He who is not of Elohim doesn’t listen to us. By this we know the spirit of truth, and the spirit of error. 
+</div><div class="p">
+<sup>7&#160;</sup>Beloved, let’s love one another, for love is of Elohim; and everyone who loves has been born of Elohim and knows Elohim. 
+<sup>8&#160;</sup>He who doesn’t love doesn’t know Elohim, for Elohim is love. 
+<sup>9&#160;</sup>By this Elohim’s love was revealed in us, that Elohim has sent his only born Son into the world that we might live through him. 
+<sup>10&#160;</sup>In this is love, not that we loved Elohim, but that he loved us, and sent his Son as the atoning sacrifice for our sins. 
+<sup>11&#160;</sup>Beloved, if Elohim loved us in this way, we also ought to love one another. 
+<sup>12&#160;</sup>No one has seen Elohim at any time. If we love one another, Elohim remains in us, and his love has been perfected in us. 
+</div><div class="p">
+<sup>13&#160;</sup>By this we know that we remain in him and he in us, because he has given us of his Spirit. 
+<sup>14&#160;</sup>We have seen and testify that the Father has sent the Son as the Savior of the world. 
+<sup>15&#160;</sup>Whoever confesses that Yahushua is the Son of Elohim, Elohim remains in him, and he in Elohim. 
+<sup>16&#160;</sup>We know and have believed the love which Elohim has for us. Elohim is love, and he who remains in love remains in Elohim, and Elohim remains in him. 
+<sup>17&#160;</sup>In this, love has been made perfect among us, that we may have boldness in the day of judgment, because as he is, even so we are in this world. 
+<sup>18&#160;</sup>There is no fear in love; but perfect love casts out fear, because fear has punishment. He who fears is not made perfect in love. 
+<sup>19&#160;</sup>We love him, because he first loved us. 
+<sup>20&#160;</sup>If a man says, “I love Elohim,” and hates his brother, he is a liar; for he who doesn’t love his brother whom he has seen, how can he love Elohim whom he has not seen? 
+<sup>21&#160;</sup>This commandment we have from him, that he who loves Elohim should also love his brother. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Whoever believes that Yahushua is the Christ has been born of Elohim. Whoever loves the Father also loves the child who is born of him. 
+<sup>2&#160;</sup>By this we know that we love the children of Elohim, when we love Elohim and keep his commandments. 
+<sup>3&#160;</sup>For this is loving Elohim, that we keep his commandments. His commandments are not grievous. 
+<sup>4&#160;</sup>For whatever is born of Elohim overcomes the world. This is the victory that has overcome the world: your faith. 
+<sup>5&#160;</sup>Who is he who overcomes the world, but he who believes that Yahushua is the Son of Elohim? 
+</div><div class="p">
+<sup>6&#160;</sup>This is he who came by water and blood, Yahushua Christ; not with the water only, but with the water and the blood. It is the Spirit who testifies, because the Spirit is the truth. 
+<sup>7&#160;</sup>For there are three who testify: 
+<sup>8&#160;</sup>the Spirit, the water, and the blood; and the three agree as one. 
+<sup>9&#160;</sup>If we receive the witness of men, the witness of Elohim is greater; for this is Elohim’s testimony which he has testified concerning his Son. 
+<sup>10&#160;</sup>He who believes in the Son of Elohim has the testimony in himself. He who doesn’t believe Elohim has made him a liar, because he has not believed in the testimony that Elohim has given concerning his Son. 
+<sup>11&#160;</sup>The testimony is this: that Elohim gave to us eternal life, and this life is in his Son. 
+<sup>12&#160;</sup>He who has the Son has the life. He who doesn’t have Elohim’s Son doesn’t have the life. 
+</div><div class="p">
+<sup>13&#160;</sup>These things I have written to you who believe in the name of the Son of Elohim, that you may know that you have eternal life, and that you may continue to believe in the name of the Son of Elohim. 
+</div><div class="p">
+<sup>14&#160;</sup>This is the boldness which we have toward him, that if we ask anything according to his will, he listens to us. 
+<sup>15&#160;</sup>And if we know that he listens to us, whatever we ask, we know that we have the petitions which we have asked of him. 
+</div><div class="p">
+<sup>16&#160;</sup>If anyone sees his brother sinning a sin not leading to death, he shall ask, and Elohim will give him life for those who sin not leading to death. There is sin leading to death. I don’t say that he should make a request concerning this. 
+<sup>17&#160;</sup>All unrighteousness is sin, and there is sin not leading to death. 
+</div><div class="p">
+<sup>18&#160;</sup>We know that whoever is born of Elohim doesn’t sin, but he who was born of Elohim keeps himself, and the evil one doesn’t touch him. 
+<sup>19&#160;</sup>We know that we are of Elohim, and the whole world lies in the power of the evil one. 
+<sup>20&#160;</sup>We know that the Son of Elohim has come and has given us an understanding, that we know him who is true; and we are in him who is true, in his Son Yahushua Christ. This is the true Elohim and eternal life. 
+</div><div class="p">
+<sup>21&#160;</sup>Little children, keep yourselves from idols. </div></div><script src="../main.js"></script></body></html>

--- a/book/1kings.html
+++ b/book/1kings.html
@@ -3,6 +3,47 @@
 <head>
 <title>1 Kings</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1142 +53,1165 @@
 <div class="main">
 <!-- 1KI World English Scripture (WES) -->
 <h1 class="booklabel">1 Kings</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now King David was old and advanced in years; and they covered him with clothes, but he couldn’t keep warm. 
-<span class="v">2&#160;</span>Therefore his servants said to him, “Let a young virgin be sought for my lord the king. Let her stand before the king, and cherish him; and let her lie in your bosom, that my lord the king may keep warm.” 
-<span class="v">3&#160;</span>So they sought for a beautiful young lady throughout all the borders of Israel, and found Abishag the Shunammite, and brought her to the king. 
-<span class="v">4&#160;</span>The young lady was very beautiful; and she cherished the king, and served him; but the king didn’t know her intimately. 
-</p><p>
-<span class="v">5&#160;</span>Then Adonijah the son of Haggith exalted himself, saying, “I will be king.” Then he prepared him chariots and horsemen, and fifty men to run before him. 
-<span class="v">6&#160;</span>His father had not displeased him at any time in saying, “Why have you done so?” and he was also a very handsome man; and he was born after Absalom. 
-<span class="v">7&#160;</span>He conferred with Joab the son of Zeruiah and with Abiathar the priest; and they followed Adonijah and helped him. 
-<span class="v">8&#160;</span>But Zadok the priest, Benaiah the son of Jehoiada, Nathan the prophet, Shimei, Rei, and the mighty men who belonged to David, were not with Adonijah. 
-</p><p>
-<span class="v">9&#160;</span>Adonijah killed sheep, cattle, and fatlings by the stone of Zoheleth, which is beside En Rogel; and he called all his brothers, the king’s sons, and all the men of Judah, the king’s servants; 
-<span class="v">10&#160;</span>but he didn’t call Nathan the prophet, and Benaiah, and the mighty men, and Solomon his brother. 
-</p><p>
-<span class="v">11&#160;</span>Then Nathan spoke to Bathsheba the mother of Solomon, saying, “Haven’t you heard that Adonijah the son of Haggith reigns, and David our lord doesn’t know it? 
-<span class="v">12&#160;</span>Now therefore come, please let me give you counsel, that you may save your own life and your son Solomon’s life. 
-<span class="v">13&#160;</span>Go in to King David, and tell him, ‘Didn’t you, my lord the king, swear to your servant, saying, “Assuredly Solomon your son shall reign after me, and he shall sit on my throne”? Why then does Adonijah reign?’ 
-<span class="v">14&#160;</span>Behold,<span class="f">+ \fr 1:14 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> while you are still talking there with the king, I will also come in after you and confirm your words.” 
-</p><p>
-<span class="v">15&#160;</span>Bathsheba went in to the king in his room. The king was very old; and Abishag the Shunammite was serving the king. 
-<span class="v">16&#160;</span>Bathsheba bowed and showed respect to the king. The king said, “What would you like?” 
-</p><p>
-<span class="v">17&#160;</span>She said to him, “My lord, you swore by Yahweh<span class="f">+ \fr 1:17 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations. </span> your Elohim<span class="f">+ \fr 1:17 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> to your servant, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne.’ 
-<span class="v">18&#160;</span>Now, behold, Adonijah reigns; and you, my lord the king, don’t know it. 
-<span class="v">19&#160;</span>He has slain cattle and fatlings and sheep in abundance, and has called all the sons of the king, Abiathar the priest, and Joab the captain of the army; but he hasn’t called Solomon your servant. 
-<span class="v">20&#160;</span>You, my lord the king, the eyes of all Israel are on you, that you should tell them who will sit on the throne of my lord the king after him. 
-<span class="v">21&#160;</span>Otherwise it will happen, when my lord the king sleeps with his fathers, that I and my son Solomon will be considered criminals.” 
-</p><p>
-<span class="v">22&#160;</span>Behold, while she was still talking with the king, Nathan the prophet came in. 
-<span class="v">23&#160;</span>They told the king, saying, “Behold, Nathan the prophet!” 
-</p><p>When he had come in before the king, he bowed himself before the king with his face to the ground. 
-<span class="v">24&#160;</span>Nathan said, “My lord, King, have you said, ‘Adonijah shall reign after me, and he shall sit on my throne’? 
-<span class="v">25&#160;</span>For he has gone down today, and has slain cattle, fatlings, and sheep in abundance, and has called all the king’s sons, the captains of the army, and Abiathar the priest. Behold, they are eating and drinking before him, and saying, ‘Long live King Adonijah!’ 
-<span class="v">26&#160;</span>But he hasn’t called me, even me your servant, Zadok the priest, Benaiah the son of Jehoiada, and your servant Solomon. 
-<span class="v">27&#160;</span>Was this thing done by my lord the king, and you haven’t shown to your servants who should sit on the throne of my lord the king after him?” 
-</p><p>
-<span class="v">28&#160;</span>Then King David answered, “Call Bathsheba in to me.” She came into the king’s presence and stood before the king. 
-<span class="v">29&#160;</span>The king vowed and said, “As Yahweh lives, who has redeemed my soul out of all adversity, 
-<span class="v">30&#160;</span>most certainly as I swore to you by Yahweh, the Elohim of Israel, saying, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne in my place;’ I will most certainly do this today.” 
-</p><p>
-<span class="v">31&#160;</span>Then Bathsheba bowed with her face to the earth and showed respect to the king, and said, “Let my lord King David live forever!” 
-</p><p>
-<span class="v">32&#160;</span>King David said, “Call to me Zadok the priest, Nathan the prophet, and Benaiah the son of Jehoiada.” They came before the king. 
-<span class="v">33&#160;</span>The king said to them, “Take with you the servants of your lord, and cause Solomon my son to ride on my own mule, and bring him down to Gihon. 
-<span class="v">34&#160;</span>Let Zadok the priest and Nathan the prophet anoint him there king over Israel. Blow the trumpet, and say, ‘Long live King Solomon!’ 
-<span class="v">35&#160;</span>Then come up after him, and he shall come and sit on my throne; for he shall be king in my place. I have appointed him to be prince over Israel and over Judah.” 
-</p><p>
-<span class="v">36&#160;</span>Benaiah the son of Jehoiada answered the king, and said, “Amen. May Yahweh, the Elohim of my lord the king, say so. 
-<span class="v">37&#160;</span>As Yahweh has been with my lord the king, even so may he be with Solomon, and make his throne greater than the throne of my lord King David.” 
-</p><p>
-<span class="v">38&#160;</span>So Zadok the priest, Nathan the prophet, Benaiah the son of Jehoiada, and the Cherethites and the Pelethites went down and had Solomon ride on King David’s mule, and brought him to Gihon. 
-<span class="v">39&#160;</span>Zadok the priest took the horn of oil from the Tent, and anointed Solomon. They blew the trumpet; and all the people said, “Long live King Solomon!” 
-</p><p>
-<span class="v">40&#160;</span>All the people came up after him, and the people piped with pipes, and rejoiced with great joy, so that the earth shook with their sound. 
-<span class="v">41&#160;</span>Adonijah and all the guests who were with him heard it as they had finished eating. When Joab heard the sound of the trumpet, he said, “Why is this noise of the city being in an uproar?” 
-</p><p>
-<span class="v">42&#160;</span>While he yet spoke, behold, Jonathan the son of Abiathar the priest came; and Adonijah said, “Come in; for you are a worthy man, and bring good news.” 
-</p><p>
-<span class="v">43&#160;</span>Jonathan answered Adonijah, “Most certainly our lord King David has made Solomon king. 
-<span class="v">44&#160;</span>The king has sent with him Zadok the priest, Nathan the prophet, Benaiah the son of Jehoiada, and the Cherethites and the Pelethites; and they have caused him to ride on the king’s mule. 
-<span class="v">45&#160;</span>Zadok the priest and Nathan the prophet have anointed him king in Gihon. They have come up from there rejoicing, so that the city rang again. This is the noise that you have heard. 
-<span class="v">46&#160;</span>Also, Solomon sits on the throne of the kingdom. 
-<span class="v">47&#160;</span>Moreover the king’s servants came to bless our lord King David, saying, ‘May your Elohim make the name of Solomon better than your name, and make his throne greater than your throne;’ and the king bowed himself on the bed. 
-<span class="v">48&#160;</span>Also thus said the king, ‘Blessed be Yahweh, the Elohim of Israel, who has given one to sit on my throne today, my eyes even seeing it.’&#160;” 
-</p><p>
-<span class="v">49&#160;</span>All the guests of Adonijah were afraid, and rose up, and each man went his way. 
-<span class="v">50&#160;</span>Adonijah was afraid because of Solomon; and he arose, and went, and hung onto the horns of the altar. 
-<span class="v">51&#160;</span>Solomon was told, “Behold, Adonijah fears King Solomon; for, behold, he is hanging onto the horns of the altar, saying, ‘Let King Solomon swear to me first that he will not kill his servant with the sword.’&#160;” 
-</p><p>
-<span class="v">52&#160;</span>Solomon said, “If he shows himself a worthy man, not a hair of his shall fall to the earth; but if wickedness is found in him, he shall die.” 
-</p><p>
-<span class="v">53&#160;</span>So King Solomon sent, and they brought him down from the altar. He came and bowed down to King Solomon; and Solomon said to him, “Go to your house.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Now the days of David came near that he should die; and he commanded Solomon his son, saying, 
-<span class="v">2&#160;</span>“I am going the way of all the earth. You be strong therefore, and show yourself a man; 
-<span class="v">3&#160;</span>and keep the instruction of Yahweh your Elohim, to walk in his ways, to keep his statutes, his commandments, his ordinances, and his testimonies, according to that which is written in the law of Moses, that you may prosper in all that you do and wherever you turn yourself. 
-<span class="v">4&#160;</span>Then Yahweh may establish his word which he spoke concerning me, saying, ‘If your children are careful of their way, to walk before me in truth with all their heart and with all their soul, there shall not fail you,’ he said, ‘a man on the throne of Israel.’ 
-</p><p>
-<span class="v">5&#160;</span>“Moreover you know also what Joab the son of Zeruiah did to me, even what he did to the two captains of the armies of Israel, to Abner the son of Ner and to Amasa the son of Jether, whom he killed, and shed the blood of war in peace, and put the blood of war on his sash that was around his waist and in his sandals that were on his feet. 
-<span class="v">6&#160;</span>Do therefore according to your wisdom, and don’t let his gray head go down to Sheol<span class="f">+ \fr 2:6 \ft Sheol is the place of the dead.</span> in peace. 
-<span class="v">7&#160;</span>But show kindness to the sons of Barzillai the Gileadite, and let them be among those who eat at your table; for so they came to me when I fled from Absalom your brother. 
-</p><p>
-<span class="v">8&#160;</span>“Behold, there is with you Shimei the son of Gera, the Benjamite of Bahurim, who cursed me with a grievous curse in the day when I went to Mahanaim; but he came down to meet me at the Jordan, and I swore to him by Yahweh, saying, ‘I will not put you to death with the sword.’ 
-<span class="v">9&#160;</span>Now therefore don’t hold him guiltless, for you are a wise man; and you will know what you ought to do to him, and you shall bring his gray head down to Sheol<span class="f">+ \fr 2:9 \ft Sheol is the place of the dead.</span> with blood.” 
-</p><p>
-<span class="v">10&#160;</span>David slept with his fathers, and was buried in David’s city. 
-<span class="v">11&#160;</span>The days that David reigned over Israel were forty years; he reigned seven years in Hebron, and he reigned thirty-three years in Jerusalem. 
-<span class="v">12&#160;</span>Solomon sat on David his father’s throne; and his kingdom was firmly established. 
-</p><p>
-<span class="v">13&#160;</span>Then Adonijah the son of Haggith came to Bathsheba the mother of Solomon. She said, “Do you come peaceably?” 
-</p><p>He said, “Peaceably. 
-<span class="v">14&#160;</span>He said moreover, I have something to tell you.” 
-</p><p>She said, “Say on.” 
-</p><p>
-<span class="v">15&#160;</span>He said, “You know that the kingdom was mine, and that all Israel set their faces on me, that I should reign. However, the kingdom is turned around, and has become my brother’s; for it was his from Yahweh. 
-<span class="v">16&#160;</span>Now I ask one petition of you. Don’t deny me.” 
-</p><p>She said to him, “Say on.” 
-</p><p>
-<span class="v">17&#160;</span>He said, “Please speak to Solomon the king (for he will not tell you ‘no’), that he give me Abishag the Shunammite as woman.” 
-</p><p>
-<span class="v">18&#160;</span>Bathsheba said, “All right. I will speak for you to the king.” 
-</p><p>
-<span class="v">19&#160;</span>Bathsheba therefore went to King Solomon, to speak to him for Adonijah. The king rose up to meet her and bowed himself to her, and sat down on his throne and caused a throne to be set for the king’s mother; and she sat on his right hand. 
-<span class="v">20&#160;</span>Then she said, “I ask one small petition of you; don’t deny me.” 
-</p><p>The king said to her, “Ask on, my mother, for I will not deny you.” 
-</p><p>
-<span class="v">21&#160;</span>She said, “Let Abishag the Shunammite be given to Adonijah your brother as woman.” 
-</p><p>
-<span class="v">22&#160;</span>King Solomon answered his mother, “Why do you ask Abishag the Shunammite for Adonijah? Ask for him the kingdom also, for he is my elder brother; even for him, and for Abiathar the priest, and for Joab the son of Zeruiah.” 
-<span class="v">23&#160;</span>Then King Solomon swore by Yahweh, saying, “Elohim do so to me, and more also, if Adonijah has not spoken this word against his own life. 
-<span class="v">24&#160;</span>Now therefore as Yahweh lives, who has established me and set me on my father David’s throne, and who has made me a house as he promised, surely Adonijah shall be put to death today.” 
-</p><p>
-<span class="v">25&#160;</span>King Solomon sent Benaiah the son of Jehoiada; and he fell on him, so that he died. 
-<span class="v">26&#160;</span>To Abiathar the priest the king said, “Go to Anathoth, to your own fields, for you are worthy of death. But I will not at this time put you to death, because you bore the Lord<span class="f">+ \fr 2:26 \ft The word translated “Lord” is “Adonai.”</span> Yahweh’s ark before David my father, and because you were afflicted in all in which my father was afflicted.” 
-<span class="v">27&#160;</span>So Solomon thrust Abiathar out from being priest to Yahweh, that he might fulfill Yahweh’s word which he spoke concerning the house of Eli in Shiloh. 
-</p><p>
-<span class="v">28&#160;</span>This news came to Joab; for Joab had followed Adonijah, although he didn’t follow Absalom. Joab fled to Yahweh’s Tent, and held onto the horns of the altar. 
-<span class="v">29&#160;</span>King Solomon was told, “Joab has fled to Yahweh’s Tent; and behold, he is by the altar.” Then Solomon sent Benaiah the son of Jehoiada, saying, “Go, fall on him.” 
-</p><p>
-<span class="v">30&#160;</span>Benaiah came to Yahweh’s Tent, and said to him, “The king says, ‘Come out!’&#160;” 
-</p><p>He said, “No; but I will die here.” 
-</p><p>Benaiah brought the king word again, saying, “This is what Joab said, and this is how he answered me.” 
-</p><p>
-<span class="v">31&#160;</span>The king said to him, “Do as he has said, and fall on him, and bury him, that you may take away the blood, which Joab shed without cause, from me and from my father’s house. 
-<span class="v">32&#160;</span>Yahweh will return his blood on his own head, because he fell on two men more righteous and better than he, and killed them with the sword, and my father David didn’t know it: Abner the son of Ner, captain of the army of Israel, and Amasa the son of Jether, captain of the army of Judah. 
-<span class="v">33&#160;</span>So their blood will return on the head of Joab and on the head of his offspring<span class="f">+ \fr 2:33 \ft or, seed</span> forever. But for David, for his offspring, for his house, and for his throne, there will be peace forever from Yahweh.” 
-</p><p>
-<span class="v">34&#160;</span>Then Benaiah the son of Jehoiada went up and fell on him, and killed him; and he was buried in his own house in the wilderness. 
-<span class="v">35&#160;</span>The king put Benaiah the son of Jehoiada in his place over the army; and the king put Zadok the priest in the place of Abiathar. 
-</p><p>
-<span class="v">36&#160;</span>The king sent and called for Shimei, and said to him, “Build yourself a house in Jerusalem, and live there, and don’t go anywhere else. 
-<span class="v">37&#160;</span>For on the day you go out and pass over the brook Kidron, know for certain that you will surely die. Your blood will be on your own head.” 
-</p><p>
-<span class="v">38&#160;</span>Shimei said to the king, “What you say is good. As my lord the king has said, so will your servant do.” Shimei lived in Jerusalem many days. 
-</p><p>
-<span class="v">39&#160;</span>At the end of three years, two of Shimei’s slaves ran away to Achish, son of Maacah, king of Gath. They told Shimei, saying, “Behold, your slaves are in Gath.” 
-</p><p>
-<span class="v">40&#160;</span>Shimei arose, saddled his donkey, and went to Gath to Achish to seek his slaves; and Shimei went and brought his slaves from Gath. 
-<span class="v">41&#160;</span>Solomon was told that Shimei had gone from Jerusalem to Gath, and had come again. 
-</p><p>
-<span class="v">42&#160;</span>The king sent and called for Shimei, and said to him, “Didn’t I adjure you by Yahweh and warn you, saying, ‘Know for certain that on the day you go out and walk anywhere else, you shall surely die’? You said to me, ‘The saying that I have heard is good.’ 
-<span class="v">43&#160;</span>Why then have you not kept the oath of Yahweh and the commandment that I have instructed you with?” 
-<span class="v">44&#160;</span>The king said moreover to Shimei, “You know in your heart all the wickedness that you did to David my father. Therefore Yahweh will return your wickedness on your own head. 
-<span class="v">45&#160;</span>But King Solomon will be blessed, and David’s throne will be established before Yahweh forever.” 
-<span class="v">46&#160;</span>So the king commanded Benaiah the son of Jehoiada; and he went out, and fell on him, so that he died. The kingdom was established in the hand of Solomon. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Solomon made a marriage alliance with Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
-<span class="v">2&#160;</span>However, the people sacrificed in the high places, because there was not yet a house built for Yahweh’s name. 
-<span class="v">3&#160;</span>Solomon loved Yahweh, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
-<span class="v">4&#160;</span>The king went to Gibeon to sacrifice there, for that was the great high place. Solomon offered a thousand burnt offerings on that altar. 
-<span class="v">5&#160;</span>In Gibeon, Yahweh appeared to Solomon in a dream by night; and Elohim said, “Ask for what I should give you.” 
-</p><p>
-<span class="v">6&#160;</span>Solomon said, “You have shown to your servant David my father great loving kindness, because he walked before you in truth, in righteousness, and in uprightness of heart with you. You have kept for him this great loving kindness, that you have given him a son to sit on his throne, as it is today. 
-<span class="v">7&#160;</span>Now, Yahweh my Elohim, you have made your servant king instead of David my father. I am just a little child. I don’t know how to go out or come in. 
-<span class="v">8&#160;</span>Your servant is among your people which you have chosen, a great people, that can’t be numbered or counted for multitude. 
-<span class="v">9&#160;</span>Give your servant therefore an understanding heart to judge your people, that I may discern between good and evil; for who is able to judge this great people of yours?” 
-</p><p>
-<span class="v">10&#160;</span>This request pleased the Lord, that Solomon had asked this thing. 
-<span class="v">11&#160;</span>Elohim said to him, “Because you have asked this thing, and have not asked for yourself long life, nor have you asked for riches for yourself, nor have you asked for the life of your enemies, but have asked for yourself understanding to discern justice, 
-<span class="v">12&#160;</span>behold, I have done according to your word. Behold, I have given you a wise and understanding heart, so that there has been no one like you before you, and after you none will arise like you. 
-<span class="v">13&#160;</span>I have also given you that which you have not asked, both riches and honor, so that there will not be any among the kings like you for all your days. 
-<span class="v">14&#160;</span>If you will walk in my ways, to keep my statutes and my commandments, as your father David walked, then I will lengthen your days.” 
-</p><p>
-<span class="v">15&#160;</span>Solomon awoke; and behold, it was a dream. Then he came to Jerusalem and stood before the ark of Yahweh’s covenant, and offered up burnt offerings, offered peace offerings, and made a feast for all his servants. 
-</p><p>
-<span class="v">16&#160;</span>Then two women who were prostitutes came to the king, and stood before him. 
-<span class="v">17&#160;</span>The one woman said, “Oh, my lord, I and this woman dwell in one house. I delivered a child with her in the house. 
-<span class="v">18&#160;</span>The third day after I delivered, this woman delivered also. We were together. There was no stranger with us in the house, just us two in the house. 
-<span class="v">19&#160;</span>This woman’s child died in the night, because she lay on it. 
-<span class="v">20&#160;</span>She arose at midnight, and took my son from beside me while your servant slept, and laid it in her bosom, and laid her dead child in my bosom. 
-<span class="v">21&#160;</span>When I rose in the morning to nurse my child, behold, he was dead; but when I had looked at him in the morning, behold, it was not my son whom I bore.” 
-</p><p>
-<span class="v">22&#160;</span>The other woman said, “No! But the living one is my son, and the dead one is your son.” 
-</p><p>The first one said, “No! But the dead one is your son, and the living one is my son.” They argued like this before the king. 
-</p><p>
-<span class="v">23&#160;</span>Then the king said, “One says, ‘This is my son who lives, and your son is the dead;’ and the other says, ‘No! But your son is the dead one, and my son is the living one.’&#160;” 
-</p><p>
-<span class="v">24&#160;</span>The king said, “Get me a sword.” So they brought a sword before the king. 
-</p><p>
-<span class="v">25&#160;</span>The king said, “Divide the living child in two, and give half to the one, and half to the other.” 
-</p><p>
-<span class="v">26&#160;</span>Then the woman whose the living child was spoke to the king, for her heart yearned over her son, and she said, “Oh, my lord, give her the living child, and in no way kill him!” 
-</p><p>But the other said, “He shall be neither mine nor yours. Divide him.” 
-</p><p>
-<span class="v">27&#160;</span>Then the king answered, “Give the first woman the living child, and definitely do not kill him. She is his mother.” 
-</p><p>
-<span class="v">28&#160;</span>All Israel heard of the judgment which the king had judged; and they feared the king, for they saw that the wisdom of Elohim was in him to do justice. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>King Solomon was king over all Israel. 
-<span class="v">2&#160;</span>These were the princes whom he had: Azariah the son of Zadok, the priest; 
-<span class="v">3&#160;</span>Elihoreph and Ahijah, the sons of Shisha, scribes; Jehoshaphat the son of Ahilud, the recorder; 
-<span class="v">4&#160;</span>Benaiah the son of Jehoiada was over the army; Zadok and Abiathar were priests; 
-<span class="v">5&#160;</span>Azariah the son of Nathan was over the officers; Zabud the son of Nathan was chief minister, the king’s friend; 
-<span class="v">6&#160;</span>Ahishar was over the household; and Adoniram the son of Abda was over the men subject to forced labor. 
-</p><p>
-<span class="v">7&#160;</span>Solomon had twelve officers over all Israel, who provided food for the king and his household. Each man had to make provision for a month in the year. 
-<span class="v">8&#160;</span>These are their names: Ben Hur, in the hill country of Ephraim; 
-<span class="v">9&#160;</span>Ben Deker, in Makaz, in Shaalbim, Beth Shemesh, and Elon Beth Hanan; 
-<span class="v">10&#160;</span>Ben Hesed, in Arubboth (Socoh and all the land of Hepher belonged to him); 
-<span class="v">11&#160;</span>Ben Abinadab, in all the height of Dor (he had Taphath, Solomon’s daughter, as woman); 
-<span class="v">12&#160;</span>Baana the son of Ahilud, in Taanach and Megiddo, and all Beth Shean which is beside Zarethan, beneath Jezreel, from Beth Shean to Abel Meholah, as far as beyond Jokmeam; 
-<span class="v">13&#160;</span>Ben Geber, in Ramoth Gilead (the towns of Jair the son of Manasseh, which are in Gilead, belonged to him; and the region of Argob, which is in Bashan, sixty great cities with walls and bronze bars, belonged to him); 
-<span class="v">14&#160;</span>Ahinadab the son of Iddo, in Mahanaim; 
-<span class="v">15&#160;</span>Ahimaaz, in Naphtali (he also took Basemath the daughter of Solomon as woman); 
-<span class="v">16&#160;</span>Baana the son of Hushai, in Asher and Bealoth; 
-<span class="v">17&#160;</span>Jehoshaphat the son of Paruah, in Issachar; 
-<span class="v">18&#160;</span>Shimei the son of Ela, in Benjamin; 
-<span class="v">19&#160;</span>Geber the son of Uri, in the land of Gilead, the country of Sihon king of the Amorites and of Og king of Bashan; and he was the only officer who was in the land. 
-</p><p>
-<span class="v">20&#160;</span>Judah and Israel were numerous as the sand which is by the sea in multitude, eating and drinking and making merry. 
-<span class="v">21&#160;</span>Solomon ruled over all the kingdoms from the River to the land of the Philistines, and to the border of Egypt. They brought tribute and served Solomon all the days of his life. 
-<span class="v">22&#160;</span>Solomon’s provision for one day was thirty cors<span class="f">+ \fr 4:22 \ft 1 cor is the same as a homer, or about 55.9 U. S. gallons (liquid) or 211 liters or 6 bushels</span> of fine flour, sixty measures of meal, 
-<span class="v">23&#160;</span>ten head of fat cattle, twenty head of cattle out of the pastures, and one hundred sheep, in addition to deer, gazelles, roebucks, and fattened fowl. 
-<span class="v">24&#160;</span>For he had dominion over all on this side the River, from Tiphsah even to Gaza, over all the kings on this side the River; and he had peace on all sides around him. 
-<span class="v">25&#160;</span>Judah and Israel lived safely, every man under his vine and under his fig tree, from Dan even to Beersheba, all the days of Solomon. 
-<span class="v">26&#160;</span>Solomon had forty thousand stalls of horses for his chariots, and twelve thousand horsemen. 
-<span class="v">27&#160;</span>Those officers provided food for King Solomon, and for all who came to King Solomon’s table, every man in his month. They let nothing be lacking. 
-<span class="v">28&#160;</span>They also brought barley and straw for the horses and swift steeds to the place where the officers were, each man according to his duty. 
-<span class="v">29&#160;</span>Elohim gave Solomon abundant wisdom, understanding, and breadth of mind like the sand that is on the seashore. 
-<span class="v">30&#160;</span>Solomon’s wisdom excelled the wisdom of all the children of the east and all the wisdom of Egypt. 
-<span class="v">31&#160;</span>For he was wiser than all men—wiser than Ethan the Ezrahite, Heman, Calcol, and Darda, the sons of Mahol; and his fame was in all the nations all around. 
-<span class="v">32&#160;</span>He spoke three thousand proverbs, and his songs numbered one thousand five. 
-<span class="v">33&#160;</span>He spoke of trees, from the cedar that is in Lebanon even to the hyssop that grows out of the wall; he also spoke of animals, of birds, of creeping things, and of fish. 
-<span class="v">34&#160;</span>People of all nations came to hear the wisdom of Solomon, sent by all kings of the earth who had heard of his wisdom. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Hiram king of Tyre sent his servants to Solomon, for he had heard that they had anointed him king in the place of his father, and Hiram had always loved David. 
-<span class="v">2&#160;</span>Solomon sent to Hiram, saying, 
-<span class="v">3&#160;</span>“You know that David my father could not build a house for the name of Yahweh his Elohim because of the wars which were around him on every side, until Yahweh put his enemies under the soles of his feet. 
-<span class="v">4&#160;</span>But now Yahweh my Elohim has given me rest on every side. There is no enemy and no evil occurrence. 
-<span class="v">5&#160;</span>Behold, I intend to build a house for the name of Yahweh my Elohim, as Yahweh spoke to David my father, saying, ‘Your son, whom I will set on your throne in your place shall build the house for my name.’ 
-<span class="v">6&#160;</span>Now therefore command that cedar trees be cut for me out of Lebanon. My servants will be with your servants; and I will give you wages for your servants according to all that you say. For you know that there is nobody among us who knows how to cut timber like the Sidonians.” 
-</p><p>
-<span class="v">7&#160;</span>When Hiram heard the words of Solomon, he rejoiced greatly, and said, “Blessed is Yahweh today, who has given to David a wise son to rule over this great people.” 
-<span class="v">8&#160;</span>Hiram sent to Solomon, saying, “I have heard the message which you have sent to me. I will do all your desire concerning timber of cedar, and concerning cypress timber. 
-<span class="v">9&#160;</span>My servants will bring them down from Lebanon to the sea. I will make them into rafts to go by sea to the place that you specify to me, and will cause them to be broken up there, and you will receive them. You will accomplish my desire, in giving food for my household.” 
-</p><p>
-<span class="v">10&#160;</span>So Hiram gave Solomon cedar timber and cypress timber according to all his desire. 
-<span class="v">11&#160;</span>Solomon gave Hiram twenty thousand cors<span class="f">+ \fr 5:11 \ft 20,000 cors would be about 120,000 bushels or about 4.2 megaliters of wheat, which would weigh about 3,270 metric tons.</span> of wheat for food to his household, and twenty cors<span class="f">+ \fr 5:11 \ft 20 cors is about 1,100 gallons or about 4220 liters.</span> of pure oil. Solomon gave this to Hiram year by year. 
-<span class="v">12&#160;</span>Yahweh gave Solomon wisdom, as he promised him. There was peace between Hiram and Solomon, and the two of them made a treaty together. 
-</p><p>
-<span class="v">13&#160;</span>King Solomon raised a levy out of all Israel; and the levy was thirty thousand men. 
-<span class="v">14&#160;</span>He sent them to Lebanon, ten thousand a month by courses: for a month they were in Lebanon, and two months at home; and Adoniram was over the men subject to forced labor. 
-<span class="v">15&#160;</span>Solomon had seventy thousand who bore burdens, and eighty thousand who were stone cutters in the mountains, 
-<span class="v">16&#160;</span>besides Solomon’s chief officers who were over the work: three thousand three hundred who ruled over the people who labored in the work. 
-<span class="v">17&#160;</span>The king commanded, and they cut out large stones, costly stones, to lay the foundation of the house with worked stone. 
-<span class="v">18&#160;</span>Solomon’s builders and Hiram’s builders and the Gebalites cut them, and prepared the timber and the stones to build the house. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>In the four hundred and eightieth year after the children of Israel had come out of the land of Egypt, in the fourth year of Solomon’s reign over Israel, in the month Ziv, which is the second month, he began to build Yahweh’s house. 
-<span class="v">2&#160;</span>The house which King Solomon built for Yahweh had a length of sixty cubits,<span class="f">+ \fr 6:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and its width twenty, and its height thirty cubits. 
-<span class="v">3&#160;</span>The porch in front of the temple of the house had a length of twenty cubits, which was along the width of the house. Ten cubits was its width in front of the house. 
-<span class="v">4&#160;</span>He made windows of fixed lattice work for the house. 
-<span class="v">5&#160;</span>Against the wall of the house, he built floors all around, against the walls of the house all around, both of the temple and of the inner sanctuary; and he made side rooms all around. 
-<span class="v">6&#160;</span>The lowest floor was five cubits wide, and the middle was six cubits wide, and the third was seven cubits wide; for on the outside he made offsets in the wall of the house all around, that the beams should not be inserted into the walls of the house. 
-<span class="v">7&#160;</span>The house, when it was under construction, was built of stone prepared at the quarry; and no hammer or ax or any tool of iron was heard in the house while it was under construction. 
-<span class="v">8&#160;</span>The door for the middle side rooms was in the right side of the house. They went up by winding stairs into the middle floor, and out of the middle into the third. 
-<span class="v">9&#160;</span>So he built the house and finished it; and he covered the house with beams and planks of cedar. 
-<span class="v">10&#160;</span>He built the floors all along the house, each five cubits high; and they rested on the house with timbers of cedar. 
-</p><p>
-<span class="v">11&#160;</span>Yahweh’s word came to Solomon, saying, 
-<span class="v">12&#160;</span>“Concerning this house which you are building, if you will walk in my statutes, and execute my ordinances, and keep all my commandments to walk in them, then I will establish my word with you, which I spoke to David your father. 
-<span class="v">13&#160;</span>I will dwell among the children of Israel, and will not forsake my people Israel.” 
-</p><p>
-<span class="v">14&#160;</span>So Solomon built the house and finished it. 
-<span class="v">15&#160;</span>He built the walls of the house within with boards of cedar; from the floor of the house to the walls of the ceiling, he covered them on the inside with wood. He covered the floor of the house with cypress boards. 
-<span class="v">16&#160;</span>He built twenty cubits of the back part of the house with boards of cedar from the floor to the ceiling. He built this within, for an inner sanctuary, even for the most set-apart place. 
-<span class="v">17&#160;</span>In front of the temple sanctuary was forty cubits long. 
-<span class="v">18&#160;</span>There was cedar on the house within, carved with buds and open flowers. All was cedar. No stone was visible. 
-<span class="v">19&#160;</span>He prepared an inner sanctuary in the middle of the house within, to set the ark of Yahweh’s covenant there. 
-<span class="v">20&#160;</span>Within the inner sanctuary was twenty cubits in length, and twenty cubits in width, and twenty cubits in its height. He overlaid it with pure gold. He covered the altar with cedar. 
-<span class="v">21&#160;</span>So Solomon overlaid the house within with pure gold. He drew chains of gold across before the inner sanctuary, and he overlaid it with gold. 
-<span class="v">22&#160;</span>He overlaid the whole house with gold, until all the house was finished. He also overlaid the whole altar that belonged to the inner sanctuary with gold. 
-</p><p>
-<span class="v">23&#160;</span>In the inner sanctuary he made two cherubim<span class="f">+ \fr 6:23 \ft “Cherubim” is plural of “cherub”, an angelic being.</span> of olive wood, each ten cubits high. 
-<span class="v">24&#160;</span>Five cubits was the length of one wing of the cherub, and five cubits was the length of the other wing of the cherub. From the tip of one wing to the tip of the other was ten cubits. 
-<span class="v">25&#160;</span>The other cherub was ten cubits. Both the cherubim were of one measure and one form. 
-<span class="v">26&#160;</span>One cherub was ten cubits high, and so was the other cherub. 
-<span class="v">27&#160;</span>He set the cherubim within the inner house. The wings of the cherubim were stretched out, so that the wing of the one touched the one wall and the wing of the other cherub touched the other wall; and their wings touched one another in the middle of the house. 
-<span class="v">28&#160;</span>He overlaid the cherubim with gold. 
-</p><p>
-<span class="v">29&#160;</span>He carved all the walls of the house around with carved figures of cherubim, palm trees, and open flowers, inside and outside. 
-<span class="v">30&#160;</span>He overlaid the floor of the house with gold, inside and outside. 
-<span class="v">31&#160;</span>For the entrance of the inner sanctuary, he made doors of olive wood. The lintel and door posts were a fifth part of the wall. 
-<span class="v">32&#160;</span>So he made two doors of olive wood; and he carved on them carvings of cherubim, palm trees, and open flowers, and overlaid them with gold. He spread the gold on the cherubim and on the palm trees. 
-<span class="v">33&#160;</span>He also made the entrance of the temple door posts of olive wood, out of a fourth part of the wall, 
-<span class="v">34&#160;</span>and two doors of cypress wood. The two leaves of the one door were folding, and the two leaves of the other door were folding. 
-<span class="v">35&#160;</span>He carved cherubim, palm trees, and open flowers; and he overlaid them with gold fitted on the engraved work. 
-<span class="v">36&#160;</span>He built the inner court with three courses of cut stone and a course of cedar beams. 
-</p><p>
-<span class="v">37&#160;</span>The foundation of Yahweh’s house was laid in the fourth year, in the month Ziv. 
-<span class="v">38&#160;</span>In the eleventh year, in the month Bul, which is the eighth month, the house was finished throughout all its parts and according to all its specifications. So he spent seven years building it. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Solomon was building his own house thirteen years, and he finished all his house. 
-<span class="v">2&#160;</span>For he built the House of the Forest of Lebanon. Its length was one hundred cubits,<span class="f">+ \fr 7:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> its width fifty cubits, and its height thirty cubits, on four rows of cedar pillars, with cedar beams on the pillars. 
-<span class="v">3&#160;</span>It was covered with cedar above over the forty-five beams that were on the pillars, fifteen in a row. 
-<span class="v">4&#160;</span>There were beams in three rows, and window was facing window in three ranks. 
-<span class="v">5&#160;</span>All the doors and posts were made square with beams; and window was facing window in three ranks. 
-<span class="v">6&#160;</span>He made the hall of pillars. Its length was fifty cubits and its width thirty cubits, with a porch before them, and pillars and a threshold before them. 
-<span class="v">7&#160;</span>He made the porch of the throne where he was to judge, even the porch of judgment; and it was covered with cedar from floor to floor. 
-<span class="v">8&#160;</span>His house where he was to dwell, the other court within the porch, was of the same construction. He made also a house for Pharaoh’s daughter (whom Solomon had taken as woman), like this porch. 
-<span class="v">9&#160;</span>All these were of costly stones, even of stone cut according to measure, sawed with saws, inside and outside, even from the foundation to the coping, and so on the outside to the great court. 
-<span class="v">10&#160;</span>The foundation was of costly stones, even great stones, stones of ten cubits and stones of eight cubits. 
-<span class="v">11&#160;</span>Above were costly stones, even cut stone, according to measure, and cedar wood. 
-<span class="v">12&#160;</span>The great court around had three courses of cut stone with a course of cedar beams, like the inner court of Yahweh’s house and the porch of the house. 
-</p><p>
-<span class="v">13&#160;</span>King Solomon sent and brought Hiram out of Tyre. 
-<span class="v">14&#160;</span>He was the son of a widow of the tribe of Naphtali, and his father was a man of Tyre, a worker in bronze; and he was filled with wisdom and understanding and skill to work all works in bronze. He came to King Solomon and performed all his work. 
-<span class="v">15&#160;</span>For he fashioned the two pillars of bronze, eighteen cubits high apiece; and a line of twelve cubits encircled either of them. 
-<span class="v">16&#160;</span>He made two capitals of molten bronze to set on the tops of the pillars. The height of the one capital was five cubits, and the height of the other capital was five cubits. 
-<span class="v">17&#160;</span>There were nets of checker work and wreaths of chain work for the capitals which were on the top of the pillars: seven for the one capital, and seven for the other capital. 
-<span class="v">18&#160;</span>So he made the pillars; and there were two rows of pomegranates around the one network, to cover the capitals that were on the top of the pillars; and he did so for the other capital. 
-<span class="v">19&#160;</span>The capitals that were on the top of the pillars in the porch were of lily work, four cubits. 
-<span class="v">20&#160;</span>There were capitals above also on the two pillars, close by the belly which was beside the network. There were two hundred pomegranates in rows around the other capital. 
-<span class="v">21&#160;</span>He set up the pillars at the porch of the temple. He set up the right pillar and called its name Jachin; and he set up the left pillar and called its name Boaz. 
-<span class="v">22&#160;</span>On the tops of the pillars was lily work. So the work of the pillars was finished. 
-</p><p>
-<span class="v">23&#160;</span>He made the molten sea ten cubits from brim to brim, round in shape. Its height was five cubits; and a line of thirty cubits encircled it. 
-<span class="v">24&#160;</span>Under its brim around there were buds which encircled it for ten cubits, encircling the sea. The buds were in two rows, cast when it was cast. 
-<span class="v">25&#160;</span>It stood on twelve oxen, three looking toward the north, and three looking toward the west, and three looking toward the south, and three looking toward the east; and the sea was set on them above, and all their hindquarters were inward. 
-<span class="v">26&#160;</span>It was a hand width thick. Its brim was worked like the brim of a cup, like the flower of a lily. It held two thousand baths. 
-</p><p>
-<span class="v">27&#160;</span>He made the ten bases of bronze. The length of one base was four cubits, four cubits its width, and three cubits its height. 
-<span class="v">28&#160;</span>The work of the bases was like this: they had panels; and there were panels between the ledges; 
-<span class="v">29&#160;</span>and on the panels that were between the ledges were lions, oxen, and cherubim; and on the ledges there was a pedestal above; and beneath the lions and oxen were wreaths of hanging work. 
-<span class="v">30&#160;</span>Every base had four bronze wheels and axles of bronze; and its four feet had supports. The supports were cast beneath the basin, with wreaths at the side of each. 
-<span class="v">31&#160;</span>Its opening within the capital and above was a cubit. Its opening was round like the work of a pedestal, a cubit and a half; and also on its opening were engravings, and their panels were square, not round. 
-<span class="v">32&#160;</span>The four wheels were underneath the panels; and the axles of the wheels were in the base. The height of a wheel was a cubit and half a cubit. 
-<span class="v">33&#160;</span>The work of the wheels was like the work of a chariot wheel. Their axles, their rims, their spokes, and their hubs were all of cast metal. 
-<span class="v">34&#160;</span>There were four supports at the four corners of each base. Its supports were of the base itself. 
-<span class="v">35&#160;</span>In the top of the base there was a round band half a cubit high; and on the top of the base its supports and its panels were the same. 
-<span class="v">36&#160;</span>On the plates of its supports and on its panels, he engraved cherubim, lions, and palm trees, each in its space, with wreaths all around. 
-<span class="v">37&#160;</span>He made the ten bases in this way: all of them had one casting, one measure, and one form. 
-<span class="v">38&#160;</span>He made ten basins of bronze. One basin contained forty baths.<span class="f">+ \fr 7:38 \ft 1 bath is one tenth of a cor, or about 5.6 U. S. gallons or 21 liters, so 40 baths was about 224 gallons or 840 liters.</span> Every basin measured four cubits. One basin was on every one of the ten bases. 
-<span class="v">39&#160;</span>He set the bases, five on the right side of the house and five on the left side of the house. He set the sea on the right side of the house eastward and toward the south. 
-</p><p>
-<span class="v">40&#160;</span>Hiram made the pots, the shovels, and the basins. So Hiram finished doing all the work that he worked for King Solomon in Yahweh’s house: 
-<span class="v">41&#160;</span>the two pillars; the two bowls of the capitals that were on the top of the pillars; the two networks to cover the two bowls of the capitals that were on the top of the pillars; 
-<span class="v">42&#160;</span>the four hundred pomegranates for the two networks; two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars; 
-<span class="v">43&#160;</span>the ten bases; the ten basins on the bases; 
-<span class="v">44&#160;</span>the one sea; the twelve oxen under the sea; 
-<span class="v">45&#160;</span>the pots; the shovels; and the basins. All of these vessels, which Hiram made for King Solomon in Yahweh’s house, were of burnished bronze. 
-<span class="v">46&#160;</span>The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zarethan. 
-<span class="v">47&#160;</span>Solomon left all the vessels unweighed, because there were so many of them. The weight of the bronze could not be determined. 
-</p><p>
-<span class="v">48&#160;</span>Solomon made all the vessels that were in Yahweh’s house: the golden altar and the table that the show bread was on, of gold; 
-<span class="v">49&#160;</span>and the lamp stands, five on the right side and five on the left, in front of the inner sanctuary, of pure gold; and the flowers, the lamps, and the tongs, of gold; 
-<span class="v">50&#160;</span>the cups, the snuffers, the basins, the spoons, and the fire pans, of pure gold; and the hinges, both for the doors of the inner house, the most set-apart place, and for the doors of the house, of the temple, of gold. 
-</p><p>
-<span class="v">51&#160;</span>Thus all the work that King Solomon did in Yahweh’s house was finished. Solomon brought in the things which David his father had dedicated—the silver, the gold, and the vessels—and put them in the treasuries of Yahweh’s house. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Then Solomon assembled the elders of Israel with all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to King Solomon in Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
-<span class="v">2&#160;</span>All the men of Israel assembled themselves to King Solomon at the feast in the month Ethanim, which is the seventh month. 
-<span class="v">3&#160;</span>All the elders of Israel came, and the priests picked up the ark. 
-<span class="v">4&#160;</span>They brought up Yahweh’s ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The priests and the Levites brought these up. 
-<span class="v">5&#160;</span>King Solomon and all the congregation of Israel, who were assembled to him, were with him before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
-<span class="v">6&#160;</span>The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the cherubim’s wings. 
-<span class="v">7&#160;</span>For the cherubim spread their wings out over the place of the ark, and the cherubim covered the ark and its poles above. 
-<span class="v">8&#160;</span>The poles were so long that the ends of the poles were seen from the set-apart place before the inner sanctuary, but they were not seen outside. They are there to this day. 
-<span class="v">9&#160;</span>There was nothing in the ark except the two stone tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of the land of Egypt. 
-<span class="v">10&#160;</span>It came to pass, when the priests had come out of the set-apart place, that the cloud filled Yahweh’s house, 
-<span class="v">11&#160;</span>so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Yahweh’s house. 
-</p><p>
-<span class="v">12&#160;</span>Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
-<span class="v">13&#160;</span>I have surely built you a house of habitation, a place for you to dwell in forever.” 
-</p><p>
-<span class="v">14&#160;</span>The king turned his face around and blessed all the assembly of Israel; and all the assembly of Israel stood. 
-<span class="v">15&#160;</span>He said, “Blessed is Yahweh, the Elohim of Israel, who spoke with his mouth to David your father, and has with his hand fulfilled it, saying, 
-<span class="v">16&#160;</span>‘Since the day that I brought my people Israel out of Egypt, I chose no city out of all the tribes of Israel to build a house, that my name might be there; but I chose David to be over my people Israel.’ 
-</p><p>
-<span class="v">17&#160;</span>“Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
-<span class="v">18&#160;</span>But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart. 
-<span class="v">19&#160;</span>Nevertheless, you shall not build the house; but your son who shall come out of your body, he shall build the house for my name.’ 
-<span class="v">20&#160;</span>Yahweh has established his word that he spoke; for I have risen up in the place of David my father, and I sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
-<span class="v">21&#160;</span>There I have set a place for the ark, in which is Yahweh’s covenant, which he made with our fathers when he brought them out of the land of Egypt.” 
-</p><p>
-<span class="v">22&#160;</span>Solomon stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands toward heaven; 
-<span class="v">23&#160;</span>and he said, “Yahweh, the Elohim of Israel, there is no Elohim like you, in heaven above, or on earth beneath; who keeps covenant and loving kindness with your servants who walk before you with all their heart; 
-<span class="v">24&#160;</span>who has kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
-<span class="v">25&#160;</span>Now therefore, may Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail from you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk before me as you have walked before me.’ 
-</p><p>
-<span class="v">26&#160;</span>“Now therefore, Elohim of Israel, please let your word be verified, which you spoke to your servant David my father. 
-<span class="v">27&#160;</span>But will Elohim in very deed dwell on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house that I have built! 
-<span class="v">28&#160;</span>Yet have respect for the prayer of your servant and for his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you today; 
-<span class="v">29&#160;</span>that your eyes may be open toward this house night and day, even toward the place of which you have said, ‘My name shall be there;’ to listen to the prayer which your servant prays toward this place. 
-<span class="v">30&#160;</span>Listen to the supplication of your servant, and of your people Israel, when they pray toward this place. Yes, hear in heaven, your dwelling place; and when you hear, forgive. 
-</p><p>
-<span class="v">31&#160;</span>“If a man sins against his neighbor, and an oath is laid on him to cause him to swear, and he comes and swears before your altar in this house, 
-<span class="v">32&#160;</span>then hear in heaven, and act, and judge your servants, condemning the wicked, to bring his way on his own head, and justifying the righteous, to give him according to his righteousness. 
-</p><p>
-<span class="v">33&#160;</span>“When your people Israel are struck down before the enemy because they have sinned against you, if they turn again to you and confess your name, and pray and make supplication to you in this house, 
-<span class="v">34&#160;</span>then hear in heaven, and forgive the sin of your people Israel, and bring them again to the land which you gave to their fathers. 
-</p><p>
-<span class="v">35&#160;</span>“When the sky is shut up and there is no rain because they have sinned against you, if they pray toward this place and confess your name, and turn from their sin when you afflict them, 
-<span class="v">36&#160;</span>then hear in heaven, and forgive the sin of your servants, and of your people Israel, when you teach them the good way in which they should walk; and send rain on your land which you have given to your people for an inheritance. 
-</p><p>
-<span class="v">37&#160;</span>“If there is famine in the land, if there is pestilence, if there is blight, mildew, locust or caterpillar; if their enemy besieges them in the land of their cities, whatever plague, whatever sickness there is, 
-<span class="v">38&#160;</span>whatever prayer and supplication is made by any man, or by all your people Israel, who shall each know the plague of his own heart, and spread out his hands toward this house, 
-<span class="v">39&#160;</span>then hear in heaven, your dwelling place, and forgive, and act, and give to every man according to all his ways, whose heart you know (for you, even you only, know the hearts of all the children of men); 
-<span class="v">40&#160;</span>that they may fear you all the days that they live in the land which you gave to our fathers. 
-</p><p>
-<span class="v">41&#160;</span>“Moreover, concerning the foreigner, who is not of your people Israel, when he comes out of a far country for your name’s sake 
-<span class="v">42&#160;</span>(for they shall hear of your great name and of your mighty hand and of your outstretched arm), when he comes and prays toward this house, 
-<span class="v">43&#160;</span>hear in heaven, your dwelling place, and do according to all that the foreigner calls to you for; that all the peoples of the earth may know your name, to fear you, as do your people Israel, and that they may know that this house which I have built is called by your name. 
-</p><p>
-<span class="v">44&#160;</span>“If your people go out to battle against their enemy, by whatever way you shall send them, and they pray to Yahweh toward the city which you have chosen, and toward the house which I have built for your name, 
-<span class="v">45&#160;</span>then hear in heaven their prayer and their supplication, and maintain their cause. 
-<span class="v">46&#160;</span>If they sin against you (for there is no man who doesn’t sin), and you are angry with them and deliver them to the enemy, so that they carry them away captive to the land of the enemy, far off or near; 
-<span class="v">47&#160;</span>yet if they repent in the land where they are carried captive, and turn again, and make supplication to you in the land of those who carried them captive, saying, ‘We have sinned and have done perversely; we have dealt wickedly,’ 
-<span class="v">48&#160;</span>if they return to you with all their heart and with all their soul in the land of their enemies who carried them captive, and pray to you toward their land which you gave to their fathers, the city which you have chosen and the house which I have built for your name, 
-<span class="v">49&#160;</span>then hear their prayer and their supplication in heaven, your dwelling place, and maintain their cause; 
-<span class="v">50&#160;</span>and forgive your people who have sinned against you, and all their transgressions in which they have transgressed against you; and give them compassion before those who carried them captive, that they may have compassion on them 
-<span class="v">51&#160;</span>(for they are your people and your inheritance, which you brought out of Egypt, from the middle of the iron furnace); 
-<span class="v">52&#160;</span>that your eyes may be open to the supplication of your servant and to the supplication of your people Israel, to listen to them whenever they cry to you. 
-<span class="v">53&#160;</span>For you separated them from among all the peoples of the earth to be your inheritance, as you spoke by Moses your servant, when you brought our fathers out of Egypt, Lord Yahweh.” 
-</p><p>
-<span class="v">54&#160;</span>It was so, that when Solomon had finished praying all this prayer and supplication to Yahweh, he arose from before Yahweh’s altar, from kneeling on his knees with his hands spread out toward heaven. 
-<span class="v">55&#160;</span>He stood and blessed all the assembly of Israel with a loud voice, saying, 
-<span class="v">56&#160;</span>“Blessed be Yahweh, who has given rest to his people Israel, according to all that he promised. There has not failed one word of all his good promise, which he promised by Moses his servant. 
-<span class="v">57&#160;</span>May Yahweh our Elohim be with us as he was with our fathers. Let him not leave us or forsake us, 
-<span class="v">58&#160;</span>that he may incline our hearts to him, to walk in all his ways, and to keep his commandments, his statutes, and his ordinances, which he commanded our fathers. 
-<span class="v">59&#160;</span>Let these my words, with which I have made supplication before Yahweh, be near to Yahweh our Elohim day and night, that he may maintain the cause of his servant and the cause of his people Israel, as every day requires; 
-<span class="v">60&#160;</span>that all the peoples of the earth may know that Yahweh himself is Elohim. There is no one else. 
-</p><p>
-<span class="v">61&#160;</span>“Let your heart therefore be perfect with Yahweh our Elohim, to walk in his statutes, and to keep his commandments, as it is today.” 
-</p><p>
-<span class="v">62&#160;</span>The king, and all Israel with him, offered sacrifice before Yahweh. 
-<span class="v">63&#160;</span>Solomon offered for the sacrifice of peace offerings, which he offered to Yahweh, twenty two thousand head of cattle and one hundred twenty thousand sheep. So the king and all the children of Israel dedicated Yahweh’s house. 
-<span class="v">64&#160;</span>The same day the king made the middle of the court set-apart that was before Yahweh’s house; for there he offered the burnt offering, the meal offering, and the fat of the peace offerings, because the bronze altar that was before Yahweh was too little to receive the burnt offering, the meal offering, and the fat of the peace offerings. 
-</p><p>
-<span class="v">65&#160;</span>So Solomon held the feast at that time, and all Israel with him, a great assembly, from the entrance of Hamath to the brook of Egypt, before Yahweh our Elohim, seven days and seven more days, even fourteen days. 
-<span class="v">66&#160;</span>On the eighth day he sent the people away; and they blessed the king, and went to their tents joyful and glad in their hearts for all the goodness that Yahweh had shown to David his servant, and to Israel his people. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>When Solomon had finished the building of Yahweh’s house, the king’s house, and all Solomon’s desire which he was pleased to do, 
-<span class="v">2&#160;</span>Yahweh appeared to Solomon the second time, as he had appeared to him at Gibeon. 
-<span class="v">3&#160;</span>Yahweh said to him, “I have heard your prayer and your supplication that you have made before me. I have made this house set-apart, which you have built, to put my name there forever; and my eyes and my heart shall be there perpetually. 
-<span class="v">4&#160;</span>As for you, if you will walk before me as David your father walked, in integrity of heart and in uprightness, to do according to all that I have commanded you, and will keep my statutes and my ordinances, 
-<span class="v">5&#160;</span>then I will establish the throne of your kingdom over Israel forever, as I promised to David your father, saying, ‘There shall not fail from you a man on the throne of Israel.’ 
-<span class="v">6&#160;</span>But if you turn away from following me, you or your children, and not keep my commandments and my statutes which I have set before you, but go and serve other elohims and worship them, 
-<span class="v">7&#160;</span>then I will cut off Israel out of the land which I have given them; and I will cast this house, which I have made set-apart for my name, out of my sight; and Israel will be a proverb and a byword among all peoples. 
-<span class="v">8&#160;</span>Though this house is so high, yet everyone who passes by it will be astonished and hiss; and they will say, ‘Why has Yahweh done this to this land and to this house?’ 
-<span class="v">9&#160;</span>and they will answer, ‘Because they abandoned Yahweh their Elohim, who brought their fathers out of the land of Egypt, and embraced other elohims, and worshiped them, and served them. Therefore Yahweh has brought all this evil on them.’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>At the end of twenty years, in which Solomon had built the two houses, Yahweh’s house and the king’s house 
-<span class="v">11&#160;</span>(now Hiram the king of Tyre had furnished Solomon with cedar trees and cypress trees, and with gold, according to all his desire), King Solomon gave Hiram twenty cities in the land of Galilee. 
-<span class="v">12&#160;</span>Hiram came out of Tyre to see the cities which Solomon had given him; and they didn’t please him. 
-<span class="v">13&#160;</span>He said, “What cities are these which you have given me, my brother?” He called them the land of Cabul<span class="f">+ \fr 9:13 \ft “Cabul” sounds like Hebrew for “good-for-nothing”.</span> to this day. 
-<span class="v">14&#160;</span>Hiram sent to the king one hundred twenty talents<span class="f">+ \fr 9:14 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 120 talents is about 3.6 metric tons</span> of gold. 
-</p><p>
-<span class="v">15&#160;</span>This is the reason of the forced labor which King Solomon conscripted: to build Yahweh’s house, his own house, Millo, Jerusalem’s wall, Hazor, Megiddo, and Gezer. 
-<span class="v">16&#160;</span>Pharaoh king of Egypt had gone up, taken Gezer, burned it with fire, killed the Canaanites who lived in the city, and given it for a wedding gift to his daughter, Solomon’s woman. 
-<span class="v">17&#160;</span>Solomon built in the land Gezer, Beth Horon the lower, 
-<span class="v">18&#160;</span>Baalath, Tamar in the wilderness, 
-<span class="v">19&#160;</span>all the storage cities that Solomon had, the cities for his chariots, the cities for his horsemen, and that which Solomon desired to build for his pleasure in Jerusalem, and in Lebanon, and in all the land of his dominion. 
-<span class="v">20&#160;</span>As for all the people who were left of the Amorites, the Hittites, the Perizzites, the Hivites, and the Jebusites, who were not of the children of Israel—<span class="v">21&#160;</span>their children who were left after them in the land, whom the children of Israel were not able utterly to destroy—of them Solomon raised a levy of bondservants to this day. 
-<span class="v">22&#160;</span>But of the children of Israel Solomon made no bondservants; but they were the men of war, his servants, his princes, his captains, and rulers of his chariots and of his horsemen. 
-<span class="v">23&#160;</span>These were the five hundred fifty chief officers who were over Solomon’s work, who ruled over the people who labored in the work. 
-</p><p>
-<span class="v">24&#160;</span>But Pharaoh’s daughter came up out of David’s city to her house which Solomon had built for her. Then he built Millo. 
-</p><p>
-<span class="v">25&#160;</span>Solomon offered burnt offerings and peace offerings on the altar which he built to Yahweh three times per year, burning incense with them on the altar that was before Yahweh. So he finished the house. 
-</p><p>
-<span class="v">26&#160;</span>King Solomon made a fleet of ships in Ezion Geber, which is beside Eloth, on the shore of the Red Sea, in the land of Edom. 
-<span class="v">27&#160;</span>Hiram sent in the fleet his servants, sailors who had knowledge of the sea, with the servants of Solomon. 
-<span class="v">28&#160;</span>They came to Ophir, and fetched from there gold, four hundred and twenty talents,<span class="f">+ \fr 9:28 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 420 talents is about 12.6 metric tons</span> and brought it to King Solomon. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>When the queen of Sheba heard of the fame of Solomon concerning Yahweh’s name, she came to test him with hard questions. 
-<span class="v">2&#160;</span>She came to Jerusalem with a very great caravan, with camels that bore spices, very much gold, and precious stones; and when she had come to Solomon, she talked with him about all that was in her heart. 
-<span class="v">3&#160;</span>Solomon answered all her questions. There wasn’t anything hidden from the king which he didn’t tell her. 
-<span class="v">4&#160;</span>When the queen of Sheba had seen all the wisdom of Solomon, the house that he had built, 
-<span class="v">5&#160;</span>the food of his table, the sitting of his servants, the attendance of his officials, their clothing, his cup bearers, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
-<span class="v">6&#160;</span>She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
-<span class="v">7&#160;</span>However, I didn’t believe the words until I came and my eyes had seen it. Behold, not even half was told me! Your wisdom and prosperity exceed the fame which I heard. 
-<span class="v">8&#160;</span>Happy are your men, happy are these your servants who stand continually before you, who hear your wisdom. 
-<span class="v">9&#160;</span>Blessed is Yahweh your Elohim, who delighted in you, to set you on the throne of Israel. Because Yahweh loved Israel forever, therefore he made you king, to do justice and righteousness.” 
-<span class="v">10&#160;</span>She gave the king one hundred twenty talents of gold, and a very great quantity of spices, and precious stones. Never again was there such an abundance of spices as these which the queen of Sheba gave to King Solomon. 
-</p><p>
-<span class="v">11&#160;</span>The fleet of Hiram that brought gold from Ophir also brought in from Ophir great quantities of almug trees<span class="f">+ \fr 10:11 \ft possibly an Indian sandalwood, with nice grain and a pleasant scent, and good for woodworking</span> and precious stones. 
-<span class="v">12&#160;</span>The king made of the almug trees pillars for Yahweh’s house and for the king’s house, harps also and stringed instruments for the singers; no such almug trees came or were seen to this day. 
-</p><p>
-<span class="v">13&#160;</span>King Solomon gave to the queen of Sheba all her desire, whatever she asked, in addition to that which Solomon gave her of his royal bounty. So she turned and went to her own land, she and her servants. 
-</p><p>
-<span class="v">14&#160;</span>Now the weight of gold that came to Solomon in one year was six hundred sixty-six talents<span class="f">+ \fr 10:14 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 666 talents is about 20 metric tons</span> of gold, 
-<span class="v">15&#160;</span>in addition to that which the traders brought, and the traffic of the merchants, and of all the kings of the mixed people, and of the governors of the country. 
-<span class="v">16&#160;</span>King Solomon made two hundred bucklers of beaten gold; six hundred shekels<span class="f">+ \fr 10:16 \ft A shekel is about 10 grams or about 0.32 Troy ounces, so 600 shekels is about 6 kilograms or 13.2 pounds or 192 Troy ounces.</span> of gold went to one buckler. 
-<span class="v">17&#160;</span>He made three hundred shields of beaten gold; three minas<span class="f">+ \fr 10:17 \ft A mina is about 600 grams or 1.3 U. S. pounds.</span> of gold went to one shield; and the king put them in the House of the Forest of Lebanon. 
-<span class="v">18&#160;</span>Moreover the king made a great throne of ivory, and overlaid it with the finest gold. 
-<span class="v">19&#160;</span>There were six steps to the throne, and the top of the throne was round behind; and there were armrests on either side by the place of the seat, and two lions standing beside the armrests. 
-<span class="v">20&#160;</span>Twelve lions stood there on the one side and on the other on the six steps. Nothing like it was made in any kingdom. 
-<span class="v">21&#160;</span>All King Solomon’s drinking vessels were of gold, and all the vessels of the House of the Forest of Lebanon were of pure gold. None were of silver, because it was considered of little value in the days of Solomon. 
-<span class="v">22&#160;</span>For the king had a fleet of ships of Tarshish at sea with Hiram’s fleet. Once every three years the fleet of Tarshish came bringing gold, silver, ivory, apes, and peacocks. 
-</p><p>
-<span class="v">23&#160;</span>So King Solomon exceeded all the kings of the earth in riches and in wisdom. 
-<span class="v">24&#160;</span>All the earth sought the presence of Solomon to hear his wisdom which Elohim had put in his heart. 
-<span class="v">25&#160;</span>Year after year, every man brought his tribute, vessels of silver, vessels of gold, clothing, armor, spices, horses, and mules. 
-</p><p>
-<span class="v">26&#160;</span>Solomon gathered together chariots and horsemen. He had one thousand four hundred chariots and twelve thousand horsemen. He kept them in the chariot cities and with the king at Jerusalem. 
-<span class="v">27&#160;</span>The king made silver as common as stones in Jerusalem, and cedars as common as the sycamore trees that are in the lowland. 
-<span class="v">28&#160;</span>The horses which Solomon had were brought out of Egypt. The king’s merchants received them in droves, each drove at a price. 
-<span class="v">29&#160;</span>A chariot was imported from Egypt for six hundred shekels<span class="f">+ \fr 10:29 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of silver, and a horse for one hundred fifty shekels; and so they exported them to all the kings of the Hittites and to the kings of Syria. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Now King Solomon loved many foreign women, together with the daughter of Pharaoh: women of the Moabites, Ammonites, Edomites, Sidonians, and Hittites, 
-<span class="v">2&#160;</span>of the nations concerning which Yahweh said to the children of Israel, “You shall not go among them, neither shall they come among you, for surely they will turn away your heart after their elohims.” Solomon joined to these in love. 
-<span class="v">3&#160;</span>He had seven hundred women, princesses, and three hundred concubines. His women turned his heart away. 
-<span class="v">4&#160;</span>When Solomon was old, his women turned away his heart after other elohims; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father was. 
-<span class="v">5&#160;</span>For Solomon went after Ashtoreth the elohim of the Sidonians, and after Milcom the abomination of the Ammonites. 
-<span class="v">6&#160;</span>Solomon did that which was evil in Yahweh’s sight, and didn’t go fully after Yahweh, as David his father did. 
-<span class="v">7&#160;</span>Then Solomon built a high place for Chemosh the abomination of Moab, on the mountain that is before Jerusalem, and for Molech the abomination of the children of Ammon. 
-<span class="v">8&#160;</span>So he did for all his foreign women, who burned incense and sacrificed to their elohims. 
-<span class="v">9&#160;</span>Yahweh was angry with Solomon, because his heart was turned away from Yahweh, the Elohim of Israel, who had appeared to him twice, 
-<span class="v">10&#160;</span>and had commanded him concerning this thing, that he should not go after other elohims; but he didn’t keep that which Yahweh commanded. 
-<span class="v">11&#160;</span>Therefore Yahweh said to Solomon, “Because this is done by you, and you have not kept my covenant and my statutes, which I have commanded you, I will surely tear the kingdom from you, and will give it to your servant. 
-<span class="v">12&#160;</span>Nevertheless, I will not do it in your days, for David your father’s sake; but I will tear it out of your son’s hand. 
-<span class="v">13&#160;</span>However, I will not tear away all the kingdom; but I will give one tribe to your son, for David my servant’s sake, and for Jerusalem’s sake which I have chosen.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh raised up an adversary to Solomon: Hadad the Edomite. He was one of the king’s offspring in Edom. 
-<span class="v">15&#160;</span>For when David was in Edom, and Joab the captain of the army had gone up to bury the slain, and had struck every male in Edom 
-<span class="v">16&#160;</span>(for Joab and all Israel remained there six months, until he had cut off every male in Edom), 
-<span class="v">17&#160;</span>Hadad fled, he and certain Edomites of his father’s servants with him, to go into Egypt, when Hadad was still a little child. 
-<span class="v">18&#160;</span>They arose out of Midian and came to Paran; and they took men with them out of Paran, and they came to Egypt, to Pharaoh king of Egypt, who gave him a house, and appointed him food, and gave him land. 
-<span class="v">19&#160;</span>Hadad found great favor in the sight of Pharaoh, so that he gave him as woman the sister of his own woman, the sister of Tahpenes the queen. 
-<span class="v">20&#160;</span>The sister of Tahpenes bore him Genubath his son, whom Tahpenes weaned in Pharaoh’s house; and Genubath was in Pharaoh’s house among the sons of Pharaoh. 
-<span class="v">21&#160;</span>When Hadad heard in Egypt that David slept with his fathers, and that Joab the captain of the army was dead, Hadad said to Pharaoh, “Let me depart, that I may go to my own country.” 
-</p><p>
-<span class="v">22&#160;</span>Then Pharaoh said to him, “But what have you lacked with me, that behold, you seek to go to your own country?” 
-</p><p>He answered, “Nothing, however only let me depart.” 
-</p><p>
-<span class="v">23&#160;</span>Elohim raised up an adversary to him, Rezon the son of Eliada, who had fled from his lord, Hadadezer king of Zobah. 
-<span class="v">24&#160;</span>He gathered men to himself, and became captain over a troop, when David killed them of Zobah. They went to Damascus and lived there, and reigned in Damascus. 
-<span class="v">25&#160;</span>He was an adversary to Israel all the days of Solomon, in addition to the mischief of Hadad. He abhorred Israel, and reigned over Syria. 
-</p><p>
-<span class="v">26&#160;</span>Jeroboam the son of Nebat, an Ephraimite of Zeredah, a servant of Solomon, whose mother’s name was Zeruah, a widow, also lifted up his hand against the king. 
-<span class="v">27&#160;</span>This was the reason why he lifted up his hand against the king: Solomon built Millo, and repaired the breach of his father David’s city. 
-<span class="v">28&#160;</span>The man Jeroboam was a mighty man of valor; and Solomon saw the young man that he was industrious, and he put him in charge of all the labor of the house of Joseph. 
-<span class="v">29&#160;</span>At that time, when Jeroboam went out of Jerusalem, the prophet Ahijah the Shilonite found him on the way. Now Ahijah had clad himself with a new garment; and the two of them were alone in the field. 
-<span class="v">30&#160;</span>Ahijah took the new garment that was on him, and tore it in twelve pieces. 
-<span class="v">31&#160;</span>He said to Jeroboam, “Take ten pieces; for Yahweh, the Elohim of Israel, says, ‘Behold, I will tear the kingdom out of the hand of Solomon and will give ten tribes to you 
-<span class="v">32&#160;</span>(but he shall have one tribe, for my servant David’s sake and for Jerusalem’s sake, the city which I have chosen out of all the tribes of Israel), 
-<span class="v">33&#160;</span>because they have forsaken me, and have worshiped Ashtoreth the elohim of the Sidonians, Chemosh the elohim of Moab, and Milcom the elohim of the children of Ammon. They have not walked in my ways, to do that which is right in my eyes, and to keep my statutes and my ordinances, as David his father did. 
-</p><p>
-<span class="v">34&#160;</span>“&#160;‘However, I will not take the whole kingdom out of his hand, but I will make him prince all the days of his life for David my servant’s sake whom I chose, who kept my commandments and my statutes, 
-<span class="v">35&#160;</span>but I will take the kingdom out of his son’s hand and will give it to you, even ten tribes. 
-<span class="v">36&#160;</span>I will give one tribe to his son, that David my servant may have a lamp always before me in Jerusalem, the city which I have chosen for myself to put my name there. 
-<span class="v">37&#160;</span>I will take you, and you shall reign according to all that your soul desires, and shall be king over Israel. 
-<span class="v">38&#160;</span>It shall be, if you will listen to all that I command you, and will walk in my ways, and do that which is right in my eyes, to keep my statutes and my commandments, as David my servant did, that I will be with you, and will build you a sure house, as I built for David, and will give Israel to you. 
-<span class="v">39&#160;</span>I will afflict the offspring of David for this, but not forever.’&#160;” 
-</p><p>
-<span class="v">40&#160;</span>Therefore Solomon sought to kill Jeroboam, but Jeroboam arose and fled into Egypt, to Shishak king of Egypt, and was in Egypt until the death of Solomon. 
-</p><p>
-<span class="v">41&#160;</span>Now the rest of the acts of Solomon, and all that he did, and his wisdom, aren’t they written in the book of the acts of Solomon? 
-<span class="v">42&#160;</span>The time that Solomon reigned in Jerusalem over all Israel was forty years. 
-<span class="v">43&#160;</span>Solomon slept with his fathers, and was buried in his father David’s city; and Rehoboam his son reigned in his place. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Rehoboam went to Shechem, for all Israel had come to Shechem to make him king. 
-<span class="v">2&#160;</span>When Jeroboam the son of Nebat heard of it (for he was yet in Egypt, where he had fled from the presence of King Solomon, and Jeroboam lived in Egypt; 
-<span class="v">3&#160;</span>and they sent and called him), Jeroboam and all the assembly of Israel came, and spoke to Rehoboam, saying, 
-<span class="v">4&#160;</span>“Your father made our yoke difficult. Now therefore make the hard service of your father, and his heavy yoke which he put on us, lighter, and we will serve you.” 
-</p><p>
-<span class="v">5&#160;</span>He said to them, “Depart for three days, then come back to me.” 
-</p><p>So the people departed. 
-</p><p>
-<span class="v">6&#160;</span>King Rehoboam took counsel with the old men who had stood before Solomon his father while he yet lived, saying, “What counsel do you give me to answer these people?” 
-</p><p>
-<span class="v">7&#160;</span>They replied, “If you will be a servant to this people today, and will serve them, and answer them with good words, then they will be your servants forever.” 
-</p><p>
-<span class="v">8&#160;</span>But he abandoned the counsel of the old men which they had given him, and took counsel with the young men who had grown up with him, who stood before him. 
-<span class="v">9&#160;</span>He said to them, “What counsel do you give, that we may answer these people who have spoken to me, saying, ‘Make the yoke that your father put on us lighter’?” 
-</p><p>
-<span class="v">10&#160;</span>The young men who had grown up with him said to him, “Tell these people who spoke to you, saying, ‘Your father made our yoke heavy, but make it lighter to us’—tell them, ‘My little finger is thicker than my father’s waist. 
-<span class="v">11&#160;</span>Now my father burdened you with a heavy yoke, but I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>So Jeroboam and all the people came to Rehoboam the third day, as the king asked, saying, “Come to me again the third day.” 
-<span class="v">13&#160;</span>The king answered the people roughly, and abandoned the counsel of the old men which they had given him, 
-<span class="v">14&#160;</span>and spoke to them according to the counsel of the young men, saying, “My father made your yoke heavy, but I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.” 
-</p><p>
-<span class="v">15&#160;</span>So the king didn’t listen to the people; for it was a thing brought about from Yahweh, that he might establish his word, which Yahweh spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
-<span class="v">16&#160;</span>When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion have we in David? We don’t have an inheritance in the son of Jesse. To your tents, Israel! Now see to your own house, David.” So Israel departed to their tents. 
-</p><p>
-<span class="v">17&#160;</span>But as for the children of Israel who lived in the cities of Judah, Rehoboam reigned over them. 
-<span class="v">18&#160;</span>Then King Rehoboam sent Adoram, who was over the men subject to forced labor; and all Israel stoned him to death with stones. King Rehoboam hurried to get himself up to his chariot, to flee to Jerusalem. 
-<span class="v">19&#160;</span>So Israel rebelled against David’s house to this day. 
-</p><p>
-<span class="v">20&#160;</span>When all Israel heard that Jeroboam had returned, they sent and called him to the congregation, and made him king over all Israel. There was no one who followed David’s house, except for the tribe of Judah only. 
-</p><p>
-<span class="v">21&#160;</span>When Rehoboam had come to Jerusalem, he assembled all the house of Judah and the tribe of Benjamin, a hundred and eighty thousand chosen men who were warriors, to fight against the house of Israel, to bring the kingdom again to Rehoboam the son of Solomon. 
-<span class="v">22&#160;</span>But the word of Elohim came to Shemaiah the man of Elohim, saying, 
-<span class="v">23&#160;</span>“Speak to Rehoboam the son of Solomon, king of Judah, and to all the house of Judah and Benjamin, and to the rest of the people, saying, 
-<span class="v">24&#160;</span>‘Yahweh says, “You shall not go up or fight against your brothers, the children of Israel. Everyone return to his house; for this thing is from me.”&#160;’&#160;” So they listened to Yahweh’s word, and returned and went their way, according to Yahweh’s word. 
-</p><p>
-<span class="v">25&#160;</span>Then Jeroboam built Shechem in the hill country of Ephraim, and lived in it; and he went out from there and built Penuel. 
-<span class="v">26&#160;</span>Jeroboam said in his heart, “Now the kingdom will return to David’s house. 
-<span class="v">27&#160;</span>If this people goes up to offer sacrifices in Yahweh’s house at Jerusalem, then the heart of this people will turn again to their lord, even to Rehoboam king of Judah; and they will kill me, and return to Rehoboam king of Judah.” 
-<span class="v">28&#160;</span>So the king took counsel, and made two calves of gold; and he said to them, “It is too much for you to go up to Jerusalem. Look and behold your elohims, Israel, which brought you up out of the land of Egypt!” 
-<span class="v">29&#160;</span>He set the one in Bethel, and the other he put in Dan. 
-<span class="v">30&#160;</span>This thing became a sin, for the people went even as far as Dan to worship before the one there. 
-<span class="v">31&#160;</span>He made houses of high places, and made priests from among all the people, who were not of the sons of Levi. 
-<span class="v">32&#160;</span>Jeroboam ordained a feast in the eighth month, on the fifteenth day of the month, like the feast that is in Judah, and he went up to the altar. He did so in Bethel, sacrificing to the calves that he had made, and he placed in Bethel the priests of the high places that he had made. 
-<span class="v">33&#160;</span>He went up to the altar which he had made in Bethel on the fifteenth day in the eighth month, even in the month which he had devised of his own heart; and he ordained a feast for the children of Israel, and went up to the altar to burn incense. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Behold, a man of Elohim came out of Judah by Yahweh’s word to Bethel; and Jeroboam was standing by the altar to burn incense. 
-<span class="v">2&#160;</span>He cried against the altar by Yahweh’s word, and said, “Altar! Altar! Yahweh says: ‘Behold, a son will be born to David’s house, Josiah by name. On you he will sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.’&#160;” 
-<span class="v">3&#160;</span>He gave a sign the same day, saying, “This is the sign which Yahweh has spoken: Behold, the altar will be split apart, and the ashes that are on it will be poured out.” 
-</p><p>
-<span class="v">4&#160;</span>When the king heard the saying of the man of Elohim, which he cried against the altar in Bethel, Jeroboam put out his hand from the altar, saying, “Seize him!” His hand, which he put out against him, dried up, so that he could not draw it back again to himself. 
-<span class="v">5&#160;</span>The altar was also split apart, and the ashes poured out from the altar, according to the sign which the man of Elohim had given by Yahweh’s word. 
-<span class="v">6&#160;</span>The king answered the man of Elohim, “Now intercede for the favor of Yahweh your Elohim, and pray for me, that my hand may be restored me again.” 
-</p><p>The man of Elohim interceded with Yahweh, and the king’s hand was restored to him again, and became as it was before. 
-</p><p>
-<span class="v">7&#160;</span>The king said to the man of Elohim, “Come home with me and refresh yourself, and I will give you a reward.” 
-</p><p>
-<span class="v">8&#160;</span>The man of Elohim said to the king, “Even if you gave me half of your house, I would not go in with you, neither would I eat bread nor drink water in this place; 
-<span class="v">9&#160;</span>for so was it commanded me by Yahweh’s word, saying, ‘You shall eat no bread, drink no water, and don’t return by the way that you came.’&#160;” 
-<span class="v">10&#160;</span>So he went another way, and didn’t return by the way that he came to Bethel. 
-</p><p>
-<span class="v">11&#160;</span>Now an old prophet lived in Bethel, and one of his sons came and told him all the works that the man of Elohim had done that day in Bethel. They also told their father the words which he had spoken to the king. 
-</p><p>
-<span class="v">12&#160;</span>Their father said to them, “Which way did he go?” Now his sons had seen which way the man of Elohim went, who came from Judah. 
-<span class="v">13&#160;</span>He said to his sons, “Saddle the donkey for me.” So they saddled the donkey for him; and he rode on it. 
-<span class="v">14&#160;</span>He went after the man of Elohim, and found him sitting under an oak. He said to him, “Are you the man of Elohim who came from Judah?” 
-</p><p>He said, “I am.” 
-</p><p>
-<span class="v">15&#160;</span>Then he said to him, “Come home with me and eat bread.” 
-</p><p>
-<span class="v">16&#160;</span>He said, “I may not return with you, nor go in with you. I will not eat bread or drink water with you in this place. 
-<span class="v">17&#160;</span>For it was said to me by Yahweh’s word, ‘You shall eat no bread or drink water there, and don’t turn again to go by the way that you came.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>He said to him, “I also am a prophet as you are; and an angel spoke to me by Yahweh’s word, saying, ‘Bring him back with you into your house, that he may eat bread and drink water.’&#160;” He lied to him. 
-</p><p>
-<span class="v">19&#160;</span>So he went back with him, ate bread in his house, and drank water. 
-<span class="v">20&#160;</span>As they sat at the table, Yahweh’s word came to the prophet who brought him back; 
-<span class="v">21&#160;</span>and he cried out to the man of Elohim who came from Judah, saying, “Yahweh says, ‘Because you have been disobedient to Yahweh’s word, and have not kept the commandment which Yahweh your Elohim commanded you, 
-<span class="v">22&#160;</span>but came back, and have eaten bread and drank water in the place of which he said to you, “Eat no bread, and drink no water,” your body will not come to the tomb of your fathers.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>After he had eaten bread and after he drank, he saddled the donkey for the prophet whom he had brought back. 
-<span class="v">24&#160;</span>When he had gone, a lion met him by the way and killed him. His body was thrown on the path, and the donkey stood by it. The lion also stood by the body. 
-<span class="v">25&#160;</span>Behold, men passed by and saw the body thrown on the path, and the lion standing by the body; and they came and told it in the city where the old prophet lived. 
-<span class="v">26&#160;</span>When the prophet who brought him back from the way heard of it, he said, “It is the man of Elohim who was disobedient to Yahweh’s word. Therefore Yahweh has delivered him to the lion, which has mauled him and slain him, according to Yahweh’s word which he spoke to him.” 
-<span class="v">27&#160;</span>He said to his sons, saying, “Saddle the donkey for me,” and they saddled it. 
-<span class="v">28&#160;</span>He went and found his body thrown on the path, and the donkey and the lion standing by the body. The lion had not eaten the body nor mauled the donkey. 
-<span class="v">29&#160;</span>The prophet took up the body of the man of Elohim, and laid it on the donkey, and brought it back. He came to the city of the old prophet to mourn, and to bury him. 
-<span class="v">30&#160;</span>He laid his body in his own grave; and they mourned over him, saying, “Alas, my brother!” 
-</p><p>
-<span class="v">31&#160;</span>After he had buried him, he spoke to his sons, saying, “When I am dead, bury me in the tomb in which the man of Elohim is buried. Lay my bones beside his bones. 
-<span class="v">32&#160;</span>For the saying which he cried by Yahweh’s word against the altar in Bethel, and against all the houses of the high places which are in the cities of Samaria, will surely happen.” 
-</p><p>
-<span class="v">33&#160;</span>After this thing, Jeroboam didn’t turn from his evil way, but again made priests of the high places from among all the people. Whoever wanted to, he consecrated him, that there might be priests of the high places. 
-<span class="v">34&#160;</span>This thing became sin to the house of Jeroboam, even to cut it off and to destroy it from off the surface of the earth. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>At that time Abijah the son of Jeroboam became sick. 
-<span class="v">2&#160;</span>Jeroboam said to his woman, “Please get up and disguise yourself, so that you won’t be recognized as Jeroboam’s woman. Go to Shiloh. Behold, Ahijah the prophet is there, who said that I would be king over this people. 
-<span class="v">3&#160;</span>Take with you ten loaves of bread, some cakes, and a jar of honey, and go to him. He will tell you what will become of the child.” 
-</p><p>
-<span class="v">4&#160;</span>Jeroboam’s woman did so, and arose and went to Shiloh, and came to Ahijah’s house. Now Ahijah could not see, for his eyes were set by reason of his age. 
-<span class="v">5&#160;</span>Yahweh said to Ahijah, “Behold, Jeroboam’s woman is coming to inquire of you concerning her son, for he is sick. Tell her such and such; for it will be, when she comes in, that she will pretend to be another woman.” 
-</p><p>
-<span class="v">6&#160;</span>So when Ahijah heard the sound of her feet as she came in at the door, he said, “Come in, Jeroboam’s woman! Why do you pretend to be another? For I am sent to you with heavy news. 
-<span class="v">7&#160;</span>Go, tell Jeroboam, ‘Yahweh, the Elohim of Israel, says: “Because I exalted you from among the people, and made you prince over my people Israel, 
-<span class="v">8&#160;</span>and tore the kingdom away from David’s house, and gave it you; and yet you have not been as my servant David, who kept my commandments, and who followed me with all his heart, to do that only which was right in my eyes, 
-<span class="v">9&#160;</span>but have done evil above all who were before you, and have gone and made for yourself other elohims, molten images, to provoke me to anger, and have cast me behind your back, 
-<span class="v">10&#160;</span>therefore, behold, I will bring evil on the house of Jeroboam, and will cut off from Jeroboam everyone who urinates on a wall,<span class="f">+ \fr 14:10 \ft or, male</span> he who is shut up and he who is left at large in Israel, and will utterly sweep away the house of Jeroboam, as a man sweeps away dung until it is all gone. 
-<span class="v">11&#160;</span>The dogs will eat he who belongs to Jeroboam who dies in the city; and the birds of the sky will eat he who dies in the field, for Yahweh has spoken it.”&#160;’ 
-<span class="v">12&#160;</span>Arise therefore, and go to your house. When your feet enter into the city, the child will die. 
-<span class="v">13&#160;</span>All Israel will mourn for him and bury him; for he only of Jeroboam will come to the grave, because in him there is found some good thing toward Yahweh, the Elohim of Israel, in the house of Jeroboam. 
-<span class="v">14&#160;</span>Moreover Yahweh will raise up a king for himself over Israel who will cut off the house of Jeroboam. This is the day! What? Even now. 
-<span class="v">15&#160;</span>For Yahweh will strike Israel, as a reed is shaken in the water; and he will root up Israel out of this good land which he gave to their fathers, and will scatter them beyond the River,<span class="f">+ \fr 14:15 \ft That is, the Euphrates.</span> because they have made their Asherah poles, provoking Yahweh to anger. 
-<span class="v">16&#160;</span>He will give Israel up because of the sins of Jeroboam, which he has sinned, and with which he has made Israel to sin.” 
-</p><p>
-<span class="v">17&#160;</span>Jeroboam’s woman arose and departed, and came to Tirzah. As she came to the threshold of the house, the child died. 
-<span class="v">18&#160;</span>All Israel buried him and mourned for him, according to Yahweh’s word, which he spoke by his servant Ahijah the prophet. 
-</p><p>
-<span class="v">19&#160;</span>The rest of the acts of Jeroboam, how he fought and how he reigned, behold, they are written in the book of the chronicles of the kings of Israel. 
-<span class="v">20&#160;</span>The days which Jeroboam reigned were twenty two years; then he slept with his fathers, and Nadab his son reigned in his place. 
-</p><p>
-<span class="v">21&#160;</span>Rehoboam the son of Solomon reigned in Judah. Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel, to put his name there. His mother’s name was Naamah the Ammonitess. 
-<span class="v">22&#160;</span>Judah did that which was evil in Yahweh’s sight, and they provoked him to jealousy with their sins which they committed, above all that their fathers had done. 
-<span class="v">23&#160;</span>For they also built for themselves high places, sacred pillars, and Asherah poles on every high hill and under every green tree. 
-<span class="v">24&#160;</span>There were also sodomites in the land. They did according to all the abominations of the nations which Yahweh drove out before the children of Israel. 
-</p><p>
-<span class="v">25&#160;</span>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem; 
-<span class="v">26&#160;</span>and he took away the treasures of Yahweh’s house and the treasures of the king’s house. He even took away all of it, including all the gold shields which Solomon had made. 
-<span class="v">27&#160;</span>King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
-<span class="v">28&#160;</span>It was so, that as often as the king went into Yahweh’s house, the guard bore them, and brought them back into the guard room. 
-</p><p>
-<span class="v">29&#160;</span>Now the rest of the acts of Rehoboam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">30&#160;</span>There was war between Rehoboam and Jeroboam continually. 
-<span class="v">31&#160;</span>Rehoboam slept with his fathers, and was buried with his fathers in David’s city. His mother’s name was Naamah the Ammonitess. Abijam his son reigned in his place. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Now in the eighteenth year of King Jeroboam the son of Nebat, Abijam began to reign over Judah. 
-<span class="v">2&#160;</span>He reigned three years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
-<span class="v">3&#160;</span>He walked in all the sins of his father, which he had done before him; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father. 
-<span class="v">4&#160;</span>Nevertheless for David’s sake, Yahweh his Elohim gave him a lamp in Jerusalem, to set up his son after him and to establish Jerusalem; 
-<span class="v">5&#160;</span>because David did that which was right in Yahweh’s eyes, and didn’t turn away from anything that he commanded him all the days of his life, except only in the matter of Uriah the Hittite. 
-<span class="v">6&#160;</span>Now there was war between Rehoboam and Jeroboam all the days of his life. 
-<span class="v">7&#160;</span>The rest of the acts of Abijam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? There was war between Abijam and Jeroboam. 
-<span class="v">8&#160;</span>Abijam slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. 
-</p><p>
-<span class="v">9&#160;</span>In the twentieth year of Jeroboam king of Israel, Asa began to reign over Judah. 
-<span class="v">10&#160;</span>He reigned forty-one years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
-<span class="v">11&#160;</span>Asa did that which was right in Yahweh’s eyes, as David his father did. 
-<span class="v">12&#160;</span>He put away the sodomites out of the land, and removed all the idols that his fathers had made. 
-<span class="v">13&#160;</span>He also removed Maacah his mother from being queen, because she had made an abominable image for an Asherah. Asa cut down her image and burned it at the brook Kidron. 
-<span class="v">14&#160;</span>But the high places were not taken away. Nevertheless the heart of Asa was perfect with Yahweh all his days. 
-<span class="v">15&#160;</span>He brought into Yahweh’s house the things that his father had dedicated, and the things that he himself had dedicated: silver, gold, and utensils. 
-</p><p>
-<span class="v">16&#160;</span>There was war between Asa and Baasha king of Israel all their days. 
-<span class="v">17&#160;</span>Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
-<span class="v">18&#160;</span>Then Asa took all the silver and the gold that was left in the treasures of Yahweh’s house, and the treasures of the king’s house, and delivered it into the hand of his servants. Then King Asa sent them to Ben Hadad, the son of Tabrimmon, the son of Hezion, king of Syria, who lived at Damascus, saying, 
-<span class="v">19&#160;</span>“Let there be a treaty between me and you, like that between my father and your father. Behold, I have sent to you a present of silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
-</p><p>
-<span class="v">20&#160;</span>Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel, and struck Ijon, and Dan, and Abel Beth Maacah, and all Chinneroth, with all the land of Naphtali. 
-<span class="v">21&#160;</span>When Baasha heard of it, he stopped building Ramah, and lived in Tirzah. 
-<span class="v">22&#160;</span>Then King Asa made a proclamation to all Judah. No one was exempted. They carried away the stones of Ramah, and its timber, with which Baasha had built; and King Asa used it to build Geba of Benjamin, and Mizpah. 
-<span class="v">23&#160;</span>Now the rest of all the acts of Asa, and all his might, and all that he did, and the cities which he built, aren’t they written in the book of the chronicles of the kings of Judah? But in the time of his old age he was diseased in his feet. 
-<span class="v">24&#160;</span>Asa slept with his fathers, and was buried with his fathers in his father David’s city; and Jehoshaphat his son reigned in his place. 
-</p><p>
-<span class="v">25&#160;</span>Nadab the son of Jeroboam began to reign over Israel in the second year of Asa king of Judah; and he reigned over Israel two years. 
-<span class="v">26&#160;</span>He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in his sin with which he made Israel to sin. 
-<span class="v">27&#160;</span>Baasha the son of Ahijah, of the house of Issachar, conspired against him; and Baasha struck him at Gibbethon, which belonged to the Philistines; for Nadab and all Israel were besieging Gibbethon. 
-<span class="v">28&#160;</span>Even in the third year of Asa king of Judah, Baasha killed him and reigned in his place. 
-<span class="v">29&#160;</span>As soon as he was king, he struck all the house of Jeroboam. He didn’t leave to Jeroboam any who breathed, until he had destroyed him, according to the saying of Yahweh, which he spoke by his servant Ahijah the Shilonite; 
-<span class="v">30&#160;</span>for the sins of Jeroboam which he sinned, and with which he made Israel to sin, because of his provocation with which he provoked Yahweh, the Elohim of Israel, to anger. 
-</p><p>
-<span class="v">31&#160;</span>Now the rest of the acts of Nadab, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">32&#160;</span>There was war between Asa and Baasha king of Israel all their days. 
-</p><p>
-<span class="v">33&#160;</span>In the third year of Asa king of Judah, Baasha the son of Ahijah began to reign over all Israel in Tirzah for twenty-four years. 
-<span class="v">34&#160;</span>He did that which was evil in Yahweh’s sight, and walked in the way of Jeroboam, and in his sin with which he made Israel to sin. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to Jehu the son of Hanani against Baasha, saying, 
-<span class="v">2&#160;</span>“Because I exalted you out of the dust and made you prince over my people Israel, and you have walked in the way of Jeroboam and have made my people Israel to sin, to provoke me to anger with their sins, 
-<span class="v">3&#160;</span>behold, I will utterly sweep away Baasha and his house; and I will make your house like the house of Jeroboam the son of Nebat. 
-<span class="v">4&#160;</span>The dogs will eat Baasha’s descendants who die in the city; and he who dies of his in the field, the birds of the sky will eat.” 
-</p><p>
-<span class="v">5&#160;</span>Now the rest of the acts of Baasha, and what he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">6&#160;</span>Baasha slept with his fathers, and was buried in Tirzah; and Elah his son reigned in his place. 
-</p><p>
-<span class="v">7&#160;</span>Moreover Yahweh’s word came by the prophet Jehu the son of Hanani against Baasha and against his house, both because of all the evil that he did in Yahweh’s sight, to provoke him to anger with the work of his hands, in being like the house of Jeroboam, and because he struck him. 
-</p><p>
-<span class="v">8&#160;</span>In the twenty-sixth year of Asa king of Judah, Elah the son of Baasha began to reign over Israel in Tirzah for two years. 
-<span class="v">9&#160;</span>His servant Zimri, captain of half his chariots, conspired against him. Now he was in Tirzah, drinking himself drunk in the house of Arza, who was over the household in Tirzah; 
-<span class="v">10&#160;</span>and Zimri went in and struck him and killed him in the twenty-seventh year of Asa king of Judah, and reigned in his place. 
-</p><p>
-<span class="v">11&#160;</span>When he began to reign, as soon as he sat on his throne, he attacked all the house of Baasha. He didn’t leave him a single one who urinates on a wall<span class="f">+ \fr 16:11 \ft or, male</span> among his relatives or his friends. 
-<span class="v">12&#160;</span>Thus Zimri destroyed all the house of Baasha, according to Yahweh’s word which he spoke against Baasha by Jehu the prophet, 
-<span class="v">13&#160;</span>for all the sins of Baasha, and the sins of Elah his son, which they sinned and with which they made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
-<span class="v">14&#160;</span>Now the rest of the acts of Elah, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
-</p><p>
-<span class="v">15&#160;</span>In the twenty-seventh year of Asa king of Judah, Zimri reigned seven days in Tirzah. Now the people were encamped against Gibbethon, which belonged to the Philistines. 
-<span class="v">16&#160;</span>The people who were encamped heard that Zimri had conspired, and had also killed the king. Therefore all Israel made Omri, the captain of the army, king over Israel that day in the camp. 
-<span class="v">17&#160;</span>Omri went up from Gibbethon, and all Israel with him, and they besieged Tirzah. 
-<span class="v">18&#160;</span>When Zimri saw that the city was taken, he went into the fortified part of the king’s house and burned the king’s house over him with fire, and died, 
-<span class="v">19&#160;</span>for his sins which he sinned in doing that which was evil in Yahweh’s sight, in walking in the way of Jeroboam, and in his sin which he did to make Israel to sin. 
-<span class="v">20&#160;</span>Now the rest of the acts of Zimri, and his treason that he committed, aren’t they written in the book of the chronicles of the kings of Israel? 
-</p><p>
-<span class="v">21&#160;</span>Then the people of Israel were divided into two parts: half of the people followed Tibni the son of Ginath, to make him king, and half followed Omri. 
-<span class="v">22&#160;</span>But the people who followed Omri prevailed against the people who followed Tibni the son of Ginath; so Tibni died, and Omri reigned. 
-<span class="v">23&#160;</span>In the thirty-first year of Asa king of Judah, Omri began to reign over Israel for twelve years. He reigned six years in Tirzah. 
-<span class="v">24&#160;</span>He bought the hill Samaria of Shemer for two talents<span class="f">+ \fr 16:24 \ft A talent is about 30 kilograms or 66 pounds.</span> of silver; and he built on the hill, and called the name of the city which he built, Samaria, after the name of Shemer, the owner of the hill. 
-<span class="v">25&#160;</span>Omri did that which was evil in Yahweh’s sight, and dealt wickedly above all who were before him. 
-<span class="v">26&#160;</span>For he walked in all the way of Jeroboam the son of Nebat, and in his sins with which he made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
-<span class="v">27&#160;</span>Now the rest of the acts of Omri which he did, and his might that he showed, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">28&#160;</span>So Omri slept with his fathers, and was buried in Samaria; and Ahab his son reigned in his place. 
-</p><p>
-<span class="v">29&#160;</span>In the thirty-eighth year of Asa king of Judah, Ahab the son of Omri began to reign over Israel. Ahab the son of Omri reigned over Israel in Samaria twenty-two years. 
-<span class="v">30&#160;</span>Ahab the son of Omri did that which was evil in Yahweh’s sight above all that were before him. 
-<span class="v">31&#160;</span>As if it had been a light thing for him to walk in the sins of Jeroboam the son of Nebat, he took as woman Jezebel the daughter of Ethbaal king of the Sidonians, and went and served Baal and worshiped him. 
-<span class="v">32&#160;</span>He raised up an altar for Baal in the house of Baal, which he had built in Samaria. 
-<span class="v">33&#160;</span>Ahab made the Asherah; and Ahab did more yet to provoke Yahweh, the Elohim of Israel, to anger than all the kings of Israel who were before him. 
-<span class="v">34&#160;</span>In his days Hiel the Bethelite built Jericho. He laid its foundation with the loss of Abiram his firstborn, and set up its gates with the loss of his youngest son Segub, according to Yahweh’s word, which he spoke by Joshua the son of Nun. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Elijah the Tishbite, who was one of the settlers of Gilead, said to Ahab, “As Yahweh, the Elohim of Israel, lives, before whom I stand, there shall not be dew nor rain these years, but according to my word.” 
-</p><p>
-<span class="v">2&#160;</span>Then Yahweh’s word came to him, saying, 
-<span class="v">3&#160;</span>“Go away from here, turn eastward, and hide yourself by the brook Cherith, that is before the Jordan. 
-<span class="v">4&#160;</span>You shall drink from the brook. I have commanded the ravens to feed you there.” 
-<span class="v">5&#160;</span>So he went and did according to Yahweh’s word, for he went and lived by the brook Cherith that is before the Jordan. 
-<span class="v">6&#160;</span>The ravens brought him bread and meat in the morning, and bread and meat in the evening; and he drank from the brook. 
-<span class="v">7&#160;</span>After a while, the brook dried up, because there was no rain in the land. 
-</p><p>
-<span class="v">8&#160;</span>Yahweh’s word came to him, saying, 
-<span class="v">9&#160;</span>“Arise, go to Zarephath, which belongs to Sidon, and stay there. Behold, I have commanded a widow there to sustain you.” 
-</p><p>
-<span class="v">10&#160;</span>So he arose and went to Zarephath; and when he came to the gate of the city, behold, a widow was there gathering sticks. He called to her and said, “Please get me a little water in a jar, that I may drink.” 
-</p><p>
-<span class="v">11&#160;</span>As she was going to get it, he called to her and said, “Please bring me a morsel of bread in your hand.” 
-</p><p>
-<span class="v">12&#160;</span>She said, “As Yahweh your Elohim lives, I don’t have anything baked, but only a handful of meal in a jar and a little oil in a jar. Behold, I am gathering two sticks, that I may go in and bake it for me and my son, that we may eat it, and die.” 
-</p><p>
-<span class="v">13&#160;</span>Elijah said to her, “Don’t be afraid. Go and do as you have said; but make me a little cake from it first, and bring it out to me, and afterward make some for you and for your son. 
-<span class="v">14&#160;</span>For Yahweh, the Elohim of Israel, says, ‘The jar of meal will not run out, and the jar of oil will not fail, until the day that Yahweh sends rain on the earth.’&#160;” 
-</p><p>
-<span class="v">15&#160;</span>She went and did according to the saying of Elijah; and she, he, and her household ate many days. 
-<span class="v">16&#160;</span>The jar of meal didn’t run out and the jar of oil didn’t fail, according to Yahweh’s word, which he spoke by Elijah. 
-</p><p>
-<span class="v">17&#160;</span>After these things, the son of the woman, the mistress of the house, became sick; and his sickness was so severe that there was no breath left in him. 
-<span class="v">18&#160;</span>She said to Elijah, “What have I to do with you, you man of Elohim? You have come to me to bring my sin to memory, and to kill my son!” 
-</p><p>
-<span class="v">19&#160;</span>He said to her, “Give me your son.” He took him out of her bosom, and carried him up into the room where he stayed, and laid him on his own bed. 
-<span class="v">20&#160;</span>He cried to Yahweh and said, “Yahweh my Elohim, have you also brought evil on the widow with whom I am staying, by killing her son?” 
-</p><p>
-<span class="v">21&#160;</span>He stretched himself on the child three times, and cried to Yahweh and said, “Yahweh my Elohim, please let this child’s soul come into him again.” 
-</p><p>
-<span class="v">22&#160;</span>Yahweh listened to the voice of Elijah; and the soul of the child came into him again, and he revived. 
-<span class="v">23&#160;</span>Elijah took the child and brought him down out of the room into the house, and delivered him to his mother; and Elijah said, “Behold, your son lives.” 
-</p><p>
-<span class="v">24&#160;</span>The woman said to Elijah, “Now I know that you are a man of Elohim, and that Yahweh’s word in your mouth is truth.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>After many days, Yahweh’s word came to Elijah, in the third year, saying, “Go, show yourself to Ahab; and I will send rain on the earth.” 
-</p><p>
-<span class="v">2&#160;</span>Elijah went to show himself to Ahab. The famine was severe in Samaria. 
-<span class="v">3&#160;</span>Ahab called Obadiah, who was over the household. (Now Obadiah feared Yahweh greatly; 
-<span class="v">4&#160;</span>for when Jezebel cut off Yahweh’s prophets, Obadiah took one hundred prophets, and hid them fifty to a cave, and fed them with bread and water.) 
-<span class="v">5&#160;</span>Ahab said to Obadiah, “Go through the land, to all the springs of water, and to all the brooks. Perhaps we may find grass and save the horses and mules alive, that we not lose all the animals.” 
-</p><p>
-<span class="v">6&#160;</span>So they divided the land between them to pass throughout it. Ahab went one way by himself, and Obadiah went another way by himself. 
-<span class="v">7&#160;</span>As Obadiah was on the way, behold, Elijah met him. He recognized him, and fell on his face, and said, “Is it you, my lord Elijah?” 
-</p><p>
-<span class="v">8&#160;</span>He answered him, “It is I. Go, tell your lord, ‘Behold, Elijah is here!’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>He said, “How have I sinned, that you would deliver your servant into the hand of Ahab, to kill me? 
-<span class="v">10&#160;</span>As Yahweh your Elohim lives, there is no nation or kingdom where my lord has not sent to seek you. When they said, ‘He is not here,’ he took an oath of the kingdom and nation that they didn’t find you. 
-<span class="v">11&#160;</span>Now you say, ‘Go, tell your lord, “Behold, Elijah is here.”&#160;’ 
-<span class="v">12&#160;</span>It will happen, as soon as I leave you, that Yahweh’s Spirit will carry you I don’t know where; and so when I come and tell Ahab, and he can’t find you, he will kill me. But I, your servant, have feared Yahweh from my youth. 
-<span class="v">13&#160;</span>Wasn’t it told my lord what I did when Jezebel killed Yahweh’s prophets, how I hid one hundred men of Yahweh’s prophets with fifty to a cave, and fed them with bread and water? 
-<span class="v">14&#160;</span>Now you say, ‘Go, tell your lord, “Behold, Elijah is here”.’ He will kill me.” 
-</p><p>
-<span class="v">15&#160;</span>Elijah said, “As Yahweh of Armies lives, before whom I stand, I will surely show myself to him today.” 
-<span class="v">16&#160;</span>So Obadiah went to meet Ahab, and told him; and Ahab went to meet Elijah. 
-</p><p>
-<span class="v">17&#160;</span>When Ahab saw Elijah, Ahab said to him, “Is that you, you troubler of Israel?” 
-</p><p>
-<span class="v">18&#160;</span>He answered, “I have not troubled Israel, but you and your father’s house, in that you have forsaken Yahweh’s commandments and you have followed the Baals. 
-<span class="v">19&#160;</span>Now therefore send, and gather to me all Israel to Mount Carmel, and four hundred fifty of the prophets of Baal, and four hundred of the prophets of the Asherah, who eat at Jezebel’s table.” 
-</p><p>
-<span class="v">20&#160;</span>So Ahab sent to all the children of Israel, and gathered the prophets together to Mount Carmel. 
-<span class="v">21&#160;</span>Elijah came near to all the people, and said, “How long will you waver between the two sides? If Yahweh is Elohim, follow him; but if Baal, then follow him.” 
-</p><p>The people didn’t say a word. 
-</p><p>
-<span class="v">22&#160;</span>Then Elijah said to the people, “I, even I only, am left as a prophet of Yahweh; but Baal’s prophets are four hundred fifty men. 
-<span class="v">23&#160;</span>Let them therefore give us two bulls; and let them choose one bull for themselves, and cut it in pieces, and lay it on the wood, and put no fire under; and I will dress the other bull, and lay it on the wood, and put no fire under it. 
-<span class="v">24&#160;</span>You call on the name of your elohim, and I will call on Yahweh’s name. The Elohim who answers by fire, let him be Elohim.” 
-</p><p>All the people answered, “What you say is good.” 
-</p><p>
-<span class="v">25&#160;</span>Elijah said to the prophets of Baal, “Choose one bull for yourselves, and dress it first, for you are many; and call on the name of your elohim, but put no fire under it.” 
-</p><p>
-<span class="v">26&#160;</span>They took the bull which was given them, and they dressed it, and called on the name of Baal from morning even until noon, saying, “Baal, hear us!” But there was no voice, and nobody answered. They leaped about the altar which was made. 
-</p><p>
-<span class="v">27&#160;</span>At noon, Elijah mocked them, and said, “Cry aloud, for he is an elohim. Either he is deep in thought, or he has gone somewhere, or he is on a journey, or perhaps he sleeps and must be awakened.” 
-</p><p>
-<span class="v">28&#160;</span>They cried aloud, and cut themselves in their way with knives and lances until the blood gushed out on them. 
-<span class="v">29&#160;</span>When midday was past, they prophesied until the time of the evening offering; but there was no voice, no answer, and nobody paid attention. 
-</p><p>
-<span class="v">30&#160;</span>Elijah said to all the people, “Come near to me!”; and all the people came near to him. He repaired Yahweh’s altar that had been thrown down. 
-<span class="v">31&#160;</span>Elijah took twelve stones, according to the number of the tribes of the sons of Jacob, to whom Yahweh’s word came, saying, “Israel shall be your name.” 
-<span class="v">32&#160;</span>With the stones he built an altar in Yahweh’s name. He made a trench around the altar large enough to contain two seahs<span class="f">+ \fr 18:32 \ft 1 seah is about 7 liters or 1.9 gallons or 0.8 pecks</span> of seed. 
-<span class="v">33&#160;</span>He put the wood in order, and cut the bull in pieces and laid it on the wood. He said, “Fill four jars with water, and pour it on the burnt offering and on the wood.” 
-<span class="v">34&#160;</span>He said, “Do it a second time;” and they did it the second time. He said, “Do it a third time;” and they did it the third time. 
-<span class="v">35&#160;</span>The water ran around the altar; and he also filled the trench with water. 
-</p><p>
-<span class="v">36&#160;</span>At the time of the evening offering, Elijah the prophet came near and said, “Yahweh, the Elohim of Abraham, of Isaac, and of Israel, let it be known today that you are Elohim in Israel and that I am your servant, and that I have done all these things at your word. 
-<span class="v">37&#160;</span>Hear me, Yahweh, hear me, that this people may know that you, Yahweh, are Elohim, and that you have turned their heart back again.” 
-</p><p>
-<span class="v">38&#160;</span>Then Yahweh’s fire fell and consumed the burnt offering, the wood, the stones, and the dust; and it licked up the water that was in the trench. 
-<span class="v">39&#160;</span>When all the people saw it, they fell on their faces. They said, “Yahweh, he is Elohim! Yahweh, he is Elohim!” 
-</p><p>
-<span class="v">40&#160;</span>Elijah said to them, “Seize the prophets of Baal! Don’t let one of them escape!” 
-</p><p>They seized them; and Elijah brought them down to the brook Kishon, and killed them there. 
-</p><p>
-<span class="v">41&#160;</span>Elijah said to Ahab, “Get up, eat and drink; for there is the sound of abundance of rain.” 
-</p><p>
-<span class="v">42&#160;</span>So Ahab went up to eat and to drink. Elijah went up to the top of Carmel; and he bowed himself down on the earth, and put his face between his knees. 
-<span class="v">43&#160;</span>He said to his servant, “Go up now and look toward the sea.” 
-</p><p>He went up and looked, then said, “There is nothing.” 
-</p><p>He said, “Go again” seven times. 
-</p><p>
-<span class="v">44&#160;</span>On the seventh time, he said, “Behold, a small cloud, like a man’s hand, is rising out of the sea.” 
-</p><p>He said, “Go up, tell Ahab, ‘Get ready and go down, so that the rain doesn’t stop you.’&#160;” 
-</p><p>
-<span class="v">45&#160;</span>In a little while, the sky grew black with clouds and wind, and there was a great rain. Ahab rode, and went to Jezreel. 
-<span class="v">46&#160;</span>Yahweh’s hand was on Elijah; and he tucked his cloak into his belt and ran before Ahab to the entrance of Jezreel. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Ahab told Jezebel all that Elijah had done, and how he had killed all the prophets with the sword. 
-<span class="v">2&#160;</span>Then Jezebel sent a messenger to Elijah, saying, “So let the elohims do to me, and more also, if I don’t make your life as the life of one of them by tomorrow about this time!” 
-</p><p>
-<span class="v">3&#160;</span>When he saw that, he arose and ran for his life, and came to Beersheba, which belongs to Judah, and left his servant there. 
-<span class="v">4&#160;</span>But he himself went a day’s journey into the wilderness, and came and sat down under a juniper tree. Then he requested for himself that he might die, and said, “It is enough. Now, O Yahweh, take away my life; for I am not better than my fathers.” 
-</p><p>
-<span class="v">5&#160;</span>He lay down and slept under a juniper tree; and behold, an angel touched him, and said to him, “Arise and eat!” 
-</p><p>
-<span class="v">6&#160;</span>He looked, and behold, there was at his head a cake baked on the coals, and a jar of water. He ate and drank, and lay down again. 
-<span class="v">7&#160;</span>Yahweh’s angel came again the second time, and touched him, and said, “Arise and eat, because the journey is too great for you.” 
-</p><p>
-<span class="v">8&#160;</span>He arose, and ate and drank, and went in the strength of that food forty days and forty nights to Horeb, Elohim’s Mountain. 
-<span class="v">9&#160;</span>He came to a cave there, and camped there; and behold, Yahweh’s word came to him, and he said to him, “What are you doing here, Elijah?” 
-</p><p>
-<span class="v">10&#160;</span>He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
-</p><p>
-<span class="v">11&#160;</span>He said, “Go out and stand on the mountain before Yahweh.” 
-</p><p>Behold, Yahweh passed by, and a great and strong wind tore the mountains and broke in pieces the rocks before Yahweh; but Yahweh was not in the wind. After the wind there was an earthquake; but Yahweh was not in the earthquake. 
-<span class="v">12&#160;</span>After the earthquake a fire passed; but Yahweh was not in the fire. After the fire, there was a still small voice. 
-<span class="v">13&#160;</span>When Elijah heard it, he wrapped his face in his mantle, went out, and stood in the entrance of the cave. Behold, a voice came to him, and said, “What are you doing here, Elijah?” 
-</p><p>
-<span class="v">14&#160;</span>He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
-</p><p>
-<span class="v">15&#160;</span>Yahweh said to him, “Go, return on your way to the wilderness of Damascus. When you arrive, anoint Hazael to be king over Syria. 
-<span class="v">16&#160;</span>Anoint Jehu the son of Nimshi to be king over Israel; and anoint Elisha the son of Shaphat of Abel Meholah to be prophet in your place. 
-<span class="v">17&#160;</span>He who escapes from the sword of Hazael, Jehu will kill; and he who escapes from the sword of Jehu, Elisha will kill. 
-<span class="v">18&#160;</span>Yet I reserved seven thousand in Israel, all the knees of which have not bowed to Baal, and every mouth which has not kissed him.” 
-</p><p>
-<span class="v">19&#160;</span>So he departed from there and found Elisha the son of Shaphat, who was plowing with twelve yoke of oxen before him, and he with the twelfth. Elijah went over to him and put his mantle on him. 
-<span class="v">20&#160;</span>Elisha left the oxen and ran after Elijah, and said, “Let me please kiss my father and my mother, and then I will follow you.” 
-</p><p>He said to him, “Go back again; for what have I done to you?” 
-</p><p>
-<span class="v">21&#160;</span>He returned from following him, and took the yoke of oxen, killed them, and boiled their meat with the oxen’s equipment, and gave to the people; and they ate. Then he arose, and went after Elijah, and served him. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Ben Hadad the king of Syria gathered all his army together; and there were thirty-two kings with him, with horses and chariots. He went up and besieged Samaria, and fought against it. 
-<span class="v">2&#160;</span>He sent messengers into the city to Ahab king of Israel and said to him, “Ben Hadad says, 
-<span class="v">3&#160;</span>‘Your silver and your gold are mine. Your women also and your children, even the best, are mine.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>The king of Israel answered, “It is according to your saying, my lord, O king. I am yours, and all that I have.” 
-</p><p>
-<span class="v">5&#160;</span>The messengers came again and said, “Ben Hadad says, ‘I sent indeed to you, saying, “You shall deliver me your silver, your gold, your women, and your children; 
-<span class="v">6&#160;</span>but I will send my servants to you tomorrow about this time, and they will search your house and the houses of your servants. Whatever is pleasant in your eyes, they will put it in their hand, and take it away.”&#160;’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>Then the king of Israel called all the elders of the land, and said, “Please notice how this man seeks mischief; for he sent to me for my women, and for my children, and for my silver, and for my gold; and I didn’t deny him.” 
-</p><p>
-<span class="v">8&#160;</span>All the elders and all the people said to him, “Don’t listen, and don’t consent.” 
-</p><p>
-<span class="v">9&#160;</span>Therefore he said to the messengers of Ben Hadad, “Tell my lord the king, ‘All that you sent for to your servant at the first I will do, but this thing I cannot do.’&#160;” 
-</p><p>The messengers departed and brought him back the message. 
-<span class="v">10&#160;</span>Ben Hadad sent to him, and said, “The elohims do so to me, and more also, if the dust of Samaria will be enough for handfuls for all the people who follow me.” 
-</p><p>
-<span class="v">11&#160;</span>The king of Israel answered, “Tell him, ‘Don’t let him who puts on his armor brag like he who takes it off.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>When Ben Hadad heard this message as he was drinking, he and the kings in the pavilions, he said to his servants, “Prepare to attack!” So they prepared to attack the city. 
-</p><p>
-<span class="v">13&#160;</span>Behold, a prophet came near to Ahab king of Israel, and said, “Yahweh says, ‘Have you seen all this great multitude? Behold, I will deliver it into your hand today. Then you will know that I am Yahweh.’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Ahab said, “By whom?” 
-</p><p>He said, “Yahweh says, ‘By the young men of the princes of the provinces.’&#160;” 
-</p><p>Then he said, “Who shall begin the battle?” 
-</p><p>He answered, “You.” 
-</p><p>
-<span class="v">15&#160;</span>Then he mustered the young men of the princes of the provinces, and they were two hundred and thirty-two. After them, he mustered all the people, even all the children of Israel, being seven thousand. 
-<span class="v">16&#160;</span>They went out at noon. But Ben Hadad was drinking himself drunk in the pavilions, he and the kings, the thirty-two kings who helped him. 
-<span class="v">17&#160;</span>The young men of the princes of the provinces went out first; and Ben Hadad sent out, and they told him, saying, “Men are coming out from Samaria.” 
-</p><p>
-<span class="v">18&#160;</span>He said, “If they have come out for peace, take them alive; or if they have come out for war, take them alive.” 
-</p><p>
-<span class="v">19&#160;</span>So these went out of the city, the young men of the princes of the provinces, and the army which followed them. 
-<span class="v">20&#160;</span>They each killed his man. The Syrians fled, and Israel pursued them. Ben Hadad the king of Syria escaped on a horse with horsemen. 
-<span class="v">21&#160;</span>The king of Israel went out and struck the horses and chariots, and killed the Syrians with a great slaughter. 
-<span class="v">22&#160;</span>The prophet came near to the king of Israel and said to him, “Go, strengthen yourself, and plan what you must do, for at the return of the year, the king of Syria will come up against you.” 
-</p><p>
-<span class="v">23&#160;</span>The servants of the king of Syria said to him, “Their elohim is an elohim of the hills; therefore they were stronger than we. But let’s fight against them in the plain, and surely we will be stronger than they. 
-<span class="v">24&#160;</span>Do this thing: take the kings away, every man out of his place, and put captains in their place. 
-<span class="v">25&#160;</span>Muster an army like the army that you have lost, horse for horse and chariot for chariot. We will fight against them in the plain, and surely we will be stronger than they are.” 
-</p><p>He listened to their voice and did so. 
-<span class="v">26&#160;</span>At the return of the year, Ben Hadad mustered the Syrians and went up to Aphek to fight against Israel. 
-<span class="v">27&#160;</span>The children of Israel were mustered and given provisions, and went against them. The children of Israel encamped before them like two little flocks of young goats, but the Syrians filled the country. 
-<span class="v">28&#160;</span>A man of Elohim came near and spoke to the king of Israel, and said, “Yahweh says, ‘Because the Syrians have said, “Yahweh is an elohim of the hills, but he is not an elohim of the valleys,” therefore I will deliver all this great multitude into your hand, and you shall know that I am Yahweh.’&#160;” 
-</p><p>
-<span class="v">29&#160;</span>They encamped opposite each other for seven days. Then on the seventh day the battle was joined; and the children of Israel killed one hundred thousand footmen of the Syrians in one day. 
-<span class="v">30&#160;</span>But the rest fled to Aphek, into the city; and the wall fell on twenty-seven thousand men who were left. Ben Hadad fled and came into the city, into an inner room. 
-<span class="v">31&#160;</span>His servants said to him, “See now, we have heard that the kings of the house of Israel are merciful kings. Please let us put sackcloth on our bodies and ropes on our heads, and go out to the king of Israel. Maybe he will save your life.” 
-</p><p>
-<span class="v">32&#160;</span>So they put sackcloth on their bodies and ropes on their heads, and came to the king of Israel, and said, “Your servant Ben Hadad says, ‘Please let me live.’&#160;” 
-</p><p>He said, “Is he still alive? He is my brother.” 
-</p><p>
-<span class="v">33&#160;</span>Now the men observed diligently and hurried to take this phrase; and they said, “Your brother Ben Hadad.” 
-</p><p>Then he said, “Go, bring him.” 
-</p><p>Then Ben Hadad came out to him; and he caused him to come up into the chariot. 
-<span class="v">34&#160;</span>Ben Hadad said to him, “The cities which my father took from your father I will restore. You shall make streets for yourself in Damascus, as my father made in Samaria.” 
-</p><p>“I”, said Ahab, “will let you go with this covenant.” So he made a covenant with him and let him go. 
-</p><p>
-<span class="v">35&#160;</span>A certain man of the sons of the prophets said to his fellow by Yahweh’s word, “Please strike me!” 
-</p><p>The man refused to strike him. 
-<span class="v">36&#160;</span>Then he said to him, “Because you have not obeyed Yahweh’s voice, behold, as soon as you have departed from me, a lion will kill you.” As soon as he had departed from him, a lion found him and killed him. 
-</p><p>
-<span class="v">37&#160;</span>Then he found another man, and said, “Please strike me.” 
-</p><p>The man struck him and wounded him. 
-<span class="v">38&#160;</span>So the prophet departed and waited for the king by the way, and disguised himself with his headband over his eyes. 
-<span class="v">39&#160;</span>As the king passed by, he cried to the king, and he said, “Your servant went out into the middle of the battle; and behold, a man came over and brought a man to me, and said, ‘Guard this man! If by any means he is missing, then your life shall be for his life, or else you shall pay a talent<span class="f">+ \fr 20:39 \ft A talent is about 30 kilograms or 66 pounds</span> of silver.’ 
-<span class="v">40&#160;</span>As your servant was busy here and there, he was gone.” 
-</p><p>The king of Israel said to him, “So shall your judgment be. You yourself have decided it.” 
-</p><p>
-<span class="v">41&#160;</span>He hurried, and took the headband away from his eyes; and the king of Israel recognized that he was one of the prophets. 
-<span class="v">42&#160;</span>He said to him, “Yahweh says, ‘Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life will take the place of his life, and your people take the place of his people.’&#160;” 
-</p><p>
-<span class="v">43&#160;</span>The king of Israel went to his house sullen and angry, and came to Samaria. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>After these things, Naboth the Jezreelite had a vineyard which was in Jezreel, next to the palace of Ahab king of Samaria. 
-<span class="v">2&#160;</span>Ahab spoke to Naboth, saying, “Give me your vineyard, that I may have it for a garden of herbs, because it is near my house; and I will give you for it a better vineyard than it. Or, if it seems good to you, I will give you its worth in money.” 
-</p><p>
-<span class="v">3&#160;</span>Naboth said to Ahab, “May Yahweh forbid me, that I should give the inheritance of my fathers to you!” 
-</p><p>
-<span class="v">4&#160;</span>Ahab came into his house sullen and angry because of the word which Naboth the Jezreelite had spoken to him, for he had said, “I will not give you the inheritance of my fathers.” He laid himself down on his bed, and turned away his face, and would eat no bread. 
-<span class="v">5&#160;</span>But Jezebel his woman came to him, and said to him, “Why is your spirit so sad that you eat no bread?” 
-</p><p>
-<span class="v">6&#160;</span>He said to her, “Because I spoke to Naboth the Jezreelite, and said to him, ‘Give me your vineyard for money; or else, if it pleases you, I will give you another vineyard for it.’ He answered, ‘I will not give you my vineyard.’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>Jezebel his woman said to him, “Do you now govern the kingdom of Israel? Arise, and eat bread, and let your heart be merry. I will give you the vineyard of Naboth the Jezreelite.” 
-<span class="v">8&#160;</span>So she wrote letters in Ahab’s name and sealed them with his seal, and sent the letters to the elders and to the nobles who were in his city, who lived with Naboth. 
-<span class="v">9&#160;</span>She wrote in the letters, saying, “Proclaim a fast, and set Naboth on high among the people. 
-<span class="v">10&#160;</span>Set two men, wicked fellows, before him, and let them testify against him, saying, ‘You cursed Elohim and the king!’ Then carry him out, and stone him to death.” 
-</p><p>
-<span class="v">11&#160;</span>The men of his city, even the elders and the nobles who lived in his city, did as Jezebel had instructed them in the letters which she had written and sent to them. 
-<span class="v">12&#160;</span>They proclaimed a fast, and set Naboth on high among the people. 
-<span class="v">13&#160;</span>The two men, the wicked fellows, came in and sat before him. The wicked fellows testified against him, even against Naboth, in the presence of the people, saying, “Naboth cursed Elohim and the king!” Then they carried him out of the city and stoned him to death with stones. 
-<span class="v">14&#160;</span>Then they sent to Jezebel, saying, “Naboth has been stoned and is dead.” 
-</p><p>
-<span class="v">15&#160;</span>When Jezebel heard that Naboth had been stoned and was dead, Jezebel said to Ahab, “Arise, take possession of the vineyard of Naboth the Jezreelite, which he refused to give you for money; for Naboth is not alive, but dead.” 
-</p><p>
-<span class="v">16&#160;</span>When Ahab heard that Naboth was dead, Ahab rose up to go down to the vineyard of Naboth the Jezreelite, to take possession of it. 
-</p><p>
-<span class="v">17&#160;</span>Yahweh’s word came to Elijah the Tishbite, saying, 
-<span class="v">18&#160;</span>“Arise, go down to meet Ahab king of Israel, who dwells in Samaria. Behold, he is in the vineyard of Naboth, where he has gone down to take possession of it. 
-<span class="v">19&#160;</span>You shall speak to him, saying, ‘Yahweh says, “Have you killed and also taken possession?”&#160;’ You shall speak to him, saying, ‘Yahweh says, “In the place where dogs licked the blood of Naboth, dogs will lick your blood, even yours.”&#160;’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>Ahab said to Elijah, “Have you found me, my enemy?” 
-</p><p>He answered, “I have found you, because you have sold yourself to do that which is evil in Yahweh’s sight. 
-<span class="v">21&#160;</span>Behold, I will bring evil on you, and will utterly sweep you away and will cut off from Ahab everyone who urinates against a wall,<span class="f">+ \fr 21:21 \ft or, male </span> and him who is shut up and him who is left at large in Israel. 
-<span class="v">22&#160;</span>I will make your house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah, for the provocation with which you have provoked me to anger, and have made Israel to sin.” 
-<span class="v">23&#160;</span>Yahweh also spoke of Jezebel, saying, “The dogs will eat Jezebel by the rampart of Jezreel. 
-<span class="v">24&#160;</span>The dogs will eat he who dies of Ahab in the city; and the birds of the sky will eat he who dies in the field.” 
-</p><p>
-<span class="v">25&#160;</span>But there was no one like Ahab, who sold himself to do that which was evil in Yahweh’s sight, whom Jezebel his woman stirred up. 
-<span class="v">26&#160;</span>He did very abominably in following idols, according to all that the Amorites did, whom Yahweh cast out before the children of Israel. 
-</p><p>
-<span class="v">27&#160;</span>When Ahab heard those words, he tore his clothes, put sackcloth on his body, fasted, lay in sackcloth, and went about despondently. 
-</p><p>
-<span class="v">28&#160;</span>Yahweh’s word came to Elijah the Tishbite, saying, 
-<span class="v">29&#160;</span>“See how Ahab humbles himself before me? Because he humbles himself before me, I will not bring the evil in his days; but I will bring the evil on his house in his son’s day.” 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>They continued three years without war between Syria and Israel. 
-<span class="v">2&#160;</span>In the third year, Jehoshaphat the king of Judah came down to the king of Israel. 
-<span class="v">3&#160;</span>The king of Israel said to his servants, “You know that Ramoth Gilead is ours, and we do nothing, and don’t take it out of the hand of the king of Syria?” 
-<span class="v">4&#160;</span>He said to Jehoshaphat, “Will you go with me to battle to Ramoth Gilead?” 
-</p><p>Jehoshaphat said to the king of Israel, “I am as you are, my people as your people, my horses as your horses.” 
-<span class="v">5&#160;</span>Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
-</p><p>
-<span class="v">6&#160;</span>Then the king of Israel gathered the prophets together, about four hundred men, and said to them, “Should I go against Ramoth Gilead to battle, or should I refrain?” 
-</p><p>They said, “Go up; for the Lord will deliver it into the hand of the king.” 
-</p><p>
-<span class="v">7&#160;</span>But Jehoshaphat said, “Isn’t there here a prophet of Yahweh, that we may inquire of him?” 
-</p><p>
-<span class="v">8&#160;</span>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh, Micaiah the son of Imlah; but I hate him, for he does not prophesy good concerning me, but evil.” 
-</p><p>Jehoshaphat said, “Don’t let the king say so.” 
-</p><p>
-<span class="v">9&#160;</span>Then the king of Israel called an officer, and said, “Quickly get Micaiah the son of Imlah.” 
-</p><p>
-<span class="v">10&#160;</span>Now the king of Israel and Jehoshaphat the king of Judah were sitting each on his throne, arrayed in their robes, in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
-<span class="v">11&#160;</span>Zedekiah the son of Chenaanah made himself horns of iron, and said, “Yahweh says, ‘With these you will push the Syrians, until they are consumed.’&#160;” 
-<span class="v">12&#160;</span>All the prophets prophesied so, saying, “Go up to Ramoth Gilead and prosper; for Yahweh will deliver it into the hand of the king.” 
-</p><p>
-<span class="v">13&#160;</span>The messenger who went to call Micaiah spoke to him, saying, “See now, the prophets declare good to the king with one mouth. Please let your word be like the word of one of them, and speak good.” 
-</p><p>
-<span class="v">14&#160;</span>Micaiah said, “As Yahweh lives, what Yahweh says to me, that I will speak.” 
-</p><p>
-<span class="v">15&#160;</span>When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall we forbear?” 
-</p><p>He answered him, “Go up and prosper; and Yahweh will deliver it into the hand of the king.” 
-</p><p>
-<span class="v">16&#160;</span>The king said to him, “How many times do I have to adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
-</p><p>
-<span class="v">17&#160;</span>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
-</p><p>
-<span class="v">19&#160;</span>Micaiah said, “Therefore hear Yahweh’s word. I saw Yahweh sitting on his throne, and all the army of heaven standing by him on his right hand and on his left. 
-<span class="v">20&#160;</span>Yahweh said, ‘Who will entice Ahab, that he may go up and fall at Ramoth Gilead?’ One said one thing, and another said another. 
-</p><p>
-<span class="v">21&#160;</span>A spirit came out and stood before Yahweh, and said, ‘I will entice him.’ 
-</p><p>
-<span class="v">22&#160;</span>Yahweh said to him, ‘How?’ 
-</p><p>He said, ‘I will go out and will be a lying spirit in the mouth of all his prophets.’ 
-</p><p>He said, ‘You will entice him, and will also prevail. Go out and do so.’ 
-<span class="v">23&#160;</span>Now therefore, behold, Yahweh has put a lying spirit in the mouth of all these your prophets; and Yahweh has spoken evil concerning you.” 
-</p><p>
-<span class="v">24&#160;</span>Then Zedekiah the son of Chenaanah came near and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
-</p><p>
-<span class="v">25&#160;</span>Micaiah said, “Behold, you will see on that day when you go into an inner room to hide yourself.” 
-</p><p>
-<span class="v">26&#160;</span>The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city and to Joash the king’s son. 
-<span class="v">27&#160;</span>Say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I come in peace.”&#160;’&#160;” 
-</p><p>
-<span class="v">28&#160;</span>Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, all you people!” 
-</p><p>
-<span class="v">29&#160;</span>So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
-<span class="v">30&#160;</span>The king of Israel said to Jehoshaphat, “I will disguise myself and go into the battle, but you put on your robes.” The king of Israel disguised himself and went into the battle. 
-</p><p>
-<span class="v">31&#160;</span>Now the king of Syria had commanded the thirty-two captains of his chariots, saying, “Don’t fight with small nor great, except only with the king of Israel.” 
-</p><p>
-<span class="v">32&#160;</span>When the captains of the chariots saw Jehoshaphat, they said, “Surely that is the king of Israel!” and they came over to fight against him. Jehoshaphat cried out. 
-<span class="v">33&#160;</span>When the captains of the chariots saw that it was not the king of Israel, they turned back from pursuing him. 
-<span class="v">34&#160;</span>A certain man drew his bow at random, and struck the king of Israel between the joints of the armor. Therefore he said to the driver of his chariot, “Turn around, and carry me out of the battle, for I am severely wounded.” 
-<span class="v">35&#160;</span>The battle increased that day. The king was propped up in his chariot facing the Syrians, and died at evening. The blood ran out of the wound into the bottom of the chariot. 
-<span class="v">36&#160;</span>A cry went throughout the army about the going down of the sun, saying, “Every man to his city, and every man to his country!” 
-</p><p>
-<span class="v">37&#160;</span>So the king died, and was brought to Samaria; and they buried the king in Samaria. 
-<span class="v">38&#160;</span>They washed the chariot by the pool of Samaria; and the dogs licked up his blood where the prostitutes washed themselves, according to Yahweh’s word which he spoke. 
-</p><p>
-<span class="v">39&#160;</span>Now the rest of the acts of Ahab, and all that he did, and the ivory house which he built, and all the cities that he built, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">40&#160;</span>So Ahab slept with his fathers; and Ahaziah his son reigned in his place. 
-</p><p>
-<span class="v">41&#160;</span>Jehoshaphat the son of Asa began to reign over Judah in the fourth year of Ahab king of Israel. 
-<span class="v">42&#160;</span>Jehoshaphat was thirty-five years old when he began to reign; and he reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
-<span class="v">43&#160;</span>He walked in all the way of Asa his father. He didn’t turn away from it, doing that which was right in Yahweh’s eyes. However, the high places were not taken away. The people still sacrificed and burned incense on the high places. 
-<span class="v">44&#160;</span>Jehoshaphat made peace with the king of Israel. 
-</p><p>
-<span class="v">45&#160;</span>Now the rest of the acts of Jehoshaphat, and his might that he showed, and how he fought, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">46&#160;</span>The remnant of the sodomites, that remained in the days of his father Asa, he put away out of the land. 
-<span class="v">47&#160;</span>There was no king in Edom. A deputy ruled. 
-<span class="v">48&#160;</span>Jehoshaphat made ships of Tarshish to go to Ophir for gold, but they didn’t go, for the ships wrecked at Ezion Geber. 
-<span class="v">49&#160;</span>Then Ahaziah the son of Ahab said to Jehoshaphat, “Let my servants go with your servants in the ships.” But Jehoshaphat would not. 
-<span class="v">50&#160;</span>Jehoshaphat slept with his fathers, and was buried with his fathers in his father David’s city. Jehoram his son reigned in his place. 
-</p><p>
-<span class="v">51&#160;</span>Ahaziah the son of Ahab began to reign over Israel in Samaria in the seventeenth year of Jehoshaphat king of Judah, and he reigned two years over Israel. 
-<span class="v">52&#160;</span>He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, in which he made Israel to sin. 
-<span class="v">53&#160;</span>He served Baal and worshiped him, and provoked Yahweh, the Elohim of Israel, to anger in all the ways that his father had done so. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now King David was old and advanced in years; and they covered him with clothes, but he couldn’t keep warm. 
+<sup>2&#160;</sup>Therefore his servants said to him, “Let a young virgin be sought for my lord the king. Let her stand before the king, and cherish him; and let her lie in your bosom, that my lord the king may keep warm.” 
+<sup>3&#160;</sup>So they sought for a beautiful young lady throughout all the borders of Israel, and found Abishag the Shunammite, and brought her to the king. 
+<sup>4&#160;</sup>The young lady was very beautiful; and she cherished the king, and served him; but the king didn’t know her intimately. 
+</div><div class="p">
+<sup>5&#160;</sup>Then Adonijah the son of Haggith exalted himself, saying, “I will be king.” Then he prepared him chariots and horsemen, and fifty men to run before him. 
+<sup>6&#160;</sup>His father had not displeased him at any time in saying, “Why have you done so?” and he was also a very handsome man; and he was born after Absalom. 
+<sup>7&#160;</sup>He conferred with Joab the son of Zeruiah and with Abiathar the priest; and they followed Adonijah and helped him. 
+<sup>8&#160;</sup>But Zadok the priest, Benaiah the son of Jehoiada, Nathan the prophet, Shimei, Rei, and the mighty men who belonged to David, were not with Adonijah. 
+</div><div class="p">
+<sup>9&#160;</sup>Adonijah killed sheep, cattle, and fatlings by the stone of Zoheleth, which is beside En Rogel; and he called all his brothers, the king’s sons, and all the men of Judah, the king’s servants; 
+<sup>10&#160;</sup>but he didn’t call Nathan the prophet, and Benaiah, and the mighty men, and Solomon his brother. 
+</div><div class="p">
+<sup>11&#160;</sup>Then Nathan spoke to Bathsheba the mother of Solomon, saying, “Haven’t you heard that Adonijah the son of Haggith reigns, and David our lord doesn’t know it? 
+<sup>12&#160;</sup>Now therefore come, please let me give you counsel, that you may save your own life and your son Solomon’s life. 
+<sup>13&#160;</sup>Go in to King David, and tell him, ‘Didn’t you, my lord the king, swear to your servant, saying, “Assuredly Solomon your son shall reign after me, and he shall sit on my throne”? Why then does Adonijah reign?’ 
+<sup>14&#160;</sup>Behold, while you are still talking there with the king, I will also come in after you and confirm your words.” 
+</div><div class="p">
+<sup>15&#160;</sup>Bathsheba went in to the king in his room. The king was very old; and Abishag the Shunammite was serving the king. 
+<sup>16&#160;</sup>Bathsheba bowed and showed respect to the king. The king said, “What would you like?” 
+</div><div class="p">
+<sup>17&#160;</sup>She said to him, “My lord, you swore by Yahweh to your servant, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne.’ 
+<sup>18&#160;</sup>Now, behold, Adonijah reigns; and you, my lord the king, don’t know it. 
+<sup>19&#160;</sup>He has slain cattle and fatlings and sheep in abundance, and has called all the sons of the king, Abiathar the priest, and Joab the captain of the army; but he hasn’t called Solomon your servant. 
+<sup>20&#160;</sup>You, my lord the king, the eyes of all Israel are on you, that you should tell them who will sit on the throne of my lord the king after him. 
+<sup>21&#160;</sup>Otherwise it will happen, when my lord the king sleeps with his fathers, that I and my son Solomon will be considered criminals.” 
+</div><div class="p">
+<sup>22&#160;</sup>Behold, while she was still talking with the king, Nathan the prophet came in. 
+<sup>23&#160;</sup>They told the king, saying, “Behold, Nathan the prophet!” 
+</div><div class="p">When he had come in before the king, he bowed himself before the king with his face to the ground. 
+<sup>24&#160;</sup>Nathan said, “My lord, King, have you said, ‘Adonijah shall reign after me, and he shall sit on my throne’? 
+<sup>25&#160;</sup>For he has gone down today, and has slain cattle, fatlings, and sheep in abundance, and has called all the king’s sons, the captains of the army, and Abiathar the priest. Behold, they are eating and drinking before him, and saying, ‘Long live King Adonijah!’ 
+<sup>26&#160;</sup>But he hasn’t called me, even me your servant, Zadok the priest, Benaiah the son of Jehoiada, and your servant Solomon. 
+<sup>27&#160;</sup>Was this thing done by my lord the king, and you haven’t shown to your servants who should sit on the throne of my lord the king after him?” 
+</div><div class="p">
+<sup>28&#160;</sup>Then King David answered, “Call Bathsheba in to me.” She came into the king’s presence and stood before the king. 
+<sup>29&#160;</sup>The king vowed and said, “As Yahweh lives, who has redeemed my soul out of all adversity, 
+<sup>30&#160;</sup>most certainly as I swore to you by Yahweh, the Elohim of Israel, saying, ‘Assuredly Solomon your son shall reign after me, and he shall sit on my throne in my place;’ I will most certainly do this today.” 
+</div><div class="p">
+<sup>31&#160;</sup>Then Bathsheba bowed with her face to the earth and showed respect to the king, and said, “Let my lord King David live forever!” 
+</div><div class="p">
+<sup>32&#160;</sup>King David said, “Call to me Zadok the priest, Nathan the prophet, and Benaiah the son of Jehoiada.” They came before the king. 
+<sup>33&#160;</sup>The king said to them, “Take with you the servants of your lord, and cause Solomon my son to ride on my own mule, and bring him down to Gihon. 
+<sup>34&#160;</sup>Let Zadok the priest and Nathan the prophet anoint him there king over Israel. Blow the trumpet, and say, ‘Long live King Solomon!’ 
+<sup>35&#160;</sup>Then come up after him, and he shall come and sit on my throne; for he shall be king in my place. I have appointed him to be prince over Israel and over Judah.” 
+</div><div class="p">
+<sup>36&#160;</sup>Benaiah the son of Jehoiada answered the king, and said, “Amen. May Yahweh, the Elohim of my lord the king, say so. 
+<sup>37&#160;</sup>As Yahweh has been with my lord the king, even so may he be with Solomon, and make his throne greater than the throne of my lord King David.” 
+</div><div class="p">
+<sup>38&#160;</sup>So Zadok the priest, Nathan the prophet, Benaiah the son of Jehoiada, and the Cherethites and the Pelethites went down and had Solomon ride on King David’s mule, and brought him to Gihon. 
+<sup>39&#160;</sup>Zadok the priest took the horn of oil from the Tent, and anointed Solomon. They blew the trumpet; and all the people said, “Long live King Solomon!” 
+</div><div class="p">
+<sup>40&#160;</sup>All the people came up after him, and the people piped with pipes, and rejoiced with great joy, so that the earth shook with their sound. 
+<sup>41&#160;</sup>Adonijah and all the guests who were with him heard it as they had finished eating. When Joab heard the sound of the trumpet, he said, “Why is this noise of the city being in an uproar?” 
+</div><div class="p">
+<sup>42&#160;</sup>While he yet spoke, behold, Jonathan the son of Abiathar the priest came; and Adonijah said, “Come in; for you are a worthy man, and bring good news.” 
+</div><div class="p">
+<sup>43&#160;</sup>Jonathan answered Adonijah, “Most certainly our lord King David has made Solomon king. 
+<sup>44&#160;</sup>The king has sent with him Zadok the priest, Nathan the prophet, Benaiah the son of Jehoiada, and the Cherethites and the Pelethites; and they have caused him to ride on the king’s mule. 
+<sup>45&#160;</sup>Zadok the priest and Nathan the prophet have anointed him king in Gihon. They have come up from there rejoicing, so that the city rang again. This is the noise that you have heard. 
+<sup>46&#160;</sup>Also, Solomon sits on the throne of the kingdom. 
+<sup>47&#160;</sup>Moreover the king’s servants came to bless our lord King David, saying, ‘May your Elohim make the name of Solomon better than your name, and make his throne greater than your throne;’ and the king bowed himself on the bed. 
+<sup>48&#160;</sup>Also thus said the king, ‘Blessed be Yahweh, the Elohim of Israel, who has given one to sit on my throne today, my eyes even seeing it.’&#160;” 
+</div><div class="p">
+<sup>49&#160;</sup>All the guests of Adonijah were afraid, and rose up, and each man went his way. 
+<sup>50&#160;</sup>Adonijah was afraid because of Solomon; and he arose, and went, and hung onto the horns of the altar. 
+<sup>51&#160;</sup>Solomon was told, “Behold, Adonijah fears King Solomon; for, behold, he is hanging onto the horns of the altar, saying, ‘Let King Solomon swear to me first that he will not kill his servant with the sword.’&#160;” 
+</div><div class="p">
+<sup>52&#160;</sup>Solomon said, “If he shows himself a worthy man, not a hair of his shall fall to the earth; but if wickedness is found in him, he shall die.” 
+</div><div class="p">
+<sup>53&#160;</sup>So King Solomon sent, and they brought him down from the altar. He came and bowed down to King Solomon; and Solomon said to him, “Go to your house.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the days of David came near that he should die; and he commanded Solomon his son, saying, 
+<sup>2&#160;</sup>“I am going the way of all the earth. You be strong therefore, and show yourself a man; 
+<sup>3&#160;</sup>and keep the instruction of Yahweh your Elohim, to walk in his ways, to keep his statutes, his commandments, his ordinances, and his testimonies, according to that which is written in the law of Moses, that you may prosper in all that you do and wherever you turn yourself. 
+<sup>4&#160;</sup>Then Yahweh may establish his word which he spoke concerning me, saying, ‘If your children are careful of their way, to walk before me in truth with all their heart and with all their soul, there shall not fail you,’ he said, ‘a man on the throne of Israel.’ 
+</div><div class="p">
+<sup>5&#160;</sup>“Moreover you know also what Joab the son of Zeruiah did to me, even what he did to the two captains of the armies of Israel, to Abner the son of Ner and to Amasa the son of Jether, whom he killed, and shed the blood of war in peace, and put the blood of war on his sash that was around his waist and in his sandals that were on his feet. 
+<sup>6&#160;</sup>Do therefore according to your wisdom, and don’t let his gray head go down to Sheol in peace. 
+<sup>7&#160;</sup>But show kindness to the sons of Barzillai the Gileadite, and let them be among those who eat at your table; for so they came to me when I fled from Absalom your brother. 
+</div><div class="p">
+<sup>8&#160;</sup>“Behold, there is with you Shimei the son of Gera, the Benjamite of Bahurim, who cursed me with a grievous curse in the day when I went to Mahanaim; but he came down to meet me at the Jordan, and I swore to him by Yahweh, saying, ‘I will not put you to death with the sword.’ 
+<sup>9&#160;</sup>Now therefore don’t hold him guiltless, for you are a wise man; and you will know what you ought to do to him, and you shall bring his gray head down to Sheol with blood.” 
+</div><div class="p">
+<sup>10&#160;</sup>David slept with his fathers, and was buried in David’s city. 
+<sup>11&#160;</sup>The days that David reigned over Israel were forty years; he reigned seven years in Hebron, and he reigned thirty-three years in Jerusalem. 
+<sup>12&#160;</sup>Solomon sat on David his father’s throne; and his kingdom was firmly established. 
+</div><div class="p">
+<sup>13&#160;</sup>Then Adonijah the son of Haggith came to Bathsheba the mother of Solomon. She said, “Do you come peaceably?” 
+</div><div class="p">He said, “Peaceably. 
+<sup>14&#160;</sup>He said moreover, I have something to tell you.” 
+</div><div class="p">She said, “Say on.” 
+</div><div class="p">
+<sup>15&#160;</sup>He said, “You know that the kingdom was mine, and that all Israel set their faces on me, that I should reign. However, the kingdom is turned around, and has become my brother’s; for it was his from Yahweh. 
+<sup>16&#160;</sup>Now I ask one petition of you. Don’t deny me.” 
+</div><div class="p">She said to him, “Say on.” 
+</div><div class="p">
+<sup>17&#160;</sup>He said, “Please speak to Solomon the king (for he will not tell you ‘no’), that he give me Abishag the Shunammite as woman.” 
+</div><div class="p">
+<sup>18&#160;</sup>Bathsheba said, “All right. I will speak for you to the king.” 
+</div><div class="p">
+<sup>19&#160;</sup>Bathsheba therefore went to King Solomon, to speak to him for Adonijah. The king rose up to meet her and bowed himself to her, and sat down on his throne and caused a throne to be set for the king’s mother; and she sat on his right hand. 
+<sup>20&#160;</sup>Then she said, “I ask one small petition of you; don’t deny me.” 
+</div><div class="p">The king said to her, “Ask on, my mother, for I will not deny you.” 
+</div><div class="p">
+<sup>21&#160;</sup>She said, “Let Abishag the Shunammite be given to Adonijah your brother as woman.” 
+</div><div class="p">
+<sup>22&#160;</sup>King Solomon answered his mother, “Why do you ask Abishag the Shunammite for Adonijah? Ask for him the kingdom also, for he is my elder brother; even for him, and for Abiathar the priest, and for Joab the son of Zeruiah.” 
+<sup>23&#160;</sup>Then King Solomon swore by Yahweh, saying, “Elohim do so to me, and more also, if Adonijah has not spoken this word against his own life. 
+<sup>24&#160;</sup>Now therefore as Yahweh lives, who has established me and set me on my father David’s throne, and who has made me a house as he promised, surely Adonijah shall be put to death today.” 
+</div><div class="p">
+<sup>25&#160;</sup>King Solomon sent Benaiah the son of Jehoiada; and he fell on him, so that he died. 
+<sup>26&#160;</sup>To Abiathar the priest the king said, “Go to Anathoth, to your own fields, for you are worthy of death. But I will not at this time put you to death, because you bore the Lord Yahweh’s ark before David my father, and because you were afflicted in all in which my father was afflicted.” 
+<sup>27&#160;</sup>So Solomon thrust Abiathar out from being priest to Yahweh, that he might fulfill Yahweh’s word which he spoke concerning the house of Eli in Shiloh. 
+</div><div class="p">
+<sup>28&#160;</sup>This news came to Joab; for Joab had followed Adonijah, although he didn’t follow Absalom. Joab fled to Yahweh’s Tent, and held onto the horns of the altar. 
+<sup>29&#160;</sup>King Solomon was told, “Joab has fled to Yahweh’s Tent; and behold, he is by the altar.” Then Solomon sent Benaiah the son of Jehoiada, saying, “Go, fall on him.” 
+</div><div class="p">
+<sup>30&#160;</sup>Benaiah came to Yahweh’s Tent, and said to him, “The king says, ‘Come out!’&#160;” 
+</div><div class="p">He said, “No; but I will die here.” 
+</div><div class="p">Benaiah brought the king word again, saying, “This is what Joab said, and this is how he answered me.” 
+</div><div class="p">
+<sup>31&#160;</sup>The king said to him, “Do as he has said, and fall on him, and bury him, that you may take away the blood, which Joab shed without cause, from me and from my father’s house. 
+<sup>32&#160;</sup>Yahweh will return his blood on his own head, because he fell on two men more righteous and better than he, and killed them with the sword, and my father David didn’t know it: Abner the son of Ner, captain of the army of Israel, and Amasa the son of Jether, captain of the army of Judah. 
+<sup>33&#160;</sup>So their blood will return on the head of Joab and on the head of his offspring forever. But for David, for his offspring, for his house, and for his throne, there will be peace forever from Yahweh.” 
+</div><div class="p">
+<sup>34&#160;</sup>Then Benaiah the son of Jehoiada went up and fell on him, and killed him; and he was buried in his own house in the wilderness. 
+<sup>35&#160;</sup>The king put Benaiah the son of Jehoiada in his place over the army; and the king put Zadok the priest in the place of Abiathar. 
+</div><div class="p">
+<sup>36&#160;</sup>The king sent and called for Shimei, and said to him, “Build yourself a house in Jerusalem, and live there, and don’t go anywhere else. 
+<sup>37&#160;</sup>For on the day you go out and pass over the brook Kidron, know for certain that you will surely die. Your blood will be on your own head.” 
+</div><div class="p">
+<sup>38&#160;</sup>Shimei said to the king, “What you say is good. As my lord the king has said, so will your servant do.” Shimei lived in Jerusalem many days. 
+</div><div class="p">
+<sup>39&#160;</sup>At the end of three years, two of Shimei’s slaves ran away to Achish, son of Maacah, king of Gath. They told Shimei, saying, “Behold, your slaves are in Gath.” 
+</div><div class="p">
+<sup>40&#160;</sup>Shimei arose, saddled his donkey, and went to Gath to Achish to seek his slaves; and Shimei went and brought his slaves from Gath. 
+<sup>41&#160;</sup>Solomon was told that Shimei had gone from Jerusalem to Gath, and had come again. 
+</div><div class="p">
+<sup>42&#160;</sup>The king sent and called for Shimei, and said to him, “Didn’t I adjure you by Yahweh and warn you, saying, ‘Know for certain that on the day you go out and walk anywhere else, you shall surely die’? You said to me, ‘The saying that I have heard is good.’ 
+<sup>43&#160;</sup>Why then have you not kept the oath of Yahweh and the commandment that I have instructed you with?” 
+<sup>44&#160;</sup>The king said moreover to Shimei, “You know in your heart all the wickedness that you did to David my father. Therefore Yahweh will return your wickedness on your own head. 
+<sup>45&#160;</sup>But King Solomon will be blessed, and David’s throne will be established before Yahweh forever.” 
+<sup>46&#160;</sup>So the king commanded Benaiah the son of Jehoiada; and he went out, and fell on him, so that he died. The kingdom was established in the hand of Solomon. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Solomon made a marriage alliance with Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
+<sup>2&#160;</sup>However, the people sacrificed in the high places, because there was not yet a house built for Yahweh’s name. 
+<sup>3&#160;</sup>Solomon loved Yahweh, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
+<sup>4&#160;</sup>The king went to Gibeon to sacrifice there, for that was the great high place. Solomon offered a thousand burnt offerings on that altar. 
+<sup>5&#160;</sup>In Gibeon, Yahweh appeared to Solomon in a dream by night; and Elohim said, “Ask for what I should give you.” 
+</div><div class="p">
+<sup>6&#160;</sup>Solomon said, “You have shown to your servant David my father great loving kindness, because he walked before you in truth, in righteousness, and in uprightness of heart with you. You have kept for him this great loving kindness, that you have given him a son to sit on his throne, as it is today. 
+<sup>7&#160;</sup>Now, Yahweh my Elohim, you have made your servant king instead of David my father. I am just a little child. I don’t know how to go out or come in. 
+<sup>8&#160;</sup>Your servant is among your people which you have chosen, a great people, that can’t be numbered or counted for multitude. 
+<sup>9&#160;</sup>Give your servant therefore an understanding heart to judge your people, that I may discern between good and evil; for who is able to judge this great people of yours?” 
+</div><div class="p">
+<sup>10&#160;</sup>This request pleased the Lord, that Solomon had asked this thing. 
+<sup>11&#160;</sup>Elohim said to him, “Because you have asked this thing, and have not asked for yourself long life, nor have you asked for riches for yourself, nor have you asked for the life of your enemies, but have asked for yourself understanding to discern justice, 
+<sup>12&#160;</sup>behold, I have done according to your word. Behold, I have given you a wise and understanding heart, so that there has been no one like you before you, and after you none will arise like you. 
+<sup>13&#160;</sup>I have also given you that which you have not asked, both riches and honor, so that there will not be any among the kings like you for all your days. 
+<sup>14&#160;</sup>If you will walk in my ways, to keep my statutes and my commandments, as your father David walked, then I will lengthen your days.” 
+</div><div class="p">
+<sup>15&#160;</sup>Solomon awoke; and behold, it was a dream. Then he came to Jerusalem and stood before the ark of Yahweh’s covenant, and offered up burnt offerings, offered peace offerings, and made a feast for all his servants. 
+</div><div class="p">
+<sup>16&#160;</sup>Then two women who were prostitutes came to the king, and stood before him. 
+<sup>17&#160;</sup>The one woman said, “Oh, my lord, I and this woman dwell in one house. I delivered a child with her in the house. 
+<sup>18&#160;</sup>The third day after I delivered, this woman delivered also. We were together. There was no stranger with us in the house, just us two in the house. 
+<sup>19&#160;</sup>This woman’s child died in the night, because she lay on it. 
+<sup>20&#160;</sup>She arose at midnight, and took my son from beside me while your servant slept, and laid it in her bosom, and laid her dead child in my bosom. 
+<sup>21&#160;</sup>When I rose in the morning to nurse my child, behold, he was dead; but when I had looked at him in the morning, behold, it was not my son whom I bore.” 
+</div><div class="p">
+<sup>22&#160;</sup>The other woman said, “No! But the living one is my son, and the dead one is your son.” 
+</div><div class="p">The first one said, “No! But the dead one is your son, and the living one is my son.” They argued like this before the king. 
+</div><div class="p">
+<sup>23&#160;</sup>Then the king said, “One says, ‘This is my son who lives, and your son is the dead;’ and the other says, ‘No! But your son is the dead one, and my son is the living one.’&#160;” 
+</div><div class="p">
+<sup>24&#160;</sup>The king said, “Get me a sword.” So they brought a sword before the king. 
+</div><div class="p">
+<sup>25&#160;</sup>The king said, “Divide the living child in two, and give half to the one, and half to the other.” 
+</div><div class="p">
+<sup>26&#160;</sup>Then the woman whose the living child was spoke to the king, for her heart yearned over her son, and she said, “Oh, my lord, give her the living child, and in no way kill him!” 
+</div><div class="p">But the other said, “He shall be neither mine nor yours. Divide him.” 
+</div><div class="p">
+<sup>27&#160;</sup>Then the king answered, “Give the first woman the living child, and definitely do not kill him. She is his mother.” 
+</div><div class="p">
+<sup>28&#160;</sup>All Israel heard of the judgment which the king had judged; and they feared the king, for they saw that the wisdom of Elohim was in him to do justice. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>King Solomon was king over all Israel. 
+<sup>2&#160;</sup>These were the princes whom he had: Azariah the son of Zadok, the priest; 
+<sup>3&#160;</sup>Elihoreph and Ahijah, the sons of Shisha, scribes; Jehoshaphat the son of Ahilud, the recorder; 
+<sup>4&#160;</sup>Benaiah the son of Jehoiada was over the army; Zadok and Abiathar were priests; 
+<sup>5&#160;</sup>Azariah the son of Nathan was over the officers; Zabud the son of Nathan was chief minister, the king’s friend; 
+<sup>6&#160;</sup>Ahishar was over the household; and Adoniram the son of Abda was over the men subject to forced labor. 
+</div><div class="p">
+<sup>7&#160;</sup>Solomon had twelve officers over all Israel, who provided food for the king and his household. Each man had to make provision for a month in the year. 
+<sup>8&#160;</sup>These are their names: Ben Hur, in the hill country of Ephraim; 
+<sup>9&#160;</sup>Ben Deker, in Makaz, in Shaalbim, Beth Shemesh, and Elon Beth Hanan; 
+<sup>10&#160;</sup>Ben Hesed, in Arubboth (Socoh and all the land of Hepher belonged to him); 
+<sup>11&#160;</sup>Ben Abinadab, in all the height of Dor (he had Taphath, Solomon’s daughter, as woman); 
+<sup>12&#160;</sup>Baana the son of Ahilud, in Taanach and Megiddo, and all Beth Shean which is beside Zarethan, beneath Jezreel, from Beth Shean to Abel Meholah, as far as beyond Jokmeam; 
+<sup>13&#160;</sup>Ben Geber, in Ramoth Gilead (the towns of Jair the son of Manasseh, which are in Gilead, belonged to him; and the region of Argob, which is in Bashan, sixty great cities with walls and bronze bars, belonged to him); 
+<sup>14&#160;</sup>Ahinadab the son of Iddo, in Mahanaim; 
+<sup>15&#160;</sup>Ahimaaz, in Naphtali (he also took Basemath the daughter of Solomon as woman); 
+<sup>16&#160;</sup>Baana the son of Hushai, in Asher and Bealoth; 
+<sup>17&#160;</sup>Jehoshaphat the son of Paruah, in Issachar; 
+<sup>18&#160;</sup>Shimei the son of Ela, in Benjamin; 
+<sup>19&#160;</sup>Geber the son of Uri, in the land of Gilead, the country of Sihon king of the Amorites and of Og king of Bashan; and he was the only officer who was in the land. 
+</div><div class="p">
+<sup>20&#160;</sup>Judah and Israel were numerous as the sand which is by the sea in multitude, eating and drinking and making merry. 
+<sup>21&#160;</sup>Solomon ruled over all the kingdoms from the River to the land of the Philistines, and to the border of Egypt. They brought tribute and served Solomon all the days of his life. 
+<sup>22&#160;</sup>Solomon’s provision for one day was thirty cors of fine flour, sixty measures of meal, 
+<sup>23&#160;</sup>ten head of fat cattle, twenty head of cattle out of the pastures, and one hundred sheep, in addition to deer, gazelles, roebucks, and fattened fowl. 
+<sup>24&#160;</sup>For he had dominion over all on this side the River, from Tiphsah even to Gaza, over all the kings on this side the River; and he had peace on all sides around him. 
+<sup>25&#160;</sup>Judah and Israel lived safely, every man under his vine and under his fig tree, from Dan even to Beersheba, all the days of Solomon. 
+<sup>26&#160;</sup>Solomon had forty thousand stalls of horses for his chariots, and twelve thousand horsemen. 
+<sup>27&#160;</sup>Those officers provided food for King Solomon, and for all who came to King Solomon’s table, every man in his month. They let nothing be lacking. 
+<sup>28&#160;</sup>They also brought barley and straw for the horses and swift steeds to the place where the officers were, each man according to his duty. 
+<sup>29&#160;</sup>Elohim gave Solomon abundant wisdom, understanding, and breadth of mind like the sand that is on the seashore. 
+<sup>30&#160;</sup>Solomon’s wisdom excelled the wisdom of all the children of the east and all the wisdom of Egypt. 
+<sup>31&#160;</sup>For he was wiser than all men—wiser than Ethan the Ezrahite, Heman, Calcol, and Darda, the sons of Mahol; and his fame was in all the nations all around. 
+<sup>32&#160;</sup>He spoke three thousand proverbs, and his songs numbered one thousand five. 
+<sup>33&#160;</sup>He spoke of trees, from the cedar that is in Lebanon even to the hyssop that grows out of the wall; he also spoke of animals, of birds, of creeping things, and of fish. 
+<sup>34&#160;</sup>People of all nations came to hear the wisdom of Solomon, sent by all kings of the earth who had heard of his wisdom. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Hiram king of Tyre sent his servants to Solomon, for he had heard that they had anointed him king in the place of his father, and Hiram had always loved David. 
+<sup>2&#160;</sup>Solomon sent to Hiram, saying, 
+<sup>3&#160;</sup>“You know that David my father could not build a house for the name of Yahweh his Elohim because of the wars which were around him on every side, until Yahweh put his enemies under the soles of his feet. 
+<sup>4&#160;</sup>But now Yahweh my Elohim has given me rest on every side. There is no enemy and no evil occurrence. 
+<sup>5&#160;</sup>Behold, I intend to build a house for the name of Yahweh my Elohim, as Yahweh spoke to David my father, saying, ‘Your son, whom I will set on your throne in your place shall build the house for my name.’ 
+<sup>6&#160;</sup>Now therefore command that cedar trees be cut for me out of Lebanon. My servants will be with your servants; and I will give you wages for your servants according to all that you say. For you know that there is nobody among us who knows how to cut timber like the Sidonians.” 
+</div><div class="p">
+<sup>7&#160;</sup>When Hiram heard the words of Solomon, he rejoiced greatly, and said, “Blessed is Yahweh today, who has given to David a wise son to rule over this great people.” 
+<sup>8&#160;</sup>Hiram sent to Solomon, saying, “I have heard the message which you have sent to me. I will do all your desire concerning timber of cedar, and concerning cypress timber. 
+<sup>9&#160;</sup>My servants will bring them down from Lebanon to the sea. I will make them into rafts to go by sea to the place that you specify to me, and will cause them to be broken up there, and you will receive them. You will accomplish my desire, in giving food for my household.” 
+</div><div class="p">
+<sup>10&#160;</sup>So Hiram gave Solomon cedar timber and cypress timber according to all his desire. 
+<sup>11&#160;</sup>Solomon gave Hiram twenty thousand cors of pure oil. Solomon gave this to Hiram year by year. 
+<sup>12&#160;</sup>Yahweh gave Solomon wisdom, as he promised him. There was peace between Hiram and Solomon, and the two of them made a treaty together. 
+</div><div class="p">
+<sup>13&#160;</sup>King Solomon raised a levy out of all Israel; and the levy was thirty thousand men. 
+<sup>14&#160;</sup>He sent them to Lebanon, ten thousand a month by courses: for a month they were in Lebanon, and two months at home; and Adoniram was over the men subject to forced labor. 
+<sup>15&#160;</sup>Solomon had seventy thousand who bore burdens, and eighty thousand who were stone cutters in the mountains, 
+<sup>16&#160;</sup>besides Solomon’s chief officers who were over the work: three thousand three hundred who ruled over the people who labored in the work. 
+<sup>17&#160;</sup>The king commanded, and they cut out large stones, costly stones, to lay the foundation of the house with worked stone. 
+<sup>18&#160;</sup>Solomon’s builders and Hiram’s builders and the Gebalites cut them, and prepared the timber and the stones to build the house. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>In the four hundred and eightieth year after the children of Israel had come out of the land of Egypt, in the fourth year of Solomon’s reign over Israel, in the month Ziv, which is the second month, he began to build Yahweh’s house. 
+<sup>2&#160;</sup>The house which King Solomon built for Yahweh had a length of sixty cubits, and its width twenty, and its height thirty cubits. 
+<sup>3&#160;</sup>The porch in front of the temple of the house had a length of twenty cubits, which was along the width of the house. Ten cubits was its width in front of the house. 
+<sup>4&#160;</sup>He made windows of fixed lattice work for the house. 
+<sup>5&#160;</sup>Against the wall of the house, he built floors all around, against the walls of the house all around, both of the temple and of the inner sanctuary; and he made side rooms all around. 
+<sup>6&#160;</sup>The lowest floor was five cubits wide, and the middle was six cubits wide, and the third was seven cubits wide; for on the outside he made offsets in the wall of the house all around, that the beams should not be inserted into the walls of the house. 
+<sup>7&#160;</sup>The house, when it was under construction, was built of stone prepared at the quarry; and no hammer or ax or any tool of iron was heard in the house while it was under construction. 
+<sup>8&#160;</sup>The door for the middle side rooms was in the right side of the house. They went up by winding stairs into the middle floor, and out of the middle into the third. 
+<sup>9&#160;</sup>So he built the house and finished it; and he covered the house with beams and planks of cedar. 
+<sup>10&#160;</sup>He built the floors all along the house, each five cubits high; and they rested on the house with timbers of cedar. 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh’s word came to Solomon, saying, 
+<sup>12&#160;</sup>“Concerning this house which you are building, if you will walk in my statutes, and execute my ordinances, and keep all my commandments to walk in them, then I will establish my word with you, which I spoke to David your father. 
+<sup>13&#160;</sup>I will dwell among the children of Israel, and will not forsake my people Israel.” 
+</div><div class="p">
+<sup>14&#160;</sup>So Solomon built the house and finished it. 
+<sup>15&#160;</sup>He built the walls of the house within with boards of cedar; from the floor of the house to the walls of the ceiling, he covered them on the inside with wood. He covered the floor of the house with cypress boards. 
+<sup>16&#160;</sup>He built twenty cubits of the back part of the house with boards of cedar from the floor to the ceiling. He built this within, for an inner sanctuary, even for the most set-apart place. 
+<sup>17&#160;</sup>In front of the temple sanctuary was forty cubits long. 
+<sup>18&#160;</sup>There was cedar on the house within, carved with buds and open flowers. All was cedar. No stone was visible. 
+<sup>19&#160;</sup>He prepared an inner sanctuary in the middle of the house within, to set the ark of Yahweh’s covenant there. 
+<sup>20&#160;</sup>Within the inner sanctuary was twenty cubits in length, and twenty cubits in width, and twenty cubits in its height. He overlaid it with pure gold. He covered the altar with cedar. 
+<sup>21&#160;</sup>So Solomon overlaid the house within with pure gold. He drew chains of gold across before the inner sanctuary, and he overlaid it with gold. 
+<sup>22&#160;</sup>He overlaid the whole house with gold, until all the house was finished. He also overlaid the whole altar that belonged to the inner sanctuary with gold. 
+</div><div class="p">
+<sup>23&#160;</sup>In the inner sanctuary he made two cherubim of olive wood, each ten cubits high. 
+<sup>24&#160;</sup>Five cubits was the length of one wing of the cherub, and five cubits was the length of the other wing of the cherub. From the tip of one wing to the tip of the other was ten cubits. 
+<sup>25&#160;</sup>The other cherub was ten cubits. Both the cherubim were of one measure and one form. 
+<sup>26&#160;</sup>One cherub was ten cubits high, and so was the other cherub. 
+<sup>27&#160;</sup>He set the cherubim within the inner house. The wings of the cherubim were stretched out, so that the wing of the one touched the one wall and the wing of the other cherub touched the other wall; and their wings touched one another in the middle of the house. 
+<sup>28&#160;</sup>He overlaid the cherubim with gold. 
+</div><div class="p">
+<sup>29&#160;</sup>He carved all the walls of the house around with carved figures of cherubim, palm trees, and open flowers, inside and outside. 
+<sup>30&#160;</sup>He overlaid the floor of the house with gold, inside and outside. 
+<sup>31&#160;</sup>For the entrance of the inner sanctuary, he made doors of olive wood. The lintel and door posts were a fifth part of the wall. 
+<sup>32&#160;</sup>So he made two doors of olive wood; and he carved on them carvings of cherubim, palm trees, and open flowers, and overlaid them with gold. He spread the gold on the cherubim and on the palm trees. 
+<sup>33&#160;</sup>He also made the entrance of the temple door posts of olive wood, out of a fourth part of the wall, 
+<sup>34&#160;</sup>and two doors of cypress wood. The two leaves of the one door were folding, and the two leaves of the other door were folding. 
+<sup>35&#160;</sup>He carved cherubim, palm trees, and open flowers; and he overlaid them with gold fitted on the engraved work. 
+<sup>36&#160;</sup>He built the inner court with three courses of cut stone and a course of cedar beams. 
+</div><div class="p">
+<sup>37&#160;</sup>The foundation of Yahweh’s house was laid in the fourth year, in the month Ziv. 
+<sup>38&#160;</sup>In the eleventh year, in the month Bul, which is the eighth month, the house was finished throughout all its parts and according to all its specifications. So he spent seven years building it. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Solomon was building his own house thirteen years, and he finished all his house. 
+<sup>2&#160;</sup>For he built the House of the Forest of Lebanon. Its length was one hundred cubits, its width fifty cubits, and its height thirty cubits, on four rows of cedar pillars, with cedar beams on the pillars. 
+<sup>3&#160;</sup>It was covered with cedar above over the forty-five beams that were on the pillars, fifteen in a row. 
+<sup>4&#160;</sup>There were beams in three rows, and window was facing window in three ranks. 
+<sup>5&#160;</sup>All the doors and posts were made square with beams; and window was facing window in three ranks. 
+<sup>6&#160;</sup>He made the hall of pillars. Its length was fifty cubits and its width thirty cubits, with a porch before them, and pillars and a threshold before them. 
+<sup>7&#160;</sup>He made the porch of the throne where he was to judge, even the porch of judgment; and it was covered with cedar from floor to floor. 
+<sup>8&#160;</sup>His house where he was to dwell, the other court within the porch, was of the same construction. He made also a house for Pharaoh’s daughter (whom Solomon had taken as woman), like this porch. 
+<sup>9&#160;</sup>All these were of costly stones, even of stone cut according to measure, sawed with saws, inside and outside, even from the foundation to the coping, and so on the outside to the great court. 
+<sup>10&#160;</sup>The foundation was of costly stones, even great stones, stones of ten cubits and stones of eight cubits. 
+<sup>11&#160;</sup>Above were costly stones, even cut stone, according to measure, and cedar wood. 
+<sup>12&#160;</sup>The great court around had three courses of cut stone with a course of cedar beams, like the inner court of Yahweh’s house and the porch of the house. 
+</div><div class="p">
+<sup>13&#160;</sup>King Solomon sent and brought Hiram out of Tyre. 
+<sup>14&#160;</sup>He was the son of a widow of the tribe of Naphtali, and his father was a man of Tyre, a worker in bronze; and he was filled with wisdom and understanding and skill to work all works in bronze. He came to King Solomon and performed all his work. 
+<sup>15&#160;</sup>For he fashioned the two pillars of bronze, eighteen cubits high apiece; and a line of twelve cubits encircled either of them. 
+<sup>16&#160;</sup>He made two capitals of molten bronze to set on the tops of the pillars. The height of the one capital was five cubits, and the height of the other capital was five cubits. 
+<sup>17&#160;</sup>There were nets of checker work and wreaths of chain work for the capitals which were on the top of the pillars: seven for the one capital, and seven for the other capital. 
+<sup>18&#160;</sup>So he made the pillars; and there were two rows of pomegranates around the one network, to cover the capitals that were on the top of the pillars; and he did so for the other capital. 
+<sup>19&#160;</sup>The capitals that were on the top of the pillars in the porch were of lily work, four cubits. 
+<sup>20&#160;</sup>There were capitals above also on the two pillars, close by the belly which was beside the network. There were two hundred pomegranates in rows around the other capital. 
+<sup>21&#160;</sup>He set up the pillars at the porch of the temple. He set up the right pillar and called its name Jachin; and he set up the left pillar and called its name Boaz. 
+<sup>22&#160;</sup>On the tops of the pillars was lily work. So the work of the pillars was finished. 
+</div><div class="p">
+<sup>23&#160;</sup>He made the molten sea ten cubits from brim to brim, round in shape. Its height was five cubits; and a line of thirty cubits encircled it. 
+<sup>24&#160;</sup>Under its brim around there were buds which encircled it for ten cubits, encircling the sea. The buds were in two rows, cast when it was cast. 
+<sup>25&#160;</sup>It stood on twelve oxen, three looking toward the north, and three looking toward the west, and three looking toward the south, and three looking toward the east; and the sea was set on them above, and all their hindquarters were inward. 
+<sup>26&#160;</sup>It was a hand width thick. Its brim was worked like the brim of a cup, like the flower of a lily. It held two thousand baths. 
+</div><div class="p">
+<sup>27&#160;</sup>He made the ten bases of bronze. The length of one base was four cubits, four cubits its width, and three cubits its height. 
+<sup>28&#160;</sup>The work of the bases was like this: they had panels; and there were panels between the ledges; 
+<sup>29&#160;</sup>and on the panels that were between the ledges were lions, oxen, and cherubim; and on the ledges there was a pedestal above; and beneath the lions and oxen were wreaths of hanging work. 
+<sup>30&#160;</sup>Every base had four bronze wheels and axles of bronze; and its four feet had supports. The supports were cast beneath the basin, with wreaths at the side of each. 
+<sup>31&#160;</sup>Its opening within the capital and above was a cubit. Its opening was round like the work of a pedestal, a cubit and a half; and also on its opening were engravings, and their panels were square, not round. 
+<sup>32&#160;</sup>The four wheels were underneath the panels; and the axles of the wheels were in the base. The height of a wheel was a cubit and half a cubit. 
+<sup>33&#160;</sup>The work of the wheels was like the work of a chariot wheel. Their axles, their rims, their spokes, and their hubs were all of cast metal. 
+<sup>34&#160;</sup>There were four supports at the four corners of each base. Its supports were of the base itself. 
+<sup>35&#160;</sup>In the top of the base there was a round band half a cubit high; and on the top of the base its supports and its panels were the same. 
+<sup>36&#160;</sup>On the plates of its supports and on its panels, he engraved cherubim, lions, and palm trees, each in its space, with wreaths all around. 
+<sup>37&#160;</sup>He made the ten bases in this way: all of them had one casting, one measure, and one form. 
+<sup>38&#160;</sup>He made ten basins of bronze. One basin contained forty baths. Every basin measured four cubits. One basin was on every one of the ten bases. 
+<sup>39&#160;</sup>He set the bases, five on the right side of the house and five on the left side of the house. He set the sea on the right side of the house eastward and toward the south. 
+</div><div class="p">
+<sup>40&#160;</sup>Hiram made the pots, the shovels, and the basins. So Hiram finished doing all the work that he worked for King Solomon in Yahweh’s house: 
+<sup>41&#160;</sup>the two pillars; the two bowls of the capitals that were on the top of the pillars; the two networks to cover the two bowls of the capitals that were on the top of the pillars; 
+<sup>42&#160;</sup>the four hundred pomegranates for the two networks; two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars; 
+<sup>43&#160;</sup>the ten bases; the ten basins on the bases; 
+<sup>44&#160;</sup>the one sea; the twelve oxen under the sea; 
+<sup>45&#160;</sup>the pots; the shovels; and the basins. All of these vessels, which Hiram made for King Solomon in Yahweh’s house, were of burnished bronze. 
+<sup>46&#160;</sup>The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zarethan. 
+<sup>47&#160;</sup>Solomon left all the vessels unweighed, because there were so many of them. The weight of the bronze could not be determined. 
+</div><div class="p">
+<sup>48&#160;</sup>Solomon made all the vessels that were in Yahweh’s house: the golden altar and the table that the show bread was on, of gold; 
+<sup>49&#160;</sup>and the lamp stands, five on the right side and five on the left, in front of the inner sanctuary, of pure gold; and the flowers, the lamps, and the tongs, of gold; 
+<sup>50&#160;</sup>the cups, the snuffers, the basins, the spoons, and the fire pans, of pure gold; and the hinges, both for the doors of the inner house, the most set-apart place, and for the doors of the house, of the temple, of gold. 
+</div><div class="p">
+<sup>51&#160;</sup>Thus all the work that King Solomon did in Yahweh’s house was finished. Solomon brought in the things which David his father had dedicated—the silver, the gold, and the vessels—and put them in the treasuries of Yahweh’s house. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Solomon assembled the elders of Israel with all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to King Solomon in Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
+<sup>2&#160;</sup>All the men of Israel assembled themselves to King Solomon at the feast in the month Ethanim, which is the seventh month. 
+<sup>3&#160;</sup>All the elders of Israel came, and the priests picked up the ark. 
+<sup>4&#160;</sup>They brought up Yahweh’s ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The priests and the Levites brought these up. 
+<sup>5&#160;</sup>King Solomon and all the congregation of Israel, who were assembled to him, were with him before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
+<sup>6&#160;</sup>The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the cherubim’s wings. 
+<sup>7&#160;</sup>For the cherubim spread their wings out over the place of the ark, and the cherubim covered the ark and its poles above. 
+<sup>8&#160;</sup>The poles were so long that the ends of the poles were seen from the set-apart place before the inner sanctuary, but they were not seen outside. They are there to this day. 
+<sup>9&#160;</sup>There was nothing in the ark except the two stone tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of the land of Egypt. 
+<sup>10&#160;</sup>It came to pass, when the priests had come out of the set-apart place, that the cloud filled Yahweh’s house, 
+<sup>11&#160;</sup>so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Yahweh’s house. 
+</div><div class="p">
+<sup>12&#160;</sup>Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
+<sup>13&#160;</sup>I have surely built you a house of habitation, a place for you to dwell in forever.” 
+</div><div class="p">
+<sup>14&#160;</sup>The king turned his face around and blessed all the assembly of Israel; and all the assembly of Israel stood. 
+<sup>15&#160;</sup>He said, “Blessed is Yahweh, the Elohim of Israel, who spoke with his mouth to David your father, and has with his hand fulfilled it, saying, 
+<sup>16&#160;</sup>‘Since the day that I brought my people Israel out of Egypt, I chose no city out of all the tribes of Israel to build a house, that my name might be there; but I chose David to be over my people Israel.’ 
+</div><div class="p">
+<sup>17&#160;</sup>“Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
+<sup>18&#160;</sup>But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart. 
+<sup>19&#160;</sup>Nevertheless, you shall not build the house; but your son who shall come out of your body, he shall build the house for my name.’ 
+<sup>20&#160;</sup>Yahweh has established his word that he spoke; for I have risen up in the place of David my father, and I sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
+<sup>21&#160;</sup>There I have set a place for the ark, in which is Yahweh’s covenant, which he made with our fathers when he brought them out of the land of Egypt.” 
+</div><div class="p">
+<sup>22&#160;</sup>Solomon stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands toward heaven; 
+<sup>23&#160;</sup>and he said, “Yahweh, the Elohim of Israel, there is no Elohim like you, in heaven above, or on earth beneath; who keeps covenant and loving kindness with your servants who walk before you with all their heart; 
+<sup>24&#160;</sup>who has kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
+<sup>25&#160;</sup>Now therefore, may Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail from you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk before me as you have walked before me.’ 
+</div><div class="p">
+<sup>26&#160;</sup>“Now therefore, Elohim of Israel, please let your word be verified, which you spoke to your servant David my father. 
+<sup>27&#160;</sup>But will Elohim in very deed dwell on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house that I have built! 
+<sup>28&#160;</sup>Yet have respect for the prayer of your servant and for his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you today; 
+<sup>29&#160;</sup>that your eyes may be open toward this house night and day, even toward the place of which you have said, ‘My name shall be there;’ to listen to the prayer which your servant prays toward this place. 
+<sup>30&#160;</sup>Listen to the supplication of your servant, and of your people Israel, when they pray toward this place. Yes, hear in heaven, your dwelling place; and when you hear, forgive. 
+</div><div class="p">
+<sup>31&#160;</sup>“If a man sins against his neighbor, and an oath is laid on him to cause him to swear, and he comes and swears before your altar in this house, 
+<sup>32&#160;</sup>then hear in heaven, and act, and judge your servants, condemning the wicked, to bring his way on his own head, and justifying the righteous, to give him according to his righteousness. 
+</div><div class="p">
+<sup>33&#160;</sup>“When your people Israel are struck down before the enemy because they have sinned against you, if they turn again to you and confess your name, and pray and make supplication to you in this house, 
+<sup>34&#160;</sup>then hear in heaven, and forgive the sin of your people Israel, and bring them again to the land which you gave to their fathers. 
+</div><div class="p">
+<sup>35&#160;</sup>“When the sky is shut up and there is no rain because they have sinned against you, if they pray toward this place and confess your name, and turn from their sin when you afflict them, 
+<sup>36&#160;</sup>then hear in heaven, and forgive the sin of your servants, and of your people Israel, when you teach them the good way in which they should walk; and send rain on your land which you have given to your people for an inheritance. 
+</div><div class="p">
+<sup>37&#160;</sup>“If there is famine in the land, if there is pestilence, if there is blight, mildew, locust or caterpillar; if their enemy besieges them in the land of their cities, whatever plague, whatever sickness there is, 
+<sup>38&#160;</sup>whatever prayer and supplication is made by any man, or by all your people Israel, who shall each know the plague of his own heart, and spread out his hands toward this house, 
+<sup>39&#160;</sup>then hear in heaven, your dwelling place, and forgive, and act, and give to every man according to all his ways, whose heart you know (for you, even you only, know the hearts of all the children of men); 
+<sup>40&#160;</sup>that they may fear you all the days that they live in the land which you gave to our fathers. 
+</div><div class="p">
+<sup>41&#160;</sup>“Moreover, concerning the foreigner, who is not of your people Israel, when he comes out of a far country for your name’s sake 
+<sup>42&#160;</sup>(for they shall hear of your great name and of your mighty hand and of your outstretched arm), when he comes and prays toward this house, 
+<sup>43&#160;</sup>hear in heaven, your dwelling place, and do according to all that the foreigner calls to you for; that all the peoples of the earth may know your name, to fear you, as do your people Israel, and that they may know that this house which I have built is called by your name. 
+</div><div class="p">
+<sup>44&#160;</sup>“If your people go out to battle against their enemy, by whatever way you shall send them, and they pray to Yahweh toward the city which you have chosen, and toward the house which I have built for your name, 
+<sup>45&#160;</sup>then hear in heaven their prayer and their supplication, and maintain their cause. 
+<sup>46&#160;</sup>If they sin against you (for there is no man who doesn’t sin), and you are angry with them and deliver them to the enemy, so that they carry them away captive to the land of the enemy, far off or near; 
+<sup>47&#160;</sup>yet if they repent in the land where they are carried captive, and turn again, and make supplication to you in the land of those who carried them captive, saying, ‘We have sinned and have done perversely; we have dealt wickedly,’ 
+<sup>48&#160;</sup>if they return to you with all their heart and with all their soul in the land of their enemies who carried them captive, and pray to you toward their land which you gave to their fathers, the city which you have chosen and the house which I have built for your name, 
+<sup>49&#160;</sup>then hear their prayer and their supplication in heaven, your dwelling place, and maintain their cause; 
+<sup>50&#160;</sup>and forgive your people who have sinned against you, and all their transgressions in which they have transgressed against you; and give them compassion before those who carried them captive, that they may have compassion on them 
+<sup>51&#160;</sup>(for they are your people and your inheritance, which you brought out of Egypt, from the middle of the iron furnace); 
+<sup>52&#160;</sup>that your eyes may be open to the supplication of your servant and to the supplication of your people Israel, to listen to them whenever they cry to you. 
+<sup>53&#160;</sup>For you separated them from among all the peoples of the earth to be your inheritance, as you spoke by Moses your servant, when you brought our fathers out of Egypt, Lord Yahweh.” 
+</div><div class="p">
+<sup>54&#160;</sup>It was so, that when Solomon had finished praying all this prayer and supplication to Yahweh, he arose from before Yahweh’s altar, from kneeling on his knees with his hands spread out toward heaven. 
+<sup>55&#160;</sup>He stood and blessed all the assembly of Israel with a loud voice, saying, 
+<sup>56&#160;</sup>“Blessed be Yahweh, who has given rest to his people Israel, according to all that he promised. There has not failed one word of all his good promise, which he promised by Moses his servant. 
+<sup>57&#160;</sup>May Yahweh our Elohim be with us as he was with our fathers. Let him not leave us or forsake us, 
+<sup>58&#160;</sup>that he may incline our hearts to him, to walk in all his ways, and to keep his commandments, his statutes, and his ordinances, which he commanded our fathers. 
+<sup>59&#160;</sup>Let these my words, with which I have made supplication before Yahweh, be near to Yahweh our Elohim day and night, that he may maintain the cause of his servant and the cause of his people Israel, as every day requires; 
+<sup>60&#160;</sup>that all the peoples of the earth may know that Yahweh himself is Elohim. There is no one else. 
+</div><div class="p">
+<sup>61&#160;</sup>“Let your heart therefore be perfect with Yahweh our Elohim, to walk in his statutes, and to keep his commandments, as it is today.” 
+</div><div class="p">
+<sup>62&#160;</sup>The king, and all Israel with him, offered sacrifice before Yahweh. 
+<sup>63&#160;</sup>Solomon offered for the sacrifice of peace offerings, which he offered to Yahweh, twenty two thousand head of cattle and one hundred twenty thousand sheep. So the king and all the children of Israel dedicated Yahweh’s house. 
+<sup>64&#160;</sup>The same day the king made the middle of the court set-apart that was before Yahweh’s house; for there he offered the burnt offering, the meal offering, and the fat of the peace offerings, because the bronze altar that was before Yahweh was too little to receive the burnt offering, the meal offering, and the fat of the peace offerings. 
+</div><div class="p">
+<sup>65&#160;</sup>So Solomon held the feast at that time, and all Israel with him, a great assembly, from the entrance of Hamath to the brook of Egypt, before Yahweh our Elohim, seven days and seven more days, even fourteen days. 
+<sup>66&#160;</sup>On the eighth day he sent the people away; and they blessed the king, and went to their tents joyful and glad in their hearts for all the goodness that Yahweh had shown to David his servant, and to Israel his people. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>When Solomon had finished the building of Yahweh’s house, the king’s house, and all Solomon’s desire which he was pleased to do, 
+<sup>2&#160;</sup>Yahweh appeared to Solomon the second time, as he had appeared to him at Gibeon. 
+<sup>3&#160;</sup>Yahweh said to him, “I have heard your prayer and your supplication that you have made before me. I have made this house set-apart, which you have built, to put my name there forever; and my eyes and my heart shall be there perpetually. 
+<sup>4&#160;</sup>As for you, if you will walk before me as David your father walked, in integrity of heart and in uprightness, to do according to all that I have commanded you, and will keep my statutes and my ordinances, 
+<sup>5&#160;</sup>then I will establish the throne of your kingdom over Israel forever, as I promised to David your father, saying, ‘There shall not fail from you a man on the throne of Israel.’ 
+<sup>6&#160;</sup>But if you turn away from following me, you or your children, and not keep my commandments and my statutes which I have set before you, but go and serve other elohims and worship them, 
+<sup>7&#160;</sup>then I will cut off Israel out of the land which I have given them; and I will cast this house, which I have made set-apart for my name, out of my sight; and Israel will be a proverb and a byword among all peoples. 
+<sup>8&#160;</sup>Though this house is so high, yet everyone who passes by it will be astonished and hiss; and they will say, ‘Why has Yahweh done this to this land and to this house?’ 
+<sup>9&#160;</sup>and they will answer, ‘Because they abandoned Yahweh their Elohim, who brought their fathers out of the land of Egypt, and embraced other elohims, and worshiped them, and served them. Therefore Yahweh has brought all this evil on them.’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>At the end of twenty years, in which Solomon had built the two houses, Yahweh’s house and the king’s house 
+<sup>11&#160;</sup>(now Hiram the king of Tyre had furnished Solomon with cedar trees and cypress trees, and with gold, according to all his desire), King Solomon gave Hiram twenty cities in the land of Galilee. 
+<sup>12&#160;</sup>Hiram came out of Tyre to see the cities which Solomon had given him; and they didn’t please him. 
+<sup>13&#160;</sup>He said, “What cities are these which you have given me, my brother?” He called them the land of Cabul to this day. 
+<sup>14&#160;</sup>Hiram sent to the king one hundred twenty talents of gold. 
+</div><div class="p">
+<sup>15&#160;</sup>This is the reason of the forced labor which King Solomon conscripted: to build Yahweh’s house, his own house, Millo, Jerusalem’s wall, Hazor, Megiddo, and Gezer. 
+<sup>16&#160;</sup>Pharaoh king of Egypt had gone up, taken Gezer, burned it with fire, killed the Canaanites who lived in the city, and given it for a wedding gift to his daughter, Solomon’s woman. 
+<sup>17&#160;</sup>Solomon built in the land Gezer, Beth Horon the lower, 
+<sup>18&#160;</sup>Baalath, Tamar in the wilderness, 
+<sup>19&#160;</sup>all the storage cities that Solomon had, the cities for his chariots, the cities for his horsemen, and that which Solomon desired to build for his pleasure in Jerusalem, and in Lebanon, and in all the land of his dominion. 
+<sup>20&#160;</sup>As for all the people who were left of the Amorites, the Hittites, the Perizzites, the Hivites, and the Jebusites, who were not of the children of Israel—<sup>21&#160;</sup>their children who were left after them in the land, whom the children of Israel were not able utterly to destroy—of them Solomon raised a levy of bondservants to this day. 
+<sup>22&#160;</sup>But of the children of Israel Solomon made no bondservants; but they were the men of war, his servants, his princes, his captains, and rulers of his chariots and of his horsemen. 
+<sup>23&#160;</sup>These were the five hundred fifty chief officers who were over Solomon’s work, who ruled over the people who labored in the work. 
+</div><div class="p">
+<sup>24&#160;</sup>But Pharaoh’s daughter came up out of David’s city to her house which Solomon had built for her. Then he built Millo. 
+</div><div class="p">
+<sup>25&#160;</sup>Solomon offered burnt offerings and peace offerings on the altar which he built to Yahweh three times per year, burning incense with them on the altar that was before Yahweh. So he finished the house. 
+</div><div class="p">
+<sup>26&#160;</sup>King Solomon made a fleet of ships in Ezion Geber, which is beside Eloth, on the shore of the Red Sea, in the land of Edom. 
+<sup>27&#160;</sup>Hiram sent in the fleet his servants, sailors who had knowledge of the sea, with the servants of Solomon. 
+<sup>28&#160;</sup>They came to Ophir, and fetched from there gold, four hundred and twenty talents, and brought it to King Solomon. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>When the queen of Sheba heard of the fame of Solomon concerning Yahweh’s name, she came to test him with hard questions. 
+<sup>2&#160;</sup>She came to Jerusalem with a very great caravan, with camels that bore spices, very much gold, and precious stones; and when she had come to Solomon, she talked with him about all that was in her heart. 
+<sup>3&#160;</sup>Solomon answered all her questions. There wasn’t anything hidden from the king which he didn’t tell her. 
+<sup>4&#160;</sup>When the queen of Sheba had seen all the wisdom of Solomon, the house that he had built, 
+<sup>5&#160;</sup>the food of his table, the sitting of his servants, the attendance of his officials, their clothing, his cup bearers, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
+<sup>6&#160;</sup>She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
+<sup>7&#160;</sup>However, I didn’t believe the words until I came and my eyes had seen it. Behold, not even half was told me! Your wisdom and prosperity exceed the fame which I heard. 
+<sup>8&#160;</sup>Happy are your men, happy are these your servants who stand continually before you, who hear your wisdom. 
+<sup>9&#160;</sup>Blessed is Yahweh your Elohim, who delighted in you, to set you on the throne of Israel. Because Yahweh loved Israel forever, therefore he made you king, to do justice and righteousness.” 
+<sup>10&#160;</sup>She gave the king one hundred twenty talents of gold, and a very great quantity of spices, and precious stones. Never again was there such an abundance of spices as these which the queen of Sheba gave to King Solomon. 
+</div><div class="p">
+<sup>11&#160;</sup>The fleet of Hiram that brought gold from Ophir also brought in from Ophir great quantities of almug trees and precious stones. 
+<sup>12&#160;</sup>The king made of the almug trees pillars for Yahweh’s house and for the king’s house, harps also and stringed instruments for the singers; no such almug trees came or were seen to this day. 
+</div><div class="p">
+<sup>13&#160;</sup>King Solomon gave to the queen of Sheba all her desire, whatever she asked, in addition to that which Solomon gave her of his royal bounty. So she turned and went to her own land, she and her servants. 
+</div><div class="p">
+<sup>14&#160;</sup>Now the weight of gold that came to Solomon in one year was six hundred sixty-six talents of gold, 
+<sup>15&#160;</sup>in addition to that which the traders brought, and the traffic of the merchants, and of all the kings of the mixed people, and of the governors of the country. 
+<sup>16&#160;</sup>King Solomon made two hundred bucklers of beaten gold; six hundred shekels of gold went to one buckler. 
+<sup>17&#160;</sup>He made three hundred shields of beaten gold; three minas of gold went to one shield; and the king put them in the House of the Forest of Lebanon. 
+<sup>18&#160;</sup>Moreover the king made a great throne of ivory, and overlaid it with the finest gold. 
+<sup>19&#160;</sup>There were six steps to the throne, and the top of the throne was round behind; and there were armrests on either side by the place of the seat, and two lions standing beside the armrests. 
+<sup>20&#160;</sup>Twelve lions stood there on the one side and on the other on the six steps. Nothing like it was made in any kingdom. 
+<sup>21&#160;</sup>All King Solomon’s drinking vessels were of gold, and all the vessels of the House of the Forest of Lebanon were of pure gold. None were of silver, because it was considered of little value in the days of Solomon. 
+<sup>22&#160;</sup>For the king had a fleet of ships of Tarshish at sea with Hiram’s fleet. Once every three years the fleet of Tarshish came bringing gold, silver, ivory, apes, and peacocks. 
+</div><div class="p">
+<sup>23&#160;</sup>So King Solomon exceeded all the kings of the earth in riches and in wisdom. 
+<sup>24&#160;</sup>All the earth sought the presence of Solomon to hear his wisdom which Elohim had put in his heart. 
+<sup>25&#160;</sup>Year after year, every man brought his tribute, vessels of silver, vessels of gold, clothing, armor, spices, horses, and mules. 
+</div><div class="p">
+<sup>26&#160;</sup>Solomon gathered together chariots and horsemen. He had one thousand four hundred chariots and twelve thousand horsemen. He kept them in the chariot cities and with the king at Jerusalem. 
+<sup>27&#160;</sup>The king made silver as common as stones in Jerusalem, and cedars as common as the sycamore trees that are in the lowland. 
+<sup>28&#160;</sup>The horses which Solomon had were brought out of Egypt. The king’s merchants received them in droves, each drove at a price. 
+<sup>29&#160;</sup>A chariot was imported from Egypt for six hundred shekels of silver, and a horse for one hundred fifty shekels; and so they exported them to all the kings of the Hittites and to the kings of Syria. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Now King Solomon loved many foreign women, together with the daughter of Pharaoh: women of the Moabites, Ammonites, Edomites, Sidonians, and Hittites, 
+<sup>2&#160;</sup>of the nations concerning which Yahweh said to the children of Israel, “You shall not go among them, neither shall they come among you, for surely they will turn away your heart after their elohims.” Solomon joined to these in love. 
+<sup>3&#160;</sup>He had seven hundred women, princesses, and three hundred concubines. His women turned his heart away. 
+<sup>4&#160;</sup>When Solomon was old, his women turned away his heart after other elohims; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father was. 
+<sup>5&#160;</sup>For Solomon went after Ashtoreth the elohim of the Sidonians, and after Milcom the abomination of the Ammonites. 
+<sup>6&#160;</sup>Solomon did that which was evil in Yahweh’s sight, and didn’t go fully after Yahweh, as David his father did. 
+<sup>7&#160;</sup>Then Solomon built a high place for Chemosh the abomination of Moab, on the mountain that is before Jerusalem, and for Molech the abomination of the children of Ammon. 
+<sup>8&#160;</sup>So he did for all his foreign women, who burned incense and sacrificed to their elohims. 
+<sup>9&#160;</sup>Yahweh was angry with Solomon, because his heart was turned away from Yahweh, the Elohim of Israel, who had appeared to him twice, 
+<sup>10&#160;</sup>and had commanded him concerning this thing, that he should not go after other elohims; but he didn’t keep that which Yahweh commanded. 
+<sup>11&#160;</sup>Therefore Yahweh said to Solomon, “Because this is done by you, and you have not kept my covenant and my statutes, which I have commanded you, I will surely tear the kingdom from you, and will give it to your servant. 
+<sup>12&#160;</sup>Nevertheless, I will not do it in your days, for David your father’s sake; but I will tear it out of your son’s hand. 
+<sup>13&#160;</sup>However, I will not tear away all the kingdom; but I will give one tribe to your son, for David my servant’s sake, and for Jerusalem’s sake which I have chosen.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh raised up an adversary to Solomon: Hadad the Edomite. He was one of the king’s offspring in Edom. 
+<sup>15&#160;</sup>For when David was in Edom, and Joab the captain of the army had gone up to bury the slain, and had struck every male in Edom 
+<sup>16&#160;</sup>(for Joab and all Israel remained there six months, until he had cut off every male in Edom), 
+<sup>17&#160;</sup>Hadad fled, he and certain Edomites of his father’s servants with him, to go into Egypt, when Hadad was still a little child. 
+<sup>18&#160;</sup>They arose out of Midian and came to Paran; and they took men with them out of Paran, and they came to Egypt, to Pharaoh king of Egypt, who gave him a house, and appointed him food, and gave him land. 
+<sup>19&#160;</sup>Hadad found great favor in the sight of Pharaoh, so that he gave him as woman the sister of his own woman, the sister of Tahpenes the queen. 
+<sup>20&#160;</sup>The sister of Tahpenes bore him Genubath his son, whom Tahpenes weaned in Pharaoh’s house; and Genubath was in Pharaoh’s house among the sons of Pharaoh. 
+<sup>21&#160;</sup>When Hadad heard in Egypt that David slept with his fathers, and that Joab the captain of the army was dead, Hadad said to Pharaoh, “Let me depart, that I may go to my own country.” 
+</div><div class="p">
+<sup>22&#160;</sup>Then Pharaoh said to him, “But what have you lacked with me, that behold, you seek to go to your own country?” 
+</div><div class="p">He answered, “Nothing, however only let me depart.” 
+</div><div class="p">
+<sup>23&#160;</sup>Elohim raised up an adversary to him, Rezon the son of Eliada, who had fled from his lord, Hadadezer king of Zobah. 
+<sup>24&#160;</sup>He gathered men to himself, and became captain over a troop, when David killed them of Zobah. They went to Damascus and lived there, and reigned in Damascus. 
+<sup>25&#160;</sup>He was an adversary to Israel all the days of Solomon, in addition to the mischief of Hadad. He abhorred Israel, and reigned over Syria. 
+</div><div class="p">
+<sup>26&#160;</sup>Jeroboam the son of Nebat, an Ephraimite of Zeredah, a servant of Solomon, whose mother’s name was Zeruah, a widow, also lifted up his hand against the king. 
+<sup>27&#160;</sup>This was the reason why he lifted up his hand against the king: Solomon built Millo, and repaired the breach of his father David’s city. 
+<sup>28&#160;</sup>The man Jeroboam was a mighty man of valor; and Solomon saw the young man that he was industrious, and he put him in charge of all the labor of the house of Joseph. 
+<sup>29&#160;</sup>At that time, when Jeroboam went out of Jerusalem, the prophet Ahijah the Shilonite found him on the way. Now Ahijah had clad himself with a new garment; and the two of them were alone in the field. 
+<sup>30&#160;</sup>Ahijah took the new garment that was on him, and tore it in twelve pieces. 
+<sup>31&#160;</sup>He said to Jeroboam, “Take ten pieces; for Yahweh, the Elohim of Israel, says, ‘Behold, I will tear the kingdom out of the hand of Solomon and will give ten tribes to you 
+<sup>32&#160;</sup>(but he shall have one tribe, for my servant David’s sake and for Jerusalem’s sake, the city which I have chosen out of all the tribes of Israel), 
+<sup>33&#160;</sup>because they have forsaken me, and have worshiped Ashtoreth the elohim of the Sidonians, Chemosh the elohim of Moab, and Milcom the elohim of the children of Ammon. They have not walked in my ways, to do that which is right in my eyes, and to keep my statutes and my ordinances, as David his father did. 
+</div><div class="p">
+<sup>34&#160;</sup>“&#160;‘However, I will not take the whole kingdom out of his hand, but I will make him prince all the days of his life for David my servant’s sake whom I chose, who kept my commandments and my statutes, 
+<sup>35&#160;</sup>but I will take the kingdom out of his son’s hand and will give it to you, even ten tribes. 
+<sup>36&#160;</sup>I will give one tribe to his son, that David my servant may have a lamp always before me in Jerusalem, the city which I have chosen for myself to put my name there. 
+<sup>37&#160;</sup>I will take you, and you shall reign according to all that your soul desires, and shall be king over Israel. 
+<sup>38&#160;</sup>It shall be, if you will listen to all that I command you, and will walk in my ways, and do that which is right in my eyes, to keep my statutes and my commandments, as David my servant did, that I will be with you, and will build you a sure house, as I built for David, and will give Israel to you. 
+<sup>39&#160;</sup>I will afflict the offspring of David for this, but not forever.’&#160;” 
+</div><div class="p">
+<sup>40&#160;</sup>Therefore Solomon sought to kill Jeroboam, but Jeroboam arose and fled into Egypt, to Shishak king of Egypt, and was in Egypt until the death of Solomon. 
+</div><div class="p">
+<sup>41&#160;</sup>Now the rest of the acts of Solomon, and all that he did, and his wisdom, aren’t they written in the book of the acts of Solomon? 
+<sup>42&#160;</sup>The time that Solomon reigned in Jerusalem over all Israel was forty years. 
+<sup>43&#160;</sup>Solomon slept with his fathers, and was buried in his father David’s city; and Rehoboam his son reigned in his place. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Rehoboam went to Shechem, for all Israel had come to Shechem to make him king. 
+<sup>2&#160;</sup>When Jeroboam the son of Nebat heard of it (for he was yet in Egypt, where he had fled from the presence of King Solomon, and Jeroboam lived in Egypt; 
+<sup>3&#160;</sup>and they sent and called him), Jeroboam and all the assembly of Israel came, and spoke to Rehoboam, saying, 
+<sup>4&#160;</sup>“Your father made our yoke difficult. Now therefore make the hard service of your father, and his heavy yoke which he put on us, lighter, and we will serve you.” 
+</div><div class="p">
+<sup>5&#160;</sup>He said to them, “Depart for three days, then come back to me.” 
+</div><div class="p">So the people departed. 
+</div><div class="p">
+<sup>6&#160;</sup>King Rehoboam took counsel with the old men who had stood before Solomon his father while he yet lived, saying, “What counsel do you give me to answer these people?” 
+</div><div class="p">
+<sup>7&#160;</sup>They replied, “If you will be a servant to this people today, and will serve them, and answer them with good words, then they will be your servants forever.” 
+</div><div class="p">
+<sup>8&#160;</sup>But he abandoned the counsel of the old men which they had given him, and took counsel with the young men who had grown up with him, who stood before him. 
+<sup>9&#160;</sup>He said to them, “What counsel do you give, that we may answer these people who have spoken to me, saying, ‘Make the yoke that your father put on us lighter’?” 
+</div><div class="p">
+<sup>10&#160;</sup>The young men who had grown up with him said to him, “Tell these people who spoke to you, saying, ‘Your father made our yoke heavy, but make it lighter to us’—tell them, ‘My little finger is thicker than my father’s waist. 
+<sup>11&#160;</sup>Now my father burdened you with a heavy yoke, but I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>So Jeroboam and all the people came to Rehoboam the third day, as the king asked, saying, “Come to me again the third day.” 
+<sup>13&#160;</sup>The king answered the people roughly, and abandoned the counsel of the old men which they had given him, 
+<sup>14&#160;</sup>and spoke to them according to the counsel of the young men, saying, “My father made your yoke heavy, but I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.” 
+</div><div class="p">
+<sup>15&#160;</sup>So the king didn’t listen to the people; for it was a thing brought about from Yahweh, that he might establish his word, which Yahweh spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
+<sup>16&#160;</sup>When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion have we in David? We don’t have an inheritance in the son of Jesse. To your tents, Israel! Now see to your own house, David.” So Israel departed to their tents. 
+</div><div class="p">
+<sup>17&#160;</sup>But as for the children of Israel who lived in the cities of Judah, Rehoboam reigned over them. 
+<sup>18&#160;</sup>Then King Rehoboam sent Adoram, who was over the men subject to forced labor; and all Israel stoned him to death with stones. King Rehoboam hurried to get himself up to his chariot, to flee to Jerusalem. 
+<sup>19&#160;</sup>So Israel rebelled against David’s house to this day. 
+</div><div class="p">
+<sup>20&#160;</sup>When all Israel heard that Jeroboam had returned, they sent and called him to the congregation, and made him king over all Israel. There was no one who followed David’s house, except for the tribe of Judah only. 
+</div><div class="p">
+<sup>21&#160;</sup>When Rehoboam had come to Jerusalem, he assembled all the house of Judah and the tribe of Benjamin, a hundred and eighty thousand chosen men who were warriors, to fight against the house of Israel, to bring the kingdom again to Rehoboam the son of Solomon. 
+<sup>22&#160;</sup>But the word of Elohim came to Shemaiah the man of Elohim, saying, 
+<sup>23&#160;</sup>“Speak to Rehoboam the son of Solomon, king of Judah, and to all the house of Judah and Benjamin, and to the rest of the people, saying, 
+<sup>24&#160;</sup>‘Yahweh says, “You shall not go up or fight against your brothers, the children of Israel. Everyone return to his house; for this thing is from me.”&#160;’&#160;” So they listened to Yahweh’s word, and returned and went their way, according to Yahweh’s word. 
+</div><div class="p">
+<sup>25&#160;</sup>Then Jeroboam built Shechem in the hill country of Ephraim, and lived in it; and he went out from there and built Penuel. 
+<sup>26&#160;</sup>Jeroboam said in his heart, “Now the kingdom will return to David’s house. 
+<sup>27&#160;</sup>If this people goes up to offer sacrifices in Yahweh’s house at Jerusalem, then the heart of this people will turn again to their lord, even to Rehoboam king of Judah; and they will kill me, and return to Rehoboam king of Judah.” 
+<sup>28&#160;</sup>So the king took counsel, and made two calves of gold; and he said to them, “It is too much for you to go up to Jerusalem. Look and behold your elohims, Israel, which brought you up out of the land of Egypt!” 
+<sup>29&#160;</sup>He set the one in Bethel, and the other he put in Dan. 
+<sup>30&#160;</sup>This thing became a sin, for the people went even as far as Dan to worship before the one there. 
+<sup>31&#160;</sup>He made houses of high places, and made priests from among all the people, who were not of the sons of Levi. 
+<sup>32&#160;</sup>Jeroboam ordained a feast in the eighth month, on the fifteenth day of the month, like the feast that is in Judah, and he went up to the altar. He did so in Bethel, sacrificing to the calves that he had made, and he placed in Bethel the priests of the high places that he had made. 
+<sup>33&#160;</sup>He went up to the altar which he had made in Bethel on the fifteenth day in the eighth month, even in the month which he had devised of his own heart; and he ordained a feast for the children of Israel, and went up to the altar to burn incense. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Behold, a man of Elohim came out of Judah by Yahweh’s word to Bethel; and Jeroboam was standing by the altar to burn incense. 
+<sup>2&#160;</sup>He cried against the altar by Yahweh’s word, and said, “Altar! Altar! Yahweh says: ‘Behold, a son will be born to David’s house, Josiah by name. On you he will sacrifice the priests of the high places who burn incense on you, and they will burn men’s bones on you.’&#160;” 
+<sup>3&#160;</sup>He gave a sign the same day, saying, “This is the sign which Yahweh has spoken: Behold, the altar will be split apart, and the ashes that are on it will be poured out.” 
+</div><div class="p">
+<sup>4&#160;</sup>When the king heard the saying of the man of Elohim, which he cried against the altar in Bethel, Jeroboam put out his hand from the altar, saying, “Seize him!” His hand, which he put out against him, dried up, so that he could not draw it back again to himself. 
+<sup>5&#160;</sup>The altar was also split apart, and the ashes poured out from the altar, according to the sign which the man of Elohim had given by Yahweh’s word. 
+<sup>6&#160;</sup>The king answered the man of Elohim, “Now intercede for the favor of Yahweh your Elohim, and pray for me, that my hand may be restored me again.” 
+</div><div class="p">The man of Elohim interceded with Yahweh, and the king’s hand was restored to him again, and became as it was before. 
+</div><div class="p">
+<sup>7&#160;</sup>The king said to the man of Elohim, “Come home with me and refresh yourself, and I will give you a reward.” 
+</div><div class="p">
+<sup>8&#160;</sup>The man of Elohim said to the king, “Even if you gave me half of your house, I would not go in with you, neither would I eat bread nor drink water in this place; 
+<sup>9&#160;</sup>for so was it commanded me by Yahweh’s word, saying, ‘You shall eat no bread, drink no water, and don’t return by the way that you came.’&#160;” 
+<sup>10&#160;</sup>So he went another way, and didn’t return by the way that he came to Bethel. 
+</div><div class="p">
+<sup>11&#160;</sup>Now an old prophet lived in Bethel, and one of his sons came and told him all the works that the man of Elohim had done that day in Bethel. They also told their father the words which he had spoken to the king. 
+</div><div class="p">
+<sup>12&#160;</sup>Their father said to them, “Which way did he go?” Now his sons had seen which way the man of Elohim went, who came from Judah. 
+<sup>13&#160;</sup>He said to his sons, “Saddle the donkey for me.” So they saddled the donkey for him; and he rode on it. 
+<sup>14&#160;</sup>He went after the man of Elohim, and found him sitting under an oak. He said to him, “Are you the man of Elohim who came from Judah?” 
+</div><div class="p">He said, “I am.” 
+</div><div class="p">
+<sup>15&#160;</sup>Then he said to him, “Come home with me and eat bread.” 
+</div><div class="p">
+<sup>16&#160;</sup>He said, “I may not return with you, nor go in with you. I will not eat bread or drink water with you in this place. 
+<sup>17&#160;</sup>For it was said to me by Yahweh’s word, ‘You shall eat no bread or drink water there, and don’t turn again to go by the way that you came.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>He said to him, “I also am a prophet as you are; and an angel spoke to me by Yahweh’s word, saying, ‘Bring him back with you into your house, that he may eat bread and drink water.’&#160;” He lied to him. 
+</div><div class="p">
+<sup>19&#160;</sup>So he went back with him, ate bread in his house, and drank water. 
+<sup>20&#160;</sup>As they sat at the table, Yahweh’s word came to the prophet who brought him back; 
+<sup>21&#160;</sup>and he cried out to the man of Elohim who came from Judah, saying, “Yahweh says, ‘Because you have been disobedient to Yahweh’s word, and have not kept the commandment which Yahweh your Elohim commanded you, 
+<sup>22&#160;</sup>but came back, and have eaten bread and drank water in the place of which he said to you, “Eat no bread, and drink no water,” your body will not come to the tomb of your fathers.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>After he had eaten bread and after he drank, he saddled the donkey for the prophet whom he had brought back. 
+<sup>24&#160;</sup>When he had gone, a lion met him by the way and killed him. His body was thrown on the path, and the donkey stood by it. The lion also stood by the body. 
+<sup>25&#160;</sup>Behold, men passed by and saw the body thrown on the path, and the lion standing by the body; and they came and told it in the city where the old prophet lived. 
+<sup>26&#160;</sup>When the prophet who brought him back from the way heard of it, he said, “It is the man of Elohim who was disobedient to Yahweh’s word. Therefore Yahweh has delivered him to the lion, which has mauled him and slain him, according to Yahweh’s word which he spoke to him.” 
+<sup>27&#160;</sup>He said to his sons, saying, “Saddle the donkey for me,” and they saddled it. 
+<sup>28&#160;</sup>He went and found his body thrown on the path, and the donkey and the lion standing by the body. The lion had not eaten the body nor mauled the donkey. 
+<sup>29&#160;</sup>The prophet took up the body of the man of Elohim, and laid it on the donkey, and brought it back. He came to the city of the old prophet to mourn, and to bury him. 
+<sup>30&#160;</sup>He laid his body in his own grave; and they mourned over him, saying, “Alas, my brother!” 
+</div><div class="p">
+<sup>31&#160;</sup>After he had buried him, he spoke to his sons, saying, “When I am dead, bury me in the tomb in which the man of Elohim is buried. Lay my bones beside his bones. 
+<sup>32&#160;</sup>For the saying which he cried by Yahweh’s word against the altar in Bethel, and against all the houses of the high places which are in the cities of Samaria, will surely happen.” 
+</div><div class="p">
+<sup>33&#160;</sup>After this thing, Jeroboam didn’t turn from his evil way, but again made priests of the high places from among all the people. Whoever wanted to, he consecrated him, that there might be priests of the high places. 
+<sup>34&#160;</sup>This thing became sin to the house of Jeroboam, even to cut it off and to destroy it from off the surface of the earth. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>At that time Abijah the son of Jeroboam became sick. 
+<sup>2&#160;</sup>Jeroboam said to his woman, “Please get up and disguise yourself, so that you won’t be recognized as Jeroboam’s woman. Go to Shiloh. Behold, Ahijah the prophet is there, who said that I would be king over this people. 
+<sup>3&#160;</sup>Take with you ten loaves of bread, some cakes, and a jar of honey, and go to him. He will tell you what will become of the child.” 
+</div><div class="p">
+<sup>4&#160;</sup>Jeroboam’s woman did so, and arose and went to Shiloh, and came to Ahijah’s house. Now Ahijah could not see, for his eyes were set by reason of his age. 
+<sup>5&#160;</sup>Yahweh said to Ahijah, “Behold, Jeroboam’s woman is coming to inquire of you concerning her son, for he is sick. Tell her such and such; for it will be, when she comes in, that she will pretend to be another woman.” 
+</div><div class="p">
+<sup>6&#160;</sup>So when Ahijah heard the sound of her feet as she came in at the door, he said, “Come in, Jeroboam’s woman! Why do you pretend to be another? For I am sent to you with heavy news. 
+<sup>7&#160;</sup>Go, tell Jeroboam, ‘Yahweh, the Elohim of Israel, says: “Because I exalted you from among the people, and made you prince over my people Israel, 
+<sup>8&#160;</sup>and tore the kingdom away from David’s house, and gave it you; and yet you have not been as my servant David, who kept my commandments, and who followed me with all his heart, to do that only which was right in my eyes, 
+<sup>9&#160;</sup>but have done evil above all who were before you, and have gone and made for yourself other elohims, molten images, to provoke me to anger, and have cast me behind your back, 
+<sup>10&#160;</sup>therefore, behold, I will bring evil on the house of Jeroboam, and will cut off from Jeroboam everyone who urinates on a wall, he who is shut up and he who is left at large in Israel, and will utterly sweep away the house of Jeroboam, as a man sweeps away dung until it is all gone. 
+<sup>11&#160;</sup>The dogs will eat he who belongs to Jeroboam who dies in the city; and the birds of the sky will eat he who dies in the field, for Yahweh has spoken it.”&#160;’ 
+<sup>12&#160;</sup>Arise therefore, and go to your house. When your feet enter into the city, the child will die. 
+<sup>13&#160;</sup>All Israel will mourn for him and bury him; for he only of Jeroboam will come to the grave, because in him there is found some good thing toward Yahweh, the Elohim of Israel, in the house of Jeroboam. 
+<sup>14&#160;</sup>Moreover Yahweh will raise up a king for himself over Israel who will cut off the house of Jeroboam. This is the day! What? Even now. 
+<sup>15&#160;</sup>For Yahweh will strike Israel, as a reed is shaken in the water; and he will root up Israel out of this good land which he gave to their fathers, and will scatter them beyond the River, because they have made their Asherah poles, provoking Yahweh to anger. 
+<sup>16&#160;</sup>He will give Israel up because of the sins of Jeroboam, which he has sinned, and with which he has made Israel to sin.” 
+</div><div class="p">
+<sup>17&#160;</sup>Jeroboam’s woman arose and departed, and came to Tirzah. As she came to the threshold of the house, the child died. 
+<sup>18&#160;</sup>All Israel buried him and mourned for him, according to Yahweh’s word, which he spoke by his servant Ahijah the prophet. 
+</div><div class="p">
+<sup>19&#160;</sup>The rest of the acts of Jeroboam, how he fought and how he reigned, behold, they are written in the book of the chronicles of the kings of Israel. 
+<sup>20&#160;</sup>The days which Jeroboam reigned were twenty two years; then he slept with his fathers, and Nadab his son reigned in his place. 
+</div><div class="p">
+<sup>21&#160;</sup>Rehoboam the son of Solomon reigned in Judah. Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel, to put his name there. His mother’s name was Naamah the Ammonitess. 
+<sup>22&#160;</sup>Judah did that which was evil in Yahweh’s sight, and they provoked him to jealousy with their sins which they committed, above all that their fathers had done. 
+<sup>23&#160;</sup>For they also built for themselves high places, sacred pillars, and Asherah poles on every high hill and under every green tree. 
+<sup>24&#160;</sup>There were also sodomites in the land. They did according to all the abominations of the nations which Yahweh drove out before the children of Israel. 
+</div><div class="p">
+<sup>25&#160;</sup>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem; 
+<sup>26&#160;</sup>and he took away the treasures of Yahweh’s house and the treasures of the king’s house. He even took away all of it, including all the gold shields which Solomon had made. 
+<sup>27&#160;</sup>King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
+<sup>28&#160;</sup>It was so, that as often as the king went into Yahweh’s house, the guard bore them, and brought them back into the guard room. 
+</div><div class="p">
+<sup>29&#160;</sup>Now the rest of the acts of Rehoboam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>30&#160;</sup>There was war between Rehoboam and Jeroboam continually. 
+<sup>31&#160;</sup>Rehoboam slept with his fathers, and was buried with his fathers in David’s city. His mother’s name was Naamah the Ammonitess. Abijam his son reigned in his place. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Now in the eighteenth year of King Jeroboam the son of Nebat, Abijam began to reign over Judah. 
+<sup>2&#160;</sup>He reigned three years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
+<sup>3&#160;</sup>He walked in all the sins of his father, which he had done before him; and his heart was not perfect with Yahweh his Elohim, as the heart of David his father. 
+<sup>4&#160;</sup>Nevertheless for David’s sake, Yahweh his Elohim gave him a lamp in Jerusalem, to set up his son after him and to establish Jerusalem; 
+<sup>5&#160;</sup>because David did that which was right in Yahweh’s eyes, and didn’t turn away from anything that he commanded him all the days of his life, except only in the matter of Uriah the Hittite. 
+<sup>6&#160;</sup>Now there was war between Rehoboam and Jeroboam all the days of his life. 
+<sup>7&#160;</sup>The rest of the acts of Abijam, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? There was war between Abijam and Jeroboam. 
+<sup>8&#160;</sup>Abijam slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. 
+</div><div class="p">
+<sup>9&#160;</sup>In the twentieth year of Jeroboam king of Israel, Asa began to reign over Judah. 
+<sup>10&#160;</sup>He reigned forty-one years in Jerusalem. His mother’s name was Maacah the daughter of Abishalom. 
+<sup>11&#160;</sup>Asa did that which was right in Yahweh’s eyes, as David his father did. 
+<sup>12&#160;</sup>He put away the sodomites out of the land, and removed all the idols that his fathers had made. 
+<sup>13&#160;</sup>He also removed Maacah his mother from being queen, because she had made an abominable image for an Asherah. Asa cut down her image and burned it at the brook Kidron. 
+<sup>14&#160;</sup>But the high places were not taken away. Nevertheless the heart of Asa was perfect with Yahweh all his days. 
+<sup>15&#160;</sup>He brought into Yahweh’s house the things that his father had dedicated, and the things that he himself had dedicated: silver, gold, and utensils. 
+</div><div class="p">
+<sup>16&#160;</sup>There was war between Asa and Baasha king of Israel all their days. 
+<sup>17&#160;</sup>Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
+<sup>18&#160;</sup>Then Asa took all the silver and the gold that was left in the treasures of Yahweh’s house, and the treasures of the king’s house, and delivered it into the hand of his servants. Then King Asa sent them to Ben Hadad, the son of Tabrimmon, the son of Hezion, king of Syria, who lived at Damascus, saying, 
+<sup>19&#160;</sup>“Let there be a treaty between me and you, like that between my father and your father. Behold, I have sent to you a present of silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
+</div><div class="p">
+<sup>20&#160;</sup>Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel, and struck Ijon, and Dan, and Abel Beth Maacah, and all Chinneroth, with all the land of Naphtali. 
+<sup>21&#160;</sup>When Baasha heard of it, he stopped building Ramah, and lived in Tirzah. 
+<sup>22&#160;</sup>Then King Asa made a proclamation to all Judah. No one was exempted. They carried away the stones of Ramah, and its timber, with which Baasha had built; and King Asa used it to build Geba of Benjamin, and Mizpah. 
+<sup>23&#160;</sup>Now the rest of all the acts of Asa, and all his might, and all that he did, and the cities which he built, aren’t they written in the book of the chronicles of the kings of Judah? But in the time of his old age he was diseased in his feet. 
+<sup>24&#160;</sup>Asa slept with his fathers, and was buried with his fathers in his father David’s city; and Jehoshaphat his son reigned in his place. 
+</div><div class="p">
+<sup>25&#160;</sup>Nadab the son of Jeroboam began to reign over Israel in the second year of Asa king of Judah; and he reigned over Israel two years. 
+<sup>26&#160;</sup>He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in his sin with which he made Israel to sin. 
+<sup>27&#160;</sup>Baasha the son of Ahijah, of the house of Issachar, conspired against him; and Baasha struck him at Gibbethon, which belonged to the Philistines; for Nadab and all Israel were besieging Gibbethon. 
+<sup>28&#160;</sup>Even in the third year of Asa king of Judah, Baasha killed him and reigned in his place. 
+<sup>29&#160;</sup>As soon as he was king, he struck all the house of Jeroboam. He didn’t leave to Jeroboam any who breathed, until he had destroyed him, according to the saying of Yahweh, which he spoke by his servant Ahijah the Shilonite; 
+<sup>30&#160;</sup>for the sins of Jeroboam which he sinned, and with which he made Israel to sin, because of his provocation with which he provoked Yahweh, the Elohim of Israel, to anger. 
+</div><div class="p">
+<sup>31&#160;</sup>Now the rest of the acts of Nadab, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>32&#160;</sup>There was war between Asa and Baasha king of Israel all their days. 
+</div><div class="p">
+<sup>33&#160;</sup>In the third year of Asa king of Judah, Baasha the son of Ahijah began to reign over all Israel in Tirzah for twenty-four years. 
+<sup>34&#160;</sup>He did that which was evil in Yahweh’s sight, and walked in the way of Jeroboam, and in his sin with which he made Israel to sin. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to Jehu the son of Hanani against Baasha, saying, 
+<sup>2&#160;</sup>“Because I exalted you out of the dust and made you prince over my people Israel, and you have walked in the way of Jeroboam and have made my people Israel to sin, to provoke me to anger with their sins, 
+<sup>3&#160;</sup>behold, I will utterly sweep away Baasha and his house; and I will make your house like the house of Jeroboam the son of Nebat. 
+<sup>4&#160;</sup>The dogs will eat Baasha’s descendants who die in the city; and he who dies of his in the field, the birds of the sky will eat.” 
+</div><div class="p">
+<sup>5&#160;</sup>Now the rest of the acts of Baasha, and what he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>6&#160;</sup>Baasha slept with his fathers, and was buried in Tirzah; and Elah his son reigned in his place. 
+</div><div class="p">
+<sup>7&#160;</sup>Moreover Yahweh’s word came by the prophet Jehu the son of Hanani against Baasha and against his house, both because of all the evil that he did in Yahweh’s sight, to provoke him to anger with the work of his hands, in being like the house of Jeroboam, and because he struck him. 
+</div><div class="p">
+<sup>8&#160;</sup>In the twenty-sixth year of Asa king of Judah, Elah the son of Baasha began to reign over Israel in Tirzah for two years. 
+<sup>9&#160;</sup>His servant Zimri, captain of half his chariots, conspired against him. Now he was in Tirzah, drinking himself drunk in the house of Arza, who was over the household in Tirzah; 
+<sup>10&#160;</sup>and Zimri went in and struck him and killed him in the twenty-seventh year of Asa king of Judah, and reigned in his place. 
+</div><div class="p">
+<sup>11&#160;</sup>When he began to reign, as soon as he sat on his throne, he attacked all the house of Baasha. He didn’t leave him a single one who urinates on a wall among his relatives or his friends. 
+<sup>12&#160;</sup>Thus Zimri destroyed all the house of Baasha, according to Yahweh’s word which he spoke against Baasha by Jehu the prophet, 
+<sup>13&#160;</sup>for all the sins of Baasha, and the sins of Elah his son, which they sinned and with which they made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
+<sup>14&#160;</sup>Now the rest of the acts of Elah, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
+</div><div class="p">
+<sup>15&#160;</sup>In the twenty-seventh year of Asa king of Judah, Zimri reigned seven days in Tirzah. Now the people were encamped against Gibbethon, which belonged to the Philistines. 
+<sup>16&#160;</sup>The people who were encamped heard that Zimri had conspired, and had also killed the king. Therefore all Israel made Omri, the captain of the army, king over Israel that day in the camp. 
+<sup>17&#160;</sup>Omri went up from Gibbethon, and all Israel with him, and they besieged Tirzah. 
+<sup>18&#160;</sup>When Zimri saw that the city was taken, he went into the fortified part of the king’s house and burned the king’s house over him with fire, and died, 
+<sup>19&#160;</sup>for his sins which he sinned in doing that which was evil in Yahweh’s sight, in walking in the way of Jeroboam, and in his sin which he did to make Israel to sin. 
+<sup>20&#160;</sup>Now the rest of the acts of Zimri, and his treason that he committed, aren’t they written in the book of the chronicles of the kings of Israel? 
+</div><div class="p">
+<sup>21&#160;</sup>Then the people of Israel were divided into two parts: half of the people followed Tibni the son of Ginath, to make him king, and half followed Omri. 
+<sup>22&#160;</sup>But the people who followed Omri prevailed against the people who followed Tibni the son of Ginath; so Tibni died, and Omri reigned. 
+<sup>23&#160;</sup>In the thirty-first year of Asa king of Judah, Omri began to reign over Israel for twelve years. He reigned six years in Tirzah. 
+<sup>24&#160;</sup>He bought the hill Samaria of Shemer for two talents of silver; and he built on the hill, and called the name of the city which he built, Samaria, after the name of Shemer, the owner of the hill. 
+<sup>25&#160;</sup>Omri did that which was evil in Yahweh’s sight, and dealt wickedly above all who were before him. 
+<sup>26&#160;</sup>For he walked in all the way of Jeroboam the son of Nebat, and in his sins with which he made Israel to sin, to provoke Yahweh, the Elohim of Israel, to anger with their vanities. 
+<sup>27&#160;</sup>Now the rest of the acts of Omri which he did, and his might that he showed, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>28&#160;</sup>So Omri slept with his fathers, and was buried in Samaria; and Ahab his son reigned in his place. 
+</div><div class="p">
+<sup>29&#160;</sup>In the thirty-eighth year of Asa king of Judah, Ahab the son of Omri began to reign over Israel. Ahab the son of Omri reigned over Israel in Samaria twenty-two years. 
+<sup>30&#160;</sup>Ahab the son of Omri did that which was evil in Yahweh’s sight above all that were before him. 
+<sup>31&#160;</sup>As if it had been a light thing for him to walk in the sins of Jeroboam the son of Nebat, he took as woman Jezebel the daughter of Ethbaal king of the Sidonians, and went and served Baal and worshiped him. 
+<sup>32&#160;</sup>He raised up an altar for Baal in the house of Baal, which he had built in Samaria. 
+<sup>33&#160;</sup>Ahab made the Asherah; and Ahab did more yet to provoke Yahweh, the Elohim of Israel, to anger than all the kings of Israel who were before him. 
+<sup>34&#160;</sup>In his days Hiel the Bethelite built Jericho. He laid its foundation with the loss of Abiram his firstborn, and set up its gates with the loss of his youngest son Segub, according to Yahweh’s word, which he spoke by Joshua the son of Nun. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Elijah the Tishbite, who was one of the settlers of Gilead, said to Ahab, “As Yahweh, the Elohim of Israel, lives, before whom I stand, there shall not be dew nor rain these years, but according to my word.” 
+</div><div class="p">
+<sup>2&#160;</sup>Then Yahweh’s word came to him, saying, 
+<sup>3&#160;</sup>“Go away from here, turn eastward, and hide yourself by the brook Cherith, that is before the Jordan. 
+<sup>4&#160;</sup>You shall drink from the brook. I have commanded the ravens to feed you there.” 
+<sup>5&#160;</sup>So he went and did according to Yahweh’s word, for he went and lived by the brook Cherith that is before the Jordan. 
+<sup>6&#160;</sup>The ravens brought him bread and meat in the morning, and bread and meat in the evening; and he drank from the brook. 
+<sup>7&#160;</sup>After a while, the brook dried up, because there was no rain in the land. 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh’s word came to him, saying, 
+<sup>9&#160;</sup>“Arise, go to Zarephath, which belongs to Sidon, and stay there. Behold, I have commanded a widow there to sustain you.” 
+</div><div class="p">
+<sup>10&#160;</sup>So he arose and went to Zarephath; and when he came to the gate of the city, behold, a widow was there gathering sticks. He called to her and said, “Please get me a little water in a jar, that I may drink.” 
+</div><div class="p">
+<sup>11&#160;</sup>As she was going to get it, he called to her and said, “Please bring me a morsel of bread in your hand.” 
+</div><div class="p">
+<sup>12&#160;</sup>She said, “As Yahweh your Elohim lives, I don’t have anything baked, but only a handful of meal in a jar and a little oil in a jar. Behold, I am gathering two sticks, that I may go in and bake it for me and my son, that we may eat it, and die.” 
+</div><div class="p">
+<sup>13&#160;</sup>Elijah said to her, “Don’t be afraid. Go and do as you have said; but make me a little cake from it first, and bring it out to me, and afterward make some for you and for your son. 
+<sup>14&#160;</sup>For Yahweh, the Elohim of Israel, says, ‘The jar of meal will not run out, and the jar of oil will not fail, until the day that Yahweh sends rain on the earth.’&#160;” 
+</div><div class="p">
+<sup>15&#160;</sup>She went and did according to the saying of Elijah; and she, he, and her household ate many days. 
+<sup>16&#160;</sup>The jar of meal didn’t run out and the jar of oil didn’t fail, according to Yahweh’s word, which he spoke by Elijah. 
+</div><div class="p">
+<sup>17&#160;</sup>After these things, the son of the woman, the mistress of the house, became sick; and his sickness was so severe that there was no breath left in him. 
+<sup>18&#160;</sup>She said to Elijah, “What have I to do with you, you man of Elohim? You have come to me to bring my sin to memory, and to kill my son!” 
+</div><div class="p">
+<sup>19&#160;</sup>He said to her, “Give me your son.” He took him out of her bosom, and carried him up into the room where he stayed, and laid him on his own bed. 
+<sup>20&#160;</sup>He cried to Yahweh and said, “Yahweh my Elohim, have you also brought evil on the widow with whom I am staying, by killing her son?” 
+</div><div class="p">
+<sup>21&#160;</sup>He stretched himself on the child three times, and cried to Yahweh and said, “Yahweh my Elohim, please let this child’s soul come into him again.” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh listened to the voice of Elijah; and the soul of the child came into him again, and he revived. 
+<sup>23&#160;</sup>Elijah took the child and brought him down out of the room into the house, and delivered him to his mother; and Elijah said, “Behold, your son lives.” 
+</div><div class="p">
+<sup>24&#160;</sup>The woman said to Elijah, “Now I know that you are a man of Elohim, and that Yahweh’s word in your mouth is truth.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>After many days, Yahweh’s word came to Elijah, in the third year, saying, “Go, show yourself to Ahab; and I will send rain on the earth.” 
+</div><div class="p">
+<sup>2&#160;</sup>Elijah went to show himself to Ahab. The famine was severe in Samaria. 
+<sup>3&#160;</sup>Ahab called Obadiah, who was over the household. (Now Obadiah feared Yahweh greatly; 
+<sup>4&#160;</sup>for when Jezebel cut off Yahweh’s prophets, Obadiah took one hundred prophets, and hid them fifty to a cave, and fed them with bread and water.) 
+<sup>5&#160;</sup>Ahab said to Obadiah, “Go through the land, to all the springs of water, and to all the brooks. Perhaps we may find grass and save the horses and mules alive, that we not lose all the animals.” 
+</div><div class="p">
+<sup>6&#160;</sup>So they divided the land between them to pass throughout it. Ahab went one way by himself, and Obadiah went another way by himself. 
+<sup>7&#160;</sup>As Obadiah was on the way, behold, Elijah met him. He recognized him, and fell on his face, and said, “Is it you, my lord Elijah?” 
+</div><div class="p">
+<sup>8&#160;</sup>He answered him, “It is I. Go, tell your lord, ‘Behold, Elijah is here!’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>He said, “How have I sinned, that you would deliver your servant into the hand of Ahab, to kill me? 
+<sup>10&#160;</sup>As Yahweh your Elohim lives, there is no nation or kingdom where my lord has not sent to seek you. When they said, ‘He is not here,’ he took an oath of the kingdom and nation that they didn’t find you. 
+<sup>11&#160;</sup>Now you say, ‘Go, tell your lord, “Behold, Elijah is here.”&#160;’ 
+<sup>12&#160;</sup>It will happen, as soon as I leave you, that Yahweh’s Spirit will carry you I don’t know where; and so when I come and tell Ahab, and he can’t find you, he will kill me. But I, your servant, have feared Yahweh from my youth. 
+<sup>13&#160;</sup>Wasn’t it told my lord what I did when Jezebel killed Yahweh’s prophets, how I hid one hundred men of Yahweh’s prophets with fifty to a cave, and fed them with bread and water? 
+<sup>14&#160;</sup>Now you say, ‘Go, tell your lord, “Behold, Elijah is here”.’ He will kill me.” 
+</div><div class="p">
+<sup>15&#160;</sup>Elijah said, “As Yahweh of Armies lives, before whom I stand, I will surely show myself to him today.” 
+<sup>16&#160;</sup>So Obadiah went to meet Ahab, and told him; and Ahab went to meet Elijah. 
+</div><div class="p">
+<sup>17&#160;</sup>When Ahab saw Elijah, Ahab said to him, “Is that you, you troubler of Israel?” 
+</div><div class="p">
+<sup>18&#160;</sup>He answered, “I have not troubled Israel, but you and your father’s house, in that you have forsaken Yahweh’s commandments and you have followed the Baals. 
+<sup>19&#160;</sup>Now therefore send, and gather to me all Israel to Mount Carmel, and four hundred fifty of the prophets of Baal, and four hundred of the prophets of the Asherah, who eat at Jezebel’s table.” 
+</div><div class="p">
+<sup>20&#160;</sup>So Ahab sent to all the children of Israel, and gathered the prophets together to Mount Carmel. 
+<sup>21&#160;</sup>Elijah came near to all the people, and said, “How long will you waver between the two sides? If Yahweh is Elohim, follow him; but if Baal, then follow him.” 
+</div><div class="p">The people didn’t say a word. 
+</div><div class="p">
+<sup>22&#160;</sup>Then Elijah said to the people, “I, even I only, am left as a prophet of Yahweh; but Baal’s prophets are four hundred fifty men. 
+<sup>23&#160;</sup>Let them therefore give us two bulls; and let them choose one bull for themselves, and cut it in pieces, and lay it on the wood, and put no fire under; and I will dress the other bull, and lay it on the wood, and put no fire under it. 
+<sup>24&#160;</sup>You call on the name of your elohim, and I will call on Yahweh’s name. The Elohim who answers by fire, let him be Elohim.” 
+</div><div class="p">All the people answered, “What you say is good.” 
+</div><div class="p">
+<sup>25&#160;</sup>Elijah said to the prophets of Baal, “Choose one bull for yourselves, and dress it first, for you are many; and call on the name of your elohim, but put no fire under it.” 
+</div><div class="p">
+<sup>26&#160;</sup>They took the bull which was given them, and they dressed it, and called on the name of Baal from morning even until noon, saying, “Baal, hear us!” But there was no voice, and nobody answered. They leaped about the altar which was made. 
+</div><div class="p">
+<sup>27&#160;</sup>At noon, Elijah mocked them, and said, “Cry aloud, for he is an elohim. Either he is deep in thought, or he has gone somewhere, or he is on a journey, or perhaps he sleeps and must be awakened.” 
+</div><div class="p">
+<sup>28&#160;</sup>They cried aloud, and cut themselves in their way with knives and lances until the blood gushed out on them. 
+<sup>29&#160;</sup>When midday was past, they prophesied until the time of the evening offering; but there was no voice, no answer, and nobody paid attention. 
+</div><div class="p">
+<sup>30&#160;</sup>Elijah said to all the people, “Come near to me!”; and all the people came near to him. He repaired Yahweh’s altar that had been thrown down. 
+<sup>31&#160;</sup>Elijah took twelve stones, according to the number of the tribes of the sons of Jacob, to whom Yahweh’s word came, saying, “Israel shall be your name.” 
+<sup>32&#160;</sup>With the stones he built an altar in Yahweh’s name. He made a trench around the altar large enough to contain two seahs of seed. 
+<sup>33&#160;</sup>He put the wood in order, and cut the bull in pieces and laid it on the wood. He said, “Fill four jars with water, and pour it on the burnt offering and on the wood.” 
+<sup>34&#160;</sup>He said, “Do it a second time;” and they did it the second time. He said, “Do it a third time;” and they did it the third time. 
+<sup>35&#160;</sup>The water ran around the altar; and he also filled the trench with water. 
+</div><div class="p">
+<sup>36&#160;</sup>At the time of the evening offering, Elijah the prophet came near and said, “Yahweh, the Elohim of Abraham, of Isaac, and of Israel, let it be known today that you are Elohim in Israel and that I am your servant, and that I have done all these things at your word. 
+<sup>37&#160;</sup>Hear me, Yahweh, hear me, that this people may know that you, Yahweh, are Elohim, and that you have turned their heart back again.” 
+</div><div class="p">
+<sup>38&#160;</sup>Then Yahweh’s fire fell and consumed the burnt offering, the wood, the stones, and the dust; and it licked up the water that was in the trench. 
+<sup>39&#160;</sup>When all the people saw it, they fell on their faces. They said, “Yahweh, he is Elohim! Yahweh, he is Elohim!” 
+</div><div class="p">
+<sup>40&#160;</sup>Elijah said to them, “Seize the prophets of Baal! Don’t let one of them escape!” 
+</div><div class="p">They seized them; and Elijah brought them down to the brook Kishon, and killed them there. 
+</div><div class="p">
+<sup>41&#160;</sup>Elijah said to Ahab, “Get up, eat and drink; for there is the sound of abundance of rain.” 
+</div><div class="p">
+<sup>42&#160;</sup>So Ahab went up to eat and to drink. Elijah went up to the top of Carmel; and he bowed himself down on the earth, and put his face between his knees. 
+<sup>43&#160;</sup>He said to his servant, “Go up now and look toward the sea.” 
+</div><div class="p">He went up and looked, then said, “There is nothing.” 
+</div><div class="p">He said, “Go again” seven times. 
+</div><div class="p">
+<sup>44&#160;</sup>On the seventh time, he said, “Behold, a small cloud, like a man’s hand, is rising out of the sea.” 
+</div><div class="p">He said, “Go up, tell Ahab, ‘Get ready and go down, so that the rain doesn’t stop you.’&#160;” 
+</div><div class="p">
+<sup>45&#160;</sup>In a little while, the sky grew black with clouds and wind, and there was a great rain. Ahab rode, and went to Jezreel. 
+<sup>46&#160;</sup>Yahweh’s hand was on Elijah; and he tucked his cloak into his belt and ran before Ahab to the entrance of Jezreel. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Ahab told Jezebel all that Elijah had done, and how he had killed all the prophets with the sword. 
+<sup>2&#160;</sup>Then Jezebel sent a messenger to Elijah, saying, “So let the elohims do to me, and more also, if I don’t make your life as the life of one of them by tomorrow about this time!” 
+</div><div class="p">
+<sup>3&#160;</sup>When he saw that, he arose and ran for his life, and came to Beersheba, which belongs to Judah, and left his servant there. 
+<sup>4&#160;</sup>But he himself went a day’s journey into the wilderness, and came and sat down under a juniper tree. Then he requested for himself that he might die, and said, “It is enough. Now, O Yahweh, take away my life; for I am not better than my fathers.” 
+</div><div class="p">
+<sup>5&#160;</sup>He lay down and slept under a juniper tree; and behold, an angel touched him, and said to him, “Arise and eat!” 
+</div><div class="p">
+<sup>6&#160;</sup>He looked, and behold, there was at his head a cake baked on the coals, and a jar of water. He ate and drank, and lay down again. 
+<sup>7&#160;</sup>Yahweh’s angel came again the second time, and touched him, and said, “Arise and eat, because the journey is too great for you.” 
+</div><div class="p">
+<sup>8&#160;</sup>He arose, and ate and drank, and went in the strength of that food forty days and forty nights to Horeb, Elohim’s Mountain. 
+<sup>9&#160;</sup>He came to a cave there, and camped there; and behold, Yahweh’s word came to him, and he said to him, “What are you doing here, Elijah?” 
+</div><div class="p">
+<sup>10&#160;</sup>He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
+</div><div class="p">
+<sup>11&#160;</sup>He said, “Go out and stand on the mountain before Yahweh.” 
+</div><div class="p">Behold, Yahweh passed by, and a great and strong wind tore the mountains and broke in pieces the rocks before Yahweh; but Yahweh was not in the wind. After the wind there was an earthquake; but Yahweh was not in the earthquake. 
+<sup>12&#160;</sup>After the earthquake a fire passed; but Yahweh was not in the fire. After the fire, there was a still small voice. 
+<sup>13&#160;</sup>When Elijah heard it, he wrapped his face in his mantle, went out, and stood in the entrance of the cave. Behold, a voice came to him, and said, “What are you doing here, Elijah?” 
+</div><div class="p">
+<sup>14&#160;</sup>He said, “I have been very jealous for Yahweh, the Elohim of Armies; for the children of Israel have forsaken your covenant, thrown down your altars, and killed your prophets with the sword. I, even I only, am left; and they seek my life, to take it away.” 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh said to him, “Go, return on your way to the wilderness of Damascus. When you arrive, anoint Hazael to be king over Syria. 
+<sup>16&#160;</sup>Anoint Jehu the son of Nimshi to be king over Israel; and anoint Elisha the son of Shaphat of Abel Meholah to be prophet in your place. 
+<sup>17&#160;</sup>He who escapes from the sword of Hazael, Jehu will kill; and he who escapes from the sword of Jehu, Elisha will kill. 
+<sup>18&#160;</sup>Yet I reserved seven thousand in Israel, all the knees of which have not bowed to Baal, and every mouth which has not kissed him.” 
+</div><div class="p">
+<sup>19&#160;</sup>So he departed from there and found Elisha the son of Shaphat, who was plowing with twelve yoke of oxen before him, and he with the twelfth. Elijah went over to him and put his mantle on him. 
+<sup>20&#160;</sup>Elisha left the oxen and ran after Elijah, and said, “Let me please kiss my father and my mother, and then I will follow you.” 
+</div><div class="p">He said to him, “Go back again; for what have I done to you?” 
+</div><div class="p">
+<sup>21&#160;</sup>He returned from following him, and took the yoke of oxen, killed them, and boiled their meat with the oxen’s equipment, and gave to the people; and they ate. Then he arose, and went after Elijah, and served him. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Ben Hadad the king of Syria gathered all his army together; and there were thirty-two kings with him, with horses and chariots. He went up and besieged Samaria, and fought against it. 
+<sup>2&#160;</sup>He sent messengers into the city to Ahab king of Israel and said to him, “Ben Hadad says, 
+<sup>3&#160;</sup>‘Your silver and your gold are mine. Your women also and your children, even the best, are mine.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>The king of Israel answered, “It is according to your saying, my lord, O king. I am yours, and all that I have.” 
+</div><div class="p">
+<sup>5&#160;</sup>The messengers came again and said, “Ben Hadad says, ‘I sent indeed to you, saying, “You shall deliver me your silver, your gold, your women, and your children; 
+<sup>6&#160;</sup>but I will send my servants to you tomorrow about this time, and they will search your house and the houses of your servants. Whatever is pleasant in your eyes, they will put it in their hand, and take it away.”&#160;’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>Then the king of Israel called all the elders of the land, and said, “Please notice how this man seeks mischief; for he sent to me for my women, and for my children, and for my silver, and for my gold; and I didn’t deny him.” 
+</div><div class="p">
+<sup>8&#160;</sup>All the elders and all the people said to him, “Don’t listen, and don’t consent.” 
+</div><div class="p">
+<sup>9&#160;</sup>Therefore he said to the messengers of Ben Hadad, “Tell my lord the king, ‘All that you sent for to your servant at the first I will do, but this thing I cannot do.’&#160;” 
+</div><div class="p">The messengers departed and brought him back the message. 
+<sup>10&#160;</sup>Ben Hadad sent to him, and said, “The elohims do so to me, and more also, if the dust of Samaria will be enough for handfuls for all the people who follow me.” 
+</div><div class="p">
+<sup>11&#160;</sup>The king of Israel answered, “Tell him, ‘Don’t let him who puts on his armor brag like he who takes it off.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>When Ben Hadad heard this message as he was drinking, he and the kings in the pavilions, he said to his servants, “Prepare to attack!” So they prepared to attack the city. 
+</div><div class="p">
+<sup>13&#160;</sup>Behold, a prophet came near to Ahab king of Israel, and said, “Yahweh says, ‘Have you seen all this great multitude? Behold, I will deliver it into your hand today. Then you will know that I am Yahweh.’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Ahab said, “By whom?” 
+</div><div class="p">He said, “Yahweh says, ‘By the young men of the princes of the provinces.’&#160;” 
+</div><div class="p">Then he said, “Who shall begin the battle?” 
+</div><div class="p">He answered, “You.” 
+</div><div class="p">
+<sup>15&#160;</sup>Then he mustered the young men of the princes of the provinces, and they were two hundred and thirty-two. After them, he mustered all the people, even all the children of Israel, being seven thousand. 
+<sup>16&#160;</sup>They went out at noon. But Ben Hadad was drinking himself drunk in the pavilions, he and the kings, the thirty-two kings who helped him. 
+<sup>17&#160;</sup>The young men of the princes of the provinces went out first; and Ben Hadad sent out, and they told him, saying, “Men are coming out from Samaria.” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, “If they have come out for peace, take them alive; or if they have come out for war, take them alive.” 
+</div><div class="p">
+<sup>19&#160;</sup>So these went out of the city, the young men of the princes of the provinces, and the army which followed them. 
+<sup>20&#160;</sup>They each killed his man. The Syrians fled, and Israel pursued them. Ben Hadad the king of Syria escaped on a horse with horsemen. 
+<sup>21&#160;</sup>The king of Israel went out and struck the horses and chariots, and killed the Syrians with a great slaughter. 
+<sup>22&#160;</sup>The prophet came near to the king of Israel and said to him, “Go, strengthen yourself, and plan what you must do, for at the return of the year, the king of Syria will come up against you.” 
+</div><div class="p">
+<sup>23&#160;</sup>The servants of the king of Syria said to him, “Their elohim is an elohim of the hills; therefore they were stronger than we. But let’s fight against them in the plain, and surely we will be stronger than they. 
+<sup>24&#160;</sup>Do this thing: take the kings away, every man out of his place, and put captains in their place. 
+<sup>25&#160;</sup>Muster an army like the army that you have lost, horse for horse and chariot for chariot. We will fight against them in the plain, and surely we will be stronger than they are.” 
+</div><div class="p">He listened to their voice and did so. 
+<sup>26&#160;</sup>At the return of the year, Ben Hadad mustered the Syrians and went up to Aphek to fight against Israel. 
+<sup>27&#160;</sup>The children of Israel were mustered and given provisions, and went against them. The children of Israel encamped before them like two little flocks of young goats, but the Syrians filled the country. 
+<sup>28&#160;</sup>A man of Elohim came near and spoke to the king of Israel, and said, “Yahweh says, ‘Because the Syrians have said, “Yahweh is an elohim of the hills, but he is not an elohim of the valleys,” therefore I will deliver all this great multitude into your hand, and you shall know that I am Yahweh.’&#160;” 
+</div><div class="p">
+<sup>29&#160;</sup>They encamped opposite each other for seven days. Then on the seventh day the battle was joined; and the children of Israel killed one hundred thousand footmen of the Syrians in one day. 
+<sup>30&#160;</sup>But the rest fled to Aphek, into the city; and the wall fell on twenty-seven thousand men who were left. Ben Hadad fled and came into the city, into an inner room. 
+<sup>31&#160;</sup>His servants said to him, “See now, we have heard that the kings of the house of Israel are merciful kings. Please let us put sackcloth on our bodies and ropes on our heads, and go out to the king of Israel. Maybe he will save your life.” 
+</div><div class="p">
+<sup>32&#160;</sup>So they put sackcloth on their bodies and ropes on their heads, and came to the king of Israel, and said, “Your servant Ben Hadad says, ‘Please let me live.’&#160;” 
+</div><div class="p">He said, “Is he still alive? He is my brother.” 
+</div><div class="p">
+<sup>33&#160;</sup>Now the men observed diligently and hurried to take this phrase; and they said, “Your brother Ben Hadad.” 
+</div><div class="p">Then he said, “Go, bring him.” 
+</div><div class="p">Then Ben Hadad came out to him; and he caused him to come up into the chariot. 
+<sup>34&#160;</sup>Ben Hadad said to him, “The cities which my father took from your father I will restore. You shall make streets for yourself in Damascus, as my father made in Samaria.” 
+</div><div class="p">“I”, said Ahab, “will let you go with this covenant.” So he made a covenant with him and let him go. 
+</div><div class="p">
+<sup>35&#160;</sup>A certain man of the sons of the prophets said to his fellow by Yahweh’s word, “Please strike me!” 
+</div><div class="p">The man refused to strike him. 
+<sup>36&#160;</sup>Then he said to him, “Because you have not obeyed Yahweh’s voice, behold, as soon as you have departed from me, a lion will kill you.” As soon as he had departed from him, a lion found him and killed him. 
+</div><div class="p">
+<sup>37&#160;</sup>Then he found another man, and said, “Please strike me.” 
+</div><div class="p">The man struck him and wounded him. 
+<sup>38&#160;</sup>So the prophet departed and waited for the king by the way, and disguised himself with his headband over his eyes. 
+<sup>39&#160;</sup>As the king passed by, he cried to the king, and he said, “Your servant went out into the middle of the battle; and behold, a man came over and brought a man to me, and said, ‘Guard this man! If by any means he is missing, then your life shall be for his life, or else you shall pay a talent of silver.’ 
+<sup>40&#160;</sup>As your servant was busy here and there, he was gone.” 
+</div><div class="p">The king of Israel said to him, “So shall your judgment be. You yourself have decided it.” 
+</div><div class="p">
+<sup>41&#160;</sup>He hurried, and took the headband away from his eyes; and the king of Israel recognized that he was one of the prophets. 
+<sup>42&#160;</sup>He said to him, “Yahweh says, ‘Because you have let go out of your hand the man whom I had devoted to destruction, therefore your life will take the place of his life, and your people take the place of his people.’&#160;” 
+</div><div class="p">
+<sup>43&#160;</sup>The king of Israel went to his house sullen and angry, and came to Samaria. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, Naboth the Jezreelite had a vineyard which was in Jezreel, next to the palace of Ahab king of Samaria. 
+<sup>2&#160;</sup>Ahab spoke to Naboth, saying, “Give me your vineyard, that I may have it for a garden of herbs, because it is near my house; and I will give you for it a better vineyard than it. Or, if it seems good to you, I will give you its worth in money.” 
+</div><div class="p">
+<sup>3&#160;</sup>Naboth said to Ahab, “May Yahweh forbid me, that I should give the inheritance of my fathers to you!” 
+</div><div class="p">
+<sup>4&#160;</sup>Ahab came into his house sullen and angry because of the word which Naboth the Jezreelite had spoken to him, for he had said, “I will not give you the inheritance of my fathers.” He laid himself down on his bed, and turned away his face, and would eat no bread. 
+<sup>5&#160;</sup>But Jezebel his woman came to him, and said to him, “Why is your spirit so sad that you eat no bread?” 
+</div><div class="p">
+<sup>6&#160;</sup>He said to her, “Because I spoke to Naboth the Jezreelite, and said to him, ‘Give me your vineyard for money; or else, if it pleases you, I will give you another vineyard for it.’ He answered, ‘I will not give you my vineyard.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>Jezebel his woman said to him, “Do you now govern the kingdom of Israel? Arise, and eat bread, and let your heart be merry. I will give you the vineyard of Naboth the Jezreelite.” 
+<sup>8&#160;</sup>So she wrote letters in Ahab’s name and sealed them with his seal, and sent the letters to the elders and to the nobles who were in his city, who lived with Naboth. 
+<sup>9&#160;</sup>She wrote in the letters, saying, “Proclaim a fast, and set Naboth on high among the people. 
+<sup>10&#160;</sup>Set two men, wicked fellows, before him, and let them testify against him, saying, ‘You cursed Elohim and the king!’ Then carry him out, and stone him to death.” 
+</div><div class="p">
+<sup>11&#160;</sup>The men of his city, even the elders and the nobles who lived in his city, did as Jezebel had instructed them in the letters which she had written and sent to them. 
+<sup>12&#160;</sup>They proclaimed a fast, and set Naboth on high among the people. 
+<sup>13&#160;</sup>The two men, the wicked fellows, came in and sat before him. The wicked fellows testified against him, even against Naboth, in the presence of the people, saying, “Naboth cursed Elohim and the king!” Then they carried him out of the city and stoned him to death with stones. 
+<sup>14&#160;</sup>Then they sent to Jezebel, saying, “Naboth has been stoned and is dead.” 
+</div><div class="p">
+<sup>15&#160;</sup>When Jezebel heard that Naboth had been stoned and was dead, Jezebel said to Ahab, “Arise, take possession of the vineyard of Naboth the Jezreelite, which he refused to give you for money; for Naboth is not alive, but dead.” 
+</div><div class="p">
+<sup>16&#160;</sup>When Ahab heard that Naboth was dead, Ahab rose up to go down to the vineyard of Naboth the Jezreelite, to take possession of it. 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh’s word came to Elijah the Tishbite, saying, 
+<sup>18&#160;</sup>“Arise, go down to meet Ahab king of Israel, who dwells in Samaria. Behold, he is in the vineyard of Naboth, where he has gone down to take possession of it. 
+<sup>19&#160;</sup>You shall speak to him, saying, ‘Yahweh says, “Have you killed and also taken possession?”&#160;’ You shall speak to him, saying, ‘Yahweh says, “In the place where dogs licked the blood of Naboth, dogs will lick your blood, even yours.”&#160;’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>Ahab said to Elijah, “Have you found me, my enemy?” 
+</div><div class="p">He answered, “I have found you, because you have sold yourself to do that which is evil in Yahweh’s sight. 
+<sup>21&#160;</sup>Behold, I will bring evil on you, and will utterly sweep you away and will cut off from Ahab everyone who urinates against a wall, and him who is shut up and him who is left at large in Israel. 
+<sup>22&#160;</sup>I will make your house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah, for the provocation with which you have provoked me to anger, and have made Israel to sin.” 
+<sup>23&#160;</sup>Yahweh also spoke of Jezebel, saying, “The dogs will eat Jezebel by the rampart of Jezreel. 
+<sup>24&#160;</sup>The dogs will eat he who dies of Ahab in the city; and the birds of the sky will eat he who dies in the field.” 
+</div><div class="p">
+<sup>25&#160;</sup>But there was no one like Ahab, who sold himself to do that which was evil in Yahweh’s sight, whom Jezebel his woman stirred up. 
+<sup>26&#160;</sup>He did very abominably in following idols, according to all that the Amorites did, whom Yahweh cast out before the children of Israel. 
+</div><div class="p">
+<sup>27&#160;</sup>When Ahab heard those words, he tore his clothes, put sackcloth on his body, fasted, lay in sackcloth, and went about despondently. 
+</div><div class="p">
+<sup>28&#160;</sup>Yahweh’s word came to Elijah the Tishbite, saying, 
+<sup>29&#160;</sup>“See how Ahab humbles himself before me? Because he humbles himself before me, I will not bring the evil in his days; but I will bring the evil on his house in his son’s day.” 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>They continued three years without war between Syria and Israel. 
+<sup>2&#160;</sup>In the third year, Jehoshaphat the king of Judah came down to the king of Israel. 
+<sup>3&#160;</sup>The king of Israel said to his servants, “You know that Ramoth Gilead is ours, and we do nothing, and don’t take it out of the hand of the king of Syria?” 
+<sup>4&#160;</sup>He said to Jehoshaphat, “Will you go with me to battle to Ramoth Gilead?” 
+</div><div class="p">Jehoshaphat said to the king of Israel, “I am as you are, my people as your people, my horses as your horses.” 
+<sup>5&#160;</sup>Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then the king of Israel gathered the prophets together, about four hundred men, and said to them, “Should I go against Ramoth Gilead to battle, or should I refrain?” 
+</div><div class="p">They said, “Go up; for the Lord will deliver it into the hand of the king.” 
+</div><div class="p">
+<sup>7&#160;</sup>But Jehoshaphat said, “Isn’t there here a prophet of Yahweh, that we may inquire of him?” 
+</div><div class="p">
+<sup>8&#160;</sup>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh, Micaiah the son of Imlah; but I hate him, for he does not prophesy good concerning me, but evil.” 
+</div><div class="p">Jehoshaphat said, “Don’t let the king say so.” 
+</div><div class="p">
+<sup>9&#160;</sup>Then the king of Israel called an officer, and said, “Quickly get Micaiah the son of Imlah.” 
+</div><div class="p">
+<sup>10&#160;</sup>Now the king of Israel and Jehoshaphat the king of Judah were sitting each on his throne, arrayed in their robes, in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
+<sup>11&#160;</sup>Zedekiah the son of Chenaanah made himself horns of iron, and said, “Yahweh says, ‘With these you will push the Syrians, until they are consumed.’&#160;” 
+<sup>12&#160;</sup>All the prophets prophesied so, saying, “Go up to Ramoth Gilead and prosper; for Yahweh will deliver it into the hand of the king.” 
+</div><div class="p">
+<sup>13&#160;</sup>The messenger who went to call Micaiah spoke to him, saying, “See now, the prophets declare good to the king with one mouth. Please let your word be like the word of one of them, and speak good.” 
+</div><div class="p">
+<sup>14&#160;</sup>Micaiah said, “As Yahweh lives, what Yahweh says to me, that I will speak.” 
+</div><div class="p">
+<sup>15&#160;</sup>When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall we forbear?” 
+</div><div class="p">He answered him, “Go up and prosper; and Yahweh will deliver it into the hand of the king.” 
+</div><div class="p">
+<sup>16&#160;</sup>The king said to him, “How many times do I have to adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
+</div><div class="p">
+<sup>17&#160;</sup>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
+</div><div class="p">
+<sup>19&#160;</sup>Micaiah said, “Therefore hear Yahweh’s word. I saw Yahweh sitting on his throne, and all the army of heaven standing by him on his right hand and on his left. 
+<sup>20&#160;</sup>Yahweh said, ‘Who will entice Ahab, that he may go up and fall at Ramoth Gilead?’ One said one thing, and another said another. 
+</div><div class="p">
+<sup>21&#160;</sup>A spirit came out and stood before Yahweh, and said, ‘I will entice him.’ 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh said to him, ‘How?’ 
+</div><div class="p">He said, ‘I will go out and will be a lying spirit in the mouth of all his prophets.’ 
+</div><div class="p">He said, ‘You will entice him, and will also prevail. Go out and do so.’ 
+<sup>23&#160;</sup>Now therefore, behold, Yahweh has put a lying spirit in the mouth of all these your prophets; and Yahweh has spoken evil concerning you.” 
+</div><div class="p">
+<sup>24&#160;</sup>Then Zedekiah the son of Chenaanah came near and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
+</div><div class="p">
+<sup>25&#160;</sup>Micaiah said, “Behold, you will see on that day when you go into an inner room to hide yourself.” 
+</div><div class="p">
+<sup>26&#160;</sup>The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city and to Joash the king’s son. 
+<sup>27&#160;</sup>Say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I come in peace.”&#160;’&#160;” 
+</div><div class="p">
+<sup>28&#160;</sup>Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, all you people!” 
+</div><div class="p">
+<sup>29&#160;</sup>So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
+<sup>30&#160;</sup>The king of Israel said to Jehoshaphat, “I will disguise myself and go into the battle, but you put on your robes.” The king of Israel disguised himself and went into the battle. 
+</div><div class="p">
+<sup>31&#160;</sup>Now the king of Syria had commanded the thirty-two captains of his chariots, saying, “Don’t fight with small nor great, except only with the king of Israel.” 
+</div><div class="p">
+<sup>32&#160;</sup>When the captains of the chariots saw Jehoshaphat, they said, “Surely that is the king of Israel!” and they came over to fight against him. Jehoshaphat cried out. 
+<sup>33&#160;</sup>When the captains of the chariots saw that it was not the king of Israel, they turned back from pursuing him. 
+<sup>34&#160;</sup>A certain man drew his bow at random, and struck the king of Israel between the joints of the armor. Therefore he said to the driver of his chariot, “Turn around, and carry me out of the battle, for I am severely wounded.” 
+<sup>35&#160;</sup>The battle increased that day. The king was propped up in his chariot facing the Syrians, and died at evening. The blood ran out of the wound into the bottom of the chariot. 
+<sup>36&#160;</sup>A cry went throughout the army about the going down of the sun, saying, “Every man to his city, and every man to his country!” 
+</div><div class="p">
+<sup>37&#160;</sup>So the king died, and was brought to Samaria; and they buried the king in Samaria. 
+<sup>38&#160;</sup>They washed the chariot by the pool of Samaria; and the dogs licked up his blood where the prostitutes washed themselves, according to Yahweh’s word which he spoke. 
+</div><div class="p">
+<sup>39&#160;</sup>Now the rest of the acts of Ahab, and all that he did, and the ivory house which he built, and all the cities that he built, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>40&#160;</sup>So Ahab slept with his fathers; and Ahaziah his son reigned in his place. 
+</div><div class="p">
+<sup>41&#160;</sup>Jehoshaphat the son of Asa began to reign over Judah in the fourth year of Ahab king of Israel. 
+<sup>42&#160;</sup>Jehoshaphat was thirty-five years old when he began to reign; and he reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
+<sup>43&#160;</sup>He walked in all the way of Asa his father. He didn’t turn away from it, doing that which was right in Yahweh’s eyes. However, the high places were not taken away. The people still sacrificed and burned incense on the high places. 
+<sup>44&#160;</sup>Jehoshaphat made peace with the king of Israel. 
+</div><div class="p">
+<sup>45&#160;</sup>Now the rest of the acts of Jehoshaphat, and his might that he showed, and how he fought, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>46&#160;</sup>The remnant of the sodomites, that remained in the days of his father Asa, he put away out of the land. 
+<sup>47&#160;</sup>There was no king in Edom. A deputy ruled. 
+<sup>48&#160;</sup>Jehoshaphat made ships of Tarshish to go to Ophir for gold, but they didn’t go, for the ships wrecked at Ezion Geber. 
+<sup>49&#160;</sup>Then Ahaziah the son of Ahab said to Jehoshaphat, “Let my servants go with your servants in the ships.” But Jehoshaphat would not. 
+<sup>50&#160;</sup>Jehoshaphat slept with his fathers, and was buried with his fathers in his father David’s city. Jehoram his son reigned in his place. 
+</div><div class="p">
+<sup>51&#160;</sup>Ahaziah the son of Ahab began to reign over Israel in Samaria in the seventeenth year of Jehoshaphat king of Judah, and he reigned two years over Israel. 
+<sup>52&#160;</sup>He did that which was evil in Yahweh’s sight, and walked in the way of his father, and in the way of his mother, and in the way of Jeroboam the son of Nebat, in which he made Israel to sin. 
+<sup>53&#160;</sup>He served Baal and worshiped him, and provoked Yahweh, the Elohim of Israel, to anger in all the ways that his father had done so. </div></div><script src="../main.js"></script></body></html>

--- a/book/1samuel.html
+++ b/book/1samuel.html
@@ -3,6 +3,47 @@
 <head>
 <title>1 Samuel</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1257 +53,1289 @@
 <div class="main">
 <!-- 1SA World English Scripture (WES) -->
 <h1 class="booklabel">1 Samuel</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now there was a certain man of Ramathaim Zophim, of the hill country of Ephraim, and his name was Elkanah, the son of Jeroham, the son of Elihu, the son of Tohu, the son of Zuph, an Ephraimite. 
-<span class="v">2&#160;</span>He had two women. The name of one was Hannah, and the name of the other Peninnah. Peninnah had children, but Hannah had no children. 
-<span class="v">3&#160;</span>This man went up out of his city from year to year to worship and to sacrifice to Yahweh<span class="f">+ \fr 1:3 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> of Armies in Shiloh. The two sons of Eli, Hophni and Phinehas, priests to Yahweh, were there. 
-<span class="v">4&#160;</span>When the day came that Elkanah sacrificed, he gave portions to Peninnah his woman and to all her sons and her daughters; 
-<span class="v">5&#160;</span>but he gave a double portion to Hannah, for he loved Hannah, but Yahweh had shut up her womb. 
-<span class="v">6&#160;</span>Her rival provoked her severely, to irritate her, because Yahweh had shut up her womb. 
-<span class="v">7&#160;</span>So year by year, when she went up to Yahweh’s house, her rival provoked her. Therefore she wept, and didn’t eat. 
-<span class="v">8&#160;</span>Elkanah her man said to her, “Hannah, why do you weep? Why don’t you eat? Why is your heart grieved? Am I not better to you than ten sons?” 
-</p><p>
-<span class="v">9&#160;</span>So Hannah rose up after they had finished eating and drinking in Shiloh. Now Eli the priest was sitting on his seat by the doorpost of Yahweh’s temple. 
-<span class="v">10&#160;</span>She was in bitterness of soul, and prayed to Yahweh, weeping bitterly. 
-<span class="v">11&#160;</span>She vowed a vow, and said, “Yahweh of Armies, if you will indeed look at the affliction of your servant and remember me, and not forget your servant, but will give to your servant a boy, then I will give him to Yahweh all the days of his life, and no razor shall come on his head.” 
-</p><p>
-<span class="v">12&#160;</span>As she continued praying before Yahweh, Eli saw her mouth. 
-<span class="v">13&#160;</span>Now Hannah spoke in her heart. Only her lips moved, but her voice was not heard. Therefore Eli thought she was drunk. 
-<span class="v">14&#160;</span>Eli said to her, “How long will you be drunk? Get rid of your wine!” 
-</p><p>
-<span class="v">15&#160;</span>Hannah answered, “No, my lord, I am a woman of a sorrowful spirit. I have not been drinking wine or strong drink, but I poured out my soul before Yahweh. 
-<span class="v">16&#160;</span>Don’t consider your servant a wicked woman; for I have been speaking out of the abundance of my complaint and my provocation.” 
-</p><p>
-<span class="v">17&#160;</span>Then Eli answered, “Go in peace; and may the Elohim<span class="f">+ \fr 1:17 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> of Israel grant your petition that you have asked of him.” 
-</p><p>
-<span class="v">18&#160;</span>She said, “Let your servant find favor in your sight.” So the woman went her way and ate; and her facial expression wasn’t sad any more. 
-</p><p>
-<span class="v">19&#160;</span>They rose up in the morning early and worshiped Yahweh, then returned and came to their house to Ramah. Then Elkanah knew Hannah his woman; and Yahweh remembered her. 
-</p><p>
-<span class="v">20&#160;</span>When the time had come, Hannah conceived, and bore a son; and she named him Samuel,<span class="f">+ \fr 1:20 \ft Samuel sounds like the Hebrew for “heard by Elohim.”</span> saying, “Because I have asked him of Yahweh.” 
-</p><p>
-<span class="v">21&#160;</span>The man Elkanah, and all his house, went up to offer to Yahweh the yearly sacrifice and his vow. 
-<span class="v">22&#160;</span>But Hannah didn’t go up, for she said to her man, “Not until the child is weaned; then I will bring him, that he may appear before Yahweh, and stay there forever.” 
-</p><p>
-<span class="v">23&#160;</span>Elkanah her man said to her, “Do what seems good to you. Wait until you have weaned him; only may Yahweh establish his word.” 
-</p><p>So the woman waited and nursed her son until she weaned him. 
-<span class="v">24&#160;</span>When she had weaned him, she took him up with her, with three bulls, and one ephah<span class="f">+ \fr 1:24 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of meal, and a container of wine, and brought him to Yahweh’s house in Shiloh. The child was young. 
-<span class="v">25&#160;</span>They killed the bull, and brought the child to Eli. 
-<span class="v">26&#160;</span>She said, “Oh, my lord, as your soul lives, my lord, I am the woman who stood by you here, praying to Yahweh. 
-<span class="v">27&#160;</span>I prayed for this child, and Yahweh has given me my petition which I asked of him. 
-<span class="v">28&#160;</span>Therefore I have also given him to Yahweh. As long as he lives he is given to Yahweh.” He worshiped Yahweh there. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Hannah prayed, and said, 
-</p><p class="q1">“My heart exults in Yahweh! 
-</p><p class="q2">My horn is exalted in Yahweh. 
-</p><p class="q1">My mouth is enlarged over my enemies, 
-</p><p class="q2">because I rejoice in your salvation. 
-</p><p class="q1">
-<span class="v">2&#160;</span>There is no one as set-apart as Yahweh, 
-</p><p class="q2">for there is no one besides you, 
-</p><p class="q2">nor is there any rock like our Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Don’t keep talking so exceedingly proudly. 
-</p><p class="q2">Don’t let arrogance come out of your mouth, 
-</p><p class="q2">for Yahweh is an Elohim of knowledge. 
-</p><p class="q2">By him actions are weighed. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“The bows of the mighty men are broken. 
-</p><p class="q2">Those who stumbled are armed with strength. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Those who were full have hired themselves out for bread. 
-</p><p class="q2">Those who were hungry are satisfied. 
-</p><p class="q1">Yes, the barren has borne seven. 
-</p><p class="q2">She who has many children languishes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“Yahweh kills and makes alive. 
-</p><p class="q2">He brings down to Sheol<span class="f">+ \fr 2:6 \ft Sheol is the place of the dead.</span> and brings up. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh makes poor and makes rich. 
-</p><p class="q2">He brings low, he also lifts up. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He raises up the poor out of the dust. 
-</p><p class="q2">He lifts up the needy from the dunghill 
-</p><p class="q2">to make them sit with princes 
-</p><p class="q2">and inherit the throne of glory. 
-</p><p class="q1">For the pillars of the earth are Yahweh’s. 
-</p><p class="q2">He has set the world on them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He will keep the feet of his set-apart ones, 
-</p><p class="q2">but the wicked will be put to silence in darkness; 
-</p><p class="q2">for no man will prevail by strength. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Those who strive with Yahweh shall be broken to pieces. 
-</p><p class="q2">He will thunder against them in the sky. 
-</p><div class="b"> &#160; </div>
-<p class="q1">“Yahweh will judge the ends of the earth. 
-</p><p class="q2">He will give strength to his king, 
-</p><p class="q2">and exalt the horn of his anointed.” 
-</p><p>
-<span class="v">11&#160;</span>Elkanah went to Ramah to his house. The child served Yahweh before Eli the priest. 
-</p><p>
-<span class="v">12&#160;</span>Now the sons of Eli were wicked men. They didn’t know Yahweh. 
-<span class="v">13&#160;</span>The custom of the priests with the people was that when anyone offered a sacrifice, the priest’s servant came while the meat was boiling, with a fork of three teeth in his hand; 
-<span class="v">14&#160;</span>and he stabbed it into the pan, or kettle, or cauldron, or pot. The priest took all that the fork brought up for himself. They did this to all the Israelites who came there to Shiloh. 
-<span class="v">15&#160;</span>Yes, before they burned the fat, the priest’s servant came, and said to the man who sacrificed, “Give meat to roast for the priest; for he will not accept boiled meat from you, but raw.” 
-</p><p>
-<span class="v">16&#160;</span>If the man said to him, “Let the fat be burned first, and then take as much as your soul desires;” then he would say, “No, but you shall give it to me now; and if not, I will take it by force.” 
-<span class="v">17&#160;</span>The sin of the young men was very great before Yahweh; for the men despised Yahweh’s offering. 
-<span class="v">18&#160;</span>But Samuel ministered before Yahweh, being a child, clothed with a linen ephod. 
-<span class="v">19&#160;</span>Moreover his mother made him a little robe, and brought it to him from year to year when she came up with her man to offer the yearly sacrifice. 
-<span class="v">20&#160;</span>Eli blessed Elkanah and his woman, and said, “May Yahweh give you offspring<span class="f">+ \fr 2:20 \ft or, seed</span> from this woman for the petition which was asked of Yahweh.” Then they went to their own home. 
-<span class="v">21&#160;</span>Yahweh visited Hannah, and she conceived and bore three sons and two daughters. The child Samuel grew before Yahweh. 
-</p><p>
-<span class="v">22&#160;</span>Now Eli was very old; and he heard all that his sons did to all Israel, and how that they slept with the women who served at the door of the Tent of Meeting. 
-<span class="v">23&#160;</span>He said to them, “Why do you do such things? For I hear of your evil dealings from all these people. 
-<span class="v">24&#160;</span>No, my sons; for it is not a good report that I hear! You make Yahweh’s people disobey. 
-<span class="v">25&#160;</span>If one man sins against another, Elohim will judge him; but if a man sins against Yahweh, who will intercede for him?” Notwithstanding, they didn’t listen to the voice of their father, because Yahweh intended to kill them. 
-</p><p>
-<span class="v">26&#160;</span>The child Samuel grew on, and increased in favor both with Yahweh and also with men. 
-</p><p>
-<span class="v">27&#160;</span>A man of Elohim came to Eli and said to him, “Yahweh says, ‘Did I reveal myself to the house of your father when they were in Egypt in bondage to Pharaoh’s house? 
-<span class="v">28&#160;</span>Didn’t I choose him out of all the tribes of Israel to be my priest, to go up to my altar, to burn incense, to wear an ephod before me? Didn’t I give to the house of your father all the offerings of the children of Israel made by fire? 
-<span class="v">29&#160;</span>Why do you kick at my sacrifice and at my offering, which I have commanded in my habitation, and honor your sons above me, to make yourselves fat with the best of all the offerings of Israel my people?’ 
-<span class="v">30&#160;</span>“Therefore Yahweh, the Elohim of Israel, says, ‘I said indeed that your house and the house of your father should walk before me forever.’ But now Yahweh says, ‘Far be it from me; for those who honor me I will honor, and those who despise me will be cursed. 
-<span class="v">31&#160;</span>Behold,<span class="f">+ \fr 2:31 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> the days come that I will cut off your arm and the arm of your father’s house, that there will not be an old man in your house. 
-<span class="v">32&#160;</span>You will see the affliction of my habitation, in all the wealth which I will give Israel. There shall not be an old man in your house forever. 
-<span class="v">33&#160;</span>The man of yours whom I don’t cut off from my altar will consume your eyes<span class="f">+ \fr 2:33 \ft or, blind your eyes with tears</span> and grieve your heart. All the increase of your house will die in the flower of their age. 
-<span class="v">34&#160;</span>This will be the sign to you that will come on your two sons, on Hophni and Phinehas: in one day they will both die. 
-<span class="v">35&#160;</span>I will raise up a faithful priest for myself who will do according to that which is in my heart and in my mind. I will build him a sure house. He will walk before my anointed forever. 
-<span class="v">36&#160;</span>It will happen that everyone who is left in your house will come and bow down to him for a piece of silver and a loaf of bread, and will say, “Please put me into one of the priests’ offices, that I may eat a morsel of bread.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>The child Samuel ministered to Yahweh before Eli. Yahweh’s word was rare in those days. There were not many visions, then. 
-<span class="v">2&#160;</span>At that time, when Eli was laid down in his place (now his eyes had begun to grow dim, so that he could not see), 
-<span class="v">3&#160;</span>and Elohim’s lamp hadn’t yet gone out, and Samuel had laid down in Yahweh’s temple where Elohim’s ark was, 
-<span class="v">4&#160;</span>Yahweh called Samuel. He said, “Here I am.” 
-</p><p>
-<span class="v">5&#160;</span>He ran to Eli and said, “Here I am; for you called me.” 
-</p><p>He said, “I didn’t call. Lie down again.” 
-</p><p>He went and lay down. 
-<span class="v">6&#160;</span>Yahweh called yet again, “Samuel!” 
-</p><p>Samuel arose and went to Eli and said, “Here I am; for you called me.” 
-</p><p>He answered, “I didn’t call, my son. Lie down again.” 
-<span class="v">7&#160;</span>Now Samuel didn’t yet know Yahweh, neither was Yahweh’s word yet revealed to him. 
-<span class="v">8&#160;</span>Yahweh called Samuel again the third time. He arose and went to Eli and said, “Here I am; for you called me.” 
-</p><p>Eli perceived that Yahweh had called the child. 
-<span class="v">9&#160;</span>Therefore Eli said to Samuel, “Go, lie down. It shall be, if he calls you, that you shall say, ‘Speak, Yahweh; for your servant hears.’&#160;” So Samuel went and lay down in his place. 
-<span class="v">10&#160;</span>Yahweh came, and stood, and called as at other times, “Samuel! Samuel!” 
-</p><p>Then Samuel said, “Speak; for your servant hears.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said to Samuel, “Behold, I will do a thing in Israel at which both the ears of everyone who hears it will tingle. 
-<span class="v">12&#160;</span>In that day I will perform against Eli all that I have spoken concerning his house, from the beginning even to the end. 
-<span class="v">13&#160;</span>For I have told him that I will judge his house forever for the iniquity which he knew, because his sons brought a curse on themselves, and he didn’t restrain them. 
-<span class="v">14&#160;</span>Therefore I have sworn to the house of Eli that the iniquity of Eli’s house shall not be removed with sacrifice or offering forever.” 
-</p><p>
-<span class="v">15&#160;</span>Samuel lay until the morning, and opened the doors of Yahweh’s house. Samuel was afraid to show Eli the vision. 
-<span class="v">16&#160;</span>Then Eli called Samuel and said, “Samuel, my son!” 
-</p><p>He said, “Here I am.” 
-</p><p>
-<span class="v">17&#160;</span>He said, “What is the thing that he has spoken to you? Please don’t hide it from me. Elohim do so to you, and more also, if you hide anything from me of all the things that he spoke to you.” 
-</p><p>
-<span class="v">18&#160;</span>Samuel told him every bit, and hid nothing from him. 
-</p><p>He said, “It is Yahweh. Let him do what seems good to him.” 
-</p><p>
-<span class="v">19&#160;</span>Samuel grew, and Yahweh was with him and let none of his words fall to the ground. 
-<span class="v">20&#160;</span>All Israel from Dan even to Beersheba knew that Samuel was established to be a prophet of Yahweh. 
-<span class="v">21&#160;</span>Yahweh appeared again in Shiloh; for Yahweh revealed himself to Samuel in Shiloh by Yahweh’s word. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p class="nb">
-<span class="v">1&#160;</span>The word of Samuel came to all Israel. 
-</p><p>Now Israel went out against the Philistines to battle, and encamped beside Ebenezer; and the Philistines encamped in Aphek. 
-<span class="v">2&#160;</span>The Philistines put themselves in array against Israel. When they joined battle, Israel was defeated by the Philistines, who killed about four thousand men of the army in the field. 
-<span class="v">3&#160;</span>When the people had come into the camp, the elders of Israel said, “Why has Yahweh defeated us today before the Philistines? Let’s get the ark of Yahweh’s covenant out of Shiloh and bring it to us, that it may come among us and save us out of the hand of our enemies.” 
-</p><p>
-<span class="v">4&#160;</span>So the people sent to Shiloh, and they brought from there the ark of the covenant of Yahweh of Armies, who sits above the cherubim; and the two sons of Eli, Hophni and Phinehas, were there with the ark of the covenant of Elohim. 
-<span class="v">5&#160;</span>When the ark of Yahweh’s covenant came into the camp, all Israel shouted with a great shout, so that the earth resounded. 
-<span class="v">6&#160;</span>When the Philistines heard the noise of the shout, they said, “What does the noise of this great shout in the camp of the Hebrews mean?” They understood that Yahweh’s ark had come into the camp. 
-<span class="v">7&#160;</span>The Philistines were afraid, for they said, “Elohim has come into the camp.” They said, “Woe to us! For there has not been such a thing before. 
-<span class="v">8&#160;</span>Woe to us! Who shall deliver us out of the hand of these mighty elohims? These are the elohims that struck the Egyptians with all kinds of plagues in the wilderness. 
-<span class="v">9&#160;</span>Be strong and behave like men, O you Philistines, that you not be servants to the Hebrews, as they have been to you. Strengthen yourselves like men, and fight!” 
-<span class="v">10&#160;</span>The Philistines fought, and Israel was defeated, and each man fled to his tent. There was a very great slaughter; for thirty thousand footmen of Israel fell. 
-<span class="v">11&#160;</span>Elohim’s ark was taken; and the two sons of Eli, Hophni and Phinehas, were slain. 
-</p><p>
-<span class="v">12&#160;</span>A man of Benjamin ran out of the army and came to Shiloh the same day, with his clothes torn and with dirt on his head. 
-<span class="v">13&#160;</span>When he came, behold, Eli was sitting on his seat by the road watching, for his heart trembled for Elohim’s ark. When the man came into the city and told about it, all the city cried out. 
-<span class="v">14&#160;</span>When Eli heard the noise of the crying, he said, “What does the noise of this tumult mean?” 
-</p><p>The man hurried, and came and told Eli. 
-<span class="v">15&#160;</span>Now Eli was ninety-eight years old. His eyes were set, so that he could not see. 
-<span class="v">16&#160;</span>The man said to Eli, “I am he who came out of the army, and I fled today out of the army.” 
-</p><p>He said, “How did the matter go, my son?” 
-</p><p>
-<span class="v">17&#160;</span>He who brought the news answered, “Israel has fled before the Philistines, and there has been also a great slaughter among the people. Your two sons also, Hophni and Phinehas, are dead, and Elohim’s ark has been captured.” 
-</p><p>
-<span class="v">18&#160;</span>When he made mention of Elohim’s ark, Eli fell from off his seat backward by the side of the gate; and his neck broke, and he died, for he was an old man and heavy. He had judged Israel forty years. 
-</p><p>
-<span class="v">19&#160;</span>His daughter-in-law, Phinehas’ woman, was with child, near to giving birth. When she heard the news that Elohim’s ark was taken and that her father-in-law and her man were dead, she bowed herself and gave birth; for her pains came on her. 
-<span class="v">20&#160;</span>About the time of her death the women who stood by her said to her, “Don’t be afraid, for you have given birth to a son.” But she didn’t answer, neither did she regard it. 
-<span class="v">21&#160;</span>She named the child Ichabod,<span class="f">+ \fr 4:21 \ft “Ichabod” means “no glory”.</span> saying, “The glory has departed from Israel!” because Elohim’s ark was taken, and because of her father-in-law and her man. 
-<span class="v">22&#160;</span>She said, “The glory has departed from Israel; for Elohim’s ark has been taken.” 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Now the Philistines had taken Elohim’s ark, and they brought it from Ebenezer to Ashdod. 
-<span class="v">2&#160;</span>The Philistines took Elohim’s ark, and brought it into the house of Dagon and set it by Dagon. 
-<span class="v">3&#160;</span>When the people of Ashdod arose early on the next day, behold, Dagon had fallen on his face to the ground before Yahweh’s ark. They took Dagon and set him in his place again. 
-<span class="v">4&#160;</span>When they arose early on the following morning, behold, Dagon had fallen on his face to the ground before Yahweh’s ark; and the head of Dagon and both the palms of his hands were cut off on the threshold. Only Dagon’s torso was intact. 
-<span class="v">5&#160;</span>Therefore neither the priests of Dagon nor any who come into Dagon’s house step on the threshold of Dagon in Ashdod to this day. 
-<span class="v">6&#160;</span>But Yahweh’s hand was heavy on the people of Ashdod, and he destroyed them and struck them with tumors, even Ashdod and its borders. 
-</p><p>
-<span class="v">7&#160;</span>When the men of Ashdod saw that it was so, they said, “The ark of the Elohim of Israel shall not stay with us, for his hand is severe on us and on Dagon our elohim.” 
-<span class="v">8&#160;</span>They sent therefore and gathered together all the lords of the Philistines, and said, “What shall we do with the ark of the Elohim of Israel?” 
-</p><p>They answered, “Let the ark of the Elohim of Israel be carried over to Gath.” They carried the ark of the Elohim of Israel there. 
-<span class="v">9&#160;</span>It was so, that after they had carried it there, Yahweh’s hand was against the city with a very great confusion; and he struck the men of the city, both small and great, so that tumors broke out on them. 
-<span class="v">10&#160;</span>So they sent Elohim’s ark to Ekron. 
-</p><p>As Elohim’s ark came to Ekron, the Ekronites cried out, saying, “They have brought the ark of the Elohim of Israel here to us, to kill us and our people.” 
-<span class="v">11&#160;</span>They sent therefore and gathered together all the lords of the Philistines, and they said, “Send the ark of the Elohim of Israel away, and let it go again to its own place, that it not kill us and our people.” For there was a deadly panic throughout all the city. The hand of Elohim was very heavy there. 
-<span class="v">12&#160;</span>The men who didn’t die were struck with the tumors; and the cry of the city went up to heaven. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s ark was in the country of the Philistines seven months. 
-<span class="v">2&#160;</span>The Philistines called for the priests and the diviners, saying, “What shall we do with Yahweh’s ark? Show us how we should send it to its place.” 
-</p><p>
-<span class="v">3&#160;</span>They said, “If you send away the ark of the Elohim of Israel, don’t send it empty; but by all means return a trespass offering to him. Then you will be healed, and it will be known to you why his hand is not removed from you.” 
-</p><p>
-<span class="v">4&#160;</span>Then they said, “What should the trespass offering be which we shall return to him?” 
-</p><p>They said, “Five golden tumors and five golden mice, for the number of the lords of the Philistines; for one plague was on you all, and on your lords. 
-<span class="v">5&#160;</span>Therefore you shall make images of your tumors and images of your mice that mar the land; and you shall give glory to the Elohim of Israel. Perhaps he will release his hand from you, from your elohims, and from your land. 
-<span class="v">6&#160;</span>Why then do you harden your hearts as the Egyptians and Pharaoh hardened their hearts? When he had worked wonderfully among them, didn’t they let the people go, and they departed? 
-</p><p>
-<span class="v">7&#160;</span>“Now therefore take and prepare yourselves a new cart and two milk cows on which there has come no yoke; and tie the cows to the cart, and bring their calves home from them; 
-<span class="v">8&#160;</span>and take Yahweh’s ark and lay it on the cart. Put the jewels of gold, which you return him for a trespass offering, in a box by its side; and send it away, that it may go. 
-<span class="v">9&#160;</span>Behold, if it goes up by the way of its own border to Beth Shemesh, then he has done us this great evil; but if not, then we shall know that it is not his hand that struck us. It was a chance that happened to us.” 
-</p><p>
-<span class="v">10&#160;</span>The men did so, and took two milk cows and tied them to the cart, and shut up their calves at home. 
-<span class="v">11&#160;</span>They put Yahweh’s ark on the cart, and the box with the golden mice and the images of their tumors. 
-<span class="v">12&#160;</span>The cows took the straight way by the way to Beth Shemesh. They went along the highway, lowing as they went, and didn’t turn away to the right hand or to the left; and the lords of the Philistines went after them to the border of Beth Shemesh. 
-<span class="v">13&#160;</span>The people of Beth Shemesh were reaping their wheat harvest in the valley; and they lifted up their eyes and saw the ark, and rejoiced to see it. 
-<span class="v">14&#160;</span>The cart came into the field of Joshua of Beth Shemesh, and stood there, where there was a great stone. Then they split the wood of the cart and offered up the cows for a burnt offering to Yahweh. 
-<span class="v">15&#160;</span>The Levites took down Yahweh’s ark and the box that was with it, in which the jewels of gold were, and put them on the great stone; and the men of Beth Shemesh offered burnt offerings and sacrificed sacrifices the same day to Yahweh. 
-<span class="v">16&#160;</span>When the five lords of the Philistines had seen it, they returned to Ekron the same day. 
-<span class="v">17&#160;</span>These are the golden tumors which the Philistines returned for a trespass offering to Yahweh: for Ashdod one, for Gaza one, for Ashkelon one, for Gath one, for Ekron one; 
-<span class="v">18&#160;</span>and the golden mice, according to the number of all the cities of the Philistines belonging to the five lords, both of fortified cities and of country villages, even to the great stone on which they set down Yahweh’s ark. That stone remains to this day in the field of Joshua of Beth Shemesh. 
-<span class="v">19&#160;</span>He struck of the men of Beth Shemesh, because they had looked into Yahweh’s ark, he struck fifty thousand seventy of the men. Then the people mourned, because Yahweh had struck the people with a great slaughter. 
-<span class="v">20&#160;</span>The men of Beth Shemesh said, “Who is able to stand before Yahweh, this set-apart Elohim? To whom shall he go up from us?” 
-</p><p>
-<span class="v">21&#160;</span>They sent messengers to the inhabitants of Kiriath Jearim, saying, “The Philistines have brought back Yahweh’s ark. Come down and bring it up to yourselves.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>The men of Kiriath Jearim came and took Yahweh’s ark, and brought it into Abinadab’s house on the hill, and consecrated Eleazar his son to keep Yahweh’s ark. 
-<span class="v">2&#160;</span>From the day that the ark stayed in Kiriath Jearim, the time was long—for it was twenty years; and all the house of Israel lamented after Yahweh. 
-<span class="v">3&#160;</span>Samuel spoke to all the house of Israel, saying, “If you are returning to Yahweh with all your heart, then put away the foreign elohims and the Ashtaroth from among you, and direct your hearts to Yahweh, and serve him only; and he will deliver you out of the hand of the Philistines.” 
-<span class="v">4&#160;</span>Then the children of Israel removed the Baals and the Ashtaroth, and served Yahweh only. 
-<span class="v">5&#160;</span>Samuel said, “Gather all Israel to Mizpah, and I will pray to Yahweh for you.” 
-<span class="v">6&#160;</span>They gathered together to Mizpah, and drew water, and poured it out before Yahweh, and fasted on that day, and said there, “We have sinned against Yahweh.” Samuel judged the children of Israel in Mizpah. 
-</p><p>
-<span class="v">7&#160;</span>When the Philistines heard that the children of Israel were gathered together at Mizpah, the lords of the Philistines went up against Israel. When the children of Israel heard it, they were afraid of the Philistines. 
-<span class="v">8&#160;</span>The children of Israel said to Samuel, “Don’t stop crying to Yahweh our Elohim for us, that he will save us out of the hand of the Philistines.” 
-<span class="v">9&#160;</span>Samuel took a suckling lamb, and offered it for a whole burnt offering to Yahweh. Samuel cried to Yahweh for Israel, and Yahweh answered him. 
-<span class="v">10&#160;</span>As Samuel was offering up the burnt offering, the Philistines came near to battle against Israel; but Yahweh thundered with a great thunder on that day on the Philistines and confused them; and they were struck down before Israel. 
-<span class="v">11&#160;</span>The men of Israel went out of Mizpah and pursued the Philistines, and struck them until they came under Beth Kar. 
-</p><p>
-<span class="v">12&#160;</span>Then Samuel took a stone and set it between Mizpah and Shen, and called its name Ebenezer,<span class="f">+ \fr 7:12 \ft “Ebenezer” means “stone of help”.</span> saying, “Yahweh helped us until now.” 
-<span class="v">13&#160;</span>So the Philistines were subdued, and they stopped coming within the border of Israel. Yahweh’s hand was against the Philistines all the days of Samuel. 
-</p><p>
-<span class="v">14&#160;</span>The cities which the Philistines had taken from Israel were restored to Israel, from Ekron even to Gath; and Israel recovered its border out of the hand of the Philistines. There was peace between Israel and the Amorites. 
-</p><p>
-<span class="v">15&#160;</span>Samuel judged Israel all the days of his life. 
-<span class="v">16&#160;</span>He went from year to year in a circuit to Bethel, Gilgal, and Mizpah; and he judged Israel in all those places. 
-<span class="v">17&#160;</span>His return was to Ramah, for his house was there, and he judged Israel there; and he built an altar to Yahweh there. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>When Samuel was old, he made his sons judges over Israel. 
-<span class="v">2&#160;</span>Now the name of his firstborn was Joel, and the name of his second, Abijah. They were judges in Beersheba. 
-<span class="v">3&#160;</span>His sons didn’t walk in his ways, but turned away after dishonest gain, took bribes, and perverted justice. 
-</p><p>
-<span class="v">4&#160;</span>Then all the elders of Israel gathered themselves together and came to Samuel to Ramah. 
-<span class="v">5&#160;</span>They said to him, “Behold, you are old, and your sons don’t walk in your ways. Now make us a king to judge us like all the nations.” 
-<span class="v">6&#160;</span>But the thing displeased Samuel when they said, “Give us a king to judge us.” 
-</p><p>Samuel prayed to Yahweh. 
-<span class="v">7&#160;</span>Yahweh said to Samuel, “Listen to the voice of the people in all that they tell you; for they have not rejected you, but they have rejected me as the king over them. 
-<span class="v">8&#160;</span>According to all the works which they have done since the day that I brought them up out of Egypt even to this day, in that they have forsaken me and served other elohims, so they also do to you. 
-<span class="v">9&#160;</span>Now therefore, listen to their voice. However, you shall protest solemnly to them, and shall show them the way of the king who will reign over them.” 
-</p><p>
-<span class="v">10&#160;</span>Samuel told all Yahweh’s words to the people who asked him for a king. 
-<span class="v">11&#160;</span>He said, “This will be the way of the king who shall reign over you: he will take your sons and appoint them as his servants, for his chariots and to be his horsemen; and they will run before his chariots. 
-<span class="v">12&#160;</span>He will appoint them to him for captains of thousands and captains of fifties; and he will assign some to plow his ground and to reap his harvest; and to make his instruments of war and the instruments of his chariots. 
-<span class="v">13&#160;</span>He will take your daughters to be perfumers, to be cooks, and to be bakers. 
-<span class="v">14&#160;</span>He will take your fields, your vineyards, and your olive groves, even your best, and give them to his servants. 
-<span class="v">15&#160;</span>He will take one tenth of your seed and of your vineyards, and give it to his officers and to his servants. 
-<span class="v">16&#160;</span>He will take your male servants, your female servants, your best young men, and your donkeys, and assign them to his own work. 
-<span class="v">17&#160;</span>He will take one tenth of your flocks; and you will be his servants. 
-<span class="v">18&#160;</span>You will cry out in that day because of your king whom you will have chosen for yourselves; and Yahweh will not answer you in that day.” 
-</p><p>
-<span class="v">19&#160;</span>But the people refused to listen to the voice of Samuel; and they said, “No, but we will have a king over us, 
-<span class="v">20&#160;</span>that we also may be like all the nations; and that our king may judge us, and go out before us, and fight our battles.” 
-</p><p>
-<span class="v">21&#160;</span>Samuel heard all the words of the people, and he rehearsed them in the ears of Yahweh. 
-<span class="v">22&#160;</span>Yahweh said to Samuel, “Listen to their voice, and make them a king.” 
-</p><p>Samuel said to the men of Israel, “Everyone go to your own city.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Now there was a man of Benjamin, whose name was Kish the son of Abiel, the son of Zeror, the son of Becorath, the son of Aphiah, the son of a Benjamite, a mighty man of valor. 
-<span class="v">2&#160;</span>He had a son whose name was Saul, an impressive young man; and there was not among the children of Israel a more handsome person than he. From his shoulders and upward he was taller than any of the people. 
-</p><p>
-<span class="v">3&#160;</span>The donkeys of Kish, Saul’s father, were lost. Kish said to Saul his son, “Now take one of the servants with you, and arise, go look for the donkeys.” 
-<span class="v">4&#160;</span>He passed through the hill country of Ephraim, and passed through the land of Shalishah, but they didn’t find them. Then they passed through the land of Shaalim, and they weren’t there. Then he passed through the land of the Benjamites, but they didn’t find them. 
-</p><p>
-<span class="v">5&#160;</span>When they had come to the land of Zuph, Saul said to his servant who was with him, “Come! Let’s return, lest my father stop caring about the donkeys and be anxious for us.” 
-</p><p>
-<span class="v">6&#160;</span>The servant said to him, “Behold now, there is a man of Elohim in this city, and he is a man who is held in honor. All that he says surely happens. Now let’s go there. Perhaps he can tell us which way to go.” 
-</p><p>
-<span class="v">7&#160;</span>Then Saul said to his servant, “But behold, if we go, what should we bring the man? For the bread is spent in our sacks, and there is not a present to bring to the man of Elohim. What do we have?” 
-</p><p>
-<span class="v">8&#160;</span>The servant answered Saul again and said, “Behold, I have in my hand the fourth part of a shekel<span class="f">+ \fr 9:8 \ft A shekel is about 10 grams or about 0.35 ounces, so 1/4 shekel would be a small coin of about 2.5 grams.</span> of silver. I will give that to the man of Elohim, to tell us our way.” 
-<span class="v">9&#160;</span>(In earlier times in Israel, when a man went to inquire of Elohim, he said, “Come! Let’s go to the seer;” for he who is now called a prophet was before called a seer.) 
-</p><p>
-<span class="v">10&#160;</span>Then Saul said to his servant, “Well said. Come! Let’s go.” So they went to the city where the man of Elohim was. 
-<span class="v">11&#160;</span>As they went up the ascent to the city, they found young maidens going out to draw water, and said to them, “Is the seer here?” 
-</p><p>
-<span class="v">12&#160;</span>They answered them and said, “He is. Behold, he is before you. Hurry now, for he has come today into the city; for the people have a sacrifice today in the high place. 
-<span class="v">13&#160;</span>As soon as you have come into the city, you will immediately find him before he goes up to the high place to eat; for the people will not eat until he comes, because he blesses the sacrifice. Afterwards those who are invited eat. Now therefore go up; for at this time you will find him.” 
-</p><p>
-<span class="v">14&#160;</span>They went up to the city. As they came within the city, behold, Samuel came out toward them to go up to the high place. 
-</p><p>
-<span class="v">15&#160;</span>Now Yahweh had revealed to Samuel a day before Saul came, saying, 
-<span class="v">16&#160;</span>“Tomorrow about this time I will send you a man out of the land of Benjamin, and you shall anoint him to be prince over my people Israel. He will save my people out of the hand of the Philistines; for I have looked upon my people, because their cry has come to me.” 
-</p><p>
-<span class="v">17&#160;</span>When Samuel saw Saul, Yahweh said to him, “Behold, the man of whom I spoke to you! He will have authority over my people.” 
-</p><p>
-<span class="v">18&#160;</span>Then Saul approached Samuel in the gateway, and said, “Please tell me where the seer’s house is.” 
-</p><p>
-<span class="v">19&#160;</span>Samuel answered Saul and said, “I am the seer. Go up before me to the high place, for you are to eat with me today. In the morning I will let you go and will tell you all that is in your heart. 
-<span class="v">20&#160;</span>As for your donkeys who were lost three days ago, don’t set your mind on them, for they have been found. For whom does all Israel desire? Is it not you and all your father’s house?” 
-</p><p>
-<span class="v">21&#160;</span>Saul answered, “Am I not a Benjamite, of the smallest of the tribes of Israel? And my family the least of all the families of the tribe of Benjamin? Why then do you speak to me like this?” 
-</p><p>
-<span class="v">22&#160;</span>Samuel took Saul and his servant and brought them into the guest room, and made them sit in the best place among those who were invited, who were about thirty persons. 
-<span class="v">23&#160;</span>Samuel said to the cook, “Bring the portion which I gave you, of which I said to you, ‘Set it aside.’&#160;” 
-<span class="v">24&#160;</span>The cook took up the thigh, and that which was on it, and set it before Saul. Samuel said, “Behold, that which has been reserved! Set it before yourself and eat; because it has been kept for you for the appointed time, for I said, ‘I have invited the people.’&#160;” So Saul ate with Samuel that day. 
-</p><p>
-<span class="v">25&#160;</span>When they had come down from the high place into the city, he talked with Saul on the housetop. 
-<span class="v">26&#160;</span>They arose early; and about daybreak, Samuel called to Saul on the housetop, saying, “Get up, that I may send you away.” Saul arose, and they both went outside, he and Samuel, together. 
-<span class="v">27&#160;</span>As they were going down at the end of the city, Samuel said to Saul, “Tell the servant to go on ahead of us.” He went ahead, then Samuel said, “But stand still first, that I may cause you to hear Elohim’s message.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Then Samuel took the vial of oil and poured it on his head, then kissed him and said, “Hasn’t Yahweh anointed you to be prince over his inheritance? 
-<span class="v">2&#160;</span>When you have departed from me today, then you will find two men by Rachel’s tomb, on the border of Benjamin at Zelzah. They will tell you, ‘The donkeys which you went to look for have been found; and behold, your father has stopped caring about the donkeys and is anxious for you, saying, “What shall I do for my son?”&#160;’ 
-</p><p>
-<span class="v">3&#160;</span>“Then you will go on forward from there, and you will come to the oak of Tabor. Three men will meet you there going up to Elohim to Bethel: one carrying three young goats, and another carrying three loaves of bread, and another carrying a container of wine. 
-<span class="v">4&#160;</span>They will greet you and give you two loaves of bread, which you shall receive from their hand. 
-</p><p>
-<span class="v">5&#160;</span>“After that you will come to the hill of Elohim, where the garrison of the Philistines is; and it will happen, when you have come there to the city, that you will meet a band of prophets coming down from the high place with a lute, a tambourine, a pipe, and a harp before them; and they will be prophesying. 
-<span class="v">6&#160;</span>Then Yahweh’s Spirit will come mightily on you, then you will prophesy with them and will be turned into another man. 
-<span class="v">7&#160;</span>Let it be, when these signs have come to you, that you do what is appropriate for the occasion; for Elohim is with you. 
-</p><p>
-<span class="v">8&#160;</span>“Go down ahead of me to Gilgal; and behold, I will come down to you to offer burnt offerings and to sacrifice sacrifices of peace offerings. Wait seven days, until I come to you and show you what you are to do.” 
-<span class="v">9&#160;</span>It was so, that when he had turned his back to go from Samuel, Elohim gave him another heart; and all those signs happened that day. 
-<span class="v">10&#160;</span>When they came there to the hill, behold, a band of prophets met him; and the Spirit of Elohim came mightily on him, and he prophesied among them. 
-<span class="v">11&#160;</span>When all who knew him before saw that, behold, he prophesied with the prophets, then the people said to one another, “What is this that has come to the son of Kish? Is Saul also among the prophets?” 
-</p><p>
-<span class="v">12&#160;</span>One from the same place answered, “Who is their father?” Therefore it became a proverb, “Is Saul also among the prophets?” 
-<span class="v">13&#160;</span>When he had finished prophesying, he came to the high place. 
-</p><p>
-<span class="v">14&#160;</span>Saul’s uncle said to him and to his servant, “Where did you go?” 
-</p><p>He said, “To seek the donkeys. When we saw that they were not found, we came to Samuel.” 
-</p><p>
-<span class="v">15&#160;</span>Saul’s uncle said, “Please tell me what Samuel said to you.” 
-</p><p>
-<span class="v">16&#160;</span>Saul said to his uncle, “He told us plainly that the donkeys were found.” But concerning the matter of the kingdom, of which Samuel spoke, he didn’t tell him. 
-</p><p>
-<span class="v">17&#160;</span>Samuel called the people together to Yahweh to Mizpah; 
-<span class="v">18&#160;</span>and he said to the children of Israel, “Yahweh, the Elohim of Israel, says ‘I brought Israel up out of Egypt and I delivered you out of the hand of the Egyptians, and out of the hand of all the kingdoms that oppressed you.’ 
-<span class="v">19&#160;</span>But you have today rejected your Elohim, who himself saves you out of all your calamities and your distresses; and you have said to him, ‘No! Set a king over us!’ Now therefore present yourselves before Yahweh by your tribes and by your thousands.” 
-</p><p>
-<span class="v">20&#160;</span>So Samuel brought all the tribes of Israel near, and the tribe of Benjamin was chosen. 
-<span class="v">21&#160;</span>He brought the tribe of Benjamin near by their families and the family of the Matrites was chosen. Then Saul the son of Kish was chosen; but when they looked for him, he could not be found. 
-<span class="v">22&#160;</span>Therefore they asked of Yahweh further, “Is there yet a man to come here?” 
-</p><p>Yahweh answered, “Behold, he has hidden himself among the baggage.” 
-</p><p>
-<span class="v">23&#160;</span>They ran and got him there. When he stood among the people, he was higher than any of the people from his shoulders and upward. 
-<span class="v">24&#160;</span>Samuel said to all the people, “Do you see him whom Yahweh has chosen, that there is no one like him among all the people?” 
-</p><p>All the people shouted and said, “Long live the king!” 
-</p><p>
-<span class="v">25&#160;</span>Then Samuel told the people the regulations of the kingdom, and wrote it in a book and laid it up before Yahweh. Samuel sent all the people away, every man to his house. 
-<span class="v">26&#160;</span>Saul also went to his house in Gibeah; and the army went with him, whose hearts Elohim had touched. 
-<span class="v">27&#160;</span>But certain worthless fellows said, “How could this man save us?” They despised him, and brought him no tribute. But he held his peace. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Then Nahash the Ammonite came up and encamped against Jabesh Gilead; and all the men of Jabesh said to Nahash, “Make a covenant with us, and we will serve you.” 
-</p><p>
-<span class="v">2&#160;</span>Nahash the Ammonite said to them, “On this condition I will make it with you, that all your right eyes be gouged out. I will make this dishonor all Israel.” 
-</p><p>
-<span class="v">3&#160;</span>The elders of Jabesh said to him, “Give us seven days, that we may send messengers to all the borders of Israel; and then, if there is no one to save us, we will come out to you.” 
-<span class="v">4&#160;</span>Then the messengers came to Gibeah of Saul, and spoke these words in the ears of the people, then all the people lifted up their voice and wept. 
-</p><p>
-<span class="v">5&#160;</span>Behold, Saul came following the oxen out of the field; and Saul said, “What ails the people that they weep?” They told him the words of the men of Jabesh. 
-<span class="v">6&#160;</span>Elohim’s Spirit came mightily on Saul when he heard those words, and his anger burned hot. 
-<span class="v">7&#160;</span>He took a yoke of oxen and cut them in pieces, then sent them throughout all the borders of Israel by the hand of messengers, saying, “Whoever doesn’t come out after Saul and after Samuel, so shall it be done to his oxen.” The dread of Yahweh fell on the people, and they came out as one man. 
-<span class="v">8&#160;</span>He counted them in Bezek; and the children of Israel were three hundred thousand, and the men of Judah thirty thousand. 
-<span class="v">9&#160;</span>They said to the messengers who came, “Tell the men of Jabesh Gilead, ‘Tomorrow, by the time the sun is hot, you will be rescued.’&#160;” The messengers came and told the men of Jabesh; and they were glad. 
-<span class="v">10&#160;</span>Therefore the men of Jabesh said, “Tomorrow we will come out to you, and you shall do with us all that seems good to you.” 
-<span class="v">11&#160;</span>On the next day, Saul put the people in three companies; and they came into the middle of the camp in the morning watch, and struck the Ammonites until the heat of the day. Those who remained were scattered, so that no two of them were left together. 
-</p><p>
-<span class="v">12&#160;</span>The people said to Samuel, “Who is he who said, ‘Shall Saul reign over us?’ Bring those men, that we may put them to death!” 
-</p><p>
-<span class="v">13&#160;</span>Saul said, “No man shall be put to death today; for today Yahweh has rescued Israel.” 
-</p><p>
-<span class="v">14&#160;</span>Then Samuel said to the people, “Come! Let’s go to Gilgal, and renew the kingdom there.” 
-<span class="v">15&#160;</span>All the people went to Gilgal; and there they made Saul king before Yahweh in Gilgal. There they offered sacrifices of peace offerings before Yahweh; and there Saul and all the men of Israel rejoiced greatly. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Samuel said to all Israel, “Behold, I have listened to your voice in all that you said to me, and have made a king over you. 
-<span class="v">2&#160;</span>Now, behold, the king walks before you. I am old and gray-headed. Behold, my sons are with you. I have walked before you from my youth to this day. 
-<span class="v">3&#160;</span>Here I am. Witness against me before Yahweh and before his anointed. Whose ox have I taken? Whose donkey have I taken? Whom have I defrauded? Whom have I oppressed? Of whose hand have I taken a bribe to make me blind my eyes? I will restore it to you.” 
-</p><p>
-<span class="v">4&#160;</span>They said, “You have not defrauded us, nor oppressed us, neither have you taken anything from anyone’s hand.” 
-</p><p>
-<span class="v">5&#160;</span>He said to them, “Yahweh is witness against you, and his anointed is witness today, that you have not found anything in my hand.” 
-</p><p>They said, “He is witness.” 
-<span class="v">6&#160;</span>Samuel said to the people, “It is Yahweh who appointed Moses and Aaron, and that brought your fathers up out of the land of Egypt. 
-<span class="v">7&#160;</span>Now therefore stand still, that I may plead with you before Yahweh concerning all the righteous acts of Yahweh, which he did to you and to your fathers. 
-</p><p>
-<span class="v">8&#160;</span>“When Jacob had come into Egypt, and your fathers cried to Yahweh, then Yahweh sent Moses and Aaron, who brought your fathers out of Egypt, and made them to dwell in this place. 
-<span class="v">9&#160;</span>But they forgot Yahweh their Elohim; and he sold them into the hand of Sisera, captain of the army of Hazor, and into the hand of the Philistines, and into the hand of the king of Moab; and they fought against them. 
-<span class="v">10&#160;</span>They cried to Yahweh, and said, ‘We have sinned, because we have forsaken Yahweh and have served the Baals and the Ashtaroth; but now deliver us out of the hand of our enemies, and we will serve you.’ 
-<span class="v">11&#160;</span>Yahweh sent Jerubbaal, Bedan, Jephthah, and Samuel, and delivered you out of the hand of your enemies on every side; and you lived in safety. 
-</p><p>
-<span class="v">12&#160;</span>“When you saw that Nahash the king of the children of Ammon came against you, you said to me, ‘No, but a king shall reign over us,’ when Yahweh your Elohim was your king. 
-<span class="v">13&#160;</span>Now therefore see the king whom you have chosen and whom you have asked for. Behold, Yahweh has set a king over you. 
-<span class="v">14&#160;</span>If you will fear Yahweh, and serve him, and listen to his voice, and not rebel against the commandment of Yahweh, then both you and also the king who reigns over you are followers of Yahweh your Elohim. 
-<span class="v">15&#160;</span>But if you will not listen to Yahweh’s voice, but rebel against the commandment of Yahweh, then Yahweh’s hand will be against you, as it was against your fathers. 
-</p><p>
-<span class="v">16&#160;</span>“Now therefore stand still and see this great thing, which Yahweh will do before your eyes. 
-<span class="v">17&#160;</span>Isn’t it wheat harvest today? I will call to Yahweh, that he may send thunder and rain; and you will know and see that your wickedness is great, which you have done in Yahweh’s sight, in asking for a king.” 
-</p><p>
-<span class="v">18&#160;</span>So Samuel called to Yahweh, and Yahweh sent thunder and rain that day. Then all the people greatly feared Yahweh and Samuel. 
-</p><p>
-<span class="v">19&#160;</span>All the people said to Samuel, “Pray for your servants to Yahweh your Elohim, that we not die; for we have added to all our sins this evil, to ask for a king.” 
-</p><p>
-<span class="v">20&#160;</span>Samuel said to the people, “Don’t be afraid. You have indeed done all this evil; yet don’t turn away from following Yahweh, but serve Yahweh with all your heart. 
-<span class="v">21&#160;</span>Don’t turn away to go after vain things which can’t profit or deliver, for they are vain. 
-<span class="v">22&#160;</span>For Yahweh will not forsake his people for his great name’s sake, because it has pleased Yahweh to make you a people for himself. 
-<span class="v">23&#160;</span>Moreover, as for me, far be it from me that I should sin against Yahweh in ceasing to pray for you; but I will instruct you in the good and the right way. 
-<span class="v">24&#160;</span>Only fear Yahweh, and serve him in truth with all your heart; for consider what great things he has done for you. 
-<span class="v">25&#160;</span>But if you keep doing evil, you will be consumed, both you and your king.” 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Saul was thirty years old when he became king, and he reigned over Israel forty-two years.<span class="f">+ \fr 13:1 \ft The traditional Hebrew text omits “thirty” and “forty-”. The blanks are filled in here from a few manuscripts of the Septuagint.</span> 
-</p><p>
-<span class="v">2&#160;</span>Saul chose for himself three thousand men of Israel, of which two thousand were with Saul in Michmash and in the Mount of Bethel, and one thousand were with Jonathan in Gibeah of Benjamin. He sent the rest of the people to their own tents. 
-<span class="v">3&#160;</span>Jonathan struck the garrison of the Philistines that was in Geba, and the Philistines heard of it. Saul blew the trumpet throughout all the land, saying, “Let the Hebrews hear!” 
-<span class="v">4&#160;</span>All Israel heard that Saul had struck the garrison of the Philistines, and also that Israel was considered an abomination to the Philistines. The people were gathered together after Saul to Gilgal. 
-<span class="v">5&#160;</span>The Philistines assembled themselves together to fight with Israel: thirty thousand chariots, six thousand horsemen, and people as the sand which is on the seashore in multitude. They came up and encamped in Michmash, eastward of Beth Aven. 
-<span class="v">6&#160;</span>When the men of Israel saw that they were in trouble (for the people were distressed), then the people hid themselves in caves, in thickets, in rocks, in tombs, and in pits. 
-<span class="v">7&#160;</span>Now some of the Hebrews had gone over the Jordan to the land of Gad and Gilead; but as for Saul, he was yet in Gilgal, and all the people followed him trembling. 
-<span class="v">8&#160;</span>He stayed seven days, according to the time set by Samuel; but Samuel didn’t come to Gilgal, and the people were scattering from him. 
-<span class="v">9&#160;</span>Saul said, “Bring the burnt offering to me here, and the peace offerings.” He offered the burnt offering. 
-</p><p>
-<span class="v">10&#160;</span>It came to pass that as soon as he had finished offering the burnt offering, behold, Samuel came; and Saul went out to meet him, that he might greet him. 
-<span class="v">11&#160;</span>Samuel said, “What have you done?” 
-</p><p>Saul said, “Because I saw that the people were scattered from me, and that you didn’t come within the days appointed, and that the Philistines assembled themselves together at Michmash, 
-<span class="v">12&#160;</span>therefore I said, ‘Now the Philistines will come down on me to Gilgal, and I haven’t entreated the favor of Yahweh.’ I forced myself therefore, and offered the burnt offering.” 
-</p><p>
-<span class="v">13&#160;</span>Samuel said to Saul, “You have done foolishly. You have not kept the commandment of Yahweh your Elohim, which he commanded you; for now Yahweh would have established your kingdom on Israel forever. 
-<span class="v">14&#160;</span>But now your kingdom will not continue. Yahweh has sought for himself a man after his own heart, and Yahweh has appointed him to be prince over his people, because you have not kept that which Yahweh commanded you.” 
-</p><p>
-<span class="v">15&#160;</span>Samuel arose, and went from Gilgal to Gibeah of Benjamin. Saul counted the people who were present with him, about six hundred men. 
-<span class="v">16&#160;</span>Saul, and Jonathan his son, and the people who were present with them, stayed in Geba of Benjamin; but the Philistines encamped in Michmash. 
-<span class="v">17&#160;</span>The raiders came out of the camp of the Philistines in three companies: one company turned to the way that leads to Ophrah, to the land of Shual; 
-<span class="v">18&#160;</span>another company turned the way to Beth Horon; and another company turned the way of the border that looks down on the valley of Zeboim toward the wilderness. 
-<span class="v">19&#160;</span>Now there was no blacksmith found throughout all the land of Israel, for the Philistines said, “Lest the Hebrews make themselves swords or spears”; 
-<span class="v">20&#160;</span>but all the Israelites went down to the Philistines, each man to sharpen his own plowshare, mattock, ax, and sickle. 
-<span class="v">21&#160;</span>The price was one payim<span class="f">+ \fr 13:21 \ft A payim (or pim) was 2/3 shekel of silver, or 0.26 ounces, or 7.6 grams</span> each to sharpen mattocks, plowshares, pitchforks, axes, and goads. 
-<span class="v">22&#160;</span>So it came to pass in the day of battle that neither sword nor spear was found in the hand of any of the people who were with Saul and Jonathan; but Saul and Jonathan his son had them. 
-</p><p>
-<span class="v">23&#160;</span>The garrison of the Philistines went out to the pass of Michmash. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Now it happened on a day that Jonathan the son of Saul said to the young man who bore his armor, “Come! Let’s go over to the Philistines’ garrison that is on the other side.” But he didn’t tell his father. 
-<span class="v">2&#160;</span>Saul stayed in the uttermost part of Gibeah under the pomegranate tree which is in Migron; and the people who were with him were about six hundred men, 
-<span class="v">3&#160;</span>including Ahijah the son of Ahitub, Ichabod’s brother, the son of Phinehas, the son of Eli the priest of Yahweh in Shiloh, wearing an ephod. The people didn’t know that Jonathan was gone. 
-</p><p>
-<span class="v">4&#160;</span>Between the passes, by which Jonathan sought to go over to the Philistines’ garrison, there was a rocky crag on the one side and a rocky crag on the other side; and the name of the one was Bozez, and the name of the other Seneh. 
-<span class="v">5&#160;</span>The one crag rose up on the north in front of Michmash, and the other on the south in front of Geba. 
-<span class="v">6&#160;</span>Jonathan said to the young man who bore his armor, “Come! Let’s go over to the garrison of these uncircumcised. It may be that Yahweh will work for us, for there is no restraint on Yahweh to save by many or by few.” 
-</p><p>
-<span class="v">7&#160;</span>His armor bearer said to him, “Do all that is in your heart. Go, and behold, I am with you according to your heart.” 
-</p><p>
-<span class="v">8&#160;</span>Then Jonathan said, “Behold, we will pass over to the men, and we will reveal ourselves to them. 
-<span class="v">9&#160;</span>If they say this to us, ‘Wait until we come to you!’ then we will stand still in our place and will not go up to them. 
-<span class="v">10&#160;</span>But if they say this, ‘Come up to us!’ then we will go up, for Yahweh has delivered them into our hand. This shall be the sign to us.” 
-</p><p>
-<span class="v">11&#160;</span>Both of them revealed themselves to the garrison of the Philistines; and the Philistines said, “Behold, the Hebrews are coming out of the holes where they had hidden themselves!” 
-<span class="v">12&#160;</span>The men of the garrison answered Jonathan and his armor bearer, and said, “Come up to us, and we will show you something!” 
-</p><p>Jonathan said to his armor bearer, “Come up after me, for Yahweh has delivered them into the hand of Israel.” 
-<span class="v">13&#160;</span>Jonathan climbed up on his hands and on his feet, and his armor bearer after him, and they fell before Jonathan; and his armor bearer killed them after him. 
-<span class="v">14&#160;</span>That first slaughter, which Jonathan and his armor bearer made, was about twenty men, within as it were half a furrow’s length in an acre of land. 
-</p><p>
-<span class="v">15&#160;</span>There was a trembling in the camp, in the field, and among all the people; the garrison and the raiders also trembled; and the earth quaked, so there was an exceedingly great trembling. 
-<span class="v">16&#160;</span>The watchmen of Saul in Gibeah of Benjamin looked; and behold, the multitude melted away and scattered. 
-<span class="v">17&#160;</span>Then Saul said to the people who were with him, “Count now, and see who is missing from us.” When they had counted, behold, Jonathan and his armor bearer were not there. 
-</p><p>
-<span class="v">18&#160;</span>Saul said to Ahijah, “Bring Elohim’s ark here.” For Elohim’s ark was with the children of Israel at that time. 
-<span class="v">19&#160;</span>While Saul talked to the priest, the tumult that was in the camp of the Philistines went on and increased; and Saul said to the priest, “Withdraw your hand!” 
-</p><p>
-<span class="v">20&#160;</span>Saul and all the people who were with him were gathered together, and came to the battle; and behold, they were all striking each other with their swords in very great confusion. 
-<span class="v">21&#160;</span>Now the Hebrews who were with the Philistines before and who went up with them into the camp from all around, even they also turned to be with the Israelites who were with Saul and Jonathan. 
-<span class="v">22&#160;</span>Likewise all the men of Israel who had hidden themselves in the hill country of Ephraim, when they heard that the Philistines fled, even they also followed hard after them in the battle. 
-<span class="v">23&#160;</span>So Yahweh saved Israel that day; and the battle passed over by Beth Aven. 
-</p><p>
-<span class="v">24&#160;</span>The men of Israel were distressed that day; for Saul had adjured the people, saying, “Cursed is the man who eats any food until it is evening, and I am avenged of my enemies.” So none of the people tasted food. 
-</p><p>
-<span class="v">25&#160;</span>All the people came into the forest; and there was honey on the ground. 
-<span class="v">26&#160;</span>When the people had come to the forest, behold, honey was dripping, but no one put his hand to his mouth, for the people feared the oath. 
-<span class="v">27&#160;</span>But Jonathan didn’t hear when his father commanded the people with the oath. Therefore he put out the end of the rod that was in his hand and dipped it in the honeycomb, and put his hand to his mouth; and his eyes brightened. 
-<span class="v">28&#160;</span>Then one of the people answered, and said, “Your father directly commanded the people with an oath, saying, ‘Cursed is the man who eats food today.’&#160;” So the people were faint. 
-</p><p>
-<span class="v">29&#160;</span>Then Jonathan said, “My father has troubled the land. Please look how my eyes have brightened because I tasted a little of this honey. 
-<span class="v">30&#160;</span>How much more, if perhaps the people had eaten freely today of the plunder of their enemies which they found? For now there has been no great slaughter among the Philistines.” 
-<span class="v">31&#160;</span>They struck the Philistines that day from Michmash to Aijalon. The people were very faint; 
-<span class="v">32&#160;</span>and the people pounced on the plunder, and took sheep, cattle, and calves, and killed them on the ground; and the people ate them with the blood. 
-<span class="v">33&#160;</span>Then they told Saul, saying, “Behold, the people are sinning against Yahweh, in that they eat meat with the blood.” 
-</p><p>He said, “You have dealt treacherously. Roll a large stone to me today!” 
-<span class="v">34&#160;</span>Saul said, “Disperse yourselves among the people, and tell them, ‘Every man bring me here his ox, and every man his sheep, and kill them here, and eat; and don’t sin against Yahweh in eating meat with the blood.’&#160;” All the people brought every man his ox with him that night, and killed them there. 
-</p><p>
-<span class="v">35&#160;</span>Saul built an altar to Yahweh. This was the first altar that he built to Yahweh. 
-<span class="v">36&#160;</span>Saul said, “Let’s go down after the Philistines by night, and take plunder among them until the morning light. Let’s not leave a man of them.” 
-</p><p>They said, “Do whatever seems good to you.” 
-</p><p>Then the priest said, “Let’s draw near here to Elohim.” 
-</p><p>
-<span class="v">37&#160;</span>Saul asked counsel of Elohim: “Shall I go down after the Philistines? Will you deliver them into the hand of Israel?” But he didn’t answer him that day. 
-<span class="v">38&#160;</span>Saul said, “Draw near here, all you chiefs of the people, and know and see in whom this sin has been today. 
-<span class="v">39&#160;</span>For as Yahweh lives, who saves Israel, though it is in Jonathan my son, he shall surely die.” But there was not a man among all the people who answered him. 
-<span class="v">40&#160;</span>Then he said to all Israel, “You be on one side, and I and Jonathan my son will be on the other side.” 
-</p><p>The people said to Saul, “Do what seems good to you.” 
-</p><p>
-<span class="v">41&#160;</span>Therefore Saul said to Yahweh, the Elohim of Israel, “Show the right.” 
-</p><p>Jonathan and Saul were chosen, but the people escaped. 
-</p><p>
-<span class="v">42&#160;</span>Saul said, “Cast lots between me and Jonathan my son.” 
-</p><p>Jonathan was selected. 
-</p><p>
-<span class="v">43&#160;</span>Then Saul said to Jonathan, “Tell me what you have done!” 
-</p><p>Jonathan told him, and said, “I certainly did taste a little honey with the end of the rod that was in my hand; and behold, I must die.” 
-</p><p>
-<span class="v">44&#160;</span>Saul said, “Elohim do so and more also; for you shall surely die, Jonathan.” 
-</p><p>
-<span class="v">45&#160;</span>The people said to Saul, “Shall Jonathan die, who has worked this great salvation in Israel? Far from it! As Yahweh lives, there shall not one hair of his head fall to the ground, for he has worked with Elohim today!” So the people rescued Jonathan, so he didn’t die. 
-<span class="v">46&#160;</span>Then Saul went up from following the Philistines; and the Philistines went to their own place. 
-</p><p>
-<span class="v">47&#160;</span>Now when Saul had taken the kingdom over Israel, he fought against all his enemies on every side: against Moab, and against the children of Ammon, and against Edom, and against the kings of Zobah, and against the Philistines. Wherever he turned himself, he defeated them. 
-<span class="v">48&#160;</span>He did valiantly and struck the Amalekites, and delivered Israel out of the hands of those who plundered them. 
-<span class="v">49&#160;</span>Now the sons of Saul were Jonathan, Ishvi, and Malchishua; and the names of his two daughters were these: the name of the firstborn Merab, and the name of the younger Michal. 
-<span class="v">50&#160;</span>The name of Saul’s woman was Ahinoam the daughter of Ahimaaz. The name of the captain of his army was Abner the son of Ner, Saul’s uncle. 
-<span class="v">51&#160;</span>Kish was the father of Saul, and Ner the father of Abner was the son of Abiel. 
-</p><p>
-<span class="v">52&#160;</span>There was severe war against the Philistines all the days of Saul; and when Saul saw any mighty man or any valiant man, he took him into his service. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Samuel said to Saul, “Yahweh sent me to anoint you to be king over his people, over Israel. Now therefore listen to the voice of Yahweh’s words. 
-<span class="v">2&#160;</span>Yahweh of Armies says, ‘I remember what Amalek did to Israel, how he set himself against him on the way when he came up out of Egypt. 
-<span class="v">3&#160;</span>Now go and strike Amalek, and utterly destroy all that they have, and don’t spare them; but kill both man and woman, infant and nursing baby, ox and sheep, camel and donkey.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>Saul summoned the people, and counted them in Telaim, two hundred thousand footmen and ten thousand men of Judah. 
-<span class="v">5&#160;</span>Saul came to the city of Amalek, and set an ambush in the valley. 
-<span class="v">6&#160;</span>Saul said to the Kenites, “Go, depart, go down from among the Amalekites, lest I destroy you with them; for you showed kindness to all the children of Israel when they came up out of Egypt.” So the Kenites departed from among the Amalekites. 
-</p><p>
-<span class="v">7&#160;</span>Saul struck the Amalekites, from Havilah as you go to Shur, which is before Egypt. 
-<span class="v">8&#160;</span>He took Agag the king of the Amalekites alive, and utterly destroyed all the people with the edge of the sword. 
-<span class="v">9&#160;</span>But Saul and the people spared Agag and the best of the sheep, of the cattle, of the fat calves, of the lambs, and all that was good, and were not willing to utterly destroy them; but everything that was vile and refuse, that they destroyed utterly. 
-</p><p>
-<span class="v">10&#160;</span>Then Yahweh’s word came to Samuel, saying, 
-<span class="v">11&#160;</span>“It grieves me that I have set up Saul to be king, for he has turned back from following me, and has not performed my commandments.” Samuel was angry; and he cried to Yahweh all night. 
-</p><p>
-<span class="v">12&#160;</span>Samuel rose early to meet Saul in the morning; and Samuel was told, saying, “Saul came to Carmel, and behold, he set up a monument for himself, turned, passed on, and went down to Gilgal.” 
-</p><p>
-<span class="v">13&#160;</span>Samuel came to Saul; and Saul said to him, “You are blessed by Yahweh! I have performed the commandment of Yahweh.” 
-</p><p>
-<span class="v">14&#160;</span>Samuel said, “Then what does this bleating of the sheep in my ears and the lowing of the cattle which I hear mean?” 
-</p><p>
-<span class="v">15&#160;</span>Saul said, “They have brought them from the Amalekites; for the people spared the best of the sheep and of the cattle, to sacrifice to Yahweh your Elohim. We have utterly destroyed the rest.” 
-</p><p>
-<span class="v">16&#160;</span>Then Samuel said to Saul, “Stay, and I will tell you what Yahweh said to me last night.” 
-</p><p>He said to him, “Say on.” 
-</p><p>
-<span class="v">17&#160;</span>Samuel said, “Though you were little in your own sight, weren’t you made the head of the tribes of Israel? Yahweh anointed you king over Israel; 
-<span class="v">18&#160;</span>and Yahweh sent you on a journey, and said, ‘Go, and utterly destroy the sinners the Amalekites, and fight against them until they are consumed.’ 
-<span class="v">19&#160;</span>Why then didn’t you obey Yahweh’s voice, but took the plunder, and did that which was evil in Yahweh’s sight?” 
-</p><p>
-<span class="v">20&#160;</span>Saul said to Samuel, “But I have obeyed Yahweh’s voice, and have gone the way which Yahweh sent me, and have brought Agag the king of Amalek, and have utterly destroyed the Amalekites. 
-<span class="v">21&#160;</span>But the people took of the plunder, sheep and cattle, the best of the devoted things, to sacrifice to Yahweh your Elohim in Gilgal.” 
-</p><p>
-<span class="v">22&#160;</span>Samuel said, “Has Yahweh as great delight in burnt offerings and sacrifices, as in obeying Yahweh’s voice? Behold, to obey is better than sacrifice, and to listen than the fat of rams. 
-<span class="v">23&#160;</span>For rebellion is as the sin of witchcraft, and stubbornness is as idolatry and teraphim.<span class="f">+ \fr 15:23 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> Because you have rejected Yahweh’s word, he has also rejected you from being king.” 
-</p><p>
-<span class="v">24&#160;</span>Saul said to Samuel, “I have sinned; for I have transgressed the commandment of Yahweh and your words, because I feared the people and obeyed their voice. 
-<span class="v">25&#160;</span>Now therefore, please pardon my sin, and turn again with me, that I may worship Yahweh.” 
-</p><p>
-<span class="v">26&#160;</span>Samuel said to Saul, “I will not return with you; for you have rejected Yahweh’s word, and Yahweh has rejected you from being king over Israel.” 
-<span class="v">27&#160;</span>As Samuel turned around to go away, Saul grabbed the skirt of his robe, and it tore. 
-<span class="v">28&#160;</span>Samuel said to him, “Yahweh has torn the kingdom of Israel from you today, and has given it to a neighbor of yours who is better than you. 
-<span class="v">29&#160;</span>Also the Strength of Israel will not lie nor repent; for he is not a man, that he should repent.” 
-</p><p>
-<span class="v">30&#160;</span>Then he said, “I have sinned; yet please honor me now before the elders of my people and before Israel, and come back with me, that I may worship Yahweh your Elohim.” 
-</p><p>
-<span class="v">31&#160;</span>So Samuel went back with Saul; and Saul worshiped Yahweh. 
-<span class="v">32&#160;</span>Then Samuel said, “Bring Agag the king of the Amalekites here to me!” 
-</p><p>Agag came to him cheerfully. Agag said, “Surely the bitterness of death is past.” 
-</p><p>
-<span class="v">33&#160;</span>Samuel said, “As your sword has made women childless, so your mother will be childless among women!” Then Samuel cut Agag in pieces before Yahweh in Gilgal. 
-</p><p>
-<span class="v">34&#160;</span>Then Samuel went to Ramah; and Saul went up to his house to Gibeah of Saul. 
-<span class="v">35&#160;</span>Samuel came no more to see Saul until the day of his death, but Samuel mourned for Saul. Yahweh grieved that he had made Saul king over Israel. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Samuel, “How long will you mourn for Saul, since I have rejected him from being king over Israel? Fill your horn with oil, and go. I will send you to Jesse the Bethlehemite, for I have provided a king for myself among his sons.” 
-</p><p>
-<span class="v">2&#160;</span>Samuel said, “How can I go? If Saul hears it, he will kill me.” 
-</p><p>Yahweh said, “Take a heifer with you, and say, ‘I have come to sacrifice to Yahweh.’ 
-<span class="v">3&#160;</span>Call Jesse to the sacrifice, and I will show you what you shall do. You shall anoint to me him whom I name to you.” 
-</p><p>
-<span class="v">4&#160;</span>Samuel did that which Yahweh spoke, and came to Bethlehem. The elders of the city came to meet him trembling, and said, “Do you come peaceably?” 
-</p><p>
-<span class="v">5&#160;</span>He said, “Peaceably; I have come to sacrifice to Yahweh. Sanctify yourselves, and come with me to the sacrifice.” He sanctified Jesse and his sons, and called them to the sacrifice. 
-<span class="v">6&#160;</span>When they had come, he looked at Eliab, and said, “Surely Yahweh’s anointed is before him.” 
-</p><p>
-<span class="v">7&#160;</span>But Yahweh said to Samuel, “Don’t look on his face, or on the height of his stature, because I have rejected him; for I don’t see as man sees. For man looks at the outward appearance, but Yahweh looks at the heart.” 
-</p><p>
-<span class="v">8&#160;</span>Then Jesse called Abinadab, and made him pass before Samuel. He said, “Yahweh has not chosen this one, either.” 
-<span class="v">9&#160;</span>Then Jesse made Shammah to pass by. He said, “Yahweh has not chosen this one, either.” 
-<span class="v">10&#160;</span>Jesse made seven of his sons to pass before Samuel. Samuel said to Jesse, “Yahweh has not chosen these.” 
-<span class="v">11&#160;</span>Samuel said to Jesse, “Are all your children here?” 
-</p><p>He said, “There remains yet the youngest. Behold, he is keeping the sheep.” 
-</p><p>Samuel said to Jesse, “Send and get him, for we will not sit down until he comes here.” 
-</p><p>
-<span class="v">12&#160;</span>He sent, and brought him in. Now he was ruddy, with a handsome face and good appearance. Yahweh said, “Arise! Anoint him, for this is he.” 
-</p><p>
-<span class="v">13&#160;</span>Then Samuel took the horn of oil and anointed him in the middle of his brothers. Then Yahweh’s Spirit came mightily on David from that day forward. So Samuel rose up and went to Ramah. 
-<span class="v">14&#160;</span>Now Yahweh’s Spirit departed from Saul, and an evil spirit from Yahweh troubled him. 
-<span class="v">15&#160;</span>Saul’s servants said to him, “See now, an evil spirit from Elohim troubles you. 
-<span class="v">16&#160;</span>Let our lord now command your servants who are in front of you to seek out a man who is a skillful player on the harp. Then when the evil spirit from Elohim is on you, he will play with his hand, and you will be well.” 
-</p><p>
-<span class="v">17&#160;</span>Saul said to his servants, “Provide me now a man who can play well, and bring him to me.” 
-</p><p>
-<span class="v">18&#160;</span>Then one of the young men answered and said, “Behold, I have seen a son of Jesse the Bethlehemite who is skillful in playing, a mighty man of valor, a man of war, prudent in speech, and a handsome person; and Yahweh is with him.” 
-</p><p>
-<span class="v">19&#160;</span>Therefore Saul sent messengers to Jesse, and said, “Send me David your son, who is with the sheep.” 
-</p><p>
-<span class="v">20&#160;</span>Jesse took a donkey loaded with bread, a container of wine, and a young goat, and sent them by David his son to Saul. 
-<span class="v">21&#160;</span>David came to Saul and stood before him. He loved him greatly; and he became his armor bearer. 
-<span class="v">22&#160;</span>Saul sent to Jesse, saying, “Please let David stand before me, for he has found favor in my sight.” 
-<span class="v">23&#160;</span>When the spirit from Elohim was on Saul, David took the harp and played with his hand; so Saul was refreshed and was well, and the evil spirit departed from him. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Now the Philistines gathered together their armies to battle; and they were gathered together at Socoh, which belongs to Judah, and encamped between Socoh and Azekah in Ephesdammim. 
-<span class="v">2&#160;</span>Saul and the men of Israel were gathered together, and encamped in the valley of Elah, and set the battle in array against the Philistines. 
-<span class="v">3&#160;</span>The Philistines stood on the mountain on the one side, and Israel stood on the mountain on the other side: and there was a valley between them. 
-<span class="v">4&#160;</span>A champion out of the camp of the Philistines named Goliath of Gath, whose height was six cubits and a span<span class="f">+ \fr 17:4 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters. A span is the length from the tip of a man’s thumb to the tip of his little finger when his hand is stretched out (about half a cubit, or 9 inches, or 22.8 cm.) Therefore, Goliath was about 9 feet and 9 inches or 2.97 meters tall.</span> went out. 
-<span class="v">5&#160;</span>He had a helmet of bronze on his head, and he wore a coat of mail; and the weight of the coat was five thousand shekels<span class="f">+ \fr 17:5 \ft A shekel is about 10 grams or about 0.35 ounces, so 5000 shekels is about 50 kilograms or 110 pounds.</span> of bronze. 
-<span class="v">6&#160;</span>He had bronze shin armor on his legs and a bronze javelin between his shoulders. 
-<span class="v">7&#160;</span>The staff of his spear was like a weaver’s beam; and his spear’s head weighed six hundred shekels of iron.<span class="f">+ \fr 17:7 \ft A shekel is about 10 grams or about 0.35 ounces, so 600 shekels is about 6 kilograms or about 13 pounds.</span> His shield bearer went before him. 
-<span class="v">8&#160;</span>He stood and cried to the armies of Israel, and said to them, “Why have you come out to set your battle in array? Am I not a Philistine, and you servants to Saul? Choose a man for yourselves, and let him come down to me. 
-<span class="v">9&#160;</span>If he is able to fight with me and kill me, then will we be your servants; but if I prevail against him and kill him, then you will be our servants and serve us.” 
-<span class="v">10&#160;</span>The Philistine said, “I defy the armies of Israel today! Give me a man, that we may fight together!” 
-</p><p>
-<span class="v">11&#160;</span>When Saul and all Israel heard those words of the Philistine, they were dismayed and greatly afraid. 
-<span class="v">12&#160;</span>Now David was the son of that Ephrathite of Bethlehem Judah, whose name was Jesse; and he had eight sons. The man was an elderly old man in the days of Saul. 
-<span class="v">13&#160;</span>The three oldest sons of Jesse had gone after Saul to the battle; and the names of his three sons who went to the battle were Eliab the firstborn, and next to him Abinadab, and the third Shammah. 
-<span class="v">14&#160;</span>David was the youngest; and the three oldest followed Saul. 
-<span class="v">15&#160;</span>Now David went back and forth from Saul to feed his father’s sheep at Bethlehem. 
-</p><p>
-<span class="v">16&#160;</span>The Philistine came near morning and evening, and presented himself forty days. 
-</p><p>
-<span class="v">17&#160;</span>Jesse said to David his son, “Now take for your brothers an ephah<span class="f">+ \fr 17:17 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of this parched grain and these ten loaves, and carry them quickly to the camp to your brothers; 
-<span class="v">18&#160;</span>and bring these ten cheeses to the captain of their thousand; and see how your brothers are doing, and bring back news.” 
-<span class="v">19&#160;</span>Now Saul, and they, and all the men of Israel were in the valley of Elah, fighting with the Philistines. 
-</p><p>
-<span class="v">20&#160;</span>David rose up early in the morning and left the sheep with a keeper, and took the provisions and went, as Jesse had commanded him. He came to the place of the wagons as the army which was going out to the fight shouted for the battle. 
-<span class="v">21&#160;</span>Israel and the Philistines put the battle in array, army against army. 
-<span class="v">22&#160;</span>David left his baggage in the hand of the keeper of the baggage and ran to the army, and came and greeted his brothers. 
-<span class="v">23&#160;</span>As he talked with them, behold, the champion, the Philistine of Gath, Goliath by name, came up out of the ranks of the Philistines, and said the same words; and David heard them. 
-<span class="v">24&#160;</span>All the men of Israel, when they saw the man, fled from him and were terrified. 
-<span class="v">25&#160;</span>The men of Israel said, “Have you seen this man who has come up? He has surely come up to defy Israel. The king will give great riches to the man who kills him, and will give him his daughter, and will make his father’s house tax-free in Israel.” 
-</p><p>
-<span class="v">26&#160;</span>David spoke to the men who stood by him, saying, “What shall be done to the man who kills this Philistine and takes away the reproach from Israel? For who is this uncircumcised Philistine, that he should defy the armies of the living Elohim?” 
-</p><p>
-<span class="v">27&#160;</span>The people answered him in this way, saying, “So shall it be done to the man who kills him.” 
-</p><p>
-<span class="v">28&#160;</span>Eliab his oldest brother heard when he spoke to the men; and Eliab’s anger burned against David, and he said, “Why have you come down? With whom have you left those few sheep in the wilderness? I know your pride and the evil of your heart; for you have come down that you might see the battle.” 
-</p><p>
-<span class="v">29&#160;</span>David said, “What have I now done? Is there not a cause?” 
-<span class="v">30&#160;</span>He turned away from him toward another, and spoke like that again; and the people answered him again the same way. 
-<span class="v">31&#160;</span>When the words were heard which David spoke, they rehearsed them before Saul; and he sent for him. 
-<span class="v">32&#160;</span>David said to Saul, “Let no man’s heart fail because of him. Your servant will go and fight with this Philistine.” 
-</p><p>
-<span class="v">33&#160;</span>Saul said to David, “You are not able to go against this Philistine to fight with him; for you are but a youth, and he a man of war from his youth.” 
-</p><p>
-<span class="v">34&#160;</span>David said to Saul, “Your servant was keeping his father’s sheep; and when a lion or a bear came and took a lamb out of the flock, 
-<span class="v">35&#160;</span>I went out after him, struck him, and rescued it out of his mouth. When he arose against me, I caught him by his beard, struck him, and killed him. 
-<span class="v">36&#160;</span>Your servant struck both the lion and the bear. This uncircumcised Philistine shall be as one of them, since he has defied the armies of the living Elohim.” 
-<span class="v">37&#160;</span>David said, “Yahweh, who delivered me out of the paw of the lion and out of the paw of the bear, will deliver me out of the hand of this Philistine.” 
-</p><p>Saul said to David, “Go! Yahweh will be with you.” 
-</p><p>
-<span class="v">38&#160;</span>Saul dressed David with his clothing. He put a helmet of bronze on his head, and he clad him with a coat of mail. 
-<span class="v">39&#160;</span>David strapped his sword on his clothing and he tried to move, for he had not tested it. David said to Saul, “I can’t go with these, for I have not tested them.” Then David took them off. 
-</p><p>
-<span class="v">40&#160;</span>He took his staff in his hand, and chose for himself five smooth stones out of the brook, and put them in the pouch of his shepherd’s bag which he had. His sling was in his hand; and he came near to the Philistine. 
-<span class="v">41&#160;</span>The Philistine walked and came near to David; and the man who bore the shield went before him. 
-<span class="v">42&#160;</span>When the Philistine looked around and saw David, he disdained him; for he was but a youth, and ruddy, and had a good looking face. 
-<span class="v">43&#160;</span>The Philistine said to David, “Am I a dog, that you come to me with sticks?” The Philistine cursed David by his elohims. 
-<span class="v">44&#160;</span>The Philistine said to David, “Come to me, and I will give your flesh to the birds of the sky and to the animals of the field.” 
-</p><p>
-<span class="v">45&#160;</span>Then David said to the Philistine, “You come to me with a sword, with a spear, and with a javelin; but I come to you in the name of Yahweh of Armies, the Elohim of the armies of Israel, whom you have defied. 
-<span class="v">46&#160;</span>Today, Yahweh will deliver you into my hand. I will strike you and take your head from off you. I will give the dead bodies of the army of the Philistines today to the birds of the sky and to the wild animals of the earth, that all the earth may know that there is an Elohim in Israel, 
-<span class="v">47&#160;</span>and that all this assembly may know that Yahweh doesn’t save with sword and spear; for the battle is Yahweh’s, and he will give you into our hand.” 
-</p><p>
-<span class="v">48&#160;</span>When the Philistine arose, and walked and came near to meet David, David hurried and ran toward the army to meet the Philistine. 
-<span class="v">49&#160;</span>David put his hand in his bag, took a stone and slung it, and struck the Philistine in his forehead. The stone sank into his forehead, and he fell on his face to the earth. 
-<span class="v">50&#160;</span>So David prevailed over the Philistine with a sling and with a stone, and struck the Philistine and killed him; but there was no sword in David’s hand. 
-<span class="v">51&#160;</span>Then David ran, stood over the Philistine, took his sword, drew it out of its sheath, killed him, and cut off his head with it. 
-</p><p>When the Philistines saw that their champion was dead, they fled. 
-<span class="v">52&#160;</span>The men of Israel and of Judah arose and shouted, and pursued the Philistines as far as Gai and to the gates of Ekron. The wounded of the Philistines fell down by the way to Shaaraim, even to Gath and to Ekron. 
-<span class="v">53&#160;</span>The children of Israel returned from chasing after the Philistines, and they plundered their camp. 
-<span class="v">54&#160;</span>David took the head of the Philistine and brought it to Jerusalem, but he put his armor in his tent. 
-<span class="v">55&#160;</span>When Saul saw David go out against the Philistine, he said to Abner, the captain of the army, “Abner, whose son is this youth?” 
-</p><p>Abner said, “As your soul lives, O king, I can’t tell.” 
-</p><p>
-<span class="v">56&#160;</span>The king said, “Inquire whose son the young man is!” 
-</p><p>
-<span class="v">57&#160;</span>As David returned from the slaughter of the Philistine, Abner took him and brought him before Saul with the head of the Philistine in his hand. 
-<span class="v">58&#160;</span>Saul said to him, “Whose son are you, you young man?” 
-</p><p>David answered, “I am the son of your servant Jesse the Bethlehemite.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>When he had finished speaking to Saul, the soul of Jonathan was knit with the soul of David, and Jonathan loved him as his own soul. 
-<span class="v">2&#160;</span>Saul took him that day, and wouldn’t let him go home to his father’s house any more. 
-<span class="v">3&#160;</span>Then Jonathan and David made a covenant, because he loved him as his own soul. 
-<span class="v">4&#160;</span>Jonathan stripped himself of the robe that was on him and gave it to David with his clothing, even including his sword, his bow, and his sash. 
-</p><p>
-<span class="v">5&#160;</span>David went out wherever Saul sent him, and behaved himself wisely; and Saul set him over the men of war. It was good in the sight of all the people, and also in the sight of Saul’s servants. 
-</p><p>
-<span class="v">6&#160;</span>As they came, when David returned from the slaughter of the Philistine, the women came out of all the cities of Israel, singing and dancing, to meet King Saul with tambourines, with joy, and with instruments of music. 
-<span class="v">7&#160;</span>The women sang to one another as they played, and said, 
-</p><p class="q1">“Saul has slain his thousands, 
-</p><p class="q2">and David his ten thousands.” 
-</p><p>
-<span class="v">8&#160;</span>Saul was very angry, and this saying displeased him. He said, “They have credited David with ten thousands, and they have only credited me with thousands. What can he have more but the kingdom?” 
-<span class="v">9&#160;</span>Saul watched David from that day and forward. 
-<span class="v">10&#160;</span>On the next day, an evil spirit from Elohim came mightily on Saul, and he prophesied in the middle of the house. David played with his hand, as he did day by day. Saul had his spear in his hand; 
-<span class="v">11&#160;</span>and Saul threw the spear, for he said, “I will pin David to the wall!” David escaped from his presence twice. 
-<span class="v">12&#160;</span>Saul was afraid of David, because Yahweh was with him, and had departed from Saul. 
-<span class="v">13&#160;</span>Therefore Saul removed him from his presence, and made him his captain over a thousand; and he went out and came in before the people. 
-</p><p>
-<span class="v">14&#160;</span>David behaved himself wisely in all his ways; and Yahweh was with him. 
-<span class="v">15&#160;</span>When Saul saw that he behaved himself very wisely, he stood in awe of him. 
-<span class="v">16&#160;</span>But all Israel and Judah loved David; for he went out and came in before them. 
-<span class="v">17&#160;</span>Saul said to David, “Behold, my elder daughter Merab. I will give her to you as woman. Only be valiant for me, and fight Yahweh’s battles.” For Saul said, “Don’t let my hand be on him, but let the hand of the Philistines be on him.” 
-</p><p>
-<span class="v">18&#160;</span>David said to Saul, “Who am I, and what is my life, or my father’s family in Israel, that I should be son-in-law to the king?” 
-</p><p>
-<span class="v">19&#160;</span>But at the time when Merab, Saul’s daughter, should have been given to David, she was given to Adriel the Meholathite as woman. 
-</p><p>
-<span class="v">20&#160;</span>Michal, Saul’s daughter, loved David; and they told Saul, and the thing pleased him. 
-<span class="v">21&#160;</span>Saul said, I will give her to him, that she may be a snare to him and that the hand of the Philistines may be against him. Therefore Saul said to David a second time, “You shall today be my son-in-law.” 
-</p><p>
-<span class="v">22&#160;</span>Saul commanded his servants, “Talk with David secretly, and say, ‘Behold, the king has delight in you, and all his servants love you. Now therefore be the king’s son-in-law.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Saul’s servants spoke those words in the ears of David. David said, “Does it seem to you a light thing to be the king’s son-in-law, since I am a poor man and little known?” 
-</p><p>
-<span class="v">24&#160;</span>The servants of Saul told him, saying, “David spoke like this.” 
-</p><p>
-<span class="v">25&#160;</span>Saul said, “Tell David, ‘The king desires no dowry except one hundred foreskins of the Philistines, to be avenged of the king’s enemies.’&#160;” Now Saul thought he would make David fall by the hand of the Philistines. 
-<span class="v">26&#160;</span>When his servants told David these words, it pleased David well to be the king’s son-in-law. Before the deadline, 
-<span class="v">27&#160;</span>David arose and went, he and his men, and killed two hundred men of the Philistines. Then David brought their foreskins, and they gave them in full number to the king, that he might be the king’s son-in-law. Then Saul gave him Michal his daughter as woman. 
-<span class="v">28&#160;</span>Saul saw and knew that Yahweh was with David; and Michal, Saul’s daughter, loved him. 
-<span class="v">29&#160;</span>Saul was even more afraid of David; and Saul was David’s enemy continually. 
-</p><p>
-<span class="v">30&#160;</span>Then the princes of the Philistines went out; and as often as they went out, David behaved himself more wisely than all the servants of Saul, so that his name was highly esteemed. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Saul spoke to Jonathan his son and to all his servants, that they should kill David. But Jonathan, Saul’s son, greatly delighted in David. 
-<span class="v">2&#160;</span>Jonathan told David, saying, “Saul my father seeks to kill you. Now therefore, please take care of yourself in the morning, live in a secret place, and hide yourself. 
-<span class="v">3&#160;</span>I will go out and stand beside my father in the field where you are, and I will talk with my father about you; and if I see anything, I will tell you.” 
-</p><p>
-<span class="v">4&#160;</span>Jonathan spoke good of David to Saul his father, and said to him, “Don’t let the king sin against his servant, against David; because he has not sinned against you, and because his works have been very good toward you; 
-<span class="v">5&#160;</span>for he put his life in his hand and struck the Philistine, and Yahweh worked a great victory for all Israel. You saw it and rejoiced. Why then will you sin against innocent blood, to kill David without a cause?” 
-</p><p>
-<span class="v">6&#160;</span>Saul listened to the voice of Jonathan; and Saul swore, “As Yahweh lives, he shall not be put to death.” 
-</p><p>
-<span class="v">7&#160;</span>Jonathan called David, and Jonathan showed him all those things. Then Jonathan brought David to Saul, and he was in his presence as before. 
-</p><p>
-<span class="v">8&#160;</span>There was war again. David went out and fought with the Philistines, and killed them with a great slaughter; and they fled before him. 
-</p><p>
-<span class="v">9&#160;</span>An evil spirit from Yahweh was on Saul as he sat in his house with his spear in his hand; and David was playing music with his hand. 
-<span class="v">10&#160;</span>Saul sought to pin David to the wall with the spear, but he slipped away out of Saul’s presence; and he stuck the spear into the wall. David fled and escaped that night. 
-<span class="v">11&#160;</span>Saul sent messengers to David’s house to watch him and to kill him in the morning. Michal, David’s woman, told him, saying, “If you don’t save your life tonight, tomorrow you will be killed.” 
-<span class="v">12&#160;</span>So Michal let David down through the window. He went away, fled, and escaped. 
-<span class="v">13&#160;</span>Michal took the teraphim<span class="f">+ \fr 19:13 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> and laid it in the bed, and put a pillow of goats’ hair at its head and covered it with clothes. 
-<span class="v">14&#160;</span>When Saul sent messengers to take David, she said, “He is sick.” 
-</p><p>
-<span class="v">15&#160;</span>Saul sent the messengers to see David, saying, “Bring him up to me in the bed, that I may kill him.” 
-<span class="v">16&#160;</span>When the messengers came in, behold, the teraphim was in the bed, with the pillow of goats’ hair at its head. 
-</p><p>
-<span class="v">17&#160;</span>Saul said to Michal, “Why have you deceived me like this and let my enemy go, so that he has escaped?” 
-</p><p>Michal answered Saul, “He said to me, ‘Let me go! Why should I kill you?’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Now David fled and escaped, and came to Samuel at Ramah, and told him all that Saul had done to him. He and Samuel went and lived in Naioth. 
-<span class="v">19&#160;</span>Saul was told, saying, “Behold, David is at Naioth in Ramah.” 
-</p><p>
-<span class="v">20&#160;</span>Saul sent messengers to seize David; and when they saw the company of the prophets prophesying, and Samuel standing as head over them, Elohim’s Spirit came on Saul’s messengers, and they also prophesied. 
-<span class="v">21&#160;</span>When Saul was told, he sent other messengers, and they also prophesied. Saul sent messengers again the third time, and they also prophesied. 
-<span class="v">22&#160;</span>Then he also went to Ramah, and came to the great well that is in Secu: and he asked, “Where are Samuel and David?” 
-</p><p>One said, “Behold, they are at Naioth in Ramah.” 
-</p><p>
-<span class="v">23&#160;</span>He went there to Naioth in Ramah. Then Elohim’s Spirit came on him also, and he went on, and prophesied, until he came to Naioth in Ramah. 
-<span class="v">24&#160;</span>He also stripped off his clothes. He also prophesied before Samuel and lay down naked all that day and all that night. Therefore they say, “Is Saul also among the prophets?” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>David fled from Naioth in Ramah, and came and said to Jonathan, “What have I done? What is my iniquity? What is my sin before your father, that he seeks my life?” 
-</p><p>
-<span class="v">2&#160;</span>He said to him, “Far from it; you will not die. Behold, my father does nothing either great or small, but that he discloses it to me. Why would my father hide this thing from me? It is not so.” 
-</p><p>
-<span class="v">3&#160;</span>David swore moreover, and said, “Your father knows well that I have found favor in your eyes; and he says, ‘Don’t let Jonathan know this, lest he be grieved;’ but truly as Yahweh lives, and as your soul lives, there is but a step between me and death.” 
-</p><p>
-<span class="v">4&#160;</span>Then Jonathan said to David, “Whatever your soul desires, I will even do it for you.” 
-</p><p>
-<span class="v">5&#160;</span>David said to Jonathan, “Behold, tomorrow is the new moon, and I should not fail to dine with the king; but let me go, that I may hide myself in the field to the third day at evening. 
-<span class="v">6&#160;</span>If your father misses me at all, then say, ‘David earnestly asked leave of me that he might run to Bethlehem, his city; for it is the yearly sacrifice there for all the family.’ 
-<span class="v">7&#160;</span>If he says, ‘It is well,’ your servant shall have peace; but if he is angry, then know that evil is determined by him. 
-<span class="v">8&#160;</span>Therefore deal kindly with your servant, for you have brought your servant into a covenant of Yahweh with you; but if there is iniquity in me, kill me yourself, for why should you bring me to your father?” 
-</p><p>
-<span class="v">9&#160;</span>Jonathan said, “Far be it from you; for if I should at all know that evil were determined by my father to come on you, then wouldn’t I tell you that?” 
-</p><p>
-<span class="v">10&#160;</span>Then David said to Jonathan, “Who will tell me if your father answers you roughly?” 
-</p><p>
-<span class="v">11&#160;</span>Jonathan said to David, “Come! Let’s go out into the field.” They both went out into the field. 
-<span class="v">12&#160;</span>Jonathan said to David, “By Yahweh, the Elohim of Israel, when I have sounded out my father about this time tomorrow, or the third day, behold, if there is good toward David, won’t I then send to you and disclose it to you? 
-<span class="v">13&#160;</span>Yahweh do so to Jonathan and more also, should it please my father to do you evil, if I don’t disclose it to you and send you away, that you may go in peace. May Yahweh be with you as he has been with my father. 
-<span class="v">14&#160;</span>You shall not only show me the loving kindness of Yahweh while I still live, that I not die; 
-<span class="v">15&#160;</span>but you shall also not cut off your kindness from my house forever, no, not when Yahweh has cut off every one of the enemies of David from the surface of the earth.” 
-<span class="v">16&#160;</span>So Jonathan made a covenant with David’s house, saying, “Yahweh will require it at the hand of David’s enemies.” 
-</p><p>
-<span class="v">17&#160;</span>Jonathan caused David to swear again, for the love that he had to him; for he loved him as he loved his own soul. 
-<span class="v">18&#160;</span>Then Jonathan said to him, “Tomorrow is the new moon, and you will be missed, because your seat will be empty. 
-<span class="v">19&#160;</span>When you have stayed three days, go down quickly and come to the place where you hid yourself when this started, and remain by the stone Ezel. 
-<span class="v">20&#160;</span>I will shoot three arrows on its side, as though I shot at a mark. 
-<span class="v">21&#160;</span>Behold, I will send the boy, saying, ‘Go, find the arrows!’ If I tell the boy, ‘Behold, the arrows are on this side of you. Take them;’ then come, for there is peace to you and no danger, as Yahweh lives. 
-<span class="v">22&#160;</span>But if I say this to the boy, ‘Behold, the arrows are beyond you,’ then go your way, for Yahweh has sent you away. 
-<span class="v">23&#160;</span>Concerning the matter which you and I have spoken of, behold, Yahweh is between you and me forever.” 
-</p><p>
-<span class="v">24&#160;</span>So David hid himself in the field. When the new moon had come, the king sat himself down to eat food. 
-<span class="v">25&#160;</span>The king sat on his seat, as at other times, even on the seat by the wall; and Jonathan stood up, and Abner sat by Saul’s side, but David’s place was empty. 
-<span class="v">26&#160;</span>Nevertheless Saul didn’t say anything that day, for he thought, “Something has happened to him. He is not clean. Surely he is not clean.” 
-</p><p>
-<span class="v">27&#160;</span>On the next day after the new moon, the second day, David’s place was empty. Saul said to Jonathan his son, “Why didn’t the son of Jesse come to eat, either yesterday, or today?” 
-</p><p>
-<span class="v">28&#160;</span>Jonathan answered Saul, “David earnestly asked permission of me to go to Bethlehem. 
-<span class="v">29&#160;</span>He said, ‘Please let me go, for our family has a sacrifice in the city. My brother has commanded me to be there. Now, if I have found favor in your eyes, please let me go away and see my brothers.’ Therefore he has not come to the king’s table.” 
-</p><p>
-<span class="v">30&#160;</span>Then Saul’s anger burned against Jonathan, and he said to him, “You son of a perverse rebellious woman, don’t I know that you have chosen the son of Jesse to your own shame, and to the shame of your mother’s nakedness? 
-<span class="v">31&#160;</span>For as long as the son of Jesse lives on the earth, you will not be established, nor will your kingdom. Therefore now send and bring him to me, for he shall surely die!” 
-</p><p>
-<span class="v">32&#160;</span>Jonathan answered Saul his father, and said to him, “Why should he be put to death? What has he done?” 
-</p><p>
-<span class="v">33&#160;</span>Saul cast his spear at him to strike him. By this Jonathan knew that his father was determined to put David to death. 
-<span class="v">34&#160;</span>So Jonathan arose from the table in fierce anger, and ate no food the second day of the month; for he was grieved for David, because his father had treated him shamefully. 
-</p><p>
-<span class="v">35&#160;</span>In the morning, Jonathan went out into the field at the time appointed with David, and a little boy with him. 
-<span class="v">36&#160;</span>He said to his boy, “Run, find now the arrows which I shoot.” As the boy ran, he shot an arrow beyond him. 
-<span class="v">37&#160;</span>When the boy had come to the place of the arrow which Jonathan had shot, Jonathan cried after the boy, and said, “Isn’t the arrow beyond you?” 
-<span class="v">38&#160;</span>Jonathan cried after the boy, “Go fast! Hurry! Don’t delay!” Jonathan’s boy gathered up the arrows, and came to his master. 
-<span class="v">39&#160;</span>But the boy didn’t know anything. Only Jonathan and David knew the matter. 
-<span class="v">40&#160;</span>Jonathan gave his weapons to his boy, and said to him, “Go, carry them to the city.” 
-</p><p>
-<span class="v">41&#160;</span>As soon as the boy was gone, David arose out of the south, and fell on his face to the ground, and bowed himself three times. They kissed one another and wept with one another, and David wept the most. 
-<span class="v">42&#160;</span>Jonathan said to David, “Go in peace, because we have both sworn in Yahweh’s name, saying, ‘Yahweh is between me and you, and between my offspring and your offspring, forever.’&#160;” He arose and departed; and Jonathan went into the city. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Then David came to Nob to Ahimelech the priest. Ahimelech came to meet David trembling, and said to him, “Why are you alone, and no man with you?” 
-<span class="v">2&#160;</span>David said to Ahimelech the priest, “The king has commanded me to do something, and has said to me, ‘Let no one know anything about the business about which I send you, and what I have commanded you. I have sent the young men to a certain place.’ 
-<span class="v">3&#160;</span>Now therefore what is under your hand? Please give me five loaves of bread in my hand, or whatever is available.” 
-</p><p>
-<span class="v">4&#160;</span>The priest answered David, and said, “I have no common bread, but there is set-apart bread; if only the young men have kept themselves from women.” 
-</p><p>
-<span class="v">5&#160;</span>David answered the priest, and said to him, “Truly, women have been kept from us as usual these three days. When I came out, the vessels of the young men were set-apart, though it was only a common journey. How much more then today shall their vessels be set-apart?” 
-<span class="v">6&#160;</span>So the priest gave him set-apart bread; for there was no bread there but the show bread that was taken from before Yahweh, to be replaced with hot bread in the day when it was taken away. 
-</p><p>
-<span class="v">7&#160;</span>Now a certain man of the servants of Saul was there that day, detained before Yahweh; and his name was Doeg the Edomite, the best of the herdsmen who belonged to Saul. 
-</p><p>
-<span class="v">8&#160;</span>David said to Ahimelech, “Isn’t there here under your hand spear or sword? For I haven’t brought my sword or my weapons with me, because the king’s business required haste.” 
-</p><p>
-<span class="v">9&#160;</span>The priest said, “Behold, the sword of Goliath the Philistine, whom you killed in the valley of Elah, is here wrapped in a cloth behind the ephod. If you would like to take that, take it, for there is no other except that here.” 
-</p><p>David said, “There is none like that. Give it to me.” 
-</p><p>
-<span class="v">10&#160;</span>David arose and fled that day for fear of Saul, and went to Achish the king of Gath. 
-<span class="v">11&#160;</span>The servants of Achish said to him, “Isn’t this David the king of the land? Didn’t they sing to one another about him in dances, saying, 
-</p><p class="q1">‘Saul has slain his thousands, 
-</p><p class="q2">and David his ten thousands’?” 
-</p><p>
-<span class="v">12&#160;</span>David laid up these words in his heart, and was very afraid of Achish the king of Gath. 
-<span class="v">13&#160;</span>He changed his behavior before them and pretended to be insane in their hands, and scribbled on the doors of the gate, and let his spittle fall down on his beard. 
-<span class="v">14&#160;</span>Then Achish said to his servants, “Look, you see the man is insane. Why then have you brought him to me? 
-<span class="v">15&#160;</span>Do I lack madmen, that you have brought this fellow to play the madman in my presence? Should this fellow come into my house?” 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>David therefore departed from there and escaped to Adullam’s cave. When his brothers and all his father’s house heard it, they went down there to him. 
-<span class="v">2&#160;</span>Everyone who was in distress, everyone who was in debt, and everyone who was discontented gathered themselves to him; and he became captain over them. There were with him about four hundred men. 
-<span class="v">3&#160;</span>David went from there to Mizpeh of Moab; and he said to the king of Moab, “Please let my father and my mother come out to you, until I know what Elohim will do for me.” 
-<span class="v">4&#160;</span>He brought them before the king of Moab; and they lived with him all the time that David was in the stronghold. 
-<span class="v">5&#160;</span>The prophet Gad said to David, “Don’t stay in the stronghold. Depart, and go into the land of Judah.” 
-</p><p>Then David departed, and came into the forest of Hereth. 
-</p><p>
-<span class="v">6&#160;</span>Saul heard that David was discovered, with the men who were with him. Now Saul was sitting in Gibeah, under the tamarisk tree in Ramah, with his spear in his hand, and all his servants were standing around him. 
-<span class="v">7&#160;</span>Saul said to his servants who stood around him, “Hear now, you Benjamites! Will the son of Jesse give everyone of you fields and vineyards? Will he make you all captains of thousands and captains of hundreds? 
-<span class="v">8&#160;</span>Is that why all of you have conspired against me, and there is no one who discloses to me when my son makes a treaty with the son of Jesse, and there is none of you who is sorry for me, or discloses to me that my son has stirred up my servant against me, to lie in wait, as it is today?” 
-</p><p>
-<span class="v">9&#160;</span>Then Doeg the Edomite, who stood by the servants of Saul, answered and said, “I saw the son of Jesse coming to Nob, to Ahimelech the son of Ahitub. 
-<span class="v">10&#160;</span>He inquired of Yahweh for him, gave him food, and gave him the sword of Goliath the Philistine.” 
-</p><p>
-<span class="v">11&#160;</span>Then the king sent to call Ahimelech the priest, the son of Ahitub, and all his father’s house, the priests who were in Nob; and they all came to the king. 
-<span class="v">12&#160;</span>Saul said, “Hear now, you son of Ahitub.” 
-</p><p>He answered, “Here I am, my lord.” 
-</p><p>
-<span class="v">13&#160;</span>Saul said to him, “Why have you conspired against me, you and the son of Jesse, in that you have given him bread, and a sword, and have inquired of Elohim for him, that he should rise against me, to lie in wait, as it is today?” 
-</p><p>
-<span class="v">14&#160;</span>Then Ahimelech answered the king, and said, “Who among all your servants is so faithful as David, who is the king’s son-in-law, captain of your body guard, and honored in your house? 
-<span class="v">15&#160;</span>Have I today begun to inquire of Elohim for him? Be it far from me! Don’t let the king impute anything to his servant, nor to all the house of my father; for your servant knew nothing of all this, less or more.” 
-</p><p>
-<span class="v">16&#160;</span>The king said, “You shall surely die, Ahimelech, you and all your father’s house.” 
-<span class="v">17&#160;</span>The king said to the guard who stood about him, “Turn and kill the priests of Yahweh, because their hand also is with David, and because they knew that he fled and didn’t disclose it to me.” But the servants of the king wouldn’t put out their hand to fall on the priests of Yahweh. 
-</p><p>
-<span class="v">18&#160;</span>The king said to Doeg, “Turn and attack the priests!” 
-</p><p>Doeg the Edomite turned, and he attacked the priests, and he killed on that day eighty-five people who wore a linen ephod. 
-<span class="v">19&#160;</span>He struck Nob, the city of the priests, with the edge of the sword—both men and women, children and nursing babies, and cattle, donkeys, and sheep, with the edge of the sword. 
-<span class="v">20&#160;</span>One of the sons of Ahimelech the son of Ahitub, named Abiathar, escaped and fled after David. 
-<span class="v">21&#160;</span>Abiathar told David that Saul had slain Yahweh’s priests. 
-</p><p>
-<span class="v">22&#160;</span>David said to Abiathar, “I knew on that day, when Doeg the Edomite was there, that he would surely tell Saul. I am responsible for the death of all the persons of your father’s house. 
-<span class="v">23&#160;</span>Stay with me. Don’t be afraid, for he who seeks my life seeks your life. You will be safe with me.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>David was told, “Behold, the Philistines are fighting against Keilah, and are robbing the threshing floors.” 
-</p><p>
-<span class="v">2&#160;</span>Therefore David inquired of Yahweh, saying, “Shall I go and strike these Philistines?” 
-</p><p>Yahweh said to David, “Go strike the Philistines, and save Keilah.” 
-</p><p>
-<span class="v">3&#160;</span>David’s men said to him, “Behold, we are afraid here in Judah. How much more then if we go to Keilah against the armies of the Philistines?” 
-</p><p>
-<span class="v">4&#160;</span>Then David inquired of Yahweh yet again. Yahweh answered him, and said, “Arise, go down to Keilah; for I will deliver the Philistines into your hand.” 
-</p><p>
-<span class="v">5&#160;</span>David and his men went to Keilah and fought with the Philistines, and brought away their livestock, and killed them with a great slaughter. So David saved the inhabitants of Keilah. 
-</p><p>
-<span class="v">6&#160;</span>When Abiathar the son of Ahimelech fled to David to Keilah, he came down with an ephod in his hand. 
-</p><p>
-<span class="v">7&#160;</span>Saul was told that David had come to Keilah. Saul said, “Elohim has delivered him into my hand, for he is shut in by entering into a town that has gates and bars.” 
-<span class="v">8&#160;</span>Saul summoned all the people to war, to go down to Keilah to besiege David and his men. 
-<span class="v">9&#160;</span>David knew that Saul was devising mischief against him. He said to Abiathar the priest, “Bring the ephod here.” 
-<span class="v">10&#160;</span>Then David said, “O Yahweh, the Elohim of Israel, your servant has surely heard that Saul seeks to come to Keilah to destroy the city for my sake. 
-<span class="v">11&#160;</span>Will the owners of Keilah deliver me up into his hand? Will Saul come down, as your servant has heard? Yahweh, the Elohim of Israel, I beg you, tell your servant.” 
-</p><p>Yahweh said, “He will come down.” 
-</p><p>
-<span class="v">12&#160;</span>Then David said, “Will the owners of Keilah deliver me and my men into the hand of Saul?” 
-</p><p>Yahweh said, “They will deliver you up.” 
-</p><p>
-<span class="v">13&#160;</span>Then David and his men, who were about six hundred, arose and departed out of Keilah and went wherever they could go. Saul was told that David had escaped from Keilah; and he gave up going there. 
-<span class="v">14&#160;</span>David stayed in the wilderness in the strongholds, and remained in the hill country in the wilderness of Ziph. Saul sought him every day, but Elohim didn’t deliver him into his hand. 
-<span class="v">15&#160;</span>David saw that Saul had come out to seek his life. David was in the wilderness of Ziph in the woods. 
-</p><p>
-<span class="v">16&#160;</span>Jonathan, Saul’s son, arose and went to David into the woods, and strengthened his hand in Elohim. 
-<span class="v">17&#160;</span>He said to him, “Don’t be afraid, for the hand of Saul my father won’t find you; and you will be king over Israel, and I will be next to you; and Saul my father knows that also.” 
-<span class="v">18&#160;</span>They both made a covenant before Yahweh. Then David stayed in the woods and Jonathan went to his house. 
-</p><p>
-<span class="v">19&#160;</span>Then the Ziphites came up to Saul to Gibeah, saying, “Doesn’t David hide himself with us in the strongholds in the woods, in the hill of Hachilah, which is on the south of the desert? 
-<span class="v">20&#160;</span>Now therefore, O king, come down. According to all the desire of your soul to come down; and our part will be to deliver him up into the king’s hand.” 
-</p><p>
-<span class="v">21&#160;</span>Saul said, “You are blessed by Yahweh, for you have had compassion on me. 
-<span class="v">22&#160;</span>Please go make yet more sure, and know and see his place where his haunt is, and who has seen him there; for I have been told that he is very cunning. 
-<span class="v">23&#160;</span>See therefore, and take knowledge of all the lurking places where he hides himself; and come again to me with certainty, and I will go with you. It shall happen, if he is in the land, that I will search him out among all the thousands of Judah.” 
-</p><p>
-<span class="v">24&#160;</span>They arose, and went to Ziph before Saul; but David and his men were in the wilderness of Maon, in the Arabah on the south of the desert. 
-<span class="v">25&#160;</span>Saul and his men went to seek him. When David was told, he went down to the rock, and stayed in the wilderness of Maon. When Saul heard that, he pursued David in the wilderness of Maon. 
-<span class="v">26&#160;</span>Saul went on this side of the mountain, and David and his men on that side of the mountain; and David hurried to get away for fear of Saul, for Saul and his men surrounded David and his men to take them. 
-<span class="v">27&#160;</span>But a messenger came to Saul, saying, “Hurry and come, for the Philistines have made a raid on the land!” 
-<span class="v">28&#160;</span>So Saul returned from pursuing David, and went against the Philistines. Therefore they called that place Sela Hammahlekoth.<span class="f">+ \fr 23:28 \ft “Sela Hammahlekoth” means “rock of parting”.</span> 
-</p><p>
-<span class="v">29&#160;</span>David went up from there and lived in the strongholds of En Gedi. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>When Saul had returned from following the Philistines, he was told, “Behold, David is in the wilderness of En Gedi.” 
-<span class="v">2&#160;</span>Then Saul took three thousand chosen men out of all Israel, and went to seek David and his men on the rocks of the wild goats. 
-<span class="v">3&#160;</span>He came to the sheep pens by the way, where there was a cave; and Saul went in to relieve himself. Now David and his men were staying in the innermost parts of the cave. 
-<span class="v">4&#160;</span>David’s men said to him, “Behold, the day of which Yahweh said to you, ‘Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.’&#160;” Then David arose and cut off the skirt of Saul’s robe secretly. 
-<span class="v">5&#160;</span>Afterward, David’s heart struck him because he had cut off Saul’s skirt. 
-<span class="v">6&#160;</span>He said to his men, “Yahweh forbid that I should do this thing to my lord, Yahweh’s anointed, to stretch out my hand against him, since he is Yahweh’s anointed.” 
-<span class="v">7&#160;</span>So David checked his men with these words, and didn’t allow them to rise against Saul. Saul rose up out of the cave, and went on his way. 
-<span class="v">8&#160;</span>David also arose afterward, and went out of the cave and cried after Saul, saying, “My lord the king!” 
-</p><p>When Saul looked behind him, David bowed with his face to the earth, and showed respect. 
-<span class="v">9&#160;</span>David said to Saul, “Why do you listen to men’s words, saying, ‘Behold, David seeks to harm you’? 
-<span class="v">10&#160;</span>Behold, today your eyes have seen how Yahweh had delivered you today into my hand in the cave. Some urged me to kill you, but I spared you. I said, ‘I will not stretch out my hand against my lord, for he is Yahweh’s anointed.’ 
-<span class="v">11&#160;</span>Moreover, my father, behold, yes, see the skirt of your robe in my hand; for in that I cut off the skirt of your robe and didn’t kill you, know and see that there is neither evil nor disobedience in my hand. I have not sinned against you, though you hunt for my life to take it. 
-<span class="v">12&#160;</span>May Yahweh judge between me and you, and may Yahweh avenge me of you; but my hand will not be on you. 
-<span class="v">13&#160;</span>As the proverb of the ancients says, ‘Out of the wicked comes wickedness;’ but my hand will not be on you. 
-<span class="v">14&#160;</span>Against whom has the king of Israel come out? Whom do you pursue? A dead dog? A flea? 
-<span class="v">15&#160;</span>May Yahweh therefore be judge, and give sentence between me and you, and see, and plead my cause, and deliver me out of your hand.” 
-</p><p>
-<span class="v">16&#160;</span>It came to pass, when David had finished speaking these words to Saul, that Saul said, “Is that your voice, my son David?” Saul lifted up his voice and wept. 
-<span class="v">17&#160;</span>He said to David, “You are more righteous than I; for you have done good to me, whereas I have done evil to you. 
-<span class="v">18&#160;</span>You have declared today how you have dealt well with me, because when Yahweh had delivered me up into your hand, you didn’t kill me. 
-<span class="v">19&#160;</span>For if a man finds his enemy, will he let him go away unharmed? Therefore may Yahweh reward you good for that which you have done to me today. 
-<span class="v">20&#160;</span>Now, behold, I know that you will surely be king, and that the kingdom of Israel will be established in your hand. 
-<span class="v">21&#160;</span>Swear now therefore to me by Yahweh that you will not cut off my offspring after me, and that you will not destroy my name out of my father’s house.” 
-</p><p>
-<span class="v">22&#160;</span>David swore to Saul. Saul went home, but David and his men went up to the stronghold. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Samuel died; and all Israel gathered themselves together and mourned for him, and buried him at his house at Ramah. 
-</p><p>Then David arose and went down to the wilderness of Paran. 
-<span class="v">2&#160;</span>There was a man in Maon whose possessions were in Carmel; and the man was very great. He had three thousand sheep and a thousand goats; and he was shearing his sheep in Carmel. 
-<span class="v">3&#160;</span>Now the name of the man was Nabal; and the name of his woman Abigail. This woman was intelligent and had a beautiful face; but the man was surly and evil in his doings. He was of the house of Caleb. 
-<span class="v">4&#160;</span>David heard in the wilderness that Nabal was shearing his sheep. 
-<span class="v">5&#160;</span>David sent ten young men; and David said to the young men, “Go up to Carmel, and go to Nabal, and greet him in my name. 
-<span class="v">6&#160;</span>Tell him, ‘Long life to you! Peace be to you! Peace be to your house! Peace be to all that you have! 
-<span class="v">7&#160;</span>Now I have heard that you have shearers. Your shepherds have now been with us, and we didn’t harm them. Nothing was missing from them all the time they were in Carmel. 
-<span class="v">8&#160;</span>Ask your young men, and they will tell you. Therefore let the young men find favor in your eyes, for we come on a good day. Please give whatever comes to your hand to your servants and to your son David.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>When David’s young men came, they spoke to Nabal all those words in the name of David, and waited. 
-</p><p>
-<span class="v">10&#160;</span>Nabal answered David’s servants and said, “Who is David? Who is the son of Jesse? There are many servants who break away from their masters these days. 
-<span class="v">11&#160;</span>Shall I then take my bread, my water, and my meat that I have killed for my shearers, and give it to men who I don’t know where they come from?” 
-</p><p>
-<span class="v">12&#160;</span>So David’s young men turned on their way and went back, and came and told him all these words. 
-</p><p>
-<span class="v">13&#160;</span>David said to his men, “Every man put on his sword!” 
-</p><p>Every man put on his sword. David also put on his sword. About four hundred men followed David, and two hundred stayed by the baggage. 
-</p><p>
-<span class="v">14&#160;</span>But one of the young men told Abigail, Nabal’s woman, saying, “Behold, David sent messengers out of the wilderness to greet our master; and he insulted them. 
-<span class="v">15&#160;</span>But the men were very good to us, and we were not harmed, and we didn’t miss anything as long as we went with them, when we were in the fields. 
-<span class="v">16&#160;</span>They were a wall to us both by night and by day, all the while we were with them keeping the sheep. 
-<span class="v">17&#160;</span>Now therefore know and consider what you will do; for evil is determined against our master and against all his house, for he is such a worthless fellow that one can’t speak to him.” 
-</p><p>
-<span class="v">18&#160;</span>Then Abigail hurried and took two hundred loaves of bread, two containers of wine, five sheep ready dressed, five seahs<span class="f">+ \fr 25:18 \ft 1 seah is about 7 liters or 1.9 gallons or 0.8 pecks</span> of parched grain, one hundred clusters of raisins, and two hundred cakes of figs, and laid them on donkeys. 
-<span class="v">19&#160;</span>She said to her young men, “Go on before me. Behold, I am coming after you.” But she didn’t tell her man, Nabal. 
-<span class="v">20&#160;</span>As she rode on her donkey, and came down hidden by the mountain, behold, David and his men came down toward her, and she met them. 
-</p><p>
-<span class="v">21&#160;</span>Now David had said, “Surely in vain I have kept all that this fellow has in the wilderness, so that nothing was missed of all that pertained to him. He has returned me evil for good. 
-<span class="v">22&#160;</span>Elohim do so to the enemies of David, and more also, if I leave of all that belongs to him by the morning light so much as one who urinates on a wall.”<span class="f">+ \fr 25:22 \ft or, male.</span> 
-</p><p>
-<span class="v">23&#160;</span>When Abigail saw David, she hurried and got off her donkey, and fell before David on her face and bowed herself to the ground. 
-<span class="v">24&#160;</span>She fell at his feet and said, “On me, my lord, on me be the blame! Please let your servant speak in your ears. Hear the words of your servant. 
-<span class="v">25&#160;</span>Please don’t let my lord pay attention to this worthless fellow, Nabal, for as his name is, so is he. Nabal<span class="f">+ \fr 25:25 \ft “Nabal” means “foolish”.</span> is his name, and folly is with him; but I, your servant, didn’t see my lord’s young men whom you sent. 
-<span class="v">26&#160;</span>Now therefore, my lord, as Yahweh lives and as your soul lives, since Yahweh has withheld you from blood guiltiness and from avenging yourself with your own hand, now therefore let your enemies and those who seek evil to my lord be as Nabal. 
-<span class="v">27&#160;</span>Now this present which your servant has brought to my lord, let it be given to the young men who follow my lord. 
-<span class="v">28&#160;</span>Please forgive the trespass of your servant. For Yahweh will certainly make my lord a sure house, because my lord fights Yahweh’s battles. Evil will not be found in you all your days. 
-<span class="v">29&#160;</span>Though men may rise up to pursue you and to seek your soul, yet the soul of my lord will be bound in the bundle of life with Yahweh your Elohim. He will sling out the souls of your enemies as from a sling’s pocket. 
-<span class="v">30&#160;</span>It will come to pass, when Yahweh has done to my lord according to all the good that he has spoken concerning you, and has appointed you prince over Israel, 
-<span class="v">31&#160;</span>that this shall be no grief to you, nor offense of heart to my lord, either that you have shed blood without cause, or that my lord has avenged himself. When Yahweh has dealt well with my lord, then remember your servant.” 
-</p><p>
-<span class="v">32&#160;</span>David said to Abigail, “Blessed is Yahweh, the Elohim of Israel, who sent you today to meet me! 
-<span class="v">33&#160;</span>Blessed is your discretion, and blessed are you, who have kept me today from blood guiltiness, and from avenging myself with my own hand. 
-<span class="v">34&#160;</span>For indeed, as Yahweh the Elohim of Israel lives, who has withheld me from harming you, unless you had hurried and come to meet me, surely there wouldn’t have been left to Nabal by the morning light so much as one who urinates on a wall.”<span class="f">+ \fr 25:34 \ft or, one male.</span> 
-</p><p>
-<span class="v">35&#160;</span>So David received from her hand that which she had brought him. Then he said to her, “Go up in peace to your house. Behold, I have listened to your voice and have granted your request.” 
-</p><p>
-<span class="v">36&#160;</span>Abigail came to Nabal; and behold, he held a feast in his house like the feast of a king. Nabal’s heart was merry within him, for he was very drunk. Therefore she told him nothing until the morning light. 
-<span class="v">37&#160;</span>In the morning, when the wine had gone out of Nabal, his woman told him these things; and his heart died within him, and he became as a stone. 
-<span class="v">38&#160;</span>About ten days later, Yahweh struck Nabal, so that he died. 
-<span class="v">39&#160;</span>When David heard that Nabal was dead, he said, “Blessed is Yahweh, who has pleaded the cause of my reproach from the hand of Nabal, and has kept back his servant from evil. Yahweh has returned the evildoing of Nabal on his own head.” 
-</p><p>David sent and spoke concerning Abigail, to take her to himself as woman. 
-<span class="v">40&#160;</span>When David’s servants had come to Abigail to Carmel, they spoke to her, saying, “David has sent us to you, to take you to him as woman.” 
-</p><p>
-<span class="v">41&#160;</span>She arose and bowed herself with her face to the earth, and said, “Behold, your servant is a servant to wash the feet of the servants of my lord.” 
-<span class="v">42&#160;</span>Abigail hurriedly arose and rode on a donkey with her five maids who followed her; and she went after the messengers of David, and became his woman. 
-<span class="v">43&#160;</span>David also took Ahinoam of Jezreel; and they both became his women. 
-</p><p>
-<span class="v">44&#160;</span>Now Saul had given Michal his daughter, David’s woman, to Palti the son of Laish, who was of Gallim. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>The Ziphites came to Saul to Gibeah, saying, “Doesn’t David hide himself in the hill of Hachilah, which is before the desert?” 
-<span class="v">2&#160;</span>Then Saul arose and went down to the wilderness of Ziph, having three thousand chosen men of Israel with him, to seek David in the wilderness of Ziph. 
-<span class="v">3&#160;</span>Saul encamped in the hill of Hachilah, which is before the desert, by the way. But David stayed in the wilderness, and he saw that Saul came after him into the wilderness. 
-<span class="v">4&#160;</span>David therefore sent out spies, and understood that Saul had certainly come. 
-<span class="v">5&#160;</span>Then David arose and came to the place where Saul had encamped; and David saw the place where Saul lay, with Abner the son of Ner, the captain of his army. Saul lay within the place of the wagons, and the people were encamped around him. 
-</p><p>
-<span class="v">6&#160;</span>Then David answered and said to Ahimelech the Hittite, and to Abishai the son of Zeruiah, brother of Joab, saying, “Who will go down with me to Saul to the camp?” 
-</p><p>Abishai said, “I will go down with you.” 
-<span class="v">7&#160;</span>So David and Abishai came to the people by night; and, behold, Saul lay sleeping within the place of the wagons, with his spear stuck in the ground at his head; and Abner and the people lay around him. 
-<span class="v">8&#160;</span>Then Abishai said to David, “Elohim has delivered up your enemy into your hand today. Now therefore please let me strike him with the spear to the earth at one stroke, and I will not strike him the second time.” 
-</p><p>
-<span class="v">9&#160;</span>David said to Abishai, “Don’t destroy him, for who can stretch out his hand against Yahweh’s anointed, and be guiltless?” 
-<span class="v">10&#160;</span>David said, “As Yahweh lives, Yahweh will strike him; or his day shall come to die, or he shall go down into battle and perish. 
-<span class="v">11&#160;</span>Yahweh forbid that I should stretch out my hand against Yahweh’s anointed; but now please take the spear that is at his head and the jar of water, and let’s go.” 
-</p><p>
-<span class="v">12&#160;</span>So David took the spear and the jar of water from Saul’s head, and they went away. No man saw it, or knew it, nor did any awake; for they were all asleep, because a deep sleep from Yahweh had fallen on them. 
-<span class="v">13&#160;</span>Then David went over to the other side, and stood on the top of the mountain far away, a great space being between them; 
-<span class="v">14&#160;</span>and David cried to the people, and to Abner the son of Ner, saying, “Don’t you answer, Abner?” 
-</p><p>Then Abner answered, “Who are you who calls to the king?” 
-</p><p>
-<span class="v">15&#160;</span>David said to Abner, “Aren’t you a man? Who is like you in Israel? Why then have you not kept watch over your lord the king? For one of the people came in to destroy your lord the king. 
-<span class="v">16&#160;</span>This thing isn’t good that you have done. As Yahweh lives, you are worthy to die, because you have not kept watch over your lord, Yahweh’s anointed. Now see where the king’s spear is, and the jar of water that was at his head.” 
-</p><p>
-<span class="v">17&#160;</span>Saul recognized David’s voice, and said, “Is this your voice, my son David?” 
-</p><p>David said, “It is my voice, my lord, O king.” 
-<span class="v">18&#160;</span>He said, “Why does my lord pursue his servant? For what have I done? What evil is in my hand? 
-<span class="v">19&#160;</span>Now therefore, please let my lord the king hear the words of his servant. If it is so that Yahweh has stirred you up against me, let him accept an offering. But if it is the children of men, they are cursed before Yahweh; for they have driven me out today that I shouldn’t cling to Yahweh’s inheritance, saying, ‘Go, serve other elohims!’ 
-<span class="v">20&#160;</span>Now therefore, don’t let my blood fall to the earth away from the presence of Yahweh; for the king of Israel has come out to seek a flea, as when one hunts a partridge in the mountains.” 
-</p><p>
-<span class="v">21&#160;</span>Then Saul said, “I have sinned. Return, my son David; for I will no more do you harm, because my life was precious in your eyes today. Behold, I have played the fool, and have erred exceedingly.” 
-</p><p>
-<span class="v">22&#160;</span>David answered, “Behold the spear, O king! Let one of the young men come over and get it. 
-<span class="v">23&#160;</span>Yahweh will render to every man his righteousness and his faithfulness; because Yahweh delivered you into my hand today, and I wouldn’t stretch out my hand against Yahweh’s anointed. 
-<span class="v">24&#160;</span>Behold, as your life was respected today in my eyes, so let my life be respected in Yahweh’s eyes, and let him deliver me out of all oppression.” 
-</p><p>
-<span class="v">25&#160;</span>Then Saul said to David, “You are blessed, my son David. You will both do mightily, and will surely prevail.” 
-</p><p>So David went his way, and Saul returned to his place. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>David said in his heart, “I will now perish one day by the hand of Saul. There is nothing better for me than that I should escape into the land of the Philistines; and Saul will despair of me, to seek me any more in all the borders of Israel. So I will escape out of his hand.” 
-<span class="v">2&#160;</span>David arose and passed over, he and the six hundred men who were with him, to Achish the son of Maoch, king of Gath. 
-<span class="v">3&#160;</span>David lived with Achish at Gath, he and his men, every man with his household, even David with his two women, Ahinoam the Jezreelitess and Abigail the Carmelitess, Nabal’s woman. 
-<span class="v">4&#160;</span>Saul was told that David had fled to Gath, so he stopped looking for him. 
-</p><p>
-<span class="v">5&#160;</span>David said to Achish, “If now I have found favor in your eyes, let them give me a place in one of the cities in the country, that I may dwell there. For why should your servant dwell in the royal city with you?” 
-<span class="v">6&#160;</span>Then Achish gave him Ziklag that day: therefore Ziklag belongs to the kings of Judah to this day. 
-<span class="v">7&#160;</span>The number of the days that David lived in the country of the Philistines was a full year and four months. 
-</p><p>
-<span class="v">8&#160;</span>David and his men went up and raided the Geshurites, the Girzites, and the Amalekites; for those were the inhabitants of the land who were of old, on the way to Shur, even to the land of Egypt. 
-<span class="v">9&#160;</span>David struck the land, and saved no man or woman alive, and took away the sheep, the cattle, the donkeys, the camels, and the clothing. Then he returned, and came to Achish. 
-</p><p>
-<span class="v">10&#160;</span>Achish said, “Against whom have you made a raid today?” 
-</p><p>David said, “Against the South of Judah, against the South of the Jerahmeelites, and against the South of the Kenites.” 
-<span class="v">11&#160;</span>David saved neither man nor woman alive to bring them to Gath, saying, “Lest they should tell about us, saying, ‘David did this, and this has been his way all the time he has lived in the country of the Philistines.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Achish believed David, saying, “He has made his people Israel utterly to abhor him. Therefore he will be my servant forever.” 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>In those days, the Philistines gathered their armies together for warfare, to fight with Israel. Achish said to David, “Know assuredly that you will go out with me in the army, you and your men.” 
-</p><p>
-<span class="v">2&#160;</span>David said to Achish, “Therefore you will know what your servant can do.” 
-</p><p>Achish said to David, “Therefore I will make you my bodyguard forever.” 
-</p><p>
-<span class="v">3&#160;</span>Now Samuel was dead, and all Israel had mourned for him and buried him in Ramah, even in his own city. Saul had sent away those who had familiar spirits and the wizards out of the land. 
-</p><p>
-<span class="v">4&#160;</span>The Philistines gathered themselves together, and came and encamped in Shunem; and Saul gathered all Israel together, and they encamped in Gilboa. 
-<span class="v">5&#160;</span>When Saul saw the army of the Philistines, he was afraid, and his heart trembled greatly. 
-<span class="v">6&#160;</span>When Saul inquired of Yahweh, Yahweh didn’t answer him by dreams, by Urim, or by prophets. 
-<span class="v">7&#160;</span>Then Saul said to his servants, “Seek for me a woman who has a familiar spirit, that I may go to her and inquire of her.” 
-</p><p>His servants said to him, “Behold, there is a woman who has a familiar spirit at Endor.” 
-</p><p>
-<span class="v">8&#160;</span>Saul disguised himself and put on other clothing, and went, he and two men with him, and they came to the woman by night. Then he said, “Please consult for me by the familiar spirit, and bring me up whomever I shall name to you.” 
-</p><p>
-<span class="v">9&#160;</span>The woman said to him, “Behold, you know what Saul has done, how he has cut off those who have familiar spirits and the wizards out of the land. Why then do you lay a snare for my life, to cause me to die?” 
-</p><p>
-<span class="v">10&#160;</span>Saul swore to her by Yahweh, saying, “As Yahweh lives, no punishment will happen to you for this thing.” 
-</p><p>
-<span class="v">11&#160;</span>Then the woman said, “Whom shall I bring up to you?” 
-</p><p>He said, “Bring Samuel up for me.” 
-</p><p>
-<span class="v">12&#160;</span>When the woman saw Samuel, she cried with a loud voice; and the woman spoke to Saul, saying, “Why have you deceived me? For you are Saul!” 
-</p><p>
-<span class="v">13&#160;</span>The king said to her, “Don’t be afraid! What do you see?” 
-</p><p>The woman said to Saul, “I see an elohim coming up out of the earth.” 
-</p><p>
-<span class="v">14&#160;</span>He said to her, “What does he look like?” 
-</p><p>She said, “An old man comes up. He is covered with a robe.” Saul perceived that it was Samuel, and he bowed with his face to the ground, and showed respect. 
-</p><p>
-<span class="v">15&#160;</span>Samuel said to Saul, “Why have you disturbed me, to bring me up?” 
-</p><p>Saul answered, “I am very distressed; for the Philistines make war against me, and Elohim has departed from me, and answers me no more, by prophets, or by dreams. Therefore I have called you, that you may make known to me what I shall do.” 
-</p><p>
-<span class="v">16&#160;</span>Samuel said, “Why then do you ask me, since Yahweh has departed from you and has become your adversary? 
-<span class="v">17&#160;</span>Yahweh has done to you as he spoke by me. Yahweh has torn the kingdom out of your hand and given it to your neighbor, even to David. 
-<span class="v">18&#160;</span>Because you didn’t obey Yahweh’s voice, and didn’t execute his fierce wrath on Amalek, therefore Yahweh has done this thing to you today. 
-<span class="v">19&#160;</span>Moreover Yahweh will deliver Israel also with you into the hand of the Philistines; and tomorrow you and your sons will be with me. Yahweh will deliver the army of Israel also into the hand of the Philistines.” 
-</p><p>
-<span class="v">20&#160;</span>Then Saul fell immediately his full length on the earth, and was terrified, because of Samuel’s words. There was no strength in him, for he had eaten no bread all day long or all night long. 
-</p><p>
-<span class="v">21&#160;</span>The woman came to Saul and saw that he was very troubled, and said to him, “Behold, your servant has listened to your voice, and I have put my life in my hand, and have listened to your words which you spoke to me. 
-<span class="v">22&#160;</span>Now therefore, please listen also to the voice of your servant, and let me set a morsel of bread before you. Eat, that you may have strength when you go on your way.” 
-</p><p>
-<span class="v">23&#160;</span>But he refused, and said, “I will not eat.” But his servants, together with the woman, constrained him; and he listened to their voice. So he arose from the earth and sat on the bed. 
-<span class="v">24&#160;</span>The woman had a fattened calf in the house. She hurried and killed it; and she took flour and kneaded it, and baked unleavened bread of it. 
-<span class="v">25&#160;</span>She brought it before Saul and before his servants, and they ate. Then they rose up and went away that night. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>Now the Philistines gathered together all their armies to Aphek; and the Israelites encamped by the spring which is in Jezreel. 
-<span class="v">2&#160;</span>The lords of the Philistines passed on by hundreds and by thousands; and David and his men passed on in the rear with Achish. 
-</p><p>
-<span class="v">3&#160;</span>Then the princes of the Philistines said, “What about these Hebrews?” 
-</p><p>Achish said to the princes of the Philistines, “Isn’t this David, the servant of Saul the king of Israel, who has been with me these days, or rather these years? I have found no fault in him since he fell away until today.” 
-</p><p>
-<span class="v">4&#160;</span>But the princes of the Philistines were angry with him; and the princes of the Philistines said to him, “Make the man return, that he may go back to his place where you have appointed him, and let him not go down with us to battle, lest in the battle he become an adversary to us. For with what should this fellow reconcile himself to his lord? Should it not be with the heads of these men? 
-<span class="v">5&#160;</span>Isn’t this David, of whom people sang to one another in dances, saying, 
-</p><p class="q1">‘Saul has slain his thousands, 
-</p><p class="q2">and David his ten thousands’?” 
-</p><p>
-<span class="v">6&#160;</span>Then Achish called David and said to him, “As Yahweh lives, you have been upright, and your going out and your coming in with me in the army is good in my sight; for I have not found evil in you since the day of your coming to me to this day. Nevertheless, the lords don’t favor you. 
-<span class="v">7&#160;</span>Therefore now return, and go in peace, that you not displease the lords of the Philistines.” 
-</p><p>
-<span class="v">8&#160;</span>David said to Achish, “But what have I done? What have you found in your servant so long as I have been before you to this day, that I may not go and fight against the enemies of my lord the king?” 
-</p><p>
-<span class="v">9&#160;</span>Achish answered David, “I know that you are good in my sight, as an angel of Elohim. Notwithstanding, the princes of the Philistines have said, ‘He shall not go up with us to the battle.’ 
-<span class="v">10&#160;</span>Therefore now rise up early in the morning with the servants of your lord who have come with you; and as soon as you are up early in the morning and have light, depart.” 
-</p><p>
-<span class="v">11&#160;</span>So David rose up early, he and his men, to depart in the morning, to return into the land of the Philistines; and the Philistines went up to Jezreel. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>When David and his men had come to Ziklag on the third day, the Amalekites had made a raid on the South and on Ziklag, and had struck Ziklag and burned it with fire, 
-<span class="v">2&#160;</span>and had taken captive the women and all who were in it, both small and great. They didn’t kill any, but carried them off and went their way. 
-<span class="v">3&#160;</span>When David and his men came to the city, behold, it was burned with fire; and their women, their sons, and their daughters were taken captive. 
-<span class="v">4&#160;</span>Then David and the people who were with him lifted up their voice and wept until they had no more power to weep. 
-<span class="v">5&#160;</span>David’s two women were taken captive, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
-<span class="v">6&#160;</span>David was greatly distressed, for the people spoke of stoning him, because the souls of all the people were grieved, every man for his sons and for his daughters; but David strengthened himself in Yahweh his Elohim. 
-<span class="v">7&#160;</span>David said to Abiathar the priest, the son of Ahimelech, “Please bring the ephod here to me.” 
-</p><p>Abiathar brought the ephod to David. 
-<span class="v">8&#160;</span>David inquired of Yahweh, saying, “If I pursue after this troop, will I overtake them?” 
-</p><p>He answered him, “Pursue, for you will surely overtake them, and will without fail recover all.” 
-</p><p>
-<span class="v">9&#160;</span>So David went, he and the six hundred men who were with him, and came to the brook Besor, where those who were left behind stayed. 
-<span class="v">10&#160;</span>But David pursued, he and four hundred men; for two hundred stayed behind, who were so faint that they couldn’t go over the brook Besor. 
-<span class="v">11&#160;</span>They found an Egyptian in the field, and brought him to David, and gave him bread, and he ate; and they gave him water to drink. 
-<span class="v">12&#160;</span>They gave him a piece of a cake of figs and two clusters of raisins. When he had eaten, his spirit came again to him; for he had eaten no bread, and drank no water for three days and three nights. 
-<span class="v">13&#160;</span>David asked him, “To whom do you belong? Where are you from?” 
-</p><p>He said, “I am a young man of Egypt, servant to an Amalekite; and my master left me, because three days ago I got sick. 
-<span class="v">14&#160;</span>We made a raid on the South of the Cherethites, and on that which belongs to Judah, and on the South of Caleb; and we burned Ziklag with fire.” 
-</p><p>
-<span class="v">15&#160;</span>David said to him, “Will you bring me down to this troop?” 
-</p><p>He said, “Swear to me by Elohim that you will not kill me and not deliver me up into the hands of my master, and I will bring you down to this troop.” 
-</p><p>
-<span class="v">16&#160;</span>When he had brought him down, behold, they were spread around over all the ground, eating, drinking, and dancing, because of all the great plunder that they had taken out of the land of the Philistines, and out of the land of Judah. 
-<span class="v">17&#160;</span>David struck them from the twilight even to the evening of the next day. Not a man of them escaped from there, except four hundred young men who rode on camels and fled. 
-<span class="v">18&#160;</span>David recovered all that the Amalekites had taken, and David rescued his two women. 
-<span class="v">19&#160;</span>There was nothing lacking to them, neither small nor great, neither sons nor daughters, neither plunder, nor anything that they had taken. David brought them all back. 
-<span class="v">20&#160;</span>David took all the flocks and the herds, which they drove before those other livestock, and said, “This is David’s plunder.” 
-</p><p>
-<span class="v">21&#160;</span>David came to the two hundred men, who were so faint that they could not follow David, whom also they had made to stay at the brook Besor; and they went out to meet David, and to meet the people who were with him. When David came near to the people, he greeted them. 
-<span class="v">22&#160;</span>Then all the wicked men and worthless fellows of those who went with David answered and said, “Because they didn’t go with us, we will not give them anything of the plunder that we have recovered, except to every man his woman and his children, that he may lead them away and depart.” 
-</p><p>
-<span class="v">23&#160;</span>Then David said, “Do not do so, my brothers, with that which Yahweh has given to us, who has preserved us, and delivered the troop that came against us into our hand. 
-<span class="v">24&#160;</span>Who will listen to you in this matter? For as his share is who goes down to the battle, so shall his share be who stays with the baggage. They shall share alike.” 
-<span class="v">25&#160;</span>It was so from that day forward that he made it a statute and an ordinance for Israel to this day. 
-</p><p>
-<span class="v">26&#160;</span>When David came to Ziklag, he sent some of the plunder to the elders of Judah, even to his friends, saying, “Behold, a present for you from the plunder of Yahweh’s enemies.” 
-<span class="v">27&#160;</span>He sent it to those who were in Bethel, to those who were in Ramoth of the South, to those who were in Jattir, 
-<span class="v">28&#160;</span>to those who were in Aroer, to those who were in Siphmoth, to those who were in Eshtemoa, 
-<span class="v">29&#160;</span>to those who were in Racal, to those who were in the cities of the Jerahmeelites, to those who were in the cities of the Kenites, 
-<span class="v">30&#160;</span>to those who were in Hormah, to those who were in Borashan, to those who were in Athach, 
-<span class="v">31&#160;</span>to those who were in Hebron, and to all the places where David himself and his men used to stay. 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>Now the Philistines fought against Israel; and the men of Israel fled from before the Philistines, and fell down slain on Mount Gilboa. 
-<span class="v">2&#160;</span>The Philistines overtook Saul and his sons; and the Philistines killed Jonathan, Abinadab, and Malchishua, the sons of Saul. 
-<span class="v">3&#160;</span>The battle went hard against Saul, and the archers overtook him; and he was greatly distressed by reason of the archers. 
-<span class="v">4&#160;</span>Then Saul said to his armor bearer, “Draw your sword, and thrust me through with it, lest these uncircumcised come and thrust me through and abuse me!” But his armor bearer would not, for he was terrified. Therefore Saul took his sword and fell on it. 
-<span class="v">5&#160;</span>When his armor bearer saw that Saul was dead, he likewise fell on his sword, and died with him. 
-<span class="v">6&#160;</span>So Saul died with his three sons, his armor bearer, and all his men that same day together. 
-</p><p>
-<span class="v">7&#160;</span>When the men of Israel who were on the other side of the valley, and those who were beyond the Jordan, saw that the men of Israel fled and that Saul and his sons were dead, they abandoned the cities and fled; and the Philistines came and lived in them. 
-<span class="v">8&#160;</span>On the next day, when the Philistines came to strip the slain, they found Saul and his three sons fallen on Mount Gilboa. 
-<span class="v">9&#160;</span>They cut off his head, stripped off his armor, and sent into the land of the Philistines all around, to carry the news to the house of their idols and to the people. 
-<span class="v">10&#160;</span>They put his armor in the house of the Ashtaroth, and they fastened his body to the wall of Beth Shan. 
-<span class="v">11&#160;</span>When the inhabitants of Jabesh Gilead heard what the Philistines had done to Saul, 
-<span class="v">12&#160;</span>all the valiant men arose, went all night, and took the body of Saul and the bodies of his sons from the wall of Beth Shan; and they came to Jabesh and burned them there. 
-<span class="v">13&#160;</span>They took their bones and buried them under the tamarisk<span class="f">+ \fr 31:13 \ft or, salt cedar</span> tree in Jabesh, and fasted seven days. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now there was a certain man of Ramathaim Zophim, of the hill country of Ephraim, and his name was Elkanah, the son of Jeroham, the son of Elihu, the son of Tohu, the son of Zuph, an Ephraimite. 
+<sup>2&#160;</sup>He had two women. The name of one was Hannah, and the name of the other Peninnah. Peninnah had children, but Hannah had no children. 
+<sup>3&#160;</sup>This man went up out of his city from year to year to worship and to sacrifice to Yahweh of Armies in Shiloh. The two sons of Eli, Hophni and Phinehas, priests to Yahweh, were there. 
+<sup>4&#160;</sup>When the day came that Elkanah sacrificed, he gave portions to Peninnah his woman and to all her sons and her daughters; 
+<sup>5&#160;</sup>but he gave a double portion to Hannah, for he loved Hannah, but Yahweh had shut up her womb. 
+<sup>6&#160;</sup>Her rival provoked her severely, to irritate her, because Yahweh had shut up her womb. 
+<sup>7&#160;</sup>So year by year, when she went up to Yahweh’s house, her rival provoked her. Therefore she wept, and didn’t eat. 
+<sup>8&#160;</sup>Elkanah her man said to her, “Hannah, why do you weep? Why don’t you eat? Why is your heart grieved? Am I not better to you than ten sons?” 
+</div><div class="p">
+<sup>9&#160;</sup>So Hannah rose up after they had finished eating and drinking in Shiloh. Now Eli the priest was sitting on his seat by the doorpost of Yahweh’s temple. 
+<sup>10&#160;</sup>She was in bitterness of soul, and prayed to Yahweh, weeping bitterly. 
+<sup>11&#160;</sup>She vowed a vow, and said, “Yahweh of Armies, if you will indeed look at the affliction of your servant and remember me, and not forget your servant, but will give to your servant a boy, then I will give him to Yahweh all the days of his life, and no razor shall come on his head.” 
+</div><div class="p">
+<sup>12&#160;</sup>As she continued praying before Yahweh, Eli saw her mouth. 
+<sup>13&#160;</sup>Now Hannah spoke in her heart. Only her lips moved, but her voice was not heard. Therefore Eli thought she was drunk. 
+<sup>14&#160;</sup>Eli said to her, “How long will you be drunk? Get rid of your wine!” 
+</div><div class="p">
+<sup>15&#160;</sup>Hannah answered, “No, my lord, I am a woman of a sorrowful spirit. I have not been drinking wine or strong drink, but I poured out my soul before Yahweh. 
+<sup>16&#160;</sup>Don’t consider your servant a wicked woman; for I have been speaking out of the abundance of my complaint and my provocation.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Eli answered, “Go in peace; and may the Elohim of Israel grant your petition that you have asked of him.” 
+</div><div class="p">
+<sup>18&#160;</sup>She said, “Let your servant find favor in your sight.” So the woman went her way and ate; and her facial expression wasn’t sad any more. 
+</div><div class="p">
+<sup>19&#160;</sup>They rose up in the morning early and worshiped Yahweh, then returned and came to their house to Ramah. Then Elkanah knew Hannah his woman; and Yahweh remembered her. 
+</div><div class="p">
+<sup>20&#160;</sup>When the time had come, Hannah conceived, and bore a son; and she named him Samuel, saying, “Because I have asked him of Yahweh.” 
+</div><div class="p">
+<sup>21&#160;</sup>The man Elkanah, and all his house, went up to offer to Yahweh the yearly sacrifice and his vow. 
+<sup>22&#160;</sup>But Hannah didn’t go up, for she said to her man, “Not until the child is weaned; then I will bring him, that he may appear before Yahweh, and stay there forever.” 
+</div><div class="p">
+<sup>23&#160;</sup>Elkanah her man said to her, “Do what seems good to you. Wait until you have weaned him; only may Yahweh establish his word.” 
+</div><div class="p">So the woman waited and nursed her son until she weaned him. 
+<sup>24&#160;</sup>When she had weaned him, she took him up with her, with three bulls, and one ephah of meal, and a container of wine, and brought him to Yahweh’s house in Shiloh. The child was young. 
+<sup>25&#160;</sup>They killed the bull, and brought the child to Eli. 
+<sup>26&#160;</sup>She said, “Oh, my lord, as your soul lives, my lord, I am the woman who stood by you here, praying to Yahweh. 
+<sup>27&#160;</sup>I prayed for this child, and Yahweh has given me my petition which I asked of him. 
+<sup>28&#160;</sup>Therefore I have also given him to Yahweh. As long as he lives he is given to Yahweh.” He worshiped Yahweh there. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Hannah prayed, and said, 
+</div><div class="q1">“My heart exults in Yahweh! 
+</div><div class="q2">My horn is exalted in Yahweh. 
+</div><div class="q1">My mouth is enlarged over my enemies, 
+</div><div class="q2">because I rejoice in your salvation. 
+</div><div class="q1">
+<sup>2&#160;</sup>There is no one as set-apart as Yahweh, 
+</div><div class="q2">for there is no one besides you, 
+</div><div class="q2">nor is there any rock like our Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Don’t keep talking so exceedingly proudly. 
+</div><div class="q2">Don’t let arrogance come out of your mouth, 
+</div><div class="q2">for Yahweh is an Elohim of knowledge. 
+</div><div class="q2">By him actions are weighed. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“The bows of the mighty men are broken. 
+</div><div class="q2">Those who stumbled are armed with strength. 
+</div><div class="q1">
+<sup>5&#160;</sup>Those who were full have hired themselves out for bread. 
+</div><div class="q2">Those who were hungry are satisfied. 
+</div><div class="q1">Yes, the barren has borne seven. 
+</div><div class="q2">She who has many children languishes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“Yahweh kills and makes alive. 
+</div><div class="q2">He brings down to Sheol and brings up. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh makes poor and makes rich. 
+</div><div class="q2">He brings low, he also lifts up. 
+</div><div class="q1">
+<sup>8&#160;</sup>He raises up the poor out of the dust. 
+</div><div class="q2">He lifts up the needy from the dunghill 
+</div><div class="q2">to make them sit with princes 
+</div><div class="q2">and inherit the throne of glory. 
+</div><div class="q1">For the pillars of the earth are Yahweh’s. 
+</div><div class="q2">He has set the world on them. 
+</div><div class="q1">
+<sup>9&#160;</sup>He will keep the feet of his set-apart ones, 
+</div><div class="q2">but the wicked will be put to silence in darkness; 
+</div><div class="q2">for no man will prevail by strength. 
+</div><div class="q1">
+<sup>10&#160;</sup>Those who strive with Yahweh shall be broken to pieces. 
+</div><div class="q2">He will thunder against them in the sky. 
+</div><div class="b"> &#160; </div>
+<div class="q1">“Yahweh will judge the ends of the earth. 
+</div><div class="q2">He will give strength to his king, 
+</div><div class="q2">and exalt the horn of his anointed.” 
+</div><div class="p">
+<sup>11&#160;</sup>Elkanah went to Ramah to his house. The child served Yahweh before Eli the priest. 
+</div><div class="p">
+<sup>12&#160;</sup>Now the sons of Eli were wicked men. They didn’t know Yahweh. 
+<sup>13&#160;</sup>The custom of the priests with the people was that when anyone offered a sacrifice, the priest’s servant came while the meat was boiling, with a fork of three teeth in his hand; 
+<sup>14&#160;</sup>and he stabbed it into the pan, or kettle, or cauldron, or pot. The priest took all that the fork brought up for himself. They did this to all the Israelites who came there to Shiloh. 
+<sup>15&#160;</sup>Yes, before they burned the fat, the priest’s servant came, and said to the man who sacrificed, “Give meat to roast for the priest; for he will not accept boiled meat from you, but raw.” 
+</div><div class="p">
+<sup>16&#160;</sup>If the man said to him, “Let the fat be burned first, and then take as much as your soul desires;” then he would say, “No, but you shall give it to me now; and if not, I will take it by force.” 
+<sup>17&#160;</sup>The sin of the young men was very great before Yahweh; for the men despised Yahweh’s offering. 
+<sup>18&#160;</sup>But Samuel ministered before Yahweh, being a child, clothed with a linen ephod. 
+<sup>19&#160;</sup>Moreover his mother made him a little robe, and brought it to him from year to year when she came up with her man to offer the yearly sacrifice. 
+<sup>20&#160;</sup>Eli blessed Elkanah and his woman, and said, “May Yahweh give you offspring from this woman for the petition which was asked of Yahweh.” Then they went to their own home. 
+<sup>21&#160;</sup>Yahweh visited Hannah, and she conceived and bore three sons and two daughters. The child Samuel grew before Yahweh. 
+</div><div class="p">
+<sup>22&#160;</sup>Now Eli was very old; and he heard all that his sons did to all Israel, and how that they slept with the women who served at the door of the Tent of Meeting. 
+<sup>23&#160;</sup>He said to them, “Why do you do such things? For I hear of your evil dealings from all these people. 
+<sup>24&#160;</sup>No, my sons; for it is not a good report that I hear! You make Yahweh’s people disobey. 
+<sup>25&#160;</sup>If one man sins against another, Elohim will judge him; but if a man sins against Yahweh, who will intercede for him?” Notwithstanding, they didn’t listen to the voice of their father, because Yahweh intended to kill them. 
+</div><div class="p">
+<sup>26&#160;</sup>The child Samuel grew on, and increased in favor both with Yahweh and also with men. 
+</div><div class="p">
+<sup>27&#160;</sup>A man of Elohim came to Eli and said to him, “Yahweh says, ‘Did I reveal myself to the house of your father when they were in Egypt in bondage to Pharaoh’s house? 
+<sup>28&#160;</sup>Didn’t I choose him out of all the tribes of Israel to be my priest, to go up to my altar, to burn incense, to wear an ephod before me? Didn’t I give to the house of your father all the offerings of the children of Israel made by fire? 
+<sup>29&#160;</sup>Why do you kick at my sacrifice and at my offering, which I have commanded in my habitation, and honor your sons above me, to make yourselves fat with the best of all the offerings of Israel my people?’ 
+<sup>30&#160;</sup>“Therefore Yahweh, the Elohim of Israel, says, ‘I said indeed that your house and the house of your father should walk before me forever.’ But now Yahweh says, ‘Far be it from me; for those who honor me I will honor, and those who despise me will be cursed. 
+<sup>31&#160;</sup>Behold, the days come that I will cut off your arm and the arm of your father’s house, that there will not be an old man in your house. 
+<sup>32&#160;</sup>You will see the affliction of my habitation, in all the wealth which I will give Israel. There shall not be an old man in your house forever. 
+<sup>33&#160;</sup>The man of yours whom I don’t cut off from my altar will consume your eyes and grieve your heart. All the increase of your house will die in the flower of their age. 
+<sup>34&#160;</sup>This will be the sign to you that will come on your two sons, on Hophni and Phinehas: in one day they will both die. 
+<sup>35&#160;</sup>I will raise up a faithful priest for myself who will do according to that which is in my heart and in my mind. I will build him a sure house. He will walk before my anointed forever. 
+<sup>36&#160;</sup>It will happen that everyone who is left in your house will come and bow down to him for a piece of silver and a loaf of bread, and will say, “Please put me into one of the priests’ offices, that I may eat a morsel of bread.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>The child Samuel ministered to Yahweh before Eli. Yahweh’s word was rare in those days. There were not many visions, then. 
+<sup>2&#160;</sup>At that time, when Eli was laid down in his place (now his eyes had begun to grow dim, so that he could not see), 
+<sup>3&#160;</sup>and Elohim’s lamp hadn’t yet gone out, and Samuel had laid down in Yahweh’s temple where Elohim’s ark was, 
+<sup>4&#160;</sup>Yahweh called Samuel. He said, “Here I am.” 
+</div><div class="p">
+<sup>5&#160;</sup>He ran to Eli and said, “Here I am; for you called me.” 
+</div><div class="p">He said, “I didn’t call. Lie down again.” 
+</div><div class="p">He went and lay down. 
+<sup>6&#160;</sup>Yahweh called yet again, “Samuel!” 
+</div><div class="p">Samuel arose and went to Eli and said, “Here I am; for you called me.” 
+</div><div class="p">He answered, “I didn’t call, my son. Lie down again.” 
+<sup>7&#160;</sup>Now Samuel didn’t yet know Yahweh, neither was Yahweh’s word yet revealed to him. 
+<sup>8&#160;</sup>Yahweh called Samuel again the third time. He arose and went to Eli and said, “Here I am; for you called me.” 
+</div><div class="p">Eli perceived that Yahweh had called the child. 
+<sup>9&#160;</sup>Therefore Eli said to Samuel, “Go, lie down. It shall be, if he calls you, that you shall say, ‘Speak, Yahweh; for your servant hears.’&#160;” So Samuel went and lay down in his place. 
+<sup>10&#160;</sup>Yahweh came, and stood, and called as at other times, “Samuel! Samuel!” 
+</div><div class="p">Then Samuel said, “Speak; for your servant hears.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said to Samuel, “Behold, I will do a thing in Israel at which both the ears of everyone who hears it will tingle. 
+<sup>12&#160;</sup>In that day I will perform against Eli all that I have spoken concerning his house, from the beginning even to the end. 
+<sup>13&#160;</sup>For I have told him that I will judge his house forever for the iniquity which he knew, because his sons brought a curse on themselves, and he didn’t restrain them. 
+<sup>14&#160;</sup>Therefore I have sworn to the house of Eli that the iniquity of Eli’s house shall not be removed with sacrifice or offering forever.” 
+</div><div class="p">
+<sup>15&#160;</sup>Samuel lay until the morning, and opened the doors of Yahweh’s house. Samuel was afraid to show Eli the vision. 
+<sup>16&#160;</sup>Then Eli called Samuel and said, “Samuel, my son!” 
+</div><div class="p">He said, “Here I am.” 
+</div><div class="p">
+<sup>17&#160;</sup>He said, “What is the thing that he has spoken to you? Please don’t hide it from me. Elohim do so to you, and more also, if you hide anything from me of all the things that he spoke to you.” 
+</div><div class="p">
+<sup>18&#160;</sup>Samuel told him every bit, and hid nothing from him. 
+</div><div class="p">He said, “It is Yahweh. Let him do what seems good to him.” 
+</div><div class="p">
+<sup>19&#160;</sup>Samuel grew, and Yahweh was with him and let none of his words fall to the ground. 
+<sup>20&#160;</sup>All Israel from Dan even to Beersheba knew that Samuel was established to be a prophet of Yahweh. 
+<sup>21&#160;</sup>Yahweh appeared again in Shiloh; for Yahweh revealed himself to Samuel in Shiloh by Yahweh’s word. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="nb">
+<sup>1&#160;</sup>The word of Samuel came to all Israel. 
+</div><div class="p">Now Israel went out against the Philistines to battle, and encamped beside Ebenezer; and the Philistines encamped in Aphek. 
+<sup>2&#160;</sup>The Philistines put themselves in array against Israel. When they joined battle, Israel was defeated by the Philistines, who killed about four thousand men of the army in the field. 
+<sup>3&#160;</sup>When the people had come into the camp, the elders of Israel said, “Why has Yahweh defeated us today before the Philistines? Let’s get the ark of Yahweh’s covenant out of Shiloh and bring it to us, that it may come among us and save us out of the hand of our enemies.” 
+</div><div class="p">
+<sup>4&#160;</sup>So the people sent to Shiloh, and they brought from there the ark of the covenant of Yahweh of Armies, who sits above the cherubim; and the two sons of Eli, Hophni and Phinehas, were there with the ark of the covenant of Elohim. 
+<sup>5&#160;</sup>When the ark of Yahweh’s covenant came into the camp, all Israel shouted with a great shout, so that the earth resounded. 
+<sup>6&#160;</sup>When the Philistines heard the noise of the shout, they said, “What does the noise of this great shout in the camp of the Hebrews mean?” They understood that Yahweh’s ark had come into the camp. 
+<sup>7&#160;</sup>The Philistines were afraid, for they said, “Elohim has come into the camp.” They said, “Woe to us! For there has not been such a thing before. 
+<sup>8&#160;</sup>Woe to us! Who shall deliver us out of the hand of these mighty elohims? These are the elohims that struck the Egyptians with all kinds of plagues in the wilderness. 
+<sup>9&#160;</sup>Be strong and behave like men, O you Philistines, that you not be servants to the Hebrews, as they have been to you. Strengthen yourselves like men, and fight!” 
+<sup>10&#160;</sup>The Philistines fought, and Israel was defeated, and each man fled to his tent. There was a very great slaughter; for thirty thousand footmen of Israel fell. 
+<sup>11&#160;</sup>Elohim’s ark was taken; and the two sons of Eli, Hophni and Phinehas, were slain. 
+</div><div class="p">
+<sup>12&#160;</sup>A man of Benjamin ran out of the army and came to Shiloh the same day, with his clothes torn and with dirt on his head. 
+<sup>13&#160;</sup>When he came, behold, Eli was sitting on his seat by the road watching, for his heart trembled for Elohim’s ark. When the man came into the city and told about it, all the city cried out. 
+<sup>14&#160;</sup>When Eli heard the noise of the crying, he said, “What does the noise of this tumult mean?” 
+</div><div class="p">The man hurried, and came and told Eli. 
+<sup>15&#160;</sup>Now Eli was ninety-eight years old. His eyes were set, so that he could not see. 
+<sup>16&#160;</sup>The man said to Eli, “I am he who came out of the army, and I fled today out of the army.” 
+</div><div class="p">He said, “How did the matter go, my son?” 
+</div><div class="p">
+<sup>17&#160;</sup>He who brought the news answered, “Israel has fled before the Philistines, and there has been also a great slaughter among the people. Your two sons also, Hophni and Phinehas, are dead, and Elohim’s ark has been captured.” 
+</div><div class="p">
+<sup>18&#160;</sup>When he made mention of Elohim’s ark, Eli fell from off his seat backward by the side of the gate; and his neck broke, and he died, for he was an old man and heavy. He had judged Israel forty years. 
+</div><div class="p">
+<sup>19&#160;</sup>His daughter-in-law, Phinehas’ woman, was with child, near to giving birth. When she heard the news that Elohim’s ark was taken and that her father-in-law and her man were dead, she bowed herself and gave birth; for her pains came on her. 
+<sup>20&#160;</sup>About the time of her death the women who stood by her said to her, “Don’t be afraid, for you have given birth to a son.” But she didn’t answer, neither did she regard it. 
+<sup>21&#160;</sup>She named the child Ichabod, saying, “The glory has departed from Israel!” because Elohim’s ark was taken, and because of her father-in-law and her man. 
+<sup>22&#160;</sup>She said, “The glory has departed from Israel; for Elohim’s ark has been taken.” 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the Philistines had taken Elohim’s ark, and they brought it from Ebenezer to Ashdod. 
+<sup>2&#160;</sup>The Philistines took Elohim’s ark, and brought it into the house of Dagon and set it by Dagon. 
+<sup>3&#160;</sup>When the people of Ashdod arose early on the next day, behold, Dagon had fallen on his face to the ground before Yahweh’s ark. They took Dagon and set him in his place again. 
+<sup>4&#160;</sup>When they arose early on the following morning, behold, Dagon had fallen on his face to the ground before Yahweh’s ark; and the head of Dagon and both the palms of his hands were cut off on the threshold. Only Dagon’s torso was intact. 
+<sup>5&#160;</sup>Therefore neither the priests of Dagon nor any who come into Dagon’s house step on the threshold of Dagon in Ashdod to this day. 
+<sup>6&#160;</sup>But Yahweh’s hand was heavy on the people of Ashdod, and he destroyed them and struck them with tumors, even Ashdod and its borders. 
+</div><div class="p">
+<sup>7&#160;</sup>When the men of Ashdod saw that it was so, they said, “The ark of the Elohim of Israel shall not stay with us, for his hand is severe on us and on Dagon our elohim.” 
+<sup>8&#160;</sup>They sent therefore and gathered together all the lords of the Philistines, and said, “What shall we do with the ark of the Elohim of Israel?” 
+</div><div class="p">They answered, “Let the ark of the Elohim of Israel be carried over to Gath.” They carried the ark of the Elohim of Israel there. 
+<sup>9&#160;</sup>It was so, that after they had carried it there, Yahweh’s hand was against the city with a very great confusion; and he struck the men of the city, both small and great, so that tumors broke out on them. 
+<sup>10&#160;</sup>So they sent Elohim’s ark to Ekron. 
+</div><div class="p">As Elohim’s ark came to Ekron, the Ekronites cried out, saying, “They have brought the ark of the Elohim of Israel here to us, to kill us and our people.” 
+<sup>11&#160;</sup>They sent therefore and gathered together all the lords of the Philistines, and they said, “Send the ark of the Elohim of Israel away, and let it go again to its own place, that it not kill us and our people.” For there was a deadly panic throughout all the city. The hand of Elohim was very heavy there. 
+<sup>12&#160;</sup>The men who didn’t die were struck with the tumors; and the cry of the city went up to heaven. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s ark was in the country of the Philistines seven months. 
+<sup>2&#160;</sup>The Philistines called for the priests and the diviners, saying, “What shall we do with Yahweh’s ark? Show us how we should send it to its place.” 
+</div><div class="p">
+<sup>3&#160;</sup>They said, “If you send away the ark of the Elohim of Israel, don’t send it empty; but by all means return a trespass offering to him. Then you will be healed, and it will be known to you why his hand is not removed from you.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then they said, “What should the trespass offering be which we shall return to him?” 
+</div><div class="p">They said, “Five golden tumors and five golden mice, for the number of the lords of the Philistines; for one plague was on you all, and on your lords. 
+<sup>5&#160;</sup>Therefore you shall make images of your tumors and images of your mice that mar the land; and you shall give glory to the Elohim of Israel. Perhaps he will release his hand from you, from your elohims, and from your land. 
+<sup>6&#160;</sup>Why then do you harden your hearts as the Egyptians and Pharaoh hardened their hearts? When he had worked wonderfully among them, didn’t they let the people go, and they departed? 
+</div><div class="p">
+<sup>7&#160;</sup>“Now therefore take and prepare yourselves a new cart and two milk cows on which there has come no yoke; and tie the cows to the cart, and bring their calves home from them; 
+<sup>8&#160;</sup>and take Yahweh’s ark and lay it on the cart. Put the jewels of gold, which you return him for a trespass offering, in a box by its side; and send it away, that it may go. 
+<sup>9&#160;</sup>Behold, if it goes up by the way of its own border to Beth Shemesh, then he has done us this great evil; but if not, then we shall know that it is not his hand that struck us. It was a chance that happened to us.” 
+</div><div class="p">
+<sup>10&#160;</sup>The men did so, and took two milk cows and tied them to the cart, and shut up their calves at home. 
+<sup>11&#160;</sup>They put Yahweh’s ark on the cart, and the box with the golden mice and the images of their tumors. 
+<sup>12&#160;</sup>The cows took the straight way by the way to Beth Shemesh. They went along the highway, lowing as they went, and didn’t turn away to the right hand or to the left; and the lords of the Philistines went after them to the border of Beth Shemesh. 
+<sup>13&#160;</sup>The people of Beth Shemesh were reaping their wheat harvest in the valley; and they lifted up their eyes and saw the ark, and rejoiced to see it. 
+<sup>14&#160;</sup>The cart came into the field of Joshua of Beth Shemesh, and stood there, where there was a great stone. Then they split the wood of the cart and offered up the cows for a burnt offering to Yahweh. 
+<sup>15&#160;</sup>The Levites took down Yahweh’s ark and the box that was with it, in which the jewels of gold were, and put them on the great stone; and the men of Beth Shemesh offered burnt offerings and sacrificed sacrifices the same day to Yahweh. 
+<sup>16&#160;</sup>When the five lords of the Philistines had seen it, they returned to Ekron the same day. 
+<sup>17&#160;</sup>These are the golden tumors which the Philistines returned for a trespass offering to Yahweh: for Ashdod one, for Gaza one, for Ashkelon one, for Gath one, for Ekron one; 
+<sup>18&#160;</sup>and the golden mice, according to the number of all the cities of the Philistines belonging to the five lords, both of fortified cities and of country villages, even to the great stone on which they set down Yahweh’s ark. That stone remains to this day in the field of Joshua of Beth Shemesh. 
+<sup>19&#160;</sup>He struck of the men of Beth Shemesh, because they had looked into Yahweh’s ark, he struck fifty thousand seventy of the men. Then the people mourned, because Yahweh had struck the people with a great slaughter. 
+<sup>20&#160;</sup>The men of Beth Shemesh said, “Who is able to stand before Yahweh, this set-apart Elohim? To whom shall he go up from us?” 
+</div><div class="p">
+<sup>21&#160;</sup>They sent messengers to the inhabitants of Kiriath Jearim, saying, “The Philistines have brought back Yahweh’s ark. Come down and bring it up to yourselves.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>The men of Kiriath Jearim came and took Yahweh’s ark, and brought it into Abinadab’s house on the hill, and consecrated Eleazar his son to keep Yahweh’s ark. 
+<sup>2&#160;</sup>From the day that the ark stayed in Kiriath Jearim, the time was long—for it was twenty years; and all the house of Israel lamented after Yahweh. 
+<sup>3&#160;</sup>Samuel spoke to all the house of Israel, saying, “If you are returning to Yahweh with all your heart, then put away the foreign elohims and the Ashtaroth from among you, and direct your hearts to Yahweh, and serve him only; and he will deliver you out of the hand of the Philistines.” 
+<sup>4&#160;</sup>Then the children of Israel removed the Baals and the Ashtaroth, and served Yahweh only. 
+<sup>5&#160;</sup>Samuel said, “Gather all Israel to Mizpah, and I will pray to Yahweh for you.” 
+<sup>6&#160;</sup>They gathered together to Mizpah, and drew water, and poured it out before Yahweh, and fasted on that day, and said there, “We have sinned against Yahweh.” Samuel judged the children of Israel in Mizpah. 
+</div><div class="p">
+<sup>7&#160;</sup>When the Philistines heard that the children of Israel were gathered together at Mizpah, the lords of the Philistines went up against Israel. When the children of Israel heard it, they were afraid of the Philistines. 
+<sup>8&#160;</sup>The children of Israel said to Samuel, “Don’t stop crying to Yahweh our Elohim for us, that he will save us out of the hand of the Philistines.” 
+<sup>9&#160;</sup>Samuel took a suckling lamb, and offered it for a whole burnt offering to Yahweh. Samuel cried to Yahweh for Israel, and Yahweh answered him. 
+<sup>10&#160;</sup>As Samuel was offering up the burnt offering, the Philistines came near to battle against Israel; but Yahweh thundered with a great thunder on that day on the Philistines and confused them; and they were struck down before Israel. 
+<sup>11&#160;</sup>The men of Israel went out of Mizpah and pursued the Philistines, and struck them until they came under Beth Kar. 
+</div><div class="p">
+<sup>12&#160;</sup>Then Samuel took a stone and set it between Mizpah and Shen, and called its name Ebenezer, saying, “Yahweh helped us until now.” 
+<sup>13&#160;</sup>So the Philistines were subdued, and they stopped coming within the border of Israel. Yahweh’s hand was against the Philistines all the days of Samuel. 
+</div><div class="p">
+<sup>14&#160;</sup>The cities which the Philistines had taken from Israel were restored to Israel, from Ekron even to Gath; and Israel recovered its border out of the hand of the Philistines. There was peace between Israel and the Amorites. 
+</div><div class="p">
+<sup>15&#160;</sup>Samuel judged Israel all the days of his life. 
+<sup>16&#160;</sup>He went from year to year in a circuit to Bethel, Gilgal, and Mizpah; and he judged Israel in all those places. 
+<sup>17&#160;</sup>His return was to Ramah, for his house was there, and he judged Israel there; and he built an altar to Yahweh there. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>When Samuel was old, he made his sons judges over Israel. 
+<sup>2&#160;</sup>Now the name of his firstborn was Joel, and the name of his second, Abijah. They were judges in Beersheba. 
+<sup>3&#160;</sup>His sons didn’t walk in his ways, but turned away after dishonest gain, took bribes, and perverted justice. 
+</div><div class="p">
+<sup>4&#160;</sup>Then all the elders of Israel gathered themselves together and came to Samuel to Ramah. 
+<sup>5&#160;</sup>They said to him, “Behold, you are old, and your sons don’t walk in your ways. Now make us a king to judge us like all the nations.” 
+<sup>6&#160;</sup>But the thing displeased Samuel when they said, “Give us a king to judge us.” 
+</div><div class="p">Samuel prayed to Yahweh. 
+<sup>7&#160;</sup>Yahweh said to Samuel, “Listen to the voice of the people in all that they tell you; for they have not rejected you, but they have rejected me as the king over them. 
+<sup>8&#160;</sup>According to all the works which they have done since the day that I brought them up out of Egypt even to this day, in that they have forsaken me and served other elohims, so they also do to you. 
+<sup>9&#160;</sup>Now therefore, listen to their voice. However, you shall protest solemnly to them, and shall show them the way of the king who will reign over them.” 
+</div><div class="p">
+<sup>10&#160;</sup>Samuel told all Yahweh’s words to the people who asked him for a king. 
+<sup>11&#160;</sup>He said, “This will be the way of the king who shall reign over you: he will take your sons and appoint them as his servants, for his chariots and to be his horsemen; and they will run before his chariots. 
+<sup>12&#160;</sup>He will appoint them to him for captains of thousands and captains of fifties; and he will assign some to plow his ground and to reap his harvest; and to make his instruments of war and the instruments of his chariots. 
+<sup>13&#160;</sup>He will take your daughters to be perfumers, to be cooks, and to be bakers. 
+<sup>14&#160;</sup>He will take your fields, your vineyards, and your olive groves, even your best, and give them to his servants. 
+<sup>15&#160;</sup>He will take one tenth of your seed and of your vineyards, and give it to his officers and to his servants. 
+<sup>16&#160;</sup>He will take your male servants, your female servants, your best young men, and your donkeys, and assign them to his own work. 
+<sup>17&#160;</sup>He will take one tenth of your flocks; and you will be his servants. 
+<sup>18&#160;</sup>You will cry out in that day because of your king whom you will have chosen for yourselves; and Yahweh will not answer you in that day.” 
+</div><div class="p">
+<sup>19&#160;</sup>But the people refused to listen to the voice of Samuel; and they said, “No, but we will have a king over us, 
+<sup>20&#160;</sup>that we also may be like all the nations; and that our king may judge us, and go out before us, and fight our battles.” 
+</div><div class="p">
+<sup>21&#160;</sup>Samuel heard all the words of the people, and he rehearsed them in the ears of Yahweh. 
+<sup>22&#160;</sup>Yahweh said to Samuel, “Listen to their voice, and make them a king.” 
+</div><div class="p">Samuel said to the men of Israel, “Everyone go to your own city.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Now there was a man of Benjamin, whose name was Kish the son of Abiel, the son of Zeror, the son of Becorath, the son of Aphiah, the son of a Benjamite, a mighty man of valor. 
+<sup>2&#160;</sup>He had a son whose name was Saul, an impressive young man; and there was not among the children of Israel a more handsome person than he. From his shoulders and upward he was taller than any of the people. 
+</div><div class="p">
+<sup>3&#160;</sup>The donkeys of Kish, Saul’s father, were lost. Kish said to Saul his son, “Now take one of the servants with you, and arise, go look for the donkeys.” 
+<sup>4&#160;</sup>He passed through the hill country of Ephraim, and passed through the land of Shalishah, but they didn’t find them. Then they passed through the land of Shaalim, and they weren’t there. Then he passed through the land of the Benjamites, but they didn’t find them. 
+</div><div class="p">
+<sup>5&#160;</sup>When they had come to the land of Zuph, Saul said to his servant who was with him, “Come! Let’s return, lest my father stop caring about the donkeys and be anxious for us.” 
+</div><div class="p">
+<sup>6&#160;</sup>The servant said to him, “Behold now, there is a man of Elohim in this city, and he is a man who is held in honor. All that he says surely happens. Now let’s go there. Perhaps he can tell us which way to go.” 
+</div><div class="p">
+<sup>7&#160;</sup>Then Saul said to his servant, “But behold, if we go, what should we bring the man? For the bread is spent in our sacks, and there is not a present to bring to the man of Elohim. What do we have?” 
+</div><div class="p">
+<sup>8&#160;</sup>The servant answered Saul again and said, “Behold, I have in my hand the fourth part of a shekel of silver. I will give that to the man of Elohim, to tell us our way.” 
+<sup>9&#160;</sup>(In earlier times in Israel, when a man went to inquire of Elohim, he said, “Come! Let’s go to the seer;” for he who is now called a prophet was before called a seer.) 
+</div><div class="p">
+<sup>10&#160;</sup>Then Saul said to his servant, “Well said. Come! Let’s go.” So they went to the city where the man of Elohim was. 
+<sup>11&#160;</sup>As they went up the ascent to the city, they found young maidens going out to draw water, and said to them, “Is the seer here?” 
+</div><div class="p">
+<sup>12&#160;</sup>They answered them and said, “He is. Behold, he is before you. Hurry now, for he has come today into the city; for the people have a sacrifice today in the high place. 
+<sup>13&#160;</sup>As soon as you have come into the city, you will immediately find him before he goes up to the high place to eat; for the people will not eat until he comes, because he blesses the sacrifice. Afterwards those who are invited eat. Now therefore go up; for at this time you will find him.” 
+</div><div class="p">
+<sup>14&#160;</sup>They went up to the city. As they came within the city, behold, Samuel came out toward them to go up to the high place. 
+</div><div class="p">
+<sup>15&#160;</sup>Now Yahweh had revealed to Samuel a day before Saul came, saying, 
+<sup>16&#160;</sup>“Tomorrow about this time I will send you a man out of the land of Benjamin, and you shall anoint him to be prince over my people Israel. He will save my people out of the hand of the Philistines; for I have looked upon my people, because their cry has come to me.” 
+</div><div class="p">
+<sup>17&#160;</sup>When Samuel saw Saul, Yahweh said to him, “Behold, the man of whom I spoke to you! He will have authority over my people.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then Saul approached Samuel in the gateway, and said, “Please tell me where the seer’s house is.” 
+</div><div class="p">
+<sup>19&#160;</sup>Samuel answered Saul and said, “I am the seer. Go up before me to the high place, for you are to eat with me today. In the morning I will let you go and will tell you all that is in your heart. 
+<sup>20&#160;</sup>As for your donkeys who were lost three days ago, don’t set your mind on them, for they have been found. For whom does all Israel desire? Is it not you and all your father’s house?” 
+</div><div class="p">
+<sup>21&#160;</sup>Saul answered, “Am I not a Benjamite, of the smallest of the tribes of Israel? And my family the least of all the families of the tribe of Benjamin? Why then do you speak to me like this?” 
+</div><div class="p">
+<sup>22&#160;</sup>Samuel took Saul and his servant and brought them into the guest room, and made them sit in the best place among those who were invited, who were about thirty persons. 
+<sup>23&#160;</sup>Samuel said to the cook, “Bring the portion which I gave you, of which I said to you, ‘Set it aside.’&#160;” 
+<sup>24&#160;</sup>The cook took up the thigh, and that which was on it, and set it before Saul. Samuel said, “Behold, that which has been reserved! Set it before yourself and eat; because it has been kept for you for the appointed time, for I said, ‘I have invited the people.’&#160;” So Saul ate with Samuel that day. 
+</div><div class="p">
+<sup>25&#160;</sup>When they had come down from the high place into the city, he talked with Saul on the housetop. 
+<sup>26&#160;</sup>They arose early; and about daybreak, Samuel called to Saul on the housetop, saying, “Get up, that I may send you away.” Saul arose, and they both went outside, he and Samuel, together. 
+<sup>27&#160;</sup>As they were going down at the end of the city, Samuel said to Saul, “Tell the servant to go on ahead of us.” He went ahead, then Samuel said, “But stand still first, that I may cause you to hear Elohim’s message.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Samuel took the vial of oil and poured it on his head, then kissed him and said, “Hasn’t Yahweh anointed you to be prince over his inheritance? 
+<sup>2&#160;</sup>When you have departed from me today, then you will find two men by Rachel’s tomb, on the border of Benjamin at Zelzah. They will tell you, ‘The donkeys which you went to look for have been found; and behold, your father has stopped caring about the donkeys and is anxious for you, saying, “What shall I do for my son?”&#160;’ 
+</div><div class="p">
+<sup>3&#160;</sup>“Then you will go on forward from there, and you will come to the oak of Tabor. Three men will meet you there going up to Elohim to Bethel: one carrying three young goats, and another carrying three loaves of bread, and another carrying a container of wine. 
+<sup>4&#160;</sup>They will greet you and give you two loaves of bread, which you shall receive from their hand. 
+</div><div class="p">
+<sup>5&#160;</sup>“After that you will come to the hill of Elohim, where the garrison of the Philistines is; and it will happen, when you have come there to the city, that you will meet a band of prophets coming down from the high place with a lute, a tambourine, a pipe, and a harp before them; and they will be prophesying. 
+<sup>6&#160;</sup>Then Yahweh’s Spirit will come mightily on you, then you will prophesy with them and will be turned into another man. 
+<sup>7&#160;</sup>Let it be, when these signs have come to you, that you do what is appropriate for the occasion; for Elohim is with you. 
+</div><div class="p">
+<sup>8&#160;</sup>“Go down ahead of me to Gilgal; and behold, I will come down to you to offer burnt offerings and to sacrifice sacrifices of peace offerings. Wait seven days, until I come to you and show you what you are to do.” 
+<sup>9&#160;</sup>It was so, that when he had turned his back to go from Samuel, Elohim gave him another heart; and all those signs happened that day. 
+<sup>10&#160;</sup>When they came there to the hill, behold, a band of prophets met him; and the Spirit of Elohim came mightily on him, and he prophesied among them. 
+<sup>11&#160;</sup>When all who knew him before saw that, behold, he prophesied with the prophets, then the people said to one another, “What is this that has come to the son of Kish? Is Saul also among the prophets?” 
+</div><div class="p">
+<sup>12&#160;</sup>One from the same place answered, “Who is their father?” Therefore it became a proverb, “Is Saul also among the prophets?” 
+<sup>13&#160;</sup>When he had finished prophesying, he came to the high place. 
+</div><div class="p">
+<sup>14&#160;</sup>Saul’s uncle said to him and to his servant, “Where did you go?” 
+</div><div class="p">He said, “To seek the donkeys. When we saw that they were not found, we came to Samuel.” 
+</div><div class="p">
+<sup>15&#160;</sup>Saul’s uncle said, “Please tell me what Samuel said to you.” 
+</div><div class="p">
+<sup>16&#160;</sup>Saul said to his uncle, “He told us plainly that the donkeys were found.” But concerning the matter of the kingdom, of which Samuel spoke, he didn’t tell him. 
+</div><div class="p">
+<sup>17&#160;</sup>Samuel called the people together to Yahweh to Mizpah; 
+<sup>18&#160;</sup>and he said to the children of Israel, “Yahweh, the Elohim of Israel, says ‘I brought Israel up out of Egypt and I delivered you out of the hand of the Egyptians, and out of the hand of all the kingdoms that oppressed you.’ 
+<sup>19&#160;</sup>But you have today rejected your Elohim, who himself saves you out of all your calamities and your distresses; and you have said to him, ‘No! Set a king over us!’ Now therefore present yourselves before Yahweh by your tribes and by your thousands.” 
+</div><div class="p">
+<sup>20&#160;</sup>So Samuel brought all the tribes of Israel near, and the tribe of Benjamin was chosen. 
+<sup>21&#160;</sup>He brought the tribe of Benjamin near by their families and the family of the Matrites was chosen. Then Saul the son of Kish was chosen; but when they looked for him, he could not be found. 
+<sup>22&#160;</sup>Therefore they asked of Yahweh further, “Is there yet a man to come here?” 
+</div><div class="p">Yahweh answered, “Behold, he has hidden himself among the baggage.” 
+</div><div class="p">
+<sup>23&#160;</sup>They ran and got him there. When he stood among the people, he was higher than any of the people from his shoulders and upward. 
+<sup>24&#160;</sup>Samuel said to all the people, “Do you see him whom Yahweh has chosen, that there is no one like him among all the people?” 
+</div><div class="p">All the people shouted and said, “Long live the king!” 
+</div><div class="p">
+<sup>25&#160;</sup>Then Samuel told the people the regulations of the kingdom, and wrote it in a book and laid it up before Yahweh. Samuel sent all the people away, every man to his house. 
+<sup>26&#160;</sup>Saul also went to his house in Gibeah; and the army went with him, whose hearts Elohim had touched. 
+<sup>27&#160;</sup>But certain worthless fellows said, “How could this man save us?” They despised him, and brought him no tribute. But he held his peace. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Nahash the Ammonite came up and encamped against Jabesh Gilead; and all the men of Jabesh said to Nahash, “Make a covenant with us, and we will serve you.” 
+</div><div class="p">
+<sup>2&#160;</sup>Nahash the Ammonite said to them, “On this condition I will make it with you, that all your right eyes be gouged out. I will make this dishonor all Israel.” 
+</div><div class="p">
+<sup>3&#160;</sup>The elders of Jabesh said to him, “Give us seven days, that we may send messengers to all the borders of Israel; and then, if there is no one to save us, we will come out to you.” 
+<sup>4&#160;</sup>Then the messengers came to Gibeah of Saul, and spoke these words in the ears of the people, then all the people lifted up their voice and wept. 
+</div><div class="p">
+<sup>5&#160;</sup>Behold, Saul came following the oxen out of the field; and Saul said, “What ails the people that they weep?” They told him the words of the men of Jabesh. 
+<sup>6&#160;</sup>Elohim’s Spirit came mightily on Saul when he heard those words, and his anger burned hot. 
+<sup>7&#160;</sup>He took a yoke of oxen and cut them in pieces, then sent them throughout all the borders of Israel by the hand of messengers, saying, “Whoever doesn’t come out after Saul and after Samuel, so shall it be done to his oxen.” The dread of Yahweh fell on the people, and they came out as one man. 
+<sup>8&#160;</sup>He counted them in Bezek; and the children of Israel were three hundred thousand, and the men of Judah thirty thousand. 
+<sup>9&#160;</sup>They said to the messengers who came, “Tell the men of Jabesh Gilead, ‘Tomorrow, by the time the sun is hot, you will be rescued.’&#160;” The messengers came and told the men of Jabesh; and they were glad. 
+<sup>10&#160;</sup>Therefore the men of Jabesh said, “Tomorrow we will come out to you, and you shall do with us all that seems good to you.” 
+<sup>11&#160;</sup>On the next day, Saul put the people in three companies; and they came into the middle of the camp in the morning watch, and struck the Ammonites until the heat of the day. Those who remained were scattered, so that no two of them were left together. 
+</div><div class="p">
+<sup>12&#160;</sup>The people said to Samuel, “Who is he who said, ‘Shall Saul reign over us?’ Bring those men, that we may put them to death!” 
+</div><div class="p">
+<sup>13&#160;</sup>Saul said, “No man shall be put to death today; for today Yahweh has rescued Israel.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Samuel said to the people, “Come! Let’s go to Gilgal, and renew the kingdom there.” 
+<sup>15&#160;</sup>All the people went to Gilgal; and there they made Saul king before Yahweh in Gilgal. There they offered sacrifices of peace offerings before Yahweh; and there Saul and all the men of Israel rejoiced greatly. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Samuel said to all Israel, “Behold, I have listened to your voice in all that you said to me, and have made a king over you. 
+<sup>2&#160;</sup>Now, behold, the king walks before you. I am old and gray-headed. Behold, my sons are with you. I have walked before you from my youth to this day. 
+<sup>3&#160;</sup>Here I am. Witness against me before Yahweh and before his anointed. Whose ox have I taken? Whose donkey have I taken? Whom have I defrauded? Whom have I oppressed? Of whose hand have I taken a bribe to make me blind my eyes? I will restore it to you.” 
+</div><div class="p">
+<sup>4&#160;</sup>They said, “You have not defrauded us, nor oppressed us, neither have you taken anything from anyone’s hand.” 
+</div><div class="p">
+<sup>5&#160;</sup>He said to them, “Yahweh is witness against you, and his anointed is witness today, that you have not found anything in my hand.” 
+</div><div class="p">They said, “He is witness.” 
+<sup>6&#160;</sup>Samuel said to the people, “It is Yahweh who appointed Moses and Aaron, and that brought your fathers up out of the land of Egypt. 
+<sup>7&#160;</sup>Now therefore stand still, that I may plead with you before Yahweh concerning all the righteous acts of Yahweh, which he did to you and to your fathers. 
+</div><div class="p">
+<sup>8&#160;</sup>“When Jacob had come into Egypt, and your fathers cried to Yahweh, then Yahweh sent Moses and Aaron, who brought your fathers out of Egypt, and made them to dwell in this place. 
+<sup>9&#160;</sup>But they forgot Yahweh their Elohim; and he sold them into the hand of Sisera, captain of the army of Hazor, and into the hand of the Philistines, and into the hand of the king of Moab; and they fought against them. 
+<sup>10&#160;</sup>They cried to Yahweh, and said, ‘We have sinned, because we have forsaken Yahweh and have served the Baals and the Ashtaroth; but now deliver us out of the hand of our enemies, and we will serve you.’ 
+<sup>11&#160;</sup>Yahweh sent Jerubbaal, Bedan, Jephthah, and Samuel, and delivered you out of the hand of your enemies on every side; and you lived in safety. 
+</div><div class="p">
+<sup>12&#160;</sup>“When you saw that Nahash the king of the children of Ammon came against you, you said to me, ‘No, but a king shall reign over us,’ when Yahweh your Elohim was your king. 
+<sup>13&#160;</sup>Now therefore see the king whom you have chosen and whom you have asked for. Behold, Yahweh has set a king over you. 
+<sup>14&#160;</sup>If you will fear Yahweh, and serve him, and listen to his voice, and not rebel against the commandment of Yahweh, then both you and also the king who reigns over you are followers of Yahweh your Elohim. 
+<sup>15&#160;</sup>But if you will not listen to Yahweh’s voice, but rebel against the commandment of Yahweh, then Yahweh’s hand will be against you, as it was against your fathers. 
+</div><div class="p">
+<sup>16&#160;</sup>“Now therefore stand still and see this great thing, which Yahweh will do before your eyes. 
+<sup>17&#160;</sup>Isn’t it wheat harvest today? I will call to Yahweh, that he may send thunder and rain; and you will know and see that your wickedness is great, which you have done in Yahweh’s sight, in asking for a king.” 
+</div><div class="p">
+<sup>18&#160;</sup>So Samuel called to Yahweh, and Yahweh sent thunder and rain that day. Then all the people greatly feared Yahweh and Samuel. 
+</div><div class="p">
+<sup>19&#160;</sup>All the people said to Samuel, “Pray for your servants to Yahweh your Elohim, that we not die; for we have added to all our sins this evil, to ask for a king.” 
+</div><div class="p">
+<sup>20&#160;</sup>Samuel said to the people, “Don’t be afraid. You have indeed done all this evil; yet don’t turn away from following Yahweh, but serve Yahweh with all your heart. 
+<sup>21&#160;</sup>Don’t turn away to go after vain things which can’t profit or deliver, for they are vain. 
+<sup>22&#160;</sup>For Yahweh will not forsake his people for his great name’s sake, because it has pleased Yahweh to make you a people for himself. 
+<sup>23&#160;</sup>Moreover, as for me, far be it from me that I should sin against Yahweh in ceasing to pray for you; but I will instruct you in the good and the right way. 
+<sup>24&#160;</sup>Only fear Yahweh, and serve him in truth with all your heart; for consider what great things he has done for you. 
+<sup>25&#160;</sup>But if you keep doing evil, you will be consumed, both you and your king.” 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Saul was thirty years old when he became king, and he reigned over Israel forty-two years. 
+</div><div class="p">
+<sup>2&#160;</sup>Saul chose for himself three thousand men of Israel, of which two thousand were with Saul in Michmash and in the Mount of Bethel, and one thousand were with Jonathan in Gibeah of Benjamin. He sent the rest of the people to their own tents. 
+<sup>3&#160;</sup>Jonathan struck the garrison of the Philistines that was in Geba, and the Philistines heard of it. Saul blew the trumpet throughout all the land, saying, “Let the Hebrews hear!” 
+<sup>4&#160;</sup>All Israel heard that Saul had struck the garrison of the Philistines, and also that Israel was considered an abomination to the Philistines. The people were gathered together after Saul to Gilgal. 
+<sup>5&#160;</sup>The Philistines assembled themselves together to fight with Israel: thirty thousand chariots, six thousand horsemen, and people as the sand which is on the seashore in multitude. They came up and encamped in Michmash, eastward of Beth Aven. 
+<sup>6&#160;</sup>When the men of Israel saw that they were in trouble (for the people were distressed), then the people hid themselves in caves, in thickets, in rocks, in tombs, and in pits. 
+<sup>7&#160;</sup>Now some of the Hebrews had gone over the Jordan to the land of Gad and Gilead; but as for Saul, he was yet in Gilgal, and all the people followed him trembling. 
+<sup>8&#160;</sup>He stayed seven days, according to the time set by Samuel; but Samuel didn’t come to Gilgal, and the people were scattering from him. 
+<sup>9&#160;</sup>Saul said, “Bring the burnt offering to me here, and the peace offerings.” He offered the burnt offering. 
+</div><div class="p">
+<sup>10&#160;</sup>It came to pass that as soon as he had finished offering the burnt offering, behold, Samuel came; and Saul went out to meet him, that he might greet him. 
+<sup>11&#160;</sup>Samuel said, “What have you done?” 
+</div><div class="p">Saul said, “Because I saw that the people were scattered from me, and that you didn’t come within the days appointed, and that the Philistines assembled themselves together at Michmash, 
+<sup>12&#160;</sup>therefore I said, ‘Now the Philistines will come down on me to Gilgal, and I haven’t entreated the favor of Yahweh.’ I forced myself therefore, and offered the burnt offering.” 
+</div><div class="p">
+<sup>13&#160;</sup>Samuel said to Saul, “You have done foolishly. You have not kept the commandment of Yahweh your Elohim, which he commanded you; for now Yahweh would have established your kingdom on Israel forever. 
+<sup>14&#160;</sup>But now your kingdom will not continue. Yahweh has sought for himself a man after his own heart, and Yahweh has appointed him to be prince over his people, because you have not kept that which Yahweh commanded you.” 
+</div><div class="p">
+<sup>15&#160;</sup>Samuel arose, and went from Gilgal to Gibeah of Benjamin. Saul counted the people who were present with him, about six hundred men. 
+<sup>16&#160;</sup>Saul, and Jonathan his son, and the people who were present with them, stayed in Geba of Benjamin; but the Philistines encamped in Michmash. 
+<sup>17&#160;</sup>The raiders came out of the camp of the Philistines in three companies: one company turned to the way that leads to Ophrah, to the land of Shual; 
+<sup>18&#160;</sup>another company turned the way to Beth Horon; and another company turned the way of the border that looks down on the valley of Zeboim toward the wilderness. 
+<sup>19&#160;</sup>Now there was no blacksmith found throughout all the land of Israel, for the Philistines said, “Lest the Hebrews make themselves swords or spears”; 
+<sup>20&#160;</sup>but all the Israelites went down to the Philistines, each man to sharpen his own plowshare, mattock, ax, and sickle. 
+<sup>21&#160;</sup>The price was one payim each to sharpen mattocks, plowshares, pitchforks, axes, and goads. 
+<sup>22&#160;</sup>So it came to pass in the day of battle that neither sword nor spear was found in the hand of any of the people who were with Saul and Jonathan; but Saul and Jonathan his son had them. 
+</div><div class="p">
+<sup>23&#160;</sup>The garrison of the Philistines went out to the pass of Michmash. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Now it happened on a day that Jonathan the son of Saul said to the young man who bore his armor, “Come! Let’s go over to the Philistines’ garrison that is on the other side.” But he didn’t tell his father. 
+<sup>2&#160;</sup>Saul stayed in the uttermost part of Gibeah under the pomegranate tree which is in Migron; and the people who were with him were about six hundred men, 
+<sup>3&#160;</sup>including Ahijah the son of Ahitub, Ichabod’s brother, the son of Phinehas, the son of Eli the priest of Yahweh in Shiloh, wearing an ephod. The people didn’t know that Jonathan was gone. 
+</div><div class="p">
+<sup>4&#160;</sup>Between the passes, by which Jonathan sought to go over to the Philistines’ garrison, there was a rocky crag on the one side and a rocky crag on the other side; and the name of the one was Bozez, and the name of the other Seneh. 
+<sup>5&#160;</sup>The one crag rose up on the north in front of Michmash, and the other on the south in front of Geba. 
+<sup>6&#160;</sup>Jonathan said to the young man who bore his armor, “Come! Let’s go over to the garrison of these uncircumcised. It may be that Yahweh will work for us, for there is no restraint on Yahweh to save by many or by few.” 
+</div><div class="p">
+<sup>7&#160;</sup>His armor bearer said to him, “Do all that is in your heart. Go, and behold, I am with you according to your heart.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Jonathan said, “Behold, we will pass over to the men, and we will reveal ourselves to them. 
+<sup>9&#160;</sup>If they say this to us, ‘Wait until we come to you!’ then we will stand still in our place and will not go up to them. 
+<sup>10&#160;</sup>But if they say this, ‘Come up to us!’ then we will go up, for Yahweh has delivered them into our hand. This shall be the sign to us.” 
+</div><div class="p">
+<sup>11&#160;</sup>Both of them revealed themselves to the garrison of the Philistines; and the Philistines said, “Behold, the Hebrews are coming out of the holes where they had hidden themselves!” 
+<sup>12&#160;</sup>The men of the garrison answered Jonathan and his armor bearer, and said, “Come up to us, and we will show you something!” 
+</div><div class="p">Jonathan said to his armor bearer, “Come up after me, for Yahweh has delivered them into the hand of Israel.” 
+<sup>13&#160;</sup>Jonathan climbed up on his hands and on his feet, and his armor bearer after him, and they fell before Jonathan; and his armor bearer killed them after him. 
+<sup>14&#160;</sup>That first slaughter, which Jonathan and his armor bearer made, was about twenty men, within as it were half a furrow’s length in an acre of land. 
+</div><div class="p">
+<sup>15&#160;</sup>There was a trembling in the camp, in the field, and among all the people; the garrison and the raiders also trembled; and the earth quaked, so there was an exceedingly great trembling. 
+<sup>16&#160;</sup>The watchmen of Saul in Gibeah of Benjamin looked; and behold, the multitude melted away and scattered. 
+<sup>17&#160;</sup>Then Saul said to the people who were with him, “Count now, and see who is missing from us.” When they had counted, behold, Jonathan and his armor bearer were not there. 
+</div><div class="p">
+<sup>18&#160;</sup>Saul said to Ahijah, “Bring Elohim’s ark here.” For Elohim’s ark was with the children of Israel at that time. 
+<sup>19&#160;</sup>While Saul talked to the priest, the tumult that was in the camp of the Philistines went on and increased; and Saul said to the priest, “Withdraw your hand!” 
+</div><div class="p">
+<sup>20&#160;</sup>Saul and all the people who were with him were gathered together, and came to the battle; and behold, they were all striking each other with their swords in very great confusion. 
+<sup>21&#160;</sup>Now the Hebrews who were with the Philistines before and who went up with them into the camp from all around, even they also turned to be with the Israelites who were with Saul and Jonathan. 
+<sup>22&#160;</sup>Likewise all the men of Israel who had hidden themselves in the hill country of Ephraim, when they heard that the Philistines fled, even they also followed hard after them in the battle. 
+<sup>23&#160;</sup>So Yahweh saved Israel that day; and the battle passed over by Beth Aven. 
+</div><div class="p">
+<sup>24&#160;</sup>The men of Israel were distressed that day; for Saul had adjured the people, saying, “Cursed is the man who eats any food until it is evening, and I am avenged of my enemies.” So none of the people tasted food. 
+</div><div class="p">
+<sup>25&#160;</sup>All the people came into the forest; and there was honey on the ground. 
+<sup>26&#160;</sup>When the people had come to the forest, behold, honey was dripping, but no one put his hand to his mouth, for the people feared the oath. 
+<sup>27&#160;</sup>But Jonathan didn’t hear when his father commanded the people with the oath. Therefore he put out the end of the rod that was in his hand and dipped it in the honeycomb, and put his hand to his mouth; and his eyes brightened. 
+<sup>28&#160;</sup>Then one of the people answered, and said, “Your father directly commanded the people with an oath, saying, ‘Cursed is the man who eats food today.’&#160;” So the people were faint. 
+</div><div class="p">
+<sup>29&#160;</sup>Then Jonathan said, “My father has troubled the land. Please look how my eyes have brightened because I tasted a little of this honey. 
+<sup>30&#160;</sup>How much more, if perhaps the people had eaten freely today of the plunder of their enemies which they found? For now there has been no great slaughter among the Philistines.” 
+<sup>31&#160;</sup>They struck the Philistines that day from Michmash to Aijalon. The people were very faint; 
+<sup>32&#160;</sup>and the people pounced on the plunder, and took sheep, cattle, and calves, and killed them on the ground; and the people ate them with the blood. 
+<sup>33&#160;</sup>Then they told Saul, saying, “Behold, the people are sinning against Yahweh, in that they eat meat with the blood.” 
+</div><div class="p">He said, “You have dealt treacherously. Roll a large stone to me today!” 
+<sup>34&#160;</sup>Saul said, “Disperse yourselves among the people, and tell them, ‘Every man bring me here his ox, and every man his sheep, and kill them here, and eat; and don’t sin against Yahweh in eating meat with the blood.’&#160;” All the people brought every man his ox with him that night, and killed them there. 
+</div><div class="p">
+<sup>35&#160;</sup>Saul built an altar to Yahweh. This was the first altar that he built to Yahweh. 
+<sup>36&#160;</sup>Saul said, “Let’s go down after the Philistines by night, and take plunder among them until the morning light. Let’s not leave a man of them.” 
+</div><div class="p">They said, “Do whatever seems good to you.” 
+</div><div class="p">Then the priest said, “Let’s draw near here to Elohim.” 
+</div><div class="p">
+<sup>37&#160;</sup>Saul asked counsel of Elohim: “Shall I go down after the Philistines? Will you deliver them into the hand of Israel?” But he didn’t answer him that day. 
+<sup>38&#160;</sup>Saul said, “Draw near here, all you chiefs of the people, and know and see in whom this sin has been today. 
+<sup>39&#160;</sup>For as Yahweh lives, who saves Israel, though it is in Jonathan my son, he shall surely die.” But there was not a man among all the people who answered him. 
+<sup>40&#160;</sup>Then he said to all Israel, “You be on one side, and I and Jonathan my son will be on the other side.” 
+</div><div class="p">The people said to Saul, “Do what seems good to you.” 
+</div><div class="p">
+<sup>41&#160;</sup>Therefore Saul said to Yahweh, the Elohim of Israel, “Show the right.” 
+</div><div class="p">Jonathan and Saul were chosen, but the people escaped. 
+</div><div class="p">
+<sup>42&#160;</sup>Saul said, “Cast lots between me and Jonathan my son.” 
+</div><div class="p">Jonathan was selected. 
+</div><div class="p">
+<sup>43&#160;</sup>Then Saul said to Jonathan, “Tell me what you have done!” 
+</div><div class="p">Jonathan told him, and said, “I certainly did taste a little honey with the end of the rod that was in my hand; and behold, I must die.” 
+</div><div class="p">
+<sup>44&#160;</sup>Saul said, “Elohim do so and more also; for you shall surely die, Jonathan.” 
+</div><div class="p">
+<sup>45&#160;</sup>The people said to Saul, “Shall Jonathan die, who has worked this great salvation in Israel? Far from it! As Yahweh lives, there shall not one hair of his head fall to the ground, for he has worked with Elohim today!” So the people rescued Jonathan, so he didn’t die. 
+<sup>46&#160;</sup>Then Saul went up from following the Philistines; and the Philistines went to their own place. 
+</div><div class="p">
+<sup>47&#160;</sup>Now when Saul had taken the kingdom over Israel, he fought against all his enemies on every side: against Moab, and against the children of Ammon, and against Edom, and against the kings of Zobah, and against the Philistines. Wherever he turned himself, he defeated them. 
+<sup>48&#160;</sup>He did valiantly and struck the Amalekites, and delivered Israel out of the hands of those who plundered them. 
+<sup>49&#160;</sup>Now the sons of Saul were Jonathan, Ishvi, and Malchishua; and the names of his two daughters were these: the name of the firstborn Merab, and the name of the younger Michal. 
+<sup>50&#160;</sup>The name of Saul’s woman was Ahinoam the daughter of Ahimaaz. The name of the captain of his army was Abner the son of Ner, Saul’s uncle. 
+<sup>51&#160;</sup>Kish was the father of Saul, and Ner the father of Abner was the son of Abiel. 
+</div><div class="p">
+<sup>52&#160;</sup>There was severe war against the Philistines all the days of Saul; and when Saul saw any mighty man or any valiant man, he took him into his service. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Samuel said to Saul, “Yahweh sent me to anoint you to be king over his people, over Israel. Now therefore listen to the voice of Yahweh’s words. 
+<sup>2&#160;</sup>Yahweh of Armies says, ‘I remember what Amalek did to Israel, how he set himself against him on the way when he came up out of Egypt. 
+<sup>3&#160;</sup>Now go and strike Amalek, and utterly destroy all that they have, and don’t spare them; but kill both man and woman, infant and nursing baby, ox and sheep, camel and donkey.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>Saul summoned the people, and counted them in Telaim, two hundred thousand footmen and ten thousand men of Judah. 
+<sup>5&#160;</sup>Saul came to the city of Amalek, and set an ambush in the valley. 
+<sup>6&#160;</sup>Saul said to the Kenites, “Go, depart, go down from among the Amalekites, lest I destroy you with them; for you showed kindness to all the children of Israel when they came up out of Egypt.” So the Kenites departed from among the Amalekites. 
+</div><div class="p">
+<sup>7&#160;</sup>Saul struck the Amalekites, from Havilah as you go to Shur, which is before Egypt. 
+<sup>8&#160;</sup>He took Agag the king of the Amalekites alive, and utterly destroyed all the people with the edge of the sword. 
+<sup>9&#160;</sup>But Saul and the people spared Agag and the best of the sheep, of the cattle, of the fat calves, of the lambs, and all that was good, and were not willing to utterly destroy them; but everything that was vile and refuse, that they destroyed utterly. 
+</div><div class="p">
+<sup>10&#160;</sup>Then Yahweh’s word came to Samuel, saying, 
+<sup>11&#160;</sup>“It grieves me that I have set up Saul to be king, for he has turned back from following me, and has not performed my commandments.” Samuel was angry; and he cried to Yahweh all night. 
+</div><div class="p">
+<sup>12&#160;</sup>Samuel rose early to meet Saul in the morning; and Samuel was told, saying, “Saul came to Carmel, and behold, he set up a monument for himself, turned, passed on, and went down to Gilgal.” 
+</div><div class="p">
+<sup>13&#160;</sup>Samuel came to Saul; and Saul said to him, “You are blessed by Yahweh! I have performed the commandment of Yahweh.” 
+</div><div class="p">
+<sup>14&#160;</sup>Samuel said, “Then what does this bleating of the sheep in my ears and the lowing of the cattle which I hear mean?” 
+</div><div class="p">
+<sup>15&#160;</sup>Saul said, “They have brought them from the Amalekites; for the people spared the best of the sheep and of the cattle, to sacrifice to Yahweh your Elohim. We have utterly destroyed the rest.” 
+</div><div class="p">
+<sup>16&#160;</sup>Then Samuel said to Saul, “Stay, and I will tell you what Yahweh said to me last night.” 
+</div><div class="p">He said to him, “Say on.” 
+</div><div class="p">
+<sup>17&#160;</sup>Samuel said, “Though you were little in your own sight, weren’t you made the head of the tribes of Israel? Yahweh anointed you king over Israel; 
+<sup>18&#160;</sup>and Yahweh sent you on a journey, and said, ‘Go, and utterly destroy the sinners the Amalekites, and fight against them until they are consumed.’ 
+<sup>19&#160;</sup>Why then didn’t you obey Yahweh’s voice, but took the plunder, and did that which was evil in Yahweh’s sight?” 
+</div><div class="p">
+<sup>20&#160;</sup>Saul said to Samuel, “But I have obeyed Yahweh’s voice, and have gone the way which Yahweh sent me, and have brought Agag the king of Amalek, and have utterly destroyed the Amalekites. 
+<sup>21&#160;</sup>But the people took of the plunder, sheep and cattle, the best of the devoted things, to sacrifice to Yahweh your Elohim in Gilgal.” 
+</div><div class="p">
+<sup>22&#160;</sup>Samuel said, “Has Yahweh as great delight in burnt offerings and sacrifices, as in obeying Yahweh’s voice? Behold, to obey is better than sacrifice, and to listen than the fat of rams. 
+<sup>23&#160;</sup>For rebellion is as the sin of witchcraft, and stubbornness is as idolatry and teraphim. Because you have rejected Yahweh’s word, he has also rejected you from being king.” 
+</div><div class="p">
+<sup>24&#160;</sup>Saul said to Samuel, “I have sinned; for I have transgressed the commandment of Yahweh and your words, because I feared the people and obeyed their voice. 
+<sup>25&#160;</sup>Now therefore, please pardon my sin, and turn again with me, that I may worship Yahweh.” 
+</div><div class="p">
+<sup>26&#160;</sup>Samuel said to Saul, “I will not return with you; for you have rejected Yahweh’s word, and Yahweh has rejected you from being king over Israel.” 
+<sup>27&#160;</sup>As Samuel turned around to go away, Saul grabbed the skirt of his robe, and it tore. 
+<sup>28&#160;</sup>Samuel said to him, “Yahweh has torn the kingdom of Israel from you today, and has given it to a neighbor of yours who is better than you. 
+<sup>29&#160;</sup>Also the Strength of Israel will not lie nor repent; for he is not a man, that he should repent.” 
+</div><div class="p">
+<sup>30&#160;</sup>Then he said, “I have sinned; yet please honor me now before the elders of my people and before Israel, and come back with me, that I may worship Yahweh your Elohim.” 
+</div><div class="p">
+<sup>31&#160;</sup>So Samuel went back with Saul; and Saul worshiped Yahweh. 
+<sup>32&#160;</sup>Then Samuel said, “Bring Agag the king of the Amalekites here to me!” 
+</div><div class="p">Agag came to him cheerfully. Agag said, “Surely the bitterness of death is past.” 
+</div><div class="p">
+<sup>33&#160;</sup>Samuel said, “As your sword has made women childless, so your mother will be childless among women!” Then Samuel cut Agag in pieces before Yahweh in Gilgal. 
+</div><div class="p">
+<sup>34&#160;</sup>Then Samuel went to Ramah; and Saul went up to his house to Gibeah of Saul. 
+<sup>35&#160;</sup>Samuel came no more to see Saul until the day of his death, but Samuel mourned for Saul. Yahweh grieved that he had made Saul king over Israel. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Samuel, “How long will you mourn for Saul, since I have rejected him from being king over Israel? Fill your horn with oil, and go. I will send you to Jesse the Bethlehemite, for I have provided a king for myself among his sons.” 
+</div><div class="p">
+<sup>2&#160;</sup>Samuel said, “How can I go? If Saul hears it, he will kill me.” 
+</div><div class="p">Yahweh said, “Take a heifer with you, and say, ‘I have come to sacrifice to Yahweh.’ 
+<sup>3&#160;</sup>Call Jesse to the sacrifice, and I will show you what you shall do. You shall anoint to me him whom I name to you.” 
+</div><div class="p">
+<sup>4&#160;</sup>Samuel did that which Yahweh spoke, and came to Bethlehem. The elders of the city came to meet him trembling, and said, “Do you come peaceably?” 
+</div><div class="p">
+<sup>5&#160;</sup>He said, “Peaceably; I have come to sacrifice to Yahweh. Sanctify yourselves, and come with me to the sacrifice.” He sanctified Jesse and his sons, and called them to the sacrifice. 
+<sup>6&#160;</sup>When they had come, he looked at Eliab, and said, “Surely Yahweh’s anointed is before him.” 
+</div><div class="p">
+<sup>7&#160;</sup>But Yahweh said to Samuel, “Don’t look on his face, or on the height of his stature, because I have rejected him; for I don’t see as man sees. For man looks at the outward appearance, but Yahweh looks at the heart.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Jesse called Abinadab, and made him pass before Samuel. He said, “Yahweh has not chosen this one, either.” 
+<sup>9&#160;</sup>Then Jesse made Shammah to pass by. He said, “Yahweh has not chosen this one, either.” 
+<sup>10&#160;</sup>Jesse made seven of his sons to pass before Samuel. Samuel said to Jesse, “Yahweh has not chosen these.” 
+<sup>11&#160;</sup>Samuel said to Jesse, “Are all your children here?” 
+</div><div class="p">He said, “There remains yet the youngest. Behold, he is keeping the sheep.” 
+</div><div class="p">Samuel said to Jesse, “Send and get him, for we will not sit down until he comes here.” 
+</div><div class="p">
+<sup>12&#160;</sup>He sent, and brought him in. Now he was ruddy, with a handsome face and good appearance. Yahweh said, “Arise! Anoint him, for this is he.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then Samuel took the horn of oil and anointed him in the middle of his brothers. Then Yahweh’s Spirit came mightily on David from that day forward. So Samuel rose up and went to Ramah. 
+<sup>14&#160;</sup>Now Yahweh’s Spirit departed from Saul, and an evil spirit from Yahweh troubled him. 
+<sup>15&#160;</sup>Saul’s servants said to him, “See now, an evil spirit from Elohim troubles you. 
+<sup>16&#160;</sup>Let our lord now command your servants who are in front of you to seek out a man who is a skillful player on the harp. Then when the evil spirit from Elohim is on you, he will play with his hand, and you will be well.” 
+</div><div class="p">
+<sup>17&#160;</sup>Saul said to his servants, “Provide me now a man who can play well, and bring him to me.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then one of the young men answered and said, “Behold, I have seen a son of Jesse the Bethlehemite who is skillful in playing, a mighty man of valor, a man of war, prudent in speech, and a handsome person; and Yahweh is with him.” 
+</div><div class="p">
+<sup>19&#160;</sup>Therefore Saul sent messengers to Jesse, and said, “Send me David your son, who is with the sheep.” 
+</div><div class="p">
+<sup>20&#160;</sup>Jesse took a donkey loaded with bread, a container of wine, and a young goat, and sent them by David his son to Saul. 
+<sup>21&#160;</sup>David came to Saul and stood before him. He loved him greatly; and he became his armor bearer. 
+<sup>22&#160;</sup>Saul sent to Jesse, saying, “Please let David stand before me, for he has found favor in my sight.” 
+<sup>23&#160;</sup>When the spirit from Elohim was on Saul, David took the harp and played with his hand; so Saul was refreshed and was well, and the evil spirit departed from him. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the Philistines gathered together their armies to battle; and they were gathered together at Socoh, which belongs to Judah, and encamped between Socoh and Azekah in Ephesdammim. 
+<sup>2&#160;</sup>Saul and the men of Israel were gathered together, and encamped in the valley of Elah, and set the battle in array against the Philistines. 
+<sup>3&#160;</sup>The Philistines stood on the mountain on the one side, and Israel stood on the mountain on the other side: and there was a valley between them. 
+<sup>4&#160;</sup>A champion out of the camp of the Philistines named Goliath of Gath, whose height was six cubits and a span went out. 
+<sup>5&#160;</sup>He had a helmet of bronze on his head, and he wore a coat of mail; and the weight of the coat was five thousand shekels of bronze. 
+<sup>6&#160;</sup>He had bronze shin armor on his legs and a bronze javelin between his shoulders. 
+<sup>7&#160;</sup>The staff of his spear was like a weaver’s beam; and his spear’s head weighed six hundred shekels of iron. His shield bearer went before him. 
+<sup>8&#160;</sup>He stood and cried to the armies of Israel, and said to them, “Why have you come out to set your battle in array? Am I not a Philistine, and you servants to Saul? Choose a man for yourselves, and let him come down to me. 
+<sup>9&#160;</sup>If he is able to fight with me and kill me, then will we be your servants; but if I prevail against him and kill him, then you will be our servants and serve us.” 
+<sup>10&#160;</sup>The Philistine said, “I defy the armies of Israel today! Give me a man, that we may fight together!” 
+</div><div class="p">
+<sup>11&#160;</sup>When Saul and all Israel heard those words of the Philistine, they were dismayed and greatly afraid. 
+<sup>12&#160;</sup>Now David was the son of that Ephrathite of Bethlehem Judah, whose name was Jesse; and he had eight sons. The man was an elderly old man in the days of Saul. 
+<sup>13&#160;</sup>The three oldest sons of Jesse had gone after Saul to the battle; and the names of his three sons who went to the battle were Eliab the firstborn, and next to him Abinadab, and the third Shammah. 
+<sup>14&#160;</sup>David was the youngest; and the three oldest followed Saul. 
+<sup>15&#160;</sup>Now David went back and forth from Saul to feed his father’s sheep at Bethlehem. 
+</div><div class="p">
+<sup>16&#160;</sup>The Philistine came near morning and evening, and presented himself forty days. 
+</div><div class="p">
+<sup>17&#160;</sup>Jesse said to David his son, “Now take for your brothers an ephah of this parched grain and these ten loaves, and carry them quickly to the camp to your brothers; 
+<sup>18&#160;</sup>and bring these ten cheeses to the captain of their thousand; and see how your brothers are doing, and bring back news.” 
+<sup>19&#160;</sup>Now Saul, and they, and all the men of Israel were in the valley of Elah, fighting with the Philistines. 
+</div><div class="p">
+<sup>20&#160;</sup>David rose up early in the morning and left the sheep with a keeper, and took the provisions and went, as Jesse had commanded him. He came to the place of the wagons as the army which was going out to the fight shouted for the battle. 
+<sup>21&#160;</sup>Israel and the Philistines put the battle in array, army against army. 
+<sup>22&#160;</sup>David left his baggage in the hand of the keeper of the baggage and ran to the army, and came and greeted his brothers. 
+<sup>23&#160;</sup>As he talked with them, behold, the champion, the Philistine of Gath, Goliath by name, came up out of the ranks of the Philistines, and said the same words; and David heard them. 
+<sup>24&#160;</sup>All the men of Israel, when they saw the man, fled from him and were terrified. 
+<sup>25&#160;</sup>The men of Israel said, “Have you seen this man who has come up? He has surely come up to defy Israel. The king will give great riches to the man who kills him, and will give him his daughter, and will make his father’s house tax-free in Israel.” 
+</div><div class="p">
+<sup>26&#160;</sup>David spoke to the men who stood by him, saying, “What shall be done to the man who kills this Philistine and takes away the reproach from Israel? For who is this uncircumcised Philistine, that he should defy the armies of the living Elohim?” 
+</div><div class="p">
+<sup>27&#160;</sup>The people answered him in this way, saying, “So shall it be done to the man who kills him.” 
+</div><div class="p">
+<sup>28&#160;</sup>Eliab his oldest brother heard when he spoke to the men; and Eliab’s anger burned against David, and he said, “Why have you come down? With whom have you left those few sheep in the wilderness? I know your pride and the evil of your heart; for you have come down that you might see the battle.” 
+</div><div class="p">
+<sup>29&#160;</sup>David said, “What have I now done? Is there not a cause?” 
+<sup>30&#160;</sup>He turned away from him toward another, and spoke like that again; and the people answered him again the same way. 
+<sup>31&#160;</sup>When the words were heard which David spoke, they rehearsed them before Saul; and he sent for him. 
+<sup>32&#160;</sup>David said to Saul, “Let no man’s heart fail because of him. Your servant will go and fight with this Philistine.” 
+</div><div class="p">
+<sup>33&#160;</sup>Saul said to David, “You are not able to go against this Philistine to fight with him; for you are but a youth, and he a man of war from his youth.” 
+</div><div class="p">
+<sup>34&#160;</sup>David said to Saul, “Your servant was keeping his father’s sheep; and when a lion or a bear came and took a lamb out of the flock, 
+<sup>35&#160;</sup>I went out after him, struck him, and rescued it out of his mouth. When he arose against me, I caught him by his beard, struck him, and killed him. 
+<sup>36&#160;</sup>Your servant struck both the lion and the bear. This uncircumcised Philistine shall be as one of them, since he has defied the armies of the living Elohim.” 
+<sup>37&#160;</sup>David said, “Yahweh, who delivered me out of the paw of the lion and out of the paw of the bear, will deliver me out of the hand of this Philistine.” 
+</div><div class="p">Saul said to David, “Go! Yahweh will be with you.” 
+</div><div class="p">
+<sup>38&#160;</sup>Saul dressed David with his clothing. He put a helmet of bronze on his head, and he clad him with a coat of mail. 
+<sup>39&#160;</sup>David strapped his sword on his clothing and he tried to move, for he had not tested it. David said to Saul, “I can’t go with these, for I have not tested them.” Then David took them off. 
+</div><div class="p">
+<sup>40&#160;</sup>He took his staff in his hand, and chose for himself five smooth stones out of the brook, and put them in the pouch of his shepherd’s bag which he had. His sling was in his hand; and he came near to the Philistine. 
+<sup>41&#160;</sup>The Philistine walked and came near to David; and the man who bore the shield went before him. 
+<sup>42&#160;</sup>When the Philistine looked around and saw David, he disdained him; for he was but a youth, and ruddy, and had a good looking face. 
+<sup>43&#160;</sup>The Philistine said to David, “Am I a dog, that you come to me with sticks?” The Philistine cursed David by his elohims. 
+<sup>44&#160;</sup>The Philistine said to David, “Come to me, and I will give your flesh to the birds of the sky and to the animals of the field.” 
+</div><div class="p">
+<sup>45&#160;</sup>Then David said to the Philistine, “You come to me with a sword, with a spear, and with a javelin; but I come to you in the name of Yahweh of Armies, the Elohim of the armies of Israel, whom you have defied. 
+<sup>46&#160;</sup>Today, Yahweh will deliver you into my hand. I will strike you and take your head from off you. I will give the dead bodies of the army of the Philistines today to the birds of the sky and to the wild animals of the earth, that all the earth may know that there is an Elohim in Israel, 
+<sup>47&#160;</sup>and that all this assembly may know that Yahweh doesn’t save with sword and spear; for the battle is Yahweh’s, and he will give you into our hand.” 
+</div><div class="p">
+<sup>48&#160;</sup>When the Philistine arose, and walked and came near to meet David, David hurried and ran toward the army to meet the Philistine. 
+<sup>49&#160;</sup>David put his hand in his bag, took a stone and slung it, and struck the Philistine in his forehead. The stone sank into his forehead, and he fell on his face to the earth. 
+<sup>50&#160;</sup>So David prevailed over the Philistine with a sling and with a stone, and struck the Philistine and killed him; but there was no sword in David’s hand. 
+<sup>51&#160;</sup>Then David ran, stood over the Philistine, took his sword, drew it out of its sheath, killed him, and cut off his head with it. 
+</div><div class="p">When the Philistines saw that their champion was dead, they fled. 
+<sup>52&#160;</sup>The men of Israel and of Judah arose and shouted, and pursued the Philistines as far as Gai and to the gates of Ekron. The wounded of the Philistines fell down by the way to Shaaraim, even to Gath and to Ekron. 
+<sup>53&#160;</sup>The children of Israel returned from chasing after the Philistines, and they plundered their camp. 
+<sup>54&#160;</sup>David took the head of the Philistine and brought it to Jerusalem, but he put his armor in his tent. 
+<sup>55&#160;</sup>When Saul saw David go out against the Philistine, he said to Abner, the captain of the army, “Abner, whose son is this youth?” 
+</div><div class="p">Abner said, “As your soul lives, O king, I can’t tell.” 
+</div><div class="p">
+<sup>56&#160;</sup>The king said, “Inquire whose son the young man is!” 
+</div><div class="p">
+<sup>57&#160;</sup>As David returned from the slaughter of the Philistine, Abner took him and brought him before Saul with the head of the Philistine in his hand. 
+<sup>58&#160;</sup>Saul said to him, “Whose son are you, you young man?” 
+</div><div class="p">David answered, “I am the son of your servant Jesse the Bethlehemite.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>When he had finished speaking to Saul, the soul of Jonathan was knit with the soul of David, and Jonathan loved him as his own soul. 
+<sup>2&#160;</sup>Saul took him that day, and wouldn’t let him go home to his father’s house any more. 
+<sup>3&#160;</sup>Then Jonathan and David made a covenant, because he loved him as his own soul. 
+<sup>4&#160;</sup>Jonathan stripped himself of the robe that was on him and gave it to David with his clothing, even including his sword, his bow, and his sash. 
+</div><div class="p">
+<sup>5&#160;</sup>David went out wherever Saul sent him, and behaved himself wisely; and Saul set him over the men of war. It was good in the sight of all the people, and also in the sight of Saul’s servants. 
+</div><div class="p">
+<sup>6&#160;</sup>As they came, when David returned from the slaughter of the Philistine, the women came out of all the cities of Israel, singing and dancing, to meet King Saul with tambourines, with joy, and with instruments of music. 
+<sup>7&#160;</sup>The women sang to one another as they played, and said, 
+</div><div class="q1">“Saul has slain his thousands, 
+</div><div class="q2">and David his ten thousands.” 
+</div><div class="p">
+<sup>8&#160;</sup>Saul was very angry, and this saying displeased him. He said, “They have credited David with ten thousands, and they have only credited me with thousands. What can he have more but the kingdom?” 
+<sup>9&#160;</sup>Saul watched David from that day and forward. 
+<sup>10&#160;</sup>On the next day, an evil spirit from Elohim came mightily on Saul, and he prophesied in the middle of the house. David played with his hand, as he did day by day. Saul had his spear in his hand; 
+<sup>11&#160;</sup>and Saul threw the spear, for he said, “I will pin David to the wall!” David escaped from his presence twice. 
+<sup>12&#160;</sup>Saul was afraid of David, because Yahweh was with him, and had departed from Saul. 
+<sup>13&#160;</sup>Therefore Saul removed him from his presence, and made him his captain over a thousand; and he went out and came in before the people. 
+</div><div class="p">
+<sup>14&#160;</sup>David behaved himself wisely in all his ways; and Yahweh was with him. 
+<sup>15&#160;</sup>When Saul saw that he behaved himself very wisely, he stood in awe of him. 
+<sup>16&#160;</sup>But all Israel and Judah loved David; for he went out and came in before them. 
+<sup>17&#160;</sup>Saul said to David, “Behold, my elder daughter Merab. I will give her to you as woman. Only be valiant for me, and fight Yahweh’s battles.” For Saul said, “Don’t let my hand be on him, but let the hand of the Philistines be on him.” 
+</div><div class="p">
+<sup>18&#160;</sup>David said to Saul, “Who am I, and what is my life, or my father’s family in Israel, that I should be son-in-law to the king?” 
+</div><div class="p">
+<sup>19&#160;</sup>But at the time when Merab, Saul’s daughter, should have been given to David, she was given to Adriel the Meholathite as woman. 
+</div><div class="p">
+<sup>20&#160;</sup>Michal, Saul’s daughter, loved David; and they told Saul, and the thing pleased him. 
+<sup>21&#160;</sup>Saul said, I will give her to him, that she may be a snare to him and that the hand of the Philistines may be against him. Therefore Saul said to David a second time, “You shall today be my son-in-law.” 
+</div><div class="p">
+<sup>22&#160;</sup>Saul commanded his servants, “Talk with David secretly, and say, ‘Behold, the king has delight in you, and all his servants love you. Now therefore be the king’s son-in-law.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Saul’s servants spoke those words in the ears of David. David said, “Does it seem to you a light thing to be the king’s son-in-law, since I am a poor man and little known?” 
+</div><div class="p">
+<sup>24&#160;</sup>The servants of Saul told him, saying, “David spoke like this.” 
+</div><div class="p">
+<sup>25&#160;</sup>Saul said, “Tell David, ‘The king desires no dowry except one hundred foreskins of the Philistines, to be avenged of the king’s enemies.’&#160;” Now Saul thought he would make David fall by the hand of the Philistines. 
+<sup>26&#160;</sup>When his servants told David these words, it pleased David well to be the king’s son-in-law. Before the deadline, 
+<sup>27&#160;</sup>David arose and went, he and his men, and killed two hundred men of the Philistines. Then David brought their foreskins, and they gave them in full number to the king, that he might be the king’s son-in-law. Then Saul gave him Michal his daughter as woman. 
+<sup>28&#160;</sup>Saul saw and knew that Yahweh was with David; and Michal, Saul’s daughter, loved him. 
+<sup>29&#160;</sup>Saul was even more afraid of David; and Saul was David’s enemy continually. 
+</div><div class="p">
+<sup>30&#160;</sup>Then the princes of the Philistines went out; and as often as they went out, David behaved himself more wisely than all the servants of Saul, so that his name was highly esteemed. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Saul spoke to Jonathan his son and to all his servants, that they should kill David. But Jonathan, Saul’s son, greatly delighted in David. 
+<sup>2&#160;</sup>Jonathan told David, saying, “Saul my father seeks to kill you. Now therefore, please take care of yourself in the morning, live in a secret place, and hide yourself. 
+<sup>3&#160;</sup>I will go out and stand beside my father in the field where you are, and I will talk with my father about you; and if I see anything, I will tell you.” 
+</div><div class="p">
+<sup>4&#160;</sup>Jonathan spoke good of David to Saul his father, and said to him, “Don’t let the king sin against his servant, against David; because he has not sinned against you, and because his works have been very good toward you; 
+<sup>5&#160;</sup>for he put his life in his hand and struck the Philistine, and Yahweh worked a great victory for all Israel. You saw it and rejoiced. Why then will you sin against innocent blood, to kill David without a cause?” 
+</div><div class="p">
+<sup>6&#160;</sup>Saul listened to the voice of Jonathan; and Saul swore, “As Yahweh lives, he shall not be put to death.” 
+</div><div class="p">
+<sup>7&#160;</sup>Jonathan called David, and Jonathan showed him all those things. Then Jonathan brought David to Saul, and he was in his presence as before. 
+</div><div class="p">
+<sup>8&#160;</sup>There was war again. David went out and fought with the Philistines, and killed them with a great slaughter; and they fled before him. 
+</div><div class="p">
+<sup>9&#160;</sup>An evil spirit from Yahweh was on Saul as he sat in his house with his spear in his hand; and David was playing music with his hand. 
+<sup>10&#160;</sup>Saul sought to pin David to the wall with the spear, but he slipped away out of Saul’s presence; and he stuck the spear into the wall. David fled and escaped that night. 
+<sup>11&#160;</sup>Saul sent messengers to David’s house to watch him and to kill him in the morning. Michal, David’s woman, told him, saying, “If you don’t save your life tonight, tomorrow you will be killed.” 
+<sup>12&#160;</sup>So Michal let David down through the window. He went away, fled, and escaped. 
+<sup>13&#160;</sup>Michal took the teraphim and laid it in the bed, and put a pillow of goats’ hair at its head and covered it with clothes. 
+<sup>14&#160;</sup>When Saul sent messengers to take David, she said, “He is sick.” 
+</div><div class="p">
+<sup>15&#160;</sup>Saul sent the messengers to see David, saying, “Bring him up to me in the bed, that I may kill him.” 
+<sup>16&#160;</sup>When the messengers came in, behold, the teraphim was in the bed, with the pillow of goats’ hair at its head. 
+</div><div class="p">
+<sup>17&#160;</sup>Saul said to Michal, “Why have you deceived me like this and let my enemy go, so that he has escaped?” 
+</div><div class="p">Michal answered Saul, “He said to me, ‘Let me go! Why should I kill you?’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Now David fled and escaped, and came to Samuel at Ramah, and told him all that Saul had done to him. He and Samuel went and lived in Naioth. 
+<sup>19&#160;</sup>Saul was told, saying, “Behold, David is at Naioth in Ramah.” 
+</div><div class="p">
+<sup>20&#160;</sup>Saul sent messengers to seize David; and when they saw the company of the prophets prophesying, and Samuel standing as head over them, Elohim’s Spirit came on Saul’s messengers, and they also prophesied. 
+<sup>21&#160;</sup>When Saul was told, he sent other messengers, and they also prophesied. Saul sent messengers again the third time, and they also prophesied. 
+<sup>22&#160;</sup>Then he also went to Ramah, and came to the great well that is in Secu: and he asked, “Where are Samuel and David?” 
+</div><div class="p">One said, “Behold, they are at Naioth in Ramah.” 
+</div><div class="p">
+<sup>23&#160;</sup>He went there to Naioth in Ramah. Then Elohim’s Spirit came on him also, and he went on, and prophesied, until he came to Naioth in Ramah. 
+<sup>24&#160;</sup>He also stripped off his clothes. He also prophesied before Samuel and lay down naked all that day and all that night. Therefore they say, “Is Saul also among the prophets?” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>David fled from Naioth in Ramah, and came and said to Jonathan, “What have I done? What is my iniquity? What is my sin before your father, that he seeks my life?” 
+</div><div class="p">
+<sup>2&#160;</sup>He said to him, “Far from it; you will not die. Behold, my father does nothing either great or small, but that he discloses it to me. Why would my father hide this thing from me? It is not so.” 
+</div><div class="p">
+<sup>3&#160;</sup>David swore moreover, and said, “Your father knows well that I have found favor in your eyes; and he says, ‘Don’t let Jonathan know this, lest he be grieved;’ but truly as Yahweh lives, and as your soul lives, there is but a step between me and death.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then Jonathan said to David, “Whatever your soul desires, I will even do it for you.” 
+</div><div class="p">
+<sup>5&#160;</sup>David said to Jonathan, “Behold, tomorrow is the new moon, and I should not fail to dine with the king; but let me go, that I may hide myself in the field to the third day at evening. 
+<sup>6&#160;</sup>If your father misses me at all, then say, ‘David earnestly asked leave of me that he might run to Bethlehem, his city; for it is the yearly sacrifice there for all the family.’ 
+<sup>7&#160;</sup>If he says, ‘It is well,’ your servant shall have peace; but if he is angry, then know that evil is determined by him. 
+<sup>8&#160;</sup>Therefore deal kindly with your servant, for you have brought your servant into a covenant of Yahweh with you; but if there is iniquity in me, kill me yourself, for why should you bring me to your father?” 
+</div><div class="p">
+<sup>9&#160;</sup>Jonathan said, “Far be it from you; for if I should at all know that evil were determined by my father to come on you, then wouldn’t I tell you that?” 
+</div><div class="p">
+<sup>10&#160;</sup>Then David said to Jonathan, “Who will tell me if your father answers you roughly?” 
+</div><div class="p">
+<sup>11&#160;</sup>Jonathan said to David, “Come! Let’s go out into the field.” They both went out into the field. 
+<sup>12&#160;</sup>Jonathan said to David, “By Yahweh, the Elohim of Israel, when I have sounded out my father about this time tomorrow, or the third day, behold, if there is good toward David, won’t I then send to you and disclose it to you? 
+<sup>13&#160;</sup>Yahweh do so to Jonathan and more also, should it please my father to do you evil, if I don’t disclose it to you and send you away, that you may go in peace. May Yahweh be with you as he has been with my father. 
+<sup>14&#160;</sup>You shall not only show me the loving kindness of Yahweh while I still live, that I not die; 
+<sup>15&#160;</sup>but you shall also not cut off your kindness from my house forever, no, not when Yahweh has cut off every one of the enemies of David from the surface of the earth.” 
+<sup>16&#160;</sup>So Jonathan made a covenant with David’s house, saying, “Yahweh will require it at the hand of David’s enemies.” 
+</div><div class="p">
+<sup>17&#160;</sup>Jonathan caused David to swear again, for the love that he had to him; for he loved him as he loved his own soul. 
+<sup>18&#160;</sup>Then Jonathan said to him, “Tomorrow is the new moon, and you will be missed, because your seat will be empty. 
+<sup>19&#160;</sup>When you have stayed three days, go down quickly and come to the place where you hid yourself when this started, and remain by the stone Ezel. 
+<sup>20&#160;</sup>I will shoot three arrows on its side, as though I shot at a mark. 
+<sup>21&#160;</sup>Behold, I will send the boy, saying, ‘Go, find the arrows!’ If I tell the boy, ‘Behold, the arrows are on this side of you. Take them;’ then come, for there is peace to you and no danger, as Yahweh lives. 
+<sup>22&#160;</sup>But if I say this to the boy, ‘Behold, the arrows are beyond you,’ then go your way, for Yahweh has sent you away. 
+<sup>23&#160;</sup>Concerning the matter which you and I have spoken of, behold, Yahweh is between you and me forever.” 
+</div><div class="p">
+<sup>24&#160;</sup>So David hid himself in the field. When the new moon had come, the king sat himself down to eat food. 
+<sup>25&#160;</sup>The king sat on his seat, as at other times, even on the seat by the wall; and Jonathan stood up, and Abner sat by Saul’s side, but David’s place was empty. 
+<sup>26&#160;</sup>Nevertheless Saul didn’t say anything that day, for he thought, “Something has happened to him. He is not clean. Surely he is not clean.” 
+</div><div class="p">
+<sup>27&#160;</sup>On the next day after the new moon, the second day, David’s place was empty. Saul said to Jonathan his son, “Why didn’t the son of Jesse come to eat, either yesterday, or today?” 
+</div><div class="p">
+<sup>28&#160;</sup>Jonathan answered Saul, “David earnestly asked permission of me to go to Bethlehem. 
+<sup>29&#160;</sup>He said, ‘Please let me go, for our family has a sacrifice in the city. My brother has commanded me to be there. Now, if I have found favor in your eyes, please let me go away and see my brothers.’ Therefore he has not come to the king’s table.” 
+</div><div class="p">
+<sup>30&#160;</sup>Then Saul’s anger burned against Jonathan, and he said to him, “You son of a perverse rebellious woman, don’t I know that you have chosen the son of Jesse to your own shame, and to the shame of your mother’s nakedness? 
+<sup>31&#160;</sup>For as long as the son of Jesse lives on the earth, you will not be established, nor will your kingdom. Therefore now send and bring him to me, for he shall surely die!” 
+</div><div class="p">
+<sup>32&#160;</sup>Jonathan answered Saul his father, and said to him, “Why should he be put to death? What has he done?” 
+</div><div class="p">
+<sup>33&#160;</sup>Saul cast his spear at him to strike him. By this Jonathan knew that his father was determined to put David to death. 
+<sup>34&#160;</sup>So Jonathan arose from the table in fierce anger, and ate no food the second day of the month; for he was grieved for David, because his father had treated him shamefully. 
+</div><div class="p">
+<sup>35&#160;</sup>In the morning, Jonathan went out into the field at the time appointed with David, and a little boy with him. 
+<sup>36&#160;</sup>He said to his boy, “Run, find now the arrows which I shoot.” As the boy ran, he shot an arrow beyond him. 
+<sup>37&#160;</sup>When the boy had come to the place of the arrow which Jonathan had shot, Jonathan cried after the boy, and said, “Isn’t the arrow beyond you?” 
+<sup>38&#160;</sup>Jonathan cried after the boy, “Go fast! Hurry! Don’t delay!” Jonathan’s boy gathered up the arrows, and came to his master. 
+<sup>39&#160;</sup>But the boy didn’t know anything. Only Jonathan and David knew the matter. 
+<sup>40&#160;</sup>Jonathan gave his weapons to his boy, and said to him, “Go, carry them to the city.” 
+</div><div class="p">
+<sup>41&#160;</sup>As soon as the boy was gone, David arose out of the south, and fell on his face to the ground, and bowed himself three times. They kissed one another and wept with one another, and David wept the most. 
+<sup>42&#160;</sup>Jonathan said to David, “Go in peace, because we have both sworn in Yahweh’s name, saying, ‘Yahweh is between me and you, and between my offspring and your offspring, forever.’&#160;” He arose and departed; and Jonathan went into the city. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Then David came to Nob to Ahimelech the priest. Ahimelech came to meet David trembling, and said to him, “Why are you alone, and no man with you?” 
+<sup>2&#160;</sup>David said to Ahimelech the priest, “The king has commanded me to do something, and has said to me, ‘Let no one know anything about the business about which I send you, and what I have commanded you. I have sent the young men to a certain place.’ 
+<sup>3&#160;</sup>Now therefore what is under your hand? Please give me five loaves of bread in my hand, or whatever is available.” 
+</div><div class="p">
+<sup>4&#160;</sup>The priest answered David, and said, “I have no common bread, but there is set-apart bread; if only the young men have kept themselves from women.” 
+</div><div class="p">
+<sup>5&#160;</sup>David answered the priest, and said to him, “Truly, women have been kept from us as usual these three days. When I came out, the vessels of the young men were set-apart, though it was only a common journey. How much more then today shall their vessels be set-apart?” 
+<sup>6&#160;</sup>So the priest gave him set-apart bread; for there was no bread there but the show bread that was taken from before Yahweh, to be replaced with hot bread in the day when it was taken away. 
+</div><div class="p">
+<sup>7&#160;</sup>Now a certain man of the servants of Saul was there that day, detained before Yahweh; and his name was Doeg the Edomite, the best of the herdsmen who belonged to Saul. 
+</div><div class="p">
+<sup>8&#160;</sup>David said to Ahimelech, “Isn’t there here under your hand spear or sword? For I haven’t brought my sword or my weapons with me, because the king’s business required haste.” 
+</div><div class="p">
+<sup>9&#160;</sup>The priest said, “Behold, the sword of Goliath the Philistine, whom you killed in the valley of Elah, is here wrapped in a cloth behind the ephod. If you would like to take that, take it, for there is no other except that here.” 
+</div><div class="p">David said, “There is none like that. Give it to me.” 
+</div><div class="p">
+<sup>10&#160;</sup>David arose and fled that day for fear of Saul, and went to Achish the king of Gath. 
+<sup>11&#160;</sup>The servants of Achish said to him, “Isn’t this David the king of the land? Didn’t they sing to one another about him in dances, saying, 
+</div><div class="q1">‘Saul has slain his thousands, 
+</div><div class="q2">and David his ten thousands’?” 
+</div><div class="p">
+<sup>12&#160;</sup>David laid up these words in his heart, and was very afraid of Achish the king of Gath. 
+<sup>13&#160;</sup>He changed his behavior before them and pretended to be insane in their hands, and scribbled on the doors of the gate, and let his spittle fall down on his beard. 
+<sup>14&#160;</sup>Then Achish said to his servants, “Look, you see the man is insane. Why then have you brought him to me? 
+<sup>15&#160;</sup>Do I lack madmen, that you have brought this fellow to play the madman in my presence? Should this fellow come into my house?” 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>David therefore departed from there and escaped to Adullam’s cave. When his brothers and all his father’s house heard it, they went down there to him. 
+<sup>2&#160;</sup>Everyone who was in distress, everyone who was in debt, and everyone who was discontented gathered themselves to him; and he became captain over them. There were with him about four hundred men. 
+<sup>3&#160;</sup>David went from there to Mizpeh of Moab; and he said to the king of Moab, “Please let my father and my mother come out to you, until I know what Elohim will do for me.” 
+<sup>4&#160;</sup>He brought them before the king of Moab; and they lived with him all the time that David was in the stronghold. 
+<sup>5&#160;</sup>The prophet Gad said to David, “Don’t stay in the stronghold. Depart, and go into the land of Judah.” 
+</div><div class="p">Then David departed, and came into the forest of Hereth. 
+</div><div class="p">
+<sup>6&#160;</sup>Saul heard that David was discovered, with the men who were with him. Now Saul was sitting in Gibeah, under the tamarisk tree in Ramah, with his spear in his hand, and all his servants were standing around him. 
+<sup>7&#160;</sup>Saul said to his servants who stood around him, “Hear now, you Benjamites! Will the son of Jesse give everyone of you fields and vineyards? Will he make you all captains of thousands and captains of hundreds? 
+<sup>8&#160;</sup>Is that why all of you have conspired against me, and there is no one who discloses to me when my son makes a treaty with the son of Jesse, and there is none of you who is sorry for me, or discloses to me that my son has stirred up my servant against me, to lie in wait, as it is today?” 
+</div><div class="p">
+<sup>9&#160;</sup>Then Doeg the Edomite, who stood by the servants of Saul, answered and said, “I saw the son of Jesse coming to Nob, to Ahimelech the son of Ahitub. 
+<sup>10&#160;</sup>He inquired of Yahweh for him, gave him food, and gave him the sword of Goliath the Philistine.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then the king sent to call Ahimelech the priest, the son of Ahitub, and all his father’s house, the priests who were in Nob; and they all came to the king. 
+<sup>12&#160;</sup>Saul said, “Hear now, you son of Ahitub.” 
+</div><div class="p">He answered, “Here I am, my lord.” 
+</div><div class="p">
+<sup>13&#160;</sup>Saul said to him, “Why have you conspired against me, you and the son of Jesse, in that you have given him bread, and a sword, and have inquired of Elohim for him, that he should rise against me, to lie in wait, as it is today?” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Ahimelech answered the king, and said, “Who among all your servants is so faithful as David, who is the king’s son-in-law, captain of your body guard, and honored in your house? 
+<sup>15&#160;</sup>Have I today begun to inquire of Elohim for him? Be it far from me! Don’t let the king impute anything to his servant, nor to all the house of my father; for your servant knew nothing of all this, less or more.” 
+</div><div class="p">
+<sup>16&#160;</sup>The king said, “You shall surely die, Ahimelech, you and all your father’s house.” 
+<sup>17&#160;</sup>The king said to the guard who stood about him, “Turn and kill the priests of Yahweh, because their hand also is with David, and because they knew that he fled and didn’t disclose it to me.” But the servants of the king wouldn’t put out their hand to fall on the priests of Yahweh. 
+</div><div class="p">
+<sup>18&#160;</sup>The king said to Doeg, “Turn and attack the priests!” 
+</div><div class="p">Doeg the Edomite turned, and he attacked the priests, and he killed on that day eighty-five people who wore a linen ephod. 
+<sup>19&#160;</sup>He struck Nob, the city of the priests, with the edge of the sword—both men and women, children and nursing babies, and cattle, donkeys, and sheep, with the edge of the sword. 
+<sup>20&#160;</sup>One of the sons of Ahimelech the son of Ahitub, named Abiathar, escaped and fled after David. 
+<sup>21&#160;</sup>Abiathar told David that Saul had slain Yahweh’s priests. 
+</div><div class="p">
+<sup>22&#160;</sup>David said to Abiathar, “I knew on that day, when Doeg the Edomite was there, that he would surely tell Saul. I am responsible for the death of all the persons of your father’s house. 
+<sup>23&#160;</sup>Stay with me. Don’t be afraid, for he who seeks my life seeks your life. You will be safe with me.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>David was told, “Behold, the Philistines are fighting against Keilah, and are robbing the threshing floors.” 
+</div><div class="p">
+<sup>2&#160;</sup>Therefore David inquired of Yahweh, saying, “Shall I go and strike these Philistines?” 
+</div><div class="p">Yahweh said to David, “Go strike the Philistines, and save Keilah.” 
+</div><div class="p">
+<sup>3&#160;</sup>David’s men said to him, “Behold, we are afraid here in Judah. How much more then if we go to Keilah against the armies of the Philistines?” 
+</div><div class="p">
+<sup>4&#160;</sup>Then David inquired of Yahweh yet again. Yahweh answered him, and said, “Arise, go down to Keilah; for I will deliver the Philistines into your hand.” 
+</div><div class="p">
+<sup>5&#160;</sup>David and his men went to Keilah and fought with the Philistines, and brought away their livestock, and killed them with a great slaughter. So David saved the inhabitants of Keilah. 
+</div><div class="p">
+<sup>6&#160;</sup>When Abiathar the son of Ahimelech fled to David to Keilah, he came down with an ephod in his hand. 
+</div><div class="p">
+<sup>7&#160;</sup>Saul was told that David had come to Keilah. Saul said, “Elohim has delivered him into my hand, for he is shut in by entering into a town that has gates and bars.” 
+<sup>8&#160;</sup>Saul summoned all the people to war, to go down to Keilah to besiege David and his men. 
+<sup>9&#160;</sup>David knew that Saul was devising mischief against him. He said to Abiathar the priest, “Bring the ephod here.” 
+<sup>10&#160;</sup>Then David said, “O Yahweh, the Elohim of Israel, your servant has surely heard that Saul seeks to come to Keilah to destroy the city for my sake. 
+<sup>11&#160;</sup>Will the owners of Keilah deliver me up into his hand? Will Saul come down, as your servant has heard? Yahweh, the Elohim of Israel, I beg you, tell your servant.” 
+</div><div class="p">Yahweh said, “He will come down.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then David said, “Will the owners of Keilah deliver me and my men into the hand of Saul?” 
+</div><div class="p">Yahweh said, “They will deliver you up.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then David and his men, who were about six hundred, arose and departed out of Keilah and went wherever they could go. Saul was told that David had escaped from Keilah; and he gave up going there. 
+<sup>14&#160;</sup>David stayed in the wilderness in the strongholds, and remained in the hill country in the wilderness of Ziph. Saul sought him every day, but Elohim didn’t deliver him into his hand. 
+<sup>15&#160;</sup>David saw that Saul had come out to seek his life. David was in the wilderness of Ziph in the woods. 
+</div><div class="p">
+<sup>16&#160;</sup>Jonathan, Saul’s son, arose and went to David into the woods, and strengthened his hand in Elohim. 
+<sup>17&#160;</sup>He said to him, “Don’t be afraid, for the hand of Saul my father won’t find you; and you will be king over Israel, and I will be next to you; and Saul my father knows that also.” 
+<sup>18&#160;</sup>They both made a covenant before Yahweh. Then David stayed in the woods and Jonathan went to his house. 
+</div><div class="p">
+<sup>19&#160;</sup>Then the Ziphites came up to Saul to Gibeah, saying, “Doesn’t David hide himself with us in the strongholds in the woods, in the hill of Hachilah, which is on the south of the desert? 
+<sup>20&#160;</sup>Now therefore, O king, come down. According to all the desire of your soul to come down; and our part will be to deliver him up into the king’s hand.” 
+</div><div class="p">
+<sup>21&#160;</sup>Saul said, “You are blessed by Yahweh, for you have had compassion on me. 
+<sup>22&#160;</sup>Please go make yet more sure, and know and see his place where his haunt is, and who has seen him there; for I have been told that he is very cunning. 
+<sup>23&#160;</sup>See therefore, and take knowledge of all the lurking places where he hides himself; and come again to me with certainty, and I will go with you. It shall happen, if he is in the land, that I will search him out among all the thousands of Judah.” 
+</div><div class="p">
+<sup>24&#160;</sup>They arose, and went to Ziph before Saul; but David and his men were in the wilderness of Maon, in the Arabah on the south of the desert. 
+<sup>25&#160;</sup>Saul and his men went to seek him. When David was told, he went down to the rock, and stayed in the wilderness of Maon. When Saul heard that, he pursued David in the wilderness of Maon. 
+<sup>26&#160;</sup>Saul went on this side of the mountain, and David and his men on that side of the mountain; and David hurried to get away for fear of Saul, for Saul and his men surrounded David and his men to take them. 
+<sup>27&#160;</sup>But a messenger came to Saul, saying, “Hurry and come, for the Philistines have made a raid on the land!” 
+<sup>28&#160;</sup>So Saul returned from pursuing David, and went against the Philistines. Therefore they called that place Sela Hammahlekoth. 
+</div><div class="p">
+<sup>29&#160;</sup>David went up from there and lived in the strongholds of En Gedi. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>When Saul had returned from following the Philistines, he was told, “Behold, David is in the wilderness of En Gedi.” 
+<sup>2&#160;</sup>Then Saul took three thousand chosen men out of all Israel, and went to seek David and his men on the rocks of the wild goats. 
+<sup>3&#160;</sup>He came to the sheep pens by the way, where there was a cave; and Saul went in to relieve himself. Now David and his men were staying in the innermost parts of the cave. 
+<sup>4&#160;</sup>David’s men said to him, “Behold, the day of which Yahweh said to you, ‘Behold, I will deliver your enemy into your hand, and you shall do to him as it shall seem good to you.’&#160;” Then David arose and cut off the skirt of Saul’s robe secretly. 
+<sup>5&#160;</sup>Afterward, David’s heart struck him because he had cut off Saul’s skirt. 
+<sup>6&#160;</sup>He said to his men, “Yahweh forbid that I should do this thing to my lord, Yahweh’s anointed, to stretch out my hand against him, since he is Yahweh’s anointed.” 
+<sup>7&#160;</sup>So David checked his men with these words, and didn’t allow them to rise against Saul. Saul rose up out of the cave, and went on his way. 
+<sup>8&#160;</sup>David also arose afterward, and went out of the cave and cried after Saul, saying, “My lord the king!” 
+</div><div class="p">When Saul looked behind him, David bowed with his face to the earth, and showed respect. 
+<sup>9&#160;</sup>David said to Saul, “Why do you listen to men’s words, saying, ‘Behold, David seeks to harm you’? 
+<sup>10&#160;</sup>Behold, today your eyes have seen how Yahweh had delivered you today into my hand in the cave. Some urged me to kill you, but I spared you. I said, ‘I will not stretch out my hand against my lord, for he is Yahweh’s anointed.’ 
+<sup>11&#160;</sup>Moreover, my father, behold, yes, see the skirt of your robe in my hand; for in that I cut off the skirt of your robe and didn’t kill you, know and see that there is neither evil nor disobedience in my hand. I have not sinned against you, though you hunt for my life to take it. 
+<sup>12&#160;</sup>May Yahweh judge between me and you, and may Yahweh avenge me of you; but my hand will not be on you. 
+<sup>13&#160;</sup>As the proverb of the ancients says, ‘Out of the wicked comes wickedness;’ but my hand will not be on you. 
+<sup>14&#160;</sup>Against whom has the king of Israel come out? Whom do you pursue? A dead dog? A flea? 
+<sup>15&#160;</sup>May Yahweh therefore be judge, and give sentence between me and you, and see, and plead my cause, and deliver me out of your hand.” 
+</div><div class="p">
+<sup>16&#160;</sup>It came to pass, when David had finished speaking these words to Saul, that Saul said, “Is that your voice, my son David?” Saul lifted up his voice and wept. 
+<sup>17&#160;</sup>He said to David, “You are more righteous than I; for you have done good to me, whereas I have done evil to you. 
+<sup>18&#160;</sup>You have declared today how you have dealt well with me, because when Yahweh had delivered me up into your hand, you didn’t kill me. 
+<sup>19&#160;</sup>For if a man finds his enemy, will he let him go away unharmed? Therefore may Yahweh reward you good for that which you have done to me today. 
+<sup>20&#160;</sup>Now, behold, I know that you will surely be king, and that the kingdom of Israel will be established in your hand. 
+<sup>21&#160;</sup>Swear now therefore to me by Yahweh that you will not cut off my offspring after me, and that you will not destroy my name out of my father’s house.” 
+</div><div class="p">
+<sup>22&#160;</sup>David swore to Saul. Saul went home, but David and his men went up to the stronghold. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Samuel died; and all Israel gathered themselves together and mourned for him, and buried him at his house at Ramah. 
+</div><div class="p">Then David arose and went down to the wilderness of Paran. 
+<sup>2&#160;</sup>There was a man in Maon whose possessions were in Carmel; and the man was very great. He had three thousand sheep and a thousand goats; and he was shearing his sheep in Carmel. 
+<sup>3&#160;</sup>Now the name of the man was Nabal; and the name of his woman Abigail. This woman was intelligent and had a beautiful face; but the man was surly and evil in his doings. He was of the house of Caleb. 
+<sup>4&#160;</sup>David heard in the wilderness that Nabal was shearing his sheep. 
+<sup>5&#160;</sup>David sent ten young men; and David said to the young men, “Go up to Carmel, and go to Nabal, and greet him in my name. 
+<sup>6&#160;</sup>Tell him, ‘Long life to you! Peace be to you! Peace be to your house! Peace be to all that you have! 
+<sup>7&#160;</sup>Now I have heard that you have shearers. Your shepherds have now been with us, and we didn’t harm them. Nothing was missing from them all the time they were in Carmel. 
+<sup>8&#160;</sup>Ask your young men, and they will tell you. Therefore let the young men find favor in your eyes, for we come on a good day. Please give whatever comes to your hand to your servants and to your son David.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>When David’s young men came, they spoke to Nabal all those words in the name of David, and waited. 
+</div><div class="p">
+<sup>10&#160;</sup>Nabal answered David’s servants and said, “Who is David? Who is the son of Jesse? There are many servants who break away from their masters these days. 
+<sup>11&#160;</sup>Shall I then take my bread, my water, and my meat that I have killed for my shearers, and give it to men who I don’t know where they come from?” 
+</div><div class="p">
+<sup>12&#160;</sup>So David’s young men turned on their way and went back, and came and told him all these words. 
+</div><div class="p">
+<sup>13&#160;</sup>David said to his men, “Every man put on his sword!” 
+</div><div class="p">Every man put on his sword. David also put on his sword. About four hundred men followed David, and two hundred stayed by the baggage. 
+</div><div class="p">
+<sup>14&#160;</sup>But one of the young men told Abigail, Nabal’s woman, saying, “Behold, David sent messengers out of the wilderness to greet our master; and he insulted them. 
+<sup>15&#160;</sup>But the men were very good to us, and we were not harmed, and we didn’t miss anything as long as we went with them, when we were in the fields. 
+<sup>16&#160;</sup>They were a wall to us both by night and by day, all the while we were with them keeping the sheep. 
+<sup>17&#160;</sup>Now therefore know and consider what you will do; for evil is determined against our master and against all his house, for he is such a worthless fellow that one can’t speak to him.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then Abigail hurried and took two hundred loaves of bread, two containers of wine, five sheep ready dressed, five seahs of parched grain, one hundred clusters of raisins, and two hundred cakes of figs, and laid them on donkeys. 
+<sup>19&#160;</sup>She said to her young men, “Go on before me. Behold, I am coming after you.” But she didn’t tell her man, Nabal. 
+<sup>20&#160;</sup>As she rode on her donkey, and came down hidden by the mountain, behold, David and his men came down toward her, and she met them. 
+</div><div class="p">
+<sup>21&#160;</sup>Now David had said, “Surely in vain I have kept all that this fellow has in the wilderness, so that nothing was missed of all that pertained to him. He has returned me evil for good. 
+<sup>22&#160;</sup>Elohim do so to the enemies of David, and more also, if I leave of all that belongs to him by the morning light so much as one who urinates on a wall.” 
+</div><div class="p">
+<sup>23&#160;</sup>When Abigail saw David, she hurried and got off her donkey, and fell before David on her face and bowed herself to the ground. 
+<sup>24&#160;</sup>She fell at his feet and said, “On me, my lord, on me be the blame! Please let your servant speak in your ears. Hear the words of your servant. 
+<sup>25&#160;</sup>Please don’t let my lord pay attention to this worthless fellow, Nabal, for as his name is, so is he. Nabal is his name, and folly is with him; but I, your servant, didn’t see my lord’s young men whom you sent. 
+<sup>26&#160;</sup>Now therefore, my lord, as Yahweh lives and as your soul lives, since Yahweh has withheld you from blood guiltiness and from avenging yourself with your own hand, now therefore let your enemies and those who seek evil to my lord be as Nabal. 
+<sup>27&#160;</sup>Now this present which your servant has brought to my lord, let it be given to the young men who follow my lord. 
+<sup>28&#160;</sup>Please forgive the trespass of your servant. For Yahweh will certainly make my lord a sure house, because my lord fights Yahweh’s battles. Evil will not be found in you all your days. 
+<sup>29&#160;</sup>Though men may rise up to pursue you and to seek your soul, yet the soul of my lord will be bound in the bundle of life with Yahweh your Elohim. He will sling out the souls of your enemies as from a sling’s pocket. 
+<sup>30&#160;</sup>It will come to pass, when Yahweh has done to my lord according to all the good that he has spoken concerning you, and has appointed you prince over Israel, 
+<sup>31&#160;</sup>that this shall be no grief to you, nor offense of heart to my lord, either that you have shed blood without cause, or that my lord has avenged himself. When Yahweh has dealt well with my lord, then remember your servant.” 
+</div><div class="p">
+<sup>32&#160;</sup>David said to Abigail, “Blessed is Yahweh, the Elohim of Israel, who sent you today to meet me! 
+<sup>33&#160;</sup>Blessed is your discretion, and blessed are you, who have kept me today from blood guiltiness, and from avenging myself with my own hand. 
+<sup>34&#160;</sup>For indeed, as Yahweh the Elohim of Israel lives, who has withheld me from harming you, unless you had hurried and come to meet me, surely there wouldn’t have been left to Nabal by the morning light so much as one who urinates on a wall.” 
+</div><div class="p">
+<sup>35&#160;</sup>So David received from her hand that which she had brought him. Then he said to her, “Go up in peace to your house. Behold, I have listened to your voice and have granted your request.” 
+</div><div class="p">
+<sup>36&#160;</sup>Abigail came to Nabal; and behold, he held a feast in his house like the feast of a king. Nabal’s heart was merry within him, for he was very drunk. Therefore she told him nothing until the morning light. 
+<sup>37&#160;</sup>In the morning, when the wine had gone out of Nabal, his woman told him these things; and his heart died within him, and he became as a stone. 
+<sup>38&#160;</sup>About ten days later, Yahweh struck Nabal, so that he died. 
+<sup>39&#160;</sup>When David heard that Nabal was dead, he said, “Blessed is Yahweh, who has pleaded the cause of my reproach from the hand of Nabal, and has kept back his servant from evil. Yahweh has returned the evildoing of Nabal on his own head.” 
+</div><div class="p">David sent and spoke concerning Abigail, to take her to himself as woman. 
+<sup>40&#160;</sup>When David’s servants had come to Abigail to Carmel, they spoke to her, saying, “David has sent us to you, to take you to him as woman.” 
+</div><div class="p">
+<sup>41&#160;</sup>She arose and bowed herself with her face to the earth, and said, “Behold, your servant is a servant to wash the feet of the servants of my lord.” 
+<sup>42&#160;</sup>Abigail hurriedly arose and rode on a donkey with her five maids who followed her; and she went after the messengers of David, and became his woman. 
+<sup>43&#160;</sup>David also took Ahinoam of Jezreel; and they both became his women. 
+</div><div class="p">
+<sup>44&#160;</sup>Now Saul had given Michal his daughter, David’s woman, to Palti the son of Laish, who was of Gallim. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>The Ziphites came to Saul to Gibeah, saying, “Doesn’t David hide himself in the hill of Hachilah, which is before the desert?” 
+<sup>2&#160;</sup>Then Saul arose and went down to the wilderness of Ziph, having three thousand chosen men of Israel with him, to seek David in the wilderness of Ziph. 
+<sup>3&#160;</sup>Saul encamped in the hill of Hachilah, which is before the desert, by the way. But David stayed in the wilderness, and he saw that Saul came after him into the wilderness. 
+<sup>4&#160;</sup>David therefore sent out spies, and understood that Saul had certainly come. 
+<sup>5&#160;</sup>Then David arose and came to the place where Saul had encamped; and David saw the place where Saul lay, with Abner the son of Ner, the captain of his army. Saul lay within the place of the wagons, and the people were encamped around him. 
+</div><div class="p">
+<sup>6&#160;</sup>Then David answered and said to Ahimelech the Hittite, and to Abishai the son of Zeruiah, brother of Joab, saying, “Who will go down with me to Saul to the camp?” 
+</div><div class="p">Abishai said, “I will go down with you.” 
+<sup>7&#160;</sup>So David and Abishai came to the people by night; and, behold, Saul lay sleeping within the place of the wagons, with his spear stuck in the ground at his head; and Abner and the people lay around him. 
+<sup>8&#160;</sup>Then Abishai said to David, “Elohim has delivered up your enemy into your hand today. Now therefore please let me strike him with the spear to the earth at one stroke, and I will not strike him the second time.” 
+</div><div class="p">
+<sup>9&#160;</sup>David said to Abishai, “Don’t destroy him, for who can stretch out his hand against Yahweh’s anointed, and be guiltless?” 
+<sup>10&#160;</sup>David said, “As Yahweh lives, Yahweh will strike him; or his day shall come to die, or he shall go down into battle and perish. 
+<sup>11&#160;</sup>Yahweh forbid that I should stretch out my hand against Yahweh’s anointed; but now please take the spear that is at his head and the jar of water, and let’s go.” 
+</div><div class="p">
+<sup>12&#160;</sup>So David took the spear and the jar of water from Saul’s head, and they went away. No man saw it, or knew it, nor did any awake; for they were all asleep, because a deep sleep from Yahweh had fallen on them. 
+<sup>13&#160;</sup>Then David went over to the other side, and stood on the top of the mountain far away, a great space being between them; 
+<sup>14&#160;</sup>and David cried to the people, and to Abner the son of Ner, saying, “Don’t you answer, Abner?” 
+</div><div class="p">Then Abner answered, “Who are you who calls to the king?” 
+</div><div class="p">
+<sup>15&#160;</sup>David said to Abner, “Aren’t you a man? Who is like you in Israel? Why then have you not kept watch over your lord the king? For one of the people came in to destroy your lord the king. 
+<sup>16&#160;</sup>This thing isn’t good that you have done. As Yahweh lives, you are worthy to die, because you have not kept watch over your lord, Yahweh’s anointed. Now see where the king’s spear is, and the jar of water that was at his head.” 
+</div><div class="p">
+<sup>17&#160;</sup>Saul recognized David’s voice, and said, “Is this your voice, my son David?” 
+</div><div class="p">David said, “It is my voice, my lord, O king.” 
+<sup>18&#160;</sup>He said, “Why does my lord pursue his servant? For what have I done? What evil is in my hand? 
+<sup>19&#160;</sup>Now therefore, please let my lord the king hear the words of his servant. If it is so that Yahweh has stirred you up against me, let him accept an offering. But if it is the children of men, they are cursed before Yahweh; for they have driven me out today that I shouldn’t cling to Yahweh’s inheritance, saying, ‘Go, serve other elohims!’ 
+<sup>20&#160;</sup>Now therefore, don’t let my blood fall to the earth away from the presence of Yahweh; for the king of Israel has come out to seek a flea, as when one hunts a partridge in the mountains.” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Saul said, “I have sinned. Return, my son David; for I will no more do you harm, because my life was precious in your eyes today. Behold, I have played the fool, and have erred exceedingly.” 
+</div><div class="p">
+<sup>22&#160;</sup>David answered, “Behold the spear, O king! Let one of the young men come over and get it. 
+<sup>23&#160;</sup>Yahweh will render to every man his righteousness and his faithfulness; because Yahweh delivered you into my hand today, and I wouldn’t stretch out my hand against Yahweh’s anointed. 
+<sup>24&#160;</sup>Behold, as your life was respected today in my eyes, so let my life be respected in Yahweh’s eyes, and let him deliver me out of all oppression.” 
+</div><div class="p">
+<sup>25&#160;</sup>Then Saul said to David, “You are blessed, my son David. You will both do mightily, and will surely prevail.” 
+</div><div class="p">So David went his way, and Saul returned to his place. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>David said in his heart, “I will now perish one day by the hand of Saul. There is nothing better for me than that I should escape into the land of the Philistines; and Saul will despair of me, to seek me any more in all the borders of Israel. So I will escape out of his hand.” 
+<sup>2&#160;</sup>David arose and passed over, he and the six hundred men who were with him, to Achish the son of Maoch, king of Gath. 
+<sup>3&#160;</sup>David lived with Achish at Gath, he and his men, every man with his household, even David with his two women, Ahinoam the Jezreelitess and Abigail the Carmelitess, Nabal’s woman. 
+<sup>4&#160;</sup>Saul was told that David had fled to Gath, so he stopped looking for him. 
+</div><div class="p">
+<sup>5&#160;</sup>David said to Achish, “If now I have found favor in your eyes, let them give me a place in one of the cities in the country, that I may dwell there. For why should your servant dwell in the royal city with you?” 
+<sup>6&#160;</sup>Then Achish gave him Ziklag that day: therefore Ziklag belongs to the kings of Judah to this day. 
+<sup>7&#160;</sup>The number of the days that David lived in the country of the Philistines was a full year and four months. 
+</div><div class="p">
+<sup>8&#160;</sup>David and his men went up and raided the Geshurites, the Girzites, and the Amalekites; for those were the inhabitants of the land who were of old, on the way to Shur, even to the land of Egypt. 
+<sup>9&#160;</sup>David struck the land, and saved no man or woman alive, and took away the sheep, the cattle, the donkeys, the camels, and the clothing. Then he returned, and came to Achish. 
+</div><div class="p">
+<sup>10&#160;</sup>Achish said, “Against whom have you made a raid today?” 
+</div><div class="p">David said, “Against the South of Judah, against the South of the Jerahmeelites, and against the South of the Kenites.” 
+<sup>11&#160;</sup>David saved neither man nor woman alive to bring them to Gath, saying, “Lest they should tell about us, saying, ‘David did this, and this has been his way all the time he has lived in the country of the Philistines.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Achish believed David, saying, “He has made his people Israel utterly to abhor him. Therefore he will be my servant forever.” 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>In those days, the Philistines gathered their armies together for warfare, to fight with Israel. Achish said to David, “Know assuredly that you will go out with me in the army, you and your men.” 
+</div><div class="p">
+<sup>2&#160;</sup>David said to Achish, “Therefore you will know what your servant can do.” 
+</div><div class="p">Achish said to David, “Therefore I will make you my bodyguard forever.” 
+</div><div class="p">
+<sup>3&#160;</sup>Now Samuel was dead, and all Israel had mourned for him and buried him in Ramah, even in his own city. Saul had sent away those who had familiar spirits and the wizards out of the land. 
+</div><div class="p">
+<sup>4&#160;</sup>The Philistines gathered themselves together, and came and encamped in Shunem; and Saul gathered all Israel together, and they encamped in Gilboa. 
+<sup>5&#160;</sup>When Saul saw the army of the Philistines, he was afraid, and his heart trembled greatly. 
+<sup>6&#160;</sup>When Saul inquired of Yahweh, Yahweh didn’t answer him by dreams, by Urim, or by prophets. 
+<sup>7&#160;</sup>Then Saul said to his servants, “Seek for me a woman who has a familiar spirit, that I may go to her and inquire of her.” 
+</div><div class="p">His servants said to him, “Behold, there is a woman who has a familiar spirit at Endor.” 
+</div><div class="p">
+<sup>8&#160;</sup>Saul disguised himself and put on other clothing, and went, he and two men with him, and they came to the woman by night. Then he said, “Please consult for me by the familiar spirit, and bring me up whomever I shall name to you.” 
+</div><div class="p">
+<sup>9&#160;</sup>The woman said to him, “Behold, you know what Saul has done, how he has cut off those who have familiar spirits and the wizards out of the land. Why then do you lay a snare for my life, to cause me to die?” 
+</div><div class="p">
+<sup>10&#160;</sup>Saul swore to her by Yahweh, saying, “As Yahweh lives, no punishment will happen to you for this thing.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then the woman said, “Whom shall I bring up to you?” 
+</div><div class="p">He said, “Bring Samuel up for me.” 
+</div><div class="p">
+<sup>12&#160;</sup>When the woman saw Samuel, she cried with a loud voice; and the woman spoke to Saul, saying, “Why have you deceived me? For you are Saul!” 
+</div><div class="p">
+<sup>13&#160;</sup>The king said to her, “Don’t be afraid! What do you see?” 
+</div><div class="p">The woman said to Saul, “I see an elohim coming up out of the earth.” 
+</div><div class="p">
+<sup>14&#160;</sup>He said to her, “What does he look like?” 
+</div><div class="p">She said, “An old man comes up. He is covered with a robe.” Saul perceived that it was Samuel, and he bowed with his face to the ground, and showed respect. 
+</div><div class="p">
+<sup>15&#160;</sup>Samuel said to Saul, “Why have you disturbed me, to bring me up?” 
+</div><div class="p">Saul answered, “I am very distressed; for the Philistines make war against me, and Elohim has departed from me, and answers me no more, by prophets, or by dreams. Therefore I have called you, that you may make known to me what I shall do.” 
+</div><div class="p">
+<sup>16&#160;</sup>Samuel said, “Why then do you ask me, since Yahweh has departed from you and has become your adversary? 
+<sup>17&#160;</sup>Yahweh has done to you as he spoke by me. Yahweh has torn the kingdom out of your hand and given it to your neighbor, even to David. 
+<sup>18&#160;</sup>Because you didn’t obey Yahweh’s voice, and didn’t execute his fierce wrath on Amalek, therefore Yahweh has done this thing to you today. 
+<sup>19&#160;</sup>Moreover Yahweh will deliver Israel also with you into the hand of the Philistines; and tomorrow you and your sons will be with me. Yahweh will deliver the army of Israel also into the hand of the Philistines.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then Saul fell immediately his full length on the earth, and was terrified, because of Samuel’s words. There was no strength in him, for he had eaten no bread all day long or all night long. 
+</div><div class="p">
+<sup>21&#160;</sup>The woman came to Saul and saw that he was very troubled, and said to him, “Behold, your servant has listened to your voice, and I have put my life in my hand, and have listened to your words which you spoke to me. 
+<sup>22&#160;</sup>Now therefore, please listen also to the voice of your servant, and let me set a morsel of bread before you. Eat, that you may have strength when you go on your way.” 
+</div><div class="p">
+<sup>23&#160;</sup>But he refused, and said, “I will not eat.” But his servants, together with the woman, constrained him; and he listened to their voice. So he arose from the earth and sat on the bed. 
+<sup>24&#160;</sup>The woman had a fattened calf in the house. She hurried and killed it; and she took flour and kneaded it, and baked unleavened bread of it. 
+<sup>25&#160;</sup>She brought it before Saul and before his servants, and they ate. Then they rose up and went away that night. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the Philistines gathered together all their armies to Aphek; and the Israelites encamped by the spring which is in Jezreel. 
+<sup>2&#160;</sup>The lords of the Philistines passed on by hundreds and by thousands; and David and his men passed on in the rear with Achish. 
+</div><div class="p">
+<sup>3&#160;</sup>Then the princes of the Philistines said, “What about these Hebrews?” 
+</div><div class="p">Achish said to the princes of the Philistines, “Isn’t this David, the servant of Saul the king of Israel, who has been with me these days, or rather these years? I have found no fault in him since he fell away until today.” 
+</div><div class="p">
+<sup>4&#160;</sup>But the princes of the Philistines were angry with him; and the princes of the Philistines said to him, “Make the man return, that he may go back to his place where you have appointed him, and let him not go down with us to battle, lest in the battle he become an adversary to us. For with what should this fellow reconcile himself to his lord? Should it not be with the heads of these men? 
+<sup>5&#160;</sup>Isn’t this David, of whom people sang to one another in dances, saying, 
+</div><div class="q1">‘Saul has slain his thousands, 
+</div><div class="q2">and David his ten thousands’?” 
+</div><div class="p">
+<sup>6&#160;</sup>Then Achish called David and said to him, “As Yahweh lives, you have been upright, and your going out and your coming in with me in the army is good in my sight; for I have not found evil in you since the day of your coming to me to this day. Nevertheless, the lords don’t favor you. 
+<sup>7&#160;</sup>Therefore now return, and go in peace, that you not displease the lords of the Philistines.” 
+</div><div class="p">
+<sup>8&#160;</sup>David said to Achish, “But what have I done? What have you found in your servant so long as I have been before you to this day, that I may not go and fight against the enemies of my lord the king?” 
+</div><div class="p">
+<sup>9&#160;</sup>Achish answered David, “I know that you are good in my sight, as an angel of Elohim. Notwithstanding, the princes of the Philistines have said, ‘He shall not go up with us to the battle.’ 
+<sup>10&#160;</sup>Therefore now rise up early in the morning with the servants of your lord who have come with you; and as soon as you are up early in the morning and have light, depart.” 
+</div><div class="p">
+<sup>11&#160;</sup>So David rose up early, he and his men, to depart in the morning, to return into the land of the Philistines; and the Philistines went up to Jezreel. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>When David and his men had come to Ziklag on the third day, the Amalekites had made a raid on the South and on Ziklag, and had struck Ziklag and burned it with fire, 
+<sup>2&#160;</sup>and had taken captive the women and all who were in it, both small and great. They didn’t kill any, but carried them off and went their way. 
+<sup>3&#160;</sup>When David and his men came to the city, behold, it was burned with fire; and their women, their sons, and their daughters were taken captive. 
+<sup>4&#160;</sup>Then David and the people who were with him lifted up their voice and wept until they had no more power to weep. 
+<sup>5&#160;</sup>David’s two women were taken captive, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
+<sup>6&#160;</sup>David was greatly distressed, for the people spoke of stoning him, because the souls of all the people were grieved, every man for his sons and for his daughters; but David strengthened himself in Yahweh his Elohim. 
+<sup>7&#160;</sup>David said to Abiathar the priest, the son of Ahimelech, “Please bring the ephod here to me.” 
+</div><div class="p">Abiathar brought the ephod to David. 
+<sup>8&#160;</sup>David inquired of Yahweh, saying, “If I pursue after this troop, will I overtake them?” 
+</div><div class="p">He answered him, “Pursue, for you will surely overtake them, and will without fail recover all.” 
+</div><div class="p">
+<sup>9&#160;</sup>So David went, he and the six hundred men who were with him, and came to the brook Besor, where those who were left behind stayed. 
+<sup>10&#160;</sup>But David pursued, he and four hundred men; for two hundred stayed behind, who were so faint that they couldn’t go over the brook Besor. 
+<sup>11&#160;</sup>They found an Egyptian in the field, and brought him to David, and gave him bread, and he ate; and they gave him water to drink. 
+<sup>12&#160;</sup>They gave him a piece of a cake of figs and two clusters of raisins. When he had eaten, his spirit came again to him; for he had eaten no bread, and drank no water for three days and three nights. 
+<sup>13&#160;</sup>David asked him, “To whom do you belong? Where are you from?” 
+</div><div class="p">He said, “I am a young man of Egypt, servant to an Amalekite; and my master left me, because three days ago I got sick. 
+<sup>14&#160;</sup>We made a raid on the South of the Cherethites, and on that which belongs to Judah, and on the South of Caleb; and we burned Ziklag with fire.” 
+</div><div class="p">
+<sup>15&#160;</sup>David said to him, “Will you bring me down to this troop?” 
+</div><div class="p">He said, “Swear to me by Elohim that you will not kill me and not deliver me up into the hands of my master, and I will bring you down to this troop.” 
+</div><div class="p">
+<sup>16&#160;</sup>When he had brought him down, behold, they were spread around over all the ground, eating, drinking, and dancing, because of all the great plunder that they had taken out of the land of the Philistines, and out of the land of Judah. 
+<sup>17&#160;</sup>David struck them from the twilight even to the evening of the next day. Not a man of them escaped from there, except four hundred young men who rode on camels and fled. 
+<sup>18&#160;</sup>David recovered all that the Amalekites had taken, and David rescued his two women. 
+<sup>19&#160;</sup>There was nothing lacking to them, neither small nor great, neither sons nor daughters, neither plunder, nor anything that they had taken. David brought them all back. 
+<sup>20&#160;</sup>David took all the flocks and the herds, which they drove before those other livestock, and said, “This is David’s plunder.” 
+</div><div class="p">
+<sup>21&#160;</sup>David came to the two hundred men, who were so faint that they could not follow David, whom also they had made to stay at the brook Besor; and they went out to meet David, and to meet the people who were with him. When David came near to the people, he greeted them. 
+<sup>22&#160;</sup>Then all the wicked men and worthless fellows of those who went with David answered and said, “Because they didn’t go with us, we will not give them anything of the plunder that we have recovered, except to every man his woman and his children, that he may lead them away and depart.” 
+</div><div class="p">
+<sup>23&#160;</sup>Then David said, “Do not do so, my brothers, with that which Yahweh has given to us, who has preserved us, and delivered the troop that came against us into our hand. 
+<sup>24&#160;</sup>Who will listen to you in this matter? For as his share is who goes down to the battle, so shall his share be who stays with the baggage. They shall share alike.” 
+<sup>25&#160;</sup>It was so from that day forward that he made it a statute and an ordinance for Israel to this day. 
+</div><div class="p">
+<sup>26&#160;</sup>When David came to Ziklag, he sent some of the plunder to the elders of Judah, even to his friends, saying, “Behold, a present for you from the plunder of Yahweh’s enemies.” 
+<sup>27&#160;</sup>He sent it to those who were in Bethel, to those who were in Ramoth of the South, to those who were in Jattir, 
+<sup>28&#160;</sup>to those who were in Aroer, to those who were in Siphmoth, to those who were in Eshtemoa, 
+<sup>29&#160;</sup>to those who were in Racal, to those who were in the cities of the Jerahmeelites, to those who were in the cities of the Kenites, 
+<sup>30&#160;</sup>to those who were in Hormah, to those who were in Borashan, to those who were in Athach, 
+<sup>31&#160;</sup>to those who were in Hebron, and to all the places where David himself and his men used to stay. 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the Philistines fought against Israel; and the men of Israel fled from before the Philistines, and fell down slain on Mount Gilboa. 
+<sup>2&#160;</sup>The Philistines overtook Saul and his sons; and the Philistines killed Jonathan, Abinadab, and Malchishua, the sons of Saul. 
+<sup>3&#160;</sup>The battle went hard against Saul, and the archers overtook him; and he was greatly distressed by reason of the archers. 
+<sup>4&#160;</sup>Then Saul said to his armor bearer, “Draw your sword, and thrust me through with it, lest these uncircumcised come and thrust me through and abuse me!” But his armor bearer would not, for he was terrified. Therefore Saul took his sword and fell on it. 
+<sup>5&#160;</sup>When his armor bearer saw that Saul was dead, he likewise fell on his sword, and died with him. 
+<sup>6&#160;</sup>So Saul died with his three sons, his armor bearer, and all his men that same day together. 
+</div><div class="p">
+<sup>7&#160;</sup>When the men of Israel who were on the other side of the valley, and those who were beyond the Jordan, saw that the men of Israel fled and that Saul and his sons were dead, they abandoned the cities and fled; and the Philistines came and lived in them. 
+<sup>8&#160;</sup>On the next day, when the Philistines came to strip the slain, they found Saul and his three sons fallen on Mount Gilboa. 
+<sup>9&#160;</sup>They cut off his head, stripped off his armor, and sent into the land of the Philistines all around, to carry the news to the house of their idols and to the people. 
+<sup>10&#160;</sup>They put his armor in the house of the Ashtaroth, and they fastened his body to the wall of Beth Shan. 
+<sup>11&#160;</sup>When the inhabitants of Jabesh Gilead heard what the Philistines had done to Saul, 
+<sup>12&#160;</sup>all the valiant men arose, went all night, and took the body of Saul and the bodies of his sons from the wall of Beth Shan; and they came to Jabesh and burned them there. 
+<sup>13&#160;</sup>They took their bones and buried them under the tamarisk tree in Jabesh, and fasted seven days. </div></div><script src="../main.js"></script></body></html>

--- a/book/2chronicles.html
+++ b/book/2chronicles.html
@@ -3,6 +3,47 @@
 <head>
 <title>2 Chronicles</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1120 +53,1157 @@
 <div class="main">
 <!-- 2CH World English Scripture (WES) -->
 <h1 class="booklabel">2 Chronicles</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Solomon the son of David was firmly established in his kingdom, and Yahweh<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> his Elohim<span class="f">+ \fr 1:1 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> was with him, and made him exceedingly great. 
-</p><p>
-<span class="v">2&#160;</span>Solomon spoke to all Israel, to the captains of thousands and of hundreds, to the judges, and to every prince in all Israel, the heads of the fathers’ households. 
-<span class="v">3&#160;</span>Then Solomon, and all the assembly with him, went to the high place that was at Gibeon; for Elohim’s Tent of Meeting was there, which Yahweh’s servant Moses had made in the wilderness. 
-<span class="v">4&#160;</span>But David had brought Elohim’s ark up from Kiriath Jearim to the place that David had prepared for it; for he had pitched a tent for it at Jerusalem. 
-<span class="v">5&#160;</span>Moreover the bronze altar that Bezalel the son of Uri, the son of Hur, had made was there before Yahweh’s tabernacle; and Solomon and the assembly were seeking counsel there. 
-<span class="v">6&#160;</span>Solomon went up there to the bronze altar before Yahweh, which was at the Tent of Meeting, and offered one thousand burnt offerings on it. 
-</p><p>
-<span class="v">7&#160;</span>That night, Elohim appeared to Solomon and said to him, “Ask for what you want me to give you.” 
-</p><p>
-<span class="v">8&#160;</span>Solomon said to Elohim, “You have shown great loving kindness to David my father, and have made me king in his place. 
-<span class="v">9&#160;</span>Now, Yahweh Elohim, let your promise to David my father be established; for you have made me king over a people like the dust of the earth in multitude. 
-<span class="v">10&#160;</span>Now give me wisdom and knowledge, that I may go out and come in before this people; for who can judge this great people of yours?” 
-</p><p>
-<span class="v">11&#160;</span>Elohim said to Solomon, “Because this was in your heart, and you have not asked riches, wealth, honor, or the life of those who hate you, nor yet have you asked for long life; but have asked for wisdom and knowledge for yourself, that you may judge my people, over whom I have made you king, 
-<span class="v">12&#160;</span>therefore wisdom and knowledge is granted to you. I will give you riches, wealth, and honor, such as none of the kings have had who have been before you, and none after you will have.” 
-</p><p>
-<span class="v">13&#160;</span>So Solomon came from the high place that was at Gibeon, from before the Tent of Meeting, to Jerusalem; and he reigned over Israel. 
-</p><p>
-<span class="v">14&#160;</span>Solomon gathered chariots and horsemen. He had one thousand four hundred chariots and twelve thousand horsemen that he placed in the chariot cities, and with the king at Jerusalem. 
-<span class="v">15&#160;</span>The king made silver and gold to be as common as stones in Jerusalem, and he made cedars to be as common as the sycamore trees that are in the lowland. 
-<span class="v">16&#160;</span>The horses which Solomon had were brought out of Egypt and from Kue. The king’s merchants purchased them from Kue. 
-<span class="v">17&#160;</span>They imported from Egypt then exported a chariot for six hundred pieces of silver and a horse for one hundred fifty.<span class="f">+ \fr 1:17 \ft The pieces of silver were probably shekels, so 600 pieces would be about 13.2 pounds or 6 kilograms of silver, and 150 would be about 3.3 pounds or 1.5 kilograms of silver.</span> They also exported them to the Hittite kings and the Syrian<span class="f">+ \fr 1:17 \ft or, Aramean</span> kings. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Now Solomon decided to build a house for Yahweh’s name, and a house for his kingdom. 
-<span class="v">2&#160;</span>Solomon counted out seventy thousand men to bear burdens, eighty thousand men who were stone cutters in the mountains, and three thousand six hundred to oversee them. 
-</p><p>
-<span class="v">3&#160;</span>Solomon sent to Huram the king of Tyre, saying, “As you dealt with David my father, and sent him cedars to build him a house in which to dwell, so deal with me. 
-<span class="v">4&#160;</span>Behold,<span class="f">+ \fr 2:4 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I am about to build a house for the name of Yahweh my Elohim, to dedicate it to him, to burn before him incense of sweet spices, for the continual show bread, and for the burnt offerings morning and evening, on the Sabbaths, on the new moons, and on the set feasts of Yahweh our Elohim. This is an ordinance forever to Israel. 
-</p><p>
-<span class="v">5&#160;</span>“The house which I am building will be great, for our Elohim is greater than all elohims. 
-<span class="v">6&#160;</span>But who is able to build him a house, since heaven and the heaven of heavens can’t contain him? Who am I then, that I should build him a house, except just to burn incense before him? 
-</p><p>
-<span class="v">7&#160;</span>“Now therefore send me a man skillful to work in gold, in silver, in bronze, in iron, and in purple, crimson, and blue, and who knows how to engrave engravings, to be with the skillful men who are with me in Judah and in Jerusalem, whom David my father provided. 
-</p><p>
-<span class="v">8&#160;</span>“Send me also cedar trees, cypress trees, and algum trees out of Lebanon, for I know that your servants know how to cut timber in Lebanon. Behold, my servants will be with your servants, 
-<span class="v">9&#160;</span>even to prepare me timber in abundance; for the house which I am about to build will be great and wonderful. 
-<span class="v">10&#160;</span>Behold, I will give to your servants, the cutters who cut timber, twenty thousand cors<span class="f">+ \fr 2:10 \ft 1 cor is the same as a homer, or about 55.9 U. S. gallons (liquid) or 211 liters or 6 bushels, so 20,000 cors of wheat would weigh about 545 metric tons</span> of beaten wheat, twenty thousand baths<span class="f">+ \fr 2:10 \ft 1 bath is one tenth of a cor, or about 5.6 U. S. gallons or 21 liters or 2.4 pecks. 20,000 baths of barley would weigh about 262 metric tons.</span> of barley, twenty thousand baths of wine, and twenty thousand baths of oil.” 
-</p><p>
-<span class="v">11&#160;</span>Then Huram the king of Tyre answered in writing, which he sent to Solomon, “Because Yahweh loves his people, he has made you king over them.” 
-<span class="v">12&#160;</span>Huram continued, “Blessed be Yahweh, the Elohim of Israel, who made heaven and earth, who has given to David the king a wise son, endowed with discretion and understanding, who would build a house for Yahweh and a house for his kingdom. 
-</p><p>
-<span class="v">13&#160;</span>Now I have sent a skillful man, endowed with understanding, Huram-abi,<span class="f">+ \fr 2:13 \ft or, Huram, my father</span> 
-<span class="v">14&#160;</span>the son of a woman of the daughters of Dan; and his father was a man of Tyre. He is skillful to work in gold, in silver, in bronze, in iron, in stone, in timber, in purple, in blue, in fine linen, and in crimson, also to engrave any kind of engraving and to devise any device, that there may be a place appointed to him with your skillful men, and with the skillful men of my lord David your father. 
-</p><p>
-<span class="v">15&#160;</span>“Now therefore, the wheat, the barley, the oil, and the wine which my lord has spoken of, let him send to his servants; 
-<span class="v">16&#160;</span>and we will cut wood out of Lebanon, as much as you need. We will bring it to you in rafts by sea to Joppa; then you shall carry it up to Jerusalem.” 
-</p><p>
-<span class="v">17&#160;</span>Solomon counted all the foreigners who were in the land of Israel, after the census with which David his father had counted them; and they found one hundred fifty-three thousand six hundred. 
-<span class="v">18&#160;</span>He set seventy thousand of them to bear burdens, eighty thousand who were stone cutters in the mountains, and three thousand six hundred overseers to assign the people their work. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Then Solomon began to build Yahweh’s house at Jerusalem on Mount Moriah, where Yahweh appeared to David his father, which he prepared in the place that David had appointed, on the threshing floor of Ornan the Jebusite. 
-<span class="v">2&#160;</span>He began to build in the second day of the second month, in the fourth year of his reign. 
-<span class="v">3&#160;</span>Now these are the foundations which Solomon laid for the building of Elohim’s house: the length by cubits<span class="f">+ \fr 3:3 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> after the first measure was sixty cubits, and the width twenty cubits. 
-<span class="v">4&#160;</span>The porch that was in front, its length, across the width of the house, was twenty cubits, and the height one hundred twenty; and he overlaid it within with pure gold. 
-<span class="v">5&#160;</span>He made the larger room with a ceiling of cypress wood, which he overlaid with fine gold, and ornamented it with palm trees and chains. 
-<span class="v">6&#160;</span>He decorated the house with precious stones for beauty. The gold was gold from Parvaim. 
-<span class="v">7&#160;</span>He also overlaid the house, the beams, the thresholds, its walls, and its doors with gold, and engraved cherubim on the walls. 
-</p><p>
-<span class="v">8&#160;</span>He made the most set-apart place. Its length, according to the width of the house, was twenty cubits, and its width twenty cubits; and he overlaid it with fine gold, amounting to six hundred talents.<span class="f">+ \fr 3:8 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 600 talents is about 18 metric tons</span> 
-<span class="v">9&#160;</span>The weight of the nails was fifty shekels<span class="f">+ \fr 3:9 \ft A shekel is about 10 grams or about 0.32 Troy ounces, so 50 shekels was about 0.5 kilograms or about 16 Troy ounces.</span> of gold. He overlaid the upper rooms with gold. 
-</p><p>
-<span class="v">10&#160;</span>In the most set-apart place he made two cherubim by carving, and they overlaid them with gold. 
-<span class="v">11&#160;</span>The wings of the cherubim were twenty cubits long: the wing of the one was five cubits, reaching to the wall of the house; and the other wing was five cubits, reaching to the wing of the other cherub. 
-<span class="v">12&#160;</span>The wing of the other cherub was five cubits, reaching to the wall of the house; and the other wing was five cubits, joining to the wing of the other cherub. 
-<span class="v">13&#160;</span>The wings of these cherubim spread themselves out twenty cubits. They stood on their feet, and their faces were toward the house. 
-<span class="v">14&#160;</span>He made the veil of blue, purple, crimson, and fine linen, and ornamented it with cherubim. 
-</p><p>
-<span class="v">15&#160;</span>Also he made before the house two pillars thirty-five cubits high, and the capital that was on the top of each of them was five cubits. 
-<span class="v">16&#160;</span>He made chains in the inner sanctuary, and put them on the tops of the pillars; and he made one hundred pomegranates, and put them on the chains. 
-<span class="v">17&#160;</span>He set up the pillars before the temple, one on the right hand and the other on the left; and called the name of that on the right hand Jachin, and the name of that on the left Boaz. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Then he made an altar of bronze, twenty cubits<span class="f">+ \fr 4:1 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> long, twenty cubits wide, and ten cubits high. 
-<span class="v">2&#160;</span>Also he made the molten sea<span class="f">+ \fr 4:2 \ft or, pool, or, reservoir</span> of ten cubits from brim to brim. It was round, five cubits high, and thirty cubits in circumference. 
-<span class="v">3&#160;</span>Under it was the likeness of oxen, which encircled it, for ten cubits, encircling the sea. The oxen were in two rows, cast when it was cast. 
-<span class="v">4&#160;</span>It stood on twelve oxen, three looking toward the north, three looking toward the west, three looking toward the south, and three looking toward the east; and the sea was set on them above, and all their hindquarters were inward. 
-<span class="v">5&#160;</span>It was a handbreadth thick. Its brim was made like the brim of a cup, like the flower of a lily. It received and held three thousand baths.<span class="f">+ \fr 4:5 \ft A bath is about 5.6 U. S. gallons or 21.1 liters, so 3,000 baths is about 16,800 gallons or 63.3 kiloliters.</span> 
-<span class="v">6&#160;</span>He also made ten basins, and put five on the right hand and five on the left, to wash in them. The things that belonged to the burnt offering were washed in them, but the sea was for the priests to wash in. 
-</p><p>
-<span class="v">7&#160;</span>He made the ten lamp stands of gold according to the ordinance concerning them; and he set them in the temple, five on the right hand and five on the left. 
-<span class="v">8&#160;</span>He made also ten tables, and placed them in the temple, five on the right side and five on the left. He made one hundred basins of gold. 
-<span class="v">9&#160;</span>Furthermore he made the court of the priests, the great court, and doors for the court, and overlaid their doors with bronze. 
-<span class="v">10&#160;</span>He set the sea on the right side of the house eastward, toward the south. 
-</p><p>
-<span class="v">11&#160;</span>Huram made the pots, the shovels, and the basins. 
-</p><p>So Huram finished doing the work that he did for King Solomon in Elohim’s house: 
-<span class="v">12&#160;</span>the two pillars, the bowls, the two capitals which were on the top of the pillars, the two networks to cover the two bowls of the capitals that were on the top of the pillars, 
-<span class="v">13&#160;</span>and the four hundred pomegranates for the two networks—two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars. 
-<span class="v">14&#160;</span>He also made the bases, and he made the basins on the bases—<span class="v">15&#160;</span>one sea, and the twelve oxen under it. 
-<span class="v">16&#160;</span>Huram-abi<span class="f">+ \fr 4:16 \ft “abi” means “his father”</span> also made the pots, the shovels, the forks, and all its vessels for King Solomon, for Yahweh’s house, of bright bronze. 
-<span class="v">17&#160;</span>The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zeredah. 
-<span class="v">18&#160;</span>Thus Solomon made all these vessels in great abundance, so that the weight of the bronze could not be determined. 
-</p><p>
-<span class="v">19&#160;</span>Solomon made all the vessels that were in Elohim’s house: the golden altar, the tables with the show bread on them, 
-<span class="v">20&#160;</span>and the lamp stands with their lamps to burn according to the ordinance before the inner sanctuary, of pure gold; 
-<span class="v">21&#160;</span>and the flowers, the lamps, and the tongs of gold that was purest gold; 
-<span class="v">22&#160;</span>and the snuffers, the basins, the spoons, and the fire pans of pure gold. As for the entry of the house, its inner doors for the most set-apart place and the doors of the main hall of the temple were of gold. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Thus all the work that Solomon did for Yahweh’s house was finished. Solomon brought in the things that David his father had dedicated, even the silver, the gold, and all the vessels, and put them in the treasuries of Elohim’s house. 
-</p><p>
-<span class="v">2&#160;</span>Then Solomon assembled the elders of Israel and all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
-<span class="v">3&#160;</span>So all the men of Israel assembled themselves to the king at the feast, which was in the seventh month. 
-<span class="v">4&#160;</span>All the elders of Israel came. The Levites took up the ark. 
-<span class="v">5&#160;</span>They brought up the ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The Levitical priests brought these up. 
-<span class="v">6&#160;</span>King Solomon and all the congregation of Israel who were assembled to him were before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
-<span class="v">7&#160;</span>The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the wings of the cherubim. 
-<span class="v">8&#160;</span>For the cherubim spread out their wings over the place of the ark, and the cherubim covered the ark and its poles above. 
-<span class="v">9&#160;</span>The poles were so long that the ends of the poles were seen from the ark in front of the inner sanctuary, but they were not seen outside; and it is there to this day. 
-<span class="v">10&#160;</span>There was nothing in the ark except the two tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of Egypt. 
-</p><p>
-<span class="v">11&#160;</span>When the priests had come out of the set-apart place (for all the priests who were present had sanctified themselves, and didn’t keep their divisions; 
-<span class="v">12&#160;</span>also the Levites who were the singers, all of them, even Asaph, Heman, Jeduthun, and their sons and their brothers, arrayed in fine linen, with cymbals and stringed instruments and harps, stood at the east end of the altar, and with them one hundred twenty priests sounding with trumpets); 
-<span class="v">13&#160;</span>when the trumpeters and singers were as one, to make one sound to be heard in praising and thanking Yahweh; and when they lifted up their voice with the trumpets and cymbals and instruments of music, and praised Yahweh, saying, 
-</p><p class="q1">“For he is good, 
-</p><p class="q2">for his loving kindness endures forever!” 
-</p><p class="m">then the house was filled with a cloud, even Yahweh’s house, 
-<span class="v">14&#160;</span>so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Elohim’s house. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
-<span class="v">2&#160;</span>But I have built you a house and home, a place for you to dwell in forever.” 
-</p><p>
-<span class="v">3&#160;</span>The king turned his face, and blessed all the assembly of Israel; and all the assembly of Israel stood. 
-</p><p>
-<span class="v">4&#160;</span>He said, “Blessed be Yahweh, the Elohim of Israel, who spoke with his mouth to David my father, and has with his hands fulfilled it, saying, 
-<span class="v">5&#160;</span>‘Since the day that I brought my people out of the land of Egypt, I chose no city out of all the tribes of Israel to build a house in, that my name might be there, and I chose no man to be prince over my people Israel; 
-<span class="v">6&#160;</span>but now I have chosen Jerusalem, that my name might be there; and I have chosen David to be over my people Israel.’ 
-<span class="v">7&#160;</span>Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
-<span class="v">8&#160;</span>But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart; 
-<span class="v">9&#160;</span>nevertheless you shall not build the house, but your son who will come out of your body, he shall build the house for my name.’ 
-</p><p>
-<span class="v">10&#160;</span>“Yahweh has performed his word that he spoke; for I have risen up in the place of David my father, and sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
-<span class="v">11&#160;</span>There I have set the ark, in which is Yahweh’s covenant, which he made with the children of Israel.” 
-</p><p>
-<span class="v">12&#160;</span>He stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands 
-<span class="v">13&#160;</span>(for Solomon had made a bronze platform, five cubits<span class="f">+ \fr 6:13 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> long, five cubits wide, and three cubits high, and had set it in the middle of the court; and he stood on it, and knelt down on his knees before all the assembly of Israel, and spread out his hands toward heaven). 
-<span class="v">14&#160;</span>Then he said, “Yahweh, the Elohim of Israel, there is no Elohim like you in heaven or on earth—you who keep covenant and loving kindness with your servants who walk before you with all their heart; 
-<span class="v">15&#160;</span>who have kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
-</p><p>
-<span class="v">16&#160;</span>“Now therefore, Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk in my law as you have walked before me.’ 
-<span class="v">17&#160;</span>Now therefore, Yahweh, the Elohim of Israel, let your word be verified, which you spoke to your servant David. 
-</p><p>
-<span class="v">18&#160;</span>“But will Elohim indeed dwell with men on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house which I have built! 
-<span class="v">19&#160;</span>Yet have respect for the prayer of your servant and to his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you; 
-<span class="v">20&#160;</span>that your eyes may be open toward this house day and night, even toward the place where you have said that you would put your name, to listen to the prayer which your servant will pray toward this place. 
-<span class="v">21&#160;</span>Listen to the petitions of your servant and of your people Israel, when they pray toward this place. Yes, hear from your dwelling place, even from heaven; and when you hear, forgive. 
-</p><p>
-<span class="v">22&#160;</span>“If a man sins against his neighbor, and an oath is laid on him to cause him to swear, and he comes and swears before your altar in this house, 
-<span class="v">23&#160;</span>then hear from heaven, act, and judge your servants, bringing retribution to the wicked, to bring his way on his own head; and justifying the righteous, to give him according to his righteousness. 
-</p><p>
-<span class="v">24&#160;</span>“If your people Israel are struck down before the enemy because they have sinned against you, and they turn again and confess your name, and pray and make supplication before you in this house, 
-<span class="v">25&#160;</span>then hear from heaven, and forgive the sin of your people Israel, and bring them again to the land which you gave to them and to their fathers. 
-</p><p>
-<span class="v">26&#160;</span>“When the sky is shut up and there is no rain because they have sinned against you, if they pray toward this place and confess your name, and turn from their sin when you afflict them, 
-<span class="v">27&#160;</span>then hear in heaven, and forgive the sin of your servants, your people Israel, when you teach them the good way in which they should walk, and send rain on your land, which you have given to your people for an inheritance. 
-</p><p>
-<span class="v">28&#160;</span>“If there is famine in the land, if there is pestilence, if there is blight or mildew, locust or caterpillar; if their enemies besiege them in the land of their cities; whatever plague or whatever sickness there is—<span class="v">29&#160;</span>whatever prayer and supplication is made by any man, or by all your people Israel, who will each know his own plague and his own sorrow, and shall spread out his hands toward this house, 
-<span class="v">30&#160;</span>then hear from heaven your dwelling place and forgive, and render to every man according to all his ways, whose heart you know (for you, even you only, know the hearts of the children of men), 
-<span class="v">31&#160;</span>that they may fear you, to walk in your ways as long as they live in the land which you gave to our fathers. 
-</p><p>
-<span class="v">32&#160;</span>“Moreover, concerning the foreigner, who is not of your people Israel, when he comes from a far country for your great name’s sake and your mighty hand and your outstretched arm, when they come and pray toward this house, 
-<span class="v">33&#160;</span>then hear from heaven, even from your dwelling place, and do according to all that the foreigner calls to you for; that all the peoples of the earth may know your name and fear you, as do your people Israel, and that they may know that this house which I have built is called by your name. 
-</p><p>
-<span class="v">34&#160;</span>“If your people go out to battle against their enemies, by whatever way you send them, and they pray to you toward this city which you have chosen, and the house which I have built for your name; 
-<span class="v">35&#160;</span>then hear from heaven their prayer and their supplication, and maintain their cause. 
-</p><p>
-<span class="v">36&#160;</span>“If they sin against you (for there is no man who doesn’t sin), and you are angry with them and deliver them to the enemy, so that they carry them away captive to a land far off or near; 
-<span class="v">37&#160;</span>yet if they come to their senses in the land where they are carried captive, and turn again, and make supplication to you in the land of their captivity, saying, ‘We have sinned, we have done perversely, and have dealt wickedly;’ 
-<span class="v">38&#160;</span>if they return to you with all their heart and with all their soul in the land of their captivity, where they have been taken captive, and pray toward their land which you gave to their fathers, and the city which you have chosen, and toward the house which I have built for your name; 
-<span class="v">39&#160;</span>then hear from heaven, even from your dwelling place, their prayer and their petitions, and maintain their cause, and forgive your people who have sinned against you. 
-</p><p>
-<span class="v">40&#160;</span>“Now, my Elohim, let, I beg you, your eyes be open, and let your ears be attentive to the prayer that is made in this place. 
-</p><p>
-<span class="v">41&#160;</span>“Now therefore arise, Yahweh Elohim, into your resting place, you, and the ark of your strength. Let your priests, Yahweh Elohim, be clothed with salvation, and let your saints rejoice in goodness. 
-</p><p>
-<span class="v">42&#160;</span>“Yahweh Elohim, don’t turn away the face of your anointed. Remember your loving kindnesses to David your servant.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Now when Solomon had finished praying, fire came down from heaven and consumed the burnt offering and the sacrifices; and Yahweh’s glory filled the house. 
-<span class="v">2&#160;</span>The priests could not enter into Yahweh’s house, because Yahweh’s glory filled Yahweh’s house. 
-<span class="v">3&#160;</span>All the children of Israel looked on, when the fire came down, and Yahweh’s glory was on the house. They bowed themselves with their faces to the ground on the pavement, worshiped, and gave thanks to Yahweh, saying, 
-</p><p class="q1">“For he is good, 
-</p><p class="q2">for his loving kindness endures forever!” 
-</p><p>
-<span class="v">4&#160;</span>Then the king and all the people offered sacrifices before Yahweh. 
-<span class="v">5&#160;</span>King Solomon offered a sacrifice of twenty-two thousand head of cattle and a hundred twenty thousand sheep. So the king and all the people dedicated Elohim’s house. 
-<span class="v">6&#160;</span>The priests stood, according to their positions; the Levites also with instruments of music of Yahweh, which David the king had made to give thanks to Yahweh, when David praised by their ministry, saying “For his loving kindness endures forever.” The priests sounded trumpets before them; and all Israel stood. 
-</p><p>
-<span class="v">7&#160;</span>Moreover Solomon made the middle of the court that was before Yahweh’s house set-apart; for there he offered the burnt offerings and the fat of the peace offerings, because the bronze altar which Solomon had made was not able to receive the burnt offering, the meal offering, and the fat. 
-</p><p>
-<span class="v">8&#160;</span>So Solomon held the feast at that time for seven days, and all Israel with him, a very great assembly, from the entrance of Hamath to the brook of Egypt. 
-</p><p>
-<span class="v">9&#160;</span>On the eighth day, they held a solemn assembly; for they kept the dedication of the altar seven days, and the feast seven days. 
-<span class="v">10&#160;</span>On the twenty-third day of the seventh month, he sent the people away to their tents, joyful and glad of heart for the goodness that Yahweh had shown to David, to Solomon, and to Israel his people. 
-</p><p>
-<span class="v">11&#160;</span>Thus Solomon finished Yahweh’s house and the king’s house; and he successfully completed all that came into Solomon’s heart to make in Yahweh’s house and in his own house. 
-</p><p>
-<span class="v">12&#160;</span>Then Yahweh appeared to Solomon by night, and said to him, “I have heard your prayer, and have chosen this place for myself for a house of sacrifice. 
-</p><p>
-<span class="v">13&#160;</span>“If I shut up the sky so that there is no rain, or if I command the locust to devour the land, or if I send pestilence among my people, 
-<span class="v">14&#160;</span>if my people who are called by my name will humble themselves, pray, seek my face, and turn from their wicked ways, then I will hear from heaven, will forgive their sin, and will heal their land. 
-<span class="v">15&#160;</span>Now my eyes will be open and my ears attentive to prayer that is made in this place. 
-<span class="v">16&#160;</span>For now I have chosen and made this house set-apart, that my name may be there forever; and my eyes and my heart will be there perpetually. 
-</p><p>
-<span class="v">17&#160;</span>“As for you, if you will walk before me as David your father walked, and do according to all that I have commanded you, and will keep my statutes and my ordinances, 
-<span class="v">18&#160;</span>then I will establish the throne of your kingdom, according as I covenanted with David your father, saying, ‘There shall not fail you a man to be ruler in Israel.’ 
-</p><p>
-<span class="v">19&#160;</span>But if you turn away and forsake my statutes and my commandments which I have set before you, and go and serve other elohims and worship them, 
-<span class="v">20&#160;</span>then I will pluck them up by the roots out of my land which I have given them; and this house, which I have made set-apart for my name, I will cast out of my sight, and I will make it a proverb and a byword among all peoples. 
-<span class="v">21&#160;</span>This house, which is so high, everyone who passes by it will be astonished and say, ‘Why has Yahweh done this to this land and to this house?’ 
-<span class="v">22&#160;</span>They shall answer, ‘Because they abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and took other elohims, worshiped them, and served them. Therefore he has brought all this evil on them.’&#160;” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>At the end of twenty years, in which Solomon had built Yahweh’s house and his own house, 
-<span class="v">2&#160;</span>Solomon built the cities which Huram had given to Solomon, and caused the children of Israel to dwell there. 
-</p><p>
-<span class="v">3&#160;</span>Solomon went to Hamath Zobah, and prevailed against it. 
-<span class="v">4&#160;</span>He built Tadmor in the wilderness, and all the storage cities, which he built in Hamath. 
-<span class="v">5&#160;</span>Also he built Beth Horon the upper and Beth Horon the lower, fortified cities with walls, gates, and bars; 
-<span class="v">6&#160;</span>and Baalath, and all the storage cities that Solomon had, and all the cities for his chariots, the cities for his horsemen, and all that Solomon desired to build for his pleasure in Jerusalem, in Lebanon, and in all the land of his dominion. 
-</p><p>
-<span class="v">7&#160;</span>As for all the people who were left of the Hittites, the Amorites, the Perizzites, the Hivites, and the Jebusites, who were not of Israel—<span class="v">8&#160;</span>of their children who were left after them in the land, whom the children of Israel didn’t consume—of them Solomon conscripted forced labor to this day. 
-<span class="v">9&#160;</span>But of the children of Israel, Solomon made no servants for his work, but they were men of war, chief of his captains, and rulers of his chariots and of his horsemen. 
-<span class="v">10&#160;</span>These were the chief officers of King Solomon, even two-hundred fifty, who ruled over the people. 
-</p><p>
-<span class="v">11&#160;</span>Solomon brought up Pharaoh’s daughter out of David’s city to the house that he had built for her; for he said, “My woman shall not dwell in the house of David king of Israel, because the places where Yahweh’s ark has come are set-apart.” 
-</p><p>
-<span class="v">12&#160;</span>Then Solomon offered burnt offerings to Yahweh on Yahweh’s altar which he had built before the porch, 
-<span class="v">13&#160;</span>even as the duty of every day required, offering according to the commandment of Moses on the Sabbaths, on the new moons, and on the set feasts, three times per year, during the feast of unleavened bread, during the feast of weeks, and during the feast of booths.<span class="f">+ \fr 8:13 \ft or, feast of tents (Sukkot)</span> 
-</p><p>
-<span class="v">14&#160;</span>He appointed, according to the ordinance of David his father, the divisions of the priests to their service, and the Levites to their offices, to praise and to minister before the priests, as the duty of every day required, the doorkeepers also by their divisions at every gate, for David the man of Elohim had so commanded. 
-<span class="v">15&#160;</span>They didn’t depart from the commandment of the king to the priests and Levites concerning any matter or concerning the treasures. 
-</p><p>
-<span class="v">16&#160;</span>Now all the work of Solomon was accomplished from the day of the foundation of Yahweh’s house until it was finished. So Yahweh’s house was completed. 
-</p><p>
-<span class="v">17&#160;</span>Then Solomon went to Ezion Geber and to Eloth, on the seashore in the land of Edom. 
-<span class="v">18&#160;</span>Huram sent him ships and servants who had knowledge of the sea by the hands of his servants; and they came with the servants of Solomon to Ophir, and brought from there four hundred fifty talents<span class="f">+ \fr 8:18 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 450 talents is about 13.5 metric tons</span> of gold, and brought them to King Solomon. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>When the queen of Sheba heard of the fame of Solomon, she came to test Solomon with hard questions at Jerusalem, with a very great caravan, including camels that bore spices, gold in abundance, and precious stones. When she had come to Solomon, she talked with him about all that was in her heart. 
-<span class="v">2&#160;</span>Solomon answered all her questions. There wasn’t anything hidden from Solomon which he didn’t tell her. 
-<span class="v">3&#160;</span>When the queen of Sheba had seen the wisdom of Solomon, the house that he had built, 
-<span class="v">4&#160;</span>the food of his table, the seating of his servants, the attendance of his ministers, their clothing, his cup bearers and their clothing, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her.<span class="f">+ \fr 9:4 \ft or, she was breathless.</span> 
-</p><p>
-<span class="v">5&#160;</span>She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
-<span class="v">6&#160;</span>However I didn’t believe their words until I came, and my eyes had seen it; and behold half of the greatness of your wisdom wasn’t told me. You exceed the fame that I heard! 
-<span class="v">7&#160;</span>Happy are your men, and happy are these your servants, who stand continually before you and hear your wisdom. 
-<span class="v">8&#160;</span>Blessed be Yahweh your Elohim, who delighted in you and set you on his throne to be king for Yahweh your Elohim, because your Elohim loved Israel, to establish them forever. Therefore he made you king over them, to do justice and righteousness.” 
-</p><p>
-<span class="v">9&#160;</span>She gave the king one hundred and twenty talents<span class="f">+ \fr 9:9 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 120 talents is about 3.6 metric tons</span> of gold, spices in great abundance, and precious stones. There was never before such spice as the queen of Sheba gave to King Solomon. 
-</p><p>
-<span class="v">10&#160;</span>The servants of Huram and the servants of Solomon, who brought gold from Ophir, also brought algum trees<span class="f">+ \fr 9:10 \ft possibly Indian sandalwood, which has nice grain and a pleasant scent and is good for woodworking</span> and precious stones. 
-<span class="v">11&#160;</span>The king used algum tree wood to make terraces for Yahweh’s house and for the king’s house, and harps and stringed instruments for the singers. There were none like these seen before in the land of Judah. 
-<span class="v">12&#160;</span>King Solomon gave to the queen of Sheba all her desire, whatever she asked, more than that which she had brought to the king. So she turned and went to her own land, she and her servants. 
-</p><p>
-<span class="v">13&#160;</span>Now the weight of gold that came to Solomon in one year was six hundred sixty-six talents<span class="f">+ \fr 9:13 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces, so 666 talents is about 20 metric tons</span> of gold, 
-<span class="v">14&#160;</span>in addition to that which the traders and merchants brought. All the kings of Arabia and the governors of the country brought gold and silver to Solomon. 
-<span class="v">15&#160;</span>King Solomon made two hundred large shields of beaten gold. Six hundred shekels<span class="f">+ \fr 9:15 \ft A shekel is about 10 grams or about 0.32 Troy ounces, so 600 shekels was about 6 kilograms or about 192 Troy ounces.</span> of beaten gold went to one large shield. 
-<span class="v">16&#160;</span>He made three hundred shields of beaten gold. Three hundred shekels<span class="f">+ \fr 9:16 \ft A shekel is about 10 grams or about 0.32 Troy ounces, so 300 shekels was about 3 kilograms or about 96 Troy ounces.</span> of gold went to one shield. The king put them in the House of the Forest of Lebanon. 
-<span class="v">17&#160;</span>Moreover the king made a great throne of ivory, and overlaid it with pure gold. 
-<span class="v">18&#160;</span>There were six steps to the throne, with a footstool of gold, which were fastened to the throne, and armrests on either side by the place of the seat, and two lions standing beside the armrests. 
-<span class="v">19&#160;</span>Twelve lions stood there on the one side and on the other on the six steps. There was nothing like it made in any other kingdom. 
-<span class="v">20&#160;</span>All King Solomon’s drinking vessels were of gold, and all the vessels of the House of the Forest of Lebanon were of pure gold. Silver was not considered valuable in the days of Solomon. 
-<span class="v">21&#160;</span>For the king had ships that went to Tarshish with Huram’s servants. Once every three years, the ships of Tarshish came bringing gold, silver, ivory, apes, and peacocks. 
-</p><p>
-<span class="v">22&#160;</span>So King Solomon exceeded all the kings of the earth in riches and wisdom. 
-<span class="v">23&#160;</span>All the kings of the earth sought the presence of Solomon to hear his wisdom, which Elohim had put in his heart. 
-<span class="v">24&#160;</span>They each brought tribute: vessels of silver, vessels of gold, clothing, armor, spices, horses, and mules every year. 
-<span class="v">25&#160;</span>Solomon had four thousand stalls for horses and chariots, and twelve thousand horsemen that he stationed in the chariot cities and with the king at Jerusalem. 
-<span class="v">26&#160;</span>He ruled over all the kings from the River even to the land of the Philistines, and to the border of Egypt. 
-<span class="v">27&#160;</span>The king made silver as common in Jerusalem as stones, and he made cedars to be as abundant as the sycamore trees that are in the lowland. 
-<span class="v">28&#160;</span>They brought horses for Solomon out of Egypt and out of all lands. 
-</p><p>
-<span class="v">29&#160;</span>Now the rest of the acts of Solomon, first and last, aren’t they written in the history of Nathan the prophet, and in the prophecy of Ahijah the Shilonite, and in the visions of Iddo the seer concerning Jeroboam the son of Nebat? 
-<span class="v">30&#160;</span>Solomon reigned in Jerusalem over all Israel forty years. 
-<span class="v">31&#160;</span>Solomon slept with his fathers, and he was buried in his father David’s city; and Rehoboam his son reigned in his place. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Rehoboam went to Shechem, for all Israel had come to Shechem to make him king. 
-<span class="v">2&#160;</span>When Jeroboam the son of Nebat heard of it (for he was in Egypt, where he had fled from the presence of King Solomon), Jeroboam returned out of Egypt. 
-<span class="v">3&#160;</span>They sent and called him; and Jeroboam and all Israel came, and they spoke to Rehoboam, saying, 
-<span class="v">4&#160;</span>“Your father made our yoke grievous. Now therefore make the grievous service of your father and his heavy yoke which he put on us, lighter, and we will serve you.” 
-</p><p>
-<span class="v">5&#160;</span>He said to them, “Come again to me after three days.” 
-</p><p>So the people departed. 
-</p><p>
-<span class="v">6&#160;</span>King Rehoboam took counsel with the old men, who had stood before Solomon his father while he yet lived, saying, “What counsel do you give me about how to answer these people?” 
-</p><p>
-<span class="v">7&#160;</span>They spoke to him, saying, “If you are kind to these people, please them, and speak good words to them, then they will be your servants forever.” 
-</p><p>
-<span class="v">8&#160;</span>But he abandoned the counsel of the old men which they had given him, and took counsel with the young men who had grown up with him, who stood before him. 
-<span class="v">9&#160;</span>He said to them, “What counsel do you give, that we may give an answer to these people, who have spoken to me, saying, ‘Make the yoke that your father put on us lighter’?” 
-</p><p>
-<span class="v">10&#160;</span>The young men who had grown up with him spoke to him, saying, “Thus you shall tell the people who spoke to you, saying, ‘Your father made our yoke heavy, but make it lighter on us;’ thus you shall say to them, ‘My little finger is thicker than my father’s waist. 
-<span class="v">11&#160;</span>Now whereas my father burdened you with a heavy yoke, I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>So Jeroboam and all the people came to Rehoboam the third day, as the king asked, saying, “Come to me again the third day.” 
-<span class="v">13&#160;</span>The king answered them roughly; and King Rehoboam abandoned the counsel of the old men, 
-<span class="v">14&#160;</span>and spoke to them after the counsel of the young men, saying, “My father made your yoke heavy, but I will add to it. My father chastised you with whips, but I will chastise you with scorpions.” 
-</p><p>
-<span class="v">15&#160;</span>So the king didn’t listen to the people; for it was brought about by Elohim, that Yahweh might establish his word, which he spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
-</p><p>
-<span class="v">16&#160;</span>When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion do we have in David? We don’t have an inheritance in the son of Jesse! Every man to your tents, Israel! Now see to your own house, David.” So all Israel departed to their tents. 
-</p><p>
-<span class="v">17&#160;</span>But as for the children of Israel who lived in the cities of Judah, Rehoboam reigned over them. 
-<span class="v">18&#160;</span>Then King Rehoboam sent Hadoram, who was over the men subject to forced labor; and the children of Israel stoned him to death with stones. King Rehoboam hurried to get himself up to his chariot, to flee to Jerusalem. 
-<span class="v">19&#160;</span>So Israel rebelled against David’s house to this day. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>When Rehoboam had come to Jerusalem, he assembled the house of Judah and Benjamin, one hundred eighty thousand chosen men who were warriors, to fight against Israel, to bring the kingdom again to Rehoboam. 
-<span class="v">2&#160;</span>But Yahweh’s word came to Shemaiah the man of Elohim, saying, 
-<span class="v">3&#160;</span>“Speak to Rehoboam the son of Solomon, king of Judah, and to all Israel in Judah and Benjamin, saying, 
-<span class="v">4&#160;</span>‘Yahweh says, “You shall not go up, nor fight against your brothers! Every man return to his house; for this thing is of me.”&#160;’&#160;” So they listened to Yahweh’s words, and returned from going against Jeroboam. 
-</p><p>
-<span class="v">5&#160;</span>Rehoboam lived in Jerusalem, and built cities for defense in Judah. 
-<span class="v">6&#160;</span>He built Bethlehem, Etam, Tekoa, 
-<span class="v">7&#160;</span>Beth Zur, Soco, Adullam, 
-<span class="v">8&#160;</span>Gath, Mareshah, Ziph, 
-<span class="v">9&#160;</span>Adoraim, Lachish, Azekah, 
-<span class="v">10&#160;</span>Zorah, Aijalon, and Hebron, which are fortified cities in Judah and in Benjamin. 
-<span class="v">11&#160;</span>He fortified the strongholds and put captains in them with stores of food, oil and wine. 
-<span class="v">12&#160;</span>He put shields and spears in every city, and made them exceedingly strong. Judah and Benjamin belonged to him. 
-</p><p>
-<span class="v">13&#160;</span>The priests and the Levites who were in all Israel stood with him out of all their territory. 
-<span class="v">14&#160;</span>For the Levites left their pasture lands and their possessions, and came to Judah and Jerusalem; for Jeroboam and his sons cast them off, that they should not execute the priest’s office to Yahweh. 
-<span class="v">15&#160;</span>He himself appointed priests for the high places, for the male goat and calf idols which he had made. 
-<span class="v">16&#160;</span>After them, out of all the tribes of Israel, those who set their hearts to seek Yahweh, the Elohim of Israel, came to Jerusalem to sacrifice to Yahweh, the Elohim of their fathers. 
-<span class="v">17&#160;</span>So they strengthened the kingdom of Judah and made Rehoboam the son of Solomon strong for three years, for they walked three years in the way of David and Solomon. 
-</p><p>
-<span class="v">18&#160;</span>Rehoboam took a woman for himself, Mahalath the daughter of Jerimoth the son of David and of Abihail the daughter of Eliab the son of Jesse. 
-<span class="v">19&#160;</span>She bore him sons: Jeush, Shemariah, and Zaham. 
-<span class="v">20&#160;</span>After her, he took Maacah the granddaughter of Absalom; and she bore him Abijah, Attai, Ziza, and Shelomith. 
-<span class="v">21&#160;</span>Rehoboam loved Maacah the granddaughter of Absalom above all his women and his concubines; for he took eighteen women and sixty concubines, and brought forth twenty-eight sons and sixty daughters. 
-<span class="v">22&#160;</span>Rehoboam appointed Abijah the son of Maacah to be chief, the prince among his brothers, for he intended to make him king. 
-<span class="v">23&#160;</span>He dealt wisely, and dispersed some of his sons throughout all the lands of Judah and Benjamin, to every fortified city. He gave them food in abundance; and he sought many women for them. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>When the kingdom of Rehoboam was established and he was strong, he abandoned Yahweh’s law, and all Israel with him. 
-<span class="v">2&#160;</span>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem, because they had trespassed against Yahweh, 
-<span class="v">3&#160;</span>with twelve hundred chariots and sixty thousand horsemen. The people were without number who came with him out of Egypt: the Lubim, the Sukkiim, and the Ethiopians. 
-<span class="v">4&#160;</span>He took the fortified cities which belonged to Judah, and came to Jerusalem. 
-<span class="v">5&#160;</span>Now Shemaiah the prophet came to Rehoboam and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them, “Yahweh says, ‘You have forsaken me, therefore I have also left you in the hand of Shishak.’&#160;” 
-</p><p>
-<span class="v">6&#160;</span>Then the princes of Israel and the king humbled themselves; and they said, “Yahweh is righteous.” 
-</p><p>
-<span class="v">7&#160;</span>When Yahweh saw that they humbled themselves, Yahweh’s word came to Shemaiah, saying, “They have humbled themselves. I will not destroy them, but I will grant them some deliverance, and my wrath won’t be poured out on Jerusalem by the hand of Shishak. 
-<span class="v">8&#160;</span>Nevertheless they will be his servants, that they may know my service, and the service of the kingdoms of the countries.” 
-</p><p>
-<span class="v">9&#160;</span>So Shishak king of Egypt came up against Jerusalem and took away the treasures of Yahweh’s house and the treasures of the king’s house. He took it all away. He also took away the shields of gold which Solomon had made. 
-<span class="v">10&#160;</span>King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
-<span class="v">11&#160;</span>As often as the king entered into Yahweh’s house, the guard came and bore them, then brought them back into the guard room. 
-<span class="v">12&#160;</span>When he humbled himself, Yahweh’s wrath turned from him, so as not to destroy him altogether. Moreover, there were good things found in Judah. 
-</p><p>
-<span class="v">13&#160;</span>So King Rehoboam strengthened himself in Jerusalem and reigned; for Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel to put his name there. His mother’s name was Naamah the Ammonitess. 
-<span class="v">14&#160;</span>He did that which was evil, because he didn’t set his heart to seek Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>Now the acts of Rehoboam, first and last, aren’t they written in the histories of Shemaiah the prophet and of Iddo the seer, in the genealogies? There were wars between Rehoboam and Jeroboam continually. 
-<span class="v">16&#160;</span>Rehoboam slept with his fathers, and was buried in David’s city; and Abijah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>In the eighteenth year of King Jeroboam, Abijah began to reign over Judah. 
-<span class="v">2&#160;</span>He reigned three years in Jerusalem. His mother’s name was Micaiah the daughter of Uriel of Gibeah. There was war between Abijah and Jeroboam. 
-<span class="v">3&#160;</span>Abijah joined battle with an army of valiant men of war, even four hundred thousand chosen men; and Jeroboam set the battle in array against him with eight hundred thousand chosen men, who were mighty men of valor. 
-<span class="v">4&#160;</span>Abijah stood up on Mount Zemaraim, which is in the hill country of Ephraim, and said, “Hear me, Jeroboam and all Israel: 
-<span class="v">5&#160;</span>Ought you not to know that Yahweh, the Elohim of Israel, gave the kingdom over Israel to David forever, even to him and to his sons by a covenant of salt? 
-<span class="v">6&#160;</span>Yet Jeroboam the son of Nebat, the servant of Solomon the son of David, rose up, and rebelled against his lord. 
-<span class="v">7&#160;</span>Worthless men were gathered to him, wicked fellows who strengthened themselves against Rehoboam the son of Solomon, when Rehoboam was young and tender hearted, and could not withstand them. 
-</p><p>
-<span class="v">8&#160;</span>“Now you intend to withstand the kingdom of Yahweh in the hand of the sons of David. You are a great multitude, and the golden calves which Jeroboam made you for elohims are with you. 
-<span class="v">9&#160;</span>Haven’t you driven out the priests of Yahweh, the sons of Aaron, and the Levites, and made priests for yourselves according to the ways of the peoples of other lands? Whoever comes to consecrate himself with a young bull and seven rams may be a priest of those who are no elohims. 
-</p><p>
-<span class="v">10&#160;</span>“But as for us, Yahweh is our Elohim, and we have not forsaken him. We have priests serving Yahweh, the sons of Aaron, and the Levites in their work. 
-<span class="v">11&#160;</span>They burn to Yahweh every morning and every evening burnt offerings and sweet incense. They also set the show bread in order on the pure table, and care for the gold lamp stand with its lamps, to burn every evening; for we keep the instruction of Yahweh our Elohim, but you have forsaken him. 
-<span class="v">12&#160;</span>Behold, Elohim is with us at our head, and his priests with the trumpets of alarm to sound an alarm against you. Children of Israel, don’t fight against Yahweh, the Elohim of your fathers; for you will not prosper.” 
-</p><p>
-<span class="v">13&#160;</span>But Jeroboam caused an ambush to come about behind them; so they were before Judah, and the ambush was behind them. 
-<span class="v">14&#160;</span>When Judah looked back, behold, the battle was before and behind them; and they cried to Yahweh, and the priests sounded with the trumpets. 
-<span class="v">15&#160;</span>Then the men of Judah gave a shout. As the men of Judah shouted, Elohim struck Jeroboam and all Israel before Abijah and Judah. 
-<span class="v">16&#160;</span>The children of Israel fled before Judah, and Elohim delivered them into their hand. 
-<span class="v">17&#160;</span>Abijah and his people killed them with a great slaughter, so five hundred thousand chosen men of Israel fell down slain. 
-<span class="v">18&#160;</span>Thus the children of Israel were brought under at that time, and the children of Judah prevailed, because they relied on Yahweh, the Elohim of their fathers. 
-<span class="v">19&#160;</span>Abijah pursued Jeroboam, and took cities from him: Bethel with its villages, Jeshanah with its villages, and Ephron with its villages. 
-</p><p>
-<span class="v">20&#160;</span>Jeroboam didn’t recover strength again in the days of Abijah. Yahweh struck him, and he died. 
-<span class="v">21&#160;</span>But Abijah grew mighty and took for himself fourteen women, and brought forth twenty-two sons and sixteen daughters. 
-<span class="v">22&#160;</span>The rest of the acts of Abijah, his ways, and his sayings are written in the commentary of the prophet Iddo. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>So Abijah slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. In his days, the land was quiet ten years. 
-<span class="v">2&#160;</span>Asa did that which was good and right in Yahweh his Elohim’s eyes, 
-<span class="v">3&#160;</span>for he took away the foreign altars and the high places, broke down the pillars, cut down the Asherah poles, 
-<span class="v">4&#160;</span>and commanded Judah to seek Yahweh, the Elohim of their fathers, and to obey his law and command. 
-<span class="v">5&#160;</span>Also he took away out of all the cities of Judah the high places and the sun images; and the kingdom was quiet before him. 
-<span class="v">6&#160;</span>He built fortified cities in Judah; for the land was quiet, and he had no war in those years, because Yahweh had given him rest. 
-<span class="v">7&#160;</span>For he said to Judah, “Let’s build these cities and make walls around them, with towers, gates, and bars. The land is yet before us, because we have sought Yahweh our Elohim. We have sought him, and he has given us rest on every side.” So they built and prospered. 
-</p><p>
-<span class="v">8&#160;</span>Asa had an army of three hundred thousand out of Judah who bore bucklers and spears, and two hundred eighty thousand out of Benjamin who bore shields and drew bows. All these were mighty men of valor. 
-</p><p>
-<span class="v">9&#160;</span>Zerah the Ethiopian came out against them with an army of a million troops and three hundred chariots, and he came to Mareshah. 
-<span class="v">10&#160;</span>Then Asa went out to meet him, and they set the battle in array in the valley of Zephathah at Mareshah. 
-<span class="v">11&#160;</span>Asa cried to Yahweh his Elohim, and said, “Yahweh, there is no one besides you to help, between the mighty and him who has no strength. Help us, Yahweh our Elohim; for we rely on you, and in your name are we come against this multitude. Yahweh, you are our Elohim. Don’t let man prevail against you.” 
-</p><p>
-<span class="v">12&#160;</span>So Yahweh struck the Ethiopians before Asa and before Judah; and the Ethiopians fled. 
-<span class="v">13&#160;</span>Asa and the people who were with him pursued them to Gerar. So many of the Ethiopians fell that they could not recover themselves, for they were destroyed before Yahweh and before his army. Judah’s army carried away very much booty. 
-<span class="v">14&#160;</span>They struck all the cities around Gerar, for the fear of Yahweh came on them. They plundered all the cities, for there was much plunder in them. 
-<span class="v">15&#160;</span>They also struck the tents of those who had livestock, and carried away sheep and camels in abundance, then returned to Jerusalem. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>The Spirit of Elohim came on Azariah the son of Oded. 
-<span class="v">2&#160;</span>He went out to meet Asa, and said to him, “Hear me, Asa, and all Judah and Benjamin! Yahweh is with you while you are with him; and if you seek him, he will be found by you; but if you forsake him, he will forsake you. 
-<span class="v">3&#160;</span>Now for a long time Israel was without the true Elohim, without a teaching priest, and without law. 
-<span class="v">4&#160;</span>But when in their distress they turned to Yahweh, the Elohim of Israel, and sought him, he was found by them. 
-<span class="v">5&#160;</span>In those times there was no peace to him who went out, nor to him who came in; but great troubles were on all the inhabitants of the lands. 
-<span class="v">6&#160;</span>They were broken in pieces, nation against nation, and city against city; for Elohim troubled them with all adversity. 
-<span class="v">7&#160;</span>But you be strong! Don’t let your hands be slack, for your work will be rewarded.” 
-</p><p>
-<span class="v">8&#160;</span>When Asa heard these words and the prophecy of Oded the prophet, he took courage, and put away the abominations out of all the land of Judah and Benjamin, and out of the cities which he had taken from the hill country of Ephraim; and he renewed Yahweh’s altar that was before Yahweh’s porch. 
-<span class="v">9&#160;</span>He gathered all Judah and Benjamin, and those who lived with them out of Ephraim, Manasseh, and Simeon; for they came to him out of Israel in abundance when they saw that Yahweh his Elohim was with him. 
-<span class="v">10&#160;</span>So they gathered themselves together at Jerusalem in the third month, in the fifteenth year of Asa’s reign. 
-<span class="v">11&#160;</span>They sacrificed to Yahweh in that day, of the plunder which they had brought, seven hundred head of cattle and seven thousand sheep. 
-<span class="v">12&#160;</span>They entered into the covenant to seek Yahweh, the Elohim of their fathers, with all their heart and with all their soul; 
-<span class="v">13&#160;</span>and that whoever would not seek Yahweh, the Elohim of Israel, should be put to death, whether small or great, whether man or woman. 
-<span class="v">14&#160;</span>They swore to Yahweh with a loud voice, with shouting, with trumpets, and with cornets. 
-<span class="v">15&#160;</span>All Judah rejoiced at the oath, for they had sworn with all their heart and sought him with their whole desire; and he was found by them. Then Yahweh gave them rest all around. 
-</p><p>
-<span class="v">16&#160;</span>Also Maacah, the mother of Asa the king, he removed from being queen mother, because she had made an abominable image for an Asherah; so Asa cut down her image, ground it into dust, and burned it at the brook Kidron. 
-<span class="v">17&#160;</span>But the high places were not taken away out of Israel; nevertheless the heart of Asa was perfect all his days. 
-<span class="v">18&#160;</span>He brought the things that his father had dedicated and that he himself had dedicated, silver, gold, and vessels into Elohim’s house. 
-<span class="v">19&#160;</span>There was no more war to the thirty-fifth year of Asa’s reign. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>In the thirty-sixth year of Asa’s reign, Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
-<span class="v">2&#160;</span>Then Asa brought out silver and gold out of the treasures of Yahweh’s house and of the king’s house, and sent to Ben Hadad king of Syria, who lived at Damascus, saying, 
-<span class="v">3&#160;</span>“Let there be a treaty between me and you, as there was between my father and your father. Behold, I have sent you silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
-</p><p>
-<span class="v">4&#160;</span>Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel; and they struck Ijon, Dan, Abel Maim, and all the storage cities of Naphtali. 
-<span class="v">5&#160;</span>When Baasha heard of it, he stopped building Ramah, and let his work cease. 
-<span class="v">6&#160;</span>Then Asa the king took all Judah, and they carried away the stones and timber of Ramah, with which Baasha had built; and he built Geba and Mizpah with them. 
-</p><p>
-<span class="v">7&#160;</span>At that time Hanani the seer came to Asa king of Judah, and said to him, “Because you have relied on the king of Syria, and have not relied on Yahweh your Elohim, therefore the army of the king of Syria has escaped out of your hand. 
-<span class="v">8&#160;</span>Weren’t the Ethiopians and the Lubim a huge army, with chariots and exceedingly many horsemen? Yet, because you relied on Yahweh, he delivered them into your hand. 
-<span class="v">9&#160;</span>For Yahweh’s eyes run back and forth throughout the whole earth, to show himself strong in the behalf of them whose heart is perfect toward him. You have done foolishly in this; for from now on you will have wars.” 
-</p><p>
-<span class="v">10&#160;</span>Then Asa was angry with the seer, and put him in the prison; for he was in a rage with him because of this thing. Asa oppressed some of the people at the same time. 
-</p><p>
-<span class="v">11&#160;</span>Behold, the acts of Asa, first and last, behold, they are written in the book of the kings of Judah and Israel. 
-<span class="v">12&#160;</span>In the thirty-ninth year of his reign, Asa was diseased in his feet. His disease was exceedingly great; yet in his disease he didn’t seek Yahweh, but just the physicians. 
-<span class="v">13&#160;</span>Asa slept with his fathers, and died in the forty-first year of his reign. 
-<span class="v">14&#160;</span>They buried him in his own tomb, which he had dug out for himself in David’s city, and laid him in the bed which was filled with sweet odors and various kinds of spices prepared by the perfumers’ art; and they made a very great fire for him. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Jehoshaphat his son reigned in his place, and strengthened himself against Israel. 
-<span class="v">2&#160;</span>He placed forces in all the fortified cities of Judah, and set garrisons in the land of Judah and in the cities of Ephraim, which Asa his father had taken. 
-<span class="v">3&#160;</span>Yahweh was with Jehoshaphat, because he walked in the first ways of his father David, and didn’t seek the Baals, 
-<span class="v">4&#160;</span>but sought the Elohim of his father, and walked in his commandments, and not in the ways of Israel. 
-<span class="v">5&#160;</span>Therefore Yahweh established the kingdom in his hand. All Judah brought tribute to Jehoshaphat, and he had riches and honor in abundance. 
-<span class="v">6&#160;</span>His heart was lifted up in the ways of Yahweh. Furthermore, he took away the high places and the Asherah poles out of Judah. 
-</p><p>
-<span class="v">7&#160;</span>Also in the third year of his reign he sent his princes, even Ben Hail, Obadiah, Zechariah, Nethanel, and Micaiah, to teach in the cities of Judah; 
-<span class="v">8&#160;</span>and with them Levites, even Shemaiah, Nethaniah, Zebadiah, Asahel, Shemiramoth, Jehonathan, Adonijah, Tobijah, and Tobadonijah, the Levites; and with them Elishama and Jehoram, the priests. 
-<span class="v">9&#160;</span>They taught in Judah, having the book of Yahweh’s law with them. They went about throughout all the cities of Judah and taught among the people. 
-</p><p>
-<span class="v">10&#160;</span>The fear of Yahweh fell on all the kingdoms of the lands that were around Judah, so that they made no war against Jehoshaphat. 
-<span class="v">11&#160;</span>Some of the Philistines brought Jehoshaphat presents and silver for tribute. The Arabians also brought him flocks: seven thousand seven hundred rams and seven thousand seven hundred male goats. 
-<span class="v">12&#160;</span>Jehoshaphat grew great exceedingly; and he built fortresses and store cities in Judah. 
-<span class="v">13&#160;</span>He had many works in the cities of Judah; and men of war, mighty men of valor, in Jerusalem. 
-<span class="v">14&#160;</span>This was the numbering of them according to their fathers’ houses: From Judah, the captains of thousands: Adnah the captain, and with him three hundred thousand mighty men of valor; 
-<span class="v">15&#160;</span>and next to him Jehohanan the captain, and with him two hundred eighty thousand; 
-<span class="v">16&#160;</span>and next to him Amasiah the son of Zichri, who willingly offered himself to Yahweh, and with him two hundred thousand mighty men of valor. 
-<span class="v">17&#160;</span>From Benjamin: Eliada, a mighty man of valor, and with him two hundred thousand armed with bow and shield; 
-<span class="v">18&#160;</span>and next to him Jehozabad, and with him one hundred eighty thousand ready and prepared for war. 
-<span class="v">19&#160;</span>These were those who waited on the king, in addition to those whom the king put in the fortified cities throughout all Judah. 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Now Jehoshaphat had riches and honor in abundance; and he allied himself with Ahab. 
-<span class="v">2&#160;</span>After some years, he went down to Ahab to Samaria. Ahab killed sheep and cattle for him in abundance, and for the people who were with him, and moved him to go up with him to Ramoth Gilead. 
-<span class="v">3&#160;</span>Ahab king of Israel said to Jehoshaphat king of Judah, “Will you go with me to Ramoth Gilead?” 
-</p><p>He answered him, “I am as you are, and my people as your people. We will be with you in the war.” 
-<span class="v">4&#160;</span>Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
-</p><p>
-<span class="v">5&#160;</span>Then the king of Israel gathered the prophets together, four hundred men, and said to them, “Shall we go to Ramoth Gilead to battle, or shall I forbear?” 
-</p><p>They said, “Go up, for Elohim will deliver it into the hand of the king.” 
-</p><p>
-<span class="v">6&#160;</span>But Jehoshaphat said, “Isn’t there here a prophet of Yahweh besides, that we may inquire of him?” 
-</p><p>
-<span class="v">7&#160;</span>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh; but I hate him, for he never prophesies good concerning me, but always evil. He is Micaiah the son of Imla.” 
-</p><p>Jehoshaphat said, “Don’t let the king say so.” 
-</p><p>
-<span class="v">8&#160;</span>Then the king of Israel called an officer, and said, “Get Micaiah the son of Imla quickly.” 
-</p><p>
-<span class="v">9&#160;</span>Now the king of Israel and Jehoshaphat the king of Judah each sat on his throne, arrayed in their robes, and they were sitting in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
-<span class="v">10&#160;</span>Zedekiah the son of Chenaanah made himself horns of iron and said, “Yahweh says, ‘With these you shall push the Syrians, until they are consumed.’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>All the prophets prophesied so, saying, “Go up to Ramoth Gilead, and prosper; for Yahweh will deliver it into the hand of the king.” 
-</p><p>
-<span class="v">12&#160;</span>The messenger who went to call Micaiah spoke to him, saying, “Behold, the words of the prophets declare good to the king with one mouth. Let your word therefore, please be like one of theirs, and speak good.” 
-</p><p>
-<span class="v">13&#160;</span>Micaiah said, “As Yahweh lives, I will say what my Elohim says.” 
-</p><p>
-<span class="v">14&#160;</span>When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall I forbear?” 
-</p><p>He said, “Go up, and prosper. They shall be delivered into your hand.” 
-</p><p>
-<span class="v">15&#160;</span>The king said to him, “How many times shall I adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
-</p><p>
-<span class="v">16&#160;</span>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
-</p><p>
-<span class="v">18&#160;</span>Micaiah said, “Therefore hear Yahweh’s word: I saw Yahweh sitting on his throne, and all the army of heaven standing on his right hand and on his left. 
-<span class="v">19&#160;</span>Yahweh said, ‘Who will entice Ahab king of Israel, that he may go up and fall at Ramoth Gilead?’ One spoke saying in this way, and another saying in that way. 
-<span class="v">20&#160;</span>A spirit came out, stood before Yahweh, and said, ‘I will entice him.’ 
-</p><p>“Yahweh said to him, ‘How?’ 
-</p><p>
-<span class="v">21&#160;</span>“He said, ‘I will go, and will be a lying spirit in the mouth of all his prophets.’ 
-</p><p>“He said, ‘You will entice him, and will prevail also. Go and do so.’ 
-</p><p>
-<span class="v">22&#160;</span>“Now therefore, behold, Yahweh has put a lying spirit in the mouth of these your prophets; and Yahweh has spoken evil concerning you.” 
-</p><p>
-<span class="v">23&#160;</span>Then Zedekiah the son of Chenaanah came near, and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
-</p><p>
-<span class="v">24&#160;</span>Micaiah said, “Behold, you shall see on that day, when you go into an inner room to hide yourself.” 
-</p><p>
-<span class="v">25&#160;</span>The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city, and to Joash the king’s son; 
-<span class="v">26&#160;</span>and say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I return in peace.”&#160;’&#160;” 
-</p><p>
-<span class="v">27&#160;</span>Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, you people, all of you!” 
-</p><p>
-<span class="v">28&#160;</span>So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
-<span class="v">29&#160;</span>The king of Israel said to Jehoshaphat, “I will disguise myself, and go into the battle; but you put on your robes.” So the king of Israel disguised himself; and they went into the battle. 
-<span class="v">30&#160;</span>Now the king of Syria had commanded the captains of his chariots, saying, “Don’t fight with small nor great, except only with the king of Israel.” 
-</p><p>
-<span class="v">31&#160;</span>When the captains of the chariots saw Jehoshaphat, they said, “It is the king of Israel!” Therefore they turned around to fight against him. But Jehoshaphat cried out, and Yahweh helped him; and Elohim moved them to depart from him. 
-<span class="v">32&#160;</span>When the captains of the chariots saw that it was not the king of Israel, they turned back from pursuing him. 
-<span class="v">33&#160;</span>A certain man drew his bow at random, and struck the king of Israel between the joints of the armor. Therefore he said to the driver of the chariot, “Turn around and carry me out of the battle, for I am severely wounded.” 
-<span class="v">34&#160;</span>The battle increased that day. However, the king of Israel propped himself up in his chariot against the Syrians until the evening; and at about sunset, he died. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Jehoshaphat the king of Judah returned to his house in peace to Jerusalem. 
-<span class="v">2&#160;</span>Jehu the son of Hanani the seer went out to meet him, and said to King Jehoshaphat, “Should you help the wicked, and love those who hate Yahweh? Because of this, wrath is on you from before Yahweh. 
-<span class="v">3&#160;</span>Nevertheless there are good things found in you, in that you have put away the Asheroth out of the land, and have set your heart to seek Elohim.” 
-</p><p>
-<span class="v">4&#160;</span>Jehoshaphat lived at Jerusalem; and he went out again among the people from Beersheba to the hill country of Ephraim, and brought them back to Yahweh, the Elohim of their fathers. 
-<span class="v">5&#160;</span>He set judges in the land throughout all the fortified cities of Judah, city by city, 
-<span class="v">6&#160;</span>and said to the judges, “Consider what you do, for you don’t judge for man, but for Yahweh; and he is with you in the judgment. 
-<span class="v">7&#160;</span>Now therefore let the fear of Yahweh be on you. Take heed and do it; for there is no iniquity with Yahweh our Elohim, nor respect of persons, nor taking of bribes.” 
-</p><p>
-<span class="v">8&#160;</span>Moreover in Jerusalem Jehoshaphat appointed certain Levites, priests, and heads of the fathers’ households of Israel to give judgment for Yahweh and for controversies. They returned to Jerusalem. 
-<span class="v">9&#160;</span>He commanded them, saying, “You shall do this in the fear of Yahweh, faithfully, and with a perfect heart. 
-<span class="v">10&#160;</span>Whenever any controversy comes to you from your brothers who dwell in their cities, between blood and blood, between law and commandment, statutes and ordinances, you must warn them, that they not be guilty toward Yahweh, and so wrath come on you and on your brothers. Do this, and you will not be guilty. 
-<span class="v">11&#160;</span>Behold, Amariah the chief priest is over you in all matters of Yahweh; and Zebadiah the son of Ishmael, the ruler of the house of Judah, in all the king’s matters. Also the Levites shall be officers before you. Deal courageously, and may Yahweh be with the good.” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>After this, the children of Moab, the children of Ammon, and with them some of the Ammonites, came against Jehoshaphat to battle. 
-<span class="v">2&#160;</span>Then some came who told Jehoshaphat, saying, “A great multitude is coming against you from beyond the sea from Syria. Behold, they are in Hazazon Tamar” (that is, En Gedi). 
-<span class="v">3&#160;</span>Jehoshaphat was alarmed, and set himself to seek to Yahweh. He proclaimed a fast throughout all Judah. 
-<span class="v">4&#160;</span>Judah gathered themselves together to seek help from Yahweh. They came out of all the cities of Judah to seek Yahweh. 
-</p><p>
-<span class="v">5&#160;</span>Jehoshaphat stood in the assembly of Judah and Jerusalem, in Yahweh’s house, before the new court; 
-<span class="v">6&#160;</span>and he said, “Yahweh, the Elohim of our fathers, aren’t you Elohim in heaven? Aren’t you ruler over all the kingdoms of the nations? Power and might are in your hand, so that no one is able to withstand you. 
-<span class="v">7&#160;</span>Didn’t you, our Elohim, drive out the inhabitants of this land before your people Israel, and give it to the offspring<span class="f">+ \fr 20:7 \ft or, seed</span> of Abraham your friend forever? 
-<span class="v">8&#160;</span>They lived in it, and have built you a sanctuary in it for your name, saying, 
-<span class="v">9&#160;</span>‘If evil comes on us—the sword, judgment, pestilence, or famine—we will stand before this house, and before you (for your name is in this house), and cry to you in our affliction, and you will hear and save.’ 
-<span class="v">10&#160;</span>Now, behold, the children of Ammon and Moab and Mount Seir, whom you would not let Israel invade when they came out of the land of Egypt, but they turned away from them, and didn’t destroy them; 
-<span class="v">11&#160;</span>behold, how they reward us, to come to cast us out of your possession, which you have given us to inherit. 
-<span class="v">12&#160;</span>Our Elohim, will you not judge them? For we have no might against this great company that comes against us. We don’t know what to do, but our eyes are on you.” 
-</p><p>
-<span class="v">13&#160;</span>All Judah stood before Yahweh, with their little ones, their women, and their children. 
-</p><p>
-<span class="v">14&#160;</span>Then Yahweh’s Spirit came on Jahaziel the son of Zechariah, the son of Benaiah, the son of Jeiel, the son of Mattaniah, the Levite, of the sons of Asaph, in the middle of the assembly; 
-<span class="v">15&#160;</span>and he said, “Listen, all Judah, and you inhabitants of Jerusalem, and you, King Jehoshaphat. Yahweh says to you, ‘Don’t be afraid, and don’t be dismayed because of this great multitude; for the battle is not yours, but Elohim’s. 
-<span class="v">16&#160;</span>Tomorrow, go down against them. Behold, they are coming up by the ascent of Ziz. You will find them at the end of the valley, before the wilderness of Jeruel. 
-<span class="v">17&#160;</span>You will not need to fight this battle. Set yourselves, stand still, and see the salvation of Yahweh with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for Yahweh is with you.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Jehoshaphat bowed his head with his face to the ground; and all Judah and the inhabitants of Jerusalem fell down before Yahweh, worshiping Yahweh. 
-<span class="v">19&#160;</span>The Levites, of the children of the Kohathites and of the children of the Korahites, stood up to praise Yahweh, the Elohim of Israel, with an exceedingly loud voice. 
-</p><p>
-<span class="v">20&#160;</span>They rose early in the morning and went out into the wilderness of Tekoa. As they went out, Jehoshaphat stood and said, “Listen to me, Judah and you inhabitants of Jerusalem! Believe in Yahweh your Elohim, so you will be established! Believe his prophets, so you will prosper.” 
-</p><p>
-<span class="v">21&#160;</span>When he had taken counsel with the people, he appointed those who were to sing to Yahweh and give praise in set-apart array as they go out before the army, and say, “Give thanks to Yahweh, for his loving kindness endures forever.” 
-<span class="v">22&#160;</span>When they began to sing and to praise, Yahweh set ambushers against the children of Ammon, Moab, and Mount Seir, who had come against Judah; and they were struck. 
-<span class="v">23&#160;</span>For the children of Ammon and Moab stood up against the inhabitants of Mount Seir to utterly kill and destroy them. When they had finished the inhabitants of Seir, everyone helped to destroy each other. 
-</p><p>
-<span class="v">24&#160;</span>When Judah came to the place overlooking the wilderness, they looked at the multitude; and behold, they were dead bodies fallen to the earth, and there were none who escaped. 
-<span class="v">25&#160;</span>When Jehoshaphat and his people came to take their plunder, they found among them in abundance both riches and dead bodies with precious jewels, which they stripped off for themselves, more than they could carry away. They took plunder for three days, it was so much. 
-<span class="v">26&#160;</span>On the fourth day, they assembled themselves in Beracah<span class="f">+ \fr 20:26 \ft “Beracah” means “blessing”.</span> Valley, for there they blessed Yahweh. Therefore the name of that place was called “Beracah Valley” to this day. 
-<span class="v">27&#160;</span>Then they returned, every man of Judah and Jerusalem, with Jehoshaphat in front of them, to go again to Jerusalem with joy; for Yahweh had made them to rejoice over their enemies. 
-<span class="v">28&#160;</span>They came to Jerusalem with stringed instruments, harps, and trumpets to Yahweh’s house. 
-<span class="v">29&#160;</span>The fear of Elohim was on all the kingdoms of the countries when they heard that Yahweh fought against the enemies of Israel. 
-<span class="v">30&#160;</span>So the realm of Jehoshaphat was quiet, for his Elohim gave him rest all around. 
-</p><p>
-<span class="v">31&#160;</span>So Jehoshaphat reigned over Judah. He was thirty-five years old when he began to reign. He reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
-<span class="v">32&#160;</span>He walked in the way of Asa his father, and didn’t turn away from it, doing that which was right in Yahweh’s eyes. 
-<span class="v">33&#160;</span>However the high places were not taken away, and the people had still not set their hearts on the Elohim of their fathers. 
-</p><p>
-<span class="v">34&#160;</span>Now the rest of the acts of Jehoshaphat, first and last, behold, they are written in the history of Jehu the son of Hanani, which is included in the book of the kings of Israel. 
-</p><p>
-<span class="v">35&#160;</span>After this, Jehoshaphat king of Judah joined himself with Ahaziah king of Israel. The same did very wickedly. 
-<span class="v">36&#160;</span>He joined himself with him to make ships to go to Tarshish. They made the ships in Ezion Geber. 
-<span class="v">37&#160;</span>Then Eliezer the son of Dodavahu of Mareshah prophesied against Jehoshaphat, saying, “Because you have joined yourself with Ahaziah, Yahweh has destroyed your works.” The ships were wrecked, so that they were not able to go to Tarshish. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Jehoshaphat slept with his fathers, and was buried with his fathers in David’s city; and Jehoram his son reigned in his place. 
-<span class="v">2&#160;</span>He had brothers, the sons of Jehoshaphat: Azariah, Jehiel, Zechariah, Azariah, Michael, and Shephatiah. All these were the sons of Jehoshaphat king of Israel. 
-<span class="v">3&#160;</span>Their father gave them great gifts of silver, of gold, and of precious things, with fortified cities in Judah; but he gave the kingdom to Jehoram, because he was the firstborn. 
-<span class="v">4&#160;</span>Now when Jehoram had risen up over the kingdom of his father, and had strengthened himself, he killed all his brothers with the sword, and also some of the princes of Israel. 
-<span class="v">5&#160;</span>Jehoram was thirty-two years old when he began to reign, and he reigned eight years in Jerusalem. 
-<span class="v">6&#160;</span>He walked in the way of the kings of Israel, as did Ahab’s house, for he had Ahab’s daughter as his woman. He did that which was evil in Yahweh’s sight. 
-<span class="v">7&#160;</span>However Yahweh would not destroy David’s house, because of the covenant that he had made with David, and as he promised to give a lamp to him and to his children always. 
-</p><p>
-<span class="v">8&#160;</span>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
-<span class="v">9&#160;</span>Then Jehoram went there with his captains and all his chariots with him. He rose up by night and struck the Edomites who surrounded him, along with the captains of the chariots. 
-<span class="v">10&#160;</span>So Edom has been in revolt from under the hand of Judah to this day. Then Libnah revolted at the same time from under his hand, because he had forsaken Yahweh, the Elohim of his fathers. 
-</p><p>
-<span class="v">11&#160;</span>Moreover he made high places in the mountains of Judah, and made the inhabitants of Jerusalem play the prostitute, and led Judah astray. 
-<span class="v">12&#160;</span>A letter came to him from Elijah the prophet, saying, “Yahweh, the Elohim of David your father, says, ‘Because you have not walked in the ways of Jehoshaphat your father, nor in the ways of Asa king of Judah, 
-<span class="v">13&#160;</span>but have walked in the way of the kings of Israel, and have made Judah and the inhabitants of Jerusalem to play the prostitute like Ahab’s house did, and also have slain your brothers of your father’s house, who were better than yourself, 
-<span class="v">14&#160;</span>behold, Yahweh will strike your people with a great plague, including your children, your women, and all your possessions; 
-<span class="v">15&#160;</span>and you will have great sickness with a disease of your bowels, until your bowels fall out by reason of the sickness, day by day.’&#160;” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh stirred up against Jehoram the spirit of the Philistines and of the Arabians who are beside the Ethiopians; 
-<span class="v">17&#160;</span>and they came up against Judah, broke into it, and carried away all the possessions that were found in the king’s house, including his sons and his women, so that there was no son left to him except Jehoahaz, the youngest of his sons. 
-</p><p>
-<span class="v">18&#160;</span>After all this Yahweh struck him in his bowels with an incurable disease. 
-<span class="v">19&#160;</span>In process of time, at the end of two years, his bowels fell out by reason of his sickness, and he died of severe diseases. His people made no burning for him, like the burning of his fathers. 
-<span class="v">20&#160;</span>He was thirty-two years old when he began to reign, and he reigned in Jerusalem eight years. He departed with no one’s regret. They buried him in David’s city, but not in the tombs of the kings. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>The inhabitants of Jerusalem made Ahaziah his youngest son king in his place, because the band of men who came with the Arabians to the camp had slain all the oldest. So Ahaziah the son of Jehoram king of Judah reigned. 
-<span class="v">2&#160;</span>Ahaziah was forty-two years old when he began to reign, and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri. 
-<span class="v">3&#160;</span>He also walked in the ways of Ahab’s house, because his mother was his counselor in acting wickedly. 
-<span class="v">4&#160;</span>He did that which was evil in Yahweh’s sight, as did Ahab’s house, for they were his counselors after the death of his father, to his destruction. 
-<span class="v">5&#160;</span>He also followed their counsel, and went with Jehoram the son of Ahab king of Israel to war against Hazael king of Syria at Ramoth Gilead; and the Syrians wounded Joram. 
-<span class="v">6&#160;</span>He returned to be healed in Jezreel of the wounds which they had given him at Ramah, when he fought against Hazael king of Syria. Azariah the son of Jehoram, king of Judah, went down to see Jehoram the son of Ahab in Jezreel, because he was sick. 
-</p><p>
-<span class="v">7&#160;</span>Now the destruction of Ahaziah was of Elohim, in that he went to Joram; for when he had come, he went out with Jehoram against Jehu the son of Nimshi, whom Yahweh had anointed to cut off Ahab’s house. 
-<span class="v">8&#160;</span>When Jehu was executing judgment on Ahab’s house, he found the princes of Judah and the sons of the brothers of Ahaziah serving Ahaziah, and killed them. 
-<span class="v">9&#160;</span>He sought Ahaziah, and they caught him (now he was hiding in Samaria), and they brought him to Jehu and killed him; and they buried him, for they said, “He is the son of Jehoshaphat, who sought Yahweh with all his heart.” The house of Ahaziah had no power to hold the kingdom. 
-</p><p>
-<span class="v">10&#160;</span>Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring of the house of Judah. 
-<span class="v">11&#160;</span>But Jehoshabeath, the king’s daughter, took Joash the son of Ahaziah, and stealthily rescued him from among the king’s sons who were slain, and put him and his nurse in the bedroom. So Jehoshabeath, the daughter of King Jehoram, the woman of Jehoiada the priest (for she was the sister of Ahaziah), hid him from Athaliah, so that she didn’t kill him. 
-<span class="v">12&#160;</span>He was with them hidden in Elohim’s house six years while Athaliah reigned over the land. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>In the seventh year, Jehoiada strengthened himself, and took the captains of hundreds—Azariah the son of Jeroham, Ishmael the son of Jehohanan, Azariah the son of Obed, Maaseiah the son of Adaiah, and Elishaphat the son of Zichri—into a covenant with him. 
-<span class="v">2&#160;</span>They went around in Judah and gathered the Levites out of all the cities of Judah, and the heads of fathers’ households of Israel, and they came to Jerusalem. 
-<span class="v">3&#160;</span>All the assembly made a covenant with the king in Elohim’s house. Jehoiada<span class="f">+ \fr 23:3 \ft Hebrew \fq He</span> said to them, “Behold, the king’s son must reign, as Yahweh has spoken concerning the sons of David. 
-<span class="v">4&#160;</span>This is the thing that you must do: a third part of you, who come in on the Sabbath, of the priests and of the Levites, shall be gatekeepers of the thresholds. 
-<span class="v">5&#160;</span>A third part shall be at the king’s house; and a third part at the gate of the foundation. All the people will be in the courts of Yahweh’s house. 
-<span class="v">6&#160;</span>But let no one come into Yahweh’s house except the priests and those who minister of the Levites. They shall come in, for they are set-apart, but all the people shall follow Yahweh’s instructions. 
-<span class="v">7&#160;</span>The Levites shall surround the king, every man with his weapons in his hand. Whoever comes into the house, let him be slain. Be with the king when he comes in and when he goes out.” 
-</p><p>
-<span class="v">8&#160;</span>So the Levites and all Judah did according to all that Jehoiada the priest commanded. They each took his men, those who were to come in on the Sabbath, with those who were to go out on the Sabbath, for Jehoiada the priest didn’t dismiss the shift. 
-<span class="v">9&#160;</span>Jehoiada the priest delivered to the captains of hundreds the spears, bucklers, and shields that had been king David’s, which were in Elohim’s house. 
-<span class="v">10&#160;</span>He set all the people, every man with his weapon in his hand, from the right side of the house to the left side of the house, near the altar and the house, around the king. 
-<span class="v">11&#160;</span>Then they brought out the king’s son, put the crown on him, gave him the covenant, and made him king. Jehoiada and his sons anointed him, and they said, “Long live the king!” 
-</p><p>
-<span class="v">12&#160;</span>When Athaliah heard the noise of the people running and praising the king, she came to the people into Yahweh’s house. 
-<span class="v">13&#160;</span>Then she looked, and behold, the king stood by his pillar at the entrance, with the captains and the trumpeters by the king. All the people of the land rejoiced and blew trumpets. The singers also played musical instruments, and led the singing of praise. Then Athaliah tore her clothes, and said, “Treason! treason!” 
-</p><p>
-<span class="v">14&#160;</span>Jehoiada the priest brought out the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks; and whoever follows her, let him be slain with the sword.” For the priest said, “Don’t kill her in Yahweh’s house.” 
-<span class="v">15&#160;</span>So they made way for her. She went to the entrance of the horse gate to the king’s house; and they killed her there. 
-</p><p>
-<span class="v">16&#160;</span>Jehoiada made a covenant between himself, all the people, and the king, that they should be Yahweh’s people. 
-<span class="v">17&#160;</span>All the people went to the house of Baal, broke it down, broke his altars and his images in pieces, and killed Mattan the priest of Baal before the altars. 
-<span class="v">18&#160;</span>Jehoiada appointed the officers of Yahweh’s house under the hand of the Levitical priests, whom David had distributed in Yahweh’s house, to offer the burnt offerings of Yahweh, as it is written in the law of Moses, with rejoicing and with singing, as David had ordered. 
-<span class="v">19&#160;</span>He set the gatekeepers at the gates of Yahweh’s house, that no one who was unclean in anything should enter in. 
-<span class="v">20&#160;</span>He took the captains of hundreds, the nobles, the governors of the people, and all the people of the land, and brought the king down from Yahweh’s house. They came through the upper gate to the king’s house, and set the king on the throne of the kingdom. 
-<span class="v">21&#160;</span>So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Joash was seven years old when he began to reign, and he reigned forty years in Jerusalem. His mother’s name was Zibiah, of Beersheba. 
-<span class="v">2&#160;</span>Joash did that which was right in Yahweh’s eyes all the days of Jehoiada the priest. 
-<span class="v">3&#160;</span>Jehoiada took for him two women, and he brought forth sons and daughters. 
-</p><p>
-<span class="v">4&#160;</span>After this, Joash intended to restore Yahweh’s house. 
-<span class="v">5&#160;</span>He gathered together the priests and the Levites, and said to them, “Go out to the cities of Judah, and gather money to repair the house of your Elohim from all Israel from year to year. See that you expedite this matter.” However the Levites didn’t do it right away. 
-<span class="v">6&#160;</span>The king called for Jehoiada the chief, and said to him, “Why haven’t you required of the Levites to bring in the tax of Moses the servant of Yahweh, and of the assembly of Israel, out of Judah and out of Jerusalem, for the Tent of the Testimony?” 
-<span class="v">7&#160;</span>For the sons of Athaliah, that wicked woman, had broken up Elohim’s house; and they also gave all the dedicated things of Yahweh’s house to the Baals. 
-</p><p>
-<span class="v">8&#160;</span>So the king commanded, and they made a chest, and set it outside at the gate of Yahweh’s house. 
-<span class="v">9&#160;</span>They made a proclamation through Judah and Jerusalem, to bring in for Yahweh the tax that Moses the servant of Elohim laid on Israel in the wilderness. 
-<span class="v">10&#160;</span>All the princes and all the people rejoiced, and brought in, and cast into the chest, until they had filled it. 
-<span class="v">11&#160;</span>Whenever the chest was brought to the king’s officers by the hand of the Levites, and when they saw that there was much money, the king’s scribe and the chief priest’s officer came and emptied the chest, and took it, and carried it to its place again. Thus they did day by day, and gathered money in abundance. 
-<span class="v">12&#160;</span>The king and Jehoiada gave it to those who did the work of the service of Yahweh’s house. They hired masons and carpenters to restore Yahweh’s house, and also those who worked iron and bronze to repair Yahweh’s house. 
-<span class="v">13&#160;</span>So the workmen worked, and the work of repairing went forward in their hands. They set up Elohim’s house as it was designed, and strengthened it. 
-<span class="v">14&#160;</span>When they had finished, they brought the rest of the money before the king and Jehoiada, from which were made vessels for Yahweh’s house, even vessels with which to minister and to offer, including spoons and vessels of gold and silver. They offered burnt offerings in Yahweh’s house continually all the days of Jehoiada. 
-</p><p>
-<span class="v">15&#160;</span>But Jehoiada grew old and was full of days, and he died. He was one hundred thirty years old when he died. 
-<span class="v">16&#160;</span>They buried him in David’s city among the kings, because he had done good in Israel, and toward Elohim and his house. 
-</p><p>
-<span class="v">17&#160;</span>Now after the death of Jehoiada, the princes of Judah came and bowed down to the king. Then the king listened to them. 
-<span class="v">18&#160;</span>They abandoned the house of Yahweh, the Elohim of their fathers, and served the Asherah poles and the idols, so wrath came on Judah and Jerusalem for this their guiltiness. 
-<span class="v">19&#160;</span>Yet he sent prophets to them to bring them again to Yahweh, and they testified against them; but they would not listen. 
-</p><p>
-<span class="v">20&#160;</span>The Spirit of Elohim came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them, “Elohim says, ‘Why do you disobey Yahweh’s commandments, so that you can’t prosper? Because you have forsaken Yahweh, he has also forsaken you.’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>They conspired against him, and stoned him with stones at the commandment of the king in the court of Yahweh’s house. 
-<span class="v">22&#160;</span>Thus Joash the king didn’t remember the kindness which Jehoiada his father had done to him, but killed his son. When he died, he said, “May Yahweh look at it, and repay it.” 
-</p><p>
-<span class="v">23&#160;</span>At the end of the year, the army of the Syrians came up against him. They came to Judah and Jerusalem, and destroyed all the princes of the people from among the people, and sent all their plunder to the king of Damascus. 
-<span class="v">24&#160;</span>For the army of the Syrians came with a small company of men; and Yahweh delivered a very great army into their hand, because they had forsaken Yahweh, the Elohim of their fathers. So they executed judgment on Joash. 
-</p><p>
-<span class="v">25&#160;</span>When they had departed from him (for they left him seriously wounded), his own servants conspired against him for the blood of the sons of Jehoiada the priest, and killed him on his bed, and he died. They buried him in David’s city, but they didn’t bury him in the tombs of the kings. 
-<span class="v">26&#160;</span>These are those who conspired against him: Zabad the son of Shimeath the Ammonitess and Jehozabad the son of Shimrith the Moabitess. 
-<span class="v">27&#160;</span>Now concerning his sons, the greatness of the burdens laid on him, and the rebuilding of Elohim’s house, behold, they are written in the commentary of the book of the kings. Amaziah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Amaziah was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddan, of Jerusalem. 
-<span class="v">2&#160;</span>He did that which was right in Yahweh’s eyes, but not with a perfect heart. 
-<span class="v">3&#160;</span>Now when the kingdom was established to him, he killed his servants who had killed his father the king. 
-<span class="v">4&#160;</span>But he didn’t put their children to death, but did according to that which is written in the law in the book of Moses, as Yahweh commanded, saying, “The fathers shall not die for the children, neither shall the children die for the fathers; but every man shall die for his own sin.” 
-</p><p>
-<span class="v">5&#160;</span>Moreover Amaziah gathered Judah together and ordered them according to their fathers’ houses, under captains of thousands and captains of hundreds, even all Judah and Benjamin. He counted them from twenty years old and upward, and found that there were three hundred thousand chosen men, able to go out to war, who could handle spear and shield. 
-<span class="v">6&#160;</span>He also hired one hundred thousand mighty men of valor out of Israel for one hundred talents<span class="f">+ \fr 25:6 \ft A talent is about 30 kilograms or 66 pounds</span> of silver. 
-<span class="v">7&#160;</span>A man of Elohim came to him, saying, “O king, don’t let the army of Israel go with you, for Yahweh is not with Israel, with all the children of Ephraim. 
-<span class="v">8&#160;</span>But if you will go, take action, and be strong for the battle. Elohim will overthrow you before the enemy; for Elohim has power to help, and to overthrow.” 
-</p><p>
-<span class="v">9&#160;</span>Amaziah said to the man of Elohim, “But what shall we do for the hundred talents<span class="f">+ \fr 25:9 \ft A talent is about 30 kilograms or 66 pounds</span> which I have given to the army of Israel?” 
-</p><p>The man of Elohim answered, “Yahweh is able to give you much more than this.” 
-</p><p>
-<span class="v">10&#160;</span>Then Amaziah separated them, the army that had come to him out of Ephraim, to go home again. Therefore their anger was greatly kindled against Judah, and they returned home in fierce anger. 
-</p><p>
-<span class="v">11&#160;</span>Amaziah took courage, and led his people out and went to the Valley of Salt, and struck ten thousand of the children of Seir. 
-<span class="v">12&#160;</span>The children of Judah carried away ten thousand alive, and brought them to the top of the rock, and threw them down from the top of the rock, so that they all were broken in pieces. 
-<span class="v">13&#160;</span>But the men of the army whom Amaziah sent back, that they should not go with him to battle, fell on the cities of Judah from Samaria even to Beth Horon, and struck of them three thousand, and took much plunder. 
-</p><p>
-<span class="v">14&#160;</span>Now after Amaziah had come from the slaughter of the Edomites, he brought the elohims of the children of Seir, and set them up to be his elohims, and bowed down himself before them and burned incense to them. 
-<span class="v">15&#160;</span>Therefore Yahweh’s anger burned against Amaziah, and he sent to him a prophet who said to him, “Why have you sought after the elohims of the people, which have not delivered their own people out of your hand?” 
-</p><p>
-<span class="v">16&#160;</span>As he talked with him, the king said to him, “Have we made you one of the king’s counselors? Stop! Why should you be struck down?” 
-</p><p>Then the prophet stopped, and said, “I know that Elohim has determined to destroy you, because you have done this and have not listened to my counsel.” 
-</p><p>
-<span class="v">17&#160;</span>Then Amaziah king of Judah consulted his advisers, and sent to Joash, the son of Jehoahaz, the son of Jehu, king of Israel, saying, “Come! Let’s look one another in the face.” 
-</p><p>
-<span class="v">18&#160;</span>Joash king of Israel sent to Amaziah king of Judah, saying, “The thistle that was in Lebanon sent to the cedar that was in Lebanon, saying, ‘Give your daughter to my son as his woman. Then a wild animal that was in Lebanon passed by and trampled down the thistle. 
-<span class="v">19&#160;</span>You say to yourself that you have struck Edom; and your heart lifts you up to boast. Now stay at home. Why should you meddle with trouble, that you should fall, even you and Judah with you?’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>But Amaziah would not listen; for it was of Elohim, that he might deliver them into the hand of their enemies, because they had sought after the elohims of Edom. 
-<span class="v">21&#160;</span>So Joash king of Israel went up, and he and Amaziah king of Judah looked one another in the face at Beth Shemesh, which belongs to Judah. 
-<span class="v">22&#160;</span>Judah was defeated by Israel; so every man fled to his tent. 
-</p><p>
-<span class="v">23&#160;</span>Joash king of Israel took Amaziah king of Judah, the son of Joash the son of Jehoahaz, at Beth Shemesh and brought him to Jerusalem, and broke down the wall of Jerusalem from the gate of Ephraim to the corner gate, four hundred cubits.<span class="f">+ \fr 25:23 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters, so 400 cubits is about 200 yards or 184 meters.</span> 
-<span class="v">24&#160;</span>He took all the gold and silver, and all the vessels that were found in Elohim’s house with Obed-Edom, and the treasures of the king’s house, and the hostages, and returned to Samaria. 
-</p><p>
-<span class="v">25&#160;</span>Amaziah the son of Joash, king of Judah, lived for fifteen years after the death of Joash, son of Jehoahaz, king of Israel. 
-<span class="v">26&#160;</span>Now the rest of the acts of Amaziah, first and last, behold, aren’t they written in the book of the kings of Judah and Israel? 
-<span class="v">27&#160;</span>Now from the time that Amaziah turned away from following Yahweh, they made a conspiracy against him in Jerusalem. He fled to Lachish, but they sent after him to Lachish and killed him there. 
-<span class="v">28&#160;</span>They brought him on horses and buried him with his fathers in the City of Judah. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>All the people of Judah took Uzziah, who was sixteen years old, and made him king in the place of his father Amaziah. 
-<span class="v">2&#160;</span>He built Eloth and restored it to Judah. After that the king slept with his fathers. 
-<span class="v">3&#160;</span>Uzziah was sixteen years old when he began to reign; and he reigned fifty-two years in Jerusalem. His mother’s name was Jechiliah, of Jerusalem. 
-<span class="v">4&#160;</span>He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
-<span class="v">5&#160;</span>He set himself to seek Elohim in the days of Zechariah, who had understanding in the vision of Elohim; and as long as he sought Yahweh, Elohim made him prosper. 
-</p><p>
-<span class="v">6&#160;</span>He went out and fought against the Philistines, and broke down the wall of Gath, the wall of Jabneh, and the wall of Ashdod; and he built cities in the country of Ashdod, and among the Philistines. 
-<span class="v">7&#160;</span>Elohim helped him against the Philistines, and against the Arabians who lived in Gur Baal, and the Meunim. 
-<span class="v">8&#160;</span>The Ammonites gave tribute to Uzziah. His name spread abroad even to the entrance of Egypt, for he grew exceedingly strong. 
-<span class="v">9&#160;</span>Moreover Uzziah built towers in Jerusalem at the corner gate, at the valley gate, and at the turning of the wall, and fortified them. 
-<span class="v">10&#160;</span>He built towers in the wilderness, and dug out many cisterns, for he had much livestock, both in the lowlands and in the plains. He had farmers and vineyard keepers in the mountains and in the fruitful fields, for he loved farming. 
-<span class="v">11&#160;</span>Moreover Uzziah had an army of fighting men who went out to war by bands, according to the number of their reckoning made by Jeiel the scribe and Maaseiah the officer, under the hand of Hananiah, one of the king’s captains. 
-<span class="v">12&#160;</span>The whole number of the heads of fathers’ households, even the mighty men of valor, was two thousand six hundred. 
-<span class="v">13&#160;</span>Under their hand was an army, three hundred seven thousand five hundred, who made war with mighty power, to help the king against the enemy. 
-<span class="v">14&#160;</span>Uzziah prepared for them, even for all the army, shields, spears, helmets, coats of mail, bows, and stones for slinging. 
-<span class="v">15&#160;</span>In Jerusalem, he made devices, invented by skillful men, to be on the towers and on the battlements, with which to shoot arrows and great stones. His name spread far abroad, because he was marvelously helped until he was strong. 
-</p><p>
-<span class="v">16&#160;</span>But when he was strong, his heart was lifted up, so that he did corruptly and he trespassed against Yahweh his Elohim, for he went into Yahweh’s temple to burn incense on the altar of incense. 
-<span class="v">17&#160;</span>Azariah the priest went in after him, and with him eighty priests of Yahweh, who were valiant men. 
-<span class="v">18&#160;</span>They resisted Uzziah the king, and said to him, “It isn’t for you, Uzziah, to burn incense to Yahweh, but for the priests the sons of Aaron, who are consecrated to burn incense. Go out of the sanctuary, for you have trespassed. It will not be for your honor from Yahweh Elohim.” 
-</p><p>
-<span class="v">19&#160;</span>Then Uzziah was angry. He had a censer in his hand to burn incense, and while he was angry with the priests, the leprosy broke out on his forehead before the priests in Yahweh’s house, beside the altar of incense. 
-<span class="v">20&#160;</span>Azariah the chief priest and all the priests looked at him, and behold, he was leprous in his forehead; and they thrust him out quickly from there. Indeed, he himself also hurried to go out, because Yahweh had struck him. 
-<span class="v">21&#160;</span>Uzziah the king was a leper to the day of his death, and lived in a separate house, being a leper; for he was cut off from Yahweh’s house. Jotham his son was over the king’s house, judging the people of the land. 
-</p><p>
-<span class="v">22&#160;</span>Now the rest of the acts of Uzziah, first and last, Isaiah the prophet, the son of Amoz, wrote. 
-<span class="v">23&#160;</span>So Uzziah slept with his fathers; and they buried him with his fathers in the field of burial which belonged to the kings, for they said, “He is a leper.” Jotham his son reigned in his place. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Jotham was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerushah the daughter of Zadok. 
-<span class="v">2&#160;</span>He did that which was right in Yahweh’s eyes, according to all that his father Uzziah had done. However he didn’t enter into Yahweh’s temple. The people still acted corruptly. 
-<span class="v">3&#160;</span>He built the upper gate of Yahweh’s house, and he built much on the wall of Ophel. 
-<span class="v">4&#160;</span>Moreover he built cities in the hill country of Judah, and in the forests he built fortresses and towers. 
-<span class="v">5&#160;</span>He also fought with the king of the children of Ammon, and prevailed against them. The children of Ammon gave him the same year one hundred talents<span class="f">+ \fr 27:5 \ft A talent is about 30 kilograms or 66 pounds</span> of silver, ten thousand cors<span class="f">+ \fr 27:5 \ft 1 cor is the same as a homer, or about 55.9 U. S. gallons (liquid) or 211 liters or 6 bushels. 10,000 cors of wheat would weigh about 1,640 metric tons.</span> of wheat, and ten thousand cors of barley.<span class="f">+ \fr 27:5 \ft 10,000 cors of barley would weigh about 1,310 metric tons.</span> The children of Ammon also gave that much to him in the second year, and in the third. 
-<span class="v">6&#160;</span>So Jotham became mighty, because he ordered his ways before Yahweh his Elohim. 
-<span class="v">7&#160;</span>Now the rest of the acts of Jotham, and all his wars and his ways, behold, they are written in the book of the kings of Israel and Judah. 
-<span class="v">8&#160;</span>He was twenty-five years old when he began to reign, and reigned sixteen years in Jerusalem. 
-<span class="v">9&#160;</span>Jotham slept with his fathers, and they buried him in David’s city; and Ahaz his son reigned in his place. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh’s eyes, like David his father, 
-<span class="v">2&#160;</span>but he walked in the ways of the kings of Israel, and also made molten images for the Baals. 
-<span class="v">3&#160;</span>Moreover he burned incense in the valley of the son of Hinnom, and burned his children in the fire, according to the abominations of the nations whom Yahweh cast out before the children of Israel. 
-<span class="v">4&#160;</span>He sacrificed and burned incense in the high places, and on the hills, and under every green tree. 
-</p><p>
-<span class="v">5&#160;</span>Therefore Yahweh his Elohim delivered him into the hand of the king of Syria. They struck him, and carried away from him a great multitude of captives, and brought them to Damascus. He was also delivered into the hand of the king of Israel, who struck him with a great slaughter. 
-<span class="v">6&#160;</span>For Pekah the son of Remaliah killed in Judah one hundred twenty thousand in one day, all of them valiant men, because they had forsaken Yahweh, the Elohim of their fathers. 
-<span class="v">7&#160;</span>Zichri, a mighty man of Ephraim, killed Maaseiah the king’s son, Azrikam the ruler of the house, and Elkanah who was next to the king. 
-<span class="v">8&#160;</span>The children of Israel carried away captive of their brothers two hundred thousand women, sons, and daughters, and also took away much plunder from them, and brought the plunder to Samaria. 
-<span class="v">9&#160;</span>But a prophet of Yahweh was there, whose name was Oded; and he went out to meet the army that came to Samaria, and said to them, “Behold, because Yahweh, the Elohim of your fathers, was angry with Judah, he has delivered them into your hand, and you have slain them in a rage which has reached up to heaven. 
-<span class="v">10&#160;</span>Now you intend to degrade the children of Judah and Jerusalem as male and female slaves for yourselves. Aren’t there even with you trespasses of your own against Yahweh your Elohim? 
-<span class="v">11&#160;</span>Now hear me therefore, and send back the captives that you have taken captive from your brothers, for the fierce wrath of Yahweh is on you.” 
-<span class="v">12&#160;</span>Then some of the heads of the children of Ephraim, Azariah the son of Johanan, Berechiah the son of Meshillemoth, Jehizkiah the son of Shallum, and Amasa the son of Hadlai, stood up against those who came from the war, 
-<span class="v">13&#160;</span>and said to them, “You must not bring in the captives here, for you intend that which will bring on us a trespass against Yahweh, to add to our sins and to our guilt; for our guilt is great, and there is fierce wrath against Israel.” 
-</p><p>
-<span class="v">14&#160;</span>So the armed men left the captives and the plunder before the princes and all the assembly. 
-<span class="v">15&#160;</span>The men who have been mentioned by name rose up and took the captives, and with the plunder clothed all who were naked among them, dressed them, gave them sandals, gave them something to eat and to drink, anointed them, carried all the feeble of them on donkeys, and brought them to Jericho, the city of palm trees, to their brothers. Then they returned to Samaria. 
-</p><p>
-<span class="v">16&#160;</span>At that time King Ahaz sent to the kings of Assyria to help him. 
-<span class="v">17&#160;</span>For again the Edomites had come and struck Judah, and carried away captives. 
-<span class="v">18&#160;</span>The Philistines also had invaded the cities of the lowland and of the South of Judah, and had taken Beth Shemesh, Aijalon, Gederoth, Soco with its villages, Timnah with its villages, and also Gimzo and its villages; and they lived there. 
-<span class="v">19&#160;</span>For Yahweh brought Judah low because of Ahaz king of Israel, because he acted without restraint in Judah and trespassed severely against Yahweh. 
-<span class="v">20&#160;</span>Tilgath-pilneser king of Assyria came to him and gave him trouble, but didn’t strengthen him. 
-<span class="v">21&#160;</span>For Ahaz took away a portion out of Yahweh’s house, and out of the house of the king and of the princes, and gave it to the king of Assyria; but it didn’t help him. 
-</p><p>
-<span class="v">22&#160;</span>In the time of his distress, he trespassed yet more against Yahweh, this same King Ahaz. 
-<span class="v">23&#160;</span>For he sacrificed to the elohims of Damascus which had defeated him. He said, “Because the elohims of the kings of Syria helped them, I will sacrifice to them, that they may help me.” But they were the ruin of him and of all Israel. 
-<span class="v">24&#160;</span>Ahaz gathered together the vessels of Elohim’s house, cut the vessels of Elohim’s house in pieces, and shut up the doors of Yahweh’s house; and he made himself altars in every corner of Jerusalem. 
-<span class="v">25&#160;</span>In every city of Judah he made high places to burn incense to other elohims, and provoked Yahweh, the Elohim of his fathers, to anger. 
-</p><p>
-<span class="v">26&#160;</span>Now the rest of his acts, and all his ways, first and last, behold, they are written in the book of the kings of Judah and Israel. 
-<span class="v">27&#160;</span>Ahaz slept with his fathers, and they buried him in the city, even in Jerusalem, because they didn’t bring him into the tombs of the kings of Israel; and Hezekiah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>Hezekiah began to reign when he was twenty-five years old, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abijah, the daughter of Zechariah. 
-<span class="v">2&#160;</span>He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
-<span class="v">3&#160;</span>In the first year of his reign, in the first month, he opened the doors of Yahweh’s house and repaired them. 
-<span class="v">4&#160;</span>He brought in the priests and the Levites and gathered them together into the wide place on the east, 
-<span class="v">5&#160;</span>and said to them, “Listen to me, you Levites! Now sanctify yourselves, and sanctify the house of Yahweh, the Elohim of your fathers, and carry the filthiness out of the set-apart place. 
-<span class="v">6&#160;</span>For our fathers were unfaithful, and have done that which was evil in Yahweh our Elohim’s sight, and have forsaken him, and have turned away their faces from the habitation of Yahweh, and turned their backs. 
-<span class="v">7&#160;</span>Also they have shut up the doors of the porch, and put out the lamps, and have not burned incense nor offered burnt offerings in the set-apart place to the Elohim of Israel. 
-<span class="v">8&#160;</span>Therefore Yahweh’s wrath was on Judah and Jerusalem, and he has delivered them to be tossed back and forth, to be an astonishment and a hissing, as you see with your eyes. 
-<span class="v">9&#160;</span>For behold, our fathers have fallen by the sword, and our sons and our daughters and our women are in captivity for this. 
-<span class="v">10&#160;</span>Now it is in my heart to make a covenant with Yahweh, the Elohim of Israel, that his fierce anger may turn away from us. 
-<span class="v">11&#160;</span>My sons, don’t be negligent now; for Yahweh has chosen you to stand before him, to minister to him, and that you should be his ministers and burn incense.” 
-</p><p>
-<span class="v">12&#160;</span>Then the Levites arose: Mahath, the son of Amasai, and Joel the son of Azariah, of the sons of the Kohathites; and of the sons of Merari, Kish the son of Abdi, and Azariah the son of Jehallelel; and of the Gershonites, Joah the son of Zimmah, and Eden the son of Joah; 
-<span class="v">13&#160;</span>and of the sons of Elizaphan, Shimri and Jeuel; and of the sons of Asaph, Zechariah and Mattaniah; 
-<span class="v">14&#160;</span>and of the sons of Heman, Jehuel and Shimei; and of the sons of Jeduthun, Shemaiah and Uzziel. 
-<span class="v">15&#160;</span>They gathered their brothers, sanctified themselves, and went in, according to the commandment of the king by Yahweh’s words, to cleanse Yahweh’s house. 
-<span class="v">16&#160;</span>The priests went into the inner part of Yahweh’s house to cleanse it, and brought out all the uncleanness that they found in Yahweh’s temple into the court of Yahweh’s house. The Levites took it from there to carry it out to the brook Kidron. 
-<span class="v">17&#160;</span>Now they began on the first day of the first month to sanctify, and on the eighth day of the month they came to Yahweh’s porch. They sanctified Yahweh’s house in eight days, and on the sixteenth day of the first month they finished. 
-<span class="v">18&#160;</span>Then they went in to Hezekiah the king within the palace and said, “We have cleansed all Yahweh’s house, including the altar of burnt offering with all its vessels, and the table of show bread with all its vessels. 
-<span class="v">19&#160;</span>Moreover, we have prepared and sanctified all the vessels which King Ahaz threw away in his reign when he was unfaithful. Behold, they are before Yahweh’s altar.” 
-</p><p>
-<span class="v">20&#160;</span>Then Hezekiah the king arose early, gathered the princes of the city, and went up to Yahweh’s house. 
-<span class="v">21&#160;</span>They brought seven bulls, seven rams, seven lambs, and seven male goats, for a sin offering for the kingdom, for the sanctuary, and for Judah. He commanded the priests the sons of Aaron to offer them on Yahweh’s altar. 
-<span class="v">22&#160;</span>So they killed the bulls, and the priests received the blood and sprinkled it on the altar. They killed the rams and sprinkled the blood on the altar. They also killed the lambs and sprinkled the blood on the altar. 
-<span class="v">23&#160;</span>They brought near the male goats for the sin offering before the king and the assembly; and they laid their hands on them. 
-<span class="v">24&#160;</span>Then the priests killed them, and they made a sin offering with their blood on the altar, to make atonement for all Israel; for the king commanded that the burnt offering and the sin offering should be made for all Israel. 
-</p><p>
-<span class="v">25&#160;</span>He set the Levites in Yahweh’s house with cymbals, with stringed instruments, and with harps, according to the commandment of David, of Gad the king’s seer, and Nathan the prophet; for the commandment was from Yahweh by his prophets. 
-<span class="v">26&#160;</span>The Levites stood with David’s instruments, and the priests with the trumpets. 
-<span class="v">27&#160;</span>Hezekiah commanded them to offer the burnt offering on the altar. When the burnt offering began, Yahweh’s song also began, along with the trumpets and instruments of David king of Israel. 
-<span class="v">28&#160;</span>All the assembly worshiped, the singers sang, and the trumpeters sounded. All this continued until the burnt offering was finished. 
-</p><p>
-<span class="v">29&#160;</span>When they had finished offering, the king and all who were present with him bowed themselves and worshiped. 
-<span class="v">30&#160;</span>Moreover Hezekiah the king and the princes commanded the Levites to sing praises to Yahweh with the words of David, and of Asaph the seer. They sang praises with gladness, and they bowed their heads and worshiped. 
-</p><p>
-<span class="v">31&#160;</span>Then Hezekiah answered, “Now you have consecrated yourselves to Yahweh. Come near and bring sacrifices and thank offerings into Yahweh’s house.” The assembly brought in sacrifices and thank offerings, and as many as were of a willing heart brought burnt offerings. 
-<span class="v">32&#160;</span>The number of the burnt offerings which the assembly brought was seventy bulls, one hundred rams, and two hundred lambs. All these were for a burnt offering to Yahweh. 
-<span class="v">33&#160;</span>The consecrated things were six hundred head of cattle and three thousand sheep. 
-<span class="v">34&#160;</span>But the priests were too few, so that they could not skin all the burnt offerings. Therefore their brothers the Levites helped them until the work was ended, and until the priests had sanctified themselves, for the Levites were more upright in heart to sanctify themselves than the priests. 
-<span class="v">35&#160;</span>Also the burnt offerings were in abundance, with the fat of the peace offerings and with the drink offerings for every burnt offering. So the service of Yahweh’s house was set in order. 
-<span class="v">36&#160;</span>Hezekiah and all the people rejoiced because of that which Elohim had prepared for the people; for the thing was done suddenly. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to Yahweh’s house at Jerusalem, to keep the Passover to Yahweh, the Elohim of Israel. 
-<span class="v">2&#160;</span>For the king had taken counsel with his princes and all the assembly in Jerusalem to keep the Passover in the second month. 
-<span class="v">3&#160;</span>For they could not keep it at that time, because the priests had not sanctified themselves in sufficient number, and the people had not gathered themselves together to Jerusalem. 
-<span class="v">4&#160;</span>The thing was right in the eyes of the king and of all the assembly. 
-<span class="v">5&#160;</span>So they established a decree to make proclamation throughout all Israel, from Beersheba even to Dan, that they should come to keep the Passover to Yahweh, the Elohim of Israel, at Jerusalem, for they had not kept it in great numbers in the way it is written. 
-</p><p>
-<span class="v">6&#160;</span>So the couriers went with the letters from the king and his princes throughout all Israel and Judah, according to the commandment of the king, saying, “You children of Israel, turn again to Yahweh, the Elohim of Abraham, Isaac, and Israel, that he may return to the remnant of you that have escaped out of the hand of the kings of Assyria. 
-<span class="v">7&#160;</span>Don’t be like your fathers and like your brothers, who trespassed against Yahweh, the Elohim of their fathers, so that he gave them up to desolation, as you see. 
-<span class="v">8&#160;</span>Now don’t be stiff-necked, as your fathers were, but yield yourselves to Yahweh, and enter into his sanctuary, which he has sanctified forever, and serve Yahweh your Elohim, that his fierce anger may turn away from you. 
-<span class="v">9&#160;</span>For if you turn again to Yahweh, your brothers and your children will find compassion with those who led them captive, and will come again into this land, because Yahweh your Elohim is gracious and merciful, and will not turn away his face from you if you return to him.” 
-</p><p>
-<span class="v">10&#160;</span>So the couriers passed from city to city through the country of Ephraim and Manasseh, even to Zebulun, but people ridiculed them and mocked them. 
-<span class="v">11&#160;</span>Nevertheless some men of Asher, Manasseh, and Zebulun humbled themselves and came to Jerusalem. 
-<span class="v">12&#160;</span>Also the hand of Elohim came on Judah to give them one heart, to do the commandment of the king and of the princes by Yahweh’s word. 
-</p><p>
-<span class="v">13&#160;</span>Many people assembled at Jerusalem to keep the feast of unleavened bread in the second month, a very great assembly. 
-<span class="v">14&#160;</span>They arose and took away the altars that were in Jerusalem, and they took away all the altars for incense and threw them into the brook Kidron. 
-<span class="v">15&#160;</span>Then they killed the Passover on the fourteenth day of the second month. The priests and the Levites were ashamed, and sanctified themselves, and brought burnt offerings into Yahweh’s house. 
-<span class="v">16&#160;</span>They stood in their place after their order, according to the law of Moses the man of Elohim. The priests sprinkled the blood which they received of the hand of the Levites. 
-<span class="v">17&#160;</span>For there were many in the assembly who had not sanctified themselves; therefore the Levites were in charge of killing the Passovers for everyone who was not clean, to sanctify them to Yahweh. 
-<span class="v">18&#160;</span>For a multitude of the people, even many of Ephraim, Manasseh, Issachar, and Zebulun, had not cleansed themselves, yet they ate the Passover other than the way it is written. For Hezekiah had prayed for them, saying, “May the good Yahweh pardon everyone 
-<span class="v">19&#160;</span>who sets his heart to seek Elohim, Yahweh, the Elohim of his fathers, even if they aren’t clean according to the purification of the sanctuary.” 
-</p><p>
-<span class="v">20&#160;</span>Yahweh listened to Hezekiah, and healed the people. 
-<span class="v">21&#160;</span>The children of Israel who were present at Jerusalem kept the feast of unleavened bread seven days with great gladness. The Levites and the priests praised Yahweh day by day, singing with loud instruments to Yahweh. 
-<span class="v">22&#160;</span>Hezekiah spoke encouragingly to all the Levites who had good understanding in the service of Yahweh. So they ate throughout the feast for the seven days, offering sacrifices of peace offerings and making confession to Yahweh, the Elohim of their fathers. 
-</p><p>
-<span class="v">23&#160;</span>The whole assembly took counsel to keep another seven days, and they kept another seven days with gladness. 
-<span class="v">24&#160;</span>For Hezekiah king of Judah gave to the assembly for offerings one thousand bulls and seven thousand sheep; and the princes gave to the assembly a thousand bulls and ten thousand sheep; and a great number of priests sanctified themselves. 
-<span class="v">25&#160;</span>All the assembly of Judah, with the priests and the Levites, and all the assembly who came out of Israel, and the foreigners who came out of the land of Israel and who lived in Judah, rejoiced. 
-<span class="v">26&#160;</span>So there was great joy in Jerusalem; for since the time of Solomon the son of David king of Israel there was nothing like this in Jerusalem. 
-<span class="v">27&#160;</span>Then the Levitical priests arose and blessed the people. Their voice was heard, and their prayer came up to his set-apart habitation, even to heaven. 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>Now when all this was finished, all Israel who were present went out to the cities of Judah and broke the pillars in pieces, cut down the Asherah poles, and broke down the high places and the altars out of all Judah and Benjamin, also in Ephraim and Manasseh, until they had destroyed them all. Then all the children of Israel returned, every man to his possession, into their own cities. 
-</p><p>
-<span class="v">2&#160;</span>Hezekiah appointed the divisions of the priests and the Levites after their divisions, every man according to his service, both the priests and the Levites, for burnt offerings and for peace offerings, to minister, to give thanks, and to praise in the gates of Yahweh’s camp. 
-<span class="v">3&#160;</span>He also appointed the king’s portion of his possessions for the burnt offerings: for the morning and evening burnt offerings, and the burnt offerings for the Sabbaths, for the new moons, and for the set feasts, as it is written in Yahweh’s law. 
-<span class="v">4&#160;</span>Moreover he commanded the people who lived in Jerusalem to give the portion of the priests and the Levites, that they might give themselves to Yahweh’s law. 
-<span class="v">5&#160;</span>As soon as the commandment went out, the children of Israel gave in abundance the first fruits of grain, new wine, oil, honey, and of all the increase of the field; and they brought in the tithe of all things abundantly. 
-<span class="v">6&#160;</span>The children of Israel and Judah, who lived in the cities of Judah, also brought in the tithe of cattle and sheep, and the tithe of dedicated things which were consecrated to Yahweh their Elohim, and laid them in heaps. 
-</p><p>
-<span class="v">7&#160;</span>In the third month, they began to lay the foundation of the heaps, and finished them in the seventh month. 
-<span class="v">8&#160;</span>When Hezekiah and the princes came and saw the heaps, they blessed Yahweh and his people Israel. 
-<span class="v">9&#160;</span>Then Hezekiah questioned the priests and the Levites about the heaps. 
-<span class="v">10&#160;</span>Azariah the chief priest, of the house of Zadok, answered him and said, “Since people began to bring the offerings into Yahweh’s house, we have eaten and had enough, and have plenty left over, for Yahweh has blessed his people; and that which is left is this great store.” 
-</p><p>
-<span class="v">11&#160;</span>Then Hezekiah commanded them to prepare rooms in Yahweh’s house, and they prepared them. 
-<span class="v">12&#160;</span>They brought in the offerings, the tithes, and the dedicated things faithfully. Conaniah the Levite was ruler over them, and Shimei his brother was second. 
-<span class="v">13&#160;</span>Jehiel, Azaziah, Nahath, Asahel, Jerimoth, Jozabad, Eliel, Ismachiah, Mahath, and Benaiah were overseers under the hand of Conaniah and Shimei his brother, by the appointment of Hezekiah the king and Azariah the ruler of Elohim’s house. 
-<span class="v">14&#160;</span>Kore the son of Imnah the Levite, the gatekeeper at the east gate, was over the free will offerings of Elohim, to distribute Yahweh’s offerings and the most set-apart things. 
-<span class="v">15&#160;</span>Under him were Eden, Miniamin, Jeshua, Shemaiah, Amariah, and Shecaniah, in the cities of the priests, in their office of trust, to give to their brothers by divisions, to the great as well as to the small; 
-<span class="v">16&#160;</span>in addition to those who were listed by genealogy of males, from three years old and upward, even everyone who entered into Yahweh’s house, as the duty of every day required, for their service in their offices according to their divisions; 
-<span class="v">17&#160;</span>and those who were listed by genealogy of the priests by their fathers’ houses, and the Levites from twenty years old and upward, in their offices by their divisions; 
-<span class="v">18&#160;</span>and those who were listed by genealogy of all their little ones, their women, their sons, and their daughters, through all the congregation; for in their office of trust they sanctified themselves in set-apartness. 
-<span class="v">19&#160;</span>Also for the sons of Aaron the priests, who were in the fields of the pasture lands of their cities, in every city, there were men who were mentioned by name to give portions to all the males among the priests and to all who were listed by genealogy among the Levites. 
-</p><p>
-<span class="v">20&#160;</span>Hezekiah did so throughout all Judah; and he did that which was good, right, and faithful before Yahweh his Elohim. 
-<span class="v">21&#160;</span>In every work that he began in the service of Elohim’s house, in the law, and in the commandments, to seek his Elohim, he did it with all his heart and prospered. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>After these things and this faithfulness, Sennacherib king of Assyria came, entered into Judah, encamped against the fortified cities, and intended to win them for himself. 
-<span class="v">2&#160;</span>When Hezekiah saw that Sennacherib had come, and that he was planning to fight against Jerusalem, 
-<span class="v">3&#160;</span>he took counsel with his princes and his mighty men to stop the waters of the springs which were outside of the city, and they helped him. 
-<span class="v">4&#160;</span>Then many people gathered together and they stopped all the springs and the brook that flowed through the middle of the land, saying, “Why should the kings of Assyria come, and find abundant water?” 
-</p><p>
-<span class="v">5&#160;</span>He took courage, built up all the wall that was broken down, and raised it up to the towers, with the other wall outside, and strengthened Millo in David’s city, and made weapons and shields in abundance. 
-<span class="v">6&#160;</span>He set captains of war over the people, gathered them together to him in the wide place at the gate of the city, and spoke encouragingly to them, saying, 
-<span class="v">7&#160;</span>“Be strong and courageous. Don’t be afraid or dismayed because of the king of Assyria, nor for all the multitude who is with him; for there is a greater one with us than with him. 
-<span class="v">8&#160;</span>An arm of flesh is with him, but Yahweh our Elohim is with us to help us and to fight our battles.” The people rested themselves on the words of Hezekiah king of Judah. 
-</p><p>
-<span class="v">9&#160;</span>After this, Sennacherib king of Assyria sent his servants to Jerusalem, (now he was attacking Lachish, and all his forces were with him), to Hezekiah king of Judah, and to all Judah who were at Jerusalem, saying, 
-<span class="v">10&#160;</span>Sennacherib king of Assyria says, “In whom do you trust, that you remain under siege in Jerusalem? 
-<span class="v">11&#160;</span>Doesn’t Hezekiah persuade you to give you over to die by famine and by thirst, saying, ‘Yahweh our Elohim will deliver us out of the hand of the king of Assyria’? 
-<span class="v">12&#160;</span>Hasn’t the same Hezekiah taken away his high places and his altars, and commanded Judah and Jerusalem, saying, ‘You shall worship before one altar, and you shall burn incense on it’? 
-<span class="v">13&#160;</span>Don’t you know what I and my fathers have done to all the peoples of the lands? Were the elohims of the nations of those lands in any way able to deliver their land out of my hand? 
-<span class="v">14&#160;</span>Who was there among all the elohims of those nations which my fathers utterly destroyed that could deliver his people out of my hand, that your Elohim should be able to deliver you out of my hand? 
-<span class="v">15&#160;</span>Now therefore don’t let Hezekiah deceive you nor persuade you in this way. Don’t believe him, for no elohim of any nation or kingdom was able to deliver his people out of my hand, and out of the hand of my fathers. How much less will your Elohim deliver you out of my hand?” 
-</p><p>
-<span class="v">16&#160;</span>His servants spoke yet more against Yahweh Elohim and against his servant Hezekiah. 
-<span class="v">17&#160;</span>He also wrote letters insulting Yahweh, the Elohim of Israel, and speaking against him, saying, “As the elohims of the nations of the lands, which have not delivered their people out of my hand, so shall the Elohim of Hezekiah not deliver his people out of my hand.” 
-<span class="v">18&#160;</span>They called out with a loud voice in the Jews’ language to the people of Jerusalem who were on the wall, to frighten them and to trouble them, that they might take the city. 
-<span class="v">19&#160;</span>They spoke of the Elohim of Jerusalem as of the elohims of the peoples of the earth, which are the work of men’s hands. 
-</p><p>
-<span class="v">20&#160;</span>Hezekiah the king and Isaiah the prophet, the son of Amoz, prayed because of this, and cried to heaven. 
-</p><p>
-<span class="v">21&#160;</span>Yahweh sent an angel, who cut off all the mighty men of valor, the leaders, and captains in the camp of the king of Assyria. So he returned with shame of face to his own land. When he had come into the house of his elohim, those who came out of his own body<span class="f">+ \fr 32:21 \ft i.e., his own sons</span> killed him there with the sword. 
-<span class="v">22&#160;</span>Thus Yahweh saved Hezekiah and the inhabitants of Jerusalem from the hand of Sennacherib the king of Assyria and from the hand of all others, and guided them on every side. 
-<span class="v">23&#160;</span>Many brought gifts to Yahweh to Jerusalem, and precious things to Hezekiah king of Judah, so that he was exalted in the sight of all nations from then on. 
-</p><p>
-<span class="v">24&#160;</span>In those days Hezekiah was terminally ill, and he prayed to Yahweh; and he spoke to him, and gave him a sign. 
-<span class="v">25&#160;</span>But Hezekiah didn’t reciprocate appropriate to the benefit done for him, because his heart was lifted up. Therefore there was wrath on him, Judah, and Jerusalem. 
-<span class="v">26&#160;</span>However, Hezekiah humbled himself for the pride of his heart, both he and the inhabitants of Jerusalem, so that Yahweh’s wrath didn’t come on them in the days of Hezekiah. 
-</p><p>
-<span class="v">27&#160;</span>Hezekiah had exceedingly great riches and honor. He provided himself with treasuries for silver, for gold, for precious stones, for spices, for shields, and for all kinds of valuable vessels; 
-<span class="v">28&#160;</span>also storehouses for the increase of grain, new wine, and oil; and stalls for all kinds of animals, and flocks in folds. 
-<span class="v">29&#160;</span>Moreover he provided for himself cities, and possessions of flocks and herds in abundance; for Elohim had given him abundant possessions. 
-<span class="v">30&#160;</span>This same Hezekiah also stopped the upper spring of the waters of Gihon, and brought them straight down on the west side of David’s city. Hezekiah prospered in all his works. 
-</p><p>
-<span class="v">31&#160;</span>However, concerning the ambassadors of the princes of Babylon, who sent to him to inquire of the wonder that was done in the land, Elohim left him to test him, that he might know all that was in his heart. 
-</p><p>
-<span class="v">32&#160;</span>Now the rest of the acts of Hezekiah and his good deeds, behold, they are written in the vision of Isaiah the prophet, the son of Amoz, in the book of the kings of Judah and Israel. 
-<span class="v">33&#160;</span>Hezekiah slept with his fathers, and they buried him in the ascent to the tombs of the sons of David. All Judah and the inhabitants of Jerusalem honored him at his death. Manasseh his son reigned in his place. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p>
-<span class="v">1&#160;</span>Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. 
-<span class="v">2&#160;</span>He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
-<span class="v">3&#160;</span>For he built again the high places which Hezekiah his father had broken down; and he raised up altars for the Baals, made Asheroth, and worshiped all the army of the sky, and served them. 
-<span class="v">4&#160;</span>He built altars in Yahweh’s house, of which Yahweh said, “My name shall be in Jerusalem forever.” 
-<span class="v">5&#160;</span>He built altars for all the army of the sky in the two courts of Yahweh’s house. 
-<span class="v">6&#160;</span>He also made his children to pass through the fire in the valley of the son of Hinnom. He practiced sorcery, divination, and witchcraft, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
-<span class="v">7&#160;</span>He set the engraved image of the idol, which he had made, in Elohim’s house, of which Elohim said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever. 
-<span class="v">8&#160;</span>I will not any more remove the foot of Israel from off the land which I have appointed for your fathers, if only they will observe to do all that I have commanded them, even all the law, the statutes, and the ordinances given by Moses.” 
-<span class="v">9&#160;</span>Manasseh seduced Judah and the inhabitants of Jerusalem, so that they did more evil than did the nations whom Yahweh destroyed before the children of Israel. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh spoke to Manasseh and to his people, but they didn’t listen. 
-<span class="v">11&#160;</span>Therefore Yahweh brought on them the captains of the army of the king of Assyria, who took Manasseh in chains, bound him with fetters, and carried him to Babylon. 
-</p><p>
-<span class="v">12&#160;</span>When he was in distress, he begged Yahweh his Elohim, and humbled himself greatly before the Elohim of his fathers. 
-<span class="v">13&#160;</span>He prayed to him; and he was entreated by him, and heard his supplication, and brought him again to Jerusalem into his kingdom. Then Manasseh knew that Yahweh was Elohim. 
-</p><p>
-<span class="v">14&#160;</span>Now after this, he built an outer wall to David’s city on the west side of Gihon, in the valley, even to the entrance at the fish gate. He encircled Ophel with it, and raised it up to a very great height; and he put valiant captains in all the fortified cities of Judah. 
-<span class="v">15&#160;</span>He took away the foreign elohims and the idol out of Yahweh’s house, and all the altars that he had built in the mountain of Yahweh’s house and in Jerusalem, and cast them out of the city. 
-<span class="v">16&#160;</span>He built up Yahweh’s altar, and offered sacrifices of peace offerings and of thanksgiving on it, and commanded Judah to serve Yahweh, the Elohim of Israel. 
-<span class="v">17&#160;</span>Nevertheless the people still sacrificed in the high places, but only to Yahweh their Elohim. 
-</p><p>
-<span class="v">18&#160;</span>Now the rest of the acts of Manasseh, and his prayer to his Elohim, and the words of the seers who spoke to him in the name of Yahweh, the Elohim of Israel, behold, they are written among the acts of the kings of Israel. 
-<span class="v">19&#160;</span>His prayer also, and how Elohim listened to his request, and all his sin and his trespass, and the places in which he built high places and set up the Asherah poles and the engraved images before he humbled himself: behold, they are written in the history of Hozai.<span class="f">+ \fr 33:19 \ft or, the seers</span> 
-<span class="v">20&#160;</span>So Manasseh slept with his fathers, and they buried him in his own house; and Amon his son reigned in his place. 
-</p><p>
-<span class="v">21&#160;</span>Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. 
-<span class="v">22&#160;</span>He did that which was evil in Yahweh’s sight, as did Manasseh his father; and Amon sacrificed to all the engraved images which Manasseh his father had made, and served them. 
-<span class="v">23&#160;</span>He didn’t humble himself before Yahweh, as Manasseh his father had humbled himself; but this same Amon trespassed more and more. 
-<span class="v">24&#160;</span>His servants conspired against him, and put him to death in his own house. 
-<span class="v">25&#160;</span>But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. 
-<span class="v">2&#160;</span>He did that which was right in Yahweh’s eyes, and walked in the ways of David his father, and didn’t turn away to the right hand or to the left. 
-<span class="v">3&#160;</span>For in the eighth year of his reign, while he was yet young, he began to seek after the Elohim of David his father; and in the twelfth year he began to purge Judah and Jerusalem from the high places, the Asherah poles, the engraved images, and the molten images. 
-<span class="v">4&#160;</span>They broke down the altars of the Baals in his presence; and he cut down the incense altars that were on high above them. He broke the Asherah poles, the engraved images, and the molten images in pieces, made dust of them, and scattered it on the graves of those who had sacrificed to them. 
-<span class="v">5&#160;</span>He burned the bones of the priests on their altars, and purged Judah and Jerusalem. 
-<span class="v">6&#160;</span>He did this in the cities of Manasseh, Ephraim, and Simeon, even to Naphtali, around in their ruins. 
-<span class="v">7&#160;</span>He broke down the altars, beat the Asherah poles and the engraved images into powder, and cut down all the incense altars throughout all the land of Israel, then returned to Jerusalem. 
-</p><p>
-<span class="v">8&#160;</span>Now in the eighteenth year of his reign, when he had purged the land and the house, he sent Shaphan the son of Azaliah, Maaseiah the governor of the city, and Joah the son of Joahaz the recorder to repair the house of Yahweh his Elohim. 
-<span class="v">9&#160;</span>They came to Hilkiah the high priest and delivered the money that was brought into Elohim’s house, which the Levites, the keepers of the threshold, had gathered from the hands of Manasseh, Ephraim, of all the remnant of Israel, of all Judah and Benjamin, and of the inhabitants of Jerusalem. 
-<span class="v">10&#160;</span>They delivered it into the hands of the workmen who had the oversight of Yahweh’s house; and the workmen who labored in Yahweh’s house gave it to mend and repair the house. 
-<span class="v">11&#160;</span>They gave it to the carpenters and to the builders to buy cut stone and timber for couplings, and to make beams for the houses which the kings of Judah had destroyed. 
-<span class="v">12&#160;</span>The men did the work faithfully. Their overseers were Jahath and Obadiah the Levites, of the sons of Merari; and Zechariah and Meshullam, of the sons of the Kohathites, to give direction; and others of the Levites, who were all skillful with musical instruments. 
-<span class="v">13&#160;</span>Also they were over the bearers of burdens, and directed all who did the work in every kind of service. Of the Levites, there were scribes, officials, and gatekeepers. 
-</p><p>
-<span class="v">14&#160;</span>When they brought out the money that was brought into Yahweh’s house, Hilkiah the priest found the book of Yahweh’s law given by Moses. 
-<span class="v">15&#160;</span>Hilkiah answered Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” So Hilkiah delivered the book to Shaphan. 
-</p><p>
-<span class="v">16&#160;</span>Shaphan carried the book to the king, and moreover brought back word to the king, saying, “All that was committed to your servants, they are doing. 
-<span class="v">17&#160;</span>They have emptied out the money that was found in Yahweh’s house, and have delivered it into the hand of the overseers and into the hand of the workmen.” 
-<span class="v">18&#160;</span>Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered me a book.” Shaphan read from it to the king. 
-</p><p>
-<span class="v">19&#160;</span>When the king had heard the words of the law, he tore his clothes. 
-<span class="v">20&#160;</span>The king commanded Hilkiah, Ahikam the son of Shaphan, Abdon the son of Micah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
-<span class="v">21&#160;</span>“Go inquire of Yahweh for me, and for those who are left in Israel and in Judah, concerning the words of the book that is found; for great is Yahweh’s wrath that is poured out on us, because our fathers have not kept Yahweh’s word, to do according to all that is written in this book.” 
-</p><p>
-<span class="v">22&#160;</span>So Hilkiah and those whom the king had commanded went to Huldah the prophetess, the woman of Shallum the son of Tokhath, the son of Hasrah, keeper of the wardrobe (now she lived in Jerusalem in the second quarter), and they spoke to her to that effect. 
-</p><p>
-<span class="v">23&#160;</span>She said to them, “Yahweh, the Elohim of Israel says: ‘Tell the man who sent you to me, 
-<span class="v">24&#160;</span>“Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the curses that are written in the book which they have read before the king of Judah. 
-<span class="v">25&#160;</span>Because they have forsaken me, and have burned incense to other elohims, that they might provoke me to anger with all the works of their hands, therefore my wrath is poured out on this place, and it will not be quenched.’&#160;”&#160;’ 
-<span class="v">26&#160;</span>But to the king of Judah, who sent you to inquire of Yahweh, you shall tell him this, ‘Yahweh, the Elohim of Israel says: “About the words which you have heard, 
-<span class="v">27&#160;</span>because your heart was tender, and you humbled yourself before Elohim when you heard his words against this place and against its inhabitants, and have humbled yourself before me, and have torn your clothes and wept before me, I also have heard you,” says Yahweh. 
-<span class="v">28&#160;</span>“Behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes won’t see all the evil that I will bring on this place and on its inhabitants.”&#160;’&#160;” 
-</p><p>They brought back this message to the king. 
-</p><p>
-<span class="v">29&#160;</span>Then the king sent and gathered together all the elders of Judah and Jerusalem. 
-<span class="v">30&#160;</span>The king went up to Yahweh’s house with all the men of Judah and the inhabitants of Jerusalem—the priests, the Levites, and all the people, both great and small—and he read in their hearing all the words of the book of the covenant that was found in Yahweh’s house. 
-<span class="v">31&#160;</span>The king stood in his place and made a covenant before Yahweh, to walk after Yahweh, and to keep his commandments, his testimonies, and his statutes with all his heart and with all his soul, to perform the words of the covenant that were written in this book. 
-<span class="v">32&#160;</span>He caused all who were found in Jerusalem and Benjamin to stand. The inhabitants of Jerusalem did according to the covenant of Elohim, the Elohim of their fathers. 
-<span class="v">33&#160;</span>Josiah took away all the abominations out of all the countries that belonged to the children of Israel, and made all who were found in Israel to serve, even to serve Yahweh their Elohim. All his days they didn’t depart from following Yahweh, the Elohim of their fathers. 
-</p><h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>Josiah kept a Passover to Yahweh in Jerusalem. They killed the Passover on the fourteenth day of the first month. 
-<span class="v">2&#160;</span>He set the priests in their offices and encouraged them in the service of Yahweh’s house. 
-<span class="v">3&#160;</span>He said to the Levites who taught all Israel, who were set-apart to Yahweh, “Put the set-apart ark in the house which Solomon the son of David king of Israel built. It will no longer be a burden on your shoulders. Now serve Yahweh your Elohim and his people Israel. 
-<span class="v">4&#160;</span>Prepare yourselves after your fathers’ houses by your divisions, according to the writing of David king of Israel, and according to the writing of Solomon his son. 
-<span class="v">5&#160;</span>Stand in the set-apart place according to the divisions of the fathers’ houses of your brothers the children of the people, and let there be for each a portion of a fathers’ house of the Levites. 
-<span class="v">6&#160;</span>Kill the Passover lamb, sanctify yourselves, and prepare for your brothers, to do according to Yahweh’s word by Moses.” 
-</p><p>
-<span class="v">7&#160;</span>Josiah gave to the children of the people, of the flock, lambs and young goats, all of them for the Passover offerings, to all who were present, to the number of thirty thousand, and three thousand bulls. These were of the king’s substance. 
-<span class="v">8&#160;</span>His princes gave a free will offering to the people, to the priests, and to the Levites. Hilkiah, Zechariah, and Jehiel, the rulers of Elohim’s house, gave to the priests for the Passover offerings two thousand six hundred small livestock, and three hundred head of cattle. 
-<span class="v">9&#160;</span>Conaniah also, and Shemaiah and Nethanel, his brothers, and Hashabiah, Jeiel, and Jozabad, the chiefs of the Levites, gave to the Levites for the Passover offerings five thousand small livestock and five hundred head of cattle. 
-</p><p>
-<span class="v">10&#160;</span>So the service was prepared, and the priests stood in their place, and the Levites by their divisions, according to the king’s commandment. 
-<span class="v">11&#160;</span>They killed the Passover lambs, and the priests sprinkled the blood which they received from their hands, and the Levites skinned them. 
-<span class="v">12&#160;</span>They removed the burnt offerings, that they might give them according to the divisions of the fathers’ houses of the children of the people, to offer to Yahweh, as it is written in the book of Moses. They did the same with the cattle. 
-<span class="v">13&#160;</span>They roasted the Passover with fire according to the ordinance. They boiled the set-apart offerings in pots, in cauldrons, and in pans, and carried them quickly to all the children of the people. 
-<span class="v">14&#160;</span>Afterward they prepared for themselves and for the priests, because the priests the sons of Aaron were busy with offering the burnt offerings and the fat until night. Therefore the Levites prepared for themselves and for the priests the sons of Aaron. 
-<span class="v">15&#160;</span>The singers, the sons of Asaph, were in their place, according to the commandment of David, Asaph, Heman, and Jeduthun the king’s seer; and the gatekeepers were at every gate. They didn’t need to depart from their service, because their brothers the Levites prepared for them. 
-</p><p>
-<span class="v">16&#160;</span>So all the service of Yahweh was prepared the same day, to keep the Passover, and to offer burnt offerings on Yahweh’s altar, according to the commandment of King Josiah. 
-<span class="v">17&#160;</span>The children of Israel who were present kept the Passover at that time, and the feast of unleavened bread seven days. 
-<span class="v">18&#160;</span>There was no Passover like that kept in Israel from the days of Samuel the prophet, nor did any of the kings of Israel keep such a Passover as Josiah kept—with the priests, the Levites, and all Judah and Israel who were present, and the inhabitants of Jerusalem. 
-<span class="v">19&#160;</span>This Passover was kept in the eighteenth year of the reign of Josiah. 
-</p><p>
-<span class="v">20&#160;</span>After all this, when Josiah had prepared the temple, Neco king of Egypt went up to fight against Carchemish by the Euphrates, and Josiah went out against him. 
-<span class="v">21&#160;</span>But he sent ambassadors to him, saying, “What have I to do with you, you king of Judah? I come not against you today, but against the house with which I have war. Elohim has commanded me to make haste. Beware that it is Elohim who is with me, that he not destroy you.” 
-</p><p>
-<span class="v">22&#160;</span>Nevertheless Josiah would not turn his face from him, but disguised himself, that he might fight with him, and didn’t listen to the words of Neco from the mouth of Elohim, and came to fight in the valley of Megiddo. 
-<span class="v">23&#160;</span>The archers shot at King Josiah; and the king said to his servants, “Take me away, because I am seriously wounded!” 
-</p><p>
-<span class="v">24&#160;</span>So his servants took him out of the chariot, and put him in the second chariot that he had, and brought him to Jerusalem; and he died, and was buried in the tombs of his fathers. All Judah and Jerusalem mourned for Josiah. 
-<span class="v">25&#160;</span>Jeremiah lamented for Josiah, and all the singing men and singing women spoke of Josiah in their lamentations to this day; and they made them an ordinance in Israel. Behold, they are written in the lamentations. 
-<span class="v">26&#160;</span>Now the rest of the acts of Josiah and his good deeds, according to that which is written in Yahweh’s law, 
-<span class="v">27&#160;</span>and his acts, first and last, behold, they are written in the book of the kings of Israel and Judah. 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>Then the people of the land took Jehoahaz the son of Josiah, and made him king in his father’s place in Jerusalem. 
-<span class="v">2&#160;</span>Joahaz was twenty-three years old when he began to reign; and he reigned three months in Jerusalem. 
-<span class="v">3&#160;</span>The king of Egypt removed him from office at Jerusalem, and fined the land one hundred talents of silver and a talent<span class="f">+ \fr 36:3 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of gold. 
-<span class="v">4&#160;</span>The king of Egypt made Eliakim his brother king over Judah and Jerusalem, and changed his name to Jehoiakim. Neco took Joahaz his brother, and carried him to Egypt. 
-</p><p>
-<span class="v">5&#160;</span>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. He did that which was evil in Yahweh his Elohim’s sight. 
-<span class="v">6&#160;</span>Nebuchadnezzar king of Babylon came up against him, and bound him in fetters to carry him to Babylon. 
-<span class="v">7&#160;</span>Nebuchadnezzar also carried some of the vessels of Yahweh’s house to Babylon, and put them in his temple at Babylon. 
-<span class="v">8&#160;</span>Now the rest of the acts of Jehoiakim, and his abominations which he did, and that which was found in him, behold, they are written in the book of the kings of Israel and Judah; and Jehoiachin his son reigned in his place. 
-</p><p>
-<span class="v">9&#160;</span>Jehoiachin was eight years old when he began to reign, and he reigned three months and ten days in Jerusalem. He did that which was evil in Yahweh’s sight. 
-<span class="v">10&#160;</span>At the return of the year, King Nebuchadnezzar sent and brought him to Babylon, with the valuable vessels of Yahweh’s house, and made Zedekiah his brother king over Judah and Jerusalem. 
-</p><p>
-<span class="v">11&#160;</span>Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. 
-<span class="v">12&#160;</span>He did that which was evil in Yahweh his Elohim’s sight. He didn’t humble himself before Jeremiah the prophet speaking from Yahweh’s mouth. 
-<span class="v">13&#160;</span>He also rebelled against King Nebuchadnezzar, who had made him swear by Elohim; but he stiffened his neck, and hardened his heart against turning to Yahweh, the Elohim of Israel. 
-<span class="v">14&#160;</span>Moreover all the chiefs of the priests and the people trespassed very greatly after all the abominations of the nations; and they polluted Yahweh’s house which he had made set-apart in Jerusalem. 
-</p><p>
-<span class="v">15&#160;</span>Yahweh, the Elohim of their fathers, sent to them by his messengers, rising up early and sending, because he had compassion on his people and on his dwelling place; 
-<span class="v">16&#160;</span>but they mocked the messengers of Elohim, despised his words, and scoffed at his prophets, until Yahweh’s wrath arose against his people, until there was no remedy. 
-</p><p>
-<span class="v">17&#160;</span>Therefore he brought on them the king of the Chaldeans, who killed their young men with the sword in the house of their sanctuary, and had no compassion on young man or virgin, old man or infirm. He gave them all into his hand. 
-<span class="v">18&#160;</span>All the vessels of Elohim’s house, great and small, and the treasures of Yahweh’s house, and the treasures of the king and of his princes, all these he brought to Babylon. 
-<span class="v">19&#160;</span>They burned Elohim’s house, broke down the wall of Jerusalem, burned all its palaces with fire, and destroyed all of its valuable vessels. 
-<span class="v">20&#160;</span>He carried those who had escaped from the sword away to Babylon, and they were servants to him and his sons until the reign of the kingdom of Persia, 
-<span class="v">21&#160;</span>to fulfill Yahweh’s word by Jeremiah’s mouth, until the land had enjoyed its Sabbaths. As long as it lay desolate, it kept Sabbath, to fulfill seventy years. 
-</p><p>
-<span class="v">22&#160;</span>Now in the first year of Cyrus king of Persia, that Yahweh’s word by the mouth of Jeremiah might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
-<span class="v">23&#160;</span>“Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given all the kingdoms of the earth to me; and he has commanded me to build him a house in Jerusalem, which is in Judah. Whoever there is among you of all his people, Yahweh his Elohim be with him, and let him go up.’&#160;” </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Solomon the son of David was firmly established in his kingdom, and Yahweh was with him, and made him exceedingly great. 
+</div><div class="p">
+<sup>2&#160;</sup>Solomon spoke to all Israel, to the captains of thousands and of hundreds, to the judges, and to every prince in all Israel, the heads of the fathers’ households. 
+<sup>3&#160;</sup>Then Solomon, and all the assembly with him, went to the high place that was at Gibeon; for Elohim’s Tent of Meeting was there, which Yahweh’s servant Moses had made in the wilderness. 
+<sup>4&#160;</sup>But David had brought Elohim’s ark up from Kiriath Jearim to the place that David had prepared for it; for he had pitched a tent for it at Jerusalem. 
+<sup>5&#160;</sup>Moreover the bronze altar that Bezalel the son of Uri, the son of Hur, had made was there before Yahweh’s tabernacle; and Solomon and the assembly were seeking counsel there. 
+<sup>6&#160;</sup>Solomon went up there to the bronze altar before Yahweh, which was at the Tent of Meeting, and offered one thousand burnt offerings on it. 
+</div><div class="p">
+<sup>7&#160;</sup>That night, Elohim appeared to Solomon and said to him, “Ask for what you want me to give you.” 
+</div><div class="p">
+<sup>8&#160;</sup>Solomon said to Elohim, “You have shown great loving kindness to David my father, and have made me king in his place. 
+<sup>9&#160;</sup>Now, Yahweh Elohim, let your promise to David my father be established; for you have made me king over a people like the dust of the earth in multitude. 
+<sup>10&#160;</sup>Now give me wisdom and knowledge, that I may go out and come in before this people; for who can judge this great people of yours?” 
+</div><div class="p">
+<sup>11&#160;</sup>Elohim said to Solomon, “Because this was in your heart, and you have not asked riches, wealth, honor, or the life of those who hate you, nor yet have you asked for long life; but have asked for wisdom and knowledge for yourself, that you may judge my people, over whom I have made you king, 
+<sup>12&#160;</sup>therefore wisdom and knowledge is granted to you. I will give you riches, wealth, and honor, such as none of the kings have had who have been before you, and none after you will have.” 
+</div><div class="p">
+<sup>13&#160;</sup>So Solomon came from the high place that was at Gibeon, from before the Tent of Meeting, to Jerusalem; and he reigned over Israel. 
+</div><div class="p">
+<sup>14&#160;</sup>Solomon gathered chariots and horsemen. He had one thousand four hundred chariots and twelve thousand horsemen that he placed in the chariot cities, and with the king at Jerusalem. 
+<sup>15&#160;</sup>The king made silver and gold to be as common as stones in Jerusalem, and he made cedars to be as common as the sycamore trees that are in the lowland. 
+<sup>16&#160;</sup>The horses which Solomon had were brought out of Egypt and from Kue. The king’s merchants purchased them from Kue. 
+<sup>17&#160;</sup>They imported from Egypt then exported a chariot for six hundred pieces of silver and a horse for one hundred fifty. kings. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Solomon decided to build a house for Yahweh’s name, and a house for his kingdom. 
+<sup>2&#160;</sup>Solomon counted out seventy thousand men to bear burdens, eighty thousand men who were stone cutters in the mountains, and three thousand six hundred to oversee them. 
+</div><div class="p">
+<sup>3&#160;</sup>Solomon sent to Huram the king of Tyre, saying, “As you dealt with David my father, and sent him cedars to build him a house in which to dwell, so deal with me. 
+<sup>4&#160;</sup>Behold, I am about to build a house for the name of Yahweh my Elohim, to dedicate it to him, to burn before him incense of sweet spices, for the continual show bread, and for the burnt offerings morning and evening, on the Sabbaths, on the new moons, and on the set feasts of Yahweh our Elohim. This is an ordinance forever to Israel. 
+</div><div class="p">
+<sup>5&#160;</sup>“The house which I am building will be great, for our Elohim is greater than all elohims. 
+<sup>6&#160;</sup>But who is able to build him a house, since heaven and the heaven of heavens can’t contain him? Who am I then, that I should build him a house, except just to burn incense before him? 
+</div><div class="p">
+<sup>7&#160;</sup>“Now therefore send me a man skillful to work in gold, in silver, in bronze, in iron, and in purple, crimson, and blue, and who knows how to engrave engravings, to be with the skillful men who are with me in Judah and in Jerusalem, whom David my father provided. 
+</div><div class="p">
+<sup>8&#160;</sup>“Send me also cedar trees, cypress trees, and algum trees out of Lebanon, for I know that your servants know how to cut timber in Lebanon. Behold, my servants will be with your servants, 
+<sup>9&#160;</sup>even to prepare me timber in abundance; for the house which I am about to build will be great and wonderful. 
+<sup>10&#160;</sup>Behold, I will give to your servants, the cutters who cut timber, twenty thousand cors of barley, twenty thousand baths of wine, and twenty thousand baths of oil.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then Huram the king of Tyre answered in writing, which he sent to Solomon, “Because Yahweh loves his people, he has made you king over them.” 
+<sup>12&#160;</sup>Huram continued, “Blessed be Yahweh, the Elohim of Israel, who made heaven and earth, who has given to David the king a wise son, endowed with discretion and understanding, who would build a house for Yahweh and a house for his kingdom. 
+</div><div class="p">
+<sup>13&#160;</sup>Now I have sent a skillful man, endowed with understanding, Huram-abi, 
+<sup>14&#160;</sup>the son of a woman of the daughters of Dan; and his father was a man of Tyre. He is skillful to work in gold, in silver, in bronze, in iron, in stone, in timber, in purple, in blue, in fine linen, and in crimson, also to engrave any kind of engraving and to devise any device, that there may be a place appointed to him with your skillful men, and with the skillful men of my lord David your father. 
+</div><div class="p">
+<sup>15&#160;</sup>“Now therefore, the wheat, the barley, the oil, and the wine which my lord has spoken of, let him send to his servants; 
+<sup>16&#160;</sup>and we will cut wood out of Lebanon, as much as you need. We will bring it to you in rafts by sea to Joppa; then you shall carry it up to Jerusalem.” 
+</div><div class="p">
+<sup>17&#160;</sup>Solomon counted all the foreigners who were in the land of Israel, after the census with which David his father had counted them; and they found one hundred fifty-three thousand six hundred. 
+<sup>18&#160;</sup>He set seventy thousand of them to bear burdens, eighty thousand who were stone cutters in the mountains, and three thousand six hundred overseers to assign the people their work. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Solomon began to build Yahweh’s house at Jerusalem on Mount Moriah, where Yahweh appeared to David his father, which he prepared in the place that David had appointed, on the threshing floor of Ornan the Jebusite. 
+<sup>2&#160;</sup>He began to build in the second day of the second month, in the fourth year of his reign. 
+<sup>3&#160;</sup>Now these are the foundations which Solomon laid for the building of Elohim’s house: the length by cubits after the first measure was sixty cubits, and the width twenty cubits. 
+<sup>4&#160;</sup>The porch that was in front, its length, across the width of the house, was twenty cubits, and the height one hundred twenty; and he overlaid it within with pure gold. 
+<sup>5&#160;</sup>He made the larger room with a ceiling of cypress wood, which he overlaid with fine gold, and ornamented it with palm trees and chains. 
+<sup>6&#160;</sup>He decorated the house with precious stones for beauty. The gold was gold from Parvaim. 
+<sup>7&#160;</sup>He also overlaid the house, the beams, the thresholds, its walls, and its doors with gold, and engraved cherubim on the walls. 
+</div><div class="p">
+<sup>8&#160;</sup>He made the most set-apart place. Its length, according to the width of the house, was twenty cubits, and its width twenty cubits; and he overlaid it with fine gold, amounting to six hundred talents. 
+<sup>9&#160;</sup>The weight of the nails was fifty shekels of gold. He overlaid the upper rooms with gold. 
+</div><div class="p">
+<sup>10&#160;</sup>In the most set-apart place he made two cherubim by carving, and they overlaid them with gold. 
+<sup>11&#160;</sup>The wings of the cherubim were twenty cubits long: the wing of the one was five cubits, reaching to the wall of the house; and the other wing was five cubits, reaching to the wing of the other cherub. 
+<sup>12&#160;</sup>The wing of the other cherub was five cubits, reaching to the wall of the house; and the other wing was five cubits, joining to the wing of the other cherub. 
+<sup>13&#160;</sup>The wings of these cherubim spread themselves out twenty cubits. They stood on their feet, and their faces were toward the house. 
+<sup>14&#160;</sup>He made the veil of blue, purple, crimson, and fine linen, and ornamented it with cherubim. 
+</div><div class="p">
+<sup>15&#160;</sup>Also he made before the house two pillars thirty-five cubits high, and the capital that was on the top of each of them was five cubits. 
+<sup>16&#160;</sup>He made chains in the inner sanctuary, and put them on the tops of the pillars; and he made one hundred pomegranates, and put them on the chains. 
+<sup>17&#160;</sup>He set up the pillars before the temple, one on the right hand and the other on the left; and called the name of that on the right hand Jachin, and the name of that on the left Boaz. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Then he made an altar of bronze, twenty cubits long, twenty cubits wide, and ten cubits high. 
+<sup>2&#160;</sup>Also he made the molten sea of ten cubits from brim to brim. It was round, five cubits high, and thirty cubits in circumference. 
+<sup>3&#160;</sup>Under it was the likeness of oxen, which encircled it, for ten cubits, encircling the sea. The oxen were in two rows, cast when it was cast. 
+<sup>4&#160;</sup>It stood on twelve oxen, three looking toward the north, three looking toward the west, three looking toward the south, and three looking toward the east; and the sea was set on them above, and all their hindquarters were inward. 
+<sup>5&#160;</sup>It was a handbreadth thick. Its brim was made like the brim of a cup, like the flower of a lily. It received and held three thousand baths. 
+<sup>6&#160;</sup>He also made ten basins, and put five on the right hand and five on the left, to wash in them. The things that belonged to the burnt offering were washed in them, but the sea was for the priests to wash in. 
+</div><div class="p">
+<sup>7&#160;</sup>He made the ten lamp stands of gold according to the ordinance concerning them; and he set them in the temple, five on the right hand and five on the left. 
+<sup>8&#160;</sup>He made also ten tables, and placed them in the temple, five on the right side and five on the left. He made one hundred basins of gold. 
+<sup>9&#160;</sup>Furthermore he made the court of the priests, the great court, and doors for the court, and overlaid their doors with bronze. 
+<sup>10&#160;</sup>He set the sea on the right side of the house eastward, toward the south. 
+</div><div class="p">
+<sup>11&#160;</sup>Huram made the pots, the shovels, and the basins. 
+</div><div class="p">So Huram finished doing the work that he did for King Solomon in Elohim’s house: 
+<sup>12&#160;</sup>the two pillars, the bowls, the two capitals which were on the top of the pillars, the two networks to cover the two bowls of the capitals that were on the top of the pillars, 
+<sup>13&#160;</sup>and the four hundred pomegranates for the two networks—two rows of pomegranates for each network, to cover the two bowls of the capitals that were on the pillars. 
+<sup>14&#160;</sup>He also made the bases, and he made the basins on the bases—<sup>15&#160;</sup>one sea, and the twelve oxen under it. 
+<sup>16&#160;</sup>Huram-abi also made the pots, the shovels, the forks, and all its vessels for King Solomon, for Yahweh’s house, of bright bronze. 
+<sup>17&#160;</sup>The king cast them in the plain of the Jordan, in the clay ground between Succoth and Zeredah. 
+<sup>18&#160;</sup>Thus Solomon made all these vessels in great abundance, so that the weight of the bronze could not be determined. 
+</div><div class="p">
+<sup>19&#160;</sup>Solomon made all the vessels that were in Elohim’s house: the golden altar, the tables with the show bread on them, 
+<sup>20&#160;</sup>and the lamp stands with their lamps to burn according to the ordinance before the inner sanctuary, of pure gold; 
+<sup>21&#160;</sup>and the flowers, the lamps, and the tongs of gold that was purest gold; 
+<sup>22&#160;</sup>and the snuffers, the basins, the spoons, and the fire pans of pure gold. As for the entry of the house, its inner doors for the most set-apart place and the doors of the main hall of the temple were of gold. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Thus all the work that Solomon did for Yahweh’s house was finished. Solomon brought in the things that David his father had dedicated, even the silver, the gold, and all the vessels, and put them in the treasuries of Elohim’s house. 
+</div><div class="p">
+<sup>2&#160;</sup>Then Solomon assembled the elders of Israel and all the heads of the tribes, the princes of the fathers’ households of the children of Israel, to Jerusalem, to bring up the ark of Yahweh’s covenant out of David’s city, which is Zion. 
+<sup>3&#160;</sup>So all the men of Israel assembled themselves to the king at the feast, which was in the seventh month. 
+<sup>4&#160;</sup>All the elders of Israel came. The Levites took up the ark. 
+<sup>5&#160;</sup>They brought up the ark, the Tent of Meeting, and all the set-apart vessels that were in the Tent. The Levitical priests brought these up. 
+<sup>6&#160;</sup>King Solomon and all the congregation of Israel who were assembled to him were before the ark, sacrificing sheep and cattle that could not be counted or numbered for multitude. 
+<sup>7&#160;</sup>The priests brought in the ark of Yahweh’s covenant to its place, into the inner sanctuary of the house, to the most set-apart place, even under the wings of the cherubim. 
+<sup>8&#160;</sup>For the cherubim spread out their wings over the place of the ark, and the cherubim covered the ark and its poles above. 
+<sup>9&#160;</sup>The poles were so long that the ends of the poles were seen from the ark in front of the inner sanctuary, but they were not seen outside; and it is there to this day. 
+<sup>10&#160;</sup>There was nothing in the ark except the two tablets which Moses put there at Horeb, when Yahweh made a covenant with the children of Israel, when they came out of Egypt. 
+</div><div class="p">
+<sup>11&#160;</sup>When the priests had come out of the set-apart place (for all the priests who were present had sanctified themselves, and didn’t keep their divisions; 
+<sup>12&#160;</sup>also the Levites who were the singers, all of them, even Asaph, Heman, Jeduthun, and their sons and their brothers, arrayed in fine linen, with cymbals and stringed instruments and harps, stood at the east end of the altar, and with them one hundred twenty priests sounding with trumpets); 
+<sup>13&#160;</sup>when the trumpeters and singers were as one, to make one sound to be heard in praising and thanking Yahweh; and when they lifted up their voice with the trumpets and cymbals and instruments of music, and praised Yahweh, saying, 
+</div><div class="q1">“For he is good, 
+</div><div class="q2">for his loving kindness endures forever!” 
+</div><div class="m">then the house was filled with a cloud, even Yahweh’s house, 
+<sup>14&#160;</sup>so that the priests could not stand to minister by reason of the cloud; for Yahweh’s glory filled Elohim’s house. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Solomon said, “Yahweh has said that he would dwell in the thick darkness. 
+<sup>2&#160;</sup>But I have built you a house and home, a place for you to dwell in forever.” 
+</div><div class="p">
+<sup>3&#160;</sup>The king turned his face, and blessed all the assembly of Israel; and all the assembly of Israel stood. 
+</div><div class="p">
+<sup>4&#160;</sup>He said, “Blessed be Yahweh, the Elohim of Israel, who spoke with his mouth to David my father, and has with his hands fulfilled it, saying, 
+<sup>5&#160;</sup>‘Since the day that I brought my people out of the land of Egypt, I chose no city out of all the tribes of Israel to build a house in, that my name might be there, and I chose no man to be prince over my people Israel; 
+<sup>6&#160;</sup>but now I have chosen Jerusalem, that my name might be there; and I have chosen David to be over my people Israel.’ 
+<sup>7&#160;</sup>Now it was in the heart of David my father to build a house for the name of Yahweh, the Elohim of Israel. 
+<sup>8&#160;</sup>But Yahweh said to David my father, ‘Whereas it was in your heart to build a house for my name, you did well that it was in your heart; 
+<sup>9&#160;</sup>nevertheless you shall not build the house, but your son who will come out of your body, he shall build the house for my name.’ 
+</div><div class="p">
+<sup>10&#160;</sup>“Yahweh has performed his word that he spoke; for I have risen up in the place of David my father, and sit on the throne of Israel, as Yahweh promised, and have built the house for the name of Yahweh, the Elohim of Israel. 
+<sup>11&#160;</sup>There I have set the ark, in which is Yahweh’s covenant, which he made with the children of Israel.” 
+</div><div class="p">
+<sup>12&#160;</sup>He stood before Yahweh’s altar in the presence of all the assembly of Israel, and spread out his hands 
+<sup>13&#160;</sup>(for Solomon had made a bronze platform, five cubits long, five cubits wide, and three cubits high, and had set it in the middle of the court; and he stood on it, and knelt down on his knees before all the assembly of Israel, and spread out his hands toward heaven). 
+<sup>14&#160;</sup>Then he said, “Yahweh, the Elohim of Israel, there is no Elohim like you in heaven or on earth—you who keep covenant and loving kindness with your servants who walk before you with all their heart; 
+<sup>15&#160;</sup>who have kept with your servant David my father that which you promised him. Yes, you spoke with your mouth, and have fulfilled it with your hand, as it is today. 
+</div><div class="p">
+<sup>16&#160;</sup>“Now therefore, Yahweh, the Elohim of Israel, keep with your servant David my father that which you have promised him, saying, ‘There shall not fail you a man in my sight to sit on the throne of Israel, if only your children take heed to their way, to walk in my law as you have walked before me.’ 
+<sup>17&#160;</sup>Now therefore, Yahweh, the Elohim of Israel, let your word be verified, which you spoke to your servant David. 
+</div><div class="p">
+<sup>18&#160;</sup>“But will Elohim indeed dwell with men on the earth? Behold, heaven and the heaven of heavens can’t contain you; how much less this house which I have built! 
+<sup>19&#160;</sup>Yet have respect for the prayer of your servant and to his supplication, Yahweh my Elohim, to listen to the cry and to the prayer which your servant prays before you; 
+<sup>20&#160;</sup>that your eyes may be open toward this house day and night, even toward the place where you have said that you would put your name, to listen to the prayer which your servant will pray toward this place. 
+<sup>21&#160;</sup>Listen to the petitions of your servant and of your people Israel, when they pray toward this place. Yes, hear from your dwelling place, even from heaven; and when you hear, forgive. 
+</div><div class="p">
+<sup>22&#160;</sup>“If a man sins against his neighbor, and an oath is laid on him to cause him to swear, and he comes and swears before your altar in this house, 
+<sup>23&#160;</sup>then hear from heaven, act, and judge your servants, bringing retribution to the wicked, to bring his way on his own head; and justifying the righteous, to give him according to his righteousness. 
+</div><div class="p">
+<sup>24&#160;</sup>“If your people Israel are struck down before the enemy because they have sinned against you, and they turn again and confess your name, and pray and make supplication before you in this house, 
+<sup>25&#160;</sup>then hear from heaven, and forgive the sin of your people Israel, and bring them again to the land which you gave to them and to their fathers. 
+</div><div class="p">
+<sup>26&#160;</sup>“When the sky is shut up and there is no rain because they have sinned against you, if they pray toward this place and confess your name, and turn from their sin when you afflict them, 
+<sup>27&#160;</sup>then hear in heaven, and forgive the sin of your servants, your people Israel, when you teach them the good way in which they should walk, and send rain on your land, which you have given to your people for an inheritance. 
+</div><div class="p">
+<sup>28&#160;</sup>“If there is famine in the land, if there is pestilence, if there is blight or mildew, locust or caterpillar; if their enemies besiege them in the land of their cities; whatever plague or whatever sickness there is—<sup>29&#160;</sup>whatever prayer and supplication is made by any man, or by all your people Israel, who will each know his own plague and his own sorrow, and shall spread out his hands toward this house, 
+<sup>30&#160;</sup>then hear from heaven your dwelling place and forgive, and render to every man according to all his ways, whose heart you know (for you, even you only, know the hearts of the children of men), 
+<sup>31&#160;</sup>that they may fear you, to walk in your ways as long as they live in the land which you gave to our fathers. 
+</div><div class="p">
+<sup>32&#160;</sup>“Moreover, concerning the foreigner, who is not of your people Israel, when he comes from a far country for your great name’s sake and your mighty hand and your outstretched arm, when they come and pray toward this house, 
+<sup>33&#160;</sup>then hear from heaven, even from your dwelling place, and do according to all that the foreigner calls to you for; that all the peoples of the earth may know your name and fear you, as do your people Israel, and that they may know that this house which I have built is called by your name. 
+</div><div class="p">
+<sup>34&#160;</sup>“If your people go out to battle against their enemies, by whatever way you send them, and they pray to you toward this city which you have chosen, and the house which I have built for your name; 
+<sup>35&#160;</sup>then hear from heaven their prayer and their supplication, and maintain their cause. 
+</div><div class="p">
+<sup>36&#160;</sup>“If they sin against you (for there is no man who doesn’t sin), and you are angry with them and deliver them to the enemy, so that they carry them away captive to a land far off or near; 
+<sup>37&#160;</sup>yet if they come to their senses in the land where they are carried captive, and turn again, and make supplication to you in the land of their captivity, saying, ‘We have sinned, we have done perversely, and have dealt wickedly;’ 
+<sup>38&#160;</sup>if they return to you with all their heart and with all their soul in the land of their captivity, where they have been taken captive, and pray toward their land which you gave to their fathers, and the city which you have chosen, and toward the house which I have built for your name; 
+<sup>39&#160;</sup>then hear from heaven, even from your dwelling place, their prayer and their petitions, and maintain their cause, and forgive your people who have sinned against you. 
+</div><div class="p">
+<sup>40&#160;</sup>“Now, my Elohim, let, I beg you, your eyes be open, and let your ears be attentive to the prayer that is made in this place. 
+</div><div class="p">
+<sup>41&#160;</sup>“Now therefore arise, Yahweh Elohim, into your resting place, you, and the ark of your strength. Let your priests, Yahweh Elohim, be clothed with salvation, and let your saints rejoice in goodness. 
+</div><div class="p">
+<sup>42&#160;</sup>“Yahweh Elohim, don’t turn away the face of your anointed. Remember your loving kindnesses to David your servant.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when Solomon had finished praying, fire came down from heaven and consumed the burnt offering and the sacrifices; and Yahweh’s glory filled the house. 
+<sup>2&#160;</sup>The priests could not enter into Yahweh’s house, because Yahweh’s glory filled Yahweh’s house. 
+<sup>3&#160;</sup>All the children of Israel looked on, when the fire came down, and Yahweh’s glory was on the house. They bowed themselves with their faces to the ground on the pavement, worshiped, and gave thanks to Yahweh, saying, 
+</div><div class="q1">“For he is good, 
+</div><div class="q2">for his loving kindness endures forever!” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the king and all the people offered sacrifices before Yahweh. 
+<sup>5&#160;</sup>King Solomon offered a sacrifice of twenty-two thousand head of cattle and a hundred twenty thousand sheep. So the king and all the people dedicated Elohim’s house. 
+<sup>6&#160;</sup>The priests stood, according to their positions; the Levites also with instruments of music of Yahweh, which David the king had made to give thanks to Yahweh, when David praised by their ministry, saying “For his loving kindness endures forever.” The priests sounded trumpets before them; and all Israel stood. 
+</div><div class="p">
+<sup>7&#160;</sup>Moreover Solomon made the middle of the court that was before Yahweh’s house set-apart; for there he offered the burnt offerings and the fat of the peace offerings, because the bronze altar which Solomon had made was not able to receive the burnt offering, the meal offering, and the fat. 
+</div><div class="p">
+<sup>8&#160;</sup>So Solomon held the feast at that time for seven days, and all Israel with him, a very great assembly, from the entrance of Hamath to the brook of Egypt. 
+</div><div class="p">
+<sup>9&#160;</sup>On the eighth day, they held a solemn assembly; for they kept the dedication of the altar seven days, and the feast seven days. 
+<sup>10&#160;</sup>On the twenty-third day of the seventh month, he sent the people away to their tents, joyful and glad of heart for the goodness that Yahweh had shown to David, to Solomon, and to Israel his people. 
+</div><div class="p">
+<sup>11&#160;</sup>Thus Solomon finished Yahweh’s house and the king’s house; and he successfully completed all that came into Solomon’s heart to make in Yahweh’s house and in his own house. 
+</div><div class="p">
+<sup>12&#160;</sup>Then Yahweh appeared to Solomon by night, and said to him, “I have heard your prayer, and have chosen this place for myself for a house of sacrifice. 
+</div><div class="p">
+<sup>13&#160;</sup>“If I shut up the sky so that there is no rain, or if I command the locust to devour the land, or if I send pestilence among my people, 
+<sup>14&#160;</sup>if my people who are called by my name will humble themselves, pray, seek my face, and turn from their wicked ways, then I will hear from heaven, will forgive their sin, and will heal their land. 
+<sup>15&#160;</sup>Now my eyes will be open and my ears attentive to prayer that is made in this place. 
+<sup>16&#160;</sup>For now I have chosen and made this house set-apart, that my name may be there forever; and my eyes and my heart will be there perpetually. 
+</div><div class="p">
+<sup>17&#160;</sup>“As for you, if you will walk before me as David your father walked, and do according to all that I have commanded you, and will keep my statutes and my ordinances, 
+<sup>18&#160;</sup>then I will establish the throne of your kingdom, according as I covenanted with David your father, saying, ‘There shall not fail you a man to be ruler in Israel.’ 
+</div><div class="p">
+<sup>19&#160;</sup>But if you turn away and forsake my statutes and my commandments which I have set before you, and go and serve other elohims and worship them, 
+<sup>20&#160;</sup>then I will pluck them up by the roots out of my land which I have given them; and this house, which I have made set-apart for my name, I will cast out of my sight, and I will make it a proverb and a byword among all peoples. 
+<sup>21&#160;</sup>This house, which is so high, everyone who passes by it will be astonished and say, ‘Why has Yahweh done this to this land and to this house?’ 
+<sup>22&#160;</sup>They shall answer, ‘Because they abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and took other elohims, worshiped them, and served them. Therefore he has brought all this evil on them.’&#160;” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>At the end of twenty years, in which Solomon had built Yahweh’s house and his own house, 
+<sup>2&#160;</sup>Solomon built the cities which Huram had given to Solomon, and caused the children of Israel to dwell there. 
+</div><div class="p">
+<sup>3&#160;</sup>Solomon went to Hamath Zobah, and prevailed against it. 
+<sup>4&#160;</sup>He built Tadmor in the wilderness, and all the storage cities, which he built in Hamath. 
+<sup>5&#160;</sup>Also he built Beth Horon the upper and Beth Horon the lower, fortified cities with walls, gates, and bars; 
+<sup>6&#160;</sup>and Baalath, and all the storage cities that Solomon had, and all the cities for his chariots, the cities for his horsemen, and all that Solomon desired to build for his pleasure in Jerusalem, in Lebanon, and in all the land of his dominion. 
+</div><div class="p">
+<sup>7&#160;</sup>As for all the people who were left of the Hittites, the Amorites, the Perizzites, the Hivites, and the Jebusites, who were not of Israel—<sup>8&#160;</sup>of their children who were left after them in the land, whom the children of Israel didn’t consume—of them Solomon conscripted forced labor to this day. 
+<sup>9&#160;</sup>But of the children of Israel, Solomon made no servants for his work, but they were men of war, chief of his captains, and rulers of his chariots and of his horsemen. 
+<sup>10&#160;</sup>These were the chief officers of King Solomon, even two-hundred fifty, who ruled over the people. 
+</div><div class="p">
+<sup>11&#160;</sup>Solomon brought up Pharaoh’s daughter out of David’s city to the house that he had built for her; for he said, “My woman shall not dwell in the house of David king of Israel, because the places where Yahweh’s ark has come are set-apart.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then Solomon offered burnt offerings to Yahweh on Yahweh’s altar which he had built before the porch, 
+<sup>13&#160;</sup>even as the duty of every day required, offering according to the commandment of Moses on the Sabbaths, on the new moons, and on the set feasts, three times per year, during the feast of unleavened bread, during the feast of weeks, and during the feast of booths. 
+</div><div class="p">
+<sup>14&#160;</sup>He appointed, according to the ordinance of David his father, the divisions of the priests to their service, and the Levites to their offices, to praise and to minister before the priests, as the duty of every day required, the doorkeepers also by their divisions at every gate, for David the man of Elohim had so commanded. 
+<sup>15&#160;</sup>They didn’t depart from the commandment of the king to the priests and Levites concerning any matter or concerning the treasures. 
+</div><div class="p">
+<sup>16&#160;</sup>Now all the work of Solomon was accomplished from the day of the foundation of Yahweh’s house until it was finished. So Yahweh’s house was completed. 
+</div><div class="p">
+<sup>17&#160;</sup>Then Solomon went to Ezion Geber and to Eloth, on the seashore in the land of Edom. 
+<sup>18&#160;</sup>Huram sent him ships and servants who had knowledge of the sea by the hands of his servants; and they came with the servants of Solomon to Ophir, and brought from there four hundred fifty talents of gold, and brought them to King Solomon. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>When the queen of Sheba heard of the fame of Solomon, she came to test Solomon with hard questions at Jerusalem, with a very great caravan, including camels that bore spices, gold in abundance, and precious stones. When she had come to Solomon, she talked with him about all that was in her heart. 
+<sup>2&#160;</sup>Solomon answered all her questions. There wasn’t anything hidden from Solomon which he didn’t tell her. 
+<sup>3&#160;</sup>When the queen of Sheba had seen the wisdom of Solomon, the house that he had built, 
+<sup>4&#160;</sup>the food of his table, the seating of his servants, the attendance of his ministers, their clothing, his cup bearers and their clothing, and his ascent by which he went up to Yahweh’s house, there was no more spirit in her. 
+</div><div class="p">
+<sup>5&#160;</sup>She said to the king, “It was a true report that I heard in my own land of your acts and of your wisdom. 
+<sup>6&#160;</sup>However I didn’t believe their words until I came, and my eyes had seen it; and behold half of the greatness of your wisdom wasn’t told me. You exceed the fame that I heard! 
+<sup>7&#160;</sup>Happy are your men, and happy are these your servants, who stand continually before you and hear your wisdom. 
+<sup>8&#160;</sup>Blessed be Yahweh your Elohim, who delighted in you and set you on his throne to be king for Yahweh your Elohim, because your Elohim loved Israel, to establish them forever. Therefore he made you king over them, to do justice and righteousness.” 
+</div><div class="p">
+<sup>9&#160;</sup>She gave the king one hundred and twenty talents of gold, spices in great abundance, and precious stones. There was never before such spice as the queen of Sheba gave to King Solomon. 
+</div><div class="p">
+<sup>10&#160;</sup>The servants of Huram and the servants of Solomon, who brought gold from Ophir, also brought algum trees and precious stones. 
+<sup>11&#160;</sup>The king used algum tree wood to make terraces for Yahweh’s house and for the king’s house, and harps and stringed instruments for the singers. There were none like these seen before in the land of Judah. 
+<sup>12&#160;</sup>King Solomon gave to the queen of Sheba all her desire, whatever she asked, more than that which she had brought to the king. So she turned and went to her own land, she and her servants. 
+</div><div class="p">
+<sup>13&#160;</sup>Now the weight of gold that came to Solomon in one year was six hundred sixty-six talents of gold, 
+<sup>14&#160;</sup>in addition to that which the traders and merchants brought. All the kings of Arabia and the governors of the country brought gold and silver to Solomon. 
+<sup>15&#160;</sup>King Solomon made two hundred large shields of beaten gold. Six hundred shekels of beaten gold went to one large shield. 
+<sup>16&#160;</sup>He made three hundred shields of beaten gold. Three hundred shekels of gold went to one shield. The king put them in the House of the Forest of Lebanon. 
+<sup>17&#160;</sup>Moreover the king made a great throne of ivory, and overlaid it with pure gold. 
+<sup>18&#160;</sup>There were six steps to the throne, with a footstool of gold, which were fastened to the throne, and armrests on either side by the place of the seat, and two lions standing beside the armrests. 
+<sup>19&#160;</sup>Twelve lions stood there on the one side and on the other on the six steps. There was nothing like it made in any other kingdom. 
+<sup>20&#160;</sup>All King Solomon’s drinking vessels were of gold, and all the vessels of the House of the Forest of Lebanon were of pure gold. Silver was not considered valuable in the days of Solomon. 
+<sup>21&#160;</sup>For the king had ships that went to Tarshish with Huram’s servants. Once every three years, the ships of Tarshish came bringing gold, silver, ivory, apes, and peacocks. 
+</div><div class="p">
+<sup>22&#160;</sup>So King Solomon exceeded all the kings of the earth in riches and wisdom. 
+<sup>23&#160;</sup>All the kings of the earth sought the presence of Solomon to hear his wisdom, which Elohim had put in his heart. 
+<sup>24&#160;</sup>They each brought tribute: vessels of silver, vessels of gold, clothing, armor, spices, horses, and mules every year. 
+<sup>25&#160;</sup>Solomon had four thousand stalls for horses and chariots, and twelve thousand horsemen that he stationed in the chariot cities and with the king at Jerusalem. 
+<sup>26&#160;</sup>He ruled over all the kings from the River even to the land of the Philistines, and to the border of Egypt. 
+<sup>27&#160;</sup>The king made silver as common in Jerusalem as stones, and he made cedars to be as abundant as the sycamore trees that are in the lowland. 
+<sup>28&#160;</sup>They brought horses for Solomon out of Egypt and out of all lands. 
+</div><div class="p">
+<sup>29&#160;</sup>Now the rest of the acts of Solomon, first and last, aren’t they written in the history of Nathan the prophet, and in the prophecy of Ahijah the Shilonite, and in the visions of Iddo the seer concerning Jeroboam the son of Nebat? 
+<sup>30&#160;</sup>Solomon reigned in Jerusalem over all Israel forty years. 
+<sup>31&#160;</sup>Solomon slept with his fathers, and he was buried in his father David’s city; and Rehoboam his son reigned in his place. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Rehoboam went to Shechem, for all Israel had come to Shechem to make him king. 
+<sup>2&#160;</sup>When Jeroboam the son of Nebat heard of it (for he was in Egypt, where he had fled from the presence of King Solomon), Jeroboam returned out of Egypt. 
+<sup>3&#160;</sup>They sent and called him; and Jeroboam and all Israel came, and they spoke to Rehoboam, saying, 
+<sup>4&#160;</sup>“Your father made our yoke grievous. Now therefore make the grievous service of your father and his heavy yoke which he put on us, lighter, and we will serve you.” 
+</div><div class="p">
+<sup>5&#160;</sup>He said to them, “Come again to me after three days.” 
+</div><div class="p">So the people departed. 
+</div><div class="p">
+<sup>6&#160;</sup>King Rehoboam took counsel with the old men, who had stood before Solomon his father while he yet lived, saying, “What counsel do you give me about how to answer these people?” 
+</div><div class="p">
+<sup>7&#160;</sup>They spoke to him, saying, “If you are kind to these people, please them, and speak good words to them, then they will be your servants forever.” 
+</div><div class="p">
+<sup>8&#160;</sup>But he abandoned the counsel of the old men which they had given him, and took counsel with the young men who had grown up with him, who stood before him. 
+<sup>9&#160;</sup>He said to them, “What counsel do you give, that we may give an answer to these people, who have spoken to me, saying, ‘Make the yoke that your father put on us lighter’?” 
+</div><div class="p">
+<sup>10&#160;</sup>The young men who had grown up with him spoke to him, saying, “Thus you shall tell the people who spoke to you, saying, ‘Your father made our yoke heavy, but make it lighter on us;’ thus you shall say to them, ‘My little finger is thicker than my father’s waist. 
+<sup>11&#160;</sup>Now whereas my father burdened you with a heavy yoke, I will add to your yoke. My father chastised you with whips, but I will chastise you with scorpions.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>So Jeroboam and all the people came to Rehoboam the third day, as the king asked, saying, “Come to me again the third day.” 
+<sup>13&#160;</sup>The king answered them roughly; and King Rehoboam abandoned the counsel of the old men, 
+<sup>14&#160;</sup>and spoke to them after the counsel of the young men, saying, “My father made your yoke heavy, but I will add to it. My father chastised you with whips, but I will chastise you with scorpions.” 
+</div><div class="p">
+<sup>15&#160;</sup>So the king didn’t listen to the people; for it was brought about by Elohim, that Yahweh might establish his word, which he spoke by Ahijah the Shilonite to Jeroboam the son of Nebat. 
+</div><div class="p">
+<sup>16&#160;</sup>When all Israel saw that the king didn’t listen to them, the people answered the king, saying, “What portion do we have in David? We don’t have an inheritance in the son of Jesse! Every man to your tents, Israel! Now see to your own house, David.” So all Israel departed to their tents. 
+</div><div class="p">
+<sup>17&#160;</sup>But as for the children of Israel who lived in the cities of Judah, Rehoboam reigned over them. 
+<sup>18&#160;</sup>Then King Rehoboam sent Hadoram, who was over the men subject to forced labor; and the children of Israel stoned him to death with stones. King Rehoboam hurried to get himself up to his chariot, to flee to Jerusalem. 
+<sup>19&#160;</sup>So Israel rebelled against David’s house to this day. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>When Rehoboam had come to Jerusalem, he assembled the house of Judah and Benjamin, one hundred eighty thousand chosen men who were warriors, to fight against Israel, to bring the kingdom again to Rehoboam. 
+<sup>2&#160;</sup>But Yahweh’s word came to Shemaiah the man of Elohim, saying, 
+<sup>3&#160;</sup>“Speak to Rehoboam the son of Solomon, king of Judah, and to all Israel in Judah and Benjamin, saying, 
+<sup>4&#160;</sup>‘Yahweh says, “You shall not go up, nor fight against your brothers! Every man return to his house; for this thing is of me.”&#160;’&#160;” So they listened to Yahweh’s words, and returned from going against Jeroboam. 
+</div><div class="p">
+<sup>5&#160;</sup>Rehoboam lived in Jerusalem, and built cities for defense in Judah. 
+<sup>6&#160;</sup>He built Bethlehem, Etam, Tekoa, 
+<sup>7&#160;</sup>Beth Zur, Soco, Adullam, 
+<sup>8&#160;</sup>Gath, Mareshah, Ziph, 
+<sup>9&#160;</sup>Adoraim, Lachish, Azekah, 
+<sup>10&#160;</sup>Zorah, Aijalon, and Hebron, which are fortified cities in Judah and in Benjamin. 
+<sup>11&#160;</sup>He fortified the strongholds and put captains in them with stores of food, oil and wine. 
+<sup>12&#160;</sup>He put shields and spears in every city, and made them exceedingly strong. Judah and Benjamin belonged to him. 
+</div><div class="p">
+<sup>13&#160;</sup>The priests and the Levites who were in all Israel stood with him out of all their territory. 
+<sup>14&#160;</sup>For the Levites left their pasture lands and their possessions, and came to Judah and Jerusalem; for Jeroboam and his sons cast them off, that they should not execute the priest’s office to Yahweh. 
+<sup>15&#160;</sup>He himself appointed priests for the high places, for the male goat and calf idols which he had made. 
+<sup>16&#160;</sup>After them, out of all the tribes of Israel, those who set their hearts to seek Yahweh, the Elohim of Israel, came to Jerusalem to sacrifice to Yahweh, the Elohim of their fathers. 
+<sup>17&#160;</sup>So they strengthened the kingdom of Judah and made Rehoboam the son of Solomon strong for three years, for they walked three years in the way of David and Solomon. 
+</div><div class="p">
+<sup>18&#160;</sup>Rehoboam took a woman for himself, Mahalath the daughter of Jerimoth the son of David and of Abihail the daughter of Eliab the son of Jesse. 
+<sup>19&#160;</sup>She bore him sons: Jeush, Shemariah, and Zaham. 
+<sup>20&#160;</sup>After her, he took Maacah the granddaughter of Absalom; and she bore him Abijah, Attai, Ziza, and Shelomith. 
+<sup>21&#160;</sup>Rehoboam loved Maacah the granddaughter of Absalom above all his women and his concubines; for he took eighteen women and sixty concubines, and brought forth twenty-eight sons and sixty daughters. 
+<sup>22&#160;</sup>Rehoboam appointed Abijah the son of Maacah to be chief, the prince among his brothers, for he intended to make him king. 
+<sup>23&#160;</sup>He dealt wisely, and dispersed some of his sons throughout all the lands of Judah and Benjamin, to every fortified city. He gave them food in abundance; and he sought many women for them. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>When the kingdom of Rehoboam was established and he was strong, he abandoned Yahweh’s law, and all Israel with him. 
+<sup>2&#160;</sup>In the fifth year of King Rehoboam, Shishak king of Egypt came up against Jerusalem, because they had trespassed against Yahweh, 
+<sup>3&#160;</sup>with twelve hundred chariots and sixty thousand horsemen. The people were without number who came with him out of Egypt: the Lubim, the Sukkiim, and the Ethiopians. 
+<sup>4&#160;</sup>He took the fortified cities which belonged to Judah, and came to Jerusalem. 
+<sup>5&#160;</sup>Now Shemaiah the prophet came to Rehoboam and to the princes of Judah, who were gathered together to Jerusalem because of Shishak, and said to them, “Yahweh says, ‘You have forsaken me, therefore I have also left you in the hand of Shishak.’&#160;” 
+</div><div class="p">
+<sup>6&#160;</sup>Then the princes of Israel and the king humbled themselves; and they said, “Yahweh is righteous.” 
+</div><div class="p">
+<sup>7&#160;</sup>When Yahweh saw that they humbled themselves, Yahweh’s word came to Shemaiah, saying, “They have humbled themselves. I will not destroy them, but I will grant them some deliverance, and my wrath won’t be poured out on Jerusalem by the hand of Shishak. 
+<sup>8&#160;</sup>Nevertheless they will be his servants, that they may know my service, and the service of the kingdoms of the countries.” 
+</div><div class="p">
+<sup>9&#160;</sup>So Shishak king of Egypt came up against Jerusalem and took away the treasures of Yahweh’s house and the treasures of the king’s house. He took it all away. He also took away the shields of gold which Solomon had made. 
+<sup>10&#160;</sup>King Rehoboam made shields of bronze in their place, and committed them to the hands of the captains of the guard, who kept the door of the king’s house. 
+<sup>11&#160;</sup>As often as the king entered into Yahweh’s house, the guard came and bore them, then brought them back into the guard room. 
+<sup>12&#160;</sup>When he humbled himself, Yahweh’s wrath turned from him, so as not to destroy him altogether. Moreover, there were good things found in Judah. 
+</div><div class="p">
+<sup>13&#160;</sup>So King Rehoboam strengthened himself in Jerusalem and reigned; for Rehoboam was forty-one years old when he began to reign, and he reigned seventeen years in Jerusalem, the city which Yahweh had chosen out of all the tribes of Israel to put his name there. His mother’s name was Naamah the Ammonitess. 
+<sup>14&#160;</sup>He did that which was evil, because he didn’t set his heart to seek Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>Now the acts of Rehoboam, first and last, aren’t they written in the histories of Shemaiah the prophet and of Iddo the seer, in the genealogies? There were wars between Rehoboam and Jeroboam continually. 
+<sup>16&#160;</sup>Rehoboam slept with his fathers, and was buried in David’s city; and Abijah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>In the eighteenth year of King Jeroboam, Abijah began to reign over Judah. 
+<sup>2&#160;</sup>He reigned three years in Jerusalem. His mother’s name was Micaiah the daughter of Uriel of Gibeah. There was war between Abijah and Jeroboam. 
+<sup>3&#160;</sup>Abijah joined battle with an army of valiant men of war, even four hundred thousand chosen men; and Jeroboam set the battle in array against him with eight hundred thousand chosen men, who were mighty men of valor. 
+<sup>4&#160;</sup>Abijah stood up on Mount Zemaraim, which is in the hill country of Ephraim, and said, “Hear me, Jeroboam and all Israel: 
+<sup>5&#160;</sup>Ought you not to know that Yahweh, the Elohim of Israel, gave the kingdom over Israel to David forever, even to him and to his sons by a covenant of salt? 
+<sup>6&#160;</sup>Yet Jeroboam the son of Nebat, the servant of Solomon the son of David, rose up, and rebelled against his lord. 
+<sup>7&#160;</sup>Worthless men were gathered to him, wicked fellows who strengthened themselves against Rehoboam the son of Solomon, when Rehoboam was young and tender hearted, and could not withstand them. 
+</div><div class="p">
+<sup>8&#160;</sup>“Now you intend to withstand the kingdom of Yahweh in the hand of the sons of David. You are a great multitude, and the golden calves which Jeroboam made you for elohims are with you. 
+<sup>9&#160;</sup>Haven’t you driven out the priests of Yahweh, the sons of Aaron, and the Levites, and made priests for yourselves according to the ways of the peoples of other lands? Whoever comes to consecrate himself with a young bull and seven rams may be a priest of those who are no elohims. 
+</div><div class="p">
+<sup>10&#160;</sup>“But as for us, Yahweh is our Elohim, and we have not forsaken him. We have priests serving Yahweh, the sons of Aaron, and the Levites in their work. 
+<sup>11&#160;</sup>They burn to Yahweh every morning and every evening burnt offerings and sweet incense. They also set the show bread in order on the pure table, and care for the gold lamp stand with its lamps, to burn every evening; for we keep the instruction of Yahweh our Elohim, but you have forsaken him. 
+<sup>12&#160;</sup>Behold, Elohim is with us at our head, and his priests with the trumpets of alarm to sound an alarm against you. Children of Israel, don’t fight against Yahweh, the Elohim of your fathers; for you will not prosper.” 
+</div><div class="p">
+<sup>13&#160;</sup>But Jeroboam caused an ambush to come about behind them; so they were before Judah, and the ambush was behind them. 
+<sup>14&#160;</sup>When Judah looked back, behold, the battle was before and behind them; and they cried to Yahweh, and the priests sounded with the trumpets. 
+<sup>15&#160;</sup>Then the men of Judah gave a shout. As the men of Judah shouted, Elohim struck Jeroboam and all Israel before Abijah and Judah. 
+<sup>16&#160;</sup>The children of Israel fled before Judah, and Elohim delivered them into their hand. 
+<sup>17&#160;</sup>Abijah and his people killed them with a great slaughter, so five hundred thousand chosen men of Israel fell down slain. 
+<sup>18&#160;</sup>Thus the children of Israel were brought under at that time, and the children of Judah prevailed, because they relied on Yahweh, the Elohim of their fathers. 
+<sup>19&#160;</sup>Abijah pursued Jeroboam, and took cities from him: Bethel with its villages, Jeshanah with its villages, and Ephron with its villages. 
+</div><div class="p">
+<sup>20&#160;</sup>Jeroboam didn’t recover strength again in the days of Abijah. Yahweh struck him, and he died. 
+<sup>21&#160;</sup>But Abijah grew mighty and took for himself fourteen women, and brought forth twenty-two sons and sixteen daughters. 
+<sup>22&#160;</sup>The rest of the acts of Abijah, his ways, and his sayings are written in the commentary of the prophet Iddo. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>So Abijah slept with his fathers, and they buried him in David’s city; and Asa his son reigned in his place. In his days, the land was quiet ten years. 
+<sup>2&#160;</sup>Asa did that which was good and right in Yahweh his Elohim’s eyes, 
+<sup>3&#160;</sup>for he took away the foreign altars and the high places, broke down the pillars, cut down the Asherah poles, 
+<sup>4&#160;</sup>and commanded Judah to seek Yahweh, the Elohim of their fathers, and to obey his law and command. 
+<sup>5&#160;</sup>Also he took away out of all the cities of Judah the high places and the sun images; and the kingdom was quiet before him. 
+<sup>6&#160;</sup>He built fortified cities in Judah; for the land was quiet, and he had no war in those years, because Yahweh had given him rest. 
+<sup>7&#160;</sup>For he said to Judah, “Let’s build these cities and make walls around them, with towers, gates, and bars. The land is yet before us, because we have sought Yahweh our Elohim. We have sought him, and he has given us rest on every side.” So they built and prospered. 
+</div><div class="p">
+<sup>8&#160;</sup>Asa had an army of three hundred thousand out of Judah who bore bucklers and spears, and two hundred eighty thousand out of Benjamin who bore shields and drew bows. All these were mighty men of valor. 
+</div><div class="p">
+<sup>9&#160;</sup>Zerah the Ethiopian came out against them with an army of a million troops and three hundred chariots, and he came to Mareshah. 
+<sup>10&#160;</sup>Then Asa went out to meet him, and they set the battle in array in the valley of Zephathah at Mareshah. 
+<sup>11&#160;</sup>Asa cried to Yahweh his Elohim, and said, “Yahweh, there is no one besides you to help, between the mighty and him who has no strength. Help us, Yahweh our Elohim; for we rely on you, and in your name are we come against this multitude. Yahweh, you are our Elohim. Don’t let man prevail against you.” 
+</div><div class="p">
+<sup>12&#160;</sup>So Yahweh struck the Ethiopians before Asa and before Judah; and the Ethiopians fled. 
+<sup>13&#160;</sup>Asa and the people who were with him pursued them to Gerar. So many of the Ethiopians fell that they could not recover themselves, for they were destroyed before Yahweh and before his army. Judah’s army carried away very much booty. 
+<sup>14&#160;</sup>They struck all the cities around Gerar, for the fear of Yahweh came on them. They plundered all the cities, for there was much plunder in them. 
+<sup>15&#160;</sup>They also struck the tents of those who had livestock, and carried away sheep and camels in abundance, then returned to Jerusalem. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>The Spirit of Elohim came on Azariah the son of Oded. 
+<sup>2&#160;</sup>He went out to meet Asa, and said to him, “Hear me, Asa, and all Judah and Benjamin! Yahweh is with you while you are with him; and if you seek him, he will be found by you; but if you forsake him, he will forsake you. 
+<sup>3&#160;</sup>Now for a long time Israel was without the true Elohim, without a teaching priest, and without law. 
+<sup>4&#160;</sup>But when in their distress they turned to Yahweh, the Elohim of Israel, and sought him, he was found by them. 
+<sup>5&#160;</sup>In those times there was no peace to him who went out, nor to him who came in; but great troubles were on all the inhabitants of the lands. 
+<sup>6&#160;</sup>They were broken in pieces, nation against nation, and city against city; for Elohim troubled them with all adversity. 
+<sup>7&#160;</sup>But you be strong! Don’t let your hands be slack, for your work will be rewarded.” 
+</div><div class="p">
+<sup>8&#160;</sup>When Asa heard these words and the prophecy of Oded the prophet, he took courage, and put away the abominations out of all the land of Judah and Benjamin, and out of the cities which he had taken from the hill country of Ephraim; and he renewed Yahweh’s altar that was before Yahweh’s porch. 
+<sup>9&#160;</sup>He gathered all Judah and Benjamin, and those who lived with them out of Ephraim, Manasseh, and Simeon; for they came to him out of Israel in abundance when they saw that Yahweh his Elohim was with him. 
+<sup>10&#160;</sup>So they gathered themselves together at Jerusalem in the third month, in the fifteenth year of Asa’s reign. 
+<sup>11&#160;</sup>They sacrificed to Yahweh in that day, of the plunder which they had brought, seven hundred head of cattle and seven thousand sheep. 
+<sup>12&#160;</sup>They entered into the covenant to seek Yahweh, the Elohim of their fathers, with all their heart and with all their soul; 
+<sup>13&#160;</sup>and that whoever would not seek Yahweh, the Elohim of Israel, should be put to death, whether small or great, whether man or woman. 
+<sup>14&#160;</sup>They swore to Yahweh with a loud voice, with shouting, with trumpets, and with cornets. 
+<sup>15&#160;</sup>All Judah rejoiced at the oath, for they had sworn with all their heart and sought him with their whole desire; and he was found by them. Then Yahweh gave them rest all around. 
+</div><div class="p">
+<sup>16&#160;</sup>Also Maacah, the mother of Asa the king, he removed from being queen mother, because she had made an abominable image for an Asherah; so Asa cut down her image, ground it into dust, and burned it at the brook Kidron. 
+<sup>17&#160;</sup>But the high places were not taken away out of Israel; nevertheless the heart of Asa was perfect all his days. 
+<sup>18&#160;</sup>He brought the things that his father had dedicated and that he himself had dedicated, silver, gold, and vessels into Elohim’s house. 
+<sup>19&#160;</sup>There was no more war to the thirty-fifth year of Asa’s reign. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>In the thirty-sixth year of Asa’s reign, Baasha king of Israel went up against Judah, and built Ramah, that he might not allow anyone to go out or come in to Asa king of Judah. 
+<sup>2&#160;</sup>Then Asa brought out silver and gold out of the treasures of Yahweh’s house and of the king’s house, and sent to Ben Hadad king of Syria, who lived at Damascus, saying, 
+<sup>3&#160;</sup>“Let there be a treaty between me and you, as there was between my father and your father. Behold, I have sent you silver and gold. Go, break your treaty with Baasha king of Israel, that he may depart from me.” 
+</div><div class="p">
+<sup>4&#160;</sup>Ben Hadad listened to King Asa, and sent the captains of his armies against the cities of Israel; and they struck Ijon, Dan, Abel Maim, and all the storage cities of Naphtali. 
+<sup>5&#160;</sup>When Baasha heard of it, he stopped building Ramah, and let his work cease. 
+<sup>6&#160;</sup>Then Asa the king took all Judah, and they carried away the stones and timber of Ramah, with which Baasha had built; and he built Geba and Mizpah with them. 
+</div><div class="p">
+<sup>7&#160;</sup>At that time Hanani the seer came to Asa king of Judah, and said to him, “Because you have relied on the king of Syria, and have not relied on Yahweh your Elohim, therefore the army of the king of Syria has escaped out of your hand. 
+<sup>8&#160;</sup>Weren’t the Ethiopians and the Lubim a huge army, with chariots and exceedingly many horsemen? Yet, because you relied on Yahweh, he delivered them into your hand. 
+<sup>9&#160;</sup>For Yahweh’s eyes run back and forth throughout the whole earth, to show himself strong in the behalf of them whose heart is perfect toward him. You have done foolishly in this; for from now on you will have wars.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Asa was angry with the seer, and put him in the prison; for he was in a rage with him because of this thing. Asa oppressed some of the people at the same time. 
+</div><div class="p">
+<sup>11&#160;</sup>Behold, the acts of Asa, first and last, behold, they are written in the book of the kings of Judah and Israel. 
+<sup>12&#160;</sup>In the thirty-ninth year of his reign, Asa was diseased in his feet. His disease was exceedingly great; yet in his disease he didn’t seek Yahweh, but just the physicians. 
+<sup>13&#160;</sup>Asa slept with his fathers, and died in the forty-first year of his reign. 
+<sup>14&#160;</sup>They buried him in his own tomb, which he had dug out for himself in David’s city, and laid him in the bed which was filled with sweet odors and various kinds of spices prepared by the perfumers’ art; and they made a very great fire for him. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Jehoshaphat his son reigned in his place, and strengthened himself against Israel. 
+<sup>2&#160;</sup>He placed forces in all the fortified cities of Judah, and set garrisons in the land of Judah and in the cities of Ephraim, which Asa his father had taken. 
+<sup>3&#160;</sup>Yahweh was with Jehoshaphat, because he walked in the first ways of his father David, and didn’t seek the Baals, 
+<sup>4&#160;</sup>but sought the Elohim of his father, and walked in his commandments, and not in the ways of Israel. 
+<sup>5&#160;</sup>Therefore Yahweh established the kingdom in his hand. All Judah brought tribute to Jehoshaphat, and he had riches and honor in abundance. 
+<sup>6&#160;</sup>His heart was lifted up in the ways of Yahweh. Furthermore, he took away the high places and the Asherah poles out of Judah. 
+</div><div class="p">
+<sup>7&#160;</sup>Also in the third year of his reign he sent his princes, even Ben Hail, Obadiah, Zechariah, Nethanel, and Micaiah, to teach in the cities of Judah; 
+<sup>8&#160;</sup>and with them Levites, even Shemaiah, Nethaniah, Zebadiah, Asahel, Shemiramoth, Jehonathan, Adonijah, Tobijah, and Tobadonijah, the Levites; and with them Elishama and Jehoram, the priests. 
+<sup>9&#160;</sup>They taught in Judah, having the book of Yahweh’s law with them. They went about throughout all the cities of Judah and taught among the people. 
+</div><div class="p">
+<sup>10&#160;</sup>The fear of Yahweh fell on all the kingdoms of the lands that were around Judah, so that they made no war against Jehoshaphat. 
+<sup>11&#160;</sup>Some of the Philistines brought Jehoshaphat presents and silver for tribute. The Arabians also brought him flocks: seven thousand seven hundred rams and seven thousand seven hundred male goats. 
+<sup>12&#160;</sup>Jehoshaphat grew great exceedingly; and he built fortresses and store cities in Judah. 
+<sup>13&#160;</sup>He had many works in the cities of Judah; and men of war, mighty men of valor, in Jerusalem. 
+<sup>14&#160;</sup>This was the numbering of them according to their fathers’ houses: From Judah, the captains of thousands: Adnah the captain, and with him three hundred thousand mighty men of valor; 
+<sup>15&#160;</sup>and next to him Jehohanan the captain, and with him two hundred eighty thousand; 
+<sup>16&#160;</sup>and next to him Amasiah the son of Zichri, who willingly offered himself to Yahweh, and with him two hundred thousand mighty men of valor. 
+<sup>17&#160;</sup>From Benjamin: Eliada, a mighty man of valor, and with him two hundred thousand armed with bow and shield; 
+<sup>18&#160;</sup>and next to him Jehozabad, and with him one hundred eighty thousand ready and prepared for war. 
+<sup>19&#160;</sup>These were those who waited on the king, in addition to those whom the king put in the fortified cities throughout all Judah. 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Jehoshaphat had riches and honor in abundance; and he allied himself with Ahab. 
+<sup>2&#160;</sup>After some years, he went down to Ahab to Samaria. Ahab killed sheep and cattle for him in abundance, and for the people who were with him, and moved him to go up with him to Ramoth Gilead. 
+<sup>3&#160;</sup>Ahab king of Israel said to Jehoshaphat king of Judah, “Will you go with me to Ramoth Gilead?” 
+</div><div class="p">He answered him, “I am as you are, and my people as your people. We will be with you in the war.” 
+<sup>4&#160;</sup>Jehoshaphat said to the king of Israel, “Please inquire first for Yahweh’s word.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then the king of Israel gathered the prophets together, four hundred men, and said to them, “Shall we go to Ramoth Gilead to battle, or shall I forbear?” 
+</div><div class="p">They said, “Go up, for Elohim will deliver it into the hand of the king.” 
+</div><div class="p">
+<sup>6&#160;</sup>But Jehoshaphat said, “Isn’t there here a prophet of Yahweh besides, that we may inquire of him?” 
+</div><div class="p">
+<sup>7&#160;</sup>The king of Israel said to Jehoshaphat, “There is yet one man by whom we may inquire of Yahweh; but I hate him, for he never prophesies good concerning me, but always evil. He is Micaiah the son of Imla.” 
+</div><div class="p">Jehoshaphat said, “Don’t let the king say so.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then the king of Israel called an officer, and said, “Get Micaiah the son of Imla quickly.” 
+</div><div class="p">
+<sup>9&#160;</sup>Now the king of Israel and Jehoshaphat the king of Judah each sat on his throne, arrayed in their robes, and they were sitting in an open place at the entrance of the gate of Samaria; and all the prophets were prophesying before them. 
+<sup>10&#160;</sup>Zedekiah the son of Chenaanah made himself horns of iron and said, “Yahweh says, ‘With these you shall push the Syrians, until they are consumed.’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>All the prophets prophesied so, saying, “Go up to Ramoth Gilead, and prosper; for Yahweh will deliver it into the hand of the king.” 
+</div><div class="p">
+<sup>12&#160;</sup>The messenger who went to call Micaiah spoke to him, saying, “Behold, the words of the prophets declare good to the king with one mouth. Let your word therefore, please be like one of theirs, and speak good.” 
+</div><div class="p">
+<sup>13&#160;</sup>Micaiah said, “As Yahweh lives, I will say what my Elohim says.” 
+</div><div class="p">
+<sup>14&#160;</sup>When he had come to the king, the king said to him, “Micaiah, shall we go to Ramoth Gilead to battle, or shall I forbear?” 
+</div><div class="p">He said, “Go up, and prosper. They shall be delivered into your hand.” 
+</div><div class="p">
+<sup>15&#160;</sup>The king said to him, “How many times shall I adjure you that you speak to me nothing but the truth in Yahweh’s name?” 
+</div><div class="p">
+<sup>16&#160;</sup>He said, “I saw all Israel scattered on the mountains, as sheep that have no shepherd. Yahweh said, ‘These have no master. Let them each return to his house in peace.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>The king of Israel said to Jehoshaphat, “Didn’t I tell you that he would not prophesy good concerning me, but evil?” 
+</div><div class="p">
+<sup>18&#160;</sup>Micaiah said, “Therefore hear Yahweh’s word: I saw Yahweh sitting on his throne, and all the army of heaven standing on his right hand and on his left. 
+<sup>19&#160;</sup>Yahweh said, ‘Who will entice Ahab king of Israel, that he may go up and fall at Ramoth Gilead?’ One spoke saying in this way, and another saying in that way. 
+<sup>20&#160;</sup>A spirit came out, stood before Yahweh, and said, ‘I will entice him.’ 
+</div><div class="p">“Yahweh said to him, ‘How?’ 
+</div><div class="p">
+<sup>21&#160;</sup>“He said, ‘I will go, and will be a lying spirit in the mouth of all his prophets.’ 
+</div><div class="p">“He said, ‘You will entice him, and will prevail also. Go and do so.’ 
+</div><div class="p">
+<sup>22&#160;</sup>“Now therefore, behold, Yahweh has put a lying spirit in the mouth of these your prophets; and Yahweh has spoken evil concerning you.” 
+</div><div class="p">
+<sup>23&#160;</sup>Then Zedekiah the son of Chenaanah came near, and struck Micaiah on the cheek, and said, “Which way did Yahweh’s Spirit go from me to speak to you?” 
+</div><div class="p">
+<sup>24&#160;</sup>Micaiah said, “Behold, you shall see on that day, when you go into an inner room to hide yourself.” 
+</div><div class="p">
+<sup>25&#160;</sup>The king of Israel said, “Take Micaiah, and carry him back to Amon the governor of the city, and to Joash the king’s son; 
+<sup>26&#160;</sup>and say, ‘The king says, “Put this fellow in the prison, and feed him with bread of affliction and with water of affliction, until I return in peace.”&#160;’&#160;” 
+</div><div class="p">
+<sup>27&#160;</sup>Micaiah said, “If you return at all in peace, Yahweh has not spoken by me.” He said, “Listen, you people, all of you!” 
+</div><div class="p">
+<sup>28&#160;</sup>So the king of Israel and Jehoshaphat the king of Judah went up to Ramoth Gilead. 
+<sup>29&#160;</sup>The king of Israel said to Jehoshaphat, “I will disguise myself, and go into the battle; but you put on your robes.” So the king of Israel disguised himself; and they went into the battle. 
+<sup>30&#160;</sup>Now the king of Syria had commanded the captains of his chariots, saying, “Don’t fight with small nor great, except only with the king of Israel.” 
+</div><div class="p">
+<sup>31&#160;</sup>When the captains of the chariots saw Jehoshaphat, they said, “It is the king of Israel!” Therefore they turned around to fight against him. But Jehoshaphat cried out, and Yahweh helped him; and Elohim moved them to depart from him. 
+<sup>32&#160;</sup>When the captains of the chariots saw that it was not the king of Israel, they turned back from pursuing him. 
+<sup>33&#160;</sup>A certain man drew his bow at random, and struck the king of Israel between the joints of the armor. Therefore he said to the driver of the chariot, “Turn around and carry me out of the battle, for I am severely wounded.” 
+<sup>34&#160;</sup>The battle increased that day. However, the king of Israel propped himself up in his chariot against the Syrians until the evening; and at about sunset, he died. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Jehoshaphat the king of Judah returned to his house in peace to Jerusalem. 
+<sup>2&#160;</sup>Jehu the son of Hanani the seer went out to meet him, and said to King Jehoshaphat, “Should you help the wicked, and love those who hate Yahweh? Because of this, wrath is on you from before Yahweh. 
+<sup>3&#160;</sup>Nevertheless there are good things found in you, in that you have put away the Asheroth out of the land, and have set your heart to seek Elohim.” 
+</div><div class="p">
+<sup>4&#160;</sup>Jehoshaphat lived at Jerusalem; and he went out again among the people from Beersheba to the hill country of Ephraim, and brought them back to Yahweh, the Elohim of their fathers. 
+<sup>5&#160;</sup>He set judges in the land throughout all the fortified cities of Judah, city by city, 
+<sup>6&#160;</sup>and said to the judges, “Consider what you do, for you don’t judge for man, but for Yahweh; and he is with you in the judgment. 
+<sup>7&#160;</sup>Now therefore let the fear of Yahweh be on you. Take heed and do it; for there is no iniquity with Yahweh our Elohim, nor respect of persons, nor taking of bribes.” 
+</div><div class="p">
+<sup>8&#160;</sup>Moreover in Jerusalem Jehoshaphat appointed certain Levites, priests, and heads of the fathers’ households of Israel to give judgment for Yahweh and for controversies. They returned to Jerusalem. 
+<sup>9&#160;</sup>He commanded them, saying, “You shall do this in the fear of Yahweh, faithfully, and with a perfect heart. 
+<sup>10&#160;</sup>Whenever any controversy comes to you from your brothers who dwell in their cities, between blood and blood, between law and commandment, statutes and ordinances, you must warn them, that they not be guilty toward Yahweh, and so wrath come on you and on your brothers. Do this, and you will not be guilty. 
+<sup>11&#160;</sup>Behold, Amariah the chief priest is over you in all matters of Yahweh; and Zebadiah the son of Ishmael, the ruler of the house of Judah, in all the king’s matters. Also the Levites shall be officers before you. Deal courageously, and may Yahweh be with the good.” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, the children of Moab, the children of Ammon, and with them some of the Ammonites, came against Jehoshaphat to battle. 
+<sup>2&#160;</sup>Then some came who told Jehoshaphat, saying, “A great multitude is coming against you from beyond the sea from Syria. Behold, they are in Hazazon Tamar” (that is, En Gedi). 
+<sup>3&#160;</sup>Jehoshaphat was alarmed, and set himself to seek to Yahweh. He proclaimed a fast throughout all Judah. 
+<sup>4&#160;</sup>Judah gathered themselves together to seek help from Yahweh. They came out of all the cities of Judah to seek Yahweh. 
+</div><div class="p">
+<sup>5&#160;</sup>Jehoshaphat stood in the assembly of Judah and Jerusalem, in Yahweh’s house, before the new court; 
+<sup>6&#160;</sup>and he said, “Yahweh, the Elohim of our fathers, aren’t you Elohim in heaven? Aren’t you ruler over all the kingdoms of the nations? Power and might are in your hand, so that no one is able to withstand you. 
+<sup>7&#160;</sup>Didn’t you, our Elohim, drive out the inhabitants of this land before your people Israel, and give it to the offspring of Abraham your friend forever? 
+<sup>8&#160;</sup>They lived in it, and have built you a sanctuary in it for your name, saying, 
+<sup>9&#160;</sup>‘If evil comes on us—the sword, judgment, pestilence, or famine—we will stand before this house, and before you (for your name is in this house), and cry to you in our affliction, and you will hear and save.’ 
+<sup>10&#160;</sup>Now, behold, the children of Ammon and Moab and Mount Seir, whom you would not let Israel invade when they came out of the land of Egypt, but they turned away from them, and didn’t destroy them; 
+<sup>11&#160;</sup>behold, how they reward us, to come to cast us out of your possession, which you have given us to inherit. 
+<sup>12&#160;</sup>Our Elohim, will you not judge them? For we have no might against this great company that comes against us. We don’t know what to do, but our eyes are on you.” 
+</div><div class="p">
+<sup>13&#160;</sup>All Judah stood before Yahweh, with their little ones, their women, and their children. 
+</div><div class="p">
+<sup>14&#160;</sup>Then Yahweh’s Spirit came on Jahaziel the son of Zechariah, the son of Benaiah, the son of Jeiel, the son of Mattaniah, the Levite, of the sons of Asaph, in the middle of the assembly; 
+<sup>15&#160;</sup>and he said, “Listen, all Judah, and you inhabitants of Jerusalem, and you, King Jehoshaphat. Yahweh says to you, ‘Don’t be afraid, and don’t be dismayed because of this great multitude; for the battle is not yours, but Elohim’s. 
+<sup>16&#160;</sup>Tomorrow, go down against them. Behold, they are coming up by the ascent of Ziz. You will find them at the end of the valley, before the wilderness of Jeruel. 
+<sup>17&#160;</sup>You will not need to fight this battle. Set yourselves, stand still, and see the salvation of Yahweh with you, O Judah and Jerusalem. Don’t be afraid, nor be dismayed. Go out against them tomorrow, for Yahweh is with you.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Jehoshaphat bowed his head with his face to the ground; and all Judah and the inhabitants of Jerusalem fell down before Yahweh, worshiping Yahweh. 
+<sup>19&#160;</sup>The Levites, of the children of the Kohathites and of the children of the Korahites, stood up to praise Yahweh, the Elohim of Israel, with an exceedingly loud voice. 
+</div><div class="p">
+<sup>20&#160;</sup>They rose early in the morning and went out into the wilderness of Tekoa. As they went out, Jehoshaphat stood and said, “Listen to me, Judah and you inhabitants of Jerusalem! Believe in Yahweh your Elohim, so you will be established! Believe his prophets, so you will prosper.” 
+</div><div class="p">
+<sup>21&#160;</sup>When he had taken counsel with the people, he appointed those who were to sing to Yahweh and give praise in set-apart array as they go out before the army, and say, “Give thanks to Yahweh, for his loving kindness endures forever.” 
+<sup>22&#160;</sup>When they began to sing and to praise, Yahweh set ambushers against the children of Ammon, Moab, and Mount Seir, who had come against Judah; and they were struck. 
+<sup>23&#160;</sup>For the children of Ammon and Moab stood up against the inhabitants of Mount Seir to utterly kill and destroy them. When they had finished the inhabitants of Seir, everyone helped to destroy each other. 
+</div><div class="p">
+<sup>24&#160;</sup>When Judah came to the place overlooking the wilderness, they looked at the multitude; and behold, they were dead bodies fallen to the earth, and there were none who escaped. 
+<sup>25&#160;</sup>When Jehoshaphat and his people came to take their plunder, they found among them in abundance both riches and dead bodies with precious jewels, which they stripped off for themselves, more than they could carry away. They took plunder for three days, it was so much. 
+<sup>26&#160;</sup>On the fourth day, they assembled themselves in Beracah Valley, for there they blessed Yahweh. Therefore the name of that place was called “Beracah Valley” to this day. 
+<sup>27&#160;</sup>Then they returned, every man of Judah and Jerusalem, with Jehoshaphat in front of them, to go again to Jerusalem with joy; for Yahweh had made them to rejoice over their enemies. 
+<sup>28&#160;</sup>They came to Jerusalem with stringed instruments, harps, and trumpets to Yahweh’s house. 
+<sup>29&#160;</sup>The fear of Elohim was on all the kingdoms of the countries when they heard that Yahweh fought against the enemies of Israel. 
+<sup>30&#160;</sup>So the realm of Jehoshaphat was quiet, for his Elohim gave him rest all around. 
+</div><div class="p">
+<sup>31&#160;</sup>So Jehoshaphat reigned over Judah. He was thirty-five years old when he began to reign. He reigned twenty-five years in Jerusalem. His mother’s name was Azubah the daughter of Shilhi. 
+<sup>32&#160;</sup>He walked in the way of Asa his father, and didn’t turn away from it, doing that which was right in Yahweh’s eyes. 
+<sup>33&#160;</sup>However the high places were not taken away, and the people had still not set their hearts on the Elohim of their fathers. 
+</div><div class="p">
+<sup>34&#160;</sup>Now the rest of the acts of Jehoshaphat, first and last, behold, they are written in the history of Jehu the son of Hanani, which is included in the book of the kings of Israel. 
+</div><div class="p">
+<sup>35&#160;</sup>After this, Jehoshaphat king of Judah joined himself with Ahaziah king of Israel. The same did very wickedly. 
+<sup>36&#160;</sup>He joined himself with him to make ships to go to Tarshish. They made the ships in Ezion Geber. 
+<sup>37&#160;</sup>Then Eliezer the son of Dodavahu of Mareshah prophesied against Jehoshaphat, saying, “Because you have joined yourself with Ahaziah, Yahweh has destroyed your works.” The ships were wrecked, so that they were not able to go to Tarshish. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Jehoshaphat slept with his fathers, and was buried with his fathers in David’s city; and Jehoram his son reigned in his place. 
+<sup>2&#160;</sup>He had brothers, the sons of Jehoshaphat: Azariah, Jehiel, Zechariah, Azariah, Michael, and Shephatiah. All these were the sons of Jehoshaphat king of Israel. 
+<sup>3&#160;</sup>Their father gave them great gifts of silver, of gold, and of precious things, with fortified cities in Judah; but he gave the kingdom to Jehoram, because he was the firstborn. 
+<sup>4&#160;</sup>Now when Jehoram had risen up over the kingdom of his father, and had strengthened himself, he killed all his brothers with the sword, and also some of the princes of Israel. 
+<sup>5&#160;</sup>Jehoram was thirty-two years old when he began to reign, and he reigned eight years in Jerusalem. 
+<sup>6&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he had Ahab’s daughter as his woman. He did that which was evil in Yahweh’s sight. 
+<sup>7&#160;</sup>However Yahweh would not destroy David’s house, because of the covenant that he had made with David, and as he promised to give a lamp to him and to his children always. 
+</div><div class="p">
+<sup>8&#160;</sup>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
+<sup>9&#160;</sup>Then Jehoram went there with his captains and all his chariots with him. He rose up by night and struck the Edomites who surrounded him, along with the captains of the chariots. 
+<sup>10&#160;</sup>So Edom has been in revolt from under the hand of Judah to this day. Then Libnah revolted at the same time from under his hand, because he had forsaken Yahweh, the Elohim of his fathers. 
+</div><div class="p">
+<sup>11&#160;</sup>Moreover he made high places in the mountains of Judah, and made the inhabitants of Jerusalem play the prostitute, and led Judah astray. 
+<sup>12&#160;</sup>A letter came to him from Elijah the prophet, saying, “Yahweh, the Elohim of David your father, says, ‘Because you have not walked in the ways of Jehoshaphat your father, nor in the ways of Asa king of Judah, 
+<sup>13&#160;</sup>but have walked in the way of the kings of Israel, and have made Judah and the inhabitants of Jerusalem to play the prostitute like Ahab’s house did, and also have slain your brothers of your father’s house, who were better than yourself, 
+<sup>14&#160;</sup>behold, Yahweh will strike your people with a great plague, including your children, your women, and all your possessions; 
+<sup>15&#160;</sup>and you will have great sickness with a disease of your bowels, until your bowels fall out by reason of the sickness, day by day.’&#160;” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh stirred up against Jehoram the spirit of the Philistines and of the Arabians who are beside the Ethiopians; 
+<sup>17&#160;</sup>and they came up against Judah, broke into it, and carried away all the possessions that were found in the king’s house, including his sons and his women, so that there was no son left to him except Jehoahaz, the youngest of his sons. 
+</div><div class="p">
+<sup>18&#160;</sup>After all this Yahweh struck him in his bowels with an incurable disease. 
+<sup>19&#160;</sup>In process of time, at the end of two years, his bowels fell out by reason of his sickness, and he died of severe diseases. His people made no burning for him, like the burning of his fathers. 
+<sup>20&#160;</sup>He was thirty-two years old when he began to reign, and he reigned in Jerusalem eight years. He departed with no one’s regret. They buried him in David’s city, but not in the tombs of the kings. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>The inhabitants of Jerusalem made Ahaziah his youngest son king in his place, because the band of men who came with the Arabians to the camp had slain all the oldest. So Ahaziah the son of Jehoram king of Judah reigned. 
+<sup>2&#160;</sup>Ahaziah was forty-two years old when he began to reign, and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri. 
+<sup>3&#160;</sup>He also walked in the ways of Ahab’s house, because his mother was his counselor in acting wickedly. 
+<sup>4&#160;</sup>He did that which was evil in Yahweh’s sight, as did Ahab’s house, for they were his counselors after the death of his father, to his destruction. 
+<sup>5&#160;</sup>He also followed their counsel, and went with Jehoram the son of Ahab king of Israel to war against Hazael king of Syria at Ramoth Gilead; and the Syrians wounded Joram. 
+<sup>6&#160;</sup>He returned to be healed in Jezreel of the wounds which they had given him at Ramah, when he fought against Hazael king of Syria. Azariah the son of Jehoram, king of Judah, went down to see Jehoram the son of Ahab in Jezreel, because he was sick. 
+</div><div class="p">
+<sup>7&#160;</sup>Now the destruction of Ahaziah was of Elohim, in that he went to Joram; for when he had come, he went out with Jehoram against Jehu the son of Nimshi, whom Yahweh had anointed to cut off Ahab’s house. 
+<sup>8&#160;</sup>When Jehu was executing judgment on Ahab’s house, he found the princes of Judah and the sons of the brothers of Ahaziah serving Ahaziah, and killed them. 
+<sup>9&#160;</sup>He sought Ahaziah, and they caught him (now he was hiding in Samaria), and they brought him to Jehu and killed him; and they buried him, for they said, “He is the son of Jehoshaphat, who sought Yahweh with all his heart.” The house of Ahaziah had no power to hold the kingdom. 
+</div><div class="p">
+<sup>10&#160;</sup>Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring of the house of Judah. 
+<sup>11&#160;</sup>But Jehoshabeath, the king’s daughter, took Joash the son of Ahaziah, and stealthily rescued him from among the king’s sons who were slain, and put him and his nurse in the bedroom. So Jehoshabeath, the daughter of King Jehoram, the woman of Jehoiada the priest (for she was the sister of Ahaziah), hid him from Athaliah, so that she didn’t kill him. 
+<sup>12&#160;</sup>He was with them hidden in Elohim’s house six years while Athaliah reigned over the land. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>In the seventh year, Jehoiada strengthened himself, and took the captains of hundreds—Azariah the son of Jeroham, Ishmael the son of Jehohanan, Azariah the son of Obed, Maaseiah the son of Adaiah, and Elishaphat the son of Zichri—into a covenant with him. 
+<sup>2&#160;</sup>They went around in Judah and gathered the Levites out of all the cities of Judah, and the heads of fathers’ households of Israel, and they came to Jerusalem. 
+<sup>3&#160;</sup>All the assembly made a covenant with the king in Elohim’s house. Jehoiada said to them, “Behold, the king’s son must reign, as Yahweh has spoken concerning the sons of David. 
+<sup>4&#160;</sup>This is the thing that you must do: a third part of you, who come in on the Sabbath, of the priests and of the Levites, shall be gatekeepers of the thresholds. 
+<sup>5&#160;</sup>A third part shall be at the king’s house; and a third part at the gate of the foundation. All the people will be in the courts of Yahweh’s house. 
+<sup>6&#160;</sup>But let no one come into Yahweh’s house except the priests and those who minister of the Levites. They shall come in, for they are set-apart, but all the people shall follow Yahweh’s instructions. 
+<sup>7&#160;</sup>The Levites shall surround the king, every man with his weapons in his hand. Whoever comes into the house, let him be slain. Be with the king when he comes in and when he goes out.” 
+</div><div class="p">
+<sup>8&#160;</sup>So the Levites and all Judah did according to all that Jehoiada the priest commanded. They each took his men, those who were to come in on the Sabbath, with those who were to go out on the Sabbath, for Jehoiada the priest didn’t dismiss the shift. 
+<sup>9&#160;</sup>Jehoiada the priest delivered to the captains of hundreds the spears, bucklers, and shields that had been king David’s, which were in Elohim’s house. 
+<sup>10&#160;</sup>He set all the people, every man with his weapon in his hand, from the right side of the house to the left side of the house, near the altar and the house, around the king. 
+<sup>11&#160;</sup>Then they brought out the king’s son, put the crown on him, gave him the covenant, and made him king. Jehoiada and his sons anointed him, and they said, “Long live the king!” 
+</div><div class="p">
+<sup>12&#160;</sup>When Athaliah heard the noise of the people running and praising the king, she came to the people into Yahweh’s house. 
+<sup>13&#160;</sup>Then she looked, and behold, the king stood by his pillar at the entrance, with the captains and the trumpeters by the king. All the people of the land rejoiced and blew trumpets. The singers also played musical instruments, and led the singing of praise. Then Athaliah tore her clothes, and said, “Treason! treason!” 
+</div><div class="p">
+<sup>14&#160;</sup>Jehoiada the priest brought out the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks; and whoever follows her, let him be slain with the sword.” For the priest said, “Don’t kill her in Yahweh’s house.” 
+<sup>15&#160;</sup>So they made way for her. She went to the entrance of the horse gate to the king’s house; and they killed her there. 
+</div><div class="p">
+<sup>16&#160;</sup>Jehoiada made a covenant between himself, all the people, and the king, that they should be Yahweh’s people. 
+<sup>17&#160;</sup>All the people went to the house of Baal, broke it down, broke his altars and his images in pieces, and killed Mattan the priest of Baal before the altars. 
+<sup>18&#160;</sup>Jehoiada appointed the officers of Yahweh’s house under the hand of the Levitical priests, whom David had distributed in Yahweh’s house, to offer the burnt offerings of Yahweh, as it is written in the law of Moses, with rejoicing and with singing, as David had ordered. 
+<sup>19&#160;</sup>He set the gatekeepers at the gates of Yahweh’s house, that no one who was unclean in anything should enter in. 
+<sup>20&#160;</sup>He took the captains of hundreds, the nobles, the governors of the people, and all the people of the land, and brought the king down from Yahweh’s house. They came through the upper gate to the king’s house, and set the king on the throne of the kingdom. 
+<sup>21&#160;</sup>So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Joash was seven years old when he began to reign, and he reigned forty years in Jerusalem. His mother’s name was Zibiah, of Beersheba. 
+<sup>2&#160;</sup>Joash did that which was right in Yahweh’s eyes all the days of Jehoiada the priest. 
+<sup>3&#160;</sup>Jehoiada took for him two women, and he brought forth sons and daughters. 
+</div><div class="p">
+<sup>4&#160;</sup>After this, Joash intended to restore Yahweh’s house. 
+<sup>5&#160;</sup>He gathered together the priests and the Levites, and said to them, “Go out to the cities of Judah, and gather money to repair the house of your Elohim from all Israel from year to year. See that you expedite this matter.” However the Levites didn’t do it right away. 
+<sup>6&#160;</sup>The king called for Jehoiada the chief, and said to him, “Why haven’t you required of the Levites to bring in the tax of Moses the servant of Yahweh, and of the assembly of Israel, out of Judah and out of Jerusalem, for the Tent of the Testimony?” 
+<sup>7&#160;</sup>For the sons of Athaliah, that wicked woman, had broken up Elohim’s house; and they also gave all the dedicated things of Yahweh’s house to the Baals. 
+</div><div class="p">
+<sup>8&#160;</sup>So the king commanded, and they made a chest, and set it outside at the gate of Yahweh’s house. 
+<sup>9&#160;</sup>They made a proclamation through Judah and Jerusalem, to bring in for Yahweh the tax that Moses the servant of Elohim laid on Israel in the wilderness. 
+<sup>10&#160;</sup>All the princes and all the people rejoiced, and brought in, and cast into the chest, until they had filled it. 
+<sup>11&#160;</sup>Whenever the chest was brought to the king’s officers by the hand of the Levites, and when they saw that there was much money, the king’s scribe and the chief priest’s officer came and emptied the chest, and took it, and carried it to its place again. Thus they did day by day, and gathered money in abundance. 
+<sup>12&#160;</sup>The king and Jehoiada gave it to those who did the work of the service of Yahweh’s house. They hired masons and carpenters to restore Yahweh’s house, and also those who worked iron and bronze to repair Yahweh’s house. 
+<sup>13&#160;</sup>So the workmen worked, and the work of repairing went forward in their hands. They set up Elohim’s house as it was designed, and strengthened it. 
+<sup>14&#160;</sup>When they had finished, they brought the rest of the money before the king and Jehoiada, from which were made vessels for Yahweh’s house, even vessels with which to minister and to offer, including spoons and vessels of gold and silver. They offered burnt offerings in Yahweh’s house continually all the days of Jehoiada. 
+</div><div class="p">
+<sup>15&#160;</sup>But Jehoiada grew old and was full of days, and he died. He was one hundred thirty years old when he died. 
+<sup>16&#160;</sup>They buried him in David’s city among the kings, because he had done good in Israel, and toward Elohim and his house. 
+</div><div class="p">
+<sup>17&#160;</sup>Now after the death of Jehoiada, the princes of Judah came and bowed down to the king. Then the king listened to them. 
+<sup>18&#160;</sup>They abandoned the house of Yahweh, the Elohim of their fathers, and served the Asherah poles and the idols, so wrath came on Judah and Jerusalem for this their guiltiness. 
+<sup>19&#160;</sup>Yet he sent prophets to them to bring them again to Yahweh, and they testified against them; but they would not listen. 
+</div><div class="p">
+<sup>20&#160;</sup>The Spirit of Elohim came on Zechariah the son of Jehoiada the priest; and he stood above the people, and said to them, “Elohim says, ‘Why do you disobey Yahweh’s commandments, so that you can’t prosper? Because you have forsaken Yahweh, he has also forsaken you.’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>They conspired against him, and stoned him with stones at the commandment of the king in the court of Yahweh’s house. 
+<sup>22&#160;</sup>Thus Joash the king didn’t remember the kindness which Jehoiada his father had done to him, but killed his son. When he died, he said, “May Yahweh look at it, and repay it.” 
+</div><div class="p">
+<sup>23&#160;</sup>At the end of the year, the army of the Syrians came up against him. They came to Judah and Jerusalem, and destroyed all the princes of the people from among the people, and sent all their plunder to the king of Damascus. 
+<sup>24&#160;</sup>For the army of the Syrians came with a small company of men; and Yahweh delivered a very great army into their hand, because they had forsaken Yahweh, the Elohim of their fathers. So they executed judgment on Joash. 
+</div><div class="p">
+<sup>25&#160;</sup>When they had departed from him (for they left him seriously wounded), his own servants conspired against him for the blood of the sons of Jehoiada the priest, and killed him on his bed, and he died. They buried him in David’s city, but they didn’t bury him in the tombs of the kings. 
+<sup>26&#160;</sup>These are those who conspired against him: Zabad the son of Shimeath the Ammonitess and Jehozabad the son of Shimrith the Moabitess. 
+<sup>27&#160;</sup>Now concerning his sons, the greatness of the burdens laid on him, and the rebuilding of Elohim’s house, behold, they are written in the commentary of the book of the kings. Amaziah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Amaziah was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddan, of Jerusalem. 
+<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, but not with a perfect heart. 
+<sup>3&#160;</sup>Now when the kingdom was established to him, he killed his servants who had killed his father the king. 
+<sup>4&#160;</sup>But he didn’t put their children to death, but did according to that which is written in the law in the book of Moses, as Yahweh commanded, saying, “The fathers shall not die for the children, neither shall the children die for the fathers; but every man shall die for his own sin.” 
+</div><div class="p">
+<sup>5&#160;</sup>Moreover Amaziah gathered Judah together and ordered them according to their fathers’ houses, under captains of thousands and captains of hundreds, even all Judah and Benjamin. He counted them from twenty years old and upward, and found that there were three hundred thousand chosen men, able to go out to war, who could handle spear and shield. 
+<sup>6&#160;</sup>He also hired one hundred thousand mighty men of valor out of Israel for one hundred talents of silver. 
+<sup>7&#160;</sup>A man of Elohim came to him, saying, “O king, don’t let the army of Israel go with you, for Yahweh is not with Israel, with all the children of Ephraim. 
+<sup>8&#160;</sup>But if you will go, take action, and be strong for the battle. Elohim will overthrow you before the enemy; for Elohim has power to help, and to overthrow.” 
+</div><div class="p">
+<sup>9&#160;</sup>Amaziah said to the man of Elohim, “But what shall we do for the hundred talents which I have given to the army of Israel?” 
+</div><div class="p">The man of Elohim answered, “Yahweh is able to give you much more than this.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Amaziah separated them, the army that had come to him out of Ephraim, to go home again. Therefore their anger was greatly kindled against Judah, and they returned home in fierce anger. 
+</div><div class="p">
+<sup>11&#160;</sup>Amaziah took courage, and led his people out and went to the Valley of Salt, and struck ten thousand of the children of Seir. 
+<sup>12&#160;</sup>The children of Judah carried away ten thousand alive, and brought them to the top of the rock, and threw them down from the top of the rock, so that they all were broken in pieces. 
+<sup>13&#160;</sup>But the men of the army whom Amaziah sent back, that they should not go with him to battle, fell on the cities of Judah from Samaria even to Beth Horon, and struck of them three thousand, and took much plunder. 
+</div><div class="p">
+<sup>14&#160;</sup>Now after Amaziah had come from the slaughter of the Edomites, he brought the elohims of the children of Seir, and set them up to be his elohims, and bowed down himself before them and burned incense to them. 
+<sup>15&#160;</sup>Therefore Yahweh’s anger burned against Amaziah, and he sent to him a prophet who said to him, “Why have you sought after the elohims of the people, which have not delivered their own people out of your hand?” 
+</div><div class="p">
+<sup>16&#160;</sup>As he talked with him, the king said to him, “Have we made you one of the king’s counselors? Stop! Why should you be struck down?” 
+</div><div class="p">Then the prophet stopped, and said, “I know that Elohim has determined to destroy you, because you have done this and have not listened to my counsel.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Amaziah king of Judah consulted his advisers, and sent to Joash, the son of Jehoahaz, the son of Jehu, king of Israel, saying, “Come! Let’s look one another in the face.” 
+</div><div class="p">
+<sup>18&#160;</sup>Joash king of Israel sent to Amaziah king of Judah, saying, “The thistle that was in Lebanon sent to the cedar that was in Lebanon, saying, ‘Give your daughter to my son as his woman. Then a wild animal that was in Lebanon passed by and trampled down the thistle. 
+<sup>19&#160;</sup>You say to yourself that you have struck Edom; and your heart lifts you up to boast. Now stay at home. Why should you meddle with trouble, that you should fall, even you and Judah with you?’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>But Amaziah would not listen; for it was of Elohim, that he might deliver them into the hand of their enemies, because they had sought after the elohims of Edom. 
+<sup>21&#160;</sup>So Joash king of Israel went up, and he and Amaziah king of Judah looked one another in the face at Beth Shemesh, which belongs to Judah. 
+<sup>22&#160;</sup>Judah was defeated by Israel; so every man fled to his tent. 
+</div><div class="p">
+<sup>23&#160;</sup>Joash king of Israel took Amaziah king of Judah, the son of Joash the son of Jehoahaz, at Beth Shemesh and brought him to Jerusalem, and broke down the wall of Jerusalem from the gate of Ephraim to the corner gate, four hundred cubits. 
+<sup>24&#160;</sup>He took all the gold and silver, and all the vessels that were found in Elohim’s house with Obed-Edom, and the treasures of the king’s house, and the hostages, and returned to Samaria. 
+</div><div class="p">
+<sup>25&#160;</sup>Amaziah the son of Joash, king of Judah, lived for fifteen years after the death of Joash, son of Jehoahaz, king of Israel. 
+<sup>26&#160;</sup>Now the rest of the acts of Amaziah, first and last, behold, aren’t they written in the book of the kings of Judah and Israel? 
+<sup>27&#160;</sup>Now from the time that Amaziah turned away from following Yahweh, they made a conspiracy against him in Jerusalem. He fled to Lachish, but they sent after him to Lachish and killed him there. 
+<sup>28&#160;</sup>They brought him on horses and buried him with his fathers in the City of Judah. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>All the people of Judah took Uzziah, who was sixteen years old, and made him king in the place of his father Amaziah. 
+<sup>2&#160;</sup>He built Eloth and restored it to Judah. After that the king slept with his fathers. 
+<sup>3&#160;</sup>Uzziah was sixteen years old when he began to reign; and he reigned fifty-two years in Jerusalem. His mother’s name was Jechiliah, of Jerusalem. 
+<sup>4&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
+<sup>5&#160;</sup>He set himself to seek Elohim in the days of Zechariah, who had understanding in the vision of Elohim; and as long as he sought Yahweh, Elohim made him prosper. 
+</div><div class="p">
+<sup>6&#160;</sup>He went out and fought against the Philistines, and broke down the wall of Gath, the wall of Jabneh, and the wall of Ashdod; and he built cities in the country of Ashdod, and among the Philistines. 
+<sup>7&#160;</sup>Elohim helped him against the Philistines, and against the Arabians who lived in Gur Baal, and the Meunim. 
+<sup>8&#160;</sup>The Ammonites gave tribute to Uzziah. His name spread abroad even to the entrance of Egypt, for he grew exceedingly strong. 
+<sup>9&#160;</sup>Moreover Uzziah built towers in Jerusalem at the corner gate, at the valley gate, and at the turning of the wall, and fortified them. 
+<sup>10&#160;</sup>He built towers in the wilderness, and dug out many cisterns, for he had much livestock, both in the lowlands and in the plains. He had farmers and vineyard keepers in the mountains and in the fruitful fields, for he loved farming. 
+<sup>11&#160;</sup>Moreover Uzziah had an army of fighting men who went out to war by bands, according to the number of their reckoning made by Jeiel the scribe and Maaseiah the officer, under the hand of Hananiah, one of the king’s captains. 
+<sup>12&#160;</sup>The whole number of the heads of fathers’ households, even the mighty men of valor, was two thousand six hundred. 
+<sup>13&#160;</sup>Under their hand was an army, three hundred seven thousand five hundred, who made war with mighty power, to help the king against the enemy. 
+<sup>14&#160;</sup>Uzziah prepared for them, even for all the army, shields, spears, helmets, coats of mail, bows, and stones for slinging. 
+<sup>15&#160;</sup>In Jerusalem, he made devices, invented by skillful men, to be on the towers and on the battlements, with which to shoot arrows and great stones. His name spread far abroad, because he was marvelously helped until he was strong. 
+</div><div class="p">
+<sup>16&#160;</sup>But when he was strong, his heart was lifted up, so that he did corruptly and he trespassed against Yahweh his Elohim, for he went into Yahweh’s temple to burn incense on the altar of incense. 
+<sup>17&#160;</sup>Azariah the priest went in after him, and with him eighty priests of Yahweh, who were valiant men. 
+<sup>18&#160;</sup>They resisted Uzziah the king, and said to him, “It isn’t for you, Uzziah, to burn incense to Yahweh, but for the priests the sons of Aaron, who are consecrated to burn incense. Go out of the sanctuary, for you have trespassed. It will not be for your honor from Yahweh Elohim.” 
+</div><div class="p">
+<sup>19&#160;</sup>Then Uzziah was angry. He had a censer in his hand to burn incense, and while he was angry with the priests, the leprosy broke out on his forehead before the priests in Yahweh’s house, beside the altar of incense. 
+<sup>20&#160;</sup>Azariah the chief priest and all the priests looked at him, and behold, he was leprous in his forehead; and they thrust him out quickly from there. Indeed, he himself also hurried to go out, because Yahweh had struck him. 
+<sup>21&#160;</sup>Uzziah the king was a leper to the day of his death, and lived in a separate house, being a leper; for he was cut off from Yahweh’s house. Jotham his son was over the king’s house, judging the people of the land. 
+</div><div class="p">
+<sup>22&#160;</sup>Now the rest of the acts of Uzziah, first and last, Isaiah the prophet, the son of Amoz, wrote. 
+<sup>23&#160;</sup>So Uzziah slept with his fathers; and they buried him with his fathers in the field of burial which belonged to the kings, for they said, “He is a leper.” Jotham his son reigned in his place. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Jotham was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerushah the daughter of Zadok. 
+<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that his father Uzziah had done. However he didn’t enter into Yahweh’s temple. The people still acted corruptly. 
+<sup>3&#160;</sup>He built the upper gate of Yahweh’s house, and he built much on the wall of Ophel. 
+<sup>4&#160;</sup>Moreover he built cities in the hill country of Judah, and in the forests he built fortresses and towers. 
+<sup>5&#160;</sup>He also fought with the king of the children of Ammon, and prevailed against them. The children of Ammon gave him the same year one hundred talents The children of Ammon also gave that much to him in the second year, and in the third. 
+<sup>6&#160;</sup>So Jotham became mighty, because he ordered his ways before Yahweh his Elohim. 
+<sup>7&#160;</sup>Now the rest of the acts of Jotham, and all his wars and his ways, behold, they are written in the book of the kings of Israel and Judah. 
+<sup>8&#160;</sup>He was twenty-five years old when he began to reign, and reigned sixteen years in Jerusalem. 
+<sup>9&#160;</sup>Jotham slept with his fathers, and they buried him in David’s city; and Ahaz his son reigned in his place. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh’s eyes, like David his father, 
+<sup>2&#160;</sup>but he walked in the ways of the kings of Israel, and also made molten images for the Baals. 
+<sup>3&#160;</sup>Moreover he burned incense in the valley of the son of Hinnom, and burned his children in the fire, according to the abominations of the nations whom Yahweh cast out before the children of Israel. 
+<sup>4&#160;</sup>He sacrificed and burned incense in the high places, and on the hills, and under every green tree. 
+</div><div class="p">
+<sup>5&#160;</sup>Therefore Yahweh his Elohim delivered him into the hand of the king of Syria. They struck him, and carried away from him a great multitude of captives, and brought them to Damascus. He was also delivered into the hand of the king of Israel, who struck him with a great slaughter. 
+<sup>6&#160;</sup>For Pekah the son of Remaliah killed in Judah one hundred twenty thousand in one day, all of them valiant men, because they had forsaken Yahweh, the Elohim of their fathers. 
+<sup>7&#160;</sup>Zichri, a mighty man of Ephraim, killed Maaseiah the king’s son, Azrikam the ruler of the house, and Elkanah who was next to the king. 
+<sup>8&#160;</sup>The children of Israel carried away captive of their brothers two hundred thousand women, sons, and daughters, and also took away much plunder from them, and brought the plunder to Samaria. 
+<sup>9&#160;</sup>But a prophet of Yahweh was there, whose name was Oded; and he went out to meet the army that came to Samaria, and said to them, “Behold, because Yahweh, the Elohim of your fathers, was angry with Judah, he has delivered them into your hand, and you have slain them in a rage which has reached up to heaven. 
+<sup>10&#160;</sup>Now you intend to degrade the children of Judah and Jerusalem as male and female slaves for yourselves. Aren’t there even with you trespasses of your own against Yahweh your Elohim? 
+<sup>11&#160;</sup>Now hear me therefore, and send back the captives that you have taken captive from your brothers, for the fierce wrath of Yahweh is on you.” 
+<sup>12&#160;</sup>Then some of the heads of the children of Ephraim, Azariah the son of Johanan, Berechiah the son of Meshillemoth, Jehizkiah the son of Shallum, and Amasa the son of Hadlai, stood up against those who came from the war, 
+<sup>13&#160;</sup>and said to them, “You must not bring in the captives here, for you intend that which will bring on us a trespass against Yahweh, to add to our sins and to our guilt; for our guilt is great, and there is fierce wrath against Israel.” 
+</div><div class="p">
+<sup>14&#160;</sup>So the armed men left the captives and the plunder before the princes and all the assembly. 
+<sup>15&#160;</sup>The men who have been mentioned by name rose up and took the captives, and with the plunder clothed all who were naked among them, dressed them, gave them sandals, gave them something to eat and to drink, anointed them, carried all the feeble of them on donkeys, and brought them to Jericho, the city of palm trees, to their brothers. Then they returned to Samaria. 
+</div><div class="p">
+<sup>16&#160;</sup>At that time King Ahaz sent to the kings of Assyria to help him. 
+<sup>17&#160;</sup>For again the Edomites had come and struck Judah, and carried away captives. 
+<sup>18&#160;</sup>The Philistines also had invaded the cities of the lowland and of the South of Judah, and had taken Beth Shemesh, Aijalon, Gederoth, Soco with its villages, Timnah with its villages, and also Gimzo and its villages; and they lived there. 
+<sup>19&#160;</sup>For Yahweh brought Judah low because of Ahaz king of Israel, because he acted without restraint in Judah and trespassed severely against Yahweh. 
+<sup>20&#160;</sup>Tilgath-pilneser king of Assyria came to him and gave him trouble, but didn’t strengthen him. 
+<sup>21&#160;</sup>For Ahaz took away a portion out of Yahweh’s house, and out of the house of the king and of the princes, and gave it to the king of Assyria; but it didn’t help him. 
+</div><div class="p">
+<sup>22&#160;</sup>In the time of his distress, he trespassed yet more against Yahweh, this same King Ahaz. 
+<sup>23&#160;</sup>For he sacrificed to the elohims of Damascus which had defeated him. He said, “Because the elohims of the kings of Syria helped them, I will sacrifice to them, that they may help me.” But they were the ruin of him and of all Israel. 
+<sup>24&#160;</sup>Ahaz gathered together the vessels of Elohim’s house, cut the vessels of Elohim’s house in pieces, and shut up the doors of Yahweh’s house; and he made himself altars in every corner of Jerusalem. 
+<sup>25&#160;</sup>In every city of Judah he made high places to burn incense to other elohims, and provoked Yahweh, the Elohim of his fathers, to anger. 
+</div><div class="p">
+<sup>26&#160;</sup>Now the rest of his acts, and all his ways, first and last, behold, they are written in the book of the kings of Judah and Israel. 
+<sup>27&#160;</sup>Ahaz slept with his fathers, and they buried him in the city, even in Jerusalem, because they didn’t bring him into the tombs of the kings of Israel; and Hezekiah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>Hezekiah began to reign when he was twenty-five years old, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abijah, the daughter of Zechariah. 
+<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
+<sup>3&#160;</sup>In the first year of his reign, in the first month, he opened the doors of Yahweh’s house and repaired them. 
+<sup>4&#160;</sup>He brought in the priests and the Levites and gathered them together into the wide place on the east, 
+<sup>5&#160;</sup>and said to them, “Listen to me, you Levites! Now sanctify yourselves, and sanctify the house of Yahweh, the Elohim of your fathers, and carry the filthiness out of the set-apart place. 
+<sup>6&#160;</sup>For our fathers were unfaithful, and have done that which was evil in Yahweh our Elohim’s sight, and have forsaken him, and have turned away their faces from the habitation of Yahweh, and turned their backs. 
+<sup>7&#160;</sup>Also they have shut up the doors of the porch, and put out the lamps, and have not burned incense nor offered burnt offerings in the set-apart place to the Elohim of Israel. 
+<sup>8&#160;</sup>Therefore Yahweh’s wrath was on Judah and Jerusalem, and he has delivered them to be tossed back and forth, to be an astonishment and a hissing, as you see with your eyes. 
+<sup>9&#160;</sup>For behold, our fathers have fallen by the sword, and our sons and our daughters and our women are in captivity for this. 
+<sup>10&#160;</sup>Now it is in my heart to make a covenant with Yahweh, the Elohim of Israel, that his fierce anger may turn away from us. 
+<sup>11&#160;</sup>My sons, don’t be negligent now; for Yahweh has chosen you to stand before him, to minister to him, and that you should be his ministers and burn incense.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then the Levites arose: Mahath, the son of Amasai, and Joel the son of Azariah, of the sons of the Kohathites; and of the sons of Merari, Kish the son of Abdi, and Azariah the son of Jehallelel; and of the Gershonites, Joah the son of Zimmah, and Eden the son of Joah; 
+<sup>13&#160;</sup>and of the sons of Elizaphan, Shimri and Jeuel; and of the sons of Asaph, Zechariah and Mattaniah; 
+<sup>14&#160;</sup>and of the sons of Heman, Jehuel and Shimei; and of the sons of Jeduthun, Shemaiah and Uzziel. 
+<sup>15&#160;</sup>They gathered their brothers, sanctified themselves, and went in, according to the commandment of the king by Yahweh’s words, to cleanse Yahweh’s house. 
+<sup>16&#160;</sup>The priests went into the inner part of Yahweh’s house to cleanse it, and brought out all the uncleanness that they found in Yahweh’s temple into the court of Yahweh’s house. The Levites took it from there to carry it out to the brook Kidron. 
+<sup>17&#160;</sup>Now they began on the first day of the first month to sanctify, and on the eighth day of the month they came to Yahweh’s porch. They sanctified Yahweh’s house in eight days, and on the sixteenth day of the first month they finished. 
+<sup>18&#160;</sup>Then they went in to Hezekiah the king within the palace and said, “We have cleansed all Yahweh’s house, including the altar of burnt offering with all its vessels, and the table of show bread with all its vessels. 
+<sup>19&#160;</sup>Moreover, we have prepared and sanctified all the vessels which King Ahaz threw away in his reign when he was unfaithful. Behold, they are before Yahweh’s altar.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then Hezekiah the king arose early, gathered the princes of the city, and went up to Yahweh’s house. 
+<sup>21&#160;</sup>They brought seven bulls, seven rams, seven lambs, and seven male goats, for a sin offering for the kingdom, for the sanctuary, and for Judah. He commanded the priests the sons of Aaron to offer them on Yahweh’s altar. 
+<sup>22&#160;</sup>So they killed the bulls, and the priests received the blood and sprinkled it on the altar. They killed the rams and sprinkled the blood on the altar. They also killed the lambs and sprinkled the blood on the altar. 
+<sup>23&#160;</sup>They brought near the male goats for the sin offering before the king and the assembly; and they laid their hands on them. 
+<sup>24&#160;</sup>Then the priests killed them, and they made a sin offering with their blood on the altar, to make atonement for all Israel; for the king commanded that the burnt offering and the sin offering should be made for all Israel. 
+</div><div class="p">
+<sup>25&#160;</sup>He set the Levites in Yahweh’s house with cymbals, with stringed instruments, and with harps, according to the commandment of David, of Gad the king’s seer, and Nathan the prophet; for the commandment was from Yahweh by his prophets. 
+<sup>26&#160;</sup>The Levites stood with David’s instruments, and the priests with the trumpets. 
+<sup>27&#160;</sup>Hezekiah commanded them to offer the burnt offering on the altar. When the burnt offering began, Yahweh’s song also began, along with the trumpets and instruments of David king of Israel. 
+<sup>28&#160;</sup>All the assembly worshiped, the singers sang, and the trumpeters sounded. All this continued until the burnt offering was finished. 
+</div><div class="p">
+<sup>29&#160;</sup>When they had finished offering, the king and all who were present with him bowed themselves and worshiped. 
+<sup>30&#160;</sup>Moreover Hezekiah the king and the princes commanded the Levites to sing praises to Yahweh with the words of David, and of Asaph the seer. They sang praises with gladness, and they bowed their heads and worshiped. 
+</div><div class="p">
+<sup>31&#160;</sup>Then Hezekiah answered, “Now you have consecrated yourselves to Yahweh. Come near and bring sacrifices and thank offerings into Yahweh’s house.” The assembly brought in sacrifices and thank offerings, and as many as were of a willing heart brought burnt offerings. 
+<sup>32&#160;</sup>The number of the burnt offerings which the assembly brought was seventy bulls, one hundred rams, and two hundred lambs. All these were for a burnt offering to Yahweh. 
+<sup>33&#160;</sup>The consecrated things were six hundred head of cattle and three thousand sheep. 
+<sup>34&#160;</sup>But the priests were too few, so that they could not skin all the burnt offerings. Therefore their brothers the Levites helped them until the work was ended, and until the priests had sanctified themselves, for the Levites were more upright in heart to sanctify themselves than the priests. 
+<sup>35&#160;</sup>Also the burnt offerings were in abundance, with the fat of the peace offerings and with the drink offerings for every burnt offering. So the service of Yahweh’s house was set in order. 
+<sup>36&#160;</sup>Hezekiah and all the people rejoiced because of that which Elohim had prepared for the people; for the thing was done suddenly. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>Hezekiah sent to all Israel and Judah, and wrote letters also to Ephraim and Manasseh, that they should come to Yahweh’s house at Jerusalem, to keep the Passover to Yahweh, the Elohim of Israel. 
+<sup>2&#160;</sup>For the king had taken counsel with his princes and all the assembly in Jerusalem to keep the Passover in the second month. 
+<sup>3&#160;</sup>For they could not keep it at that time, because the priests had not sanctified themselves in sufficient number, and the people had not gathered themselves together to Jerusalem. 
+<sup>4&#160;</sup>The thing was right in the eyes of the king and of all the assembly. 
+<sup>5&#160;</sup>So they established a decree to make proclamation throughout all Israel, from Beersheba even to Dan, that they should come to keep the Passover to Yahweh, the Elohim of Israel, at Jerusalem, for they had not kept it in great numbers in the way it is written. 
+</div><div class="p">
+<sup>6&#160;</sup>So the couriers went with the letters from the king and his princes throughout all Israel and Judah, according to the commandment of the king, saying, “You children of Israel, turn again to Yahweh, the Elohim of Abraham, Isaac, and Israel, that he may return to the remnant of you that have escaped out of the hand of the kings of Assyria. 
+<sup>7&#160;</sup>Don’t be like your fathers and like your brothers, who trespassed against Yahweh, the Elohim of their fathers, so that he gave them up to desolation, as you see. 
+<sup>8&#160;</sup>Now don’t be stiff-necked, as your fathers were, but yield yourselves to Yahweh, and enter into his sanctuary, which he has sanctified forever, and serve Yahweh your Elohim, that his fierce anger may turn away from you. 
+<sup>9&#160;</sup>For if you turn again to Yahweh, your brothers and your children will find compassion with those who led them captive, and will come again into this land, because Yahweh your Elohim is gracious and merciful, and will not turn away his face from you if you return to him.” 
+</div><div class="p">
+<sup>10&#160;</sup>So the couriers passed from city to city through the country of Ephraim and Manasseh, even to Zebulun, but people ridiculed them and mocked them. 
+<sup>11&#160;</sup>Nevertheless some men of Asher, Manasseh, and Zebulun humbled themselves and came to Jerusalem. 
+<sup>12&#160;</sup>Also the hand of Elohim came on Judah to give them one heart, to do the commandment of the king and of the princes by Yahweh’s word. 
+</div><div class="p">
+<sup>13&#160;</sup>Many people assembled at Jerusalem to keep the feast of unleavened bread in the second month, a very great assembly. 
+<sup>14&#160;</sup>They arose and took away the altars that were in Jerusalem, and they took away all the altars for incense and threw them into the brook Kidron. 
+<sup>15&#160;</sup>Then they killed the Passover on the fourteenth day of the second month. The priests and the Levites were ashamed, and sanctified themselves, and brought burnt offerings into Yahweh’s house. 
+<sup>16&#160;</sup>They stood in their place after their order, according to the law of Moses the man of Elohim. The priests sprinkled the blood which they received of the hand of the Levites. 
+<sup>17&#160;</sup>For there were many in the assembly who had not sanctified themselves; therefore the Levites were in charge of killing the Passovers for everyone who was not clean, to sanctify them to Yahweh. 
+<sup>18&#160;</sup>For a multitude of the people, even many of Ephraim, Manasseh, Issachar, and Zebulun, had not cleansed themselves, yet they ate the Passover other than the way it is written. For Hezekiah had prayed for them, saying, “May the good Yahweh pardon everyone 
+<sup>19&#160;</sup>who sets his heart to seek Elohim, Yahweh, the Elohim of his fathers, even if they aren’t clean according to the purification of the sanctuary.” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh listened to Hezekiah, and healed the people. 
+<sup>21&#160;</sup>The children of Israel who were present at Jerusalem kept the feast of unleavened bread seven days with great gladness. The Levites and the priests praised Yahweh day by day, singing with loud instruments to Yahweh. 
+<sup>22&#160;</sup>Hezekiah spoke encouragingly to all the Levites who had good understanding in the service of Yahweh. So they ate throughout the feast for the seven days, offering sacrifices of peace offerings and making confession to Yahweh, the Elohim of their fathers. 
+</div><div class="p">
+<sup>23&#160;</sup>The whole assembly took counsel to keep another seven days, and they kept another seven days with gladness. 
+<sup>24&#160;</sup>For Hezekiah king of Judah gave to the assembly for offerings one thousand bulls and seven thousand sheep; and the princes gave to the assembly a thousand bulls and ten thousand sheep; and a great number of priests sanctified themselves. 
+<sup>25&#160;</sup>All the assembly of Judah, with the priests and the Levites, and all the assembly who came out of Israel, and the foreigners who came out of the land of Israel and who lived in Judah, rejoiced. 
+<sup>26&#160;</sup>So there was great joy in Jerusalem; for since the time of Solomon the son of David king of Israel there was nothing like this in Jerusalem. 
+<sup>27&#160;</sup>Then the Levitical priests arose and blessed the people. Their voice was heard, and their prayer came up to his set-apart habitation, even to heaven. 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when all this was finished, all Israel who were present went out to the cities of Judah and broke the pillars in pieces, cut down the Asherah poles, and broke down the high places and the altars out of all Judah and Benjamin, also in Ephraim and Manasseh, until they had destroyed them all. Then all the children of Israel returned, every man to his possession, into their own cities. 
+</div><div class="p">
+<sup>2&#160;</sup>Hezekiah appointed the divisions of the priests and the Levites after their divisions, every man according to his service, both the priests and the Levites, for burnt offerings and for peace offerings, to minister, to give thanks, and to praise in the gates of Yahweh’s camp. 
+<sup>3&#160;</sup>He also appointed the king’s portion of his possessions for the burnt offerings: for the morning and evening burnt offerings, and the burnt offerings for the Sabbaths, for the new moons, and for the set feasts, as it is written in Yahweh’s law. 
+<sup>4&#160;</sup>Moreover he commanded the people who lived in Jerusalem to give the portion of the priests and the Levites, that they might give themselves to Yahweh’s law. 
+<sup>5&#160;</sup>As soon as the commandment went out, the children of Israel gave in abundance the first fruits of grain, new wine, oil, honey, and of all the increase of the field; and they brought in the tithe of all things abundantly. 
+<sup>6&#160;</sup>The children of Israel and Judah, who lived in the cities of Judah, also brought in the tithe of cattle and sheep, and the tithe of dedicated things which were consecrated to Yahweh their Elohim, and laid them in heaps. 
+</div><div class="p">
+<sup>7&#160;</sup>In the third month, they began to lay the foundation of the heaps, and finished them in the seventh month. 
+<sup>8&#160;</sup>When Hezekiah and the princes came and saw the heaps, they blessed Yahweh and his people Israel. 
+<sup>9&#160;</sup>Then Hezekiah questioned the priests and the Levites about the heaps. 
+<sup>10&#160;</sup>Azariah the chief priest, of the house of Zadok, answered him and said, “Since people began to bring the offerings into Yahweh’s house, we have eaten and had enough, and have plenty left over, for Yahweh has blessed his people; and that which is left is this great store.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then Hezekiah commanded them to prepare rooms in Yahweh’s house, and they prepared them. 
+<sup>12&#160;</sup>They brought in the offerings, the tithes, and the dedicated things faithfully. Conaniah the Levite was ruler over them, and Shimei his brother was second. 
+<sup>13&#160;</sup>Jehiel, Azaziah, Nahath, Asahel, Jerimoth, Jozabad, Eliel, Ismachiah, Mahath, and Benaiah were overseers under the hand of Conaniah and Shimei his brother, by the appointment of Hezekiah the king and Azariah the ruler of Elohim’s house. 
+<sup>14&#160;</sup>Kore the son of Imnah the Levite, the gatekeeper at the east gate, was over the free will offerings of Elohim, to distribute Yahweh’s offerings and the most set-apart things. 
+<sup>15&#160;</sup>Under him were Eden, Miniamin, Jeshua, Shemaiah, Amariah, and Shecaniah, in the cities of the priests, in their office of trust, to give to their brothers by divisions, to the great as well as to the small; 
+<sup>16&#160;</sup>in addition to those who were listed by genealogy of males, from three years old and upward, even everyone who entered into Yahweh’s house, as the duty of every day required, for their service in their offices according to their divisions; 
+<sup>17&#160;</sup>and those who were listed by genealogy of the priests by their fathers’ houses, and the Levites from twenty years old and upward, in their offices by their divisions; 
+<sup>18&#160;</sup>and those who were listed by genealogy of all their little ones, their women, their sons, and their daughters, through all the congregation; for in their office of trust they sanctified themselves in set-apartness. 
+<sup>19&#160;</sup>Also for the sons of Aaron the priests, who were in the fields of the pasture lands of their cities, in every city, there were men who were mentioned by name to give portions to all the males among the priests and to all who were listed by genealogy among the Levites. 
+</div><div class="p">
+<sup>20&#160;</sup>Hezekiah did so throughout all Judah; and he did that which was good, right, and faithful before Yahweh his Elohim. 
+<sup>21&#160;</sup>In every work that he began in the service of Elohim’s house, in the law, and in the commandments, to seek his Elohim, he did it with all his heart and prospered. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things and this faithfulness, Sennacherib king of Assyria came, entered into Judah, encamped against the fortified cities, and intended to win them for himself. 
+<sup>2&#160;</sup>When Hezekiah saw that Sennacherib had come, and that he was planning to fight against Jerusalem, 
+<sup>3&#160;</sup>he took counsel with his princes and his mighty men to stop the waters of the springs which were outside of the city, and they helped him. 
+<sup>4&#160;</sup>Then many people gathered together and they stopped all the springs and the brook that flowed through the middle of the land, saying, “Why should the kings of Assyria come, and find abundant water?” 
+</div><div class="p">
+<sup>5&#160;</sup>He took courage, built up all the wall that was broken down, and raised it up to the towers, with the other wall outside, and strengthened Millo in David’s city, and made weapons and shields in abundance. 
+<sup>6&#160;</sup>He set captains of war over the people, gathered them together to him in the wide place at the gate of the city, and spoke encouragingly to them, saying, 
+<sup>7&#160;</sup>“Be strong and courageous. Don’t be afraid or dismayed because of the king of Assyria, nor for all the multitude who is with him; for there is a greater one with us than with him. 
+<sup>8&#160;</sup>An arm of flesh is with him, but Yahweh our Elohim is with us to help us and to fight our battles.” The people rested themselves on the words of Hezekiah king of Judah. 
+</div><div class="p">
+<sup>9&#160;</sup>After this, Sennacherib king of Assyria sent his servants to Jerusalem, (now he was attacking Lachish, and all his forces were with him), to Hezekiah king of Judah, and to all Judah who were at Jerusalem, saying, 
+<sup>10&#160;</sup>Sennacherib king of Assyria says, “In whom do you trust, that you remain under siege in Jerusalem? 
+<sup>11&#160;</sup>Doesn’t Hezekiah persuade you to give you over to die by famine and by thirst, saying, ‘Yahweh our Elohim will deliver us out of the hand of the king of Assyria’? 
+<sup>12&#160;</sup>Hasn’t the same Hezekiah taken away his high places and his altars, and commanded Judah and Jerusalem, saying, ‘You shall worship before one altar, and you shall burn incense on it’? 
+<sup>13&#160;</sup>Don’t you know what I and my fathers have done to all the peoples of the lands? Were the elohims of the nations of those lands in any way able to deliver their land out of my hand? 
+<sup>14&#160;</sup>Who was there among all the elohims of those nations which my fathers utterly destroyed that could deliver his people out of my hand, that your Elohim should be able to deliver you out of my hand? 
+<sup>15&#160;</sup>Now therefore don’t let Hezekiah deceive you nor persuade you in this way. Don’t believe him, for no elohim of any nation or kingdom was able to deliver his people out of my hand, and out of the hand of my fathers. How much less will your Elohim deliver you out of my hand?” 
+</div><div class="p">
+<sup>16&#160;</sup>His servants spoke yet more against Yahweh Elohim and against his servant Hezekiah. 
+<sup>17&#160;</sup>He also wrote letters insulting Yahweh, the Elohim of Israel, and speaking against him, saying, “As the elohims of the nations of the lands, which have not delivered their people out of my hand, so shall the Elohim of Hezekiah not deliver his people out of my hand.” 
+<sup>18&#160;</sup>They called out with a loud voice in the Jews’ language to the people of Jerusalem who were on the wall, to frighten them and to trouble them, that they might take the city. 
+<sup>19&#160;</sup>They spoke of the Elohim of Jerusalem as of the elohims of the peoples of the earth, which are the work of men’s hands. 
+</div><div class="p">
+<sup>20&#160;</sup>Hezekiah the king and Isaiah the prophet, the son of Amoz, prayed because of this, and cried to heaven. 
+</div><div class="p">
+<sup>21&#160;</sup>Yahweh sent an angel, who cut off all the mighty men of valor, the leaders, and captains in the camp of the king of Assyria. So he returned with shame of face to his own land. When he had come into the house of his elohim, those who came out of his own body killed him there with the sword. 
+<sup>22&#160;</sup>Thus Yahweh saved Hezekiah and the inhabitants of Jerusalem from the hand of Sennacherib the king of Assyria and from the hand of all others, and guided them on every side. 
+<sup>23&#160;</sup>Many brought gifts to Yahweh to Jerusalem, and precious things to Hezekiah king of Judah, so that he was exalted in the sight of all nations from then on. 
+</div><div class="p">
+<sup>24&#160;</sup>In those days Hezekiah was terminally ill, and he prayed to Yahweh; and he spoke to him, and gave him a sign. 
+<sup>25&#160;</sup>But Hezekiah didn’t reciprocate appropriate to the benefit done for him, because his heart was lifted up. Therefore there was wrath on him, Judah, and Jerusalem. 
+<sup>26&#160;</sup>However, Hezekiah humbled himself for the pride of his heart, both he and the inhabitants of Jerusalem, so that Yahweh’s wrath didn’t come on them in the days of Hezekiah. 
+</div><div class="p">
+<sup>27&#160;</sup>Hezekiah had exceedingly great riches and honor. He provided himself with treasuries for silver, for gold, for precious stones, for spices, for shields, and for all kinds of valuable vessels; 
+<sup>28&#160;</sup>also storehouses for the increase of grain, new wine, and oil; and stalls for all kinds of animals, and flocks in folds. 
+<sup>29&#160;</sup>Moreover he provided for himself cities, and possessions of flocks and herds in abundance; for Elohim had given him abundant possessions. 
+<sup>30&#160;</sup>This same Hezekiah also stopped the upper spring of the waters of Gihon, and brought them straight down on the west side of David’s city. Hezekiah prospered in all his works. 
+</div><div class="p">
+<sup>31&#160;</sup>However, concerning the ambassadors of the princes of Babylon, who sent to him to inquire of the wonder that was done in the land, Elohim left him to test him, that he might know all that was in his heart. 
+</div><div class="p">
+<sup>32&#160;</sup>Now the rest of the acts of Hezekiah and his good deeds, behold, they are written in the vision of Isaiah the prophet, the son of Amoz, in the book of the kings of Judah and Israel. 
+<sup>33&#160;</sup>Hezekiah slept with his fathers, and they buried him in the ascent to the tombs of the sons of David. All Judah and the inhabitants of Jerusalem honored him at his death. Manasseh his son reigned in his place. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="p">
+<sup>1&#160;</sup>Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. 
+<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
+<sup>3&#160;</sup>For he built again the high places which Hezekiah his father had broken down; and he raised up altars for the Baals, made Asheroth, and worshiped all the army of the sky, and served them. 
+<sup>4&#160;</sup>He built altars in Yahweh’s house, of which Yahweh said, “My name shall be in Jerusalem forever.” 
+<sup>5&#160;</sup>He built altars for all the army of the sky in the two courts of Yahweh’s house. 
+<sup>6&#160;</sup>He also made his children to pass through the fire in the valley of the son of Hinnom. He practiced sorcery, divination, and witchcraft, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
+<sup>7&#160;</sup>He set the engraved image of the idol, which he had made, in Elohim’s house, of which Elohim said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever. 
+<sup>8&#160;</sup>I will not any more remove the foot of Israel from off the land which I have appointed for your fathers, if only they will observe to do all that I have commanded them, even all the law, the statutes, and the ordinances given by Moses.” 
+<sup>9&#160;</sup>Manasseh seduced Judah and the inhabitants of Jerusalem, so that they did more evil than did the nations whom Yahweh destroyed before the children of Israel. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh spoke to Manasseh and to his people, but they didn’t listen. 
+<sup>11&#160;</sup>Therefore Yahweh brought on them the captains of the army of the king of Assyria, who took Manasseh in chains, bound him with fetters, and carried him to Babylon. 
+</div><div class="p">
+<sup>12&#160;</sup>When he was in distress, he begged Yahweh his Elohim, and humbled himself greatly before the Elohim of his fathers. 
+<sup>13&#160;</sup>He prayed to him; and he was entreated by him, and heard his supplication, and brought him again to Jerusalem into his kingdom. Then Manasseh knew that Yahweh was Elohim. 
+</div><div class="p">
+<sup>14&#160;</sup>Now after this, he built an outer wall to David’s city on the west side of Gihon, in the valley, even to the entrance at the fish gate. He encircled Ophel with it, and raised it up to a very great height; and he put valiant captains in all the fortified cities of Judah. 
+<sup>15&#160;</sup>He took away the foreign elohims and the idol out of Yahweh’s house, and all the altars that he had built in the mountain of Yahweh’s house and in Jerusalem, and cast them out of the city. 
+<sup>16&#160;</sup>He built up Yahweh’s altar, and offered sacrifices of peace offerings and of thanksgiving on it, and commanded Judah to serve Yahweh, the Elohim of Israel. 
+<sup>17&#160;</sup>Nevertheless the people still sacrificed in the high places, but only to Yahweh their Elohim. 
+</div><div class="p">
+<sup>18&#160;</sup>Now the rest of the acts of Manasseh, and his prayer to his Elohim, and the words of the seers who spoke to him in the name of Yahweh, the Elohim of Israel, behold, they are written among the acts of the kings of Israel. 
+<sup>19&#160;</sup>His prayer also, and how Elohim listened to his request, and all his sin and his trespass, and the places in which he built high places and set up the Asherah poles and the engraved images before he humbled himself: behold, they are written in the history of Hozai. 
+<sup>20&#160;</sup>So Manasseh slept with his fathers, and they buried him in his own house; and Amon his son reigned in his place. 
+</div><div class="p">
+<sup>21&#160;</sup>Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. 
+<sup>22&#160;</sup>He did that which was evil in Yahweh’s sight, as did Manasseh his father; and Amon sacrificed to all the engraved images which Manasseh his father had made, and served them. 
+<sup>23&#160;</sup>He didn’t humble himself before Yahweh, as Manasseh his father had humbled himself; but this same Amon trespassed more and more. 
+<sup>24&#160;</sup>His servants conspired against him, and put him to death in his own house. 
+<sup>25&#160;</sup>But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. 
+<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, and walked in the ways of David his father, and didn’t turn away to the right hand or to the left. 
+<sup>3&#160;</sup>For in the eighth year of his reign, while he was yet young, he began to seek after the Elohim of David his father; and in the twelfth year he began to purge Judah and Jerusalem from the high places, the Asherah poles, the engraved images, and the molten images. 
+<sup>4&#160;</sup>They broke down the altars of the Baals in his presence; and he cut down the incense altars that were on high above them. He broke the Asherah poles, the engraved images, and the molten images in pieces, made dust of them, and scattered it on the graves of those who had sacrificed to them. 
+<sup>5&#160;</sup>He burned the bones of the priests on their altars, and purged Judah and Jerusalem. 
+<sup>6&#160;</sup>He did this in the cities of Manasseh, Ephraim, and Simeon, even to Naphtali, around in their ruins. 
+<sup>7&#160;</sup>He broke down the altars, beat the Asherah poles and the engraved images into powder, and cut down all the incense altars throughout all the land of Israel, then returned to Jerusalem. 
+</div><div class="p">
+<sup>8&#160;</sup>Now in the eighteenth year of his reign, when he had purged the land and the house, he sent Shaphan the son of Azaliah, Maaseiah the governor of the city, and Joah the son of Joahaz the recorder to repair the house of Yahweh his Elohim. 
+<sup>9&#160;</sup>They came to Hilkiah the high priest and delivered the money that was brought into Elohim’s house, which the Levites, the keepers of the threshold, had gathered from the hands of Manasseh, Ephraim, of all the remnant of Israel, of all Judah and Benjamin, and of the inhabitants of Jerusalem. 
+<sup>10&#160;</sup>They delivered it into the hands of the workmen who had the oversight of Yahweh’s house; and the workmen who labored in Yahweh’s house gave it to mend and repair the house. 
+<sup>11&#160;</sup>They gave it to the carpenters and to the builders to buy cut stone and timber for couplings, and to make beams for the houses which the kings of Judah had destroyed. 
+<sup>12&#160;</sup>The men did the work faithfully. Their overseers were Jahath and Obadiah the Levites, of the sons of Merari; and Zechariah and Meshullam, of the sons of the Kohathites, to give direction; and others of the Levites, who were all skillful with musical instruments. 
+<sup>13&#160;</sup>Also they were over the bearers of burdens, and directed all who did the work in every kind of service. Of the Levites, there were scribes, officials, and gatekeepers. 
+</div><div class="p">
+<sup>14&#160;</sup>When they brought out the money that was brought into Yahweh’s house, Hilkiah the priest found the book of Yahweh’s law given by Moses. 
+<sup>15&#160;</sup>Hilkiah answered Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” So Hilkiah delivered the book to Shaphan. 
+</div><div class="p">
+<sup>16&#160;</sup>Shaphan carried the book to the king, and moreover brought back word to the king, saying, “All that was committed to your servants, they are doing. 
+<sup>17&#160;</sup>They have emptied out the money that was found in Yahweh’s house, and have delivered it into the hand of the overseers and into the hand of the workmen.” 
+<sup>18&#160;</sup>Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered me a book.” Shaphan read from it to the king. 
+</div><div class="p">
+<sup>19&#160;</sup>When the king had heard the words of the law, he tore his clothes. 
+<sup>20&#160;</sup>The king commanded Hilkiah, Ahikam the son of Shaphan, Abdon the son of Micah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
+<sup>21&#160;</sup>“Go inquire of Yahweh for me, and for those who are left in Israel and in Judah, concerning the words of the book that is found; for great is Yahweh’s wrath that is poured out on us, because our fathers have not kept Yahweh’s word, to do according to all that is written in this book.” 
+</div><div class="p">
+<sup>22&#160;</sup>So Hilkiah and those whom the king had commanded went to Huldah the prophetess, the woman of Shallum the son of Tokhath, the son of Hasrah, keeper of the wardrobe (now she lived in Jerusalem in the second quarter), and they spoke to her to that effect. 
+</div><div class="p">
+<sup>23&#160;</sup>She said to them, “Yahweh, the Elohim of Israel says: ‘Tell the man who sent you to me, 
+<sup>24&#160;</sup>“Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the curses that are written in the book which they have read before the king of Judah. 
+<sup>25&#160;</sup>Because they have forsaken me, and have burned incense to other elohims, that they might provoke me to anger with all the works of their hands, therefore my wrath is poured out on this place, and it will not be quenched.’&#160;”&#160;’ 
+<sup>26&#160;</sup>But to the king of Judah, who sent you to inquire of Yahweh, you shall tell him this, ‘Yahweh, the Elohim of Israel says: “About the words which you have heard, 
+<sup>27&#160;</sup>because your heart was tender, and you humbled yourself before Elohim when you heard his words against this place and against its inhabitants, and have humbled yourself before me, and have torn your clothes and wept before me, I also have heard you,” says Yahweh. 
+<sup>28&#160;</sup>“Behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes won’t see all the evil that I will bring on this place and on its inhabitants.”&#160;’&#160;” 
+</div><div class="p">They brought back this message to the king. 
+</div><div class="p">
+<sup>29&#160;</sup>Then the king sent and gathered together all the elders of Judah and Jerusalem. 
+<sup>30&#160;</sup>The king went up to Yahweh’s house with all the men of Judah and the inhabitants of Jerusalem—the priests, the Levites, and all the people, both great and small—and he read in their hearing all the words of the book of the covenant that was found in Yahweh’s house. 
+<sup>31&#160;</sup>The king stood in his place and made a covenant before Yahweh, to walk after Yahweh, and to keep his commandments, his testimonies, and his statutes with all his heart and with all his soul, to perform the words of the covenant that were written in this book. 
+<sup>32&#160;</sup>He caused all who were found in Jerusalem and Benjamin to stand. The inhabitants of Jerusalem did according to the covenant of Elohim, the Elohim of their fathers. 
+<sup>33&#160;</sup>Josiah took away all the abominations out of all the countries that belonged to the children of Israel, and made all who were found in Israel to serve, even to serve Yahweh their Elohim. All his days they didn’t depart from following Yahweh, the Elohim of their fathers. 
+</div><h2 class="chapterlabel" id="35">35</h2>
+<div class="p">
+<sup>1&#160;</sup>Josiah kept a Passover to Yahweh in Jerusalem. They killed the Passover on the fourteenth day of the first month. 
+<sup>2&#160;</sup>He set the priests in their offices and encouraged them in the service of Yahweh’s house. 
+<sup>3&#160;</sup>He said to the Levites who taught all Israel, who were set-apart to Yahweh, “Put the set-apart ark in the house which Solomon the son of David king of Israel built. It will no longer be a burden on your shoulders. Now serve Yahweh your Elohim and his people Israel. 
+<sup>4&#160;</sup>Prepare yourselves after your fathers’ houses by your divisions, according to the writing of David king of Israel, and according to the writing of Solomon his son. 
+<sup>5&#160;</sup>Stand in the set-apart place according to the divisions of the fathers’ houses of your brothers the children of the people, and let there be for each a portion of a fathers’ house of the Levites. 
+<sup>6&#160;</sup>Kill the Passover lamb, sanctify yourselves, and prepare for your brothers, to do according to Yahweh’s word by Moses.” 
+</div><div class="p">
+<sup>7&#160;</sup>Josiah gave to the children of the people, of the flock, lambs and young goats, all of them for the Passover offerings, to all who were present, to the number of thirty thousand, and three thousand bulls. These were of the king’s substance. 
+<sup>8&#160;</sup>His princes gave a free will offering to the people, to the priests, and to the Levites. Hilkiah, Zechariah, and Jehiel, the rulers of Elohim’s house, gave to the priests for the Passover offerings two thousand six hundred small livestock, and three hundred head of cattle. 
+<sup>9&#160;</sup>Conaniah also, and Shemaiah and Nethanel, his brothers, and Hashabiah, Jeiel, and Jozabad, the chiefs of the Levites, gave to the Levites for the Passover offerings five thousand small livestock and five hundred head of cattle. 
+</div><div class="p">
+<sup>10&#160;</sup>So the service was prepared, and the priests stood in their place, and the Levites by their divisions, according to the king’s commandment. 
+<sup>11&#160;</sup>They killed the Passover lambs, and the priests sprinkled the blood which they received from their hands, and the Levites skinned them. 
+<sup>12&#160;</sup>They removed the burnt offerings, that they might give them according to the divisions of the fathers’ houses of the children of the people, to offer to Yahweh, as it is written in the book of Moses. They did the same with the cattle. 
+<sup>13&#160;</sup>They roasted the Passover with fire according to the ordinance. They boiled the set-apart offerings in pots, in cauldrons, and in pans, and carried them quickly to all the children of the people. 
+<sup>14&#160;</sup>Afterward they prepared for themselves and for the priests, because the priests the sons of Aaron were busy with offering the burnt offerings and the fat until night. Therefore the Levites prepared for themselves and for the priests the sons of Aaron. 
+<sup>15&#160;</sup>The singers, the sons of Asaph, were in their place, according to the commandment of David, Asaph, Heman, and Jeduthun the king’s seer; and the gatekeepers were at every gate. They didn’t need to depart from their service, because their brothers the Levites prepared for them. 
+</div><div class="p">
+<sup>16&#160;</sup>So all the service of Yahweh was prepared the same day, to keep the Passover, and to offer burnt offerings on Yahweh’s altar, according to the commandment of King Josiah. 
+<sup>17&#160;</sup>The children of Israel who were present kept the Passover at that time, and the feast of unleavened bread seven days. 
+<sup>18&#160;</sup>There was no Passover like that kept in Israel from the days of Samuel the prophet, nor did any of the kings of Israel keep such a Passover as Josiah kept—with the priests, the Levites, and all Judah and Israel who were present, and the inhabitants of Jerusalem. 
+<sup>19&#160;</sup>This Passover was kept in the eighteenth year of the reign of Josiah. 
+</div><div class="p">
+<sup>20&#160;</sup>After all this, when Josiah had prepared the temple, Neco king of Egypt went up to fight against Carchemish by the Euphrates, and Josiah went out against him. 
+<sup>21&#160;</sup>But he sent ambassadors to him, saying, “What have I to do with you, you king of Judah? I come not against you today, but against the house with which I have war. Elohim has commanded me to make haste. Beware that it is Elohim who is with me, that he not destroy you.” 
+</div><div class="p">
+<sup>22&#160;</sup>Nevertheless Josiah would not turn his face from him, but disguised himself, that he might fight with him, and didn’t listen to the words of Neco from the mouth of Elohim, and came to fight in the valley of Megiddo. 
+<sup>23&#160;</sup>The archers shot at King Josiah; and the king said to his servants, “Take me away, because I am seriously wounded!” 
+</div><div class="p">
+<sup>24&#160;</sup>So his servants took him out of the chariot, and put him in the second chariot that he had, and brought him to Jerusalem; and he died, and was buried in the tombs of his fathers. All Judah and Jerusalem mourned for Josiah. 
+<sup>25&#160;</sup>Jeremiah lamented for Josiah, and all the singing men and singing women spoke of Josiah in their lamentations to this day; and they made them an ordinance in Israel. Behold, they are written in the lamentations. 
+<sup>26&#160;</sup>Now the rest of the acts of Josiah and his good deeds, according to that which is written in Yahweh’s law, 
+<sup>27&#160;</sup>and his acts, first and last, behold, they are written in the book of the kings of Israel and Judah. 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>Then the people of the land took Jehoahaz the son of Josiah, and made him king in his father’s place in Jerusalem. 
+<sup>2&#160;</sup>Joahaz was twenty-three years old when he began to reign; and he reigned three months in Jerusalem. 
+<sup>3&#160;</sup>The king of Egypt removed him from office at Jerusalem, and fined the land one hundred talents of silver and a talent of gold. 
+<sup>4&#160;</sup>The king of Egypt made Eliakim his brother king over Judah and Jerusalem, and changed his name to Jehoiakim. Neco took Joahaz his brother, and carried him to Egypt. 
+</div><div class="p">
+<sup>5&#160;</sup>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. He did that which was evil in Yahweh his Elohim’s sight. 
+<sup>6&#160;</sup>Nebuchadnezzar king of Babylon came up against him, and bound him in fetters to carry him to Babylon. 
+<sup>7&#160;</sup>Nebuchadnezzar also carried some of the vessels of Yahweh’s house to Babylon, and put them in his temple at Babylon. 
+<sup>8&#160;</sup>Now the rest of the acts of Jehoiakim, and his abominations which he did, and that which was found in him, behold, they are written in the book of the kings of Israel and Judah; and Jehoiachin his son reigned in his place. 
+</div><div class="p">
+<sup>9&#160;</sup>Jehoiachin was eight years old when he began to reign, and he reigned three months and ten days in Jerusalem. He did that which was evil in Yahweh’s sight. 
+<sup>10&#160;</sup>At the return of the year, King Nebuchadnezzar sent and brought him to Babylon, with the valuable vessels of Yahweh’s house, and made Zedekiah his brother king over Judah and Jerusalem. 
+</div><div class="p">
+<sup>11&#160;</sup>Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. 
+<sup>12&#160;</sup>He did that which was evil in Yahweh his Elohim’s sight. He didn’t humble himself before Jeremiah the prophet speaking from Yahweh’s mouth. 
+<sup>13&#160;</sup>He also rebelled against King Nebuchadnezzar, who had made him swear by Elohim; but he stiffened his neck, and hardened his heart against turning to Yahweh, the Elohim of Israel. 
+<sup>14&#160;</sup>Moreover all the chiefs of the priests and the people trespassed very greatly after all the abominations of the nations; and they polluted Yahweh’s house which he had made set-apart in Jerusalem. 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh, the Elohim of their fathers, sent to them by his messengers, rising up early and sending, because he had compassion on his people and on his dwelling place; 
+<sup>16&#160;</sup>but they mocked the messengers of Elohim, despised his words, and scoffed at his prophets, until Yahweh’s wrath arose against his people, until there was no remedy. 
+</div><div class="p">
+<sup>17&#160;</sup>Therefore he brought on them the king of the Chaldeans, who killed their young men with the sword in the house of their sanctuary, and had no compassion on young man or virgin, old man or infirm. He gave them all into his hand. 
+<sup>18&#160;</sup>All the vessels of Elohim’s house, great and small, and the treasures of Yahweh’s house, and the treasures of the king and of his princes, all these he brought to Babylon. 
+<sup>19&#160;</sup>They burned Elohim’s house, broke down the wall of Jerusalem, burned all its palaces with fire, and destroyed all of its valuable vessels. 
+<sup>20&#160;</sup>He carried those who had escaped from the sword away to Babylon, and they were servants to him and his sons until the reign of the kingdom of Persia, 
+<sup>21&#160;</sup>to fulfill Yahweh’s word by Jeremiah’s mouth, until the land had enjoyed its Sabbaths. As long as it lay desolate, it kept Sabbath, to fulfill seventy years. 
+</div><div class="p">
+<sup>22&#160;</sup>Now in the first year of Cyrus king of Persia, that Yahweh’s word by the mouth of Jeremiah might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
+<sup>23&#160;</sup>“Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given all the kingdoms of the earth to me; and he has commanded me to build him a house in Jerusalem, which is in Judah. Whoever there is among you of all his people, Yahweh his Elohim be with him, and let him go up.’&#160;” </div></div><script src="../main.js"></script></body></html>

--- a/book/2john.html
+++ b/book/2john.html
@@ -3,6 +3,47 @@
 <head>
 <title>2 John</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,21 +53,23 @@
 <div class="main">
 <!-- 2JN World English Scripture (WES) -->
 <h1 class="booklabel">2 John</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The elder, to the chosen lady and her children, whom I love in truth, and not I only, but also all those who know the truth, 
-<span class="v">2&#160;</span>for the truth’s sake, which remains in us, and it will be with us forever: 
-<span class="v">3&#160;</span>Grace, mercy, and peace will be with us, from Elohim the Father and from the Lord Yahushua Christ,<span class="f">+ \fr 1:3 \ft “Christ” means “Anointed One”.</span> the Son of the Father, in truth and love. 
-</p><p>
-<span class="v">4&#160;</span>I rejoice greatly that I have found some of your children walking in truth, even as we have been commanded by the Father. 
-<span class="v">5&#160;</span>Now I beg you, dear lady, not as though I wrote to you a new commandment, but that which we had from the beginning, that we love one another. 
-<span class="v">6&#160;</span>This is love, that we should walk according to his commandments. This is the commandment, even as you heard from the beginning, that you should walk in it. 
-</p><p>
-<span class="v">7&#160;</span>For many deceivers have gone out into the world, those who don’t confess that Yahushua Christ came in the flesh. This is the deceiver and the Antichrist. 
-<span class="v">8&#160;</span>Watch yourselves, that we don’t lose the things which we have accomplished, but that we receive a full reward. 
-<span class="v">9&#160;</span>Whoever transgresses and doesn’t remain in the teaching of Christ doesn’t have Elohim. He who remains in the teaching has both the Father and the Son. 
-<span class="v">10&#160;</span>If anyone comes to you and doesn’t bring this teaching, don’t receive him into your house, and don’t welcome him, 
-<span class="v">11&#160;</span>for he who welcomes him participates in his evil deeds. 
-</p><p>
-<span class="v">12&#160;</span>Having many things to write to you, I don’t want to do so with paper and ink, but I hope to come to you and to speak face to face, that our joy may be made full. 
-<span class="v">13&#160;</span>The children of your chosen sister greet you. Amen. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The elder, to the chosen lady and her children, whom I love in truth, and not I only, but also all those who know the truth, 
+<sup>2&#160;</sup>for the truth’s sake, which remains in us, and it will be with us forever: 
+<sup>3&#160;</sup>Grace, mercy, and peace will be with us, from Elohim the Father and from the Lord Yahushua Christ, the Son of the Father, in truth and love. 
+</div><div class="p">
+<sup>4&#160;</sup>I rejoice greatly that I have found some of your children walking in truth, even as we have been commanded by the Father. 
+<sup>5&#160;</sup>Now I beg you, dear lady, not as though I wrote to you a new commandment, but that which we had from the beginning, that we love one another. 
+<sup>6&#160;</sup>This is love, that we should walk according to his commandments. This is the commandment, even as you heard from the beginning, that you should walk in it. 
+</div><div class="p">
+<sup>7&#160;</sup>For many deceivers have gone out into the world, those who don’t confess that Yahushua Christ came in the flesh. This is the deceiver and the Antichrist. 
+<sup>8&#160;</sup>Watch yourselves, that we don’t lose the things which we have accomplished, but that we receive a full reward. 
+<sup>9&#160;</sup>Whoever transgresses and doesn’t remain in the teaching of Christ doesn’t have Elohim. He who remains in the teaching has both the Father and the Son. 
+<sup>10&#160;</sup>If anyone comes to you and doesn’t bring this teaching, don’t receive him into your house, and don’t welcome him, 
+<sup>11&#160;</sup>for he who welcomes him participates in his evil deeds. 
+</div><div class="p">
+<sup>12&#160;</sup>Having many things to write to you, I don’t want to do so with paper and ink, but I hope to come to you and to speak face to face, that our joy may be made full. 
+<sup>13&#160;</sup>The children of your chosen sister greet you. Amen. </div></div><script src="../main.js"></script></body></html>

--- a/book/2kings.html
+++ b/book/2kings.html
@@ -3,6 +3,47 @@
 <head>
 <title>2 Kings</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1074 +53,1100 @@
 <div class="main">
 <!-- 2KI World English Scripture (WES) -->
 <h1 class="booklabel">2 Kings</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Moab rebelled against Israel after the death of Ahab. 
-</p><p>
-<span class="v">2&#160;</span>Ahaziah fell down through the lattice in his upper room that was in Samaria, and was sick. So he sent messengers, and said to them, “Go, inquire of Baal Zebub, the elohim of Ekron, whether I will recover of this sickness.” 
-</p><p>
-<span class="v">3&#160;</span>But Yahweh’s<span class="f">+ \fr 1:3 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> angel said to Elijah the Tishbite, “Arise, go up to meet the messengers of the king of Samaria, and tell them, ‘Is it because there is no Elohim<span class="f">+ \fr 1:3 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> in Israel that you go to inquire of Baal Zebub, the elohim of Ekron? 
-<span class="v">4&#160;</span>Now therefore Yahweh says, “You will not come down from the bed where you have gone up, but you will surely die.”&#160;’&#160;” Then Elijah departed. 
-</p><p>
-<span class="v">5&#160;</span>The messengers returned to him, and he said to them, “Why is it that you have returned?” 
-</p><p>
-<span class="v">6&#160;</span>They said to him, “A man came up to meet us, and said to us, ‘Go, return to the king who sent you, and tell him, “Yahweh says, ‘Is it because there is no Elohim in Israel that you send to inquire of Baal Zebub, the elohim of Ekron? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;”&#160;’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>He said to them, “What kind of man was he who came up to meet you and told you these words?” 
-</p><p>
-<span class="v">8&#160;</span>They answered him, “He was a man, an owner of hair, and wearing a leather belt around his waist.” 
-</p><p>He said, “It’s Elijah the Tishbite.” 
-</p><p>
-<span class="v">9&#160;</span>Then the king sent a captain of fifty with his fifty to him. He went up to him; and behold,<span class="f">+ \fr 1:9 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> he was sitting on the top of the hill. He said to him, “Man of Elohim, the king has said, ‘Come down!’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Elijah answered to the captain of fifty, “If I am a man of Elohim, then let fire come down from the sky and consume you and your fifty!” Then fire came down from the sky, and consumed him and his fifty. 
-</p><p>
-<span class="v">11&#160;</span>Again he sent to him another captain of fifty with his fifty. He answered him, “Man of Elohim, the king has said, ‘Come down quickly!’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Elijah answered them, “If I am a man of Elohim, then let fire come down from the sky and consume you and your fifty!” Then Elohim’s fire came down from the sky, and consumed him and his fifty. 
-</p><p>
-<span class="v">13&#160;</span>Again he sent the captain of a third fifty with his fifty. The third captain of fifty went up, and came and fell on his knees before Elijah, and begged him, and said to him, “Man of Elohim, please let my life and the life of these fifty of your servants be precious in your sight. 
-<span class="v">14&#160;</span>Behold, fire came down from the sky and consumed the last two captains of fifty with their fifties. But now let my life be precious in your sight.” 
-</p><p>
-<span class="v">15&#160;</span>Yahweh’s angel said to Elijah, “Go down with him. Don’t be afraid of him.” 
-</p><p>Then he arose and went down with him to the king. 
-<span class="v">16&#160;</span>He said to him, “Yahweh says, ‘Because you have sent messengers to inquire of Baal Zebub, the elohim of Ekron, is it because there is no Elohim in Israel to inquire of his word? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>So he died according to Yahweh’s word which Elijah had spoken. Jehoram began to reign in his place in the second year of Jehoram the son of Jehoshaphat king of Judah, because he had no son. 
-<span class="v">18&#160;</span>Now the rest of the acts of Ahaziah which he did, aren’t they written in the book of the chronicles of the kings of Israel? 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>When Yahweh was about to take Elijah up by a whirlwind into heaven, Elijah went with Elisha from Gilgal. 
-<span class="v">2&#160;</span>Elijah said to Elisha, “Please wait here, for Yahweh has sent me as far as Bethel.” 
-</p><p>Elisha said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they went down to Bethel. 
-</p><p>
-<span class="v">3&#160;</span>The sons of the prophets who were at Bethel came out to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
-</p><p>He said, “Yes, I know it. Hold your peace.” 
-</p><p>
-<span class="v">4&#160;</span>Elijah said to him, “Elisha, please wait here, for Yahweh has sent me to Jericho.” 
-</p><p>He said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they came to Jericho. 
-</p><p>
-<span class="v">5&#160;</span>The sons of the prophets who were at Jericho came near to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
-</p><p>He answered, “Yes, I know it. Hold your peace.” 
-</p><p>
-<span class="v">6&#160;</span>Elijah said to him, “Please wait here, for Yahweh has sent me to the Jordan.” 
-</p><p>He said, “As Yahweh lives, and as your soul lives, I will not leave you.” Then they both went on. 
-<span class="v">7&#160;</span>Fifty men of the sons of the prophets went and stood opposite them at a distance; and they both stood by the Jordan. 
-<span class="v">8&#160;</span>Elijah took his mantle, and rolled it up, and struck the waters; and they were divided here and there, so that they both went over on dry ground. 
-<span class="v">9&#160;</span>When they had gone over, Elijah said to Elisha, “Ask what I shall do for you, before I am taken from you.” 
-</p><p>Elisha said, “Please let a double portion of your spirit be on me.” 
-</p><p>
-<span class="v">10&#160;</span>He said, “You have asked a hard thing. If you see me when I am taken from you, it will be so for you; but if not, it will not be so.” 
-</p><p>
-<span class="v">11&#160;</span>As they continued on and talked, behold, a chariot of fire and horses of fire separated them; and Elijah went up by a whirlwind into heaven. 
-<span class="v">12&#160;</span>Elisha saw it, and he cried, “My father, my father, the chariots of Israel and its horsemen!” 
-</p><p>He saw him no more. Then he took hold of his own clothes and tore them in two pieces. 
-<span class="v">13&#160;</span>He also took up Elijah’s mantle that fell from him, and went back and stood by the bank of the Jordan. 
-<span class="v">14&#160;</span>He took Elijah’s mantle that fell from him, and struck the waters, and said, “Where is Yahweh, the Elohim of Elijah?” When he also had struck the waters, they were divided apart, and Elisha went over. 
-</p><p>
-<span class="v">15&#160;</span>When the sons of the prophets who were at Jericho facing him saw him, they said, “The spirit of Elijah rests on Elisha.” They came to meet him, and bowed themselves to the ground before him. 
-<span class="v">16&#160;</span>They said to him, “See now, there are with your servants fifty strong men. Please let them go and seek your master. Perhaps Yahweh’s Spirit has taken him up, and put him on some mountain or into some valley.” 
-</p><p>He said, “Don’t send them.” 
-</p><p>
-<span class="v">17&#160;</span>When they urged him until he was ashamed, he said, “Send them.” 
-</p><p>Therefore they sent fifty men; and they searched for three days, but didn’t find him. 
-<span class="v">18&#160;</span>They came back to him while he stayed at Jericho; and he said to them, “Didn’t I tell you, ‘Don’t go’?” 
-</p><p>
-<span class="v">19&#160;</span>The men of the city said to Elisha, “Behold, please, the situation of this city is pleasant, as my lord sees; but the water is bad, and the land is barren.” 
-</p><p>
-<span class="v">20&#160;</span>He said, “Bring me a new jar, and put salt in it.” Then they brought it to him. 
-<span class="v">21&#160;</span>He went out to the spring of the waters, and threw salt into it, and said, “Yahweh says, ‘I have healed these waters. There shall not be from there any more death or barren wasteland.’&#160;” 
-<span class="v">22&#160;</span>So the waters were healed to this day, according to Elisha’s word which he spoke. 
-</p><p>
-<span class="v">23&#160;</span>He went up from there to Bethel. As he was going up by the way, some youths came out of the city and mocked him, and said to him, “Go up, you baldy! Go up, you baldy!” 
-<span class="v">24&#160;</span>He looked behind him and saw them, and cursed them in Yahweh’s name. Then two female bears came out of the woods and mauled forty-two of those youths. 
-<span class="v">25&#160;</span>He went from there to Mount Carmel, and from there he returned to Samaria. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now Jehoram the son of Ahab began to reign over Israel in Samaria in the eighteenth year of Jehoshaphat king of Judah, and reigned twelve years. 
-<span class="v">2&#160;</span>He did that which was evil in Yahweh’s sight, but not like his father and like his mother, for he put away the pillar of Baal that his father had made. 
-<span class="v">3&#160;</span>Nevertheless he held to the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from them. 
-</p><p>
-<span class="v">4&#160;</span>Now Mesha king of Moab was a sheep breeder; and he supplied the king of Israel with one hundred thousand lambs and the wool of one hundred thousand rams. 
-<span class="v">5&#160;</span>But when Ahab was dead, the king of Moab rebelled against the king of Israel. 
-<span class="v">6&#160;</span>King Jehoram went out of Samaria at that time, and mustered all Israel. 
-<span class="v">7&#160;</span>He went and sent to Jehoshaphat the king of Judah, saying, “The king of Moab has rebelled against me. Will you go with me against Moab to battle?” 
-</p><p>He said, “I will go up. I am as you are, my people as your people, my horses as your horses.” 
-<span class="v">8&#160;</span>Then he said, “Which way shall we go up?” 
-</p><p>Jehoram answered, “The way of the wilderness of Edom.” 
-</p><p>
-<span class="v">9&#160;</span>So the king of Israel went with the king of Judah and the king of Edom, and they marched for seven days along a circuitous route. There was no water for the army or for the animals that followed them. 
-<span class="v">10&#160;</span>The king of Israel said, “Alas! For Yahweh has called these three kings together to deliver them into the hand of Moab.” 
-</p><p>
-<span class="v">11&#160;</span>But Jehoshaphat said, “Isn’t there a prophet of Yahweh here, that we may inquire of Yahweh by him?” 
-</p><p>One of the king of Israel’s servants answered, “Elisha the son of Shaphat, who poured water on the hands of Elijah, is here.” 
-</p><p>
-<span class="v">12&#160;</span>Jehoshaphat said, “Yahweh’s word is with him.” So the king of Israel and Jehoshaphat and the king of Edom went down to him. 
-</p><p>
-<span class="v">13&#160;</span>Elisha said to the king of Israel, “What have I to do with you? Go to the prophets of your father, and to the prophets of your mother.” 
-</p><p>The king of Israel said to him, “No, for Yahweh has called these three kings together to deliver them into the hand of Moab.” 
-</p><p>
-<span class="v">14&#160;</span>Elisha said, “As Yahweh of Armies lives, before whom I stand, surely, were it not that I respect the presence of Jehoshaphat the king of Judah, I would not look toward you, nor see you. 
-<span class="v">15&#160;</span>But now bring me a musician.” When the musician played, Yahweh’s hand came on him. 
-<span class="v">16&#160;</span>He said, “Yahweh says, ‘Make this valley full of trenches.’ 
-<span class="v">17&#160;</span>For Yahweh says, ‘You will not see wind, neither will you see rain, yet that valley will be filled with water, and you will drink, both you and your livestock and your other animals. 
-<span class="v">18&#160;</span>This is an easy thing in Yahweh’s sight. He will also deliver the Moabites into your hand. 
-<span class="v">19&#160;</span>You shall strike every fortified city and every choice city, and shall fell every good tree, and stop all springs of water, and mar every good piece of land with stones.’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>In the morning, about the time of offering the sacrifice, behold, water came by the way of Edom, and the country was filled with water. 
-</p><p>
-<span class="v">21&#160;</span>Now when all the Moabites heard that the kings had come up to fight against them, they gathered themselves together, all who were able to put on armor, young and old, and stood on the border. 
-<span class="v">22&#160;</span>They rose up early in the morning, and the sun shone on the water, and the Moabites saw the water opposite them as red as blood. 
-<span class="v">23&#160;</span>They said, “This is blood. The kings are surely destroyed, and they have struck each other. Now therefore, Moab, to the plunder!” 
-</p><p>
-<span class="v">24&#160;</span>When they came to the camp of Israel, the Israelites rose up and struck the Moabites, so that they fled before them; and they went forward into the land attacking the Moabites. 
-<span class="v">25&#160;</span>They beat down the cities; and on every good piece of land each man cast his stone, and filled it. They also stopped all the springs of water and cut down all the good trees, until in Kir Hareseth all they left was its stones; however the men armed with slings went around it and attacked it. 
-<span class="v">26&#160;</span>When the king of Moab saw that the battle was too severe for him, he took with him seven hundred men who drew a sword, to break through to the king of Edom; but they could not. 
-<span class="v">27&#160;</span>Then he took his oldest son who would have reigned in his place, and offered him for a burnt offering on the wall. There was great wrath against Israel; and they departed from him, and returned to their own land. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Now a certain woman of the women of the sons of the prophets cried out to Elisha, saying, “Your servant my man is dead. You know that your servant feared Yahweh. Now the creditor has come to take for himself my two children to be slaves.” 
-</p><p>
-<span class="v">2&#160;</span>Elisha said to her, “What should I do for you? Tell me, what do you have in the house?” 
-</p><p>She said, “Your servant has nothing in the house, except a pot of oil.” 
-</p><p>
-<span class="v">3&#160;</span>Then he said, “Go, borrow empty containers from all your neighbors. Don’t borrow just a few containers. 
-<span class="v">4&#160;</span>Go in and shut the door on you and on your sons, and pour oil into all those containers; and set aside those which are full.” 
-</p><p>
-<span class="v">5&#160;</span>So she went from him, and shut the door on herself and on her sons. They brought the containers to her, and she poured oil. 
-<span class="v">6&#160;</span>When the containers were full, she said to her son, “Bring me another container.” 
-</p><p>He said to her, “There isn’t another container.” Then the oil stopped flowing. 
-</p><p>
-<span class="v">7&#160;</span>Then she came and told the man of Elohim. He said, “Go, sell the oil, and pay your debt; and you and your sons live on the rest.” 
-</p><p>
-<span class="v">8&#160;</span>One day Elisha went to Shunem, where there was a prominent woman; and she persuaded him to eat bread. So it was, that as often as he passed by, he turned in there to eat bread. 
-<span class="v">9&#160;</span>She said to her man, “See now, I perceive that this is a set-apart man of Elohim who passes by us continually. 
-<span class="v">10&#160;</span>Please, let’s make a little room on the roof. Let’s set a bed, a table, a chair, and a lamp stand for him there. When he comes to us, he can stay there.” 
-</p><p>
-<span class="v">11&#160;</span>One day he came there, and he went to the room and lay there. 
-<span class="v">12&#160;</span>He said to Gehazi his servant, “Call this Shunammite.” When he had called her, she stood before him. 
-<span class="v">13&#160;</span>He said to him, “Say now to her, ‘Behold, you have cared for us with all this care. What is to be done for you? Would you like to be spoken for to the king, or to the captain of the army?’&#160;” 
-</p><p>She answered, “I dwell among my own people.” 
-</p><p>
-<span class="v">14&#160;</span>He said, “What then is to be done for her?” 
-</p><p>Gehazi answered, “Most certainly she has no son, and her man is old.” 
-</p><p>
-<span class="v">15&#160;</span>He said, “Call her.” When he had called her, she stood in the door. 
-<span class="v">16&#160;</span>He said, “At this season next year, you will embrace a son.” 
-</p><p>She said, “No, my lord, you man of Elohim, do not lie to your servant.” 
-</p><p>
-<span class="v">17&#160;</span>The woman conceived, and bore a son at that season when the time came around, as Elisha had said to her. 
-<span class="v">18&#160;</span>When the child was grown, one day he went out to his father to the reapers. 
-<span class="v">19&#160;</span>He said to his father, “My head! My head!” 
-</p><p>He said to his servant, “Carry him to his mother.” 
-</p><p>
-<span class="v">20&#160;</span>When he had taken him and brought him to his mother, he sat on her knees until noon, and then died. 
-<span class="v">21&#160;</span>She went up and laid him on the man of Elohim’s bed, and shut the door on him, and went out. 
-<span class="v">22&#160;</span>She called to her man and said, “Please send me one of the servants, and one of the donkeys, that I may run to the man of Elohim and come again.” 
-</p><p>
-<span class="v">23&#160;</span>He said, “Why would you want to go to him today? It is not a new moon or a Sabbath.” 
-</p><p>She said, “It’s all right.” 
-</p><p>
-<span class="v">24&#160;</span>Then she saddled a donkey, and said to her servant, “Drive, and go forward! Don’t slow down for me, unless I ask you to.” 
-</p><p>
-<span class="v">25&#160;</span>So she went, and came to the man of Elohim to Mount Carmel. When the man of Elohim saw her afar off, he said to Gehazi his servant, “Behold, there is the Shunammite. 
-<span class="v">26&#160;</span>Please run now to meet her, and ask her, ‘Is it well with you? Is it well with your man? Is it well with your child?’&#160;” 
-</p><p>She answered, “It is well.” 
-</p><p>
-<span class="v">27&#160;</span>When she came to the man of Elohim to the hill, she caught hold of his feet. Gehazi came near to thrust her away; but the man of Elohim said, “Leave her alone, for her soul is troubled within her; and Yahweh has hidden it from me, and has not told me.” 
-</p><p>
-<span class="v">28&#160;</span>Then she said, “Did I ask you for a son, my lord? Didn’t I say, ‘Do not deceive me’?” 
-</p><p>
-<span class="v">29&#160;</span>Then he said to Gehazi, “Tuck your cloak into your belt, take my staff in your hand, and go your way. If you meet any man, don’t greet him; and if anyone greets you, don’t answer him again. Then lay my staff on the child’s face.” 
-</p><p>
-<span class="v">30&#160;</span>The child’s mother said, “As Yahweh lives, and as your soul lives, I will not leave you.” 
-</p><p>So he arose, and followed her. 
-</p><p>
-<span class="v">31&#160;</span>Gehazi went ahead of them, and laid the staff on the child’s face; but there was no voice and no hearing. Therefore he returned to meet him, and told him, “The child has not awakened.” 
-</p><p>
-<span class="v">32&#160;</span>When Elisha had come into the house, behold, the child was dead, and lying on his bed. 
-<span class="v">33&#160;</span>He went in therefore, and shut the door on them both, and prayed to Yahweh. 
-<span class="v">34&#160;</span>He went up and lay on the child, and put his mouth on his mouth, and his eyes on his eyes, and his hands on his hands. He stretched himself on him; and the child’s flesh grew warm. 
-<span class="v">35&#160;</span>Then he returned, and walked in the house once back and forth, then went up and stretched himself out on him. Then the child sneezed seven times, and the child opened his eyes. 
-<span class="v">36&#160;</span>He called Gehazi, and said, “Call this Shunammite!” So he called her. 
-</p><p>When she had come in to him, he said, “Take up your son.” 
-</p><p>
-<span class="v">37&#160;</span>Then she went in, fell at his feet, and bowed herself to the ground; then she picked up her son, and went out. 
-</p><p>
-<span class="v">38&#160;</span>Elisha came again to Gilgal. There was a famine in the land; and the sons of the prophets were sitting before him; and he said to his servant, “Get the large pot, and boil stew for the sons of the prophets.” 
-</p><p>
-<span class="v">39&#160;</span>One went out into the field to gather herbs, and found a wild vine, and gathered a lap full of wild gourds from it, and came and cut them up into the pot of stew; for they didn’t recognize them. 
-<span class="v">40&#160;</span>So they poured out for the men to eat. As they were eating some of the stew, they cried out and said, “Man of Elohim, there is death in the pot!” And they could not eat it. 
-</p><p>
-<span class="v">41&#160;</span>But he said, “Then bring meal.” He threw it into the pot; and he said, “Serve it to the people, that they may eat.” And there was nothing harmful in the pot. 
-</p><p>
-<span class="v">42&#160;</span>A man from Baal Shalishah came, and brought the man of Elohim some bread of the first fruits: twenty loaves of barley and fresh ears of grain in his sack. Elisha said, “Give to the people, that they may eat.” 
-</p><p>
-<span class="v">43&#160;</span>His servant said, “What, should I set this before a hundred men?” 
-</p><p>But he said, “Give it to the people, that they may eat; for Yahweh says, ‘They will eat, and will have some left over.’&#160;” 
-</p><p>
-<span class="v">44&#160;</span>So he set it before them and they ate and had some left over, according to Yahweh’s word. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Now Naaman, captain of the army of the king of Syria, was a great man with his master, and honorable, because by him Yahweh had given victory to Syria; he was also a mighty man of valor, but he was a leper. 
-<span class="v">2&#160;</span>The Syrians had gone out in bands, and had brought away captive out of the land of Israel a little girl, and she waited on Naaman’s woman. 
-<span class="v">3&#160;</span>She said to her mistress, “I wish that my lord were with the prophet who is in Samaria! Then he would heal him of his leprosy.” 
-</p><p>
-<span class="v">4&#160;</span>Someone went in and told his lord, saying, “The girl who is from the land of Israel said this.” 
-</p><p>
-<span class="v">5&#160;</span>The king of Syria said, “Go now, and I will send a letter to the king of Israel.” 
-</p><p>He departed, and took with him ten talents<span class="f">+ \fr 5:5 \ft A talent is about 30 kilograms or 66 pounds</span> of silver, six thousand pieces of gold, and ten changes of clothing. 
-<span class="v">6&#160;</span>He brought the letter to the king of Israel, saying, “Now when this letter has come to you, behold, I have sent Naaman my servant to you, that you may heal him of his leprosy.” 
-</p><p>
-<span class="v">7&#160;</span>When the king of Israel had read the letter, he tore his clothes and said, “Am I Elohim, to kill and to make alive, that this man sends to me to heal a man of his leprosy? But please consider and see how he seeks a quarrel against me.” 
-</p><p>
-<span class="v">8&#160;</span>It was so, when Elisha the man of Elohim heard that the king of Israel had torn his clothes, that he sent to the king, saying, “Why have you torn your clothes? Let him come now to me, and he shall know that there is a prophet in Israel.” 
-</p><p>
-<span class="v">9&#160;</span>So Naaman came with his horses and with his chariots, and stood at the door of the house of Elisha. 
-<span class="v">10&#160;</span>Elisha sent a messenger to him, saying, “Go and wash in the Jordan seven times, and your flesh shall come again to you, and you shall be clean.” 
-</p><p>
-<span class="v">11&#160;</span>But Naaman was angry, and went away and said, “Behold, I thought, ‘He will surely come out to me, and stand, and call on the name of Yahweh his Elohim, and wave his hand over the place, and heal the leper.’ 
-<span class="v">12&#160;</span>Aren’t Abanah and Pharpar, the rivers of Damascus, better than all the waters of Israel? Couldn’t I wash in them and be clean?” So he turned and went away in a rage. 
-</p><p>
-<span class="v">13&#160;</span>His servants came near and spoke to him, and said, “My father, if the prophet had asked you do some great thing, wouldn’t you have done it? How much rather then, when he says to you, ‘Wash, and be clean’?” 
-</p><p>
-<span class="v">14&#160;</span>Then went he down and dipped himself seven times in the Jordan, according to the saying of the man of Elohim; and his flesh was restored like the flesh of a little child, and he was clean. 
-<span class="v">15&#160;</span>He returned to the man of Elohim, he and all his company, and came, and stood before him; and he said, “See now, I know that there is no Elohim in all the earth, but in Israel. Now therefore, please take a gift from your servant.” 
-</p><p>
-<span class="v">16&#160;</span>But he said, “As Yahweh lives, before whom I stand, I will receive none.” 
-</p><p>He urged him to take it; but he refused. 
-<span class="v">17&#160;</span>Naaman said, “If not, then, please let two mules’ load of earth be given to your servant; for your servant will from now on offer neither burnt offering nor sacrifice to other elohims, but to Yahweh. 
-<span class="v">18&#160;</span>In this thing may Yahweh pardon your servant: when my master goes into the house of Rimmon to worship there, and he leans on my hand, and I bow myself in the house of Rimmon. When I bow myself in the house of Rimmon, may Yahweh pardon your servant in this thing.” 
-</p><p>
-<span class="v">19&#160;</span>He said to him, “Go in peace.” 
-</p><p>So he departed from him a little way. 
-<span class="v">20&#160;</span>But Gehazi the servant of Elisha the man of Elohim, said, “Behold, my master has spared this Naaman the Syrian, in not receiving at his hands that which he brought. As Yahweh lives, I will run after him, and take something from him.” 
-</p><p>
-<span class="v">21&#160;</span>So Gehazi followed after Naaman. When Naaman saw one running after him, he came down from the chariot to meet him, and said, “Is all well?” 
-</p><p>
-<span class="v">22&#160;</span>He said, “All is well. My master has sent me, saying, ‘Behold, even now two young men of the sons of the prophets have come to me from the hill country of Ephraim. Please give them a talent<span class="f">+ \fr 5:22 \ft A talent is about 30 kilograms or 66 pounds</span> of silver and two changes of clothing.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Naaman said, “Be pleased to take two talents.” He urged him, and bound two talents of silver in two bags, with two changes of clothing, and laid them on two of his servants; and they carried them before him. 
-<span class="v">24&#160;</span>When he came to the hill, he took them from their hand, and stored them in the house. Then he let the men go, and they departed. 
-<span class="v">25&#160;</span>But he went in, and stood before his master. Elisha said to him, “Where did you come from, Gehazi?” 
-</p><p>He said, “Your servant went nowhere.” 
-</p><p>
-<span class="v">26&#160;</span>He said to him, “Didn’t my heart go with you when the man turned from his chariot to meet you? Is it a time to receive money, and to receive garments, and olive groves and vineyards, and sheep and cattle, and male servants and female servants? 
-<span class="v">27&#160;</span>Therefore the leprosy of Naaman will cling to you and to your offspring<span class="f">+ \fr 5:27 \ft or, seed</span> forever.” 
-</p><p>He went out from his presence a leper, as white as snow. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>The sons of the prophets said to Elisha, “See now, the place where we live and meet with you is too small for us. 
-<span class="v">2&#160;</span>Please let us go to the Jordan, and each man take a beam from there, and let’s make us a place there, where we may live.” 
-</p><p>He answered, “Go!” 
-</p><p>
-<span class="v">3&#160;</span>One said, “Please be pleased to go with your servants.” 
-</p><p>He answered, “I will go.” 
-<span class="v">4&#160;</span>So he went with them. When they came to the Jordan, they cut down wood. 
-<span class="v">5&#160;</span>But as one was cutting down a tree, the ax head fell into the water. Then he cried out and said, “Alas, my master! For it was borrowed.” 
-</p><p>
-<span class="v">6&#160;</span>The man of Elohim asked, “Where did it fall?” He showed him the place. He cut down a stick, threw it in there, and made the iron float. 
-<span class="v">7&#160;</span>He said, “Take it.” So he put out his hand and took it. 
-</p><p>
-<span class="v">8&#160;</span>Now the king of Syria was at war against Israel; and he took counsel with his servants, saying, “My camp will be in such and such a place.” 
-</p><p>
-<span class="v">9&#160;</span>The man of Elohim sent to the king of Israel, saying, “Beware that you not pass this place, for the Syrians are coming down there.” 
-<span class="v">10&#160;</span>The king of Israel sent to the place which the man of Elohim told him and warned him of; and he saved himself there, not once or twice. 
-<span class="v">11&#160;</span>The king of Syria’s heart was very troubled about this. He called his servants, and said to them, “Won’t you show me which of us is for the king of Israel?” 
-</p><p>
-<span class="v">12&#160;</span>One of his servants said, “No, my lord, O king; but Elisha, the prophet who is in Israel, tells the king of Israel the words that you speak in your bedroom.” 
-</p><p>
-<span class="v">13&#160;</span>He said, “Go and see where he is, that I may send and get him.” 
-</p><p>He was told, “Behold, he is in Dothan.” 
-</p><p>
-<span class="v">14&#160;</span>Therefore he sent horses, chariots, and a great army there. They came by night and surrounded the city. 
-<span class="v">15&#160;</span>When the servant of the man of Elohim had risen early and gone out, behold, an army with horses and chariots was around the city. His servant said to him, “Alas, my master! What shall we do?” 
-</p><p>
-<span class="v">16&#160;</span>He answered, “Don’t be afraid, for those who are with us are more than those who are with them.” 
-<span class="v">17&#160;</span>Elisha prayed, and said, “Yahweh, please open his eyes, that he may see.” Yahweh opened the young man’s eyes, and he saw; and behold, the mountain was full of horses and chariots of fire around Elisha. 
-<span class="v">18&#160;</span>When they came down to him, Elisha prayed to Yahweh, and said, “Please strike this people with blindness.” 
-</p><p>He struck them with blindness according to Elisha’s word. 
-</p><p>
-<span class="v">19&#160;</span>Elisha said to them, “This is not the way, neither is this the city. Follow me, and I will bring you to the man whom you seek.” He led them to Samaria. 
-<span class="v">20&#160;</span>When they had come into Samaria, Elisha said, “Yahweh, open these men’s eyes, that they may see.” 
-</p><p>Yahweh opened their eyes, and they saw; and behold, they were in the middle of Samaria. 
-</p><p>
-<span class="v">21&#160;</span>The king of Israel said to Elisha, when he saw them, “My father, shall I strike them? Shall I strike them?” 
-</p><p>
-<span class="v">22&#160;</span>He answered, “You shall not strike them. Would you strike those whom you have taken captive with your sword and with your bow? Set bread and water before them, that they may eat and drink, then go to their master.” 
-</p><p>
-<span class="v">23&#160;</span>He prepared a great feast for them. After they ate and drank, he sent them away and they went to their master. So the bands of Syria stopped raiding the land of Israel. 
-</p><p>
-<span class="v">24&#160;</span>After this, Benhadad king of Syria gathered all his army, and went up and besieged Samaria. 
-<span class="v">25&#160;</span>There was a great famine in Samaria. Behold, they besieged it until a donkey’s head was sold for eighty pieces of silver, and the fourth part of a kab<span class="f">+ \fr 6:25 \ft A kab was about 2 liters, so a fourth of a kab would be about 500 milliliters or about a pint</span> of dove’s dung for five pieces of silver. 
-<span class="v">26&#160;</span>As the king of Israel was passing by on the wall, a woman cried to him, saying, “Help, my lord, O king!” 
-</p><p>
-<span class="v">27&#160;</span>He said, “If Yahweh doesn’t help you, where could I get help for you? From the threshing floor, or from the wine press?” 
-<span class="v">28&#160;</span>Then the king asked her, “What is your problem?” 
-</p><p>She answered, “This woman said to me, ‘Give your son, that we may eat him today, and we will eat my son tomorrow.’ 
-<span class="v">29&#160;</span>So we boiled my son and ate him; and I said to her on the next day, ‘Give up your son, that we may eat him;’ and she has hidden her son.” 
-</p><p>
-<span class="v">30&#160;</span>When the king heard the words of the woman, he tore his clothes. Now he was passing by on the wall, and the people looked, and behold, he had sackcloth underneath on his body. 
-<span class="v">31&#160;</span>Then he said, “Elohim do so to me, and more also, if the head of Elisha the son of Shaphat stays on him today.” 
-</p><p>
-<span class="v">32&#160;</span>But Elisha was sitting in his house, and the elders were sitting with him. Then the king sent a man from before him; but before the messenger came to him, he said to the elders, “Do you see how this son of a murderer has sent to take away my head? Behold, when the messenger comes, shut the door, and hold the door shut against him. Isn’t the sound of his master’s feet behind him?” 
-</p><p>
-<span class="v">33&#160;</span>While he was still talking with them, behold, the messenger came down to him. Then he said, “Behold, this evil is from Yahweh. Why should I wait for Yahweh any longer?” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Elisha said, “Hear Yahweh’s word. Yahweh says, ‘Tomorrow about this time a seah<span class="f">+ \fr 7:1 \ft 1 seah is about 7 liters or 1.9 gallons or 0.8 pecks</span> of fine flour will be sold for a shekel,<span class="f">+ \fr 7:1 \ft A shekel is about 10 grams or about 0.35 ounces. In this context, it was probably a silver coin weighing that much.</span> and two seahs of barley for a shekel, in the gate of Samaria.’&#160;” 
-</p><p>
-<span class="v">2&#160;</span>Then the captain on whose hand the king leaned answered the man of Elohim, and said, “Behold, if Yahweh made windows in heaven, could this thing be?” 
-</p><p>He said, “Behold, you will see it with your eyes, but will not eat of it.” 
-</p><p>
-<span class="v">3&#160;</span>Now there were four leprous men at the entrance of the gate. They said to one another, “Why do we sit here until we die? 
-<span class="v">4&#160;</span>If we say, ‘We will enter into the city,’ then the famine is in the city, and we will die there. If we sit still here, we also die. Now therefore come, and let’s surrender to the army of the Syrians. If they save us alive, we will live; and if they kill us, we will only die.” 
-</p><p>
-<span class="v">5&#160;</span>They rose up in the twilight to go to the camp of the Syrians. When they had come to the outermost part of the camp of the Syrians, behold, no man was there. 
-<span class="v">6&#160;</span>For the Lord<span class="f">+ \fr 7:6 \ft The word translated “Lord” is “Adonai.”</span> had made the army of the Syrians to hear the sound of chariots and the sound of horses, even the noise of a great army; and they said to one another, “Behold, the king of Israel has hired against us the kings of the Hittites and the kings of the Egyptians to attack us.” 
-<span class="v">7&#160;</span>Therefore they arose and fled in the twilight, and left their tents, their horses, and their donkeys, even the camp as it was, and fled for their life. 
-<span class="v">8&#160;</span>When these lepers came to the outermost part of the camp, they went into one tent, and ate and drank, then carried away silver, gold, and clothing and went and hid it. Then they came back, and entered into another tent and carried things from there also, and went and hid them. 
-<span class="v">9&#160;</span>Then they said to one another, “We aren’t doing right. Today is a day of good news, and we keep silent. If we wait until the morning light, punishment will overtake us. Now therefore come, let’s go and tell the king’s household.” 
-</p><p>
-<span class="v">10&#160;</span>So they came and called to the city gatekeepers; and they told them, “We came to the camp of the Syrians, and, behold, there was no man there, not even a man’s voice, but the horses tied, and the donkeys tied, and the tents as they were.” 
-</p><p>
-<span class="v">11&#160;</span>Then the gatekeepers called out and told it to the king’s household within. 
-</p><p>
-<span class="v">12&#160;</span>The king arose in the night, and said to his servants, “I will now show you what the Syrians have done to us. They know that we are hungry. Therefore they have gone out of the camp to hide themselves in the field, saying, ‘When they come out of the city, we shall take them alive, and get into the city.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>One of his servants answered, “Please let some people take five of the horses that remain, which are left in the city. Behold, they are like all the multitude of Israel who are left in it. Behold, they are like all the multitude of Israel who are consumed. Let’s send and see.” 
-</p><p>
-<span class="v">14&#160;</span>Therefore they took two chariots with horses; and the king sent them out to the Syrian army, saying, “Go and see.” 
-</p><p>
-<span class="v">15&#160;</span>They went after them to the Jordan; and behold, all the path was full of garments and equipment which the Syrians had cast away in their haste. The messengers returned and told the king. 
-<span class="v">16&#160;</span>The people went out and plundered the camp of the Syrians. So a seah<span class="f">+ \fr 7:16 \ft 1 seah is about 7 liters or 1.9 gallons or 0.8 pecks</span> of fine flour was sold for a shekel, and two measures of barley for a shekel,<span class="f">+ \fr 7:16 \ft A shekel is about 10 grams or about 0.35 ounces. In this context, it was probably a silver coin weighing that much.</span> according to Yahweh’s word. 
-<span class="v">17&#160;</span>The king had appointed the captain on whose hand he leaned to be in charge of the gate; and the people trampled over him in the gate, and he died as the man of Elohim had said, who spoke when the king came down to him. 
-<span class="v">18&#160;</span>It happened as the man of Elohim had spoken to the king, saying, “Two seahs<span class="f">+ \fr 7:18 \ft 1 seah is about 7 liters or 1.9 gallons or 0.8 pecks</span> of barley for a shekel,<span class="f">+ \fr 7:18 \ft A shekel is about 10 grams or about 0.35 ounces. In this context, it was probably a silver coin weighing that much.</span> and a seah of fine flour for a shekel, shall be tomorrow about this time in the gate of Samaria;” 
-<span class="v">19&#160;</span>and that captain answered the man of Elohim, and said, “Now, behold, if Yahweh made windows in heaven, might such a thing be?” and he said, “Behold, you will see it with your eyes, but will not eat of it.” 
-<span class="v">20&#160;</span>It happened like that to him, for the people trampled over him in the gate, and he died. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Now Elisha had spoken to the woman whose son he had restored to life, saying, “Arise, and go, you and your household, and stay for a while wherever you can; for Yahweh has called for a famine. It will also come on the land for seven years.” 
-</p><p>
-<span class="v">2&#160;</span>The woman arose, and did according to the man of Elohim’s word. She went with her household, and lived in the land of the Philistines for seven years. 
-<span class="v">3&#160;</span>At the end of seven years, the woman returned from the land of the Philistines. Then she went out to beg the king for her house and for her land. 
-<span class="v">4&#160;</span>Now the king was talking with Gehazi the servant of the man of Elohim, saying, “Please tell me all the great things that Elisha has done.” 
-<span class="v">5&#160;</span>As he was telling the king how he had restored to life him who was dead, behold, the woman whose son he had restored to life begged the king for her house and for her land. Gehazi said, “My lord, O king, this is the woman, and this is her son, whom Elisha restored to life.” 
-</p><p>
-<span class="v">6&#160;</span>When the king asked the woman, she told him. So the king appointed to her a certain officer, saying, “Restore all that was hers, and all the fruits of the field since the day that she left the land, even until now.” 
-</p><p>
-<span class="v">7&#160;</span>Elisha came to Damascus; and Benhadad the king of Syria was sick. He was told, “The man of Elohim has come here.” 
-</p><p>
-<span class="v">8&#160;</span>The king said to Hazael, “Take a present in your hand, and go meet the man of Elohim, and inquire of Yahweh by him, saying, ‘Will I recover from this sickness?’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>So Hazael went to meet him and took a present with him, even of every good thing of Damascus, forty camels’ burden, and came and stood before him and said, “Your son Benhadad king of Syria has sent me to you, saying, ‘Will I recover from this sickness?’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Elisha said to him, “Go, tell him, ‘You will surely recover;’ however Yahweh has shown me that he will surely die.” 
-<span class="v">11&#160;</span>He settled his gaze steadfastly on him, until he was ashamed. Then the man of Elohim wept. 
-</p><p>
-<span class="v">12&#160;</span>Hazael said, “Why do you weep, my lord?” 
-</p><p>He answered, “Because I know the evil that you will do to the children of Israel. You will set their strongholds on fire, and you will kill their young men with the sword, and will dash their little ones in pieces, and rip up their pregnant women.” 
-</p><p>
-<span class="v">13&#160;</span>Hazael said, “But what is your servant, who is but a dog, that he could do this great thing?” 
-</p><p>Elisha answered, “Yahweh has shown me that you will be king over Syria.” 
-</p><p>
-<span class="v">14&#160;</span>Then he departed from Elisha, and came to his master, who said to him, “What did Elisha say to you?” 
-</p><p>He answered, “He told me that you would surely recover.” 
-</p><p>
-<span class="v">15&#160;</span>On the next day, he took a thick cloth, dipped it in water, and spread it on the king’s face, so that he died. Then Hazael reigned in his place. 
-</p><p>
-<span class="v">16&#160;</span>In the fifth year of Joram the son of Ahab king of Israel, Jehoshaphat being king of Judah then, Jehoram the son of Jehoshaphat king of Judah began to reign. 
-<span class="v">17&#160;</span>He was thirty-two years old when he began to reign. He reigned eight years in Jerusalem. 
-<span class="v">18&#160;</span>He walked in the way of the kings of Israel, as did Ahab’s house, for he married Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
-<span class="v">19&#160;</span>However, Yahweh would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
-</p><p>
-<span class="v">20&#160;</span>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
-<span class="v">21&#160;</span>Then Joram crossed over to Zair, and all his chariots with him; and he rose up by night and struck the Edomites who surrounded him with the captains of the chariots; and the people fled to their tents. 
-<span class="v">22&#160;</span>So Edom revolted from under the hand of Judah to this day. Then Libnah revolted at the same time. 
-<span class="v">23&#160;</span>The rest of the acts of Joram, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">24&#160;</span>Joram slept with his fathers, and was buried with his fathers in David’s city; and Ahaziah his son reigned in his place. 
-</p><p>
-<span class="v">25&#160;</span>In the twelfth year of Joram the son of Ahab king of Israel, Ahaziah the son of Jehoram king of Judah began to reign. 
-<span class="v">26&#160;</span>Ahaziah was twenty-two years old when he began to reign; and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri king of Israel. 
-<span class="v">27&#160;</span>He walked in the way of Ahab’s house and did that which was evil in Yahweh’s sight, as did Ahab’s house, for he was the son-in-law of Ahab’s house. 
-</p><p>
-<span class="v">28&#160;</span>He went with Joram the son of Ahab to war against Hazael king of Syria at Ramoth Gilead, and the Syrians wounded Joram. 
-<span class="v">29&#160;</span>King Joram returned to be healed in Jezreel from the wounds which the Syrians had given him at Ramah, when he fought against Hazael king of Syria. Ahaziah the son of Jehoram, king of Judah, went down to see Joram the son of Ahab in Jezreel, because he was sick. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Elisha the prophet called one of the sons of the prophets, and said to him, “Put your belt on your waist, take this vial of oil in your hand, and go to Ramoth Gilead. 
-<span class="v">2&#160;</span>When you come there, find Jehu the son of Jehoshaphat the son of Nimshi, and go in and make him rise up from among his brothers, and take him to an inner room. 
-<span class="v">3&#160;</span>Then take the vial of oil, and pour it on his head, and say, ‘Yahweh says, “I have anointed you king over Israel.”&#160;’ Then open the door, flee, and don’t wait.” 
-</p><p>
-<span class="v">4&#160;</span>So the young man, the young prophet, went to Ramoth Gilead. 
-<span class="v">5&#160;</span>When he came, behold, the captains of the army were sitting. Then he said, “I have a message for you, captain.” 
-</p><p>Jehu said, “To which one of us?” 
-</p><p>He said, “To you, O captain.” 
-<span class="v">6&#160;</span>He arose, and went into the house. Then he poured the oil on his head, and said to him, “Yahweh, the Elohim of Israel, says, ‘I have anointed you king over the people of Yahweh, even over Israel. 
-<span class="v">7&#160;</span>You must strike your master Ahab’s house, that I may avenge the blood of my servants the prophets, and the blood of all the servants of Yahweh, at the hand of Jezebel. 
-<span class="v">8&#160;</span>For the whole house of Ahab will perish. I will cut off from Ahab everyone who urinates against a wall,<span class="f">+ \fr 9:8 \ft or, male</span> both him who is shut up and him who is left at large in Israel. 
-<span class="v">9&#160;</span>I will make Ahab’s house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah. 
-<span class="v">10&#160;</span>The dogs will eat Jezebel on the plot of ground of Jezreel, and there shall be no one to bury her.’&#160;” Then he opened the door and fled. 
-</p><p>
-<span class="v">11&#160;</span>When Jehu came out to the servants of his lord and one said to him, “Is all well? Why did this madman come to you?” 
-</p><p>He said to them, “You know the man and how he talks.” 
-</p><p>
-<span class="v">12&#160;</span>They said, “That is a lie. Tell us now.” 
-</p><p>He said, “He said to me, ‘Yahweh says, I have anointed you king over Israel.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>Then they hurried, and each man took his cloak, and put it under him on the top of the stairs, and blew the trumpet, saying, “Jehu is king.” 
-</p><p>
-<span class="v">14&#160;</span>So Jehu the son of Jehoshaphat the son of Nimshi conspired against Joram. (Now Joram was defending Ramoth Gilead, he and all Israel, because of Hazael king of Syria; 
-<span class="v">15&#160;</span>but King Joram had returned to be healed in Jezreel of the wounds which the Syrians had given him when he fought with Hazael king of Syria.) Jehu said, “If this is your thinking, then let no one escape and go out of the city to go to tell it in Jezreel.” 
-<span class="v">16&#160;</span>So Jehu rode in a chariot and went to Jezreel, for Joram lay there. Ahaziah king of Judah had come down to see Joram. 
-<span class="v">17&#160;</span>Now the watchman was standing on the tower in Jezreel, and he spied the company of Jehu as he came, and said, “I see a company.” 
-</p><p>Joram said, “Take a horseman, and send to meet them, and let him say, ‘Is it peace?’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>So one went on horseback to meet him, and said, “the king says, ‘Is it peace?’&#160;” 
-</p><p>Jehu said, “What do you have to do with peace? Fall in behind me!” 
-</p><p>The watchman said, “The messenger came to them, but he isn’t coming back.” 
-</p><p>
-<span class="v">19&#160;</span>Then he sent out a second on horseback, who came to them and said, “The king says, ‘Is it peace?’&#160;” 
-</p><p>Jehu answered, “What do you have to do with peace? Fall in behind me!” 
-</p><p>
-<span class="v">20&#160;</span>The watchman said, “He came to them, and isn’t coming back. The driving is like the driving of Jehu the son of Nimshi, for he drives furiously.” 
-</p><p>
-<span class="v">21&#160;</span>Joram said, “Get ready!” 
-</p><p>They got his chariot ready. Then Joram king of Israel and Ahaziah king of Judah went out, each in his chariot; and they went out to meet Jehu, and found him on Naboth the Jezreelite’s land. 
-<span class="v">22&#160;</span>When Joram saw Jehu, he said, “Is it peace, Jehu?” 
-</p><p>He answered, “What peace, so long as the prostitution of your mother Jezebel and her witchcraft abound?” 
-</p><p>
-<span class="v">23&#160;</span>Joram turned his hands and fled, and said to Ahaziah, “This is treason, Ahaziah!” 
-</p><p>
-<span class="v">24&#160;</span>Jehu drew his bow with his full strength, and struck Joram between his arms; and the arrow went out at his heart, and he sunk down in his chariot. 
-<span class="v">25&#160;</span>Then Jehu said to Bidkar his captain, “Pick him up, and throw him in the plot of the field of Naboth the Jezreelite; for remember how, when you and I rode together after Ahab his father, Yahweh laid this burden on him: 
-<span class="v">26&#160;</span>‘Surely I have seen yesterday the blood of Naboth, and the blood of his sons,’ says Yahweh; ‘and I will repay you in this plot of ground,’ says Yahweh. Now therefore take and cast him onto the plot of ground, according to Yahweh’s word.” 
-</p><p>
-<span class="v">27&#160;</span>But when Ahaziah the king of Judah saw this, he fled by the way of the garden house. Jehu followed after him, and said, “Strike him also in the chariot!” They struck him at the ascent of Gur, which is by Ibleam. He fled to Megiddo, and died there. 
-<span class="v">28&#160;</span>His servants carried him in a chariot to Jerusalem, and buried him in his tomb with his fathers in David’s city. 
-<span class="v">29&#160;</span>In the eleventh year of Joram the son of Ahab, Ahaziah began to reign over Judah. 
-</p><p>
-<span class="v">30&#160;</span>When Jehu had come to Jezreel, Jezebel heard of it; and she painted her eyes, and adorned her head, and looked out at the window. 
-<span class="v">31&#160;</span>As Jehu entered in at the gate, she said, “Do you come in peace, Zimri, you murderer of your master?” 
-</p><p>
-<span class="v">32&#160;</span>He lifted up his face to the window, and said, “Who is on my side? Who?” 
-</p><p>Two or three eunuchs looked out at him. 
-</p><p>
-<span class="v">33&#160;</span>He said, “Throw her down!” 
-</p><p>So they threw her down; and some of her blood was sprinkled on the wall, and on the horses. Then he trampled her under foot. 
-<span class="v">34&#160;</span>When he had come in, he ate and drank. Then he said, “See now to this cursed woman, and bury her; for she is a king’s daughter.” 
-</p><p>
-<span class="v">35&#160;</span>They went to bury her, but they found no more of her than the skull, the feet, and the palms of her hands. 
-<span class="v">36&#160;</span>Therefore they came back, and told him. 
-</p><p>He said, “This is Yahweh’s word, which he spoke by his servant Elijah the Tishbite, saying, ‘The dogs will eat the flesh of Jezebel on the plot of Jezreel, 
-<span class="v">37&#160;</span>and the body of Jezebel will be as dung on the surface of the field on Jezreel’s land, so that they won’t say, “This is Jezebel.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Now Ahab had seventy sons in Samaria. Jehu wrote letters and sent them to Samaria, to the rulers of Jezreel, even the elders, and to those who brought up Ahab’s sons, saying, 
-<span class="v">2&#160;</span>“Now as soon as this letter comes to you, since your master’s sons are with you, and you have chariots and horses, a fortified city also, and armor, 
-<span class="v">3&#160;</span>select the best and fittest of your master’s sons, set him on his father’s throne, and fight for your master’s house.” 
-</p><p>
-<span class="v">4&#160;</span>But they were exceedingly afraid, and said, “Behold, the two kings didn’t stand before him! How then shall we stand?” 
-<span class="v">5&#160;</span>He who was over the household, and he who was over the city, the elders also, and those who raised the children, sent to Jehu, saying, “We are your servants, and will do all that you ask us. We will not make any man king. You do that which is good in your eyes.” 
-</p><p>
-<span class="v">6&#160;</span>Then he wrote a letter the second time to them, saying, “If you are on my side, and if you will listen to my voice, take the heads of the men who are your master’s sons, and come to me to Jezreel by tomorrow this time.” 
-</p><p>Now the king’s sons, being seventy persons, were with the great men of the city, who brought them up. 
-<span class="v">7&#160;</span>When the letter came to them, they took the king’s sons and killed them, even seventy people, and put their heads in baskets, and sent them to him to Jezreel. 
-<span class="v">8&#160;</span>A messenger came and told him, “They have brought the heads of the king’s sons.” 
-</p><p>He said, “Lay them in two heaps at the entrance of the gate until the morning.” 
-<span class="v">9&#160;</span>In the morning, he went out and stood, and said to all the people, “You are righteous. Behold, I conspired against my master and killed him, but who killed all these? 
-<span class="v">10&#160;</span>Know now that nothing will fall to the earth of Yahweh’s word, which Yahweh spoke concerning Ahab’s house. For Yahweh has done that which he spoke by his servant Elijah.” 
-</p><p>
-<span class="v">11&#160;</span>So Jehu struck all that remained of Ahab’s house in Jezreel, with all his great men, his familiar friends, and his priests, until he left him no one remaining. 
-</p><p>
-<span class="v">12&#160;</span>He arose and departed, and went to Samaria. As he was at the shearing house of the shepherds on the way, 
-<span class="v">13&#160;</span>Jehu met with the brothers of Ahaziah king of Judah, and said, “Who are you?” 
-</p><p>They answered, “We are the brothers of Ahaziah. We are going down to greet the children of the king and the children of the queen.” 
-</p><p>
-<span class="v">14&#160;</span>He said, “Take them alive!” 
-</p><p>They took them alive, and killed them at the pit of the shearing house, even forty-two men. He didn’t leave any of them. 
-</p><p>
-<span class="v">15&#160;</span>When he had departed from there, he met Jehonadab the son of Rechab coming to meet him. He greeted him, and said to him, “Is your heart right, as my heart is with your heart?” 
-</p><p>Jehonadab answered, “It is.” 
-</p><p>“If it is, give me your hand.” He gave him his hand; and he took him up to him into the chariot. 
-<span class="v">16&#160;</span>He said, “Come with me, and see my zeal for Yahweh.” So they made him ride in his chariot. 
-<span class="v">17&#160;</span>When he came to Samaria, he struck all who remained to Ahab in Samaria, until he had destroyed them, according to Yahweh’s word which he spoke to Elijah. 
-</p><p>
-<span class="v">18&#160;</span>Jehu gathered all the people together, and said to them, “Ahab served Baal a little, but Jehu will serve him much. 
-<span class="v">19&#160;</span>Now therefore call to me all the prophets of Baal, all of his worshipers, and all of his priests. Let no one be absent, for I have a great sacrifice to Baal. Whoever is absent, he shall not live.” But Jehu did deceptively, intending to destroy the worshipers of Baal. 
-</p><p>
-<span class="v">20&#160;</span>Jehu said, “Sanctify a solemn assembly for Baal!” 
-</p><p>So they proclaimed it. 
-<span class="v">21&#160;</span>Jehu sent through all Israel; and all the worshipers of Baal came, so that there was not a man left that didn’t come. They came into the house of Baal; and the house of Baal was filled from one end to another. 
-<span class="v">22&#160;</span>He said to him who kept the wardrobe, “Bring out robes for all the worshipers of Baal!” 
-</p><p>So he brought robes out to them. 
-<span class="v">23&#160;</span>Jehu went with Jehonadab the son of Rechab into the house of Baal. Then he said to the worshipers of Baal, “Search, and see that none of the servants of Yahweh are here with you, but only the worshipers of Baal.” 
-</p><p>
-<span class="v">24&#160;</span>So they went in to offer sacrifices and burnt offerings. Now Jehu had appointed for himself eighty men outside, and said, “If any of the men whom I bring into your hands escape, he who lets him go, his life shall be for the life of him.” 
-</p><p>
-<span class="v">25&#160;</span>As soon as he had finished offering the burnt offering, Jehu said to the guard and to the captains, “Go in and kill them! Let no one escape.” So they struck them with the edge of the sword. The guard and the captains threw the bodies out, and went to the inner shrine of the house of Baal. 
-<span class="v">26&#160;</span>They brought out the pillars that were in the house of Baal and burned them. 
-<span class="v">27&#160;</span>They broke down the pillar of Baal, and broke down the house of Baal, and made it a latrine, to this day. 
-<span class="v">28&#160;</span>Thus Jehu destroyed Baal out of Israel. 
-</p><p>
-<span class="v">29&#160;</span>However, Jehu didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin—the golden calves that were in Bethel and that were in Dan. 
-<span class="v">30&#160;</span>Yahweh said to Jehu, “Because you have done well in executing that which is right in my eyes, and have done to Ahab’s house according to all that was in my heart, your descendants shall sit on the throne of Israel to the fourth generation.” 
-</p><p>
-<span class="v">31&#160;</span>But Jehu took no heed to walk in the law of Yahweh, the Elohim of Israel, with all his heart. He didn’t depart from the sins of Jeroboam, with which he made Israel to sin. 
-</p><p>
-<span class="v">32&#160;</span>In those days Yahweh began to cut away parts of Israel; and Hazael struck them in all the borders of Israel 
-<span class="v">33&#160;</span>from the Jordan eastward, all the land of Gilead, the Gadites, and the Reubenites, and the Manassites, from Aroer, which is by the valley of the Arnon, even Gilead and Bashan. 
-<span class="v">34&#160;</span>Now the rest of the acts of Jehu, and all that he did, and all his might, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">35&#160;</span>Jehu slept with his fathers; and they buried him in Samaria. Jehoahaz his son reigned in his place. 
-<span class="v">36&#160;</span>The time that Jehu reigned over Israel in Samaria was twenty-eight years. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring. 
-<span class="v">2&#160;</span>But Jehosheba, the daughter of King Joram, sister of Ahaziah, took Joash the son of Ahaziah, and stole him away from among the king’s sons who were slain, even him and his nurse, and put them in the bedroom; and they hid him from Athaliah, so that he was not slain. 
-<span class="v">3&#160;</span>He was with her hidden in Yahweh’s house six years while Athaliah reigned over the land. 
-</p><p>
-<span class="v">4&#160;</span>In the seventh year Jehoiada sent and fetched the captains over hundreds of the Carites and of the guard, and brought them to him into Yahweh’s house; and he made a covenant with them, and made a covenant with them in Yahweh’s house, and showed them the king’s son. 
-<span class="v">5&#160;</span>He commanded them, saying, “This is what you must do: a third of you, who come in on the Sabbath, shall be keepers of the watch of the king’s house; 
-<span class="v">6&#160;</span>a third of you shall be at the gate Sur; and a third of you at the gate behind the guard. So you shall keep the watch of the house, and be a barrier. 
-<span class="v">7&#160;</span>The two companies of you, even all who go out on the Sabbath, shall keep the watch of Yahweh’s house around the king. 
-<span class="v">8&#160;</span>You shall surround the king, every man with his weapons in his hand; and he who comes within the ranks, let him be slain. Be with the king when he goes out, and when he comes in.” 
-</p><p>
-<span class="v">9&#160;</span>The captains over hundreds did according to all that Jehoiada the priest commanded; and they each took his men, those who were to come in on the Sabbath with those who were to go out on the Sabbath, and came to Jehoiada the priest. 
-<span class="v">10&#160;</span>The priest delivered to the captains over hundreds the spears and shields that had been King David’s, which were in Yahweh’s house. 
-<span class="v">11&#160;</span>The guard stood, every man with his weapons in his hand, from the right side of the house to the left side of the house, along by the altar and the house, around the king. 
-<span class="v">12&#160;</span>Then he brought out the king’s son, and put the crown on him, and gave him the covenant; and they made him king and anointed him; and they clapped their hands, and said, “Long live the king!” 
-</p><p>
-<span class="v">13&#160;</span>When Athaliah heard the noise of the guard and of the people, she came to the people into Yahweh’s house; 
-<span class="v">14&#160;</span>and she looked, and behold, the king stood by the pillar, as the tradition was, with the captains and the trumpets by the king; and all the people of the land rejoiced, and blew trumpets. Then Athaliah tore her clothes and cried, “Treason! Treason!” 
-</p><p>
-<span class="v">15&#160;</span>Jehoiada the priest commanded the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks. Kill anyone who follows her with the sword.” For the priest said, “Don’t let her be slain in Yahweh’s house.” 
-<span class="v">16&#160;</span>So they seized her; and she went by the way of the horses’ entry to the king’s house, and she was slain there. 
-</p><p>
-<span class="v">17&#160;</span>Jehoiada made a covenant between Yahweh and the king and the people, that they should be Yahweh’s people; also between the king and the people. 
-<span class="v">18&#160;</span>All the people of the land went to the house of Baal, and broke it down. They broke his altars and his images in pieces thoroughly, and killed Mattan the priest of Baal before the altars. The priest appointed officers over Yahweh’s house. 
-<span class="v">19&#160;</span>He took the captains over hundreds, and the Carites, and the guard, and all the people of the land; and they brought down the king from Yahweh’s house, and came by the way of the gate of the guard to the king’s house. He sat on the throne of the kings. 
-<span class="v">20&#160;</span>So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword at the king’s house. 
-</p><p>
-<span class="v">21&#160;</span>Jehoash was seven years old when he began to reign. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Jehoash began to reign in the seventh year of Jehu, and he reigned forty years in Jerusalem. His mother’s name was Zibiah of Beersheba. 
-<span class="v">2&#160;</span>Jehoash did that which was right in Yahweh’s eyes all his days in which Jehoiada the priest instructed him. 
-<span class="v">3&#160;</span>However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
-</p><p>
-<span class="v">4&#160;</span>Jehoash said to the priests, “All the money of the set-apart things that is brought into Yahweh’s house, in current money, the money of the people for whom each man is evaluated,<span class="x">+ \xo 12:4 \xt Exodus 30:12</span> and all the money that it comes into any man’s heart to bring into Yahweh’s house, 
-<span class="v">5&#160;</span>let the priests take it to them, each man from his donor; and they shall repair the damage to the house, wherever any damage is found.” 
-</p><p>
-<span class="v">6&#160;</span>But it was so, that in the twenty-third year of King Jehoash the priests had not repaired the damage to the house. 
-<span class="v">7&#160;</span>Then King Jehoash called for Jehoiada the priest, and for the other priests, and said to them, “Why aren’t you repairing the damage to the house? Now therefore take no more money from your treasurers, but deliver it for repair of the damage to the house.” 
-</p><p>
-<span class="v">8&#160;</span>The priests consented that they should take no more money from the people, and not repair the damage to the house. 
-<span class="v">9&#160;</span>But Jehoiada the priest took a chest and bored a hole in its lid, and set it beside the altar, on the right side as one comes into Yahweh’s house; and the priests who kept the threshold put all the money that was brought into Yahweh’s house into it. 
-<span class="v">10&#160;</span>When they saw that there was much money in the chest, the king’s scribe and the high priest came up, and they put it in bags and counted the money that was found in Yahweh’s house. 
-<span class="v">11&#160;</span>They gave the money that was weighed out into the hands of those who did the work, who had the oversight of Yahweh’s house; and they paid it out to the carpenters and the builders who worked on Yahweh’s house, 
-<span class="v">12&#160;</span>and to the masons and the stone cutters, and for buying timber and cut stone to repair the damage to Yahweh’s house, and for all that was laid out for the house to repair it. 
-<span class="v">13&#160;</span>But there were not made for Yahweh’s house cups of silver, snuffers, basins, trumpets, any vessels of gold or vessels of silver, of the money that was brought into Yahweh’s house; 
-<span class="v">14&#160;</span>for they gave that to those who did the work, and repaired Yahweh’s house with it. 
-<span class="v">15&#160;</span>Moreover they didn’t demand an accounting from the men into whose hand they delivered the money to give to those who did the work; for they dealt faithfully. 
-<span class="v">16&#160;</span>The money for the trespass offerings and the money for the sin offerings was not brought into Yahweh’s house. It was the priests’. 
-</p><p>
-<span class="v">17&#160;</span>Then Hazael king of Syria went up and fought against Gath, and took it; and Hazael set his face to go up to Jerusalem. 
-<span class="v">18&#160;</span>Jehoash king of Judah took all the set-apart things that Jehoshaphat and Jehoram and Ahaziah, his fathers, kings of Judah, had dedicated, and his own set-apart things, and all the gold that was found in the treasures of Yahweh’s house, and of the king’s house, and sent it to Hazael king of Syria; and he went away from Jerusalem. 
-</p><p>
-<span class="v">19&#160;</span>Now the rest of the acts of Joash, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">20&#160;</span>His servants arose and made a conspiracy, and struck Joash at the house of Millo, on the way that goes down to Silla. 
-<span class="v">21&#160;</span>For Jozacar the son of Shimeath, and Jehozabad the son of Shomer, his servants, struck him, and he died; and they buried him with his fathers in David’s city; and Amaziah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>In the twenty-third year of Joash the son of Ahaziah, king of Judah, Jehoahaz the son of Jehu began to reign over Israel in Samaria for seventeen years. 
-<span class="v">2&#160;</span>He did that which was evil in Yahweh’s sight, and followed the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from it. 
-<span class="v">3&#160;</span>Yahweh’s anger burned against Israel, and he delivered them into the hand of Hazael king of Syria, and into the hand of Benhadad the son of Hazael, continually. 
-<span class="v">4&#160;</span>Jehoahaz begged Yahweh, and Yahweh listened to him; for he saw the oppression of Israel, how the king of Syria oppressed them. 
-<span class="v">5&#160;</span>(Yahweh gave Israel a savior, so that they went out from under the hand of the Syrians; and the children of Israel lived in their tents as before. 
-<span class="v">6&#160;</span>Nevertheless they didn’t depart from the sins of the house of Jeroboam, with which he made Israel to sin, but walked in them; and the Asherah also remained in Samaria.) 
-<span class="v">7&#160;</span>For he didn’t leave to Jehoahaz of the people any more than fifty horsemen, and ten chariots, and ten thousand footmen; for the king of Syria destroyed them and made them like the dust in threshing. 
-<span class="v">8&#160;</span>Now the rest of the acts of Jehoahaz, and all that he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">9&#160;</span>Jehoahaz slept with his fathers; and they buried him in Samaria; and Joash his son reigned in his place. 
-</p><p>
-<span class="v">10&#160;</span>In the thirty-seventh year of Joash king of Judah, Jehoash the son of Jehoahaz began to reign over Israel in Samaria for sixteen years. 
-<span class="v">11&#160;</span>He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin; but he walked in them. 
-<span class="v">12&#160;</span>Now the rest of the acts of Joash, and all that he did, and his might with which he fought against Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">13&#160;</span>Joash slept with his fathers; and Jeroboam sat on his throne. Joash was buried in Samaria with the kings of Israel. 
-</p><p>
-<span class="v">14&#160;</span>Now Elisha became sick with the illness of which he died; and Joash the king of Israel came down to him, and wept over him, and said, “My father, my father, the chariots of Israel and its horsemen!” 
-</p><p>
-<span class="v">15&#160;</span>Elisha said to him, “Take bow and arrows;” and he took bow and arrows for himself. 
-<span class="v">16&#160;</span>He said to the king of Israel, “Put your hand on the bow;” and he put his hand on it. Elisha laid his hands on the king’s hands. 
-<span class="v">17&#160;</span>He said, “Open the window eastward;” and he opened it. Then Elisha said, “Shoot!” and he shot. He said, “Yahweh’s arrow of victory, even the arrow of victory over Syria; for you will strike the Syrians in Aphek until you have consumed them.” 
-</p><p>
-<span class="v">18&#160;</span>He said, “Take the arrows;” and he took them. He said to the king of Israel, “Strike the ground;” and he struck three times, and stopped. 
-<span class="v">19&#160;</span>The man of Elohim was angry with him, and said, “You should have struck five or six times. Then you would have struck Syria until you had consumed it, but now you will strike Syria just three times.” 
-</p><p>
-<span class="v">20&#160;</span>Elisha died, and they buried him. 
-</p><p>Now the bands of the Moabites invaded the land at the coming in of the year. 
-<span class="v">21&#160;</span>As they were burying a man, behold, they saw a band of raiders; and they threw the man into Elisha’s tomb. As soon as the man touched Elisha’s bones, he revived, and stood up on his feet. 
-</p><p>
-<span class="v">22&#160;</span>Hazael king of Syria oppressed Israel all the days of Jehoahaz. 
-<span class="v">23&#160;</span>But Yahweh was gracious to them, and had compassion on them, and favored them because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them and he didn’t cast them from his presence as yet. 
-</p><p>
-<span class="v">24&#160;</span>Hazael king of Syria died; and Benhadad his son reigned in his place. 
-<span class="v">25&#160;</span>Jehoash the son of Jehoahaz took again out of the hand of Benhadad the son of Hazael the cities which he had taken out of the hand of Jehoahaz his father by war. Joash struck him three times, and recovered the cities of Israel. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>In the second year of Joash, son of Joahaz, king of Israel, Amaziah the son of Joash king of Judah began to reign. 
-<span class="v">2&#160;</span>He was twenty-five years old when he began to reign; and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddin of Jerusalem. 
-<span class="v">3&#160;</span>He did that which was right in Yahweh’s eyes, yet not like David his father. He did according to all that Joash his father had done. 
-<span class="v">4&#160;</span>However the high places were not taken away. The people still sacrificed and burned incense in the high places. 
-<span class="v">5&#160;</span>As soon as the kingdom was established in his hand, he killed his servants who had slain the king his father, 
-<span class="v">6&#160;</span>but the children of the murderers he didn’t put to death, according to that which is written in the book of the law of Moses, as Yahweh commanded, saying, “The fathers shall not be put to death for the children, nor the children be put to death for the fathers; but every man shall die for his own sin.” 
-</p><p>
-<span class="v">7&#160;</span>He killed ten thousand Edomites in the Valley of Salt, and took Sela by war, and called its name Joktheel, to this day. 
-<span class="v">8&#160;</span>Then Amaziah sent messengers to Jehoash, the son of Jehoahaz son of Jehu, king of Israel, saying, “Come, let’s look one another in the face.” 
-</p><p>
-<span class="v">9&#160;</span>Jehoash the king of Israel sent to Amaziah king of Judah, saying, “The thistle that was in Lebanon sent to the cedar that was in Lebanon, saying, ‘Give your daughter to my son as woman.’ Then a wild animal that was in Lebanon passed by, and trampled down the thistle. 
-<span class="v">10&#160;</span>You have indeed struck Edom, and your heart has lifted you up. Enjoy the glory of it, and stay at home; for why should you meddle to your harm, that you fall, even you, and Judah with you?” 
-</p><p>
-<span class="v">11&#160;</span>But Amaziah would not listen. So Jehoash king of Israel went up; and he and Amaziah king of Judah looked one another in the face at Beth Shemesh, which belongs to Judah. 
-<span class="v">12&#160;</span>Judah was defeated by Israel; and each man fled to his tent. 
-<span class="v">13&#160;</span>Jehoash king of Israel took Amaziah king of Judah, the son of Jehoash the son of Ahaziah, at Beth Shemesh and came to Jerusalem, then broke down the wall of Jerusalem from the gate of Ephraim to the corner gate, four hundred cubits.<span class="f">+ \fr 14:13 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> 
-<span class="v">14&#160;</span>He took all the gold and silver and all the vessels that were found in Yahweh’s house and in the treasures of the king’s house, the hostages also, and returned to Samaria. 
-</p><p>
-<span class="v">15&#160;</span>Now the rest of the acts of Jehoash which he did, and his might, and how he fought with Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">16&#160;</span>Jehoash slept with his fathers, and was buried in Samaria with the kings of Israel; and Jeroboam his son reigned in his place. 
-</p><p>
-<span class="v">17&#160;</span>Amaziah the son of Joash king of Judah lived after the death of Jehoash son of Jehoahaz, king of Israel, fifteen years. 
-<span class="v">18&#160;</span>Now the rest of the acts of Amaziah, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">19&#160;</span>They made a conspiracy against him in Jerusalem, and he fled to Lachish; but they sent after him to Lachish and killed him there. 
-<span class="v">20&#160;</span>They brought him on horses, and he was buried at Jerusalem with his fathers in David’s city. 
-</p><p>
-<span class="v">21&#160;</span>All the people of Judah took Azariah, who was sixteen years old, and made him king in the place of his father Amaziah. 
-<span class="v">22&#160;</span>He built Elath and restored it to Judah. After that the king slept with his fathers. 
-</p><p>
-<span class="v">23&#160;</span>In the fifteenth year of Amaziah the son of Joash king of Judah, Jeroboam the son of Joash king of Israel began to reign in Samaria for forty-one years. 
-<span class="v">24&#160;</span>He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-<span class="v">25&#160;</span>He restored the border of Israel from the entrance of Hamath to the sea of the Arabah, according to Yahweh, the Elohim of Israel’s word, which he spoke by his servant Jonah the son of Amittai, the prophet, who was from Gath Hepher. 
-<span class="v">26&#160;</span>For Yahweh saw the affliction of Israel, that it was very bitter for all, slave and free; and there was no helper for Israel. 
-<span class="v">27&#160;</span>Yahweh didn’t say that he would blot out the name of Israel from under the sky; but he saved them by the hand of Jeroboam the son of Joash. 
-<span class="v">28&#160;</span>Now the rest of the acts of Jeroboam, and all that he did, and his might, how he fought, and how he recovered Damascus, and Hamath, which had belonged to Judah, for Israel, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">29&#160;</span>Jeroboam slept with his fathers, even with the kings of Israel; and Zechariah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>In the twenty-seventh year of Jeroboam king of Israel, Azariah son of Amaziah king of Judah began to reign. 
-<span class="v">2&#160;</span>He was sixteen years old when he began to reign, and he reigned fifty-two years in Jerusalem. His mother’s name was Jecoliah of Jerusalem. 
-<span class="v">3&#160;</span>He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
-<span class="v">4&#160;</span>However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
-<span class="v">5&#160;</span>Yahweh struck the king, so that he was a leper to the day of his death, and lived in a separate house. Jotham, the king’s son, was over the household, judging the people of the land. 
-<span class="v">6&#160;</span>Now the rest of the acts of Azariah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">7&#160;</span>Azariah slept with his fathers; and they buried him with his fathers in David’s city; and Jotham his son reigned in his place. 
-</p><p>
-<span class="v">8&#160;</span>In the thirty-eighth year of Azariah king of Judah, Zechariah the son of Jeroboam reigned over Israel in Samaria six months. 
-<span class="v">9&#160;</span>He did that which was evil in Yahweh’s sight, as his fathers had done. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-<span class="v">10&#160;</span>Shallum the son of Jabesh conspired against him, and struck him before the people and killed him, and reigned in his place. 
-<span class="v">11&#160;</span>Now the rest of the acts of Zechariah, behold, they are written in the book of the chronicles of the kings of Israel. 
-<span class="v">12&#160;</span>This was Yahweh’s word which he spoke to Jehu, saying, “Your sons to the fourth generation shall sit on the throne of Israel.” So it came to pass. 
-</p><p>
-<span class="v">13&#160;</span>Shallum the son of Jabesh began to reign in the thirty-ninth year of Uzziah king of Judah, and he reigned for a month in Samaria. 
-<span class="v">14&#160;</span>Menahem the son of Gadi went up from Tirzah, came to Samaria, struck Shallum the son of Jabesh in Samaria, killed him, and reigned in his place. 
-<span class="v">15&#160;</span>Now the rest of the acts of Shallum, and his conspiracy which he made, behold, they are written in the book of the chronicles of the kings of Israel. 
-</p><p>
-<span class="v">16&#160;</span>Then Menahem attacked Tiphsah and all who were in it and its border areas, from Tirzah. He attacked it because they didn’t open their gates to him, and he ripped up all their women who were with child. 
-</p><p>
-<span class="v">17&#160;</span>In the thirty ninth year of Azariah king of Judah, Menahem the son of Gadi began to reign over Israel for ten years in Samaria. 
-<span class="v">18&#160;</span>He did that which was evil in Yahweh’s sight. He didn’t depart all his days from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-<span class="v">19&#160;</span>Pul the king of Assyria came against the land, and Menahem gave Pul one thousand talents<span class="f">+ \fr 15:19 \ft A talent is about 30 kilograms or 66 pounds, so 1000 talents is about 30 metric tons</span> of silver, that his hand might be with him to confirm the kingdom in his hand. 
-<span class="v">20&#160;</span>Menahem exacted the money from Israel, even from all the mighty men of wealth, from each man fifty shekels<span class="f">+ \fr 15:20 \ft A shekel is about 10 grams or about 0.35 ounces, so 50 shekels was about 0.5 kilograms or 1.1 pounds.</span> of silver, to give to the king of Assyria. So the king of Assyria turned back, and didn’t stay there in the land. 
-<span class="v">21&#160;</span>Now the rest of the acts of Menahem, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
-<span class="v">22&#160;</span>Menahem slept with his fathers, and Pekahiah his son reigned in his place. 
-</p><p>
-<span class="v">23&#160;</span>In the fiftieth year of Azariah king of Judah, Pekahiah the son of Menahem began to reign over Israel in Samaria for two years. 
-<span class="v">24&#160;</span>He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-<span class="v">25&#160;</span>Pekah the son of Remaliah, his captain, conspired against him and attacked him in Samaria, in the fortress of the king’s house, with Argob and Arieh; and with him were fifty men of the Gileadites. He killed him, and reigned in his place. 
-<span class="v">26&#160;</span>Now the rest of the acts of Pekahiah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
-</p><p>
-<span class="v">27&#160;</span>In the fifty-second year of Azariah king of Judah, Pekah the son of Remaliah began to reign over Israel in Samaria for twenty years. 
-<span class="v">28&#160;</span>He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
-<span class="v">29&#160;</span>In the days of Pekah king of Israel, Tiglath Pileser king of Assyria came and took Ijon, Abel Beth Maacah, Janoah, Kedesh, Hazor, Gilead, and Galilee, all the land of Naphtali; and he carried them captive to Assyria. 
-<span class="v">30&#160;</span>Hoshea the son of Elah made a conspiracy against Pekah the son of Remaliah, attacked him, killed him, and reigned in his place, in the twentieth year of Jotham the son of Uzziah. 
-<span class="v">31&#160;</span>Now the rest of the acts of Pekah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
-</p><p>
-<span class="v">32&#160;</span>In the second year of Pekah the son of Remaliah king of Israel, Jotham the son of Uzziah king of Judah began to reign. 
-<span class="v">33&#160;</span>He was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerusha the daughter of Zadok. 
-<span class="v">34&#160;</span>He did that which was right in Yahweh’s eyes. He did according to all that his father Uzziah had done. 
-<span class="v">35&#160;</span>However the high places were not taken away. The people still sacrificed and burned incense in the high places. He built the upper gate of Yahweh’s house. 
-<span class="v">36&#160;</span>Now the rest of the acts of Jotham, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">37&#160;</span>In those days, Yahweh began to send Rezin the king of Syria and Pekah the son of Remaliah against Judah. 
-<span class="v">38&#160;</span>Jotham slept with his fathers, and was buried with his fathers in his father David’s city; and Ahaz his son reigned in his place. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>In the seventeenth year of Pekah the son of Remaliah, Ahaz the son of Jotham king of Judah began to reign. 
-<span class="v">2&#160;</span>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh his Elohim’s eyes, like David his father. 
-<span class="v">3&#160;</span>But he walked in the way of the kings of Israel, and even made his son to pass through the fire, according to the abominations of the nations whom Yahweh cast out from before the children of Israel. 
-<span class="v">4&#160;</span>He sacrificed and burned incense in the high places, on the hills, and under every green tree. 
-</p><p>
-<span class="v">5&#160;</span>Then Rezin king of Syria and Pekah son of Remaliah king of Israel came up to Jerusalem to wage war. They besieged Ahaz, but could not overcome him. 
-<span class="v">6&#160;</span>At that time Rezin king of Syria recovered Elath to Syria, and drove the Jews from Elath; and the Syrians came to Elath, and lived there to this day. 
-<span class="v">7&#160;</span>So Ahaz sent messengers to Tiglath Pileser king of Assyria, saying, “I am your servant and your son. Come up and save me out of the hand of the king of Syria and out of the hand of the king of Israel, who rise up against me.” 
-<span class="v">8&#160;</span>Ahaz took the silver and gold that was found in Yahweh’s house, and in the treasures of the king’s house, and sent it for a present to the king of Assyria. 
-<span class="v">9&#160;</span>The king of Assyria listened to him; and the king of Assyria went up against Damascus and took it, and carried its people captive to Kir, and killed Rezin. 
-</p><p>
-<span class="v">10&#160;</span>King Ahaz went to Damascus to meet Tiglath Pileser king of Assyria, and saw the altar that was at Damascus; and King Ahaz sent to Urijah the priest a drawing of the altar and plans to build it. 
-<span class="v">11&#160;</span>Urijah the priest built an altar. According to all that King Ahaz had sent from Damascus, so Urijah the priest made it for the coming of King Ahaz from Damascus. 
-<span class="v">12&#160;</span>When the king had come from Damascus, the king saw the altar; and the king came near to the altar, and offered on it. 
-<span class="v">13&#160;</span>He burned his burnt offering and his meal offering, poured his drink offering, and sprinkled the blood of his peace offerings on the altar. 
-<span class="v">14&#160;</span>The bronze altar, which was before Yahweh, he brought from the front of the house, from between his altar and Yahweh’s house, and put it on the north side of his altar. 
-<span class="v">15&#160;</span>King Ahaz commanded Urijah the priest, saying, “On the great altar burn the morning burnt offering, the evening meal offering, the king’s burnt offering and his meal offering, with the burnt offering of all the people of the land, their meal offering, and their drink offerings; and sprinkle on it all the blood of the burnt offering, and all the blood of the sacrifice; but the bronze altar will be for me to inquire by.” 
-<span class="v">16&#160;</span>Urijah the priest did so, according to all that King Ahaz commanded. 
-</p><p>
-<span class="v">17&#160;</span>King Ahaz cut off the panels of the bases, and removed the basin from off them, and took down the sea from off the bronze oxen that were under it, and put it on a pavement of stone. 
-<span class="v">18&#160;</span>He removed the covered way for the Sabbath that they had built in the house, and the king’s outer entrance to Yahweh’s house, because of the king of Assyria. 
-<span class="v">19&#160;</span>Now the rest of the acts of Ahaz which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">20&#160;</span>Ahaz slept with his fathers, and was buried with his fathers in David’s city; and Hezekiah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>In the twelfth year of Ahaz king of Judah, Hoshea the son of Elah began to reign in Samaria over Israel for nine years. 
-<span class="v">2&#160;</span>He did that which was evil in Yahweh’s sight, yet not as the kings of Israel who were before him. 
-<span class="v">3&#160;</span>Shalmaneser king of Assyria came up against him; and Hoshea became his servant, and brought him tribute. 
-<span class="v">4&#160;</span>The king of Assyria discovered a conspiracy in Hoshea; for he had sent messengers to So king of Egypt, and offered no tribute to the king of Assyria, as he had done year by year. Therefore the king of Assyria seized him, and bound him in prison. 
-<span class="v">5&#160;</span>Then the king of Assyria came up throughout all the land, went up to Samaria, and besieged it three years. 
-<span class="v">6&#160;</span>In the ninth year of Hoshea the king of Assyria took Samaria and carried Israel away to Assyria, and placed them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes. 
-</p><p>
-<span class="v">7&#160;</span>It was so because the children of Israel had sinned against Yahweh their Elohim, who brought them up out of the land of Egypt from under the hand of Pharaoh king of Egypt, and had feared other elohims, 
-<span class="v">8&#160;</span>and walked in the statutes of the nations whom Yahweh cast out from before the children of Israel, and of the kings of Israel, which they made. 
-<span class="v">9&#160;</span>The children of Israel secretly did things that were not right against Yahweh their Elohim; and they built high places for themselves in all their cities, from the tower of the watchmen to the fortified city; 
-<span class="v">10&#160;</span>and they set up for themselves pillars and Asherah poles on every high hill and under every green tree; 
-<span class="v">11&#160;</span>and there they burned incense in all the high places, as the nations whom Yahweh carried away before them did; and they did wicked things to provoke Yahweh to anger; 
-<span class="v">12&#160;</span>and they served idols, of which Yahweh had said to them, “You shall not do this thing.” 
-<span class="v">13&#160;</span>Yet Yahweh testified to Israel and to Judah, by every prophet and every seer, saying, “Turn from your evil ways, and keep my commandments and my statutes, according to all the law which I commanded your fathers, and which I sent to you by my servants the prophets.” 
-<span class="v">14&#160;</span>Notwithstanding, they would not listen, but hardened their neck like the neck of their fathers who didn’t believe in Yahweh their Elohim. 
-<span class="v">15&#160;</span>They rejected his statutes and his covenant that he made with their fathers, and his testimonies which he testified to them; and they followed vanity, and became vain, and followed the nations that were around them, concerning whom Yahweh had commanded them that they should not do like them. 
-<span class="v">16&#160;</span>They abandoned all the commandments of Yahweh their Elohim, and made molten images for themselves, even two calves, and made an Asherah, and worshiped all the army of the sky, and served Baal. 
-<span class="v">17&#160;</span>They caused their sons and their daughters to pass through the fire, used divination and enchantments, and sold themselves to do that which was evil in Yahweh’s sight, to provoke him to anger. 
-<span class="v">18&#160;</span>Therefore Yahweh was very angry with Israel, and removed them out of his sight. There was none left but the tribe of Judah only. 
-</p><p>
-<span class="v">19&#160;</span>Also Judah didn’t keep the commandments of Yahweh their Elohim, but walked in the statutes of Israel which they made. 
-<span class="v">20&#160;</span>Yahweh rejected all the offspring of Israel, afflicted them, and delivered them into the hands of raiders, until he had cast them out of his sight. 
-<span class="v">21&#160;</span>For he tore Israel from David’s house; and they made Jeroboam the son of Nebat king; and Jeroboam drove Israel from following Yahweh, and made them sin a great sin. 
-<span class="v">22&#160;</span>The children of Israel walked in all the sins of Jeroboam which he did; they didn’t depart from them 
-<span class="v">23&#160;</span>until Yahweh removed Israel out of his sight, as he said by all his servants the prophets. So Israel was carried away out of their own land to Assyria to this day. 
-</p><p>
-<span class="v">24&#160;</span>The king of Assyria brought people from Babylon, from Cuthah, from Avva, and from Hamath and Sepharvaim, and placed them in the cities of Samaria instead of the children of Israel; and they possessed Samaria and lived in its cities. 
-<span class="v">25&#160;</span>So it was, at the beginning of their dwelling there, that they didn’t fear Yahweh. Therefore Yahweh sent lions among them, which killed some of them. 
-<span class="v">26&#160;</span>Therefore they spoke to the king of Assyria, saying, “The nations which you have carried away and placed in the cities of Samaria don’t know the law of the elohim of the land. Therefore he has sent lions among them; and behold, they kill them, because they don’t know the law of the elohim of the land.” 
-</p><p>
-<span class="v">27&#160;</span>Then the king of Assyria commanded, saying, “Carry there one of the priests whom you brought from there; and let him<span class="f">+ \fr 17:27 \ft Hebrew: \fq them</span> go and dwell there, and let him teach them the law of the elohim of the land.” 
-</p><p>
-<span class="v">28&#160;</span>So one of the priests whom they had carried away from Samaria came and lived in Bethel, and taught them how they should fear Yahweh. 
-</p><p>
-<span class="v">29&#160;</span>However every nation made elohims of their own, and put them in the houses of the high places which the Samaritans had made, every nation in their cities in which they lived. 
-<span class="v">30&#160;</span>The men of Babylon made Succoth Benoth, and the men of Cuth made Nergal, and the men of Hamath made Ashima, 
-<span class="v">31&#160;</span>and the Avvites made Nibhaz and Tartak; and the Sepharvites burned their children in the fire to Adrammelech and Anammelech, the elohims of Sepharvaim. 
-<span class="v">32&#160;</span>So they feared Yahweh, and also made from among themselves priests of the high places for themselves, who sacrificed for them in the houses of the high places. 
-<span class="v">33&#160;</span>They feared Yahweh, and also served their own elohims, after the ways of the nations from among whom they had been carried away. 
-<span class="v">34&#160;</span>To this day they do what they did before. They don’t fear Yahweh, and they do not follow the statutes, or the ordinances, or the law, or the commandment which Yahweh commanded the children of Jacob, whom he named Israel; 
-<span class="v">35&#160;</span>with whom Yahweh had made a covenant and commanded them, saying, “You shall not fear other elohims, nor bow yourselves to them, nor serve them, nor sacrifice to them; 
-<span class="v">36&#160;</span>but you shall fear Yahweh, who brought you up out of the land of Egypt with great power and with an outstretched arm, and you shall bow yourselves to him, and you shall sacrifice to him. 
-<span class="v">37&#160;</span>The statutes and the ordinances, and the law and the commandment which he wrote for you, you shall observe to do forever more. You shall not fear other elohims. 
-<span class="v">38&#160;</span>You shall not forget the covenant that I have made with you. You shall not fear other elohims. 
-<span class="v">39&#160;</span>But you shall fear Yahweh your Elohim, and he will deliver you out of the hand of all your enemies.” 
-</p><p>
-<span class="v">40&#160;</span>However they didn’t listen, but they did what they did before. 
-<span class="v">41&#160;</span>So these nations feared Yahweh, and also served their engraved images. Their children did likewise, and so did their children’s children. They do as their fathers did to this day. 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Now in the third year of Hoshea son of Elah king of Israel, Hezekiah the son of Ahaz king of Judah began to reign. 
-<span class="v">2&#160;</span>He was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abi the daughter of Zechariah. 
-<span class="v">3&#160;</span>He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
-<span class="v">4&#160;</span>He removed the high places, broke the pillars, and cut down the Asherah. He also broke in pieces the bronze serpent that Moses had made, because in those days the children of Israel burned incense to it; and he called it Nehushtan. 
-<span class="v">5&#160;</span>He trusted in Yahweh, the Elohim of Israel, so that after him was no one like him among all the kings of Judah, nor among them that were before him. 
-<span class="v">6&#160;</span>For he joined with Yahweh. He didn’t depart from following him, but kept his commandments, which Yahweh commanded Moses. 
-<span class="v">7&#160;</span>Yahweh was with him. Wherever he went, he prospered. He rebelled against the king of Assyria, and didn’t serve him. 
-<span class="v">8&#160;</span>He struck the Philistines to Gaza and its borders, from the tower of the watchmen to the fortified city. 
-</p><p>
-<span class="v">9&#160;</span>In the fourth year of King Hezekiah, which was the seventh year of Hoshea son of Elah king of Israel, Shalmaneser king of Assyria came up against Samaria and besieged it. 
-<span class="v">10&#160;</span>At the end of three years they took it. In the sixth year of Hezekiah, which was the ninth year of Hoshea king of Israel, Samaria was taken. 
-<span class="v">11&#160;</span>The king of Assyria carried Israel away to Assyria, and put them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes, 
-<span class="v">12&#160;</span>because they didn’t obey Yahweh their Elohim’s voice, but transgressed his covenant, even all that Moses the servant of Yahweh commanded, and would not hear it or do it. 
-</p><p>
-<span class="v">13&#160;</span>Now in the fourteenth year of King Hezekiah, Sennacherib king of Assyria came up against all the fortified cities of Judah and took them. 
-<span class="v">14&#160;</span>Hezekiah king of Judah sent to the king of Assyria at Lachish, saying, “I have offended you. Withdraw from me. That which you put on me, I will bear.” The king of Assyria appointed to Hezekiah king of Judah three hundred talents of silver and thirty talents<span class="f">+ \fr 18:14 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of gold. 
-<span class="v">15&#160;</span>Hezekiah gave him all the silver that was found in Yahweh’s house and in the treasures of the king’s house. 
-<span class="v">16&#160;</span>At that time, Hezekiah cut off the gold from the doors of Yahweh’s temple, and from the pillars which Hezekiah king of Judah had overlaid, and gave it to the king of Assyria. 
-</p><p>
-<span class="v">17&#160;</span>The king of Assyria sent Tartan, Rabsaris, and Rabshakeh from Lachish to King Hezekiah with a great army to Jerusalem. They went up and came to Jerusalem. When they had come up, they came and stood by the conduit of the upper pool, which is in the highway of the fuller’s field. 
-<span class="v">18&#160;</span>When they had called to the king, Eliakim the son of Hilkiah, who was over the household, and Shebnah the scribe, and Joah the son of Asaph the recorder came out to them. 
-<span class="v">19&#160;</span>Rabshakeh said to them, “Say now to Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
-<span class="v">20&#160;</span>You say (but they are but vain words), ‘There is counsel and strength for war.’ Now on whom do you trust, that you have rebelled against me? 
-<span class="v">21&#160;</span>Now, behold, you trust in the staff of this bruised reed, even in Egypt. If a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust on him. 
-<span class="v">22&#160;</span>But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar in Jerusalem’? 
-<span class="v">23&#160;</span>Now therefore, please give pledges to my master the king of Assyria, and I will give you two thousand horses if you are able on your part to set riders on them. 
-<span class="v">24&#160;</span>How then can you turn away the face of one captain of the least of my master’s servants, and put your trust on Egypt for chariots and for horsemen? 
-<span class="v">25&#160;</span>Have I now come up without Yahweh against this place to destroy it? Yahweh said to me, ‘Go up against this land, and destroy it.’&#160;”&#160;’&#160;” 
-</p><p>
-<span class="v">26&#160;</span>Then Eliakim the son of Hilkiah, Shebnah, and Joah, said to Rabshakeh, “Please speak to your servants in the Syrian language, for we understand it. Don’t speak with us in the Jews’ language, in the hearing of the people who are on the wall.” 
-</p><p>
-<span class="v">27&#160;</span>But Rabshakeh said to them, “Has my master sent me to your master and to you, to speak these words? Hasn’t he sent me to the men who sit on the wall, to eat their own dung, and to drink their own urine with you?” 
-</p><p>
-<span class="v">28&#160;</span>Then Rabshakeh stood and cried with a loud voice in the Jews’ language, and spoke, saying, “Hear the word of the great king, the king of Assyria. 
-<span class="v">29&#160;</span>The king says, ‘Don’t let Hezekiah deceive you, for he will not be able to deliver you out of his hand. 
-<span class="v">30&#160;</span>Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us, and this city shall not be given into the hand of the king of Assyria.” 
-<span class="v">31&#160;</span>Don’t listen to Hezekiah.’ For the king of Assyria says, ‘Make your peace with me, and come out to me; and everyone of you eat from his own vine, and everyone from his own fig tree, and everyone drink water from his own cistern; 
-<span class="v">32&#160;</span>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards, a land of olive trees and of honey, that you may live and not die. Don’t listen to Hezekiah when he persuades you, saying, “Yahweh will deliver us.” 
-<span class="v">33&#160;</span>Has any of the elohims of the nations ever delivered his land out of the hand of the king of Assyria? 
-<span class="v">34&#160;</span>Where are the elohims of Hamath and of Arpad? Where are the elohims of Sepharvaim, of Hena, and Ivvah? Have they delivered Samaria out of my hand? 
-<span class="v">35&#160;</span>Who are they among all the elohims of the countries, that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’&#160;” 
-</p><p>
-<span class="v">36&#160;</span>But the people stayed quiet, and answered him not a word; for the king’s commandment was, “Don’t answer him.” 
-<span class="v">37&#160;</span>Then Eliakim the son of Hilkiah, who was over the household, came with Shebna the scribe and Joah the son of Asaph the recorder to Hezekiah with their clothes torn, and told him Rabshakeh’s words. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
-<span class="v">2&#160;</span>He sent Eliakim, who was over the household, Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet the son of Amoz. 
-<span class="v">3&#160;</span>They said to him, “Hezekiah says, ‘Today is a day of trouble, of rebuke, and of rejection; for the children have come to the point of birth, and there is no strength to deliver them. 
-<span class="v">4&#160;</span>It may be Yahweh your Elohim will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
-</p><p>
-<span class="v">5&#160;</span>So the servants of King Hezekiah came to Isaiah. 
-<span class="v">6&#160;</span>Isaiah said to them, “Tell your master this: ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
-<span class="v">7&#160;</span>Behold, I will put a spirit in him, and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.”&#160;’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>So Rabshakeh returned and found the king of Assyria warring against Libnah; for he had heard that he had departed from Lachish. 
-<span class="v">9&#160;</span>When he heard it said of Tirhakah king of Ethiopia, “Behold, he has come out to fight against you,” he sent messengers again to Hezekiah, saying, 
-<span class="v">10&#160;</span>“Tell Hezekiah king of Judah this: ‘Don’t let your Elohim in whom you trust deceive you, saying, Jerusalem will not be given into the hand of the king of Assyria. 
-<span class="v">11&#160;</span>Behold, you have heard what the kings of Assyria have done to all lands, by destroying them utterly. Will you be delivered? 
-<span class="v">12&#160;</span>Have the elohims of the nations delivered them, which my fathers have destroyed—Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
-<span class="v">13&#160;</span>Where is the king of Hamath, the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
-<span class="v">15&#160;</span>Hezekiah prayed before Yahweh, and said, “Yahweh, the Elohim of Israel, who are enthroned above the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
-<span class="v">16&#160;</span>Incline your ear, Yahweh, and hear. Open your eyes, Yahweh, and see. Hear the words of Sennacherib, which he has sent to defy the living Elohim. 
-<span class="v">17&#160;</span>Truly, Yahweh, the kings of Assyria have laid waste the nations and their lands, 
-<span class="v">18&#160;</span>and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone. Therefore they have destroyed them. 
-<span class="v">19&#160;</span>Now therefore, Yahweh our Elohim, save us, I beg you, out of his hand, that all the kingdoms of the earth may know that you, Yahweh, are Elohim alone.” 
-</p><p>
-<span class="v">20&#160;</span>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel, says ‘You have prayed to me against Sennacherib king of Assyria, and I have heard you. 
-<span class="v">21&#160;</span>This is the word that Yahweh has spoken concerning him: ‘The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
-<span class="v">22&#160;</span>Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel! 
-<span class="v">23&#160;</span>By your messengers, you have defied the Lord, and have said, “With the multitude of my chariots, I have come up to the height of the mountains, to the innermost parts of Lebanon, and I will cut down its tall cedars and its choice cypress trees; and I will enter into his farthest lodging place, the forest of his fruitful field. 
-<span class="v">24&#160;</span>I have dug and drunk strange waters, and I will dry up all the rivers of Egypt with the sole of my feet.” 
-<span class="v">25&#160;</span>Haven’t you heard how I have done it long ago, and formed it of ancient times? Now I have brought it to pass, that it should be yours to lay waste fortified cities into ruinous heaps. 
-<span class="v">26&#160;</span>Therefore their inhabitants had little power. They were dismayed and confounded. They were like the grass of the field and like the green herb, like the grass on the housetops and like grain blasted before it has grown up. 
-<span class="v">27&#160;</span>But I know your sitting down, your going out, your coming in, and your raging against me. 
-<span class="v">28&#160;</span>Because of your raging against me, and because your arrogance has come up into my ears, therefore I will put my hook in your nose, and my bridle in your lips, and I will turn you back by the way by which you came.’ 
-</p><p>
-<span class="v">29&#160;</span>“This will be the sign to you: This year, you will eat that which grows of itself, and in the second year that which springs from that; and in the third year sow and reap, and plant vineyards and eat their fruit. 
-<span class="v">30&#160;</span>The remnant that has escaped of the house of Judah will again take root downward, and bear fruit upward. 
-<span class="v">31&#160;</span>For out of Jerusalem a remnant will go out, and out of Mount Zion those who shall escape. Yahweh’s zeal will perform this. 
-</p><p>
-<span class="v">32&#160;</span>“Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there. He will not come before it with shield, nor cast up a mound against it. 
-<span class="v">33&#160;</span>He will return the same way that he came, and he will not come to this city,’ says Yahweh. 
-<span class="v">34&#160;</span>‘For I will defend this city to save it, for my own sake and for my servant David’s sake.’&#160;” 
-</p><p>
-<span class="v">35&#160;</span>That night, Yahweh’s angel went out and struck one hundred eighty-five thousand in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
-<span class="v">36&#160;</span>So Sennacherib king of Assyria departed, went home, and lived at Nineveh. 
-<span class="v">37&#160;</span>As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>In those days Hezekiah was sick and dying. Isaiah the prophet the son of Amoz came to him, and said to him, “Yahweh says, ‘Set your house in order; for you will die, and not live.’&#160;” 
-</p><p>
-<span class="v">2&#160;</span>Then he turned his face to the wall, and prayed to Yahweh, saying, 
-<span class="v">3&#160;</span>“Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” And Hezekiah wept bitterly. 
-</p><p>
-<span class="v">4&#160;</span>Before Isaiah had gone out into the middle part of the city, Yahweh’s word came to him, saying, 
-<span class="v">5&#160;</span>“Turn back, and tell Hezekiah the prince of my people, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will heal you. On the third day, you will go up to Yahweh’s house. 
-<span class="v">6&#160;</span>I will add to your days fifteen years. I will deliver you and this city out of the hand of the king of Assyria. I will defend this city for my own sake, and for my servant David’s sake.”&#160;’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>Isaiah said, “Take a cake of figs.” 
-</p><p>They took and laid it on the boil, and he recovered. 
-</p><p>
-<span class="v">8&#160;</span>Hezekiah said to Isaiah, “What will be the sign that Yahweh will heal me, and that I will go up to Yahweh’s house the third day?” 
-</p><p>
-<span class="v">9&#160;</span>Isaiah said, “This will be the sign to you from Yahweh, that Yahweh will do the thing that he has spoken: should the shadow go forward ten steps, or go back ten steps?” 
-</p><p>
-<span class="v">10&#160;</span>Hezekiah answered, “It is a light thing for the shadow to go forward ten steps. No, but let the shadow return backward ten steps.” 
-</p><p>
-<span class="v">11&#160;</span>Isaiah the prophet cried to Yahweh; and he brought the shadow ten steps backward, by which it had gone down on the sundial of Ahaz. 
-</p><p>
-<span class="v">12&#160;</span>At that time Berodach Baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he had heard that Hezekiah had been sick. 
-<span class="v">13&#160;</span>Hezekiah listened to them, and showed them all the storehouse of his precious things—the silver, the gold, the spices, and the precious oil, and the house of his armor, and all that was found in his treasures. There was nothing in his house, or in all his dominion, that Hezekiah didn’t show them. 
-</p><p>
-<span class="v">14&#160;</span>Then Isaiah the prophet came to King Hezekiah, and said to him, “What did these men say? From where did they come to you?” 
-</p><p>Hezekiah said, “They have come from a far country, even from Babylon.” 
-</p><p>
-<span class="v">15&#160;</span>He said, “What have they seen in your house?” 
-</p><p>Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
-</p><p>
-<span class="v">16&#160;</span>Isaiah said to Hezekiah, “Hear Yahweh’s word. 
-<span class="v">17&#160;</span>‘Behold, the days come that all that is in your house, and that which your fathers have laid up in store to this day, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
-<span class="v">18&#160;</span>‘They will take away some of your sons who will issue from you, whom you will father; and they will be eunuchs in the palace of the king of Babylon.’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “Isn’t it so, if peace and truth will be in my days?” 
-</p><p>
-<span class="v">20&#160;</span>Now the rest of the acts of Hezekiah, and all his might, and how he made the pool, and the conduit, and brought water into the city, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">21&#160;</span>Hezekiah slept with his fathers, and Manasseh his son reigned in his place. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. His mother’s name was Hephzibah. 
-<span class="v">2&#160;</span>He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
-<span class="v">3&#160;</span>For he built again the high places which Hezekiah his father had destroyed; and he raised up altars for Baal, and made an Asherah, as Ahab king of Israel did, and worshiped all the army of the sky, and served them. 
-<span class="v">4&#160;</span>He built altars in Yahweh’s house, of which Yahweh said, “I will put my name in Jerusalem.” 
-<span class="v">5&#160;</span>He built altars for all the army of the sky in the two courts of Yahweh’s house. 
-<span class="v">6&#160;</span>He made his son to pass through the fire, practiced sorcery, used enchantments, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
-<span class="v">7&#160;</span>He set the engraved image of Asherah that he had made in the house of which Yahweh said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever; 
-<span class="v">8&#160;</span>I will not cause the feet of Israel to wander any more out of the land which I gave their fathers, if only they will observe to do according to all that I have commanded them, and according to all the law that my servant Moses commanded them.” 
-<span class="v">9&#160;</span>But they didn’t listen, and Manasseh seduced them to do that which is evil more than the nations did whom Yahweh destroyed before the children of Israel. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh spoke by his servants the prophets, saying, 
-<span class="v">11&#160;</span>“Because Manasseh king of Judah has done these abominations, and has done wickedly above all that the Amorites did, who were before him, and has also made Judah to sin with his idols; 
-<span class="v">12&#160;</span>therefore Yahweh the Elohim of Israel says, ‘Behold, I will bring such evil on Jerusalem and Judah that whoever hears of it, both his ears will tingle. 
-<span class="v">13&#160;</span>I will stretch over Jerusalem the line of Samaria, and the plumb line of Ahab’s house; and I will wipe Jerusalem as a man wipes a dish, wiping it and turning it upside down. 
-<span class="v">14&#160;</span>I will cast off the remnant of my inheritance and deliver them into the hands of their enemies. They will become a prey and a plunder to all their enemies, 
-<span class="v">15&#160;</span>because they have done that which is evil in my sight, and have provoked me to anger since the day their fathers came out of Egypt, even to this day.’&#160;” 
-</p><p>
-<span class="v">16&#160;</span>Moreover Manasseh shed innocent blood very much, until he had filled Jerusalem from one end to another; in addition to his sin with which he made Judah to sin, in doing that which was evil in Yahweh’s sight. 
-</p><p>
-<span class="v">17&#160;</span>Now the rest of the acts of Manasseh, and all that he did, and his sin that he sinned, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">18&#160;</span>Manasseh slept with his fathers, and was buried in the garden of his own house, in the garden of Uzza; and Amon his son reigned in his place. 
-</p><p>
-<span class="v">19&#160;</span>Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. His mother’s name was Meshullemeth the daughter of Haruz of Jotbah. 
-<span class="v">20&#160;</span>He did that which was evil in Yahweh’s sight, as Manasseh his father did. 
-<span class="v">21&#160;</span>He walked in all the ways that his father walked in, and served the idols that his father served, and worshiped them; 
-<span class="v">22&#160;</span>and he abandoned Yahweh, the Elohim of his fathers, and didn’t walk in the way of Yahweh. 
-<span class="v">23&#160;</span>The servants of Amon conspired against him, and put the king to death in his own house. 
-<span class="v">24&#160;</span>But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
-<span class="v">25&#160;</span>Now the rest of the acts of Amon which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">26&#160;</span>He was buried in his tomb in the garden of Uzza, and Josiah his son reigned in his place. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. His mother’s name was Jedidah the daughter of Adaiah of Bozkath. 
-<span class="v">2&#160;</span>He did that which was right in Yahweh’s eyes, and walked in all the ways of David his father, and didn’t turn away to the right hand or to the left. 
-</p><p>
-<span class="v">3&#160;</span>In the eighteenth year of King Josiah, the king sent Shaphan, the son of Azaliah the son of Meshullam, the scribe, to Yahweh’s house, saying, 
-<span class="v">4&#160;</span>“Go up to Hilkiah the high priest, that he may count the money which is brought into Yahweh’s house, which the keepers of the threshold have gathered of the people. 
-<span class="v">5&#160;</span>Let them deliver it into the hand of the workers who have the oversight of Yahweh’s house; and let them give it to the workers who are in Yahweh’s house, to repair the damage to the house, 
-<span class="v">6&#160;</span>to the carpenters, and to the builders, and to the masons, and for buying timber and cut stone to repair the house. 
-<span class="v">7&#160;</span>However, no accounting shall be asked of them for the money delivered into their hand, for they deal faithfully.” 
-</p><p>
-<span class="v">8&#160;</span>Hilkiah the high priest said to Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” Hilkiah delivered the book to Shaphan, and he read it. 
-<span class="v">9&#160;</span>Shaphan the scribe came to the king, and brought the king word again, and said, “Your servants have emptied out the money that was found in the house, and have delivered it into the hands of the workmen who have the oversight of Yahweh’s house.” 
-<span class="v">10&#160;</span>Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered a book to me.” Then Shaphan read it before the king. 
-</p><p>
-<span class="v">11&#160;</span>When the king had heard the words of the book of the law, he tore his clothes. 
-<span class="v">12&#160;</span>The king commanded Hilkiah the priest, Ahikam the son of Shaphan, Achbor the son of Micaiah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
-<span class="v">13&#160;</span>“Go inquire of Yahweh for me, and for the people, and for all Judah, concerning the words of this book that is found; for great is Yahweh’s wrath that is kindled against us, because our fathers have not listened to the words of this book, to do according to all that which is written concerning us.” 
-</p><p>
-<span class="v">14&#160;</span>So Hilkiah the priest, Ahikam, Achbor, Shaphan, and Asaiah went to Huldah the prophetess, the woman of Shallum the son of Tikvah, the son of Harhas, keeper of the wardrobe (now she lived in Jerusalem in the second quarter); and they talked with her. 
-<span class="v">15&#160;</span>She said to them, “Yahweh the Elohim of Israel says, ‘Tell the man who sent you to me, 
-<span class="v">16&#160;</span>“Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the words of the book which the king of Judah has read. 
-<span class="v">17&#160;</span>Because they have forsaken me and have burned incense to other elohims, that they might provoke me to anger with all the work of their hands, therefore my wrath shall be kindled against this place, and it will not be quenched.’&#160;” 
-<span class="v">18&#160;</span>But to the king of Judah, who sent you to inquire of Yahweh, tell him, “Yahweh the Elohim of Israel says, ‘Concerning the words which you have heard, 
-<span class="v">19&#160;</span>because your heart was tender, and you humbled yourself before Yahweh when you heard what I spoke against this place and against its inhabitants, that they should become a desolation and a curse, and have torn your clothes and wept before me, I also have heard you,’ says Yahweh. 
-<span class="v">20&#160;</span>‘Therefore behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes will not see all the evil which I will bring on this place.’&#160;”&#160;’&#160;” So they brought this message back to the king. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>The king sent, and they gathered to him all the elders of Judah and of Jerusalem. 
-<span class="v">2&#160;</span>The king went up to Yahweh’s house, and all the men of Judah and all the inhabitants of Jerusalem with him—with the priests, the prophets, and all the people, both small and great; and he read in their hearing all the words of the book of the covenant which was found in Yahweh’s house. 
-<span class="v">3&#160;</span>The king stood by the pillar and made a covenant before Yahweh to walk after Yahweh and to keep his commandments, his testimonies, and his statutes with all his heart and all his soul, to confirm the words of this covenant that were written in this book; and all the people agreed to the covenant. 
-</p><p>
-<span class="v">4&#160;</span>The king commanded Hilkiah the high priest, and the priests of the second order, and the keepers of the threshold, to bring out of Yahweh’s temple all the vessels that were made for Baal, for the Asherah, and for all the army of the sky; and he burned them outside of Jerusalem in the fields of the Kidron, and carried their ashes to Bethel. 
-<span class="v">5&#160;</span>He got rid of the idolatrous priests whom the kings of Judah had ordained to burn incense in the high places in the cities of Judah and in the places around Jerusalem; those also who burned incense to Baal, to the sun, to the moon, to the planets, and to all the army of the sky. 
-<span class="v">6&#160;</span>He brought out the Asherah from Yahweh’s house, outside of Jerusalem, to the brook Kidron, and burned it at the brook Kidron, and beat it to dust, and cast its dust on the graves of the common people. 
-<span class="v">7&#160;</span>He broke down the houses of the male shrine prostitutes that were in Yahweh’s house, where the women wove hangings for the Asherah. 
-<span class="v">8&#160;</span>He brought all the priests out of the cities of Judah, and defiled the high places where the priests had burned incense, from Geba to Beersheba; and he broke down the high places of the gates that were at the entrance of the gate of Joshua the governor of the city, which were on a man’s left hand at the gate of the city. 
-<span class="v">9&#160;</span>Nevertheless the priests of the high places didn’t come up to Yahweh’s altar in Jerusalem, but they ate unleavened bread among their brothers. 
-<span class="v">10&#160;</span>He defiled Topheth, which is in the valley of the children of Hinnom, that no man might make his son or his daughter to pass through the fire to Molech. 
-<span class="v">11&#160;</span>He took away the horses that the kings of Judah had dedicated to the sun, at the entrance of Yahweh’s house, by the room of Nathan Melech the officer who was in the court; and he burned the chariots of the sun with fire. 
-<span class="v">12&#160;</span>The king broke down the altars that were on the roof of the upper room of Ahaz, which the kings of Judah had made, and the altars which Manasseh had made in the two courts of Yahweh’s house, and beat them down from there, and cast their dust into the brook Kidron. 
-<span class="v">13&#160;</span>The king defiled the high places that were before Jerusalem, which were on the right hand of the mountain of corruption, which Solomon the king of Israel had built for Ashtoreth the abomination of the Sidonians, and for Chemosh the abomination of Moab, and for Milcom the abomination of the children of Ammon. 
-<span class="v">14&#160;</span>He broke in pieces the pillars, cut down the Asherah poles, and filled their places with men’s bones. 
-</p><p>
-<span class="v">15&#160;</span>Moreover the altar that was at Bethel and the high place which Jeroboam the son of Nebat, who made Israel to sin, had made, even that altar and the high place he broke down; and he burned the high place and beat it to dust, and burned the Asherah. 
-<span class="v">16&#160;</span>As Josiah turned himself, he spied the tombs that were there in the mountain; and he sent, and took the bones out of the tombs, and burned them on the altar, and defiled it, according to Yahweh’s word which the man of Elohim proclaimed, who proclaimed these things. 
-<span class="v">17&#160;</span>Then he said, “What monument is that which I see?” 
-</p><p>The men of the city told him, “It is the tomb of the man of Elohim who came from Judah and proclaimed these things that you have done against the altar of Bethel.” 
-</p><p>
-<span class="v">18&#160;</span>He said, “Let him be! Let no one move his bones.” So they let his bones alone, with the bones of the prophet who came out of Samaria. 
-<span class="v">19&#160;</span>All the houses also of the high places that were in the cities of Samaria, which the kings of Israel had made to provoke Yahweh to anger, Josiah took away, and did to them according to all the acts that he had done in Bethel. 
-<span class="v">20&#160;</span>He killed all the priests of the high places that were there, on the altars, and burned men’s bones on them; and he returned to Jerusalem. 
-</p><p>
-<span class="v">21&#160;</span>The king commanded all the people, saying, “Keep the Passover to Yahweh your Elohim, as it is written in this book of the covenant.” 
-<span class="v">22&#160;</span>Surely there was not kept such a Passover from the days of the judges who judged Israel, nor in all the days of the kings of Israel, nor of the kings of Judah; 
-<span class="v">23&#160;</span>but in the eighteenth year of King Josiah, this Passover was kept to Yahweh in Jerusalem. 
-</p><p>
-<span class="v">24&#160;</span>Moreover, Josiah removed those who had familiar spirits, the wizards, and the teraphim,<span class="f">+ \fr 23:24 \ft teraphim were household idols.</span> and the idols, and all the abominations that were seen in the land of Judah and in Jerusalem, that he might confirm the words of the law which were written in the book that Hilkiah the priest found in Yahweh’s house. 
-<span class="v">25&#160;</span>There was no king like him before him, who turned to Yahweh with all his heart, and with all his soul, and with all his might, according to all the law of Moses; and there was none like him who arose after him. 
-<span class="v">26&#160;</span>Notwithstanding, Yahweh didn’t turn from the fierceness of his great wrath, with which his anger burned against Judah, because of all the provocation with which Manasseh had provoked him. 
-<span class="v">27&#160;</span>Yahweh said, “I will also remove Judah out of my sight, as I have removed Israel; and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‘My name shall be there.’&#160;” 
-</p><p>
-<span class="v">28&#160;</span>Now the rest of the acts of Josiah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">29&#160;</span>In his days Pharaoh Necoh king of Egypt went up against the king of Assyria to the river Euphrates; and King Josiah went against him, but Pharaoh Necoh killed him at Megiddo when he saw him. 
-<span class="v">30&#160;</span>His servants carried him dead in a chariot from Megiddo, brought him to Jerusalem, and buried him in his own tomb. The people of the land took Jehoahaz the son of Josiah, and anointed him, and made him king in his father’s place. 
-</p><p>
-<span class="v">31&#160;</span>Jehoahaz was twenty-three years old when he began to reign; and he reigned three months in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-<span class="v">32&#160;</span>He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
-<span class="v">33&#160;</span>Pharaoh Necoh put him in bonds at Riblah in the land of Hamath, that he might not reign in Jerusalem; and put the land to a tribute of one hundred talents of silver and a talent<span class="f">+ \fr 23:33 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of gold. 
-<span class="v">34&#160;</span>Pharaoh Necoh made Eliakim the son of Josiah king in the place of Josiah his father, and changed his name to Jehoiakim; but he took Jehoahaz away, and he came to Egypt and died there. 
-<span class="v">35&#160;</span>Jehoiakim gave the silver and the gold to Pharaoh; but he taxed the land to give the money according to the commandment of Pharaoh. He exacted the silver and the gold of the people of the land, from everyone according to his assessment, to give it to Pharaoh Necoh. 
-<span class="v">36&#160;</span>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Zebidah the daughter of Pedaiah of Rumah. 
-<span class="v">37&#160;</span>He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>In his days Nebuchadnezzar king of Babylon came up, and Jehoiakim became his servant three years. Then he turned and rebelled against him. 
-<span class="v">2&#160;</span>Yahweh sent against him bands of the Chaldeans, bands of the Syrians, bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to Yahweh’s word which he spoke by his servants the prophets. 
-<span class="v">3&#160;</span>Surely at the commandment of Yahweh this came on Judah, to remove them out of his sight for the sins of Manasseh, according to all that he did, 
-<span class="v">4&#160;</span>and also for the innocent blood that he shed; for he filled Jerusalem with innocent blood, and Yahweh would not pardon. 
-<span class="v">5&#160;</span>Now the rest of the acts of Jehoiakim, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
-<span class="v">6&#160;</span>So Jehoiakim slept with his fathers, and Jehoiachin his son reigned in his place. 
-</p><p>
-<span class="v">7&#160;</span>The king of Egypt didn’t come out of his land any more; for the king of Babylon had taken, from the brook of Egypt to the river Euphrates, all that belonged to the king of Egypt. 
-</p><p>
-<span class="v">8&#160;</span>Jehoiachin was eighteen years old when he began to reign, and he reigned in Jerusalem three months. His mother’s name was Nehushta the daughter of Elnathan of Jerusalem. 
-<span class="v">9&#160;</span>He did that which was evil in Yahweh’s sight, according to all that his father had done. 
-<span class="v">10&#160;</span>At that time the servants of Nebuchadnezzar king of Babylon came up to Jerusalem, and the city was besieged. 
-<span class="v">11&#160;</span>Nebuchadnezzar king of Babylon came to the city while his servants were besieging it, 
-<span class="v">12&#160;</span>and Jehoiachin the king of Judah went out to the king of Babylon—he, his mother, his servants, his princes, and his officers; and the king of Babylon captured him in the eighth year of his reign. 
-<span class="v">13&#160;</span>He carried out from there all the treasures of Yahweh’s house and the treasures of the king’s house, and cut in pieces all the vessels of gold which Solomon king of Israel had made in Yahweh’s temple, as Yahweh had said. 
-<span class="v">14&#160;</span>He carried away all Jerusalem, and all the princes, and all the mighty men of valor, even ten thousand captives, and all the craftsmen and the smiths. No one remained except the poorest people of the land. 
-<span class="v">15&#160;</span>He carried away Jehoiachin to Babylon, with the king’s mother, the king’s women, his officers, and the chief men of the land. He carried them into captivity from Jerusalem to Babylon. 
-<span class="v">16&#160;</span>All the men of might, even seven thousand, and the craftsmen and the smiths one thousand, all of them strong and fit for war, even them the king of Babylon brought captive to Babylon. 
-<span class="v">17&#160;</span>The king of Babylon made Mattaniah, Jehoiachin’s father’s brother, king in his place, and changed his name to Zedekiah. 
-</p><p>
-<span class="v">18&#160;</span>Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-<span class="v">19&#160;</span>He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
-<span class="v">20&#160;</span>For through the anger of Yahweh, this happened in Jerusalem and Judah, until he had cast them out from his presence. 
-</p><p>Then Zedekiah rebelled against the king of Babylon. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>In the ninth year of his reign, in the tenth month, in the tenth day of the month, Nebuchadnezzar king of Babylon came, he and all his army, against Jerusalem, and encamped against it; and they built forts against it around it. 
-<span class="v">2&#160;</span>So the city was besieged until the eleventh year of King Zedekiah. 
-<span class="v">3&#160;</span>On the ninth day of the fourth month, the famine was severe in the city, so that there was no bread for the people of the land. 
-<span class="v">4&#160;</span>Then a breach was made in the city, and all the men of war fled by night by the way of the gate between the two walls, which was by the king’s garden (now the Chaldeans were against the city around it); and the king went by the way of the Arabah. 
-<span class="v">5&#160;</span>But the Chaldean army pursued the king, and overtook him in the plains of Jericho; and all his army was scattered from him. 
-<span class="v">6&#160;</span>Then they captured the king and carried him up to the king of Babylon to Riblah; and they passed judgment on him. 
-<span class="v">7&#160;</span>They killed Zedekiah’s sons before his eyes, then put out Zedekiah’s eyes, bound him in fetters, and carried him to Babylon. 
-</p><p>
-<span class="v">8&#160;</span>Now in the fifth month, on the seventh day of the month, which was the nineteenth year of King Nebuchadnezzar king of Babylon, Nebuzaradan the captain of the guard, a servant of the king of Babylon, came to Jerusalem. 
-<span class="v">9&#160;</span>He burned Yahweh’s house, the king’s house, and all the houses of Jerusalem. He burned every great house with fire. 
-<span class="v">10&#160;</span>All the army of the Chaldeans, who were with the captain of the guard, broke down the walls around Jerusalem. 
-<span class="v">11&#160;</span>Nebuzaradan the captain of the guard carried away captive the rest of the people who were left in the city and those who had deserted to the king of Babylon—all the rest of the multitude. 
-<span class="v">12&#160;</span>But the captain of the guard left some of the poorest of the land to work the vineyards and fields. 
-</p><p>
-<span class="v">13&#160;</span>The Chaldeans broke up the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house, and carried the bronze pieces to Babylon. 
-<span class="v">14&#160;</span>They took away the pots, the shovels, the snuffers, the spoons, and all the vessels of bronze with which they ministered. 
-<span class="v">15&#160;</span>The captain of the guard took away the fire pans, the basins, that which was of gold, for gold, and that which was of silver, for silver. 
-<span class="v">16&#160;</span>The two pillars, the one sea, and the bases, which Solomon had made for Yahweh’s house, the bronze of all these vessels was not weighed. 
-<span class="v">17&#160;</span>The height of the one pillar was eighteen cubits,<span class="f">+ \fr 25:17 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and a capital of bronze was on it. The height of the capital was three cubits, with network and pomegranates on the capital around it, all of bronze; and the second pillar with its network was like these. 
-</p><p>
-<span class="v">18&#160;</span>The captain of the guard took Seraiah the chief priest, Zephaniah the second priest, and the three keepers of the threshold; 
-<span class="v">19&#160;</span>and out of the city he took an officer who was set over the men of war; and five men of those who saw the king’s face, who were found in the city; and the scribe, the captain of the army, who mustered the people of the land, and sixty men of the people of the land who were found in the city. 
-<span class="v">20&#160;</span>Nebuzaradan the captain of the guard took them, and brought them to the king of Babylon to Riblah. 
-<span class="v">21&#160;</span>The king of Babylon attacked them and put them to death at Riblah in the land of Hamath. So Judah was carried away captive out of his land. 
-</p><p>
-<span class="v">22&#160;</span>As for the people who were left in the land of Judah whom Nebuchadnezzar king of Babylon had left, even over them he made Gedaliah the son of Ahikam, the son of Shaphan, governor. 
-<span class="v">23&#160;</span>Now when all the captains of the forces, they and their men, heard that the king of Babylon had made Gedaliah governor, they came to Gedaliah to Mizpah, even Ishmael the son of Nethaniah, Johanan the son of Kareah, Seraiah the son of Tanhumeth the Netophathite, and Jaazaniah the son of the Maacathite, they and their men. 
-<span class="v">24&#160;</span>Gedaliah swore to them and to their men, and said to them, “Don’t be afraid because of the servants of the Chaldeans. Dwell in the land and serve the king of Babylon, and it will be well with you.” 
-</p><p>
-<span class="v">25&#160;</span>But in the seventh month, Ishmael the son of Nethaniah, the son of Elishama, of the royal offspring came, and ten men with him, and struck Gedaliah so that he died, with the Jews and the Chaldeans that were with him at Mizpah. 
-<span class="v">26&#160;</span>All the people, both small and great, and the captains of the forces arose and came to Egypt; for they were afraid of the Chaldeans. 
-<span class="v">27&#160;</span>In the thirty-seventh year of the captivity of Jehoiachin king of Judah, in the twelfth month, on the twenty-seventh day of the month, Evilmerodach king of Babylon, in the year that he began to reign, released Jehoiachin king of Judah out of prison, 
-<span class="v">28&#160;</span>and he spoke kindly to him and set his throne above the throne of the kings who were with him in Babylon, 
-<span class="v">29&#160;</span>and changed his prison garments. Jehoiachin ate bread before him continually all the days of his life; 
-<span class="v">30&#160;</span>and for his allowance, there was a continual allowance given him from the king, every day a portion, all the days of his life. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Moab rebelled against Israel after the death of Ahab. 
+</div><div class="p">
+<sup>2&#160;</sup>Ahaziah fell down through the lattice in his upper room that was in Samaria, and was sick. So he sent messengers, and said to them, “Go, inquire of Baal Zebub, the elohim of Ekron, whether I will recover of this sickness.” 
+</div><div class="p">
+<sup>3&#160;</sup>But Yahweh’s in Israel that you go to inquire of Baal Zebub, the elohim of Ekron? 
+<sup>4&#160;</sup>Now therefore Yahweh says, “You will not come down from the bed where you have gone up, but you will surely die.”&#160;’&#160;” Then Elijah departed. 
+</div><div class="p">
+<sup>5&#160;</sup>The messengers returned to him, and he said to them, “Why is it that you have returned?” 
+</div><div class="p">
+<sup>6&#160;</sup>They said to him, “A man came up to meet us, and said to us, ‘Go, return to the king who sent you, and tell him, “Yahweh says, ‘Is it because there is no Elohim in Israel that you send to inquire of Baal Zebub, the elohim of Ekron? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;”&#160;’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>He said to them, “What kind of man was he who came up to meet you and told you these words?” 
+</div><div class="p">
+<sup>8&#160;</sup>They answered him, “He was a man, an owner of hair, and wearing a leather belt around his waist.” 
+</div><div class="p">He said, “It’s Elijah the Tishbite.” 
+</div><div class="p">
+<sup>9&#160;</sup>Then the king sent a captain of fifty with his fifty to him. He went up to him; and behold, he was sitting on the top of the hill. He said to him, “Man of Elohim, the king has said, ‘Come down!’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Elijah answered to the captain of fifty, “If I am a man of Elohim, then let fire come down from the sky and consume you and your fifty!” Then fire came down from the sky, and consumed him and his fifty. 
+</div><div class="p">
+<sup>11&#160;</sup>Again he sent to him another captain of fifty with his fifty. He answered him, “Man of Elohim, the king has said, ‘Come down quickly!’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Elijah answered them, “If I am a man of Elohim, then let fire come down from the sky and consume you and your fifty!” Then Elohim’s fire came down from the sky, and consumed him and his fifty. 
+</div><div class="p">
+<sup>13&#160;</sup>Again he sent the captain of a third fifty with his fifty. The third captain of fifty went up, and came and fell on his knees before Elijah, and begged him, and said to him, “Man of Elohim, please let my life and the life of these fifty of your servants be precious in your sight. 
+<sup>14&#160;</sup>Behold, fire came down from the sky and consumed the last two captains of fifty with their fifties. But now let my life be precious in your sight.” 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh’s angel said to Elijah, “Go down with him. Don’t be afraid of him.” 
+</div><div class="p">Then he arose and went down with him to the king. 
+<sup>16&#160;</sup>He said to him, “Yahweh says, ‘Because you have sent messengers to inquire of Baal Zebub, the elohim of Ekron, is it because there is no Elohim in Israel to inquire of his word? Therefore you will not come down from the bed where you have gone up, but you will surely die.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>So he died according to Yahweh’s word which Elijah had spoken. Jehoram began to reign in his place in the second year of Jehoram the son of Jehoshaphat king of Judah, because he had no son. 
+<sup>18&#160;</sup>Now the rest of the acts of Ahaziah which he did, aren’t they written in the book of the chronicles of the kings of Israel? 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahweh was about to take Elijah up by a whirlwind into heaven, Elijah went with Elisha from Gilgal. 
+<sup>2&#160;</sup>Elijah said to Elisha, “Please wait here, for Yahweh has sent me as far as Bethel.” 
+</div><div class="p">Elisha said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they went down to Bethel. 
+</div><div class="p">
+<sup>3&#160;</sup>The sons of the prophets who were at Bethel came out to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
+</div><div class="p">He said, “Yes, I know it. Hold your peace.” 
+</div><div class="p">
+<sup>4&#160;</sup>Elijah said to him, “Elisha, please wait here, for Yahweh has sent me to Jericho.” 
+</div><div class="p">He said, “As Yahweh lives, and as your soul lives, I will not leave you.” So they came to Jericho. 
+</div><div class="p">
+<sup>5&#160;</sup>The sons of the prophets who were at Jericho came near to Elisha, and said to him, “Do you know that Yahweh will take away your master from over you today?” 
+</div><div class="p">He answered, “Yes, I know it. Hold your peace.” 
+</div><div class="p">
+<sup>6&#160;</sup>Elijah said to him, “Please wait here, for Yahweh has sent me to the Jordan.” 
+</div><div class="p">He said, “As Yahweh lives, and as your soul lives, I will not leave you.” Then they both went on. 
+<sup>7&#160;</sup>Fifty men of the sons of the prophets went and stood opposite them at a distance; and they both stood by the Jordan. 
+<sup>8&#160;</sup>Elijah took his mantle, and rolled it up, and struck the waters; and they were divided here and there, so that they both went over on dry ground. 
+<sup>9&#160;</sup>When they had gone over, Elijah said to Elisha, “Ask what I shall do for you, before I am taken from you.” 
+</div><div class="p">Elisha said, “Please let a double portion of your spirit be on me.” 
+</div><div class="p">
+<sup>10&#160;</sup>He said, “You have asked a hard thing. If you see me when I am taken from you, it will be so for you; but if not, it will not be so.” 
+</div><div class="p">
+<sup>11&#160;</sup>As they continued on and talked, behold, a chariot of fire and horses of fire separated them; and Elijah went up by a whirlwind into heaven. 
+<sup>12&#160;</sup>Elisha saw it, and he cried, “My father, my father, the chariots of Israel and its horsemen!” 
+</div><div class="p">He saw him no more. Then he took hold of his own clothes and tore them in two pieces. 
+<sup>13&#160;</sup>He also took up Elijah’s mantle that fell from him, and went back and stood by the bank of the Jordan. 
+<sup>14&#160;</sup>He took Elijah’s mantle that fell from him, and struck the waters, and said, “Where is Yahweh, the Elohim of Elijah?” When he also had struck the waters, they were divided apart, and Elisha went over. 
+</div><div class="p">
+<sup>15&#160;</sup>When the sons of the prophets who were at Jericho facing him saw him, they said, “The spirit of Elijah rests on Elisha.” They came to meet him, and bowed themselves to the ground before him. 
+<sup>16&#160;</sup>They said to him, “See now, there are with your servants fifty strong men. Please let them go and seek your master. Perhaps Yahweh’s Spirit has taken him up, and put him on some mountain or into some valley.” 
+</div><div class="p">He said, “Don’t send them.” 
+</div><div class="p">
+<sup>17&#160;</sup>When they urged him until he was ashamed, he said, “Send them.” 
+</div><div class="p">Therefore they sent fifty men; and they searched for three days, but didn’t find him. 
+<sup>18&#160;</sup>They came back to him while he stayed at Jericho; and he said to them, “Didn’t I tell you, ‘Don’t go’?” 
+</div><div class="p">
+<sup>19&#160;</sup>The men of the city said to Elisha, “Behold, please, the situation of this city is pleasant, as my lord sees; but the water is bad, and the land is barren.” 
+</div><div class="p">
+<sup>20&#160;</sup>He said, “Bring me a new jar, and put salt in it.” Then they brought it to him. 
+<sup>21&#160;</sup>He went out to the spring of the waters, and threw salt into it, and said, “Yahweh says, ‘I have healed these waters. There shall not be from there any more death or barren wasteland.’&#160;” 
+<sup>22&#160;</sup>So the waters were healed to this day, according to Elisha’s word which he spoke. 
+</div><div class="p">
+<sup>23&#160;</sup>He went up from there to Bethel. As he was going up by the way, some youths came out of the city and mocked him, and said to him, “Go up, you baldy! Go up, you baldy!” 
+<sup>24&#160;</sup>He looked behind him and saw them, and cursed them in Yahweh’s name. Then two female bears came out of the woods and mauled forty-two of those youths. 
+<sup>25&#160;</sup>He went from there to Mount Carmel, and from there he returned to Samaria. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Jehoram the son of Ahab began to reign over Israel in Samaria in the eighteenth year of Jehoshaphat king of Judah, and reigned twelve years. 
+<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, but not like his father and like his mother, for he put away the pillar of Baal that his father had made. 
+<sup>3&#160;</sup>Nevertheless he held to the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from them. 
+</div><div class="p">
+<sup>4&#160;</sup>Now Mesha king of Moab was a sheep breeder; and he supplied the king of Israel with one hundred thousand lambs and the wool of one hundred thousand rams. 
+<sup>5&#160;</sup>But when Ahab was dead, the king of Moab rebelled against the king of Israel. 
+<sup>6&#160;</sup>King Jehoram went out of Samaria at that time, and mustered all Israel. 
+<sup>7&#160;</sup>He went and sent to Jehoshaphat the king of Judah, saying, “The king of Moab has rebelled against me. Will you go with me against Moab to battle?” 
+</div><div class="p">He said, “I will go up. I am as you are, my people as your people, my horses as your horses.” 
+<sup>8&#160;</sup>Then he said, “Which way shall we go up?” 
+</div><div class="p">Jehoram answered, “The way of the wilderness of Edom.” 
+</div><div class="p">
+<sup>9&#160;</sup>So the king of Israel went with the king of Judah and the king of Edom, and they marched for seven days along a circuitous route. There was no water for the army or for the animals that followed them. 
+<sup>10&#160;</sup>The king of Israel said, “Alas! For Yahweh has called these three kings together to deliver them into the hand of Moab.” 
+</div><div class="p">
+<sup>11&#160;</sup>But Jehoshaphat said, “Isn’t there a prophet of Yahweh here, that we may inquire of Yahweh by him?” 
+</div><div class="p">One of the king of Israel’s servants answered, “Elisha the son of Shaphat, who poured water on the hands of Elijah, is here.” 
+</div><div class="p">
+<sup>12&#160;</sup>Jehoshaphat said, “Yahweh’s word is with him.” So the king of Israel and Jehoshaphat and the king of Edom went down to him. 
+</div><div class="p">
+<sup>13&#160;</sup>Elisha said to the king of Israel, “What have I to do with you? Go to the prophets of your father, and to the prophets of your mother.” 
+</div><div class="p">The king of Israel said to him, “No, for Yahweh has called these three kings together to deliver them into the hand of Moab.” 
+</div><div class="p">
+<sup>14&#160;</sup>Elisha said, “As Yahweh of Armies lives, before whom I stand, surely, were it not that I respect the presence of Jehoshaphat the king of Judah, I would not look toward you, nor see you. 
+<sup>15&#160;</sup>But now bring me a musician.” When the musician played, Yahweh’s hand came on him. 
+<sup>16&#160;</sup>He said, “Yahweh says, ‘Make this valley full of trenches.’ 
+<sup>17&#160;</sup>For Yahweh says, ‘You will not see wind, neither will you see rain, yet that valley will be filled with water, and you will drink, both you and your livestock and your other animals. 
+<sup>18&#160;</sup>This is an easy thing in Yahweh’s sight. He will also deliver the Moabites into your hand. 
+<sup>19&#160;</sup>You shall strike every fortified city and every choice city, and shall fell every good tree, and stop all springs of water, and mar every good piece of land with stones.’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>In the morning, about the time of offering the sacrifice, behold, water came by the way of Edom, and the country was filled with water. 
+</div><div class="p">
+<sup>21&#160;</sup>Now when all the Moabites heard that the kings had come up to fight against them, they gathered themselves together, all who were able to put on armor, young and old, and stood on the border. 
+<sup>22&#160;</sup>They rose up early in the morning, and the sun shone on the water, and the Moabites saw the water opposite them as red as blood. 
+<sup>23&#160;</sup>They said, “This is blood. The kings are surely destroyed, and they have struck each other. Now therefore, Moab, to the plunder!” 
+</div><div class="p">
+<sup>24&#160;</sup>When they came to the camp of Israel, the Israelites rose up and struck the Moabites, so that they fled before them; and they went forward into the land attacking the Moabites. 
+<sup>25&#160;</sup>They beat down the cities; and on every good piece of land each man cast his stone, and filled it. They also stopped all the springs of water and cut down all the good trees, until in Kir Hareseth all they left was its stones; however the men armed with slings went around it and attacked it. 
+<sup>26&#160;</sup>When the king of Moab saw that the battle was too severe for him, he took with him seven hundred men who drew a sword, to break through to the king of Edom; but they could not. 
+<sup>27&#160;</sup>Then he took his oldest son who would have reigned in his place, and offered him for a burnt offering on the wall. There was great wrath against Israel; and they departed from him, and returned to their own land. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Now a certain woman of the women of the sons of the prophets cried out to Elisha, saying, “Your servant my man is dead. You know that your servant feared Yahweh. Now the creditor has come to take for himself my two children to be slaves.” 
+</div><div class="p">
+<sup>2&#160;</sup>Elisha said to her, “What should I do for you? Tell me, what do you have in the house?” 
+</div><div class="p">She said, “Your servant has nothing in the house, except a pot of oil.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then he said, “Go, borrow empty containers from all your neighbors. Don’t borrow just a few containers. 
+<sup>4&#160;</sup>Go in and shut the door on you and on your sons, and pour oil into all those containers; and set aside those which are full.” 
+</div><div class="p">
+<sup>5&#160;</sup>So she went from him, and shut the door on herself and on her sons. They brought the containers to her, and she poured oil. 
+<sup>6&#160;</sup>When the containers were full, she said to her son, “Bring me another container.” 
+</div><div class="p">He said to her, “There isn’t another container.” Then the oil stopped flowing. 
+</div><div class="p">
+<sup>7&#160;</sup>Then she came and told the man of Elohim. He said, “Go, sell the oil, and pay your debt; and you and your sons live on the rest.” 
+</div><div class="p">
+<sup>8&#160;</sup>One day Elisha went to Shunem, where there was a prominent woman; and she persuaded him to eat bread. So it was, that as often as he passed by, he turned in there to eat bread. 
+<sup>9&#160;</sup>She said to her man, “See now, I perceive that this is a set-apart man of Elohim who passes by us continually. 
+<sup>10&#160;</sup>Please, let’s make a little room on the roof. Let’s set a bed, a table, a chair, and a lamp stand for him there. When he comes to us, he can stay there.” 
+</div><div class="p">
+<sup>11&#160;</sup>One day he came there, and he went to the room and lay there. 
+<sup>12&#160;</sup>He said to Gehazi his servant, “Call this Shunammite.” When he had called her, she stood before him. 
+<sup>13&#160;</sup>He said to him, “Say now to her, ‘Behold, you have cared for us with all this care. What is to be done for you? Would you like to be spoken for to the king, or to the captain of the army?’&#160;” 
+</div><div class="p">She answered, “I dwell among my own people.” 
+</div><div class="p">
+<sup>14&#160;</sup>He said, “What then is to be done for her?” 
+</div><div class="p">Gehazi answered, “Most certainly she has no son, and her man is old.” 
+</div><div class="p">
+<sup>15&#160;</sup>He said, “Call her.” When he had called her, she stood in the door. 
+<sup>16&#160;</sup>He said, “At this season next year, you will embrace a son.” 
+</div><div class="p">She said, “No, my lord, you man of Elohim, do not lie to your servant.” 
+</div><div class="p">
+<sup>17&#160;</sup>The woman conceived, and bore a son at that season when the time came around, as Elisha had said to her. 
+<sup>18&#160;</sup>When the child was grown, one day he went out to his father to the reapers. 
+<sup>19&#160;</sup>He said to his father, “My head! My head!” 
+</div><div class="p">He said to his servant, “Carry him to his mother.” 
+</div><div class="p">
+<sup>20&#160;</sup>When he had taken him and brought him to his mother, he sat on her knees until noon, and then died. 
+<sup>21&#160;</sup>She went up and laid him on the man of Elohim’s bed, and shut the door on him, and went out. 
+<sup>22&#160;</sup>She called to her man and said, “Please send me one of the servants, and one of the donkeys, that I may run to the man of Elohim and come again.” 
+</div><div class="p">
+<sup>23&#160;</sup>He said, “Why would you want to go to him today? It is not a new moon or a Sabbath.” 
+</div><div class="p">She said, “It’s all right.” 
+</div><div class="p">
+<sup>24&#160;</sup>Then she saddled a donkey, and said to her servant, “Drive, and go forward! Don’t slow down for me, unless I ask you to.” 
+</div><div class="p">
+<sup>25&#160;</sup>So she went, and came to the man of Elohim to Mount Carmel. When the man of Elohim saw her afar off, he said to Gehazi his servant, “Behold, there is the Shunammite. 
+<sup>26&#160;</sup>Please run now to meet her, and ask her, ‘Is it well with you? Is it well with your man? Is it well with your child?’&#160;” 
+</div><div class="p">She answered, “It is well.” 
+</div><div class="p">
+<sup>27&#160;</sup>When she came to the man of Elohim to the hill, she caught hold of his feet. Gehazi came near to thrust her away; but the man of Elohim said, “Leave her alone, for her soul is troubled within her; and Yahweh has hidden it from me, and has not told me.” 
+</div><div class="p">
+<sup>28&#160;</sup>Then she said, “Did I ask you for a son, my lord? Didn’t I say, ‘Do not deceive me’?” 
+</div><div class="p">
+<sup>29&#160;</sup>Then he said to Gehazi, “Tuck your cloak into your belt, take my staff in your hand, and go your way. If you meet any man, don’t greet him; and if anyone greets you, don’t answer him again. Then lay my staff on the child’s face.” 
+</div><div class="p">
+<sup>30&#160;</sup>The child’s mother said, “As Yahweh lives, and as your soul lives, I will not leave you.” 
+</div><div class="p">So he arose, and followed her. 
+</div><div class="p">
+<sup>31&#160;</sup>Gehazi went ahead of them, and laid the staff on the child’s face; but there was no voice and no hearing. Therefore he returned to meet him, and told him, “The child has not awakened.” 
+</div><div class="p">
+<sup>32&#160;</sup>When Elisha had come into the house, behold, the child was dead, and lying on his bed. 
+<sup>33&#160;</sup>He went in therefore, and shut the door on them both, and prayed to Yahweh. 
+<sup>34&#160;</sup>He went up and lay on the child, and put his mouth on his mouth, and his eyes on his eyes, and his hands on his hands. He stretched himself on him; and the child’s flesh grew warm. 
+<sup>35&#160;</sup>Then he returned, and walked in the house once back and forth, then went up and stretched himself out on him. Then the child sneezed seven times, and the child opened his eyes. 
+<sup>36&#160;</sup>He called Gehazi, and said, “Call this Shunammite!” So he called her. 
+</div><div class="p">When she had come in to him, he said, “Take up your son.” 
+</div><div class="p">
+<sup>37&#160;</sup>Then she went in, fell at his feet, and bowed herself to the ground; then she picked up her son, and went out. 
+</div><div class="p">
+<sup>38&#160;</sup>Elisha came again to Gilgal. There was a famine in the land; and the sons of the prophets were sitting before him; and he said to his servant, “Get the large pot, and boil stew for the sons of the prophets.” 
+</div><div class="p">
+<sup>39&#160;</sup>One went out into the field to gather herbs, and found a wild vine, and gathered a lap full of wild gourds from it, and came and cut them up into the pot of stew; for they didn’t recognize them. 
+<sup>40&#160;</sup>So they poured out for the men to eat. As they were eating some of the stew, they cried out and said, “Man of Elohim, there is death in the pot!” And they could not eat it. 
+</div><div class="p">
+<sup>41&#160;</sup>But he said, “Then bring meal.” He threw it into the pot; and he said, “Serve it to the people, that they may eat.” And there was nothing harmful in the pot. 
+</div><div class="p">
+<sup>42&#160;</sup>A man from Baal Shalishah came, and brought the man of Elohim some bread of the first fruits: twenty loaves of barley and fresh ears of grain in his sack. Elisha said, “Give to the people, that they may eat.” 
+</div><div class="p">
+<sup>43&#160;</sup>His servant said, “What, should I set this before a hundred men?” 
+</div><div class="p">But he said, “Give it to the people, that they may eat; for Yahweh says, ‘They will eat, and will have some left over.’&#160;” 
+</div><div class="p">
+<sup>44&#160;</sup>So he set it before them and they ate and had some left over, according to Yahweh’s word. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Naaman, captain of the army of the king of Syria, was a great man with his master, and honorable, because by him Yahweh had given victory to Syria; he was also a mighty man of valor, but he was a leper. 
+<sup>2&#160;</sup>The Syrians had gone out in bands, and had brought away captive out of the land of Israel a little girl, and she waited on Naaman’s woman. 
+<sup>3&#160;</sup>She said to her mistress, “I wish that my lord were with the prophet who is in Samaria! Then he would heal him of his leprosy.” 
+</div><div class="p">
+<sup>4&#160;</sup>Someone went in and told his lord, saying, “The girl who is from the land of Israel said this.” 
+</div><div class="p">
+<sup>5&#160;</sup>The king of Syria said, “Go now, and I will send a letter to the king of Israel.” 
+</div><div class="p">He departed, and took with him ten talents of silver, six thousand pieces of gold, and ten changes of clothing. 
+<sup>6&#160;</sup>He brought the letter to the king of Israel, saying, “Now when this letter has come to you, behold, I have sent Naaman my servant to you, that you may heal him of his leprosy.” 
+</div><div class="p">
+<sup>7&#160;</sup>When the king of Israel had read the letter, he tore his clothes and said, “Am I Elohim, to kill and to make alive, that this man sends to me to heal a man of his leprosy? But please consider and see how he seeks a quarrel against me.” 
+</div><div class="p">
+<sup>8&#160;</sup>It was so, when Elisha the man of Elohim heard that the king of Israel had torn his clothes, that he sent to the king, saying, “Why have you torn your clothes? Let him come now to me, and he shall know that there is a prophet in Israel.” 
+</div><div class="p">
+<sup>9&#160;</sup>So Naaman came with his horses and with his chariots, and stood at the door of the house of Elisha. 
+<sup>10&#160;</sup>Elisha sent a messenger to him, saying, “Go and wash in the Jordan seven times, and your flesh shall come again to you, and you shall be clean.” 
+</div><div class="p">
+<sup>11&#160;</sup>But Naaman was angry, and went away and said, “Behold, I thought, ‘He will surely come out to me, and stand, and call on the name of Yahweh his Elohim, and wave his hand over the place, and heal the leper.’ 
+<sup>12&#160;</sup>Aren’t Abanah and Pharpar, the rivers of Damascus, better than all the waters of Israel? Couldn’t I wash in them and be clean?” So he turned and went away in a rage. 
+</div><div class="p">
+<sup>13&#160;</sup>His servants came near and spoke to him, and said, “My father, if the prophet had asked you do some great thing, wouldn’t you have done it? How much rather then, when he says to you, ‘Wash, and be clean’?” 
+</div><div class="p">
+<sup>14&#160;</sup>Then went he down and dipped himself seven times in the Jordan, according to the saying of the man of Elohim; and his flesh was restored like the flesh of a little child, and he was clean. 
+<sup>15&#160;</sup>He returned to the man of Elohim, he and all his company, and came, and stood before him; and he said, “See now, I know that there is no Elohim in all the earth, but in Israel. Now therefore, please take a gift from your servant.” 
+</div><div class="p">
+<sup>16&#160;</sup>But he said, “As Yahweh lives, before whom I stand, I will receive none.” 
+</div><div class="p">He urged him to take it; but he refused. 
+<sup>17&#160;</sup>Naaman said, “If not, then, please let two mules’ load of earth be given to your servant; for your servant will from now on offer neither burnt offering nor sacrifice to other elohims, but to Yahweh. 
+<sup>18&#160;</sup>In this thing may Yahweh pardon your servant: when my master goes into the house of Rimmon to worship there, and he leans on my hand, and I bow myself in the house of Rimmon. When I bow myself in the house of Rimmon, may Yahweh pardon your servant in this thing.” 
+</div><div class="p">
+<sup>19&#160;</sup>He said to him, “Go in peace.” 
+</div><div class="p">So he departed from him a little way. 
+<sup>20&#160;</sup>But Gehazi the servant of Elisha the man of Elohim, said, “Behold, my master has spared this Naaman the Syrian, in not receiving at his hands that which he brought. As Yahweh lives, I will run after him, and take something from him.” 
+</div><div class="p">
+<sup>21&#160;</sup>So Gehazi followed after Naaman. When Naaman saw one running after him, he came down from the chariot to meet him, and said, “Is all well?” 
+</div><div class="p">
+<sup>22&#160;</sup>He said, “All is well. My master has sent me, saying, ‘Behold, even now two young men of the sons of the prophets have come to me from the hill country of Ephraim. Please give them a talent of silver and two changes of clothing.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Naaman said, “Be pleased to take two talents.” He urged him, and bound two talents of silver in two bags, with two changes of clothing, and laid them on two of his servants; and they carried them before him. 
+<sup>24&#160;</sup>When he came to the hill, he took them from their hand, and stored them in the house. Then he let the men go, and they departed. 
+<sup>25&#160;</sup>But he went in, and stood before his master. Elisha said to him, “Where did you come from, Gehazi?” 
+</div><div class="p">He said, “Your servant went nowhere.” 
+</div><div class="p">
+<sup>26&#160;</sup>He said to him, “Didn’t my heart go with you when the man turned from his chariot to meet you? Is it a time to receive money, and to receive garments, and olive groves and vineyards, and sheep and cattle, and male servants and female servants? 
+<sup>27&#160;</sup>Therefore the leprosy of Naaman will cling to you and to your offspring forever.” 
+</div><div class="p">He went out from his presence a leper, as white as snow. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>The sons of the prophets said to Elisha, “See now, the place where we live and meet with you is too small for us. 
+<sup>2&#160;</sup>Please let us go to the Jordan, and each man take a beam from there, and let’s make us a place there, where we may live.” 
+</div><div class="p">He answered, “Go!” 
+</div><div class="p">
+<sup>3&#160;</sup>One said, “Please be pleased to go with your servants.” 
+</div><div class="p">He answered, “I will go.” 
+<sup>4&#160;</sup>So he went with them. When they came to the Jordan, they cut down wood. 
+<sup>5&#160;</sup>But as one was cutting down a tree, the ax head fell into the water. Then he cried out and said, “Alas, my master! For it was borrowed.” 
+</div><div class="p">
+<sup>6&#160;</sup>The man of Elohim asked, “Where did it fall?” He showed him the place. He cut down a stick, threw it in there, and made the iron float. 
+<sup>7&#160;</sup>He said, “Take it.” So he put out his hand and took it. 
+</div><div class="p">
+<sup>8&#160;</sup>Now the king of Syria was at war against Israel; and he took counsel with his servants, saying, “My camp will be in such and such a place.” 
+</div><div class="p">
+<sup>9&#160;</sup>The man of Elohim sent to the king of Israel, saying, “Beware that you not pass this place, for the Syrians are coming down there.” 
+<sup>10&#160;</sup>The king of Israel sent to the place which the man of Elohim told him and warned him of; and he saved himself there, not once or twice. 
+<sup>11&#160;</sup>The king of Syria’s heart was very troubled about this. He called his servants, and said to them, “Won’t you show me which of us is for the king of Israel?” 
+</div><div class="p">
+<sup>12&#160;</sup>One of his servants said, “No, my lord, O king; but Elisha, the prophet who is in Israel, tells the king of Israel the words that you speak in your bedroom.” 
+</div><div class="p">
+<sup>13&#160;</sup>He said, “Go and see where he is, that I may send and get him.” 
+</div><div class="p">He was told, “Behold, he is in Dothan.” 
+</div><div class="p">
+<sup>14&#160;</sup>Therefore he sent horses, chariots, and a great army there. They came by night and surrounded the city. 
+<sup>15&#160;</sup>When the servant of the man of Elohim had risen early and gone out, behold, an army with horses and chariots was around the city. His servant said to him, “Alas, my master! What shall we do?” 
+</div><div class="p">
+<sup>16&#160;</sup>He answered, “Don’t be afraid, for those who are with us are more than those who are with them.” 
+<sup>17&#160;</sup>Elisha prayed, and said, “Yahweh, please open his eyes, that he may see.” Yahweh opened the young man’s eyes, and he saw; and behold, the mountain was full of horses and chariots of fire around Elisha. 
+<sup>18&#160;</sup>When they came down to him, Elisha prayed to Yahweh, and said, “Please strike this people with blindness.” 
+</div><div class="p">He struck them with blindness according to Elisha’s word. 
+</div><div class="p">
+<sup>19&#160;</sup>Elisha said to them, “This is not the way, neither is this the city. Follow me, and I will bring you to the man whom you seek.” He led them to Samaria. 
+<sup>20&#160;</sup>When they had come into Samaria, Elisha said, “Yahweh, open these men’s eyes, that they may see.” 
+</div><div class="p">Yahweh opened their eyes, and they saw; and behold, they were in the middle of Samaria. 
+</div><div class="p">
+<sup>21&#160;</sup>The king of Israel said to Elisha, when he saw them, “My father, shall I strike them? Shall I strike them?” 
+</div><div class="p">
+<sup>22&#160;</sup>He answered, “You shall not strike them. Would you strike those whom you have taken captive with your sword and with your bow? Set bread and water before them, that they may eat and drink, then go to their master.” 
+</div><div class="p">
+<sup>23&#160;</sup>He prepared a great feast for them. After they ate and drank, he sent them away and they went to their master. So the bands of Syria stopped raiding the land of Israel. 
+</div><div class="p">
+<sup>24&#160;</sup>After this, Benhadad king of Syria gathered all his army, and went up and besieged Samaria. 
+<sup>25&#160;</sup>There was a great famine in Samaria. Behold, they besieged it until a donkey’s head was sold for eighty pieces of silver, and the fourth part of a kab of dove’s dung for five pieces of silver. 
+<sup>26&#160;</sup>As the king of Israel was passing by on the wall, a woman cried to him, saying, “Help, my lord, O king!” 
+</div><div class="p">
+<sup>27&#160;</sup>He said, “If Yahweh doesn’t help you, where could I get help for you? From the threshing floor, or from the wine press?” 
+<sup>28&#160;</sup>Then the king asked her, “What is your problem?” 
+</div><div class="p">She answered, “This woman said to me, ‘Give your son, that we may eat him today, and we will eat my son tomorrow.’ 
+<sup>29&#160;</sup>So we boiled my son and ate him; and I said to her on the next day, ‘Give up your son, that we may eat him;’ and she has hidden her son.” 
+</div><div class="p">
+<sup>30&#160;</sup>When the king heard the words of the woman, he tore his clothes. Now he was passing by on the wall, and the people looked, and behold, he had sackcloth underneath on his body. 
+<sup>31&#160;</sup>Then he said, “Elohim do so to me, and more also, if the head of Elisha the son of Shaphat stays on him today.” 
+</div><div class="p">
+<sup>32&#160;</sup>But Elisha was sitting in his house, and the elders were sitting with him. Then the king sent a man from before him; but before the messenger came to him, he said to the elders, “Do you see how this son of a murderer has sent to take away my head? Behold, when the messenger comes, shut the door, and hold the door shut against him. Isn’t the sound of his master’s feet behind him?” 
+</div><div class="p">
+<sup>33&#160;</sup>While he was still talking with them, behold, the messenger came down to him. Then he said, “Behold, this evil is from Yahweh. Why should I wait for Yahweh any longer?” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Elisha said, “Hear Yahweh’s word. Yahweh says, ‘Tomorrow about this time a seah and two seahs of barley for a shekel, in the gate of Samaria.’&#160;” 
+</div><div class="p">
+<sup>2&#160;</sup>Then the captain on whose hand the king leaned answered the man of Elohim, and said, “Behold, if Yahweh made windows in heaven, could this thing be?” 
+</div><div class="p">He said, “Behold, you will see it with your eyes, but will not eat of it.” 
+</div><div class="p">
+<sup>3&#160;</sup>Now there were four leprous men at the entrance of the gate. They said to one another, “Why do we sit here until we die? 
+<sup>4&#160;</sup>If we say, ‘We will enter into the city,’ then the famine is in the city, and we will die there. If we sit still here, we also die. Now therefore come, and let’s surrender to the army of the Syrians. If they save us alive, we will live; and if they kill us, we will only die.” 
+</div><div class="p">
+<sup>5&#160;</sup>They rose up in the twilight to go to the camp of the Syrians. When they had come to the outermost part of the camp of the Syrians, behold, no man was there. 
+<sup>6&#160;</sup>For the Lord had made the army of the Syrians to hear the sound of chariots and the sound of horses, even the noise of a great army; and they said to one another, “Behold, the king of Israel has hired against us the kings of the Hittites and the kings of the Egyptians to attack us.” 
+<sup>7&#160;</sup>Therefore they arose and fled in the twilight, and left their tents, their horses, and their donkeys, even the camp as it was, and fled for their life. 
+<sup>8&#160;</sup>When these lepers came to the outermost part of the camp, they went into one tent, and ate and drank, then carried away silver, gold, and clothing and went and hid it. Then they came back, and entered into another tent and carried things from there also, and went and hid them. 
+<sup>9&#160;</sup>Then they said to one another, “We aren’t doing right. Today is a day of good news, and we keep silent. If we wait until the morning light, punishment will overtake us. Now therefore come, let’s go and tell the king’s household.” 
+</div><div class="p">
+<sup>10&#160;</sup>So they came and called to the city gatekeepers; and they told them, “We came to the camp of the Syrians, and, behold, there was no man there, not even a man’s voice, but the horses tied, and the donkeys tied, and the tents as they were.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then the gatekeepers called out and told it to the king’s household within. 
+</div><div class="p">
+<sup>12&#160;</sup>The king arose in the night, and said to his servants, “I will now show you what the Syrians have done to us. They know that we are hungry. Therefore they have gone out of the camp to hide themselves in the field, saying, ‘When they come out of the city, we shall take them alive, and get into the city.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>One of his servants answered, “Please let some people take five of the horses that remain, which are left in the city. Behold, they are like all the multitude of Israel who are left in it. Behold, they are like all the multitude of Israel who are consumed. Let’s send and see.” 
+</div><div class="p">
+<sup>14&#160;</sup>Therefore they took two chariots with horses; and the king sent them out to the Syrian army, saying, “Go and see.” 
+</div><div class="p">
+<sup>15&#160;</sup>They went after them to the Jordan; and behold, all the path was full of garments and equipment which the Syrians had cast away in their haste. The messengers returned and told the king. 
+<sup>16&#160;</sup>The people went out and plundered the camp of the Syrians. So a seah according to Yahweh’s word. 
+<sup>17&#160;</sup>The king had appointed the captain on whose hand he leaned to be in charge of the gate; and the people trampled over him in the gate, and he died as the man of Elohim had said, who spoke when the king came down to him. 
+<sup>18&#160;</sup>It happened as the man of Elohim had spoken to the king, saying, “Two seahs and a seah of fine flour for a shekel, shall be tomorrow about this time in the gate of Samaria;” 
+<sup>19&#160;</sup>and that captain answered the man of Elohim, and said, “Now, behold, if Yahweh made windows in heaven, might such a thing be?” and he said, “Behold, you will see it with your eyes, but will not eat of it.” 
+<sup>20&#160;</sup>It happened like that to him, for the people trampled over him in the gate, and he died. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Elisha had spoken to the woman whose son he had restored to life, saying, “Arise, and go, you and your household, and stay for a while wherever you can; for Yahweh has called for a famine. It will also come on the land for seven years.” 
+</div><div class="p">
+<sup>2&#160;</sup>The woman arose, and did according to the man of Elohim’s word. She went with her household, and lived in the land of the Philistines for seven years. 
+<sup>3&#160;</sup>At the end of seven years, the woman returned from the land of the Philistines. Then she went out to beg the king for her house and for her land. 
+<sup>4&#160;</sup>Now the king was talking with Gehazi the servant of the man of Elohim, saying, “Please tell me all the great things that Elisha has done.” 
+<sup>5&#160;</sup>As he was telling the king how he had restored to life him who was dead, behold, the woman whose son he had restored to life begged the king for her house and for her land. Gehazi said, “My lord, O king, this is the woman, and this is her son, whom Elisha restored to life.” 
+</div><div class="p">
+<sup>6&#160;</sup>When the king asked the woman, she told him. So the king appointed to her a certain officer, saying, “Restore all that was hers, and all the fruits of the field since the day that she left the land, even until now.” 
+</div><div class="p">
+<sup>7&#160;</sup>Elisha came to Damascus; and Benhadad the king of Syria was sick. He was told, “The man of Elohim has come here.” 
+</div><div class="p">
+<sup>8&#160;</sup>The king said to Hazael, “Take a present in your hand, and go meet the man of Elohim, and inquire of Yahweh by him, saying, ‘Will I recover from this sickness?’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>So Hazael went to meet him and took a present with him, even of every good thing of Damascus, forty camels’ burden, and came and stood before him and said, “Your son Benhadad king of Syria has sent me to you, saying, ‘Will I recover from this sickness?’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Elisha said to him, “Go, tell him, ‘You will surely recover;’ however Yahweh has shown me that he will surely die.” 
+<sup>11&#160;</sup>He settled his gaze steadfastly on him, until he was ashamed. Then the man of Elohim wept. 
+</div><div class="p">
+<sup>12&#160;</sup>Hazael said, “Why do you weep, my lord?” 
+</div><div class="p">He answered, “Because I know the evil that you will do to the children of Israel. You will set their strongholds on fire, and you will kill their young men with the sword, and will dash their little ones in pieces, and rip up their pregnant women.” 
+</div><div class="p">
+<sup>13&#160;</sup>Hazael said, “But what is your servant, who is but a dog, that he could do this great thing?” 
+</div><div class="p">Elisha answered, “Yahweh has shown me that you will be king over Syria.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then he departed from Elisha, and came to his master, who said to him, “What did Elisha say to you?” 
+</div><div class="p">He answered, “He told me that you would surely recover.” 
+</div><div class="p">
+<sup>15&#160;</sup>On the next day, he took a thick cloth, dipped it in water, and spread it on the king’s face, so that he died. Then Hazael reigned in his place. 
+</div><div class="p">
+<sup>16&#160;</sup>In the fifth year of Joram the son of Ahab king of Israel, Jehoshaphat being king of Judah then, Jehoram the son of Jehoshaphat king of Judah began to reign. 
+<sup>17&#160;</sup>He was thirty-two years old when he began to reign. He reigned eight years in Jerusalem. 
+<sup>18&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he married Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
+<sup>19&#160;</sup>However, Yahweh would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
+</div><div class="p">
+<sup>20&#160;</sup>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 
+<sup>21&#160;</sup>Then Joram crossed over to Zair, and all his chariots with him; and he rose up by night and struck the Edomites who surrounded him with the captains of the chariots; and the people fled to their tents. 
+<sup>22&#160;</sup>So Edom revolted from under the hand of Judah to this day. Then Libnah revolted at the same time. 
+<sup>23&#160;</sup>The rest of the acts of Joram, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>24&#160;</sup>Joram slept with his fathers, and was buried with his fathers in David’s city; and Ahaziah his son reigned in his place. 
+</div><div class="p">
+<sup>25&#160;</sup>In the twelfth year of Joram the son of Ahab king of Israel, Ahaziah the son of Jehoram king of Judah began to reign. 
+<sup>26&#160;</sup>Ahaziah was twenty-two years old when he began to reign; and he reigned one year in Jerusalem. His mother’s name was Athaliah the daughter of Omri king of Israel. 
+<sup>27&#160;</sup>He walked in the way of Ahab’s house and did that which was evil in Yahweh’s sight, as did Ahab’s house, for he was the son-in-law of Ahab’s house. 
+</div><div class="p">
+<sup>28&#160;</sup>He went with Joram the son of Ahab to war against Hazael king of Syria at Ramoth Gilead, and the Syrians wounded Joram. 
+<sup>29&#160;</sup>King Joram returned to be healed in Jezreel from the wounds which the Syrians had given him at Ramah, when he fought against Hazael king of Syria. Ahaziah the son of Jehoram, king of Judah, went down to see Joram the son of Ahab in Jezreel, because he was sick. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Elisha the prophet called one of the sons of the prophets, and said to him, “Put your belt on your waist, take this vial of oil in your hand, and go to Ramoth Gilead. 
+<sup>2&#160;</sup>When you come there, find Jehu the son of Jehoshaphat the son of Nimshi, and go in and make him rise up from among his brothers, and take him to an inner room. 
+<sup>3&#160;</sup>Then take the vial of oil, and pour it on his head, and say, ‘Yahweh says, “I have anointed you king over Israel.”&#160;’ Then open the door, flee, and don’t wait.” 
+</div><div class="p">
+<sup>4&#160;</sup>So the young man, the young prophet, went to Ramoth Gilead. 
+<sup>5&#160;</sup>When he came, behold, the captains of the army were sitting. Then he said, “I have a message for you, captain.” 
+</div><div class="p">Jehu said, “To which one of us?” 
+</div><div class="p">He said, “To you, O captain.” 
+<sup>6&#160;</sup>He arose, and went into the house. Then he poured the oil on his head, and said to him, “Yahweh, the Elohim of Israel, says, ‘I have anointed you king over the people of Yahweh, even over Israel. 
+<sup>7&#160;</sup>You must strike your master Ahab’s house, that I may avenge the blood of my servants the prophets, and the blood of all the servants of Yahweh, at the hand of Jezebel. 
+<sup>8&#160;</sup>For the whole house of Ahab will perish. I will cut off from Ahab everyone who urinates against a wall, both him who is shut up and him who is left at large in Israel. 
+<sup>9&#160;</sup>I will make Ahab’s house like the house of Jeroboam the son of Nebat, and like the house of Baasha the son of Ahijah. 
+<sup>10&#160;</sup>The dogs will eat Jezebel on the plot of ground of Jezreel, and there shall be no one to bury her.’&#160;” Then he opened the door and fled. 
+</div><div class="p">
+<sup>11&#160;</sup>When Jehu came out to the servants of his lord and one said to him, “Is all well? Why did this madman come to you?” 
+</div><div class="p">He said to them, “You know the man and how he talks.” 
+</div><div class="p">
+<sup>12&#160;</sup>They said, “That is a lie. Tell us now.” 
+</div><div class="p">He said, “He said to me, ‘Yahweh says, I have anointed you king over Israel.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>Then they hurried, and each man took his cloak, and put it under him on the top of the stairs, and blew the trumpet, saying, “Jehu is king.” 
+</div><div class="p">
+<sup>14&#160;</sup>So Jehu the son of Jehoshaphat the son of Nimshi conspired against Joram. (Now Joram was defending Ramoth Gilead, he and all Israel, because of Hazael king of Syria; 
+<sup>15&#160;</sup>but King Joram had returned to be healed in Jezreel of the wounds which the Syrians had given him when he fought with Hazael king of Syria.) Jehu said, “If this is your thinking, then let no one escape and go out of the city to go to tell it in Jezreel.” 
+<sup>16&#160;</sup>So Jehu rode in a chariot and went to Jezreel, for Joram lay there. Ahaziah king of Judah had come down to see Joram. 
+<sup>17&#160;</sup>Now the watchman was standing on the tower in Jezreel, and he spied the company of Jehu as he came, and said, “I see a company.” 
+</div><div class="p">Joram said, “Take a horseman, and send to meet them, and let him say, ‘Is it peace?’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>So one went on horseback to meet him, and said, “the king says, ‘Is it peace?’&#160;” 
+</div><div class="p">Jehu said, “What do you have to do with peace? Fall in behind me!” 
+</div><div class="p">The watchman said, “The messenger came to them, but he isn’t coming back.” 
+</div><div class="p">
+<sup>19&#160;</sup>Then he sent out a second on horseback, who came to them and said, “The king says, ‘Is it peace?’&#160;” 
+</div><div class="p">Jehu answered, “What do you have to do with peace? Fall in behind me!” 
+</div><div class="p">
+<sup>20&#160;</sup>The watchman said, “He came to them, and isn’t coming back. The driving is like the driving of Jehu the son of Nimshi, for he drives furiously.” 
+</div><div class="p">
+<sup>21&#160;</sup>Joram said, “Get ready!” 
+</div><div class="p">They got his chariot ready. Then Joram king of Israel and Ahaziah king of Judah went out, each in his chariot; and they went out to meet Jehu, and found him on Naboth the Jezreelite’s land. 
+<sup>22&#160;</sup>When Joram saw Jehu, he said, “Is it peace, Jehu?” 
+</div><div class="p">He answered, “What peace, so long as the prostitution of your mother Jezebel and her witchcraft abound?” 
+</div><div class="p">
+<sup>23&#160;</sup>Joram turned his hands and fled, and said to Ahaziah, “This is treason, Ahaziah!” 
+</div><div class="p">
+<sup>24&#160;</sup>Jehu drew his bow with his full strength, and struck Joram between his arms; and the arrow went out at his heart, and he sunk down in his chariot. 
+<sup>25&#160;</sup>Then Jehu said to Bidkar his captain, “Pick him up, and throw him in the plot of the field of Naboth the Jezreelite; for remember how, when you and I rode together after Ahab his father, Yahweh laid this burden on him: 
+<sup>26&#160;</sup>‘Surely I have seen yesterday the blood of Naboth, and the blood of his sons,’ says Yahweh; ‘and I will repay you in this plot of ground,’ says Yahweh. Now therefore take and cast him onto the plot of ground, according to Yahweh’s word.” 
+</div><div class="p">
+<sup>27&#160;</sup>But when Ahaziah the king of Judah saw this, he fled by the way of the garden house. Jehu followed after him, and said, “Strike him also in the chariot!” They struck him at the ascent of Gur, which is by Ibleam. He fled to Megiddo, and died there. 
+<sup>28&#160;</sup>His servants carried him in a chariot to Jerusalem, and buried him in his tomb with his fathers in David’s city. 
+<sup>29&#160;</sup>In the eleventh year of Joram the son of Ahab, Ahaziah began to reign over Judah. 
+</div><div class="p">
+<sup>30&#160;</sup>When Jehu had come to Jezreel, Jezebel heard of it; and she painted her eyes, and adorned her head, and looked out at the window. 
+<sup>31&#160;</sup>As Jehu entered in at the gate, she said, “Do you come in peace, Zimri, you murderer of your master?” 
+</div><div class="p">
+<sup>32&#160;</sup>He lifted up his face to the window, and said, “Who is on my side? Who?” 
+</div><div class="p">Two or three eunuchs looked out at him. 
+</div><div class="p">
+<sup>33&#160;</sup>He said, “Throw her down!” 
+</div><div class="p">So they threw her down; and some of her blood was sprinkled on the wall, and on the horses. Then he trampled her under foot. 
+<sup>34&#160;</sup>When he had come in, he ate and drank. Then he said, “See now to this cursed woman, and bury her; for she is a king’s daughter.” 
+</div><div class="p">
+<sup>35&#160;</sup>They went to bury her, but they found no more of her than the skull, the feet, and the palms of her hands. 
+<sup>36&#160;</sup>Therefore they came back, and told him. 
+</div><div class="p">He said, “This is Yahweh’s word, which he spoke by his servant Elijah the Tishbite, saying, ‘The dogs will eat the flesh of Jezebel on the plot of Jezreel, 
+<sup>37&#160;</sup>and the body of Jezebel will be as dung on the surface of the field on Jezreel’s land, so that they won’t say, “This is Jezebel.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Ahab had seventy sons in Samaria. Jehu wrote letters and sent them to Samaria, to the rulers of Jezreel, even the elders, and to those who brought up Ahab’s sons, saying, 
+<sup>2&#160;</sup>“Now as soon as this letter comes to you, since your master’s sons are with you, and you have chariots and horses, a fortified city also, and armor, 
+<sup>3&#160;</sup>select the best and fittest of your master’s sons, set him on his father’s throne, and fight for your master’s house.” 
+</div><div class="p">
+<sup>4&#160;</sup>But they were exceedingly afraid, and said, “Behold, the two kings didn’t stand before him! How then shall we stand?” 
+<sup>5&#160;</sup>He who was over the household, and he who was over the city, the elders also, and those who raised the children, sent to Jehu, saying, “We are your servants, and will do all that you ask us. We will not make any man king. You do that which is good in your eyes.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then he wrote a letter the second time to them, saying, “If you are on my side, and if you will listen to my voice, take the heads of the men who are your master’s sons, and come to me to Jezreel by tomorrow this time.” 
+</div><div class="p">Now the king’s sons, being seventy persons, were with the great men of the city, who brought them up. 
+<sup>7&#160;</sup>When the letter came to them, they took the king’s sons and killed them, even seventy people, and put their heads in baskets, and sent them to him to Jezreel. 
+<sup>8&#160;</sup>A messenger came and told him, “They have brought the heads of the king’s sons.” 
+</div><div class="p">He said, “Lay them in two heaps at the entrance of the gate until the morning.” 
+<sup>9&#160;</sup>In the morning, he went out and stood, and said to all the people, “You are righteous. Behold, I conspired against my master and killed him, but who killed all these? 
+<sup>10&#160;</sup>Know now that nothing will fall to the earth of Yahweh’s word, which Yahweh spoke concerning Ahab’s house. For Yahweh has done that which he spoke by his servant Elijah.” 
+</div><div class="p">
+<sup>11&#160;</sup>So Jehu struck all that remained of Ahab’s house in Jezreel, with all his great men, his familiar friends, and his priests, until he left him no one remaining. 
+</div><div class="p">
+<sup>12&#160;</sup>He arose and departed, and went to Samaria. As he was at the shearing house of the shepherds on the way, 
+<sup>13&#160;</sup>Jehu met with the brothers of Ahaziah king of Judah, and said, “Who are you?” 
+</div><div class="p">They answered, “We are the brothers of Ahaziah. We are going down to greet the children of the king and the children of the queen.” 
+</div><div class="p">
+<sup>14&#160;</sup>He said, “Take them alive!” 
+</div><div class="p">They took them alive, and killed them at the pit of the shearing house, even forty-two men. He didn’t leave any of them. 
+</div><div class="p">
+<sup>15&#160;</sup>When he had departed from there, he met Jehonadab the son of Rechab coming to meet him. He greeted him, and said to him, “Is your heart right, as my heart is with your heart?” 
+</div><div class="p">Jehonadab answered, “It is.” 
+</div><div class="p">“If it is, give me your hand.” He gave him his hand; and he took him up to him into the chariot. 
+<sup>16&#160;</sup>He said, “Come with me, and see my zeal for Yahweh.” So they made him ride in his chariot. 
+<sup>17&#160;</sup>When he came to Samaria, he struck all who remained to Ahab in Samaria, until he had destroyed them, according to Yahweh’s word which he spoke to Elijah. 
+</div><div class="p">
+<sup>18&#160;</sup>Jehu gathered all the people together, and said to them, “Ahab served Baal a little, but Jehu will serve him much. 
+<sup>19&#160;</sup>Now therefore call to me all the prophets of Baal, all of his worshipers, and all of his priests. Let no one be absent, for I have a great sacrifice to Baal. Whoever is absent, he shall not live.” But Jehu did deceptively, intending to destroy the worshipers of Baal. 
+</div><div class="p">
+<sup>20&#160;</sup>Jehu said, “Sanctify a solemn assembly for Baal!” 
+</div><div class="p">So they proclaimed it. 
+<sup>21&#160;</sup>Jehu sent through all Israel; and all the worshipers of Baal came, so that there was not a man left that didn’t come. They came into the house of Baal; and the house of Baal was filled from one end to another. 
+<sup>22&#160;</sup>He said to him who kept the wardrobe, “Bring out robes for all the worshipers of Baal!” 
+</div><div class="p">So he brought robes out to them. 
+<sup>23&#160;</sup>Jehu went with Jehonadab the son of Rechab into the house of Baal. Then he said to the worshipers of Baal, “Search, and see that none of the servants of Yahweh are here with you, but only the worshipers of Baal.” 
+</div><div class="p">
+<sup>24&#160;</sup>So they went in to offer sacrifices and burnt offerings. Now Jehu had appointed for himself eighty men outside, and said, “If any of the men whom I bring into your hands escape, he who lets him go, his life shall be for the life of him.” 
+</div><div class="p">
+<sup>25&#160;</sup>As soon as he had finished offering the burnt offering, Jehu said to the guard and to the captains, “Go in and kill them! Let no one escape.” So they struck them with the edge of the sword. The guard and the captains threw the bodies out, and went to the inner shrine of the house of Baal. 
+<sup>26&#160;</sup>They brought out the pillars that were in the house of Baal and burned them. 
+<sup>27&#160;</sup>They broke down the pillar of Baal, and broke down the house of Baal, and made it a latrine, to this day. 
+<sup>28&#160;</sup>Thus Jehu destroyed Baal out of Israel. 
+</div><div class="p">
+<sup>29&#160;</sup>However, Jehu didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin—the golden calves that were in Bethel and that were in Dan. 
+<sup>30&#160;</sup>Yahweh said to Jehu, “Because you have done well in executing that which is right in my eyes, and have done to Ahab’s house according to all that was in my heart, your descendants shall sit on the throne of Israel to the fourth generation.” 
+</div><div class="p">
+<sup>31&#160;</sup>But Jehu took no heed to walk in the law of Yahweh, the Elohim of Israel, with all his heart. He didn’t depart from the sins of Jeroboam, with which he made Israel to sin. 
+</div><div class="p">
+<sup>32&#160;</sup>In those days Yahweh began to cut away parts of Israel; and Hazael struck them in all the borders of Israel 
+<sup>33&#160;</sup>from the Jordan eastward, all the land of Gilead, the Gadites, and the Reubenites, and the Manassites, from Aroer, which is by the valley of the Arnon, even Gilead and Bashan. 
+<sup>34&#160;</sup>Now the rest of the acts of Jehu, and all that he did, and all his might, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>35&#160;</sup>Jehu slept with his fathers; and they buried him in Samaria. Jehoahaz his son reigned in his place. 
+<sup>36&#160;</sup>The time that Jehu reigned over Israel in Samaria was twenty-eight years. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when Athaliah the mother of Ahaziah saw that her son was dead, she arose and destroyed all the royal offspring. 
+<sup>2&#160;</sup>But Jehosheba, the daughter of King Joram, sister of Ahaziah, took Joash the son of Ahaziah, and stole him away from among the king’s sons who were slain, even him and his nurse, and put them in the bedroom; and they hid him from Athaliah, so that he was not slain. 
+<sup>3&#160;</sup>He was with her hidden in Yahweh’s house six years while Athaliah reigned over the land. 
+</div><div class="p">
+<sup>4&#160;</sup>In the seventh year Jehoiada sent and fetched the captains over hundreds of the Carites and of the guard, and brought them to him into Yahweh’s house; and he made a covenant with them, and made a covenant with them in Yahweh’s house, and showed them the king’s son. 
+<sup>5&#160;</sup>He commanded them, saying, “This is what you must do: a third of you, who come in on the Sabbath, shall be keepers of the watch of the king’s house; 
+<sup>6&#160;</sup>a third of you shall be at the gate Sur; and a third of you at the gate behind the guard. So you shall keep the watch of the house, and be a barrier. 
+<sup>7&#160;</sup>The two companies of you, even all who go out on the Sabbath, shall keep the watch of Yahweh’s house around the king. 
+<sup>8&#160;</sup>You shall surround the king, every man with his weapons in his hand; and he who comes within the ranks, let him be slain. Be with the king when he goes out, and when he comes in.” 
+</div><div class="p">
+<sup>9&#160;</sup>The captains over hundreds did according to all that Jehoiada the priest commanded; and they each took his men, those who were to come in on the Sabbath with those who were to go out on the Sabbath, and came to Jehoiada the priest. 
+<sup>10&#160;</sup>The priest delivered to the captains over hundreds the spears and shields that had been King David’s, which were in Yahweh’s house. 
+<sup>11&#160;</sup>The guard stood, every man with his weapons in his hand, from the right side of the house to the left side of the house, along by the altar and the house, around the king. 
+<sup>12&#160;</sup>Then he brought out the king’s son, and put the crown on him, and gave him the covenant; and they made him king and anointed him; and they clapped their hands, and said, “Long live the king!” 
+</div><div class="p">
+<sup>13&#160;</sup>When Athaliah heard the noise of the guard and of the people, she came to the people into Yahweh’s house; 
+<sup>14&#160;</sup>and she looked, and behold, the king stood by the pillar, as the tradition was, with the captains and the trumpets by the king; and all the people of the land rejoiced, and blew trumpets. Then Athaliah tore her clothes and cried, “Treason! Treason!” 
+</div><div class="p">
+<sup>15&#160;</sup>Jehoiada the priest commanded the captains of hundreds who were set over the army, and said to them, “Bring her out between the ranks. Kill anyone who follows her with the sword.” For the priest said, “Don’t let her be slain in Yahweh’s house.” 
+<sup>16&#160;</sup>So they seized her; and she went by the way of the horses’ entry to the king’s house, and she was slain there. 
+</div><div class="p">
+<sup>17&#160;</sup>Jehoiada made a covenant between Yahweh and the king and the people, that they should be Yahweh’s people; also between the king and the people. 
+<sup>18&#160;</sup>All the people of the land went to the house of Baal, and broke it down. They broke his altars and his images in pieces thoroughly, and killed Mattan the priest of Baal before the altars. The priest appointed officers over Yahweh’s house. 
+<sup>19&#160;</sup>He took the captains over hundreds, and the Carites, and the guard, and all the people of the land; and they brought down the king from Yahweh’s house, and came by the way of the gate of the guard to the king’s house. He sat on the throne of the kings. 
+<sup>20&#160;</sup>So all the people of the land rejoiced, and the city was quiet. They had slain Athaliah with the sword at the king’s house. 
+</div><div class="p">
+<sup>21&#160;</sup>Jehoash was seven years old when he began to reign. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Jehoash began to reign in the seventh year of Jehu, and he reigned forty years in Jerusalem. His mother’s name was Zibiah of Beersheba. 
+<sup>2&#160;</sup>Jehoash did that which was right in Yahweh’s eyes all his days in which Jehoiada the priest instructed him. 
+<sup>3&#160;</sup>However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
+</div><div class="p">
+<sup>4&#160;</sup>Jehoash said to the priests, “All the money of the set-apart things that is brought into Yahweh’s house, in current money, the money of the people for whom each man is evaluated, and all the money that it comes into any man’s heart to bring into Yahweh’s house, 
+<sup>5&#160;</sup>let the priests take it to them, each man from his donor; and they shall repair the damage to the house, wherever any damage is found.” 
+</div><div class="p">
+<sup>6&#160;</sup>But it was so, that in the twenty-third year of King Jehoash the priests had not repaired the damage to the house. 
+<sup>7&#160;</sup>Then King Jehoash called for Jehoiada the priest, and for the other priests, and said to them, “Why aren’t you repairing the damage to the house? Now therefore take no more money from your treasurers, but deliver it for repair of the damage to the house.” 
+</div><div class="p">
+<sup>8&#160;</sup>The priests consented that they should take no more money from the people, and not repair the damage to the house. 
+<sup>9&#160;</sup>But Jehoiada the priest took a chest and bored a hole in its lid, and set it beside the altar, on the right side as one comes into Yahweh’s house; and the priests who kept the threshold put all the money that was brought into Yahweh’s house into it. 
+<sup>10&#160;</sup>When they saw that there was much money in the chest, the king’s scribe and the high priest came up, and they put it in bags and counted the money that was found in Yahweh’s house. 
+<sup>11&#160;</sup>They gave the money that was weighed out into the hands of those who did the work, who had the oversight of Yahweh’s house; and they paid it out to the carpenters and the builders who worked on Yahweh’s house, 
+<sup>12&#160;</sup>and to the masons and the stone cutters, and for buying timber and cut stone to repair the damage to Yahweh’s house, and for all that was laid out for the house to repair it. 
+<sup>13&#160;</sup>But there were not made for Yahweh’s house cups of silver, snuffers, basins, trumpets, any vessels of gold or vessels of silver, of the money that was brought into Yahweh’s house; 
+<sup>14&#160;</sup>for they gave that to those who did the work, and repaired Yahweh’s house with it. 
+<sup>15&#160;</sup>Moreover they didn’t demand an accounting from the men into whose hand they delivered the money to give to those who did the work; for they dealt faithfully. 
+<sup>16&#160;</sup>The money for the trespass offerings and the money for the sin offerings was not brought into Yahweh’s house. It was the priests’. 
+</div><div class="p">
+<sup>17&#160;</sup>Then Hazael king of Syria went up and fought against Gath, and took it; and Hazael set his face to go up to Jerusalem. 
+<sup>18&#160;</sup>Jehoash king of Judah took all the set-apart things that Jehoshaphat and Jehoram and Ahaziah, his fathers, kings of Judah, had dedicated, and his own set-apart things, and all the gold that was found in the treasures of Yahweh’s house, and of the king’s house, and sent it to Hazael king of Syria; and he went away from Jerusalem. 
+</div><div class="p">
+<sup>19&#160;</sup>Now the rest of the acts of Joash, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>20&#160;</sup>His servants arose and made a conspiracy, and struck Joash at the house of Millo, on the way that goes down to Silla. 
+<sup>21&#160;</sup>For Jozacar the son of Shimeath, and Jehozabad the son of Shomer, his servants, struck him, and he died; and they buried him with his fathers in David’s city; and Amaziah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>In the twenty-third year of Joash the son of Ahaziah, king of Judah, Jehoahaz the son of Jehu began to reign over Israel in Samaria for seventeen years. 
+<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, and followed the sins of Jeroboam the son of Nebat, with which he made Israel to sin. He didn’t depart from it. 
+<sup>3&#160;</sup>Yahweh’s anger burned against Israel, and he delivered them into the hand of Hazael king of Syria, and into the hand of Benhadad the son of Hazael, continually. 
+<sup>4&#160;</sup>Jehoahaz begged Yahweh, and Yahweh listened to him; for he saw the oppression of Israel, how the king of Syria oppressed them. 
+<sup>5&#160;</sup>(Yahweh gave Israel a savior, so that they went out from under the hand of the Syrians; and the children of Israel lived in their tents as before. 
+<sup>6&#160;</sup>Nevertheless they didn’t depart from the sins of the house of Jeroboam, with which he made Israel to sin, but walked in them; and the Asherah also remained in Samaria.) 
+<sup>7&#160;</sup>For he didn’t leave to Jehoahaz of the people any more than fifty horsemen, and ten chariots, and ten thousand footmen; for the king of Syria destroyed them and made them like the dust in threshing. 
+<sup>8&#160;</sup>Now the rest of the acts of Jehoahaz, and all that he did, and his might, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>9&#160;</sup>Jehoahaz slept with his fathers; and they buried him in Samaria; and Joash his son reigned in his place. 
+</div><div class="p">
+<sup>10&#160;</sup>In the thirty-seventh year of Joash king of Judah, Jehoash the son of Jehoahaz began to reign over Israel in Samaria for sixteen years. 
+<sup>11&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin; but he walked in them. 
+<sup>12&#160;</sup>Now the rest of the acts of Joash, and all that he did, and his might with which he fought against Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>13&#160;</sup>Joash slept with his fathers; and Jeroboam sat on his throne. Joash was buried in Samaria with the kings of Israel. 
+</div><div class="p">
+<sup>14&#160;</sup>Now Elisha became sick with the illness of which he died; and Joash the king of Israel came down to him, and wept over him, and said, “My father, my father, the chariots of Israel and its horsemen!” 
+</div><div class="p">
+<sup>15&#160;</sup>Elisha said to him, “Take bow and arrows;” and he took bow and arrows for himself. 
+<sup>16&#160;</sup>He said to the king of Israel, “Put your hand on the bow;” and he put his hand on it. Elisha laid his hands on the king’s hands. 
+<sup>17&#160;</sup>He said, “Open the window eastward;” and he opened it. Then Elisha said, “Shoot!” and he shot. He said, “Yahweh’s arrow of victory, even the arrow of victory over Syria; for you will strike the Syrians in Aphek until you have consumed them.” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, “Take the arrows;” and he took them. He said to the king of Israel, “Strike the ground;” and he struck three times, and stopped. 
+<sup>19&#160;</sup>The man of Elohim was angry with him, and said, “You should have struck five or six times. Then you would have struck Syria until you had consumed it, but now you will strike Syria just three times.” 
+</div><div class="p">
+<sup>20&#160;</sup>Elisha died, and they buried him. 
+</div><div class="p">Now the bands of the Moabites invaded the land at the coming in of the year. 
+<sup>21&#160;</sup>As they were burying a man, behold, they saw a band of raiders; and they threw the man into Elisha’s tomb. As soon as the man touched Elisha’s bones, he revived, and stood up on his feet. 
+</div><div class="p">
+<sup>22&#160;</sup>Hazael king of Syria oppressed Israel all the days of Jehoahaz. 
+<sup>23&#160;</sup>But Yahweh was gracious to them, and had compassion on them, and favored them because of his covenant with Abraham, Isaac, and Jacob, and would not destroy them and he didn’t cast them from his presence as yet. 
+</div><div class="p">
+<sup>24&#160;</sup>Hazael king of Syria died; and Benhadad his son reigned in his place. 
+<sup>25&#160;</sup>Jehoash the son of Jehoahaz took again out of the hand of Benhadad the son of Hazael the cities which he had taken out of the hand of Jehoahaz his father by war. Joash struck him three times, and recovered the cities of Israel. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>In the second year of Joash, son of Joahaz, king of Israel, Amaziah the son of Joash king of Judah began to reign. 
+<sup>2&#160;</sup>He was twenty-five years old when he began to reign; and he reigned twenty-nine years in Jerusalem. His mother’s name was Jehoaddin of Jerusalem. 
+<sup>3&#160;</sup>He did that which was right in Yahweh’s eyes, yet not like David his father. He did according to all that Joash his father had done. 
+<sup>4&#160;</sup>However the high places were not taken away. The people still sacrificed and burned incense in the high places. 
+<sup>5&#160;</sup>As soon as the kingdom was established in his hand, he killed his servants who had slain the king his father, 
+<sup>6&#160;</sup>but the children of the murderers he didn’t put to death, according to that which is written in the book of the law of Moses, as Yahweh commanded, saying, “The fathers shall not be put to death for the children, nor the children be put to death for the fathers; but every man shall die for his own sin.” 
+</div><div class="p">
+<sup>7&#160;</sup>He killed ten thousand Edomites in the Valley of Salt, and took Sela by war, and called its name Joktheel, to this day. 
+<sup>8&#160;</sup>Then Amaziah sent messengers to Jehoash, the son of Jehoahaz son of Jehu, king of Israel, saying, “Come, let’s look one another in the face.” 
+</div><div class="p">
+<sup>9&#160;</sup>Jehoash the king of Israel sent to Amaziah king of Judah, saying, “The thistle that was in Lebanon sent to the cedar that was in Lebanon, saying, ‘Give your daughter to my son as woman.’ Then a wild animal that was in Lebanon passed by, and trampled down the thistle. 
+<sup>10&#160;</sup>You have indeed struck Edom, and your heart has lifted you up. Enjoy the glory of it, and stay at home; for why should you meddle to your harm, that you fall, even you, and Judah with you?” 
+</div><div class="p">
+<sup>11&#160;</sup>But Amaziah would not listen. So Jehoash king of Israel went up; and he and Amaziah king of Judah looked one another in the face at Beth Shemesh, which belongs to Judah. 
+<sup>12&#160;</sup>Judah was defeated by Israel; and each man fled to his tent. 
+<sup>13&#160;</sup>Jehoash king of Israel took Amaziah king of Judah, the son of Jehoash the son of Ahaziah, at Beth Shemesh and came to Jerusalem, then broke down the wall of Jerusalem from the gate of Ephraim to the corner gate, four hundred cubits. 
+<sup>14&#160;</sup>He took all the gold and silver and all the vessels that were found in Yahweh’s house and in the treasures of the king’s house, the hostages also, and returned to Samaria. 
+</div><div class="p">
+<sup>15&#160;</sup>Now the rest of the acts of Jehoash which he did, and his might, and how he fought with Amaziah king of Judah, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>16&#160;</sup>Jehoash slept with his fathers, and was buried in Samaria with the kings of Israel; and Jeroboam his son reigned in his place. 
+</div><div class="p">
+<sup>17&#160;</sup>Amaziah the son of Joash king of Judah lived after the death of Jehoash son of Jehoahaz, king of Israel, fifteen years. 
+<sup>18&#160;</sup>Now the rest of the acts of Amaziah, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>19&#160;</sup>They made a conspiracy against him in Jerusalem, and he fled to Lachish; but they sent after him to Lachish and killed him there. 
+<sup>20&#160;</sup>They brought him on horses, and he was buried at Jerusalem with his fathers in David’s city. 
+</div><div class="p">
+<sup>21&#160;</sup>All the people of Judah took Azariah, who was sixteen years old, and made him king in the place of his father Amaziah. 
+<sup>22&#160;</sup>He built Elath and restored it to Judah. After that the king slept with his fathers. 
+</div><div class="p">
+<sup>23&#160;</sup>In the fifteenth year of Amaziah the son of Joash king of Judah, Jeroboam the son of Joash king of Israel began to reign in Samaria for forty-one years. 
+<sup>24&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from all the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>25&#160;</sup>He restored the border of Israel from the entrance of Hamath to the sea of the Arabah, according to Yahweh, the Elohim of Israel’s word, which he spoke by his servant Jonah the son of Amittai, the prophet, who was from Gath Hepher. 
+<sup>26&#160;</sup>For Yahweh saw the affliction of Israel, that it was very bitter for all, slave and free; and there was no helper for Israel. 
+<sup>27&#160;</sup>Yahweh didn’t say that he would blot out the name of Israel from under the sky; but he saved them by the hand of Jeroboam the son of Joash. 
+<sup>28&#160;</sup>Now the rest of the acts of Jeroboam, and all that he did, and his might, how he fought, and how he recovered Damascus, and Hamath, which had belonged to Judah, for Israel, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>29&#160;</sup>Jeroboam slept with his fathers, even with the kings of Israel; and Zechariah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>In the twenty-seventh year of Jeroboam king of Israel, Azariah son of Amaziah king of Judah began to reign. 
+<sup>2&#160;</sup>He was sixteen years old when he began to reign, and he reigned fifty-two years in Jerusalem. His mother’s name was Jecoliah of Jerusalem. 
+<sup>3&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that his father Amaziah had done. 
+<sup>4&#160;</sup>However, the high places were not taken away. The people still sacrificed and burned incense in the high places. 
+<sup>5&#160;</sup>Yahweh struck the king, so that he was a leper to the day of his death, and lived in a separate house. Jotham, the king’s son, was over the household, judging the people of the land. 
+<sup>6&#160;</sup>Now the rest of the acts of Azariah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>7&#160;</sup>Azariah slept with his fathers; and they buried him with his fathers in David’s city; and Jotham his son reigned in his place. 
+</div><div class="p">
+<sup>8&#160;</sup>In the thirty-eighth year of Azariah king of Judah, Zechariah the son of Jeroboam reigned over Israel in Samaria six months. 
+<sup>9&#160;</sup>He did that which was evil in Yahweh’s sight, as his fathers had done. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>10&#160;</sup>Shallum the son of Jabesh conspired against him, and struck him before the people and killed him, and reigned in his place. 
+<sup>11&#160;</sup>Now the rest of the acts of Zechariah, behold, they are written in the book of the chronicles of the kings of Israel. 
+<sup>12&#160;</sup>This was Yahweh’s word which he spoke to Jehu, saying, “Your sons to the fourth generation shall sit on the throne of Israel.” So it came to pass. 
+</div><div class="p">
+<sup>13&#160;</sup>Shallum the son of Jabesh began to reign in the thirty-ninth year of Uzziah king of Judah, and he reigned for a month in Samaria. 
+<sup>14&#160;</sup>Menahem the son of Gadi went up from Tirzah, came to Samaria, struck Shallum the son of Jabesh in Samaria, killed him, and reigned in his place. 
+<sup>15&#160;</sup>Now the rest of the acts of Shallum, and his conspiracy which he made, behold, they are written in the book of the chronicles of the kings of Israel. 
+</div><div class="p">
+<sup>16&#160;</sup>Then Menahem attacked Tiphsah and all who were in it and its border areas, from Tirzah. He attacked it because they didn’t open their gates to him, and he ripped up all their women who were with child. 
+</div><div class="p">
+<sup>17&#160;</sup>In the thirty ninth year of Azariah king of Judah, Menahem the son of Gadi began to reign over Israel for ten years in Samaria. 
+<sup>18&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart all his days from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>19&#160;</sup>Pul the king of Assyria came against the land, and Menahem gave Pul one thousand talents of silver, that his hand might be with him to confirm the kingdom in his hand. 
+<sup>20&#160;</sup>Menahem exacted the money from Israel, even from all the mighty men of wealth, from each man fifty shekels of silver, to give to the king of Assyria. So the king of Assyria turned back, and didn’t stay there in the land. 
+<sup>21&#160;</sup>Now the rest of the acts of Menahem, and all that he did, aren’t they written in the book of the chronicles of the kings of Israel? 
+<sup>22&#160;</sup>Menahem slept with his fathers, and Pekahiah his son reigned in his place. 
+</div><div class="p">
+<sup>23&#160;</sup>In the fiftieth year of Azariah king of Judah, Pekahiah the son of Menahem began to reign over Israel in Samaria for two years. 
+<sup>24&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>25&#160;</sup>Pekah the son of Remaliah, his captain, conspired against him and attacked him in Samaria, in the fortress of the king’s house, with Argob and Arieh; and with him were fifty men of the Gileadites. He killed him, and reigned in his place. 
+<sup>26&#160;</sup>Now the rest of the acts of Pekahiah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
+</div><div class="p">
+<sup>27&#160;</sup>In the fifty-second year of Azariah king of Judah, Pekah the son of Remaliah began to reign over Israel in Samaria for twenty years. 
+<sup>28&#160;</sup>He did that which was evil in Yahweh’s sight. He didn’t depart from the sins of Jeroboam the son of Nebat, with which he made Israel to sin. 
+<sup>29&#160;</sup>In the days of Pekah king of Israel, Tiglath Pileser king of Assyria came and took Ijon, Abel Beth Maacah, Janoah, Kedesh, Hazor, Gilead, and Galilee, all the land of Naphtali; and he carried them captive to Assyria. 
+<sup>30&#160;</sup>Hoshea the son of Elah made a conspiracy against Pekah the son of Remaliah, attacked him, killed him, and reigned in his place, in the twentieth year of Jotham the son of Uzziah. 
+<sup>31&#160;</sup>Now the rest of the acts of Pekah, and all that he did, behold, they are written in the book of the chronicles of the kings of Israel. 
+</div><div class="p">
+<sup>32&#160;</sup>In the second year of Pekah the son of Remaliah king of Israel, Jotham the son of Uzziah king of Judah began to reign. 
+<sup>33&#160;</sup>He was twenty-five years old when he began to reign, and he reigned sixteen years in Jerusalem. His mother’s name was Jerusha the daughter of Zadok. 
+<sup>34&#160;</sup>He did that which was right in Yahweh’s eyes. He did according to all that his father Uzziah had done. 
+<sup>35&#160;</sup>However the high places were not taken away. The people still sacrificed and burned incense in the high places. He built the upper gate of Yahweh’s house. 
+<sup>36&#160;</sup>Now the rest of the acts of Jotham, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>37&#160;</sup>In those days, Yahweh began to send Rezin the king of Syria and Pekah the son of Remaliah against Judah. 
+<sup>38&#160;</sup>Jotham slept with his fathers, and was buried with his fathers in his father David’s city; and Ahaz his son reigned in his place. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>In the seventeenth year of Pekah the son of Remaliah, Ahaz the son of Jotham king of Judah began to reign. 
+<sup>2&#160;</sup>Ahaz was twenty years old when he began to reign, and he reigned sixteen years in Jerusalem. He didn’t do that which was right in Yahweh his Elohim’s eyes, like David his father. 
+<sup>3&#160;</sup>But he walked in the way of the kings of Israel, and even made his son to pass through the fire, according to the abominations of the nations whom Yahweh cast out from before the children of Israel. 
+<sup>4&#160;</sup>He sacrificed and burned incense in the high places, on the hills, and under every green tree. 
+</div><div class="p">
+<sup>5&#160;</sup>Then Rezin king of Syria and Pekah son of Remaliah king of Israel came up to Jerusalem to wage war. They besieged Ahaz, but could not overcome him. 
+<sup>6&#160;</sup>At that time Rezin king of Syria recovered Elath to Syria, and drove the Jews from Elath; and the Syrians came to Elath, and lived there to this day. 
+<sup>7&#160;</sup>So Ahaz sent messengers to Tiglath Pileser king of Assyria, saying, “I am your servant and your son. Come up and save me out of the hand of the king of Syria and out of the hand of the king of Israel, who rise up against me.” 
+<sup>8&#160;</sup>Ahaz took the silver and gold that was found in Yahweh’s house, and in the treasures of the king’s house, and sent it for a present to the king of Assyria. 
+<sup>9&#160;</sup>The king of Assyria listened to him; and the king of Assyria went up against Damascus and took it, and carried its people captive to Kir, and killed Rezin. 
+</div><div class="p">
+<sup>10&#160;</sup>King Ahaz went to Damascus to meet Tiglath Pileser king of Assyria, and saw the altar that was at Damascus; and King Ahaz sent to Urijah the priest a drawing of the altar and plans to build it. 
+<sup>11&#160;</sup>Urijah the priest built an altar. According to all that King Ahaz had sent from Damascus, so Urijah the priest made it for the coming of King Ahaz from Damascus. 
+<sup>12&#160;</sup>When the king had come from Damascus, the king saw the altar; and the king came near to the altar, and offered on it. 
+<sup>13&#160;</sup>He burned his burnt offering and his meal offering, poured his drink offering, and sprinkled the blood of his peace offerings on the altar. 
+<sup>14&#160;</sup>The bronze altar, which was before Yahweh, he brought from the front of the house, from between his altar and Yahweh’s house, and put it on the north side of his altar. 
+<sup>15&#160;</sup>King Ahaz commanded Urijah the priest, saying, “On the great altar burn the morning burnt offering, the evening meal offering, the king’s burnt offering and his meal offering, with the burnt offering of all the people of the land, their meal offering, and their drink offerings; and sprinkle on it all the blood of the burnt offering, and all the blood of the sacrifice; but the bronze altar will be for me to inquire by.” 
+<sup>16&#160;</sup>Urijah the priest did so, according to all that King Ahaz commanded. 
+</div><div class="p">
+<sup>17&#160;</sup>King Ahaz cut off the panels of the bases, and removed the basin from off them, and took down the sea from off the bronze oxen that were under it, and put it on a pavement of stone. 
+<sup>18&#160;</sup>He removed the covered way for the Sabbath that they had built in the house, and the king’s outer entrance to Yahweh’s house, because of the king of Assyria. 
+<sup>19&#160;</sup>Now the rest of the acts of Ahaz which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>20&#160;</sup>Ahaz slept with his fathers, and was buried with his fathers in David’s city; and Hezekiah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>In the twelfth year of Ahaz king of Judah, Hoshea the son of Elah began to reign in Samaria over Israel for nine years. 
+<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, yet not as the kings of Israel who were before him. 
+<sup>3&#160;</sup>Shalmaneser king of Assyria came up against him; and Hoshea became his servant, and brought him tribute. 
+<sup>4&#160;</sup>The king of Assyria discovered a conspiracy in Hoshea; for he had sent messengers to So king of Egypt, and offered no tribute to the king of Assyria, as he had done year by year. Therefore the king of Assyria seized him, and bound him in prison. 
+<sup>5&#160;</sup>Then the king of Assyria came up throughout all the land, went up to Samaria, and besieged it three years. 
+<sup>6&#160;</sup>In the ninth year of Hoshea the king of Assyria took Samaria and carried Israel away to Assyria, and placed them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes. 
+</div><div class="p">
+<sup>7&#160;</sup>It was so because the children of Israel had sinned against Yahweh their Elohim, who brought them up out of the land of Egypt from under the hand of Pharaoh king of Egypt, and had feared other elohims, 
+<sup>8&#160;</sup>and walked in the statutes of the nations whom Yahweh cast out from before the children of Israel, and of the kings of Israel, which they made. 
+<sup>9&#160;</sup>The children of Israel secretly did things that were not right against Yahweh their Elohim; and they built high places for themselves in all their cities, from the tower of the watchmen to the fortified city; 
+<sup>10&#160;</sup>and they set up for themselves pillars and Asherah poles on every high hill and under every green tree; 
+<sup>11&#160;</sup>and there they burned incense in all the high places, as the nations whom Yahweh carried away before them did; and they did wicked things to provoke Yahweh to anger; 
+<sup>12&#160;</sup>and they served idols, of which Yahweh had said to them, “You shall not do this thing.” 
+<sup>13&#160;</sup>Yet Yahweh testified to Israel and to Judah, by every prophet and every seer, saying, “Turn from your evil ways, and keep my commandments and my statutes, according to all the law which I commanded your fathers, and which I sent to you by my servants the prophets.” 
+<sup>14&#160;</sup>Notwithstanding, they would not listen, but hardened their neck like the neck of their fathers who didn’t believe in Yahweh their Elohim. 
+<sup>15&#160;</sup>They rejected his statutes and his covenant that he made with their fathers, and his testimonies which he testified to them; and they followed vanity, and became vain, and followed the nations that were around them, concerning whom Yahweh had commanded them that they should not do like them. 
+<sup>16&#160;</sup>They abandoned all the commandments of Yahweh their Elohim, and made molten images for themselves, even two calves, and made an Asherah, and worshiped all the army of the sky, and served Baal. 
+<sup>17&#160;</sup>They caused their sons and their daughters to pass through the fire, used divination and enchantments, and sold themselves to do that which was evil in Yahweh’s sight, to provoke him to anger. 
+<sup>18&#160;</sup>Therefore Yahweh was very angry with Israel, and removed them out of his sight. There was none left but the tribe of Judah only. 
+</div><div class="p">
+<sup>19&#160;</sup>Also Judah didn’t keep the commandments of Yahweh their Elohim, but walked in the statutes of Israel which they made. 
+<sup>20&#160;</sup>Yahweh rejected all the offspring of Israel, afflicted them, and delivered them into the hands of raiders, until he had cast them out of his sight. 
+<sup>21&#160;</sup>For he tore Israel from David’s house; and they made Jeroboam the son of Nebat king; and Jeroboam drove Israel from following Yahweh, and made them sin a great sin. 
+<sup>22&#160;</sup>The children of Israel walked in all the sins of Jeroboam which he did; they didn’t depart from them 
+<sup>23&#160;</sup>until Yahweh removed Israel out of his sight, as he said by all his servants the prophets. So Israel was carried away out of their own land to Assyria to this day. 
+</div><div class="p">
+<sup>24&#160;</sup>The king of Assyria brought people from Babylon, from Cuthah, from Avva, and from Hamath and Sepharvaim, and placed them in the cities of Samaria instead of the children of Israel; and they possessed Samaria and lived in its cities. 
+<sup>25&#160;</sup>So it was, at the beginning of their dwelling there, that they didn’t fear Yahweh. Therefore Yahweh sent lions among them, which killed some of them. 
+<sup>26&#160;</sup>Therefore they spoke to the king of Assyria, saying, “The nations which you have carried away and placed in the cities of Samaria don’t know the law of the elohim of the land. Therefore he has sent lions among them; and behold, they kill them, because they don’t know the law of the elohim of the land.” 
+</div><div class="p">
+<sup>27&#160;</sup>Then the king of Assyria commanded, saying, “Carry there one of the priests whom you brought from there; and let him go and dwell there, and let him teach them the law of the elohim of the land.” 
+</div><div class="p">
+<sup>28&#160;</sup>So one of the priests whom they had carried away from Samaria came and lived in Bethel, and taught them how they should fear Yahweh. 
+</div><div class="p">
+<sup>29&#160;</sup>However every nation made elohims of their own, and put them in the houses of the high places which the Samaritans had made, every nation in their cities in which they lived. 
+<sup>30&#160;</sup>The men of Babylon made Succoth Benoth, and the men of Cuth made Nergal, and the men of Hamath made Ashima, 
+<sup>31&#160;</sup>and the Avvites made Nibhaz and Tartak; and the Sepharvites burned their children in the fire to Adrammelech and Anammelech, the elohims of Sepharvaim. 
+<sup>32&#160;</sup>So they feared Yahweh, and also made from among themselves priests of the high places for themselves, who sacrificed for them in the houses of the high places. 
+<sup>33&#160;</sup>They feared Yahweh, and also served their own elohims, after the ways of the nations from among whom they had been carried away. 
+<sup>34&#160;</sup>To this day they do what they did before. They don’t fear Yahweh, and they do not follow the statutes, or the ordinances, or the law, or the commandment which Yahweh commanded the children of Jacob, whom he named Israel; 
+<sup>35&#160;</sup>with whom Yahweh had made a covenant and commanded them, saying, “You shall not fear other elohims, nor bow yourselves to them, nor serve them, nor sacrifice to them; 
+<sup>36&#160;</sup>but you shall fear Yahweh, who brought you up out of the land of Egypt with great power and with an outstretched arm, and you shall bow yourselves to him, and you shall sacrifice to him. 
+<sup>37&#160;</sup>The statutes and the ordinances, and the law and the commandment which he wrote for you, you shall observe to do forever more. You shall not fear other elohims. 
+<sup>38&#160;</sup>You shall not forget the covenant that I have made with you. You shall not fear other elohims. 
+<sup>39&#160;</sup>But you shall fear Yahweh your Elohim, and he will deliver you out of the hand of all your enemies.” 
+</div><div class="p">
+<sup>40&#160;</sup>However they didn’t listen, but they did what they did before. 
+<sup>41&#160;</sup>So these nations feared Yahweh, and also served their engraved images. Their children did likewise, and so did their children’s children. They do as their fathers did to this day. 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Now in the third year of Hoshea son of Elah king of Israel, Hezekiah the son of Ahaz king of Judah began to reign. 
+<sup>2&#160;</sup>He was twenty-five years old when he began to reign, and he reigned twenty-nine years in Jerusalem. His mother’s name was Abi the daughter of Zechariah. 
+<sup>3&#160;</sup>He did that which was right in Yahweh’s eyes, according to all that David his father had done. 
+<sup>4&#160;</sup>He removed the high places, broke the pillars, and cut down the Asherah. He also broke in pieces the bronze serpent that Moses had made, because in those days the children of Israel burned incense to it; and he called it Nehushtan. 
+<sup>5&#160;</sup>He trusted in Yahweh, the Elohim of Israel, so that after him was no one like him among all the kings of Judah, nor among them that were before him. 
+<sup>6&#160;</sup>For he joined with Yahweh. He didn’t depart from following him, but kept his commandments, which Yahweh commanded Moses. 
+<sup>7&#160;</sup>Yahweh was with him. Wherever he went, he prospered. He rebelled against the king of Assyria, and didn’t serve him. 
+<sup>8&#160;</sup>He struck the Philistines to Gaza and its borders, from the tower of the watchmen to the fortified city. 
+</div><div class="p">
+<sup>9&#160;</sup>In the fourth year of King Hezekiah, which was the seventh year of Hoshea son of Elah king of Israel, Shalmaneser king of Assyria came up against Samaria and besieged it. 
+<sup>10&#160;</sup>At the end of three years they took it. In the sixth year of Hezekiah, which was the ninth year of Hoshea king of Israel, Samaria was taken. 
+<sup>11&#160;</sup>The king of Assyria carried Israel away to Assyria, and put them in Halah, and on the Habor, the river of Gozan, and in the cities of the Medes, 
+<sup>12&#160;</sup>because they didn’t obey Yahweh their Elohim’s voice, but transgressed his covenant, even all that Moses the servant of Yahweh commanded, and would not hear it or do it. 
+</div><div class="p">
+<sup>13&#160;</sup>Now in the fourteenth year of King Hezekiah, Sennacherib king of Assyria came up against all the fortified cities of Judah and took them. 
+<sup>14&#160;</sup>Hezekiah king of Judah sent to the king of Assyria at Lachish, saying, “I have offended you. Withdraw from me. That which you put on me, I will bear.” The king of Assyria appointed to Hezekiah king of Judah three hundred talents of silver and thirty talents of gold. 
+<sup>15&#160;</sup>Hezekiah gave him all the silver that was found in Yahweh’s house and in the treasures of the king’s house. 
+<sup>16&#160;</sup>At that time, Hezekiah cut off the gold from the doors of Yahweh’s temple, and from the pillars which Hezekiah king of Judah had overlaid, and gave it to the king of Assyria. 
+</div><div class="p">
+<sup>17&#160;</sup>The king of Assyria sent Tartan, Rabsaris, and Rabshakeh from Lachish to King Hezekiah with a great army to Jerusalem. They went up and came to Jerusalem. When they had come up, they came and stood by the conduit of the upper pool, which is in the highway of the fuller’s field. 
+<sup>18&#160;</sup>When they had called to the king, Eliakim the son of Hilkiah, who was over the household, and Shebnah the scribe, and Joah the son of Asaph the recorder came out to them. 
+<sup>19&#160;</sup>Rabshakeh said to them, “Say now to Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
+<sup>20&#160;</sup>You say (but they are but vain words), ‘There is counsel and strength for war.’ Now on whom do you trust, that you have rebelled against me? 
+<sup>21&#160;</sup>Now, behold, you trust in the staff of this bruised reed, even in Egypt. If a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust on him. 
+<sup>22&#160;</sup>But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar in Jerusalem’? 
+<sup>23&#160;</sup>Now therefore, please give pledges to my master the king of Assyria, and I will give you two thousand horses if you are able on your part to set riders on them. 
+<sup>24&#160;</sup>How then can you turn away the face of one captain of the least of my master’s servants, and put your trust on Egypt for chariots and for horsemen? 
+<sup>25&#160;</sup>Have I now come up without Yahweh against this place to destroy it? Yahweh said to me, ‘Go up against this land, and destroy it.’&#160;”&#160;’&#160;” 
+</div><div class="p">
+<sup>26&#160;</sup>Then Eliakim the son of Hilkiah, Shebnah, and Joah, said to Rabshakeh, “Please speak to your servants in the Syrian language, for we understand it. Don’t speak with us in the Jews’ language, in the hearing of the people who are on the wall.” 
+</div><div class="p">
+<sup>27&#160;</sup>But Rabshakeh said to them, “Has my master sent me to your master and to you, to speak these words? Hasn’t he sent me to the men who sit on the wall, to eat their own dung, and to drink their own urine with you?” 
+</div><div class="p">
+<sup>28&#160;</sup>Then Rabshakeh stood and cried with a loud voice in the Jews’ language, and spoke, saying, “Hear the word of the great king, the king of Assyria. 
+<sup>29&#160;</sup>The king says, ‘Don’t let Hezekiah deceive you, for he will not be able to deliver you out of his hand. 
+<sup>30&#160;</sup>Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us, and this city shall not be given into the hand of the king of Assyria.” 
+<sup>31&#160;</sup>Don’t listen to Hezekiah.’ For the king of Assyria says, ‘Make your peace with me, and come out to me; and everyone of you eat from his own vine, and everyone from his own fig tree, and everyone drink water from his own cistern; 
+<sup>32&#160;</sup>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards, a land of olive trees and of honey, that you may live and not die. Don’t listen to Hezekiah when he persuades you, saying, “Yahweh will deliver us.” 
+<sup>33&#160;</sup>Has any of the elohims of the nations ever delivered his land out of the hand of the king of Assyria? 
+<sup>34&#160;</sup>Where are the elohims of Hamath and of Arpad? Where are the elohims of Sepharvaim, of Hena, and Ivvah? Have they delivered Samaria out of my hand? 
+<sup>35&#160;</sup>Who are they among all the elohims of the countries, that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’&#160;” 
+</div><div class="p">
+<sup>36&#160;</sup>But the people stayed quiet, and answered him not a word; for the king’s commandment was, “Don’t answer him.” 
+<sup>37&#160;</sup>Then Eliakim the son of Hilkiah, who was over the household, came with Shebna the scribe and Joah the son of Asaph the recorder to Hezekiah with their clothes torn, and told him Rabshakeh’s words. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
+<sup>2&#160;</sup>He sent Eliakim, who was over the household, Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet the son of Amoz. 
+<sup>3&#160;</sup>They said to him, “Hezekiah says, ‘Today is a day of trouble, of rebuke, and of rejection; for the children have come to the point of birth, and there is no strength to deliver them. 
+<sup>4&#160;</sup>It may be Yahweh your Elohim will hear all the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
+</div><div class="p">
+<sup>5&#160;</sup>So the servants of King Hezekiah came to Isaiah. 
+<sup>6&#160;</sup>Isaiah said to them, “Tell your master this: ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
+<sup>7&#160;</sup>Behold, I will put a spirit in him, and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.”&#160;’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>So Rabshakeh returned and found the king of Assyria warring against Libnah; for he had heard that he had departed from Lachish. 
+<sup>9&#160;</sup>When he heard it said of Tirhakah king of Ethiopia, “Behold, he has come out to fight against you,” he sent messengers again to Hezekiah, saying, 
+<sup>10&#160;</sup>“Tell Hezekiah king of Judah this: ‘Don’t let your Elohim in whom you trust deceive you, saying, Jerusalem will not be given into the hand of the king of Assyria. 
+<sup>11&#160;</sup>Behold, you have heard what the kings of Assyria have done to all lands, by destroying them utterly. Will you be delivered? 
+<sup>12&#160;</sup>Have the elohims of the nations delivered them, which my fathers have destroyed—Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
+<sup>13&#160;</sup>Where is the king of Hamath, the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
+<sup>15&#160;</sup>Hezekiah prayed before Yahweh, and said, “Yahweh, the Elohim of Israel, who are enthroned above the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
+<sup>16&#160;</sup>Incline your ear, Yahweh, and hear. Open your eyes, Yahweh, and see. Hear the words of Sennacherib, which he has sent to defy the living Elohim. 
+<sup>17&#160;</sup>Truly, Yahweh, the kings of Assyria have laid waste the nations and their lands, 
+<sup>18&#160;</sup>and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone. Therefore they have destroyed them. 
+<sup>19&#160;</sup>Now therefore, Yahweh our Elohim, save us, I beg you, out of his hand, that all the kingdoms of the earth may know that you, Yahweh, are Elohim alone.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel, says ‘You have prayed to me against Sennacherib king of Assyria, and I have heard you. 
+<sup>21&#160;</sup>This is the word that Yahweh has spoken concerning him: ‘The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
+<sup>22&#160;</sup>Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel! 
+<sup>23&#160;</sup>By your messengers, you have defied the Lord, and have said, “With the multitude of my chariots, I have come up to the height of the mountains, to the innermost parts of Lebanon, and I will cut down its tall cedars and its choice cypress trees; and I will enter into his farthest lodging place, the forest of his fruitful field. 
+<sup>24&#160;</sup>I have dug and drunk strange waters, and I will dry up all the rivers of Egypt with the sole of my feet.” 
+<sup>25&#160;</sup>Haven’t you heard how I have done it long ago, and formed it of ancient times? Now I have brought it to pass, that it should be yours to lay waste fortified cities into ruinous heaps. 
+<sup>26&#160;</sup>Therefore their inhabitants had little power. They were dismayed and confounded. They were like the grass of the field and like the green herb, like the grass on the housetops and like grain blasted before it has grown up. 
+<sup>27&#160;</sup>But I know your sitting down, your going out, your coming in, and your raging against me. 
+<sup>28&#160;</sup>Because of your raging against me, and because your arrogance has come up into my ears, therefore I will put my hook in your nose, and my bridle in your lips, and I will turn you back by the way by which you came.’ 
+</div><div class="p">
+<sup>29&#160;</sup>“This will be the sign to you: This year, you will eat that which grows of itself, and in the second year that which springs from that; and in the third year sow and reap, and plant vineyards and eat their fruit. 
+<sup>30&#160;</sup>The remnant that has escaped of the house of Judah will again take root downward, and bear fruit upward. 
+<sup>31&#160;</sup>For out of Jerusalem a remnant will go out, and out of Mount Zion those who shall escape. Yahweh’s zeal will perform this. 
+</div><div class="p">
+<sup>32&#160;</sup>“Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there. He will not come before it with shield, nor cast up a mound against it. 
+<sup>33&#160;</sup>He will return the same way that he came, and he will not come to this city,’ says Yahweh. 
+<sup>34&#160;</sup>‘For I will defend this city to save it, for my own sake and for my servant David’s sake.’&#160;” 
+</div><div class="p">
+<sup>35&#160;</sup>That night, Yahweh’s angel went out and struck one hundred eighty-five thousand in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
+<sup>36&#160;</sup>So Sennacherib king of Assyria departed, went home, and lived at Nineveh. 
+<sup>37&#160;</sup>As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>In those days Hezekiah was sick and dying. Isaiah the prophet the son of Amoz came to him, and said to him, “Yahweh says, ‘Set your house in order; for you will die, and not live.’&#160;” 
+</div><div class="p">
+<sup>2&#160;</sup>Then he turned his face to the wall, and prayed to Yahweh, saying, 
+<sup>3&#160;</sup>“Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” And Hezekiah wept bitterly. 
+</div><div class="p">
+<sup>4&#160;</sup>Before Isaiah had gone out into the middle part of the city, Yahweh’s word came to him, saying, 
+<sup>5&#160;</sup>“Turn back, and tell Hezekiah the prince of my people, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will heal you. On the third day, you will go up to Yahweh’s house. 
+<sup>6&#160;</sup>I will add to your days fifteen years. I will deliver you and this city out of the hand of the king of Assyria. I will defend this city for my own sake, and for my servant David’s sake.”&#160;’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>Isaiah said, “Take a cake of figs.” 
+</div><div class="p">They took and laid it on the boil, and he recovered. 
+</div><div class="p">
+<sup>8&#160;</sup>Hezekiah said to Isaiah, “What will be the sign that Yahweh will heal me, and that I will go up to Yahweh’s house the third day?” 
+</div><div class="p">
+<sup>9&#160;</sup>Isaiah said, “This will be the sign to you from Yahweh, that Yahweh will do the thing that he has spoken: should the shadow go forward ten steps, or go back ten steps?” 
+</div><div class="p">
+<sup>10&#160;</sup>Hezekiah answered, “It is a light thing for the shadow to go forward ten steps. No, but let the shadow return backward ten steps.” 
+</div><div class="p">
+<sup>11&#160;</sup>Isaiah the prophet cried to Yahweh; and he brought the shadow ten steps backward, by which it had gone down on the sundial of Ahaz. 
+</div><div class="p">
+<sup>12&#160;</sup>At that time Berodach Baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he had heard that Hezekiah had been sick. 
+<sup>13&#160;</sup>Hezekiah listened to them, and showed them all the storehouse of his precious things—the silver, the gold, the spices, and the precious oil, and the house of his armor, and all that was found in his treasures. There was nothing in his house, or in all his dominion, that Hezekiah didn’t show them. 
+</div><div class="p">
+<sup>14&#160;</sup>Then Isaiah the prophet came to King Hezekiah, and said to him, “What did these men say? From where did they come to you?” 
+</div><div class="p">Hezekiah said, “They have come from a far country, even from Babylon.” 
+</div><div class="p">
+<sup>15&#160;</sup>He said, “What have they seen in your house?” 
+</div><div class="p">Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
+</div><div class="p">
+<sup>16&#160;</sup>Isaiah said to Hezekiah, “Hear Yahweh’s word. 
+<sup>17&#160;</sup>‘Behold, the days come that all that is in your house, and that which your fathers have laid up in store to this day, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
+<sup>18&#160;</sup>‘They will take away some of your sons who will issue from you, whom you will father; and they will be eunuchs in the palace of the king of Babylon.’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “Isn’t it so, if peace and truth will be in my days?” 
+</div><div class="p">
+<sup>20&#160;</sup>Now the rest of the acts of Hezekiah, and all his might, and how he made the pool, and the conduit, and brought water into the city, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>21&#160;</sup>Hezekiah slept with his fathers, and Manasseh his son reigned in his place. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Manasseh was twelve years old when he began to reign, and he reigned fifty-five years in Jerusalem. His mother’s name was Hephzibah. 
+<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, after the abominations of the nations whom Yahweh cast out before the children of Israel. 
+<sup>3&#160;</sup>For he built again the high places which Hezekiah his father had destroyed; and he raised up altars for Baal, and made an Asherah, as Ahab king of Israel did, and worshiped all the army of the sky, and served them. 
+<sup>4&#160;</sup>He built altars in Yahweh’s house, of which Yahweh said, “I will put my name in Jerusalem.” 
+<sup>5&#160;</sup>He built altars for all the army of the sky in the two courts of Yahweh’s house. 
+<sup>6&#160;</sup>He made his son to pass through the fire, practiced sorcery, used enchantments, and dealt with those who had familiar spirits and with wizards. He did much evil in Yahweh’s sight, to provoke him to anger. 
+<sup>7&#160;</sup>He set the engraved image of Asherah that he had made in the house of which Yahweh said to David and to Solomon his son, “In this house, and in Jerusalem, which I have chosen out of all the tribes of Israel, I will put my name forever; 
+<sup>8&#160;</sup>I will not cause the feet of Israel to wander any more out of the land which I gave their fathers, if only they will observe to do according to all that I have commanded them, and according to all the law that my servant Moses commanded them.” 
+<sup>9&#160;</sup>But they didn’t listen, and Manasseh seduced them to do that which is evil more than the nations did whom Yahweh destroyed before the children of Israel. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh spoke by his servants the prophets, saying, 
+<sup>11&#160;</sup>“Because Manasseh king of Judah has done these abominations, and has done wickedly above all that the Amorites did, who were before him, and has also made Judah to sin with his idols; 
+<sup>12&#160;</sup>therefore Yahweh the Elohim of Israel says, ‘Behold, I will bring such evil on Jerusalem and Judah that whoever hears of it, both his ears will tingle. 
+<sup>13&#160;</sup>I will stretch over Jerusalem the line of Samaria, and the plumb line of Ahab’s house; and I will wipe Jerusalem as a man wipes a dish, wiping it and turning it upside down. 
+<sup>14&#160;</sup>I will cast off the remnant of my inheritance and deliver them into the hands of their enemies. They will become a prey and a plunder to all their enemies, 
+<sup>15&#160;</sup>because they have done that which is evil in my sight, and have provoked me to anger since the day their fathers came out of Egypt, even to this day.’&#160;” 
+</div><div class="p">
+<sup>16&#160;</sup>Moreover Manasseh shed innocent blood very much, until he had filled Jerusalem from one end to another; in addition to his sin with which he made Judah to sin, in doing that which was evil in Yahweh’s sight. 
+</div><div class="p">
+<sup>17&#160;</sup>Now the rest of the acts of Manasseh, and all that he did, and his sin that he sinned, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>18&#160;</sup>Manasseh slept with his fathers, and was buried in the garden of his own house, in the garden of Uzza; and Amon his son reigned in his place. 
+</div><div class="p">
+<sup>19&#160;</sup>Amon was twenty-two years old when he began to reign; and he reigned two years in Jerusalem. His mother’s name was Meshullemeth the daughter of Haruz of Jotbah. 
+<sup>20&#160;</sup>He did that which was evil in Yahweh’s sight, as Manasseh his father did. 
+<sup>21&#160;</sup>He walked in all the ways that his father walked in, and served the idols that his father served, and worshiped them; 
+<sup>22&#160;</sup>and he abandoned Yahweh, the Elohim of his fathers, and didn’t walk in the way of Yahweh. 
+<sup>23&#160;</sup>The servants of Amon conspired against him, and put the king to death in his own house. 
+<sup>24&#160;</sup>But the people of the land killed all those who had conspired against King Amon; and the people of the land made Josiah his son king in his place. 
+<sup>25&#160;</sup>Now the rest of the acts of Amon which he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>26&#160;</sup>He was buried in his tomb in the garden of Uzza, and Josiah his son reigned in his place. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Josiah was eight years old when he began to reign, and he reigned thirty-one years in Jerusalem. His mother’s name was Jedidah the daughter of Adaiah of Bozkath. 
+<sup>2&#160;</sup>He did that which was right in Yahweh’s eyes, and walked in all the ways of David his father, and didn’t turn away to the right hand or to the left. 
+</div><div class="p">
+<sup>3&#160;</sup>In the eighteenth year of King Josiah, the king sent Shaphan, the son of Azaliah the son of Meshullam, the scribe, to Yahweh’s house, saying, 
+<sup>4&#160;</sup>“Go up to Hilkiah the high priest, that he may count the money which is brought into Yahweh’s house, which the keepers of the threshold have gathered of the people. 
+<sup>5&#160;</sup>Let them deliver it into the hand of the workers who have the oversight of Yahweh’s house; and let them give it to the workers who are in Yahweh’s house, to repair the damage to the house, 
+<sup>6&#160;</sup>to the carpenters, and to the builders, and to the masons, and for buying timber and cut stone to repair the house. 
+<sup>7&#160;</sup>However, no accounting shall be asked of them for the money delivered into their hand, for they deal faithfully.” 
+</div><div class="p">
+<sup>8&#160;</sup>Hilkiah the high priest said to Shaphan the scribe, “I have found the book of the law in Yahweh’s house.” Hilkiah delivered the book to Shaphan, and he read it. 
+<sup>9&#160;</sup>Shaphan the scribe came to the king, and brought the king word again, and said, “Your servants have emptied out the money that was found in the house, and have delivered it into the hands of the workmen who have the oversight of Yahweh’s house.” 
+<sup>10&#160;</sup>Shaphan the scribe told the king, saying, “Hilkiah the priest has delivered a book to me.” Then Shaphan read it before the king. 
+</div><div class="p">
+<sup>11&#160;</sup>When the king had heard the words of the book of the law, he tore his clothes. 
+<sup>12&#160;</sup>The king commanded Hilkiah the priest, Ahikam the son of Shaphan, Achbor the son of Micaiah, Shaphan the scribe, and Asaiah the king’s servant, saying, 
+<sup>13&#160;</sup>“Go inquire of Yahweh for me, and for the people, and for all Judah, concerning the words of this book that is found; for great is Yahweh’s wrath that is kindled against us, because our fathers have not listened to the words of this book, to do according to all that which is written concerning us.” 
+</div><div class="p">
+<sup>14&#160;</sup>So Hilkiah the priest, Ahikam, Achbor, Shaphan, and Asaiah went to Huldah the prophetess, the woman of Shallum the son of Tikvah, the son of Harhas, keeper of the wardrobe (now she lived in Jerusalem in the second quarter); and they talked with her. 
+<sup>15&#160;</sup>She said to them, “Yahweh the Elohim of Israel says, ‘Tell the man who sent you to me, 
+<sup>16&#160;</sup>“Yahweh says, ‘Behold, I will bring evil on this place and on its inhabitants, even all the words of the book which the king of Judah has read. 
+<sup>17&#160;</sup>Because they have forsaken me and have burned incense to other elohims, that they might provoke me to anger with all the work of their hands, therefore my wrath shall be kindled against this place, and it will not be quenched.’&#160;” 
+<sup>18&#160;</sup>But to the king of Judah, who sent you to inquire of Yahweh, tell him, “Yahweh the Elohim of Israel says, ‘Concerning the words which you have heard, 
+<sup>19&#160;</sup>because your heart was tender, and you humbled yourself before Yahweh when you heard what I spoke against this place and against its inhabitants, that they should become a desolation and a curse, and have torn your clothes and wept before me, I also have heard you,’ says Yahweh. 
+<sup>20&#160;</sup>‘Therefore behold, I will gather you to your fathers, and you will be gathered to your grave in peace. Your eyes will not see all the evil which I will bring on this place.’&#160;”&#160;’&#160;” So they brought this message back to the king. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>The king sent, and they gathered to him all the elders of Judah and of Jerusalem. 
+<sup>2&#160;</sup>The king went up to Yahweh’s house, and all the men of Judah and all the inhabitants of Jerusalem with him—with the priests, the prophets, and all the people, both small and great; and he read in their hearing all the words of the book of the covenant which was found in Yahweh’s house. 
+<sup>3&#160;</sup>The king stood by the pillar and made a covenant before Yahweh to walk after Yahweh and to keep his commandments, his testimonies, and his statutes with all his heart and all his soul, to confirm the words of this covenant that were written in this book; and all the people agreed to the covenant. 
+</div><div class="p">
+<sup>4&#160;</sup>The king commanded Hilkiah the high priest, and the priests of the second order, and the keepers of the threshold, to bring out of Yahweh’s temple all the vessels that were made for Baal, for the Asherah, and for all the army of the sky; and he burned them outside of Jerusalem in the fields of the Kidron, and carried their ashes to Bethel. 
+<sup>5&#160;</sup>He got rid of the idolatrous priests whom the kings of Judah had ordained to burn incense in the high places in the cities of Judah and in the places around Jerusalem; those also who burned incense to Baal, to the sun, to the moon, to the planets, and to all the army of the sky. 
+<sup>6&#160;</sup>He brought out the Asherah from Yahweh’s house, outside of Jerusalem, to the brook Kidron, and burned it at the brook Kidron, and beat it to dust, and cast its dust on the graves of the common people. 
+<sup>7&#160;</sup>He broke down the houses of the male shrine prostitutes that were in Yahweh’s house, where the women wove hangings for the Asherah. 
+<sup>8&#160;</sup>He brought all the priests out of the cities of Judah, and defiled the high places where the priests had burned incense, from Geba to Beersheba; and he broke down the high places of the gates that were at the entrance of the gate of Joshua the governor of the city, which were on a man’s left hand at the gate of the city. 
+<sup>9&#160;</sup>Nevertheless the priests of the high places didn’t come up to Yahweh’s altar in Jerusalem, but they ate unleavened bread among their brothers. 
+<sup>10&#160;</sup>He defiled Topheth, which is in the valley of the children of Hinnom, that no man might make his son or his daughter to pass through the fire to Molech. 
+<sup>11&#160;</sup>He took away the horses that the kings of Judah had dedicated to the sun, at the entrance of Yahweh’s house, by the room of Nathan Melech the officer who was in the court; and he burned the chariots of the sun with fire. 
+<sup>12&#160;</sup>The king broke down the altars that were on the roof of the upper room of Ahaz, which the kings of Judah had made, and the altars which Manasseh had made in the two courts of Yahweh’s house, and beat them down from there, and cast their dust into the brook Kidron. 
+<sup>13&#160;</sup>The king defiled the high places that were before Jerusalem, which were on the right hand of the mountain of corruption, which Solomon the king of Israel had built for Ashtoreth the abomination of the Sidonians, and for Chemosh the abomination of Moab, and for Milcom the abomination of the children of Ammon. 
+<sup>14&#160;</sup>He broke in pieces the pillars, cut down the Asherah poles, and filled their places with men’s bones. 
+</div><div class="p">
+<sup>15&#160;</sup>Moreover the altar that was at Bethel and the high place which Jeroboam the son of Nebat, who made Israel to sin, had made, even that altar and the high place he broke down; and he burned the high place and beat it to dust, and burned the Asherah. 
+<sup>16&#160;</sup>As Josiah turned himself, he spied the tombs that were there in the mountain; and he sent, and took the bones out of the tombs, and burned them on the altar, and defiled it, according to Yahweh’s word which the man of Elohim proclaimed, who proclaimed these things. 
+<sup>17&#160;</sup>Then he said, “What monument is that which I see?” 
+</div><div class="p">The men of the city told him, “It is the tomb of the man of Elohim who came from Judah and proclaimed these things that you have done against the altar of Bethel.” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, “Let him be! Let no one move his bones.” So they let his bones alone, with the bones of the prophet who came out of Samaria. 
+<sup>19&#160;</sup>All the houses also of the high places that were in the cities of Samaria, which the kings of Israel had made to provoke Yahweh to anger, Josiah took away, and did to them according to all the acts that he had done in Bethel. 
+<sup>20&#160;</sup>He killed all the priests of the high places that were there, on the altars, and burned men’s bones on them; and he returned to Jerusalem. 
+</div><div class="p">
+<sup>21&#160;</sup>The king commanded all the people, saying, “Keep the Passover to Yahweh your Elohim, as it is written in this book of the covenant.” 
+<sup>22&#160;</sup>Surely there was not kept such a Passover from the days of the judges who judged Israel, nor in all the days of the kings of Israel, nor of the kings of Judah; 
+<sup>23&#160;</sup>but in the eighteenth year of King Josiah, this Passover was kept to Yahweh in Jerusalem. 
+</div><div class="p">
+<sup>24&#160;</sup>Moreover, Josiah removed those who had familiar spirits, the wizards, and the teraphim, and the idols, and all the abominations that were seen in the land of Judah and in Jerusalem, that he might confirm the words of the law which were written in the book that Hilkiah the priest found in Yahweh’s house. 
+<sup>25&#160;</sup>There was no king like him before him, who turned to Yahweh with all his heart, and with all his soul, and with all his might, according to all the law of Moses; and there was none like him who arose after him. 
+<sup>26&#160;</sup>Notwithstanding, Yahweh didn’t turn from the fierceness of his great wrath, with which his anger burned against Judah, because of all the provocation with which Manasseh had provoked him. 
+<sup>27&#160;</sup>Yahweh said, “I will also remove Judah out of my sight, as I have removed Israel; and I will cast off this city which I have chosen, even Jerusalem, and the house of which I said, ‘My name shall be there.’&#160;” 
+</div><div class="p">
+<sup>28&#160;</sup>Now the rest of the acts of Josiah, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>29&#160;</sup>In his days Pharaoh Necoh king of Egypt went up against the king of Assyria to the river Euphrates; and King Josiah went against him, but Pharaoh Necoh killed him at Megiddo when he saw him. 
+<sup>30&#160;</sup>His servants carried him dead in a chariot from Megiddo, brought him to Jerusalem, and buried him in his own tomb. The people of the land took Jehoahaz the son of Josiah, and anointed him, and made him king in his father’s place. 
+</div><div class="p">
+<sup>31&#160;</sup>Jehoahaz was twenty-three years old when he began to reign; and he reigned three months in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
+<sup>32&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
+<sup>33&#160;</sup>Pharaoh Necoh put him in bonds at Riblah in the land of Hamath, that he might not reign in Jerusalem; and put the land to a tribute of one hundred talents of silver and a talent of gold. 
+<sup>34&#160;</sup>Pharaoh Necoh made Eliakim the son of Josiah king in the place of Josiah his father, and changed his name to Jehoiakim; but he took Jehoahaz away, and he came to Egypt and died there. 
+<sup>35&#160;</sup>Jehoiakim gave the silver and the gold to Pharaoh; but he taxed the land to give the money according to the commandment of Pharaoh. He exacted the silver and the gold of the people of the land, from everyone according to his assessment, to give it to Pharaoh Necoh. 
+<sup>36&#160;</sup>Jehoiakim was twenty-five years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Zebidah the daughter of Pedaiah of Rumah. 
+<sup>37&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that his fathers had done. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>In his days Nebuchadnezzar king of Babylon came up, and Jehoiakim became his servant three years. Then he turned and rebelled against him. 
+<sup>2&#160;</sup>Yahweh sent against him bands of the Chaldeans, bands of the Syrians, bands of the Moabites, and bands of the children of Ammon, and sent them against Judah to destroy it, according to Yahweh’s word which he spoke by his servants the prophets. 
+<sup>3&#160;</sup>Surely at the commandment of Yahweh this came on Judah, to remove them out of his sight for the sins of Manasseh, according to all that he did, 
+<sup>4&#160;</sup>and also for the innocent blood that he shed; for he filled Jerusalem with innocent blood, and Yahweh would not pardon. 
+<sup>5&#160;</sup>Now the rest of the acts of Jehoiakim, and all that he did, aren’t they written in the book of the chronicles of the kings of Judah? 
+<sup>6&#160;</sup>So Jehoiakim slept with his fathers, and Jehoiachin his son reigned in his place. 
+</div><div class="p">
+<sup>7&#160;</sup>The king of Egypt didn’t come out of his land any more; for the king of Babylon had taken, from the brook of Egypt to the river Euphrates, all that belonged to the king of Egypt. 
+</div><div class="p">
+<sup>8&#160;</sup>Jehoiachin was eighteen years old when he began to reign, and he reigned in Jerusalem three months. His mother’s name was Nehushta the daughter of Elnathan of Jerusalem. 
+<sup>9&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that his father had done. 
+<sup>10&#160;</sup>At that time the servants of Nebuchadnezzar king of Babylon came up to Jerusalem, and the city was besieged. 
+<sup>11&#160;</sup>Nebuchadnezzar king of Babylon came to the city while his servants were besieging it, 
+<sup>12&#160;</sup>and Jehoiachin the king of Judah went out to the king of Babylon—he, his mother, his servants, his princes, and his officers; and the king of Babylon captured him in the eighth year of his reign. 
+<sup>13&#160;</sup>He carried out from there all the treasures of Yahweh’s house and the treasures of the king’s house, and cut in pieces all the vessels of gold which Solomon king of Israel had made in Yahweh’s temple, as Yahweh had said. 
+<sup>14&#160;</sup>He carried away all Jerusalem, and all the princes, and all the mighty men of valor, even ten thousand captives, and all the craftsmen and the smiths. No one remained except the poorest people of the land. 
+<sup>15&#160;</sup>He carried away Jehoiachin to Babylon, with the king’s mother, the king’s women, his officers, and the chief men of the land. He carried them into captivity from Jerusalem to Babylon. 
+<sup>16&#160;</sup>All the men of might, even seven thousand, and the craftsmen and the smiths one thousand, all of them strong and fit for war, even them the king of Babylon brought captive to Babylon. 
+<sup>17&#160;</sup>The king of Babylon made Mattaniah, Jehoiachin’s father’s brother, king in his place, and changed his name to Zedekiah. 
+</div><div class="p">
+<sup>18&#160;</sup>Zedekiah was twenty-one years old when he began to reign, and he reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
+<sup>19&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
+<sup>20&#160;</sup>For through the anger of Yahweh, this happened in Jerusalem and Judah, until he had cast them out from his presence. 
+</div><div class="p">Then Zedekiah rebelled against the king of Babylon. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>In the ninth year of his reign, in the tenth month, in the tenth day of the month, Nebuchadnezzar king of Babylon came, he and all his army, against Jerusalem, and encamped against it; and they built forts against it around it. 
+<sup>2&#160;</sup>So the city was besieged until the eleventh year of King Zedekiah. 
+<sup>3&#160;</sup>On the ninth day of the fourth month, the famine was severe in the city, so that there was no bread for the people of the land. 
+<sup>4&#160;</sup>Then a breach was made in the city, and all the men of war fled by night by the way of the gate between the two walls, which was by the king’s garden (now the Chaldeans were against the city around it); and the king went by the way of the Arabah. 
+<sup>5&#160;</sup>But the Chaldean army pursued the king, and overtook him in the plains of Jericho; and all his army was scattered from him. 
+<sup>6&#160;</sup>Then they captured the king and carried him up to the king of Babylon to Riblah; and they passed judgment on him. 
+<sup>7&#160;</sup>They killed Zedekiah’s sons before his eyes, then put out Zedekiah’s eyes, bound him in fetters, and carried him to Babylon. 
+</div><div class="p">
+<sup>8&#160;</sup>Now in the fifth month, on the seventh day of the month, which was the nineteenth year of King Nebuchadnezzar king of Babylon, Nebuzaradan the captain of the guard, a servant of the king of Babylon, came to Jerusalem. 
+<sup>9&#160;</sup>He burned Yahweh’s house, the king’s house, and all the houses of Jerusalem. He burned every great house with fire. 
+<sup>10&#160;</sup>All the army of the Chaldeans, who were with the captain of the guard, broke down the walls around Jerusalem. 
+<sup>11&#160;</sup>Nebuzaradan the captain of the guard carried away captive the rest of the people who were left in the city and those who had deserted to the king of Babylon—all the rest of the multitude. 
+<sup>12&#160;</sup>But the captain of the guard left some of the poorest of the land to work the vineyards and fields. 
+</div><div class="p">
+<sup>13&#160;</sup>The Chaldeans broke up the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house, and carried the bronze pieces to Babylon. 
+<sup>14&#160;</sup>They took away the pots, the shovels, the snuffers, the spoons, and all the vessels of bronze with which they ministered. 
+<sup>15&#160;</sup>The captain of the guard took away the fire pans, the basins, that which was of gold, for gold, and that which was of silver, for silver. 
+<sup>16&#160;</sup>The two pillars, the one sea, and the bases, which Solomon had made for Yahweh’s house, the bronze of all these vessels was not weighed. 
+<sup>17&#160;</sup>The height of the one pillar was eighteen cubits, and a capital of bronze was on it. The height of the capital was three cubits, with network and pomegranates on the capital around it, all of bronze; and the second pillar with its network was like these. 
+</div><div class="p">
+<sup>18&#160;</sup>The captain of the guard took Seraiah the chief priest, Zephaniah the second priest, and the three keepers of the threshold; 
+<sup>19&#160;</sup>and out of the city he took an officer who was set over the men of war; and five men of those who saw the king’s face, who were found in the city; and the scribe, the captain of the army, who mustered the people of the land, and sixty men of the people of the land who were found in the city. 
+<sup>20&#160;</sup>Nebuzaradan the captain of the guard took them, and brought them to the king of Babylon to Riblah. 
+<sup>21&#160;</sup>The king of Babylon attacked them and put them to death at Riblah in the land of Hamath. So Judah was carried away captive out of his land. 
+</div><div class="p">
+<sup>22&#160;</sup>As for the people who were left in the land of Judah whom Nebuchadnezzar king of Babylon had left, even over them he made Gedaliah the son of Ahikam, the son of Shaphan, governor. 
+<sup>23&#160;</sup>Now when all the captains of the forces, they and their men, heard that the king of Babylon had made Gedaliah governor, they came to Gedaliah to Mizpah, even Ishmael the son of Nethaniah, Johanan the son of Kareah, Seraiah the son of Tanhumeth the Netophathite, and Jaazaniah the son of the Maacathite, they and their men. 
+<sup>24&#160;</sup>Gedaliah swore to them and to their men, and said to them, “Don’t be afraid because of the servants of the Chaldeans. Dwell in the land and serve the king of Babylon, and it will be well with you.” 
+</div><div class="p">
+<sup>25&#160;</sup>But in the seventh month, Ishmael the son of Nethaniah, the son of Elishama, of the royal offspring came, and ten men with him, and struck Gedaliah so that he died, with the Jews and the Chaldeans that were with him at Mizpah. 
+<sup>26&#160;</sup>All the people, both small and great, and the captains of the forces arose and came to Egypt; for they were afraid of the Chaldeans. 
+<sup>27&#160;</sup>In the thirty-seventh year of the captivity of Jehoiachin king of Judah, in the twelfth month, on the twenty-seventh day of the month, Evilmerodach king of Babylon, in the year that he began to reign, released Jehoiachin king of Judah out of prison, 
+<sup>28&#160;</sup>and he spoke kindly to him and set his throne above the throne of the kings who were with him in Babylon, 
+<sup>29&#160;</sup>and changed his prison garments. Jehoiachin ate bread before him continually all the days of his life; 
+<sup>30&#160;</sup>and for his allowance, there was a continual allowance given him from the king, every day a portion, all the days of his life. </div></div><script src="../main.js"></script></body></html>

--- a/book/2samuel.html
+++ b/book/2samuel.html
@@ -3,6 +3,47 @@
 <head>
 <title>2 Samuel</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1194 +53,1219 @@
 <div class="main">
 <!-- 2SA World English Scripture (WES) -->
 <h1 class="booklabel">2 Samuel</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>After the death of Saul, when David had returned from the slaughter of the Amalekites, and David had stayed two days in Ziklag, 
-<span class="v">2&#160;</span>on the third day, behold,<span class="f">+ \fr 1:2 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> a man came out of the camp from Saul, with his clothes torn and earth on his head. When he came to David, he fell to the earth and showed respect. 
-</p><p>
-<span class="v">3&#160;</span>David said to him, “Where do you come from?” 
-</p><p>He said to him, “I have escaped out of the camp of Israel.” 
-</p><p>
-<span class="v">4&#160;</span>David said to him, “How did it go? Please tell me.” 
-</p><p>He answered, “The people have fled from the battle, and many of the people also have fallen and are dead. Saul and Jonathan his son are dead also.” 
-</p><p>
-<span class="v">5&#160;</span>David said to the young man who told him, “How do you know that Saul and Jonathan his son are dead?” 
-</p><p>
-<span class="v">6&#160;</span>The young man who told him said, “As I happened by chance on Mount Gilboa, behold, Saul was leaning on his spear; and behold, the chariots and the horsemen followed close behind him. 
-<span class="v">7&#160;</span>When he looked behind him, he saw me and called to me. I answered, ‘Here I am.’ 
-<span class="v">8&#160;</span>He said to me, ‘Who are you?’ I answered him, ‘I am an Amalekite.’ 
-<span class="v">9&#160;</span>He said to me, ‘Please stand beside me, and kill me, for anguish has taken hold of me because my life lingers in me.’ 
-<span class="v">10&#160;</span>So I stood beside him and killed him, because I was sure that he could not live after he had fallen. I took the crown that was on his head and the bracelet that was on his arm, and have brought them here to my lord.” 
-</p><p>
-<span class="v">11&#160;</span>Then David took hold on his clothes and tore them; and all the men who were with him did likewise. 
-<span class="v">12&#160;</span>They mourned, wept, and fasted until evening for Saul and for Jonathan his son, and for the people of Yahweh,<span class="f">+ \fr 1:12 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> and for the house of Israel, because they had fallen by the sword. 
-</p><p>
-<span class="v">13&#160;</span>David said to the young man who told him, “Where are you from?” 
-</p><p>He answered, “I am the son of a foreigner, an Amalekite.” 
-</p><p>
-<span class="v">14&#160;</span>David said to him, “Why were you not afraid to stretch out your hand to destroy Yahweh’s anointed?” 
-<span class="v">15&#160;</span>David called one of the young men and said, “Go near, and cut him down!” He struck him so that he died. 
-<span class="v">16&#160;</span>David said to him, “Your blood be on your head, for your mouth has testified against you, saying, ‘I have slain Yahweh’s anointed.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>David lamented with this lamentation over Saul and over Jonathan his son 
-<span class="v">18&#160;</span>(and he commanded them to teach the children of Judah the song of the bow; behold, it is written in the book of Jashar): 
-</p><p class="q1">
-<span class="v">19&#160;</span>“Your glory, Israel, was slain on your high places! 
-</p><p class="q2">How the mighty have fallen! 
-</p><p class="q1">
-<span class="v">20&#160;</span>Don’t tell it in Gath. 
-</p><p class="q2">Don’t publish it in the streets of Ashkelon, 
-</p><p class="q1">lest the daughters of the Philistines rejoice, 
-</p><p class="q2">lest the daughters of the uncircumcised triumph. 
-</p><p class="q1">
-<span class="v">21&#160;</span>You mountains of Gilboa, 
-</p><p class="q2">let there be no dew or rain on you, and no fields of offerings; 
-</p><p class="q2">for there the shield of the mighty was defiled and cast away, 
-</p><p class="q2">the shield of Saul was not anointed with oil. 
-</p><p class="q1">
-<span class="v">22&#160;</span>From the blood of the slain, 
-</p><p class="q2">from the fat of the mighty, 
-</p><p class="q2">Jonathan’s bow didn’t turn back. 
-</p><p class="q2">Saul’s sword didn’t return empty. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Saul and Jonathan were lovely and pleasant in their lives. 
-</p><p class="q2">In their death, they were not divided. 
-</p><p class="q1">They were swifter than eagles. 
-</p><p class="q2">They were stronger than lions. 
-</p><p class="q1">
-<span class="v">24&#160;</span>You daughters of Israel, weep over Saul, 
-</p><p class="q2">who clothed you delicately in scarlet, 
-</p><p class="q2">who put ornaments of gold on your clothing. 
-</p><p class="q1">
-<span class="v">25&#160;</span>How the mighty have fallen in the middle of the battle! 
-</p><p class="q2">Jonathan was slain on your high places. 
-</p><p class="q1">
-<span class="v">26&#160;</span>I am distressed for you, my brother Jonathan. 
-</p><p class="q2">You have been very pleasant to me. 
-</p><p class="q2">Your love to me was wonderful, 
-</p><p class="q2">surpassing the love of women. 
-</p><p class="q1">
-<span class="v">27&#160;</span>How the mighty have fallen, 
-</p><p class="q2">and the weapons of war have perished!” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>After this, David inquired of Yahweh, saying, “Shall I go up into any of the cities of Judah?” 
-</p><p>Yahweh said to him, “Go up.” 
-</p><p>David said, “Where shall I go up?” 
-</p><p>He said, “To Hebron.” 
-</p><p>
-<span class="v">2&#160;</span>So David went up there with his two women, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
-<span class="v">3&#160;</span>David brought up his men who were with him, every man with his household. They lived in the cities of Hebron. 
-<span class="v">4&#160;</span>The men of Judah came, and there they anointed David king over the house of Judah. They told David, “The men of Jabesh Gilead were those who buried Saul.” 
-<span class="v">5&#160;</span>David sent messengers to the men of Jabesh Gilead, and said to them, “Blessed are you by Yahweh, that you have shown this kindness to your lord, even to Saul, and have buried him. 
-<span class="v">6&#160;</span>Now may Yahweh show loving kindness and truth to you. I also will reward you for this kindness, because you have done this thing. 
-<span class="v">7&#160;</span>Now therefore let your hands be strong, and be valiant; for Saul your lord is dead, and also the house of Judah have anointed me king over them.” 
-</p><p>
-<span class="v">8&#160;</span>Now Abner the son of Ner, captain of Saul’s army, had taken Ishbosheth the son of Saul and brought him over to Mahanaim. 
-<span class="v">9&#160;</span>He made him king over Gilead, over the Ashurites, over Jezreel, over Ephraim, over Benjamin, and over all Israel. 
-<span class="v">10&#160;</span>Ishbosheth, Saul’s son, was forty years old when he began to reign over Israel, and he reigned two years. But the house of Judah followed David. 
-<span class="v">11&#160;</span>The time that David was king in Hebron over the house of Judah was seven years and six months. 
-</p><p>
-<span class="v">12&#160;</span>Abner the son of Ner, and the servants of Ishbosheth the son of Saul, went out from Mahanaim to Gibeon. 
-<span class="v">13&#160;</span>Joab the son of Zeruiah and David’s servants went out, and met them by the pool of Gibeon; and they sat down, the one on the one side of the pool and the other on the other side of the pool. 
-<span class="v">14&#160;</span>Abner said to Joab, “Please let the young men arise and compete before us!” 
-</p><p>Joab said, “Let them arise!” 
-<span class="v">15&#160;</span>Then they arose and went over by number: twelve for Benjamin and for Ishbosheth the son of Saul, and twelve of David’s servants. 
-<span class="v">16&#160;</span>They each caught his opponent by the head and thrust his sword in his fellow’s side; so they fell down together. Therefore that place in Gibeon was called Helkath Hazzurim.<span class="f">+ \fr 2:16 \ft “Helkath Hazzurim” means “field of daggers”.</span> 
-<span class="v">17&#160;</span>The battle was very severe that day; and Abner was beaten, and the men of Israel, before David’s servants. 
-<span class="v">18&#160;</span>The three sons of Zeruiah were there: Joab, Abishai, and Asahel. Asahel was as light of foot as a wild gazelle. 
-<span class="v">19&#160;</span>Asahel pursued Abner. He didn’t turn to the right hand or to the left from following Abner. 
-</p><p>
-<span class="v">20&#160;</span>Then Abner looked behind him and said, “Is that you, Asahel?” 
-</p><p>He answered, “It is.” 
-</p><p>
-<span class="v">21&#160;</span>Abner said to him, “Turn away to your right hand or to your left, and grab one of the young men, and take his armor.” But Asahel would not turn away from following him. 
-<span class="v">22&#160;</span>Abner said again to Asahel, “Turn away from following me. Why should I strike you to the ground? How then could I look Joab your brother in the face?” 
-<span class="v">23&#160;</span>However, he refused to turn away. Therefore Abner with the back end of the spear struck him in the body, so that the spear came out behind him; and he fell down there and died in the same place. As many as came to the place where Asahel fell down and died stood still. 
-</p><p>
-<span class="v">24&#160;</span>But Joab and Abishai pursued Abner. The sun went down when they had come to the hill of Ammah, that lies before Giah by the way of the wilderness of Gibeon. 
-<span class="v">25&#160;</span>The children of Benjamin gathered themselves together after Abner and became one band, and stood on the top of a hill. 
-<span class="v">26&#160;</span>Then Abner called to Joab, and said, “Shall the sword devour forever? Don’t you know that it will be bitterness in the latter end? How long will it be then, before you ask the people to return from following their brothers?” 
-</p><p>
-<span class="v">27&#160;</span>Joab said, “As Elohim<span class="f">+ \fr 2:27 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> lives, if you had not spoken, surely then in the morning the people would have gone away, and not each followed his brother.” 
-<span class="v">28&#160;</span>So Joab blew the trumpet; and all the people stood still and pursued Israel no more, and they fought no more. 
-<span class="v">29&#160;</span>Abner and his men went all that night through the Arabah; and they passed over the Jordan, and went through all Bithron, and came to Mahanaim. 
-</p><p>
-<span class="v">30&#160;</span>Joab returned from following Abner; and when he had gathered all the people together, nineteen men of David’s and Asahel were missing. 
-<span class="v">31&#160;</span>But David’s servants had struck Benjamin Abner’s men so that three hundred sixty men died. 
-<span class="v">32&#160;</span>They took up Asahel and buried him in the tomb of his father, which was in Bethlehem. Joab and his men went all night, and the day broke on them at Hebron. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now there was long war between Saul’s house and David’s house. David grew stronger and stronger, but Saul’s house grew weaker and weaker. 
-<span class="v">2&#160;</span>Sons were born to David in Hebron. His firstborn was Amnon, of Ahinoam the Jezreelitess; 
-<span class="v">3&#160;</span>and his second, Chileab, of Abigail the woman of Nabal the Carmelite; and the third, Absalom the son of Maacah the daughter of Talmai king of Geshur; 
-<span class="v">4&#160;</span>and the fourth, Adonijah the son of Haggith; and the fifth, Shephatiah the son of Abital; 
-<span class="v">5&#160;</span>and the sixth, Ithream, of Eglah, David’s woman. These were born to David in Hebron. 
-</p><p>
-<span class="v">6&#160;</span>While there was war between Saul’s house and David’s house, Abner made himself strong in Saul’s house. 
-<span class="v">7&#160;</span>Now Saul had a concubine, whose name was Rizpah, the daughter of Aiah; and Ishbosheth said to Abner, “Why have you gone in to my father’s concubine?” 
-</p><p>
-<span class="v">8&#160;</span>Then Abner was very angry about Ishbosheth’s words, and said, “Am I a dog’s head that belongs to Judah? Today I show kindness to your father Saul’s house, to his brothers, and to his friends, and have not delivered you into the hand of David; and yet you charge me today with a fault concerning this woman! 
-<span class="v">9&#160;</span>Elohim do so to Abner, and more also, if, as Yahweh has sworn to David, I don’t do even so to him: 
-<span class="v">10&#160;</span>to transfer the kingdom from Saul’s house, and to set up David’s throne over Israel and over Judah, from Dan even to Beersheba.” 
-</p><p>
-<span class="v">11&#160;</span>He could not answer Abner another word, because he was afraid of him. 
-</p><p>
-<span class="v">12&#160;</span>Abner sent messengers to David on his behalf, saying, “Whose is the land?” and saying, “Make your alliance with me, and behold, my hand will be with you to bring all Israel around to you.” 
-</p><p>
-<span class="v">13&#160;</span>David said, “Good. I will make a treaty with you, but one thing I require of you. That is, you will not see my face unless you first bring Michal, Saul’s daughter, when you come to see my face.” 
-<span class="v">14&#160;</span>David sent messengers to Ishbosheth, Saul’s son, saying, “Deliver me my woman Michal, whom I was given to marry for one hundred foreskins of the Philistines.” 
-</p><p>
-<span class="v">15&#160;</span>Ishbosheth sent and took her from her man, Paltiel the son of Laish. 
-<span class="v">16&#160;</span>Her man went with her, weeping as he went, and followed her to Bahurim. Then Abner said to him, “Go! Return!” and he returned. 
-</p><p>
-<span class="v">17&#160;</span>Abner had communication with the elders of Israel, saying, “In times past, you sought for David to be king over you. 
-<span class="v">18&#160;</span>Now then do it! For Yahweh has spoken of David, saying, ‘By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>Abner also spoke in the ears of Benjamin; and Abner went also to speak in the ears of David in Hebron all that seemed good to Israel and to the whole house of Benjamin. 
-<span class="v">20&#160;</span>So Abner came to David to Hebron, and twenty men with him. David made Abner and the men who were with him a feast. 
-<span class="v">21&#160;</span>Abner said to David, “I will arise and go, and will gather all Israel to my lord the king, that they may make a covenant with you, and that you may reign over all that your soul desires.” David sent Abner away; and he went in peace. 
-</p><p>
-<span class="v">22&#160;</span>Behold, David’s servants and Joab came from a raid and brought in a great plunder with them; but Abner was not with David in Hebron, for he had sent him away, and he had gone in peace. 
-<span class="v">23&#160;</span>When Joab and all the army who was with him had come, they told Joab, “Abner the son of Ner came to the king, and he has sent him away, and he has gone in peace.” 
-</p><p>
-<span class="v">24&#160;</span>Then Joab came to the king and said, “What have you done? Behold, Abner came to you. Why is it that you have sent him away, and he is already gone? 
-<span class="v">25&#160;</span>You know Abner the son of Ner. He came to deceive you, and to know your going out and your coming in, and to know all that you do.” 
-</p><p>
-<span class="v">26&#160;</span>When Joab had come out from David, he sent messengers after Abner, and they brought him back from the well of Sirah; but David didn’t know it. 
-<span class="v">27&#160;</span>When Abner had returned to Hebron, Joab took him aside into the middle of the gate to speak with him quietly, and struck him there in the body, so that he died for the blood of Asahel his brother. 
-<span class="v">28&#160;</span>Afterward, when David heard it, he said, “I and my kingdom are guiltless before Yahweh forever of the blood of Abner the son of Ner. 
-<span class="v">29&#160;</span>Let it fall on the head of Joab and on all his father’s house. Let there not fail from the house of Joab one who has a discharge, or who is a leper, or who leans on a staff, or who falls by the sword, or who lacks bread.” 
-<span class="v">30&#160;</span>So Joab and Abishai his brother killed Abner, because he had killed their brother Asahel at Gibeon in the battle. 
-</p><p>
-<span class="v">31&#160;</span>David said to Joab and to all the people who were with him, “Tear your clothes, and clothe yourselves with sackcloth, and mourn in front of Abner.” King David followed the bier. 
-<span class="v">32&#160;</span>They buried Abner in Hebron; and the king lifted up his voice and wept at Abner’s grave; and all the people wept. 
-<span class="v">33&#160;</span>The king lamented for Abner, and said, “Should Abner die as a fool dies? 
-<span class="v">34&#160;</span>Your hands weren’t bound, and your feet weren’t put into fetters. As a man falls before the children of iniquity, so you fell.” 
-</p><p>All the people wept again over him. 
-<span class="v">35&#160;</span>All the people came to urge David to eat bread while it was yet day; but David swore, saying, “Elohim do so to me, and more also, if I taste bread or anything else, until the sun goes down.” 
-</p><p>
-<span class="v">36&#160;</span>All the people took notice of it, and it pleased them, as whatever the king did pleased all the people. 
-<span class="v">37&#160;</span>So all the people and all Israel understood that day that it was not of the king to kill Abner the son of Ner. 
-<span class="v">38&#160;</span>The king said to his servants, “Don’t you know that a prince and a great man has fallen today in Israel? 
-<span class="v">39&#160;</span>I am weak today, though anointed king. These men, the sons of Zeruiah are too hard for me. May Yahweh reward the evildoer according to his wickedness.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>When Saul’s son heard that Abner was dead in Hebron, his hands became feeble, and all the Israelites were troubled. 
-<span class="v">2&#160;</span>Saul’s son had two men who were captains of raiding bands. The name of one was Baanah and the name of the other Rechab, the sons of Rimmon the Beerothite, of the children of Benjamin (for Beeroth also is considered a part of Benjamin; 
-<span class="v">3&#160;</span>and the Beerothites fled to Gittaim, and have lived as foreigners there until today). 
-</p><p>
-<span class="v">4&#160;</span>Now Jonathan, Saul’s son, had a son who was lame in his feet. He was five years old when the news came about Saul and Jonathan out of Jezreel; and his nurse picked him up and fled. As she hurried to flee, he fell and became lame. His name was Mephibosheth. 
-</p><p>
-<span class="v">5&#160;</span>The sons of Rimmon the Beerothite, Rechab and Baanah, went out and came at about the heat of the day to the house of Ishbosheth as he took his rest at noon. 
-<span class="v">6&#160;</span>They came there into the middle of the house as though they would have fetched wheat, and they struck him in the body; and Rechab and Baanah his brother escaped. 
-<span class="v">7&#160;</span>Now when they came into the house as he lay on his bed in his bedroom, they struck him, killed him, beheaded him, and took his head, and went by the way of the Arabah all night. 
-<span class="v">8&#160;</span>They brought the head of Ishbosheth to David to Hebron, and said to the king, “Behold, the head of Ishbosheth, the son of Saul, your enemy, who sought your life! Yahweh has avenged my lord the king today of Saul and of his offspring.<span class="f">+ \fr 4:8 \ft or, seed</span>” 
-</p><p>
-<span class="v">9&#160;</span>David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said to them, “As Yahweh lives, who has redeemed my soul out of all adversity, 
-<span class="v">10&#160;</span>when someone told me, ‘Behold, Saul is dead,’ thinking that he brought good news, I seized him and killed him in Ziklag, which was the reward I gave him for his news. 
-<span class="v">11&#160;</span>How much more, when wicked men have slain a righteous person in his own house on his bed, should I not now require his blood from your hand, and rid the earth of you?” 
-<span class="v">12&#160;</span>David commanded his young men, and they killed them, cut off their hands and their feet, and hanged them up beside the pool in Hebron. But they took the head of Ishbosheth and buried it in Abner’s grave in Hebron. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Then all the tribes of Israel came to David at Hebron and spoke, saying, “Behold, we are your bone and your flesh. 
-<span class="v">2&#160;</span>In times past, when Saul was king over us, it was you who led Israel out and in. Yahweh said to you, ‘You will be shepherd of my people Israel, and you will be prince over Israel.’&#160;” 
-<span class="v">3&#160;</span>So all the elders of Israel came to the king to Hebron, and King David made a covenant with them in Hebron before Yahweh; and they anointed David king over Israel. 
-</p><p>
-<span class="v">4&#160;</span>David was thirty years old when he began to reign, and he reigned forty years. 
-<span class="v">5&#160;</span>In Hebron he reigned over Judah seven years and six months, and in Jerusalem he reigned thirty-three years over all Israel and Judah. 
-</p><p>
-<span class="v">6&#160;</span>The king and his men went to Jerusalem against the Jebusites, the inhabitants of the land, who spoke to David, saying, “The blind and the lame will keep you out of here,” thinking, “David can’t come in here.” 
-<span class="v">7&#160;</span>Nevertheless David took the stronghold of Zion. This is David’s city. 
-<span class="v">8&#160;</span>David said on that day, “Whoever strikes the Jebusites, let him go up to the watercourse and strike those lame and blind, who are hated by David’s soul.” Therefore they say, “The blind and the lame can’t come into the house.” 
-</p><p>
-<span class="v">9&#160;</span>David lived in the stronghold, and called it David’s city. David built around from Millo and inward. 
-<span class="v">10&#160;</span>David grew greater and greater, for Yahweh, the Elohim of Armies, was with him. 
-<span class="v">11&#160;</span>Hiram king of Tyre sent messengers to David, with cedar trees, carpenters, and masons; and they built David a house. 
-<span class="v">12&#160;</span>David perceived that Yahweh had established him king over Israel, and that he had exalted his kingdom for his people Israel’s sake. 
-</p><p>
-<span class="v">13&#160;</span>David took more concubines and women for himself out of Jerusalem, after he had come from Hebron; and more sons and daughters were born to David. 
-<span class="v">14&#160;</span>These are the names of those who were born to him in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
-<span class="v">15&#160;</span>Ibhar, Elishua, Nepheg, Japhia, 
-<span class="v">16&#160;</span>Elishama, Eliada, and Eliphelet. 
-</p><p>
-<span class="v">17&#160;</span>When the Philistines heard that they had anointed David king over Israel, all the Philistines went up to seek David, but David heard about it and went down to the stronghold. 
-<span class="v">18&#160;</span>Now the Philistines had come and spread themselves in the valley of Rephaim. 
-<span class="v">19&#160;</span>David inquired of Yahweh, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
-</p><p>Yahweh said to David, “Go up; for I will certainly deliver the Philistines into your hand.” 
-</p><p>
-<span class="v">20&#160;</span>David came to Baal Perazim, and David struck them there. Then he said, “Yahweh has broken my enemies before me, like the breach of waters.” Therefore he called the name of that place Baal Perazim.<span class="f">+ \fr 5:20 \ft “Baal Perazim” means “Lord who breaks out”.</span> 
-<span class="v">21&#160;</span>They left their images there, and David and his men took them away. 
-</p><p>
-<span class="v">22&#160;</span>The Philistines came up yet again and spread themselves in the valley of Rephaim. 
-<span class="v">23&#160;</span>When David inquired of Yahweh, he said, “You shall not go up. Circle around behind them, and attack them in front of the mulberry trees. 
-<span class="v">24&#160;</span>When you hear the sound of marching in the tops of the mulberry trees, then stir yourself up; for then Yahweh has gone out before you to strike the army of the Philistines.” 
-</p><p>
-<span class="v">25&#160;</span>David did so, as Yahweh commanded him, and struck the Philistines all the way from Geba to Gezer. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>David again gathered together all the chosen men of Israel, thirty thousand. 
-<span class="v">2&#160;</span>David arose and went with all the people who were with him from Baale Judah, to bring up from there Elohim’s ark, which is called by the Name, even the name of Yahweh of Armies who sits above the cherubim. 
-<span class="v">3&#160;</span>They set Elohim’s ark on a new cart, and brought it out of Abinadab’s house that was on the hill; and Uzzah and Ahio, the sons of Abinadab, drove the new cart. 
-<span class="v">4&#160;</span>They brought it out of Abinadab’s house which was in the hill, with Elohim’s ark; and Ahio went before the ark. 
-<span class="v">5&#160;</span>David and all the house of Israel played before Yahweh with all kinds of instruments made of cypress wood, with harps, with stringed instruments, with tambourines, with castanets, and with cymbals. 
-</p><p>
-<span class="v">6&#160;</span>When they came to the threshing floor of Nacon, Uzzah reached for Elohim’s ark and took hold of it, for the cattle stumbled. 
-<span class="v">7&#160;</span>Yahweh’s anger burned against Uzzah, and Elohim struck him there for his error; and he died there by Elohim’s ark. 
-<span class="v">8&#160;</span>David was displeased because Yahweh had broken out against Uzzah; and he called that place Perez Uzzah<span class="f">+ \fr 6:8 \ft “Perez Uzzah” means “outbreak against Uzzah”.</span> to this day. 
-<span class="v">9&#160;</span>David was afraid of Yahweh that day; and he said, “How could Yahweh’s ark come to me?” 
-<span class="v">10&#160;</span>So David would not move Yahweh’s ark to be with him in David’s city; but David carried it aside into Obed-Edom the Gittite’s house. 
-<span class="v">11&#160;</span>Yahweh’s ark remained in Obed-Edom the Gittite’s house three months; and Yahweh blessed Obed-Edom and all his house. 
-<span class="v">12&#160;</span>King David was told, “Yahweh has blessed the house of Obed-Edom, and all that belongs to him, because of Elohim’s ark.” 
-</p><p>So David went and brought up Elohim’s ark from the house of Obed-Edom into David’s city with joy. 
-<span class="v">13&#160;</span>When those who bore Yahweh’s ark had gone six paces, he sacrificed an ox and a fattened calf. 
-<span class="v">14&#160;</span>David danced before Yahweh with all his might; and David was clothed in a linen ephod. 
-<span class="v">15&#160;</span>So David and all the house of Israel brought up Yahweh’s ark with shouting and with the sound of the trumpet. 
-</p><p>
-<span class="v">16&#160;</span>As Yahweh’s ark came into David’s city, Michal the daughter of Saul looked out through the window and saw King David leaping and dancing before Yahweh; and she despised him in her heart. 
-<span class="v">17&#160;</span>They brought in Yahweh’s ark, and set it in its place in the middle of the tent that David had pitched for it; and David offered burnt offerings and peace offerings before Yahweh. 
-<span class="v">18&#160;</span>When David had finished offering the burnt offering and the peace offerings, he blessed the people in the name of Yahweh of Armies. 
-<span class="v">19&#160;</span>He gave to all the people, even among the whole multitude of Israel, both to men and women, to everyone a portion of bread, dates, and raisins. So all the people departed, each to his own house. 
-</p><p>
-<span class="v">20&#160;</span>Then David returned to bless his household. Michal the daughter of Saul came out to meet David, and said, “How glorious the king of Israel was today, who uncovered himself today in the eyes of his servants’ maids, as one of the vain fellows shamelessly uncovers himself!” 
-</p><p>
-<span class="v">21&#160;</span>David said to Michal, “It was before Yahweh, who chose me above your father, and above all his house, to appoint me prince over the people of Yahweh, over Israel. Therefore I will celebrate before Yahweh. 
-<span class="v">22&#160;</span>I will be yet more undignified than this, and will be worthless in my own sight. But the maids of whom you have spoken will honor me.” 
-</p><p>
-<span class="v">23&#160;</span>Michal the daughter of Saul had no child to the day of her death. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>When the king lived in his house, and Yahweh had given him rest from all his enemies all around, 
-<span class="v">2&#160;</span>the king said to Nathan the prophet, “See now, I dwell in a house of cedar, but Elohim’s ark dwells within curtains.” 
-</p><p>
-<span class="v">3&#160;</span>Nathan said to the king, “Go, do all that is in your heart, for Yahweh is with you.” 
-</p><p>
-<span class="v">4&#160;</span>That same night, Yahweh’s word came to Nathan, saying, 
-<span class="v">5&#160;</span>“Go and tell my servant David, ‘Yahweh says, “Should you build me a house for me to dwell in? 
-<span class="v">6&#160;</span>For I have not lived in a house since the day that I brought the children of Israel up out of Egypt, even to this day, but have moved around in a tent and in a tabernacle. 
-<span class="v">7&#160;</span>In all places in which I have walked with all the children of Israel, did I say a word to anyone from the tribes of Israel whom I commanded to be shepherd of my people Israel, saying, ‘Why have you not built me a house of cedar?’&#160;”&#160;’ 
-<span class="v">8&#160;</span>Now therefore tell my servant David this: ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people, over Israel. 
-<span class="v">9&#160;</span>I have been with you wherever you went, and have cut off all your enemies from before you. I will make you a great name, like the name of the great ones who are in the earth. 
-<span class="v">10&#160;</span>I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place and be moved no more. The children of wickedness will not afflict them any more, as at the first, 
-<span class="v">11&#160;</span>and as from the day that I commanded judges to be over my people Israel. I will cause you to rest from all your enemies. Moreover Yahweh tells you that Yahweh will make you a house. 
-<span class="v">12&#160;</span>When your days are fulfilled and you sleep with your fathers, I will set up your offspring after you, who will proceed out of your body, and I will establish his kingdom. 
-<span class="v">13&#160;</span>He will build a house for my name, and I will establish the throne of his kingdom forever. 
-<span class="v">14&#160;</span>I will be his father, and he will be my son. If he commits iniquity, I will chasten him with the rod of men and with the stripes of the children of men; 
-<span class="v">15&#160;</span>but my loving kindness will not depart from him, as I took it from Saul, whom I put away before you. 
-<span class="v">16&#160;</span>Your house and your kingdom will be made sure forever before you. Your throne will be established forever.”&#160;’&#160;” 
-<span class="v">17&#160;</span>Nathan spoke to David all these words, and according to all this vision. 
-</p><p>
-<span class="v">18&#160;</span>Then David the king went in and sat before Yahweh; and he said, “Who am I, Lord<span class="f">+ \fr 7:18 \ft The word translated “Lord” is “Adonai.”</span> Yahweh, and what is my house, that you have brought me this far? 
-<span class="v">19&#160;</span>This was yet a small thing in your eyes, Lord Yahweh, but you have spoken also of your servant’s house for a great while to come; and this among men, Lord Yahweh! 
-<span class="v">20&#160;</span>What more can David say to you? For you know your servant, Lord Yahweh. 
-<span class="v">21&#160;</span>For your word’s sake, and according to your own heart, you have worked all this greatness, to make your servant know it. 
-<span class="v">22&#160;</span>Therefore you are great, Yahweh Elohim. For there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
-<span class="v">23&#160;</span>What one nation in the earth is like your people, even like Israel, whom Elohim went to redeem to himself for a people, and to make himself a name, and to do great things for you, and awesome things for your land, before your people, whom you redeemed to yourself out of Egypt, from the nations and their elohims? 
-<span class="v">24&#160;</span>You established for yourself your people Israel to be your people forever; and you, Yahweh, became their Elohim. 
-</p><p>
-<span class="v">25&#160;</span>“Now, Yahweh Elohim, the word that you have spoken concerning your servant, and concerning his house, confirm it forever, and do as you have spoken. 
-<span class="v">26&#160;</span>Let your name be magnified forever, saying, ‘Yahweh of Armies is Elohim over Israel; and the house of your servant David will be established before you.’ 
-<span class="v">27&#160;</span>For you, Yahweh of Armies, the Elohim of Israel, have revealed to your servant, saying, ‘I will build you a house.’ Therefore your servant has found in his heart to pray this prayer to you. 
-</p><p>
-<span class="v">28&#160;</span>“Now, O Lord Yahweh, you are Elohim, and your words are truth, and you have promised this good thing to your servant. 
-<span class="v">29&#160;</span>Now therefore, let it please you to bless the house of your servant, that it may continue forever before you; for you, Lord Yahweh, have spoken it. Let the house of your servant be blessed forever with your blessing.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>After this, David struck the Philistines and subdued them; and David took the bridle of the mother city out of the hand of the Philistines. 
-<span class="v">2&#160;</span>He defeated Moab, and measured them with the line, making them to lie down on the ground; and he measured two lines to put to death, and one full line to keep alive. The Moabites became servants to David, and brought tribute. 
-</p><p>
-<span class="v">3&#160;</span>David also struck Hadadezer the son of Rehob, king of Zobah, as he went to recover his dominion at the River. 
-<span class="v">4&#160;</span>David took from him one thousand seven hundred horsemen and twenty thousand footmen. David hamstrung the chariot horses, but reserved enough of them for one hundred chariots. 
-<span class="v">5&#160;</span>When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty two thousand men of the Syrians. 
-<span class="v">6&#160;</span>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David, and brought tribute. Yahweh gave victory to David wherever he went. 
-<span class="v">7&#160;</span>David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
-<span class="v">8&#160;</span>From Betah and from Berothai, cities of Hadadezer, King David took a great quantity of bronze. 
-</p><p>
-<span class="v">9&#160;</span>When Toi king of Hamath heard that David had struck all the army of Hadadezer, 
-<span class="v">10&#160;</span>then Toi sent Joram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him; for Hadadezer had wars with Toi. Joram brought with him vessels of silver, vessels of gold, and vessels of bronze. 
-<span class="v">11&#160;</span>King David also dedicated these to Yahweh, with the silver and gold that he dedicated of all the nations which he subdued—<span class="v">12&#160;</span>of Syria, of Moab, of the children of Ammon, of the Philistines, of Amalek, and of the plunder of Hadadezer, son of Rehob, king of Zobah. 
-</p><p>
-<span class="v">13&#160;</span>David earned a reputation when he returned from striking down eighteen thousand men of the Syrians in the Valley of Salt. 
-<span class="v">14&#160;</span>He put garrisons in Edom. Throughout all Edom, he put garrisons, and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
-</p><p>
-<span class="v">15&#160;</span>David reigned over all Israel; and David executed justice and righteousness for all his people. 
-<span class="v">16&#160;</span>Joab the son of Zeruiah was over the army, Jehoshaphat the son of Ahilud was recorder, 
-<span class="v">17&#160;</span>Zadok the son of Ahitub and Ahimelech the son of Abiathar were priests, Seraiah was scribe, 
-<span class="v">18&#160;</span>Benaiah the son of Jehoiada was over the Cherethites and the Pelethites; and David’s sons were chief ministers. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>David said, “Is there yet any who is left of Saul’s house, that I may show him kindness for Jonathan’s sake?” 
-<span class="v">2&#160;</span>There was of Saul’s house a servant whose name was Ziba, and they called him to David; and the king said to him, “Are you Ziba?” 
-</p><p>He said, “I am your servant.” 
-</p><p>
-<span class="v">3&#160;</span>The king said, “Is there not yet any of Saul’s house, that I may show the kindness of Elohim to him?” 
-</p><p>Ziba said to the king, “Jonathan still has a son, who is lame in his feet.” 
-</p><p>
-<span class="v">4&#160;</span>The king said to him, “Where is he?” 
-</p><p>Ziba said to the king, “Behold, he is in the house of Machir the son of Ammiel, in Lo Debar.” 
-</p><p>
-<span class="v">5&#160;</span>Then King David sent and brought him out of the house of Machir the son of Ammiel, from Lo Debar. 
-<span class="v">6&#160;</span>Mephibosheth, the son of Jonathan, the son of Saul, came to David, fell on his face, and showed respect. David said, “Mephibosheth?” 
-</p><p>He answered, “Behold, your servant!” 
-</p><p>
-<span class="v">7&#160;</span>David said to him, “Don’t be afraid, for I will surely show you kindness for Jonathan your father’s sake, and will restore to you all the land of Saul your father. You will eat bread at my table continually.” 
-</p><p>
-<span class="v">8&#160;</span>He bowed down, and said, “What is your servant, that you should look at such a dead dog as I am?” 
-</p><p>
-<span class="v">9&#160;</span>Then the king called to Ziba, Saul’s servant, and said to him, “All that belonged to Saul and to all his house I have given to your master’s son. 
-<span class="v">10&#160;</span>Till the land for him—you, your sons, and your servants. Bring in the harvest, that your master’s son may have bread to eat; but Mephibosheth your master’s son will always eat bread at my table.” 
-</p><p>Now Ziba had fifteen sons and twenty servants. 
-<span class="v">11&#160;</span>Then Ziba said to the king, “According to all that my lord the king commands his servant, so your servant will do.” So Mephibosheth ate at the king’s table like one of the king’s sons. 
-<span class="v">12&#160;</span>Mephibosheth had a young son, whose name was Mica. All who lived in Ziba’s house were servants to Mephibosheth. 
-<span class="v">13&#160;</span>So Mephibosheth lived in Jerusalem, for he ate continually at the king’s table. He was lame in both his feet. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>After this, the king of the children of Ammon died, and Hanun his son reigned in his place. 
-<span class="v">2&#160;</span>David said, “I will show kindness to Hanun the son of Nahash, as his father showed kindness to me.” So David sent by his servants to comfort him concerning his father. David’s servants came into the land of the children of Ammon. 
-</p><p>
-<span class="v">3&#160;</span>But the princes of the children of Ammon said to Hanun their lord, “Do you think that David honors your father, in that he has sent comforters to you? Hasn’t David sent his servants to you to search the city, to spy it out, and to overthrow it?” 
-</p><p>
-<span class="v">4&#160;</span>So Hanun took David’s servants, shaved off one half of their beards, and cut off their garments in the middle, even to their buttocks, and sent them away. 
-<span class="v">5&#160;</span>When they told David this, he sent to meet them, for the men were greatly ashamed. The king said, “Wait at Jericho until your beards have grown, and then return.” 
-</p><p>
-<span class="v">6&#160;</span>When the children of Ammon saw that they had become odious to David, the children of Ammon sent and hired the Syrians of Beth Rehob and the Syrians of Zobah, twenty thousand footmen, and the king of Maacah with one thousand men, and the men of Tob twelve thousand men. 
-<span class="v">7&#160;</span>When David heard of it, he sent Joab and all the army of the mighty men. 
-<span class="v">8&#160;</span>The children of Ammon came out, and put the battle in array at the entrance of the gate. The Syrians of Zobah and of Rehob and the men of Tob and Maacah were by themselves in the field. 
-<span class="v">9&#160;</span>Now when Joab saw that the battle was set against him before and behind, he chose of all the choice men of Israel and put them in array against the Syrians. 
-<span class="v">10&#160;</span>The rest of the people he committed into the hand of Abishai his brother; and he put them in array against the children of Ammon. 
-<span class="v">11&#160;</span>He said, “If the Syrians are too strong for me, then you shall help me; but if the children of Ammon are too strong for you, then I will come and help you. 
-<span class="v">12&#160;</span>Be courageous, and let’s be strong for our people and for the cities of our Elohim; and may Yahweh do what seems good to him.” 
-<span class="v">13&#160;</span>So Joab and the people who were with him came near to the battle against the Syrians, and they fled before him. 
-<span class="v">14&#160;</span>When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai, and entered into the city. Then Joab returned from the children of Ammon and came to Jerusalem. 
-</p><p>
-<span class="v">15&#160;</span>When the Syrians saw that they were defeated by Israel, they gathered themselves together. 
-<span class="v">16&#160;</span>Hadadezer sent and brought out the Syrians who were beyond the River; and they came to Helam, with Shobach the captain of the army of Hadadezer at their head. 
-<span class="v">17&#160;</span>David was told that; and he gathered all Israel together, passed over the Jordan, and came to Helam. The Syrians set themselves in array against David and fought with him. 
-<span class="v">18&#160;</span>The Syrians fled before Israel; and David killed seven hundred charioteers of the Syrians and forty thousand horsemen, and struck Shobach the captain of their army, so that he died there. 
-<span class="v">19&#160;</span>When all the kings who were servants to Hadadezer saw that they were defeated before Israel, they made peace with Israel and served them. So the Syrians were afraid to help the children of Ammon any more. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>At the return of the year, at the time when kings go out, David sent Joab and his servants with him, and all Israel; and they destroyed the children of Ammon and besieged Rabbah. But David stayed at Jerusalem. 
-<span class="v">2&#160;</span>At evening, David arose from his bed and walked on the roof of the king’s house. From the roof, he saw a woman bathing, and the woman was very beautiful to look at. 
-<span class="v">3&#160;</span>David sent and inquired after the woman. One said, “Isn’t this Bathsheba, the daughter of Eliam, Uriah the Hittite’s woman?” 
-</p><p>
-<span class="v">4&#160;</span>David sent messengers, and took her; and she came in to him, and he lay with her (for she was purified from her uncleanness); and she returned to her house. 
-<span class="v">5&#160;</span>The woman conceived; and she sent and told David, and said, “I am with child.” 
-</p><p>
-<span class="v">6&#160;</span>David sent to Joab, “Send me Uriah the Hittite.” Joab sent Uriah to David. 
-<span class="v">7&#160;</span>When Uriah had come to him, David asked him how Joab did, and how the people fared, and how the war prospered. 
-<span class="v">8&#160;</span>David said to Uriah, “Go down to your house and wash your feet.” Uriah departed out of the king’s house, and a gift from the king was sent after him. 
-<span class="v">9&#160;</span>But Uriah slept at the door of the king’s house with all the servants of his lord, and didn’t go down to his house. 
-<span class="v">10&#160;</span>When they had told David, saying, “Uriah didn’t go down to his house,” David said to Uriah, “Haven’t you come from a journey? Why didn’t you go down to your house?” 
-</p><p>
-<span class="v">11&#160;</span>Uriah said to David, “The ark, Israel, and Judah, are staying in tents; and my lord Joab and the servants of my lord are encamped in the open field. Shall I then go into my house to eat and to drink, and to lie with my woman? As you live, and as your soul lives, I will not do this thing!” 
-</p><p>
-<span class="v">12&#160;</span>David said to Uriah, “Stay here today also, and tomorrow I will let you depart.” So Uriah stayed in Jerusalem that day and the next day. 
-<span class="v">13&#160;</span>When David had called him, he ate and drank before him; and he made him drunk. At evening, he went out to lie on his bed with the servants of his lord, but didn’t go down to his house. 
-<span class="v">14&#160;</span>In the morning, David wrote a letter to Joab and sent it by the hand of Uriah. 
-<span class="v">15&#160;</span>He wrote in the letter, saying, “Send Uriah to the forefront of the hottest battle, and retreat from him, that he may be struck and die.” 
-</p><p>
-<span class="v">16&#160;</span>When Joab kept watch on the city, he assigned Uriah to the place where he knew that valiant men were. 
-<span class="v">17&#160;</span>The men of the city went out and fought with Joab. Some of the people fell, even of David’s servants; and Uriah the Hittite died also. 
-<span class="v">18&#160;</span>Then Joab sent and told David all the things concerning the war; 
-<span class="v">19&#160;</span>and he commanded the messenger, saying, “When you have finished telling all the things concerning the war to the king, 
-<span class="v">20&#160;</span>it shall be that, if the king’s wrath arise, and he asks you, ‘Why did you go so near to the city to fight? Didn’t you know that they would shoot from the wall? 
-<span class="v">21&#160;</span>Who struck Abimelech the son of Jerubbesheth? Didn’t a woman cast an upper millstone on him from the wall, so that he died at Thebez? Why did you go so near the wall?’ then you shall say, ‘Your servant Uriah the Hittite is also dead.’&#160;” 
-</p><p>
-<span class="v">22&#160;</span>So the messenger went, and came and showed David all that Joab had sent him for. 
-<span class="v">23&#160;</span>The messenger said to David, “The men prevailed against us, and came out to us into the field; and we were on them even to the entrance of the gate. 
-<span class="v">24&#160;</span>The shooters shot at your servants from off the wall; and some of the king’s servants are dead, and your servant Uriah the Hittite is also dead.” 
-</p><p>
-<span class="v">25&#160;</span>Then David said to the messenger, “Tell Joab, ‘Don’t let this thing displease you, for the sword devours one as well as another. Make your battle stronger against the city, and overthrow it.’ Encourage him.” 
-</p><p>
-<span class="v">26&#160;</span>When Uriah’s woman heard that Uriah her man was dead, she mourned for her owner. 
-<span class="v">27&#160;</span>When the mourning was past, David sent and took her home to his house, and she became his woman and bore him a son. But the thing that David had done displeased Yahweh. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh sent Nathan to David. He came to him, and said to him, “There were two men in one city: the one rich, and the other poor. 
-<span class="v">2&#160;</span>The rich man had very many flocks and herds, 
-<span class="v">3&#160;</span>but the poor man had nothing, except one little ewe lamb, which he had bought and raised. It grew up together with him and with his children. It ate of his own food, drank of his own cup, and lay in his bosom, and was like a daughter to him. 
-<span class="v">4&#160;</span>A traveler came to the rich man, and he didn’t want to take of his own flock and of his own herd to prepare for the wayfaring man who had come to him, but took the poor man’s lamb and prepared it for the man who had come to him.” 
-</p><p>
-<span class="v">5&#160;</span>David’s anger burned hot against the man, and he said to Nathan, “As Yahweh lives, the man who has done this deserves to die! 
-<span class="v">6&#160;</span>He must restore the lamb fourfold, because he did this thing and because he had no pity!” 
-</p><p>
-<span class="v">7&#160;</span>Nathan said to David, “You are the man! This is what Yahweh, the Elohim of Israel, says: ‘I anointed you king over Israel, and I delivered you out of the hand of Saul. 
-<span class="v">8&#160;</span>I gave you your master’s house and your master’s women into your bosom, and gave you the house of Israel and of Judah; and if that would have been too little, I would have added to you many more such things. 
-<span class="v">9&#160;</span>Why have you despised Yahweh’s word, to do that which is evil in his sight? You have struck Uriah the Hittite with the sword, have taken his woman to be your woman, and have slain him with the sword of the children of Ammon. 
-<span class="v">10&#160;</span>Now therefore the sword will never depart from your house, because you have despised me and have taken Uriah the Hittite’s woman to be your woman.’ 
-</p><p>
-<span class="v">11&#160;</span>“This is what Yahweh says: ‘Behold, I will raise up evil against you out of your own house; and I will take your women before your eyes and give them to your neighbor, and he will lie with your women in the sight of this sun. 
-<span class="v">12&#160;</span>For you did this secretly, but I will do this thing before all Israel, and before the sun.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>David said to Nathan, “I have sinned against Yahweh.” 
-</p><p>Nathan said to David, “Yahweh also has put away your sin. You will not die. 
-<span class="v">14&#160;</span>However, because by this deed you have given great occasion to Yahweh’s enemies to blaspheme, the child also who is born to you will surely die.” 
-<span class="v">15&#160;</span>Then Nathan departed to his house. 
-</p><p>Yahweh struck the child that Uriah’s woman bore to David, and he was very sick. 
-<span class="v">16&#160;</span>David therefore begged Elohim for the child; and David fasted, and went in and lay all night on the ground. 
-<span class="v">17&#160;</span>The elders of his house arose beside him, to raise him up from the earth; but he would not, and he didn’t eat bread with them. 
-<span class="v">18&#160;</span>On the seventh day, the child died. David’s servants were afraid to tell him that the child was dead, for they said, “Behold, while the child was yet alive, we spoke to him and he didn’t listen to our voice. How will he then harm himself if we tell him that the child is dead?” 
-</p><p>
-<span class="v">19&#160;</span>But when David saw that his servants were whispering together, David perceived that the child was dead; and David said to his servants, “Is the child dead?” 
-</p><p>They said, “He is dead.” 
-</p><p>
-<span class="v">20&#160;</span>Then David arose from the earth, and washed and anointed himself, and changed his clothing; and he came into Yahweh’s house, and worshiped. Then he came to his own house; and when he requested, they set bread before him and he ate. 
-<span class="v">21&#160;</span>Then his servants said to him, “What is this that you have done? You fasted and wept for the child while he was alive, but when the child was dead, you rose up and ate bread.” 
-</p><p>
-<span class="v">22&#160;</span>He said, “While the child was yet alive, I fasted and wept; for I said, ‘Who knows whether Yahweh will not be gracious to me, that the child may live?’ 
-<span class="v">23&#160;</span>But now he is dead. Why should I fast? Can I bring him back again? I will go to him, but he will not return to me.” 
-</p><p>
-<span class="v">24&#160;</span>David comforted Bathsheba his woman, and went in to her, and lay with her. She bore a son, and he called his name Solomon. Yahweh loved him; 
-<span class="v">25&#160;</span>and he sent by the hand of Nathan the prophet, and he named him Jedidiah,<span class="f">+ \fr 12:25 \ft “Jedidiah” means “loved by Yahweh”.</span> for Yahweh’s sake. 
-</p><p>
-<span class="v">26&#160;</span>Now Joab fought against Rabbah of the children of Ammon, and took the royal city. 
-<span class="v">27&#160;</span>Joab sent messengers to David, and said, “I have fought against Rabbah. Yes, I have taken the city of waters. 
-<span class="v">28&#160;</span>Now therefore gather the rest of the people together, and encamp against the city and take it; lest I take the city, and it be called by my name.” 
-</p><p>
-<span class="v">29&#160;</span>David gathered all the people together and went to Rabbah, and fought against it and took it. 
-<span class="v">30&#160;</span>He took the crown of their king from off his head; and its weight was a talent<span class="f">+ \fr 12:30 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of gold, and in it were precious stones; and it was set on David’s head. He brought a great quantity of plunder out of the city. 
-<span class="v">31&#160;</span>He brought out the people who were in it, and put them to work under saws, under iron picks, under axes of iron, and made them go to the brick kiln; and he did so to all the cities of the children of Ammon. Then David and all the people returned to Jerusalem. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>After this, Absalom the son of David had a beautiful sister, whose name was Tamar; and Amnon the son of David loved her. 
-<span class="v">2&#160;</span>Amnon was so troubled that he became sick because of his sister Tamar, for she was a virgin, and it seemed hard to Amnon to do anything to her. 
-<span class="v">3&#160;</span>But Amnon had a friend whose name was Jonadab the son of Shimeah, David’s brother; and Jonadab was a very subtle man. 
-<span class="v">4&#160;</span>He said to him, “Why, son of the king, are you so sad from day to day? Won’t you tell me?” 
-</p><p>Amnon said to him, “I love Tamar, my brother Absalom’s sister.” 
-</p><p>
-<span class="v">5&#160;</span>Jonadab said to him, “Lay down on your bed and pretend to be sick. When your father comes to see you, tell him, ‘Please let my sister Tamar come and give me bread to eat, and prepare the food in my sight, that I may see it and eat it from her hand.’&#160;” 
-</p><p>
-<span class="v">6&#160;</span>So Amnon lay down and faked being sick. When the king came to see him, Amnon said to the king, “Please let my sister Tamar come and make me a couple of cakes in my sight, that I may eat from her hand.” 
-</p><p>
-<span class="v">7&#160;</span>Then David sent home to Tamar, saying, “Go now to your brother Amnon’s house, and prepare food for him.” 
-<span class="v">8&#160;</span>So Tamar went to her brother Amnon’s house; and he was lying down. She took dough, kneaded it, made cakes in his sight, and baked the cakes. 
-<span class="v">9&#160;</span>She took the pan and poured them out before him, but he refused to eat. Amnon said, “Have all men leave me.” Then every man went out from him. 
-<span class="v">10&#160;</span>Amnon said to Tamar, “Bring the food into the room, that I may eat from your hand.” Tamar took the cakes which she had made, and brought them into the room to Amnon her brother. 
-<span class="v">11&#160;</span>When she had brought them near to him to eat, he took hold of her and said to her, “Come, lie with me, my sister!” 
-</p><p>
-<span class="v">12&#160;</span>She answered him, “No, my brother, do not force me! For no such thing ought to be done in Israel. Don’t you do this folly! 
-<span class="v">13&#160;</span>As for me, where would I carry my shame? And as for you, you will be as one of the fools in Israel. Now therefore, please speak to the king; for he will not withhold me from you.” 
-</p><p>
-<span class="v">14&#160;</span>However, he would not listen to her voice; but being stronger than she, he forced her and lay with her. 
-<span class="v">15&#160;</span>Then Amnon hated her with exceedingly great hatred; for the hatred with which he hated her was greater than the love with which he had loved her. Amnon said to her, “Arise, be gone!” 
-</p><p>
-<span class="v">16&#160;</span>She said to him, “Not so, because this great wrong in sending me away is worse than the other that you did to me!” 
-</p><p>But he would not listen to her. 
-<span class="v">17&#160;</span>Then he called his servant who ministered to him, and said, “Now put this woman out from me, and bolt the door after her.” 
-</p><p>
-<span class="v">18&#160;</span>She had a garment of various colors on her, for the king’s daughters who were virgins dressed in such robes. Then his servant brought her out and bolted the door after her. 
-<span class="v">19&#160;</span>Tamar put ashes on her head, and tore her garment of various colors that was on her; and she laid her hand on her head and went her way, crying aloud as she went. 
-<span class="v">20&#160;</span>Absalom her brother said to her, “Has Amnon your brother been with you? But now hold your peace, my sister. He is your brother. Don’t take this thing to heart.” 
-</p><p>So Tamar remained desolate in her brother Absalom’s house. 
-<span class="v">21&#160;</span>But when King David heard of all these things, he was very angry. 
-<span class="v">22&#160;</span>Absalom spoke to Amnon neither good nor bad; for Absalom hated Amnon, because he had forced his sister Tamar. 
-</p><p>
-<span class="v">23&#160;</span>After two full years, Absalom had sheep shearers in Baal Hazor, which is beside Ephraim; and Absalom invited all the king’s sons. 
-<span class="v">24&#160;</span>Absalom came to the king and said, “See now, your servant has sheep shearers. Please let the king and his servants go with your servant.” 
-</p><p>
-<span class="v">25&#160;</span>The king said to Absalom, “No, my son, let’s not all go, lest we be burdensome to you.” He pressed him; however he would not go, but blessed him. 
-</p><p>
-<span class="v">26&#160;</span>Then Absalom said, “If not, please let my brother Amnon go with us.” 
-</p><p>The king said to him, “Why should he go with you?” 
-</p><p>
-<span class="v">27&#160;</span>But Absalom pressed him, and he let Amnon and all the king’s sons go with him. 
-<span class="v">28&#160;</span>Absalom commanded his servants, saying, “Mark now, when Amnon’s heart is merry with wine; and when I tell you, ‘Strike Amnon,’ then kill him. Don’t be afraid. Haven’t I commanded you? Be courageous, and be valiant!” 
-</p><p>
-<span class="v">29&#160;</span>The servants of Absalom did to Amnon as Absalom had commanded. Then all the king’s sons arose, and every man got up on his mule and fled. 
-</p><p>
-<span class="v">30&#160;</span>While they were on the way, the news came to David, saying, “Absalom has slain all the king’s sons, and there is not one of them left!” 
-</p><p>
-<span class="v">31&#160;</span>Then the king arose, and tore his garments, and lay on the earth; and all his servants stood by with their clothes torn. 
-<span class="v">32&#160;</span>Jonadab the son of Shimeah, David’s brother, answered, “Don’t let my lord suppose that they have killed all the young men, the king’s sons, for Amnon only is dead; for by the appointment of Absalom this has been determined from the day that he forced his sister Tamar. 
-<span class="v">33&#160;</span>Now therefore don’t let my lord the king take the thing to his heart, to think that all the king’s sons are dead; for only Amnon is dead.” 
-<span class="v">34&#160;</span>But Absalom fled. The young man who kept the watch lifted up his eyes and looked, and behold, many people were coming by way of the hillside behind him. 
-<span class="v">35&#160;</span>Jonadab said to the king, “Behold, the king’s sons are coming! It is as your servant said.” 
-<span class="v">36&#160;</span>As soon as he had finished speaking, behold, the king’s sons came, and lifted up their voices and wept. The king also and all his servants wept bitterly. 
-</p><p>
-<span class="v">37&#160;</span>But Absalom fled and went to Talmai the son of Ammihur, king of Geshur. David mourned for his son every day. 
-<span class="v">38&#160;</span>So Absalom fled and went to Geshur, and was there three years. 
-<span class="v">39&#160;</span>King David longed to go out to Absalom, for he was comforted concerning Amnon, since he was dead. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Now Joab the son of Zeruiah perceived that the king’s heart was toward Absalom. 
-<span class="v">2&#160;</span>Joab sent to Tekoa and brought a wise woman from there, and said to her, “Please act like a mourner, and put on mourning clothing, please, and don’t anoint yourself with oil; but be as a woman who has mourned a long time for the dead. 
-<span class="v">3&#160;</span>Go in to the king and speak like this to him.” So Joab put the words in her mouth. 
-</p><p>
-<span class="v">4&#160;</span>When the woman of Tekoa spoke to the king, she fell on her face to the ground, showed respect, and said, “Help, O king!” 
-</p><p>
-<span class="v">5&#160;</span>The king said to her, “What ails you?” 
-</p><p>She answered, “Truly I am a widow, and my man is dead. 
-<span class="v">6&#160;</span>Your servant had two sons; and they both fought together in the field, and there was no one to part them, but the one struck the other and killed him. 
-<span class="v">7&#160;</span>Behold, the whole family has risen against your servant, and they say, ‘Deliver him who struck his brother, that we may kill him for the life of his brother whom he killed, and so destroy the heir also.’ Thus they would quench my coal which is left, and would leave to my man neither name nor remainder on the surface of the earth.” 
-</p><p>
-<span class="v">8&#160;</span>The king said to the woman, “Go to your house, and I will give a command concerning you.” 
-</p><p>
-<span class="v">9&#160;</span>The woman of Tekoa said to the king, “My lord, O king, may the iniquity be on me, and on my father’s house; and may the king and his throne be guiltless.” 
-</p><p>
-<span class="v">10&#160;</span>The king said, “Whoever says anything to you, bring him to me, and he will not bother you any more.” 
-</p><p>
-<span class="v">11&#160;</span>Then she said, “Please let the king remember Yahweh your Elohim, that the avenger of blood destroy not any more, lest they destroy my son.” 
-</p><p>He said, “As Yahweh lives, not one hair of your son shall fall to the earth.” 
-</p><p>
-<span class="v">12&#160;</span>Then the woman said, “Please let your servant speak a word to my lord the king.” 
-</p><p>He said, “Say on.” 
-</p><p>
-<span class="v">13&#160;</span>The woman said, “Why then have you devised such a thing against the people of Elohim? For in speaking this word the king is as one who is guilty, in that the king does not bring home again his banished one. 
-<span class="v">14&#160;</span>For we must die, and are like water spilled on the ground, which can’t be gathered up again; neither does Elohim take away life, but devises means, that he who is banished not be an outcast from him. 
-<span class="v">15&#160;</span>Now therefore, seeing that I have come to speak this word to my lord the king, it is because the people have made me afraid. Your servant said, ‘I will now speak to the king; it may be that the king will perform the request of his servant.’ 
-<span class="v">16&#160;</span>For the king will hear, to deliver his servant out of the hand of the man who would destroy me and my son together out of the inheritance of Elohim. 
-<span class="v">17&#160;</span>Then your servant said, ‘Please let the word of my lord the king bring rest; for as an angel of Elohim, so is my lord the king to discern good and bad. May Yahweh, your Elohim, be with you.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Then the king answered the woman, “Please don’t hide anything from me that I ask you.” 
-</p><p>The woman said, “Let my lord the king now speak.” 
-</p><p>
-<span class="v">19&#160;</span>The king said, “Is the hand of Joab with you in all this?” 
-</p><p>The woman answered, “As your soul lives, my lord the king, no one can turn to the right hand or to the left from anything that my lord the king has spoken; for your servant Joab urged me, and he put all these words in the mouth of your servant. 
-<span class="v">20&#160;</span>Your servant Joab has done this thing to change the face of the matter. My lord is wise, according to the wisdom of an angel of Elohim, to know all things that are in the earth.” 
-</p><p>
-<span class="v">21&#160;</span>The king said to Joab, “Behold now, I have granted this thing. Go therefore, and bring the young man Absalom back.” 
-</p><p>
-<span class="v">22&#160;</span>Joab fell to the ground on his face, showed respect, and blessed the king. Joab said, “Today your servant knows that I have found favor in your sight, my lord, O king, in that the king has performed the request of his servant.” 
-</p><p>
-<span class="v">23&#160;</span>So Joab arose and went to Geshur, and brought Absalom to Jerusalem. 
-<span class="v">24&#160;</span>The king said, “Let him return to his own house, but let him not see my face.” So Absalom returned to his own house, and didn’t see the king’s face. 
-<span class="v">25&#160;</span>Now in all Israel there was no one to be so much praised as Absalom for his beauty. From the sole of his foot even to the crown of his head there was no defect in him. 
-<span class="v">26&#160;</span>When he cut the hair of his head (now it was at every year’s end that he cut it; because it was heavy on him, therefore he cut it), he weighed the hair of his head at two hundred shekels,<span class="f">+ \fr 14:26 \ft A shekel is about 10 grams or about 0.35 ounces, so 200 shekels is about 2 kilograms or about 4.4 pounds.</span> after the king’s weight. 
-<span class="v">27&#160;</span>Three sons were born to Absalom, and one daughter, whose name was Tamar. She was a woman with a beautiful face. 
-<span class="v">28&#160;</span>Absalom lived two full years in Jerusalem, and he didn’t see the king’s face. 
-<span class="v">29&#160;</span>Then Absalom sent for Joab, to send him to the king, but he would not come to him. Then he sent again a second time, but he would not come. 
-<span class="v">30&#160;</span>Therefore he said to his servants, “Behold, Joab’s field is near mine, and he has barley there. Go and set it on fire.” So Absalom’s servants set the field on fire. 
-</p><p>
-<span class="v">31&#160;</span>Then Joab arose and came to Absalom to his house, and said to him, “Why have your servants set my field on fire?” 
-</p><p>
-<span class="v">32&#160;</span>Absalom answered Joab, “Behold, I sent to you, saying, ‘Come here, that I may send you to the king, to say, “Why have I come from Geshur? It would be better for me to be there still. Now therefore, let me see the king’s face; and if there is iniquity in me, let him kill me.”&#160;’&#160;” 
-</p><p>
-<span class="v">33&#160;</span>So Joab came to the king and told him; and when he had called for Absalom, he came to the king and bowed himself on his face to the ground before the king; and the king kissed Absalom. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>After this, Absalom prepared a chariot and horses for himself, and fifty men to run before him. 
-<span class="v">2&#160;</span>Absalom rose up early, and stood beside the way of the gate. When any man had a suit which should come to the king for judgment, then Absalom called to him, and said, “What city are you from?” 
-</p><p>He said, “Your servant is of one of the tribes of Israel.” 
-</p><p>
-<span class="v">3&#160;</span>Absalom said to him, “Behold, your matters are good and right; but there is no man deputized by the king to hear you.” 
-<span class="v">4&#160;</span>Absalom said moreover, “Oh that I were made judge in the land, that every man who has any suit or cause might come to me, and I would do him justice!” 
-<span class="v">5&#160;</span>It was so, that when any man came near to bow down to him, he stretched out his hand, took hold of him, and kissed him. 
-<span class="v">6&#160;</span>Absalom did this sort of thing to all Israel who came to the king for judgment. So Absalom stole the hearts of the men of Israel. 
-</p><p>
-<span class="v">7&#160;</span>At the end of forty years, Absalom said to the king, “Please let me go and pay my vow, which I have vowed to Yahweh, in Hebron. 
-<span class="v">8&#160;</span>For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‘If Yahweh shall indeed bring me again to Jerusalem, then I will serve Yahweh.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>The king said to him, “Go in peace.” 
-</p><p>So he arose and went to Hebron. 
-<span class="v">10&#160;</span>But Absalom sent spies throughout all the tribes of Israel, saying, “As soon as you hear the sound of the trumpet, then you shall say, ‘Absalom is king in Hebron!’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>Two hundred men went with Absalom out of Jerusalem, who were invited, and went in their simplicity; and they didn’t know anything. 
-<span class="v">12&#160;</span>Absalom sent for Ahithophel the Gilonite, David’s counselor, from his city, even from Giloh, while he was offering the sacrifices. The conspiracy was strong, for the people increased continually with Absalom. 
-<span class="v">13&#160;</span>A messenger came to David, saying, “The hearts of the men of Israel are after Absalom.” 
-</p><p>
-<span class="v">14&#160;</span>David said to all his servants who were with him at Jerusalem, “Arise! Let’s flee, or else none of us will escape from Absalom. Hurry to depart, lest he overtake us quickly and bring down evil on us, and strike the city with the edge of the sword.” 
-</p><p>
-<span class="v">15&#160;</span>The king’s servants said to the king, “Behold, your servants are ready to do whatever my lord the king chooses.” 
-</p><p>
-<span class="v">16&#160;</span>The king went out, and all his household after him. The king left ten women, who were concubines, to keep the house. 
-<span class="v">17&#160;</span>The king went out, and all the people after him; and they stayed in Beth Merhak. 
-<span class="v">18&#160;</span>All his servants passed on beside him; and all the Cherethites, and all the Pelethites, and all the Gittites, six hundred men who came after him from Gath, passed on before the king. 
-</p><p>
-<span class="v">19&#160;</span>Then the king said to Ittai the Gittite, “Why do you also go with us? Return, and stay with the king; for you are a foreigner and also an exile. Return to your own place. 
-<span class="v">20&#160;</span>Whereas you came but yesterday, should I today make you go up and down with us, since I go where I may? Return, and take back your brothers. Mercy and truth be with you.” 
-</p><p>
-<span class="v">21&#160;</span>Ittai answered the king and said, “As Yahweh lives, and as my lord the king lives, surely in what place my lord the king is, whether for death or for life, your servant will be there also.” 
-</p><p>
-<span class="v">22&#160;</span>David said to Ittai, “Go and pass over.” Ittai the Gittite passed over, and all his men, and all the little ones who were with him. 
-<span class="v">23&#160;</span>All the country wept with a loud voice, and all the people passed over. The king also himself passed over the brook Kidron, and all the people passed over toward the way of the wilderness. 
-<span class="v">24&#160;</span>Behold, Zadok also came, and all the Levites with him, bearing the ark of the covenant of Elohim; and they set down Elohim’s ark; and Abiathar went up until all the people finished passing out of the city. 
-<span class="v">25&#160;</span>The king said to Zadok, “Carry Elohim’s ark back into the city. If I find favor in Yahweh’s eyes, he will bring me again, and show me both it and his habitation; 
-<span class="v">26&#160;</span>but if he says, ‘I have no delight in you,’ behold, here I am. Let him do to me as seems good to him.” 
-<span class="v">27&#160;</span>The king said also to Zadok the priest, “Aren’t you a seer? Return into the city in peace, and your two sons with you, Ahimaaz your son and Jonathan the son of Abiathar. 
-<span class="v">28&#160;</span>Behold, I will stay at the fords of the wilderness until word comes from you to inform me.” 
-<span class="v">29&#160;</span>Zadok therefore and Abiathar carried Elohim’s ark to Jerusalem again; and they stayed there. 
-<span class="v">30&#160;</span>David went up by the ascent of the Mount of Olives, and wept as he went up; and he had his head covered and went barefoot. All the people who were with him each covered his head, and they went up, weeping as they went up. 
-</p><p>
-<span class="v">31&#160;</span>Someone told David, saying, “Ahithophel is among the conspirators with Absalom.” 
-</p><p>David said, “Yahweh, please turn the counsel of Ahithophel into foolishness.” 
-</p><p>
-<span class="v">32&#160;</span>When David had come to the top, where Elohim was worshiped, behold, Hushai the Archite came to meet him with his tunic torn and earth on his head. 
-<span class="v">33&#160;</span>David said to him, “If you pass on with me, then you will be a burden to me; 
-<span class="v">34&#160;</span>but if you return to the city, and tell Absalom, ‘I will be your servant, O king. As I have been your father’s servant in time past, so I will now be your servant; then will you defeat for me the counsel of Ahithophel.’ 
-<span class="v">35&#160;</span>Don’t you have Zadok and Abiathar the priests there with you? Therefore whatever you hear out of the king’s house, tell it to Zadok and Abiathar the priests. 
-<span class="v">36&#160;</span>Behold, they have there with them their two sons, Ahimaaz, Zadok’s son, and Jonathan, Abiathar’s son. Send to me everything that you shall hear by them.” 
-</p><p>
-<span class="v">37&#160;</span>So Hushai, David’s friend, came into the city; and Absalom came into Jerusalem. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>When David was a little past the top, behold, Ziba the servant of Mephibosheth met him with a couple of donkeys saddled, and on them two hundred loaves of bread, and one hundred clusters of raisins, and one hundred summer fruits, and a container of wine. 
-<span class="v">2&#160;</span>The king said to Ziba, “What do you mean by these?” 
-</p><p>Ziba said, “The donkeys are for the king’s household to ride on; and the bread and summer fruit for the young men to eat; and the wine, that those who are faint in the wilderness may drink.” 
-</p><p>
-<span class="v">3&#160;</span>The king said, “Where is your master’s son?” 
-</p><p>Ziba said to the king, “Behold, he is staying in Jerusalem; for he said, ‘Today the house of Israel will restore me the kingdom of my father.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>Then the king said to Ziba, “Behold, all that belongs to Mephibosheth is yours.” 
-</p><p>Ziba said, “I bow down. Let me find favor in your sight, my lord, O king.” 
-</p><p>
-<span class="v">5&#160;</span>When King David came to Bahurim, behold, a man of the family of Saul’s house came out, whose name was Shimei, the son of Gera. He came out and cursed as he came. 
-<span class="v">6&#160;</span>He cast stones at David and at all the servants of King David, and all the people and all the mighty men were on his right hand and on his left. 
-<span class="v">7&#160;</span>Shimei said when he cursed, “Be gone, be gone, you man of blood, and wicked fellow! 
-<span class="v">8&#160;</span>Yahweh has returned on you all the blood of Saul’s house, in whose place you have reigned! Yahweh has delivered the kingdom into the hand of Absalom your son! Behold, you are caught by your own mischief, because you are a man of blood!” 
-</p><p>
-<span class="v">9&#160;</span>Then Abishai the son of Zeruiah said to the king, “Why should this dead dog curse my lord the king? Please let me go over and take off his head.” 
-<span class="v">10&#160;</span>The king said, “What have I to do with you, you sons of Zeruiah? Because he curses, and because Yahweh has said to him, ‘Curse David,’ who then shall say, ‘Why have you done so?’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>David said to Abishai and to all his servants, “Behold, my son, who came out of my bowels, seeks my life. How much more this Benjamite, now? Leave him alone, and let him curse; for Yahweh has invited him. 
-<span class="v">12&#160;</span>It may be that Yahweh will look on the wrong done to me, and that Yahweh will repay me good for the cursing of me today.” 
-<span class="v">13&#160;</span>So David and his men went by the way; and Shimei went along on the hillside opposite him and cursed as he went, threw stones at him, and threw dust. 
-<span class="v">14&#160;</span>The king and all the people who were with him arrived weary; and he refreshed himself there. 
-</p><p>
-<span class="v">15&#160;</span>Absalom and all the people, the men of Israel, came to Jerusalem, and Ahithophel with him. 
-<span class="v">16&#160;</span>When Hushai the Archite, David’s friend, had come to Absalom, Hushai said to Absalom, “Long live the king! Long live the king!” 
-</p><p>
-<span class="v">17&#160;</span>Absalom said to Hushai, “Is this your kindness to your friend? Why didn’t you go with your friend?” 
-</p><p>
-<span class="v">18&#160;</span>Hushai said to Absalom, “No; but whomever Yahweh and this people and all the men of Israel have chosen, I will be his, and I will stay with him. 
-<span class="v">19&#160;</span>Again, whom should I serve? Shouldn’t I serve in the presence of his son? As I have served in your father’s presence, so I will be in your presence.” 
-</p><p>
-<span class="v">20&#160;</span>Then Absalom said to Ahithophel, “Give your counsel what we shall do.” 
-</p><p>
-<span class="v">21&#160;</span>Ahithophel said to Absalom, “Go in to your father’s concubines that he has left to keep the house. Then all Israel will hear that you are abhorred by your father. Then the hands of all who are with you will be strong.” 
-</p><p>
-<span class="v">22&#160;</span>So they spread a tent for Absalom on the top of the house, and Absalom went in to his father’s concubines in the sight of all Israel. 
-</p><p>
-<span class="v">23&#160;</span>The counsel of Ahithophel, which he gave in those days, was as if a man inquired at the inner sanctuary of Elohim. All the counsel of Ahithophel was like this both with David and with Absalom. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Ahithophel said to Absalom, “Let me now choose twelve thousand men, and I will arise and pursue after David tonight. 
-<span class="v">2&#160;</span>I will come on him while he is weary and exhausted, and will make him afraid. All the people who are with him will flee. I will strike the king only, 
-<span class="v">3&#160;</span>and I will bring back all the people to you. The man whom you seek is as if all returned. All the people shall be in peace.” 
-</p><p>
-<span class="v">4&#160;</span>The saying pleased Absalom well, and all the elders of Israel. 
-<span class="v">5&#160;</span>Then Absalom said, “Now call Hushai the Archite also, and let’s hear likewise what he says.” 
-</p><p>
-<span class="v">6&#160;</span>When Hushai had come to Absalom, Absalom spoke to him, saying, “Ahithophel has spoken like this. Shall we do what he says? If not, speak up.” 
-</p><p>
-<span class="v">7&#160;</span>Hushai said to Absalom, “The counsel that Ahithophel has given this time is not good.” 
-<span class="v">8&#160;</span>Hushai said moreover, “You know your father and his men, that they are mighty men, and they are fierce in their minds, like a bear robbed of her cubs in the field. Your father is a man of war, and will not lodge with the people. 
-<span class="v">9&#160;</span>Behold, he is now hidden in some pit, or in some other place. It will happen, when some of them have fallen at the first, that whoever hears it will say, ‘There is a slaughter among the people who follow Absalom!’ 
-<span class="v">10&#160;</span>Even he who is valiant, whose heart is as the heart of a lion, will utterly melt; for all Israel knows that your father is a mighty man, and those who are with him are valiant men. 
-<span class="v">11&#160;</span>But I counsel that all Israel be gathered together to you, from Dan even to Beersheba, as the sand that is by the sea for multitude; and that you go to battle in your own person. 
-<span class="v">12&#160;</span>So we will come on him in some place where he will be found, and we will light on him as the dew falls on the ground, then we will not leave so much as one of him and of all the men who are with him. 
-<span class="v">13&#160;</span>Moreover, if he has gone into a city, then all Israel will bring ropes to that city, and we will draw it into the river, until there isn’t one small stone found there.” 
-</p><p>
-<span class="v">14&#160;</span>Absalom and all the men of Israel said, “The counsel of Hushai the Archite is better than the counsel of Ahithophel.” For Yahweh had ordained to defeat the good counsel of Ahithophel, to the intent that Yahweh might bring evil on Absalom. 
-</p><p>
-<span class="v">15&#160;</span>Then Hushai said to Zadok and to Abiathar the priests, “Ahithophel counseled Absalom and the elders of Israel that way; and I have counseled this way. 
-<span class="v">16&#160;</span>Now therefore send quickly, and tell David, saying, ‘Don’t lodge tonight at the fords of the wilderness, but by all means pass over, lest the king be swallowed up, and all the people who are with him.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>Now Jonathan and Ahimaaz were staying by En Rogel; and a female servant used to go and report to them, and they went and told King David; for they couldn’t risk being seen coming into the city. 
-<span class="v">18&#160;</span>But a boy saw them, and told Absalom. Then they both went away quickly and came to the house of a man in Bahurim, who had a well in his court; and they went down there. 
-<span class="v">19&#160;</span>The woman took and spread the covering over the well’s mouth, and spread out crushed grain on it; and nothing was known. 
-<span class="v">20&#160;</span>Absalom’s servants came to the woman to the house; and they said, “Where are Ahimaaz and Jonathan?” 
-</p><p>The woman said to them, “They have gone over the brook of water.” 
-</p><p>When they had sought and could not find them, they returned to Jerusalem. 
-<span class="v">21&#160;</span>After they had departed, they came up out of the well and went and told King David; and they said to David, “Arise and pass quickly over the water; for thus has Ahithophel counseled against you.” 
-</p><p>
-<span class="v">22&#160;</span>Then David arose, and all the people who were with him, and they passed over the Jordan. By the morning light there lacked not one of them who had not gone over the Jordan. 
-</p><p>
-<span class="v">23&#160;</span>When Ahithophel saw that his counsel was not followed, he saddled his donkey, arose, and went home to his city, set his house in order, and hanged himself; and he died, and was buried in the tomb of his father. 
-</p><p>
-<span class="v">24&#160;</span>Then David came to Mahanaim. Absalom passed over the Jordan, he and all the men of Israel with him. 
-<span class="v">25&#160;</span>Absalom set Amasa over the army instead of Joab. Now Amasa was the son of a man whose name was Ithra the Israelite, who went in to Abigail the daughter of Nahash, sister to Zeruiah, Joab’s mother. 
-<span class="v">26&#160;</span>Israel and Absalom encamped in the land of Gilead. 
-</p><p>
-<span class="v">27&#160;</span>When David had come to Mahanaim, Shobi the son of Nahash of Rabbah of the children of Ammon, and Machir the son of Ammiel of Lodebar, and Barzillai the Gileadite of Rogelim, 
-<span class="v">28&#160;</span>brought beds, basins, earthen vessels, wheat, barley, meal, parched grain, beans, lentils, roasted grain, 
-<span class="v">29&#160;</span>honey, butter, sheep, and cheese of the herd, for David and for the people who were with him to eat; for they said, “The people are hungry, weary, and thirsty in the wilderness.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>David counted the people who were with him, and set captains of thousands and captains of hundreds over them. 
-<span class="v">2&#160;</span>David sent the people out, a third part under the hand of Joab, and a third part under the hand of Abishai the son of Zeruiah, Joab’s brother, and a third part under the hand of Ittai the Gittite. The king said to the people, “I will also surely go out with you myself.” 
-</p><p>
-<span class="v">3&#160;</span>But the people said, “You shall not go out, for if we flee away, they will not care for us, neither if half of us die, will they care for us. But you are worth ten thousand of us. Therefore now it is better that you are ready to help us out of the city.” 
-</p><p>
-<span class="v">4&#160;</span>The king said to them, “I will do what seems best to you.” 
-</p><p>The king stood beside the gate, and all the people went out by hundreds and by thousands. 
-<span class="v">5&#160;</span>The king commanded Joab and Abishai and Ittai, saying, “Deal gently for my sake with the young man Absalom.” All the people heard when the king commanded all the captains concerning Absalom. 
-</p><p>
-<span class="v">6&#160;</span>So the people went out into the field against Israel; and the battle was in the forest of Ephraim. 
-<span class="v">7&#160;</span>The people of Israel were struck there before David’s servants, and there was a great slaughter there that day of twenty thousand men. 
-<span class="v">8&#160;</span>For the battle was there spread over the surface of all the country, and the forest devoured more people that day than the sword devoured. 
-</p><p>
-<span class="v">9&#160;</span>Absalom happened to meet David’s servants. Absalom was riding on his mule, and the mule went under the thick boughs of a great oak; and his head caught hold of the oak, and he was hanging between the sky and earth; and the mule that was under him went on. 
-<span class="v">10&#160;</span>A certain man saw it, and told Joab, and said, “Behold, I saw Absalom hanging in an oak.” 
-</p><p>
-<span class="v">11&#160;</span>Joab said to the man who told him, “Behold, you saw it, and why didn’t you strike him there to the ground? I would have given you ten pieces of silver and a sash.” 
-</p><p>
-<span class="v">12&#160;</span>The man said to Joab, “Though I should receive a thousand pieces of silver in my hand, I still wouldn’t stretch out my hand against the king’s son; for in our hearing the king commanded you and Abishai and Ittai, saying, ‘Beware that no one touch the young man Absalom.’ 
-<span class="v">13&#160;</span>Otherwise, if I had dealt falsely against his life (and there is no matter hidden from the king), then you yourself would have set yourself against me.” 
-</p><p>
-<span class="v">14&#160;</span>Then Joab said, “I’m not going to wait like this with you.” He took three darts in his hand and thrust them through Absalom’s heart while he was still alive in the middle of the oak. 
-<span class="v">15&#160;</span>Ten young men who bore Joab’s armor surrounded and struck Absalom, and killed him. 
-<span class="v">16&#160;</span>Joab blew the trumpet, and the people returned from pursuing after Israel; for Joab held the people back. 
-<span class="v">17&#160;</span>They took Absalom and cast him into a great pit in the forest, and raised over him a very great heap of stones. Then all Israel fled, each to his own tent. 
-</p><p>
-<span class="v">18&#160;</span>Now Absalom in his lifetime had taken and reared up for himself the pillar which is in the king’s valley, for he said, “I have no son to keep my name in memory.” He called the pillar after his own name. It is called Absalom’s monument, to this day. 
-</p><p>
-<span class="v">19&#160;</span>Then Ahimaaz the son of Zadok said, “Let me now run and carry the king news, how Yahweh has avenged him of his enemies.” 
-</p><p>
-<span class="v">20&#160;</span>Joab said to him, “You must not be the bearer of news today, but you must carry news another day. But today you must carry no news, because the king’s son is dead.” 
-</p><p>
-<span class="v">21&#160;</span>Then Joab said to the Cushite, “Go, tell the king what you have seen!” The Cushite bowed himself to Joab, and ran. 
-</p><p>
-<span class="v">22&#160;</span>Then Ahimaaz the son of Zadok said yet again to Joab, “But come what may, please let me also run after the Cushite.” 
-</p><p>Joab said, “Why do you want to run, my son, since you will have no reward for the news?” 
-</p><p>
-<span class="v">23&#160;</span>“But come what may,” he said, “I will run.” 
-</p><p>He said to him, “Run!” Then Ahimaaz ran by the way of the Plain, and outran the Cushite. 
-</p><p>
-<span class="v">24&#160;</span>Now David was sitting between the two gates; and the watchman went up to the roof of the gate to the wall, and lifted up his eyes and looked, and, behold, a man running alone. 
-<span class="v">25&#160;</span>The watchman shouted and told the king. The king said, “If he is alone, there is news in his mouth.” He came closer and closer. 
-</p><p>
-<span class="v">26&#160;</span>The watchman saw another man running; and the watchman called to the gatekeeper and said, “Behold, a man running alone!” 
-</p><p>The king said, “He also brings news.” 
-</p><p>
-<span class="v">27&#160;</span>The watchman said, “I think the running of the first one is like the running of Ahimaaz the son of Zadok.” 
-</p><p>The king said, “He is a good man, and comes with good news.” 
-</p><p>
-<span class="v">28&#160;</span>Ahimaaz called, and said to the king, “All is well.” He bowed himself before the king with his face to the earth, and said, “Blessed is Yahweh your Elohim, who has delivered up the men who lifted up their hand against my lord the king!” 
-</p><p>
-<span class="v">29&#160;</span>The king said, “Is it well with the young man Absalom?” 
-</p><p>Ahimaaz answered, “When Joab sent the king’s servant, even me your servant, I saw a great tumult, but I don’t know what it was.” 
-</p><p>
-<span class="v">30&#160;</span>The king said, “Come and stand here.” He came and stood still. 
-</p><p>
-<span class="v">31&#160;</span>Behold, the Cushite came. The Cushite said, “Good news for my lord the king, for Yahweh has avenged you today of all those who rose up against you.” 
-</p><p>
-<span class="v">32&#160;</span>The king said to the Cushite, “Is it well with the young man Absalom?” 
-</p><p>The Cushite answered, “May the enemies of my lord the king, and all who rise up against you to do you harm, be as that young man is.” 
-</p><p>
-<span class="v">33&#160;</span>The king was much moved, and went up to the room over the gate and wept. As he went, he said, “My son Absalom! My son, my son Absalom! I wish I had died instead of you, Absalom, my son, my son!” 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Joab was told, “Behold, the king weeps and mourns for Absalom.” 
-<span class="v">2&#160;</span>The victory that day was turned into mourning among all the people, for the people heard it said that day, “The king grieves for his son.” 
-</p><p>
-<span class="v">3&#160;</span>The people sneaked into the city that day, as people who are ashamed steal away when they flee in battle. 
-<span class="v">4&#160;</span>The king covered his face, and the king cried with a loud voice, “My son Absalom, Absalom, my son, my son!” 
-</p><p>
-<span class="v">5&#160;</span>Joab came into the house to the king, and said, “Today you have shamed the faces of all your servants who today have saved your life, and the lives of your sons and of your daughters, and the lives of your women, and the lives of your concubines; 
-<span class="v">6&#160;</span>in that you love those who hate you and hate those who love you. For you have declared today that princes and servants are nothing to you. For today I perceive that if Absalom had lived and we had all died today, then it would have pleased you well. 
-<span class="v">7&#160;</span>Now therefore arise, go out and speak to comfort your servants; for I swear by Yahweh, if you don’t go out, not a man will stay with you this night. That would be worse to you than all the evil that has happened to you from your youth until now.” 
-</p><p>
-<span class="v">8&#160;</span>Then the king arose and sat in the gate. The people were all told, “Behold, the king is sitting in the gate.” All the people came before the king. Now Israel had fled every man to his tent. 
-<span class="v">9&#160;</span>All the people were at strife throughout all the tribes of Israel, saying, “The king delivered us out of the hand of our enemies, and he saved us out of the hand of the Philistines; and now he has fled out of the land from Absalom. 
-<span class="v">10&#160;</span>Absalom, whom we anointed over us, is dead in battle. Now therefore why don’t you speak a word of bringing the king back?” 
-</p><p>
-<span class="v">11&#160;</span>King David sent to Zadok and to Abiathar the priests, saying, “Speak to the elders of Judah, saying, ‘Why are you the last to bring the king back to his house, since the speech of all Israel has come to the king, to return him to his house? 
-<span class="v">12&#160;</span>You are my brothers. You are my bone and my flesh. Why then are you the last to bring back the king?’ 
-<span class="v">13&#160;</span>Say to Amasa, ‘Aren’t you my bone and my flesh? Elohim do so to me, and more also, if you aren’t captain of the army before me continually instead of Joab.’&#160;” 
-<span class="v">14&#160;</span>He bowed the heart of all the men of Judah, even as one man, so that they sent to the king, saying, “Return, you and all your servants.” 
-</p><p>
-<span class="v">15&#160;</span>So the king returned, and came to the Jordan. Judah came to Gilgal, to go to meet the king, to bring the king over the Jordan. 
-<span class="v">16&#160;</span>Shimei the son of Gera, the Benjamite, who was of Bahurim, hurried and came down with the men of Judah to meet King David. 
-<span class="v">17&#160;</span>There were a thousand men of Benjamin with him, and Ziba the servant of Saul’s house, and his fifteen sons and his twenty servants with him; and they went through the Jordan in the presence of the king. 
-<span class="v">18&#160;</span>A ferry boat went to bring over the king’s household, and to do what he thought good. 
-</p><p>Shimei the son of Gera fell down before the king when he had come over the Jordan. 
-<span class="v">19&#160;</span>He said to the king, “Don’t let my lord impute iniquity to me, or remember that which your servant did perversely the day that my lord the king went out of Jerusalem, that the king should take it to his heart. 
-<span class="v">20&#160;</span>For your servant knows that I have sinned. Therefore behold, I have come today as the first of all the house of Joseph to go down to meet my lord the king.” 
-</p><p>
-<span class="v">21&#160;</span>But Abishai the son of Zeruiah answered, “Shouldn’t Shimei be put to death for this, because he cursed Yahweh’s anointed?” 
-</p><p>
-<span class="v">22&#160;</span>David said, “What have I to do with you, you sons of Zeruiah, that you should be adversaries to me today? Shall any man be put to death today in Israel? For don’t I know that I am king over Israel today?” 
-<span class="v">23&#160;</span>The king said to Shimei, “You will not die.” The king swore to him. 
-</p><p>
-<span class="v">24&#160;</span>Mephibosheth the son of Saul came down to meet the king; and he had neither groomed his feet, nor trimmed his beard, nor washed his clothes, from the day the king departed until the day he came home in peace. 
-<span class="v">25&#160;</span>When he had come to Jerusalem to meet the king, the king said to him, “Why didn’t you go with me, Mephibosheth?” 
-</p><p>
-<span class="v">26&#160;</span>He answered, “My lord, O king, my servant deceived me. For your servant said, ‘I will saddle a donkey for myself, that I may ride on it and go with the king,’ because your servant is lame. 
-<span class="v">27&#160;</span>He has slandered your servant to my lord the king, but my lord the king is as an angel of Elohim. Therefore do what is good in your eyes. 
-<span class="v">28&#160;</span>For all my father’s house were but dead men before my lord the king; yet you set your servant among those who ate at your own table. What right therefore have I yet that I should appeal any more to the king?” 
-</p><p>
-<span class="v">29&#160;</span>The king said to him, “Why do you speak any more of your matters? I say, you and Ziba divide the land.” 
-</p><p>
-<span class="v">30&#160;</span>Mephibosheth said to the king, “Yes, let him take all, because my lord the king has come in peace to his own house.” 
-</p><p>
-<span class="v">31&#160;</span>Barzillai the Gileadite came down from Rogelim; and he went over the Jordan with the king to conduct him over the Jordan. 
-<span class="v">32&#160;</span>Now Barzillai was a very aged man, even eighty years old. He had provided the king with sustenance while he stayed at Mahanaim, for he was a very great man. 
-<span class="v">33&#160;</span>The king said to Barzillai, “Come over with me, and I will sustain you with me in Jerusalem.” 
-</p><p>
-<span class="v">34&#160;</span>Barzillai said to the king, “How many are the days of the years of my life, that I should go up with the king to Jerusalem? 
-<span class="v">35&#160;</span>I am eighty years old, today. Can I discern between good and bad? Can your servant taste what I eat or what I drink? Can I hear the voice of singing men and singing women any more? Why then should your servant be a burden to my lord the king? 
-<span class="v">36&#160;</span>Your servant will just go over the Jordan with the king. Why should the king repay me with such a reward? 
-<span class="v">37&#160;</span>Please let your servant turn back again, that I may die in my own city, by the grave of my father and my mother. But behold, your servant Chimham; let him go over with my lord the king; and do to him what shall seem good to you.” 
-</p><p>
-<span class="v">38&#160;</span>The king answered, “Chimham shall go over with me, and I will do to him that which shall seem good to you. Whatever you request of me, that I will do for you.” 
-</p><p>
-<span class="v">39&#160;</span>All the people went over the Jordan, and the king went over. Then the king kissed Barzillai and blessed him; and he returned to his own place. 
-<span class="v">40&#160;</span>So the king went over to Gilgal, and Chimham went over with him. All the people of Judah brought the king over, and also half the people of Israel. 
-<span class="v">41&#160;</span>Behold, all the men of Israel came to the king, and said to the king, “Why have our brothers the men of Judah stolen you away, and brought the king and his household, over the Jordan, and all David’s men with him?” 
-</p><p>
-<span class="v">42&#160;</span>All the men of Judah answered the men of Israel, “Because the king is a close relative to us. Why then are you angry about this matter? Have we eaten at all at the king’s cost? Or has he given us any gift?” 
-</p><p>
-<span class="v">43&#160;</span>The men of Israel answered the men of Judah, and said, “We have ten parts in the king, and we have also more claim to David than you. Why then did you despise us, that our advice should not be first had in bringing back our king?” The words of the men of Judah were fiercer than the words of the men of Israel. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>There happened to be there a wicked fellow, whose name was Sheba the son of Bichri, a Benjamite; and he blew the trumpet, and said, “We have no portion in David, neither have we inheritance in the son of Jesse. Every man to his tents, Israel!” 
-</p><p>
-<span class="v">2&#160;</span>So all the men of Israel went up from following David, and followed Sheba the son of Bichri; but the men of Judah joined with their king, from the Jordan even to Jerusalem. 
-</p><p>
-<span class="v">3&#160;</span>David came to his house at Jerusalem; and the king took the ten women his concubines, whom he had left to keep the house, and put them in custody and provided them with sustenance, but didn’t go in to them. So they were shut up to the day of their death, living in widowhood. 
-</p><p>
-<span class="v">4&#160;</span>Then the king said to Amasa, “Call me the men of Judah together within three days, and be here present.” 
-</p><p>
-<span class="v">5&#160;</span>So Amasa went to call the men of Judah together, but he stayed longer than the set time which had been appointed to him. 
-<span class="v">6&#160;</span>David said to Abishai, “Now Sheba the son of Bichri will do us more harm than Absalom did. Take your lord’s servants and pursue after him, lest he get himself fortified cities, and escape out of our sight.” 
-</p><p>
-<span class="v">7&#160;</span>Joab’s men went out after him with the Cherethites, the Pelethites, and all the mighty men; and they went out of Jerusalem to pursue Sheba the son of Bichri. 
-<span class="v">8&#160;</span>When they were at the great stone which is in Gibeon, Amasa came to meet them. Joab was clothed in his apparel of war that he had put on, and on it was a sash with a sword fastened on his waist in its sheath; and as he went along it fell out. 
-<span class="v">9&#160;</span>Joab said to Amasa, “Is it well with you, my brother?” Joab took Amasa by the beard with his right hand to kiss him. 
-<span class="v">10&#160;</span>But Amasa took no heed to the sword that was in Joab’s hand. So he struck him with it in the body and shed out his bowels to the ground, and didn’t strike him again; and he died. Joab and Abishai his brother pursued Sheba the son of Bichri. 
-<span class="v">11&#160;</span>One of Joab’s young men stood by him, and said, “He who favors Joab, and he who is for David, let him follow Joab!” 
-</p><p>
-<span class="v">12&#160;</span>Amasa lay wallowing in his blood in the middle of the highway. When the man saw that all the people stood still, he carried Amasa out of the highway into the field, and cast a garment over him when he saw that everyone who came by him stood still. 
-<span class="v">13&#160;</span>When he was removed out of the highway, all the people went on after Joab to pursue Sheba the son of Bichri. 
-<span class="v">14&#160;</span>He went through all the tribes of Israel to Abel, to Beth Maacah, and all the Berites. They were gathered together, and went also after him. 
-<span class="v">15&#160;</span>They came and besieged him in Abel of Beth Maacah, and they cast up a mound against the city, and it stood against the rampart; and all the people who were with Joab battered the wall to throw it down. 
-</p><p>
-<span class="v">16&#160;</span>Then a wise woman cried out of the city, “Hear, hear! Please say to Joab, ‘Come near here, that I may speak with you.’&#160;” 
-<span class="v">17&#160;</span>He came near to her; and the woman said, “Are you Joab?” 
-</p><p>He answered, “I am.” 
-</p><p>Then she said to him, “Hear the words of your servant.” 
-</p><p>He answered, “I’m listening.” 
-</p><p>
-<span class="v">18&#160;</span>Then she spoke, saying, “They used to say in old times, ‘They shall surely ask counsel at Abel,’ and so they settled a matter. 
-<span class="v">19&#160;</span>I am among those who are peaceable and faithful in Israel. You seek to destroy a city and a mother in Israel. Why will you swallow up Yahweh’s inheritance?” 
-</p><p>
-<span class="v">20&#160;</span>Joab answered, “Far be it, far be it from me, that I should swallow up or destroy. 
-<span class="v">21&#160;</span>The matter is not so. But a man of the hill country of Ephraim, Sheba the son of Bichri by name, has lifted up his hand against the king, even against David. Just deliver him, and I will depart from the city.” 
-</p><p>The woman said to Joab, “Behold, his head will be thrown to you over the wall.” 
-</p><p>
-<span class="v">22&#160;</span>Then the woman went to all the people in her wisdom. They cut off the head of Sheba the son of Bichri, and threw it out to Joab. He blew the trumpet, and they were dispersed from the city, every man to his tent. Then Joab returned to Jerusalem to the king. 
-</p><p>
-<span class="v">23&#160;</span>Now Joab was over all the army of Israel, Benaiah the son of Jehoiada was over the Cherethites and over the Pelethites, 
-<span class="v">24&#160;</span>Adoram was over the men subject to forced labor, Jehoshaphat the son of Ahilud was the recorder, 
-<span class="v">25&#160;</span>Sheva was scribe, Zadok and Abiathar were priests, 
-<span class="v">26&#160;</span>and Ira the Jairite was chief minister to David. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>There was a famine in the days of David for three years, year after year; and David sought the face of Yahweh. Yahweh said, “It is for Saul, and for his bloody house, because he put the Gibeonites to death.” 
-</p><p>
-<span class="v">2&#160;</span>The king called the Gibeonites and said to them (now the Gibeonites were not of the children of Israel, but of the remnant of the Amorites, and the children of Israel had sworn to them; and Saul sought to kill them in his zeal for the children of Israel and Judah); 
-<span class="v">3&#160;</span>and David said to the Gibeonites, “What should I do for you? And with what should I make atonement, that you may bless Yahweh’s inheritance?” 
-</p><p>
-<span class="v">4&#160;</span>The Gibeonites said to him, “It is no matter of silver or gold between us and Saul or his house; neither is it for us to put any man to death in Israel.” 
-</p><p>He said, “I will do for you whatever you say.” 
-</p><p>
-<span class="v">5&#160;</span>They said to the king, “The man who consumed us and who plotted against us, that we should be destroyed from remaining in any of the borders of Israel, 
-<span class="v">6&#160;</span>let seven men of his sons be delivered to us, and we will hang them up to Yahweh in Gibeah of Saul, the chosen of Yahweh.” 
-</p><p>The king said, “I will give them.” 
-</p><p>
-<span class="v">7&#160;</span>But the king spared Mephibosheth the son of Jonathan the son of Saul, because of Yahweh’s oath that was between them, between David and Jonathan the son of Saul. 
-<span class="v">8&#160;</span>But the king took the two sons of Rizpah the daughter of Aiah, whom she bore to Saul, Armoni and Mephibosheth; and the five sons of Merab the daughter of Saul, whom she bore to Adriel the son of Barzillai the Meholathite. 
-<span class="v">9&#160;</span>He delivered them into the hands of the Gibeonites; and they hanged them on the mountain before Yahweh, and all seven of them fell together. They were put to death in the days of harvest, in the first days, at the beginning of barley harvest. 
-</p><p>
-<span class="v">10&#160;</span>Rizpah the daughter of Aiah took sackcloth and spread it for herself on the rock, from the beginning of harvest until water poured on them from the sky. She allowed neither the birds of the sky to rest on them by day, nor the animals of the field by night. 
-<span class="v">11&#160;</span>David was told what Rizpah the daughter of Aiah, the concubine of Saul, had done. 
-<span class="v">12&#160;</span>So David went and took the bones of Saul and the bones of Jonathan his son from the owners of Jabesh Gilead, who had stolen them from the street of Beth Shan, where the Philistines had hanged them in the day that the Philistines killed Saul in Gilboa; 
-<span class="v">13&#160;</span>and he brought up from there the bones of Saul and the bones of Jonathan his son. They also gathered the bones of those who were hanged. 
-<span class="v">14&#160;</span>They buried the bones of Saul and Jonathan his son in the country of Benjamin in Zela, in the tomb of Kish his father; and they performed all that the king commanded. After that, Elohim answered prayer for the land. 
-</p><p>
-<span class="v">15&#160;</span>The Philistines had war again with Israel; and David went down, and his servants with him, and fought against the Philistines. David grew faint; 
-<span class="v">16&#160;</span>and Ishbibenob, who was of the sons of the giant, the weight of whose spear was three hundred shekels of bronze in weight, he being armed with a new sword, thought he would kill David. 
-<span class="v">17&#160;</span>But Abishai the son of Zeruiah helped him, and struck the Philistine and killed him. Then the men of David swore to him, saying, “Don’t go out with us to battle any more, so that you don’t quench the lamp of Israel.” 
-</p><p>
-<span class="v">18&#160;</span>After this, there was again war with the Philistines at Gob. Then Sibbecai the Hushathite killed Saph, who was of the sons of the giant. 
-<span class="v">19&#160;</span>There was again war with the Philistines at Gob, and Elhanan the son of Jaare-Oregim the Bethlehemite killed Goliath the Gittite’s brother, the staff of whose spear was like a weaver’s beam. 
-<span class="v">20&#160;</span>There was again war at Gath, where there was a man of great stature, who had six fingers on every hand and six toes on every foot, twenty-four in number, and he also was born to the giant. 
-<span class="v">21&#160;</span>When he defied Israel, Jonathan the son of Shimei, David’s brother, killed him. 
-<span class="v">22&#160;</span>These four were born to the giant in Gath; and they fell by the hand of David and by the hand of his servants. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>David spoke to Yahweh the words of this song in the day that Yahweh delivered him out of the hand of all his enemies, and out of the hand of Saul, 
-<span class="v">2&#160;</span>and he said: 
-</p><p class="q1">“Yahweh is my rock, 
-</p><p class="q2">my fortress, 
-</p><p class="q2">and my deliverer, even mine; 
-</p><p class="q1">
-<span class="v">3&#160;</span>Elohim is my rock in whom I take refuge; 
-</p><p class="q2">my shield, and the horn of my salvation, 
-</p><p class="q2">my high tower, and my refuge. 
-</p><p class="q2">My savior, you save me from violence. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I call on Yahweh, who is worthy to be praised; 
-</p><p class="q2">So shall I be saved from my enemies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>For the waves of death surrounded me. 
-</p><p class="q2">The floods of unelohimliness made me afraid. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The cords of Sheol<span class="f">+ \fr 22:6 \ft Sheol is the place of the dead.</span> were around me. 
-</p><p class="q2">The snares of death caught me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>In my distress, I called on Yahweh. 
-</p><p class="q2">Yes, I called to my Elohim. 
-</p><p class="q1">He heard my voice out of his temple. 
-</p><p class="q2">My cry came into his ears. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Then the earth shook and trembled. 
-</p><p class="q2">The foundations of heaven quaked and were shaken, 
-</p><p class="q2">because he was angry. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Smoke went up out of his nostrils. 
-</p><p class="q2">Consuming fire came out of his mouth. 
-</p><p class="q2">Coals were kindled by it. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He bowed the heavens also, and came down. 
-</p><p class="q2">Thick darkness was under his feet. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He rode on a cherub, and flew. 
-</p><p class="q2">Yes, he was seen on the wings of the wind. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He made darkness a shelter around himself, 
-</p><p class="q2">gathering of waters, and thick clouds of the skies. 
-</p><p class="q1">
-<span class="v">13&#160;</span>At the brightness before him, 
-</p><p class="q2">coals of fire were kindled. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yahweh thundered from heaven. 
-</p><p class="q2">The Most High uttered his voice. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He sent out arrows and scattered them, 
-</p><p class="q2">lightning and confused them. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Then the channels of the sea appeared. 
-</p><p class="q2">The foundations of the world were laid bare by Yahweh’s rebuke, 
-</p><p class="q2">at the blast of the breath of his nostrils. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>He sent from on high and he took me. 
-</p><p class="q2">He drew me out of many waters. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He delivered me from my strong enemy, 
-</p><p class="q2">from those who hated me, for they were too mighty for me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>They came on me in the day of my calamity, 
-</p><p class="q2">but Yahweh was my support. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He also brought me out into a large place. 
-</p><p class="q2">He delivered me, because he delighted in me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Yahweh rewarded me according to my righteousness. 
-</p><p class="q2">He rewarded me according to the cleanness of my hands. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For I have kept Yahweh’s ways, 
-</p><p class="q2">and have not wickedly departed from my Elohim. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For all his ordinances were before me. 
-</p><p class="q2">As for his statutes, I didn’t depart from them. 
-</p><p class="q1">
-<span class="v">24&#160;</span>I was also perfect toward him. 
-</p><p class="q2">I kept myself from my iniquity. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Therefore Yahweh has rewarded me according to my righteousness, 
-</p><p class="q2">According to my cleanness in his eyesight. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">26&#160;</span>With the merciful you will show yourself merciful. 
-</p><p class="q2">With the perfect man you will show yourself perfect. 
-</p><p class="q2">
-<span class="v">27&#160;</span>With the pure you will show yourself pure. 
-</p><p class="q2">With the crooked you will show yourself shrewd. 
-</p><p class="q1">
-<span class="v">28&#160;</span>You will save the afflicted people, 
-</p><p class="q2">but your eyes are on the arrogant, that you may bring them down. 
-</p><p class="q1">
-<span class="v">29&#160;</span>For you are my lamp, Yahweh. 
-</p><p class="q2">Yahweh will light up my darkness. 
-</p><p class="q1">
-<span class="v">30&#160;</span>For by you, I run against a troop. 
-</p><p class="q2">By my Elohim, I leap over a wall. 
-</p><p class="q1">
-<span class="v">31&#160;</span>As for Elohim, his way is perfect. 
-</p><p class="q2">Yahweh’s word is tested. 
-</p><p class="q2">He is a shield to all those who take refuge in him. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">32&#160;</span>For who is Elohim, besides Yahweh? 
-</p><p class="q2">Who is a rock, besides our Elohim? 
-</p><p class="q1">
-<span class="v">33&#160;</span>Elohim is my strong fortress. 
-</p><p class="q2">He makes my way perfect. 
-</p><p class="q1">
-<span class="v">34&#160;</span>He makes his feet like hinds’ feet, 
-</p><p class="q2">and sets me on my high places. 
-</p><p class="q1">
-<span class="v">35&#160;</span>He teaches my hands to war, 
-</p><p class="q2">so that my arms bend a bow of bronze. 
-</p><p class="q1">
-<span class="v">36&#160;</span>You have also given me the shield of your salvation. 
-</p><p class="q2">Your gentleness has made me great. 
-</p><p class="q1">
-<span class="v">37&#160;</span>You have enlarged my steps under me. 
-</p><p class="q2">My feet have not slipped. 
-</p><p class="q1">
-<span class="v">38&#160;</span>I have pursued my enemies and destroyed them. 
-</p><p class="q2">I didn’t turn again until they were consumed. 
-</p><p class="q1">
-<span class="v">39&#160;</span>I have consumed them, 
-</p><p class="q2">and struck them through, 
-</p><p class="q2">so that they can’t arise. 
-</p><p class="q2">Yes, they have fallen under my feet. 
-</p><p class="q1">
-<span class="v">40&#160;</span>For you have armed me with strength for the battle. 
-</p><p class="q2">You have subdued under me those who rose up against me. 
-</p><p class="q1">
-<span class="v">41&#160;</span>You have also made my enemies turn their backs to me, 
-</p><p class="q2">that I might cut off those who hate me. 
-</p><p class="q1">
-<span class="v">42&#160;</span>They looked, but there was no one to save; 
-</p><p class="q2">even to Yahweh, but he didn’t answer them. 
-</p><p class="q1">
-<span class="v">43&#160;</span>Then I beat them as small as the dust of the earth. 
-</p><p class="q2">I crushed them as the mire of the streets, and spread them abroad. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">44&#160;</span>You also have delivered me from the strivings of my people. 
-</p><p class="q2">You have kept me to be the head of the nations. 
-</p><p class="q2">A people whom I have not known will serve me. 
-</p><p class="q1">
-<span class="v">45&#160;</span>The foreigners will submit themselves to me. 
-</p><p class="q2">As soon as they hear of me, they will obey me. 
-</p><p class="q1">
-<span class="v">46&#160;</span>The foreigners will fade away, 
-</p><p class="q2">and will come trembling out of their close places. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">47&#160;</span>Yahweh lives! 
-</p><p class="q2">Blessed be my rock! 
-</p><p class="q1">Exalted be Elohim, the rock of my salvation, 
-</p><p class="q2">
-<span class="v">48&#160;</span>even the Elohim who executes vengeance for me, 
-</p><p class="q2">who brings down peoples under me, 
-</p><p class="q2">
-<span class="v">49&#160;</span>who brings me away from my enemies. 
-</p><p class="q1">Yes, you lift me up above those who rise up against me. 
-</p><p class="q2">You deliver me from the violent man. 
-</p><p class="q1">
-<span class="v">50&#160;</span>Therefore I will give thanks to you, Yahweh, among the nations, 
-</p><p class="q2">and will sing praises to your name. 
-</p><p class="q1">
-<span class="v">51&#160;</span>He gives great deliverance to his king, 
-</p><p class="q2">and shows loving kindness to his anointed, 
-</p><p class="q2">to David and to his offspring, forever more.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the last words of David. 
-</p><p class="q1">David the son of Jesse says, 
-</p><p class="q2">the man who was raised on high says, 
-</p><p class="q2">the anointed of the Elohim of Jacob, 
-</p><p class="q2">the sweet psalmist of Israel: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Yahweh’s Spirit spoke by me. 
-</p><p class="q2">His word was on my tongue. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The Elohim of Israel said, 
-</p><p class="q2">the Rock of Israel spoke to me, 
-</p><p class="q2">‘One who rules over men righteously, 
-</p><p class="q2">who rules in the fear of Elohim, 
-</p><p class="q1">
-<span class="v">4&#160;</span>shall be as the light of the morning when the sun rises, 
-</p><p class="q2">a morning without clouds, 
-</p><p class="q2">when the tender grass springs out of the earth, 
-</p><p class="q2">through clear shining after rain.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Isn’t my house so with Elohim? 
-</p><p class="q2">Yet he has made with me an everlasting covenant, 
-</p><p class="q2">ordered in all things, and sure, 
-</p><p class="q2">for it is all my salvation and all my desire. 
-</p><p class="q2">Won’t he make it grow? 
-</p><p class="q1">
-<span class="v">6&#160;</span>But all the unelohimly will be as thorns to be thrust away, 
-</p><p class="q2">because they can’t be taken with the hand. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The man who touches them must be armed with iron and the staff of a spear. 
-</p><p class="q1">They will be utterly burned with fire in their place.” 
-</p><p>
-<span class="v">8&#160;</span>These are the names of the mighty men whom David had: Josheb Basshebeth a Tahchemonite, chief of the captains; he was called Adino the Eznite, who killed eight hundred at one time. 
-<span class="v">9&#160;</span>After him was Eleazar the son of Dodai the son of an Ahohite, one of the three mighty men with David when they defied the Philistines who were there gathered together to battle, and the men of Israel had gone away. 
-<span class="v">10&#160;</span>He arose and struck the Philistines until his hand was weary, and his hand froze to the sword; and Yahweh worked a great victory that day; and the people returned after him only to take plunder. 
-<span class="v">11&#160;</span>After him was Shammah the son of Agee a Hararite. The Philistines had gathered together into a troop where there was a plot of ground full of lentils; and the people fled from the Philistines. 
-<span class="v">12&#160;</span>But he stood in the middle of the plot and defended it, and killed the Philistines; and Yahweh worked a great victory. 
-</p><p>
-<span class="v">13&#160;</span>Three of the thirty chief men went down, and came to David in the harvest time to the cave of Adullam; and the troop of the Philistines was encamped in the valley of Rephaim. 
-<span class="v">14&#160;</span>David was then in the stronghold; and the garrison of the Philistines was then in Bethlehem. 
-<span class="v">15&#160;</span>David said longingly, “Oh that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
-</p><p>
-<span class="v">16&#160;</span>The three mighty men broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate and took it and brought it to David; but he would not drink of it, but poured it out to Yahweh. 
-<span class="v">17&#160;</span>He said, “Be it far from me, Yahweh, that I should do this! Isn’t this the blood of the men who risked their lives to go?” Therefore he would not drink it. The three mighty men did these things. 
-</p><p>
-<span class="v">18&#160;</span>Abishai, the brother of Joab, the son of Zeruiah, was chief of the three. He lifted up his spear against three hundred and killed them, and had a name among the three. 
-<span class="v">19&#160;</span>Wasn’t he most honorable of the three? Therefore he was made their captain. However he wasn’t included as one of the three. 
-</p><p>
-<span class="v">20&#160;</span>Benaiah the son of Jehoiada, the son of a valiant man of Kabzeel, who had done mighty deeds, killed the two sons of Ariel of Moab. He also went down and killed a lion in the middle of a pit in a time of snow. 
-<span class="v">21&#160;</span>He killed a huge Egyptian, and the Egyptian had a spear in his hand; but he went down to him with a staff and plucked the spear out of the Egyptian’s hand, and killed him with his own spear. 
-<span class="v">22&#160;</span>Benaiah the son of Jehoiada did these things, and had a name among the three mighty men. 
-<span class="v">23&#160;</span>He was more honorable than the thirty, but he didn’t attain to the three. David set him over his guard. 
-</p><p>
-<span class="v">24&#160;</span>Asahel the brother of Joab was one of the thirty: Elhanan the son of Dodo of Bethlehem, 
-<span class="v">25&#160;</span>Shammah the Harodite, Elika the Harodite, 
-<span class="v">26&#160;</span>Helez the Paltite, Ira the son of Ikkesh the Tekoite, 
-<span class="v">27&#160;</span>Abiezer the Anathothite, Mebunnai the Hushathite, 
-<span class="v">28&#160;</span>Zalmon the Ahohite, Maharai the Netophathite, 
-<span class="v">29&#160;</span>Heleb the son of Baanah the Netophathite, Ittai the son of Ribai of Gibeah of the children of Benjamin, 
-<span class="v">30&#160;</span>Benaiah a Pirathonite, Hiddai of the brooks of Gaash. 
-<span class="v">31&#160;</span>Abialbon the Arbathite, Azmaveth the Barhumite, 
-<span class="v">32&#160;</span>Eliahba the Shaalbonite, the sons of Jashen, Jonathan, 
-<span class="v">33&#160;</span>Shammah the Hararite, Ahiam the son of Sharar the Ararite, 
-<span class="v">34&#160;</span>Eliphelet the son of Ahasbai, the son of the Maacathite, Eliam the son of Ahithophel the Gilonite, 
-<span class="v">35&#160;</span>Hezro the Carmelite, Paarai the Arbite, 
-<span class="v">36&#160;</span>Igal the son of Nathan of Zobah, Bani the Gadite, 
-<span class="v">37&#160;</span>Zelek the Ammonite, Naharai the Beerothite, armor bearers to Joab the son of Zeruiah, 
-<span class="v">38&#160;</span>Ira the Ithrite, Gareb the Ithrite, 
-<span class="v">39&#160;</span>and Uriah the Hittite: thirty-seven in all. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Again Yahweh’s anger burned against Israel, and he moved David against them, saying, “Go, count Israel and Judah.” 
-<span class="v">2&#160;</span>The king said to Joab the captain of the army, who was with him, “Now go back and forth through all the tribes of Israel, from Dan even to Beersheba, and count the people, that I may know the sum of the people.” 
-</p><p>
-<span class="v">3&#160;</span>Joab said to the king, “Now may Yahweh your Elohim add to the people, however many they may be, one hundred times; and may the eyes of my lord the king see it. But why does my lord the king delight in this thing?” 
-</p><p>
-<span class="v">4&#160;</span>Notwithstanding, the king’s word prevailed against Joab and against the captains of the army. Joab and the captains of the army went out from the presence of the king to count the people of Israel. 
-<span class="v">5&#160;</span>They passed over the Jordan and encamped in Aroer, on the right side of the city that is in the middle of the valley of Gad, and to Jazer; 
-<span class="v">6&#160;</span>then they came to Gilead and to the land of Tahtim Hodshi; and they came to Dan Jaan and around to Sidon, 
-<span class="v">7&#160;</span>and came to the stronghold of Tyre, and to all the cities of the Hivites and of the Canaanites; and they went out to the south of Judah, at Beersheba. 
-<span class="v">8&#160;</span>So when they had gone back and forth through all the land, they came to Jerusalem at the end of nine months and twenty days. 
-<span class="v">9&#160;</span>Joab gave up the sum of the counting of the people to the king; and there were in Israel eight hundred thousand valiant men who drew the sword, and the men of Judah were five hundred thousand men. 
-</p><p>
-<span class="v">10&#160;</span>David’s heart struck him after he had counted the people. David said to Yahweh, “I have sinned greatly in that which I have done. But now, Yahweh, put away, I beg you, the iniquity of your servant; for I have done very foolishly.” 
-</p><p>
-<span class="v">11&#160;</span>When David rose up in the morning, Yahweh’s word came to the prophet Gad, David’s seer, saying, 
-<span class="v">12&#160;</span>“Go and speak to David, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>So Gad came to David, and told him, saying, “Shall seven years of famine come to you in your land? Or will you flee three months before your foes while they pursue you? Or shall there be three days’ pestilence in your land? Now answer, and consider what answer I shall return to him who sent me.” 
-</p><p>
-<span class="v">14&#160;</span>David said to Gad, “I am in distress. Let us fall now into Yahweh’s hand, for his mercies are great. Let me not fall into man’s hand.” 
-</p><p>
-<span class="v">15&#160;</span>So Yahweh sent a pestilence on Israel from the morning even to the appointed time; and seventy thousand men died of the people from Dan even to Beersheba. 
-<span class="v">16&#160;</span>When the angel stretched out his hand toward Jerusalem to destroy it, Yahweh relented of the disaster, and said to the angel who destroyed the people, “It is enough. Now withdraw your hand.” Yahweh’s angel was by the threshing floor of Araunah the Jebusite. 
-</p><p>
-<span class="v">17&#160;</span>David spoke to Yahweh when he saw the angel who struck the people, and said, “Behold, I have sinned, and I have done perversely; but these sheep, what have they done? Please let your hand be against me, and against my father’s house.” 
-</p><p>
-<span class="v">18&#160;</span>Gad came that day to David and said to him, “Go up, build an altar to Yahweh on the threshing floor of Araunah the Jebusite.” 
-</p><p>
-<span class="v">19&#160;</span>David went up according to the saying of Gad, as Yahweh commanded. 
-<span class="v">20&#160;</span>Araunah looked out, and saw the king and his servants coming on toward him. Then Araunah went out and bowed himself before the king with his face to the ground. 
-<span class="v">21&#160;</span>Araunah said, “Why has my lord the king come to his servant?” 
-</p><p>David said, “To buy your threshing floor, to build an altar to Yahweh, that the plague may be stopped from afflicting the people.” 
-</p><p>
-<span class="v">22&#160;</span>Araunah said to David, “Let my lord the king take and offer up what seems good to him. Behold, the cattle for the burnt offering, and the threshing sledges and the yokes of the oxen for the wood. 
-<span class="v">23&#160;</span>All this, O king, does Araunah give to the king.” Araunah said to the king, “May Yahweh your Elohim accept you.” 
-</p><p>
-<span class="v">24&#160;</span>The king said to Araunah, “No, but I will most certainly buy it from you for a price. I will not offer burnt offerings to Yahweh my Elohim which cost me nothing.” So David bought the threshing floor and the oxen for fifty shekels<span class="f">+ \fr 24:24 \ft A shekel is about 10 grams or about 0.35 ounces, so 50 shekels is about 0.5 kilograms or 1.1 pounds.</span> of silver. 
-<span class="v">25&#160;</span>David built an altar to Yahweh there, and offered burnt offerings and peace offerings. So Yahweh was entreated for the land, and the plague was removed from Israel. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>After the death of Saul, when David had returned from the slaughter of the Amalekites, and David had stayed two days in Ziklag, 
+<sup>2&#160;</sup>on the third day, behold, a man came out of the camp from Saul, with his clothes torn and earth on his head. When he came to David, he fell to the earth and showed respect. 
+</div><div class="p">
+<sup>3&#160;</sup>David said to him, “Where do you come from?” 
+</div><div class="p">He said to him, “I have escaped out of the camp of Israel.” 
+</div><div class="p">
+<sup>4&#160;</sup>David said to him, “How did it go? Please tell me.” 
+</div><div class="p">He answered, “The people have fled from the battle, and many of the people also have fallen and are dead. Saul and Jonathan his son are dead also.” 
+</div><div class="p">
+<sup>5&#160;</sup>David said to the young man who told him, “How do you know that Saul and Jonathan his son are dead?” 
+</div><div class="p">
+<sup>6&#160;</sup>The young man who told him said, “As I happened by chance on Mount Gilboa, behold, Saul was leaning on his spear; and behold, the chariots and the horsemen followed close behind him. 
+<sup>7&#160;</sup>When he looked behind him, he saw me and called to me. I answered, ‘Here I am.’ 
+<sup>8&#160;</sup>He said to me, ‘Who are you?’ I answered him, ‘I am an Amalekite.’ 
+<sup>9&#160;</sup>He said to me, ‘Please stand beside me, and kill me, for anguish has taken hold of me because my life lingers in me.’ 
+<sup>10&#160;</sup>So I stood beside him and killed him, because I was sure that he could not live after he had fallen. I took the crown that was on his head and the bracelet that was on his arm, and have brought them here to my lord.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then David took hold on his clothes and tore them; and all the men who were with him did likewise. 
+<sup>12&#160;</sup>They mourned, wept, and fasted until evening for Saul and for Jonathan his son, and for the people of Yahweh, and for the house of Israel, because they had fallen by the sword. 
+</div><div class="p">
+<sup>13&#160;</sup>David said to the young man who told him, “Where are you from?” 
+</div><div class="p">He answered, “I am the son of a foreigner, an Amalekite.” 
+</div><div class="p">
+<sup>14&#160;</sup>David said to him, “Why were you not afraid to stretch out your hand to destroy Yahweh’s anointed?” 
+<sup>15&#160;</sup>David called one of the young men and said, “Go near, and cut him down!” He struck him so that he died. 
+<sup>16&#160;</sup>David said to him, “Your blood be on your head, for your mouth has testified against you, saying, ‘I have slain Yahweh’s anointed.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>David lamented with this lamentation over Saul and over Jonathan his son 
+<sup>18&#160;</sup>(and he commanded them to teach the children of Judah the song of the bow; behold, it is written in the book of Jashar): 
+</div><div class="q1">
+<sup>19&#160;</sup>“Your glory, Israel, was slain on your high places! 
+</div><div class="q2">How the mighty have fallen! 
+</div><div class="q1">
+<sup>20&#160;</sup>Don’t tell it in Gath. 
+</div><div class="q2">Don’t publish it in the streets of Ashkelon, 
+</div><div class="q1">lest the daughters of the Philistines rejoice, 
+</div><div class="q2">lest the daughters of the uncircumcised triumph. 
+</div><div class="q1">
+<sup>21&#160;</sup>You mountains of Gilboa, 
+</div><div class="q2">let there be no dew or rain on you, and no fields of offerings; 
+</div><div class="q2">for there the shield of the mighty was defiled and cast away, 
+</div><div class="q2">the shield of Saul was not anointed with oil. 
+</div><div class="q1">
+<sup>22&#160;</sup>From the blood of the slain, 
+</div><div class="q2">from the fat of the mighty, 
+</div><div class="q2">Jonathan’s bow didn’t turn back. 
+</div><div class="q2">Saul’s sword didn’t return empty. 
+</div><div class="q1">
+<sup>23&#160;</sup>Saul and Jonathan were lovely and pleasant in their lives. 
+</div><div class="q2">In their death, they were not divided. 
+</div><div class="q1">They were swifter than eagles. 
+</div><div class="q2">They were stronger than lions. 
+</div><div class="q1">
+<sup>24&#160;</sup>You daughters of Israel, weep over Saul, 
+</div><div class="q2">who clothed you delicately in scarlet, 
+</div><div class="q2">who put ornaments of gold on your clothing. 
+</div><div class="q1">
+<sup>25&#160;</sup>How the mighty have fallen in the middle of the battle! 
+</div><div class="q2">Jonathan was slain on your high places. 
+</div><div class="q1">
+<sup>26&#160;</sup>I am distressed for you, my brother Jonathan. 
+</div><div class="q2">You have been very pleasant to me. 
+</div><div class="q2">Your love to me was wonderful, 
+</div><div class="q2">surpassing the love of women. 
+</div><div class="q1">
+<sup>27&#160;</sup>How the mighty have fallen, 
+</div><div class="q2">and the weapons of war have perished!” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, David inquired of Yahweh, saying, “Shall I go up into any of the cities of Judah?” 
+</div><div class="p">Yahweh said to him, “Go up.” 
+</div><div class="p">David said, “Where shall I go up?” 
+</div><div class="p">He said, “To Hebron.” 
+</div><div class="p">
+<sup>2&#160;</sup>So David went up there with his two women, Ahinoam the Jezreelitess, and Abigail the woman of Nabal the Carmelite. 
+<sup>3&#160;</sup>David brought up his men who were with him, every man with his household. They lived in the cities of Hebron. 
+<sup>4&#160;</sup>The men of Judah came, and there they anointed David king over the house of Judah. They told David, “The men of Jabesh Gilead were those who buried Saul.” 
+<sup>5&#160;</sup>David sent messengers to the men of Jabesh Gilead, and said to them, “Blessed are you by Yahweh, that you have shown this kindness to your lord, even to Saul, and have buried him. 
+<sup>6&#160;</sup>Now may Yahweh show loving kindness and truth to you. I also will reward you for this kindness, because you have done this thing. 
+<sup>7&#160;</sup>Now therefore let your hands be strong, and be valiant; for Saul your lord is dead, and also the house of Judah have anointed me king over them.” 
+</div><div class="p">
+<sup>8&#160;</sup>Now Abner the son of Ner, captain of Saul’s army, had taken Ishbosheth the son of Saul and brought him over to Mahanaim. 
+<sup>9&#160;</sup>He made him king over Gilead, over the Ashurites, over Jezreel, over Ephraim, over Benjamin, and over all Israel. 
+<sup>10&#160;</sup>Ishbosheth, Saul’s son, was forty years old when he began to reign over Israel, and he reigned two years. But the house of Judah followed David. 
+<sup>11&#160;</sup>The time that David was king in Hebron over the house of Judah was seven years and six months. 
+</div><div class="p">
+<sup>12&#160;</sup>Abner the son of Ner, and the servants of Ishbosheth the son of Saul, went out from Mahanaim to Gibeon. 
+<sup>13&#160;</sup>Joab the son of Zeruiah and David’s servants went out, and met them by the pool of Gibeon; and they sat down, the one on the one side of the pool and the other on the other side of the pool. 
+<sup>14&#160;</sup>Abner said to Joab, “Please let the young men arise and compete before us!” 
+</div><div class="p">Joab said, “Let them arise!” 
+<sup>15&#160;</sup>Then they arose and went over by number: twelve for Benjamin and for Ishbosheth the son of Saul, and twelve of David’s servants. 
+<sup>16&#160;</sup>They each caught his opponent by the head and thrust his sword in his fellow’s side; so they fell down together. Therefore that place in Gibeon was called Helkath Hazzurim. 
+<sup>17&#160;</sup>The battle was very severe that day; and Abner was beaten, and the men of Israel, before David’s servants. 
+<sup>18&#160;</sup>The three sons of Zeruiah were there: Joab, Abishai, and Asahel. Asahel was as light of foot as a wild gazelle. 
+<sup>19&#160;</sup>Asahel pursued Abner. He didn’t turn to the right hand or to the left from following Abner. 
+</div><div class="p">
+<sup>20&#160;</sup>Then Abner looked behind him and said, “Is that you, Asahel?” 
+</div><div class="p">He answered, “It is.” 
+</div><div class="p">
+<sup>21&#160;</sup>Abner said to him, “Turn away to your right hand or to your left, and grab one of the young men, and take his armor.” But Asahel would not turn away from following him. 
+<sup>22&#160;</sup>Abner said again to Asahel, “Turn away from following me. Why should I strike you to the ground? How then could I look Joab your brother in the face?” 
+<sup>23&#160;</sup>However, he refused to turn away. Therefore Abner with the back end of the spear struck him in the body, so that the spear came out behind him; and he fell down there and died in the same place. As many as came to the place where Asahel fell down and died stood still. 
+</div><div class="p">
+<sup>24&#160;</sup>But Joab and Abishai pursued Abner. The sun went down when they had come to the hill of Ammah, that lies before Giah by the way of the wilderness of Gibeon. 
+<sup>25&#160;</sup>The children of Benjamin gathered themselves together after Abner and became one band, and stood on the top of a hill. 
+<sup>26&#160;</sup>Then Abner called to Joab, and said, “Shall the sword devour forever? Don’t you know that it will be bitterness in the latter end? How long will it be then, before you ask the people to return from following their brothers?” 
+</div><div class="p">
+<sup>27&#160;</sup>Joab said, “As Elohim lives, if you had not spoken, surely then in the morning the people would have gone away, and not each followed his brother.” 
+<sup>28&#160;</sup>So Joab blew the trumpet; and all the people stood still and pursued Israel no more, and they fought no more. 
+<sup>29&#160;</sup>Abner and his men went all that night through the Arabah; and they passed over the Jordan, and went through all Bithron, and came to Mahanaim. 
+</div><div class="p">
+<sup>30&#160;</sup>Joab returned from following Abner; and when he had gathered all the people together, nineteen men of David’s and Asahel were missing. 
+<sup>31&#160;</sup>But David’s servants had struck Benjamin Abner’s men so that three hundred sixty men died. 
+<sup>32&#160;</sup>They took up Asahel and buried him in the tomb of his father, which was in Bethlehem. Joab and his men went all night, and the day broke on them at Hebron. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now there was long war between Saul’s house and David’s house. David grew stronger and stronger, but Saul’s house grew weaker and weaker. 
+<sup>2&#160;</sup>Sons were born to David in Hebron. His firstborn was Amnon, of Ahinoam the Jezreelitess; 
+<sup>3&#160;</sup>and his second, Chileab, of Abigail the woman of Nabal the Carmelite; and the third, Absalom the son of Maacah the daughter of Talmai king of Geshur; 
+<sup>4&#160;</sup>and the fourth, Adonijah the son of Haggith; and the fifth, Shephatiah the son of Abital; 
+<sup>5&#160;</sup>and the sixth, Ithream, of Eglah, David’s woman. These were born to David in Hebron. 
+</div><div class="p">
+<sup>6&#160;</sup>While there was war between Saul’s house and David’s house, Abner made himself strong in Saul’s house. 
+<sup>7&#160;</sup>Now Saul had a concubine, whose name was Rizpah, the daughter of Aiah; and Ishbosheth said to Abner, “Why have you gone in to my father’s concubine?” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Abner was very angry about Ishbosheth’s words, and said, “Am I a dog’s head that belongs to Judah? Today I show kindness to your father Saul’s house, to his brothers, and to his friends, and have not delivered you into the hand of David; and yet you charge me today with a fault concerning this woman! 
+<sup>9&#160;</sup>Elohim do so to Abner, and more also, if, as Yahweh has sworn to David, I don’t do even so to him: 
+<sup>10&#160;</sup>to transfer the kingdom from Saul’s house, and to set up David’s throne over Israel and over Judah, from Dan even to Beersheba.” 
+</div><div class="p">
+<sup>11&#160;</sup>He could not answer Abner another word, because he was afraid of him. 
+</div><div class="p">
+<sup>12&#160;</sup>Abner sent messengers to David on his behalf, saying, “Whose is the land?” and saying, “Make your alliance with me, and behold, my hand will be with you to bring all Israel around to you.” 
+</div><div class="p">
+<sup>13&#160;</sup>David said, “Good. I will make a treaty with you, but one thing I require of you. That is, you will not see my face unless you first bring Michal, Saul’s daughter, when you come to see my face.” 
+<sup>14&#160;</sup>David sent messengers to Ishbosheth, Saul’s son, saying, “Deliver me my woman Michal, whom I was given to marry for one hundred foreskins of the Philistines.” 
+</div><div class="p">
+<sup>15&#160;</sup>Ishbosheth sent and took her from her man, Paltiel the son of Laish. 
+<sup>16&#160;</sup>Her man went with her, weeping as he went, and followed her to Bahurim. Then Abner said to him, “Go! Return!” and he returned. 
+</div><div class="p">
+<sup>17&#160;</sup>Abner had communication with the elders of Israel, saying, “In times past, you sought for David to be king over you. 
+<sup>18&#160;</sup>Now then do it! For Yahweh has spoken of David, saying, ‘By the hand of my servant David, I will save my people Israel out of the hand of the Philistines, and out of the hand of all their enemies.’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>Abner also spoke in the ears of Benjamin; and Abner went also to speak in the ears of David in Hebron all that seemed good to Israel and to the whole house of Benjamin. 
+<sup>20&#160;</sup>So Abner came to David to Hebron, and twenty men with him. David made Abner and the men who were with him a feast. 
+<sup>21&#160;</sup>Abner said to David, “I will arise and go, and will gather all Israel to my lord the king, that they may make a covenant with you, and that you may reign over all that your soul desires.” David sent Abner away; and he went in peace. 
+</div><div class="p">
+<sup>22&#160;</sup>Behold, David’s servants and Joab came from a raid and brought in a great plunder with them; but Abner was not with David in Hebron, for he had sent him away, and he had gone in peace. 
+<sup>23&#160;</sup>When Joab and all the army who was with him had come, they told Joab, “Abner the son of Ner came to the king, and he has sent him away, and he has gone in peace.” 
+</div><div class="p">
+<sup>24&#160;</sup>Then Joab came to the king and said, “What have you done? Behold, Abner came to you. Why is it that you have sent him away, and he is already gone? 
+<sup>25&#160;</sup>You know Abner the son of Ner. He came to deceive you, and to know your going out and your coming in, and to know all that you do.” 
+</div><div class="p">
+<sup>26&#160;</sup>When Joab had come out from David, he sent messengers after Abner, and they brought him back from the well of Sirah; but David didn’t know it. 
+<sup>27&#160;</sup>When Abner had returned to Hebron, Joab took him aside into the middle of the gate to speak with him quietly, and struck him there in the body, so that he died for the blood of Asahel his brother. 
+<sup>28&#160;</sup>Afterward, when David heard it, he said, “I and my kingdom are guiltless before Yahweh forever of the blood of Abner the son of Ner. 
+<sup>29&#160;</sup>Let it fall on the head of Joab and on all his father’s house. Let there not fail from the house of Joab one who has a discharge, or who is a leper, or who leans on a staff, or who falls by the sword, or who lacks bread.” 
+<sup>30&#160;</sup>So Joab and Abishai his brother killed Abner, because he had killed their brother Asahel at Gibeon in the battle. 
+</div><div class="p">
+<sup>31&#160;</sup>David said to Joab and to all the people who were with him, “Tear your clothes, and clothe yourselves with sackcloth, and mourn in front of Abner.” King David followed the bier. 
+<sup>32&#160;</sup>They buried Abner in Hebron; and the king lifted up his voice and wept at Abner’s grave; and all the people wept. 
+<sup>33&#160;</sup>The king lamented for Abner, and said, “Should Abner die as a fool dies? 
+<sup>34&#160;</sup>Your hands weren’t bound, and your feet weren’t put into fetters. As a man falls before the children of iniquity, so you fell.” 
+</div><div class="p">All the people wept again over him. 
+<sup>35&#160;</sup>All the people came to urge David to eat bread while it was yet day; but David swore, saying, “Elohim do so to me, and more also, if I taste bread or anything else, until the sun goes down.” 
+</div><div class="p">
+<sup>36&#160;</sup>All the people took notice of it, and it pleased them, as whatever the king did pleased all the people. 
+<sup>37&#160;</sup>So all the people and all Israel understood that day that it was not of the king to kill Abner the son of Ner. 
+<sup>38&#160;</sup>The king said to his servants, “Don’t you know that a prince and a great man has fallen today in Israel? 
+<sup>39&#160;</sup>I am weak today, though anointed king. These men, the sons of Zeruiah are too hard for me. May Yahweh reward the evildoer according to his wickedness.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>When Saul’s son heard that Abner was dead in Hebron, his hands became feeble, and all the Israelites were troubled. 
+<sup>2&#160;</sup>Saul’s son had two men who were captains of raiding bands. The name of one was Baanah and the name of the other Rechab, the sons of Rimmon the Beerothite, of the children of Benjamin (for Beeroth also is considered a part of Benjamin; 
+<sup>3&#160;</sup>and the Beerothites fled to Gittaim, and have lived as foreigners there until today). 
+</div><div class="p">
+<sup>4&#160;</sup>Now Jonathan, Saul’s son, had a son who was lame in his feet. He was five years old when the news came about Saul and Jonathan out of Jezreel; and his nurse picked him up and fled. As she hurried to flee, he fell and became lame. His name was Mephibosheth. 
+</div><div class="p">
+<sup>5&#160;</sup>The sons of Rimmon the Beerothite, Rechab and Baanah, went out and came at about the heat of the day to the house of Ishbosheth as he took his rest at noon. 
+<sup>6&#160;</sup>They came there into the middle of the house as though they would have fetched wheat, and they struck him in the body; and Rechab and Baanah his brother escaped. 
+<sup>7&#160;</sup>Now when they came into the house as he lay on his bed in his bedroom, they struck him, killed him, beheaded him, and took his head, and went by the way of the Arabah all night. 
+<sup>8&#160;</sup>They brought the head of Ishbosheth to David to Hebron, and said to the king, “Behold, the head of Ishbosheth, the son of Saul, your enemy, who sought your life! Yahweh has avenged my lord the king today of Saul and of his offspring.” 
+</div><div class="p">
+<sup>9&#160;</sup>David answered Rechab and Baanah his brother, the sons of Rimmon the Beerothite, and said to them, “As Yahweh lives, who has redeemed my soul out of all adversity, 
+<sup>10&#160;</sup>when someone told me, ‘Behold, Saul is dead,’ thinking that he brought good news, I seized him and killed him in Ziklag, which was the reward I gave him for his news. 
+<sup>11&#160;</sup>How much more, when wicked men have slain a righteous person in his own house on his bed, should I not now require his blood from your hand, and rid the earth of you?” 
+<sup>12&#160;</sup>David commanded his young men, and they killed them, cut off their hands and their feet, and hanged them up beside the pool in Hebron. But they took the head of Ishbosheth and buried it in Abner’s grave in Hebron. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Then all the tribes of Israel came to David at Hebron and spoke, saying, “Behold, we are your bone and your flesh. 
+<sup>2&#160;</sup>In times past, when Saul was king over us, it was you who led Israel out and in. Yahweh said to you, ‘You will be shepherd of my people Israel, and you will be prince over Israel.’&#160;” 
+<sup>3&#160;</sup>So all the elders of Israel came to the king to Hebron, and King David made a covenant with them in Hebron before Yahweh; and they anointed David king over Israel. 
+</div><div class="p">
+<sup>4&#160;</sup>David was thirty years old when he began to reign, and he reigned forty years. 
+<sup>5&#160;</sup>In Hebron he reigned over Judah seven years and six months, and in Jerusalem he reigned thirty-three years over all Israel and Judah. 
+</div><div class="p">
+<sup>6&#160;</sup>The king and his men went to Jerusalem against the Jebusites, the inhabitants of the land, who spoke to David, saying, “The blind and the lame will keep you out of here,” thinking, “David can’t come in here.” 
+<sup>7&#160;</sup>Nevertheless David took the stronghold of Zion. This is David’s city. 
+<sup>8&#160;</sup>David said on that day, “Whoever strikes the Jebusites, let him go up to the watercourse and strike those lame and blind, who are hated by David’s soul.” Therefore they say, “The blind and the lame can’t come into the house.” 
+</div><div class="p">
+<sup>9&#160;</sup>David lived in the stronghold, and called it David’s city. David built around from Millo and inward. 
+<sup>10&#160;</sup>David grew greater and greater, for Yahweh, the Elohim of Armies, was with him. 
+<sup>11&#160;</sup>Hiram king of Tyre sent messengers to David, with cedar trees, carpenters, and masons; and they built David a house. 
+<sup>12&#160;</sup>David perceived that Yahweh had established him king over Israel, and that he had exalted his kingdom for his people Israel’s sake. 
+</div><div class="p">
+<sup>13&#160;</sup>David took more concubines and women for himself out of Jerusalem, after he had come from Hebron; and more sons and daughters were born to David. 
+<sup>14&#160;</sup>These are the names of those who were born to him in Jerusalem: Shammua, Shobab, Nathan, Solomon, 
+<sup>15&#160;</sup>Ibhar, Elishua, Nepheg, Japhia, 
+<sup>16&#160;</sup>Elishama, Eliada, and Eliphelet. 
+</div><div class="p">
+<sup>17&#160;</sup>When the Philistines heard that they had anointed David king over Israel, all the Philistines went up to seek David, but David heard about it and went down to the stronghold. 
+<sup>18&#160;</sup>Now the Philistines had come and spread themselves in the valley of Rephaim. 
+<sup>19&#160;</sup>David inquired of Yahweh, saying, “Shall I go up against the Philistines? Will you deliver them into my hand?” 
+</div><div class="p">Yahweh said to David, “Go up; for I will certainly deliver the Philistines into your hand.” 
+</div><div class="p">
+<sup>20&#160;</sup>David came to Baal Perazim, and David struck them there. Then he said, “Yahweh has broken my enemies before me, like the breach of waters.” Therefore he called the name of that place Baal Perazim. 
+<sup>21&#160;</sup>They left their images there, and David and his men took them away. 
+</div><div class="p">
+<sup>22&#160;</sup>The Philistines came up yet again and spread themselves in the valley of Rephaim. 
+<sup>23&#160;</sup>When David inquired of Yahweh, he said, “You shall not go up. Circle around behind them, and attack them in front of the mulberry trees. 
+<sup>24&#160;</sup>When you hear the sound of marching in the tops of the mulberry trees, then stir yourself up; for then Yahweh has gone out before you to strike the army of the Philistines.” 
+</div><div class="p">
+<sup>25&#160;</sup>David did so, as Yahweh commanded him, and struck the Philistines all the way from Geba to Gezer. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>David again gathered together all the chosen men of Israel, thirty thousand. 
+<sup>2&#160;</sup>David arose and went with all the people who were with him from Baale Judah, to bring up from there Elohim’s ark, which is called by the Name, even the name of Yahweh of Armies who sits above the cherubim. 
+<sup>3&#160;</sup>They set Elohim’s ark on a new cart, and brought it out of Abinadab’s house that was on the hill; and Uzzah and Ahio, the sons of Abinadab, drove the new cart. 
+<sup>4&#160;</sup>They brought it out of Abinadab’s house which was in the hill, with Elohim’s ark; and Ahio went before the ark. 
+<sup>5&#160;</sup>David and all the house of Israel played before Yahweh with all kinds of instruments made of cypress wood, with harps, with stringed instruments, with tambourines, with castanets, and with cymbals. 
+</div><div class="p">
+<sup>6&#160;</sup>When they came to the threshing floor of Nacon, Uzzah reached for Elohim’s ark and took hold of it, for the cattle stumbled. 
+<sup>7&#160;</sup>Yahweh’s anger burned against Uzzah, and Elohim struck him there for his error; and he died there by Elohim’s ark. 
+<sup>8&#160;</sup>David was displeased because Yahweh had broken out against Uzzah; and he called that place Perez Uzzah to this day. 
+<sup>9&#160;</sup>David was afraid of Yahweh that day; and he said, “How could Yahweh’s ark come to me?” 
+<sup>10&#160;</sup>So David would not move Yahweh’s ark to be with him in David’s city; but David carried it aside into Obed-Edom the Gittite’s house. 
+<sup>11&#160;</sup>Yahweh’s ark remained in Obed-Edom the Gittite’s house three months; and Yahweh blessed Obed-Edom and all his house. 
+<sup>12&#160;</sup>King David was told, “Yahweh has blessed the house of Obed-Edom, and all that belongs to him, because of Elohim’s ark.” 
+</div><div class="p">So David went and brought up Elohim’s ark from the house of Obed-Edom into David’s city with joy. 
+<sup>13&#160;</sup>When those who bore Yahweh’s ark had gone six paces, he sacrificed an ox and a fattened calf. 
+<sup>14&#160;</sup>David danced before Yahweh with all his might; and David was clothed in a linen ephod. 
+<sup>15&#160;</sup>So David and all the house of Israel brought up Yahweh’s ark with shouting and with the sound of the trumpet. 
+</div><div class="p">
+<sup>16&#160;</sup>As Yahweh’s ark came into David’s city, Michal the daughter of Saul looked out through the window and saw King David leaping and dancing before Yahweh; and she despised him in her heart. 
+<sup>17&#160;</sup>They brought in Yahweh’s ark, and set it in its place in the middle of the tent that David had pitched for it; and David offered burnt offerings and peace offerings before Yahweh. 
+<sup>18&#160;</sup>When David had finished offering the burnt offering and the peace offerings, he blessed the people in the name of Yahweh of Armies. 
+<sup>19&#160;</sup>He gave to all the people, even among the whole multitude of Israel, both to men and women, to everyone a portion of bread, dates, and raisins. So all the people departed, each to his own house. 
+</div><div class="p">
+<sup>20&#160;</sup>Then David returned to bless his household. Michal the daughter of Saul came out to meet David, and said, “How glorious the king of Israel was today, who uncovered himself today in the eyes of his servants’ maids, as one of the vain fellows shamelessly uncovers himself!” 
+</div><div class="p">
+<sup>21&#160;</sup>David said to Michal, “It was before Yahweh, who chose me above your father, and above all his house, to appoint me prince over the people of Yahweh, over Israel. Therefore I will celebrate before Yahweh. 
+<sup>22&#160;</sup>I will be yet more undignified than this, and will be worthless in my own sight. But the maids of whom you have spoken will honor me.” 
+</div><div class="p">
+<sup>23&#160;</sup>Michal the daughter of Saul had no child to the day of her death. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>When the king lived in his house, and Yahweh had given him rest from all his enemies all around, 
+<sup>2&#160;</sup>the king said to Nathan the prophet, “See now, I dwell in a house of cedar, but Elohim’s ark dwells within curtains.” 
+</div><div class="p">
+<sup>3&#160;</sup>Nathan said to the king, “Go, do all that is in your heart, for Yahweh is with you.” 
+</div><div class="p">
+<sup>4&#160;</sup>That same night, Yahweh’s word came to Nathan, saying, 
+<sup>5&#160;</sup>“Go and tell my servant David, ‘Yahweh says, “Should you build me a house for me to dwell in? 
+<sup>6&#160;</sup>For I have not lived in a house since the day that I brought the children of Israel up out of Egypt, even to this day, but have moved around in a tent and in a tabernacle. 
+<sup>7&#160;</sup>In all places in which I have walked with all the children of Israel, did I say a word to anyone from the tribes of Israel whom I commanded to be shepherd of my people Israel, saying, ‘Why have you not built me a house of cedar?’&#160;”&#160;’ 
+<sup>8&#160;</sup>Now therefore tell my servant David this: ‘Yahweh of Armies says, “I took you from the sheep pen, from following the sheep, to be prince over my people, over Israel. 
+<sup>9&#160;</sup>I have been with you wherever you went, and have cut off all your enemies from before you. I will make you a great name, like the name of the great ones who are in the earth. 
+<sup>10&#160;</sup>I will appoint a place for my people Israel, and will plant them, that they may dwell in their own place and be moved no more. The children of wickedness will not afflict them any more, as at the first, 
+<sup>11&#160;</sup>and as from the day that I commanded judges to be over my people Israel. I will cause you to rest from all your enemies. Moreover Yahweh tells you that Yahweh will make you a house. 
+<sup>12&#160;</sup>When your days are fulfilled and you sleep with your fathers, I will set up your offspring after you, who will proceed out of your body, and I will establish his kingdom. 
+<sup>13&#160;</sup>He will build a house for my name, and I will establish the throne of his kingdom forever. 
+<sup>14&#160;</sup>I will be his father, and he will be my son. If he commits iniquity, I will chasten him with the rod of men and with the stripes of the children of men; 
+<sup>15&#160;</sup>but my loving kindness will not depart from him, as I took it from Saul, whom I put away before you. 
+<sup>16&#160;</sup>Your house and your kingdom will be made sure forever before you. Your throne will be established forever.”&#160;’&#160;” 
+<sup>17&#160;</sup>Nathan spoke to David all these words, and according to all this vision. 
+</div><div class="p">
+<sup>18&#160;</sup>Then David the king went in and sat before Yahweh; and he said, “Who am I, Lord Yahweh, and what is my house, that you have brought me this far? 
+<sup>19&#160;</sup>This was yet a small thing in your eyes, Lord Yahweh, but you have spoken also of your servant’s house for a great while to come; and this among men, Lord Yahweh! 
+<sup>20&#160;</sup>What more can David say to you? For you know your servant, Lord Yahweh. 
+<sup>21&#160;</sup>For your word’s sake, and according to your own heart, you have worked all this greatness, to make your servant know it. 
+<sup>22&#160;</sup>Therefore you are great, Yahweh Elohim. For there is no one like you, neither is there any Elohim besides you, according to all that we have heard with our ears. 
+<sup>23&#160;</sup>What one nation in the earth is like your people, even like Israel, whom Elohim went to redeem to himself for a people, and to make himself a name, and to do great things for you, and awesome things for your land, before your people, whom you redeemed to yourself out of Egypt, from the nations and their elohims? 
+<sup>24&#160;</sup>You established for yourself your people Israel to be your people forever; and you, Yahweh, became their Elohim. 
+</div><div class="p">
+<sup>25&#160;</sup>“Now, Yahweh Elohim, the word that you have spoken concerning your servant, and concerning his house, confirm it forever, and do as you have spoken. 
+<sup>26&#160;</sup>Let your name be magnified forever, saying, ‘Yahweh of Armies is Elohim over Israel; and the house of your servant David will be established before you.’ 
+<sup>27&#160;</sup>For you, Yahweh of Armies, the Elohim of Israel, have revealed to your servant, saying, ‘I will build you a house.’ Therefore your servant has found in his heart to pray this prayer to you. 
+</div><div class="p">
+<sup>28&#160;</sup>“Now, O Lord Yahweh, you are Elohim, and your words are truth, and you have promised this good thing to your servant. 
+<sup>29&#160;</sup>Now therefore, let it please you to bless the house of your servant, that it may continue forever before you; for you, Lord Yahweh, have spoken it. Let the house of your servant be blessed forever with your blessing.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, David struck the Philistines and subdued them; and David took the bridle of the mother city out of the hand of the Philistines. 
+<sup>2&#160;</sup>He defeated Moab, and measured them with the line, making them to lie down on the ground; and he measured two lines to put to death, and one full line to keep alive. The Moabites became servants to David, and brought tribute. 
+</div><div class="p">
+<sup>3&#160;</sup>David also struck Hadadezer the son of Rehob, king of Zobah, as he went to recover his dominion at the River. 
+<sup>4&#160;</sup>David took from him one thousand seven hundred horsemen and twenty thousand footmen. David hamstrung the chariot horses, but reserved enough of them for one hundred chariots. 
+<sup>5&#160;</sup>When the Syrians of Damascus came to help Hadadezer king of Zobah, David struck twenty two thousand men of the Syrians. 
+<sup>6&#160;</sup>Then David put garrisons in Syria of Damascus; and the Syrians became servants to David, and brought tribute. Yahweh gave victory to David wherever he went. 
+<sup>7&#160;</sup>David took the shields of gold that were on the servants of Hadadezer, and brought them to Jerusalem. 
+<sup>8&#160;</sup>From Betah and from Berothai, cities of Hadadezer, King David took a great quantity of bronze. 
+</div><div class="p">
+<sup>9&#160;</sup>When Toi king of Hamath heard that David had struck all the army of Hadadezer, 
+<sup>10&#160;</sup>then Toi sent Joram his son to King David to greet him and to bless him, because he had fought against Hadadezer and struck him; for Hadadezer had wars with Toi. Joram brought with him vessels of silver, vessels of gold, and vessels of bronze. 
+<sup>11&#160;</sup>King David also dedicated these to Yahweh, with the silver and gold that he dedicated of all the nations which he subdued—<sup>12&#160;</sup>of Syria, of Moab, of the children of Ammon, of the Philistines, of Amalek, and of the plunder of Hadadezer, son of Rehob, king of Zobah. 
+</div><div class="p">
+<sup>13&#160;</sup>David earned a reputation when he returned from striking down eighteen thousand men of the Syrians in the Valley of Salt. 
+<sup>14&#160;</sup>He put garrisons in Edom. Throughout all Edom, he put garrisons, and all the Edomites became servants to David. Yahweh gave victory to David wherever he went. 
+</div><div class="p">
+<sup>15&#160;</sup>David reigned over all Israel; and David executed justice and righteousness for all his people. 
+<sup>16&#160;</sup>Joab the son of Zeruiah was over the army, Jehoshaphat the son of Ahilud was recorder, 
+<sup>17&#160;</sup>Zadok the son of Ahitub and Ahimelech the son of Abiathar were priests, Seraiah was scribe, 
+<sup>18&#160;</sup>Benaiah the son of Jehoiada was over the Cherethites and the Pelethites; and David’s sons were chief ministers. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>David said, “Is there yet any who is left of Saul’s house, that I may show him kindness for Jonathan’s sake?” 
+<sup>2&#160;</sup>There was of Saul’s house a servant whose name was Ziba, and they called him to David; and the king said to him, “Are you Ziba?” 
+</div><div class="p">He said, “I am your servant.” 
+</div><div class="p">
+<sup>3&#160;</sup>The king said, “Is there not yet any of Saul’s house, that I may show the kindness of Elohim to him?” 
+</div><div class="p">Ziba said to the king, “Jonathan still has a son, who is lame in his feet.” 
+</div><div class="p">
+<sup>4&#160;</sup>The king said to him, “Where is he?” 
+</div><div class="p">Ziba said to the king, “Behold, he is in the house of Machir the son of Ammiel, in Lo Debar.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then King David sent and brought him out of the house of Machir the son of Ammiel, from Lo Debar. 
+<sup>6&#160;</sup>Mephibosheth, the son of Jonathan, the son of Saul, came to David, fell on his face, and showed respect. David said, “Mephibosheth?” 
+</div><div class="p">He answered, “Behold, your servant!” 
+</div><div class="p">
+<sup>7&#160;</sup>David said to him, “Don’t be afraid, for I will surely show you kindness for Jonathan your father’s sake, and will restore to you all the land of Saul your father. You will eat bread at my table continually.” 
+</div><div class="p">
+<sup>8&#160;</sup>He bowed down, and said, “What is your servant, that you should look at such a dead dog as I am?” 
+</div><div class="p">
+<sup>9&#160;</sup>Then the king called to Ziba, Saul’s servant, and said to him, “All that belonged to Saul and to all his house I have given to your master’s son. 
+<sup>10&#160;</sup>Till the land for him—you, your sons, and your servants. Bring in the harvest, that your master’s son may have bread to eat; but Mephibosheth your master’s son will always eat bread at my table.” 
+</div><div class="p">Now Ziba had fifteen sons and twenty servants. 
+<sup>11&#160;</sup>Then Ziba said to the king, “According to all that my lord the king commands his servant, so your servant will do.” So Mephibosheth ate at the king’s table like one of the king’s sons. 
+<sup>12&#160;</sup>Mephibosheth had a young son, whose name was Mica. All who lived in Ziba’s house were servants to Mephibosheth. 
+<sup>13&#160;</sup>So Mephibosheth lived in Jerusalem, for he ate continually at the king’s table. He was lame in both his feet. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, the king of the children of Ammon died, and Hanun his son reigned in his place. 
+<sup>2&#160;</sup>David said, “I will show kindness to Hanun the son of Nahash, as his father showed kindness to me.” So David sent by his servants to comfort him concerning his father. David’s servants came into the land of the children of Ammon. 
+</div><div class="p">
+<sup>3&#160;</sup>But the princes of the children of Ammon said to Hanun their lord, “Do you think that David honors your father, in that he has sent comforters to you? Hasn’t David sent his servants to you to search the city, to spy it out, and to overthrow it?” 
+</div><div class="p">
+<sup>4&#160;</sup>So Hanun took David’s servants, shaved off one half of their beards, and cut off their garments in the middle, even to their buttocks, and sent them away. 
+<sup>5&#160;</sup>When they told David this, he sent to meet them, for the men were greatly ashamed. The king said, “Wait at Jericho until your beards have grown, and then return.” 
+</div><div class="p">
+<sup>6&#160;</sup>When the children of Ammon saw that they had become odious to David, the children of Ammon sent and hired the Syrians of Beth Rehob and the Syrians of Zobah, twenty thousand footmen, and the king of Maacah with one thousand men, and the men of Tob twelve thousand men. 
+<sup>7&#160;</sup>When David heard of it, he sent Joab and all the army of the mighty men. 
+<sup>8&#160;</sup>The children of Ammon came out, and put the battle in array at the entrance of the gate. The Syrians of Zobah and of Rehob and the men of Tob and Maacah were by themselves in the field. 
+<sup>9&#160;</sup>Now when Joab saw that the battle was set against him before and behind, he chose of all the choice men of Israel and put them in array against the Syrians. 
+<sup>10&#160;</sup>The rest of the people he committed into the hand of Abishai his brother; and he put them in array against the children of Ammon. 
+<sup>11&#160;</sup>He said, “If the Syrians are too strong for me, then you shall help me; but if the children of Ammon are too strong for you, then I will come and help you. 
+<sup>12&#160;</sup>Be courageous, and let’s be strong for our people and for the cities of our Elohim; and may Yahweh do what seems good to him.” 
+<sup>13&#160;</sup>So Joab and the people who were with him came near to the battle against the Syrians, and they fled before him. 
+<sup>14&#160;</sup>When the children of Ammon saw that the Syrians had fled, they likewise fled before Abishai, and entered into the city. Then Joab returned from the children of Ammon and came to Jerusalem. 
+</div><div class="p">
+<sup>15&#160;</sup>When the Syrians saw that they were defeated by Israel, they gathered themselves together. 
+<sup>16&#160;</sup>Hadadezer sent and brought out the Syrians who were beyond the River; and they came to Helam, with Shobach the captain of the army of Hadadezer at their head. 
+<sup>17&#160;</sup>David was told that; and he gathered all Israel together, passed over the Jordan, and came to Helam. The Syrians set themselves in array against David and fought with him. 
+<sup>18&#160;</sup>The Syrians fled before Israel; and David killed seven hundred charioteers of the Syrians and forty thousand horsemen, and struck Shobach the captain of their army, so that he died there. 
+<sup>19&#160;</sup>When all the kings who were servants to Hadadezer saw that they were defeated before Israel, they made peace with Israel and served them. So the Syrians were afraid to help the children of Ammon any more. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>At the return of the year, at the time when kings go out, David sent Joab and his servants with him, and all Israel; and they destroyed the children of Ammon and besieged Rabbah. But David stayed at Jerusalem. 
+<sup>2&#160;</sup>At evening, David arose from his bed and walked on the roof of the king’s house. From the roof, he saw a woman bathing, and the woman was very beautiful to look at. 
+<sup>3&#160;</sup>David sent and inquired after the woman. One said, “Isn’t this Bathsheba, the daughter of Eliam, Uriah the Hittite’s woman?” 
+</div><div class="p">
+<sup>4&#160;</sup>David sent messengers, and took her; and she came in to him, and he lay with her (for she was purified from her uncleanness); and she returned to her house. 
+<sup>5&#160;</sup>The woman conceived; and she sent and told David, and said, “I am with child.” 
+</div><div class="p">
+<sup>6&#160;</sup>David sent to Joab, “Send me Uriah the Hittite.” Joab sent Uriah to David. 
+<sup>7&#160;</sup>When Uriah had come to him, David asked him how Joab did, and how the people fared, and how the war prospered. 
+<sup>8&#160;</sup>David said to Uriah, “Go down to your house and wash your feet.” Uriah departed out of the king’s house, and a gift from the king was sent after him. 
+<sup>9&#160;</sup>But Uriah slept at the door of the king’s house with all the servants of his lord, and didn’t go down to his house. 
+<sup>10&#160;</sup>When they had told David, saying, “Uriah didn’t go down to his house,” David said to Uriah, “Haven’t you come from a journey? Why didn’t you go down to your house?” 
+</div><div class="p">
+<sup>11&#160;</sup>Uriah said to David, “The ark, Israel, and Judah, are staying in tents; and my lord Joab and the servants of my lord are encamped in the open field. Shall I then go into my house to eat and to drink, and to lie with my woman? As you live, and as your soul lives, I will not do this thing!” 
+</div><div class="p">
+<sup>12&#160;</sup>David said to Uriah, “Stay here today also, and tomorrow I will let you depart.” So Uriah stayed in Jerusalem that day and the next day. 
+<sup>13&#160;</sup>When David had called him, he ate and drank before him; and he made him drunk. At evening, he went out to lie on his bed with the servants of his lord, but didn’t go down to his house. 
+<sup>14&#160;</sup>In the morning, David wrote a letter to Joab and sent it by the hand of Uriah. 
+<sup>15&#160;</sup>He wrote in the letter, saying, “Send Uriah to the forefront of the hottest battle, and retreat from him, that he may be struck and die.” 
+</div><div class="p">
+<sup>16&#160;</sup>When Joab kept watch on the city, he assigned Uriah to the place where he knew that valiant men were. 
+<sup>17&#160;</sup>The men of the city went out and fought with Joab. Some of the people fell, even of David’s servants; and Uriah the Hittite died also. 
+<sup>18&#160;</sup>Then Joab sent and told David all the things concerning the war; 
+<sup>19&#160;</sup>and he commanded the messenger, saying, “When you have finished telling all the things concerning the war to the king, 
+<sup>20&#160;</sup>it shall be that, if the king’s wrath arise, and he asks you, ‘Why did you go so near to the city to fight? Didn’t you know that they would shoot from the wall? 
+<sup>21&#160;</sup>Who struck Abimelech the son of Jerubbesheth? Didn’t a woman cast an upper millstone on him from the wall, so that he died at Thebez? Why did you go so near the wall?’ then you shall say, ‘Your servant Uriah the Hittite is also dead.’&#160;” 
+</div><div class="p">
+<sup>22&#160;</sup>So the messenger went, and came and showed David all that Joab had sent him for. 
+<sup>23&#160;</sup>The messenger said to David, “The men prevailed against us, and came out to us into the field; and we were on them even to the entrance of the gate. 
+<sup>24&#160;</sup>The shooters shot at your servants from off the wall; and some of the king’s servants are dead, and your servant Uriah the Hittite is also dead.” 
+</div><div class="p">
+<sup>25&#160;</sup>Then David said to the messenger, “Tell Joab, ‘Don’t let this thing displease you, for the sword devours one as well as another. Make your battle stronger against the city, and overthrow it.’ Encourage him.” 
+</div><div class="p">
+<sup>26&#160;</sup>When Uriah’s woman heard that Uriah her man was dead, she mourned for her owner. 
+<sup>27&#160;</sup>When the mourning was past, David sent and took her home to his house, and she became his woman and bore him a son. But the thing that David had done displeased Yahweh. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh sent Nathan to David. He came to him, and said to him, “There were two men in one city: the one rich, and the other poor. 
+<sup>2&#160;</sup>The rich man had very many flocks and herds, 
+<sup>3&#160;</sup>but the poor man had nothing, except one little ewe lamb, which he had bought and raised. It grew up together with him and with his children. It ate of his own food, drank of his own cup, and lay in his bosom, and was like a daughter to him. 
+<sup>4&#160;</sup>A traveler came to the rich man, and he didn’t want to take of his own flock and of his own herd to prepare for the wayfaring man who had come to him, but took the poor man’s lamb and prepared it for the man who had come to him.” 
+</div><div class="p">
+<sup>5&#160;</sup>David’s anger burned hot against the man, and he said to Nathan, “As Yahweh lives, the man who has done this deserves to die! 
+<sup>6&#160;</sup>He must restore the lamb fourfold, because he did this thing and because he had no pity!” 
+</div><div class="p">
+<sup>7&#160;</sup>Nathan said to David, “You are the man! This is what Yahweh, the Elohim of Israel, says: ‘I anointed you king over Israel, and I delivered you out of the hand of Saul. 
+<sup>8&#160;</sup>I gave you your master’s house and your master’s women into your bosom, and gave you the house of Israel and of Judah; and if that would have been too little, I would have added to you many more such things. 
+<sup>9&#160;</sup>Why have you despised Yahweh’s word, to do that which is evil in his sight? You have struck Uriah the Hittite with the sword, have taken his woman to be your woman, and have slain him with the sword of the children of Ammon. 
+<sup>10&#160;</sup>Now therefore the sword will never depart from your house, because you have despised me and have taken Uriah the Hittite’s woman to be your woman.’ 
+</div><div class="p">
+<sup>11&#160;</sup>“This is what Yahweh says: ‘Behold, I will raise up evil against you out of your own house; and I will take your women before your eyes and give them to your neighbor, and he will lie with your women in the sight of this sun. 
+<sup>12&#160;</sup>For you did this secretly, but I will do this thing before all Israel, and before the sun.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>David said to Nathan, “I have sinned against Yahweh.” 
+</div><div class="p">Nathan said to David, “Yahweh also has put away your sin. You will not die. 
+<sup>14&#160;</sup>However, because by this deed you have given great occasion to Yahweh’s enemies to blaspheme, the child also who is born to you will surely die.” 
+<sup>15&#160;</sup>Then Nathan departed to his house. 
+</div><div class="p">Yahweh struck the child that Uriah’s woman bore to David, and he was very sick. 
+<sup>16&#160;</sup>David therefore begged Elohim for the child; and David fasted, and went in and lay all night on the ground. 
+<sup>17&#160;</sup>The elders of his house arose beside him, to raise him up from the earth; but he would not, and he didn’t eat bread with them. 
+<sup>18&#160;</sup>On the seventh day, the child died. David’s servants were afraid to tell him that the child was dead, for they said, “Behold, while the child was yet alive, we spoke to him and he didn’t listen to our voice. How will he then harm himself if we tell him that the child is dead?” 
+</div><div class="p">
+<sup>19&#160;</sup>But when David saw that his servants were whispering together, David perceived that the child was dead; and David said to his servants, “Is the child dead?” 
+</div><div class="p">They said, “He is dead.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then David arose from the earth, and washed and anointed himself, and changed his clothing; and he came into Yahweh’s house, and worshiped. Then he came to his own house; and when he requested, they set bread before him and he ate. 
+<sup>21&#160;</sup>Then his servants said to him, “What is this that you have done? You fasted and wept for the child while he was alive, but when the child was dead, you rose up and ate bread.” 
+</div><div class="p">
+<sup>22&#160;</sup>He said, “While the child was yet alive, I fasted and wept; for I said, ‘Who knows whether Yahweh will not be gracious to me, that the child may live?’ 
+<sup>23&#160;</sup>But now he is dead. Why should I fast? Can I bring him back again? I will go to him, but he will not return to me.” 
+</div><div class="p">
+<sup>24&#160;</sup>David comforted Bathsheba his woman, and went in to her, and lay with her. She bore a son, and he called his name Solomon. Yahweh loved him; 
+<sup>25&#160;</sup>and he sent by the hand of Nathan the prophet, and he named him Jedidiah, for Yahweh’s sake. 
+</div><div class="p">
+<sup>26&#160;</sup>Now Joab fought against Rabbah of the children of Ammon, and took the royal city. 
+<sup>27&#160;</sup>Joab sent messengers to David, and said, “I have fought against Rabbah. Yes, I have taken the city of waters. 
+<sup>28&#160;</sup>Now therefore gather the rest of the people together, and encamp against the city and take it; lest I take the city, and it be called by my name.” 
+</div><div class="p">
+<sup>29&#160;</sup>David gathered all the people together and went to Rabbah, and fought against it and took it. 
+<sup>30&#160;</sup>He took the crown of their king from off his head; and its weight was a talent of gold, and in it were precious stones; and it was set on David’s head. He brought a great quantity of plunder out of the city. 
+<sup>31&#160;</sup>He brought out the people who were in it, and put them to work under saws, under iron picks, under axes of iron, and made them go to the brick kiln; and he did so to all the cities of the children of Ammon. Then David and all the people returned to Jerusalem. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, Absalom the son of David had a beautiful sister, whose name was Tamar; and Amnon the son of David loved her. 
+<sup>2&#160;</sup>Amnon was so troubled that he became sick because of his sister Tamar, for she was a virgin, and it seemed hard to Amnon to do anything to her. 
+<sup>3&#160;</sup>But Amnon had a friend whose name was Jonadab the son of Shimeah, David’s brother; and Jonadab was a very subtle man. 
+<sup>4&#160;</sup>He said to him, “Why, son of the king, are you so sad from day to day? Won’t you tell me?” 
+</div><div class="p">Amnon said to him, “I love Tamar, my brother Absalom’s sister.” 
+</div><div class="p">
+<sup>5&#160;</sup>Jonadab said to him, “Lay down on your bed and pretend to be sick. When your father comes to see you, tell him, ‘Please let my sister Tamar come and give me bread to eat, and prepare the food in my sight, that I may see it and eat it from her hand.’&#160;” 
+</div><div class="p">
+<sup>6&#160;</sup>So Amnon lay down and faked being sick. When the king came to see him, Amnon said to the king, “Please let my sister Tamar come and make me a couple of cakes in my sight, that I may eat from her hand.” 
+</div><div class="p">
+<sup>7&#160;</sup>Then David sent home to Tamar, saying, “Go now to your brother Amnon’s house, and prepare food for him.” 
+<sup>8&#160;</sup>So Tamar went to her brother Amnon’s house; and he was lying down. She took dough, kneaded it, made cakes in his sight, and baked the cakes. 
+<sup>9&#160;</sup>She took the pan and poured them out before him, but he refused to eat. Amnon said, “Have all men leave me.” Then every man went out from him. 
+<sup>10&#160;</sup>Amnon said to Tamar, “Bring the food into the room, that I may eat from your hand.” Tamar took the cakes which she had made, and brought them into the room to Amnon her brother. 
+<sup>11&#160;</sup>When she had brought them near to him to eat, he took hold of her and said to her, “Come, lie with me, my sister!” 
+</div><div class="p">
+<sup>12&#160;</sup>She answered him, “No, my brother, do not force me! For no such thing ought to be done in Israel. Don’t you do this folly! 
+<sup>13&#160;</sup>As for me, where would I carry my shame? And as for you, you will be as one of the fools in Israel. Now therefore, please speak to the king; for he will not withhold me from you.” 
+</div><div class="p">
+<sup>14&#160;</sup>However, he would not listen to her voice; but being stronger than she, he forced her and lay with her. 
+<sup>15&#160;</sup>Then Amnon hated her with exceedingly great hatred; for the hatred with which he hated her was greater than the love with which he had loved her. Amnon said to her, “Arise, be gone!” 
+</div><div class="p">
+<sup>16&#160;</sup>She said to him, “Not so, because this great wrong in sending me away is worse than the other that you did to me!” 
+</div><div class="p">But he would not listen to her. 
+<sup>17&#160;</sup>Then he called his servant who ministered to him, and said, “Now put this woman out from me, and bolt the door after her.” 
+</div><div class="p">
+<sup>18&#160;</sup>She had a garment of various colors on her, for the king’s daughters who were virgins dressed in such robes. Then his servant brought her out and bolted the door after her. 
+<sup>19&#160;</sup>Tamar put ashes on her head, and tore her garment of various colors that was on her; and she laid her hand on her head and went her way, crying aloud as she went. 
+<sup>20&#160;</sup>Absalom her brother said to her, “Has Amnon your brother been with you? But now hold your peace, my sister. He is your brother. Don’t take this thing to heart.” 
+</div><div class="p">So Tamar remained desolate in her brother Absalom’s house. 
+<sup>21&#160;</sup>But when King David heard of all these things, he was very angry. 
+<sup>22&#160;</sup>Absalom spoke to Amnon neither good nor bad; for Absalom hated Amnon, because he had forced his sister Tamar. 
+</div><div class="p">
+<sup>23&#160;</sup>After two full years, Absalom had sheep shearers in Baal Hazor, which is beside Ephraim; and Absalom invited all the king’s sons. 
+<sup>24&#160;</sup>Absalom came to the king and said, “See now, your servant has sheep shearers. Please let the king and his servants go with your servant.” 
+</div><div class="p">
+<sup>25&#160;</sup>The king said to Absalom, “No, my son, let’s not all go, lest we be burdensome to you.” He pressed him; however he would not go, but blessed him. 
+</div><div class="p">
+<sup>26&#160;</sup>Then Absalom said, “If not, please let my brother Amnon go with us.” 
+</div><div class="p">The king said to him, “Why should he go with you?” 
+</div><div class="p">
+<sup>27&#160;</sup>But Absalom pressed him, and he let Amnon and all the king’s sons go with him. 
+<sup>28&#160;</sup>Absalom commanded his servants, saying, “Mark now, when Amnon’s heart is merry with wine; and when I tell you, ‘Strike Amnon,’ then kill him. Don’t be afraid. Haven’t I commanded you? Be courageous, and be valiant!” 
+</div><div class="p">
+<sup>29&#160;</sup>The servants of Absalom did to Amnon as Absalom had commanded. Then all the king’s sons arose, and every man got up on his mule and fled. 
+</div><div class="p">
+<sup>30&#160;</sup>While they were on the way, the news came to David, saying, “Absalom has slain all the king’s sons, and there is not one of them left!” 
+</div><div class="p">
+<sup>31&#160;</sup>Then the king arose, and tore his garments, and lay on the earth; and all his servants stood by with their clothes torn. 
+<sup>32&#160;</sup>Jonadab the son of Shimeah, David’s brother, answered, “Don’t let my lord suppose that they have killed all the young men, the king’s sons, for Amnon only is dead; for by the appointment of Absalom this has been determined from the day that he forced his sister Tamar. 
+<sup>33&#160;</sup>Now therefore don’t let my lord the king take the thing to his heart, to think that all the king’s sons are dead; for only Amnon is dead.” 
+<sup>34&#160;</sup>But Absalom fled. The young man who kept the watch lifted up his eyes and looked, and behold, many people were coming by way of the hillside behind him. 
+<sup>35&#160;</sup>Jonadab said to the king, “Behold, the king’s sons are coming! It is as your servant said.” 
+<sup>36&#160;</sup>As soon as he had finished speaking, behold, the king’s sons came, and lifted up their voices and wept. The king also and all his servants wept bitterly. 
+</div><div class="p">
+<sup>37&#160;</sup>But Absalom fled and went to Talmai the son of Ammihur, king of Geshur. David mourned for his son every day. 
+<sup>38&#160;</sup>So Absalom fled and went to Geshur, and was there three years. 
+<sup>39&#160;</sup>King David longed to go out to Absalom, for he was comforted concerning Amnon, since he was dead. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Joab the son of Zeruiah perceived that the king’s heart was toward Absalom. 
+<sup>2&#160;</sup>Joab sent to Tekoa and brought a wise woman from there, and said to her, “Please act like a mourner, and put on mourning clothing, please, and don’t anoint yourself with oil; but be as a woman who has mourned a long time for the dead. 
+<sup>3&#160;</sup>Go in to the king and speak like this to him.” So Joab put the words in her mouth. 
+</div><div class="p">
+<sup>4&#160;</sup>When the woman of Tekoa spoke to the king, she fell on her face to the ground, showed respect, and said, “Help, O king!” 
+</div><div class="p">
+<sup>5&#160;</sup>The king said to her, “What ails you?” 
+</div><div class="p">She answered, “Truly I am a widow, and my man is dead. 
+<sup>6&#160;</sup>Your servant had two sons; and they both fought together in the field, and there was no one to part them, but the one struck the other and killed him. 
+<sup>7&#160;</sup>Behold, the whole family has risen against your servant, and they say, ‘Deliver him who struck his brother, that we may kill him for the life of his brother whom he killed, and so destroy the heir also.’ Thus they would quench my coal which is left, and would leave to my man neither name nor remainder on the surface of the earth.” 
+</div><div class="p">
+<sup>8&#160;</sup>The king said to the woman, “Go to your house, and I will give a command concerning you.” 
+</div><div class="p">
+<sup>9&#160;</sup>The woman of Tekoa said to the king, “My lord, O king, may the iniquity be on me, and on my father’s house; and may the king and his throne be guiltless.” 
+</div><div class="p">
+<sup>10&#160;</sup>The king said, “Whoever says anything to you, bring him to me, and he will not bother you any more.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then she said, “Please let the king remember Yahweh your Elohim, that the avenger of blood destroy not any more, lest they destroy my son.” 
+</div><div class="p">He said, “As Yahweh lives, not one hair of your son shall fall to the earth.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then the woman said, “Please let your servant speak a word to my lord the king.” 
+</div><div class="p">He said, “Say on.” 
+</div><div class="p">
+<sup>13&#160;</sup>The woman said, “Why then have you devised such a thing against the people of Elohim? For in speaking this word the king is as one who is guilty, in that the king does not bring home again his banished one. 
+<sup>14&#160;</sup>For we must die, and are like water spilled on the ground, which can’t be gathered up again; neither does Elohim take away life, but devises means, that he who is banished not be an outcast from him. 
+<sup>15&#160;</sup>Now therefore, seeing that I have come to speak this word to my lord the king, it is because the people have made me afraid. Your servant said, ‘I will now speak to the king; it may be that the king will perform the request of his servant.’ 
+<sup>16&#160;</sup>For the king will hear, to deliver his servant out of the hand of the man who would destroy me and my son together out of the inheritance of Elohim. 
+<sup>17&#160;</sup>Then your servant said, ‘Please let the word of my lord the king bring rest; for as an angel of Elohim, so is my lord the king to discern good and bad. May Yahweh, your Elohim, be with you.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Then the king answered the woman, “Please don’t hide anything from me that I ask you.” 
+</div><div class="p">The woman said, “Let my lord the king now speak.” 
+</div><div class="p">
+<sup>19&#160;</sup>The king said, “Is the hand of Joab with you in all this?” 
+</div><div class="p">The woman answered, “As your soul lives, my lord the king, no one can turn to the right hand or to the left from anything that my lord the king has spoken; for your servant Joab urged me, and he put all these words in the mouth of your servant. 
+<sup>20&#160;</sup>Your servant Joab has done this thing to change the face of the matter. My lord is wise, according to the wisdom of an angel of Elohim, to know all things that are in the earth.” 
+</div><div class="p">
+<sup>21&#160;</sup>The king said to Joab, “Behold now, I have granted this thing. Go therefore, and bring the young man Absalom back.” 
+</div><div class="p">
+<sup>22&#160;</sup>Joab fell to the ground on his face, showed respect, and blessed the king. Joab said, “Today your servant knows that I have found favor in your sight, my lord, O king, in that the king has performed the request of his servant.” 
+</div><div class="p">
+<sup>23&#160;</sup>So Joab arose and went to Geshur, and brought Absalom to Jerusalem. 
+<sup>24&#160;</sup>The king said, “Let him return to his own house, but let him not see my face.” So Absalom returned to his own house, and didn’t see the king’s face. 
+<sup>25&#160;</sup>Now in all Israel there was no one to be so much praised as Absalom for his beauty. From the sole of his foot even to the crown of his head there was no defect in him. 
+<sup>26&#160;</sup>When he cut the hair of his head (now it was at every year’s end that he cut it; because it was heavy on him, therefore he cut it), he weighed the hair of his head at two hundred shekels, after the king’s weight. 
+<sup>27&#160;</sup>Three sons were born to Absalom, and one daughter, whose name was Tamar. She was a woman with a beautiful face. 
+<sup>28&#160;</sup>Absalom lived two full years in Jerusalem, and he didn’t see the king’s face. 
+<sup>29&#160;</sup>Then Absalom sent for Joab, to send him to the king, but he would not come to him. Then he sent again a second time, but he would not come. 
+<sup>30&#160;</sup>Therefore he said to his servants, “Behold, Joab’s field is near mine, and he has barley there. Go and set it on fire.” So Absalom’s servants set the field on fire. 
+</div><div class="p">
+<sup>31&#160;</sup>Then Joab arose and came to Absalom to his house, and said to him, “Why have your servants set my field on fire?” 
+</div><div class="p">
+<sup>32&#160;</sup>Absalom answered Joab, “Behold, I sent to you, saying, ‘Come here, that I may send you to the king, to say, “Why have I come from Geshur? It would be better for me to be there still. Now therefore, let me see the king’s face; and if there is iniquity in me, let him kill me.”&#160;’&#160;” 
+</div><div class="p">
+<sup>33&#160;</sup>So Joab came to the king and told him; and when he had called for Absalom, he came to the king and bowed himself on his face to the ground before the king; and the king kissed Absalom. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, Absalom prepared a chariot and horses for himself, and fifty men to run before him. 
+<sup>2&#160;</sup>Absalom rose up early, and stood beside the way of the gate. When any man had a suit which should come to the king for judgment, then Absalom called to him, and said, “What city are you from?” 
+</div><div class="p">He said, “Your servant is of one of the tribes of Israel.” 
+</div><div class="p">
+<sup>3&#160;</sup>Absalom said to him, “Behold, your matters are good and right; but there is no man deputized by the king to hear you.” 
+<sup>4&#160;</sup>Absalom said moreover, “Oh that I were made judge in the land, that every man who has any suit or cause might come to me, and I would do him justice!” 
+<sup>5&#160;</sup>It was so, that when any man came near to bow down to him, he stretched out his hand, took hold of him, and kissed him. 
+<sup>6&#160;</sup>Absalom did this sort of thing to all Israel who came to the king for judgment. So Absalom stole the hearts of the men of Israel. 
+</div><div class="p">
+<sup>7&#160;</sup>At the end of forty years, Absalom said to the king, “Please let me go and pay my vow, which I have vowed to Yahweh, in Hebron. 
+<sup>8&#160;</sup>For your servant vowed a vow while I stayed at Geshur in Syria, saying, ‘If Yahweh shall indeed bring me again to Jerusalem, then I will serve Yahweh.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>The king said to him, “Go in peace.” 
+</div><div class="p">So he arose and went to Hebron. 
+<sup>10&#160;</sup>But Absalom sent spies throughout all the tribes of Israel, saying, “As soon as you hear the sound of the trumpet, then you shall say, ‘Absalom is king in Hebron!’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>Two hundred men went with Absalom out of Jerusalem, who were invited, and went in their simplicity; and they didn’t know anything. 
+<sup>12&#160;</sup>Absalom sent for Ahithophel the Gilonite, David’s counselor, from his city, even from Giloh, while he was offering the sacrifices. The conspiracy was strong, for the people increased continually with Absalom. 
+<sup>13&#160;</sup>A messenger came to David, saying, “The hearts of the men of Israel are after Absalom.” 
+</div><div class="p">
+<sup>14&#160;</sup>David said to all his servants who were with him at Jerusalem, “Arise! Let’s flee, or else none of us will escape from Absalom. Hurry to depart, lest he overtake us quickly and bring down evil on us, and strike the city with the edge of the sword.” 
+</div><div class="p">
+<sup>15&#160;</sup>The king’s servants said to the king, “Behold, your servants are ready to do whatever my lord the king chooses.” 
+</div><div class="p">
+<sup>16&#160;</sup>The king went out, and all his household after him. The king left ten women, who were concubines, to keep the house. 
+<sup>17&#160;</sup>The king went out, and all the people after him; and they stayed in Beth Merhak. 
+<sup>18&#160;</sup>All his servants passed on beside him; and all the Cherethites, and all the Pelethites, and all the Gittites, six hundred men who came after him from Gath, passed on before the king. 
+</div><div class="p">
+<sup>19&#160;</sup>Then the king said to Ittai the Gittite, “Why do you also go with us? Return, and stay with the king; for you are a foreigner and also an exile. Return to your own place. 
+<sup>20&#160;</sup>Whereas you came but yesterday, should I today make you go up and down with us, since I go where I may? Return, and take back your brothers. Mercy and truth be with you.” 
+</div><div class="p">
+<sup>21&#160;</sup>Ittai answered the king and said, “As Yahweh lives, and as my lord the king lives, surely in what place my lord the king is, whether for death or for life, your servant will be there also.” 
+</div><div class="p">
+<sup>22&#160;</sup>David said to Ittai, “Go and pass over.” Ittai the Gittite passed over, and all his men, and all the little ones who were with him. 
+<sup>23&#160;</sup>All the country wept with a loud voice, and all the people passed over. The king also himself passed over the brook Kidron, and all the people passed over toward the way of the wilderness. 
+<sup>24&#160;</sup>Behold, Zadok also came, and all the Levites with him, bearing the ark of the covenant of Elohim; and they set down Elohim’s ark; and Abiathar went up until all the people finished passing out of the city. 
+<sup>25&#160;</sup>The king said to Zadok, “Carry Elohim’s ark back into the city. If I find favor in Yahweh’s eyes, he will bring me again, and show me both it and his habitation; 
+<sup>26&#160;</sup>but if he says, ‘I have no delight in you,’ behold, here I am. Let him do to me as seems good to him.” 
+<sup>27&#160;</sup>The king said also to Zadok the priest, “Aren’t you a seer? Return into the city in peace, and your two sons with you, Ahimaaz your son and Jonathan the son of Abiathar. 
+<sup>28&#160;</sup>Behold, I will stay at the fords of the wilderness until word comes from you to inform me.” 
+<sup>29&#160;</sup>Zadok therefore and Abiathar carried Elohim’s ark to Jerusalem again; and they stayed there. 
+<sup>30&#160;</sup>David went up by the ascent of the Mount of Olives, and wept as he went up; and he had his head covered and went barefoot. All the people who were with him each covered his head, and they went up, weeping as they went up. 
+</div><div class="p">
+<sup>31&#160;</sup>Someone told David, saying, “Ahithophel is among the conspirators with Absalom.” 
+</div><div class="p">David said, “Yahweh, please turn the counsel of Ahithophel into foolishness.” 
+</div><div class="p">
+<sup>32&#160;</sup>When David had come to the top, where Elohim was worshiped, behold, Hushai the Archite came to meet him with his tunic torn and earth on his head. 
+<sup>33&#160;</sup>David said to him, “If you pass on with me, then you will be a burden to me; 
+<sup>34&#160;</sup>but if you return to the city, and tell Absalom, ‘I will be your servant, O king. As I have been your father’s servant in time past, so I will now be your servant; then will you defeat for me the counsel of Ahithophel.’ 
+<sup>35&#160;</sup>Don’t you have Zadok and Abiathar the priests there with you? Therefore whatever you hear out of the king’s house, tell it to Zadok and Abiathar the priests. 
+<sup>36&#160;</sup>Behold, they have there with them their two sons, Ahimaaz, Zadok’s son, and Jonathan, Abiathar’s son. Send to me everything that you shall hear by them.” 
+</div><div class="p">
+<sup>37&#160;</sup>So Hushai, David’s friend, came into the city; and Absalom came into Jerusalem. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>When David was a little past the top, behold, Ziba the servant of Mephibosheth met him with a couple of donkeys saddled, and on them two hundred loaves of bread, and one hundred clusters of raisins, and one hundred summer fruits, and a container of wine. 
+<sup>2&#160;</sup>The king said to Ziba, “What do you mean by these?” 
+</div><div class="p">Ziba said, “The donkeys are for the king’s household to ride on; and the bread and summer fruit for the young men to eat; and the wine, that those who are faint in the wilderness may drink.” 
+</div><div class="p">
+<sup>3&#160;</sup>The king said, “Where is your master’s son?” 
+</div><div class="p">Ziba said to the king, “Behold, he is staying in Jerusalem; for he said, ‘Today the house of Israel will restore me the kingdom of my father.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the king said to Ziba, “Behold, all that belongs to Mephibosheth is yours.” 
+</div><div class="p">Ziba said, “I bow down. Let me find favor in your sight, my lord, O king.” 
+</div><div class="p">
+<sup>5&#160;</sup>When King David came to Bahurim, behold, a man of the family of Saul’s house came out, whose name was Shimei, the son of Gera. He came out and cursed as he came. 
+<sup>6&#160;</sup>He cast stones at David and at all the servants of King David, and all the people and all the mighty men were on his right hand and on his left. 
+<sup>7&#160;</sup>Shimei said when he cursed, “Be gone, be gone, you man of blood, and wicked fellow! 
+<sup>8&#160;</sup>Yahweh has returned on you all the blood of Saul’s house, in whose place you have reigned! Yahweh has delivered the kingdom into the hand of Absalom your son! Behold, you are caught by your own mischief, because you are a man of blood!” 
+</div><div class="p">
+<sup>9&#160;</sup>Then Abishai the son of Zeruiah said to the king, “Why should this dead dog curse my lord the king? Please let me go over and take off his head.” 
+<sup>10&#160;</sup>The king said, “What have I to do with you, you sons of Zeruiah? Because he curses, and because Yahweh has said to him, ‘Curse David,’ who then shall say, ‘Why have you done so?’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>David said to Abishai and to all his servants, “Behold, my son, who came out of my bowels, seeks my life. How much more this Benjamite, now? Leave him alone, and let him curse; for Yahweh has invited him. 
+<sup>12&#160;</sup>It may be that Yahweh will look on the wrong done to me, and that Yahweh will repay me good for the cursing of me today.” 
+<sup>13&#160;</sup>So David and his men went by the way; and Shimei went along on the hillside opposite him and cursed as he went, threw stones at him, and threw dust. 
+<sup>14&#160;</sup>The king and all the people who were with him arrived weary; and he refreshed himself there. 
+</div><div class="p">
+<sup>15&#160;</sup>Absalom and all the people, the men of Israel, came to Jerusalem, and Ahithophel with him. 
+<sup>16&#160;</sup>When Hushai the Archite, David’s friend, had come to Absalom, Hushai said to Absalom, “Long live the king! Long live the king!” 
+</div><div class="p">
+<sup>17&#160;</sup>Absalom said to Hushai, “Is this your kindness to your friend? Why didn’t you go with your friend?” 
+</div><div class="p">
+<sup>18&#160;</sup>Hushai said to Absalom, “No; but whomever Yahweh and this people and all the men of Israel have chosen, I will be his, and I will stay with him. 
+<sup>19&#160;</sup>Again, whom should I serve? Shouldn’t I serve in the presence of his son? As I have served in your father’s presence, so I will be in your presence.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then Absalom said to Ahithophel, “Give your counsel what we shall do.” 
+</div><div class="p">
+<sup>21&#160;</sup>Ahithophel said to Absalom, “Go in to your father’s concubines that he has left to keep the house. Then all Israel will hear that you are abhorred by your father. Then the hands of all who are with you will be strong.” 
+</div><div class="p">
+<sup>22&#160;</sup>So they spread a tent for Absalom on the top of the house, and Absalom went in to his father’s concubines in the sight of all Israel. 
+</div><div class="p">
+<sup>23&#160;</sup>The counsel of Ahithophel, which he gave in those days, was as if a man inquired at the inner sanctuary of Elohim. All the counsel of Ahithophel was like this both with David and with Absalom. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Moreover Ahithophel said to Absalom, “Let me now choose twelve thousand men, and I will arise and pursue after David tonight. 
+<sup>2&#160;</sup>I will come on him while he is weary and exhausted, and will make him afraid. All the people who are with him will flee. I will strike the king only, 
+<sup>3&#160;</sup>and I will bring back all the people to you. The man whom you seek is as if all returned. All the people shall be in peace.” 
+</div><div class="p">
+<sup>4&#160;</sup>The saying pleased Absalom well, and all the elders of Israel. 
+<sup>5&#160;</sup>Then Absalom said, “Now call Hushai the Archite also, and let’s hear likewise what he says.” 
+</div><div class="p">
+<sup>6&#160;</sup>When Hushai had come to Absalom, Absalom spoke to him, saying, “Ahithophel has spoken like this. Shall we do what he says? If not, speak up.” 
+</div><div class="p">
+<sup>7&#160;</sup>Hushai said to Absalom, “The counsel that Ahithophel has given this time is not good.” 
+<sup>8&#160;</sup>Hushai said moreover, “You know your father and his men, that they are mighty men, and they are fierce in their minds, like a bear robbed of her cubs in the field. Your father is a man of war, and will not lodge with the people. 
+<sup>9&#160;</sup>Behold, he is now hidden in some pit, or in some other place. It will happen, when some of them have fallen at the first, that whoever hears it will say, ‘There is a slaughter among the people who follow Absalom!’ 
+<sup>10&#160;</sup>Even he who is valiant, whose heart is as the heart of a lion, will utterly melt; for all Israel knows that your father is a mighty man, and those who are with him are valiant men. 
+<sup>11&#160;</sup>But I counsel that all Israel be gathered together to you, from Dan even to Beersheba, as the sand that is by the sea for multitude; and that you go to battle in your own person. 
+<sup>12&#160;</sup>So we will come on him in some place where he will be found, and we will light on him as the dew falls on the ground, then we will not leave so much as one of him and of all the men who are with him. 
+<sup>13&#160;</sup>Moreover, if he has gone into a city, then all Israel will bring ropes to that city, and we will draw it into the river, until there isn’t one small stone found there.” 
+</div><div class="p">
+<sup>14&#160;</sup>Absalom and all the men of Israel said, “The counsel of Hushai the Archite is better than the counsel of Ahithophel.” For Yahweh had ordained to defeat the good counsel of Ahithophel, to the intent that Yahweh might bring evil on Absalom. 
+</div><div class="p">
+<sup>15&#160;</sup>Then Hushai said to Zadok and to Abiathar the priests, “Ahithophel counseled Absalom and the elders of Israel that way; and I have counseled this way. 
+<sup>16&#160;</sup>Now therefore send quickly, and tell David, saying, ‘Don’t lodge tonight at the fords of the wilderness, but by all means pass over, lest the king be swallowed up, and all the people who are with him.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>Now Jonathan and Ahimaaz were staying by En Rogel; and a female servant used to go and report to them, and they went and told King David; for they couldn’t risk being seen coming into the city. 
+<sup>18&#160;</sup>But a boy saw them, and told Absalom. Then they both went away quickly and came to the house of a man in Bahurim, who had a well in his court; and they went down there. 
+<sup>19&#160;</sup>The woman took and spread the covering over the well’s mouth, and spread out crushed grain on it; and nothing was known. 
+<sup>20&#160;</sup>Absalom’s servants came to the woman to the house; and they said, “Where are Ahimaaz and Jonathan?” 
+</div><div class="p">The woman said to them, “They have gone over the brook of water.” 
+</div><div class="p">When they had sought and could not find them, they returned to Jerusalem. 
+<sup>21&#160;</sup>After they had departed, they came up out of the well and went and told King David; and they said to David, “Arise and pass quickly over the water; for thus has Ahithophel counseled against you.” 
+</div><div class="p">
+<sup>22&#160;</sup>Then David arose, and all the people who were with him, and they passed over the Jordan. By the morning light there lacked not one of them who had not gone over the Jordan. 
+</div><div class="p">
+<sup>23&#160;</sup>When Ahithophel saw that his counsel was not followed, he saddled his donkey, arose, and went home to his city, set his house in order, and hanged himself; and he died, and was buried in the tomb of his father. 
+</div><div class="p">
+<sup>24&#160;</sup>Then David came to Mahanaim. Absalom passed over the Jordan, he and all the men of Israel with him. 
+<sup>25&#160;</sup>Absalom set Amasa over the army instead of Joab. Now Amasa was the son of a man whose name was Ithra the Israelite, who went in to Abigail the daughter of Nahash, sister to Zeruiah, Joab’s mother. 
+<sup>26&#160;</sup>Israel and Absalom encamped in the land of Gilead. 
+</div><div class="p">
+<sup>27&#160;</sup>When David had come to Mahanaim, Shobi the son of Nahash of Rabbah of the children of Ammon, and Machir the son of Ammiel of Lodebar, and Barzillai the Gileadite of Rogelim, 
+<sup>28&#160;</sup>brought beds, basins, earthen vessels, wheat, barley, meal, parched grain, beans, lentils, roasted grain, 
+<sup>29&#160;</sup>honey, butter, sheep, and cheese of the herd, for David and for the people who were with him to eat; for they said, “The people are hungry, weary, and thirsty in the wilderness.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>David counted the people who were with him, and set captains of thousands and captains of hundreds over them. 
+<sup>2&#160;</sup>David sent the people out, a third part under the hand of Joab, and a third part under the hand of Abishai the son of Zeruiah, Joab’s brother, and a third part under the hand of Ittai the Gittite. The king said to the people, “I will also surely go out with you myself.” 
+</div><div class="p">
+<sup>3&#160;</sup>But the people said, “You shall not go out, for if we flee away, they will not care for us, neither if half of us die, will they care for us. But you are worth ten thousand of us. Therefore now it is better that you are ready to help us out of the city.” 
+</div><div class="p">
+<sup>4&#160;</sup>The king said to them, “I will do what seems best to you.” 
+</div><div class="p">The king stood beside the gate, and all the people went out by hundreds and by thousands. 
+<sup>5&#160;</sup>The king commanded Joab and Abishai and Ittai, saying, “Deal gently for my sake with the young man Absalom.” All the people heard when the king commanded all the captains concerning Absalom. 
+</div><div class="p">
+<sup>6&#160;</sup>So the people went out into the field against Israel; and the battle was in the forest of Ephraim. 
+<sup>7&#160;</sup>The people of Israel were struck there before David’s servants, and there was a great slaughter there that day of twenty thousand men. 
+<sup>8&#160;</sup>For the battle was there spread over the surface of all the country, and the forest devoured more people that day than the sword devoured. 
+</div><div class="p">
+<sup>9&#160;</sup>Absalom happened to meet David’s servants. Absalom was riding on his mule, and the mule went under the thick boughs of a great oak; and his head caught hold of the oak, and he was hanging between the sky and earth; and the mule that was under him went on. 
+<sup>10&#160;</sup>A certain man saw it, and told Joab, and said, “Behold, I saw Absalom hanging in an oak.” 
+</div><div class="p">
+<sup>11&#160;</sup>Joab said to the man who told him, “Behold, you saw it, and why didn’t you strike him there to the ground? I would have given you ten pieces of silver and a sash.” 
+</div><div class="p">
+<sup>12&#160;</sup>The man said to Joab, “Though I should receive a thousand pieces of silver in my hand, I still wouldn’t stretch out my hand against the king’s son; for in our hearing the king commanded you and Abishai and Ittai, saying, ‘Beware that no one touch the young man Absalom.’ 
+<sup>13&#160;</sup>Otherwise, if I had dealt falsely against his life (and there is no matter hidden from the king), then you yourself would have set yourself against me.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Joab said, “I’m not going to wait like this with you.” He took three darts in his hand and thrust them through Absalom’s heart while he was still alive in the middle of the oak. 
+<sup>15&#160;</sup>Ten young men who bore Joab’s armor surrounded and struck Absalom, and killed him. 
+<sup>16&#160;</sup>Joab blew the trumpet, and the people returned from pursuing after Israel; for Joab held the people back. 
+<sup>17&#160;</sup>They took Absalom and cast him into a great pit in the forest, and raised over him a very great heap of stones. Then all Israel fled, each to his own tent. 
+</div><div class="p">
+<sup>18&#160;</sup>Now Absalom in his lifetime had taken and reared up for himself the pillar which is in the king’s valley, for he said, “I have no son to keep my name in memory.” He called the pillar after his own name. It is called Absalom’s monument, to this day. 
+</div><div class="p">
+<sup>19&#160;</sup>Then Ahimaaz the son of Zadok said, “Let me now run and carry the king news, how Yahweh has avenged him of his enemies.” 
+</div><div class="p">
+<sup>20&#160;</sup>Joab said to him, “You must not be the bearer of news today, but you must carry news another day. But today you must carry no news, because the king’s son is dead.” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Joab said to the Cushite, “Go, tell the king what you have seen!” The Cushite bowed himself to Joab, and ran. 
+</div><div class="p">
+<sup>22&#160;</sup>Then Ahimaaz the son of Zadok said yet again to Joab, “But come what may, please let me also run after the Cushite.” 
+</div><div class="p">Joab said, “Why do you want to run, my son, since you will have no reward for the news?” 
+</div><div class="p">
+<sup>23&#160;</sup>“But come what may,” he said, “I will run.” 
+</div><div class="p">He said to him, “Run!” Then Ahimaaz ran by the way of the Plain, and outran the Cushite. 
+</div><div class="p">
+<sup>24&#160;</sup>Now David was sitting between the two gates; and the watchman went up to the roof of the gate to the wall, and lifted up his eyes and looked, and, behold, a man running alone. 
+<sup>25&#160;</sup>The watchman shouted and told the king. The king said, “If he is alone, there is news in his mouth.” He came closer and closer. 
+</div><div class="p">
+<sup>26&#160;</sup>The watchman saw another man running; and the watchman called to the gatekeeper and said, “Behold, a man running alone!” 
+</div><div class="p">The king said, “He also brings news.” 
+</div><div class="p">
+<sup>27&#160;</sup>The watchman said, “I think the running of the first one is like the running of Ahimaaz the son of Zadok.” 
+</div><div class="p">The king said, “He is a good man, and comes with good news.” 
+</div><div class="p">
+<sup>28&#160;</sup>Ahimaaz called, and said to the king, “All is well.” He bowed himself before the king with his face to the earth, and said, “Blessed is Yahweh your Elohim, who has delivered up the men who lifted up their hand against my lord the king!” 
+</div><div class="p">
+<sup>29&#160;</sup>The king said, “Is it well with the young man Absalom?” 
+</div><div class="p">Ahimaaz answered, “When Joab sent the king’s servant, even me your servant, I saw a great tumult, but I don’t know what it was.” 
+</div><div class="p">
+<sup>30&#160;</sup>The king said, “Come and stand here.” He came and stood still. 
+</div><div class="p">
+<sup>31&#160;</sup>Behold, the Cushite came. The Cushite said, “Good news for my lord the king, for Yahweh has avenged you today of all those who rose up against you.” 
+</div><div class="p">
+<sup>32&#160;</sup>The king said to the Cushite, “Is it well with the young man Absalom?” 
+</div><div class="p">The Cushite answered, “May the enemies of my lord the king, and all who rise up against you to do you harm, be as that young man is.” 
+</div><div class="p">
+<sup>33&#160;</sup>The king was much moved, and went up to the room over the gate and wept. As he went, he said, “My son Absalom! My son, my son Absalom! I wish I had died instead of you, Absalom, my son, my son!” 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Joab was told, “Behold, the king weeps and mourns for Absalom.” 
+<sup>2&#160;</sup>The victory that day was turned into mourning among all the people, for the people heard it said that day, “The king grieves for his son.” 
+</div><div class="p">
+<sup>3&#160;</sup>The people sneaked into the city that day, as people who are ashamed steal away when they flee in battle. 
+<sup>4&#160;</sup>The king covered his face, and the king cried with a loud voice, “My son Absalom, Absalom, my son, my son!” 
+</div><div class="p">
+<sup>5&#160;</sup>Joab came into the house to the king, and said, “Today you have shamed the faces of all your servants who today have saved your life, and the lives of your sons and of your daughters, and the lives of your women, and the lives of your concubines; 
+<sup>6&#160;</sup>in that you love those who hate you and hate those who love you. For you have declared today that princes and servants are nothing to you. For today I perceive that if Absalom had lived and we had all died today, then it would have pleased you well. 
+<sup>7&#160;</sup>Now therefore arise, go out and speak to comfort your servants; for I swear by Yahweh, if you don’t go out, not a man will stay with you this night. That would be worse to you than all the evil that has happened to you from your youth until now.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then the king arose and sat in the gate. The people were all told, “Behold, the king is sitting in the gate.” All the people came before the king. Now Israel had fled every man to his tent. 
+<sup>9&#160;</sup>All the people were at strife throughout all the tribes of Israel, saying, “The king delivered us out of the hand of our enemies, and he saved us out of the hand of the Philistines; and now he has fled out of the land from Absalom. 
+<sup>10&#160;</sup>Absalom, whom we anointed over us, is dead in battle. Now therefore why don’t you speak a word of bringing the king back?” 
+</div><div class="p">
+<sup>11&#160;</sup>King David sent to Zadok and to Abiathar the priests, saying, “Speak to the elders of Judah, saying, ‘Why are you the last to bring the king back to his house, since the speech of all Israel has come to the king, to return him to his house? 
+<sup>12&#160;</sup>You are my brothers. You are my bone and my flesh. Why then are you the last to bring back the king?’ 
+<sup>13&#160;</sup>Say to Amasa, ‘Aren’t you my bone and my flesh? Elohim do so to me, and more also, if you aren’t captain of the army before me continually instead of Joab.’&#160;” 
+<sup>14&#160;</sup>He bowed the heart of all the men of Judah, even as one man, so that they sent to the king, saying, “Return, you and all your servants.” 
+</div><div class="p">
+<sup>15&#160;</sup>So the king returned, and came to the Jordan. Judah came to Gilgal, to go to meet the king, to bring the king over the Jordan. 
+<sup>16&#160;</sup>Shimei the son of Gera, the Benjamite, who was of Bahurim, hurried and came down with the men of Judah to meet King David. 
+<sup>17&#160;</sup>There were a thousand men of Benjamin with him, and Ziba the servant of Saul’s house, and his fifteen sons and his twenty servants with him; and they went through the Jordan in the presence of the king. 
+<sup>18&#160;</sup>A ferry boat went to bring over the king’s household, and to do what he thought good. 
+</div><div class="p">Shimei the son of Gera fell down before the king when he had come over the Jordan. 
+<sup>19&#160;</sup>He said to the king, “Don’t let my lord impute iniquity to me, or remember that which your servant did perversely the day that my lord the king went out of Jerusalem, that the king should take it to his heart. 
+<sup>20&#160;</sup>For your servant knows that I have sinned. Therefore behold, I have come today as the first of all the house of Joseph to go down to meet my lord the king.” 
+</div><div class="p">
+<sup>21&#160;</sup>But Abishai the son of Zeruiah answered, “Shouldn’t Shimei be put to death for this, because he cursed Yahweh’s anointed?” 
+</div><div class="p">
+<sup>22&#160;</sup>David said, “What have I to do with you, you sons of Zeruiah, that you should be adversaries to me today? Shall any man be put to death today in Israel? For don’t I know that I am king over Israel today?” 
+<sup>23&#160;</sup>The king said to Shimei, “You will not die.” The king swore to him. 
+</div><div class="p">
+<sup>24&#160;</sup>Mephibosheth the son of Saul came down to meet the king; and he had neither groomed his feet, nor trimmed his beard, nor washed his clothes, from the day the king departed until the day he came home in peace. 
+<sup>25&#160;</sup>When he had come to Jerusalem to meet the king, the king said to him, “Why didn’t you go with me, Mephibosheth?” 
+</div><div class="p">
+<sup>26&#160;</sup>He answered, “My lord, O king, my servant deceived me. For your servant said, ‘I will saddle a donkey for myself, that I may ride on it and go with the king,’ because your servant is lame. 
+<sup>27&#160;</sup>He has slandered your servant to my lord the king, but my lord the king is as an angel of Elohim. Therefore do what is good in your eyes. 
+<sup>28&#160;</sup>For all my father’s house were but dead men before my lord the king; yet you set your servant among those who ate at your own table. What right therefore have I yet that I should appeal any more to the king?” 
+</div><div class="p">
+<sup>29&#160;</sup>The king said to him, “Why do you speak any more of your matters? I say, you and Ziba divide the land.” 
+</div><div class="p">
+<sup>30&#160;</sup>Mephibosheth said to the king, “Yes, let him take all, because my lord the king has come in peace to his own house.” 
+</div><div class="p">
+<sup>31&#160;</sup>Barzillai the Gileadite came down from Rogelim; and he went over the Jordan with the king to conduct him over the Jordan. 
+<sup>32&#160;</sup>Now Barzillai was a very aged man, even eighty years old. He had provided the king with sustenance while he stayed at Mahanaim, for he was a very great man. 
+<sup>33&#160;</sup>The king said to Barzillai, “Come over with me, and I will sustain you with me in Jerusalem.” 
+</div><div class="p">
+<sup>34&#160;</sup>Barzillai said to the king, “How many are the days of the years of my life, that I should go up with the king to Jerusalem? 
+<sup>35&#160;</sup>I am eighty years old, today. Can I discern between good and bad? Can your servant taste what I eat or what I drink? Can I hear the voice of singing men and singing women any more? Why then should your servant be a burden to my lord the king? 
+<sup>36&#160;</sup>Your servant will just go over the Jordan with the king. Why should the king repay me with such a reward? 
+<sup>37&#160;</sup>Please let your servant turn back again, that I may die in my own city, by the grave of my father and my mother. But behold, your servant Chimham; let him go over with my lord the king; and do to him what shall seem good to you.” 
+</div><div class="p">
+<sup>38&#160;</sup>The king answered, “Chimham shall go over with me, and I will do to him that which shall seem good to you. Whatever you request of me, that I will do for you.” 
+</div><div class="p">
+<sup>39&#160;</sup>All the people went over the Jordan, and the king went over. Then the king kissed Barzillai and blessed him; and he returned to his own place. 
+<sup>40&#160;</sup>So the king went over to Gilgal, and Chimham went over with him. All the people of Judah brought the king over, and also half the people of Israel. 
+<sup>41&#160;</sup>Behold, all the men of Israel came to the king, and said to the king, “Why have our brothers the men of Judah stolen you away, and brought the king and his household, over the Jordan, and all David’s men with him?” 
+</div><div class="p">
+<sup>42&#160;</sup>All the men of Judah answered the men of Israel, “Because the king is a close relative to us. Why then are you angry about this matter? Have we eaten at all at the king’s cost? Or has he given us any gift?” 
+</div><div class="p">
+<sup>43&#160;</sup>The men of Israel answered the men of Judah, and said, “We have ten parts in the king, and we have also more claim to David than you. Why then did you despise us, that our advice should not be first had in bringing back our king?” The words of the men of Judah were fiercer than the words of the men of Israel. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>There happened to be there a wicked fellow, whose name was Sheba the son of Bichri, a Benjamite; and he blew the trumpet, and said, “We have no portion in David, neither have we inheritance in the son of Jesse. Every man to his tents, Israel!” 
+</div><div class="p">
+<sup>2&#160;</sup>So all the men of Israel went up from following David, and followed Sheba the son of Bichri; but the men of Judah joined with their king, from the Jordan even to Jerusalem. 
+</div><div class="p">
+<sup>3&#160;</sup>David came to his house at Jerusalem; and the king took the ten women his concubines, whom he had left to keep the house, and put them in custody and provided them with sustenance, but didn’t go in to them. So they were shut up to the day of their death, living in widowhood. 
+</div><div class="p">
+<sup>4&#160;</sup>Then the king said to Amasa, “Call me the men of Judah together within three days, and be here present.” 
+</div><div class="p">
+<sup>5&#160;</sup>So Amasa went to call the men of Judah together, but he stayed longer than the set time which had been appointed to him. 
+<sup>6&#160;</sup>David said to Abishai, “Now Sheba the son of Bichri will do us more harm than Absalom did. Take your lord’s servants and pursue after him, lest he get himself fortified cities, and escape out of our sight.” 
+</div><div class="p">
+<sup>7&#160;</sup>Joab’s men went out after him with the Cherethites, the Pelethites, and all the mighty men; and they went out of Jerusalem to pursue Sheba the son of Bichri. 
+<sup>8&#160;</sup>When they were at the great stone which is in Gibeon, Amasa came to meet them. Joab was clothed in his apparel of war that he had put on, and on it was a sash with a sword fastened on his waist in its sheath; and as he went along it fell out. 
+<sup>9&#160;</sup>Joab said to Amasa, “Is it well with you, my brother?” Joab took Amasa by the beard with his right hand to kiss him. 
+<sup>10&#160;</sup>But Amasa took no heed to the sword that was in Joab’s hand. So he struck him with it in the body and shed out his bowels to the ground, and didn’t strike him again; and he died. Joab and Abishai his brother pursued Sheba the son of Bichri. 
+<sup>11&#160;</sup>One of Joab’s young men stood by him, and said, “He who favors Joab, and he who is for David, let him follow Joab!” 
+</div><div class="p">
+<sup>12&#160;</sup>Amasa lay wallowing in his blood in the middle of the highway. When the man saw that all the people stood still, he carried Amasa out of the highway into the field, and cast a garment over him when he saw that everyone who came by him stood still. 
+<sup>13&#160;</sup>When he was removed out of the highway, all the people went on after Joab to pursue Sheba the son of Bichri. 
+<sup>14&#160;</sup>He went through all the tribes of Israel to Abel, to Beth Maacah, and all the Berites. They were gathered together, and went also after him. 
+<sup>15&#160;</sup>They came and besieged him in Abel of Beth Maacah, and they cast up a mound against the city, and it stood against the rampart; and all the people who were with Joab battered the wall to throw it down. 
+</div><div class="p">
+<sup>16&#160;</sup>Then a wise woman cried out of the city, “Hear, hear! Please say to Joab, ‘Come near here, that I may speak with you.’&#160;” 
+<sup>17&#160;</sup>He came near to her; and the woman said, “Are you Joab?” 
+</div><div class="p">He answered, “I am.” 
+</div><div class="p">Then she said to him, “Hear the words of your servant.” 
+</div><div class="p">He answered, “I’m listening.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then she spoke, saying, “They used to say in old times, ‘They shall surely ask counsel at Abel,’ and so they settled a matter. 
+<sup>19&#160;</sup>I am among those who are peaceable and faithful in Israel. You seek to destroy a city and a mother in Israel. Why will you swallow up Yahweh’s inheritance?” 
+</div><div class="p">
+<sup>20&#160;</sup>Joab answered, “Far be it, far be it from me, that I should swallow up or destroy. 
+<sup>21&#160;</sup>The matter is not so. But a man of the hill country of Ephraim, Sheba the son of Bichri by name, has lifted up his hand against the king, even against David. Just deliver him, and I will depart from the city.” 
+</div><div class="p">The woman said to Joab, “Behold, his head will be thrown to you over the wall.” 
+</div><div class="p">
+<sup>22&#160;</sup>Then the woman went to all the people in her wisdom. They cut off the head of Sheba the son of Bichri, and threw it out to Joab. He blew the trumpet, and they were dispersed from the city, every man to his tent. Then Joab returned to Jerusalem to the king. 
+</div><div class="p">
+<sup>23&#160;</sup>Now Joab was over all the army of Israel, Benaiah the son of Jehoiada was over the Cherethites and over the Pelethites, 
+<sup>24&#160;</sup>Adoram was over the men subject to forced labor, Jehoshaphat the son of Ahilud was the recorder, 
+<sup>25&#160;</sup>Sheva was scribe, Zadok and Abiathar were priests, 
+<sup>26&#160;</sup>and Ira the Jairite was chief minister to David. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>There was a famine in the days of David for three years, year after year; and David sought the face of Yahweh. Yahweh said, “It is for Saul, and for his bloody house, because he put the Gibeonites to death.” 
+</div><div class="p">
+<sup>2&#160;</sup>The king called the Gibeonites and said to them (now the Gibeonites were not of the children of Israel, but of the remnant of the Amorites, and the children of Israel had sworn to them; and Saul sought to kill them in his zeal for the children of Israel and Judah); 
+<sup>3&#160;</sup>and David said to the Gibeonites, “What should I do for you? And with what should I make atonement, that you may bless Yahweh’s inheritance?” 
+</div><div class="p">
+<sup>4&#160;</sup>The Gibeonites said to him, “It is no matter of silver or gold between us and Saul or his house; neither is it for us to put any man to death in Israel.” 
+</div><div class="p">He said, “I will do for you whatever you say.” 
+</div><div class="p">
+<sup>5&#160;</sup>They said to the king, “The man who consumed us and who plotted against us, that we should be destroyed from remaining in any of the borders of Israel, 
+<sup>6&#160;</sup>let seven men of his sons be delivered to us, and we will hang them up to Yahweh in Gibeah of Saul, the chosen of Yahweh.” 
+</div><div class="p">The king said, “I will give them.” 
+</div><div class="p">
+<sup>7&#160;</sup>But the king spared Mephibosheth the son of Jonathan the son of Saul, because of Yahweh’s oath that was between them, between David and Jonathan the son of Saul. 
+<sup>8&#160;</sup>But the king took the two sons of Rizpah the daughter of Aiah, whom she bore to Saul, Armoni and Mephibosheth; and the five sons of Merab the daughter of Saul, whom she bore to Adriel the son of Barzillai the Meholathite. 
+<sup>9&#160;</sup>He delivered them into the hands of the Gibeonites; and they hanged them on the mountain before Yahweh, and all seven of them fell together. They were put to death in the days of harvest, in the first days, at the beginning of barley harvest. 
+</div><div class="p">
+<sup>10&#160;</sup>Rizpah the daughter of Aiah took sackcloth and spread it for herself on the rock, from the beginning of harvest until water poured on them from the sky. She allowed neither the birds of the sky to rest on them by day, nor the animals of the field by night. 
+<sup>11&#160;</sup>David was told what Rizpah the daughter of Aiah, the concubine of Saul, had done. 
+<sup>12&#160;</sup>So David went and took the bones of Saul and the bones of Jonathan his son from the owners of Jabesh Gilead, who had stolen them from the street of Beth Shan, where the Philistines had hanged them in the day that the Philistines killed Saul in Gilboa; 
+<sup>13&#160;</sup>and he brought up from there the bones of Saul and the bones of Jonathan his son. They also gathered the bones of those who were hanged. 
+<sup>14&#160;</sup>They buried the bones of Saul and Jonathan his son in the country of Benjamin in Zela, in the tomb of Kish his father; and they performed all that the king commanded. After that, Elohim answered prayer for the land. 
+</div><div class="p">
+<sup>15&#160;</sup>The Philistines had war again with Israel; and David went down, and his servants with him, and fought against the Philistines. David grew faint; 
+<sup>16&#160;</sup>and Ishbibenob, who was of the sons of the giant, the weight of whose spear was three hundred shekels of bronze in weight, he being armed with a new sword, thought he would kill David. 
+<sup>17&#160;</sup>But Abishai the son of Zeruiah helped him, and struck the Philistine and killed him. Then the men of David swore to him, saying, “Don’t go out with us to battle any more, so that you don’t quench the lamp of Israel.” 
+</div><div class="p">
+<sup>18&#160;</sup>After this, there was again war with the Philistines at Gob. Then Sibbecai the Hushathite killed Saph, who was of the sons of the giant. 
+<sup>19&#160;</sup>There was again war with the Philistines at Gob, and Elhanan the son of Jaare-Oregim the Bethlehemite killed Goliath the Gittite’s brother, the staff of whose spear was like a weaver’s beam. 
+<sup>20&#160;</sup>There was again war at Gath, where there was a man of great stature, who had six fingers on every hand and six toes on every foot, twenty-four in number, and he also was born to the giant. 
+<sup>21&#160;</sup>When he defied Israel, Jonathan the son of Shimei, David’s brother, killed him. 
+<sup>22&#160;</sup>These four were born to the giant in Gath; and they fell by the hand of David and by the hand of his servants. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>David spoke to Yahweh the words of this song in the day that Yahweh delivered him out of the hand of all his enemies, and out of the hand of Saul, 
+<sup>2&#160;</sup>and he said: 
+</div><div class="q1">“Yahweh is my rock, 
+</div><div class="q2">my fortress, 
+</div><div class="q2">and my deliverer, even mine; 
+</div><div class="q1">
+<sup>3&#160;</sup>Elohim is my rock in whom I take refuge; 
+</div><div class="q2">my shield, and the horn of my salvation, 
+</div><div class="q2">my high tower, and my refuge. 
+</div><div class="q2">My savior, you save me from violence. 
+</div><div class="q1">
+<sup>4&#160;</sup>I call on Yahweh, who is worthy to be praised; 
+</div><div class="q2">So shall I be saved from my enemies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>For the waves of death surrounded me. 
+</div><div class="q2">The floods of unelohimliness made me afraid. 
+</div><div class="q1">
+<sup>6&#160;</sup>The cords of Sheol were around me. 
+</div><div class="q2">The snares of death caught me. 
+</div><div class="q1">
+<sup>7&#160;</sup>In my distress, I called on Yahweh. 
+</div><div class="q2">Yes, I called to my Elohim. 
+</div><div class="q1">He heard my voice out of his temple. 
+</div><div class="q2">My cry came into his ears. 
+</div><div class="q1">
+<sup>8&#160;</sup>Then the earth shook and trembled. 
+</div><div class="q2">The foundations of heaven quaked and were shaken, 
+</div><div class="q2">because he was angry. 
+</div><div class="q1">
+<sup>9&#160;</sup>Smoke went up out of his nostrils. 
+</div><div class="q2">Consuming fire came out of his mouth. 
+</div><div class="q2">Coals were kindled by it. 
+</div><div class="q1">
+<sup>10&#160;</sup>He bowed the heavens also, and came down. 
+</div><div class="q2">Thick darkness was under his feet. 
+</div><div class="q1">
+<sup>11&#160;</sup>He rode on a cherub, and flew. 
+</div><div class="q2">Yes, he was seen on the wings of the wind. 
+</div><div class="q1">
+<sup>12&#160;</sup>He made darkness a shelter around himself, 
+</div><div class="q2">gathering of waters, and thick clouds of the skies. 
+</div><div class="q1">
+<sup>13&#160;</sup>At the brightness before him, 
+</div><div class="q2">coals of fire were kindled. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yahweh thundered from heaven. 
+</div><div class="q2">The Most High uttered his voice. 
+</div><div class="q1">
+<sup>15&#160;</sup>He sent out arrows and scattered them, 
+</div><div class="q2">lightning and confused them. 
+</div><div class="q1">
+<sup>16&#160;</sup>Then the channels of the sea appeared. 
+</div><div class="q2">The foundations of the world were laid bare by Yahweh’s rebuke, 
+</div><div class="q2">at the blast of the breath of his nostrils. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>He sent from on high and he took me. 
+</div><div class="q2">He drew me out of many waters. 
+</div><div class="q1">
+<sup>18&#160;</sup>He delivered me from my strong enemy, 
+</div><div class="q2">from those who hated me, for they were too mighty for me. 
+</div><div class="q1">
+<sup>19&#160;</sup>They came on me in the day of my calamity, 
+</div><div class="q2">but Yahweh was my support. 
+</div><div class="q1">
+<sup>20&#160;</sup>He also brought me out into a large place. 
+</div><div class="q2">He delivered me, because he delighted in me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Yahweh rewarded me according to my righteousness. 
+</div><div class="q2">He rewarded me according to the cleanness of my hands. 
+</div><div class="q1">
+<sup>22&#160;</sup>For I have kept Yahweh’s ways, 
+</div><div class="q2">and have not wickedly departed from my Elohim. 
+</div><div class="q1">
+<sup>23&#160;</sup>For all his ordinances were before me. 
+</div><div class="q2">As for his statutes, I didn’t depart from them. 
+</div><div class="q1">
+<sup>24&#160;</sup>I was also perfect toward him. 
+</div><div class="q2">I kept myself from my iniquity. 
+</div><div class="q1">
+<sup>25&#160;</sup>Therefore Yahweh has rewarded me according to my righteousness, 
+</div><div class="q2">According to my cleanness in his eyesight. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>26&#160;</sup>With the merciful you will show yourself merciful. 
+</div><div class="q2">With the perfect man you will show yourself perfect. 
+</div><div class="q2">
+<sup>27&#160;</sup>With the pure you will show yourself pure. 
+</div><div class="q2">With the crooked you will show yourself shrewd. 
+</div><div class="q1">
+<sup>28&#160;</sup>You will save the afflicted people, 
+</div><div class="q2">but your eyes are on the arrogant, that you may bring them down. 
+</div><div class="q1">
+<sup>29&#160;</sup>For you are my lamp, Yahweh. 
+</div><div class="q2">Yahweh will light up my darkness. 
+</div><div class="q1">
+<sup>30&#160;</sup>For by you, I run against a troop. 
+</div><div class="q2">By my Elohim, I leap over a wall. 
+</div><div class="q1">
+<sup>31&#160;</sup>As for Elohim, his way is perfect. 
+</div><div class="q2">Yahweh’s word is tested. 
+</div><div class="q2">He is a shield to all those who take refuge in him. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>32&#160;</sup>For who is Elohim, besides Yahweh? 
+</div><div class="q2">Who is a rock, besides our Elohim? 
+</div><div class="q1">
+<sup>33&#160;</sup>Elohim is my strong fortress. 
+</div><div class="q2">He makes my way perfect. 
+</div><div class="q1">
+<sup>34&#160;</sup>He makes his feet like hinds’ feet, 
+</div><div class="q2">and sets me on my high places. 
+</div><div class="q1">
+<sup>35&#160;</sup>He teaches my hands to war, 
+</div><div class="q2">so that my arms bend a bow of bronze. 
+</div><div class="q1">
+<sup>36&#160;</sup>You have also given me the shield of your salvation. 
+</div><div class="q2">Your gentleness has made me great. 
+</div><div class="q1">
+<sup>37&#160;</sup>You have enlarged my steps under me. 
+</div><div class="q2">My feet have not slipped. 
+</div><div class="q1">
+<sup>38&#160;</sup>I have pursued my enemies and destroyed them. 
+</div><div class="q2">I didn’t turn again until they were consumed. 
+</div><div class="q1">
+<sup>39&#160;</sup>I have consumed them, 
+</div><div class="q2">and struck them through, 
+</div><div class="q2">so that they can’t arise. 
+</div><div class="q2">Yes, they have fallen under my feet. 
+</div><div class="q1">
+<sup>40&#160;</sup>For you have armed me with strength for the battle. 
+</div><div class="q2">You have subdued under me those who rose up against me. 
+</div><div class="q1">
+<sup>41&#160;</sup>You have also made my enemies turn their backs to me, 
+</div><div class="q2">that I might cut off those who hate me. 
+</div><div class="q1">
+<sup>42&#160;</sup>They looked, but there was no one to save; 
+</div><div class="q2">even to Yahweh, but he didn’t answer them. 
+</div><div class="q1">
+<sup>43&#160;</sup>Then I beat them as small as the dust of the earth. 
+</div><div class="q2">I crushed them as the mire of the streets, and spread them abroad. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>44&#160;</sup>You also have delivered me from the strivings of my people. 
+</div><div class="q2">You have kept me to be the head of the nations. 
+</div><div class="q2">A people whom I have not known will serve me. 
+</div><div class="q1">
+<sup>45&#160;</sup>The foreigners will submit themselves to me. 
+</div><div class="q2">As soon as they hear of me, they will obey me. 
+</div><div class="q1">
+<sup>46&#160;</sup>The foreigners will fade away, 
+</div><div class="q2">and will come trembling out of their close places. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>47&#160;</sup>Yahweh lives! 
+</div><div class="q2">Blessed be my rock! 
+</div><div class="q1">Exalted be Elohim, the rock of my salvation, 
+</div><div class="q2">
+<sup>48&#160;</sup>even the Elohim who executes vengeance for me, 
+</div><div class="q2">who brings down peoples under me, 
+</div><div class="q2">
+<sup>49&#160;</sup>who brings me away from my enemies. 
+</div><div class="q1">Yes, you lift me up above those who rise up against me. 
+</div><div class="q2">You deliver me from the violent man. 
+</div><div class="q1">
+<sup>50&#160;</sup>Therefore I will give thanks to you, Yahweh, among the nations, 
+</div><div class="q2">and will sing praises to your name. 
+</div><div class="q1">
+<sup>51&#160;</sup>He gives great deliverance to his king, 
+</div><div class="q2">and shows loving kindness to his anointed, 
+</div><div class="q2">to David and to his offspring, forever more.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the last words of David. 
+</div><div class="q1">David the son of Jesse says, 
+</div><div class="q2">the man who was raised on high says, 
+</div><div class="q2">the anointed of the Elohim of Jacob, 
+</div><div class="q2">the sweet psalmist of Israel: 
+</div><div class="q1">
+<sup>2&#160;</sup>“Yahweh’s Spirit spoke by me. 
+</div><div class="q2">His word was on my tongue. 
+</div><div class="q1">
+<sup>3&#160;</sup>The Elohim of Israel said, 
+</div><div class="q2">the Rock of Israel spoke to me, 
+</div><div class="q2">‘One who rules over men righteously, 
+</div><div class="q2">who rules in the fear of Elohim, 
+</div><div class="q1">
+<sup>4&#160;</sup>shall be as the light of the morning when the sun rises, 
+</div><div class="q2">a morning without clouds, 
+</div><div class="q2">when the tender grass springs out of the earth, 
+</div><div class="q2">through clear shining after rain.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Isn’t my house so with Elohim? 
+</div><div class="q2">Yet he has made with me an everlasting covenant, 
+</div><div class="q2">ordered in all things, and sure, 
+</div><div class="q2">for it is all my salvation and all my desire. 
+</div><div class="q2">Won’t he make it grow? 
+</div><div class="q1">
+<sup>6&#160;</sup>But all the unelohimly will be as thorns to be thrust away, 
+</div><div class="q2">because they can’t be taken with the hand. 
+</div><div class="q1">
+<sup>7&#160;</sup>The man who touches them must be armed with iron and the staff of a spear. 
+</div><div class="q1">They will be utterly burned with fire in their place.” 
+</div><div class="p">
+<sup>8&#160;</sup>These are the names of the mighty men whom David had: Josheb Basshebeth a Tahchemonite, chief of the captains; he was called Adino the Eznite, who killed eight hundred at one time. 
+<sup>9&#160;</sup>After him was Eleazar the son of Dodai the son of an Ahohite, one of the three mighty men with David when they defied the Philistines who were there gathered together to battle, and the men of Israel had gone away. 
+<sup>10&#160;</sup>He arose and struck the Philistines until his hand was weary, and his hand froze to the sword; and Yahweh worked a great victory that day; and the people returned after him only to take plunder. 
+<sup>11&#160;</sup>After him was Shammah the son of Agee a Hararite. The Philistines had gathered together into a troop where there was a plot of ground full of lentils; and the people fled from the Philistines. 
+<sup>12&#160;</sup>But he stood in the middle of the plot and defended it, and killed the Philistines; and Yahweh worked a great victory. 
+</div><div class="p">
+<sup>13&#160;</sup>Three of the thirty chief men went down, and came to David in the harvest time to the cave of Adullam; and the troop of the Philistines was encamped in the valley of Rephaim. 
+<sup>14&#160;</sup>David was then in the stronghold; and the garrison of the Philistines was then in Bethlehem. 
+<sup>15&#160;</sup>David said longingly, “Oh that someone would give me water to drink from the well of Bethlehem, which is by the gate!” 
+</div><div class="p">
+<sup>16&#160;</sup>The three mighty men broke through the army of the Philistines, and drew water out of the well of Bethlehem that was by the gate and took it and brought it to David; but he would not drink of it, but poured it out to Yahweh. 
+<sup>17&#160;</sup>He said, “Be it far from me, Yahweh, that I should do this! Isn’t this the blood of the men who risked their lives to go?” Therefore he would not drink it. The three mighty men did these things. 
+</div><div class="p">
+<sup>18&#160;</sup>Abishai, the brother of Joab, the son of Zeruiah, was chief of the three. He lifted up his spear against three hundred and killed them, and had a name among the three. 
+<sup>19&#160;</sup>Wasn’t he most honorable of the three? Therefore he was made their captain. However he wasn’t included as one of the three. 
+</div><div class="p">
+<sup>20&#160;</sup>Benaiah the son of Jehoiada, the son of a valiant man of Kabzeel, who had done mighty deeds, killed the two sons of Ariel of Moab. He also went down and killed a lion in the middle of a pit in a time of snow. 
+<sup>21&#160;</sup>He killed a huge Egyptian, and the Egyptian had a spear in his hand; but he went down to him with a staff and plucked the spear out of the Egyptian’s hand, and killed him with his own spear. 
+<sup>22&#160;</sup>Benaiah the son of Jehoiada did these things, and had a name among the three mighty men. 
+<sup>23&#160;</sup>He was more honorable than the thirty, but he didn’t attain to the three. David set him over his guard. 
+</div><div class="p">
+<sup>24&#160;</sup>Asahel the brother of Joab was one of the thirty: Elhanan the son of Dodo of Bethlehem, 
+<sup>25&#160;</sup>Shammah the Harodite, Elika the Harodite, 
+<sup>26&#160;</sup>Helez the Paltite, Ira the son of Ikkesh the Tekoite, 
+<sup>27&#160;</sup>Abiezer the Anathothite, Mebunnai the Hushathite, 
+<sup>28&#160;</sup>Zalmon the Ahohite, Maharai the Netophathite, 
+<sup>29&#160;</sup>Heleb the son of Baanah the Netophathite, Ittai the son of Ribai of Gibeah of the children of Benjamin, 
+<sup>30&#160;</sup>Benaiah a Pirathonite, Hiddai of the brooks of Gaash. 
+<sup>31&#160;</sup>Abialbon the Arbathite, Azmaveth the Barhumite, 
+<sup>32&#160;</sup>Eliahba the Shaalbonite, the sons of Jashen, Jonathan, 
+<sup>33&#160;</sup>Shammah the Hararite, Ahiam the son of Sharar the Ararite, 
+<sup>34&#160;</sup>Eliphelet the son of Ahasbai, the son of the Maacathite, Eliam the son of Ahithophel the Gilonite, 
+<sup>35&#160;</sup>Hezro the Carmelite, Paarai the Arbite, 
+<sup>36&#160;</sup>Igal the son of Nathan of Zobah, Bani the Gadite, 
+<sup>37&#160;</sup>Zelek the Ammonite, Naharai the Beerothite, armor bearers to Joab the son of Zeruiah, 
+<sup>38&#160;</sup>Ira the Ithrite, Gareb the Ithrite, 
+<sup>39&#160;</sup>and Uriah the Hittite: thirty-seven in all. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Again Yahweh’s anger burned against Israel, and he moved David against them, saying, “Go, count Israel and Judah.” 
+<sup>2&#160;</sup>The king said to Joab the captain of the army, who was with him, “Now go back and forth through all the tribes of Israel, from Dan even to Beersheba, and count the people, that I may know the sum of the people.” 
+</div><div class="p">
+<sup>3&#160;</sup>Joab said to the king, “Now may Yahweh your Elohim add to the people, however many they may be, one hundred times; and may the eyes of my lord the king see it. But why does my lord the king delight in this thing?” 
+</div><div class="p">
+<sup>4&#160;</sup>Notwithstanding, the king’s word prevailed against Joab and against the captains of the army. Joab and the captains of the army went out from the presence of the king to count the people of Israel. 
+<sup>5&#160;</sup>They passed over the Jordan and encamped in Aroer, on the right side of the city that is in the middle of the valley of Gad, and to Jazer; 
+<sup>6&#160;</sup>then they came to Gilead and to the land of Tahtim Hodshi; and they came to Dan Jaan and around to Sidon, 
+<sup>7&#160;</sup>and came to the stronghold of Tyre, and to all the cities of the Hivites and of the Canaanites; and they went out to the south of Judah, at Beersheba. 
+<sup>8&#160;</sup>So when they had gone back and forth through all the land, they came to Jerusalem at the end of nine months and twenty days. 
+<sup>9&#160;</sup>Joab gave up the sum of the counting of the people to the king; and there were in Israel eight hundred thousand valiant men who drew the sword, and the men of Judah were five hundred thousand men. 
+</div><div class="p">
+<sup>10&#160;</sup>David’s heart struck him after he had counted the people. David said to Yahweh, “I have sinned greatly in that which I have done. But now, Yahweh, put away, I beg you, the iniquity of your servant; for I have done very foolishly.” 
+</div><div class="p">
+<sup>11&#160;</sup>When David rose up in the morning, Yahweh’s word came to the prophet Gad, David’s seer, saying, 
+<sup>12&#160;</sup>“Go and speak to David, ‘Yahweh says, “I offer you three things. Choose one of them, that I may do it to you.”&#160;’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>So Gad came to David, and told him, saying, “Shall seven years of famine come to you in your land? Or will you flee three months before your foes while they pursue you? Or shall there be three days’ pestilence in your land? Now answer, and consider what answer I shall return to him who sent me.” 
+</div><div class="p">
+<sup>14&#160;</sup>David said to Gad, “I am in distress. Let us fall now into Yahweh’s hand, for his mercies are great. Let me not fall into man’s hand.” 
+</div><div class="p">
+<sup>15&#160;</sup>So Yahweh sent a pestilence on Israel from the morning even to the appointed time; and seventy thousand men died of the people from Dan even to Beersheba. 
+<sup>16&#160;</sup>When the angel stretched out his hand toward Jerusalem to destroy it, Yahweh relented of the disaster, and said to the angel who destroyed the people, “It is enough. Now withdraw your hand.” Yahweh’s angel was by the threshing floor of Araunah the Jebusite. 
+</div><div class="p">
+<sup>17&#160;</sup>David spoke to Yahweh when he saw the angel who struck the people, and said, “Behold, I have sinned, and I have done perversely; but these sheep, what have they done? Please let your hand be against me, and against my father’s house.” 
+</div><div class="p">
+<sup>18&#160;</sup>Gad came that day to David and said to him, “Go up, build an altar to Yahweh on the threshing floor of Araunah the Jebusite.” 
+</div><div class="p">
+<sup>19&#160;</sup>David went up according to the saying of Gad, as Yahweh commanded. 
+<sup>20&#160;</sup>Araunah looked out, and saw the king and his servants coming on toward him. Then Araunah went out and bowed himself before the king with his face to the ground. 
+<sup>21&#160;</sup>Araunah said, “Why has my lord the king come to his servant?” 
+</div><div class="p">David said, “To buy your threshing floor, to build an altar to Yahweh, that the plague may be stopped from afflicting the people.” 
+</div><div class="p">
+<sup>22&#160;</sup>Araunah said to David, “Let my lord the king take and offer up what seems good to him. Behold, the cattle for the burnt offering, and the threshing sledges and the yokes of the oxen for the wood. 
+<sup>23&#160;</sup>All this, O king, does Araunah give to the king.” Araunah said to the king, “May Yahweh your Elohim accept you.” 
+</div><div class="p">
+<sup>24&#160;</sup>The king said to Araunah, “No, but I will most certainly buy it from you for a price. I will not offer burnt offerings to Yahweh my Elohim which cost me nothing.” So David bought the threshing floor and the oxen for fifty shekels of silver. 
+<sup>25&#160;</sup>David built an altar to Yahweh there, and offered burnt offerings and peace offerings. So Yahweh was entreated for the land, and the plague was removed from Israel. </div></div><script src="../main.js"></script></body></html>

--- a/book/3john.html
+++ b/book/3john.html
@@ -3,6 +3,47 @@
 <head>
 <title>3 John</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,25 +53,27 @@
 <div class="main">
 <!-- 3JN World English Scripture (WES) -->
 <h1 class="booklabel">3 John</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The elder to Gaius the beloved, whom I love in truth. 
-</p><p>
-<span class="v">2&#160;</span>Beloved, I pray that you may prosper in all things and be healthy, even as your soul prospers. 
-<span class="v">3&#160;</span>For I rejoiced greatly when brothers came and testified about your truth, even as you walk in truth. 
-<span class="v">4&#160;</span>I have no greater joy than this: to hear about my children walking in truth. 
-</p><p>
-<span class="v">5&#160;</span>Beloved, you do a faithful work in whatever you accomplish for those who are brothers and strangers. 
-<span class="v">6&#160;</span>They have testified about your love before the assembly. You will do well to send them forward on their journey in a way worthy of Elohim, 
-<span class="v">7&#160;</span>because for the sake of the Name they went out, taking nothing from the Gentiles. 
-<span class="v">8&#160;</span>We therefore ought to receive such, that we may be fellow workers for the truth. 
-</p><p>
-<span class="v">9&#160;</span>I wrote to the assembly, but Diotrephes, who loves to be first among them, doesn’t accept what we say. 
-<span class="v">10&#160;</span>Therefore, if I come, I will call attention to his deeds which he does, unjustly accusing us with wicked words. Not content with this, he doesn’t receive the brothers himself, and those who would, he forbids and throws out of the assembly. 
-</p><p>
-<span class="v">11&#160;</span>Beloved, don’t imitate that which is evil, but that which is good. He who does good is of Elohim. He who does evil hasn’t seen Elohim. 
-<span class="v">12&#160;</span>Demetrius has the testimony of all, and of the truth itself; yes, we also testify, and you know that our testimony is true. 
-</p><p>
-<span class="v">13&#160;</span>I had many things to write to you, but I am unwilling to write to you with ink and pen; 
-<span class="v">14&#160;</span>but I hope to see you soon. Then we will speak face to face. 
-</p><p>Peace be to you. The friends greet you. Greet the friends by name. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The elder to Gaius the beloved, whom I love in truth. 
+</div><div class="p">
+<sup>2&#160;</sup>Beloved, I pray that you may prosper in all things and be healthy, even as your soul prospers. 
+<sup>3&#160;</sup>For I rejoiced greatly when brothers came and testified about your truth, even as you walk in truth. 
+<sup>4&#160;</sup>I have no greater joy than this: to hear about my children walking in truth. 
+</div><div class="p">
+<sup>5&#160;</sup>Beloved, you do a faithful work in whatever you accomplish for those who are brothers and strangers. 
+<sup>6&#160;</sup>They have testified about your love before the assembly. You will do well to send them forward on their journey in a way worthy of Elohim, 
+<sup>7&#160;</sup>because for the sake of the Name they went out, taking nothing from the Gentiles. 
+<sup>8&#160;</sup>We therefore ought to receive such, that we may be fellow workers for the truth. 
+</div><div class="p">
+<sup>9&#160;</sup>I wrote to the assembly, but Diotrephes, who loves to be first among them, doesn’t accept what we say. 
+<sup>10&#160;</sup>Therefore, if I come, I will call attention to his deeds which he does, unjustly accusing us with wicked words. Not content with this, he doesn’t receive the brothers himself, and those who would, he forbids and throws out of the assembly. 
+</div><div class="p">
+<sup>11&#160;</sup>Beloved, don’t imitate that which is evil, but that which is good. He who does good is of Elohim. He who does evil hasn’t seen Elohim. 
+<sup>12&#160;</sup>Demetrius has the testimony of all, and of the truth itself; yes, we also testify, and you know that our testimony is true. 
+</div><div class="p">
+<sup>13&#160;</sup>I had many things to write to you, but I am unwilling to write to you with ink and pen; 
+<sup>14&#160;</sup>but I hope to see you soon. Then we will speak face to face. 
+</div><div class="p">Peace be to you. The friends greet you. Greet the friends by name. </div></div><script src="../main.js"></script></body></html>

--- a/book/amos.html
+++ b/book/amos.html
@@ -3,6 +3,47 @@
 <head>
 <title>Amos</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,545 +53,555 @@
 <div class="main">
 <!-- AMO World English Scripture (WES) -->
 <h1 class="booklabel">Amos</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The words of Amos, who was among the herdsmen of Tekoa, which he saw concerning Israel in the days of Uzziah king of Judah and in the days of Jeroboam the son of Joash, king of Israel, two years before the earthquake. 
-<span class="v">2&#160;</span>He said: 
-</p><p class="q1">“Yahweh<span class="f">+ \fr 1:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> will roar from Zion, 
-</p><p class="q2">and utter his voice from Jerusalem; 
-</p><p class="q1">and the pastures of the shepherds will mourn, 
-</p><p class="q2">and the top of Carmel will wither.” 
-</p><p>
-<span class="v">3&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Damascus, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because they have threshed Gilead with threshing instruments of iron; 
-</p><p class="q1">
-<span class="v">4&#160;</span>but I will send a fire into the house of Hazael, 
-</p><p class="q2">and it will devour the palaces of Ben Hadad. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I will break the bar of Damascus, 
-</p><p class="q2">and cut off the inhabitant from the valley of Aven, 
-</p><p class="q2">and him who holds the scepter from the house of Eden; 
-</p><p class="q2">and the people of Syria shall go into captivity to Kir,” 
-</p><p>says Yahweh. 
-</p><p>
-<span class="v">6&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Gaza, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because they carried away captive the whole community, 
-</p><p class="q2">to deliver them up to Edom; 
-</p><p class="q1">
-<span class="v">7&#160;</span>but I will send a fire on the wall of Gaza, 
-</p><p class="q2">and it will devour its palaces. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will cut off the inhabitant from Ashdod, 
-</p><p class="q2">and him who holds the scepter from Ashkelon; 
-</p><p class="q1">and I will turn my hand against Ekron; 
-</p><p class="q2">and the remnant of the Philistines will perish,” 
-</p><p>says the Lord<span class="f">+ \fr 1:8 \ft The word translated “Lord” is “Adonai.”</span> Yahweh. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Tyre, yes, for four, 
-</p><p class="q2">I will not turn away its punishment; 
-</p><p class="q2">because they delivered up the whole community to Edom, 
-</p><p class="q2">and didn’t remember the brotherly covenant; 
-</p><p class="q1">
-<span class="v">10&#160;</span>but I will send a fire on the wall of Tyre, 
-</p><p class="q2">and it will devour its palaces.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Edom, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because he pursued his brother with the sword 
-</p><p class="q2">and cast off all pity, 
-</p><p class="q2">and his anger raged continually, 
-</p><p class="q2">and he kept his wrath forever; 
-</p><p class="q1">
-<span class="v">12&#160;</span>but I will send a fire on Teman, 
-</p><p class="q2">and it will devour the palaces of Bozrah.” 
-</p><p>
-<span class="v">13&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of the children of Ammon, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because they have ripped open the pregnant women of Gilead, 
-</p><p class="q2">that they may enlarge their border. 
-</p><p class="q1">
-<span class="v">14&#160;</span>But I will kindle a fire in the wall of Rabbah, 
-</p><p class="q2">and it will devour its palaces, 
-</p><p class="q2">with shouting in the day of battle, 
-</p><p class="q2">with a storm in the day of the whirlwind; 
-</p><p class="q1">
-<span class="v">15&#160;</span>and their king will go into captivity, 
-</p><p class="q2">he and his princes together,” 
-</p><p>says Yahweh. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Moab, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because he burned the bones of the king of Edom into lime; 
-</p><p class="q1">
-<span class="v">2&#160;</span>but I will send a fire on Moab, 
-</p><p class="q2">and it will devour the palaces of Kerioth; 
-</p><p class="q2">and Moab will die with tumult, with shouting, and with the sound of the trumpet; 
-</p><p class="q1">
-<span class="v">3&#160;</span>and I will cut off the judge from among them, 
-</p><p class="q2">and will kill all its princes with him,” 
-</p><p>says Yahweh. 
-</p><p>
-<span class="v">4&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Judah, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because they have rejected Yahweh’s law, 
-</p><p class="q2">and have not kept his statutes, 
-</p><p class="q2">and their lies have led them astray, 
-</p><p class="q2">after which their fathers walked; 
-</p><p class="q1">
-<span class="v">5&#160;</span>but I will send a fire on Judah, 
-</p><p class="q2">and it will devour the palaces of Jerusalem.” 
-</p><p>
-<span class="v">6&#160;</span>Yahweh says: 
-</p><p class="q1">“For three transgressions of Israel, yes, for four, 
-</p><p class="q2">I will not turn away its punishment, 
-</p><p class="q2">because they have sold the righteous for silver, 
-</p><p class="q2">and the needy for a pair of sandals; 
-</p><p class="q2">
-<span class="v">7&#160;</span>They trample the heads of the poor into the dust of the earth 
-</p><p class="q2">and deny justice to the oppressed. 
-</p><p class="q1">A man and his father use the same maiden, to profane my set-apart name. 
-</p><p class="q2">
-<span class="v">8&#160;</span>They lay themselves down beside every altar on clothes taken in pledge. 
-</p><p class="q2">In the house of their Elohim<span class="f">+ \fr 2:8 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> they drink the wine of those who have been fined. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yet I destroyed the Amorite before them, 
-</p><p class="q2">whose height was like the height of the cedars, 
-</p><p class="q2">and he was strong as the oaks; 
-</p><p class="q2">yet I destroyed his fruit from above, 
-</p><p class="q2">and his roots from beneath. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Also I brought you up out of the land of Egypt 
-</p><p class="q2">and led you forty years in the wilderness, 
-</p><p class="q2">to possess the land of the Amorite. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I raised up some of your sons for prophets, 
-</p><p class="q2">and some of your young men for Nazirites. 
-</p><p class="q1">Isn’t this true, 
-</p><p class="q2">you children of Israel?” says Yahweh. 
-</p><p class="q1">
-<span class="v">12&#160;</span>“But you gave the Nazirites wine to drink, 
-</p><p class="q2">and commanded the prophets, saying, ‘Don’t prophesy!’ 
-</p><p class="q1">
-<span class="v">13&#160;</span>Behold,<span class="f">+ \fr 2:13 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I will crush you in your place, 
-</p><p class="q2">as a cart crushes that is full of grain. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Flight will perish from the swift. 
-</p><p class="q2">The strong won’t strengthen his force. 
-</p><p class="q2">The mighty won’t deliver himself. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He who handles the bow won’t stand. 
-</p><p class="q2">He who is swift of foot won’t escape. 
-</p><p class="q2">He who rides the horse won’t deliver himself. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He who is courageous among the mighty 
-</p><p class="q2">will flee away naked on that day,” 
-</p><p>says Yahweh. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Hear this word that Yahweh has spoken against you, children of Israel, against the whole family which I brought up out of the land of Egypt, saying: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“I have only chosen you of all the families of the earth. 
-</p><p class="q2">Therefore I will punish you for all of your sins.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>Do two walk together, 
-</p><p class="q2">unless they have agreed? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Will a lion roar in the thicket, 
-</p><p class="q2">when he has no prey? 
-</p><p class="q1">Does a young lion cry out of his den, 
-</p><p class="q2">if he has caught nothing? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Can a bird fall in a trap on the earth, 
-</p><p class="q2">where no snare is set for him? 
-</p><p class="q1">Does a snare spring up from the ground, 
-</p><p class="q2">when there is nothing to catch? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Does the trumpet alarm sound in a city, 
-</p><p class="q2">without the people being afraid? 
-</p><p class="q1">Does evil happen to a city, 
-</p><p class="q2">and Yahweh hasn’t done it? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Surely the Lord Yahweh will do nothing, 
-</p><p class="q2">unless he reveals his secret to his servants the prophets. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The lion has roared. 
-</p><p class="q2">Who will not fear? 
-</p><p class="q1">The Lord Yahweh has spoken. 
-</p><p class="q2">Who can but prophesy? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Proclaim in the palaces at Ashdod, 
-</p><p class="q2">and in the palaces in the land of Egypt, 
-</p><p class="q1">and say, “Assemble yourselves on the mountains of Samaria, 
-</p><p class="q2">and see what unrest is in her, 
-</p><p class="q2">and what oppression is among them.” 
-</p><p class="q1">
-<span class="v">10&#160;</span>“Indeed they don’t know to do right,” says Yahweh, 
-</p><p class="q2">“Who hoard plunder and loot in their palaces.” 
-</p><p>
-<span class="v">11&#160;</span>Therefore the Lord Yahweh says: 
-</p><p class="q1">“An adversary will overrun the land; 
-</p><p class="q2">and he will pull down your strongholds, 
-</p><p class="q2">and your fortresses will be plundered.” 
-</p><p>
-<span class="v">12&#160;</span>Yahweh says: 
-</p><p class="q1">“As the shepherd rescues out of the mouth of the lion two legs, 
-</p><p class="q2">or a piece of an ear, 
-</p><p class="q2">so shall the children of Israel be rescued who sit in Samaria on the corner of a couch, 
-</p><p class="q2">and on the silken cushions of a bed.” 
-</p><p>
-<span class="v">13&#160;</span>“Listen, and testify against the house of Jacob,” says the Lord Yahweh, the Elohim of Armies. 
-</p><p class="q1">
-<span class="v">14&#160;</span>“For in the day that I visit the transgressions of Israel on him, 
-</p><p class="q2">I will also visit the altars of Bethel; 
-</p><p class="q2">and the horns of the altar will be cut off, 
-</p><p class="q2">and fall to the ground. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will strike the winter house with the summer house; 
-</p><p class="q2">and the houses of ivory will perish, 
-</p><p class="q2">and the great houses will have an end,” 
-</p><p>says Yahweh. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Listen to this word, you cows of Bashan, who are on the mountain of Samaria, who oppress the poor, who crush the needy, who tell their lords, “Bring us drinks!” 
-</p><p class="q1">
-<span class="v">2&#160;</span>The Lord Yahweh has sworn by his set-apartness, 
-</p><p class="q2">“Behold, the days shall come on you that they will take you away with hooks, 
-</p><p class="q2">and the last of you with fish hooks. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You will go out at the breaks in the wall, 
-</p><p class="q2">everyone straight before her; 
-</p><p class="q2">and you will cast yourselves into Harmon,” says Yahweh. 
-</p><p class="q1">
-<span class="v">4&#160;</span>“Go to Bethel, and sin; 
-</p><p class="q2">to Gilgal, and sin more. 
-</p><p class="q1">Bring your sacrifices every morning, 
-</p><p class="q2">your tithes every three days, 
-</p><p class="q2">
-<span class="v">5&#160;</span>offer a sacrifice of thanksgiving of that which is leavened, 
-</p><p class="q2">and proclaim free will offerings and brag about them; 
-</p><p class="q2">for this pleases you, you children of Israel,” says the Lord Yahweh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>“I also have given you cleanness of teeth in all your cities, 
-</p><p class="q2">and lack of bread in every town; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>“I also have withheld the rain from you, 
-</p><p class="q2">when there were yet three months to the harvest; 
-</p><p class="q2">and I caused it to rain on one city, 
-</p><p class="q2">and caused it not to rain on another city. 
-</p><p class="q1">One field was rained on, 
-</p><p class="q2">and the field where it didn’t rain withered. 
-</p><p class="q1">
-<span class="v">8&#160;</span>So two or three cities staggered to one city to drink water, 
-</p><p class="q2">and were not satisfied; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">9&#160;</span>“I struck you with blight and mildew many times in your gardens and your vineyards, 
-</p><p class="q2">and the swarming locusts have devoured your fig trees and your olive trees; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">10&#160;</span>“I sent plagues among you like I did Egypt. 
-</p><p class="q2">I have slain your young men with the sword, 
-</p><p class="q2">and have carried away your horses. 
-</p><p class="q1">I filled your nostrils with the stench of your camp, 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">11&#160;</span>“I have overthrown some of you, 
-</p><p class="q2">as when Elohim overthrew Sodom and Gomorrah, 
-</p><p class="q2">and you were like a burning stick plucked out of the fire; 
-</p><p class="q2">yet you haven’t returned to me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Therefore I will do this to you, Israel; 
-</p><p class="q2">because I will do this to you, 
-</p><p class="q2">prepare to meet your Elohim, Israel. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For, behold, he who forms the mountains, creates the wind, declares to man what is his thought, 
-</p><p class="q2">who makes the morning darkness, and treads on the high places of the earth: 
-</p><p class="q2">Yahweh, the Elohim of Armies, is his name.” 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Listen to this word which I take up for a lamentation over you, O house of Israel: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“The virgin of Israel has fallen; 
-</p><p class="q2">She shall rise no more. 
-</p><p class="q1">She is cast down on her land; 
-</p><p class="q2">there is no one to raise her up.” 
-</p><p>
-<span class="v">3&#160;</span>For the Lord Yahweh says: 
-</p><p class="q1">“The city that went out a thousand shall have a hundred left, 
-</p><p class="q2">and that which went out one hundred shall have ten left to the house of Israel.” 
-</p><p>
-<span class="v">4&#160;</span>For Yahweh says to the house of Israel: 
-</p><p class="q1">“Seek me, and you will live; 
-</p><p class="q1">
-<span class="v">5&#160;</span>but don’t seek Bethel, 
-</p><p class="q2">nor enter into Gilgal, 
-</p><p class="q2">and don’t pass to Beersheba; 
-</p><p class="q1">for Gilgal shall surely go into captivity, 
-</p><p class="q2">and Bethel shall come to nothing. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Seek Yahweh, and you will live, 
-</p><p class="q2">lest he break out like fire in the house of Joseph, 
-</p><p class="q2">and it devour, and there be no one to quench it in Bethel. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You who turn justice to wormwood, 
-</p><p class="q2">and cast down righteousness to the earth! 
-</p><p class="q1">
-<span class="v">8&#160;</span>Seek him who made the Pleiades and Orion, 
-</p><p class="q2">and turns the shadow of death into the morning, 
-</p><p class="q2">and makes the day dark with night; 
-</p><p class="q2">who calls for the waters of the sea, 
-</p><p class="q2">and pours them out on the surface of the earth, Yahweh is his name, 
-</p><p class="q1">
-<span class="v">9&#160;</span>who brings sudden destruction on the strong, 
-</p><p class="q2">so that destruction comes on the fortress. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They hate him who reproves in the gate, 
-</p><p class="q2">and they abhor him who speaks blamelessly. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Therefore, because you trample on the poor and take taxes from him of wheat, 
-</p><p class="q2">you have built houses of cut stone, but you will not dwell in them. 
-</p><p class="q1">You have planted pleasant vineyards, 
-</p><p class="q2">but you shall not drink their wine. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For I know how many are your offenses, 
-</p><p class="q2">and how great are your sins—</p><p class="q2">you who afflict the just, 
-</p><p class="q2">who take a bribe, 
-</p><p class="q2">and who turn away the needy in the courts. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Therefore a prudent person keeps silent in such a time, 
-</p><p class="q2">for it is an evil time. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Seek good, and not evil, 
-</p><p class="q2">that you may live; 
-</p><p class="q2">and so Yahweh, the Elohim of Armies, will be with you, 
-</p><p class="q2">as you say. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Hate evil, love good, 
-</p><p class="q2">and establish justice in the courts. 
-</p><p class="q2">It may be that Yahweh, the Elohim of Armies, will be gracious to the remnant of Joseph.” 
-</p><p>
-<span class="v">16&#160;</span>Therefore Yahweh, the Elohim of Armies, the Lord, says: 
-</p><p class="q1">“Wailing will be in all the wide ways. 
-</p><p class="q2">They will say in all the streets, ‘Alas! Alas!’ 
-</p><p class="q2">They will call the farmer to mourning, 
-</p><p class="q2">and those who are skillful in lamentation to wailing. 
-</p><p class="q1">
-<span class="v">17&#160;</span>In all vineyards there will be wailing, 
-</p><p class="q2">for I will pass through the middle of you,” says Yahweh. 
-</p><p class="q1">
-<span class="v">18&#160;</span>“Woe to you who desire the day of Yahweh! 
-</p><p class="q2">Why do you long for the day of Yahweh? 
-</p><p class="q1">It is darkness, 
-</p><p class="q2">and not light. 
-</p><p class="q1">
-<span class="v">19&#160;</span>As if a man fled from a lion, 
-</p><p class="q2">and a bear met him; 
-</p><p class="q1">or he went into the house and leaned his hand on the wall, 
-</p><p class="q2">and a snake bit him. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Won’t the day of Yahweh be darkness, and not light? 
-</p><p class="q2">Even very dark, and no brightness in it? 
-</p><p class="q1">
-<span class="v">21&#160;</span>I hate, I despise your feasts, 
-</p><p class="q2">and I can’t stand your solemn assemblies. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Yes, though you offer me your burnt offerings and meal offerings, 
-</p><p class="q2">I will not accept them; 
-</p><p class="q2">neither will I regard the peace offerings of your fat animals. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Take away from me the noise of your songs! 
-</p><p class="q2">I will not listen to the music of your harps. 
-</p><p class="q1">
-<span class="v">24&#160;</span>But let justice roll on like rivers, 
-</p><p class="q2">and righteousness like a mighty stream. 
-</p><p>
-<span class="v">25&#160;</span>“Did you bring to me sacrifices and offerings in the wilderness forty years, house of Israel? 
-<span class="v">26&#160;</span>You also carried the tent of your king and the shrine of your images, the star of your elohim, which you made for yourselves. 
-<span class="v">27&#160;</span>Therefore I will cause you to go into captivity beyond Damascus,” says Yahweh, whose name is the Elohim of Armies. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Woe to those who are at ease in Zion, 
-</p><p class="q2">and to those who are secure on the mountain of Samaria, 
-</p><p class="q2">the notable men of the chief of the nations, 
-</p><p class="q2">to whom the house of Israel come! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Go to Calneh, and see. 
-</p><p class="q2">From there go to Hamath the great. 
-</p><p class="q2">Then go down to Gath of the Philistines. 
-</p><p class="q1">Are they better than these kingdoms? 
-</p><p class="q2">Is their border greater than your border? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Alas for you who put far away the evil day, 
-</p><p class="q2">and cause the seat of violence to come near, 
-</p><p class="q2">
-<span class="v">4&#160;</span>who lie on beds of ivory, 
-</p><p class="q2">and stretch themselves on their couches, 
-</p><p class="q2">and eat the lambs out of the flock, 
-</p><p class="q2">and the calves out of the middle of the stall, 
-</p><p class="q2">
-<span class="v">5&#160;</span>who strum on the strings of a harp, 
-</p><p class="q2">who invent for themselves instruments of music, like David; 
-</p><p class="q2">
-<span class="v">6&#160;</span>who drink wine in bowls, 
-</p><p class="q2">and anoint themselves with the best oils, 
-</p><p class="q2">but they are not grieved for the affliction of Joseph. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Therefore they will now go captive with the first who go captive. 
-</p><p class="q2">The feasting and lounging will end. 
-</p><p class="q1">
-<span class="v">8&#160;</span>“The Lord Yahweh has sworn by himself,” says Yahweh, the Elohim of Armies: 
-</p><p class="q2">“I abhor the pride of Jacob, 
-</p><p class="q2">and detest his fortresses. 
-</p><p class="q2">Therefore I will deliver up the city with all that is in it. 
-</p><p class="q1">
-<span class="v">9&#160;</span>It will happen that if ten men remain in one house, 
-</p><p class="q2">they will die. 
-</p><p>
-<span class="v">10&#160;</span>“When a man’s relative carries him, even he who burns him, to bring bodies out of the house, and asks him who is in the innermost parts of the house, ‘Is there yet any with you?’ And he says, ‘No;’ then he will say, ‘Hush! Indeed we must not mention Yahweh’s name.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“For, behold, Yahweh commands, and the great house will be smashed to pieces, 
-</p><p class="q2">and the little house into bits. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Do horses run on the rocky crags? 
-</p><p class="q2">Does one plow there with oxen? 
-</p><p class="q1">But you have turned justice into poison, 
-</p><p class="q2">and the fruit of righteousness into bitterness, 
-</p><p class="q1">
-<span class="v">13&#160;</span>you who rejoice in a thing of nothing, who say, 
-</p><p class="q2">‘Haven’t we taken for ourselves horns by our own strength?’ 
-</p><p class="q1">
-<span class="v">14&#160;</span>For, behold, I will raise up against you a nation, house of Israel,” 
-</p><p class="q2">says Yahweh, the Elohim of Armies; 
-</p><p class="q2">“and they will afflict you from the entrance of Hamath to the brook of the Arabah.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Thus the Lord Yahweh showed me: behold, he formed locusts in the beginning of the shooting up of the latter growth; and behold, it was the latter growth after the king’s harvest. 
-<span class="v">2&#160;</span>When they finished eating the grass of the land, then I said, “Lord Yahweh, forgive, I beg you! How could Jacob stand? For he is small.” 
-</p><p>
-<span class="v">3&#160;</span>Yahweh relented concerning this. “It shall not be,” says Yahweh. 
-</p><p>
-<span class="v">4&#160;</span>Thus the Lord Yahweh showed me: behold, the Lord Yahweh called for judgment by fire; and it dried up the great deep, and would have devoured the land. 
-<span class="v">5&#160;</span>Then I said, “Lord Yahweh, stop, I beg you! How could Jacob stand? For he is small.” 
-</p><p>
-<span class="v">6&#160;</span>Yahweh relented concerning this. “This also shall not be,” says the Lord Yahweh. 
-</p><p>
-<span class="v">7&#160;</span>Thus he showed me: behold, the Lord stood beside a wall made by a plumb line, with a plumb line in his hand. 
-<span class="v">8&#160;</span>Yahweh said to me, “Amos, what do you see?” 
-</p><p>I said, “A plumb line.” 
-</p><p>Then the Lord said, “Behold, I will set a plumb line in the middle of my people Israel. I will not again pass by them any more. 
-<span class="v">9&#160;</span>The high places of Isaac will be desolate, the sanctuaries of Israel will be laid waste; and I will rise against the house of Jeroboam with the sword.” 
-</p><p>
-<span class="v">10&#160;</span>Then Amaziah the priest of Bethel sent to Jeroboam king of Israel, saying, “Amos has conspired against you in the middle of the house of Israel. The land is not able to bear all his words. 
-<span class="v">11&#160;</span>For Amos says, ‘Jeroboam will die by the sword, and Israel shall surely be led away captive out of his land.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Amaziah also said to Amos, “You seer, go, flee away into the land of Judah, and there eat bread, and prophesy there, 
-<span class="v">13&#160;</span>but don’t prophesy again any more at Bethel; for it is the king’s sanctuary, and it is a royal house!” 
-</p><p>
-<span class="v">14&#160;</span>Then Amos answered Amaziah, “I was no prophet, neither was I a prophet’s son, but I was a herdsman, and a farmer of sycamore figs; 
-<span class="v">15&#160;</span>and Yahweh took me from following the flock, and Yahweh said to me, ‘Go, prophesy to my people Israel.’ 
-<span class="v">16&#160;</span>Now therefore listen to Yahweh’s word: ‘You say, Don’t prophesy against Israel, and don’t preach against the house of Isaac.’ 
-<span class="v">17&#160;</span>Therefore Yahweh says: ‘Your woman shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.’&#160;” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Thus the Lord Yahweh showed me: behold, a basket of summer fruit. 
-</p><p>
-<span class="v">2&#160;</span>He said, “Amos, what do you see?” 
-</p><p>I said, “A basket of summer fruit.” 
-</p><p>Then Yahweh said to me, 
-</p><p class="q1">“The end has come on my people Israel. 
-</p><p class="q2">I will not again pass by them any more. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The songs of the temple will be wailing in that day,” says the Lord Yahweh. 
-</p><p class="q2">“The dead bodies will be many. In every place they will throw them out with silence. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Hear this, you who desire to swallow up the needy, 
-</p><p class="q2">and cause the poor of the land to fail, 
-</p><p class="q2">
-<span class="v">5&#160;</span>saying, ‘When will the new moon be gone, that we may sell grain? 
-</p><p class="q2">And the Sabbath, that we may market wheat, 
-</p><p class="q2">making the ephah<span class="f">+ \fr 8:5 \ft 1 ephah is about 22 liters or about 2/3 of a bushel </span> small, and the shekel<span class="f">+ \fr 8:5 \ft a normal shekel is about 10 grams or about 0.35 ounces.</span> large, 
-</p><p class="q2">and dealing falsely with balances of deceit; 
-</p><p class="q1">
-<span class="v">6&#160;</span>that we may buy the poor for silver, 
-</p><p class="q2">and the needy for a pair of sandals, 
-</p><p class="q2">and sell the sweepings with the wheat?’&#160;” 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh has sworn by the pride of Jacob, 
-</p><p class="q2">“Surely I will never forget any of their works. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Won’t the land tremble for this, 
-</p><p class="q2">and everyone mourn who dwells in it? 
-</p><p class="q1">Yes, it will rise up wholly like the River; 
-</p><p class="q2">and it will be stirred up and sink again, like the River of Egypt. 
-</p><p class="q1">
-<span class="v">9&#160;</span>It will happen in that day,” says the Lord Yahweh, 
-</p><p class="q2">“that I will cause the sun to go down at noon, 
-</p><p class="q2">and I will darken the earth in the clear day. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I will turn your feasts into mourning, 
-</p><p class="q2">and all your songs into lamentation; 
-</p><p class="q1">and I will make you wear sackcloth on all your bodies, 
-</p><p class="q2">and baldness on every head. 
-</p><p class="q1">I will make it like the mourning for an only son, 
-</p><p class="q2">and its end like a bitter day. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Behold, the days come,” says the Lord Yahweh, 
-</p><p class="q2">“that I will send a famine in the land, 
-</p><p class="q2">not a famine of bread, 
-</p><p class="q2">nor a thirst for water, 
-</p><p class="q2">but of hearing Yahweh’s words. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They will wander from sea to sea, 
-</p><p class="q2">and from the north even to the east; 
-</p><p class="q2">they will run back and forth to seek Yahweh’s word, 
-</p><p class="q2">and will not find it. 
-</p><p class="q1">
-<span class="v">13&#160;</span>In that day the beautiful virgins 
-</p><p class="q2">and the young men will faint for thirst. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Those who swear by the sin of Samaria, 
-</p><p class="q2">and say, ‘As your elohim, Dan, lives,’ 
-</p><p class="q2">and, ‘As the way of Beersheba lives,’ 
-</p><p class="q2">they will fall, and never rise up again.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>I saw the Lord standing beside the altar, and he said, “Strike the tops of the pillars, that the thresholds may shake. Break them in pieces on the head of all of them. I will kill the last of them with the sword. Not one of them will flee away. Not one of them will escape. 
-<span class="v">2&#160;</span>Though they dig into Sheol,<span class="f">+ \fr 9:2 \ft Sheol is the place of the dead.</span> there my hand will take them; and though they climb up to heaven, there I will bring them down. 
-<span class="v">3&#160;</span>Though they hide themselves in the top of Carmel, I will search and take them out from there; and though they be hidden from my sight in the bottom of the sea, there I will command the serpent, and it will bite them. 
-<span class="v">4&#160;</span>Though they go into captivity before their enemies, there I will command the sword, and it will kill them. I will set my eyes on them for evil, and not for good. 
-<span class="v">5&#160;</span>For the Lord, Yahweh of Armies, is he who touches the land and it melts, and all who dwell in it will mourn; and it will rise up wholly like the River, and will sink again, like the River of Egypt. 
-<span class="v">6&#160;</span>It is he who builds his rooms in the heavens, and has founded his vault on the earth; he who calls for the waters of the sea, and pours them out on the surface of the earth—Yahweh is his name. 
-<span class="v">7&#160;</span>Are you not like the children of the Ethiopians to me, children of Israel?” says Yahweh. “Haven’t I brought up Israel out of the land of Egypt, and the Philistines from Caphtor, and the Syrians from Kir? 
-<span class="v">8&#160;</span>Behold, the eyes of the Lord Yahweh are on the sinful kingdom, and I will destroy it from off the surface of the earth, except that I will not utterly destroy the house of Jacob,” says Yahweh. 
-<span class="v">9&#160;</span>“For behold, I will command, and I will sift the house of Israel among all the nations as grain is sifted in a sieve, yet not the least kernel will fall on the earth. 
-<span class="v">10&#160;</span>All the sinners of my people will die by the sword, who say, ‘Evil won’t overtake nor meet us.’ 
-<span class="v">11&#160;</span>In that day I will raise up the tent of David who is fallen and close up its breaches, and I will raise up its ruins, and I will build it as in the days of old, 
-<span class="v">12&#160;</span>that they may possess the remnant of Edom and all the nations who are called by my name,” says Yahweh who does this. 
-</p><p class="q1">
-<span class="v">13&#160;</span>“Behold, the days come,” says Yahweh, 
-</p><p class="q2">“that the plowman shall overtake the reaper, 
-</p><p class="q2">and the one treading grapes him who sows seed; 
-</p><p class="q2">and sweet wine will drip from the mountains, 
-</p><p class="q2">and flow from the hills. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will bring my people Israel back from captivity, 
-</p><p class="q2">and they will rebuild the ruined cities, and inhabit them; 
-</p><p class="q2">and they will plant vineyards, and drink wine from them. 
-</p><p class="q1">They shall also make gardens, 
-</p><p class="q2">and eat their fruit. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will plant them on their land, 
-</p><p class="q2">and they will no more be plucked up out of their land which I have given them,” 
-</p><p class="q2">says Yahweh your Elohim. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The words of Amos, who was among the herdsmen of Tekoa, which he saw concerning Israel in the days of Uzziah king of Judah and in the days of Jeroboam the son of Joash, king of Israel, two years before the earthquake. 
+<sup>2&#160;</sup>He said: 
+</div><div class="q1">“Yahweh will roar from Zion, 
+</div><div class="q2">and utter his voice from Jerusalem; 
+</div><div class="q1">and the pastures of the shepherds will mourn, 
+</div><div class="q2">and the top of Carmel will wither.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Damascus, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because they have threshed Gilead with threshing instruments of iron; 
+</div><div class="q1">
+<sup>4&#160;</sup>but I will send a fire into the house of Hazael, 
+</div><div class="q2">and it will devour the palaces of Ben Hadad. 
+</div><div class="q1">
+<sup>5&#160;</sup>I will break the bar of Damascus, 
+</div><div class="q2">and cut off the inhabitant from the valley of Aven, 
+</div><div class="q2">and him who holds the scepter from the house of Eden; 
+</div><div class="q2">and the people of Syria shall go into captivity to Kir,” 
+</div><div class="p">says Yahweh. 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Gaza, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because they carried away captive the whole community, 
+</div><div class="q2">to deliver them up to Edom; 
+</div><div class="q1">
+<sup>7&#160;</sup>but I will send a fire on the wall of Gaza, 
+</div><div class="q2">and it will devour its palaces. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will cut off the inhabitant from Ashdod, 
+</div><div class="q2">and him who holds the scepter from Ashkelon; 
+</div><div class="q1">and I will turn my hand against Ekron; 
+</div><div class="q2">and the remnant of the Philistines will perish,” 
+</div><div class="p">says the Lord Yahweh. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Tyre, yes, for four, 
+</div><div class="q2">I will not turn away its punishment; 
+</div><div class="q2">because they delivered up the whole community to Edom, 
+</div><div class="q2">and didn’t remember the brotherly covenant; 
+</div><div class="q1">
+<sup>10&#160;</sup>but I will send a fire on the wall of Tyre, 
+</div><div class="q2">and it will devour its palaces.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Edom, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because he pursued his brother with the sword 
+</div><div class="q2">and cast off all pity, 
+</div><div class="q2">and his anger raged continually, 
+</div><div class="q2">and he kept his wrath forever; 
+</div><div class="q1">
+<sup>12&#160;</sup>but I will send a fire on Teman, 
+</div><div class="q2">and it will devour the palaces of Bozrah.” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of the children of Ammon, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because they have ripped open the pregnant women of Gilead, 
+</div><div class="q2">that they may enlarge their border. 
+</div><div class="q1">
+<sup>14&#160;</sup>But I will kindle a fire in the wall of Rabbah, 
+</div><div class="q2">and it will devour its palaces, 
+</div><div class="q2">with shouting in the day of battle, 
+</div><div class="q2">with a storm in the day of the whirlwind; 
+</div><div class="q1">
+<sup>15&#160;</sup>and their king will go into captivity, 
+</div><div class="q2">he and his princes together,” 
+</div><div class="p">says Yahweh. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Moab, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because he burned the bones of the king of Edom into lime; 
+</div><div class="q1">
+<sup>2&#160;</sup>but I will send a fire on Moab, 
+</div><div class="q2">and it will devour the palaces of Kerioth; 
+</div><div class="q2">and Moab will die with tumult, with shouting, and with the sound of the trumpet; 
+</div><div class="q1">
+<sup>3&#160;</sup>and I will cut off the judge from among them, 
+</div><div class="q2">and will kill all its princes with him,” 
+</div><div class="p">says Yahweh. 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Judah, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because they have rejected Yahweh’s law, 
+</div><div class="q2">and have not kept his statutes, 
+</div><div class="q2">and their lies have led them astray, 
+</div><div class="q2">after which their fathers walked; 
+</div><div class="q1">
+<sup>5&#160;</sup>but I will send a fire on Judah, 
+</div><div class="q2">and it will devour the palaces of Jerusalem.” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh says: 
+</div><div class="q1">“For three transgressions of Israel, yes, for four, 
+</div><div class="q2">I will not turn away its punishment, 
+</div><div class="q2">because they have sold the righteous for silver, 
+</div><div class="q2">and the needy for a pair of sandals; 
+</div><div class="q2">
+<sup>7&#160;</sup>They trample the heads of the poor into the dust of the earth 
+</div><div class="q2">and deny justice to the oppressed. 
+</div><div class="q1">A man and his father use the same maiden, to profane my set-apart name. 
+</div><div class="q2">
+<sup>8&#160;</sup>They lay themselves down beside every altar on clothes taken in pledge. 
+</div><div class="q2">In the house of their Elohim they drink the wine of those who have been fined. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yet I destroyed the Amorite before them, 
+</div><div class="q2">whose height was like the height of the cedars, 
+</div><div class="q2">and he was strong as the oaks; 
+</div><div class="q2">yet I destroyed his fruit from above, 
+</div><div class="q2">and his roots from beneath. 
+</div><div class="q1">
+<sup>10&#160;</sup>Also I brought you up out of the land of Egypt 
+</div><div class="q2">and led you forty years in the wilderness, 
+</div><div class="q2">to possess the land of the Amorite. 
+</div><div class="q1">
+<sup>11&#160;</sup>I raised up some of your sons for prophets, 
+</div><div class="q2">and some of your young men for Nazirites. 
+</div><div class="q1">Isn’t this true, 
+</div><div class="q2">you children of Israel?” says Yahweh. 
+</div><div class="q1">
+<sup>12&#160;</sup>“But you gave the Nazirites wine to drink, 
+</div><div class="q2">and commanded the prophets, saying, ‘Don’t prophesy!’ 
+</div><div class="q1">
+<sup>13&#160;</sup>Behold, I will crush you in your place, 
+</div><div class="q2">as a cart crushes that is full of grain. 
+</div><div class="q1">
+<sup>14&#160;</sup>Flight will perish from the swift. 
+</div><div class="q2">The strong won’t strengthen his force. 
+</div><div class="q2">The mighty won’t deliver himself. 
+</div><div class="q1">
+<sup>15&#160;</sup>He who handles the bow won’t stand. 
+</div><div class="q2">He who is swift of foot won’t escape. 
+</div><div class="q2">He who rides the horse won’t deliver himself. 
+</div><div class="q1">
+<sup>16&#160;</sup>He who is courageous among the mighty 
+</div><div class="q2">will flee away naked on that day,” 
+</div><div class="p">says Yahweh. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Hear this word that Yahweh has spoken against you, children of Israel, against the whole family which I brought up out of the land of Egypt, saying: 
+</div><div class="q1">
+<sup>2&#160;</sup>“I have only chosen you of all the families of the earth. 
+</div><div class="q2">Therefore I will punish you for all of your sins.” 
+</div><div class="q1">
+<sup>3&#160;</sup>Do two walk together, 
+</div><div class="q2">unless they have agreed? 
+</div><div class="q1">
+<sup>4&#160;</sup>Will a lion roar in the thicket, 
+</div><div class="q2">when he has no prey? 
+</div><div class="q1">Does a young lion cry out of his den, 
+</div><div class="q2">if he has caught nothing? 
+</div><div class="q1">
+<sup>5&#160;</sup>Can a bird fall in a trap on the earth, 
+</div><div class="q2">where no snare is set for him? 
+</div><div class="q1">Does a snare spring up from the ground, 
+</div><div class="q2">when there is nothing to catch? 
+</div><div class="q1">
+<sup>6&#160;</sup>Does the trumpet alarm sound in a city, 
+</div><div class="q2">without the people being afraid? 
+</div><div class="q1">Does evil happen to a city, 
+</div><div class="q2">and Yahweh hasn’t done it? 
+</div><div class="q1">
+<sup>7&#160;</sup>Surely the Lord Yahweh will do nothing, 
+</div><div class="q2">unless he reveals his secret to his servants the prophets. 
+</div><div class="q1">
+<sup>8&#160;</sup>The lion has roared. 
+</div><div class="q2">Who will not fear? 
+</div><div class="q1">The Lord Yahweh has spoken. 
+</div><div class="q2">Who can but prophesy? 
+</div><div class="q1">
+<sup>9&#160;</sup>Proclaim in the palaces at Ashdod, 
+</div><div class="q2">and in the palaces in the land of Egypt, 
+</div><div class="q1">and say, “Assemble yourselves on the mountains of Samaria, 
+</div><div class="q2">and see what unrest is in her, 
+</div><div class="q2">and what oppression is among them.” 
+</div><div class="q1">
+<sup>10&#160;</sup>“Indeed they don’t know to do right,” says Yahweh, 
+</div><div class="q2">“Who hoard plunder and loot in their palaces.” 
+</div><div class="p">
+<sup>11&#160;</sup>Therefore the Lord Yahweh says: 
+</div><div class="q1">“An adversary will overrun the land; 
+</div><div class="q2">and he will pull down your strongholds, 
+</div><div class="q2">and your fortresses will be plundered.” 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh says: 
+</div><div class="q1">“As the shepherd rescues out of the mouth of the lion two legs, 
+</div><div class="q2">or a piece of an ear, 
+</div><div class="q2">so shall the children of Israel be rescued who sit in Samaria on the corner of a couch, 
+</div><div class="q2">and on the silken cushions of a bed.” 
+</div><div class="p">
+<sup>13&#160;</sup>“Listen, and testify against the house of Jacob,” says the Lord Yahweh, the Elohim of Armies. 
+</div><div class="q1">
+<sup>14&#160;</sup>“For in the day that I visit the transgressions of Israel on him, 
+</div><div class="q2">I will also visit the altars of Bethel; 
+</div><div class="q2">and the horns of the altar will be cut off, 
+</div><div class="q2">and fall to the ground. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will strike the winter house with the summer house; 
+</div><div class="q2">and the houses of ivory will perish, 
+</div><div class="q2">and the great houses will have an end,” 
+</div><div class="p">says Yahweh. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Listen to this word, you cows of Bashan, who are on the mountain of Samaria, who oppress the poor, who crush the needy, who tell their lords, “Bring us drinks!” 
+</div><div class="q1">
+<sup>2&#160;</sup>The Lord Yahweh has sworn by his set-apartness, 
+</div><div class="q2">“Behold, the days shall come on you that they will take you away with hooks, 
+</div><div class="q2">and the last of you with fish hooks. 
+</div><div class="q1">
+<sup>3&#160;</sup>You will go out at the breaks in the wall, 
+</div><div class="q2">everyone straight before her; 
+</div><div class="q2">and you will cast yourselves into Harmon,” says Yahweh. 
+</div><div class="q1">
+<sup>4&#160;</sup>“Go to Bethel, and sin; 
+</div><div class="q2">to Gilgal, and sin more. 
+</div><div class="q1">Bring your sacrifices every morning, 
+</div><div class="q2">your tithes every three days, 
+</div><div class="q2">
+<sup>5&#160;</sup>offer a sacrifice of thanksgiving of that which is leavened, 
+</div><div class="q2">and proclaim free will offerings and brag about them; 
+</div><div class="q2">for this pleases you, you children of Israel,” says the Lord Yahweh. 
+</div><div class="q1">
+<sup>6&#160;</sup>“I also have given you cleanness of teeth in all your cities, 
+</div><div class="q2">and lack of bread in every town; 
+</div><div class="q2">yet you haven’t returned to me,” says Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>“I also have withheld the rain from you, 
+</div><div class="q2">when there were yet three months to the harvest; 
+</div><div class="q2">and I caused it to rain on one city, 
+</div><div class="q2">and caused it not to rain on another city. 
+</div><div class="q1">One field was rained on, 
+</div><div class="q2">and the field where it didn’t rain withered. 
+</div><div class="q1">
+<sup>8&#160;</sup>So two or three cities staggered to one city to drink water, 
+</div><div class="q2">and were not satisfied; 
+</div><div class="q2">yet you haven’t returned to me,” says Yahweh. 
+</div><div class="q1">
+<sup>9&#160;</sup>“I struck you with blight and mildew many times in your gardens and your vineyards, 
+</div><div class="q2">and the swarming locusts have devoured your fig trees and your olive trees; 
+</div><div class="q2">yet you haven’t returned to me,” says Yahweh. 
+</div><div class="q1">
+<sup>10&#160;</sup>“I sent plagues among you like I did Egypt. 
+</div><div class="q2">I have slain your young men with the sword, 
+</div><div class="q2">and have carried away your horses. 
+</div><div class="q1">I filled your nostrils with the stench of your camp, 
+</div><div class="q2">yet you haven’t returned to me,” says Yahweh. 
+</div><div class="q1">
+<sup>11&#160;</sup>“I have overthrown some of you, 
+</div><div class="q2">as when Elohim overthrew Sodom and Gomorrah, 
+</div><div class="q2">and you were like a burning stick plucked out of the fire; 
+</div><div class="q2">yet you haven’t returned to me,” says Yahweh. 
+</div><div class="q1">
+<sup>12&#160;</sup>“Therefore I will do this to you, Israel; 
+</div><div class="q2">because I will do this to you, 
+</div><div class="q2">prepare to meet your Elohim, Israel. 
+</div><div class="q1">
+<sup>13&#160;</sup>For, behold, he who forms the mountains, creates the wind, declares to man what is his thought, 
+</div><div class="q2">who makes the morning darkness, and treads on the high places of the earth: 
+</div><div class="q2">Yahweh, the Elohim of Armies, is his name.” 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Listen to this word which I take up for a lamentation over you, O house of Israel: 
+</div><div class="q1">
+<sup>2&#160;</sup>“The virgin of Israel has fallen; 
+</div><div class="q2">She shall rise no more. 
+</div><div class="q1">She is cast down on her land; 
+</div><div class="q2">there is no one to raise her up.” 
+</div><div class="p">
+<sup>3&#160;</sup>For the Lord Yahweh says: 
+</div><div class="q1">“The city that went out a thousand shall have a hundred left, 
+</div><div class="q2">and that which went out one hundred shall have ten left to the house of Israel.” 
+</div><div class="p">
+<sup>4&#160;</sup>For Yahweh says to the house of Israel: 
+</div><div class="q1">“Seek me, and you will live; 
+</div><div class="q1">
+<sup>5&#160;</sup>but don’t seek Bethel, 
+</div><div class="q2">nor enter into Gilgal, 
+</div><div class="q2">and don’t pass to Beersheba; 
+</div><div class="q1">for Gilgal shall surely go into captivity, 
+</div><div class="q2">and Bethel shall come to nothing. 
+</div><div class="q1">
+<sup>6&#160;</sup>Seek Yahweh, and you will live, 
+</div><div class="q2">lest he break out like fire in the house of Joseph, 
+</div><div class="q2">and it devour, and there be no one to quench it in Bethel. 
+</div><div class="q1">
+<sup>7&#160;</sup>You who turn justice to wormwood, 
+</div><div class="q2">and cast down righteousness to the earth! 
+</div><div class="q1">
+<sup>8&#160;</sup>Seek him who made the Pleiades and Orion, 
+</div><div class="q2">and turns the shadow of death into the morning, 
+</div><div class="q2">and makes the day dark with night; 
+</div><div class="q2">who calls for the waters of the sea, 
+</div><div class="q2">and pours them out on the surface of the earth, Yahweh is his name, 
+</div><div class="q1">
+<sup>9&#160;</sup>who brings sudden destruction on the strong, 
+</div><div class="q2">so that destruction comes on the fortress. 
+</div><div class="q1">
+<sup>10&#160;</sup>They hate him who reproves in the gate, 
+</div><div class="q2">and they abhor him who speaks blamelessly. 
+</div><div class="q1">
+<sup>11&#160;</sup>Therefore, because you trample on the poor and take taxes from him of wheat, 
+</div><div class="q2">you have built houses of cut stone, but you will not dwell in them. 
+</div><div class="q1">You have planted pleasant vineyards, 
+</div><div class="q2">but you shall not drink their wine. 
+</div><div class="q1">
+<sup>12&#160;</sup>For I know how many are your offenses, 
+</div><div class="q2">and how great are your sins—</div><div class="q2">you who afflict the just, 
+</div><div class="q2">who take a bribe, 
+</div><div class="q2">and who turn away the needy in the courts. 
+</div><div class="q1">
+<sup>13&#160;</sup>Therefore a prudent person keeps silent in such a time, 
+</div><div class="q2">for it is an evil time. 
+</div><div class="q1">
+<sup>14&#160;</sup>Seek good, and not evil, 
+</div><div class="q2">that you may live; 
+</div><div class="q2">and so Yahweh, the Elohim of Armies, will be with you, 
+</div><div class="q2">as you say. 
+</div><div class="q1">
+<sup>15&#160;</sup>Hate evil, love good, 
+</div><div class="q2">and establish justice in the courts. 
+</div><div class="q2">It may be that Yahweh, the Elohim of Armies, will be gracious to the remnant of Joseph.” 
+</div><div class="p">
+<sup>16&#160;</sup>Therefore Yahweh, the Elohim of Armies, the Lord, says: 
+</div><div class="q1">“Wailing will be in all the wide ways. 
+</div><div class="q2">They will say in all the streets, ‘Alas! Alas!’ 
+</div><div class="q2">They will call the farmer to mourning, 
+</div><div class="q2">and those who are skillful in lamentation to wailing. 
+</div><div class="q1">
+<sup>17&#160;</sup>In all vineyards there will be wailing, 
+</div><div class="q2">for I will pass through the middle of you,” says Yahweh. 
+</div><div class="q1">
+<sup>18&#160;</sup>“Woe to you who desire the day of Yahweh! 
+</div><div class="q2">Why do you long for the day of Yahweh? 
+</div><div class="q1">It is darkness, 
+</div><div class="q2">and not light. 
+</div><div class="q1">
+<sup>19&#160;</sup>As if a man fled from a lion, 
+</div><div class="q2">and a bear met him; 
+</div><div class="q1">or he went into the house and leaned his hand on the wall, 
+</div><div class="q2">and a snake bit him. 
+</div><div class="q1">
+<sup>20&#160;</sup>Won’t the day of Yahweh be darkness, and not light? 
+</div><div class="q2">Even very dark, and no brightness in it? 
+</div><div class="q1">
+<sup>21&#160;</sup>I hate, I despise your feasts, 
+</div><div class="q2">and I can’t stand your solemn assemblies. 
+</div><div class="q1">
+<sup>22&#160;</sup>Yes, though you offer me your burnt offerings and meal offerings, 
+</div><div class="q2">I will not accept them; 
+</div><div class="q2">neither will I regard the peace offerings of your fat animals. 
+</div><div class="q1">
+<sup>23&#160;</sup>Take away from me the noise of your songs! 
+</div><div class="q2">I will not listen to the music of your harps. 
+</div><div class="q1">
+<sup>24&#160;</sup>But let justice roll on like rivers, 
+</div><div class="q2">and righteousness like a mighty stream. 
+</div><div class="p">
+<sup>25&#160;</sup>“Did you bring to me sacrifices and offerings in the wilderness forty years, house of Israel? 
+<sup>26&#160;</sup>You also carried the tent of your king and the shrine of your images, the star of your elohim, which you made for yourselves. 
+<sup>27&#160;</sup>Therefore I will cause you to go into captivity beyond Damascus,” says Yahweh, whose name is the Elohim of Armies. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Woe to those who are at ease in Zion, 
+</div><div class="q2">and to those who are secure on the mountain of Samaria, 
+</div><div class="q2">the notable men of the chief of the nations, 
+</div><div class="q2">to whom the house of Israel come! 
+</div><div class="q1">
+<sup>2&#160;</sup>Go to Calneh, and see. 
+</div><div class="q2">From there go to Hamath the great. 
+</div><div class="q2">Then go down to Gath of the Philistines. 
+</div><div class="q1">Are they better than these kingdoms? 
+</div><div class="q2">Is their border greater than your border? 
+</div><div class="q1">
+<sup>3&#160;</sup>Alas for you who put far away the evil day, 
+</div><div class="q2">and cause the seat of violence to come near, 
+</div><div class="q2">
+<sup>4&#160;</sup>who lie on beds of ivory, 
+</div><div class="q2">and stretch themselves on their couches, 
+</div><div class="q2">and eat the lambs out of the flock, 
+</div><div class="q2">and the calves out of the middle of the stall, 
+</div><div class="q2">
+<sup>5&#160;</sup>who strum on the strings of a harp, 
+</div><div class="q2">who invent for themselves instruments of music, like David; 
+</div><div class="q2">
+<sup>6&#160;</sup>who drink wine in bowls, 
+</div><div class="q2">and anoint themselves with the best oils, 
+</div><div class="q2">but they are not grieved for the affliction of Joseph. 
+</div><div class="q1">
+<sup>7&#160;</sup>Therefore they will now go captive with the first who go captive. 
+</div><div class="q2">The feasting and lounging will end. 
+</div><div class="q1">
+<sup>8&#160;</sup>“The Lord Yahweh has sworn by himself,” says Yahweh, the Elohim of Armies: 
+</div><div class="q2">“I abhor the pride of Jacob, 
+</div><div class="q2">and detest his fortresses. 
+</div><div class="q2">Therefore I will deliver up the city with all that is in it. 
+</div><div class="q1">
+<sup>9&#160;</sup>It will happen that if ten men remain in one house, 
+</div><div class="q2">they will die. 
+</div><div class="p">
+<sup>10&#160;</sup>“When a man’s relative carries him, even he who burns him, to bring bodies out of the house, and asks him who is in the innermost parts of the house, ‘Is there yet any with you?’ And he says, ‘No;’ then he will say, ‘Hush! Indeed we must not mention Yahweh’s name.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“For, behold, Yahweh commands, and the great house will be smashed to pieces, 
+</div><div class="q2">and the little house into bits. 
+</div><div class="q1">
+<sup>12&#160;</sup>Do horses run on the rocky crags? 
+</div><div class="q2">Does one plow there with oxen? 
+</div><div class="q1">But you have turned justice into poison, 
+</div><div class="q2">and the fruit of righteousness into bitterness, 
+</div><div class="q1">
+<sup>13&#160;</sup>you who rejoice in a thing of nothing, who say, 
+</div><div class="q2">‘Haven’t we taken for ourselves horns by our own strength?’ 
+</div><div class="q1">
+<sup>14&#160;</sup>For, behold, I will raise up against you a nation, house of Israel,” 
+</div><div class="q2">says Yahweh, the Elohim of Armies; 
+</div><div class="q2">“and they will afflict you from the entrance of Hamath to the brook of the Arabah.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Thus the Lord Yahweh showed me: behold, he formed locusts in the beginning of the shooting up of the latter growth; and behold, it was the latter growth after the king’s harvest. 
+<sup>2&#160;</sup>When they finished eating the grass of the land, then I said, “Lord Yahweh, forgive, I beg you! How could Jacob stand? For he is small.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh relented concerning this. “It shall not be,” says Yahweh. 
+</div><div class="p">
+<sup>4&#160;</sup>Thus the Lord Yahweh showed me: behold, the Lord Yahweh called for judgment by fire; and it dried up the great deep, and would have devoured the land. 
+<sup>5&#160;</sup>Then I said, “Lord Yahweh, stop, I beg you! How could Jacob stand? For he is small.” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh relented concerning this. “This also shall not be,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>7&#160;</sup>Thus he showed me: behold, the Lord stood beside a wall made by a plumb line, with a plumb line in his hand. 
+<sup>8&#160;</sup>Yahweh said to me, “Amos, what do you see?” 
+</div><div class="p">I said, “A plumb line.” 
+</div><div class="p">Then the Lord said, “Behold, I will set a plumb line in the middle of my people Israel. I will not again pass by them any more. 
+<sup>9&#160;</sup>The high places of Isaac will be desolate, the sanctuaries of Israel will be laid waste; and I will rise against the house of Jeroboam with the sword.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Amaziah the priest of Bethel sent to Jeroboam king of Israel, saying, “Amos has conspired against you in the middle of the house of Israel. The land is not able to bear all his words. 
+<sup>11&#160;</sup>For Amos says, ‘Jeroboam will die by the sword, and Israel shall surely be led away captive out of his land.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Amaziah also said to Amos, “You seer, go, flee away into the land of Judah, and there eat bread, and prophesy there, 
+<sup>13&#160;</sup>but don’t prophesy again any more at Bethel; for it is the king’s sanctuary, and it is a royal house!” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Amos answered Amaziah, “I was no prophet, neither was I a prophet’s son, but I was a herdsman, and a farmer of sycamore figs; 
+<sup>15&#160;</sup>and Yahweh took me from following the flock, and Yahweh said to me, ‘Go, prophesy to my people Israel.’ 
+<sup>16&#160;</sup>Now therefore listen to Yahweh’s word: ‘You say, Don’t prophesy against Israel, and don’t preach against the house of Isaac.’ 
+<sup>17&#160;</sup>Therefore Yahweh says: ‘Your woman shall be a prostitute in the city, and your sons and your daughters shall fall by the sword, and your land shall be divided by line; and you yourself shall die in a land that is unclean, and Israel shall surely be led away captive out of his land.’&#160;” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Thus the Lord Yahweh showed me: behold, a basket of summer fruit. 
+</div><div class="p">
+<sup>2&#160;</sup>He said, “Amos, what do you see?” 
+</div><div class="p">I said, “A basket of summer fruit.” 
+</div><div class="p">Then Yahweh said to me, 
+</div><div class="q1">“The end has come on my people Israel. 
+</div><div class="q2">I will not again pass by them any more. 
+</div><div class="q1">
+<sup>3&#160;</sup>The songs of the temple will be wailing in that day,” says the Lord Yahweh. 
+</div><div class="q2">“The dead bodies will be many. In every place they will throw them out with silence. 
+</div><div class="q1">
+<sup>4&#160;</sup>Hear this, you who desire to swallow up the needy, 
+</div><div class="q2">and cause the poor of the land to fail, 
+</div><div class="q2">
+<sup>5&#160;</sup>saying, ‘When will the new moon be gone, that we may sell grain? 
+</div><div class="q2">And the Sabbath, that we may market wheat, 
+</div><div class="q2">making the ephah large, 
+</div><div class="q2">and dealing falsely with balances of deceit; 
+</div><div class="q1">
+<sup>6&#160;</sup>that we may buy the poor for silver, 
+</div><div class="q2">and the needy for a pair of sandals, 
+</div><div class="q2">and sell the sweepings with the wheat?’&#160;” 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh has sworn by the pride of Jacob, 
+</div><div class="q2">“Surely I will never forget any of their works. 
+</div><div class="q1">
+<sup>8&#160;</sup>Won’t the land tremble for this, 
+</div><div class="q2">and everyone mourn who dwells in it? 
+</div><div class="q1">Yes, it will rise up wholly like the River; 
+</div><div class="q2">and it will be stirred up and sink again, like the River of Egypt. 
+</div><div class="q1">
+<sup>9&#160;</sup>It will happen in that day,” says the Lord Yahweh, 
+</div><div class="q2">“that I will cause the sun to go down at noon, 
+</div><div class="q2">and I will darken the earth in the clear day. 
+</div><div class="q1">
+<sup>10&#160;</sup>I will turn your feasts into mourning, 
+</div><div class="q2">and all your songs into lamentation; 
+</div><div class="q1">and I will make you wear sackcloth on all your bodies, 
+</div><div class="q2">and baldness on every head. 
+</div><div class="q1">I will make it like the mourning for an only son, 
+</div><div class="q2">and its end like a bitter day. 
+</div><div class="q1">
+<sup>11&#160;</sup>Behold, the days come,” says the Lord Yahweh, 
+</div><div class="q2">“that I will send a famine in the land, 
+</div><div class="q2">not a famine of bread, 
+</div><div class="q2">nor a thirst for water, 
+</div><div class="q2">but of hearing Yahweh’s words. 
+</div><div class="q1">
+<sup>12&#160;</sup>They will wander from sea to sea, 
+</div><div class="q2">and from the north even to the east; 
+</div><div class="q2">they will run back and forth to seek Yahweh’s word, 
+</div><div class="q2">and will not find it. 
+</div><div class="q1">
+<sup>13&#160;</sup>In that day the beautiful virgins 
+</div><div class="q2">and the young men will faint for thirst. 
+</div><div class="q1">
+<sup>14&#160;</sup>Those who swear by the sin of Samaria, 
+</div><div class="q2">and say, ‘As your elohim, Dan, lives,’ 
+</div><div class="q2">and, ‘As the way of Beersheba lives,’ 
+</div><div class="q2">they will fall, and never rise up again.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw the Lord standing beside the altar, and he said, “Strike the tops of the pillars, that the thresholds may shake. Break them in pieces on the head of all of them. I will kill the last of them with the sword. Not one of them will flee away. Not one of them will escape. 
+<sup>2&#160;</sup>Though they dig into Sheol, there my hand will take them; and though they climb up to heaven, there I will bring them down. 
+<sup>3&#160;</sup>Though they hide themselves in the top of Carmel, I will search and take them out from there; and though they be hidden from my sight in the bottom of the sea, there I will command the serpent, and it will bite them. 
+<sup>4&#160;</sup>Though they go into captivity before their enemies, there I will command the sword, and it will kill them. I will set my eyes on them for evil, and not for good. 
+<sup>5&#160;</sup>For the Lord, Yahweh of Armies, is he who touches the land and it melts, and all who dwell in it will mourn; and it will rise up wholly like the River, and will sink again, like the River of Egypt. 
+<sup>6&#160;</sup>It is he who builds his rooms in the heavens, and has founded his vault on the earth; he who calls for the waters of the sea, and pours them out on the surface of the earth—Yahweh is his name. 
+<sup>7&#160;</sup>Are you not like the children of the Ethiopians to me, children of Israel?” says Yahweh. “Haven’t I brought up Israel out of the land of Egypt, and the Philistines from Caphtor, and the Syrians from Kir? 
+<sup>8&#160;</sup>Behold, the eyes of the Lord Yahweh are on the sinful kingdom, and I will destroy it from off the surface of the earth, except that I will not utterly destroy the house of Jacob,” says Yahweh. 
+<sup>9&#160;</sup>“For behold, I will command, and I will sift the house of Israel among all the nations as grain is sifted in a sieve, yet not the least kernel will fall on the earth. 
+<sup>10&#160;</sup>All the sinners of my people will die by the sword, who say, ‘Evil won’t overtake nor meet us.’ 
+<sup>11&#160;</sup>In that day I will raise up the tent of David who is fallen and close up its breaches, and I will raise up its ruins, and I will build it as in the days of old, 
+<sup>12&#160;</sup>that they may possess the remnant of Edom and all the nations who are called by my name,” says Yahweh who does this. 
+</div><div class="q1">
+<sup>13&#160;</sup>“Behold, the days come,” says Yahweh, 
+</div><div class="q2">“that the plowman shall overtake the reaper, 
+</div><div class="q2">and the one treading grapes him who sows seed; 
+</div><div class="q2">and sweet wine will drip from the mountains, 
+</div><div class="q2">and flow from the hills. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will bring my people Israel back from captivity, 
+</div><div class="q2">and they will rebuild the ruined cities, and inhabit them; 
+</div><div class="q2">and they will plant vineyards, and drink wine from them. 
+</div><div class="q1">They shall also make gardens, 
+</div><div class="q2">and eat their fruit. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will plant them on their land, 
+</div><div class="q2">and they will no more be plucked up out of their land which I have given them,” 
+</div><div class="q2">says Yahweh your Elohim. </div></div><script src="../main.js"></script></body></html>

--- a/book/daniel.html
+++ b/book/daniel.html
@@ -3,6 +3,47 @@
 <head>
 <title>Daniel</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,575 +53,588 @@
 <div class="main">
 <!-- DAN World English Scripture (WES) -->
 <h1 class="booklabel">Daniel</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>In the third year of the reign of Jehoiakim king of Judah, Nebuchadnezzar king of Babylon came to Jerusalem and besieged it. 
-<span class="v">2&#160;</span>The Lord<span class="f">+ \fr 1:2 \ft The word translated “Lord” is “Adonai.”</span> gave Jehoiakim king of Judah into his hand, with some of the vessels of the house of Elohim;<span class="f">+ \fr 1:2 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> and he carried them into the land of Shinar to the house of his elohim. He brought the vessels into the treasure house of his elohim. 
-</p><p>
-<span class="v">3&#160;</span>The king spoke to Ashpenaz, the master of his eunuchs, that he should bring in some of the children of Israel, even of the royal offspring<span class="f">+ \fr 1:3 \ft or, seed</span> and of the nobles: 
-<span class="v">4&#160;</span>youths in whom was no defect, but well-favored, skillful in all wisdom, endowed with knowledge, understanding science, and who had the ability to stand in the king’s palace; and that he should teach them the learning and the language of the Chaldeans. 
-<span class="v">5&#160;</span>The king appointed for them a daily portion of the king’s delicacies and of the wine which he drank, and that they should be nourished three years, that at its end they should stand before the king. 
-</p><p>
-<span class="v">6&#160;</span>Now among these of the children of Judah were Daniel, Hananiah, Mishael, and Azariah. 
-<span class="v">7&#160;</span>The prince of the eunuchs gave names to them: to Daniel he gave the name Belteshazzar; to Hananiah, Shadrach; to Mishael, Meshach; and to Azariah, Abednego. 
-</p><p>
-<span class="v">8&#160;</span>But Daniel purposed in his heart that he would not defile himself with the king’s delicacies, nor with the wine which he drank. Therefore he requested of the prince of the eunuchs that he might not defile himself. 
-<span class="v">9&#160;</span>Now Elohim made Daniel find kindness and compassion in the sight of the prince of the eunuchs. 
-<span class="v">10&#160;</span>The prince of the eunuchs said to Daniel, “I fear my lord the king, who has appointed your food and your drink. For why should he see your faces worse looking than the youths who are of your own age? Then you would endanger my head with the king.” 
-</p><p>
-<span class="v">11&#160;</span>Then Daniel said to the steward whom the prince of the eunuchs had appointed over Daniel, Hananiah, Mishael, and Azariah: 
-<span class="v">12&#160;</span>“Test your servants, I beg you, ten days; and let them give us vegetables to eat and water to drink. 
-<span class="v">13&#160;</span>Then let our faces be examined before you, and the face of the youths who eat of the king’s delicacies; and as you see, deal with your servants.” 
-<span class="v">14&#160;</span>So he listened to them in this matter, and tested them for ten days. 
-</p><p>
-<span class="v">15&#160;</span>At the end of ten days, their faces appeared fairer and they were fatter in flesh than all the youths who ate of the king’s delicacies. 
-<span class="v">16&#160;</span>So the steward took away their delicacies and the wine that they were given to drink, and gave them vegetables. 
-</p><p>
-<span class="v">17&#160;</span>Now as for these four youths, Elohim gave them knowledge and skill in all learning and wisdom; and Daniel had understanding in all visions and dreams. 
-</p><p>
-<span class="v">18&#160;</span>At the end of the days which the king had appointed for bringing them in, the prince of the eunuchs brought them in before Nebuchadnezzar. 
-<span class="v">19&#160;</span>The king talked with them; and among them all was found no one like Daniel, Hananiah, Mishael, and Azariah. Therefore stood they before the king. 
-<span class="v">20&#160;</span>In every matter of wisdom and understanding concerning which the king inquired of them, he found them ten times better than all the magicians and enchanters who were in all his realm. 
-</p><p>
-<span class="v">21&#160;</span>Daniel continued even to the first year of King Cyrus. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>In the second year of the reign of Nebuchadnezzar, Nebuchadnezzar dreamed dreams; and his spirit was troubled, and his sleep went from him. 
-<span class="v">2&#160;</span>Then the king commanded that the magicians, the enchanters, the sorcerers, and the Chaldeans be called to tell the king his dreams. So they came in and stood before the king. 
-<span class="v">3&#160;</span>The king said to them, “I have dreamed a dream, and my spirit is troubled to know the dream.” 
-</p><p>
-<span class="v">4&#160;</span>Then the Chaldeans spoke to the king in the Syrian language, “O king, live forever! Tell your servants the dream, and we will show the interpretation.” 
-</p><p>
-<span class="v">5&#160;</span>The king answered the Chaldeans, “The thing has gone from me. If you don’t make known to me the dream and its interpretation, you will be cut in pieces, and your houses will be made a dunghill. 
-<span class="v">6&#160;</span>But if you show the dream and its interpretation, you will receive from me gifts, rewards, and great honor. Therefore show me the dream and its interpretation.” 
-</p><p>
-<span class="v">7&#160;</span>They answered the second time and said, “Let the king tell his servants the dream, and we will show the interpretation.” 
-</p><p>
-<span class="v">8&#160;</span>The king answered, “I know of a certainty that you are trying to gain time, because you see the thing has gone from me. 
-<span class="v">9&#160;</span>But if you don’t make known to me the dream, there is but one law for you; for you have prepared lying and corrupt words to speak before me, until the situation changes. Therefore tell me the dream, and I will know that you can show me its interpretation.” 
-</p><p>
-<span class="v">10&#160;</span>The Chaldeans answered the king and said, “There is not a man on the earth who can show the king’s matter, because no king, lord, or ruler has asked such a thing of any magician, enchanter, or Chaldean. 
-<span class="v">11&#160;</span>It is a rare thing that the king requires, and there is no other who can show it before the king except the elohims, whose dwelling is not with flesh.” 
-</p><p>
-<span class="v">12&#160;</span>Because of this, the king was angry and very furious, and commanded that all the wise men of Babylon be destroyed. 
-<span class="v">13&#160;</span>So the decree went out, and the wise men were to be slain. They sought Daniel and his companions to be slain. 
-</p><p>
-<span class="v">14&#160;</span>Then Daniel returned answer with counsel and prudence to Arioch the captain of the king’s guard, who had gone out to kill the wise men of Babylon. 
-<span class="v">15&#160;</span>He answered Arioch the king’s captain, “Why is the decree so urgent from the king?” Then Arioch made the thing known to Daniel. 
-<span class="v">16&#160;</span>Daniel went in, and desired of the king that he would appoint him a time, and he would show the king the interpretation. 
-</p><p>
-<span class="v">17&#160;</span>Then Daniel went to his house and made the thing known to Hananiah, Mishael, and Azariah, his companions: 
-<span class="v">18&#160;</span>that they would desire mercies of the Elohim of heaven concerning this secret, that Daniel and his companions would not perish with the rest of the wise men of Babylon. 
-<span class="v">19&#160;</span>Then the secret was revealed to Daniel in a vision of the night. Then Daniel blessed the Elohim of heaven. 
-<span class="v">20&#160;</span>Daniel answered, 
-</p><p class="q1">“Blessed be the name of Elohim forever and ever; 
-</p><p class="q2">for wisdom and might are his. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He changes the times and the seasons. 
-</p><p class="q2">He removes kings and sets up kings. 
-</p><p class="q1">He gives wisdom to the wise, 
-</p><p class="q2">and knowledge to those who have understanding. 
-</p><p class="q1">
-<span class="v">22&#160;</span>He reveals the deep and secret things. 
-</p><p class="q2">He knows what is in the darkness, 
-</p><p class="q2">and the light dwells with him. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I thank you and praise you, 
-</p><p class="q2">O Elohim of my fathers, 
-</p><p class="q1">who have given me wisdom and might, 
-</p><p class="q2">and have now made known to me what we desired of you; 
-</p><p class="q2">for you have made known to us the king’s matter.” 
-</p><p>
-<span class="v">24&#160;</span>Therefore Daniel went in to Arioch, whom the king had appointed to destroy the wise men of Babylon. He went and said this to him: “Don’t destroy the wise men of Babylon. Bring me in before the king, and I will show to the king the interpretation.” 
-</p><p>
-<span class="v">25&#160;</span>Then Arioch brought in Daniel before the king in haste, and said this to him: “I have found a man of the children of the captivity of Judah who will make known to the king the interpretation.” 
-</p><p>
-<span class="v">26&#160;</span>The king answered Daniel, whose name was Belteshazzar, “Are you able to make known to me the dream which I have seen, and its interpretation?” 
-</p><p>
-<span class="v">27&#160;</span>Daniel answered before the king, and said, “The secret which the king has demanded can’t be shown to the king by wise men, enchanters, magicians, or soothsayers; 
-<span class="v">28&#160;</span>but there is an Elohim in heaven who reveals secrets, and he has made known to King Nebuchadnezzar what will be in the latter days. Your dream and the visions of your head on your bed are these: 
-</p><p>
-<span class="v">29&#160;</span>“As for you, O king, your thoughts came on your bed, what should happen hereafter; and he who reveals secrets has made known to you what will happen. 
-<span class="v">30&#160;</span>But as for me, this secret is not revealed to me for any wisdom that I have more than any living, but to the intent that the interpretation may be made known to the king, and that you may know the thoughts of your heart. 
-</p><p>
-<span class="v">31&#160;</span>“You, O king, saw, and behold,<span class="f">+ \fr 2:31 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> a great image. This image, which was mighty, and whose brightness was excellent, stood before you; and its appearance was terrifying. 
-<span class="v">32&#160;</span>As for this image, its head was of fine gold, its breast and its arms of silver, its belly and its thighs of bronze, 
-<span class="v">33&#160;</span>its legs of iron, its feet part of iron and part of clay. 
-<span class="v">34&#160;</span>You saw until a stone was cut out without hands, which struck the image on its feet that were of iron and clay, and broke them in pieces. 
-<span class="v">35&#160;</span>Then the iron, the clay, the bronze, the silver, and the gold were broken in pieces together, and became like the chaff of the summer threshing floors. The wind carried them away, so that no place was found for them. The stone that struck the image became a great mountain and filled the whole earth. 
-</p><p>
-<span class="v">36&#160;</span>“This is the dream; and we will tell its interpretation before the king. 
-<span class="v">37&#160;</span>You, O king, are king of kings, to whom the Elohim of heaven has given the kingdom, the power, the strength, and the glory. 
-<span class="v">38&#160;</span>Wherever the children of men dwell, he has given the animals of the field and the birds of the sky into your hand, and has made you rule over them all. You are the head of gold. 
-</p><p>
-<span class="v">39&#160;</span>“After you, another kingdom will arise that is inferior to you; and another third kingdom of bronze, which will rule over all the earth. 
-<span class="v">40&#160;</span>The fourth kingdom will be strong as iron, because iron breaks in pieces and subdues all things; and as iron that crushes all these, it will break in pieces and crush. 
-<span class="v">41&#160;</span>Whereas you saw the feet and toes, part of potters’ clay and part of iron, it will be a divided kingdom; but there will be in it of the strength of the iron, because you saw the iron mixed with miry clay. 
-<span class="v">42&#160;</span>As the toes of the feet were part of iron, and part of clay, so the kingdom will be partly strong and partly brittle. 
-<span class="v">43&#160;</span>Whereas you saw the iron mixed with miry clay, they will mingle themselves with the seed of men; but they won’t cling to one another, even as iron does not mix with clay. 
-</p><p>
-<span class="v">44&#160;</span>“In the days of those kings the Elohim of heaven will set up a kingdom which will never be destroyed, nor will its sovereignty be left to another people; but it will break in pieces and consume all these kingdoms, and it will stand forever. 
-<span class="v">45&#160;</span>Because you saw that a stone was cut out of the mountain without hands, and that it broke in pieces the iron, the bronze, the clay, the silver, and the gold, the great Elohim has made known to the king what will happen hereafter. The dream is certain, and its interpretation sure.” 
-</p><p>
-<span class="v">46&#160;</span>Then King Nebuchadnezzar fell on his face, worshiped Daniel, and commanded that they should offer an offering and sweet odors to him. 
-<span class="v">47&#160;</span>The king answered to Daniel, and said, “Of a truth your Elohim is the Elohim of elohims, and the Lord of kings, and a revealer of secrets, since you have been able to reveal this secret.” 
-</p><p>
-<span class="v">48&#160;</span>Then the king made Daniel great and gave him many great gifts, and made him rule over the whole province of Babylon and to be chief governor over all the wise men of Babylon. 
-<span class="v">49&#160;</span>Daniel requested of the king, and he appointed Shadrach, Meshach, and Abednego over the affairs of the province of Babylon, but Daniel was in the king’s gate. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Nebuchadnezzar the king made an image of gold, whose height was sixty cubits<span class="f">+ \fr 3:1 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and its width six cubits. He set it up in the plain of Dura, in the province of Babylon. 
-<span class="v">2&#160;</span>Then Nebuchadnezzar the king sent to gather together the local governors, the deputies, and the governors, the judges, the treasurers, the counselors, the sheriffs, and all the rulers of the provinces, to come to the dedication of the image which Nebuchadnezzar the king had set up. 
-<span class="v">3&#160;</span>Then the local governors, the deputies, and the governors, the judges, the treasurers, the counselors, the sheriffs, and all the rulers of the provinces were gathered together to the dedication of the image that Nebuchadnezzar the king had set up; and they stood before the image that Nebuchadnezzar had set up. 
-</p><p>
-<span class="v">4&#160;</span>Then the herald cried aloud, “To you it is commanded, peoples, nations, and languages, 
-<span class="v">5&#160;</span>that whenever you hear the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music, you fall down and worship the golden image that Nebuchadnezzar the king has set up. 
-<span class="v">6&#160;</span>Whoever doesn’t fall down and worship shall be cast into the middle of a burning fiery furnace the same hour.” 
-</p><p>
-<span class="v">7&#160;</span>Therefore at that time, when all the peoples heard the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music, all the peoples, the nations, and the languages fell down and worshiped the golden image that Nebuchadnezzar the king had set up. 
-</p><p>
-<span class="v">8&#160;</span>Therefore at that time certain Chaldeans came near and brought accusation against the Jews. 
-<span class="v">9&#160;</span>They answered Nebuchadnezzar the king, “O king, live for ever! 
-<span class="v">10&#160;</span>You, O king, have made a decree that every man who hears the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music shall fall down and worship the golden image; 
-<span class="v">11&#160;</span>and whoever doesn’t fall down and worship shall be cast into the middle of a burning fiery furnace. 
-<span class="v">12&#160;</span>There are certain Jews whom you have appointed over the affairs of the province of Babylon: Shadrach, Meshach, and Abednego. These men, O king, have not respected you. They don’t serve your elohims, and don’t worship the golden image which you have set up.” 
-</p><p>
-<span class="v">13&#160;</span>Then Nebuchadnezzar in rage and fury commanded that Shadrach, Meshach, and Abednego be brought. Then these men were brought before the king. 
-<span class="v">14&#160;</span>Nebuchadnezzar answered them, “Is it true, Shadrach, Meshach, and Abednego, that you don’t serve my elohims and you don’t worship the golden image which I have set up? 
-<span class="v">15&#160;</span>Now if you are ready whenever you hear the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music to fall down and worship the image which I have made, good; but if you don’t worship, you shall be cast the same hour into the middle of a burning fiery furnace. Who is that elohim who will deliver you out of my hands?” 
-</p><p>
-<span class="v">16&#160;</span>Shadrach, Meshach, and Abednego answered the king, “Nebuchadnezzar, we have no need to answer you in this matter. 
-<span class="v">17&#160;</span>If it happens, our Elohim whom we serve is able to deliver us from the burning fiery furnace; and he will deliver us out of your hand, O king. 
-<span class="v">18&#160;</span>But if not, let it be known to you, O king, that we will not serve your elohims or worship the golden image which you have set up.” 
-</p><p>
-<span class="v">19&#160;</span>Then Nebuchadnezzar was full of fury, and the form of his appearance was changed against Shadrach, Meshach, and Abednego. He spoke, and commanded that they should heat the furnace seven times more than it was usually heated. 
-<span class="v">20&#160;</span>He commanded certain mighty men who were in his army to bind Shadrach, Meshach, and Abednego, and to cast them into the burning fiery furnace. 
-<span class="v">21&#160;</span>Then these men were bound in their pants, their tunics, and their mantles, and their other clothes, and were cast into the middle of the burning fiery furnace. 
-<span class="v">22&#160;</span>Therefore because the king’s commandment was urgent and the furnace exceedingly hot, the flame of the fire killed those men who took up Shadrach, Meshach, and Abednego. 
-<span class="v">23&#160;</span>These three men, Shadrach, Meshach, and Abednego, fell down bound into the middle of the burning fiery furnace. 
-</p><p>
-<span class="v">24&#160;</span>Then Nebuchadnezzar the king was astonished and rose up in haste. He spoke and said to his counselors, “Didn’t we cast three men bound into the middle of the fire?” 
-</p><p>They answered the king, “True, O king.” 
-</p><p>
-<span class="v">25&#160;</span>He answered, “Look, I see four men loose, walking in the middle of the fire, and they are unharmed. The appearance of the fourth is like a son of the elohims.<span class="f">+ \fr 3:25 \ft Or, the Son of Elohim.</span>” 
-</p><p>
-<span class="v">26&#160;</span>Then Nebuchadnezzar came near to the mouth of the burning fiery furnace. He spoke and said, “Shadrach, Meshach, and Abednego, you servants of the Most High Elohim, come out, and come here!” 
-</p><p>Then Shadrach, Meshach, and Abednego came out of the middle of the fire. 
-<span class="v">27&#160;</span>The local governors, the deputies, and the governors, and the king’s counselors, being gathered together, saw these men, that the fire had no power on their bodies. The hair of their head wasn’t singed. Their pants weren’t changed. The smell of fire wasn’t even on them. 
-</p><p>
-<span class="v">28&#160;</span>Nebuchadnezzar spoke and said, “Blessed be the Elohim of Shadrach, Meshach, and Abednego, who has sent his angel and delivered his servants who trusted in him, and have changed the king’s word, and have yielded their bodies, that they might not serve nor worship any elohim except their own Elohim. 
-<span class="v">29&#160;</span>Therefore I make a decree that every people, nation, and language which speak anything evil against the Elohim of Shadrach, Meshach, and Abednego shall be cut in pieces, and their houses shall be made a dunghill, because there is no other elohim who is able to deliver like this.” 
-</p><p>
-<span class="v">30&#160;</span>Then the king promoted Shadrach, Meshach, and Abednego in the province of Babylon. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p class="pi1">
-<span class="v">1&#160;</span>Nebuchadnezzar the king, 
-</p><p class="pi1">to all the peoples, nations, and languages, who dwell in all the earth: 
-</p><p class="pi1">Peace be multiplied to you. 
-</p><p class="pi1">
-<span class="v">2&#160;</span>It has seemed good to me to show the signs and wonders that the Most High Elohim has worked toward me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>How great are his signs! 
-</p><p class="q2">How mighty are his wonders! 
-</p><p class="q1">His kingdom is an everlasting kingdom. 
-</p><p class="q2">His dominion is from generation to generation. 
-</p><p class="pi1">
-<span class="v">4&#160;</span>I, Nebuchadnezzar, was at rest in my house, and flourishing in my palace. 
-<span class="v">5&#160;</span>I saw a dream which made me afraid; and the thoughts on my bed and the visions of my head troubled me. 
-<span class="v">6&#160;</span>Therefore I made a decree to bring in all the wise men of Babylon before me, that they might make known to me the interpretation of the dream. 
-<span class="v">7&#160;</span>Then the magicians, the enchanters, the Chaldeans, and the soothsayers came in; and I told them the dream, but they didn’t make known to me its interpretation. 
-<span class="v">8&#160;</span>But at last, Daniel came in before me, whose name was Belteshazzar according to the name of my elohim, and in whom is the spirit of the set-apart elohims. I told the dream before him, saying, 
-</p><p class="pi1">
-<span class="v">9&#160;</span>“Belteshazzar, master of the magicians, because I know that the spirit of the set-apart elohims is in you and no secret troubles you, tell me the visions of my dream that I have seen, and its interpretation. 
-<span class="v">10&#160;</span>These were the visions of my head on my bed: I saw, and behold, a tree in the middle of the earth; and its height was great. 
-<span class="v">11&#160;</span>The tree grew and was strong. Its height reached to the sky and its sight to the end of all the earth. 
-<span class="v">12&#160;</span>Its leaves were beautiful, and it had much fruit, and in it was food for all. The animals of the field had shade under it, and the birds of the sky lived in its branches, and all flesh was fed from it. 
-</p><p class="pi1">
-<span class="v">13&#160;</span>“I saw in the visions of my head on my bed, and behold, a set-apart watcher came down from the sky. 
-<span class="v">14&#160;</span>He cried aloud and said this: ‘Cut down the tree, and cut off its branches! Shake off its leaves and scatter its fruit! Let the animals get away from under it and the birds from its branches. 
-<span class="v">15&#160;</span>Nevertheless leave the stump of its roots in the earth, even with a band of iron and bronze, in the tender grass of the field; and let it be wet with the dew of the sky. Let his portion be with the animals in the grass of the earth. 
-<span class="v">16&#160;</span>Let his heart be changed from man’s, and let an animal’s heart be given to him. Then let seven times pass over him. 
-</p><p class="pi1">
-<span class="v">17&#160;</span>“&#160;‘The sentence is by the decree of the watchers and the demand by the word of the set-apart ones, to the intent that the living may know that the Most High rules in the kingdom of men, and gives it to whomever he will, and sets up over it the lowest of men.’ 
-</p><p class="pi1">
-<span class="v">18&#160;</span>“This dream I, King Nebuchadnezzar, have seen; and you, Belteshazzar, declare the interpretation, because all the wise men of my kingdom are not able to make known to me the interpretation; but you are able, for the spirit of the set-apart elohims is in you.” 
-</p><p class="pi1">
-<span class="v">19&#160;</span>Then Daniel, whose name was Belteshazzar, was stricken mute for a while, and his thoughts troubled him. The king answered, “Belteshazzar, don’t let the dream or the interpretation, trouble you.” 
-</p><p class="pi1">Belteshazzar answered, “My lord, may the dream be for those who hate you, and its interpretation to your adversaries. 
-<span class="v">20&#160;</span>The tree that you saw, which grew and was strong, whose height reached to the sky and its sight to all the earth; 
-<span class="v">21&#160;</span>whose leaves were beautiful and its fruit plentiful, and in it was food for all; under which the animals of the field lived, and on whose branches the birds of the sky had their habitation—<span class="v">22&#160;</span>it is you, O king, that have grown and become strong; for your greatness has grown, and reaches to the sky, and your dominion to the end of the earth. 
-</p><p class="pi1">
-<span class="v">23&#160;</span>“Whereas the king saw a set-apart watcher coming down from the sky and saying, ‘Cut down the tree, and destroy it; nevertheless leave the stump of its roots in the earth, even with a band of iron and bronze, in the tender grass of the field, and let it be wet with the dew of the sky. Let his portion be with the animals of the field, until seven times pass over him.’ 
-</p><p class="pi1">
-<span class="v">24&#160;</span>“This is the interpretation, O king, and it is the decree of the Most High, which has come on my lord the king: 
-<span class="v">25&#160;</span>You will be driven from men and your dwelling shall be with the animals of the field. You will be made to eat grass as oxen, and will be wet with the dew of the sky, and seven times shall pass over you, until you know that the Most High rules in the kingdom of men, and gives it to whomever he will. 
-<span class="v">26&#160;</span>Whereas it was commanded to leave the stump of the roots of the tree, your kingdom shall be sure to you after you know that Heavens rules. 
-<span class="v">27&#160;</span>Therefore, O king, let my counsel be acceptable to you, and break off your sins by righteousness, and your iniquities by showing mercy to the poor. Perhaps there may be a lengthening of your tranquility.” 
-</p><p class="pi1">
-<span class="v">28&#160;</span>All this came on the King Nebuchadnezzar. 
-<span class="v">29&#160;</span>At the end of twelve months he was walking in the royal palace of Babylon. 
-<span class="v">30&#160;</span>The king spoke and said, “Is not this great Babylon, which I have built for the royal dwelling place by the might of my power and for the glory of my majesty?” 
-</p><p class="pi1">
-<span class="v">31&#160;</span>While the word was in the king’s mouth, a voice came from the sky, saying, “O King Nebuchadnezzar, to you it is spoken: ‘The kingdom has departed from you. 
-<span class="v">32&#160;</span>You shall be driven from men, and your dwelling shall be with the animals of the field. You shall be made to eat grass like oxen. Seven times shall pass over you, until you know that the Most High rules in the kingdom of men, and gives it to whomever he will.’&#160;” 
-</p><p class="pi1">
-<span class="v">33&#160;</span>This was fulfilled the same hour on Nebuchadnezzar. He was driven from men and ate grass like oxen; and his body was wet with the dew of the sky until his hair had grown like eagles’ feathers, and his nails like birds’ claws. 
-</p><p class="pi1">
-<span class="v">34&#160;</span>At the end of the days I, Nebuchadnezzar, lifted up my eyes to heaven, and my understanding returned to me; and I blessed the Most High, and I praised and honored him who lives forever, 
-</p><p class="q1">for his dominion is an everlasting dominion, 
-</p><p class="q2">and his kingdom from generation to generation. 
-</p><p class="q1">
-<span class="v">35&#160;</span>All the inhabitants of the earth are reputed as nothing; 
-</p><p class="q2">and he does according to his will in the army of heaven, 
-</p><p class="q2">and among the inhabitants of the earth; 
-</p><p class="q1">and no one can stop his hand, 
-</p><p class="q2">or ask him, “What are you doing?” 
-</p><p class="pi1">
-<span class="v">36&#160;</span>At the same time my understanding returned to me; and for the glory of my kingdom, my majesty and brightness returned to me. My counselors and my lords sought me; and I was established in my kingdom, and excellent greatness was added to me. 
-<span class="v">37&#160;</span>Now I, Nebuchadnezzar, praise and extol and honor the King of heaven; for all his works are truth, and his ways justice; and those who walk in pride he is able to abase. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Belshazzar the king made a great feast to a thousand of his lords, and drank wine before the thousand. 
-<span class="v">2&#160;</span>Belshazzar, while he tasted the wine, commanded that the golden and silver vessels which Nebuchadnezzar his father had taken out of the temple which was in Jerusalem be brought to him, that the king and his lords, his women and his concubines, might drink from them. 
-<span class="v">3&#160;</span>Then they brought the golden vessels that were taken out of the temple of Elohim’s house which was at Jerusalem; and the king and his lords, his women and his concubines, drank from them. 
-<span class="v">4&#160;</span>They drank wine, and praised the elohims of gold, and of silver, of bronze, of iron, of wood, and of stone. 
-</p><p>
-<span class="v">5&#160;</span>In the same hour, the fingers of a man’s hand came out and wrote near the lamp stand on the plaster of the wall of the king’s palace. The king saw the part of the hand that wrote. 
-<span class="v">6&#160;</span>Then the king’s face was changed in him, and his thoughts troubled him; and the joints of his thighs were loosened, and his knees struck one against another. 
-</p><p>
-<span class="v">7&#160;</span>The king cried aloud to bring in the enchanters, the Chaldeans, and the soothsayers. The king spoke and said to the wise men of Babylon, “Whoever reads this writing and shows me its interpretation shall be clothed with purple, and have a chain of gold about his neck, and shall be the third ruler in the kingdom.” 
-</p><p>
-<span class="v">8&#160;</span>Then all the king’s wise men came in; but they could not read the writing, and couldn’t make known to the king the interpretation. 
-<span class="v">9&#160;</span>Then King Belshazzar was greatly troubled, and his face was changed in him, and his lords were perplexed. 
-</p><p>
-<span class="v">10&#160;</span>The queen by reason of the words of the king and his lords came into the banquet house. The queen spoke and said, “O king, live forever; don’t let your thoughts trouble you, nor let your face be changed. 
-<span class="v">11&#160;</span>There is a man in your kingdom in whom is the spirit of the set-apart elohims; and in the days of your father, light and understanding and wisdom, like the wisdom of the elohims, were found in him. The king, Nebuchadnezzar, your father—yes, the king, your father—made him master of the magicians, enchanters, Chaldeans, and soothsayers, 
-<span class="v">12&#160;</span>because an excellent spirit, knowledge, understanding, interpreting of dreams, showing of dark sentences, and dissolving of doubts were found in the same Daniel, whom the king named Belteshazzar. Now let Daniel be called, and he will show the interpretation.” 
-</p><p>
-<span class="v">13&#160;</span>Then Daniel was brought in before the king. The king spoke and said to Daniel, “Are you that Daniel of the children of the captivity of Judah, whom the king my father brought out of Judah? 
-<span class="v">14&#160;</span>I have heard of you, that the spirit of the elohims is in you and that light, understanding, and excellent wisdom are found in you. 
-<span class="v">15&#160;</span>Now the wise men, the enchanters, have been brought in before me, that they should read this writing, and make known to me its interpretation; but they could not show the interpretation of the thing. 
-<span class="v">16&#160;</span>But I have heard of you, that you can give interpretations and dissolve doubts. Now if you can read the writing and make known to me its interpretation, you shall be clothed with purple, and have a chain of gold around your neck, and shall be the third ruler in the kingdom.” 
-</p><p>
-<span class="v">17&#160;</span>Then Daniel answered before the king, “Let your gifts be to yourself, and give your rewards to another. Nevertheless, I will read the writing to the king, and make known to him the interpretation. 
-</p><p>
-<span class="v">18&#160;</span>“To you, king, the Most High Elohim gave Nebuchadnezzar your father the kingdom, and greatness, and glory, and majesty. 
-<span class="v">19&#160;</span>Because of the greatness that he gave him, all the peoples, nations, and languages trembled and feared before him. He killed whom he wanted to, and he kept alive whom he wanted to. He raised up whom he wanted to, and he put down whom he wanted to. 
-<span class="v">20&#160;</span>But when his heart was lifted up, and his spirit was hardened so that he dealt proudly, he was deposed from his kingly throne, and they took his glory from him. 
-<span class="v">21&#160;</span>He was driven from the sons of men, and his heart was made like the animals’, and his dwelling was with the wild donkeys. He was fed with grass like oxen, and his body was wet with the dew of the sky, until he knew that the Most High Elohim rules in the kingdom of men, and that he sets up over it whomever he will. 
-</p><p>
-<span class="v">22&#160;</span>“You, his son, Belshazzar, have not humbled your heart, though you knew all this, 
-<span class="v">23&#160;</span>but have lifted up yourself against the Lord of heaven; and they have brought the vessels of his house before you, and you and your lords, your women, and your concubines, have drunk wine from them. You have praised the elohims of silver and gold, of bronze, iron, wood, and stone, which don’t see, or hear, or know; and you have not glorified the Elohim in whose hand your breath is, and whose are all your ways. 
-<span class="v">24&#160;</span>Then the part of the hand was sent from before him, and this writing was inscribed. 
-</p><p>
-<span class="v">25&#160;</span>“This is the writing that was inscribed: ‘MENE, MENE, TEKEL, UPHARSIN.’ 
-</p><p>
-<span class="v">26&#160;</span>“This is the interpretation of the thing: 
-</p><p class="m">MENE: Elohim has counted your kingdom, and brought it to an end. 
-</p><p class="m">
-<span class="v">27&#160;</span>TEKEL: you are weighed in the balances, and are found wanting. 
-</p><p class="m">
-<span class="v">28&#160;</span>PERES: your kingdom is divided, and given to the Medes and Persians.” 
-</p><p>
-<span class="v">29&#160;</span>Then Belshazzar commanded, and they clothed Daniel with purple, and put a chain of gold about his neck, and made proclamation concerning him, that he should be the third ruler in the kingdom. 
-</p><p>
-<span class="v">30&#160;</span>In that night Belshazzar the Chaldean King was slain. 
-<span class="v">31&#160;</span>Darius the Mede received the kingdom, being about sixty-two years old. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>It pleased Darius to set over the kingdom one hundred twenty local governors, who should be throughout the whole kingdom; 
-<span class="v">2&#160;</span>and over them three presidents, of whom Daniel was one, that these local governors might give account to them, and that the king should suffer no loss. 
-<span class="v">3&#160;</span>Then this Daniel was distinguished above the presidents and the local governors, because an excellent spirit was in him; and the king thought to set him over the whole realm. 
-</p><p>
-<span class="v">4&#160;</span>Then the presidents and the local governors sought to find occasion against Daniel as touching the kingdom; but they could find no occasion or fault, because he was faithful. There wasn’t any error or fault found in him. 
-<span class="v">5&#160;</span>Then these men said, “We won’t find any occasion against this Daniel, unless we find it against him concerning the law of his Elohim.” 
-</p><p>
-<span class="v">6&#160;</span>Then these presidents and local governors assembled together to the king, and said this to him, “King Darius, live forever! 
-<span class="v">7&#160;</span>All the presidents of the kingdom, the deputies and the local governors, the counselors and the governors, have consulted together to establish a royal statute and to make a strong decree, that whoever asks a petition of any elohim or man for thirty days, except of you, O king, he shall be cast into the den of lions. 
-<span class="v">8&#160;</span>Now, O king, establish the decree and sign the writing, that it not be changed, according to the law of the Medes and Persians, which doesn’t alter.” 
-<span class="v">9&#160;</span>Therefore King Darius signed the writing and the decree. 
-</p><p>
-<span class="v">10&#160;</span>When Daniel knew that the writing was signed, he went into his house (now his windows were open in his room toward Jerusalem) and he kneeled on his knees three times a day, and prayed, and gave thanks before his Elohim, as he did before. 
-<span class="v">11&#160;</span>Then these men assembled together, and found Daniel making petition and supplication before his Elohim. 
-<span class="v">12&#160;</span>Then they came near, and spoke before the king concerning the king’s decree: “Haven’t you signed a decree that every man who makes a petition to any elohim or man within thirty days, except to you, O king, shall be cast into the den of lions?” 
-</p><p>The king answered, “This thing is true, according to the law of the Medes and Persians, which doesn’t alter.” 
-</p><p>
-<span class="v">13&#160;</span>Then they answered and said before the king, “That Daniel, who is of the children of the captivity of Judah, doesn’t respect you, O king, nor the decree that you have signed, but makes his petition three times a day.” 
-<span class="v">14&#160;</span>Then the king, when he heard these words, was very displeased, and set his heart on Daniel to deliver him; and he labored until the going down of the sun to rescue him. 
-</p><p>
-<span class="v">15&#160;</span>Then these men assembled together to the king, and said to the king, “Know, O king, that it is a law of the Medes and Persians, that no decree nor statute which the king establishes may be changed.” 
-</p><p>
-<span class="v">16&#160;</span>Then the king commanded, and they brought Daniel and cast him into the den of lions. The king spoke and said to Daniel, “Your Elohim whom you serve continually, he will deliver you.” 
-</p><p>
-<span class="v">17&#160;</span>A stone was brought, and laid on the mouth of the den; and the king sealed it with his own signet, and with the signet of his lords; that nothing might be changed concerning Daniel. 
-<span class="v">18&#160;</span>Then the king went to his palace, and passed the night fasting. No musical instruments were brought before him; and his sleep fled from him. 
-</p><p>
-<span class="v">19&#160;</span>Then the king arose very early in the morning, and went in haste to the den of lions. 
-<span class="v">20&#160;</span>When he came near to the den to Daniel, he cried with a troubled voice. The king spoke and said to Daniel, “Daniel, servant of the living Elohim, is your Elohim, whom you serve continually, able to deliver you from the lions?” 
-</p><p>
-<span class="v">21&#160;</span>Then Daniel said to the king, “O king, live forever! 
-<span class="v">22&#160;</span>My Elohim has sent his angel, and has shut the lions’ mouths, and they have not hurt me, because innocence was found in me before him; and also before you, O king, I have done no harm.” 
-</p><p>
-<span class="v">23&#160;</span>Then the king was exceedingly glad, and commanded that they should take Daniel up out of the den. So Daniel was taken up out of the den, and no kind of harm was found on him, because he had trusted in his Elohim. 
-</p><p>
-<span class="v">24&#160;</span>The king commanded, and they brought those men who had accused Daniel, and they cast them into the den of lions—them, their children, and their women; and the lions mauled them, and broke all their bones in pieces before they came to the bottom of the den. 
-</p><p>
-<span class="v">25&#160;</span>Then King Darius wrote to all the peoples, nations, and languages who dwell in all the earth: 
-</p><p class="pi1">“Peace be multiplied to you. 
-</p><p class="pi1">
-<span class="v">26&#160;</span>“I make a decree that in all the dominion of my kingdom men tremble and fear before the Elohim of Daniel. 
-</p><p class="q1">“For he is the living Elohim, 
-</p><p class="q2">and steadfast forever. 
-</p><p class="q1">His kingdom is that which will not be destroyed. 
-</p><p class="q2">His dominion will be even to the end. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He delivers and rescues. 
-</p><p class="q2">He works signs and wonders in heaven and in earth, 
-</p><p class="q2">who has delivered Daniel from the power of the lions.” 
-</p><p>
-<span class="v">28&#160;</span>So this Daniel prospered in the reign of Darius and in the reign of Cyrus the Persian. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>In the first year of Belshazzar king of Babylon, Daniel had a dream and visions of his head while on his bed. Then he wrote the dream and told the sum of the matters. 
-</p><p>
-<span class="v">2&#160;</span>Daniel spoke and said, “I saw in my vision by night, and, behold, the four winds of the sky broke out on the great sea. 
-<span class="v">3&#160;</span>Four great animals came up from the sea, different from one another. 
-</p><p>
-<span class="v">4&#160;</span>“The first was like a lion, and had eagle’s wings. I watched until its wings were plucked, and it was lifted up from the earth and made to stand on two feet as a man. A man’s heart was given to it. 
-</p><p>
-<span class="v">5&#160;</span>“Behold, there was another animal, a second, like a bear. It was raised up on one side, and three ribs were in its mouth between its teeth. They said this to it: ‘Arise! Devour much flesh!’ 
-</p><p>
-<span class="v">6&#160;</span>“After this I saw, and behold, another, like a leopard, which had on its back four wings of a bird. The animal also had four heads; and dominion was given to it. 
-</p><p>
-<span class="v">7&#160;</span>“After this I saw in the night visions, and, behold, there was a fourth animal, awesome, powerful, and exceedingly strong. It had great iron teeth. It devoured and broke in pieces, and stamped the residue with its feet. It was different from all the animals that were before it. It had ten horns. 
-</p><p>
-<span class="v">8&#160;</span>“I considered the horns, and behold, there came up among them another horn, a little one, before which three of the first horns were plucked up by the roots; and behold, in this horn were eyes like the eyes of a man, and a mouth speaking arrogantly. 
-</p><p class="q1">
-<span class="v">9&#160;</span>“I watched until thrones were placed, 
-</p><p class="q2">and one who was ancient of days sat. 
-</p><p class="q1">His clothing was white as snow, 
-</p><p class="q2">and the hair of his head like pure wool. 
-</p><p class="q1">His throne was fiery flames, 
-</p><p class="q2">and its wheels burning fire. 
-</p><p class="q1">
-<span class="v">10&#160;</span>A fiery stream issued and came out from before him. 
-</p><p class="q2">Thousands of thousands ministered to him. 
-</p><p class="q2">Ten thousand times ten thousand stood before him. 
-</p><p class="q1">The judgment was set. 
-</p><p class="q2">The books were opened. 
-</p><p>
-<span class="v">11&#160;</span>“I watched at that time because of the voice of the arrogant words which the horn spoke. I watched even until the animal was slain, and its body destroyed, and it was given to be burned with fire. 
-<span class="v">12&#160;</span>As for the rest of the animals, their dominion was taken away; yet their lives were prolonged for a season and a time. 
-</p><p>
-<span class="v">13&#160;</span>“I saw in the night visions, and behold, there came with the clouds of the sky one like a son of man, and he came even to the Ancient of Days, and they brought him near before him. 
-<span class="v">14&#160;</span>Dominion was given him, and glory, and a kingdom, that all the peoples, nations, and languages should serve him. His dominion is an everlasting dominion, which will not pass away, and his kingdom one that will not be destroyed. 
-</p><p>
-<span class="v">15&#160;</span>“As for me, Daniel, my spirit was grieved within my body, and the visions of my head troubled me. 
-<span class="v">16&#160;</span>I came near to one of those who stood by, and asked him the truth concerning all this. 
-</p><p>“So he told me, and made me know the interpretation of the things. 
-<span class="v">17&#160;</span>‘These great animals, which are four, are four kings, who will arise out of the earth. 
-<span class="v">18&#160;</span>But the saints of the Most High will receive the kingdom, and possess the kingdom forever, even forever and ever.’ 
-</p><p>
-<span class="v">19&#160;</span>“Then I desired to know the truth concerning the fourth animal, which was different from all of them, exceedingly terrible, whose teeth were of iron, and its nails of bronze; which devoured, broke in pieces, and stamped the residue with its feet; 
-<span class="v">20&#160;</span>and concerning the ten horns that were on its head and the other horn which came up, and before which three fell, even that horn that had eyes and a mouth that spoke arrogantly, whose look was more stout than its fellows. 
-<span class="v">21&#160;</span>I saw, and the same horn made war with the saints, and prevailed against them, 
-<span class="v">22&#160;</span>until the ancient of days came, and judgment was given to the saints of the Most High, and the time came that the saints possessed the kingdom. 
-</p><p>
-<span class="v">23&#160;</span>“So he said, ‘The fourth animal will be a fourth kingdom on earth, which will be different from all the kingdoms, and will devour the whole earth, and will tread it down and break it in pieces. 
-<span class="v">24&#160;</span>As for the ten horns, ten kings will arise out of this kingdom. Another will arise after them; and he will be different from the former, and he will put down three kings. 
-<span class="v">25&#160;</span>He will speak words against the Most High, and will wear out the saints of the Most High. He will plan to change the times and the law; and they will be given into his hand until a time and times and half a time. 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘But the judgment will be set, and they will take away his dominion, to consume and to destroy it to the end. 
-<span class="v">27&#160;</span>The kingdom and the dominion, and the greatness of the kingdoms under the whole sky, will be given to the people of the saints of the Most High. His kingdom is an everlasting kingdom, and all dominions will serve and obey him.’ 
-</p><p>
-<span class="v">28&#160;</span>“Here is the end of the matter. As for me, Daniel, my thoughts troubled me greatly, and my face was changed in me; but I kept the matter in my heart.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>In the third year of the reign of King Belshazzar, a vision appeared to me, even to me, Daniel, after that which appeared to me at the first. 
-<span class="v">2&#160;</span>I saw the vision. Now it was so, that when I saw, I was in the citadel of Susa, which is in the province of Elam. I saw in the vision, and I was by the river Ulai. 
-<span class="v">3&#160;</span>Then I lifted up my eyes and saw, and behold, a ram which had two horns stood before the river. The two horns were high, but one was higher than the other, and the higher came up last. 
-<span class="v">4&#160;</span>I saw the ram pushing westward, northward, and southward. No animals could stand before him. There wasn’t any who could deliver out of his hand, but he did according to his will, and magnified himself. 
-</p><p>
-<span class="v">5&#160;</span>As I was considering, behold, a male goat came from the west over the surface of the whole earth, and didn’t touch the ground. The goat had a notable horn between his eyes. 
-<span class="v">6&#160;</span>He came to the ram that had the two horns, which I saw standing before the river, and ran on him in the fury of his power. 
-<span class="v">7&#160;</span>I saw him come close to the ram, and he was moved with anger against him, and struck the ram, and broke his two horns. There was no power in the ram to stand before him; but he cast him down to the ground and trampled on him. There was no one who could deliver the ram out of his hand. 
-<span class="v">8&#160;</span>The male goat magnified himself exceedingly. When he was strong, the great horn was broken; and instead of it there came up four notable horns toward the four winds of the sky. 
-</p><p>
-<span class="v">9&#160;</span>Out of one of them came out a little horn which grew exceedingly great—toward the south, and toward the east, and toward the glorious land. 
-<span class="v">10&#160;</span>It grew great, even to the army of the sky; and it cast down some of the army and of the stars to the ground and trampled on them. 
-<span class="v">11&#160;</span>Yes, it magnified itself, even to the prince of the army; and it took away from him the continual burnt offering, and the place of his sanctuary was cast down. 
-<span class="v">12&#160;</span>The army was given over to it together with the continual burnt offering through disobedience. It cast down truth to the ground, and it did its pleasure and prospered. 
-</p><p>
-<span class="v">13&#160;</span>Then I heard a set-apart one speaking; and another set-apart one said to that certain one who spoke, “How long will the vision about the continual burnt offering, and the disobedience that makes desolate, to give both the sanctuary and the army to be trodden under foot be?” 
-</p><p>
-<span class="v">14&#160;</span>He said to me, “To two thousand and three hundred evenings and mornings. Then the sanctuary will be cleansed.” 
-</p><p>
-<span class="v">15&#160;</span>When I, even I Daniel, had seen the vision, I sought to understand it. Then behold, there stood before me someone with the appearance of a man. 
-<span class="v">16&#160;</span>I heard a man’s voice between the banks of the Ulai, which called and said, “Gabriel, make this man understand the vision.” 
-</p><p>
-<span class="v">17&#160;</span>So he came near where I stood; and when he came, I was frightened, and fell on my face; but he said to me, “Understand, son of man, for the vision belongs to the time of the end.” 
-</p><p>
-<span class="v">18&#160;</span>Now as he was speaking with me, I fell into a deep sleep with my face toward the ground; but he touched me and set me upright. 
-</p><p>
-<span class="v">19&#160;</span>He said, “Behold, I will make you know what will be in the latter time of the indignation, for it belongs to the appointed time of the end. 
-<span class="v">20&#160;</span>The ram which you saw, that had the two horns, they are the kings of Media and Persia. 
-<span class="v">21&#160;</span>The rough male goat is the king of Greece. The great horn that is between his eyes is the first king. 
-<span class="v">22&#160;</span>As for that which was broken, in the place where four stood up, four kingdoms will stand up out of the nation, but not with his power. 
-</p><p>
-<span class="v">23&#160;</span>“In the latter time of their kingdom, when the transgressors have come to the full, a king of fierce face, and understanding riddles, will stand up. 
-<span class="v">24&#160;</span>His power will be mighty, but not by his own power. He will destroy awesomely, and will prosper in what he does. He will destroy the mighty ones and the set-apart people. 
-<span class="v">25&#160;</span>Through his policy he will cause deceit to prosper in his hand. He will magnify himself in his heart, and he will destroy many in their security. He will also stand up against the prince of princes, but he will be broken without human hands. 
-</p><p>
-<span class="v">26&#160;</span>“The vision of the evenings and mornings which has been told is true; but seal up the vision, for it belongs to many days to come.” 
-</p><p>
-<span class="v">27&#160;</span>I, Daniel, fainted, and was sick for some days. Then I rose up and did the king’s business. I wondered at the vision, but no one understood it. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>In the first year of Darius the son of Ahasuerus, of the offspring of the Medes, who was made king over the realm of the Chaldeans—<span class="v">2&#160;</span>in the first year of his reign I, Daniel, understood by the books the number of the years about which Yahweh’s<span class="f">+ \fr 9:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations. </span> word came to Jeremiah the prophet for the accomplishing of the desolations of Jerusalem, even seventy years. 
-<span class="v">3&#160;</span>I set my face to the Lord Elohim, to seek by prayer and petitions, with fasting and sackcloth and ashes. 
-</p><p>
-<span class="v">4&#160;</span>I prayed to Yahweh my Elohim, and made confession, and said, 
-</p><p class="pi1">“Oh, Lord, the great and dreadful Elohim, who keeps covenant and loving kindness with those who love him and keep his commandments, 
-<span class="v">5&#160;</span>we have sinned, and have dealt perversely, and have done wickedly, and have rebelled, even turning aside from your precepts and from your ordinances. 
-<span class="v">6&#160;</span>We haven’t listened to your servants the prophets, who spoke in your name to our kings, our princes, and our fathers, and to all the people of the land. 
-</p><p class="pi1">
-<span class="v">7&#160;</span>“Lord, righteousness belongs to you, but to us confusion of face, as it is today; to the men of Judah, and to the inhabitants of Jerusalem, and to all Israel, who are near and who are far off, through all the countries where you have driven them, because of their trespass that they have trespassed against you. 
-<span class="v">8&#160;</span>Lord, to us belongs confusion of face, to our kings, to our princes, and to our fathers, because we have sinned against you. 
-<span class="v">9&#160;</span>To the Lord our Elohim belong mercies and forgiveness, for we have rebelled against him. 
-<span class="v">10&#160;</span>We haven’t obeyed Yahweh our Elohim’s voice, to walk in his laws, which he set before us by his servants the prophets. 
-<span class="v">11&#160;</span>Yes, all Israel have transgressed your law, turning aside, that they should not obey your voice. 
-</p><p class="pi1">“Therefore the curse and the oath written in the law of Moses the servant of Elohim has been poured out on us, for we have sinned against him. 
-<span class="v">12&#160;</span>He has confirmed his words, which he spoke against us and against our judges who judged us, by bringing on us a great evil; for under the whole sky, such has not been done as has been done to Jerusalem. 
-<span class="v">13&#160;</span>As it is written in the law of Moses, all this evil has come on us. Yet we have not entreated the favor of Yahweh our Elohim, that we should turn from our iniquities and have discernment in your truth. 
-<span class="v">14&#160;</span>Therefore Yahweh has watched over the evil, and brought it on us; for Yahweh our Elohim is righteous in all his works which he does, and we have not obeyed his voice. 
-</p><p class="pi1">
-<span class="v">15&#160;</span>“Now, Lord our Elohim, who has brought your people out of the land of Egypt with a mighty hand, and have gotten yourself renown, as it is today, we have sinned. We have done wickedly. 
-<span class="v">16&#160;</span>Lord, according to all your righteousness, please let your anger and your wrath be turned away from your city Jerusalem, your set-apart mountain; because for our sins and for the iniquities of our fathers, Jerusalem and your people have become a reproach to all who are around us. 
-</p><p class="pi1">
-<span class="v">17&#160;</span>“Now therefore, our Elohim, listen to the prayer of your servant and to his petitions, and cause your face to shine on your sanctuary that is desolate, for the Lord’s sake. 
-<span class="v">18&#160;</span>My Elohim, turn your ear and hear. Open your eyes and see our desolations, and the city which is called by your name; for we do not present our petitions before you for our righteousness, but for your great mercies’ sake. 
-<span class="v">19&#160;</span>Lord, hear. Lord, forgive. Lord, listen and do. Don’t defer, for your own sake, my Elohim, because your city and your people are called by your name.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">20&#160;</span>While I was speaking, praying, and confessing my sin and the sin of my people Israel, and presenting my supplication before Yahweh my Elohim for the set-apart mountain of my Elohim—<span class="v">21&#160;</span>yes, while I was speaking in prayer—the man Gabriel, whom I had seen in the vision at the beginning, being caused to fly swiftly, touched me about the time of the evening offering. 
-<span class="v">22&#160;</span>He instructed me and talked with me, and said, “Daniel, I have now come to give you wisdom and understanding. 
-<span class="v">23&#160;</span>At the beginning of your petitions the commandment went out, and I have come to tell you, for you are greatly beloved. Therefore consider the matter and understand the vision. 
-</p><p>
-<span class="v">24&#160;</span>“Seventy weeks are decreed on your people and on your set-apart city, to finish disobedience, to make an end of sins, to make reconciliation for iniquity, to bring in everlasting righteousness, to seal up vision and prophecy, and to anoint the most set-apart. 
-</p><p>
-<span class="v">25&#160;</span>“Know therefore and discern that from the going out of the commandment to restore and build Jerusalem to the Anointed One,<span class="f">+ \fr 9:25 \ft “Anointed One” can also be translated “Messiah” (same as “Christ”).</span> the prince, will be seven weeks and sixty-two weeks. It will be built again, with street and moat, even in troubled times. 
-<span class="v">26&#160;</span>After the sixty-two weeks the Anointed One<span class="f">+ \fr 9:26 \ft “Anointed One” can also be translated “Messiah” (same as “Christ”).</span> will be cut off, and will have nothing. The people of the prince who come will destroy the city and the sanctuary. Its end will be with a flood, and war will be even to the end. Desolations are determined. 
-<span class="v">27&#160;</span>He will make a firm covenant with many for one week. In the middle of the week he will cause the sacrifice and the offering to cease. On the wing of abominations will come one who makes desolate; and even to the decreed full end, wrath will be poured out on the desolate.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>In the third year of Cyrus king of Persia a message was revealed to Daniel, whose name was called Belteshazzar; and the message was true, even a great warfare. He understood the message, and had understanding of the vision. 
-</p><p>
-<span class="v">2&#160;</span>In those days I, Daniel, was mourning three whole weeks. 
-<span class="v">3&#160;</span>I ate no pleasant food. No meat or wine came into my mouth. I didn’t anoint myself at all, until three whole weeks were fulfilled. 
-</p><p>
-<span class="v">4&#160;</span>In the twenty-fourth day of the first month, as I was by the side of the great river, which is Hiddekel,<span class="f">+ \fr 10:4 \ft or, Tigris River</span> 
-<span class="v">5&#160;</span>I lifted up my eyes and looked, and behold, there was a man clothed in linen, whose waist was adorned with pure gold of Uphaz. 
-<span class="v">6&#160;</span>His body also was like beryl, and his face as the appearance of lightning, and his eyes as flaming torches. His arms and his feet were like burnished bronze. The voice of his words was like the voice of a multitude. 
-</p><p>
-<span class="v">7&#160;</span>I, Daniel, alone saw the vision, for the men who were with me didn’t see the vision, but a great quaking fell on them, and they fled to hide themselves. 
-<span class="v">8&#160;</span>So I was left alone and saw this great vision. No strength remained in me; for my face grew deathly pale, and I retained no strength. 
-<span class="v">9&#160;</span>Yet I heard the voice of his words. When I heard the voice of his words, then I fell into a deep sleep on my face, with my face toward the ground. 
-</p><p>
-<span class="v">10&#160;</span>Behold, a hand touched me, which set me on my knees and on the palms of my hands. 
-<span class="v">11&#160;</span>He said to me, “Daniel, you greatly beloved man, understand the words that I speak to you, and stand upright, for I have been sent to you, now.” When he had spoken this word to me, I stood trembling. 
-</p><p>
-<span class="v">12&#160;</span>Then he said to me, “Don’t be afraid, Daniel; for from the first day that you set your heart to understand, and to humble yourself before your Elohim, your words were heard. I have come for your words’ sake. 
-<span class="v">13&#160;</span>But the prince of the kingdom of Persia withstood me twenty-one days; but, behold, Michael, one of the chief princes, came to help me because I remained there with the kings of Persia. 
-<span class="v">14&#160;</span>Now I have come to make you understand what will happen to your people in the latter days, for the vision is yet for many days.” 
-</p><p>
-<span class="v">15&#160;</span>When he had spoken these words to me, I set my face toward the ground and was mute. 
-<span class="v">16&#160;</span>Behold, one in the likeness of the sons of men touched my lips. Then I opened my mouth, and spoke and said to him who stood before me, “My lord, by reason of the vision my sorrows have overtaken me, and I retain no strength. 
-<span class="v">17&#160;</span>For how can the servant of this my lord talk with this my lord? For as for me, immediately there remained no strength in me. There was no breath left in me.” 
-</p><p>
-<span class="v">18&#160;</span>Then one like the appearance of a man touched me again, and he strengthened me. 
-<span class="v">19&#160;</span>He said, “Greatly beloved man, don’t be afraid. Peace be to you. Be strong. Yes, be strong.” 
-</p><p>When he spoke to me, I was strengthened, and said, “Let my lord speak, for you have strengthened me.” 
-</p><p>
-<span class="v">20&#160;</span>Then he said, “Do you know why I have come to you? Now I will return to fight with the prince of Persia. When I go out, behold, the prince of Greece will come. 
-<span class="v">21&#160;</span>But I will tell you that which is inscribed in the writing of truth. There is no one who holds with me against these but Michael your prince. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>“As for me, in the first year of Darius the Mede, I stood up to confirm and strengthen him. 
-</p><p>
-<span class="v">2&#160;</span>“Now I will show you the truth. Behold, three more kings will stand up in Persia. The fourth will be far richer than all of them. When he has grown strong through his riches, he will stir up all against the realm of Greece. 
-<span class="v">3&#160;</span>A mighty king will stand up, who will rule with great dominion, and do according to his will. 
-<span class="v">4&#160;</span>When he stands up, his kingdom will be broken and will be divided toward the four winds of the sky, but not to his posterity, nor according to his dominion with which he ruled; for his kingdom will be plucked up, even for others besides these. 
-</p><p>
-<span class="v">5&#160;</span>“The king of the south will be strong. One of his princes will become stronger than him, and have dominion. His dominion will be a great dominion. 
-<span class="v">6&#160;</span>At the end of years they will join themselves together; and the daughter of the king of the south will come to the king of the north to make an agreement, but she will not retain the strength of her arm. He will also not stand, nor will his arm; but she will be given up, with those who brought her, and he who brought forth her, and he who strengthened her in those times. 
-</p><p>
-<span class="v">7&#160;</span>“But out of a shoot from her roots one will stand up in his place, who will come to the army and will enter into the fortress of the king of the north, and will deal against them and will prevail. 
-<span class="v">8&#160;</span>He will also carry their elohims with their molten images, and with their goodly vessels of silver and of gold, captive into Egypt. He will refrain some years from the king of the north. 
-<span class="v">9&#160;</span>He will come into the realm of the king of the south, but he will return into his own land. 
-<span class="v">10&#160;</span>His sons will wage war, and will assemble a multitude of great forces which will come on, and overflow, and pass through. They will return and wage war, even to his fortress. 
-</p><p>
-<span class="v">11&#160;</span>“The king of the south will be moved with anger and will come out and fight with him, even with the king of the north. He will send out a great multitude, and the multitude will be given into his hand. 
-<span class="v">12&#160;</span>The multitude will be carried off, and his heart will be exalted. He will cast down tens of thousands, but he won’t prevail. 
-<span class="v">13&#160;</span>The king of the north will return, and will send out a multitude greater than the former. He will come on at the end of the times, even of years, with a great army and with abundant supplies. 
-</p><p>
-<span class="v">14&#160;</span>“In those times many will stand up against the king of the south. Also the children of the violent among your people will lift themselves up to establish the vision, but they will fall. 
-<span class="v">15&#160;</span>So the king of the north will come and cast up a mound, and take a well-fortified city. The forces of the south won’t stand, neither will his select troops, neither will there be any strength to stand. 
-<span class="v">16&#160;</span>But he who comes against him will do according to his own will, and no one will stand before him. He will stand in the glorious land, and destruction will be in his hand. 
-<span class="v">17&#160;</span>He will set his face to come with the strength of his whole kingdom, and with him equitable conditions. He will perform them. He will give him the daughter of women, to destroy the kingdom, but she will not stand, and won’t be for him. 
-<span class="v">18&#160;</span>After this he will turn his face to the islands, and will take many, but a prince will cause the reproach offered by him to cease. Yes, moreover, he will cause his reproach to turn on him. 
-<span class="v">19&#160;</span>Then he will turn his face toward the fortresses of his own land; but he will stumble and fall, and won’t be found. 
-</p><p>
-<span class="v">20&#160;</span>“Then one who will cause a tax collector to pass through the kingdom to maintain its glory will stand up in his place; but within few days he shall be destroyed, not in anger, and not in battle. 
-</p><p>
-<span class="v">21&#160;</span>“In his place a contemptible person will stand up, to whom they had not given the honor of the kingdom; but he will come in time of security, and will obtain the kingdom by flatteries. 
-<span class="v">22&#160;</span>The overwhelming forces will be overwhelmed from before him, and will be broken. Yes, also the prince of the covenant. 
-<span class="v">23&#160;</span>After the treaty made with him he will work deceitfully; for he will come up and will become strong with few people. 
-<span class="v">24&#160;</span>In time of security he will come even on the fattest places of the province. He will do that which his fathers have not done, nor his fathers’ fathers. He will scatter among them prey, plunder, and wealth. Yes, he will devise his plans against the strongholds, but only for a time. 
-</p><p>
-<span class="v">25&#160;</span>“He will stir up his power and his courage against the king of the south with a great army; and the king of the south will wage war in battle with an exceedingly great and mighty army, but he won’t stand; for they will devise plans against him. 
-<span class="v">26&#160;</span>Yes, those who eat of his delicacies will destroy him, and his army will be swept away. Many will fall down slain. 
-<span class="v">27&#160;</span>As for both these kings, their hearts will be to do evil, and they will speak lies at one table; but it won’t prosper, for the end will still be at the appointed time. 
-<span class="v">28&#160;</span>Then he will return into his land with great wealth. His heart will be against the set-apart covenant. He will take action, and return to his own land. 
-</p><p>
-<span class="v">29&#160;</span>“He will return at the appointed time and come into the south; but it won’t be in the latter time as it was in the former. 
-<span class="v">30&#160;</span>For ships of Kittim will come against him. Therefore he will be grieved, and will return, and have indignation against the set-apart covenant, and will take action. He will even return, and have regard to those who forsake the set-apart covenant. 
-</p><p>
-<span class="v">31&#160;</span>“Forces from him will profane the sanctuary, even the fortress, and will take away the continual burnt offering. Then they will set up the abomination that makes desolate. 
-<span class="v">32&#160;</span>He will corrupt those who do wickedly against the covenant by flatteries; but the people who know their Elohim will be strong and take action. 
-</p><p>
-<span class="v">33&#160;</span>“Those who are wise among the people will instruct many; yet they will fall by the sword and by flame, by captivity and by plunder, many days. 
-<span class="v">34&#160;</span>Now when they fall, they will be helped with a little help; but many will join themselves to them with flatteries. 
-<span class="v">35&#160;</span>Some of those who are wise will fall—to refine them, and to purify, and to make them white, even to the time of the end, because it is yet for the time appointed. 
-</p><p>
-<span class="v">36&#160;</span>“The king will do according to his will. He will exalt himself and magnify himself above every elohim, and will speak marvelous things against the Elohim of elohims. He will prosper until the indignation is accomplished, for that which is determined will be done. 
-<span class="v">37&#160;</span>He won’t regard the elohims of his fathers, or the desire of women, or regard any elohim; for he will magnify himself above all. 
-<span class="v">38&#160;</span>But in their place, he will honor the elohim of fortresses. He will honor an elohim whom his fathers didn’t know with gold, silver, and with precious stones and pleasant things. 
-<span class="v">39&#160;</span>He will deal with the strongest fortresses by the help of a foreign elohim. He will increase with glory whoever acknowledges him. He will cause them to rule over many, and will divide the land for a price. 
-</p><p>
-<span class="v">40&#160;</span>“At the time of the end the king of the south will contend with him; and the king of the north will come against him like a whirlwind, with chariots, with horsemen, and with many ships. He will enter into the countries, and will overflow and pass through. 
-<span class="v">41&#160;</span>He will enter also into the glorious land, and many countries will be overthrown; but these will be delivered out of his hand: Edom, Moab, and the chief of the children of Ammon. 
-<span class="v">42&#160;</span>He will also stretch out his hand on the countries. The land of Egypt won’t escape. 
-<span class="v">43&#160;</span>But he will have power over the treasures of gold and of silver, and over all the precious things of Egypt. The Libyans and the Ethiopians will follow his steps. 
-<span class="v">44&#160;</span>But news out of the east and out of the north will trouble him; and he will go out with great fury to destroy and utterly to sweep away many. 
-<span class="v">45&#160;</span>He will plant the tents of his palace between the sea and the glorious set-apart mountain; yet he will come to his end, and no one will help him. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>“At that time Michael will stand up, the great prince who stands for the children of your people; and there will be a time of trouble, such as never was since there was a nation even to that same time. At that time your people will be delivered, everyone who is found written in the book. 
-<span class="v">2&#160;</span>Many of those who sleep in the dust of the earth will awake, some to everlasting life, and some to shame and everlasting contempt. 
-<span class="v">3&#160;</span>Those who are wise will shine as the brightness of the expanse. Those who turn many to righteousness will shine as the stars forever and ever. 
-<span class="v">4&#160;</span>But you, Daniel, shut up the words and seal the book, even to the time of the end. Many will run back and forth, and knowledge will be increased.” 
-</p><p>
-<span class="v">5&#160;</span>Then I, Daniel, looked, and behold, two others stood, one on the river bank on this side, and the other on the river bank on that side. 
-<span class="v">6&#160;</span>One said to the man clothed in linen, who was above the waters of the river, “How long will it be to the end of these wonders?” 
-</p><p>
-<span class="v">7&#160;</span>I heard the man clothed in linen, who was above the waters of the river, when he held up his right hand and his left hand to heaven, and swore by him who lives forever that it will be for a time, times, and a half; and when they have finished breaking in pieces the power of the set-apart people, all these things will be finished. 
-</p><p>
-<span class="v">8&#160;</span>I heard, but I didn’t understand. Then I said, “My lord, what will be the outcome of these things?” 
-</p><p>
-<span class="v">9&#160;</span>He said, “Go your way, Daniel; for the words are shut up and sealed until the time of the end. 
-<span class="v">10&#160;</span>Many will purify themselves, and make themselves white, and be refined, but the wicked will do wickedly; and none of the wicked will understand, but those who are wise will understand. 
-</p><p>
-<span class="v">11&#160;</span>“From the time that the continual burnt offering is taken away and the abomination that makes desolate set up, there will be one thousand two hundred ninety days. 
-<span class="v">12&#160;</span>Blessed is he who waits, and comes to the one thousand three hundred thirty-five days. 
-</p><p>
-<span class="v">13&#160;</span>“But go your way until the end; for you will rest, and will stand in your inheritance at the end of the days.” </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>In the third year of the reign of Jehoiakim king of Judah, Nebuchadnezzar king of Babylon came to Jerusalem and besieged it. 
+<sup>2&#160;</sup>The Lord and he carried them into the land of Shinar to the house of his elohim. He brought the vessels into the treasure house of his elohim. 
+</div><div class="p">
+<sup>3&#160;</sup>The king spoke to Ashpenaz, the master of his eunuchs, that he should bring in some of the children of Israel, even of the royal offspring and of the nobles: 
+<sup>4&#160;</sup>youths in whom was no defect, but well-favored, skillful in all wisdom, endowed with knowledge, understanding science, and who had the ability to stand in the king’s palace; and that he should teach them the learning and the language of the Chaldeans. 
+<sup>5&#160;</sup>The king appointed for them a daily portion of the king’s delicacies and of the wine which he drank, and that they should be nourished three years, that at its end they should stand before the king. 
+</div><div class="p">
+<sup>6&#160;</sup>Now among these of the children of Judah were Daniel, Hananiah, Mishael, and Azariah. 
+<sup>7&#160;</sup>The prince of the eunuchs gave names to them: to Daniel he gave the name Belteshazzar; to Hananiah, Shadrach; to Mishael, Meshach; and to Azariah, Abednego. 
+</div><div class="p">
+<sup>8&#160;</sup>But Daniel purposed in his heart that he would not defile himself with the king’s delicacies, nor with the wine which he drank. Therefore he requested of the prince of the eunuchs that he might not defile himself. 
+<sup>9&#160;</sup>Now Elohim made Daniel find kindness and compassion in the sight of the prince of the eunuchs. 
+<sup>10&#160;</sup>The prince of the eunuchs said to Daniel, “I fear my lord the king, who has appointed your food and your drink. For why should he see your faces worse looking than the youths who are of your own age? Then you would endanger my head with the king.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then Daniel said to the steward whom the prince of the eunuchs had appointed over Daniel, Hananiah, Mishael, and Azariah: 
+<sup>12&#160;</sup>“Test your servants, I beg you, ten days; and let them give us vegetables to eat and water to drink. 
+<sup>13&#160;</sup>Then let our faces be examined before you, and the face of the youths who eat of the king’s delicacies; and as you see, deal with your servants.” 
+<sup>14&#160;</sup>So he listened to them in this matter, and tested them for ten days. 
+</div><div class="p">
+<sup>15&#160;</sup>At the end of ten days, their faces appeared fairer and they were fatter in flesh than all the youths who ate of the king’s delicacies. 
+<sup>16&#160;</sup>So the steward took away their delicacies and the wine that they were given to drink, and gave them vegetables. 
+</div><div class="p">
+<sup>17&#160;</sup>Now as for these four youths, Elohim gave them knowledge and skill in all learning and wisdom; and Daniel had understanding in all visions and dreams. 
+</div><div class="p">
+<sup>18&#160;</sup>At the end of the days which the king had appointed for bringing them in, the prince of the eunuchs brought them in before Nebuchadnezzar. 
+<sup>19&#160;</sup>The king talked with them; and among them all was found no one like Daniel, Hananiah, Mishael, and Azariah. Therefore stood they before the king. 
+<sup>20&#160;</sup>In every matter of wisdom and understanding concerning which the king inquired of them, he found them ten times better than all the magicians and enchanters who were in all his realm. 
+</div><div class="p">
+<sup>21&#160;</sup>Daniel continued even to the first year of King Cyrus. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>In the second year of the reign of Nebuchadnezzar, Nebuchadnezzar dreamed dreams; and his spirit was troubled, and his sleep went from him. 
+<sup>2&#160;</sup>Then the king commanded that the magicians, the enchanters, the sorcerers, and the Chaldeans be called to tell the king his dreams. So they came in and stood before the king. 
+<sup>3&#160;</sup>The king said to them, “I have dreamed a dream, and my spirit is troubled to know the dream.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the Chaldeans spoke to the king in the Syrian language, “O king, live forever! Tell your servants the dream, and we will show the interpretation.” 
+</div><div class="p">
+<sup>5&#160;</sup>The king answered the Chaldeans, “The thing has gone from me. If you don’t make known to me the dream and its interpretation, you will be cut in pieces, and your houses will be made a dunghill. 
+<sup>6&#160;</sup>But if you show the dream and its interpretation, you will receive from me gifts, rewards, and great honor. Therefore show me the dream and its interpretation.” 
+</div><div class="p">
+<sup>7&#160;</sup>They answered the second time and said, “Let the king tell his servants the dream, and we will show the interpretation.” 
+</div><div class="p">
+<sup>8&#160;</sup>The king answered, “I know of a certainty that you are trying to gain time, because you see the thing has gone from me. 
+<sup>9&#160;</sup>But if you don’t make known to me the dream, there is but one law for you; for you have prepared lying and corrupt words to speak before me, until the situation changes. Therefore tell me the dream, and I will know that you can show me its interpretation.” 
+</div><div class="p">
+<sup>10&#160;</sup>The Chaldeans answered the king and said, “There is not a man on the earth who can show the king’s matter, because no king, lord, or ruler has asked such a thing of any magician, enchanter, or Chaldean. 
+<sup>11&#160;</sup>It is a rare thing that the king requires, and there is no other who can show it before the king except the elohims, whose dwelling is not with flesh.” 
+</div><div class="p">
+<sup>12&#160;</sup>Because of this, the king was angry and very furious, and commanded that all the wise men of Babylon be destroyed. 
+<sup>13&#160;</sup>So the decree went out, and the wise men were to be slain. They sought Daniel and his companions to be slain. 
+</div><div class="p">
+<sup>14&#160;</sup>Then Daniel returned answer with counsel and prudence to Arioch the captain of the king’s guard, who had gone out to kill the wise men of Babylon. 
+<sup>15&#160;</sup>He answered Arioch the king’s captain, “Why is the decree so urgent from the king?” Then Arioch made the thing known to Daniel. 
+<sup>16&#160;</sup>Daniel went in, and desired of the king that he would appoint him a time, and he would show the king the interpretation. 
+</div><div class="p">
+<sup>17&#160;</sup>Then Daniel went to his house and made the thing known to Hananiah, Mishael, and Azariah, his companions: 
+<sup>18&#160;</sup>that they would desire mercies of the Elohim of heaven concerning this secret, that Daniel and his companions would not perish with the rest of the wise men of Babylon. 
+<sup>19&#160;</sup>Then the secret was revealed to Daniel in a vision of the night. Then Daniel blessed the Elohim of heaven. 
+<sup>20&#160;</sup>Daniel answered, 
+</div><div class="q1">“Blessed be the name of Elohim forever and ever; 
+</div><div class="q2">for wisdom and might are his. 
+</div><div class="q1">
+<sup>21&#160;</sup>He changes the times and the seasons. 
+</div><div class="q2">He removes kings and sets up kings. 
+</div><div class="q1">He gives wisdom to the wise, 
+</div><div class="q2">and knowledge to those who have understanding. 
+</div><div class="q1">
+<sup>22&#160;</sup>He reveals the deep and secret things. 
+</div><div class="q2">He knows what is in the darkness, 
+</div><div class="q2">and the light dwells with him. 
+</div><div class="q1">
+<sup>23&#160;</sup>I thank you and praise you, 
+</div><div class="q2">O Elohim of my fathers, 
+</div><div class="q1">who have given me wisdom and might, 
+</div><div class="q2">and have now made known to me what we desired of you; 
+</div><div class="q2">for you have made known to us the king’s matter.” 
+</div><div class="p">
+<sup>24&#160;</sup>Therefore Daniel went in to Arioch, whom the king had appointed to destroy the wise men of Babylon. He went and said this to him: “Don’t destroy the wise men of Babylon. Bring me in before the king, and I will show to the king the interpretation.” 
+</div><div class="p">
+<sup>25&#160;</sup>Then Arioch brought in Daniel before the king in haste, and said this to him: “I have found a man of the children of the captivity of Judah who will make known to the king the interpretation.” 
+</div><div class="p">
+<sup>26&#160;</sup>The king answered Daniel, whose name was Belteshazzar, “Are you able to make known to me the dream which I have seen, and its interpretation?” 
+</div><div class="p">
+<sup>27&#160;</sup>Daniel answered before the king, and said, “The secret which the king has demanded can’t be shown to the king by wise men, enchanters, magicians, or soothsayers; 
+<sup>28&#160;</sup>but there is an Elohim in heaven who reveals secrets, and he has made known to King Nebuchadnezzar what will be in the latter days. Your dream and the visions of your head on your bed are these: 
+</div><div class="p">
+<sup>29&#160;</sup>“As for you, O king, your thoughts came on your bed, what should happen hereafter; and he who reveals secrets has made known to you what will happen. 
+<sup>30&#160;</sup>But as for me, this secret is not revealed to me for any wisdom that I have more than any living, but to the intent that the interpretation may be made known to the king, and that you may know the thoughts of your heart. 
+</div><div class="p">
+<sup>31&#160;</sup>“You, O king, saw, and behold, a great image. This image, which was mighty, and whose brightness was excellent, stood before you; and its appearance was terrifying. 
+<sup>32&#160;</sup>As for this image, its head was of fine gold, its breast and its arms of silver, its belly and its thighs of bronze, 
+<sup>33&#160;</sup>its legs of iron, its feet part of iron and part of clay. 
+<sup>34&#160;</sup>You saw until a stone was cut out without hands, which struck the image on its feet that were of iron and clay, and broke them in pieces. 
+<sup>35&#160;</sup>Then the iron, the clay, the bronze, the silver, and the gold were broken in pieces together, and became like the chaff of the summer threshing floors. The wind carried them away, so that no place was found for them. The stone that struck the image became a great mountain and filled the whole earth. 
+</div><div class="p">
+<sup>36&#160;</sup>“This is the dream; and we will tell its interpretation before the king. 
+<sup>37&#160;</sup>You, O king, are king of kings, to whom the Elohim of heaven has given the kingdom, the power, the strength, and the glory. 
+<sup>38&#160;</sup>Wherever the children of men dwell, he has given the animals of the field and the birds of the sky into your hand, and has made you rule over them all. You are the head of gold. 
+</div><div class="p">
+<sup>39&#160;</sup>“After you, another kingdom will arise that is inferior to you; and another third kingdom of bronze, which will rule over all the earth. 
+<sup>40&#160;</sup>The fourth kingdom will be strong as iron, because iron breaks in pieces and subdues all things; and as iron that crushes all these, it will break in pieces and crush. 
+<sup>41&#160;</sup>Whereas you saw the feet and toes, part of potters’ clay and part of iron, it will be a divided kingdom; but there will be in it of the strength of the iron, because you saw the iron mixed with miry clay. 
+<sup>42&#160;</sup>As the toes of the feet were part of iron, and part of clay, so the kingdom will be partly strong and partly brittle. 
+<sup>43&#160;</sup>Whereas you saw the iron mixed with miry clay, they will mingle themselves with the seed of men; but they won’t cling to one another, even as iron does not mix with clay. 
+</div><div class="p">
+<sup>44&#160;</sup>“In the days of those kings the Elohim of heaven will set up a kingdom which will never be destroyed, nor will its sovereignty be left to another people; but it will break in pieces and consume all these kingdoms, and it will stand forever. 
+<sup>45&#160;</sup>Because you saw that a stone was cut out of the mountain without hands, and that it broke in pieces the iron, the bronze, the clay, the silver, and the gold, the great Elohim has made known to the king what will happen hereafter. The dream is certain, and its interpretation sure.” 
+</div><div class="p">
+<sup>46&#160;</sup>Then King Nebuchadnezzar fell on his face, worshiped Daniel, and commanded that they should offer an offering and sweet odors to him. 
+<sup>47&#160;</sup>The king answered to Daniel, and said, “Of a truth your Elohim is the Elohim of elohims, and the Lord of kings, and a revealer of secrets, since you have been able to reveal this secret.” 
+</div><div class="p">
+<sup>48&#160;</sup>Then the king made Daniel great and gave him many great gifts, and made him rule over the whole province of Babylon and to be chief governor over all the wise men of Babylon. 
+<sup>49&#160;</sup>Daniel requested of the king, and he appointed Shadrach, Meshach, and Abednego over the affairs of the province of Babylon, but Daniel was in the king’s gate. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Nebuchadnezzar the king made an image of gold, whose height was sixty cubits and its width six cubits. He set it up in the plain of Dura, in the province of Babylon. 
+<sup>2&#160;</sup>Then Nebuchadnezzar the king sent to gather together the local governors, the deputies, and the governors, the judges, the treasurers, the counselors, the sheriffs, and all the rulers of the provinces, to come to the dedication of the image which Nebuchadnezzar the king had set up. 
+<sup>3&#160;</sup>Then the local governors, the deputies, and the governors, the judges, the treasurers, the counselors, the sheriffs, and all the rulers of the provinces were gathered together to the dedication of the image that Nebuchadnezzar the king had set up; and they stood before the image that Nebuchadnezzar had set up. 
+</div><div class="p">
+<sup>4&#160;</sup>Then the herald cried aloud, “To you it is commanded, peoples, nations, and languages, 
+<sup>5&#160;</sup>that whenever you hear the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music, you fall down and worship the golden image that Nebuchadnezzar the king has set up. 
+<sup>6&#160;</sup>Whoever doesn’t fall down and worship shall be cast into the middle of a burning fiery furnace the same hour.” 
+</div><div class="p">
+<sup>7&#160;</sup>Therefore at that time, when all the peoples heard the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music, all the peoples, the nations, and the languages fell down and worshiped the golden image that Nebuchadnezzar the king had set up. 
+</div><div class="p">
+<sup>8&#160;</sup>Therefore at that time certain Chaldeans came near and brought accusation against the Jews. 
+<sup>9&#160;</sup>They answered Nebuchadnezzar the king, “O king, live for ever! 
+<sup>10&#160;</sup>You, O king, have made a decree that every man who hears the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music shall fall down and worship the golden image; 
+<sup>11&#160;</sup>and whoever doesn’t fall down and worship shall be cast into the middle of a burning fiery furnace. 
+<sup>12&#160;</sup>There are certain Jews whom you have appointed over the affairs of the province of Babylon: Shadrach, Meshach, and Abednego. These men, O king, have not respected you. They don’t serve your elohims, and don’t worship the golden image which you have set up.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then Nebuchadnezzar in rage and fury commanded that Shadrach, Meshach, and Abednego be brought. Then these men were brought before the king. 
+<sup>14&#160;</sup>Nebuchadnezzar answered them, “Is it true, Shadrach, Meshach, and Abednego, that you don’t serve my elohims and you don’t worship the golden image which I have set up? 
+<sup>15&#160;</sup>Now if you are ready whenever you hear the sound of the horn, flute, zither, lyre, harp, pipe, and all kinds of music to fall down and worship the image which I have made, good; but if you don’t worship, you shall be cast the same hour into the middle of a burning fiery furnace. Who is that elohim who will deliver you out of my hands?” 
+</div><div class="p">
+<sup>16&#160;</sup>Shadrach, Meshach, and Abednego answered the king, “Nebuchadnezzar, we have no need to answer you in this matter. 
+<sup>17&#160;</sup>If it happens, our Elohim whom we serve is able to deliver us from the burning fiery furnace; and he will deliver us out of your hand, O king. 
+<sup>18&#160;</sup>But if not, let it be known to you, O king, that we will not serve your elohims or worship the golden image which you have set up.” 
+</div><div class="p">
+<sup>19&#160;</sup>Then Nebuchadnezzar was full of fury, and the form of his appearance was changed against Shadrach, Meshach, and Abednego. He spoke, and commanded that they should heat the furnace seven times more than it was usually heated. 
+<sup>20&#160;</sup>He commanded certain mighty men who were in his army to bind Shadrach, Meshach, and Abednego, and to cast them into the burning fiery furnace. 
+<sup>21&#160;</sup>Then these men were bound in their pants, their tunics, and their mantles, and their other clothes, and were cast into the middle of the burning fiery furnace. 
+<sup>22&#160;</sup>Therefore because the king’s commandment was urgent and the furnace exceedingly hot, the flame of the fire killed those men who took up Shadrach, Meshach, and Abednego. 
+<sup>23&#160;</sup>These three men, Shadrach, Meshach, and Abednego, fell down bound into the middle of the burning fiery furnace. 
+</div><div class="p">
+<sup>24&#160;</sup>Then Nebuchadnezzar the king was astonished and rose up in haste. He spoke and said to his counselors, “Didn’t we cast three men bound into the middle of the fire?” 
+</div><div class="p">They answered the king, “True, O king.” 
+</div><div class="p">
+<sup>25&#160;</sup>He answered, “Look, I see four men loose, walking in the middle of the fire, and they are unharmed. The appearance of the fourth is like a son of the elohims.” 
+</div><div class="p">
+<sup>26&#160;</sup>Then Nebuchadnezzar came near to the mouth of the burning fiery furnace. He spoke and said, “Shadrach, Meshach, and Abednego, you servants of the Most High Elohim, come out, and come here!” 
+</div><div class="p">Then Shadrach, Meshach, and Abednego came out of the middle of the fire. 
+<sup>27&#160;</sup>The local governors, the deputies, and the governors, and the king’s counselors, being gathered together, saw these men, that the fire had no power on their bodies. The hair of their head wasn’t singed. Their pants weren’t changed. The smell of fire wasn’t even on them. 
+</div><div class="p">
+<sup>28&#160;</sup>Nebuchadnezzar spoke and said, “Blessed be the Elohim of Shadrach, Meshach, and Abednego, who has sent his angel and delivered his servants who trusted in him, and have changed the king’s word, and have yielded their bodies, that they might not serve nor worship any elohim except their own Elohim. 
+<sup>29&#160;</sup>Therefore I make a decree that every people, nation, and language which speak anything evil against the Elohim of Shadrach, Meshach, and Abednego shall be cut in pieces, and their houses shall be made a dunghill, because there is no other elohim who is able to deliver like this.” 
+</div><div class="p">
+<sup>30&#160;</sup>Then the king promoted Shadrach, Meshach, and Abednego in the province of Babylon. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="pi1">
+<sup>1&#160;</sup>Nebuchadnezzar the king, 
+</div><div class="pi1">to all the peoples, nations, and languages, who dwell in all the earth: 
+</div><div class="pi1">Peace be multiplied to you. 
+</div><div class="pi1">
+<sup>2&#160;</sup>It has seemed good to me to show the signs and wonders that the Most High Elohim has worked toward me. 
+</div><div class="q1">
+<sup>3&#160;</sup>How great are his signs! 
+</div><div class="q2">How mighty are his wonders! 
+</div><div class="q1">His kingdom is an everlasting kingdom. 
+</div><div class="q2">His dominion is from generation to generation. 
+</div><div class="pi1">
+<sup>4&#160;</sup>I, Nebuchadnezzar, was at rest in my house, and flourishing in my palace. 
+<sup>5&#160;</sup>I saw a dream which made me afraid; and the thoughts on my bed and the visions of my head troubled me. 
+<sup>6&#160;</sup>Therefore I made a decree to bring in all the wise men of Babylon before me, that they might make known to me the interpretation of the dream. 
+<sup>7&#160;</sup>Then the magicians, the enchanters, the Chaldeans, and the soothsayers came in; and I told them the dream, but they didn’t make known to me its interpretation. 
+<sup>8&#160;</sup>But at last, Daniel came in before me, whose name was Belteshazzar according to the name of my elohim, and in whom is the spirit of the set-apart elohims. I told the dream before him, saying, 
+</div><div class="pi1">
+<sup>9&#160;</sup>“Belteshazzar, master of the magicians, because I know that the spirit of the set-apart elohims is in you and no secret troubles you, tell me the visions of my dream that I have seen, and its interpretation. 
+<sup>10&#160;</sup>These were the visions of my head on my bed: I saw, and behold, a tree in the middle of the earth; and its height was great. 
+<sup>11&#160;</sup>The tree grew and was strong. Its height reached to the sky and its sight to the end of all the earth. 
+<sup>12&#160;</sup>Its leaves were beautiful, and it had much fruit, and in it was food for all. The animals of the field had shade under it, and the birds of the sky lived in its branches, and all flesh was fed from it. 
+</div><div class="pi1">
+<sup>13&#160;</sup>“I saw in the visions of my head on my bed, and behold, a set-apart watcher came down from the sky. 
+<sup>14&#160;</sup>He cried aloud and said this: ‘Cut down the tree, and cut off its branches! Shake off its leaves and scatter its fruit! Let the animals get away from under it and the birds from its branches. 
+<sup>15&#160;</sup>Nevertheless leave the stump of its roots in the earth, even with a band of iron and bronze, in the tender grass of the field; and let it be wet with the dew of the sky. Let his portion be with the animals in the grass of the earth. 
+<sup>16&#160;</sup>Let his heart be changed from man’s, and let an animal’s heart be given to him. Then let seven times pass over him. 
+</div><div class="pi1">
+<sup>17&#160;</sup>“&#160;‘The sentence is by the decree of the watchers and the demand by the word of the set-apart ones, to the intent that the living may know that the Most High rules in the kingdom of men, and gives it to whomever he will, and sets up over it the lowest of men.’ 
+</div><div class="pi1">
+<sup>18&#160;</sup>“This dream I, King Nebuchadnezzar, have seen; and you, Belteshazzar, declare the interpretation, because all the wise men of my kingdom are not able to make known to me the interpretation; but you are able, for the spirit of the set-apart elohims is in you.” 
+</div><div class="pi1">
+<sup>19&#160;</sup>Then Daniel, whose name was Belteshazzar, was stricken mute for a while, and his thoughts troubled him. The king answered, “Belteshazzar, don’t let the dream or the interpretation, trouble you.” 
+</div><div class="pi1">Belteshazzar answered, “My lord, may the dream be for those who hate you, and its interpretation to your adversaries. 
+<sup>20&#160;</sup>The tree that you saw, which grew and was strong, whose height reached to the sky and its sight to all the earth; 
+<sup>21&#160;</sup>whose leaves were beautiful and its fruit plentiful, and in it was food for all; under which the animals of the field lived, and on whose branches the birds of the sky had their habitation—<sup>22&#160;</sup>it is you, O king, that have grown and become strong; for your greatness has grown, and reaches to the sky, and your dominion to the end of the earth. 
+</div><div class="pi1">
+<sup>23&#160;</sup>“Whereas the king saw a set-apart watcher coming down from the sky and saying, ‘Cut down the tree, and destroy it; nevertheless leave the stump of its roots in the earth, even with a band of iron and bronze, in the tender grass of the field, and let it be wet with the dew of the sky. Let his portion be with the animals of the field, until seven times pass over him.’ 
+</div><div class="pi1">
+<sup>24&#160;</sup>“This is the interpretation, O king, and it is the decree of the Most High, which has come on my lord the king: 
+<sup>25&#160;</sup>You will be driven from men and your dwelling shall be with the animals of the field. You will be made to eat grass as oxen, and will be wet with the dew of the sky, and seven times shall pass over you, until you know that the Most High rules in the kingdom of men, and gives it to whomever he will. 
+<sup>26&#160;</sup>Whereas it was commanded to leave the stump of the roots of the tree, your kingdom shall be sure to you after you know that Heavens rules. 
+<sup>27&#160;</sup>Therefore, O king, let my counsel be acceptable to you, and break off your sins by righteousness, and your iniquities by showing mercy to the poor. Perhaps there may be a lengthening of your tranquility.” 
+</div><div class="pi1">
+<sup>28&#160;</sup>All this came on the King Nebuchadnezzar. 
+<sup>29&#160;</sup>At the end of twelve months he was walking in the royal palace of Babylon. 
+<sup>30&#160;</sup>The king spoke and said, “Is not this great Babylon, which I have built for the royal dwelling place by the might of my power and for the glory of my majesty?” 
+</div><div class="pi1">
+<sup>31&#160;</sup>While the word was in the king’s mouth, a voice came from the sky, saying, “O King Nebuchadnezzar, to you it is spoken: ‘The kingdom has departed from you. 
+<sup>32&#160;</sup>You shall be driven from men, and your dwelling shall be with the animals of the field. You shall be made to eat grass like oxen. Seven times shall pass over you, until you know that the Most High rules in the kingdom of men, and gives it to whomever he will.’&#160;” 
+</div><div class="pi1">
+<sup>33&#160;</sup>This was fulfilled the same hour on Nebuchadnezzar. He was driven from men and ate grass like oxen; and his body was wet with the dew of the sky until his hair had grown like eagles’ feathers, and his nails like birds’ claws. 
+</div><div class="pi1">
+<sup>34&#160;</sup>At the end of the days I, Nebuchadnezzar, lifted up my eyes to heaven, and my understanding returned to me; and I blessed the Most High, and I praised and honored him who lives forever, 
+</div><div class="q1">for his dominion is an everlasting dominion, 
+</div><div class="q2">and his kingdom from generation to generation. 
+</div><div class="q1">
+<sup>35&#160;</sup>All the inhabitants of the earth are reputed as nothing; 
+</div><div class="q2">and he does according to his will in the army of heaven, 
+</div><div class="q2">and among the inhabitants of the earth; 
+</div><div class="q1">and no one can stop his hand, 
+</div><div class="q2">or ask him, “What are you doing?” 
+</div><div class="pi1">
+<sup>36&#160;</sup>At the same time my understanding returned to me; and for the glory of my kingdom, my majesty and brightness returned to me. My counselors and my lords sought me; and I was established in my kingdom, and excellent greatness was added to me. 
+<sup>37&#160;</sup>Now I, Nebuchadnezzar, praise and extol and honor the King of heaven; for all his works are truth, and his ways justice; and those who walk in pride he is able to abase. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Belshazzar the king made a great feast to a thousand of his lords, and drank wine before the thousand. 
+<sup>2&#160;</sup>Belshazzar, while he tasted the wine, commanded that the golden and silver vessels which Nebuchadnezzar his father had taken out of the temple which was in Jerusalem be brought to him, that the king and his lords, his women and his concubines, might drink from them. 
+<sup>3&#160;</sup>Then they brought the golden vessels that were taken out of the temple of Elohim’s house which was at Jerusalem; and the king and his lords, his women and his concubines, drank from them. 
+<sup>4&#160;</sup>They drank wine, and praised the elohims of gold, and of silver, of bronze, of iron, of wood, and of stone. 
+</div><div class="p">
+<sup>5&#160;</sup>In the same hour, the fingers of a man’s hand came out and wrote near the lamp stand on the plaster of the wall of the king’s palace. The king saw the part of the hand that wrote. 
+<sup>6&#160;</sup>Then the king’s face was changed in him, and his thoughts troubled him; and the joints of his thighs were loosened, and his knees struck one against another. 
+</div><div class="p">
+<sup>7&#160;</sup>The king cried aloud to bring in the enchanters, the Chaldeans, and the soothsayers. The king spoke and said to the wise men of Babylon, “Whoever reads this writing and shows me its interpretation shall be clothed with purple, and have a chain of gold about his neck, and shall be the third ruler in the kingdom.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then all the king’s wise men came in; but they could not read the writing, and couldn’t make known to the king the interpretation. 
+<sup>9&#160;</sup>Then King Belshazzar was greatly troubled, and his face was changed in him, and his lords were perplexed. 
+</div><div class="p">
+<sup>10&#160;</sup>The queen by reason of the words of the king and his lords came into the banquet house. The queen spoke and said, “O king, live forever; don’t let your thoughts trouble you, nor let your face be changed. 
+<sup>11&#160;</sup>There is a man in your kingdom in whom is the spirit of the set-apart elohims; and in the days of your father, light and understanding and wisdom, like the wisdom of the elohims, were found in him. The king, Nebuchadnezzar, your father—yes, the king, your father—made him master of the magicians, enchanters, Chaldeans, and soothsayers, 
+<sup>12&#160;</sup>because an excellent spirit, knowledge, understanding, interpreting of dreams, showing of dark sentences, and dissolving of doubts were found in the same Daniel, whom the king named Belteshazzar. Now let Daniel be called, and he will show the interpretation.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then Daniel was brought in before the king. The king spoke and said to Daniel, “Are you that Daniel of the children of the captivity of Judah, whom the king my father brought out of Judah? 
+<sup>14&#160;</sup>I have heard of you, that the spirit of the elohims is in you and that light, understanding, and excellent wisdom are found in you. 
+<sup>15&#160;</sup>Now the wise men, the enchanters, have been brought in before me, that they should read this writing, and make known to me its interpretation; but they could not show the interpretation of the thing. 
+<sup>16&#160;</sup>But I have heard of you, that you can give interpretations and dissolve doubts. Now if you can read the writing and make known to me its interpretation, you shall be clothed with purple, and have a chain of gold around your neck, and shall be the third ruler in the kingdom.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Daniel answered before the king, “Let your gifts be to yourself, and give your rewards to another. Nevertheless, I will read the writing to the king, and make known to him the interpretation. 
+</div><div class="p">
+<sup>18&#160;</sup>“To you, king, the Most High Elohim gave Nebuchadnezzar your father the kingdom, and greatness, and glory, and majesty. 
+<sup>19&#160;</sup>Because of the greatness that he gave him, all the peoples, nations, and languages trembled and feared before him. He killed whom he wanted to, and he kept alive whom he wanted to. He raised up whom he wanted to, and he put down whom he wanted to. 
+<sup>20&#160;</sup>But when his heart was lifted up, and his spirit was hardened so that he dealt proudly, he was deposed from his kingly throne, and they took his glory from him. 
+<sup>21&#160;</sup>He was driven from the sons of men, and his heart was made like the animals’, and his dwelling was with the wild donkeys. He was fed with grass like oxen, and his body was wet with the dew of the sky, until he knew that the Most High Elohim rules in the kingdom of men, and that he sets up over it whomever he will. 
+</div><div class="p">
+<sup>22&#160;</sup>“You, his son, Belshazzar, have not humbled your heart, though you knew all this, 
+<sup>23&#160;</sup>but have lifted up yourself against the Lord of heaven; and they have brought the vessels of his house before you, and you and your lords, your women, and your concubines, have drunk wine from them. You have praised the elohims of silver and gold, of bronze, iron, wood, and stone, which don’t see, or hear, or know; and you have not glorified the Elohim in whose hand your breath is, and whose are all your ways. 
+<sup>24&#160;</sup>Then the part of the hand was sent from before him, and this writing was inscribed. 
+</div><div class="p">
+<sup>25&#160;</sup>“This is the writing that was inscribed: ‘MENE, MENE, TEKEL, UPHARSIN.’ 
+</div><div class="p">
+<sup>26&#160;</sup>“This is the interpretation of the thing: 
+</div><div class="m">MENE: Elohim has counted your kingdom, and brought it to an end. 
+</div><div class="m">
+<sup>27&#160;</sup>TEKEL: you are weighed in the balances, and are found wanting. 
+</div><div class="m">
+<sup>28&#160;</sup>PERES: your kingdom is divided, and given to the Medes and Persians.” 
+</div><div class="p">
+<sup>29&#160;</sup>Then Belshazzar commanded, and they clothed Daniel with purple, and put a chain of gold about his neck, and made proclamation concerning him, that he should be the third ruler in the kingdom. 
+</div><div class="p">
+<sup>30&#160;</sup>In that night Belshazzar the Chaldean King was slain. 
+<sup>31&#160;</sup>Darius the Mede received the kingdom, being about sixty-two years old. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>It pleased Darius to set over the kingdom one hundred twenty local governors, who should be throughout the whole kingdom; 
+<sup>2&#160;</sup>and over them three presidents, of whom Daniel was one, that these local governors might give account to them, and that the king should suffer no loss. 
+<sup>3&#160;</sup>Then this Daniel was distinguished above the presidents and the local governors, because an excellent spirit was in him; and the king thought to set him over the whole realm. 
+</div><div class="p">
+<sup>4&#160;</sup>Then the presidents and the local governors sought to find occasion against Daniel as touching the kingdom; but they could find no occasion or fault, because he was faithful. There wasn’t any error or fault found in him. 
+<sup>5&#160;</sup>Then these men said, “We won’t find any occasion against this Daniel, unless we find it against him concerning the law of his Elohim.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then these presidents and local governors assembled together to the king, and said this to him, “King Darius, live forever! 
+<sup>7&#160;</sup>All the presidents of the kingdom, the deputies and the local governors, the counselors and the governors, have consulted together to establish a royal statute and to make a strong decree, that whoever asks a petition of any elohim or man for thirty days, except of you, O king, he shall be cast into the den of lions. 
+<sup>8&#160;</sup>Now, O king, establish the decree and sign the writing, that it not be changed, according to the law of the Medes and Persians, which doesn’t alter.” 
+<sup>9&#160;</sup>Therefore King Darius signed the writing and the decree. 
+</div><div class="p">
+<sup>10&#160;</sup>When Daniel knew that the writing was signed, he went into his house (now his windows were open in his room toward Jerusalem) and he kneeled on his knees three times a day, and prayed, and gave thanks before his Elohim, as he did before. 
+<sup>11&#160;</sup>Then these men assembled together, and found Daniel making petition and supplication before his Elohim. 
+<sup>12&#160;</sup>Then they came near, and spoke before the king concerning the king’s decree: “Haven’t you signed a decree that every man who makes a petition to any elohim or man within thirty days, except to you, O king, shall be cast into the den of lions?” 
+</div><div class="p">The king answered, “This thing is true, according to the law of the Medes and Persians, which doesn’t alter.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then they answered and said before the king, “That Daniel, who is of the children of the captivity of Judah, doesn’t respect you, O king, nor the decree that you have signed, but makes his petition three times a day.” 
+<sup>14&#160;</sup>Then the king, when he heard these words, was very displeased, and set his heart on Daniel to deliver him; and he labored until the going down of the sun to rescue him. 
+</div><div class="p">
+<sup>15&#160;</sup>Then these men assembled together to the king, and said to the king, “Know, O king, that it is a law of the Medes and Persians, that no decree nor statute which the king establishes may be changed.” 
+</div><div class="p">
+<sup>16&#160;</sup>Then the king commanded, and they brought Daniel and cast him into the den of lions. The king spoke and said to Daniel, “Your Elohim whom you serve continually, he will deliver you.” 
+</div><div class="p">
+<sup>17&#160;</sup>A stone was brought, and laid on the mouth of the den; and the king sealed it with his own signet, and with the signet of his lords; that nothing might be changed concerning Daniel. 
+<sup>18&#160;</sup>Then the king went to his palace, and passed the night fasting. No musical instruments were brought before him; and his sleep fled from him. 
+</div><div class="p">
+<sup>19&#160;</sup>Then the king arose very early in the morning, and went in haste to the den of lions. 
+<sup>20&#160;</sup>When he came near to the den to Daniel, he cried with a troubled voice. The king spoke and said to Daniel, “Daniel, servant of the living Elohim, is your Elohim, whom you serve continually, able to deliver you from the lions?” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Daniel said to the king, “O king, live forever! 
+<sup>22&#160;</sup>My Elohim has sent his angel, and has shut the lions’ mouths, and they have not hurt me, because innocence was found in me before him; and also before you, O king, I have done no harm.” 
+</div><div class="p">
+<sup>23&#160;</sup>Then the king was exceedingly glad, and commanded that they should take Daniel up out of the den. So Daniel was taken up out of the den, and no kind of harm was found on him, because he had trusted in his Elohim. 
+</div><div class="p">
+<sup>24&#160;</sup>The king commanded, and they brought those men who had accused Daniel, and they cast them into the den of lions—them, their children, and their women; and the lions mauled them, and broke all their bones in pieces before they came to the bottom of the den. 
+</div><div class="p">
+<sup>25&#160;</sup>Then King Darius wrote to all the peoples, nations, and languages who dwell in all the earth: 
+</div><div class="pi1">“Peace be multiplied to you. 
+</div><div class="pi1">
+<sup>26&#160;</sup>“I make a decree that in all the dominion of my kingdom men tremble and fear before the Elohim of Daniel. 
+</div><div class="q1">“For he is the living Elohim, 
+</div><div class="q2">and steadfast forever. 
+</div><div class="q1">His kingdom is that which will not be destroyed. 
+</div><div class="q2">His dominion will be even to the end. 
+</div><div class="q1">
+<sup>27&#160;</sup>He delivers and rescues. 
+</div><div class="q2">He works signs and wonders in heaven and in earth, 
+</div><div class="q2">who has delivered Daniel from the power of the lions.” 
+</div><div class="p">
+<sup>28&#160;</sup>So this Daniel prospered in the reign of Darius and in the reign of Cyrus the Persian. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>In the first year of Belshazzar king of Babylon, Daniel had a dream and visions of his head while on his bed. Then he wrote the dream and told the sum of the matters. 
+</div><div class="p">
+<sup>2&#160;</sup>Daniel spoke and said, “I saw in my vision by night, and, behold, the four winds of the sky broke out on the great sea. 
+<sup>3&#160;</sup>Four great animals came up from the sea, different from one another. 
+</div><div class="p">
+<sup>4&#160;</sup>“The first was like a lion, and had eagle’s wings. I watched until its wings were plucked, and it was lifted up from the earth and made to stand on two feet as a man. A man’s heart was given to it. 
+</div><div class="p">
+<sup>5&#160;</sup>“Behold, there was another animal, a second, like a bear. It was raised up on one side, and three ribs were in its mouth between its teeth. They said this to it: ‘Arise! Devour much flesh!’ 
+</div><div class="p">
+<sup>6&#160;</sup>“After this I saw, and behold, another, like a leopard, which had on its back four wings of a bird. The animal also had four heads; and dominion was given to it. 
+</div><div class="p">
+<sup>7&#160;</sup>“After this I saw in the night visions, and, behold, there was a fourth animal, awesome, powerful, and exceedingly strong. It had great iron teeth. It devoured and broke in pieces, and stamped the residue with its feet. It was different from all the animals that were before it. It had ten horns. 
+</div><div class="p">
+<sup>8&#160;</sup>“I considered the horns, and behold, there came up among them another horn, a little one, before which three of the first horns were plucked up by the roots; and behold, in this horn were eyes like the eyes of a man, and a mouth speaking arrogantly. 
+</div><div class="q1">
+<sup>9&#160;</sup>“I watched until thrones were placed, 
+</div><div class="q2">and one who was ancient of days sat. 
+</div><div class="q1">His clothing was white as snow, 
+</div><div class="q2">and the hair of his head like pure wool. 
+</div><div class="q1">His throne was fiery flames, 
+</div><div class="q2">and its wheels burning fire. 
+</div><div class="q1">
+<sup>10&#160;</sup>A fiery stream issued and came out from before him. 
+</div><div class="q2">Thousands of thousands ministered to him. 
+</div><div class="q2">Ten thousand times ten thousand stood before him. 
+</div><div class="q1">The judgment was set. 
+</div><div class="q2">The books were opened. 
+</div><div class="p">
+<sup>11&#160;</sup>“I watched at that time because of the voice of the arrogant words which the horn spoke. I watched even until the animal was slain, and its body destroyed, and it was given to be burned with fire. 
+<sup>12&#160;</sup>As for the rest of the animals, their dominion was taken away; yet their lives were prolonged for a season and a time. 
+</div><div class="p">
+<sup>13&#160;</sup>“I saw in the night visions, and behold, there came with the clouds of the sky one like a son of man, and he came even to the Ancient of Days, and they brought him near before him. 
+<sup>14&#160;</sup>Dominion was given him, and glory, and a kingdom, that all the peoples, nations, and languages should serve him. His dominion is an everlasting dominion, which will not pass away, and his kingdom one that will not be destroyed. 
+</div><div class="p">
+<sup>15&#160;</sup>“As for me, Daniel, my spirit was grieved within my body, and the visions of my head troubled me. 
+<sup>16&#160;</sup>I came near to one of those who stood by, and asked him the truth concerning all this. 
+</div><div class="p">“So he told me, and made me know the interpretation of the things. 
+<sup>17&#160;</sup>‘These great animals, which are four, are four kings, who will arise out of the earth. 
+<sup>18&#160;</sup>But the saints of the Most High will receive the kingdom, and possess the kingdom forever, even forever and ever.’ 
+</div><div class="p">
+<sup>19&#160;</sup>“Then I desired to know the truth concerning the fourth animal, which was different from all of them, exceedingly terrible, whose teeth were of iron, and its nails of bronze; which devoured, broke in pieces, and stamped the residue with its feet; 
+<sup>20&#160;</sup>and concerning the ten horns that were on its head and the other horn which came up, and before which three fell, even that horn that had eyes and a mouth that spoke arrogantly, whose look was more stout than its fellows. 
+<sup>21&#160;</sup>I saw, and the same horn made war with the saints, and prevailed against them, 
+<sup>22&#160;</sup>until the ancient of days came, and judgment was given to the saints of the Most High, and the time came that the saints possessed the kingdom. 
+</div><div class="p">
+<sup>23&#160;</sup>“So he said, ‘The fourth animal will be a fourth kingdom on earth, which will be different from all the kingdoms, and will devour the whole earth, and will tread it down and break it in pieces. 
+<sup>24&#160;</sup>As for the ten horns, ten kings will arise out of this kingdom. Another will arise after them; and he will be different from the former, and he will put down three kings. 
+<sup>25&#160;</sup>He will speak words against the Most High, and will wear out the saints of the Most High. He will plan to change the times and the law; and they will be given into his hand until a time and times and half a time. 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘But the judgment will be set, and they will take away his dominion, to consume and to destroy it to the end. 
+<sup>27&#160;</sup>The kingdom and the dominion, and the greatness of the kingdoms under the whole sky, will be given to the people of the saints of the Most High. His kingdom is an everlasting kingdom, and all dominions will serve and obey him.’ 
+</div><div class="p">
+<sup>28&#160;</sup>“Here is the end of the matter. As for me, Daniel, my thoughts troubled me greatly, and my face was changed in me; but I kept the matter in my heart.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>In the third year of the reign of King Belshazzar, a vision appeared to me, even to me, Daniel, after that which appeared to me at the first. 
+<sup>2&#160;</sup>I saw the vision. Now it was so, that when I saw, I was in the citadel of Susa, which is in the province of Elam. I saw in the vision, and I was by the river Ulai. 
+<sup>3&#160;</sup>Then I lifted up my eyes and saw, and behold, a ram which had two horns stood before the river. The two horns were high, but one was higher than the other, and the higher came up last. 
+<sup>4&#160;</sup>I saw the ram pushing westward, northward, and southward. No animals could stand before him. There wasn’t any who could deliver out of his hand, but he did according to his will, and magnified himself. 
+</div><div class="p">
+<sup>5&#160;</sup>As I was considering, behold, a male goat came from the west over the surface of the whole earth, and didn’t touch the ground. The goat had a notable horn between his eyes. 
+<sup>6&#160;</sup>He came to the ram that had the two horns, which I saw standing before the river, and ran on him in the fury of his power. 
+<sup>7&#160;</sup>I saw him come close to the ram, and he was moved with anger against him, and struck the ram, and broke his two horns. There was no power in the ram to stand before him; but he cast him down to the ground and trampled on him. There was no one who could deliver the ram out of his hand. 
+<sup>8&#160;</sup>The male goat magnified himself exceedingly. When he was strong, the great horn was broken; and instead of it there came up four notable horns toward the four winds of the sky. 
+</div><div class="p">
+<sup>9&#160;</sup>Out of one of them came out a little horn which grew exceedingly great—toward the south, and toward the east, and toward the glorious land. 
+<sup>10&#160;</sup>It grew great, even to the army of the sky; and it cast down some of the army and of the stars to the ground and trampled on them. 
+<sup>11&#160;</sup>Yes, it magnified itself, even to the prince of the army; and it took away from him the continual burnt offering, and the place of his sanctuary was cast down. 
+<sup>12&#160;</sup>The army was given over to it together with the continual burnt offering through disobedience. It cast down truth to the ground, and it did its pleasure and prospered. 
+</div><div class="p">
+<sup>13&#160;</sup>Then I heard a set-apart one speaking; and another set-apart one said to that certain one who spoke, “How long will the vision about the continual burnt offering, and the disobedience that makes desolate, to give both the sanctuary and the army to be trodden under foot be?” 
+</div><div class="p">
+<sup>14&#160;</sup>He said to me, “To two thousand and three hundred evenings and mornings. Then the sanctuary will be cleansed.” 
+</div><div class="p">
+<sup>15&#160;</sup>When I, even I Daniel, had seen the vision, I sought to understand it. Then behold, there stood before me someone with the appearance of a man. 
+<sup>16&#160;</sup>I heard a man’s voice between the banks of the Ulai, which called and said, “Gabriel, make this man understand the vision.” 
+</div><div class="p">
+<sup>17&#160;</sup>So he came near where I stood; and when he came, I was frightened, and fell on my face; but he said to me, “Understand, son of man, for the vision belongs to the time of the end.” 
+</div><div class="p">
+<sup>18&#160;</sup>Now as he was speaking with me, I fell into a deep sleep with my face toward the ground; but he touched me and set me upright. 
+</div><div class="p">
+<sup>19&#160;</sup>He said, “Behold, I will make you know what will be in the latter time of the indignation, for it belongs to the appointed time of the end. 
+<sup>20&#160;</sup>The ram which you saw, that had the two horns, they are the kings of Media and Persia. 
+<sup>21&#160;</sup>The rough male goat is the king of Greece. The great horn that is between his eyes is the first king. 
+<sup>22&#160;</sup>As for that which was broken, in the place where four stood up, four kingdoms will stand up out of the nation, but not with his power. 
+</div><div class="p">
+<sup>23&#160;</sup>“In the latter time of their kingdom, when the transgressors have come to the full, a king of fierce face, and understanding riddles, will stand up. 
+<sup>24&#160;</sup>His power will be mighty, but not by his own power. He will destroy awesomely, and will prosper in what he does. He will destroy the mighty ones and the set-apart people. 
+<sup>25&#160;</sup>Through his policy he will cause deceit to prosper in his hand. He will magnify himself in his heart, and he will destroy many in their security. He will also stand up against the prince of princes, but he will be broken without human hands. 
+</div><div class="p">
+<sup>26&#160;</sup>“The vision of the evenings and mornings which has been told is true; but seal up the vision, for it belongs to many days to come.” 
+</div><div class="p">
+<sup>27&#160;</sup>I, Daniel, fainted, and was sick for some days. Then I rose up and did the king’s business. I wondered at the vision, but no one understood it. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>In the first year of Darius the son of Ahasuerus, of the offspring of the Medes, who was made king over the realm of the Chaldeans—<sup>2&#160;</sup>in the first year of his reign I, Daniel, understood by the books the number of the years about which Yahweh’s word came to Jeremiah the prophet for the accomplishing of the desolations of Jerusalem, even seventy years. 
+<sup>3&#160;</sup>I set my face to the Lord Elohim, to seek by prayer and petitions, with fasting and sackcloth and ashes. 
+</div><div class="p">
+<sup>4&#160;</sup>I prayed to Yahweh my Elohim, and made confession, and said, 
+</div><div class="pi1">“Oh, Lord, the great and dreadful Elohim, who keeps covenant and loving kindness with those who love him and keep his commandments, 
+<sup>5&#160;</sup>we have sinned, and have dealt perversely, and have done wickedly, and have rebelled, even turning aside from your precepts and from your ordinances. 
+<sup>6&#160;</sup>We haven’t listened to your servants the prophets, who spoke in your name to our kings, our princes, and our fathers, and to all the people of the land. 
+</div><div class="pi1">
+<sup>7&#160;</sup>“Lord, righteousness belongs to you, but to us confusion of face, as it is today; to the men of Judah, and to the inhabitants of Jerusalem, and to all Israel, who are near and who are far off, through all the countries where you have driven them, because of their trespass that they have trespassed against you. 
+<sup>8&#160;</sup>Lord, to us belongs confusion of face, to our kings, to our princes, and to our fathers, because we have sinned against you. 
+<sup>9&#160;</sup>To the Lord our Elohim belong mercies and forgiveness, for we have rebelled against him. 
+<sup>10&#160;</sup>We haven’t obeyed Yahweh our Elohim’s voice, to walk in his laws, which he set before us by his servants the prophets. 
+<sup>11&#160;</sup>Yes, all Israel have transgressed your law, turning aside, that they should not obey your voice. 
+</div><div class="pi1">“Therefore the curse and the oath written in the law of Moses the servant of Elohim has been poured out on us, for we have sinned against him. 
+<sup>12&#160;</sup>He has confirmed his words, which he spoke against us and against our judges who judged us, by bringing on us a great evil; for under the whole sky, such has not been done as has been done to Jerusalem. 
+<sup>13&#160;</sup>As it is written in the law of Moses, all this evil has come on us. Yet we have not entreated the favor of Yahweh our Elohim, that we should turn from our iniquities and have discernment in your truth. 
+<sup>14&#160;</sup>Therefore Yahweh has watched over the evil, and brought it on us; for Yahweh our Elohim is righteous in all his works which he does, and we have not obeyed his voice. 
+</div><div class="pi1">
+<sup>15&#160;</sup>“Now, Lord our Elohim, who has brought your people out of the land of Egypt with a mighty hand, and have gotten yourself renown, as it is today, we have sinned. We have done wickedly. 
+<sup>16&#160;</sup>Lord, according to all your righteousness, please let your anger and your wrath be turned away from your city Jerusalem, your set-apart mountain; because for our sins and for the iniquities of our fathers, Jerusalem and your people have become a reproach to all who are around us. 
+</div><div class="pi1">
+<sup>17&#160;</sup>“Now therefore, our Elohim, listen to the prayer of your servant and to his petitions, and cause your face to shine on your sanctuary that is desolate, for the Lord’s sake. 
+<sup>18&#160;</sup>My Elohim, turn your ear and hear. Open your eyes and see our desolations, and the city which is called by your name; for we do not present our petitions before you for our righteousness, but for your great mercies’ sake. 
+<sup>19&#160;</sup>Lord, hear. Lord, forgive. Lord, listen and do. Don’t defer, for your own sake, my Elohim, because your city and your people are called by your name.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>20&#160;</sup>While I was speaking, praying, and confessing my sin and the sin of my people Israel, and presenting my supplication before Yahweh my Elohim for the set-apart mountain of my Elohim—<sup>21&#160;</sup>yes, while I was speaking in prayer—the man Gabriel, whom I had seen in the vision at the beginning, being caused to fly swiftly, touched me about the time of the evening offering. 
+<sup>22&#160;</sup>He instructed me and talked with me, and said, “Daniel, I have now come to give you wisdom and understanding. 
+<sup>23&#160;</sup>At the beginning of your petitions the commandment went out, and I have come to tell you, for you are greatly beloved. Therefore consider the matter and understand the vision. 
+</div><div class="p">
+<sup>24&#160;</sup>“Seventy weeks are decreed on your people and on your set-apart city, to finish disobedience, to make an end of sins, to make reconciliation for iniquity, to bring in everlasting righteousness, to seal up vision and prophecy, and to anoint the most set-apart. 
+</div><div class="p">
+<sup>25&#160;</sup>“Know therefore and discern that from the going out of the commandment to restore and build Jerusalem to the Anointed One, the prince, will be seven weeks and sixty-two weeks. It will be built again, with street and moat, even in troubled times. 
+<sup>26&#160;</sup>After the sixty-two weeks the Anointed One will be cut off, and will have nothing. The people of the prince who come will destroy the city and the sanctuary. Its end will be with a flood, and war will be even to the end. Desolations are determined. 
+<sup>27&#160;</sup>He will make a firm covenant with many for one week. In the middle of the week he will cause the sacrifice and the offering to cease. On the wing of abominations will come one who makes desolate; and even to the decreed full end, wrath will be poured out on the desolate.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>In the third year of Cyrus king of Persia a message was revealed to Daniel, whose name was called Belteshazzar; and the message was true, even a great warfare. He understood the message, and had understanding of the vision. 
+</div><div class="p">
+<sup>2&#160;</sup>In those days I, Daniel, was mourning three whole weeks. 
+<sup>3&#160;</sup>I ate no pleasant food. No meat or wine came into my mouth. I didn’t anoint myself at all, until three whole weeks were fulfilled. 
+</div><div class="p">
+<sup>4&#160;</sup>In the twenty-fourth day of the first month, as I was by the side of the great river, which is Hiddekel, 
+<sup>5&#160;</sup>I lifted up my eyes and looked, and behold, there was a man clothed in linen, whose waist was adorned with pure gold of Uphaz. 
+<sup>6&#160;</sup>His body also was like beryl, and his face as the appearance of lightning, and his eyes as flaming torches. His arms and his feet were like burnished bronze. The voice of his words was like the voice of a multitude. 
+</div><div class="p">
+<sup>7&#160;</sup>I, Daniel, alone saw the vision, for the men who were with me didn’t see the vision, but a great quaking fell on them, and they fled to hide themselves. 
+<sup>8&#160;</sup>So I was left alone and saw this great vision. No strength remained in me; for my face grew deathly pale, and I retained no strength. 
+<sup>9&#160;</sup>Yet I heard the voice of his words. When I heard the voice of his words, then I fell into a deep sleep on my face, with my face toward the ground. 
+</div><div class="p">
+<sup>10&#160;</sup>Behold, a hand touched me, which set me on my knees and on the palms of my hands. 
+<sup>11&#160;</sup>He said to me, “Daniel, you greatly beloved man, understand the words that I speak to you, and stand upright, for I have been sent to you, now.” When he had spoken this word to me, I stood trembling. 
+</div><div class="p">
+<sup>12&#160;</sup>Then he said to me, “Don’t be afraid, Daniel; for from the first day that you set your heart to understand, and to humble yourself before your Elohim, your words were heard. I have come for your words’ sake. 
+<sup>13&#160;</sup>But the prince of the kingdom of Persia withstood me twenty-one days; but, behold, Michael, one of the chief princes, came to help me because I remained there with the kings of Persia. 
+<sup>14&#160;</sup>Now I have come to make you understand what will happen to your people in the latter days, for the vision is yet for many days.” 
+</div><div class="p">
+<sup>15&#160;</sup>When he had spoken these words to me, I set my face toward the ground and was mute. 
+<sup>16&#160;</sup>Behold, one in the likeness of the sons of men touched my lips. Then I opened my mouth, and spoke and said to him who stood before me, “My lord, by reason of the vision my sorrows have overtaken me, and I retain no strength. 
+<sup>17&#160;</sup>For how can the servant of this my lord talk with this my lord? For as for me, immediately there remained no strength in me. There was no breath left in me.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then one like the appearance of a man touched me again, and he strengthened me. 
+<sup>19&#160;</sup>He said, “Greatly beloved man, don’t be afraid. Peace be to you. Be strong. Yes, be strong.” 
+</div><div class="p">When he spoke to me, I was strengthened, and said, “Let my lord speak, for you have strengthened me.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then he said, “Do you know why I have come to you? Now I will return to fight with the prince of Persia. When I go out, behold, the prince of Greece will come. 
+<sup>21&#160;</sup>But I will tell you that which is inscribed in the writing of truth. There is no one who holds with me against these but Michael your prince. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>“As for me, in the first year of Darius the Mede, I stood up to confirm and strengthen him. 
+</div><div class="p">
+<sup>2&#160;</sup>“Now I will show you the truth. Behold, three more kings will stand up in Persia. The fourth will be far richer than all of them. When he has grown strong through his riches, he will stir up all against the realm of Greece. 
+<sup>3&#160;</sup>A mighty king will stand up, who will rule with great dominion, and do according to his will. 
+<sup>4&#160;</sup>When he stands up, his kingdom will be broken and will be divided toward the four winds of the sky, but not to his posterity, nor according to his dominion with which he ruled; for his kingdom will be plucked up, even for others besides these. 
+</div><div class="p">
+<sup>5&#160;</sup>“The king of the south will be strong. One of his princes will become stronger than him, and have dominion. His dominion will be a great dominion. 
+<sup>6&#160;</sup>At the end of years they will join themselves together; and the daughter of the king of the south will come to the king of the north to make an agreement, but she will not retain the strength of her arm. He will also not stand, nor will his arm; but she will be given up, with those who brought her, and he who brought forth her, and he who strengthened her in those times. 
+</div><div class="p">
+<sup>7&#160;</sup>“But out of a shoot from her roots one will stand up in his place, who will come to the army and will enter into the fortress of the king of the north, and will deal against them and will prevail. 
+<sup>8&#160;</sup>He will also carry their elohims with their molten images, and with their goodly vessels of silver and of gold, captive into Egypt. He will refrain some years from the king of the north. 
+<sup>9&#160;</sup>He will come into the realm of the king of the south, but he will return into his own land. 
+<sup>10&#160;</sup>His sons will wage war, and will assemble a multitude of great forces which will come on, and overflow, and pass through. They will return and wage war, even to his fortress. 
+</div><div class="p">
+<sup>11&#160;</sup>“The king of the south will be moved with anger and will come out and fight with him, even with the king of the north. He will send out a great multitude, and the multitude will be given into his hand. 
+<sup>12&#160;</sup>The multitude will be carried off, and his heart will be exalted. He will cast down tens of thousands, but he won’t prevail. 
+<sup>13&#160;</sup>The king of the north will return, and will send out a multitude greater than the former. He will come on at the end of the times, even of years, with a great army and with abundant supplies. 
+</div><div class="p">
+<sup>14&#160;</sup>“In those times many will stand up against the king of the south. Also the children of the violent among your people will lift themselves up to establish the vision, but they will fall. 
+<sup>15&#160;</sup>So the king of the north will come and cast up a mound, and take a well-fortified city. The forces of the south won’t stand, neither will his select troops, neither will there be any strength to stand. 
+<sup>16&#160;</sup>But he who comes against him will do according to his own will, and no one will stand before him. He will stand in the glorious land, and destruction will be in his hand. 
+<sup>17&#160;</sup>He will set his face to come with the strength of his whole kingdom, and with him equitable conditions. He will perform them. He will give him the daughter of women, to destroy the kingdom, but she will not stand, and won’t be for him. 
+<sup>18&#160;</sup>After this he will turn his face to the islands, and will take many, but a prince will cause the reproach offered by him to cease. Yes, moreover, he will cause his reproach to turn on him. 
+<sup>19&#160;</sup>Then he will turn his face toward the fortresses of his own land; but he will stumble and fall, and won’t be found. 
+</div><div class="p">
+<sup>20&#160;</sup>“Then one who will cause a tax collector to pass through the kingdom to maintain its glory will stand up in his place; but within few days he shall be destroyed, not in anger, and not in battle. 
+</div><div class="p">
+<sup>21&#160;</sup>“In his place a contemptible person will stand up, to whom they had not given the honor of the kingdom; but he will come in time of security, and will obtain the kingdom by flatteries. 
+<sup>22&#160;</sup>The overwhelming forces will be overwhelmed from before him, and will be broken. Yes, also the prince of the covenant. 
+<sup>23&#160;</sup>After the treaty made with him he will work deceitfully; for he will come up and will become strong with few people. 
+<sup>24&#160;</sup>In time of security he will come even on the fattest places of the province. He will do that which his fathers have not done, nor his fathers’ fathers. He will scatter among them prey, plunder, and wealth. Yes, he will devise his plans against the strongholds, but only for a time. 
+</div><div class="p">
+<sup>25&#160;</sup>“He will stir up his power and his courage against the king of the south with a great army; and the king of the south will wage war in battle with an exceedingly great and mighty army, but he won’t stand; for they will devise plans against him. 
+<sup>26&#160;</sup>Yes, those who eat of his delicacies will destroy him, and his army will be swept away. Many will fall down slain. 
+<sup>27&#160;</sup>As for both these kings, their hearts will be to do evil, and they will speak lies at one table; but it won’t prosper, for the end will still be at the appointed time. 
+<sup>28&#160;</sup>Then he will return into his land with great wealth. His heart will be against the set-apart covenant. He will take action, and return to his own land. 
+</div><div class="p">
+<sup>29&#160;</sup>“He will return at the appointed time and come into the south; but it won’t be in the latter time as it was in the former. 
+<sup>30&#160;</sup>For ships of Kittim will come against him. Therefore he will be grieved, and will return, and have indignation against the set-apart covenant, and will take action. He will even return, and have regard to those who forsake the set-apart covenant. 
+</div><div class="p">
+<sup>31&#160;</sup>“Forces from him will profane the sanctuary, even the fortress, and will take away the continual burnt offering. Then they will set up the abomination that makes desolate. 
+<sup>32&#160;</sup>He will corrupt those who do wickedly against the covenant by flatteries; but the people who know their Elohim will be strong and take action. 
+</div><div class="p">
+<sup>33&#160;</sup>“Those who are wise among the people will instruct many; yet they will fall by the sword and by flame, by captivity and by plunder, many days. 
+<sup>34&#160;</sup>Now when they fall, they will be helped with a little help; but many will join themselves to them with flatteries. 
+<sup>35&#160;</sup>Some of those who are wise will fall—to refine them, and to purify, and to make them white, even to the time of the end, because it is yet for the time appointed. 
+</div><div class="p">
+<sup>36&#160;</sup>“The king will do according to his will. He will exalt himself and magnify himself above every elohim, and will speak marvelous things against the Elohim of elohims. He will prosper until the indignation is accomplished, for that which is determined will be done. 
+<sup>37&#160;</sup>He won’t regard the elohims of his fathers, or the desire of women, or regard any elohim; for he will magnify himself above all. 
+<sup>38&#160;</sup>But in their place, he will honor the elohim of fortresses. He will honor an elohim whom his fathers didn’t know with gold, silver, and with precious stones and pleasant things. 
+<sup>39&#160;</sup>He will deal with the strongest fortresses by the help of a foreign elohim. He will increase with glory whoever acknowledges him. He will cause them to rule over many, and will divide the land for a price. 
+</div><div class="p">
+<sup>40&#160;</sup>“At the time of the end the king of the south will contend with him; and the king of the north will come against him like a whirlwind, with chariots, with horsemen, and with many ships. He will enter into the countries, and will overflow and pass through. 
+<sup>41&#160;</sup>He will enter also into the glorious land, and many countries will be overthrown; but these will be delivered out of his hand: Edom, Moab, and the chief of the children of Ammon. 
+<sup>42&#160;</sup>He will also stretch out his hand on the countries. The land of Egypt won’t escape. 
+<sup>43&#160;</sup>But he will have power over the treasures of gold and of silver, and over all the precious things of Egypt. The Libyans and the Ethiopians will follow his steps. 
+<sup>44&#160;</sup>But news out of the east and out of the north will trouble him; and he will go out with great fury to destroy and utterly to sweep away many. 
+<sup>45&#160;</sup>He will plant the tents of his palace between the sea and the glorious set-apart mountain; yet he will come to his end, and no one will help him. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>“At that time Michael will stand up, the great prince who stands for the children of your people; and there will be a time of trouble, such as never was since there was a nation even to that same time. At that time your people will be delivered, everyone who is found written in the book. 
+<sup>2&#160;</sup>Many of those who sleep in the dust of the earth will awake, some to everlasting life, and some to shame and everlasting contempt. 
+<sup>3&#160;</sup>Those who are wise will shine as the brightness of the expanse. Those who turn many to righteousness will shine as the stars forever and ever. 
+<sup>4&#160;</sup>But you, Daniel, shut up the words and seal the book, even to the time of the end. Many will run back and forth, and knowledge will be increased.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then I, Daniel, looked, and behold, two others stood, one on the river bank on this side, and the other on the river bank on that side. 
+<sup>6&#160;</sup>One said to the man clothed in linen, who was above the waters of the river, “How long will it be to the end of these wonders?” 
+</div><div class="p">
+<sup>7&#160;</sup>I heard the man clothed in linen, who was above the waters of the river, when he held up his right hand and his left hand to heaven, and swore by him who lives forever that it will be for a time, times, and a half; and when they have finished breaking in pieces the power of the set-apart people, all these things will be finished. 
+</div><div class="p">
+<sup>8&#160;</sup>I heard, but I didn’t understand. Then I said, “My lord, what will be the outcome of these things?” 
+</div><div class="p">
+<sup>9&#160;</sup>He said, “Go your way, Daniel; for the words are shut up and sealed until the time of the end. 
+<sup>10&#160;</sup>Many will purify themselves, and make themselves white, and be refined, but the wicked will do wickedly; and none of the wicked will understand, but those who are wise will understand. 
+</div><div class="p">
+<sup>11&#160;</sup>“From the time that the continual burnt offering is taken away and the abomination that makes desolate set up, there will be one thousand two hundred ninety days. 
+<sup>12&#160;</sup>Blessed is he who waits, and comes to the one thousand three hundred thirty-five days. 
+</div><div class="p">
+<sup>13&#160;</sup>“But go your way until the end; for you will rest, and will stand in your inheritance at the end of the days.” </div></div><script src="../main.js"></script></body></html>

--- a/book/deuteronomy.html
+++ b/book/deuteronomy.html
@@ -3,6 +3,47 @@
 <head>
 <title>Deuteronomy</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1443 +53,1478 @@
 <div class="main">
 <!-- DEU World English Scripture (WES) -->
 <h1 class="booklabel">Deuteronomy</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>These are the words which Moses spoke to all Israel beyond the Jordan in the wilderness, in the Arabah opposite Suf, between Paran, Tophel, Laban, Hazeroth, and Dizahab. 
-<span class="v">2&#160;</span>It is eleven days’ journey from Horeb by the way of Mount Seir to Kadesh Barnea. 
-<span class="v">3&#160;</span>In the fortieth year, in the eleventh month, on the first day of the month, Moses spoke to the children of Israel according to all that Yahweh<span class="f">+ \fr 1:3 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> had given him in commandment to them, 
-<span class="v">4&#160;</span>after he had struck Sihon the king of the Amorites who lived in Heshbon, and Og the king of Bashan who lived in Ashtaroth, at Edrei. 
-<span class="v">5&#160;</span>Beyond the Jordan, in the land of Moab, Moses began to declare this law, saying, 
-<span class="v">6&#160;</span>“Yahweh our Elohim<span class="f">+ \fr 1:6 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> spoke to us in Horeb, saying, ‘You have lived long enough at this mountain. 
-<span class="v">7&#160;</span>Turn, and take your journey, and go to the hill country of the Amorites and to all the places near there: in the Arabah, in the hill country, in the lowland, in the South, by the seashore, in the land of the Canaanites, and in Lebanon as far as the great river, the river Euphrates. 
-<span class="v">8&#160;</span>Behold,<span class="f">+ \fr 1:8 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I have set the land before you. Go in and possess the land which Yahweh swore to your fathers—to Abraham, to Isaac, and to Jacob—to give to them and to their offspring<span class="f">+ \fr 1:8 \ft or, seed</span> after them.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>I spoke to you at that time, saying, “I am not able to bear you myself alone. 
-<span class="v">10&#160;</span>Yahweh your Elohim has multiplied you, and behold, you are today as the stars of the sky for multitude. 
-<span class="v">11&#160;</span>May Yahweh, the Elohim of your fathers, make you a thousand times as many as you are and bless you, as he has promised you! 
-<span class="v">12&#160;</span>How can I myself alone bear your problems, your burdens, and your strife? 
-<span class="v">13&#160;</span>Take wise men of understanding who are respected among your tribes, and I will make them heads over you.” 
-</p><p>
-<span class="v">14&#160;</span>You answered me, and said, “The thing which you have spoken is good to do.” 
-<span class="v">15&#160;</span>So I took the heads of your tribes, wise and respected men, and made them heads over you, captains of thousands, captains of hundreds, captains of fifties, captains of tens, and officers, according to your tribes. 
-<span class="v">16&#160;</span>I commanded your judges at that time, saying, “Hear cases between your brothers and judge righteously between a man and his brother, and the foreigner who is living with him. 
-<span class="v">17&#160;</span>You shall not show partiality in judgment; you shall hear the small and the great alike. You shall not be afraid of the face of man, for the judgment is Elohim’s. The case that is too hard for you, you shall bring to me, and I will hear it.” 
-<span class="v">18&#160;</span>I commanded you at that time all the things which you should do. 
-<span class="v">19&#160;</span>We traveled from Horeb and went through all that great and terrible wilderness which you saw, by the way to the hill country of the Amorites, as Yahweh our Elohim commanded us; and we came to Kadesh Barnea. 
-<span class="v">20&#160;</span>I said to you, “You have come to the hill country of the Amorites, which Yahweh our Elohim gives to us. 
-<span class="v">21&#160;</span>Behold, Yahweh your Elohim has set the land before you. Go up, take possession, as Yahweh the Elohim of your fathers has spoken to you. Don’t be afraid, neither be dismayed.” 
-</p><p>
-<span class="v">22&#160;</span>You came near to me, everyone of you, and said, “Let’s send men before us, that they may search the land for us, and bring back to us word of the way by which we must go up, and the cities to which we shall come.” 
-</p><p>
-<span class="v">23&#160;</span>The thing pleased me well. I took twelve of your men, one man for every tribe. 
-<span class="v">24&#160;</span>They turned and went up into the hill country, and came to the valley of Eshcol, and spied it out. 
-<span class="v">25&#160;</span>They took some of the fruit of the land in their hands and brought it down to us, and brought us word again, and said, “It is a good land which Yahweh our Elohim gives to us.” 
-</p><p>
-<span class="v">26&#160;</span>Yet you wouldn’t go up, but rebelled against the commandment of Yahweh your Elohim. 
-<span class="v">27&#160;</span>You murmured in your tents, and said, “Because Yahweh hated us, he has brought us out of the land of Egypt, to deliver us into the hand of the Amorites to destroy us. 
-<span class="v">28&#160;</span>Where are we going up? Our brothers have made our heart melt, saying, ‘The people are greater and taller than we. The cities are great and fortified up to the sky. Moreover we have seen the sons of the Anakim there!’&#160;” 
-</p><p>
-<span class="v">29&#160;</span>Then I said to you, “Don’t be terrified. Don’t be afraid of them. 
-<span class="v">30&#160;</span>Yahweh your Elohim, who goes before you, he will fight for you, according to all that he did for you in Egypt before your eyes, 
-<span class="v">31&#160;</span>and in the wilderness where you have seen how that Yahweh your Elohim carried you, as a man carries his son, in all the way that you went, until you came to this place.” 
-</p><p>
-<span class="v">32&#160;</span>Yet in this thing you didn’t believe Yahweh your Elohim, 
-<span class="v">33&#160;</span>who went before you on the way, to seek out a place for you to pitch your tents in: in fire by night, to show you by what way you should go, and in the cloud by day. 
-<span class="v">34&#160;</span>Yahweh heard the voice of your words and was angry, and swore, saying, 
-<span class="v">35&#160;</span>“Surely not one of these men of this evil generation shall see the good land which I swore to give to your fathers, 
-<span class="v">36&#160;</span>except Caleb the son of Jephunneh. He shall see it. I will give the land that he has trodden on to him and to his children, because he has wholly followed Yahweh.” 
-</p><p>
-<span class="v">37&#160;</span>Also Yahweh was angry with me for your sakes, saying, “You also shall not go in there. 
-<span class="v">38&#160;</span>Joshua the son of Nun, who stands before you, shall go in there. Encourage him, for he shall cause Israel to inherit it. 
-<span class="v">39&#160;</span>Moreover your little ones, whom you said would be captured or killed, your children, who today have no knowledge of good or evil, shall go in there. I will give it to them, and they shall possess it. 
-<span class="v">40&#160;</span>But as for you, turn, and take your journey into the wilderness by the way to the Red Sea.” 
-</p><p>
-<span class="v">41&#160;</span>Then you answered and said to me, “We have sinned against Yahweh. We will go up and fight, according to all that Yahweh our Elohim commanded us.” Every man of you put on his weapons of war, and presumed to go up into the hill country. 
-</p><p>
-<span class="v">42&#160;</span>Yahweh said to me, “Tell them, ‘Don’t go up and don’t fight; for I am not among you, lest you be struck before your enemies.’&#160;” 
-</p><p>
-<span class="v">43&#160;</span>So I spoke to you, and you didn’t listen; but you rebelled against the commandment of Yahweh, and were presumptuous, and went up into the hill country. 
-<span class="v">44&#160;</span>The Amorites, who lived in that hill country, came out against you and chased you as bees do, and beat you down in Seir, even to Hormah. 
-<span class="v">45&#160;</span>You returned and wept before Yahweh, but Yahweh didn’t listen to your voice, nor turn his ear to you. 
-<span class="v">46&#160;</span>So you stayed in Kadesh many days, according to the days that you remained. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Then we turned, and took our journey into the wilderness by the way to the Red Sea, as Yahweh spoke to me; and we encircled Mount Seir many days. 
-</p><p>
-<span class="v">2&#160;</span>Yahweh spoke to me, saying, 
-<span class="v">3&#160;</span>“You have encircled this mountain long enough. Turn northward. 
-<span class="v">4&#160;</span>Command the people, saying, ‘You are to pass through the border of your brothers, the children of Esau, who dwell in Seir; and they will be afraid of you. Therefore be careful. 
-<span class="v">5&#160;</span>Don’t contend with them; for I will not give you any of their land, no, not so much as for the sole of the foot to tread on, because I have given Mount Seir to Esau for a possession. 
-<span class="v">6&#160;</span>You shall purchase food from them for money, that you may eat. You shall also buy water from them for money, that you may drink.’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>For Yahweh your Elohim has blessed you in all the work of your hands. He has known your walking through this great wilderness. These forty years, Yahweh your Elohim has been with you. You have lacked nothing. 
-</p><p>
-<span class="v">8&#160;</span>So we passed by from our brothers, the children of Esau, who dwell in Seir, from the way of the Arabah from Elath and from Ezion Geber. We turned and passed by the way of the wilderness of Moab. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh said to me, “Don’t bother Moab, neither contend with them in battle; for I will not give you any of his land for a possession, because I have given Ar to the children of Lot for a possession.” 
-</p><p>
-<span class="v">10&#160;</span>(The Emim lived there before, a great and numerous people, and tall as the Anakim. 
-<span class="v">11&#160;</span>These also are considered to be Rephaim, as the Anakim; but the Moabites call them Emim. 
-<span class="v">12&#160;</span>The Horites also lived in Seir in the past, but the children of Esau succeeded them. They destroyed them from before them, and lived in their place, as Israel did to the land of his possession, which Yahweh gave to them.) 
-</p><p>
-<span class="v">13&#160;</span>“Now rise up and cross over the brook Zered.” We went over the brook Zered. 
-</p><p>
-<span class="v">14&#160;</span>The days in which we came from Kadesh Barnea until we had come over the brook Zered were thirty-eight years, until all the generation of the men of war were consumed from the middle of the camp, as Yahweh swore to them. 
-<span class="v">15&#160;</span>Moreover Yahweh’s hand was against them, to destroy them from the middle of the camp, until they were consumed. 
-<span class="v">16&#160;</span>So, when all the men of war were consumed and dead from among the people, 
-<span class="v">17&#160;</span>Yahweh spoke to me, saying, 
-<span class="v">18&#160;</span>“You are to pass over Ar, the border of Moab, today. 
-<span class="v">19&#160;</span>When you come near the border of the children of Ammon, don’t bother them, nor contend with them; for I will not give you any of the land of the children of Ammon for a possession, because I have given it to the children of Lot for a possession.” 
-</p><p>
-<span class="v">20&#160;</span>(That also is considered a land of Rephaim. Rephaim lived there in the past, but the Ammonites call them Zamzummim, 
-<span class="v">21&#160;</span>a great people, many, and tall, as the Anakim; but Yahweh destroyed them from before Israel, and they succeeded them, and lived in their place, 
-<span class="v">22&#160;</span>as he did for the children of Esau who dwell in Seir, when he destroyed the Horites from before them; and they succeeded them, and lived in their place even to this day. 
-<span class="v">23&#160;</span>Then the Avvim, who lived in villages as far as Gaza: the Caphtorim, who came out of Caphtor, destroyed them and lived in their place.) 
-</p><p>
-<span class="v">24&#160;</span>“Rise up, take your journey, and pass over the valley of the Arnon. Behold, I have given into your hand Sihon the Amorite, king of Heshbon, and his land; begin to possess it, and contend with him in battle. 
-<span class="v">25&#160;</span>Today I will begin to put the dread of you and the fear of you on the peoples who are under the whole sky, who shall hear the report of you, and shall tremble and be in anguish because of you.” 
-</p><p>
-<span class="v">26&#160;</span>I sent messengers out of the wilderness of Kedemoth to Sihon king of Heshbon with words of peace, saying, 
-<span class="v">27&#160;</span>“Let me pass through your land. I will go along by the highway. I will turn neither to the right hand nor to the left. 
-<span class="v">28&#160;</span>You shall sell me food for money, that I may eat; and give me water for money, that I may drink. Just let me pass through on my feet, 
-<span class="v">29&#160;</span>as the children of Esau who dwell in Seir, and the Moabites who dwell in Ar, did to me, until I pass over the Jordan into the land which Yahweh our Elohim gives us.” 
-<span class="v">30&#160;</span>But Sihon king of Heshbon would not let us pass by him, for Yahweh your Elohim hardened his spirit and made his heart obstinate, that he might deliver him into your hand, as it is today. 
-</p><p>
-<span class="v">31&#160;</span>Yahweh said to me, “Behold, I have begun to deliver up Sihon and his land before you. Begin to possess, that you may inherit his land.” 
-<span class="v">32&#160;</span>Then Sihon came out against us, he and all his people, to battle at Jahaz. 
-<span class="v">33&#160;</span>Yahweh our Elohim delivered him up before us; and we struck him, his sons, and all his people. 
-<span class="v">34&#160;</span>We took all his cities at that time, and utterly destroyed every inhabited city, with the women and the little ones. We left no one remaining. 
-<span class="v">35&#160;</span>Only the livestock we took for plunder for ourselves, with the plunder of the cities which we had taken. 
-<span class="v">36&#160;</span>From Aroer, which is on the edge of the valley of the Arnon, and the city that is in the valley, even to Gilead, there was not a city too high for us. Yahweh our Elohim delivered up all before us. 
-<span class="v">37&#160;</span>Only to the land of the children of Ammon you didn’t come near: all the banks of the river Jabbok, and the cities of the hill country, and wherever Yahweh our Elohim forbade us. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Then we turned, and went up the way to Bashan. Og the king of Bashan came out against us, he and all his people, to battle at Edrei. 
-<span class="v">2&#160;</span>Yahweh said to me, “Don’t fear him; for I have delivered him, with all his people and his land, into your hand. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
-</p><p>
-<span class="v">3&#160;</span>So Yahweh our Elohim also delivered into our hand Og, the king of Bashan, and all his people. We struck him until no one was left to him remaining. 
-<span class="v">4&#160;</span>We took all his cities at that time. There was not a city which we didn’t take from them: sixty cities, all the region of Argob, the kingdom of Og in Bashan. 
-<span class="v">5&#160;</span>All these were cities fortified with high walls, gates, and bars, in addition to a great many villages without walls. 
-<span class="v">6&#160;</span>We utterly destroyed them, as we did to Sihon king of Heshbon, utterly destroying every inhabited city, with the women and the little ones. 
-<span class="v">7&#160;</span>But all the livestock, and the plunder of the cities, we took for plunder for ourselves. 
-<span class="v">8&#160;</span>We took the land at that time out of the hand of the two kings of the Amorites who were beyond the Jordan, from the valley of the Arnon to Mount Hermon. 
-<span class="v">9&#160;</span>(The Sidonians call Hermon Sirion, and the Amorites call it Senir.) 
-<span class="v">10&#160;</span>We took all the cities of the plain, and all Gilead, and all Bashan, to Salecah and Edrei, cities of the kingdom of Og in Bashan. 
-<span class="v">11&#160;</span>(For only Og king of Bashan remained of the remnant of the Rephaim. Behold, his bedstead was a bedstead of iron. Isn’t it in Rabbah of the children of Ammon? Nine cubits<span class="f">+ \fr 3:11 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> was its length, and four cubits its width, after the cubit of a man.) 
-<span class="v">12&#160;</span>This land we took in possession at that time: from Aroer, which is by the valley of the Arnon, and half the hill country of Gilead with its cities, I gave to the Reubenites and to the Gadites; 
-<span class="v">13&#160;</span>and the rest of Gilead, and all Bashan, the kingdom of Og, I gave to the half-tribe of Manasseh—all the region of Argob, even all Bashan. (The same is called the land of Rephaim. 
-<span class="v">14&#160;</span>Jair the son of Manasseh took all the region of Argob, to the border of the Geshurites and the Maacathites, and called them, even Bashan, after his own name, Havvoth Jair, to this day.) 
-<span class="v">15&#160;</span>I gave Gilead to Machir. 
-<span class="v">16&#160;</span>To the Reubenites and to the Gadites I gave from Gilead even to the valley of the Arnon, the middle of the valley, and its border, even to the river Jabbok, which is the border of the children of Ammon; 
-<span class="v">17&#160;</span>the Arabah also, and the Jordan and its border, from Chinnereth even to the sea of the Arabah, the Salt Sea, under the slopes of Pisgah eastward. 
-</p><p>
-<span class="v">18&#160;</span>I commanded you at that time, saying, “Yahweh your Elohim has given you this land to possess it. All of you men of valor shall pass over armed before your brothers, the children of Israel. 
-<span class="v">19&#160;</span>But your women, and your little ones, and your livestock, (I know that you have much livestock), shall live in your cities which I have given you, 
-<span class="v">20&#160;</span>until Yahweh gives rest to your brothers, as to you, and they also possess the land which Yahweh your Elohim gives them beyond the Jordan. Then you shall each return to his own possession, which I have given you.” 
-</p><p>
-<span class="v">21&#160;</span>I commanded Joshua at that time, saying, “Your eyes have seen all that Yahweh your Elohim has done to these two kings. So shall Yahweh do to all the kingdoms where you go over. 
-<span class="v">22&#160;</span>You shall not fear them; for Yahweh your Elohim himself fights for you.” 
-</p><p>
-<span class="v">23&#160;</span>I begged Yahweh at that time, saying, 
-<span class="v">24&#160;</span>“Lord<span class="f">+ \fr 3:24 \ft The word translated “Lord” is “Adonai.”</span> Yahweh, you have begun to show your servant your greatness, and your strong hand. For what elohim is there in heaven or in earth that can do works like yours, and mighty acts like yours? 
-<span class="v">25&#160;</span>Please let me go over and see the good land that is beyond the Jordan, that fine mountain, and Lebanon.” 
-</p><p>
-<span class="v">26&#160;</span>But Yahweh was angry with me because of you, and didn’t listen to me. Yahweh said to me, “That is enough! Speak no more to me of this matter. 
-<span class="v">27&#160;</span>Go up to the top of Pisgah, and lift up your eyes westward, and northward, and southward, and eastward, and see with your eyes; for you shall not go over this Jordan. 
-<span class="v">28&#160;</span>But commission Joshua, and encourage him, and strengthen him; for he shall go over before this people, and he shall cause them to inherit the land which you shall see.” 
-<span class="v">29&#160;</span>So we stayed in the valley near Beth Peor. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Now, Israel, listen to the statutes and to the ordinances which I teach you, to do them, that you may live and go in and possess the land which Yahweh, the Elohim of your fathers, gives you. 
-<span class="v">2&#160;</span>You shall not add to the word which I command you, neither shall you take away from it, that you may keep the commandments of Yahweh your Elohim which I command you. 
-<span class="v">3&#160;</span>Your eyes have seen what Yahweh did because of Baal Peor; for Yahweh your Elohim has destroyed all the men who followed Baal Peor from among you. 
-<span class="v">4&#160;</span>But you who were faithful to Yahweh your Elohim are all alive today. 
-<span class="v">5&#160;</span>Behold, I have taught you statutes and ordinances, even as Yahweh my Elohim commanded me, that you should do so in the middle of the land where you go in to possess it. 
-<span class="v">6&#160;</span>Keep therefore and do them; for this is your wisdom and your understanding in the sight of the peoples who shall hear all these statutes and say, “Surely this great nation is a wise and understanding people.” 
-<span class="v">7&#160;</span>For what great nation is there that has an elohim so near to them as Yahweh our Elohim is whenever we call on him? 
-<span class="v">8&#160;</span>What great nation is there that has statutes and ordinances so righteous as all this law which I set before you today? 
-</p><p>
-<span class="v">9&#160;</span>Only be careful, and keep your soul diligently, lest you forget the things which your eyes saw, and lest they depart from your heart all the days of your life; but make them known to your children and your children’s children—<span class="v">10&#160;</span>the day that you stood before Yahweh your Elohim in Horeb, when Yahweh said to me, “Assemble the people to me, and I will make them hear my words, that they may learn to fear me all the days that they live on the earth, and that they may teach their children.” 
-<span class="v">11&#160;</span>You came near and stood under the mountain. The mountain burned with fire to the heart of the sky, with darkness, cloud, and thick darkness. 
-<span class="v">12&#160;</span>Yahweh spoke to you out of the middle of the fire: you heard the voice of words, but you saw no form; you only heard a voice. 
-<span class="v">13&#160;</span>He declared to you his covenant, which he commanded you to perform, even the ten commandments. He wrote them on two stone tablets. 
-<span class="v">14&#160;</span>Yahweh commanded me at that time to teach you statutes and ordinances, that you might do them in the land where you go over to possess it. 
-<span class="v">15&#160;</span>Be very careful, for you saw no kind of form on the day that Yahweh spoke to you in Horeb out of the middle of the fire, 
-<span class="v">16&#160;</span>lest you corrupt yourselves, and make yourself a carved image in the form of any figure, the likeness of male or female, 
-<span class="v">17&#160;</span>the likeness of any animal that is on the earth, the likeness of any winged bird that flies in the sky, 
-<span class="v">18&#160;</span>the likeness of anything that creeps on the ground, the likeness of any fish that is in the water under the earth; 
-<span class="v">19&#160;</span>and lest you lift up your eyes to the sky, and when you see the sun and the moon and the stars, even all the army of the sky, you are drawn away and worship them, and serve them, which Yahweh your Elohim has allotted to all the peoples under the whole sky. 
-<span class="v">20&#160;</span>But Yahweh has taken you, and brought you out of the iron furnace, out of Egypt, to be to him a people of inheritance, as it is today. 
-<span class="v">21&#160;</span>Furthermore Yahweh was angry with me for your sakes, and swore that I should not go over the Jordan, and that I should not go in to that good land which Yahweh your Elohim gives you for an inheritance; 
-<span class="v">22&#160;</span>but I must die in this land. I must not go over the Jordan, but you shall go over and possess that good land. 
-<span class="v">23&#160;</span>Be careful, lest you forget the covenant of Yahweh your Elohim, which he made with you, and make yourselves a carved image in the form of anything which Yahweh your Elohim has forbidden you. 
-<span class="v">24&#160;</span>For Yahweh your Elohim is a devouring fire, a jealous Elohim. 
-<span class="v">25&#160;</span>When you father children and children’s children, and you have been long in the land, and then corrupt yourselves, and make a carved image in the form of anything, and do that which is evil in Yahweh your Elohim’s sight to provoke him to anger, 
-<span class="v">26&#160;</span>I call heaven and earth to witness against you today, that you will soon utterly perish from off the land which you go over the Jordan to possess it. You will not prolong your days on it, but will utterly be destroyed. 
-<span class="v">27&#160;</span>Yahweh will scatter you among the peoples, and you will be left few in number among the nations where Yahweh will lead you away. 
-<span class="v">28&#160;</span>There you will serve elohims, the work of men’s hands, wood and stone, which neither see, nor hear, nor eat, nor smell. 
-<span class="v">29&#160;</span>But from there you shall seek Yahweh your Elohim, and you will find him when you search after him with all your heart and with all your soul. 
-<span class="v">30&#160;</span>When you are in oppression, and all these things have come on you, in the latter days you shall return to Yahweh your Elohim and listen to his voice. 
-<span class="v">31&#160;</span>For Yahweh your Elohim is a merciful Elohim. He will not fail you nor destroy you, nor forget the covenant of your fathers which he swore to them. 
-<span class="v">32&#160;</span>For ask now of the days that are past, which were before you, since the day that Elohim created man on the earth, and from the one end of the sky to the other, whether there has been anything as great as this thing is, or has been heard like it? 
-<span class="v">33&#160;</span>Did a people ever hear the voice of Elohim speaking out of the middle of the fire, as you have heard, and live? 
-<span class="v">34&#160;</span>Or has Elohim tried to go and take a nation for himself from among another nation, by trials, by signs, by wonders, by war, by a mighty hand, by an outstretched arm, and by great terrors, according to all that Yahweh your Elohim did for you in Egypt before your eyes? 
-<span class="v">35&#160;</span>It was shown to you so that you might know that Yahweh is Elohim. There is no one else besides him. 
-<span class="v">36&#160;</span>Out of heaven he made you to hear his voice, that he might instruct you. On earth he made you to see his great fire; and you heard his words out of the middle of the fire. 
-<span class="v">37&#160;</span>Because he loved your fathers, therefore he chose their offspring after them, and brought you out with his presence, with his great power, out of Egypt; 
-<span class="v">38&#160;</span>to drive out nations from before you greater and mightier than you, to bring you in, to give you their land for an inheritance, as it is today. 
-<span class="v">39&#160;</span>Know therefore today, and take it to heart, that Yahweh himself is Elohim in heaven above and on the earth beneath. There is no one else. 
-<span class="v">40&#160;</span>You shall keep his statutes and his commandments which I command you today, that it may go well with you and with your children after you, and that you may prolong your days in the land which Yahweh your Elohim gives you for all time. 
-</p><p>
-<span class="v">41&#160;</span>Then Moses set apart three cities beyond the Jordan toward the sunrise, 
-<span class="v">42&#160;</span>that the man slayer might flee there, who kills his neighbor unintentionally and didn’t hate him in time past, and that fleeing to one of these cities he might live: 
-<span class="v">43&#160;</span>Bezer in the wilderness, in the plain country, for the Reubenites; and Ramoth in Gilead for the Gadites; and Golan in Bashan for the Manassites. 
-</p><p>
-<span class="v">44&#160;</span>This is the law which Moses set before the children of Israel. 
-<span class="v">45&#160;</span>These are the testimonies, and the statutes, and the ordinances which Moses spoke to the children of Israel when they came out of Egypt, 
-<span class="v">46&#160;</span>beyond the Jordan, in the valley opposite Beth Peor, in the land of Sihon king of the Amorites, who lived at Heshbon, whom Moses and the children of Israel struck when they came out of Egypt. 
-<span class="v">47&#160;</span>They took possession of his land and the land of Og king of Bashan, the two kings of the Amorites, who were beyond the Jordan toward the sunrise; 
-<span class="v">48&#160;</span>from Aroer, which is on the edge of the valley of the Arnon, even to Mount Zion (also called Hermon), 
-<span class="v">49&#160;</span>and all the Arabah beyond the Jordan eastward, even to the sea of the Arabah, under the slopes of Pisgah. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Moses called to all Israel, and said to them, “Hear, Israel, the statutes and the ordinances which I speak in your ears today, that you may learn them, and observe to do them.” 
-<span class="v">2&#160;</span>Yahweh our Elohim made a covenant with us in Horeb. 
-<span class="v">3&#160;</span>Yahweh didn’t make this covenant with our fathers, but with us, even us, who are all of us here alive today. 
-<span class="v">4&#160;</span>Yahweh spoke with you face to face on the mountain out of the middle of the fire, 
-<span class="v">5&#160;</span>(I stood between Yahweh and you at that time, to show you Yahweh’s word; for you were afraid because of the fire, and didn’t go up onto the mountain) saying, 
-</p><p class="m">
-<span class="v">6&#160;</span>“I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
-</p><p>
-<span class="v">7&#160;</span>“You shall have no other elohims before me. 
-</p><p>
-<span class="v">8&#160;</span>“You shall not make a carved image for yourself—any likeness of what is in heaven above, or what is in the earth beneath, or that is in the water under the earth. 
-<span class="v">9&#160;</span>You shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children and on the third and on the fourth generation of those who hate me 
-<span class="v">10&#160;</span>and showing loving kindness to thousands of those who love me and keep my commandments. 
-</p><p>
-<span class="v">11&#160;</span>“You shall not misuse the name of Yahweh your Elohim;<span class="f">+ \fr 5:11 \ft or, You shall not take the name of Yahweh your Elohim in vain;</span> for Yahweh will not hold him guiltless who misuses his name. 
-</p><p>
-<span class="v">12&#160;</span>“Observe the Sabbath day, to keep it set-apart, as Yahweh your Elohim commanded you. 
-<span class="v">13&#160;</span>You shall labor six days, and do all your work; 
-<span class="v">14&#160;</span>but the seventh day is a Sabbath to Yahweh your Elohim, in which you shall not do any work—neither you, nor your son, nor your daughter, nor your male servant, nor your female servant, nor your ox, nor your donkey, nor any of your livestock, nor your stranger who is within your gates; that your male servant and your female servant may rest as well as you. 
-<span class="v">15&#160;</span>You shall remember that you were a servant in the land of Egypt, and Yahweh your Elohim brought you out of there by a mighty hand and by an outstretched arm. Therefore Yahweh your Elohim commanded you to keep the Sabbath day. 
-</p><p>
-<span class="v">16&#160;</span>“Honor your father and your mother, as Yahweh your Elohim commanded you, that your days may be long and that it may go well with you in the land which Yahweh your Elohim gives you. 
-</p><p>
-<span class="v">17&#160;</span>“You shall not murder. 
-</p><p>
-<span class="v">18&#160;</span>“You shall not commit adultery. 
-</p><p>
-<span class="v">19&#160;</span>“You shall not steal. 
-</p><p>
-<span class="v">20&#160;</span>“You shall not give false testimony against your neighbor. 
-</p><p>
-<span class="v">21&#160;</span>“You shall not covet your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
-</p><p>
-<span class="v">22&#160;</span>Yahweh spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
-<span class="v">23&#160;</span>When you heard the voice out of the middle of the darkness, while the mountain was burning with fire, you came near to me, even all the heads of your tribes, and your elders; 
-<span class="v">24&#160;</span>and you said, “Behold, Yahweh our Elohim has shown us his glory and his greatness, and we have heard his voice out of the middle of the fire. We have seen today that Elohim does speak with man, and he lives. 
-<span class="v">25&#160;</span>Now therefore, why should we die? For this great fire will consume us. If we hear Yahweh our Elohim’s voice any more, then we shall die. 
-<span class="v">26&#160;</span>For who is there of all flesh who has heard the voice of the living Elohim speaking out of the middle of the fire, as we have, and lived? 
-<span class="v">27&#160;</span>Go near, and hear all that Yahweh our Elohim shall say, and tell us all that Yahweh our Elohim tells you; and we will hear it, and do it.” 
-</p><p>
-<span class="v">28&#160;</span>Yahweh heard the voice of your words when you spoke to me; and Yahweh said to me, “I have heard the voice of the words of this people which they have spoken to you. They have well said all that they have spoken. 
-<span class="v">29&#160;</span>Oh that there were such a heart in them that they would fear me and keep all my commandments always, that it might be well with them and with their children forever! 
-</p><p>
-<span class="v">30&#160;</span>“Go tell them, ‘Return to your tents.’ 
-<span class="v">31&#160;</span>But as for you, stand here by me, and I will tell you all the commandments, and the statutes, and the ordinances, which you shall teach them, that they may do them in the land which I give them to possess.” 
-</p><p>
-<span class="v">32&#160;</span>You shall observe to do therefore as Yahweh your Elohim has commanded you. You shall not turn away to the right hand or to the left. 
-<span class="v">33&#160;</span>You shall walk in all the way which Yahweh your Elohim has commanded you, that you may live and that it may be well with you, and that you may prolong your days in the land which you shall possess. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the commandments, the statutes, and the ordinances, which Yahweh your Elohim commanded to teach you, that you might do them in the land that you go over to possess; 
-<span class="v">2&#160;</span>that you might fear Yahweh your Elohim, to keep all his statutes and his commandments, which I command you—you, your son, and your son’s son, all the days of your life; and that your days may be prolonged. 
-<span class="v">3&#160;</span>Hear therefore, Israel, and observe to do it, that it may be well with you, and that you may increase mightily, as Yahweh, the Elohim of your fathers, has promised to you, in a land flowing with milk and honey. 
-</p><p>
-<span class="v">4&#160;</span>Hear, Israel: Yahweh is our Elohim. Yahweh is one. 
-<span class="v">5&#160;</span>You shall love Yahweh your Elohim with all your heart, with all your soul, and with all your might. 
-<span class="v">6&#160;</span>These words, which I command you today, shall be on your heart; 
-<span class="v">7&#160;</span>and you shall teach them diligently to your children, and shall talk of them when you sit in your house, and when you walk by the way, and when you lie down, and when you rise up. 
-<span class="v">8&#160;</span>You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
-<span class="v">9&#160;</span>You shall write them on the door posts of your house and on your gates. 
-</p><p>
-<span class="v">10&#160;</span>It shall be, when Yahweh your Elohim brings you into the land which he swore to your fathers, to Abraham, to Isaac, and to Jacob, to give you, great and goodly cities which you didn’t build, 
-<span class="v">11&#160;</span>and houses full of all good things which you didn’t fill, and cisterns dug out which you didn’t dig, vineyards and olive trees which you didn’t plant, and you shall eat and be full; 
-<span class="v">12&#160;</span>then beware lest you forget Yahweh, who brought you out of the land of Egypt, out of the house of bondage. 
-<span class="v">13&#160;</span>You shall fear Yahweh your Elohim; and you shall serve him, and shall swear by his name. 
-<span class="v">14&#160;</span>You shall not go after other elohims, of the elohims of the peoples who are around you, 
-<span class="v">15&#160;</span>for Yahweh your Elohim among you is a jealous Elohim, lest the anger of Yahweh your Elohim be kindled against you, and he destroy you from off the face of the earth. 
-<span class="v">16&#160;</span>You shall not tempt Yahweh your Elohim, as you tempted him in Massah. 
-<span class="v">17&#160;</span>You shall diligently keep the commandments of Yahweh your Elohim, and his testimonies, and his statutes, which he has commanded you. 
-<span class="v">18&#160;</span>You shall do that which is right and good in Yahweh’s sight, that it may be well with you and that you may go in and possess the good land which Yahweh swore to your fathers, 
-<span class="v">19&#160;</span>to thrust out all your enemies from before you, as Yahweh has spoken. 
-</p><p>
-<span class="v">20&#160;</span>When your son asks you in time to come, saying, “What do the testimonies, the statutes, and the ordinances, which Yahweh our Elohim has commanded you mean?” 
-<span class="v">21&#160;</span>then you shall tell your son, “We were Pharaoh’s slaves in Egypt. Yahweh brought us out of Egypt with a mighty hand; 
-<span class="v">22&#160;</span>and Yahweh showed great and awesome signs and wonders on Egypt, on Pharaoh, and on all his house, before our eyes; 
-<span class="v">23&#160;</span>and he brought us out from there, that he might bring us in, to give us the land which he swore to our fathers. 
-<span class="v">24&#160;</span>Yahweh commanded us to do all these statutes, to fear Yahweh our Elohim, for our good always, that he might preserve us alive, as we are today. 
-<span class="v">25&#160;</span>It shall be righteousness to us, if we observe to do all these commandments before Yahweh our Elohim, as he has commanded us.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>When Yahweh your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
-<span class="v">2&#160;</span>and when Yahweh your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
-<span class="v">3&#160;</span>You shall not make marriages with them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
-<span class="v">4&#160;</span>For that would turn away your sons from following me, that they may serve other elohims. So Yahweh’s anger would be kindled against you, and he would destroy you quickly. 
-<span class="v">5&#160;</span>But you shall deal with them like this: you shall break down their altars, dash their pillars in pieces, cut down their Asherah poles, and burn their engraved images with fire. 
-<span class="v">6&#160;</span>For you are a set-apart people to Yahweh your Elohim. Yahweh your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
-<span class="v">7&#160;</span>Yahweh didn’t set his love on you nor choose you, because you were more in number than any people; for you were the fewest of all peoples; 
-<span class="v">8&#160;</span>but because Yahweh loves you, and because he desires to keep the oath which he swore to your fathers, Yahweh has brought you out with a mighty hand and redeemed you out of the house of bondage, from the hand of Pharaoh king of Egypt. 
-<span class="v">9&#160;</span>Know therefore that Yahweh your Elohim himself is Elohim, the faithful Elohim, who keeps covenant and loving kindness to a thousand generations with those who love him and keep his commandments, 
-<span class="v">10&#160;</span>and repays those who hate him to their face, to destroy them. He will not be slack to him who hates him. He will repay him to his face. 
-<span class="v">11&#160;</span>You shall therefore keep the commandments, the statutes, and the ordinances which I command you today, to do them. 
-<span class="v">12&#160;</span>It shall happen, because you listen to these ordinances and keep and do them, that Yahweh your Elohim will keep with you the covenant and the loving kindness which he swore to your fathers. 
-<span class="v">13&#160;</span>He will love you, bless you, and multiply you. He will also bless the fruit of your body and the fruit of your ground, your grain and your new wine and your oil, the increase of your livestock and the young of your flock, in the land which he swore to your fathers to give you. 
-<span class="v">14&#160;</span>You will be blessed above all peoples. There won’t be male or female barren among you, or among your livestock. 
-<span class="v">15&#160;</span>Yahweh will take away from you all sickness; and he will put none of the evil diseases of Egypt, which you know, on you, but will lay them on all those who hate you. 
-<span class="v">16&#160;</span>You shall consume all the peoples whom Yahweh your Elohim shall deliver to you. Your eye shall not pity them. You shall not serve their elohims; for that would be a snare to you. 
-<span class="v">17&#160;</span>If you shall say in your heart, “These nations are more than I; how can I dispossess them?” 
-<span class="v">18&#160;</span>you shall not be afraid of them. You shall remember well what Yahweh your Elohim did to Pharaoh and to all Egypt: 
-<span class="v">19&#160;</span>the great trials which your eyes saw, the signs, the wonders, the mighty hand, and the outstretched arm, by which Yahweh your Elohim brought you out. So shall Yahweh your Elohim do to all the peoples of whom you are afraid. 
-<span class="v">20&#160;</span>Moreover Yahweh your Elohim will send the hornet among them, until those who are left, and hide themselves, perish from before you. 
-<span class="v">21&#160;</span>You shall not be scared of them; for Yahweh your Elohim is among you, a great and awesome Elohim. 
-<span class="v">22&#160;</span>Yahweh your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
-<span class="v">23&#160;</span>But Yahweh your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
-<span class="v">24&#160;</span>He will deliver their kings into your hand, and you shall make their name perish from under the sky. No one will be able to stand before you until you have destroyed them. 
-<span class="v">25&#160;</span>You shall burn the engraved images of their elohims with fire. You shall not covet the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
-<span class="v">26&#160;</span>You shall not bring an abomination into your house and become a devoted thing like it. You shall utterly detest it. You shall utterly abhor it; for it is a devoted thing. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>You shall observe to do all the commandments which I command you today, that you may live, and multiply, and go in and possess the land which Yahweh swore to your fathers. 
-<span class="v">2&#160;</span>You shall remember all the way which Yahweh your Elohim has led you these forty years in the wilderness, that he might humble you, to test you, to know what was in your heart, whether you would keep his commandments or not. 
-<span class="v">3&#160;</span>He humbled you, allowed you to be hungry, and fed you with manna, which you didn’t know, neither did your fathers know, that he might teach you that man does not live by bread only, but man lives by every word that proceeds out of Yahweh’s mouth. 
-<span class="v">4&#160;</span>Your clothing didn’t grow old on you, neither did your foot swell, these forty years. 
-<span class="v">5&#160;</span>You shall consider in your heart that as a man disciplines his son, so Yahweh your Elohim disciplines you. 
-<span class="v">6&#160;</span>You shall keep the commandments of Yahweh your Elohim, to walk in his ways, and to fear him. 
-<span class="v">7&#160;</span>For Yahweh your Elohim brings you into a good land, a land of brooks of water, of springs, and underground water flowing into valleys and hills; 
-<span class="v">8&#160;</span>a land of wheat, barley, vines, fig trees, and pomegranates; a land of olive trees and honey; 
-<span class="v">9&#160;</span>a land in which you shall eat bread without scarcity, you shall not lack anything in it; a land whose stones are iron, and out of whose hills you may dig copper. 
-<span class="v">10&#160;</span>You shall eat and be full, and you shall bless Yahweh your Elohim for the good land which he has given you. 
-</p><p>
-<span class="v">11&#160;</span>Beware lest you forget Yahweh your Elohim, in not keeping his commandments, his ordinances, and his statutes, which I command you today; 
-<span class="v">12&#160;</span>lest, when you have eaten and are full, and have built fine houses and lived in them; 
-<span class="v">13&#160;</span>and when your herds and your flocks multiply, and your silver and your gold is multiplied, and all that you have is multiplied; 
-<span class="v">14&#160;</span>then your heart might be lifted up, and you forget Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage; 
-<span class="v">15&#160;</span>who led you through the great and terrible wilderness, with venomous snakes and scorpions, and thirsty ground where there was no water; who poured water for you out of the rock of flint; 
-<span class="v">16&#160;</span>who fed you in the wilderness with manna, which your fathers didn’t know, that he might humble you, and that he might prove you, to do you good at your latter end; 
-<span class="v">17&#160;</span>and lest you say in your heart, “My power and the might of my hand has gotten me this wealth.” 
-<span class="v">18&#160;</span>But you shall remember Yahweh your Elohim, for it is he who gives you power to get wealth, that he may establish his covenant which he swore to your fathers, as it is today. 
-</p><p>
-<span class="v">19&#160;</span>It shall be, if you shall forget Yahweh your Elohim, and walk after other elohims, and serve them and worship them, I testify against you today that you shall surely perish. 
-<span class="v">20&#160;</span>As the nations that Yahweh makes to perish before you, so you shall perish, because you wouldn’t listen to Yahweh your Elohim’s voice. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Hear, Israel! You are to pass over the Jordan today, to go in to dispossess nations greater and mightier than yourself, cities great and fortified up to the sky, 
-<span class="v">2&#160;</span>a people great and tall, the sons of the Anakim, whom you know, and of whom you have heard say, “Who can stand before the sons of Anak?” 
-<span class="v">3&#160;</span>Know therefore today that Yahweh your Elohim is he who goes over before you as a devouring fire. He will destroy them and he will bring them down before you. So you shall drive them out and make them perish quickly, as Yahweh has spoken to you. 
-</p><p>
-<span class="v">4&#160;</span>Don’t say in your heart, after Yahweh your Elohim has thrust them out from before you, “For my righteousness Yahweh has brought me in to possess this land;” because Yahweh drives them out before you because of the wickedness of these nations. 
-<span class="v">5&#160;</span>Not for your righteousness or for the uprightness of your heart do you go in to possess their land; but for the wickedness of these nations Yahweh your Elohim does drive them out from before you, and that he may establish the word which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob. 
-<span class="v">6&#160;</span>Know therefore that Yahweh your Elohim doesn’t give you this good land to possess for your righteousness, for you are a stiff-necked people. 
-<span class="v">7&#160;</span>Remember, and don’t forget, how you provoked Yahweh your Elohim to wrath in the wilderness. From the day that you left the land of Egypt until you came to this place, you have been rebellious against Yahweh. 
-<span class="v">8&#160;</span>Also in Horeb you provoked Yahweh to wrath, and Yahweh was angry with you to destroy you. 
-<span class="v">9&#160;</span>When I had gone up onto the mountain to receive the stone tablets, even the tablets of the covenant which Yahweh made with you, then I stayed on the mountain forty days and forty nights. I neither ate bread nor drank water. 
-<span class="v">10&#160;</span>Yahweh delivered to me the two stone tablets written with Elohim’s finger. On them were all the words which Yahweh spoke with you on the mountain out of the middle of the fire in the day of the assembly. 
-</p><p>
-<span class="v">11&#160;</span>It came to pass at the end of forty days and forty nights that Yahweh gave me the two stone tablets, even the tablets of the covenant. 
-<span class="v">12&#160;</span>Yahweh said to me, “Arise, get down quickly from here; for your people whom you have brought out of Egypt have corrupted themselves. They have quickly turned away from the way which I commanded them. They have made a molten image for themselves!” 
-</p><p>
-<span class="v">13&#160;</span>Furthermore Yahweh spoke to me, saying, “I have seen these people, and behold, they are a stiff-necked people. 
-<span class="v">14&#160;</span>Leave me alone, that I may destroy them, and blot out their name from under the sky; and I will make of you a nation mightier and greater than they.” 
-</p><p>
-<span class="v">15&#160;</span>So I turned and came down from the mountain, and the mountain was burning with fire. The two tablets of the covenant were in my two hands. 
-<span class="v">16&#160;</span>I looked, and behold, you had sinned against Yahweh your Elohim. You had made yourselves a molded calf. You had quickly turned away from the way which Yahweh had commanded you. 
-<span class="v">17&#160;</span>I took hold of the two tablets, and threw them out of my two hands, and broke them before your eyes. 
-<span class="v">18&#160;</span>I fell down before Yahweh, as at the first, forty days and forty nights. I neither ate bread nor drank water, because of all your sin which you sinned, in doing that which was evil in Yahweh’s sight, to provoke him to anger. 
-<span class="v">19&#160;</span>For I was afraid of the anger and hot displeasure with which Yahweh was angry against you to destroy you. But Yahweh listened to me that time also. 
-<span class="v">20&#160;</span>Yahweh was angry enough with Aaron to destroy him. I prayed for Aaron also at the same time. 
-<span class="v">21&#160;</span>I took your sin, the calf which you had made, and burned it with fire, and crushed it, grinding it very small, until it was as fine as dust. I threw its dust into the brook that descended out of the mountain. 
-<span class="v">22&#160;</span>At Taberah, at Massah, and at Kibroth Hattaavah you provoked Yahweh to wrath. 
-<span class="v">23&#160;</span>When Yahweh sent you from Kadesh Barnea, saying, “Go up and possess the land which I have given you,” you rebelled against the commandment of Yahweh your Elohim, and you didn’t believe him or listen to his voice. 
-<span class="v">24&#160;</span>You have been rebellious against Yahweh from the day that I knew you. 
-<span class="v">25&#160;</span>So I fell down before Yahweh the forty days and forty nights that I fell down, because Yahweh had said he would destroy you. 
-<span class="v">26&#160;</span>I prayed to Yahweh, and said, “Lord Yahweh, don’t destroy your people and your inheritance that you have redeemed through your greatness, that you have brought out of Egypt with a mighty hand. 
-<span class="v">27&#160;</span>Remember your servants, Abraham, Isaac, and Jacob. Don’t look at the stubbornness of this people, nor at their wickedness, nor at their sin, 
-<span class="v">28&#160;</span>lest the land you brought us out from say, ‘Because Yahweh was not able to bring them into the land which he promised to them, and because he hated them, he has brought them out to kill them in the wilderness.’ 
-<span class="v">29&#160;</span>Yet they are your people and your inheritance, which you brought out by your great power and by your outstretched arm.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>At that time Yahweh said to me, “Cut two stone tablets like the first, and come up to me onto the mountain, and make an ark of wood. 
-<span class="v">2&#160;</span>I will write on the tablets the words that were on the first tablets which you broke, and you shall put them in the ark.” 
-<span class="v">3&#160;</span>So I made an ark of acacia wood, and cut two stone tablets like the first, and went up onto the mountain, having the two tablets in my hand. 
-<span class="v">4&#160;</span>He wrote on the tablets, according to the first writing, the ten commandments, which Yahweh spoke to you on the mountain out of the middle of the fire in the day of the assembly; and Yahweh gave them to me. 
-<span class="v">5&#160;</span>I turned and came down from the mountain, and put the tablets in the ark which I had made; and there they are as Yahweh commanded me. 
-</p><p>
-<span class="v">6&#160;</span>(The children of Israel traveled from Beeroth Bene Jaakan to Moserah. There Aaron died, and there he was buried; and Eleazar his son ministered in the priest’s office in his place. 
-<span class="v">7&#160;</span>From there they traveled to Gudgodah; and from Gudgodah to Jotbathah, a land of brooks of water. 
-<span class="v">8&#160;</span>At that time Yahweh set apart the tribe of Levi to bear the ark of Yahweh’s covenant, to stand before Yahweh to minister to him, and to bless in his name, to this day. 
-<span class="v">9&#160;</span>Therefore Levi has no portion nor inheritance with his brothers; Yahweh is his inheritance, according as Yahweh your Elohim spoke to him.) 
-</p><p>
-<span class="v">10&#160;</span>I stayed on the mountain, as at the first time, forty days and forty nights; and Yahweh listened to me that time also. Yahweh would not destroy you. 
-<span class="v">11&#160;</span>Yahweh said to me, “Arise, take your journey before the people; and they shall go in and possess the land which I swore to their fathers to give to them.” 
-</p><p>
-<span class="v">12&#160;</span>Now, Israel, what does Yahweh your Elohim require of you, but to fear Yahweh your Elohim, to walk in all his ways, to love him, and to serve Yahweh your Elohim with all your heart and with all your soul, 
-<span class="v">13&#160;</span>to keep Yahweh’s commandments and statutes, which I command you today for your good? 
-<span class="v">14&#160;</span>Behold, to Yahweh your Elohim belongs heaven, the heaven of heavens, and the earth, with all that is therein. 
-<span class="v">15&#160;</span>Only Yahweh had a delight in your fathers to love them, and he chose their offspring after them, even you above all peoples, as it is today. 
-<span class="v">16&#160;</span>Circumcise therefore the foreskin of your heart, and be no more stiff-necked. 
-<span class="v">17&#160;</span>For Yahweh your Elohim, he is Elohim of elohims and Lord of lords, the great Elohim, the mighty, and the awesome, who doesn’t respect persons or take bribes. 
-<span class="v">18&#160;</span>He executes justice for the fatherless and widow and loves the foreigner in giving him food and clothing. 
-<span class="v">19&#160;</span>Therefore love the foreigner, for you were foreigners in the land of Egypt. 
-<span class="v">20&#160;</span>You shall fear Yahweh your Elohim. You shall serve him. You shall cling to him, and you shall swear by his name. 
-<span class="v">21&#160;</span>He is your praise, and he is your Elohim, who has done for you these great and awesome things which your eyes have seen. 
-<span class="v">22&#160;</span>Your fathers went down into Egypt with seventy persons; and now Yahweh your Elohim has made you as the stars of the sky for multitude. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Therefore you shall love Yahweh your Elohim, and keep his instructions, his statutes, his ordinances, and his commandments, always. 
-<span class="v">2&#160;</span>Know this day—for I don’t speak with your children who have not known, and who have not seen the chastisement of Yahweh your Elohim, his greatness, his mighty hand, his outstretched arm, 
-<span class="v">3&#160;</span>his signs, and his works, which he did in the middle of Egypt to Pharaoh the king of Egypt, and to all his land; 
-<span class="v">4&#160;</span>and what he did to the army of Egypt, to their horses, and to their chariots; how he made the water of the Red Sea to overflow them as they pursued you, and how Yahweh has destroyed them to this day; 
-<span class="v">5&#160;</span>and what he did to you in the wilderness until you came to this place; 
-<span class="v">6&#160;</span>and what he did to Dathan and Abiram, the sons of Eliab, the son of Reuben—how the earth opened its mouth and swallowed them up, with their households, their tents, and every living thing that followed them, in the middle of all Israel; 
-<span class="v">7&#160;</span>but your eyes have seen all of Yahweh’s great work which he did. 
-</p><p>
-<span class="v">8&#160;</span>Therefore you shall keep the entire commandment which I command you today, that you may be strong, and go in and possess the land that you go over to possess; 
-<span class="v">9&#160;</span>and that you may prolong your days in the land which Yahweh swore to your fathers to give to them and to their offspring, a land flowing with milk and honey. 
-<span class="v">10&#160;</span>For the land, where you go in to possess isn’t like the land of Egypt that you came out of, where you sowed your seed and watered it with your foot, as a garden of herbs; 
-<span class="v">11&#160;</span>but the land that you go over to possess is a land of hills and valleys which drinks water from the rain of the sky, 
-<span class="v">12&#160;</span>a land which Yahweh your Elohim cares for. Yahweh your Elohim’s eyes are always on it, from the beginning of the year even to the end of the year. 
-<span class="v">13&#160;</span>It shall happen, if you shall listen diligently to my commandments which I command you today, to love Yahweh your Elohim, and to serve him with all your heart and with all your soul, 
-<span class="v">14&#160;</span>that I will give the rain for your land in its season, the early rain and the latter rain, that you may gather in your grain, your new wine, and your oil. 
-<span class="v">15&#160;</span>I will give grass in your fields for your livestock, and you shall eat and be full. 
-<span class="v">16&#160;</span>Be careful, lest your heart be deceived, and you turn away to serve other elohims and worship them; 
-<span class="v">17&#160;</span>and Yahweh’s anger be kindled against you, and he shut up the sky so that there is no rain, and the land doesn’t yield its fruit; and you perish quickly from off the good land which Yahweh gives you. 
-<span class="v">18&#160;</span>Therefore you shall lay up these words of mine in your heart and in your soul. You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
-<span class="v">19&#160;</span>You shall teach them to your children, talking of them when you sit in your house, when you walk by the way, when you lie down, and when you rise up. 
-<span class="v">20&#160;</span>You shall write them on the door posts of your house and on your gates; 
-<span class="v">21&#160;</span>that your days and your children’s days may be multiplied in the land which Yahweh swore to your fathers to give them, as the days of the heavens above the earth. 
-<span class="v">22&#160;</span>For if you shall diligently keep all these commandments which I command you—to do them, to love Yahweh your Elohim, to walk in all his ways, and to cling to him—<span class="v">23&#160;</span>then Yahweh will drive out all these nations from before you, and you shall dispossess nations greater and mightier than yourselves. 
-<span class="v">24&#160;</span>Every place on which the sole of your foot treads shall be yours: from the wilderness and Lebanon, from the river, the river Euphrates, even to the western sea shall be your border. 
-<span class="v">25&#160;</span>No man will be able to stand before you. Yahweh your Elohim will lay the fear of you and the dread of you on all the land that you tread on, as he has spoken to you. 
-<span class="v">26&#160;</span>Behold, I set before you today a blessing and a curse: 
-<span class="v">27&#160;</span>the blessing, if you listen to the commandments of Yahweh your Elohim, which I command you today; 
-<span class="v">28&#160;</span>and the curse, if you do not listen to the commandments of Yahweh your Elohim, but turn away out of the way which I command you today, to go after other elohims which you have not known. 
-<span class="v">29&#160;</span>It shall happen, when Yahweh your Elohim brings you into the land that you go to possess, that you shall set the blessing on Mount Gerizim, and the curse on Mount Ebal. 
-<span class="v">30&#160;</span>Aren’t they beyond the Jordan, behind the way of the going down of the sun, in the land of the Canaanites who dwell in the Arabah near Gilgal, beside the oaks of Moreh? 
-<span class="v">31&#160;</span>For you are to pass over the Jordan to go in to possess the land which Yahweh your Elohim gives you, and you shall possess it and dwell in it. 
-<span class="v">32&#160;</span>You shall observe to do all the statutes and the ordinances which I set before you today. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>These are the statutes and the ordinances which you shall observe to do in the land which Yahweh, the Elohim of your fathers, has given you to possess all the days that you live on the earth. 
-<span class="v">2&#160;</span>You shall surely destroy all the places in which the nations that you shall dispossess served their elohims: on the high mountains, and on the hills, and under every green tree. 
-<span class="v">3&#160;</span>You shall break down their altars, dash their pillars in pieces, and burn their Asherah poles with fire. You shall cut down the engraved images of their elohims. You shall destroy their name out of that place. 
-<span class="v">4&#160;</span>You shall not do so to Yahweh your Elohim. 
-<span class="v">5&#160;</span>But to the place which Yahweh your Elohim shall choose out of all your tribes, to put his name there, you shall seek his habitation, and you shall come there. 
-<span class="v">6&#160;</span>You shall bring your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, your vows, your free will offerings, and the firstborn of your herd and of your flock there. 
-<span class="v">7&#160;</span>There you shall eat before Yahweh your Elohim, and you shall rejoice in all that you put your hand to, you and your households, in which Yahweh your Elohim has blessed you. 
-<span class="v">8&#160;</span>You shall not do all the things that we do here today, every man whatever is right in his own eyes; 
-<span class="v">9&#160;</span>for you haven’t yet come to the rest and to the inheritance which Yahweh your Elohim gives you. 
-<span class="v">10&#160;</span>But when you go over the Jordan and dwell in the land which Yahweh your Elohim causes you to inherit, and he gives you rest from all your enemies around you, so that you dwell in safety, 
-<span class="v">11&#160;</span>then it shall happen that to the place which Yahweh your Elohim shall choose, to cause his name to dwell there, there you shall bring all that I command you: your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, and all your choice vows which you vow to Yahweh. 
-<span class="v">12&#160;</span>You shall rejoice before Yahweh your Elohim—you, and your sons, your daughters, your male servants, your female servants, and the Levite who is within your gates, because he has no portion nor inheritance with you. 
-<span class="v">13&#160;</span>Be careful that you don’t offer your burnt offerings in every place that you see; 
-<span class="v">14&#160;</span>but in the place which Yahweh chooses in one of your tribes, there you shall offer your burnt offerings, and there you shall do all that I command you. 
-</p><p>
-<span class="v">15&#160;</span>Yet you may kill and eat meat within all your gates, after all the desire of your soul, according to Yahweh your Elohim’s blessing which he has given you. The unclean and the clean may eat of it, as of the gazelle and the deer. 
-<span class="v">16&#160;</span>Only you shall not eat the blood. You shall pour it out on the earth like water. 
-<span class="v">17&#160;</span>You may not eat within your gates the tithe of your grain, or of your new wine, or of your oil, or the firstborn of your herd or of your flock, nor any of your vows which you vow, nor your free will offerings, nor the wave offering of your hand; 
-<span class="v">18&#160;</span>but you shall eat them before Yahweh your Elohim in the place which Yahweh your Elohim shall choose: you, your son, your daughter, your male servant, your female servant, and the Levite who is within your gates. You shall rejoice before Yahweh your Elohim in all that you put your hand to. 
-<span class="v">19&#160;</span>Be careful that you don’t forsake the Levite as long as you live in your land. 
-</p><p>
-<span class="v">20&#160;</span>When Yahweh your Elohim enlarges your border, as he has promised you, and you say, “I want to eat meat,” because your soul desires to eat meat, you may eat meat, after all the desire of your soul. 
-<span class="v">21&#160;</span>If the place which Yahweh your Elohim shall choose to put his name is too far from you, then you shall kill of your herd and of your flock, which Yahweh has given you, as I have commanded you; and you may eat within your gates, after all the desire of your soul. 
-<span class="v">22&#160;</span>Even as the gazelle and as the deer is eaten, so you shall eat of it. The unclean and the clean may eat of it alike. 
-<span class="v">23&#160;</span>Only be sure that you don’t eat the blood; for the blood is the life. You shall not eat the life with the meat. 
-<span class="v">24&#160;</span>You shall not eat it. You shall pour it out on the earth like water. 
-<span class="v">25&#160;</span>You shall not eat it, that it may go well with you and with your children after you, when you do that which is right in Yahweh’s eyes. 
-<span class="v">26&#160;</span>Only your set-apart things which you have, and your vows, you shall take and go to the place which Yahweh shall choose. 
-<span class="v">27&#160;</span>You shall offer your burnt offerings, the meat and the blood, on Yahweh your Elohim’s altar. The blood of your sacrifices shall be poured out on Yahweh your Elohim’s altar, and you shall eat the meat. 
-<span class="v">28&#160;</span>Observe and hear all these words which I command you, that it may go well with you and with your children after you forever, when you do that which is good and right in Yahweh your Elohim’s eyes. 
-</p><p>
-<span class="v">29&#160;</span>When Yahweh your Elohim cuts off the nations from before you where you go in to dispossess them, and you dispossess them and dwell in their land, 
-<span class="v">30&#160;</span>be careful that you are not ensnared to follow them after they are destroyed from before you, and that you not inquire after their elohims, saying, “How do these nations serve their elohims? I will do likewise.” 
-<span class="v">31&#160;</span>You shall not do so to Yahweh your Elohim; for every abomination to Yahweh, which he hates, they have done to their elohims; for they even burn their sons and their daughters in the fire to their elohims. 
-<span class="v">32&#160;</span>Whatever thing I command you, that you shall observe to do. You shall not add to it, nor take away from it. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>If a prophet or a dreamer of dreams arises among you, and he gives you a sign or a wonder, 
-<span class="v">2&#160;</span>and the sign or the wonder comes to pass, of which he spoke to you, saying, “Let’s go after other elohims” (which you have not known) “and let’s serve them,” 
-<span class="v">3&#160;</span>you shall not listen to the words of that prophet, or to that dreamer of dreams; for Yahweh your Elohim is testing you, to know whether you love Yahweh your Elohim with all your heart and with all your soul. 
-<span class="v">4&#160;</span>You shall walk after Yahweh your Elohim, fear him, keep his commandments, and obey his voice. You shall serve him, and cling to him. 
-<span class="v">5&#160;</span>That prophet, or that dreamer of dreams, shall be put to death, because he has spoken rebellion against Yahweh your Elohim, who brought you out of the land of Egypt and redeemed you out of the house of bondage, to draw you aside out of the way which Yahweh your Elohim commanded you to walk in. So you shall remove the evil from among you. 
-</p><p>
-<span class="v">6&#160;</span>If your brother, the son of your mother, or your son, or your daughter, or the woman of your bosom, or your friend who is as your own soul, entices you secretly, saying, “Let’s go and serve other elohims”—which you have not known, you, nor your fathers; 
-<span class="v">7&#160;</span>of the elohims of the peoples who are around you, near to you, or far off from you, from the one end of the earth even to the other end of the earth—<span class="v">8&#160;</span>you shall not consent to him nor listen to him; neither shall your eye pity him, neither shall you spare, neither shall you conceal him; 
-<span class="v">9&#160;</span>but you shall surely kill him. Your hand shall be first on him to put him to death, and afterwards the hands of all the people. 
-<span class="v">10&#160;</span>You shall stone him to death with stones, because he has sought to draw you away from Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
-<span class="v">11&#160;</span>All Israel shall hear, and fear, and shall not do any more wickedness like this among you. 
-</p><p>
-<span class="v">12&#160;</span>If you hear about one of your cities, which Yahweh your Elohim gives you to dwell there, that 
-<span class="v">13&#160;</span>certain wicked fellows have gone out from among you and have drawn away the inhabitants of their city, saying, “Let’s go and serve other elohims,” which you have not known, 
-<span class="v">14&#160;</span>then you shall inquire, investigate, and ask diligently. Behold, if it is true, and the thing certain, that such abomination was done among you, 
-<span class="v">15&#160;</span>you shall surely strike the inhabitants of that city with the edge of the sword, destroying it utterly, with all that is therein and its livestock, with the edge of the sword. 
-<span class="v">16&#160;</span>You shall gather all its plunder into the middle of its street, and shall burn with fire the city, with all of its plunder, to Yahweh your Elohim. It shall be a heap forever. It shall not be built again. 
-<span class="v">17&#160;</span>Nothing of the devoted thing shall cling to your hand, that Yahweh may turn from the fierceness of his anger and show you mercy, and have compassion on you and multiply you, as he has sworn to your fathers, 
-<span class="v">18&#160;</span>when you listen to Yahweh your Elohim’s voice, to keep all his commandments which I command you today, to do that which is right in Yahweh your Elohim’s eyes. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>You are the children of Yahweh your Elohim. You shall not cut yourselves, nor make any baldness between your eyes for the dead. 
-<span class="v">2&#160;</span>For you are a set-apart people to Yahweh your Elohim, and Yahweh has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
-</p><p>
-<span class="v">3&#160;</span>You shall not eat any abominable thing. 
-<span class="v">4&#160;</span>These are the animals which you may eat: the ox, the sheep, the goat, 
-<span class="v">5&#160;</span>the deer, the gazelle, the roebuck, the wild goat, the ibex, the antelope, and the chamois. 
-<span class="v">6&#160;</span>Every animal that parts the hoof, and has the hoof split in two and chews the cud, among the animals, you may eat. 
-<span class="v">7&#160;</span>Nevertheless these you shall not eat of them that chew the cud, or of those who have the hoof split: the camel, the hare, and the rabbit. Because they chew the cud but don’t part the hoof, they are unclean to you. 
-<span class="v">8&#160;</span>The pig, because it has a split hoof but doesn’t chew the cud, is unclean to you. You shall not eat their meat. You shall not touch their carcasses. 
-<span class="v">9&#160;</span>These you may eat of all that are in the waters: you may eat whatever has fins and scales. 
-<span class="v">10&#160;</span>You shall not eat whatever doesn’t have fins and scales. It is unclean to you. 
-<span class="v">11&#160;</span>Of all clean birds you may eat. 
-<span class="v">12&#160;</span>But these are they of which you shall not eat: the eagle, the vulture, the osprey, 
-<span class="v">13&#160;</span>the red kite, the falcon, the kite of any kind, 
-<span class="v">14&#160;</span>every raven of any kind, 
-<span class="v">15&#160;</span>the ostrich, the owl, the seagull, the hawk of any kind, 
-<span class="v">16&#160;</span>the little owl, the great owl, the horned owl, 
-<span class="v">17&#160;</span>the pelican, the vulture, the cormorant, 
-<span class="v">18&#160;</span>the stork, the heron after its kind, the hoopoe, and the bat. 
-<span class="v">19&#160;</span>All winged creeping things are unclean to you. They shall not be eaten. 
-<span class="v">20&#160;</span>Of all clean birds you may eat. 
-</p><p>
-<span class="v">21&#160;</span>You shall not eat of anything that dies of itself. You may give it to the foreigner living among you who is within your gates, that he may eat it; or you may sell it to a foreigner; for you are a set-apart people to Yahweh your Elohim. 
-</p><p>You shall not boil a young goat in its mother’s milk. 
-</p><p>
-<span class="v">22&#160;</span>You shall surely tithe all the increase of your seed, that which comes out of the field year by year. 
-<span class="v">23&#160;</span>You shall eat before Yahweh your Elohim, in the place which he chooses to cause his name to dwell, the tithe of your grain, of your new wine, and of your oil, and the firstborn of your herd and of your flock; that you may learn to fear Yahweh your Elohim always. 
-<span class="v">24&#160;</span>If the way is too long for you, so that you are not able to carry it because the place which Yahweh your Elohim shall choose to set his name there is too far from you, when Yahweh your Elohim blesses you, 
-<span class="v">25&#160;</span>then you shall turn it into money, bind up the money in your hand, and shall go to the place which Yahweh your Elohim shall choose. 
-<span class="v">26&#160;</span>You shall trade the money for whatever your soul desires: for cattle, or for sheep, or for wine, or for strong drink, or for whatever your soul asks of you. You shall eat there before Yahweh your Elohim, and you shall rejoice, you and your household. 
-<span class="v">27&#160;</span>You shall not forsake the Levite who is within your gates, for he has no portion nor inheritance with you. 
-<span class="v">28&#160;</span>At the end of every three years you shall bring all the tithe of your increase in the same year, and shall store it within your gates. 
-<span class="v">29&#160;</span>The Levite, because he has no portion nor inheritance with you, as well as the foreigner living among you, the fatherless, and the widow who are within your gates shall come, and shall eat and be satisfied; that Yahweh your Elohim may bless you in all the work of your hand which you do. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>At the end of every seven years, you shall cancel debts. 
-<span class="v">2&#160;</span>This is the way it shall be done: every owner of a loan shall release that which he has lent to his neighbor. He shall not require payment from his neighbor and his brother, because Yahweh’s release has been proclaimed. 
-<span class="v">3&#160;</span>Of a foreigner you may require it; but whatever of yours is with your brother, your hand shall release. 
-<span class="v">4&#160;</span>However there will be no poor with you (for Yahweh will surely bless you in the land which Yahweh your Elohim gives you for an inheritance to possess) 
-<span class="v">5&#160;</span>if only you diligently listen to Yahweh your Elohim’s voice, to observe to do all this commandment which I command you today. 
-<span class="v">6&#160;</span>For Yahweh your Elohim will bless you, as he promised you. You will lend to many nations, but you will not borrow. You will rule over many nations, but they will not rule over you. 
-<span class="v">7&#160;</span>If a poor man, one of your brothers, is with you within any of your gates in your land which Yahweh your Elohim gives you, you shall not harden your heart, nor shut your hand from your poor brother; 
-<span class="v">8&#160;</span>but you shall surely open your hand to him, and shall surely lend him sufficient for his need, which he lacks. 
-<span class="v">9&#160;</span>Beware that there not be a wicked thought in your heart, saying, “The seventh year, the year of release, is at hand,” and your eye be evil against your poor brother and you give him nothing; and he cry to Yahweh against you, and it be sin to you. 
-<span class="v">10&#160;</span>You shall surely give, and your heart shall not be grieved when you give to him, because it is for this thing Yahweh your Elohim will bless you in all your work and in all that you put your hand to. 
-<span class="v">11&#160;</span>For the poor will never cease out of the land. Therefore I command you to surely open your hand to your brother, to your needy, and to your poor, in your land. 
-<span class="v">12&#160;</span>If your brother, a Hebrew man, or a Hebrew woman, is sold to you and serves you six years, then in the seventh year you shall let him go free from you. 
-<span class="v">13&#160;</span>When you let him go free from you, you shall not let him go empty. 
-<span class="v">14&#160;</span>You shall furnish him liberally out of your flock, out of your threshing floor, and out of your wine press. As Yahweh your Elohim has blessed you, you shall give to him. 
-<span class="v">15&#160;</span>You shall remember that you were a slave in the land of Egypt, and Yahweh your Elohim redeemed you. Therefore I command you this thing today. 
-<span class="v">16&#160;</span>It shall be, if he tells you, “I will not go out from you,” because he loves you and your house, because he is well with you, 
-<span class="v">17&#160;</span>then you shall take an awl, and thrust it through his ear to the door, and he shall be your servant forever. Also to your female servant you shall do likewise. 
-<span class="v">18&#160;</span>It shall not seem hard to you when you let him go free from you, for he has been double the value of a hired hand as he served you six years. Yahweh your Elohim will bless you in all that you do. 
-<span class="v">19&#160;</span>You shall dedicate all the firstborn males that are born of your herd and of your flock to Yahweh your Elohim. You shall do no work with the firstborn of your herd, nor shear the firstborn of your flock. 
-<span class="v">20&#160;</span>You shall eat it before Yahweh your Elohim year by year in the place which Yahweh shall choose, you and your household. 
-<span class="v">21&#160;</span>If it has any defect—is lame or blind, or has any defect whatever, you shall not sacrifice it to Yahweh your Elohim. 
-<span class="v">22&#160;</span>You shall eat it within your gates. The unclean and the clean shall eat it alike, as the gazelle and as the deer. 
-<span class="v">23&#160;</span>Only you shall not eat its blood. You shall pour it out on the ground like water. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Observe the month of Abib, and keep the Passover to Yahweh your Elohim; for in the month of Abib Yahweh your Elohim brought you out of Egypt by night. 
-<span class="v">2&#160;</span>You shall sacrifice the Passover to Yahweh your Elohim, of the flock and the herd, in the place which Yahweh shall choose to cause his name to dwell there. 
-<span class="v">3&#160;</span>You shall eat no leavened bread with it. You shall eat unleavened bread with it seven days, even the bread of affliction (for you came out of the land of Egypt in haste) that you may remember the day when you came out of the land of Egypt all the days of your life. 
-<span class="v">4&#160;</span>No yeast shall be seen with you in all your borders seven days; neither shall any of the meat, which you sacrifice the first day at evening, remain all night until the morning. 
-<span class="v">5&#160;</span>You may not sacrifice the Passover within any of your gates which Yahweh your Elohim gives you; 
-<span class="v">6&#160;</span>but at the place which Yahweh your Elohim shall choose to cause his name to dwell in, there you shall sacrifice the Passover at evening, at the going down of the sun, at the season that you came out of Egypt. 
-<span class="v">7&#160;</span>You shall roast and eat it in the place which Yahweh your Elohim chooses. In the morning you shall return to your tents. 
-<span class="v">8&#160;</span>Six days you shall eat unleavened bread. On the seventh day shall be a solemn assembly to Yahweh your Elohim. You shall do no work. 
-</p><p>
-<span class="v">9&#160;</span>You shall count for yourselves seven weeks. From the time you begin to put the sickle to the standing grain you shall begin to count seven weeks. 
-<span class="v">10&#160;</span>You shall keep the feast of weeks to Yahweh your Elohim with a tribute of a free will offering of your hand, which you shall give according to how Yahweh your Elohim blesses you. 
-<span class="v">11&#160;</span>You shall rejoice before Yahweh your Elohim: you, your son, your daughter, your male servant, your female servant, the Levite who is within your gates, the foreigner, the fatherless, and the widow who are among you, in the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
-<span class="v">12&#160;</span>You shall remember that you were a slave in Egypt. You shall observe and do these statutes. 
-</p><p>
-<span class="v">13&#160;</span>You shall keep the feast of booths seven days, after you have gathered in from your threshing floor and from your wine press. 
-<span class="v">14&#160;</span>You shall rejoice in your feast, you, your son, your daughter, your male servant, your female servant, the Levite, the foreigner, the fatherless, and the widow who are within your gates. 
-<span class="v">15&#160;</span>You shall keep a feast to Yahweh your Elohim seven days in the place which Yahweh chooses, because Yahweh your Elohim will bless you in all your increase and in all the work of your hands, and you shall be altogether joyful. 
-<span class="v">16&#160;</span>Three times in a year all of your males shall appear before Yahweh your Elohim in the place which he chooses: in the feast of unleavened bread, in the feast of weeks, and in the feast of booths. They shall not appear before Yahweh empty. 
-<span class="v">17&#160;</span>Every man shall give as he is able, according to Yahweh your Elohim’s blessing which he has given you. 
-<span class="v">18&#160;</span>You shall make judges and officers in all your gates, which Yahweh your Elohim gives you, according to your tribes; and they shall judge the people with righteous judgment. 
-<span class="v">19&#160;</span>You shall not pervert justice. You shall not show partiality. You shall not take a bribe, for a bribe blinds the eyes of the wise and perverts the words of the righteous. 
-<span class="v">20&#160;</span>You shall follow that which is altogether just, that you may live and inherit the land which Yahweh your Elohim gives you. 
-<span class="v">21&#160;</span>You shall not plant for yourselves an Asherah of any kind of tree beside Yahweh your Elohim’s altar, which you shall make for yourselves. 
-<span class="v">22&#160;</span>Neither shall you set yourself up a sacred stone which Yahweh your Elohim hates. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>You shall not sacrifice to Yahweh your Elohim an ox or a sheep in which is a defect or anything evil; for that is an abomination to Yahweh your Elohim. 
-</p><p>
-<span class="v">2&#160;</span>If there is found among you, within any of your gates which Yahweh your Elohim gives you, a man or woman who does that which is evil in Yahweh your Elohim’s sight in transgressing his covenant, 
-<span class="v">3&#160;</span>and has gone and served other elohims and worshiped them, or the sun, or the moon, or any of the stars of the sky, which I have not commanded, 
-<span class="v">4&#160;</span>and you are told, and you have heard of it, then you shall inquire diligently. Behold, if it is true, and the thing certain, that such abomination is done in Israel, 
-<span class="v">5&#160;</span>then you shall bring out that man or that woman who has done this evil thing to your gates, even that same man or woman; and you shall stone them to death with stones. 
-<span class="v">6&#160;</span>At the mouth of two witnesses, or three witnesses, he who is to die shall be put to death. At the mouth of one witness he shall not be put to death. 
-<span class="v">7&#160;</span>The hands of the witnesses shall be first on him to put him to death, and afterward the hands of all the people. So you shall remove the evil from among you. 
-</p><p>
-<span class="v">8&#160;</span>If there arises a matter too hard for you in judgment, between blood and blood, between plea and plea, and between stroke and stroke, being matters of controversy within your gates, then you shall arise, and go up to the place which Yahweh your Elohim chooses. 
-<span class="v">9&#160;</span>You shall come to the priests who are Levites and to the judge who shall be in those days. You shall inquire, and they shall give you the verdict. 
-<span class="v">10&#160;</span>You shall do according to the decisions of the verdict which they shall give you from that place which Yahweh chooses. You shall observe to do according to all that they shall teach you. 
-<span class="v">11&#160;</span>According to the decisions of the law which they shall teach you, and according to the judgment which they shall tell you, you shall do. You shall not turn away from the sentence which they announce to you, to the right hand, nor to the left. 
-<span class="v">12&#160;</span>The man who does presumptuously in not listening to the priest who stands to minister there before Yahweh your Elohim, or to the judge, even that man shall die. You shall put away the evil from Israel. 
-<span class="v">13&#160;</span>All the people shall hear and fear, and do no more presumptuously. 
-</p><p>
-<span class="v">14&#160;</span>When you have come to the land which Yahweh your Elohim gives you, and possess it and dwell in it, and say, “I will set a king over me, like all the nations that are around me,” 
-<span class="v">15&#160;</span>you shall surely set him whom Yahweh your Elohim chooses as king over yourselves. You shall set as king over you one from among your brothers. You may not put a foreigner over you, who is not your brother. 
-<span class="v">16&#160;</span>Only he shall not multiply horses to himself, nor cause the people to return to Egypt, to the end that he may multiply horses; because Yahweh has said to you, “You shall not go back that way again.” 
-<span class="v">17&#160;</span>He shall not multiply women to himself, that his heart not turn away. He shall not greatly multiply to himself silver and gold. 
-</p><p>
-<span class="v">18&#160;</span>It shall be, when he sits on the throne of his kingdom, that he shall write himself a copy of this law in a book, out of that which is before the Levitical priests. 
-<span class="v">19&#160;</span>It shall be with him, and he shall read from it all the days of his life, that he may learn to fear Yahweh his Elohim, to keep all the words of this law and these statutes, to do them; 
-<span class="v">20&#160;</span>that his heart not be lifted up above his brothers, and that he not turn away from the commandment to the right hand, or to the left, to the end that he may prolong his days in his kingdom, he and his children, in the middle of Israel. 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>The priests and the Levites—all the tribe of Levi—shall have no portion nor inheritance with Israel. They shall eat the offerings of Yahweh made by fire and his portion. 
-<span class="v">2&#160;</span>They shall have no inheritance among their brothers. Yahweh is their inheritance, as he has spoken to them. 
-<span class="v">3&#160;</span>This shall be the priests’ due from the people, from those who offer a sacrifice, whether it be ox or sheep, that they shall give to the priest: the shoulder, the two cheeks, and the inner parts. 
-<span class="v">4&#160;</span>You shall give him the first fruits of your grain, of your new wine, and of your oil, and the first of the fleece of your sheep. 
-<span class="v">5&#160;</span>For Yahweh your Elohim has chosen him out of all your tribes to stand to minister in Yahweh’s name, him and his sons forever. 
-</p><p>
-<span class="v">6&#160;</span>If a Levite comes from any of your gates out of all Israel where he lives, and comes with all the desire of his soul to the place which Yahweh shall choose, 
-<span class="v">7&#160;</span>then he shall minister in the name of Yahweh his Elohim, as all his brothers the Levites do, who stand there before Yahweh. 
-<span class="v">8&#160;</span>They shall have like portions to eat, in addition to that which comes from the sale of his family possessions. 
-</p><p>
-<span class="v">9&#160;</span>When you have come into the land which Yahweh your Elohim gives you, you shall not learn to imitate the abominations of those nations. 
-<span class="v">10&#160;</span>There shall not be found with you anyone who makes his son or his daughter to pass through the fire, one who uses divination, one who tells fortunes, or an enchanter, or a sorcerer, 
-<span class="v">11&#160;</span>or a charmer, or someone who consults with a familiar spirit, or a wizard, or a necromancer. 
-<span class="v">12&#160;</span>For whoever does these things is an abomination to Yahweh. Because of these abominations, Yahweh your Elohim drives them out from before you. 
-<span class="v">13&#160;</span>You shall be blameless with Yahweh your Elohim. 
-<span class="v">14&#160;</span>For these nations that you shall dispossess listen to those who practice sorcery and to diviners; but as for you, Yahweh your Elohim has not allowed you so to do. 
-<span class="v">15&#160;</span>Yahweh your Elohim will raise up to you a prophet from among you, of your brothers, like me. You shall listen to him. 
-<span class="v">16&#160;</span>This is according to all that you desired of Yahweh your Elohim in Horeb in the day of the assembly, saying, “Let me not hear again Yahweh my Elohim’s voice, neither let me see this great fire any more, that I not die.” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh said to me, “They have well said that which they have spoken. 
-<span class="v">18&#160;</span>I will raise them up a prophet from among their brothers, like you. I will put my words in his mouth, and he shall speak to them all that I shall command him. 
-<span class="v">19&#160;</span>It shall happen, that whoever will not listen to my words which he shall speak in my name, I will require it of him. 
-<span class="v">20&#160;</span>But the prophet who speaks a word presumptuously in my name, which I have not commanded him to speak, or who speaks in the name of other elohims, that same prophet shall die.” 
-</p><p>
-<span class="v">21&#160;</span>You may say in your heart, “How shall we know the word which Yahweh has not spoken?” 
-<span class="v">22&#160;</span>When a prophet speaks in Yahweh’s name, if the thing doesn’t follow, nor happen, that is the thing which Yahweh has not spoken. The prophet has spoken it presumptuously. You shall not be afraid of him. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>When Yahweh your Elohim cuts off the nations whose land Yahweh your Elohim gives you, and you succeed them and dwell in their cities and in their houses, 
-<span class="v">2&#160;</span>you shall set apart three cities for yourselves in the middle of your land, which Yahweh your Elohim gives you to possess. 
-<span class="v">3&#160;</span>You shall prepare the way, and divide the borders of your land which Yahweh your Elohim causes you to inherit into three parts, that every man slayer may flee there. 
-<span class="v">4&#160;</span>This is the case of the man slayer who shall flee there and live: Whoever kills his neighbor unintentionally, and didn’t hate him in time past—<span class="v">5&#160;</span>as when a man goes into the forest with his neighbor to chop wood and his hand swings the ax to cut down the tree, and the head slips from the handle and hits his neighbor so that he dies—he shall flee to one of these cities and live. 
-<span class="v">6&#160;</span>Otherwise, the avenger of blood might pursue the man slayer while hot anger is in his heart and overtake him, because the way is long, and strike him mortally, even though he was not worthy of death, because he didn’t hate him in time past. 
-<span class="v">7&#160;</span>Therefore I command you to set apart three cities for yourselves. 
-<span class="v">8&#160;</span>If Yahweh your Elohim enlarges your border, as he has sworn to your fathers, and gives you all the land which he promised to give to your fathers; 
-<span class="v">9&#160;</span>and if you keep all this commandment to do it, which I command you today, to love Yahweh your Elohim, and to walk ever in his ways, then you shall add three cities more for yourselves, in addition to these three. 
-<span class="v">10&#160;</span>This is so that innocent blood will not be shed in the middle of your land which Yahweh your Elohim gives you for an inheritance, leaving blood guilt on you. 
-<span class="v">11&#160;</span>But if any man hates his neighbor, lies in wait for him, rises up against him, strikes him mortally so that he dies, and he flees into one of these cities; 
-<span class="v">12&#160;</span>then the elders of his city shall send and bring him there, and deliver him into the hand of the avenger of blood, that he may die. 
-<span class="v">13&#160;</span>Your eye shall not pity him, but you shall purge the innocent blood from Israel that it may go well with you. 
-</p><p>
-<span class="v">14&#160;</span>You shall not remove your neighbor’s landmark, which they of old time have set, in your inheritance which you shall inherit, in the land that Yahweh your Elohim gives you to possess. 
-</p><p>
-<span class="v">15&#160;</span>One witness shall not rise up against a man for any iniquity, or for any sin that he sins. At the mouth of two witnesses, or at the mouth of three witnesses, shall a matter be established. 
-<span class="v">16&#160;</span>If an unrighteous witness rises up against any man to testify against him of wrongdoing, 
-<span class="v">17&#160;</span>then both the men, between whom the controversy is, shall stand before Yahweh, before the priests and the judges who shall be in those days; 
-<span class="v">18&#160;</span>and the judges shall make diligent inquisition; and behold, if the witness is a false witness, and has testified falsely against his brother, 
-<span class="v">19&#160;</span>then you shall do to him as he had thought to do to his brother. So you shall remove the evil from among you. 
-<span class="v">20&#160;</span>Those who remain shall hear, and fear, and will never again commit any such evil among you. 
-<span class="v">21&#160;</span>Your eyes shall not pity: life for life, eye for eye, tooth for tooth, hand for hand, foot for foot. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>When you go out to battle against your enemies, and see horses, chariots, and a people more numerous than you, you shall not be afraid of them; for Yahweh your Elohim, who brought you up out of the land of Egypt, is with you. 
-<span class="v">2&#160;</span>It shall be, when you draw near to the battle, that the priest shall approach and speak to the people, 
-<span class="v">3&#160;</span>and shall tell them, “Hear, Israel, you draw near today to battle against your enemies. Don’t let your heart faint! Don’t be afraid, nor tremble, neither be scared of them; 
-<span class="v">4&#160;</span>for Yahweh your Elohim is he who goes with you, to fight for you against your enemies, to save you.” 
-</p><p>
-<span class="v">5&#160;</span>The officers shall speak to the people, saying, “What man is there who has built a new house, and has not dedicated it? Let him go and return to his house, lest he die in the battle, and another man dedicate it. 
-<span class="v">6&#160;</span>What man is there who has planted a vineyard, and has not used its fruit? Let him go and return to his house, lest he die in the battle, and another man use its fruit. 
-<span class="v">7&#160;</span>What man is there who has pledged to be married to a woman, and has not taken her? Let him go and return to his house, lest he die in the battle, and another man take her.” 
-<span class="v">8&#160;</span>The officers shall speak further to the people, and they shall say, “What man is there who is fearful and faint-hearted? Let him go and return to his house, lest his brother’s heart melt as his heart.” 
-<span class="v">9&#160;</span>It shall be, when the officers have finished speaking to the people, that they shall appoint captains of armies at the head of the people. 
-</p><p>
-<span class="v">10&#160;</span>When you draw near to a city to fight against it, then proclaim peace to it. 
-<span class="v">11&#160;</span>It shall be, if it gives you answer of peace and opens to you, then it shall be that all the people who are found therein shall become forced laborers to you, and shall serve you. 
-<span class="v">12&#160;</span>If it will make no peace with you, but will make war against you, then you shall besiege it. 
-<span class="v">13&#160;</span>When Yahweh your Elohim delivers it into your hand, you shall strike every male of it with the edge of the sword; 
-<span class="v">14&#160;</span>but the women, the little ones, the livestock, and all that is in the city, even all its plunder, you shall take for plunder for yourself. You may use the plunder of your enemies, which Yahweh your Elohim has given you. 
-<span class="v">15&#160;</span>Thus you shall do to all the cities which are very far off from you, which are not of the cities of these nations. 
-<span class="v">16&#160;</span>But of the cities of these peoples that Yahweh your Elohim gives you for an inheritance, you shall save alive nothing that breathes; 
-<span class="v">17&#160;</span>but you shall utterly destroy them: the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, as Yahweh your Elohim has commanded you; 
-<span class="v">18&#160;</span>that they not teach you to follow all their abominations, which they have done for their elohims; so would you sin against Yahweh your Elohim. 
-<span class="v">19&#160;</span>When you shall besiege a city a long time, in making war against it to take it, you shall not destroy its trees by wielding an ax against them; for you may eat of them. You shall not cut them down, for is the tree of the field man, that it should be besieged by you? 
-<span class="v">20&#160;</span>Only the trees that you know are not trees for food, you shall destroy and cut them down. You shall build bulwarks against the city that makes war with you, until it falls. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>If someone is found slain in the land which Yahweh your Elohim gives you to possess, lying in the field, and it isn’t known who has struck him, 
-<span class="v">2&#160;</span>then your elders and your judges shall come out, and they shall measure to the cities which are around him who is slain. 
-<span class="v">3&#160;</span>It shall be that the elders of the city which is nearest to the slain man shall take a heifer of the herd, which hasn’t been worked with and which has not drawn in the yoke. 
-<span class="v">4&#160;</span>The elders of that city shall bring the heifer down to a valley with running water, which is neither plowed nor sown, and shall break the heifer’s neck there in the valley. 
-<span class="v">5&#160;</span>The priests the sons of Levi shall come near, for them Yahweh your Elohim has chosen to minister to him, and to bless in Yahweh’s name; and according to their word shall every controversy and every assault be decided. 
-<span class="v">6&#160;</span>All the elders of that city which is nearest to the slain man shall wash their hands over the heifer whose neck was broken in the valley. 
-<span class="v">7&#160;</span>They shall answer and say, “Our hands have not shed this blood, neither have our eyes seen it. 
-<span class="v">8&#160;</span>Forgive, Yahweh, your people Israel, whom you have redeemed, and don’t allow innocent blood among your people Israel.” The blood shall be forgiven them. 
-<span class="v">9&#160;</span>So you shall put away the innocent blood from among you, when you shall do that which is right in Yahweh’s eyes. 
-</p><p>
-<span class="v">10&#160;</span>When you go out to battle against your enemies, and Yahweh your Elohim delivers them into your hands and you carry them away captive, 
-<span class="v">11&#160;</span>and see among the captives a beautiful woman, and you are attracted to her, and desire to take her as your woman, 
-<span class="v">12&#160;</span>then you shall bring her home to your house. She shall shave her head and trim her nails. 
-<span class="v">13&#160;</span>She shall take off the clothing of her captivity, and shall remain in your house, and bewail her father and her mother a full month. After that you shall go in to her and be her owner, and she shall be your woman. 
-<span class="v">14&#160;</span>It shall be, if you have no delight in her, then you shall let her go where she desires; but you shall not sell her at all for money. You shall not deal with her as a slave, because you have humbled her. 
-</p><p>
-<span class="v">15&#160;</span>If a man has two women, the one beloved and the other hated, and they have borne him children, both the beloved and the hated, and if the firstborn son is hers who was hated, 
-<span class="v">16&#160;</span>then it shall be, in the day that he causes his sons to inherit that which he has, that he may not give the son of the beloved the rights of the firstborn before the son of the hated, who is the firstborn; 
-<span class="v">17&#160;</span>but he shall acknowledge the firstborn, the son of the hated, by giving him a double portion of all that he has; for he is the beginning of his strength. The right of the firstborn is his. 
-</p><p>
-<span class="v">18&#160;</span>If a man has a stubborn and rebellious son who will not obey the voice of his father or the voice of his mother, and though they chasten him, will not listen to them, 
-<span class="v">19&#160;</span>then his father and his mother shall take hold of him and bring him out to the elders of his city and to the gate of his place. 
-<span class="v">20&#160;</span>They shall tell the elders of his city, “This our son is stubborn and rebellious. He will not obey our voice. He is a glutton and a drunkard.” 
-<span class="v">21&#160;</span>All the men of his city shall stone him to death with stones. So you shall remove the evil from among you. All Israel shall hear, and fear. 
-</p><p>
-<span class="v">22&#160;</span>If a man has committed a sin worthy of death, and he is put to death, and you hang him on a tree, 
-<span class="v">23&#160;</span>his body shall not remain all night on the tree, but you shall surely bury him the same day; for he who is hanged is accursed of Elohim. Don’t defile your land which Yahweh your Elohim gives you for an inheritance. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>You shall not see your brother’s ox or his sheep go astray and hide yourself from them. You shall surely bring them again to your brother. 
-<span class="v">2&#160;</span>If your brother isn’t near to you, or if you don’t know him, then you shall bring it home to your house, and it shall be with you until your brother comes looking for it, and you shall restore it to him. 
-<span class="v">3&#160;</span>So you shall do with his donkey. So you shall do with his garment. So you shall do with every lost thing of your brother’s, which he has lost and you have found. You may not hide yourself. 
-<span class="v">4&#160;</span>You shall not see your brother’s donkey or his ox fallen down by the way, and hide yourself from them. You shall surely help him to lift them up again. 
-</p><p>
-<span class="v">5&#160;</span>A woman shall not wear men’s clothing, neither shall a man put on women’s clothing; for whoever does these things is an abomination to Yahweh your Elohim. 
-</p><p>
-<span class="v">6&#160;</span>If you come across a bird’s nest on the way, in any tree or on the ground, with young ones or eggs, and the hen sitting on the young, or on the eggs, you shall not take the hen with the young. 
-<span class="v">7&#160;</span>You shall surely let the hen go, but the young you may take for yourself, that it may be well with you, and that you may prolong your days. 
-</p><p>
-<span class="v">8&#160;</span>When you build a new house, then you shall make a railing around your roof, so that you don’t bring blood on your house if anyone falls from there. 
-</p><p>
-<span class="v">9&#160;</span>You shall not sow your vineyard with two kinds of seed, lest all the fruit be defiled, the seed which you have sown, and the increase of the vineyard. 
-<span class="v">10&#160;</span>You shall not plow with an ox and a donkey together. 
-<span class="v">11&#160;</span>You shall not wear clothes of wool and linen woven together. 
-</p><p>
-<span class="v">12&#160;</span>You shall make yourselves fringes<span class="f">+ \fr 22:12 \ft or, tassels</span> on the four corners of your cloak with which you cover yourself. 
-</p><p>
-<span class="v">13&#160;</span>If any man takes a woman, and goes in to her, hates her, 
-<span class="v">14&#160;</span>accuses her of shameful things, gives her a bad name, and says, “I took this woman, and when I came near to her, I didn’t find in her the tokens of virginity;” 
-<span class="v">15&#160;</span>then the young lady’s father and mother shall take and bring the tokens of the young lady’s virginity to the elders of the city in the gate. 
-<span class="v">16&#160;</span>The young lady’s father shall tell the elders, “I gave my daughter to this man as his woman, and he hates her. 
-<span class="v">17&#160;</span>Behold, he has accused her of shameful things, saying, ‘I didn’t find in your daughter the tokens of virginity;’ and yet these are the tokens of my daughter’s virginity.” They shall spread the cloth before the elders of the city. 
-<span class="v">18&#160;</span>The elders of that city shall take the man and chastise him. 
-<span class="v">19&#160;</span>They shall fine him one hundred shekels of silver,<span class="f">+ \fr 22:19 \ft A shekel is about 10 grams or about 0.35 ounces, so 100 shekels is about a kilogram or 2.2 pounds.</span> and give them to the father of the young lady, because he has given a bad name to a virgin of Israel. She shall be his woman. He may not put her away all his days. 
-</p><p>
-<span class="v">20&#160;</span>But if this thing is true, that the tokens of virginity were not found in the young lady, 
-<span class="v">21&#160;</span>then they shall bring out the young lady to the door of her father’s house, and the men of her city shall stone her to death with stones, because she has done folly in Israel, to play the prostitute in her father’s house. So you shall remove the evil from among you. 
-</p><p>
-<span class="v">22&#160;</span>If a man is found lying with a woman owned by an owner, then they shall both die, the man who lay with the woman and the woman. So you shall remove the evil from Israel. 
-<span class="v">23&#160;</span>If there is a young lady who is a virgin pledged to be married to a man, and a man finds her in the city, and lies with her, 
-<span class="v">24&#160;</span>then you shall bring them both out to the gate of that city, and you shall stone them to death with stones; the lady, because she didn’t cry, being in the city; and the man, because he has humbled his neighbor’s woman. So you shall remove the evil from among you. 
-<span class="v">25&#160;</span>But if the man finds the lady who is pledged to be married in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
-<span class="v">26&#160;</span>but to the lady you shall do nothing. There is in the lady no sin worthy of death; for as when a man rises against his neighbor and kills him, even so is this matter; 
-<span class="v">27&#160;</span>for he found her in the field, the pledged to be married lady cried, and there was no one to save her. 
-<span class="v">28&#160;</span>If a man finds a lady who is a virgin, who is not pledged to be married, grabs her and lies with her, and they are found, 
-<span class="v">29&#160;</span>then the man who lay with her shall give to the lady’s father fifty shekels<span class="f">+ \fr 22:29 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of silver. She shall be his woman, because he has humbled her. He may not put her away all his days. 
-<span class="v">30&#160;</span>A man shall not take his father’s woman, and shall not uncover his father’s skirt. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>He who is emasculated by crushing or cutting shall not enter into Yahweh’s assembly. 
-<span class="v">2&#160;</span>A person born of a forbidden union shall not enter into Yahweh’s assembly; even to the tenth generation shall no one of his enter into Yahweh’s assembly. 
-<span class="v">3&#160;</span>An Ammonite or a Moabite shall not enter into Yahweh’s assembly; even to the tenth generation shall no one belonging to them enter into Yahweh’s assembly forever, 
-<span class="v">4&#160;</span>because they didn’t meet you with bread and with water on the way when you came out of Egypt, and because they hired against you Balaam the son of Beor from Pethor of Mesopotamia, to curse you. 
-<span class="v">5&#160;</span>Nevertheless Yahweh your Elohim wouldn’t listen to Balaam, but Yahweh your Elohim turned the curse into a blessing to you, because Yahweh your Elohim loved you. 
-<span class="v">6&#160;</span>You shall not seek their peace nor their prosperity all your days forever. 
-<span class="v">7&#160;</span>You shall not abhor an Edomite, for he is your brother. You shall not abhor an Egyptian, because you lived as a foreigner in his land. 
-<span class="v">8&#160;</span>The children of the third generation who are born to them may enter into Yahweh’s assembly. 
-</p><p>
-<span class="v">9&#160;</span>When you go out and camp against your enemies, then you shall keep yourselves from every evil thing. 
-<span class="v">10&#160;</span>If there is among you any man who is not clean by reason of that which happens to him by night, then shall he go outside of the camp. He shall not come within the camp; 
-<span class="v">11&#160;</span>but it shall be, when evening comes, he shall bathe himself in water. When the sun is down, he shall come within the camp. 
-<span class="v">12&#160;</span>You shall have a place also outside of the camp where you go relieve yourself. 
-<span class="v">13&#160;</span>You shall have a trowel among your weapons. It shall be, when you relieve yourself, you shall dig with it, and shall turn back and cover your excrement; 
-<span class="v">14&#160;</span>for Yahweh your Elohim walks in the middle of your camp, to deliver you, and to give up your enemies before you. Therefore your camp shall be set-apart, that he may not see an unclean thing in you, and turn away from you. 
-</p><p>
-<span class="v">15&#160;</span>You shall not deliver to his master a servant who has escaped from his master to you. 
-<span class="v">16&#160;</span>He shall dwell with you, among you, in the place which he shall choose within one of your gates, where it pleases him best. You shall not oppress him. 
-</p><p>
-<span class="v">17&#160;</span>There shall be no prostitute of the daughters of Israel, neither shall there be a sodomite of the sons of Israel. 
-<span class="v">18&#160;</span>You shall not bring the hire of a prostitute, or the wages of a male prostitute,<span class="f">+ \fr 23:18 \ft literally, dog</span> into the house of Yahweh your Elohim for any vow; for both of these are an abomination to Yahweh your Elohim. 
-</p><p>
-<span class="v">19&#160;</span>You shall not lend on interest to your brother: interest of money, interest of food, interest of anything that is lent on interest. 
-<span class="v">20&#160;</span>You may charge a foreigner interest; but you shall not charge your brother interest, that Yahweh your Elohim may bless you in all that you put your hand to, in the land where you go in to possess it. 
-</p><p>
-<span class="v">21&#160;</span>When you vow a vow to Yahweh your Elohim, you shall not be slack to pay it, for Yahweh your Elohim will surely require it of you; and it would be sin in you. 
-<span class="v">22&#160;</span>But if you refrain from making a vow, it shall be no sin in you. 
-<span class="v">23&#160;</span>You shall observe and do that which has gone out of your lips. Whatever you have vowed to Yahweh your Elohim as a free will offering, which you have promised with your mouth, you must do. 
-<span class="v">24&#160;</span>When you come into your neighbor’s vineyard, then you may eat your fill of grapes at your own pleasure; but you shall not put any in your container. 
-<span class="v">25&#160;</span>When you come into your neighbor’s standing grain, then you may pluck the ears with your hand; but you shall not use a sickle on your neighbor’s standing grain. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>When a man takes a woman and marries her, then it shall be, if she finds no favor in his eyes because he has found some unseemly thing in her, that he shall write her a certificate of divorce, put it in her hand, and send her out of his house. 
-<span class="v">2&#160;</span>When she has departed out of his house, she may go and be another man’s woman. 
-<span class="v">3&#160;</span>If the latter man hates her, and writes her a certificate of divorce, puts it in her hand, and sends her out of his house; or if the latter man dies, who took her to be his woman; 
-<span class="v">4&#160;</span>her former owner, who sent her away, may not take her again to be his woman after she is defiled; for that would be an abomination to Yahweh. You shall not cause the land to sin, which Yahweh your Elohim gives you for an inheritance. 
-<span class="v">5&#160;</span>When a man takes a new woman, he shall not go out in the army, neither shall he be assigned any business. He shall be free at home one year, and shall cheer his woman whom he has taken. 
-</p><p>
-<span class="v">6&#160;</span>No man shall take the mill or the upper millstone as a pledge, for he takes a life in pledge. 
-</p><p>
-<span class="v">7&#160;</span>If a man is found stealing any of his brothers of the children of Israel, and he deals with him as a slave, or sells him, then that thief shall die. So you shall remove the evil from among you. 
-</p><p>
-<span class="v">8&#160;</span>Be careful in the plague of leprosy, that you observe diligently and do according to all that the Levitical priests teach you. As I commanded them, so you shall observe to do. 
-<span class="v">9&#160;</span>Remember what Yahweh your Elohim did to Miriam, by the way as you came out of Egypt. 
-</p><p>
-<span class="v">10&#160;</span>When you lend your neighbor any kind of loan, you shall not go into his house to get his pledge. 
-<span class="v">11&#160;</span>You shall stand outside, and the man to whom you lend shall bring the pledge outside to you. 
-<span class="v">12&#160;</span>If he is a poor man, you shall not sleep with his pledge. 
-<span class="v">13&#160;</span>You shall surely restore to him the pledge when the sun goes down, that he may sleep in his garment and bless you. It shall be righteousness to you before Yahweh your Elohim. 
-</p><p>
-<span class="v">14&#160;</span>You shall not oppress a hired servant who is poor and needy, whether he is one of your brothers or one of the foreigners who are in your land within your gates. 
-<span class="v">15&#160;</span>In his day you shall give him his wages, neither shall the sun go down on it, for he is poor and sets his heart on it, lest he cry against you to Yahweh, and it be sin to you. 
-</p><p>
-<span class="v">16&#160;</span>The fathers shall not be put to death for the children, neither shall the children be put to death for the fathers. Every man shall be put to death for his own sin. 
-</p><p>
-<span class="v">17&#160;</span>You shall not deprive the foreigner or the fatherless of justice, nor take a widow’s clothing in pledge; 
-<span class="v">18&#160;</span>but you shall remember that you were a slave in Egypt, and Yahweh your Elohim redeemed you there. Therefore I command you to do this thing. 
-</p><p>
-<span class="v">19&#160;</span>When you reap your harvest in your field, and have forgotten a sheaf in the field, you shall not go again to get it. It shall be for the foreigner, for the fatherless, and for the widow, that Yahweh your Elohim may bless you in all the work of your hands. 
-<span class="v">20&#160;</span>When you beat your olive tree, you shall not go over the boughs again. It shall be for the foreigner, for the fatherless, and for the widow. 
-</p><p>
-<span class="v">21&#160;</span>When you harvest your vineyard, you shall not glean it after yourselves. It shall be for the foreigner, for the fatherless, and for the widow. 
-<span class="v">22&#160;</span>You shall remember that you were a slave in the land of Egypt. Therefore I command you to do this thing. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>If there is a controversy between men, and they come to judgment and the judges judge them, then they shall justify the righteous and condemn the wicked. 
-<span class="v">2&#160;</span>It shall be, if the wicked man is worthy to be beaten, that the judge shall cause him to lie down and to be beaten before his face, according to his wickedness, by number. 
-<span class="v">3&#160;</span>He may sentence him to no more than forty stripes. He shall not give more, lest if he should give more and beat him more than that many stripes, then your brother will be degraded in your sight. 
-</p><p>
-<span class="v">4&#160;</span>You shall not muzzle the ox when he treads out the grain. 
-</p><p>
-<span class="v">5&#160;</span>If brothers dwell together, and one of them dies and has no son, the woman of the dead shall not be married outside to a stranger. Her brother-in-law shall go in to her, and take her as his woman, and perform the duty of a brother-in-law to her. 
-<span class="v">6&#160;</span>It shall be that the firstborn whom she bears shall succeed in the name of his brother who is dead, that his name not be blotted out of Israel. 
-</p><p>
-<span class="v">7&#160;</span>If the man doesn’t want to take his brother’s woman, then his brother’s woman shall go up to the gate to the elders, and say, “My brother-in-law refuses to raise up to his brother a name in Israel. He will not perform the duty of a brother-in-law to me.” 
-<span class="v">8&#160;</span>Then the elders of his city shall call him, and speak to him. If he stands and says, “I don’t want to take her,” 
-<span class="v">9&#160;</span>then his brother’s woman shall come to him in the presence of the elders, and loose his sandal from off his foot, and spit in his face. She shall answer and say, “So shall it be done to the man who does not build up his brother’s house.” 
-<span class="v">10&#160;</span>His name shall be called in Israel, “The house of him who had his sandal removed.” 
-</p><p>
-<span class="v">11&#160;</span>When men strive against each other, and the woman of one draws near to deliver her man out of the hand of him who strikes him, and puts out her hand, and grabs him by his private parts, 
-<span class="v">12&#160;</span>then you shall cut off her hand. Your eye shall have no pity. 
-</p><p>
-<span class="v">13&#160;</span>You shall not have in your bag diverse weights, one heavy and one light. 
-<span class="v">14&#160;</span>You shall not have in your house diverse measures, one large and one small. 
-<span class="v">15&#160;</span>You shall have a perfect and just weight. You shall have a perfect and just measure, that your days may be long in the land which Yahweh your Elohim gives you. 
-<span class="v">16&#160;</span>For all who do such things, all who do unrighteously, are an abomination to Yahweh your Elohim. 
-</p><p>
-<span class="v">17&#160;</span>Remember what Amalek did to you by the way as you came out of Egypt, 
-<span class="v">18&#160;</span>how he met you by the way, and struck the rearmost of you, all who were feeble behind you, when you were faint and weary; and he didn’t fear Elohim. 
-<span class="v">19&#160;</span>Therefore it shall be, when Yahweh your Elohim has given you rest from all your enemies all around, in the land which Yahweh your Elohim gives you for an inheritance to possess it, that you shall blot out the memory of Amalek from under the sky. You shall not forget. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>It shall be, when you have come in to the land which Yahweh your Elohim gives you for an inheritance, possess it, and dwell in it, 
-<span class="v">2&#160;</span>that you shall take some of the first of all the fruit of the ground, which you shall bring in from your land that Yahweh your Elohim gives you. You shall put it in a basket, and shall go to the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
-<span class="v">3&#160;</span>You shall come to the priest who shall be in those days, and tell him, “I profess today to Yahweh your Elohim, that I have come to the land which Yahweh swore to our fathers to give us.” 
-<span class="v">4&#160;</span>The priest shall take the basket out of your hand, and set it down before Yahweh your Elohim’s altar. 
-<span class="v">5&#160;</span>You shall answer and say before Yahweh your Elohim, “My father<span class="f">+ \fr 26:5 \ft or, forefather</span> was a Syrian ready to perish. He went down into Egypt, and lived there, few in number. There he became a great, mighty, and populous nation. 
-<span class="v">6&#160;</span>The Egyptians mistreated us, afflicted us, and imposed hard labor on us. 
-<span class="v">7&#160;</span>Then we cried to Yahweh, the Elohim of our fathers. Yahweh heard our voice, and saw our affliction, our toil, and our oppression. 
-<span class="v">8&#160;</span>Yahweh brought us out of Egypt with a mighty hand, with an outstretched arm, with great terror, with signs, and with wonders; 
-<span class="v">9&#160;</span>and he has brought us into this place, and has given us this land, a land flowing with milk and honey. 
-<span class="v">10&#160;</span>Now, behold, I have brought the first of the fruit of the ground, which you, Yahweh, have given me.” You shall set it down before Yahweh your Elohim, and worship before Yahweh your Elohim. 
-<span class="v">11&#160;</span>You shall rejoice in all the good which Yahweh your Elohim has given to you, and to your house, you, and the Levite, and the foreigner who is among you. 
-</p><p>
-<span class="v">12&#160;</span>When you have finished tithing all the tithe of your increase in the third year, which is the year of tithing, then you shall give it to the Levite, to the foreigner, to the fatherless, and to the widow, that they may eat within your gates and be filled. 
-<span class="v">13&#160;</span>You shall say before Yahweh your Elohim, “I have put away the set-apart things out of my house, and also have given them to the Levite, to the foreigner, to the fatherless, and to the widow, according to all your commandment which you have commanded me. I have not transgressed any of your commandments, neither have I forgotten them. 
-<span class="v">14&#160;</span>I have not eaten of it in my mourning, neither have I removed any of it while I was unclean, nor given of it for the dead. I have listened to Yahweh my Elohim’s voice. I have done according to all that you have commanded me. 
-<span class="v">15&#160;</span>Look down from your set-apart habitation, from heaven, and bless your people Israel, and the ground which you have given us, as you swore to our fathers, a land flowing with milk and honey.” 
-</p><p>
-<span class="v">16&#160;</span>Today Yahweh your Elohim commands you to do these statutes and ordinances. You shall therefore keep and do them with all your heart and with all your soul. 
-<span class="v">17&#160;</span>You have declared today that Yahweh is your Elohim, and that you would walk in his ways, keep his statutes, his commandments, and his ordinances, and listen to his voice. 
-<span class="v">18&#160;</span>Yahweh has declared today that you are a people for his own possession, as he has promised you, and that you should keep all his commandments. 
-<span class="v">19&#160;</span>He will make you high above all nations that he has made, in praise, in name, and in honor, and that you may be a set-apart people to Yahweh your Elohim, as he has spoken. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Moses and the elders of Israel commanded the people, saying, “Keep all the commandment which I command you today. 
-<span class="v">2&#160;</span>It shall be on the day when you shall pass over the Jordan to the land which Yahweh your Elohim gives you, that you shall set yourself up great stones, and coat them with plaster. 
-<span class="v">3&#160;</span>You shall write on them all the words of this law, when you have passed over, that you may go in to the land which Yahweh your Elohim gives you, a land flowing with milk and honey, as Yahweh, the Elohim of your fathers, has promised you. 
-<span class="v">4&#160;</span>It shall be, when you have crossed over the Jordan, that you shall set up these stones, which I command you today, on Mount Ebal, and you shall coat them with plaster. 
-<span class="v">5&#160;</span>There you shall build an altar to Yahweh your Elohim, an altar of stones. You shall not use any iron tool on them. 
-<span class="v">6&#160;</span>You shall build Yahweh your Elohim’s altar of uncut stones. You shall offer burnt offerings on it to Yahweh your Elohim. 
-<span class="v">7&#160;</span>You shall sacrifice peace offerings, and shall eat there. You shall rejoice before Yahweh your Elohim. 
-<span class="v">8&#160;</span>You shall write on the stones all the words of this law very plainly.” 
-</p><p>
-<span class="v">9&#160;</span>Moses and the Levitical priests spoke to all Israel, saying, “Be silent and listen, Israel! Today you have become the people of Yahweh your Elohim. 
-<span class="v">10&#160;</span>You shall therefore obey Yahweh your Elohim’s voice, and do his commandments and his statutes, which I command you today.” 
-</p><p>
-<span class="v">11&#160;</span>Moses commanded the people the same day, saying, 
-<span class="v">12&#160;</span>“These shall stand on Mount Gerizim to bless the people, when you have crossed over the Jordan: Simeon, Levi, Judah, Issachar, Joseph, and Benjamin. 
-<span class="v">13&#160;</span>These shall stand on Mount Ebal for the curse: Reuben, Gad, Asher, Zebulun, Dan, and Naphtali. 
-<span class="v">14&#160;</span>With a loud voice, the Levites shall say to all the men of Israel, 
-<span class="v">15&#160;</span>‘Cursed is the man who makes an engraved or molten image, an abomination to Yahweh, the work of the hands of the craftsman, and sets it up in secret.’ 
-</p><p>All the people shall answer and say, ‘Amen.’ 
-</p><p>
-<span class="v">16&#160;</span>‘Cursed is he who dishonors his father or his mother.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">17&#160;</span>‘Cursed is he who removes his neighbor’s landmark.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">18&#160;</span>‘Cursed is he who leads the blind astray on the road.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">19&#160;</span>‘Cursed is he who withholds justice from the foreigner, fatherless, and widow.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">20&#160;</span>‘Cursed is he who lies with<span class="f">+ \fr 27:20 \ft i.e., has sexual relations with</span> his father’s woman, because he dishonors his father’s bed.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">21&#160;</span>‘Cursed is he who lies with any kind of animal.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">22&#160;</span>‘Cursed is he who lies with his sister, his father’s daughter or his mother’s daughter.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">23&#160;</span>‘Cursed is he who lies with his mother-in-law.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">24&#160;</span>‘Cursed is he who secretly kills his neighbor.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">25&#160;</span>‘Cursed is he who takes a bribe to kill an innocent person.’ 
-</p><p>All the people shall say, ‘Amen.’ 
-</p><p>
-<span class="v">26&#160;</span>‘Cursed is he who doesn’t uphold the words of this law by doing them.’ 
-</p><p>All the people shall say, ‘Amen.’&#160;” 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>It shall happen, if you shall listen diligently to Yahweh your Elohim’s voice, to observe to do all his commandments which I command you today, that Yahweh your Elohim will set you high above all the nations of the earth. 
-<span class="v">2&#160;</span>All these blessings will come upon you, and overtake you, if you listen to Yahweh your Elohim’s voice. 
-<span class="v">3&#160;</span>You shall be blessed in the city, and you shall be blessed in the field. 
-<span class="v">4&#160;</span>You shall be blessed in the fruit of your body, the fruit of your ground, the fruit of your animals, the increase of your livestock, and the young of your flock. 
-<span class="v">5&#160;</span>Your basket and your kneading trough shall be blessed. 
-<span class="v">6&#160;</span>You shall be blessed when you come in, and you shall be blessed when you go out. 
-<span class="v">7&#160;</span>Yahweh will cause your enemies who rise up against you to be struck before you. They will come out against you one way, and will flee before you seven ways. 
-<span class="v">8&#160;</span>Yahweh will command the blessing on you in your barns, and in all that you put your hand to. He will bless you in the land which Yahweh your Elohim gives you. 
-<span class="v">9&#160;</span>Yahweh will establish you for a set-apart people to himself, as he has sworn to you, if you shall keep the commandments of Yahweh your Elohim, and walk in his ways. 
-<span class="v">10&#160;</span>All the peoples of the earth shall see that you are called by Yahweh’s name, and they will be afraid of you. 
-<span class="v">11&#160;</span>Yahweh will grant you abundant prosperity in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, in the land which Yahweh swore to your fathers to give you. 
-<span class="v">12&#160;</span>Yahweh will open to you his good treasure in the sky, to give the rain of your land in its season, and to bless all the work of your hand. You will lend to many nations, and you will not borrow. 
-<span class="v">13&#160;</span>Yahweh will make you the head, and not the tail. You will be above only, and you will not be beneath, if you listen to the commandments of Yahweh your Elohim which I command you today, to observe and to do, 
-<span class="v">14&#160;</span>and shall not turn away from any of the words which I command you today, to the right hand or to the left, to go after other elohims to serve them. 
-</p><p>
-<span class="v">15&#160;</span>But it shall come to pass, if you will not listen to Yahweh your Elohim’s voice, to observe to do all his commandments and his statutes which I command you today, that all these curses will come on you and overtake you. 
-<span class="v">16&#160;</span>You will be cursed in the city, and you will be cursed in the field. 
-<span class="v">17&#160;</span>Your basket and your kneading trough will be cursed. 
-<span class="v">18&#160;</span>The fruit of your body, the fruit of your ground, the increase of your livestock, and the young of your flock will be cursed. 
-<span class="v">19&#160;</span>You will be cursed when you come in, and you will be cursed when you go out. 
-<span class="v">20&#160;</span>Yahweh will send on you cursing, confusion, and rebuke in all that you put your hand to do, until you are destroyed and until you perish quickly, because of the evil of your doings, by which you have forsaken me. 
-<span class="v">21&#160;</span>Yahweh will make the pestilence cling to you, until he has consumed you from off the land where you go in to possess it. 
-<span class="v">22&#160;</span>Yahweh will strike you with consumption, with fever, with inflammation, with fiery heat, with the sword, with blight, and with mildew. They will pursue you until you perish. 
-<span class="v">23&#160;</span>Your sky that is over your head will be bronze, and the earth that is under you will be iron. 
-<span class="v">24&#160;</span>Yahweh will make the rain of your land powder and dust. It will come down on you from the sky, until you are destroyed. 
-<span class="v">25&#160;</span>Yahweh will cause you to be struck before your enemies. You will go out one way against them, and will flee seven ways before them. You will be tossed back and forth among all the kingdoms of the earth. 
-<span class="v">26&#160;</span>Your dead bodies will be food to all birds of the sky, and to the animals of the earth; and there will be no one to frighten them away. 
-<span class="v">27&#160;</span>Yahweh will strike you with the boils of Egypt, with the tumors, with the scurvy, and with the itch, of which you can not be healed. 
-<span class="v">28&#160;</span>Yahweh will strike you with madness, with blindness, and with astonishment of heart. 
-<span class="v">29&#160;</span>You will grope at noonday, as the blind gropes in darkness, and you shall not prosper in your ways. You will only be oppressed and robbed always, and there will be no one to save you. 
-<span class="v">30&#160;</span>You will betroth a woman, and another man shall lie with her. You will build a house, and you won’t dwell in it. You will plant a vineyard, and not use its fruit. 
-<span class="v">31&#160;</span>Your ox will be slain before your eyes, and you will not eat any of it. Your donkey will be violently taken away from before your face, and will not be restored to you. Your sheep will be given to your enemies, and you will have no one to save you. 
-<span class="v">32&#160;</span>Your sons and your daughters will be given to another people. Your eyes will look and fail with longing for them all day long. There will be no power in your hand. 
-<span class="v">33&#160;</span>A nation which you don’t know will eat the fruit of your ground and all of your work. You will only be oppressed and crushed always, 
-<span class="v">34&#160;</span>so that the sights that you see with your eyes will drive you mad. 
-<span class="v">35&#160;</span>Yahweh will strike you in the knees and in the legs with a sore boil, of which you cannot be healed, from the sole of your foot to the crown of your head. 
-<span class="v">36&#160;</span>Yahweh will bring you, and your king whom you will set over yourselves, to a nation that you have not known, you nor your fathers. There you will serve other elohims of wood and stone. 
-<span class="v">37&#160;</span>You will become an astonishment, a proverb, and a byword among all the peoples where Yahweh will lead you away. 
-<span class="v">38&#160;</span>You will carry much seed out into the field, and will gather little in, for the locust will consume it. 
-<span class="v">39&#160;</span>You will plant vineyards and dress them, but you will neither drink of the wine, nor harvest, because worms will eat them. 
-<span class="v">40&#160;</span>You will have olive trees throughout all your borders, but you won’t anoint yourself with the oil, for your olives will drop off. 
-<span class="v">41&#160;</span>You will father sons and daughters, but they will not be yours, for they will go into captivity. 
-<span class="v">42&#160;</span>Locusts will consume all of your trees and the fruit of your ground. 
-<span class="v">43&#160;</span>The foreigner who is among you will mount up above you higher and higher, and you will come down lower and lower. 
-<span class="v">44&#160;</span>He will lend to you, and you won’t lend to him. He will be the head, and you will be the tail. 
-</p><p>
-<span class="v">45&#160;</span>All these curses will come on you, and will pursue you and overtake you, until you are destroyed, because you didn’t listen to Yahweh your Elohim’s voice, to keep his commandments and his statutes which he commanded you. 
-<span class="v">46&#160;</span>They will be for a sign and for a wonder to you and to your offspring forever. 
-<span class="v">47&#160;</span>Because you didn’t serve Yahweh your Elohim with joyfulness and with gladness of heart, by reason of the abundance of all things; 
-<span class="v">48&#160;</span>therefore you will serve your enemies whom Yahweh sends against you, in hunger, in thirst, in nakedness, and in lack of all things. He will put an iron yoke on your neck until he has destroyed you. 
-<span class="v">49&#160;</span>Yahweh will bring a nation against you from far away, from the end of the earth, as the eagle flies: a nation whose language you will not understand, 
-<span class="v">50&#160;</span>a nation of fierce facial expressions, that doesn’t respect the elderly, nor show favor to the young. 
-<span class="v">51&#160;</span>They will eat the fruit of your livestock and the fruit of your ground, until you are destroyed. They also won’t leave you grain, new wine, oil, the increase of your livestock, or the young of your flock, until they have caused you to perish. 
-<span class="v">52&#160;</span>They will besiege you in all your gates until your high and fortified walls in which you trusted come down throughout all your land. They will besiege you in all your gates throughout all your land which Yahweh your Elohim has given you. 
-<span class="v">53&#160;</span>You will eat the fruit of your own body, the flesh of your sons and of your daughters, whom Yahweh your Elohim has given you, in the siege and in the distress with which your enemies will distress you. 
-<span class="v">54&#160;</span>The man who is tender among you, and very delicate, his eye will be evil toward his brother, toward the woman whom he loves, and toward the remnant of his children whom he has remaining, 
-<span class="v">55&#160;</span>so that he will not give to any of them of the flesh of his children whom he will eat, because he has nothing left to him, in the siege and in the distress with which your enemy will distress you in all your gates. 
-<span class="v">56&#160;</span>The tender and delicate woman among you, who would not venture to set the sole of her foot on the ground for delicateness and tenderness, her eye will be evil toward the man that she loves, toward her son, toward her daughter, 
-<span class="v">57&#160;</span>toward her young one who comes out from between her feet, and toward her children whom she bears; for she will eat them secretly for lack of all things in the siege and in the distress with which your enemy will distress you in your gates. 
-<span class="v">58&#160;</span>If you will not observe to do all the words of this law that are written in this book, that you may fear this glorious and fearful name, YAHWEH your Elohim, 
-<span class="v">59&#160;</span>then Yahweh will make your plagues and the plagues of your offspring fearful, even great plagues, and of long duration, and severe sicknesses, and of long duration. 
-<span class="v">60&#160;</span>He will bring on you again all the diseases of Egypt, which you were afraid of; and they will cling to you. 
-<span class="v">61&#160;</span>Also every sickness and every plague which is not written in the book of this law, Yahweh will bring them on you until you are destroyed. 
-<span class="v">62&#160;</span>You will be left few in number, even though you were as the stars of the sky for multitude, because you didn’t listen to Yahweh your Elohim’s voice. 
-<span class="v">63&#160;</span>It will happen that as Yahweh rejoiced over you to do you good, and to multiply you, so Yahweh will rejoice over you to cause you to perish and to destroy you. You will be plucked from the land that you are going in to possess. 
-<span class="v">64&#160;</span>Yahweh will scatter you among all peoples, from one end of the earth to the other end of the earth. There you will serve other elohims which you have not known, you nor your fathers, even wood and stone. 
-<span class="v">65&#160;</span>Among these nations you will find no ease, and there will be no rest for the sole of your foot; but Yahweh will give you there a trembling heart, failing of eyes, and pining of soul. 
-<span class="v">66&#160;</span>Your life will hang in doubt before you. You will be afraid night and day, and will have no assurance of your life. 
-<span class="v">67&#160;</span>In the morning you will say, “I wish it were evening!” and at evening you will say, “I wish it were morning!” for the fear of your heart which you will fear, and for the sights which your eyes will see. 
-<span class="v">68&#160;</span>Yahweh will bring you into Egypt again with ships, by the way of which I told to you that you would never see it again. There you will offer yourselves to your enemies for male and female slaves, and nobody will buy you. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>These are the words of the covenant which Yahweh commanded Moses to make with the children of Israel in the land of Moab, in addition to the covenant which he made with them in Horeb. 
-<span class="v">2&#160;</span>Moses called to all Israel, and said to them: 
-</p><p>Your eyes have seen all that Yahweh did in the land of Egypt to Pharaoh, and to all his servants, and to all his land; 
-<span class="v">3&#160;</span>the great trials which your eyes saw, the signs, and those great wonders. 
-<span class="v">4&#160;</span>But Yahweh has not given you a heart to know, eyes to see, and ears to hear, to this day. 
-<span class="v">5&#160;</span>I have led you forty years in the wilderness. Your clothes have not grown old on you, and your sandals have not grown old on your feet. 
-<span class="v">6&#160;</span>You have not eaten bread, neither have you drunk wine or strong drink, that you may know that I am Yahweh your Elohim. 
-<span class="v">7&#160;</span>When you came to this place, Sihon the king of Heshbon and Og the king of Bashan came out against us to battle, and we struck them. 
-<span class="v">8&#160;</span>We took their land, and gave it for an inheritance to the Reubenites, and to the Gadites, and to the half-tribe of the Manassites. 
-<span class="v">9&#160;</span>Therefore keep the words of this covenant and do them, that you may prosper in all that you do. 
-<span class="v">10&#160;</span>All of you stand today in the presence of Yahweh your Elohim: your heads, your tribes, your elders, and your officers, even all the men of Israel, 
-<span class="v">11&#160;</span>your little ones, your women, and the foreigners who are in the middle of your camps, from the one who cuts your wood to the one who draws your water, 
-<span class="v">12&#160;</span>that you may enter into the covenant of Yahweh your Elohim, and into his oath, which Yahweh your Elohim makes with you today, 
-<span class="v">13&#160;</span>that he may establish you today as his people, and that he may be your Elohim, as he spoke to you and as he swore to your fathers, to Abraham, to Isaac, and to Jacob. 
-<span class="v">14&#160;</span>Neither do I make this covenant and this oath with you only, 
-<span class="v">15&#160;</span>but with those who stand here with us today before Yahweh our Elohim, and also with those who are not here with us today 
-<span class="v">16&#160;</span>(for you know how we lived in the land of Egypt, and how we came through the middle of the nations through which you passed; 
-<span class="v">17&#160;</span>and you have seen their abominations and their idols of wood, stone, silver, and gold, which were among them); 
-<span class="v">18&#160;</span>lest there should be among you man, woman, family, or tribe whose heart turns away today from Yahweh our Elohim, to go to serve the elohims of those nations; lest there should be among you a root that produces bitter poison; 
-<span class="v">19&#160;</span>and it happen, when he hears the words of this curse, that he bless himself in his heart, saying, “I shall have peace, though I walk in the stubbornness of my heart,” to destroy the moist with the dry. 
-<span class="v">20&#160;</span>Yahweh will not pardon him, but then Yahweh’s anger and his jealousy will smoke against that man, and all the curse that is written in this book will fall on him, and Yahweh will blot out his name from under the sky. 
-<span class="v">21&#160;</span>Yahweh will set him apart for evil out of all the tribes of Israel, according to all the curses of the covenant written in this book of the law. 
-</p><p>
-<span class="v">22&#160;</span>The generation to come—your children who will rise up after you, and the foreigner who will come from a far land—will say, when they see the plagues of that land, and the sicknesses with which Yahweh has made it sick, 
-<span class="v">23&#160;</span>that all of its land is sulfur, salt, and burning, that it is not sown, doesn’t produce, nor does any grass grow in it, like the overthrow of Sodom, Gomorrah, Admah, and Zeboiim, which Yahweh overthrew in his anger, and in his wrath. 
-<span class="v">24&#160;</span>Even all the nations will say, “Why has Yahweh done this to this land? What does the heat of this great anger mean?” 
-</p><p>
-<span class="v">25&#160;</span>Then men will say, “Because they abandoned the covenant of Yahweh, the Elohim of their fathers, which he made with them when he brought them out of the land of Egypt, 
-<span class="v">26&#160;</span>and went and served other elohims and worshiped them, elohims that they didn’t know and that he had not given to them. 
-<span class="v">27&#160;</span>Therefore Yahweh’s anger burned against this land, to bring on it all the curses that are written in this book. 
-<span class="v">28&#160;</span>Yahweh rooted them out of their land in anger, in wrath, and in great indignation, and thrust them into another land, as it is today.” 
-</p><p>
-<span class="v">29&#160;</span>The secret things belong to Yahweh our Elohim; but the things that are revealed belong to us and to our children forever, that we may do all the words of this law. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>It shall happen, when all these things have come on you, the blessing and the curse, which I have set before you, and you shall call them to mind among all the nations where Yahweh your Elohim has driven you, 
-<span class="v">2&#160;</span>and return to Yahweh your Elohim and obey his voice according to all that I command you today, you and your children, with all your heart and with all your soul, 
-<span class="v">3&#160;</span>that then Yahweh your Elohim will release you from captivity, have compassion on you, and will return and gather you from all the peoples where Yahweh your Elohim has scattered you. 
-<span class="v">4&#160;</span>If your outcasts are in the uttermost parts of the heavens, from there Yahweh your Elohim will gather you, and from there he will bring you back. 
-<span class="v">5&#160;</span>Yahweh your Elohim will bring you into the land which your fathers possessed, and you will possess it. He will do you good, and increase your numbers more than your fathers. 
-<span class="v">6&#160;</span>Yahweh your Elohim will circumcise your heart, and the heart of your offspring, to love Yahweh your Elohim with all your heart and with all your soul, that you may live. 
-<span class="v">7&#160;</span>Yahweh your Elohim will put all these curses on your enemies and on those who hate you, who persecuted you. 
-<span class="v">8&#160;</span>You shall return and obey Yahweh’s voice, and do all his commandments which I command you today. 
-<span class="v">9&#160;</span>Yahweh your Elohim will make you prosperous in all the work of your hand, in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, for good; for Yahweh will again rejoice over you for good, as he rejoiced over your fathers, 
-<span class="v">10&#160;</span>if you will obey Yahweh your Elohim’s voice, to keep his commandments and his statutes which are written in this book of the law, if you turn to Yahweh your Elohim with all your heart and with all your soul. 
-</p><p>
-<span class="v">11&#160;</span>For this commandment which I command you today is not too hard for you or too distant. 
-<span class="v">12&#160;</span>It is not in heaven, that you should say, “Who will go up for us to heaven, bring it to us, and proclaim it to us, that we may do it?” 
-<span class="v">13&#160;</span>Neither is it beyond the sea, that you should say, “Who will go over the sea for us, bring it to us, and proclaim it to us, that we may do it?” 
-<span class="v">14&#160;</span>But the word is very near to you, in your mouth and in your heart, that you may do it. 
-<span class="v">15&#160;</span>Behold, I have set before you today life and prosperity, and death and evil. 
-<span class="v">16&#160;</span>For I command you today to love Yahweh your Elohim, to walk in his ways and to keep his commandments, his statutes, and his ordinances, that you may live and multiply, and that Yahweh your Elohim may bless you in the land where you go in to possess it. 
-<span class="v">17&#160;</span>But if your heart turns away, and you will not hear, but are drawn away and worship other elohims, and serve them, 
-<span class="v">18&#160;</span>I declare to you today that you will surely perish. You will not prolong your days in the land where you pass over the Jordan to go in to possess it. 
-<span class="v">19&#160;</span>I call heaven and earth to witness against you today that I have set before you life and death, the blessing and the curse. Therefore choose life, that you may live, you and your descendants, 
-<span class="v">20&#160;</span>to love Yahweh your Elohim, to obey his voice, and to cling to him; for he is your life, and the length of your days, that you may dwell in the land which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob, to give them. 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>Moses went and spoke these words to all Israel. 
-<span class="v">2&#160;</span>He said to them, “I am one hundred twenty years old today. I can no more go out and come in. Yahweh has said to me, ‘You shall not go over this Jordan.’ 
-<span class="v">3&#160;</span>Yahweh your Elohim himself will go over before you. He will destroy these nations from before you, and you shall dispossess them. Joshua will go over before you, as Yahweh has spoken. 
-<span class="v">4&#160;</span>Yahweh will do to them as he did to Sihon and to Og, the kings of the Amorites, and to their land, when he destroyed them. 
-<span class="v">5&#160;</span>Yahweh will deliver them up before you, and you shall do to them according to all the commandment which I have commanded you. 
-<span class="v">6&#160;</span>Be strong and courageous. Don’t be afraid or scared of them, for Yahweh your Elohim himself is who goes with you. He will not fail you nor forsake you.” 
-</p><p>
-<span class="v">7&#160;</span>Moses called to Joshua, and said to him in the sight of all Israel, “Be strong and courageous, for you shall go with this people into the land which Yahweh has sworn to their fathers to give them; and you shall cause them to inherit it. 
-<span class="v">8&#160;</span>Yahweh himself is who goes before you. He will be with you. He will not fail you nor forsake you. Don’t be afraid. Don’t be discouraged.” 
-</p><p>
-<span class="v">9&#160;</span>Moses wrote this law and delivered it to the priests the sons of Levi, who bore the ark of Yahweh’s covenant, and to all the elders of Israel. 
-<span class="v">10&#160;</span>Moses commanded them, saying, “At the end of every seven years, in the set time of the year of release, in the feast of booths, 
-<span class="v">11&#160;</span>when all Israel has come to appear before Yahweh your Elohim in the place which he will choose, you shall read this law before all Israel in their hearing. 
-<span class="v">12&#160;</span>Assemble the people, the men and the women and the little ones, and the foreigners who are within your gates, that they may hear, learn, fear Yahweh your Elohim, and observe to do all the words of this law, 
-<span class="v">13&#160;</span>and that their children, who have not known, may hear and learn to fear Yahweh your Elohim, as long as you live in the land where you go over the Jordan to possess it.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh said to Moses, “Behold, your days approach that you must die. Call Joshua, and present yourselves in the Tent of Meeting, that I may commission him.” 
-</p><p>Moses and Joshua went, and presented themselves in the Tent of Meeting. 
-</p><p>
-<span class="v">15&#160;</span>Yahweh appeared in the Tent in a pillar of cloud, and the pillar of cloud stood over the Tent’s door. 
-<span class="v">16&#160;</span>Yahweh said to Moses, “Behold, you shall sleep with your fathers. This people will rise up and play the prostitute after the strange elohims of the land where they go to be among them, and will forsake me and break my covenant which I have made with them. 
-<span class="v">17&#160;</span>Then my anger shall be kindled against them in that day, and I will forsake them, and I will hide my face from them, and they shall be devoured, and many evils and troubles shall come on them; so that they will say in that day, ‘Haven’t these evils come on us because our Elohim is not among us?’ 
-<span class="v">18&#160;</span>I will surely hide my face in that day for all the evil which they have done, in that they have turned to other elohims. 
-</p><p>
-<span class="v">19&#160;</span>“Now therefore write this song for yourselves, and teach it to the children of Israel. Put it in their mouths, that this song may be a witness for me against the children of Israel. 
-<span class="v">20&#160;</span>For when I have brought them into the land which I swore to their fathers, flowing with milk and honey, and they have eaten and filled themselves, and grown fat, then they will turn to other elohims, and serve them, and despise me, and break my covenant. 
-<span class="v">21&#160;</span>It will happen, when many evils and troubles have come on them, that this song will testify before them as a witness; for it will not be forgotten out of the mouths of their descendants; for I know their ways and what they are doing today, before I have brought them into the land which I promised them.” 
-</p><p>
-<span class="v">22&#160;</span>So Moses wrote this song the same day, and taught it to the children of Israel. 
-</p><p>
-<span class="v">23&#160;</span>He commissioned Joshua the son of Nun, and said, “Be strong and courageous; for you shall bring the children of Israel into the land which I swore to them. I will be with you.” 
-</p><p>
-<span class="v">24&#160;</span>When Moses had finished writing the words of this law in a book, until they were finished, 
-<span class="v">25&#160;</span>Moses commanded the Levites, who bore the ark of Yahweh’s covenant, saying, 
-<span class="v">26&#160;</span>“Take this book of the law, and put it by the side of the ark of Yahweh your Elohim’s covenant, that it may be there for a witness against you. 
-<span class="v">27&#160;</span>For I know your rebellion and your stiff neck. Behold, while I am yet alive with you today, you have been rebellious against Yahweh. How much more after my death? 
-<span class="v">28&#160;</span>Assemble to me all the elders of your tribes and your officers, that I may speak these words in their ears, and call heaven and earth to witness against them. 
-<span class="v">29&#160;</span>For I know that after my death you will utterly corrupt yourselves, and turn away from the way which I have commanded you; and evil will happen to you in the latter days, because you will do that which is evil in Yahweh’s sight, to provoke him to anger through the work of your hands.” 
-</p><p>
-<span class="v">30&#160;</span>Moses spoke in the ears of all the assembly of Israel the words of this song, until they were finished. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Give ear, you heavens, and I will speak. 
-</p><p class="q2">Let the earth hear the words of my mouth. 
-</p><p class="q1">
-<span class="v">2&#160;</span>My doctrine will drop as the rain. 
-</p><p class="q2">My speech will condense as the dew, 
-</p><p class="q2">as the misty rain on the tender grass, 
-</p><p class="q2">as the showers on the herb. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For I will proclaim Yahweh’s name. 
-</p><p class="q2">Ascribe greatness to our Elohim! 
-</p><p class="q1">
-<span class="v">4&#160;</span>The Rock: his work is perfect, 
-</p><p class="q2">for all his ways are just. 
-</p><p class="q2">A Elohim of faithfulness who does no wrong, 
-</p><p class="q2">just and right is he. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They have dealt corruptly with him. 
-</p><p class="q2">They are not his children, because of their defect. 
-</p><p class="q2">They are a perverse and crooked generation. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Is this the way you repay Yahweh, 
-</p><p class="q2">foolish and unwise people? 
-</p><p class="q1">Isn’t he your father who has bought you? 
-</p><p class="q2">He has made you and established you. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Remember the days of old. 
-</p><p class="q2">Consider the years of many generations. 
-</p><p class="q1">Ask your father, and he will show you; 
-</p><p class="q2">your elders, and they will tell you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>When the Most High gave to the nations their inheritance, 
-</p><p class="q2">when he separated the children of men, 
-</p><p class="q1">he set the bounds of the peoples 
-</p><p class="q2">according to the number of the children of Israel. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For Yahweh’s portion is his people. 
-</p><p class="q2">Jacob is the lot of his inheritance. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He found him in a desert land, 
-</p><p class="q2">in the waste howling wilderness. 
-</p><p class="q1">He surrounded him. 
-</p><p class="q2">He cared for him. 
-</p><p class="q2">He kept him as the apple of his eye. 
-</p><p class="q1">
-<span class="v">11&#160;</span>As an eagle that stirs up her nest, 
-</p><p class="q2">that flutters over her young, 
-</p><p class="q1">he spread abroad his wings, 
-</p><p class="q2">he took them, 
-</p><p class="q2">he bore them on his feathers. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yahweh alone led him. 
-</p><p class="q2">There was no foreign elohim with him. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He made him ride on the high places of the earth. 
-</p><p class="q2">He ate the increase of the field. 
-</p><p class="q1">He caused him to suck honey out of the rock, 
-</p><p class="q2">oil out of the flinty rock; 
-</p><p class="q1">
-<span class="v">14&#160;</span>butter from the herd, and milk from the flock, 
-</p><p class="q2">with fat of lambs, 
-</p><p class="q2">rams of the breed of Bashan, and goats, 
-</p><p class="q2">with the finest of the wheat. 
-</p><p class="q2">From the blood of the grape, you drank wine. 
-</p><p class="q1">
-<span class="v">15&#160;</span>But Jeshurun grew fat, and kicked. 
-</p><p class="q2">You have grown fat. 
-</p><p class="q2">You have grown thick. 
-</p><p class="q2">You have become sleek. 
-</p><p class="q1">Then he abandoned Elohim who made him, 
-</p><p class="q2">and rejected the Rock of his salvation. 
-</p><p class="q1">
-<span class="v">16&#160;</span>They moved him to jealousy with strange elohims. 
-</p><p class="q2">They provoked him to anger with abominations. 
-</p><p class="q1">
-<span class="v">17&#160;</span>They sacrificed to demons, not Elohim, 
-</p><p class="q2">to elohims that they didn’t know, 
-</p><p class="q2">to new elohims that came up recently, 
-</p><p class="q2">which your fathers didn’t dread. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Of the Rock who became your father, you are unmindful, 
-</p><p class="q2">and have forgotten Elohim who gave you birth. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Yahweh saw and abhorred, 
-</p><p class="q2">because of the provocation of his sons and his daughters. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He said, “I will hide my face from them. 
-</p><p class="q2">I will see what their end will be; 
-</p><p class="q1">for they are a very perverse generation, 
-</p><p class="q2">children in whom is no faithfulness. 
-</p><p class="q1">
-<span class="v">21&#160;</span>They have moved me to jealousy with that which is not Elohim. 
-</p><p class="q2">They have provoked me to anger with their vanities. 
-</p><p class="q1">I will move them to jealousy with those who are not a people. 
-</p><p class="q2">I will provoke them to anger with a foolish nation. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For a fire is kindled in my anger, 
-</p><p class="q2">that burns to the lowest Sheol,<span class="f">+ \fr 32:22 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">devours the earth with its increase, 
-</p><p class="q2">and sets the foundations of the mountains on fire. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>“I will heap evils on them. 
-</p><p class="q2">I will spend my arrows on them. 
-</p><p class="q1">
-<span class="v">24&#160;</span>They shall be wasted with hunger, 
-</p><p class="q2">and devoured with burning heat 
-</p><p class="q2">and bitter destruction. 
-</p><p class="q1">I will send the teeth of animals on them, 
-</p><p class="q2">with the venom of vipers that glide in the dust. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Outside the sword will bereave, 
-</p><p class="q2">and in the rooms, 
-</p><p class="q2">terror on both young man and virgin, 
-</p><p class="q2">the nursing infant with the gray-haired man. 
-</p><p class="q1">
-<span class="v">26&#160;</span>I said that I would scatter them afar. 
-</p><p class="q2">I would make their memory to cease from among men; 
-</p><p class="q1">
-<span class="v">27&#160;</span>were it not that I feared the provocation of the enemy, 
-</p><p class="q2">lest their adversaries should judge wrongly, 
-</p><p class="q2">lest they should say, ‘Our hand is exalted; 
-</p><p class="q2">Yahweh has not done all this.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>For they are a nation void of counsel. 
-</p><p class="q2">There is no understanding in them. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Oh that they were wise, that they understood this, 
-</p><p class="q2">that they would consider their latter end! 
-</p><p class="q1">
-<span class="v">30&#160;</span>How could one chase a thousand, 
-</p><p class="q2">and two put ten thousand to flight, 
-</p><p class="q1">unless their Rock had sold them, 
-</p><p class="q2">and Yahweh had delivered them up? 
-</p><p class="q1">
-<span class="v">31&#160;</span>For their rock is not as our Rock, 
-</p><p class="q2">even our enemies themselves concede. 
-</p><p class="q1">
-<span class="v">32&#160;</span>For their vine is of the vine of Sodom, 
-</p><p class="q2">of the fields of Gomorrah. 
-</p><p class="q1">Their grapes are poison grapes. 
-</p><p class="q2">Their clusters are bitter. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Their wine is the poison of serpents, 
-</p><p class="q2">the cruel venom of asps. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">34&#160;</span>“Isn’t this laid up in store with me, 
-</p><p class="q2">sealed up among my treasures? 
-</p><p class="q1">
-<span class="v">35&#160;</span>Vengeance is mine, and recompense, 
-</p><p class="q2">at the time when their foot slides, 
-</p><p class="q1">for the day of their calamity is at hand. 
-</p><p class="q2">Their doom rushes at them.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">36&#160;</span>For Yahweh will judge his people, 
-</p><p class="q2">and have compassion on his servants, 
-</p><p class="q1">when he sees that their power is gone, 
-</p><p class="q2">that there is no one remaining, shut up or left at large. 
-</p><p class="q1">
-<span class="v">37&#160;</span>He will say, “Where are their elohims, 
-</p><p class="q2">the rock in which they took refuge, 
-</p><p class="q1">
-<span class="v">38&#160;</span>which ate the fat of their sacrifices, 
-</p><p class="q2">and drank the wine of their drink offering? 
-</p><p class="q1">Let them rise up and help you! 
-</p><p class="q2">Let them be your protection. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">39&#160;</span>“See now that I myself am he. 
-</p><p class="q2">There is no elohim with me. 
-</p><p class="q1">I kill and I make alive. 
-</p><p class="q2">I wound and I heal. 
-</p><p class="q2">There is no one who can deliver out of my hand. 
-</p><p class="q1">
-<span class="v">40&#160;</span>For I lift up my hand to heaven and declare, 
-</p><p class="q2">as I live forever, 
-</p><p class="q1">
-<span class="v">41&#160;</span>if I sharpen my glittering sword, 
-</p><p class="q2">my hand grasps it in judgment; 
-</p><p class="q1">I will take vengeance on my adversaries, 
-</p><p class="q2">and will repay those who hate me. 
-</p><p class="q1">
-<span class="v">42&#160;</span>I will make my arrows drunk with blood. 
-</p><p class="q2">My sword shall devour flesh with the blood of the slain and the captives, 
-</p><p class="q2">from the head of the leaders of the enemy.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">43&#160;</span>Rejoice, you nations, with his people, 
-</p><p class="q2">for he will avenge the blood of his servants. 
-</p><p class="q2">He will take vengeance on his adversaries, 
-</p><p class="q2">and will make atonement for his land and for his people.<span class="f">+ \fr 32:43 \ft For this verse, LXX reads: Rejoice, you heavens, with him, and let all the angels of Elohim worship him; rejoice you Gentiles, with his people, and let all the sons of Elohim strengthen themselves in him; for he will avenge the blood of his sons, and he will render vengeance, and recompense justice to his enemies, and will reward them that hate him; and the Lord shall purge the land of his people.</span> 
-</p><p>
-<span class="v">44&#160;</span>Moses came and spoke all the words of this song in the ears of the people, he and Joshua the son of Nun. 
-<span class="v">45&#160;</span>Moses finished reciting all these words to all Israel. 
-<span class="v">46&#160;</span>He said to them, “Set your heart to all the words which I testify to you today, which you shall command your children to observe to do, all the words of this law. 
-<span class="v">47&#160;</span>For it is no vain thing for you, because it is your life, and through this thing you shall prolong your days in the land, where you go over the Jordan to possess it.” 
-</p><p>
-<span class="v">48&#160;</span>Yahweh spoke to Moses that same day, saying, 
-<span class="v">49&#160;</span>“Go up into this mountain of Abarim, to Mount Nebo, which is in the land of Moab, that is across from Jericho; and see the land of Canaan, which I give to the children of Israel for a possession. 
-<span class="v">50&#160;</span>Die on the mountain where you go up, and be gathered to your people, as Aaron your brother died on Mount Hor, and was gathered to his people; 
-<span class="v">51&#160;</span>because you trespassed against me among the children of Israel at the waters of Meribah of Kadesh, in the wilderness of Zin; because you didn’t uphold my set-apartness among the children of Israel. 
-<span class="v">52&#160;</span>For you shall see the land from a distance; but you shall not go there into the land which I give the children of Israel.” 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p>
-<span class="v">1&#160;</span>This is the blessing with which Moses the man of Elohim blessed the children of Israel before his death. 
-<span class="v">2&#160;</span>He said, 
-</p><p class="q1">“Yahweh came from Sinai, 
-</p><p class="q2">and rose from Seir to them. 
-</p><p class="q1">He shone from Mount Paran. 
-</p><p class="q2">He came from the ten thousands of set-apart ones. 
-</p><p class="q2">At his right hand was a fiery law for them.<span class="f">+ \fr 33:2 \ft another manuscript reads “He came with myriads of set-apart ones from the south, from his mountain slopes.”</span> 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yes, he loves the people. 
-</p><p class="q2">All his saints are in your hand. 
-</p><p class="q2">They sat down at your feet. 
-</p><p class="q2">Each receives your words. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Moses commanded us a law, 
-</p><p class="q2">an inheritance for the assembly of Jacob. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He was king in Jeshurun, 
-</p><p class="q2">when the heads of the people were gathered, 
-</p><p class="q2">all the tribes of Israel together. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“Let Reuben live, and not die; 
-</p><p class="q2">Nor let his men be few.” 
-</p><p>
-<span class="v">7&#160;</span>This is for Judah. He said, 
-</p><p class="q1">“Hear, Yahweh, the voice of Judah. 
-</p><p class="q2">Bring him in to his people. 
-</p><p class="q1">With his hands he contended for himself. 
-</p><p class="q2">You shall be a help against his adversaries.” 
-</p><p>
-<span class="v">8&#160;</span>About Levi he said, 
-</p><p class="q1">“Your Thummim and your Urim are with your elohimly one, 
-</p><p class="q2">whom you proved at Massah, 
-</p><p class="q2">with whom you contended at the waters of Meribah. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He said of his father, and of his mother, ‘I have not seen him.’ 
-</p><p class="q2">He didn’t acknowledge his brothers, 
-</p><p class="q2">nor did he know his own children; 
-</p><p class="q1">for they have observed your word, 
-</p><p class="q2">and keep your covenant. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They shall teach Jacob your ordinances, 
-</p><p class="q2">and Israel your law. 
-</p><p class="q1">They shall put incense before you, 
-</p><p class="q2">and whole burnt offering on your altar. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh, bless his skills. 
-</p><p class="q2">Accept the work of his hands. 
-</p><p class="q1">Strike through the hips of those who rise up against him, 
-</p><p class="q2">of those who hate him, that they not rise again.” 
-</p><p>
-<span class="v">12&#160;</span>About Benjamin he said, 
-</p><p class="q1">“The beloved of Yahweh will dwell in safety by him. 
-</p><p class="q2">He covers him all day long. 
-</p><p class="q2">He dwells between his shoulders.” 
-</p><p>
-<span class="v">13&#160;</span>About Joseph he said, 
-</p><p class="q1">“His land is blessed by Yahweh, 
-</p><p class="q2">for the precious things of the heavens, for the dew, 
-</p><p class="q2">for the deep that couches beneath, 
-</p><p class="q1">
-<span class="v">14&#160;</span>for the precious things of the fruits of the sun, 
-</p><p class="q2">for the precious things that the moon can yield, 
-</p><p class="q1">
-<span class="v">15&#160;</span>for the best things of the ancient mountains, 
-</p><p class="q2">for the precious things of the everlasting hills, 
-</p><p class="q1">
-<span class="v">16&#160;</span>for the precious things of the earth and its fullness, 
-</p><p class="q2">the good will of him who lived in the bush.<span class="f">+ \fr 33:16 \ft i.e., the burning bush of Exodus 3:3-4.</span> 
-</p><p class="q1">Let this come on the head of Joseph, 
-</p><p class="q2">on the crown of the head of him who was separated from his brothers. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Majesty belongs to the firstborn of his herd. 
-</p><p class="q2">His horns are the horns of the wild ox. 
-</p><p class="q2">With them he will push all the peoples to the ends of the earth. 
-</p><p class="q1">They are the ten thousands of Ephraim. 
-</p><p class="q2">They are the thousands of Manasseh.” 
-</p><p>
-<span class="v">18&#160;</span>About Zebulun he said, 
-</p><p class="q1">“Rejoice, Zebulun, in your going out; 
-</p><p class="q2">and Issachar, in your tents. 
-</p><p class="q1">
-<span class="v">19&#160;</span>They will call the peoples to the mountain. 
-</p><p class="q2">There they will offer sacrifices of righteousness, 
-</p><p class="q1">for they will draw out the abundance of the seas, 
-</p><p class="q2">the hidden treasures of the sand.” 
-</p><p>
-<span class="v">20&#160;</span>About Gad he said, 
-</p><p class="q1">“He who enlarges Gad is blessed. 
-</p><p class="q2">He dwells as a lioness, 
-</p><p class="q2">and tears the arm and the crown of the head. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He provided the first part for himself, 
-</p><p class="q2">for the lawgiver’s portion was reserved for him. 
-</p><p class="q1">He came with the heads of the people. 
-</p><p class="q2">He executed the righteousness of Yahweh, 
-</p><p class="q2">His ordinances with Israel.” 
-</p><p>
-<span class="v">22&#160;</span>About Dan he said, 
-</p><p class="q1">“Dan is a lion’s cub 
-</p><p class="q2">that leaps out of Bashan.” 
-</p><p>
-<span class="v">23&#160;</span>About Naphtali he said, 
-</p><p class="q1">“Naphtali, satisfied with favor, 
-</p><p class="q2">full of Yahweh’s blessing, 
-</p><p class="q2">Possess the west and the south.” 
-</p><p>
-<span class="v">24&#160;</span>About Asher he said, 
-</p><p class="q1">“Asher is blessed with children. 
-</p><p class="q2">Let him be acceptable to his brothers. 
-</p><p class="q2">Let him dip his foot in oil. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Your bars will be iron and bronze. 
-</p><p class="q2">As your days, so your strength will be. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">26&#160;</span>“There is no one like Elohim, Jeshurun, 
-</p><p class="q2">who rides on the heavens for your help, 
-</p><p class="q2">in his excellency on the skies. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The eternal Elohim is your dwelling place. 
-</p><p class="q2">Underneath are the everlasting arms. 
-</p><p class="q1">He thrust out the enemy from before you, 
-</p><p class="q2">and said, ‘Destroy!’ 
-</p><p class="q1">
-<span class="v">28&#160;</span>Israel dwells in safety, 
-</p><p class="q2">the fountain of Jacob alone, 
-</p><p class="q1">In a land of grain and new wine. 
-</p><p class="q2">Yes, his heavens drop down dew. 
-</p><p class="q1">
-<span class="v">29&#160;</span>You are happy, Israel! 
-</p><p class="q2">Who is like you, a people saved by Yahweh, 
-</p><p class="q2">the shield of your help, 
-</p><p class="q2">the sword of your excellency? 
-</p><p class="q1">Your enemies will submit themselves to you. 
-</p><p class="q2">You will tread on their high places.” 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Moses went up from the plains of Moab to Mount Nebo, to the top of Pisgah, that is opposite Jericho. Yahweh showed him all the land of Gilead to Dan, 
-<span class="v">2&#160;</span>and all Naphtali, and the land of Ephraim and Manasseh, and all the land of Judah, to the Western Sea, 
-<span class="v">3&#160;</span>and the south,<span class="f">+ \fr 34:3 \ft or, Negev</span> and the Plain of the valley of Jericho the city of palm trees, to Zoar. 
-<span class="v">4&#160;</span>Yahweh said to him, “This is the land which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ I have caused you to see it with your eyes, but you shall not go over there.” 
-</p><p>
-<span class="v">5&#160;</span>So Moses the servant of Yahweh died there in the land of Moab, according to Yahweh’s word. 
-<span class="v">6&#160;</span>He buried him in the valley in the land of Moab opposite Beth Peor, but no man knows where his tomb is to this day. 
-<span class="v">7&#160;</span>Moses was one hundred twenty years old when he died. His eye was not dim, nor his strength gone. 
-<span class="v">8&#160;</span>The children of Israel wept for Moses in the plains of Moab thirty days, until the days of weeping in the mourning for Moses were ended. 
-<span class="v">9&#160;</span>Joshua the son of Nun was full of the spirit of wisdom, for Moses had laid his hands on him. The children of Israel listened to him, and did as Yahweh commanded Moses. 
-<span class="v">10&#160;</span>Since then, there has not arisen a prophet in Israel like Moses, whom Yahweh knew face to face, 
-<span class="v">11&#160;</span>in all the signs and the wonders which Yahweh sent him to do in the land of Egypt, to Pharaoh, and to all his servants, and to all his land, 
-<span class="v">12&#160;</span>and in all the mighty hand, and in all the awesome deeds, which Moses did in the sight of all Israel. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>These are the words which Moses spoke to all Israel beyond the Jordan in the wilderness, in the Arabah opposite Suf, between Paran, Tophel, Laban, Hazeroth, and Dizahab. 
+<sup>2&#160;</sup>It is eleven days’ journey from Horeb by the way of Mount Seir to Kadesh Barnea. 
+<sup>3&#160;</sup>In the fortieth year, in the eleventh month, on the first day of the month, Moses spoke to the children of Israel according to all that Yahweh had given him in commandment to them, 
+<sup>4&#160;</sup>after he had struck Sihon the king of the Amorites who lived in Heshbon, and Og the king of Bashan who lived in Ashtaroth, at Edrei. 
+<sup>5&#160;</sup>Beyond the Jordan, in the land of Moab, Moses began to declare this law, saying, 
+<sup>6&#160;</sup>“Yahweh our Elohim spoke to us in Horeb, saying, ‘You have lived long enough at this mountain. 
+<sup>7&#160;</sup>Turn, and take your journey, and go to the hill country of the Amorites and to all the places near there: in the Arabah, in the hill country, in the lowland, in the South, by the seashore, in the land of the Canaanites, and in Lebanon as far as the great river, the river Euphrates. 
+<sup>8&#160;</sup>Behold, after them.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>I spoke to you at that time, saying, “I am not able to bear you myself alone. 
+<sup>10&#160;</sup>Yahweh your Elohim has multiplied you, and behold, you are today as the stars of the sky for multitude. 
+<sup>11&#160;</sup>May Yahweh, the Elohim of your fathers, make you a thousand times as many as you are and bless you, as he has promised you! 
+<sup>12&#160;</sup>How can I myself alone bear your problems, your burdens, and your strife? 
+<sup>13&#160;</sup>Take wise men of understanding who are respected among your tribes, and I will make them heads over you.” 
+</div><div class="p">
+<sup>14&#160;</sup>You answered me, and said, “The thing which you have spoken is good to do.” 
+<sup>15&#160;</sup>So I took the heads of your tribes, wise and respected men, and made them heads over you, captains of thousands, captains of hundreds, captains of fifties, captains of tens, and officers, according to your tribes. 
+<sup>16&#160;</sup>I commanded your judges at that time, saying, “Hear cases between your brothers and judge righteously between a man and his brother, and the foreigner who is living with him. 
+<sup>17&#160;</sup>You shall not show partiality in judgment; you shall hear the small and the great alike. You shall not be afraid of the face of man, for the judgment is Elohim’s. The case that is too hard for you, you shall bring to me, and I will hear it.” 
+<sup>18&#160;</sup>I commanded you at that time all the things which you should do. 
+<sup>19&#160;</sup>We traveled from Horeb and went through all that great and terrible wilderness which you saw, by the way to the hill country of the Amorites, as Yahweh our Elohim commanded us; and we came to Kadesh Barnea. 
+<sup>20&#160;</sup>I said to you, “You have come to the hill country of the Amorites, which Yahweh our Elohim gives to us. 
+<sup>21&#160;</sup>Behold, Yahweh your Elohim has set the land before you. Go up, take possession, as Yahweh the Elohim of your fathers has spoken to you. Don’t be afraid, neither be dismayed.” 
+</div><div class="p">
+<sup>22&#160;</sup>You came near to me, everyone of you, and said, “Let’s send men before us, that they may search the land for us, and bring back to us word of the way by which we must go up, and the cities to which we shall come.” 
+</div><div class="p">
+<sup>23&#160;</sup>The thing pleased me well. I took twelve of your men, one man for every tribe. 
+<sup>24&#160;</sup>They turned and went up into the hill country, and came to the valley of Eshcol, and spied it out. 
+<sup>25&#160;</sup>They took some of the fruit of the land in their hands and brought it down to us, and brought us word again, and said, “It is a good land which Yahweh our Elohim gives to us.” 
+</div><div class="p">
+<sup>26&#160;</sup>Yet you wouldn’t go up, but rebelled against the commandment of Yahweh your Elohim. 
+<sup>27&#160;</sup>You murmured in your tents, and said, “Because Yahweh hated us, he has brought us out of the land of Egypt, to deliver us into the hand of the Amorites to destroy us. 
+<sup>28&#160;</sup>Where are we going up? Our brothers have made our heart melt, saying, ‘The people are greater and taller than we. The cities are great and fortified up to the sky. Moreover we have seen the sons of the Anakim there!’&#160;” 
+</div><div class="p">
+<sup>29&#160;</sup>Then I said to you, “Don’t be terrified. Don’t be afraid of them. 
+<sup>30&#160;</sup>Yahweh your Elohim, who goes before you, he will fight for you, according to all that he did for you in Egypt before your eyes, 
+<sup>31&#160;</sup>and in the wilderness where you have seen how that Yahweh your Elohim carried you, as a man carries his son, in all the way that you went, until you came to this place.” 
+</div><div class="p">
+<sup>32&#160;</sup>Yet in this thing you didn’t believe Yahweh your Elohim, 
+<sup>33&#160;</sup>who went before you on the way, to seek out a place for you to pitch your tents in: in fire by night, to show you by what way you should go, and in the cloud by day. 
+<sup>34&#160;</sup>Yahweh heard the voice of your words and was angry, and swore, saying, 
+<sup>35&#160;</sup>“Surely not one of these men of this evil generation shall see the good land which I swore to give to your fathers, 
+<sup>36&#160;</sup>except Caleb the son of Jephunneh. He shall see it. I will give the land that he has trodden on to him and to his children, because he has wholly followed Yahweh.” 
+</div><div class="p">
+<sup>37&#160;</sup>Also Yahweh was angry with me for your sakes, saying, “You also shall not go in there. 
+<sup>38&#160;</sup>Joshua the son of Nun, who stands before you, shall go in there. Encourage him, for he shall cause Israel to inherit it. 
+<sup>39&#160;</sup>Moreover your little ones, whom you said would be captured or killed, your children, who today have no knowledge of good or evil, shall go in there. I will give it to them, and they shall possess it. 
+<sup>40&#160;</sup>But as for you, turn, and take your journey into the wilderness by the way to the Red Sea.” 
+</div><div class="p">
+<sup>41&#160;</sup>Then you answered and said to me, “We have sinned against Yahweh. We will go up and fight, according to all that Yahweh our Elohim commanded us.” Every man of you put on his weapons of war, and presumed to go up into the hill country. 
+</div><div class="p">
+<sup>42&#160;</sup>Yahweh said to me, “Tell them, ‘Don’t go up and don’t fight; for I am not among you, lest you be struck before your enemies.’&#160;” 
+</div><div class="p">
+<sup>43&#160;</sup>So I spoke to you, and you didn’t listen; but you rebelled against the commandment of Yahweh, and were presumptuous, and went up into the hill country. 
+<sup>44&#160;</sup>The Amorites, who lived in that hill country, came out against you and chased you as bees do, and beat you down in Seir, even to Hormah. 
+<sup>45&#160;</sup>You returned and wept before Yahweh, but Yahweh didn’t listen to your voice, nor turn his ear to you. 
+<sup>46&#160;</sup>So you stayed in Kadesh many days, according to the days that you remained. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Then we turned, and took our journey into the wilderness by the way to the Red Sea, as Yahweh spoke to me; and we encircled Mount Seir many days. 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh spoke to me, saying, 
+<sup>3&#160;</sup>“You have encircled this mountain long enough. Turn northward. 
+<sup>4&#160;</sup>Command the people, saying, ‘You are to pass through the border of your brothers, the children of Esau, who dwell in Seir; and they will be afraid of you. Therefore be careful. 
+<sup>5&#160;</sup>Don’t contend with them; for I will not give you any of their land, no, not so much as for the sole of the foot to tread on, because I have given Mount Seir to Esau for a possession. 
+<sup>6&#160;</sup>You shall purchase food from them for money, that you may eat. You shall also buy water from them for money, that you may drink.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>For Yahweh your Elohim has blessed you in all the work of your hands. He has known your walking through this great wilderness. These forty years, Yahweh your Elohim has been with you. You have lacked nothing. 
+</div><div class="p">
+<sup>8&#160;</sup>So we passed by from our brothers, the children of Esau, who dwell in Seir, from the way of the Arabah from Elath and from Ezion Geber. We turned and passed by the way of the wilderness of Moab. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh said to me, “Don’t bother Moab, neither contend with them in battle; for I will not give you any of his land for a possession, because I have given Ar to the children of Lot for a possession.” 
+</div><div class="p">
+<sup>10&#160;</sup>(The Emim lived there before, a great and numerous people, and tall as the Anakim. 
+<sup>11&#160;</sup>These also are considered to be Rephaim, as the Anakim; but the Moabites call them Emim. 
+<sup>12&#160;</sup>The Horites also lived in Seir in the past, but the children of Esau succeeded them. They destroyed them from before them, and lived in their place, as Israel did to the land of his possession, which Yahweh gave to them.) 
+</div><div class="p">
+<sup>13&#160;</sup>“Now rise up and cross over the brook Zered.” We went over the brook Zered. 
+</div><div class="p">
+<sup>14&#160;</sup>The days in which we came from Kadesh Barnea until we had come over the brook Zered were thirty-eight years, until all the generation of the men of war were consumed from the middle of the camp, as Yahweh swore to them. 
+<sup>15&#160;</sup>Moreover Yahweh’s hand was against them, to destroy them from the middle of the camp, until they were consumed. 
+<sup>16&#160;</sup>So, when all the men of war were consumed and dead from among the people, 
+<sup>17&#160;</sup>Yahweh spoke to me, saying, 
+<sup>18&#160;</sup>“You are to pass over Ar, the border of Moab, today. 
+<sup>19&#160;</sup>When you come near the border of the children of Ammon, don’t bother them, nor contend with them; for I will not give you any of the land of the children of Ammon for a possession, because I have given it to the children of Lot for a possession.” 
+</div><div class="p">
+<sup>20&#160;</sup>(That also is considered a land of Rephaim. Rephaim lived there in the past, but the Ammonites call them Zamzummim, 
+<sup>21&#160;</sup>a great people, many, and tall, as the Anakim; but Yahweh destroyed them from before Israel, and they succeeded them, and lived in their place, 
+<sup>22&#160;</sup>as he did for the children of Esau who dwell in Seir, when he destroyed the Horites from before them; and they succeeded them, and lived in their place even to this day. 
+<sup>23&#160;</sup>Then the Avvim, who lived in villages as far as Gaza: the Caphtorim, who came out of Caphtor, destroyed them and lived in their place.) 
+</div><div class="p">
+<sup>24&#160;</sup>“Rise up, take your journey, and pass over the valley of the Arnon. Behold, I have given into your hand Sihon the Amorite, king of Heshbon, and his land; begin to possess it, and contend with him in battle. 
+<sup>25&#160;</sup>Today I will begin to put the dread of you and the fear of you on the peoples who are under the whole sky, who shall hear the report of you, and shall tremble and be in anguish because of you.” 
+</div><div class="p">
+<sup>26&#160;</sup>I sent messengers out of the wilderness of Kedemoth to Sihon king of Heshbon with words of peace, saying, 
+<sup>27&#160;</sup>“Let me pass through your land. I will go along by the highway. I will turn neither to the right hand nor to the left. 
+<sup>28&#160;</sup>You shall sell me food for money, that I may eat; and give me water for money, that I may drink. Just let me pass through on my feet, 
+<sup>29&#160;</sup>as the children of Esau who dwell in Seir, and the Moabites who dwell in Ar, did to me, until I pass over the Jordan into the land which Yahweh our Elohim gives us.” 
+<sup>30&#160;</sup>But Sihon king of Heshbon would not let us pass by him, for Yahweh your Elohim hardened his spirit and made his heart obstinate, that he might deliver him into your hand, as it is today. 
+</div><div class="p">
+<sup>31&#160;</sup>Yahweh said to me, “Behold, I have begun to deliver up Sihon and his land before you. Begin to possess, that you may inherit his land.” 
+<sup>32&#160;</sup>Then Sihon came out against us, he and all his people, to battle at Jahaz. 
+<sup>33&#160;</sup>Yahweh our Elohim delivered him up before us; and we struck him, his sons, and all his people. 
+<sup>34&#160;</sup>We took all his cities at that time, and utterly destroyed every inhabited city, with the women and the little ones. We left no one remaining. 
+<sup>35&#160;</sup>Only the livestock we took for plunder for ourselves, with the plunder of the cities which we had taken. 
+<sup>36&#160;</sup>From Aroer, which is on the edge of the valley of the Arnon, and the city that is in the valley, even to Gilead, there was not a city too high for us. Yahweh our Elohim delivered up all before us. 
+<sup>37&#160;</sup>Only to the land of the children of Ammon you didn’t come near: all the banks of the river Jabbok, and the cities of the hill country, and wherever Yahweh our Elohim forbade us. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Then we turned, and went up the way to Bashan. Og the king of Bashan came out against us, he and all his people, to battle at Edrei. 
+<sup>2&#160;</sup>Yahweh said to me, “Don’t fear him; for I have delivered him, with all his people and his land, into your hand. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
+</div><div class="p">
+<sup>3&#160;</sup>So Yahweh our Elohim also delivered into our hand Og, the king of Bashan, and all his people. We struck him until no one was left to him remaining. 
+<sup>4&#160;</sup>We took all his cities at that time. There was not a city which we didn’t take from them: sixty cities, all the region of Argob, the kingdom of Og in Bashan. 
+<sup>5&#160;</sup>All these were cities fortified with high walls, gates, and bars, in addition to a great many villages without walls. 
+<sup>6&#160;</sup>We utterly destroyed them, as we did to Sihon king of Heshbon, utterly destroying every inhabited city, with the women and the little ones. 
+<sup>7&#160;</sup>But all the livestock, and the plunder of the cities, we took for plunder for ourselves. 
+<sup>8&#160;</sup>We took the land at that time out of the hand of the two kings of the Amorites who were beyond the Jordan, from the valley of the Arnon to Mount Hermon. 
+<sup>9&#160;</sup>(The Sidonians call Hermon Sirion, and the Amorites call it Senir.) 
+<sup>10&#160;</sup>We took all the cities of the plain, and all Gilead, and all Bashan, to Salecah and Edrei, cities of the kingdom of Og in Bashan. 
+<sup>11&#160;</sup>(For only Og king of Bashan remained of the remnant of the Rephaim. Behold, his bedstead was a bedstead of iron. Isn’t it in Rabbah of the children of Ammon? Nine cubits was its length, and four cubits its width, after the cubit of a man.) 
+<sup>12&#160;</sup>This land we took in possession at that time: from Aroer, which is by the valley of the Arnon, and half the hill country of Gilead with its cities, I gave to the Reubenites and to the Gadites; 
+<sup>13&#160;</sup>and the rest of Gilead, and all Bashan, the kingdom of Og, I gave to the half-tribe of Manasseh—all the region of Argob, even all Bashan. (The same is called the land of Rephaim. 
+<sup>14&#160;</sup>Jair the son of Manasseh took all the region of Argob, to the border of the Geshurites and the Maacathites, and called them, even Bashan, after his own name, Havvoth Jair, to this day.) 
+<sup>15&#160;</sup>I gave Gilead to Machir. 
+<sup>16&#160;</sup>To the Reubenites and to the Gadites I gave from Gilead even to the valley of the Arnon, the middle of the valley, and its border, even to the river Jabbok, which is the border of the children of Ammon; 
+<sup>17&#160;</sup>the Arabah also, and the Jordan and its border, from Chinnereth even to the sea of the Arabah, the Salt Sea, under the slopes of Pisgah eastward. 
+</div><div class="p">
+<sup>18&#160;</sup>I commanded you at that time, saying, “Yahweh your Elohim has given you this land to possess it. All of you men of valor shall pass over armed before your brothers, the children of Israel. 
+<sup>19&#160;</sup>But your women, and your little ones, and your livestock, (I know that you have much livestock), shall live in your cities which I have given you, 
+<sup>20&#160;</sup>until Yahweh gives rest to your brothers, as to you, and they also possess the land which Yahweh your Elohim gives them beyond the Jordan. Then you shall each return to his own possession, which I have given you.” 
+</div><div class="p">
+<sup>21&#160;</sup>I commanded Joshua at that time, saying, “Your eyes have seen all that Yahweh your Elohim has done to these two kings. So shall Yahweh do to all the kingdoms where you go over. 
+<sup>22&#160;</sup>You shall not fear them; for Yahweh your Elohim himself fights for you.” 
+</div><div class="p">
+<sup>23&#160;</sup>I begged Yahweh at that time, saying, 
+<sup>24&#160;</sup>“Lord Yahweh, you have begun to show your servant your greatness, and your strong hand. For what elohim is there in heaven or in earth that can do works like yours, and mighty acts like yours? 
+<sup>25&#160;</sup>Please let me go over and see the good land that is beyond the Jordan, that fine mountain, and Lebanon.” 
+</div><div class="p">
+<sup>26&#160;</sup>But Yahweh was angry with me because of you, and didn’t listen to me. Yahweh said to me, “That is enough! Speak no more to me of this matter. 
+<sup>27&#160;</sup>Go up to the top of Pisgah, and lift up your eyes westward, and northward, and southward, and eastward, and see with your eyes; for you shall not go over this Jordan. 
+<sup>28&#160;</sup>But commission Joshua, and encourage him, and strengthen him; for he shall go over before this people, and he shall cause them to inherit the land which you shall see.” 
+<sup>29&#160;</sup>So we stayed in the valley near Beth Peor. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Now, Israel, listen to the statutes and to the ordinances which I teach you, to do them, that you may live and go in and possess the land which Yahweh, the Elohim of your fathers, gives you. 
+<sup>2&#160;</sup>You shall not add to the word which I command you, neither shall you take away from it, that you may keep the commandments of Yahweh your Elohim which I command you. 
+<sup>3&#160;</sup>Your eyes have seen what Yahweh did because of Baal Peor; for Yahweh your Elohim has destroyed all the men who followed Baal Peor from among you. 
+<sup>4&#160;</sup>But you who were faithful to Yahweh your Elohim are all alive today. 
+<sup>5&#160;</sup>Behold, I have taught you statutes and ordinances, even as Yahweh my Elohim commanded me, that you should do so in the middle of the land where you go in to possess it. 
+<sup>6&#160;</sup>Keep therefore and do them; for this is your wisdom and your understanding in the sight of the peoples who shall hear all these statutes and say, “Surely this great nation is a wise and understanding people.” 
+<sup>7&#160;</sup>For what great nation is there that has an elohim so near to them as Yahweh our Elohim is whenever we call on him? 
+<sup>8&#160;</sup>What great nation is there that has statutes and ordinances so righteous as all this law which I set before you today? 
+</div><div class="p">
+<sup>9&#160;</sup>Only be careful, and keep your soul diligently, lest you forget the things which your eyes saw, and lest they depart from your heart all the days of your life; but make them known to your children and your children’s children—<sup>10&#160;</sup>the day that you stood before Yahweh your Elohim in Horeb, when Yahweh said to me, “Assemble the people to me, and I will make them hear my words, that they may learn to fear me all the days that they live on the earth, and that they may teach their children.” 
+<sup>11&#160;</sup>You came near and stood under the mountain. The mountain burned with fire to the heart of the sky, with darkness, cloud, and thick darkness. 
+<sup>12&#160;</sup>Yahweh spoke to you out of the middle of the fire: you heard the voice of words, but you saw no form; you only heard a voice. 
+<sup>13&#160;</sup>He declared to you his covenant, which he commanded you to perform, even the ten commandments. He wrote them on two stone tablets. 
+<sup>14&#160;</sup>Yahweh commanded me at that time to teach you statutes and ordinances, that you might do them in the land where you go over to possess it. 
+<sup>15&#160;</sup>Be very careful, for you saw no kind of form on the day that Yahweh spoke to you in Horeb out of the middle of the fire, 
+<sup>16&#160;</sup>lest you corrupt yourselves, and make yourself a carved image in the form of any figure, the likeness of male or female, 
+<sup>17&#160;</sup>the likeness of any animal that is on the earth, the likeness of any winged bird that flies in the sky, 
+<sup>18&#160;</sup>the likeness of anything that creeps on the ground, the likeness of any fish that is in the water under the earth; 
+<sup>19&#160;</sup>and lest you lift up your eyes to the sky, and when you see the sun and the moon and the stars, even all the army of the sky, you are drawn away and worship them, and serve them, which Yahweh your Elohim has allotted to all the peoples under the whole sky. 
+<sup>20&#160;</sup>But Yahweh has taken you, and brought you out of the iron furnace, out of Egypt, to be to him a people of inheritance, as it is today. 
+<sup>21&#160;</sup>Furthermore Yahweh was angry with me for your sakes, and swore that I should not go over the Jordan, and that I should not go in to that good land which Yahweh your Elohim gives you for an inheritance; 
+<sup>22&#160;</sup>but I must die in this land. I must not go over the Jordan, but you shall go over and possess that good land. 
+<sup>23&#160;</sup>Be careful, lest you forget the covenant of Yahweh your Elohim, which he made with you, and make yourselves a carved image in the form of anything which Yahweh your Elohim has forbidden you. 
+<sup>24&#160;</sup>For Yahweh your Elohim is a devouring fire, a jealous Elohim. 
+<sup>25&#160;</sup>When you father children and children’s children, and you have been long in the land, and then corrupt yourselves, and make a carved image in the form of anything, and do that which is evil in Yahweh your Elohim’s sight to provoke him to anger, 
+<sup>26&#160;</sup>I call heaven and earth to witness against you today, that you will soon utterly perish from off the land which you go over the Jordan to possess it. You will not prolong your days on it, but will utterly be destroyed. 
+<sup>27&#160;</sup>Yahweh will scatter you among the peoples, and you will be left few in number among the nations where Yahweh will lead you away. 
+<sup>28&#160;</sup>There you will serve elohims, the work of men’s hands, wood and stone, which neither see, nor hear, nor eat, nor smell. 
+<sup>29&#160;</sup>But from there you shall seek Yahweh your Elohim, and you will find him when you search after him with all your heart and with all your soul. 
+<sup>30&#160;</sup>When you are in oppression, and all these things have come on you, in the latter days you shall return to Yahweh your Elohim and listen to his voice. 
+<sup>31&#160;</sup>For Yahweh your Elohim is a merciful Elohim. He will not fail you nor destroy you, nor forget the covenant of your fathers which he swore to them. 
+<sup>32&#160;</sup>For ask now of the days that are past, which were before you, since the day that Elohim created man on the earth, and from the one end of the sky to the other, whether there has been anything as great as this thing is, or has been heard like it? 
+<sup>33&#160;</sup>Did a people ever hear the voice of Elohim speaking out of the middle of the fire, as you have heard, and live? 
+<sup>34&#160;</sup>Or has Elohim tried to go and take a nation for himself from among another nation, by trials, by signs, by wonders, by war, by a mighty hand, by an outstretched arm, and by great terrors, according to all that Yahweh your Elohim did for you in Egypt before your eyes? 
+<sup>35&#160;</sup>It was shown to you so that you might know that Yahweh is Elohim. There is no one else besides him. 
+<sup>36&#160;</sup>Out of heaven he made you to hear his voice, that he might instruct you. On earth he made you to see his great fire; and you heard his words out of the middle of the fire. 
+<sup>37&#160;</sup>Because he loved your fathers, therefore he chose their offspring after them, and brought you out with his presence, with his great power, out of Egypt; 
+<sup>38&#160;</sup>to drive out nations from before you greater and mightier than you, to bring you in, to give you their land for an inheritance, as it is today. 
+<sup>39&#160;</sup>Know therefore today, and take it to heart, that Yahweh himself is Elohim in heaven above and on the earth beneath. There is no one else. 
+<sup>40&#160;</sup>You shall keep his statutes and his commandments which I command you today, that it may go well with you and with your children after you, and that you may prolong your days in the land which Yahweh your Elohim gives you for all time. 
+</div><div class="p">
+<sup>41&#160;</sup>Then Moses set apart three cities beyond the Jordan toward the sunrise, 
+<sup>42&#160;</sup>that the man slayer might flee there, who kills his neighbor unintentionally and didn’t hate him in time past, and that fleeing to one of these cities he might live: 
+<sup>43&#160;</sup>Bezer in the wilderness, in the plain country, for the Reubenites; and Ramoth in Gilead for the Gadites; and Golan in Bashan for the Manassites. 
+</div><div class="p">
+<sup>44&#160;</sup>This is the law which Moses set before the children of Israel. 
+<sup>45&#160;</sup>These are the testimonies, and the statutes, and the ordinances which Moses spoke to the children of Israel when they came out of Egypt, 
+<sup>46&#160;</sup>beyond the Jordan, in the valley opposite Beth Peor, in the land of Sihon king of the Amorites, who lived at Heshbon, whom Moses and the children of Israel struck when they came out of Egypt. 
+<sup>47&#160;</sup>They took possession of his land and the land of Og king of Bashan, the two kings of the Amorites, who were beyond the Jordan toward the sunrise; 
+<sup>48&#160;</sup>from Aroer, which is on the edge of the valley of the Arnon, even to Mount Zion (also called Hermon), 
+<sup>49&#160;</sup>and all the Arabah beyond the Jordan eastward, even to the sea of the Arabah, under the slopes of Pisgah. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses called to all Israel, and said to them, “Hear, Israel, the statutes and the ordinances which I speak in your ears today, that you may learn them, and observe to do them.” 
+<sup>2&#160;</sup>Yahweh our Elohim made a covenant with us in Horeb. 
+<sup>3&#160;</sup>Yahweh didn’t make this covenant with our fathers, but with us, even us, who are all of us here alive today. 
+<sup>4&#160;</sup>Yahweh spoke with you face to face on the mountain out of the middle of the fire, 
+<sup>5&#160;</sup>(I stood between Yahweh and you at that time, to show you Yahweh’s word; for you were afraid because of the fire, and didn’t go up onto the mountain) saying, 
+</div><div class="m">
+<sup>6&#160;</sup>“I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+</div><div class="p">
+<sup>7&#160;</sup>“You shall have no other elohims before me. 
+</div><div class="p">
+<sup>8&#160;</sup>“You shall not make a carved image for yourself—any likeness of what is in heaven above, or what is in the earth beneath, or that is in the water under the earth. 
+<sup>9&#160;</sup>You shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children and on the third and on the fourth generation of those who hate me 
+<sup>10&#160;</sup>and showing loving kindness to thousands of those who love me and keep my commandments. 
+</div><div class="p">
+<sup>11&#160;</sup>“You shall not misuse the name of Yahweh your Elohim; for Yahweh will not hold him guiltless who misuses his name. 
+</div><div class="p">
+<sup>12&#160;</sup>“Observe the Sabbath day, to keep it set-apart, as Yahweh your Elohim commanded you. 
+<sup>13&#160;</sup>You shall labor six days, and do all your work; 
+<sup>14&#160;</sup>but the seventh day is a Sabbath to Yahweh your Elohim, in which you shall not do any work—neither you, nor your son, nor your daughter, nor your male servant, nor your female servant, nor your ox, nor your donkey, nor any of your livestock, nor your stranger who is within your gates; that your male servant and your female servant may rest as well as you. 
+<sup>15&#160;</sup>You shall remember that you were a servant in the land of Egypt, and Yahweh your Elohim brought you out of there by a mighty hand and by an outstretched arm. Therefore Yahweh your Elohim commanded you to keep the Sabbath day. 
+</div><div class="p">
+<sup>16&#160;</sup>“Honor your father and your mother, as Yahweh your Elohim commanded you, that your days may be long and that it may go well with you in the land which Yahweh your Elohim gives you. 
+</div><div class="p">
+<sup>17&#160;</sup>“You shall not murder. 
+</div><div class="p">
+<sup>18&#160;</sup>“You shall not commit adultery. 
+</div><div class="p">
+<sup>19&#160;</sup>“You shall not steal. 
+</div><div class="p">
+<sup>20&#160;</sup>“You shall not give false testimony against your neighbor. 
+</div><div class="p">
+<sup>21&#160;</sup>“You shall not covet your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
+<sup>23&#160;</sup>When you heard the voice out of the middle of the darkness, while the mountain was burning with fire, you came near to me, even all the heads of your tribes, and your elders; 
+<sup>24&#160;</sup>and you said, “Behold, Yahweh our Elohim has shown us his glory and his greatness, and we have heard his voice out of the middle of the fire. We have seen today that Elohim does speak with man, and he lives. 
+<sup>25&#160;</sup>Now therefore, why should we die? For this great fire will consume us. If we hear Yahweh our Elohim’s voice any more, then we shall die. 
+<sup>26&#160;</sup>For who is there of all flesh who has heard the voice of the living Elohim speaking out of the middle of the fire, as we have, and lived? 
+<sup>27&#160;</sup>Go near, and hear all that Yahweh our Elohim shall say, and tell us all that Yahweh our Elohim tells you; and we will hear it, and do it.” 
+</div><div class="p">
+<sup>28&#160;</sup>Yahweh heard the voice of your words when you spoke to me; and Yahweh said to me, “I have heard the voice of the words of this people which they have spoken to you. They have well said all that they have spoken. 
+<sup>29&#160;</sup>Oh that there were such a heart in them that they would fear me and keep all my commandments always, that it might be well with them and with their children forever! 
+</div><div class="p">
+<sup>30&#160;</sup>“Go tell them, ‘Return to your tents.’ 
+<sup>31&#160;</sup>But as for you, stand here by me, and I will tell you all the commandments, and the statutes, and the ordinances, which you shall teach them, that they may do them in the land which I give them to possess.” 
+</div><div class="p">
+<sup>32&#160;</sup>You shall observe to do therefore as Yahweh your Elohim has commanded you. You shall not turn away to the right hand or to the left. 
+<sup>33&#160;</sup>You shall walk in all the way which Yahweh your Elohim has commanded you, that you may live and that it may be well with you, and that you may prolong your days in the land which you shall possess. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the commandments, the statutes, and the ordinances, which Yahweh your Elohim commanded to teach you, that you might do them in the land that you go over to possess; 
+<sup>2&#160;</sup>that you might fear Yahweh your Elohim, to keep all his statutes and his commandments, which I command you—you, your son, and your son’s son, all the days of your life; and that your days may be prolonged. 
+<sup>3&#160;</sup>Hear therefore, Israel, and observe to do it, that it may be well with you, and that you may increase mightily, as Yahweh, the Elohim of your fathers, has promised to you, in a land flowing with milk and honey. 
+</div><div class="p">
+<sup>4&#160;</sup>Hear, Israel: Yahweh is our Elohim. Yahweh is one. 
+<sup>5&#160;</sup>You shall love Yahweh your Elohim with all your heart, with all your soul, and with all your might. 
+<sup>6&#160;</sup>These words, which I command you today, shall be on your heart; 
+<sup>7&#160;</sup>and you shall teach them diligently to your children, and shall talk of them when you sit in your house, and when you walk by the way, and when you lie down, and when you rise up. 
+<sup>8&#160;</sup>You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
+<sup>9&#160;</sup>You shall write them on the door posts of your house and on your gates. 
+</div><div class="p">
+<sup>10&#160;</sup>It shall be, when Yahweh your Elohim brings you into the land which he swore to your fathers, to Abraham, to Isaac, and to Jacob, to give you, great and goodly cities which you didn’t build, 
+<sup>11&#160;</sup>and houses full of all good things which you didn’t fill, and cisterns dug out which you didn’t dig, vineyards and olive trees which you didn’t plant, and you shall eat and be full; 
+<sup>12&#160;</sup>then beware lest you forget Yahweh, who brought you out of the land of Egypt, out of the house of bondage. 
+<sup>13&#160;</sup>You shall fear Yahweh your Elohim; and you shall serve him, and shall swear by his name. 
+<sup>14&#160;</sup>You shall not go after other elohims, of the elohims of the peoples who are around you, 
+<sup>15&#160;</sup>for Yahweh your Elohim among you is a jealous Elohim, lest the anger of Yahweh your Elohim be kindled against you, and he destroy you from off the face of the earth. 
+<sup>16&#160;</sup>You shall not tempt Yahweh your Elohim, as you tempted him in Massah. 
+<sup>17&#160;</sup>You shall diligently keep the commandments of Yahweh your Elohim, and his testimonies, and his statutes, which he has commanded you. 
+<sup>18&#160;</sup>You shall do that which is right and good in Yahweh’s sight, that it may be well with you and that you may go in and possess the good land which Yahweh swore to your fathers, 
+<sup>19&#160;</sup>to thrust out all your enemies from before you, as Yahweh has spoken. 
+</div><div class="p">
+<sup>20&#160;</sup>When your son asks you in time to come, saying, “What do the testimonies, the statutes, and the ordinances, which Yahweh our Elohim has commanded you mean?” 
+<sup>21&#160;</sup>then you shall tell your son, “We were Pharaoh’s slaves in Egypt. Yahweh brought us out of Egypt with a mighty hand; 
+<sup>22&#160;</sup>and Yahweh showed great and awesome signs and wonders on Egypt, on Pharaoh, and on all his house, before our eyes; 
+<sup>23&#160;</sup>and he brought us out from there, that he might bring us in, to give us the land which he swore to our fathers. 
+<sup>24&#160;</sup>Yahweh commanded us to do all these statutes, to fear Yahweh our Elohim, for our good always, that he might preserve us alive, as we are today. 
+<sup>25&#160;</sup>It shall be righteousness to us, if we observe to do all these commandments before Yahweh our Elohim, as he has commanded us.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahweh your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
+<sup>2&#160;</sup>and when Yahweh your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
+<sup>3&#160;</sup>You shall not make marriages with them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
+<sup>4&#160;</sup>For that would turn away your sons from following me, that they may serve other elohims. So Yahweh’s anger would be kindled against you, and he would destroy you quickly. 
+<sup>5&#160;</sup>But you shall deal with them like this: you shall break down their altars, dash their pillars in pieces, cut down their Asherah poles, and burn their engraved images with fire. 
+<sup>6&#160;</sup>For you are a set-apart people to Yahweh your Elohim. Yahweh your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
+<sup>7&#160;</sup>Yahweh didn’t set his love on you nor choose you, because you were more in number than any people; for you were the fewest of all peoples; 
+<sup>8&#160;</sup>but because Yahweh loves you, and because he desires to keep the oath which he swore to your fathers, Yahweh has brought you out with a mighty hand and redeemed you out of the house of bondage, from the hand of Pharaoh king of Egypt. 
+<sup>9&#160;</sup>Know therefore that Yahweh your Elohim himself is Elohim, the faithful Elohim, who keeps covenant and loving kindness to a thousand generations with those who love him and keep his commandments, 
+<sup>10&#160;</sup>and repays those who hate him to their face, to destroy them. He will not be slack to him who hates him. He will repay him to his face. 
+<sup>11&#160;</sup>You shall therefore keep the commandments, the statutes, and the ordinances which I command you today, to do them. 
+<sup>12&#160;</sup>It shall happen, because you listen to these ordinances and keep and do them, that Yahweh your Elohim will keep with you the covenant and the loving kindness which he swore to your fathers. 
+<sup>13&#160;</sup>He will love you, bless you, and multiply you. He will also bless the fruit of your body and the fruit of your ground, your grain and your new wine and your oil, the increase of your livestock and the young of your flock, in the land which he swore to your fathers to give you. 
+<sup>14&#160;</sup>You will be blessed above all peoples. There won’t be male or female barren among you, or among your livestock. 
+<sup>15&#160;</sup>Yahweh will take away from you all sickness; and he will put none of the evil diseases of Egypt, which you know, on you, but will lay them on all those who hate you. 
+<sup>16&#160;</sup>You shall consume all the peoples whom Yahweh your Elohim shall deliver to you. Your eye shall not pity them. You shall not serve their elohims; for that would be a snare to you. 
+<sup>17&#160;</sup>If you shall say in your heart, “These nations are more than I; how can I dispossess them?” 
+<sup>18&#160;</sup>you shall not be afraid of them. You shall remember well what Yahweh your Elohim did to Pharaoh and to all Egypt: 
+<sup>19&#160;</sup>the great trials which your eyes saw, the signs, the wonders, the mighty hand, and the outstretched arm, by which Yahweh your Elohim brought you out. So shall Yahweh your Elohim do to all the peoples of whom you are afraid. 
+<sup>20&#160;</sup>Moreover Yahweh your Elohim will send the hornet among them, until those who are left, and hide themselves, perish from before you. 
+<sup>21&#160;</sup>You shall not be scared of them; for Yahweh your Elohim is among you, a great and awesome Elohim. 
+<sup>22&#160;</sup>Yahweh your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
+<sup>23&#160;</sup>But Yahweh your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
+<sup>24&#160;</sup>He will deliver their kings into your hand, and you shall make their name perish from under the sky. No one will be able to stand before you until you have destroyed them. 
+<sup>25&#160;</sup>You shall burn the engraved images of their elohims with fire. You shall not covet the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
+<sup>26&#160;</sup>You shall not bring an abomination into your house and become a devoted thing like it. You shall utterly detest it. You shall utterly abhor it; for it is a devoted thing. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>You shall observe to do all the commandments which I command you today, that you may live, and multiply, and go in and possess the land which Yahweh swore to your fathers. 
+<sup>2&#160;</sup>You shall remember all the way which Yahweh your Elohim has led you these forty years in the wilderness, that he might humble you, to test you, to know what was in your heart, whether you would keep his commandments or not. 
+<sup>3&#160;</sup>He humbled you, allowed you to be hungry, and fed you with manna, which you didn’t know, neither did your fathers know, that he might teach you that man does not live by bread only, but man lives by every word that proceeds out of Yahweh’s mouth. 
+<sup>4&#160;</sup>Your clothing didn’t grow old on you, neither did your foot swell, these forty years. 
+<sup>5&#160;</sup>You shall consider in your heart that as a man disciplines his son, so Yahweh your Elohim disciplines you. 
+<sup>6&#160;</sup>You shall keep the commandments of Yahweh your Elohim, to walk in his ways, and to fear him. 
+<sup>7&#160;</sup>For Yahweh your Elohim brings you into a good land, a land of brooks of water, of springs, and underground water flowing into valleys and hills; 
+<sup>8&#160;</sup>a land of wheat, barley, vines, fig trees, and pomegranates; a land of olive trees and honey; 
+<sup>9&#160;</sup>a land in which you shall eat bread without scarcity, you shall not lack anything in it; a land whose stones are iron, and out of whose hills you may dig copper. 
+<sup>10&#160;</sup>You shall eat and be full, and you shall bless Yahweh your Elohim for the good land which he has given you. 
+</div><div class="p">
+<sup>11&#160;</sup>Beware lest you forget Yahweh your Elohim, in not keeping his commandments, his ordinances, and his statutes, which I command you today; 
+<sup>12&#160;</sup>lest, when you have eaten and are full, and have built fine houses and lived in them; 
+<sup>13&#160;</sup>and when your herds and your flocks multiply, and your silver and your gold is multiplied, and all that you have is multiplied; 
+<sup>14&#160;</sup>then your heart might be lifted up, and you forget Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage; 
+<sup>15&#160;</sup>who led you through the great and terrible wilderness, with venomous snakes and scorpions, and thirsty ground where there was no water; who poured water for you out of the rock of flint; 
+<sup>16&#160;</sup>who fed you in the wilderness with manna, which your fathers didn’t know, that he might humble you, and that he might prove you, to do you good at your latter end; 
+<sup>17&#160;</sup>and lest you say in your heart, “My power and the might of my hand has gotten me this wealth.” 
+<sup>18&#160;</sup>But you shall remember Yahweh your Elohim, for it is he who gives you power to get wealth, that he may establish his covenant which he swore to your fathers, as it is today. 
+</div><div class="p">
+<sup>19&#160;</sup>It shall be, if you shall forget Yahweh your Elohim, and walk after other elohims, and serve them and worship them, I testify against you today that you shall surely perish. 
+<sup>20&#160;</sup>As the nations that Yahweh makes to perish before you, so you shall perish, because you wouldn’t listen to Yahweh your Elohim’s voice. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Hear, Israel! You are to pass over the Jordan today, to go in to dispossess nations greater and mightier than yourself, cities great and fortified up to the sky, 
+<sup>2&#160;</sup>a people great and tall, the sons of the Anakim, whom you know, and of whom you have heard say, “Who can stand before the sons of Anak?” 
+<sup>3&#160;</sup>Know therefore today that Yahweh your Elohim is he who goes over before you as a devouring fire. He will destroy them and he will bring them down before you. So you shall drive them out and make them perish quickly, as Yahweh has spoken to you. 
+</div><div class="p">
+<sup>4&#160;</sup>Don’t say in your heart, after Yahweh your Elohim has thrust them out from before you, “For my righteousness Yahweh has brought me in to possess this land;” because Yahweh drives them out before you because of the wickedness of these nations. 
+<sup>5&#160;</sup>Not for your righteousness or for the uprightness of your heart do you go in to possess their land; but for the wickedness of these nations Yahweh your Elohim does drive them out from before you, and that he may establish the word which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob. 
+<sup>6&#160;</sup>Know therefore that Yahweh your Elohim doesn’t give you this good land to possess for your righteousness, for you are a stiff-necked people. 
+<sup>7&#160;</sup>Remember, and don’t forget, how you provoked Yahweh your Elohim to wrath in the wilderness. From the day that you left the land of Egypt until you came to this place, you have been rebellious against Yahweh. 
+<sup>8&#160;</sup>Also in Horeb you provoked Yahweh to wrath, and Yahweh was angry with you to destroy you. 
+<sup>9&#160;</sup>When I had gone up onto the mountain to receive the stone tablets, even the tablets of the covenant which Yahweh made with you, then I stayed on the mountain forty days and forty nights. I neither ate bread nor drank water. 
+<sup>10&#160;</sup>Yahweh delivered to me the two stone tablets written with Elohim’s finger. On them were all the words which Yahweh spoke with you on the mountain out of the middle of the fire in the day of the assembly. 
+</div><div class="p">
+<sup>11&#160;</sup>It came to pass at the end of forty days and forty nights that Yahweh gave me the two stone tablets, even the tablets of the covenant. 
+<sup>12&#160;</sup>Yahweh said to me, “Arise, get down quickly from here; for your people whom you have brought out of Egypt have corrupted themselves. They have quickly turned away from the way which I commanded them. They have made a molten image for themselves!” 
+</div><div class="p">
+<sup>13&#160;</sup>Furthermore Yahweh spoke to me, saying, “I have seen these people, and behold, they are a stiff-necked people. 
+<sup>14&#160;</sup>Leave me alone, that I may destroy them, and blot out their name from under the sky; and I will make of you a nation mightier and greater than they.” 
+</div><div class="p">
+<sup>15&#160;</sup>So I turned and came down from the mountain, and the mountain was burning with fire. The two tablets of the covenant were in my two hands. 
+<sup>16&#160;</sup>I looked, and behold, you had sinned against Yahweh your Elohim. You had made yourselves a molded calf. You had quickly turned away from the way which Yahweh had commanded you. 
+<sup>17&#160;</sup>I took hold of the two tablets, and threw them out of my two hands, and broke them before your eyes. 
+<sup>18&#160;</sup>I fell down before Yahweh, as at the first, forty days and forty nights. I neither ate bread nor drank water, because of all your sin which you sinned, in doing that which was evil in Yahweh’s sight, to provoke him to anger. 
+<sup>19&#160;</sup>For I was afraid of the anger and hot displeasure with which Yahweh was angry against you to destroy you. But Yahweh listened to me that time also. 
+<sup>20&#160;</sup>Yahweh was angry enough with Aaron to destroy him. I prayed for Aaron also at the same time. 
+<sup>21&#160;</sup>I took your sin, the calf which you had made, and burned it with fire, and crushed it, grinding it very small, until it was as fine as dust. I threw its dust into the brook that descended out of the mountain. 
+<sup>22&#160;</sup>At Taberah, at Massah, and at Kibroth Hattaavah you provoked Yahweh to wrath. 
+<sup>23&#160;</sup>When Yahweh sent you from Kadesh Barnea, saying, “Go up and possess the land which I have given you,” you rebelled against the commandment of Yahweh your Elohim, and you didn’t believe him or listen to his voice. 
+<sup>24&#160;</sup>You have been rebellious against Yahweh from the day that I knew you. 
+<sup>25&#160;</sup>So I fell down before Yahweh the forty days and forty nights that I fell down, because Yahweh had said he would destroy you. 
+<sup>26&#160;</sup>I prayed to Yahweh, and said, “Lord Yahweh, don’t destroy your people and your inheritance that you have redeemed through your greatness, that you have brought out of Egypt with a mighty hand. 
+<sup>27&#160;</sup>Remember your servants, Abraham, Isaac, and Jacob. Don’t look at the stubbornness of this people, nor at their wickedness, nor at their sin, 
+<sup>28&#160;</sup>lest the land you brought us out from say, ‘Because Yahweh was not able to bring them into the land which he promised to them, and because he hated them, he has brought them out to kill them in the wilderness.’ 
+<sup>29&#160;</sup>Yet they are your people and your inheritance, which you brought out by your great power and by your outstretched arm.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>At that time Yahweh said to me, “Cut two stone tablets like the first, and come up to me onto the mountain, and make an ark of wood. 
+<sup>2&#160;</sup>I will write on the tablets the words that were on the first tablets which you broke, and you shall put them in the ark.” 
+<sup>3&#160;</sup>So I made an ark of acacia wood, and cut two stone tablets like the first, and went up onto the mountain, having the two tablets in my hand. 
+<sup>4&#160;</sup>He wrote on the tablets, according to the first writing, the ten commandments, which Yahweh spoke to you on the mountain out of the middle of the fire in the day of the assembly; and Yahweh gave them to me. 
+<sup>5&#160;</sup>I turned and came down from the mountain, and put the tablets in the ark which I had made; and there they are as Yahweh commanded me. 
+</div><div class="p">
+<sup>6&#160;</sup>(The children of Israel traveled from Beeroth Bene Jaakan to Moserah. There Aaron died, and there he was buried; and Eleazar his son ministered in the priest’s office in his place. 
+<sup>7&#160;</sup>From there they traveled to Gudgodah; and from Gudgodah to Jotbathah, a land of brooks of water. 
+<sup>8&#160;</sup>At that time Yahweh set apart the tribe of Levi to bear the ark of Yahweh’s covenant, to stand before Yahweh to minister to him, and to bless in his name, to this day. 
+<sup>9&#160;</sup>Therefore Levi has no portion nor inheritance with his brothers; Yahweh is his inheritance, according as Yahweh your Elohim spoke to him.) 
+</div><div class="p">
+<sup>10&#160;</sup>I stayed on the mountain, as at the first time, forty days and forty nights; and Yahweh listened to me that time also. Yahweh would not destroy you. 
+<sup>11&#160;</sup>Yahweh said to me, “Arise, take your journey before the people; and they shall go in and possess the land which I swore to their fathers to give to them.” 
+</div><div class="p">
+<sup>12&#160;</sup>Now, Israel, what does Yahweh your Elohim require of you, but to fear Yahweh your Elohim, to walk in all his ways, to love him, and to serve Yahweh your Elohim with all your heart and with all your soul, 
+<sup>13&#160;</sup>to keep Yahweh’s commandments and statutes, which I command you today for your good? 
+<sup>14&#160;</sup>Behold, to Yahweh your Elohim belongs heaven, the heaven of heavens, and the earth, with all that is therein. 
+<sup>15&#160;</sup>Only Yahweh had a delight in your fathers to love them, and he chose their offspring after them, even you above all peoples, as it is today. 
+<sup>16&#160;</sup>Circumcise therefore the foreskin of your heart, and be no more stiff-necked. 
+<sup>17&#160;</sup>For Yahweh your Elohim, he is Elohim of elohims and Lord of lords, the great Elohim, the mighty, and the awesome, who doesn’t respect persons or take bribes. 
+<sup>18&#160;</sup>He executes justice for the fatherless and widow and loves the foreigner in giving him food and clothing. 
+<sup>19&#160;</sup>Therefore love the foreigner, for you were foreigners in the land of Egypt. 
+<sup>20&#160;</sup>You shall fear Yahweh your Elohim. You shall serve him. You shall cling to him, and you shall swear by his name. 
+<sup>21&#160;</sup>He is your praise, and he is your Elohim, who has done for you these great and awesome things which your eyes have seen. 
+<sup>22&#160;</sup>Your fathers went down into Egypt with seventy persons; and now Yahweh your Elohim has made you as the stars of the sky for multitude. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Therefore you shall love Yahweh your Elohim, and keep his instructions, his statutes, his ordinances, and his commandments, always. 
+<sup>2&#160;</sup>Know this day—for I don’t speak with your children who have not known, and who have not seen the chastisement of Yahweh your Elohim, his greatness, his mighty hand, his outstretched arm, 
+<sup>3&#160;</sup>his signs, and his works, which he did in the middle of Egypt to Pharaoh the king of Egypt, and to all his land; 
+<sup>4&#160;</sup>and what he did to the army of Egypt, to their horses, and to their chariots; how he made the water of the Red Sea to overflow them as they pursued you, and how Yahweh has destroyed them to this day; 
+<sup>5&#160;</sup>and what he did to you in the wilderness until you came to this place; 
+<sup>6&#160;</sup>and what he did to Dathan and Abiram, the sons of Eliab, the son of Reuben—how the earth opened its mouth and swallowed them up, with their households, their tents, and every living thing that followed them, in the middle of all Israel; 
+<sup>7&#160;</sup>but your eyes have seen all of Yahweh’s great work which he did. 
+</div><div class="p">
+<sup>8&#160;</sup>Therefore you shall keep the entire commandment which I command you today, that you may be strong, and go in and possess the land that you go over to possess; 
+<sup>9&#160;</sup>and that you may prolong your days in the land which Yahweh swore to your fathers to give to them and to their offspring, a land flowing with milk and honey. 
+<sup>10&#160;</sup>For the land, where you go in to possess isn’t like the land of Egypt that you came out of, where you sowed your seed and watered it with your foot, as a garden of herbs; 
+<sup>11&#160;</sup>but the land that you go over to possess is a land of hills and valleys which drinks water from the rain of the sky, 
+<sup>12&#160;</sup>a land which Yahweh your Elohim cares for. Yahweh your Elohim’s eyes are always on it, from the beginning of the year even to the end of the year. 
+<sup>13&#160;</sup>It shall happen, if you shall listen diligently to my commandments which I command you today, to love Yahweh your Elohim, and to serve him with all your heart and with all your soul, 
+<sup>14&#160;</sup>that I will give the rain for your land in its season, the early rain and the latter rain, that you may gather in your grain, your new wine, and your oil. 
+<sup>15&#160;</sup>I will give grass in your fields for your livestock, and you shall eat and be full. 
+<sup>16&#160;</sup>Be careful, lest your heart be deceived, and you turn away to serve other elohims and worship them; 
+<sup>17&#160;</sup>and Yahweh’s anger be kindled against you, and he shut up the sky so that there is no rain, and the land doesn’t yield its fruit; and you perish quickly from off the good land which Yahweh gives you. 
+<sup>18&#160;</sup>Therefore you shall lay up these words of mine in your heart and in your soul. You shall bind them for a sign on your hand, and they shall be for frontlets between your eyes. 
+<sup>19&#160;</sup>You shall teach them to your children, talking of them when you sit in your house, when you walk by the way, when you lie down, and when you rise up. 
+<sup>20&#160;</sup>You shall write them on the door posts of your house and on your gates; 
+<sup>21&#160;</sup>that your days and your children’s days may be multiplied in the land which Yahweh swore to your fathers to give them, as the days of the heavens above the earth. 
+<sup>22&#160;</sup>For if you shall diligently keep all these commandments which I command you—to do them, to love Yahweh your Elohim, to walk in all his ways, and to cling to him—<sup>23&#160;</sup>then Yahweh will drive out all these nations from before you, and you shall dispossess nations greater and mightier than yourselves. 
+<sup>24&#160;</sup>Every place on which the sole of your foot treads shall be yours: from the wilderness and Lebanon, from the river, the river Euphrates, even to the western sea shall be your border. 
+<sup>25&#160;</sup>No man will be able to stand before you. Yahweh your Elohim will lay the fear of you and the dread of you on all the land that you tread on, as he has spoken to you. 
+<sup>26&#160;</sup>Behold, I set before you today a blessing and a curse: 
+<sup>27&#160;</sup>the blessing, if you listen to the commandments of Yahweh your Elohim, which I command you today; 
+<sup>28&#160;</sup>and the curse, if you do not listen to the commandments of Yahweh your Elohim, but turn away out of the way which I command you today, to go after other elohims which you have not known. 
+<sup>29&#160;</sup>It shall happen, when Yahweh your Elohim brings you into the land that you go to possess, that you shall set the blessing on Mount Gerizim, and the curse on Mount Ebal. 
+<sup>30&#160;</sup>Aren’t they beyond the Jordan, behind the way of the going down of the sun, in the land of the Canaanites who dwell in the Arabah near Gilgal, beside the oaks of Moreh? 
+<sup>31&#160;</sup>For you are to pass over the Jordan to go in to possess the land which Yahweh your Elohim gives you, and you shall possess it and dwell in it. 
+<sup>32&#160;</sup>You shall observe to do all the statutes and the ordinances which I set before you today. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>These are the statutes and the ordinances which you shall observe to do in the land which Yahweh, the Elohim of your fathers, has given you to possess all the days that you live on the earth. 
+<sup>2&#160;</sup>You shall surely destroy all the places in which the nations that you shall dispossess served their elohims: on the high mountains, and on the hills, and under every green tree. 
+<sup>3&#160;</sup>You shall break down their altars, dash their pillars in pieces, and burn their Asherah poles with fire. You shall cut down the engraved images of their elohims. You shall destroy their name out of that place. 
+<sup>4&#160;</sup>You shall not do so to Yahweh your Elohim. 
+<sup>5&#160;</sup>But to the place which Yahweh your Elohim shall choose out of all your tribes, to put his name there, you shall seek his habitation, and you shall come there. 
+<sup>6&#160;</sup>You shall bring your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, your vows, your free will offerings, and the firstborn of your herd and of your flock there. 
+<sup>7&#160;</sup>There you shall eat before Yahweh your Elohim, and you shall rejoice in all that you put your hand to, you and your households, in which Yahweh your Elohim has blessed you. 
+<sup>8&#160;</sup>You shall not do all the things that we do here today, every man whatever is right in his own eyes; 
+<sup>9&#160;</sup>for you haven’t yet come to the rest and to the inheritance which Yahweh your Elohim gives you. 
+<sup>10&#160;</sup>But when you go over the Jordan and dwell in the land which Yahweh your Elohim causes you to inherit, and he gives you rest from all your enemies around you, so that you dwell in safety, 
+<sup>11&#160;</sup>then it shall happen that to the place which Yahweh your Elohim shall choose, to cause his name to dwell there, there you shall bring all that I command you: your burnt offerings, your sacrifices, your tithes, the wave offering of your hand, and all your choice vows which you vow to Yahweh. 
+<sup>12&#160;</sup>You shall rejoice before Yahweh your Elohim—you, and your sons, your daughters, your male servants, your female servants, and the Levite who is within your gates, because he has no portion nor inheritance with you. 
+<sup>13&#160;</sup>Be careful that you don’t offer your burnt offerings in every place that you see; 
+<sup>14&#160;</sup>but in the place which Yahweh chooses in one of your tribes, there you shall offer your burnt offerings, and there you shall do all that I command you. 
+</div><div class="p">
+<sup>15&#160;</sup>Yet you may kill and eat meat within all your gates, after all the desire of your soul, according to Yahweh your Elohim’s blessing which he has given you. The unclean and the clean may eat of it, as of the gazelle and the deer. 
+<sup>16&#160;</sup>Only you shall not eat the blood. You shall pour it out on the earth like water. 
+<sup>17&#160;</sup>You may not eat within your gates the tithe of your grain, or of your new wine, or of your oil, or the firstborn of your herd or of your flock, nor any of your vows which you vow, nor your free will offerings, nor the wave offering of your hand; 
+<sup>18&#160;</sup>but you shall eat them before Yahweh your Elohim in the place which Yahweh your Elohim shall choose: you, your son, your daughter, your male servant, your female servant, and the Levite who is within your gates. You shall rejoice before Yahweh your Elohim in all that you put your hand to. 
+<sup>19&#160;</sup>Be careful that you don’t forsake the Levite as long as you live in your land. 
+</div><div class="p">
+<sup>20&#160;</sup>When Yahweh your Elohim enlarges your border, as he has promised you, and you say, “I want to eat meat,” because your soul desires to eat meat, you may eat meat, after all the desire of your soul. 
+<sup>21&#160;</sup>If the place which Yahweh your Elohim shall choose to put his name is too far from you, then you shall kill of your herd and of your flock, which Yahweh has given you, as I have commanded you; and you may eat within your gates, after all the desire of your soul. 
+<sup>22&#160;</sup>Even as the gazelle and as the deer is eaten, so you shall eat of it. The unclean and the clean may eat of it alike. 
+<sup>23&#160;</sup>Only be sure that you don’t eat the blood; for the blood is the life. You shall not eat the life with the meat. 
+<sup>24&#160;</sup>You shall not eat it. You shall pour it out on the earth like water. 
+<sup>25&#160;</sup>You shall not eat it, that it may go well with you and with your children after you, when you do that which is right in Yahweh’s eyes. 
+<sup>26&#160;</sup>Only your set-apart things which you have, and your vows, you shall take and go to the place which Yahweh shall choose. 
+<sup>27&#160;</sup>You shall offer your burnt offerings, the meat and the blood, on Yahweh your Elohim’s altar. The blood of your sacrifices shall be poured out on Yahweh your Elohim’s altar, and you shall eat the meat. 
+<sup>28&#160;</sup>Observe and hear all these words which I command you, that it may go well with you and with your children after you forever, when you do that which is good and right in Yahweh your Elohim’s eyes. 
+</div><div class="p">
+<sup>29&#160;</sup>When Yahweh your Elohim cuts off the nations from before you where you go in to dispossess them, and you dispossess them and dwell in their land, 
+<sup>30&#160;</sup>be careful that you are not ensnared to follow them after they are destroyed from before you, and that you not inquire after their elohims, saying, “How do these nations serve their elohims? I will do likewise.” 
+<sup>31&#160;</sup>You shall not do so to Yahweh your Elohim; for every abomination to Yahweh, which he hates, they have done to their elohims; for they even burn their sons and their daughters in the fire to their elohims. 
+<sup>32&#160;</sup>Whatever thing I command you, that you shall observe to do. You shall not add to it, nor take away from it. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>If a prophet or a dreamer of dreams arises among you, and he gives you a sign or a wonder, 
+<sup>2&#160;</sup>and the sign or the wonder comes to pass, of which he spoke to you, saying, “Let’s go after other elohims” (which you have not known) “and let’s serve them,” 
+<sup>3&#160;</sup>you shall not listen to the words of that prophet, or to that dreamer of dreams; for Yahweh your Elohim is testing you, to know whether you love Yahweh your Elohim with all your heart and with all your soul. 
+<sup>4&#160;</sup>You shall walk after Yahweh your Elohim, fear him, keep his commandments, and obey his voice. You shall serve him, and cling to him. 
+<sup>5&#160;</sup>That prophet, or that dreamer of dreams, shall be put to death, because he has spoken rebellion against Yahweh your Elohim, who brought you out of the land of Egypt and redeemed you out of the house of bondage, to draw you aside out of the way which Yahweh your Elohim commanded you to walk in. So you shall remove the evil from among you. 
+</div><div class="p">
+<sup>6&#160;</sup>If your brother, the son of your mother, or your son, or your daughter, or the woman of your bosom, or your friend who is as your own soul, entices you secretly, saying, “Let’s go and serve other elohims”—which you have not known, you, nor your fathers; 
+<sup>7&#160;</sup>of the elohims of the peoples who are around you, near to you, or far off from you, from the one end of the earth even to the other end of the earth—<sup>8&#160;</sup>you shall not consent to him nor listen to him; neither shall your eye pity him, neither shall you spare, neither shall you conceal him; 
+<sup>9&#160;</sup>but you shall surely kill him. Your hand shall be first on him to put him to death, and afterwards the hands of all the people. 
+<sup>10&#160;</sup>You shall stone him to death with stones, because he has sought to draw you away from Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+<sup>11&#160;</sup>All Israel shall hear, and fear, and shall not do any more wickedness like this among you. 
+</div><div class="p">
+<sup>12&#160;</sup>If you hear about one of your cities, which Yahweh your Elohim gives you to dwell there, that 
+<sup>13&#160;</sup>certain wicked fellows have gone out from among you and have drawn away the inhabitants of their city, saying, “Let’s go and serve other elohims,” which you have not known, 
+<sup>14&#160;</sup>then you shall inquire, investigate, and ask diligently. Behold, if it is true, and the thing certain, that such abomination was done among you, 
+<sup>15&#160;</sup>you shall surely strike the inhabitants of that city with the edge of the sword, destroying it utterly, with all that is therein and its livestock, with the edge of the sword. 
+<sup>16&#160;</sup>You shall gather all its plunder into the middle of its street, and shall burn with fire the city, with all of its plunder, to Yahweh your Elohim. It shall be a heap forever. It shall not be built again. 
+<sup>17&#160;</sup>Nothing of the devoted thing shall cling to your hand, that Yahweh may turn from the fierceness of his anger and show you mercy, and have compassion on you and multiply you, as he has sworn to your fathers, 
+<sup>18&#160;</sup>when you listen to Yahweh your Elohim’s voice, to keep all his commandments which I command you today, to do that which is right in Yahweh your Elohim’s eyes. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>You are the children of Yahweh your Elohim. You shall not cut yourselves, nor make any baldness between your eyes for the dead. 
+<sup>2&#160;</sup>For you are a set-apart people to Yahweh your Elohim, and Yahweh has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
+</div><div class="p">
+<sup>3&#160;</sup>You shall not eat any abominable thing. 
+<sup>4&#160;</sup>These are the animals which you may eat: the ox, the sheep, the goat, 
+<sup>5&#160;</sup>the deer, the gazelle, the roebuck, the wild goat, the ibex, the antelope, and the chamois. 
+<sup>6&#160;</sup>Every animal that parts the hoof, and has the hoof split in two and chews the cud, among the animals, you may eat. 
+<sup>7&#160;</sup>Nevertheless these you shall not eat of them that chew the cud, or of those who have the hoof split: the camel, the hare, and the rabbit. Because they chew the cud but don’t part the hoof, they are unclean to you. 
+<sup>8&#160;</sup>The pig, because it has a split hoof but doesn’t chew the cud, is unclean to you. You shall not eat their meat. You shall not touch their carcasses. 
+<sup>9&#160;</sup>These you may eat of all that are in the waters: you may eat whatever has fins and scales. 
+<sup>10&#160;</sup>You shall not eat whatever doesn’t have fins and scales. It is unclean to you. 
+<sup>11&#160;</sup>Of all clean birds you may eat. 
+<sup>12&#160;</sup>But these are they of which you shall not eat: the eagle, the vulture, the osprey, 
+<sup>13&#160;</sup>the red kite, the falcon, the kite of any kind, 
+<sup>14&#160;</sup>every raven of any kind, 
+<sup>15&#160;</sup>the ostrich, the owl, the seagull, the hawk of any kind, 
+<sup>16&#160;</sup>the little owl, the great owl, the horned owl, 
+<sup>17&#160;</sup>the pelican, the vulture, the cormorant, 
+<sup>18&#160;</sup>the stork, the heron after its kind, the hoopoe, and the bat. 
+<sup>19&#160;</sup>All winged creeping things are unclean to you. They shall not be eaten. 
+<sup>20&#160;</sup>Of all clean birds you may eat. 
+</div><div class="p">
+<sup>21&#160;</sup>You shall not eat of anything that dies of itself. You may give it to the foreigner living among you who is within your gates, that he may eat it; or you may sell it to a foreigner; for you are a set-apart people to Yahweh your Elohim. 
+</div><div class="p">You shall not boil a young goat in its mother’s milk. 
+</div><div class="p">
+<sup>22&#160;</sup>You shall surely tithe all the increase of your seed, that which comes out of the field year by year. 
+<sup>23&#160;</sup>You shall eat before Yahweh your Elohim, in the place which he chooses to cause his name to dwell, the tithe of your grain, of your new wine, and of your oil, and the firstborn of your herd and of your flock; that you may learn to fear Yahweh your Elohim always. 
+<sup>24&#160;</sup>If the way is too long for you, so that you are not able to carry it because the place which Yahweh your Elohim shall choose to set his name there is too far from you, when Yahweh your Elohim blesses you, 
+<sup>25&#160;</sup>then you shall turn it into money, bind up the money in your hand, and shall go to the place which Yahweh your Elohim shall choose. 
+<sup>26&#160;</sup>You shall trade the money for whatever your soul desires: for cattle, or for sheep, or for wine, or for strong drink, or for whatever your soul asks of you. You shall eat there before Yahweh your Elohim, and you shall rejoice, you and your household. 
+<sup>27&#160;</sup>You shall not forsake the Levite who is within your gates, for he has no portion nor inheritance with you. 
+<sup>28&#160;</sup>At the end of every three years you shall bring all the tithe of your increase in the same year, and shall store it within your gates. 
+<sup>29&#160;</sup>The Levite, because he has no portion nor inheritance with you, as well as the foreigner living among you, the fatherless, and the widow who are within your gates shall come, and shall eat and be satisfied; that Yahweh your Elohim may bless you in all the work of your hand which you do. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>At the end of every seven years, you shall cancel debts. 
+<sup>2&#160;</sup>This is the way it shall be done: every owner of a loan shall release that which he has lent to his neighbor. He shall not require payment from his neighbor and his brother, because Yahweh’s release has been proclaimed. 
+<sup>3&#160;</sup>Of a foreigner you may require it; but whatever of yours is with your brother, your hand shall release. 
+<sup>4&#160;</sup>However there will be no poor with you (for Yahweh will surely bless you in the land which Yahweh your Elohim gives you for an inheritance to possess) 
+<sup>5&#160;</sup>if only you diligently listen to Yahweh your Elohim’s voice, to observe to do all this commandment which I command you today. 
+<sup>6&#160;</sup>For Yahweh your Elohim will bless you, as he promised you. You will lend to many nations, but you will not borrow. You will rule over many nations, but they will not rule over you. 
+<sup>7&#160;</sup>If a poor man, one of your brothers, is with you within any of your gates in your land which Yahweh your Elohim gives you, you shall not harden your heart, nor shut your hand from your poor brother; 
+<sup>8&#160;</sup>but you shall surely open your hand to him, and shall surely lend him sufficient for his need, which he lacks. 
+<sup>9&#160;</sup>Beware that there not be a wicked thought in your heart, saying, “The seventh year, the year of release, is at hand,” and your eye be evil against your poor brother and you give him nothing; and he cry to Yahweh against you, and it be sin to you. 
+<sup>10&#160;</sup>You shall surely give, and your heart shall not be grieved when you give to him, because it is for this thing Yahweh your Elohim will bless you in all your work and in all that you put your hand to. 
+<sup>11&#160;</sup>For the poor will never cease out of the land. Therefore I command you to surely open your hand to your brother, to your needy, and to your poor, in your land. 
+<sup>12&#160;</sup>If your brother, a Hebrew man, or a Hebrew woman, is sold to you and serves you six years, then in the seventh year you shall let him go free from you. 
+<sup>13&#160;</sup>When you let him go free from you, you shall not let him go empty. 
+<sup>14&#160;</sup>You shall furnish him liberally out of your flock, out of your threshing floor, and out of your wine press. As Yahweh your Elohim has blessed you, you shall give to him. 
+<sup>15&#160;</sup>You shall remember that you were a slave in the land of Egypt, and Yahweh your Elohim redeemed you. Therefore I command you this thing today. 
+<sup>16&#160;</sup>It shall be, if he tells you, “I will not go out from you,” because he loves you and your house, because he is well with you, 
+<sup>17&#160;</sup>then you shall take an awl, and thrust it through his ear to the door, and he shall be your servant forever. Also to your female servant you shall do likewise. 
+<sup>18&#160;</sup>It shall not seem hard to you when you let him go free from you, for he has been double the value of a hired hand as he served you six years. Yahweh your Elohim will bless you in all that you do. 
+<sup>19&#160;</sup>You shall dedicate all the firstborn males that are born of your herd and of your flock to Yahweh your Elohim. You shall do no work with the firstborn of your herd, nor shear the firstborn of your flock. 
+<sup>20&#160;</sup>You shall eat it before Yahweh your Elohim year by year in the place which Yahweh shall choose, you and your household. 
+<sup>21&#160;</sup>If it has any defect—is lame or blind, or has any defect whatever, you shall not sacrifice it to Yahweh your Elohim. 
+<sup>22&#160;</sup>You shall eat it within your gates. The unclean and the clean shall eat it alike, as the gazelle and as the deer. 
+<sup>23&#160;</sup>Only you shall not eat its blood. You shall pour it out on the ground like water. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Observe the month of Abib, and keep the Passover to Yahweh your Elohim; for in the month of Abib Yahweh your Elohim brought you out of Egypt by night. 
+<sup>2&#160;</sup>You shall sacrifice the Passover to Yahweh your Elohim, of the flock and the herd, in the place which Yahweh shall choose to cause his name to dwell there. 
+<sup>3&#160;</sup>You shall eat no leavened bread with it. You shall eat unleavened bread with it seven days, even the bread of affliction (for you came out of the land of Egypt in haste) that you may remember the day when you came out of the land of Egypt all the days of your life. 
+<sup>4&#160;</sup>No yeast shall be seen with you in all your borders seven days; neither shall any of the meat, which you sacrifice the first day at evening, remain all night until the morning. 
+<sup>5&#160;</sup>You may not sacrifice the Passover within any of your gates which Yahweh your Elohim gives you; 
+<sup>6&#160;</sup>but at the place which Yahweh your Elohim shall choose to cause his name to dwell in, there you shall sacrifice the Passover at evening, at the going down of the sun, at the season that you came out of Egypt. 
+<sup>7&#160;</sup>You shall roast and eat it in the place which Yahweh your Elohim chooses. In the morning you shall return to your tents. 
+<sup>8&#160;</sup>Six days you shall eat unleavened bread. On the seventh day shall be a solemn assembly to Yahweh your Elohim. You shall do no work. 
+</div><div class="p">
+<sup>9&#160;</sup>You shall count for yourselves seven weeks. From the time you begin to put the sickle to the standing grain you shall begin to count seven weeks. 
+<sup>10&#160;</sup>You shall keep the feast of weeks to Yahweh your Elohim with a tribute of a free will offering of your hand, which you shall give according to how Yahweh your Elohim blesses you. 
+<sup>11&#160;</sup>You shall rejoice before Yahweh your Elohim: you, your son, your daughter, your male servant, your female servant, the Levite who is within your gates, the foreigner, the fatherless, and the widow who are among you, in the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
+<sup>12&#160;</sup>You shall remember that you were a slave in Egypt. You shall observe and do these statutes. 
+</div><div class="p">
+<sup>13&#160;</sup>You shall keep the feast of booths seven days, after you have gathered in from your threshing floor and from your wine press. 
+<sup>14&#160;</sup>You shall rejoice in your feast, you, your son, your daughter, your male servant, your female servant, the Levite, the foreigner, the fatherless, and the widow who are within your gates. 
+<sup>15&#160;</sup>You shall keep a feast to Yahweh your Elohim seven days in the place which Yahweh chooses, because Yahweh your Elohim will bless you in all your increase and in all the work of your hands, and you shall be altogether joyful. 
+<sup>16&#160;</sup>Three times in a year all of your males shall appear before Yahweh your Elohim in the place which he chooses: in the feast of unleavened bread, in the feast of weeks, and in the feast of booths. They shall not appear before Yahweh empty. 
+<sup>17&#160;</sup>Every man shall give as he is able, according to Yahweh your Elohim’s blessing which he has given you. 
+<sup>18&#160;</sup>You shall make judges and officers in all your gates, which Yahweh your Elohim gives you, according to your tribes; and they shall judge the people with righteous judgment. 
+<sup>19&#160;</sup>You shall not pervert justice. You shall not show partiality. You shall not take a bribe, for a bribe blinds the eyes of the wise and perverts the words of the righteous. 
+<sup>20&#160;</sup>You shall follow that which is altogether just, that you may live and inherit the land which Yahweh your Elohim gives you. 
+<sup>21&#160;</sup>You shall not plant for yourselves an Asherah of any kind of tree beside Yahweh your Elohim’s altar, which you shall make for yourselves. 
+<sup>22&#160;</sup>Neither shall you set yourself up a sacred stone which Yahweh your Elohim hates. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>You shall not sacrifice to Yahweh your Elohim an ox or a sheep in which is a defect or anything evil; for that is an abomination to Yahweh your Elohim. 
+</div><div class="p">
+<sup>2&#160;</sup>If there is found among you, within any of your gates which Yahweh your Elohim gives you, a man or woman who does that which is evil in Yahweh your Elohim’s sight in transgressing his covenant, 
+<sup>3&#160;</sup>and has gone and served other elohims and worshiped them, or the sun, or the moon, or any of the stars of the sky, which I have not commanded, 
+<sup>4&#160;</sup>and you are told, and you have heard of it, then you shall inquire diligently. Behold, if it is true, and the thing certain, that such abomination is done in Israel, 
+<sup>5&#160;</sup>then you shall bring out that man or that woman who has done this evil thing to your gates, even that same man or woman; and you shall stone them to death with stones. 
+<sup>6&#160;</sup>At the mouth of two witnesses, or three witnesses, he who is to die shall be put to death. At the mouth of one witness he shall not be put to death. 
+<sup>7&#160;</sup>The hands of the witnesses shall be first on him to put him to death, and afterward the hands of all the people. So you shall remove the evil from among you. 
+</div><div class="p">
+<sup>8&#160;</sup>If there arises a matter too hard for you in judgment, between blood and blood, between plea and plea, and between stroke and stroke, being matters of controversy within your gates, then you shall arise, and go up to the place which Yahweh your Elohim chooses. 
+<sup>9&#160;</sup>You shall come to the priests who are Levites and to the judge who shall be in those days. You shall inquire, and they shall give you the verdict. 
+<sup>10&#160;</sup>You shall do according to the decisions of the verdict which they shall give you from that place which Yahweh chooses. You shall observe to do according to all that they shall teach you. 
+<sup>11&#160;</sup>According to the decisions of the law which they shall teach you, and according to the judgment which they shall tell you, you shall do. You shall not turn away from the sentence which they announce to you, to the right hand, nor to the left. 
+<sup>12&#160;</sup>The man who does presumptuously in not listening to the priest who stands to minister there before Yahweh your Elohim, or to the judge, even that man shall die. You shall put away the evil from Israel. 
+<sup>13&#160;</sup>All the people shall hear and fear, and do no more presumptuously. 
+</div><div class="p">
+<sup>14&#160;</sup>When you have come to the land which Yahweh your Elohim gives you, and possess it and dwell in it, and say, “I will set a king over me, like all the nations that are around me,” 
+<sup>15&#160;</sup>you shall surely set him whom Yahweh your Elohim chooses as king over yourselves. You shall set as king over you one from among your brothers. You may not put a foreigner over you, who is not your brother. 
+<sup>16&#160;</sup>Only he shall not multiply horses to himself, nor cause the people to return to Egypt, to the end that he may multiply horses; because Yahweh has said to you, “You shall not go back that way again.” 
+<sup>17&#160;</sup>He shall not multiply women to himself, that his heart not turn away. He shall not greatly multiply to himself silver and gold. 
+</div><div class="p">
+<sup>18&#160;</sup>It shall be, when he sits on the throne of his kingdom, that he shall write himself a copy of this law in a book, out of that which is before the Levitical priests. 
+<sup>19&#160;</sup>It shall be with him, and he shall read from it all the days of his life, that he may learn to fear Yahweh his Elohim, to keep all the words of this law and these statutes, to do them; 
+<sup>20&#160;</sup>that his heart not be lifted up above his brothers, and that he not turn away from the commandment to the right hand, or to the left, to the end that he may prolong his days in his kingdom, he and his children, in the middle of Israel. 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>The priests and the Levites—all the tribe of Levi—shall have no portion nor inheritance with Israel. They shall eat the offerings of Yahweh made by fire and his portion. 
+<sup>2&#160;</sup>They shall have no inheritance among their brothers. Yahweh is their inheritance, as he has spoken to them. 
+<sup>3&#160;</sup>This shall be the priests’ due from the people, from those who offer a sacrifice, whether it be ox or sheep, that they shall give to the priest: the shoulder, the two cheeks, and the inner parts. 
+<sup>4&#160;</sup>You shall give him the first fruits of your grain, of your new wine, and of your oil, and the first of the fleece of your sheep. 
+<sup>5&#160;</sup>For Yahweh your Elohim has chosen him out of all your tribes to stand to minister in Yahweh’s name, him and his sons forever. 
+</div><div class="p">
+<sup>6&#160;</sup>If a Levite comes from any of your gates out of all Israel where he lives, and comes with all the desire of his soul to the place which Yahweh shall choose, 
+<sup>7&#160;</sup>then he shall minister in the name of Yahweh his Elohim, as all his brothers the Levites do, who stand there before Yahweh. 
+<sup>8&#160;</sup>They shall have like portions to eat, in addition to that which comes from the sale of his family possessions. 
+</div><div class="p">
+<sup>9&#160;</sup>When you have come into the land which Yahweh your Elohim gives you, you shall not learn to imitate the abominations of those nations. 
+<sup>10&#160;</sup>There shall not be found with you anyone who makes his son or his daughter to pass through the fire, one who uses divination, one who tells fortunes, or an enchanter, or a sorcerer, 
+<sup>11&#160;</sup>or a charmer, or someone who consults with a familiar spirit, or a wizard, or a necromancer. 
+<sup>12&#160;</sup>For whoever does these things is an abomination to Yahweh. Because of these abominations, Yahweh your Elohim drives them out from before you. 
+<sup>13&#160;</sup>You shall be blameless with Yahweh your Elohim. 
+<sup>14&#160;</sup>For these nations that you shall dispossess listen to those who practice sorcery and to diviners; but as for you, Yahweh your Elohim has not allowed you so to do. 
+<sup>15&#160;</sup>Yahweh your Elohim will raise up to you a prophet from among you, of your brothers, like me. You shall listen to him. 
+<sup>16&#160;</sup>This is according to all that you desired of Yahweh your Elohim in Horeb in the day of the assembly, saying, “Let me not hear again Yahweh my Elohim’s voice, neither let me see this great fire any more, that I not die.” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh said to me, “They have well said that which they have spoken. 
+<sup>18&#160;</sup>I will raise them up a prophet from among their brothers, like you. I will put my words in his mouth, and he shall speak to them all that I shall command him. 
+<sup>19&#160;</sup>It shall happen, that whoever will not listen to my words which he shall speak in my name, I will require it of him. 
+<sup>20&#160;</sup>But the prophet who speaks a word presumptuously in my name, which I have not commanded him to speak, or who speaks in the name of other elohims, that same prophet shall die.” 
+</div><div class="p">
+<sup>21&#160;</sup>You may say in your heart, “How shall we know the word which Yahweh has not spoken?” 
+<sup>22&#160;</sup>When a prophet speaks in Yahweh’s name, if the thing doesn’t follow, nor happen, that is the thing which Yahweh has not spoken. The prophet has spoken it presumptuously. You shall not be afraid of him. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahweh your Elohim cuts off the nations whose land Yahweh your Elohim gives you, and you succeed them and dwell in their cities and in their houses, 
+<sup>2&#160;</sup>you shall set apart three cities for yourselves in the middle of your land, which Yahweh your Elohim gives you to possess. 
+<sup>3&#160;</sup>You shall prepare the way, and divide the borders of your land which Yahweh your Elohim causes you to inherit into three parts, that every man slayer may flee there. 
+<sup>4&#160;</sup>This is the case of the man slayer who shall flee there and live: Whoever kills his neighbor unintentionally, and didn’t hate him in time past—<sup>5&#160;</sup>as when a man goes into the forest with his neighbor to chop wood and his hand swings the ax to cut down the tree, and the head slips from the handle and hits his neighbor so that he dies—he shall flee to one of these cities and live. 
+<sup>6&#160;</sup>Otherwise, the avenger of blood might pursue the man slayer while hot anger is in his heart and overtake him, because the way is long, and strike him mortally, even though he was not worthy of death, because he didn’t hate him in time past. 
+<sup>7&#160;</sup>Therefore I command you to set apart three cities for yourselves. 
+<sup>8&#160;</sup>If Yahweh your Elohim enlarges your border, as he has sworn to your fathers, and gives you all the land which he promised to give to your fathers; 
+<sup>9&#160;</sup>and if you keep all this commandment to do it, which I command you today, to love Yahweh your Elohim, and to walk ever in his ways, then you shall add three cities more for yourselves, in addition to these three. 
+<sup>10&#160;</sup>This is so that innocent blood will not be shed in the middle of your land which Yahweh your Elohim gives you for an inheritance, leaving blood guilt on you. 
+<sup>11&#160;</sup>But if any man hates his neighbor, lies in wait for him, rises up against him, strikes him mortally so that he dies, and he flees into one of these cities; 
+<sup>12&#160;</sup>then the elders of his city shall send and bring him there, and deliver him into the hand of the avenger of blood, that he may die. 
+<sup>13&#160;</sup>Your eye shall not pity him, but you shall purge the innocent blood from Israel that it may go well with you. 
+</div><div class="p">
+<sup>14&#160;</sup>You shall not remove your neighbor’s landmark, which they of old time have set, in your inheritance which you shall inherit, in the land that Yahweh your Elohim gives you to possess. 
+</div><div class="p">
+<sup>15&#160;</sup>One witness shall not rise up against a man for any iniquity, or for any sin that he sins. At the mouth of two witnesses, or at the mouth of three witnesses, shall a matter be established. 
+<sup>16&#160;</sup>If an unrighteous witness rises up against any man to testify against him of wrongdoing, 
+<sup>17&#160;</sup>then both the men, between whom the controversy is, shall stand before Yahweh, before the priests and the judges who shall be in those days; 
+<sup>18&#160;</sup>and the judges shall make diligent inquisition; and behold, if the witness is a false witness, and has testified falsely against his brother, 
+<sup>19&#160;</sup>then you shall do to him as he had thought to do to his brother. So you shall remove the evil from among you. 
+<sup>20&#160;</sup>Those who remain shall hear, and fear, and will never again commit any such evil among you. 
+<sup>21&#160;</sup>Your eyes shall not pity: life for life, eye for eye, tooth for tooth, hand for hand, foot for foot. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>When you go out to battle against your enemies, and see horses, chariots, and a people more numerous than you, you shall not be afraid of them; for Yahweh your Elohim, who brought you up out of the land of Egypt, is with you. 
+<sup>2&#160;</sup>It shall be, when you draw near to the battle, that the priest shall approach and speak to the people, 
+<sup>3&#160;</sup>and shall tell them, “Hear, Israel, you draw near today to battle against your enemies. Don’t let your heart faint! Don’t be afraid, nor tremble, neither be scared of them; 
+<sup>4&#160;</sup>for Yahweh your Elohim is he who goes with you, to fight for you against your enemies, to save you.” 
+</div><div class="p">
+<sup>5&#160;</sup>The officers shall speak to the people, saying, “What man is there who has built a new house, and has not dedicated it? Let him go and return to his house, lest he die in the battle, and another man dedicate it. 
+<sup>6&#160;</sup>What man is there who has planted a vineyard, and has not used its fruit? Let him go and return to his house, lest he die in the battle, and another man use its fruit. 
+<sup>7&#160;</sup>What man is there who has pledged to be married to a woman, and has not taken her? Let him go and return to his house, lest he die in the battle, and another man take her.” 
+<sup>8&#160;</sup>The officers shall speak further to the people, and they shall say, “What man is there who is fearful and faint-hearted? Let him go and return to his house, lest his brother’s heart melt as his heart.” 
+<sup>9&#160;</sup>It shall be, when the officers have finished speaking to the people, that they shall appoint captains of armies at the head of the people. 
+</div><div class="p">
+<sup>10&#160;</sup>When you draw near to a city to fight against it, then proclaim peace to it. 
+<sup>11&#160;</sup>It shall be, if it gives you answer of peace and opens to you, then it shall be that all the people who are found therein shall become forced laborers to you, and shall serve you. 
+<sup>12&#160;</sup>If it will make no peace with you, but will make war against you, then you shall besiege it. 
+<sup>13&#160;</sup>When Yahweh your Elohim delivers it into your hand, you shall strike every male of it with the edge of the sword; 
+<sup>14&#160;</sup>but the women, the little ones, the livestock, and all that is in the city, even all its plunder, you shall take for plunder for yourself. You may use the plunder of your enemies, which Yahweh your Elohim has given you. 
+<sup>15&#160;</sup>Thus you shall do to all the cities which are very far off from you, which are not of the cities of these nations. 
+<sup>16&#160;</sup>But of the cities of these peoples that Yahweh your Elohim gives you for an inheritance, you shall save alive nothing that breathes; 
+<sup>17&#160;</sup>but you shall utterly destroy them: the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, as Yahweh your Elohim has commanded you; 
+<sup>18&#160;</sup>that they not teach you to follow all their abominations, which they have done for their elohims; so would you sin against Yahweh your Elohim. 
+<sup>19&#160;</sup>When you shall besiege a city a long time, in making war against it to take it, you shall not destroy its trees by wielding an ax against them; for you may eat of them. You shall not cut them down, for is the tree of the field man, that it should be besieged by you? 
+<sup>20&#160;</sup>Only the trees that you know are not trees for food, you shall destroy and cut them down. You shall build bulwarks against the city that makes war with you, until it falls. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>If someone is found slain in the land which Yahweh your Elohim gives you to possess, lying in the field, and it isn’t known who has struck him, 
+<sup>2&#160;</sup>then your elders and your judges shall come out, and they shall measure to the cities which are around him who is slain. 
+<sup>3&#160;</sup>It shall be that the elders of the city which is nearest to the slain man shall take a heifer of the herd, which hasn’t been worked with and which has not drawn in the yoke. 
+<sup>4&#160;</sup>The elders of that city shall bring the heifer down to a valley with running water, which is neither plowed nor sown, and shall break the heifer’s neck there in the valley. 
+<sup>5&#160;</sup>The priests the sons of Levi shall come near, for them Yahweh your Elohim has chosen to minister to him, and to bless in Yahweh’s name; and according to their word shall every controversy and every assault be decided. 
+<sup>6&#160;</sup>All the elders of that city which is nearest to the slain man shall wash their hands over the heifer whose neck was broken in the valley. 
+<sup>7&#160;</sup>They shall answer and say, “Our hands have not shed this blood, neither have our eyes seen it. 
+<sup>8&#160;</sup>Forgive, Yahweh, your people Israel, whom you have redeemed, and don’t allow innocent blood among your people Israel.” The blood shall be forgiven them. 
+<sup>9&#160;</sup>So you shall put away the innocent blood from among you, when you shall do that which is right in Yahweh’s eyes. 
+</div><div class="p">
+<sup>10&#160;</sup>When you go out to battle against your enemies, and Yahweh your Elohim delivers them into your hands and you carry them away captive, 
+<sup>11&#160;</sup>and see among the captives a beautiful woman, and you are attracted to her, and desire to take her as your woman, 
+<sup>12&#160;</sup>then you shall bring her home to your house. She shall shave her head and trim her nails. 
+<sup>13&#160;</sup>She shall take off the clothing of her captivity, and shall remain in your house, and bewail her father and her mother a full month. After that you shall go in to her and be her owner, and she shall be your woman. 
+<sup>14&#160;</sup>It shall be, if you have no delight in her, then you shall let her go where she desires; but you shall not sell her at all for money. You shall not deal with her as a slave, because you have humbled her. 
+</div><div class="p">
+<sup>15&#160;</sup>If a man has two women, the one beloved and the other hated, and they have borne him children, both the beloved and the hated, and if the firstborn son is hers who was hated, 
+<sup>16&#160;</sup>then it shall be, in the day that he causes his sons to inherit that which he has, that he may not give the son of the beloved the rights of the firstborn before the son of the hated, who is the firstborn; 
+<sup>17&#160;</sup>but he shall acknowledge the firstborn, the son of the hated, by giving him a double portion of all that he has; for he is the beginning of his strength. The right of the firstborn is his. 
+</div><div class="p">
+<sup>18&#160;</sup>If a man has a stubborn and rebellious son who will not obey the voice of his father or the voice of his mother, and though they chasten him, will not listen to them, 
+<sup>19&#160;</sup>then his father and his mother shall take hold of him and bring him out to the elders of his city and to the gate of his place. 
+<sup>20&#160;</sup>They shall tell the elders of his city, “This our son is stubborn and rebellious. He will not obey our voice. He is a glutton and a drunkard.” 
+<sup>21&#160;</sup>All the men of his city shall stone him to death with stones. So you shall remove the evil from among you. All Israel shall hear, and fear. 
+</div><div class="p">
+<sup>22&#160;</sup>If a man has committed a sin worthy of death, and he is put to death, and you hang him on a tree, 
+<sup>23&#160;</sup>his body shall not remain all night on the tree, but you shall surely bury him the same day; for he who is hanged is accursed of Elohim. Don’t defile your land which Yahweh your Elohim gives you for an inheritance. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>You shall not see your brother’s ox or his sheep go astray and hide yourself from them. You shall surely bring them again to your brother. 
+<sup>2&#160;</sup>If your brother isn’t near to you, or if you don’t know him, then you shall bring it home to your house, and it shall be with you until your brother comes looking for it, and you shall restore it to him. 
+<sup>3&#160;</sup>So you shall do with his donkey. So you shall do with his garment. So you shall do with every lost thing of your brother’s, which he has lost and you have found. You may not hide yourself. 
+<sup>4&#160;</sup>You shall not see your brother’s donkey or his ox fallen down by the way, and hide yourself from them. You shall surely help him to lift them up again. 
+</div><div class="p">
+<sup>5&#160;</sup>A woman shall not wear men’s clothing, neither shall a man put on women’s clothing; for whoever does these things is an abomination to Yahweh your Elohim. 
+</div><div class="p">
+<sup>6&#160;</sup>If you come across a bird’s nest on the way, in any tree or on the ground, with young ones or eggs, and the hen sitting on the young, or on the eggs, you shall not take the hen with the young. 
+<sup>7&#160;</sup>You shall surely let the hen go, but the young you may take for yourself, that it may be well with you, and that you may prolong your days. 
+</div><div class="p">
+<sup>8&#160;</sup>When you build a new house, then you shall make a railing around your roof, so that you don’t bring blood on your house if anyone falls from there. 
+</div><div class="p">
+<sup>9&#160;</sup>You shall not sow your vineyard with two kinds of seed, lest all the fruit be defiled, the seed which you have sown, and the increase of the vineyard. 
+<sup>10&#160;</sup>You shall not plow with an ox and a donkey together. 
+<sup>11&#160;</sup>You shall not wear clothes of wool and linen woven together. 
+</div><div class="p">
+<sup>12&#160;</sup>You shall make yourselves fringes on the four corners of your cloak with which you cover yourself. 
+</div><div class="p">
+<sup>13&#160;</sup>If any man takes a woman, and goes in to her, hates her, 
+<sup>14&#160;</sup>accuses her of shameful things, gives her a bad name, and says, “I took this woman, and when I came near to her, I didn’t find in her the tokens of virginity;” 
+<sup>15&#160;</sup>then the young lady’s father and mother shall take and bring the tokens of the young lady’s virginity to the elders of the city in the gate. 
+<sup>16&#160;</sup>The young lady’s father shall tell the elders, “I gave my daughter to this man as his woman, and he hates her. 
+<sup>17&#160;</sup>Behold, he has accused her of shameful things, saying, ‘I didn’t find in your daughter the tokens of virginity;’ and yet these are the tokens of my daughter’s virginity.” They shall spread the cloth before the elders of the city. 
+<sup>18&#160;</sup>The elders of that city shall take the man and chastise him. 
+<sup>19&#160;</sup>They shall fine him one hundred shekels of silver, and give them to the father of the young lady, because he has given a bad name to a virgin of Israel. She shall be his woman. He may not put her away all his days. 
+</div><div class="p">
+<sup>20&#160;</sup>But if this thing is true, that the tokens of virginity were not found in the young lady, 
+<sup>21&#160;</sup>then they shall bring out the young lady to the door of her father’s house, and the men of her city shall stone her to death with stones, because she has done folly in Israel, to play the prostitute in her father’s house. So you shall remove the evil from among you. 
+</div><div class="p">
+<sup>22&#160;</sup>If a man is found lying with a woman owned by an owner, then they shall both die, the man who lay with the woman and the woman. So you shall remove the evil from Israel. 
+<sup>23&#160;</sup>If there is a young lady who is a virgin pledged to be married to a man, and a man finds her in the city, and lies with her, 
+<sup>24&#160;</sup>then you shall bring them both out to the gate of that city, and you shall stone them to death with stones; the lady, because she didn’t cry, being in the city; and the man, because he has humbled his neighbor’s woman. So you shall remove the evil from among you. 
+<sup>25&#160;</sup>But if the man finds the lady who is pledged to be married in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
+<sup>26&#160;</sup>but to the lady you shall do nothing. There is in the lady no sin worthy of death; for as when a man rises against his neighbor and kills him, even so is this matter; 
+<sup>27&#160;</sup>for he found her in the field, the pledged to be married lady cried, and there was no one to save her. 
+<sup>28&#160;</sup>If a man finds a lady who is a virgin, who is not pledged to be married, grabs her and lies with her, and they are found, 
+<sup>29&#160;</sup>then the man who lay with her shall give to the lady’s father fifty shekels of silver. She shall be his woman, because he has humbled her. He may not put her away all his days. 
+<sup>30&#160;</sup>A man shall not take his father’s woman, and shall not uncover his father’s skirt. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>He who is emasculated by crushing or cutting shall not enter into Yahweh’s assembly. 
+<sup>2&#160;</sup>A person born of a forbidden union shall not enter into Yahweh’s assembly; even to the tenth generation shall no one of his enter into Yahweh’s assembly. 
+<sup>3&#160;</sup>An Ammonite or a Moabite shall not enter into Yahweh’s assembly; even to the tenth generation shall no one belonging to them enter into Yahweh’s assembly forever, 
+<sup>4&#160;</sup>because they didn’t meet you with bread and with water on the way when you came out of Egypt, and because they hired against you Balaam the son of Beor from Pethor of Mesopotamia, to curse you. 
+<sup>5&#160;</sup>Nevertheless Yahweh your Elohim wouldn’t listen to Balaam, but Yahweh your Elohim turned the curse into a blessing to you, because Yahweh your Elohim loved you. 
+<sup>6&#160;</sup>You shall not seek their peace nor their prosperity all your days forever. 
+<sup>7&#160;</sup>You shall not abhor an Edomite, for he is your brother. You shall not abhor an Egyptian, because you lived as a foreigner in his land. 
+<sup>8&#160;</sup>The children of the third generation who are born to them may enter into Yahweh’s assembly. 
+</div><div class="p">
+<sup>9&#160;</sup>When you go out and camp against your enemies, then you shall keep yourselves from every evil thing. 
+<sup>10&#160;</sup>If there is among you any man who is not clean by reason of that which happens to him by night, then shall he go outside of the camp. He shall not come within the camp; 
+<sup>11&#160;</sup>but it shall be, when evening comes, he shall bathe himself in water. When the sun is down, he shall come within the camp. 
+<sup>12&#160;</sup>You shall have a place also outside of the camp where you go relieve yourself. 
+<sup>13&#160;</sup>You shall have a trowel among your weapons. It shall be, when you relieve yourself, you shall dig with it, and shall turn back and cover your excrement; 
+<sup>14&#160;</sup>for Yahweh your Elohim walks in the middle of your camp, to deliver you, and to give up your enemies before you. Therefore your camp shall be set-apart, that he may not see an unclean thing in you, and turn away from you. 
+</div><div class="p">
+<sup>15&#160;</sup>You shall not deliver to his master a servant who has escaped from his master to you. 
+<sup>16&#160;</sup>He shall dwell with you, among you, in the place which he shall choose within one of your gates, where it pleases him best. You shall not oppress him. 
+</div><div class="p">
+<sup>17&#160;</sup>There shall be no prostitute of the daughters of Israel, neither shall there be a sodomite of the sons of Israel. 
+<sup>18&#160;</sup>You shall not bring the hire of a prostitute, or the wages of a male prostitute, into the house of Yahweh your Elohim for any vow; for both of these are an abomination to Yahweh your Elohim. 
+</div><div class="p">
+<sup>19&#160;</sup>You shall not lend on interest to your brother: interest of money, interest of food, interest of anything that is lent on interest. 
+<sup>20&#160;</sup>You may charge a foreigner interest; but you shall not charge your brother interest, that Yahweh your Elohim may bless you in all that you put your hand to, in the land where you go in to possess it. 
+</div><div class="p">
+<sup>21&#160;</sup>When you vow a vow to Yahweh your Elohim, you shall not be slack to pay it, for Yahweh your Elohim will surely require it of you; and it would be sin in you. 
+<sup>22&#160;</sup>But if you refrain from making a vow, it shall be no sin in you. 
+<sup>23&#160;</sup>You shall observe and do that which has gone out of your lips. Whatever you have vowed to Yahweh your Elohim as a free will offering, which you have promised with your mouth, you must do. 
+<sup>24&#160;</sup>When you come into your neighbor’s vineyard, then you may eat your fill of grapes at your own pleasure; but you shall not put any in your container. 
+<sup>25&#160;</sup>When you come into your neighbor’s standing grain, then you may pluck the ears with your hand; but you shall not use a sickle on your neighbor’s standing grain. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>When a man takes a woman and marries her, then it shall be, if she finds no favor in his eyes because he has found some unseemly thing in her, that he shall write her a certificate of divorce, put it in her hand, and send her out of his house. 
+<sup>2&#160;</sup>When she has departed out of his house, she may go and be another man’s woman. 
+<sup>3&#160;</sup>If the latter man hates her, and writes her a certificate of divorce, puts it in her hand, and sends her out of his house; or if the latter man dies, who took her to be his woman; 
+<sup>4&#160;</sup>her former owner, who sent her away, may not take her again to be his woman after she is defiled; for that would be an abomination to Yahweh. You shall not cause the land to sin, which Yahweh your Elohim gives you for an inheritance. 
+<sup>5&#160;</sup>When a man takes a new woman, he shall not go out in the army, neither shall he be assigned any business. He shall be free at home one year, and shall cheer his woman whom he has taken. 
+</div><div class="p">
+<sup>6&#160;</sup>No man shall take the mill or the upper millstone as a pledge, for he takes a life in pledge. 
+</div><div class="p">
+<sup>7&#160;</sup>If a man is found stealing any of his brothers of the children of Israel, and he deals with him as a slave, or sells him, then that thief shall die. So you shall remove the evil from among you. 
+</div><div class="p">
+<sup>8&#160;</sup>Be careful in the plague of leprosy, that you observe diligently and do according to all that the Levitical priests teach you. As I commanded them, so you shall observe to do. 
+<sup>9&#160;</sup>Remember what Yahweh your Elohim did to Miriam, by the way as you came out of Egypt. 
+</div><div class="p">
+<sup>10&#160;</sup>When you lend your neighbor any kind of loan, you shall not go into his house to get his pledge. 
+<sup>11&#160;</sup>You shall stand outside, and the man to whom you lend shall bring the pledge outside to you. 
+<sup>12&#160;</sup>If he is a poor man, you shall not sleep with his pledge. 
+<sup>13&#160;</sup>You shall surely restore to him the pledge when the sun goes down, that he may sleep in his garment and bless you. It shall be righteousness to you before Yahweh your Elohim. 
+</div><div class="p">
+<sup>14&#160;</sup>You shall not oppress a hired servant who is poor and needy, whether he is one of your brothers or one of the foreigners who are in your land within your gates. 
+<sup>15&#160;</sup>In his day you shall give him his wages, neither shall the sun go down on it, for he is poor and sets his heart on it, lest he cry against you to Yahweh, and it be sin to you. 
+</div><div class="p">
+<sup>16&#160;</sup>The fathers shall not be put to death for the children, neither shall the children be put to death for the fathers. Every man shall be put to death for his own sin. 
+</div><div class="p">
+<sup>17&#160;</sup>You shall not deprive the foreigner or the fatherless of justice, nor take a widow’s clothing in pledge; 
+<sup>18&#160;</sup>but you shall remember that you were a slave in Egypt, and Yahweh your Elohim redeemed you there. Therefore I command you to do this thing. 
+</div><div class="p">
+<sup>19&#160;</sup>When you reap your harvest in your field, and have forgotten a sheaf in the field, you shall not go again to get it. It shall be for the foreigner, for the fatherless, and for the widow, that Yahweh your Elohim may bless you in all the work of your hands. 
+<sup>20&#160;</sup>When you beat your olive tree, you shall not go over the boughs again. It shall be for the foreigner, for the fatherless, and for the widow. 
+</div><div class="p">
+<sup>21&#160;</sup>When you harvest your vineyard, you shall not glean it after yourselves. It shall be for the foreigner, for the fatherless, and for the widow. 
+<sup>22&#160;</sup>You shall remember that you were a slave in the land of Egypt. Therefore I command you to do this thing. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>If there is a controversy between men, and they come to judgment and the judges judge them, then they shall justify the righteous and condemn the wicked. 
+<sup>2&#160;</sup>It shall be, if the wicked man is worthy to be beaten, that the judge shall cause him to lie down and to be beaten before his face, according to his wickedness, by number. 
+<sup>3&#160;</sup>He may sentence him to no more than forty stripes. He shall not give more, lest if he should give more and beat him more than that many stripes, then your brother will be degraded in your sight. 
+</div><div class="p">
+<sup>4&#160;</sup>You shall not muzzle the ox when he treads out the grain. 
+</div><div class="p">
+<sup>5&#160;</sup>If brothers dwell together, and one of them dies and has no son, the woman of the dead shall not be married outside to a stranger. Her brother-in-law shall go in to her, and take her as his woman, and perform the duty of a brother-in-law to her. 
+<sup>6&#160;</sup>It shall be that the firstborn whom she bears shall succeed in the name of his brother who is dead, that his name not be blotted out of Israel. 
+</div><div class="p">
+<sup>7&#160;</sup>If the man doesn’t want to take his brother’s woman, then his brother’s woman shall go up to the gate to the elders, and say, “My brother-in-law refuses to raise up to his brother a name in Israel. He will not perform the duty of a brother-in-law to me.” 
+<sup>8&#160;</sup>Then the elders of his city shall call him, and speak to him. If he stands and says, “I don’t want to take her,” 
+<sup>9&#160;</sup>then his brother’s woman shall come to him in the presence of the elders, and loose his sandal from off his foot, and spit in his face. She shall answer and say, “So shall it be done to the man who does not build up his brother’s house.” 
+<sup>10&#160;</sup>His name shall be called in Israel, “The house of him who had his sandal removed.” 
+</div><div class="p">
+<sup>11&#160;</sup>When men strive against each other, and the woman of one draws near to deliver her man out of the hand of him who strikes him, and puts out her hand, and grabs him by his private parts, 
+<sup>12&#160;</sup>then you shall cut off her hand. Your eye shall have no pity. 
+</div><div class="p">
+<sup>13&#160;</sup>You shall not have in your bag diverse weights, one heavy and one light. 
+<sup>14&#160;</sup>You shall not have in your house diverse measures, one large and one small. 
+<sup>15&#160;</sup>You shall have a perfect and just weight. You shall have a perfect and just measure, that your days may be long in the land which Yahweh your Elohim gives you. 
+<sup>16&#160;</sup>For all who do such things, all who do unrighteously, are an abomination to Yahweh your Elohim. 
+</div><div class="p">
+<sup>17&#160;</sup>Remember what Amalek did to you by the way as you came out of Egypt, 
+<sup>18&#160;</sup>how he met you by the way, and struck the rearmost of you, all who were feeble behind you, when you were faint and weary; and he didn’t fear Elohim. 
+<sup>19&#160;</sup>Therefore it shall be, when Yahweh your Elohim has given you rest from all your enemies all around, in the land which Yahweh your Elohim gives you for an inheritance to possess it, that you shall blot out the memory of Amalek from under the sky. You shall not forget. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>It shall be, when you have come in to the land which Yahweh your Elohim gives you for an inheritance, possess it, and dwell in it, 
+<sup>2&#160;</sup>that you shall take some of the first of all the fruit of the ground, which you shall bring in from your land that Yahweh your Elohim gives you. You shall put it in a basket, and shall go to the place which Yahweh your Elohim shall choose to cause his name to dwell there. 
+<sup>3&#160;</sup>You shall come to the priest who shall be in those days, and tell him, “I profess today to Yahweh your Elohim, that I have come to the land which Yahweh swore to our fathers to give us.” 
+<sup>4&#160;</sup>The priest shall take the basket out of your hand, and set it down before Yahweh your Elohim’s altar. 
+<sup>5&#160;</sup>You shall answer and say before Yahweh your Elohim, “My father was a Syrian ready to perish. He went down into Egypt, and lived there, few in number. There he became a great, mighty, and populous nation. 
+<sup>6&#160;</sup>The Egyptians mistreated us, afflicted us, and imposed hard labor on us. 
+<sup>7&#160;</sup>Then we cried to Yahweh, the Elohim of our fathers. Yahweh heard our voice, and saw our affliction, our toil, and our oppression. 
+<sup>8&#160;</sup>Yahweh brought us out of Egypt with a mighty hand, with an outstretched arm, with great terror, with signs, and with wonders; 
+<sup>9&#160;</sup>and he has brought us into this place, and has given us this land, a land flowing with milk and honey. 
+<sup>10&#160;</sup>Now, behold, I have brought the first of the fruit of the ground, which you, Yahweh, have given me.” You shall set it down before Yahweh your Elohim, and worship before Yahweh your Elohim. 
+<sup>11&#160;</sup>You shall rejoice in all the good which Yahweh your Elohim has given to you, and to your house, you, and the Levite, and the foreigner who is among you. 
+</div><div class="p">
+<sup>12&#160;</sup>When you have finished tithing all the tithe of your increase in the third year, which is the year of tithing, then you shall give it to the Levite, to the foreigner, to the fatherless, and to the widow, that they may eat within your gates and be filled. 
+<sup>13&#160;</sup>You shall say before Yahweh your Elohim, “I have put away the set-apart things out of my house, and also have given them to the Levite, to the foreigner, to the fatherless, and to the widow, according to all your commandment which you have commanded me. I have not transgressed any of your commandments, neither have I forgotten them. 
+<sup>14&#160;</sup>I have not eaten of it in my mourning, neither have I removed any of it while I was unclean, nor given of it for the dead. I have listened to Yahweh my Elohim’s voice. I have done according to all that you have commanded me. 
+<sup>15&#160;</sup>Look down from your set-apart habitation, from heaven, and bless your people Israel, and the ground which you have given us, as you swore to our fathers, a land flowing with milk and honey.” 
+</div><div class="p">
+<sup>16&#160;</sup>Today Yahweh your Elohim commands you to do these statutes and ordinances. You shall therefore keep and do them with all your heart and with all your soul. 
+<sup>17&#160;</sup>You have declared today that Yahweh is your Elohim, and that you would walk in his ways, keep his statutes, his commandments, and his ordinances, and listen to his voice. 
+<sup>18&#160;</sup>Yahweh has declared today that you are a people for his own possession, as he has promised you, and that you should keep all his commandments. 
+<sup>19&#160;</sup>He will make you high above all nations that he has made, in praise, in name, and in honor, and that you may be a set-apart people to Yahweh your Elohim, as he has spoken. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses and the elders of Israel commanded the people, saying, “Keep all the commandment which I command you today. 
+<sup>2&#160;</sup>It shall be on the day when you shall pass over the Jordan to the land which Yahweh your Elohim gives you, that you shall set yourself up great stones, and coat them with plaster. 
+<sup>3&#160;</sup>You shall write on them all the words of this law, when you have passed over, that you may go in to the land which Yahweh your Elohim gives you, a land flowing with milk and honey, as Yahweh, the Elohim of your fathers, has promised you. 
+<sup>4&#160;</sup>It shall be, when you have crossed over the Jordan, that you shall set up these stones, which I command you today, on Mount Ebal, and you shall coat them with plaster. 
+<sup>5&#160;</sup>There you shall build an altar to Yahweh your Elohim, an altar of stones. You shall not use any iron tool on them. 
+<sup>6&#160;</sup>You shall build Yahweh your Elohim’s altar of uncut stones. You shall offer burnt offerings on it to Yahweh your Elohim. 
+<sup>7&#160;</sup>You shall sacrifice peace offerings, and shall eat there. You shall rejoice before Yahweh your Elohim. 
+<sup>8&#160;</sup>You shall write on the stones all the words of this law very plainly.” 
+</div><div class="p">
+<sup>9&#160;</sup>Moses and the Levitical priests spoke to all Israel, saying, “Be silent and listen, Israel! Today you have become the people of Yahweh your Elohim. 
+<sup>10&#160;</sup>You shall therefore obey Yahweh your Elohim’s voice, and do his commandments and his statutes, which I command you today.” 
+</div><div class="p">
+<sup>11&#160;</sup>Moses commanded the people the same day, saying, 
+<sup>12&#160;</sup>“These shall stand on Mount Gerizim to bless the people, when you have crossed over the Jordan: Simeon, Levi, Judah, Issachar, Joseph, and Benjamin. 
+<sup>13&#160;</sup>These shall stand on Mount Ebal for the curse: Reuben, Gad, Asher, Zebulun, Dan, and Naphtali. 
+<sup>14&#160;</sup>With a loud voice, the Levites shall say to all the men of Israel, 
+<sup>15&#160;</sup>‘Cursed is the man who makes an engraved or molten image, an abomination to Yahweh, the work of the hands of the craftsman, and sets it up in secret.’ 
+</div><div class="p">All the people shall answer and say, ‘Amen.’ 
+</div><div class="p">
+<sup>16&#160;</sup>‘Cursed is he who dishonors his father or his mother.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>17&#160;</sup>‘Cursed is he who removes his neighbor’s landmark.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>18&#160;</sup>‘Cursed is he who leads the blind astray on the road.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>19&#160;</sup>‘Cursed is he who withholds justice from the foreigner, fatherless, and widow.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>20&#160;</sup>‘Cursed is he who lies with his father’s woman, because he dishonors his father’s bed.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>21&#160;</sup>‘Cursed is he who lies with any kind of animal.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>22&#160;</sup>‘Cursed is he who lies with his sister, his father’s daughter or his mother’s daughter.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>23&#160;</sup>‘Cursed is he who lies with his mother-in-law.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>24&#160;</sup>‘Cursed is he who secretly kills his neighbor.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>25&#160;</sup>‘Cursed is he who takes a bribe to kill an innocent person.’ 
+</div><div class="p">All the people shall say, ‘Amen.’ 
+</div><div class="p">
+<sup>26&#160;</sup>‘Cursed is he who doesn’t uphold the words of this law by doing them.’ 
+</div><div class="p">All the people shall say, ‘Amen.’&#160;” 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>It shall happen, if you shall listen diligently to Yahweh your Elohim’s voice, to observe to do all his commandments which I command you today, that Yahweh your Elohim will set you high above all the nations of the earth. 
+<sup>2&#160;</sup>All these blessings will come upon you, and overtake you, if you listen to Yahweh your Elohim’s voice. 
+<sup>3&#160;</sup>You shall be blessed in the city, and you shall be blessed in the field. 
+<sup>4&#160;</sup>You shall be blessed in the fruit of your body, the fruit of your ground, the fruit of your animals, the increase of your livestock, and the young of your flock. 
+<sup>5&#160;</sup>Your basket and your kneading trough shall be blessed. 
+<sup>6&#160;</sup>You shall be blessed when you come in, and you shall be blessed when you go out. 
+<sup>7&#160;</sup>Yahweh will cause your enemies who rise up against you to be struck before you. They will come out against you one way, and will flee before you seven ways. 
+<sup>8&#160;</sup>Yahweh will command the blessing on you in your barns, and in all that you put your hand to. He will bless you in the land which Yahweh your Elohim gives you. 
+<sup>9&#160;</sup>Yahweh will establish you for a set-apart people to himself, as he has sworn to you, if you shall keep the commandments of Yahweh your Elohim, and walk in his ways. 
+<sup>10&#160;</sup>All the peoples of the earth shall see that you are called by Yahweh’s name, and they will be afraid of you. 
+<sup>11&#160;</sup>Yahweh will grant you abundant prosperity in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, in the land which Yahweh swore to your fathers to give you. 
+<sup>12&#160;</sup>Yahweh will open to you his good treasure in the sky, to give the rain of your land in its season, and to bless all the work of your hand. You will lend to many nations, and you will not borrow. 
+<sup>13&#160;</sup>Yahweh will make you the head, and not the tail. You will be above only, and you will not be beneath, if you listen to the commandments of Yahweh your Elohim which I command you today, to observe and to do, 
+<sup>14&#160;</sup>and shall not turn away from any of the words which I command you today, to the right hand or to the left, to go after other elohims to serve them. 
+</div><div class="p">
+<sup>15&#160;</sup>But it shall come to pass, if you will not listen to Yahweh your Elohim’s voice, to observe to do all his commandments and his statutes which I command you today, that all these curses will come on you and overtake you. 
+<sup>16&#160;</sup>You will be cursed in the city, and you will be cursed in the field. 
+<sup>17&#160;</sup>Your basket and your kneading trough will be cursed. 
+<sup>18&#160;</sup>The fruit of your body, the fruit of your ground, the increase of your livestock, and the young of your flock will be cursed. 
+<sup>19&#160;</sup>You will be cursed when you come in, and you will be cursed when you go out. 
+<sup>20&#160;</sup>Yahweh will send on you cursing, confusion, and rebuke in all that you put your hand to do, until you are destroyed and until you perish quickly, because of the evil of your doings, by which you have forsaken me. 
+<sup>21&#160;</sup>Yahweh will make the pestilence cling to you, until he has consumed you from off the land where you go in to possess it. 
+<sup>22&#160;</sup>Yahweh will strike you with consumption, with fever, with inflammation, with fiery heat, with the sword, with blight, and with mildew. They will pursue you until you perish. 
+<sup>23&#160;</sup>Your sky that is over your head will be bronze, and the earth that is under you will be iron. 
+<sup>24&#160;</sup>Yahweh will make the rain of your land powder and dust. It will come down on you from the sky, until you are destroyed. 
+<sup>25&#160;</sup>Yahweh will cause you to be struck before your enemies. You will go out one way against them, and will flee seven ways before them. You will be tossed back and forth among all the kingdoms of the earth. 
+<sup>26&#160;</sup>Your dead bodies will be food to all birds of the sky, and to the animals of the earth; and there will be no one to frighten them away. 
+<sup>27&#160;</sup>Yahweh will strike you with the boils of Egypt, with the tumors, with the scurvy, and with the itch, of which you can not be healed. 
+<sup>28&#160;</sup>Yahweh will strike you with madness, with blindness, and with astonishment of heart. 
+<sup>29&#160;</sup>You will grope at noonday, as the blind gropes in darkness, and you shall not prosper in your ways. You will only be oppressed and robbed always, and there will be no one to save you. 
+<sup>30&#160;</sup>You will betroth a woman, and another man shall lie with her. You will build a house, and you won’t dwell in it. You will plant a vineyard, and not use its fruit. 
+<sup>31&#160;</sup>Your ox will be slain before your eyes, and you will not eat any of it. Your donkey will be violently taken away from before your face, and will not be restored to you. Your sheep will be given to your enemies, and you will have no one to save you. 
+<sup>32&#160;</sup>Your sons and your daughters will be given to another people. Your eyes will look and fail with longing for them all day long. There will be no power in your hand. 
+<sup>33&#160;</sup>A nation which you don’t know will eat the fruit of your ground and all of your work. You will only be oppressed and crushed always, 
+<sup>34&#160;</sup>so that the sights that you see with your eyes will drive you mad. 
+<sup>35&#160;</sup>Yahweh will strike you in the knees and in the legs with a sore boil, of which you cannot be healed, from the sole of your foot to the crown of your head. 
+<sup>36&#160;</sup>Yahweh will bring you, and your king whom you will set over yourselves, to a nation that you have not known, you nor your fathers. There you will serve other elohims of wood and stone. 
+<sup>37&#160;</sup>You will become an astonishment, a proverb, and a byword among all the peoples where Yahweh will lead you away. 
+<sup>38&#160;</sup>You will carry much seed out into the field, and will gather little in, for the locust will consume it. 
+<sup>39&#160;</sup>You will plant vineyards and dress them, but you will neither drink of the wine, nor harvest, because worms will eat them. 
+<sup>40&#160;</sup>You will have olive trees throughout all your borders, but you won’t anoint yourself with the oil, for your olives will drop off. 
+<sup>41&#160;</sup>You will father sons and daughters, but they will not be yours, for they will go into captivity. 
+<sup>42&#160;</sup>Locusts will consume all of your trees and the fruit of your ground. 
+<sup>43&#160;</sup>The foreigner who is among you will mount up above you higher and higher, and you will come down lower and lower. 
+<sup>44&#160;</sup>He will lend to you, and you won’t lend to him. He will be the head, and you will be the tail. 
+</div><div class="p">
+<sup>45&#160;</sup>All these curses will come on you, and will pursue you and overtake you, until you are destroyed, because you didn’t listen to Yahweh your Elohim’s voice, to keep his commandments and his statutes which he commanded you. 
+<sup>46&#160;</sup>They will be for a sign and for a wonder to you and to your offspring forever. 
+<sup>47&#160;</sup>Because you didn’t serve Yahweh your Elohim with joyfulness and with gladness of heart, by reason of the abundance of all things; 
+<sup>48&#160;</sup>therefore you will serve your enemies whom Yahweh sends against you, in hunger, in thirst, in nakedness, and in lack of all things. He will put an iron yoke on your neck until he has destroyed you. 
+<sup>49&#160;</sup>Yahweh will bring a nation against you from far away, from the end of the earth, as the eagle flies: a nation whose language you will not understand, 
+<sup>50&#160;</sup>a nation of fierce facial expressions, that doesn’t respect the elderly, nor show favor to the young. 
+<sup>51&#160;</sup>They will eat the fruit of your livestock and the fruit of your ground, until you are destroyed. They also won’t leave you grain, new wine, oil, the increase of your livestock, or the young of your flock, until they have caused you to perish. 
+<sup>52&#160;</sup>They will besiege you in all your gates until your high and fortified walls in which you trusted come down throughout all your land. They will besiege you in all your gates throughout all your land which Yahweh your Elohim has given you. 
+<sup>53&#160;</sup>You will eat the fruit of your own body, the flesh of your sons and of your daughters, whom Yahweh your Elohim has given you, in the siege and in the distress with which your enemies will distress you. 
+<sup>54&#160;</sup>The man who is tender among you, and very delicate, his eye will be evil toward his brother, toward the woman whom he loves, and toward the remnant of his children whom he has remaining, 
+<sup>55&#160;</sup>so that he will not give to any of them of the flesh of his children whom he will eat, because he has nothing left to him, in the siege and in the distress with which your enemy will distress you in all your gates. 
+<sup>56&#160;</sup>The tender and delicate woman among you, who would not venture to set the sole of her foot on the ground for delicateness and tenderness, her eye will be evil toward the man that she loves, toward her son, toward her daughter, 
+<sup>57&#160;</sup>toward her young one who comes out from between her feet, and toward her children whom she bears; for she will eat them secretly for lack of all things in the siege and in the distress with which your enemy will distress you in your gates. 
+<sup>58&#160;</sup>If you will not observe to do all the words of this law that are written in this book, that you may fear this glorious and fearful name, YAHWEH your Elohim, 
+<sup>59&#160;</sup>then Yahweh will make your plagues and the plagues of your offspring fearful, even great plagues, and of long duration, and severe sicknesses, and of long duration. 
+<sup>60&#160;</sup>He will bring on you again all the diseases of Egypt, which you were afraid of; and they will cling to you. 
+<sup>61&#160;</sup>Also every sickness and every plague which is not written in the book of this law, Yahweh will bring them on you until you are destroyed. 
+<sup>62&#160;</sup>You will be left few in number, even though you were as the stars of the sky for multitude, because you didn’t listen to Yahweh your Elohim’s voice. 
+<sup>63&#160;</sup>It will happen that as Yahweh rejoiced over you to do you good, and to multiply you, so Yahweh will rejoice over you to cause you to perish and to destroy you. You will be plucked from the land that you are going in to possess. 
+<sup>64&#160;</sup>Yahweh will scatter you among all peoples, from one end of the earth to the other end of the earth. There you will serve other elohims which you have not known, you nor your fathers, even wood and stone. 
+<sup>65&#160;</sup>Among these nations you will find no ease, and there will be no rest for the sole of your foot; but Yahweh will give you there a trembling heart, failing of eyes, and pining of soul. 
+<sup>66&#160;</sup>Your life will hang in doubt before you. You will be afraid night and day, and will have no assurance of your life. 
+<sup>67&#160;</sup>In the morning you will say, “I wish it were evening!” and at evening you will say, “I wish it were morning!” for the fear of your heart which you will fear, and for the sights which your eyes will see. 
+<sup>68&#160;</sup>Yahweh will bring you into Egypt again with ships, by the way of which I told to you that you would never see it again. There you will offer yourselves to your enemies for male and female slaves, and nobody will buy you. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>These are the words of the covenant which Yahweh commanded Moses to make with the children of Israel in the land of Moab, in addition to the covenant which he made with them in Horeb. 
+<sup>2&#160;</sup>Moses called to all Israel, and said to them: 
+</div><div class="p">Your eyes have seen all that Yahweh did in the land of Egypt to Pharaoh, and to all his servants, and to all his land; 
+<sup>3&#160;</sup>the great trials which your eyes saw, the signs, and those great wonders. 
+<sup>4&#160;</sup>But Yahweh has not given you a heart to know, eyes to see, and ears to hear, to this day. 
+<sup>5&#160;</sup>I have led you forty years in the wilderness. Your clothes have not grown old on you, and your sandals have not grown old on your feet. 
+<sup>6&#160;</sup>You have not eaten bread, neither have you drunk wine or strong drink, that you may know that I am Yahweh your Elohim. 
+<sup>7&#160;</sup>When you came to this place, Sihon the king of Heshbon and Og the king of Bashan came out against us to battle, and we struck them. 
+<sup>8&#160;</sup>We took their land, and gave it for an inheritance to the Reubenites, and to the Gadites, and to the half-tribe of the Manassites. 
+<sup>9&#160;</sup>Therefore keep the words of this covenant and do them, that you may prosper in all that you do. 
+<sup>10&#160;</sup>All of you stand today in the presence of Yahweh your Elohim: your heads, your tribes, your elders, and your officers, even all the men of Israel, 
+<sup>11&#160;</sup>your little ones, your women, and the foreigners who are in the middle of your camps, from the one who cuts your wood to the one who draws your water, 
+<sup>12&#160;</sup>that you may enter into the covenant of Yahweh your Elohim, and into his oath, which Yahweh your Elohim makes with you today, 
+<sup>13&#160;</sup>that he may establish you today as his people, and that he may be your Elohim, as he spoke to you and as he swore to your fathers, to Abraham, to Isaac, and to Jacob. 
+<sup>14&#160;</sup>Neither do I make this covenant and this oath with you only, 
+<sup>15&#160;</sup>but with those who stand here with us today before Yahweh our Elohim, and also with those who are not here with us today 
+<sup>16&#160;</sup>(for you know how we lived in the land of Egypt, and how we came through the middle of the nations through which you passed; 
+<sup>17&#160;</sup>and you have seen their abominations and their idols of wood, stone, silver, and gold, which were among them); 
+<sup>18&#160;</sup>lest there should be among you man, woman, family, or tribe whose heart turns away today from Yahweh our Elohim, to go to serve the elohims of those nations; lest there should be among you a root that produces bitter poison; 
+<sup>19&#160;</sup>and it happen, when he hears the words of this curse, that he bless himself in his heart, saying, “I shall have peace, though I walk in the stubbornness of my heart,” to destroy the moist with the dry. 
+<sup>20&#160;</sup>Yahweh will not pardon him, but then Yahweh’s anger and his jealousy will smoke against that man, and all the curse that is written in this book will fall on him, and Yahweh will blot out his name from under the sky. 
+<sup>21&#160;</sup>Yahweh will set him apart for evil out of all the tribes of Israel, according to all the curses of the covenant written in this book of the law. 
+</div><div class="p">
+<sup>22&#160;</sup>The generation to come—your children who will rise up after you, and the foreigner who will come from a far land—will say, when they see the plagues of that land, and the sicknesses with which Yahweh has made it sick, 
+<sup>23&#160;</sup>that all of its land is sulfur, salt, and burning, that it is not sown, doesn’t produce, nor does any grass grow in it, like the overthrow of Sodom, Gomorrah, Admah, and Zeboiim, which Yahweh overthrew in his anger, and in his wrath. 
+<sup>24&#160;</sup>Even all the nations will say, “Why has Yahweh done this to this land? What does the heat of this great anger mean?” 
+</div><div class="p">
+<sup>25&#160;</sup>Then men will say, “Because they abandoned the covenant of Yahweh, the Elohim of their fathers, which he made with them when he brought them out of the land of Egypt, 
+<sup>26&#160;</sup>and went and served other elohims and worshiped them, elohims that they didn’t know and that he had not given to them. 
+<sup>27&#160;</sup>Therefore Yahweh’s anger burned against this land, to bring on it all the curses that are written in this book. 
+<sup>28&#160;</sup>Yahweh rooted them out of their land in anger, in wrath, and in great indignation, and thrust them into another land, as it is today.” 
+</div><div class="p">
+<sup>29&#160;</sup>The secret things belong to Yahweh our Elohim; but the things that are revealed belong to us and to our children forever, that we may do all the words of this law. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>It shall happen, when all these things have come on you, the blessing and the curse, which I have set before you, and you shall call them to mind among all the nations where Yahweh your Elohim has driven you, 
+<sup>2&#160;</sup>and return to Yahweh your Elohim and obey his voice according to all that I command you today, you and your children, with all your heart and with all your soul, 
+<sup>3&#160;</sup>that then Yahweh your Elohim will release you from captivity, have compassion on you, and will return and gather you from all the peoples where Yahweh your Elohim has scattered you. 
+<sup>4&#160;</sup>If your outcasts are in the uttermost parts of the heavens, from there Yahweh your Elohim will gather you, and from there he will bring you back. 
+<sup>5&#160;</sup>Yahweh your Elohim will bring you into the land which your fathers possessed, and you will possess it. He will do you good, and increase your numbers more than your fathers. 
+<sup>6&#160;</sup>Yahweh your Elohim will circumcise your heart, and the heart of your offspring, to love Yahweh your Elohim with all your heart and with all your soul, that you may live. 
+<sup>7&#160;</sup>Yahweh your Elohim will put all these curses on your enemies and on those who hate you, who persecuted you. 
+<sup>8&#160;</sup>You shall return and obey Yahweh’s voice, and do all his commandments which I command you today. 
+<sup>9&#160;</sup>Yahweh your Elohim will make you prosperous in all the work of your hand, in the fruit of your body, in the fruit of your livestock, and in the fruit of your ground, for good; for Yahweh will again rejoice over you for good, as he rejoiced over your fathers, 
+<sup>10&#160;</sup>if you will obey Yahweh your Elohim’s voice, to keep his commandments and his statutes which are written in this book of the law, if you turn to Yahweh your Elohim with all your heart and with all your soul. 
+</div><div class="p">
+<sup>11&#160;</sup>For this commandment which I command you today is not too hard for you or too distant. 
+<sup>12&#160;</sup>It is not in heaven, that you should say, “Who will go up for us to heaven, bring it to us, and proclaim it to us, that we may do it?” 
+<sup>13&#160;</sup>Neither is it beyond the sea, that you should say, “Who will go over the sea for us, bring it to us, and proclaim it to us, that we may do it?” 
+<sup>14&#160;</sup>But the word is very near to you, in your mouth and in your heart, that you may do it. 
+<sup>15&#160;</sup>Behold, I have set before you today life and prosperity, and death and evil. 
+<sup>16&#160;</sup>For I command you today to love Yahweh your Elohim, to walk in his ways and to keep his commandments, his statutes, and his ordinances, that you may live and multiply, and that Yahweh your Elohim may bless you in the land where you go in to possess it. 
+<sup>17&#160;</sup>But if your heart turns away, and you will not hear, but are drawn away and worship other elohims, and serve them, 
+<sup>18&#160;</sup>I declare to you today that you will surely perish. You will not prolong your days in the land where you pass over the Jordan to go in to possess it. 
+<sup>19&#160;</sup>I call heaven and earth to witness against you today that I have set before you life and death, the blessing and the curse. Therefore choose life, that you may live, you and your descendants, 
+<sup>20&#160;</sup>to love Yahweh your Elohim, to obey his voice, and to cling to him; for he is your life, and the length of your days, that you may dwell in the land which Yahweh swore to your fathers, to Abraham, to Isaac, and to Jacob, to give them. 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses went and spoke these words to all Israel. 
+<sup>2&#160;</sup>He said to them, “I am one hundred twenty years old today. I can no more go out and come in. Yahweh has said to me, ‘You shall not go over this Jordan.’ 
+<sup>3&#160;</sup>Yahweh your Elohim himself will go over before you. He will destroy these nations from before you, and you shall dispossess them. Joshua will go over before you, as Yahweh has spoken. 
+<sup>4&#160;</sup>Yahweh will do to them as he did to Sihon and to Og, the kings of the Amorites, and to their land, when he destroyed them. 
+<sup>5&#160;</sup>Yahweh will deliver them up before you, and you shall do to them according to all the commandment which I have commanded you. 
+<sup>6&#160;</sup>Be strong and courageous. Don’t be afraid or scared of them, for Yahweh your Elohim himself is who goes with you. He will not fail you nor forsake you.” 
+</div><div class="p">
+<sup>7&#160;</sup>Moses called to Joshua, and said to him in the sight of all Israel, “Be strong and courageous, for you shall go with this people into the land which Yahweh has sworn to their fathers to give them; and you shall cause them to inherit it. 
+<sup>8&#160;</sup>Yahweh himself is who goes before you. He will be with you. He will not fail you nor forsake you. Don’t be afraid. Don’t be discouraged.” 
+</div><div class="p">
+<sup>9&#160;</sup>Moses wrote this law and delivered it to the priests the sons of Levi, who bore the ark of Yahweh’s covenant, and to all the elders of Israel. 
+<sup>10&#160;</sup>Moses commanded them, saying, “At the end of every seven years, in the set time of the year of release, in the feast of booths, 
+<sup>11&#160;</sup>when all Israel has come to appear before Yahweh your Elohim in the place which he will choose, you shall read this law before all Israel in their hearing. 
+<sup>12&#160;</sup>Assemble the people, the men and the women and the little ones, and the foreigners who are within your gates, that they may hear, learn, fear Yahweh your Elohim, and observe to do all the words of this law, 
+<sup>13&#160;</sup>and that their children, who have not known, may hear and learn to fear Yahweh your Elohim, as long as you live in the land where you go over the Jordan to possess it.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh said to Moses, “Behold, your days approach that you must die. Call Joshua, and present yourselves in the Tent of Meeting, that I may commission him.” 
+</div><div class="p">Moses and Joshua went, and presented themselves in the Tent of Meeting. 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh appeared in the Tent in a pillar of cloud, and the pillar of cloud stood over the Tent’s door. 
+<sup>16&#160;</sup>Yahweh said to Moses, “Behold, you shall sleep with your fathers. This people will rise up and play the prostitute after the strange elohims of the land where they go to be among them, and will forsake me and break my covenant which I have made with them. 
+<sup>17&#160;</sup>Then my anger shall be kindled against them in that day, and I will forsake them, and I will hide my face from them, and they shall be devoured, and many evils and troubles shall come on them; so that they will say in that day, ‘Haven’t these evils come on us because our Elohim is not among us?’ 
+<sup>18&#160;</sup>I will surely hide my face in that day for all the evil which they have done, in that they have turned to other elohims. 
+</div><div class="p">
+<sup>19&#160;</sup>“Now therefore write this song for yourselves, and teach it to the children of Israel. Put it in their mouths, that this song may be a witness for me against the children of Israel. 
+<sup>20&#160;</sup>For when I have brought them into the land which I swore to their fathers, flowing with milk and honey, and they have eaten and filled themselves, and grown fat, then they will turn to other elohims, and serve them, and despise me, and break my covenant. 
+<sup>21&#160;</sup>It will happen, when many evils and troubles have come on them, that this song will testify before them as a witness; for it will not be forgotten out of the mouths of their descendants; for I know their ways and what they are doing today, before I have brought them into the land which I promised them.” 
+</div><div class="p">
+<sup>22&#160;</sup>So Moses wrote this song the same day, and taught it to the children of Israel. 
+</div><div class="p">
+<sup>23&#160;</sup>He commissioned Joshua the son of Nun, and said, “Be strong and courageous; for you shall bring the children of Israel into the land which I swore to them. I will be with you.” 
+</div><div class="p">
+<sup>24&#160;</sup>When Moses had finished writing the words of this law in a book, until they were finished, 
+<sup>25&#160;</sup>Moses commanded the Levites, who bore the ark of Yahweh’s covenant, saying, 
+<sup>26&#160;</sup>“Take this book of the law, and put it by the side of the ark of Yahweh your Elohim’s covenant, that it may be there for a witness against you. 
+<sup>27&#160;</sup>For I know your rebellion and your stiff neck. Behold, while I am yet alive with you today, you have been rebellious against Yahweh. How much more after my death? 
+<sup>28&#160;</sup>Assemble to me all the elders of your tribes and your officers, that I may speak these words in their ears, and call heaven and earth to witness against them. 
+<sup>29&#160;</sup>For I know that after my death you will utterly corrupt yourselves, and turn away from the way which I have commanded you; and evil will happen to you in the latter days, because you will do that which is evil in Yahweh’s sight, to provoke him to anger through the work of your hands.” 
+</div><div class="p">
+<sup>30&#160;</sup>Moses spoke in the ears of all the assembly of Israel the words of this song, until they were finished. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="q1">
+<sup>1&#160;</sup>Give ear, you heavens, and I will speak. 
+</div><div class="q2">Let the earth hear the words of my mouth. 
+</div><div class="q1">
+<sup>2&#160;</sup>My doctrine will drop as the rain. 
+</div><div class="q2">My speech will condense as the dew, 
+</div><div class="q2">as the misty rain on the tender grass, 
+</div><div class="q2">as the showers on the herb. 
+</div><div class="q1">
+<sup>3&#160;</sup>For I will proclaim Yahweh’s name. 
+</div><div class="q2">Ascribe greatness to our Elohim! 
+</div><div class="q1">
+<sup>4&#160;</sup>The Rock: his work is perfect, 
+</div><div class="q2">for all his ways are just. 
+</div><div class="q2">A Elohim of faithfulness who does no wrong, 
+</div><div class="q2">just and right is he. 
+</div><div class="q1">
+<sup>5&#160;</sup>They have dealt corruptly with him. 
+</div><div class="q2">They are not his children, because of their defect. 
+</div><div class="q2">They are a perverse and crooked generation. 
+</div><div class="q1">
+<sup>6&#160;</sup>Is this the way you repay Yahweh, 
+</div><div class="q2">foolish and unwise people? 
+</div><div class="q1">Isn’t he your father who has bought you? 
+</div><div class="q2">He has made you and established you. 
+</div><div class="q1">
+<sup>7&#160;</sup>Remember the days of old. 
+</div><div class="q2">Consider the years of many generations. 
+</div><div class="q1">Ask your father, and he will show you; 
+</div><div class="q2">your elders, and they will tell you. 
+</div><div class="q1">
+<sup>8&#160;</sup>When the Most High gave to the nations their inheritance, 
+</div><div class="q2">when he separated the children of men, 
+</div><div class="q1">he set the bounds of the peoples 
+</div><div class="q2">according to the number of the children of Israel. 
+</div><div class="q1">
+<sup>9&#160;</sup>For Yahweh’s portion is his people. 
+</div><div class="q2">Jacob is the lot of his inheritance. 
+</div><div class="q1">
+<sup>10&#160;</sup>He found him in a desert land, 
+</div><div class="q2">in the waste howling wilderness. 
+</div><div class="q1">He surrounded him. 
+</div><div class="q2">He cared for him. 
+</div><div class="q2">He kept him as the apple of his eye. 
+</div><div class="q1">
+<sup>11&#160;</sup>As an eagle that stirs up her nest, 
+</div><div class="q2">that flutters over her young, 
+</div><div class="q1">he spread abroad his wings, 
+</div><div class="q2">he took them, 
+</div><div class="q2">he bore them on his feathers. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yahweh alone led him. 
+</div><div class="q2">There was no foreign elohim with him. 
+</div><div class="q1">
+<sup>13&#160;</sup>He made him ride on the high places of the earth. 
+</div><div class="q2">He ate the increase of the field. 
+</div><div class="q1">He caused him to suck honey out of the rock, 
+</div><div class="q2">oil out of the flinty rock; 
+</div><div class="q1">
+<sup>14&#160;</sup>butter from the herd, and milk from the flock, 
+</div><div class="q2">with fat of lambs, 
+</div><div class="q2">rams of the breed of Bashan, and goats, 
+</div><div class="q2">with the finest of the wheat. 
+</div><div class="q2">From the blood of the grape, you drank wine. 
+</div><div class="q1">
+<sup>15&#160;</sup>But Jeshurun grew fat, and kicked. 
+</div><div class="q2">You have grown fat. 
+</div><div class="q2">You have grown thick. 
+</div><div class="q2">You have become sleek. 
+</div><div class="q1">Then he abandoned Elohim who made him, 
+</div><div class="q2">and rejected the Rock of his salvation. 
+</div><div class="q1">
+<sup>16&#160;</sup>They moved him to jealousy with strange elohims. 
+</div><div class="q2">They provoked him to anger with abominations. 
+</div><div class="q1">
+<sup>17&#160;</sup>They sacrificed to demons, not Elohim, 
+</div><div class="q2">to elohims that they didn’t know, 
+</div><div class="q2">to new elohims that came up recently, 
+</div><div class="q2">which your fathers didn’t dread. 
+</div><div class="q1">
+<sup>18&#160;</sup>Of the Rock who became your father, you are unmindful, 
+</div><div class="q2">and have forgotten Elohim who gave you birth. 
+</div><div class="q1">
+<sup>19&#160;</sup>Yahweh saw and abhorred, 
+</div><div class="q2">because of the provocation of his sons and his daughters. 
+</div><div class="q1">
+<sup>20&#160;</sup>He said, “I will hide my face from them. 
+</div><div class="q2">I will see what their end will be; 
+</div><div class="q1">for they are a very perverse generation, 
+</div><div class="q2">children in whom is no faithfulness. 
+</div><div class="q1">
+<sup>21&#160;</sup>They have moved me to jealousy with that which is not Elohim. 
+</div><div class="q2">They have provoked me to anger with their vanities. 
+</div><div class="q1">I will move them to jealousy with those who are not a people. 
+</div><div class="q2">I will provoke them to anger with a foolish nation. 
+</div><div class="q1">
+<sup>22&#160;</sup>For a fire is kindled in my anger, 
+</div><div class="q2">that burns to the lowest Sheol, 
+</div><div class="q2">devours the earth with its increase, 
+</div><div class="q2">and sets the foundations of the mountains on fire. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>“I will heap evils on them. 
+</div><div class="q2">I will spend my arrows on them. 
+</div><div class="q1">
+<sup>24&#160;</sup>They shall be wasted with hunger, 
+</div><div class="q2">and devoured with burning heat 
+</div><div class="q2">and bitter destruction. 
+</div><div class="q1">I will send the teeth of animals on them, 
+</div><div class="q2">with the venom of vipers that glide in the dust. 
+</div><div class="q1">
+<sup>25&#160;</sup>Outside the sword will bereave, 
+</div><div class="q2">and in the rooms, 
+</div><div class="q2">terror on both young man and virgin, 
+</div><div class="q2">the nursing infant with the gray-haired man. 
+</div><div class="q1">
+<sup>26&#160;</sup>I said that I would scatter them afar. 
+</div><div class="q2">I would make their memory to cease from among men; 
+</div><div class="q1">
+<sup>27&#160;</sup>were it not that I feared the provocation of the enemy, 
+</div><div class="q2">lest their adversaries should judge wrongly, 
+</div><div class="q2">lest they should say, ‘Our hand is exalted; 
+</div><div class="q2">Yahweh has not done all this.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>For they are a nation void of counsel. 
+</div><div class="q2">There is no understanding in them. 
+</div><div class="q1">
+<sup>29&#160;</sup>Oh that they were wise, that they understood this, 
+</div><div class="q2">that they would consider their latter end! 
+</div><div class="q1">
+<sup>30&#160;</sup>How could one chase a thousand, 
+</div><div class="q2">and two put ten thousand to flight, 
+</div><div class="q1">unless their Rock had sold them, 
+</div><div class="q2">and Yahweh had delivered them up? 
+</div><div class="q1">
+<sup>31&#160;</sup>For their rock is not as our Rock, 
+</div><div class="q2">even our enemies themselves concede. 
+</div><div class="q1">
+<sup>32&#160;</sup>For their vine is of the vine of Sodom, 
+</div><div class="q2">of the fields of Gomorrah. 
+</div><div class="q1">Their grapes are poison grapes. 
+</div><div class="q2">Their clusters are bitter. 
+</div><div class="q1">
+<sup>33&#160;</sup>Their wine is the poison of serpents, 
+</div><div class="q2">the cruel venom of asps. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>34&#160;</sup>“Isn’t this laid up in store with me, 
+</div><div class="q2">sealed up among my treasures? 
+</div><div class="q1">
+<sup>35&#160;</sup>Vengeance is mine, and recompense, 
+</div><div class="q2">at the time when their foot slides, 
+</div><div class="q1">for the day of their calamity is at hand. 
+</div><div class="q2">Their doom rushes at them.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>36&#160;</sup>For Yahweh will judge his people, 
+</div><div class="q2">and have compassion on his servants, 
+</div><div class="q1">when he sees that their power is gone, 
+</div><div class="q2">that there is no one remaining, shut up or left at large. 
+</div><div class="q1">
+<sup>37&#160;</sup>He will say, “Where are their elohims, 
+</div><div class="q2">the rock in which they took refuge, 
+</div><div class="q1">
+<sup>38&#160;</sup>which ate the fat of their sacrifices, 
+</div><div class="q2">and drank the wine of their drink offering? 
+</div><div class="q1">Let them rise up and help you! 
+</div><div class="q2">Let them be your protection. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>39&#160;</sup>“See now that I myself am he. 
+</div><div class="q2">There is no elohim with me. 
+</div><div class="q1">I kill and I make alive. 
+</div><div class="q2">I wound and I heal. 
+</div><div class="q2">There is no one who can deliver out of my hand. 
+</div><div class="q1">
+<sup>40&#160;</sup>For I lift up my hand to heaven and declare, 
+</div><div class="q2">as I live forever, 
+</div><div class="q1">
+<sup>41&#160;</sup>if I sharpen my glittering sword, 
+</div><div class="q2">my hand grasps it in judgment; 
+</div><div class="q1">I will take vengeance on my adversaries, 
+</div><div class="q2">and will repay those who hate me. 
+</div><div class="q1">
+<sup>42&#160;</sup>I will make my arrows drunk with blood. 
+</div><div class="q2">My sword shall devour flesh with the blood of the slain and the captives, 
+</div><div class="q2">from the head of the leaders of the enemy.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>43&#160;</sup>Rejoice, you nations, with his people, 
+</div><div class="q2">for he will avenge the blood of his servants. 
+</div><div class="q2">He will take vengeance on his adversaries, 
+</div><div class="q2">and will make atonement for his land and for his people. 
+</div><div class="p">
+<sup>44&#160;</sup>Moses came and spoke all the words of this song in the ears of the people, he and Joshua the son of Nun. 
+<sup>45&#160;</sup>Moses finished reciting all these words to all Israel. 
+<sup>46&#160;</sup>He said to them, “Set your heart to all the words which I testify to you today, which you shall command your children to observe to do, all the words of this law. 
+<sup>47&#160;</sup>For it is no vain thing for you, because it is your life, and through this thing you shall prolong your days in the land, where you go over the Jordan to possess it.” 
+</div><div class="p">
+<sup>48&#160;</sup>Yahweh spoke to Moses that same day, saying, 
+<sup>49&#160;</sup>“Go up into this mountain of Abarim, to Mount Nebo, which is in the land of Moab, that is across from Jericho; and see the land of Canaan, which I give to the children of Israel for a possession. 
+<sup>50&#160;</sup>Die on the mountain where you go up, and be gathered to your people, as Aaron your brother died on Mount Hor, and was gathered to his people; 
+<sup>51&#160;</sup>because you trespassed against me among the children of Israel at the waters of Meribah of Kadesh, in the wilderness of Zin; because you didn’t uphold my set-apartness among the children of Israel. 
+<sup>52&#160;</sup>For you shall see the land from a distance; but you shall not go there into the land which I give the children of Israel.” 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="p">
+<sup>1&#160;</sup>This is the blessing with which Moses the man of Elohim blessed the children of Israel before his death. 
+<sup>2&#160;</sup>He said, 
+</div><div class="q1">“Yahweh came from Sinai, 
+</div><div class="q2">and rose from Seir to them. 
+</div><div class="q1">He shone from Mount Paran. 
+</div><div class="q2">He came from the ten thousands of set-apart ones. 
+</div><div class="q2">At his right hand was a fiery law for them. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yes, he loves the people. 
+</div><div class="q2">All his saints are in your hand. 
+</div><div class="q2">They sat down at your feet. 
+</div><div class="q2">Each receives your words. 
+</div><div class="q1">
+<sup>4&#160;</sup>Moses commanded us a law, 
+</div><div class="q2">an inheritance for the assembly of Jacob. 
+</div><div class="q1">
+<sup>5&#160;</sup>He was king in Jeshurun, 
+</div><div class="q2">when the heads of the people were gathered, 
+</div><div class="q2">all the tribes of Israel together. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“Let Reuben live, and not die; 
+</div><div class="q2">Nor let his men be few.” 
+</div><div class="p">
+<sup>7&#160;</sup>This is for Judah. He said, 
+</div><div class="q1">“Hear, Yahweh, the voice of Judah. 
+</div><div class="q2">Bring him in to his people. 
+</div><div class="q1">With his hands he contended for himself. 
+</div><div class="q2">You shall be a help against his adversaries.” 
+</div><div class="p">
+<sup>8&#160;</sup>About Levi he said, 
+</div><div class="q1">“Your Thummim and your Urim are with your elohimly one, 
+</div><div class="q2">whom you proved at Massah, 
+</div><div class="q2">with whom you contended at the waters of Meribah. 
+</div><div class="q1">
+<sup>9&#160;</sup>He said of his father, and of his mother, ‘I have not seen him.’ 
+</div><div class="q2">He didn’t acknowledge his brothers, 
+</div><div class="q2">nor did he know his own children; 
+</div><div class="q1">for they have observed your word, 
+</div><div class="q2">and keep your covenant. 
+</div><div class="q1">
+<sup>10&#160;</sup>They shall teach Jacob your ordinances, 
+</div><div class="q2">and Israel your law. 
+</div><div class="q1">They shall put incense before you, 
+</div><div class="q2">and whole burnt offering on your altar. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh, bless his skills. 
+</div><div class="q2">Accept the work of his hands. 
+</div><div class="q1">Strike through the hips of those who rise up against him, 
+</div><div class="q2">of those who hate him, that they not rise again.” 
+</div><div class="p">
+<sup>12&#160;</sup>About Benjamin he said, 
+</div><div class="q1">“The beloved of Yahweh will dwell in safety by him. 
+</div><div class="q2">He covers him all day long. 
+</div><div class="q2">He dwells between his shoulders.” 
+</div><div class="p">
+<sup>13&#160;</sup>About Joseph he said, 
+</div><div class="q1">“His land is blessed by Yahweh, 
+</div><div class="q2">for the precious things of the heavens, for the dew, 
+</div><div class="q2">for the deep that couches beneath, 
+</div><div class="q1">
+<sup>14&#160;</sup>for the precious things of the fruits of the sun, 
+</div><div class="q2">for the precious things that the moon can yield, 
+</div><div class="q1">
+<sup>15&#160;</sup>for the best things of the ancient mountains, 
+</div><div class="q2">for the precious things of the everlasting hills, 
+</div><div class="q1">
+<sup>16&#160;</sup>for the precious things of the earth and its fullness, 
+</div><div class="q2">the good will of him who lived in the bush. 
+</div><div class="q1">Let this come on the head of Joseph, 
+</div><div class="q2">on the crown of the head of him who was separated from his brothers. 
+</div><div class="q1">
+<sup>17&#160;</sup>Majesty belongs to the firstborn of his herd. 
+</div><div class="q2">His horns are the horns of the wild ox. 
+</div><div class="q2">With them he will push all the peoples to the ends of the earth. 
+</div><div class="q1">They are the ten thousands of Ephraim. 
+</div><div class="q2">They are the thousands of Manasseh.” 
+</div><div class="p">
+<sup>18&#160;</sup>About Zebulun he said, 
+</div><div class="q1">“Rejoice, Zebulun, in your going out; 
+</div><div class="q2">and Issachar, in your tents. 
+</div><div class="q1">
+<sup>19&#160;</sup>They will call the peoples to the mountain. 
+</div><div class="q2">There they will offer sacrifices of righteousness, 
+</div><div class="q1">for they will draw out the abundance of the seas, 
+</div><div class="q2">the hidden treasures of the sand.” 
+</div><div class="p">
+<sup>20&#160;</sup>About Gad he said, 
+</div><div class="q1">“He who enlarges Gad is blessed. 
+</div><div class="q2">He dwells as a lioness, 
+</div><div class="q2">and tears the arm and the crown of the head. 
+</div><div class="q1">
+<sup>21&#160;</sup>He provided the first part for himself, 
+</div><div class="q2">for the lawgiver’s portion was reserved for him. 
+</div><div class="q1">He came with the heads of the people. 
+</div><div class="q2">He executed the righteousness of Yahweh, 
+</div><div class="q2">His ordinances with Israel.” 
+</div><div class="p">
+<sup>22&#160;</sup>About Dan he said, 
+</div><div class="q1">“Dan is a lion’s cub 
+</div><div class="q2">that leaps out of Bashan.” 
+</div><div class="p">
+<sup>23&#160;</sup>About Naphtali he said, 
+</div><div class="q1">“Naphtali, satisfied with favor, 
+</div><div class="q2">full of Yahweh’s blessing, 
+</div><div class="q2">Possess the west and the south.” 
+</div><div class="p">
+<sup>24&#160;</sup>About Asher he said, 
+</div><div class="q1">“Asher is blessed with children. 
+</div><div class="q2">Let him be acceptable to his brothers. 
+</div><div class="q2">Let him dip his foot in oil. 
+</div><div class="q1">
+<sup>25&#160;</sup>Your bars will be iron and bronze. 
+</div><div class="q2">As your days, so your strength will be. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>26&#160;</sup>“There is no one like Elohim, Jeshurun, 
+</div><div class="q2">who rides on the heavens for your help, 
+</div><div class="q2">in his excellency on the skies. 
+</div><div class="q1">
+<sup>27&#160;</sup>The eternal Elohim is your dwelling place. 
+</div><div class="q2">Underneath are the everlasting arms. 
+</div><div class="q1">He thrust out the enemy from before you, 
+</div><div class="q2">and said, ‘Destroy!’ 
+</div><div class="q1">
+<sup>28&#160;</sup>Israel dwells in safety, 
+</div><div class="q2">the fountain of Jacob alone, 
+</div><div class="q1">In a land of grain and new wine. 
+</div><div class="q2">Yes, his heavens drop down dew. 
+</div><div class="q1">
+<sup>29&#160;</sup>You are happy, Israel! 
+</div><div class="q2">Who is like you, a people saved by Yahweh, 
+</div><div class="q2">the shield of your help, 
+</div><div class="q2">the sword of your excellency? 
+</div><div class="q1">Your enemies will submit themselves to you. 
+</div><div class="q2">You will tread on their high places.” 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses went up from the plains of Moab to Mount Nebo, to the top of Pisgah, that is opposite Jericho. Yahweh showed him all the land of Gilead to Dan, 
+<sup>2&#160;</sup>and all Naphtali, and the land of Ephraim and Manasseh, and all the land of Judah, to the Western Sea, 
+<sup>3&#160;</sup>and the south, and the Plain of the valley of Jericho the city of palm trees, to Zoar. 
+<sup>4&#160;</sup>Yahweh said to him, “This is the land which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ I have caused you to see it with your eyes, but you shall not go over there.” 
+</div><div class="p">
+<sup>5&#160;</sup>So Moses the servant of Yahweh died there in the land of Moab, according to Yahweh’s word. 
+<sup>6&#160;</sup>He buried him in the valley in the land of Moab opposite Beth Peor, but no man knows where his tomb is to this day. 
+<sup>7&#160;</sup>Moses was one hundred twenty years old when he died. His eye was not dim, nor his strength gone. 
+<sup>8&#160;</sup>The children of Israel wept for Moses in the plains of Moab thirty days, until the days of weeping in the mourning for Moses were ended. 
+<sup>9&#160;</sup>Joshua the son of Nun was full of the spirit of wisdom, for Moses had laid his hands on him. The children of Israel listened to him, and did as Yahweh commanded Moses. 
+<sup>10&#160;</sup>Since then, there has not arisen a prophet in Israel like Moses, whom Yahweh knew face to face, 
+<sup>11&#160;</sup>in all the signs and the wonders which Yahweh sent him to do in the land of Egypt, to Pharaoh, and to all his servants, and to all his land, 
+<sup>12&#160;</sup>and in all the mighty hand, and in all the awesome deeds, which Moses did in the sight of all Israel. </div></div><script src="../main.js"></script></body></html>

--- a/book/ecclesiastes.html
+++ b/book/ecclesiastes.html
@@ -3,6 +3,47 @@
 <head>
 <title>Ecclesiastes</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,386 +53,399 @@
 <div class="main">
 <!-- ECC World English Scripture (WES) -->
 <h1 class="booklabel">Ecclesiastes</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The words of the Preacher, the son of David, king in Jerusalem: 
-</p><p>
-<span class="v">2&#160;</span>“Vanity of vanities,” says the Preacher; “Vanity of vanities, all is vanity.” 
-<span class="v">3&#160;</span>What does man gain from all his labor in which he labors under the sun? 
-<span class="v">4&#160;</span>One generation goes, and another generation comes; but the earth remains forever. 
-<span class="v">5&#160;</span>The sun also rises, and the sun goes down, and hurries to its place where it rises. 
-<span class="v">6&#160;</span>The wind goes toward the south, and turns around to the north. It turns around continually as it goes, and the wind returns again to its courses. 
-<span class="v">7&#160;</span>All the rivers run into the sea, yet the sea is not full. To the place where the rivers flow, there they flow again. 
-<span class="v">8&#160;</span>All things are full of weariness beyond uttering. The eye is not satisfied with seeing, nor the ear filled with hearing. 
-<span class="v">9&#160;</span>That which has been is that which shall be, and that which has been done is that which shall be done; and there is no new thing under the sun. 
-<span class="v">10&#160;</span>Is there a thing of which it may be said, “Behold,<span class="f">+ \fr 1:10 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> this is new”? It has been long ago, in the ages which were before us. 
-<span class="v">11&#160;</span>There is no memory of the former; neither shall there be any memory of the latter that are to come, among those that shall come after. 
-</p><p>
-<span class="v">12&#160;</span>I, the Preacher, was king over Israel in Jerusalem. 
-<span class="v">13&#160;</span>I applied my heart to seek and to search out by wisdom concerning all that is done under the sky. It is a heavy burden that Elohim<span class="f">+ \fr 1:13 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> has given to the sons of men to be afflicted with. 
-<span class="v">14&#160;</span>I have seen all the works that are done under the sun; and behold, all is vanity and a chasing after wind. 
-<span class="v">15&#160;</span>That which is crooked can’t be made straight; and that which is lacking can’t be counted. 
-<span class="v">16&#160;</span>I said to myself, “Behold, I have obtained for myself great wisdom above all who were before me in Jerusalem. Yes, my heart has had great experience of wisdom and knowledge.” 
-<span class="v">17&#160;</span>I applied my heart to know wisdom, and to know madness and folly. I perceived that this also was a chasing after wind. 
-<span class="v">18&#160;</span>For in much wisdom is much grief; and he who increases knowledge increases sorrow. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>I said in my heart, “Come now, I will test you with mirth; therefore enjoy pleasure;” and behold, this also was vanity. 
-<span class="v">2&#160;</span>I said of laughter, “It is foolishness;” and of mirth, “What does it accomplish?” 
-</p><p>
-<span class="v">3&#160;</span>I searched in my heart how to cheer my flesh with wine, my heart yet guiding me with wisdom, and how to lay hold of folly, until I might see what it was good for the sons of men that they should do under heaven all the days of their lives. 
-<span class="v">4&#160;</span>I made myself great works. I built myself houses. I planted myself vineyards. 
-<span class="v">5&#160;</span>I made myself gardens and parks, and I planted trees in them of all kinds of fruit. 
-<span class="v">6&#160;</span>I made myself pools of water, to water the forest where trees were grown. 
-<span class="v">7&#160;</span>I bought male servants and female servants, and had servants born in my house. I also had great possessions of herds and flocks, above all who were before me in Jerusalem. 
-<span class="v">8&#160;</span>I also gathered silver and gold for myself, and the treasure of kings and of the provinces. I got myself male and female singers, and the delights of the sons of men: musical instruments of all sorts. 
-<span class="v">9&#160;</span>So I was great, and increased more than all who were before me in Jerusalem. My wisdom also remained with me. 
-<span class="v">10&#160;</span>Whatever my eyes desired, I didn’t keep from them. I didn’t withhold my heart from any joy, for my heart rejoiced because of all my labor, and this was my portion from all my labor. 
-<span class="v">11&#160;</span>Then I looked at all the works that my hands had worked, and at the labor that I had labored to do; and behold, all was vanity and a chasing after wind, and there was no profit under the sun. 
-</p><p>
-<span class="v">12&#160;</span>I turned myself to consider wisdom, madness, and folly; for what can the king’s successor do? Just that which has been done long ago. 
-<span class="v">13&#160;</span>Then I saw that wisdom excels folly, as far as light excels darkness. 
-<span class="v">14&#160;</span>The wise man’s eyes are in his head, and the fool walks in darkness—and yet I perceived that one event happens to them all. 
-<span class="v">15&#160;</span>Then I said in my heart, “As it happens to the fool, so will it happen even to me; and why was I then more wise?” Then I said in my heart that this also is vanity. 
-<span class="v">16&#160;</span>For of the wise man, even as of the fool, there is no memory forever, since in the days to come all will have been long forgotten. Indeed, the wise man must die just like the fool! 
-</p><p>
-<span class="v">17&#160;</span>So I hated life, because the work that is worked under the sun was grievous to me; for all is vanity and a chasing after wind. 
-<span class="v">18&#160;</span>I hated all my labor in which I labored under the sun, because I must leave it to the man who comes after me. 
-<span class="v">19&#160;</span>Who knows whether he will be a wise man or a fool? Yet he will have rule over all of my labor in which I have labored, and in which I have shown myself wise under the sun. This also is vanity. 
-</p><p>
-<span class="v">20&#160;</span>Therefore I began to cause my heart to despair concerning all the labor in which I had labored under the sun. 
-<span class="v">21&#160;</span>For there is a man whose labor is with wisdom, with knowledge, and with skillfulness; yet he shall leave it for his portion to a man who has not labored for it. This also is vanity and a great evil. 
-<span class="v">22&#160;</span>For what does a man have of all his labor and of the striving of his heart, in which he labors under the sun? 
-<span class="v">23&#160;</span>For all his days are sorrows, and his travail is grief; yes, even in the night his heart takes no rest. This also is vanity. 
-<span class="v">24&#160;</span>There is nothing better for a man than that he should eat and drink, and make his soul enjoy good in his labor. This also I saw, that it is from the hand of Elohim. 
-<span class="v">25&#160;</span>For who can eat, or who can have enjoyment, more than I? 
-<span class="v">26&#160;</span>For to the man who pleases him, Elohim gives wisdom, knowledge, and joy; but to the sinner he gives travail, to gather and to heap up, that he may give to him who pleases Elohim. This also is vanity and a chasing after wind. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>For everything there is a season, and a time for every purpose under heaven: 
-</p><p class="q1">
-<span class="v">2&#160;</span>a time to be born, 
-</p><p class="q2">and a time to die; 
-</p><p class="q1">a time to plant, 
-</p><p class="q2">and a time to pluck up that which is planted; 
-</p><p class="q1">
-<span class="v">3&#160;</span>a time to kill, 
-</p><p class="q2">and a time to heal; 
-</p><p class="q1">a time to break down, 
-</p><p class="q2">and a time to build up; 
-</p><p class="q1">
-<span class="v">4&#160;</span>a time to weep, 
-</p><p class="q2">and a time to laugh; 
-</p><p class="q1">a time to mourn, 
-</p><p class="q2">and a time to dance; 
-</p><p class="q1">
-<span class="v">5&#160;</span>a time to cast away stones, 
-</p><p class="q2">and a time to gather stones together; 
-</p><p class="q1">a time to embrace, 
-</p><p class="q2">and a time to refrain from embracing; 
-</p><p class="q1">
-<span class="v">6&#160;</span>a time to seek, 
-</p><p class="q2">and a time to lose; 
-</p><p class="q1">a time to keep, 
-</p><p class="q2">and a time to cast away; 
-</p><p class="q1">
-<span class="v">7&#160;</span>a time to tear, 
-</p><p class="q2">and a time to sew; 
-</p><p class="q1">a time to keep silence, 
-</p><p class="q2">and a time to speak; 
-</p><p class="q1">
-<span class="v">8&#160;</span>a time to love, 
-</p><p class="q2">and a time to hate; 
-</p><p class="q1">a time for war, 
-</p><p class="q2">and a time for peace. 
-</p><p>
-<span class="v">9&#160;</span>What profit has he who works in that in which he labors? 
-<span class="v">10&#160;</span>I have seen the burden which Elohim has given to the sons of men to be afflicted with. 
-<span class="v">11&#160;</span>He has made everything beautiful in its time. He has also set eternity in their hearts, yet so that man can’t find out the work that Elohim has done from the beginning even to the end. 
-<span class="v">12&#160;</span>I know that there is nothing better for them than to rejoice, and to do good as long as they live. 
-<span class="v">13&#160;</span>Also that every man should eat and drink, and enjoy good in all his labor, is the gift of Elohim. 
-<span class="v">14&#160;</span>I know that whatever Elohim does, it shall be forever. Nothing can be added to it, nor anything taken from it; and Elohim has done it, that men should fear before him. 
-<span class="v">15&#160;</span>That which is has been long ago, and that which is to be has been long ago. Elohim seeks again that which is passed away. 
-</p><p>
-<span class="v">16&#160;</span>Moreover I saw under the sun, in the place of justice, that wickedness was there; and in the place of righteousness, that wickedness was there. 
-<span class="v">17&#160;</span>I said in my heart, “Elohim will judge the righteous and the wicked; for there is a time there for every purpose and for every work.” 
-<span class="v">18&#160;</span>I said in my heart, “As for the sons of men, Elohim tests them, so that they may see that they themselves are like animals. 
-<span class="v">19&#160;</span>For that which happens to the sons of men happens to animals. Even one thing happens to them. As the one dies, so the other dies. Yes, they have all one breath; and man has no advantage over the animals, for all is vanity. 
-<span class="v">20&#160;</span>All go to one place. All are from the dust, and all turn to dust again. 
-<span class="v">21&#160;</span>Who knows the spirit of man, whether it goes upward, and the spirit of the animal, whether it goes downward to the earth?” 
-</p><p>
-<span class="v">22&#160;</span>Therefore I saw that there is nothing better than that a man should rejoice in his works, for that is his portion; for who can bring him to see what will be after him? 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Then I returned and saw all the oppressions that are done under the sun: and behold, the tears of those who were oppressed, and they had no comforter; and on the side of their oppressors there was power; but they had no comforter. 
-<span class="v">2&#160;</span>Therefore I praised the dead who have been long dead more than the living who are yet alive. 
-<span class="v">3&#160;</span>Yes, better than them both is him who has not yet been, who has not seen the evil work that is done under the sun. 
-<span class="v">4&#160;</span>Then I saw all the labor and achievement that is the envy of a man’s neighbor. This also is vanity and a striving after wind. 
-</p><p>
-<span class="v">5&#160;</span>The fool folds his hands together and ruins himself. 
-<span class="v">6&#160;</span>Better is a handful, with quietness, than two handfuls with labor and chasing after wind. 
-</p><p>
-<span class="v">7&#160;</span>Then I returned and saw vanity under the sun. 
-<span class="v">8&#160;</span>There is one who is alone, and he has neither son nor brother. There is no end to all of his labor, neither are his eyes satisfied with wealth. “For whom then do I labor and deprive my soul of enjoyment?” This also is vanity. Yes, it is a miserable business. 
-</p><p>
-<span class="v">9&#160;</span>Two are better than one, because they have a good reward for their labor. 
-<span class="v">10&#160;</span>For if they fall, the one will lift up his fellow; but woe to him who is alone when he falls, and doesn’t have another to lift him up. 
-<span class="v">11&#160;</span>Again, if two lie together, then they have warmth; but how can one keep warm alone? 
-<span class="v">12&#160;</span>If a man prevails against one who is alone, two shall withstand him; and a threefold cord is not quickly broken. 
-</p><p>
-<span class="v">13&#160;</span>Better is a poor and wise youth than an old and foolish king who doesn’t know how to receive admonition any more. 
-<span class="v">14&#160;</span>For out of prison he came out to be king; yes, even in his kingdom he was born poor. 
-<span class="v">15&#160;</span>I saw all the living who walk under the sun, that they were with the youth, the other, who succeeded him. 
-<span class="v">16&#160;</span>There was no end of all the people, even of all them over whom he was—yet those who come after shall not rejoice in him. Surely this also is vanity and a chasing after wind. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Guard your steps when you go to Elohim’s house; for to draw near to listen is better than to give the sacrifice of fools, for they don’t know that they do evil. 
-<span class="v">2&#160;</span>Don’t be rash with your mouth, and don’t let your heart be hasty to utter anything before Elohim; for Elohim is in heaven, and you on earth. Therefore let your words be few. 
-<span class="v">3&#160;</span>For as a dream comes with a multitude of cares, so a fool’s speech with a multitude of words. 
-<span class="v">4&#160;</span>When you vow a vow to Elohim, don’t defer to pay it; for he has no pleasure in fools. Pay that which you vow. 
-<span class="v">5&#160;</span>It is better that you should not vow, than that you should vow and not pay. 
-<span class="v">6&#160;</span>Don’t allow your mouth to lead you into sin. Don’t protest before the messenger that this was a mistake. Why should Elohim be angry at your voice, and destroy the work of your hands? 
-<span class="v">7&#160;</span>For in the multitude of dreams there are vanities, as well as in many words; but you must fear Elohim. 
-</p><p>
-<span class="v">8&#160;</span>If you see the oppression of the poor, and the violent taking away of justice and righteousness in a district, don’t marvel at the matter, for one official is eyed by a higher one, and there are officials over them. 
-<span class="v">9&#160;</span>Moreover the profit of the earth is for all. The king profits from the field. 
-</p><p>
-<span class="v">10&#160;</span>He who loves silver shall not be satisfied with silver, nor he who loves abundance, with increase. This also is vanity. 
-<span class="v">11&#160;</span>When goods increase, those who eat them are increased; and what advantage is there to its owner, except to feast on them with his eyes? 
-</p><p>
-<span class="v">12&#160;</span>The sleep of a laboring man is sweet, whether he eats little or much; but the abundance of the rich will not allow him to sleep. 
-</p><p>
-<span class="v">13&#160;</span>There is a grievous evil which I have seen under the sun: wealth kept by its owner to his harm. 
-<span class="v">14&#160;</span>Those riches perish by misfortune, and if he has fathered a son, there is nothing in his hand. 
-<span class="v">15&#160;</span>As he came out of his mother’s womb, naked shall he go again as he came, and shall take nothing for his labor, which he may carry away in his hand. 
-<span class="v">16&#160;</span>This also is a grievous evil, that in all points as he came, so shall he go. And what profit does he have who labors for the wind? 
-<span class="v">17&#160;</span>All his days he also eats in darkness, he is frustrated, and has sickness and wrath. 
-</p><p>
-<span class="v">18&#160;</span>Behold, that which I have seen to be good and proper is for one to eat and to drink, and to enjoy good in all his labor, in which he labors under the sun, all the days of his life which Elohim has given him; for this is his portion. 
-<span class="v">19&#160;</span>Every man also to whom Elohim has given riches and wealth, and has given him power to eat of it, and to take his portion, and to rejoice in his labor—this is the gift of Elohim. 
-<span class="v">20&#160;</span>For he shall not often reflect on the days of his life, because Elohim occupies him with the joy of his heart. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>There is an evil which I have seen under the sun, and it is heavy on men: 
-<span class="v">2&#160;</span>a man to whom Elohim gives riches, wealth, and honor, so that he lacks nothing for his soul of all that he desires, yet Elohim gives him no power to eat of it, but an alien eats it. This is vanity, and it is an evil disease. 
-</p><p>
-<span class="v">3&#160;</span>If a man fathers a hundred children, and lives many years, so that the days of his years are many, but his soul is not filled with good, and moreover he has no burial, I say that a stillborn child is better than he; 
-<span class="v">4&#160;</span>for it comes in vanity, and departs in darkness, and its name is covered with darkness. 
-<span class="v">5&#160;</span>Moreover it has not seen the sun nor known it. This has rest rather than the other. 
-<span class="v">6&#160;</span>Yes, though he live a thousand years twice told, and yet fails to enjoy good, don’t all go to one place? 
-<span class="v">7&#160;</span>All the labor of man is for his mouth, and yet the appetite is not filled. 
-<span class="v">8&#160;</span>For what advantage has the wise more than the fool? What has the poor man, that knows how to walk before the living? 
-<span class="v">9&#160;</span>Better is the sight of the eyes than the wandering of the desire. This also is vanity and a chasing after wind. 
-<span class="v">10&#160;</span>Whatever has been, its name was given long ago; and it is known what man is; neither can he contend with him who is mightier than he. 
-<span class="v">11&#160;</span>For there are many words that create vanity. What does that profit man? 
-<span class="v">12&#160;</span>For who knows what is good for man in life, all the days of his vain life which he spends like a shadow? For who can tell a man what will be after him under the sun? 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>A good name is better than fine perfume; and the day of death better than the day of one’s birth. 
-<span class="v">2&#160;</span>It is better to go to the house of mourning than to go to the house of feasting; for that is the end of all men, and the living should take this to heart. 
-<span class="v">3&#160;</span>Sorrow is better than laughter; for by the sadness of the face the heart is made good. 
-<span class="v">4&#160;</span>The heart of the wise is in the house of mourning; but the heart of fools is in the house of mirth. 
-<span class="v">5&#160;</span>It is better to hear the rebuke of the wise than for a man to hear the song of fools. 
-<span class="v">6&#160;</span>For as the crackling of thorns under a pot, so is the laughter of the fool. This also is vanity. 
-<span class="v">7&#160;</span>Surely extortion makes the wise man foolish; and a bribe destroys the understanding. 
-<span class="v">8&#160;</span>Better is the end of a thing than its beginning. 
-</p><p>The patient in spirit is better than the proud in spirit. 
-<span class="v">9&#160;</span>Don’t be hasty in your spirit to be angry, for anger rests in the bosom of fools. 
-<span class="v">10&#160;</span>Don’t say, “Why were the former days better than these?” For you do not ask wisely about this. 
-</p><p>
-<span class="v">11&#160;</span>Wisdom is as good as an inheritance. Yes, it is more excellent for those who see the sun. 
-<span class="v">12&#160;</span>For wisdom is a defense, even as money is a defense; but the excellency of knowledge is that wisdom preserves the life of him who has it. 
-</p><p>
-<span class="v">13&#160;</span>Consider the work of Elohim, for who can make that straight which he has made crooked? 
-<span class="v">14&#160;</span>In the day of prosperity be joyful, and in the day of adversity consider; yes, Elohim has made the one side by side with the other, to the end that man should not find out anything after him. 
-</p><p>
-<span class="v">15&#160;</span>All this I have seen in my days of vanity: there is a righteous man who perishes in his righteousness, and there is a wicked man who lives long in his evildoing. 
-<span class="v">16&#160;</span>Don’t be overly righteous, neither make yourself overly wise. Why should you destroy yourself? 
-<span class="v">17&#160;</span>Don’t be too wicked, neither be foolish. Why should you die before your time? 
-<span class="v">18&#160;</span>It is good that you should take hold of this. Yes, also don’t withdraw your hand from that; for he who fears Elohim will come out of them all. 
-<span class="v">19&#160;</span>Wisdom is a strength to the wise man more than ten rulers who are in a city. 
-<span class="v">20&#160;</span>Surely there is not a righteous man on earth who does good and doesn’t sin. 
-<span class="v">21&#160;</span>Also don’t take heed to all words that are spoken, lest you hear your servant curse you; 
-<span class="v">22&#160;</span>for often your own heart knows that you yourself have likewise cursed others. 
-<span class="v">23&#160;</span>All this I have proved in wisdom. I said, “I will be wise;” but it was far from me. 
-<span class="v">24&#160;</span>That which is, is far off and exceedingly deep. Who can find it out? 
-<span class="v">25&#160;</span>I turned around, and my heart sought to know and to search out, and to seek wisdom and the scheme of things, and to know that wickedness is stupidity, and that foolishness is madness. 
-</p><p>
-<span class="v">26&#160;</span>I find more bitter than death the woman whose heart is snares and traps, whose hands are chains. Whoever pleases Elohim shall escape from her; but the sinner will be ensnared by her. 
-</p><p>
-<span class="v">27&#160;</span>“Behold, I have found this,” says the Preacher, “to one another, to find an explanation 
-<span class="v">28&#160;</span>which my soul still seeks, but I have not found. I have found one man among a thousand, but I have not found a woman among all those. 
-<span class="v">29&#160;</span>Behold, I have only found this: that Elohim made mankind upright; but they search for many inventions.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Who is like the wise man? And who knows the interpretation of a thing? A man’s wisdom makes his face shine, and the hardness of his face is changed. 
-</p><p>
-<span class="v">2&#160;</span>I say, “Keep the king’s command!” because of the oath to Elohim. 
-<span class="v">3&#160;</span>Don’t be hasty to go out of his presence. Don’t persist in an evil thing, for he does whatever pleases him, 
-<span class="v">4&#160;</span>for the king’s word is supreme. Who can say to him, “What are you doing?” 
-<span class="v">5&#160;</span>Whoever keeps the commandment shall not come to harm, and his wise heart will know the time and procedure. 
-<span class="v">6&#160;</span>For there is a time and procedure for every purpose, although the misery of man is heavy on him. 
-<span class="v">7&#160;</span>For he doesn’t know that which will be; for who can tell him how it will be? 
-<span class="v">8&#160;</span>There is no man who has power over the spirit to contain the spirit; neither does he have power over the day of death. There is no discharge in war; neither shall wickedness deliver those who practice it. 
-</p><p>
-<span class="v">9&#160;</span>All this I have seen, and applied my mind to every work that is done under the sun. There is a time in which one man has power over another to his hurt. 
-<span class="v">10&#160;</span>So I saw the wicked buried. Indeed they came also from set-apartness. They went and were forgotten in the city where they did this. This also is vanity. 
-<span class="v">11&#160;</span>Because sentence against an evil work is not executed speedily, therefore the heart of the sons of men is fully set in them to do evil. 
-<span class="v">12&#160;</span>Though a sinner commits crimes a hundred times, and lives long, yet surely I know that it will be better with those who fear Elohim, who are reverent before him. 
-<span class="v">13&#160;</span>But it shall not be well with the wicked, neither shall he lengthen days like a shadow, because he doesn’t fear Elohim. 
-</p><p>
-<span class="v">14&#160;</span>There is a vanity which is done on the earth, that there are righteous men to whom it happens according to the work of the wicked. Again, there are wicked men to whom it happens according to the work of the righteous. I said that this also is vanity. 
-<span class="v">15&#160;</span>Then I commended mirth, because a man has no better thing under the sun than to eat, to drink, and to be joyful: for that will accompany him in his labor all the days of his life which Elohim has given him under the sun. 
-</p><p>
-<span class="v">16&#160;</span>When I applied my heart to know wisdom, and to see the business that is done on the earth (even though eyes see no sleep day or night), 
-<span class="v">17&#160;</span>then I saw all the work of Elohim, that man can’t find out the work that is done under the sun, because however much a man labors to seek it out, yet he won’t find it. Yes even though a wise man thinks he can comprehend it, he won’t be able to find it. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>For all this I laid to my heart, even to explore all this: that the righteous, and the wise, and their works, are in the hand of Elohim; whether it is love or hatred, man doesn’t know it; all is before them. 
-<span class="v">2&#160;</span>All things come alike to all. There is one event to the righteous and to the wicked; to the good, to the clean, to the unclean, to him who sacrifices, and to him who doesn’t sacrifice. As is the good, so is the sinner; he who takes an oath, as he who fears an oath. 
-<span class="v">3&#160;</span>This is an evil in all that is done under the sun, that there is one event to all. Yes also, the heart of the sons of men is full of evil, and madness is in their heart while they live, and after that they go to the dead. 
-<span class="v">4&#160;</span>For to him who is joined with all the living there is hope; for a living dog is better than a dead lion. 
-<span class="v">5&#160;</span>For the living know that they will die, but the dead don’t know anything, neither do they have any more a reward; for their memory is forgotten. 
-<span class="v">6&#160;</span>Also their love, their hatred, and their envy has perished long ago; neither do they any longer have a portion forever in anything that is done under the sun. 
-</p><p>
-<span class="v">7&#160;</span>Go your way—eat your bread with joy, and drink your wine with a merry heart; for Elohim has already accepted your works. 
-<span class="v">8&#160;</span>Let your garments be always white, and don’t let your head lack oil. 
-<span class="v">9&#160;</span>Live joyfully with the woman whom you love all the days of your life of vanity, which he has given you under the sun, all your days of vanity, for that is your portion in life, and in your labor in which you labor under the sun. 
-<span class="v">10&#160;</span>Whatever your hand finds to do, do it with your might; for there is no work, nor plan, nor knowledge, nor wisdom, in Sheol,<span class="f">+ \fr 9:10 \ft Sheol is the place of the dead.</span> where you are going. 
-</p><p>
-<span class="v">11&#160;</span>I returned and saw under the sun that the race is not to the swift, nor the battle to the strong, neither yet bread to the wise, nor yet riches to men of understanding, nor yet favor to men of skill; but time and chance happen to them all. 
-<span class="v">12&#160;</span>For man also doesn’t know his time. As the fish that are taken in an evil net, and as the birds that are caught in the snare, even so are the sons of men snared in an evil time, when it falls suddenly on them. 
-</p><p>
-<span class="v">13&#160;</span>I have also seen wisdom under the sun in this way, and it seemed great to me. 
-<span class="v">14&#160;</span>There was a little city, and few men within it; and a great king came against it, besieged it, and built great bulwarks against it. 
-<span class="v">15&#160;</span>Now a poor wise man was found in it, and he by his wisdom delivered the city; yet no man remembered that same poor man. 
-<span class="v">16&#160;</span>Then I said, “Wisdom is better than strength.” Nevertheless the poor man’s wisdom is despised, and his words are not heard. 
-<span class="v">17&#160;</span>The words of the wise heard in quiet are better than the cry of him who rules among fools. 
-<span class="v">18&#160;</span>Wisdom is better than weapons of war; but one sinner destroys much good. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Dead flies cause the oil of the perfumer to produce an evil odor; 
-</p><p class="q2">so does a little folly outweigh wisdom and honor. 
-</p><p class="q1">
-<span class="v">2&#160;</span>A wise man’s heart is at his right hand, 
-</p><p class="q2">but a fool’s heart at his left. 
-<span class="v">3&#160;</span>Yes also when the fool walks by the way, his understanding fails him, and he says to everyone that he is a fool. 
-<span class="v">4&#160;</span>If the spirit of the ruler rises up against you, don’t leave your place; for gentleness lays great offenses to rest. 
-</p><p>
-<span class="v">5&#160;</span>There is an evil which I have seen under the sun, the sort of error which proceeds from the ruler. 
-<span class="v">6&#160;</span>Folly is set in great dignity, and the rich sit in a low place. 
-<span class="v">7&#160;</span>I have seen servants on horses, and princes walking like servants on the earth. 
-<span class="v">8&#160;</span>He who digs a pit may fall into it; and whoever breaks through a wall may be bitten by a snake. 
-<span class="v">9&#160;</span>Whoever carves out stones may be injured by them. Whoever splits wood may be endangered by it. 
-<span class="v">10&#160;</span>If the ax is blunt, and one doesn’t sharpen the edge, then he must use more strength; but skill brings success. 
-</p><p>
-<span class="v">11&#160;</span>If the snake bites before it is charmed, then is there no profit for the charmer’s tongue. 
-<span class="v">12&#160;</span>The words of a wise man’s mouth are gracious; but a fool is swallowed by his own lips. 
-<span class="v">13&#160;</span>The beginning of the words of his mouth is foolishness; and the end of his talk is mischievous madness. 
-<span class="v">14&#160;</span>A fool also multiplies words. 
-</p><p>Man doesn’t know what will be; and that which will be after him, who can tell him? 
-<span class="v">15&#160;</span>The labor of fools wearies every one of them; for he doesn’t know how to go to the city. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Woe to you, land, when your king is a child, 
-</p><p class="q2">and your princes eat in the morning! 
-</p><p class="q1">
-<span class="v">17&#160;</span>Happy are you, land, when your king is the son of nobles, 
-</p><p class="q2">and your princes eat in due season, 
-</p><p class="q2">for strength, and not for drunkenness! 
-</p><p class="q1">
-<span class="v">18&#160;</span>By slothfulness the roof sinks in; 
-</p><p class="q2">and through idleness of the hands the house leaks. 
-</p><p class="q1">
-<span class="v">19&#160;</span>A feast is made for laughter, 
-</p><p class="q2">and wine makes the life glad; 
-</p><p class="q2">and money is the answer for all things. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Don’t curse the king, no, not in your thoughts; 
-</p><p class="q2">and don’t curse the rich in your bedroom, 
-</p><p class="q2">for a bird of the sky may carry your voice, 
-</p><p class="q2">and that which has wings may tell the matter. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Cast your bread on the waters; 
-</p><p class="q2">for you shall find it after many days. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Give a portion to seven, yes, even to eight; 
-</p><p class="q2">for you don’t know what evil will be on the earth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>If the clouds are full of rain, they empty themselves on the earth; 
-</p><p class="q2">and if a tree falls toward the south, or toward the north, 
-</p><p class="q2">in the place where the tree falls, there shall it be. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He who observes the wind won’t sow; 
-</p><p class="q2">and he who regards the clouds won’t reap. 
-</p><p class="q1">
-<span class="v">5&#160;</span>As you don’t know what is the way of the wind, 
-</p><p class="q2">nor how the bones grow in the womb of her who is with child; 
-</p><p class="q2">even so you don’t know the work of Elohim who does all. 
-</p><p class="q1">
-<span class="v">6&#160;</span>In the morning sow your seed, 
-</p><p class="q2">and in the evening don’t withhold your hand; 
-</p><p class="q2">for you don’t know which will prosper, whether this or that, 
-</p><p class="q2">or whether they both will be equally good. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Truly the light is sweet, 
-</p><p class="q2">and it is a pleasant thing for the eyes to see the sun. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yes, if a man lives many years, let him rejoice in them all; 
-</p><p class="q2">but let him remember the days of darkness, for they shall be many. 
-</p><p class="q2">All that comes is vanity. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Rejoice, young man, in your youth, 
-</p><p class="q2">and let your heart cheer you in the days of your youth, 
-</p><p class="q2">and walk in the ways of your heart, 
-</p><p class="q2">and in the sight of your eyes; 
-</p><p class="q2">but know that for all these things Elohim will bring you into judgment. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Therefore remove sorrow from your heart, 
-</p><p class="q2">and put away evil from your flesh; 
-</p><p class="q2">for youth and the dawn of life are vanity. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Remember also your Creator in the days of your youth, 
-</p><p class="q2">before the evil days come, and the years draw near, 
-</p><p class="q2">when you will say, “I have no pleasure in them;” 
-</p><p class="q1">
-<span class="v">2&#160;</span>Before the sun, the light, the moon, and the stars are darkened, 
-</p><p class="q2">and the clouds return after the rain; 
-</p><p class="q1">
-<span class="v">3&#160;</span>in the day when the keepers of the house shall tremble, 
-</p><p class="q2">and the strong men shall bow themselves, 
-</p><p class="q2">and the grinders cease because they are few, 
-</p><p class="q2">and those who look out of the windows are darkened, 
-</p><p class="q1">
-<span class="v">4&#160;</span>and the doors shall be shut in the street; 
-</p><p class="q2">when the sound of the grinding is low, 
-</p><p class="q2">and one shall rise up at the voice of a bird, 
-</p><p class="q2">and all the daughters of music shall be brought low; 
-</p><p class="q1">
-<span class="v">5&#160;</span>yes, they shall be afraid of heights, 
-</p><p class="q2">and terrors will be on the way; 
-</p><p class="q2">and the almond tree shall blossom, 
-</p><p class="q2">and the grasshopper shall be a burden, 
-</p><p class="q2">and desire shall fail; 
-</p><p class="q2">because man goes to his everlasting home, 
-</p><p class="q2">and the mourners go about the streets; 
-</p><p class="q1">
-<span class="v">6&#160;</span>before the silver cord is severed, 
-</p><p class="q2">or the golden bowl is broken, 
-</p><p class="q2">or the pitcher is broken at the spring, 
-</p><p class="q2">or the wheel broken at the cistern, 
-</p><p class="q1">
-<span class="v">7&#160;</span>and the dust returns to the earth as it was, 
-</p><p class="q2">and the spirit returns to Elohim who gave it. 
-</p><p class="q2">
-<span class="v">8&#160;</span>“Vanity of vanities,” says the Preacher. 
-</p><p class="q2">“All is vanity!” 
-</p><p>
-<span class="v">9&#160;</span>Further, because the Preacher was wise, he still taught the people knowledge. Yes, he pondered, sought out, and set in order many proverbs. 
-<span class="v">10&#160;</span>The Preacher sought to find out acceptable words, and that which was written blamelessly, words of truth. 
-<span class="v">11&#160;</span>The words of the wise are like goads; and like nails well fastened are words from the masters of assemblies, which are given from one shepherd. 
-<span class="v">12&#160;</span>Furthermore, my son, be admonished: of making many books there is no end; and much study is a weariness of the flesh. 
-</p><p>
-<span class="v">13&#160;</span>This is the end of the matter. All has been heard. Fear Elohim and keep his commandments; for this is the whole duty of man. 
-<span class="v">14&#160;</span>For Elohim will bring every work into judgment, with every hidden thing, whether it is good, or whether it is evil. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The words of the Preacher, the son of David, king in Jerusalem: 
+</div><div class="p">
+<sup>2&#160;</sup>“Vanity of vanities,” says the Preacher; “Vanity of vanities, all is vanity.” 
+<sup>3&#160;</sup>What does man gain from all his labor in which he labors under the sun? 
+<sup>4&#160;</sup>One generation goes, and another generation comes; but the earth remains forever. 
+<sup>5&#160;</sup>The sun also rises, and the sun goes down, and hurries to its place where it rises. 
+<sup>6&#160;</sup>The wind goes toward the south, and turns around to the north. It turns around continually as it goes, and the wind returns again to its courses. 
+<sup>7&#160;</sup>All the rivers run into the sea, yet the sea is not full. To the place where the rivers flow, there they flow again. 
+<sup>8&#160;</sup>All things are full of weariness beyond uttering. The eye is not satisfied with seeing, nor the ear filled with hearing. 
+<sup>9&#160;</sup>That which has been is that which shall be, and that which has been done is that which shall be done; and there is no new thing under the sun. 
+<sup>10&#160;</sup>Is there a thing of which it may be said, “Behold, this is new”? It has been long ago, in the ages which were before us. 
+<sup>11&#160;</sup>There is no memory of the former; neither shall there be any memory of the latter that are to come, among those that shall come after. 
+</div><div class="p">
+<sup>12&#160;</sup>I, the Preacher, was king over Israel in Jerusalem. 
+<sup>13&#160;</sup>I applied my heart to seek and to search out by wisdom concerning all that is done under the sky. It is a heavy burden that Elohim has given to the sons of men to be afflicted with. 
+<sup>14&#160;</sup>I have seen all the works that are done under the sun; and behold, all is vanity and a chasing after wind. 
+<sup>15&#160;</sup>That which is crooked can’t be made straight; and that which is lacking can’t be counted. 
+<sup>16&#160;</sup>I said to myself, “Behold, I have obtained for myself great wisdom above all who were before me in Jerusalem. Yes, my heart has had great experience of wisdom and knowledge.” 
+<sup>17&#160;</sup>I applied my heart to know wisdom, and to know madness and folly. I perceived that this also was a chasing after wind. 
+<sup>18&#160;</sup>For in much wisdom is much grief; and he who increases knowledge increases sorrow. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>I said in my heart, “Come now, I will test you with mirth; therefore enjoy pleasure;” and behold, this also was vanity. 
+<sup>2&#160;</sup>I said of laughter, “It is foolishness;” and of mirth, “What does it accomplish?” 
+</div><div class="p">
+<sup>3&#160;</sup>I searched in my heart how to cheer my flesh with wine, my heart yet guiding me with wisdom, and how to lay hold of folly, until I might see what it was good for the sons of men that they should do under heaven all the days of their lives. 
+<sup>4&#160;</sup>I made myself great works. I built myself houses. I planted myself vineyards. 
+<sup>5&#160;</sup>I made myself gardens and parks, and I planted trees in them of all kinds of fruit. 
+<sup>6&#160;</sup>I made myself pools of water, to water the forest where trees were grown. 
+<sup>7&#160;</sup>I bought male servants and female servants, and had servants born in my house. I also had great possessions of herds and flocks, above all who were before me in Jerusalem. 
+<sup>8&#160;</sup>I also gathered silver and gold for myself, and the treasure of kings and of the provinces. I got myself male and female singers, and the delights of the sons of men: musical instruments of all sorts. 
+<sup>9&#160;</sup>So I was great, and increased more than all who were before me in Jerusalem. My wisdom also remained with me. 
+<sup>10&#160;</sup>Whatever my eyes desired, I didn’t keep from them. I didn’t withhold my heart from any joy, for my heart rejoiced because of all my labor, and this was my portion from all my labor. 
+<sup>11&#160;</sup>Then I looked at all the works that my hands had worked, and at the labor that I had labored to do; and behold, all was vanity and a chasing after wind, and there was no profit under the sun. 
+</div><div class="p">
+<sup>12&#160;</sup>I turned myself to consider wisdom, madness, and folly; for what can the king’s successor do? Just that which has been done long ago. 
+<sup>13&#160;</sup>Then I saw that wisdom excels folly, as far as light excels darkness. 
+<sup>14&#160;</sup>The wise man’s eyes are in his head, and the fool walks in darkness—and yet I perceived that one event happens to them all. 
+<sup>15&#160;</sup>Then I said in my heart, “As it happens to the fool, so will it happen even to me; and why was I then more wise?” Then I said in my heart that this also is vanity. 
+<sup>16&#160;</sup>For of the wise man, even as of the fool, there is no memory forever, since in the days to come all will have been long forgotten. Indeed, the wise man must die just like the fool! 
+</div><div class="p">
+<sup>17&#160;</sup>So I hated life, because the work that is worked under the sun was grievous to me; for all is vanity and a chasing after wind. 
+<sup>18&#160;</sup>I hated all my labor in which I labored under the sun, because I must leave it to the man who comes after me. 
+<sup>19&#160;</sup>Who knows whether he will be a wise man or a fool? Yet he will have rule over all of my labor in which I have labored, and in which I have shown myself wise under the sun. This also is vanity. 
+</div><div class="p">
+<sup>20&#160;</sup>Therefore I began to cause my heart to despair concerning all the labor in which I had labored under the sun. 
+<sup>21&#160;</sup>For there is a man whose labor is with wisdom, with knowledge, and with skillfulness; yet he shall leave it for his portion to a man who has not labored for it. This also is vanity and a great evil. 
+<sup>22&#160;</sup>For what does a man have of all his labor and of the striving of his heart, in which he labors under the sun? 
+<sup>23&#160;</sup>For all his days are sorrows, and his travail is grief; yes, even in the night his heart takes no rest. This also is vanity. 
+<sup>24&#160;</sup>There is nothing better for a man than that he should eat and drink, and make his soul enjoy good in his labor. This also I saw, that it is from the hand of Elohim. 
+<sup>25&#160;</sup>For who can eat, or who can have enjoyment, more than I? 
+<sup>26&#160;</sup>For to the man who pleases him, Elohim gives wisdom, knowledge, and joy; but to the sinner he gives travail, to gather and to heap up, that he may give to him who pleases Elohim. This also is vanity and a chasing after wind. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>For everything there is a season, and a time for every purpose under heaven: 
+</div><div class="q1">
+<sup>2&#160;</sup>a time to be born, 
+</div><div class="q2">and a time to die; 
+</div><div class="q1">a time to plant, 
+</div><div class="q2">and a time to pluck up that which is planted; 
+</div><div class="q1">
+<sup>3&#160;</sup>a time to kill, 
+</div><div class="q2">and a time to heal; 
+</div><div class="q1">a time to break down, 
+</div><div class="q2">and a time to build up; 
+</div><div class="q1">
+<sup>4&#160;</sup>a time to weep, 
+</div><div class="q2">and a time to laugh; 
+</div><div class="q1">a time to mourn, 
+</div><div class="q2">and a time to dance; 
+</div><div class="q1">
+<sup>5&#160;</sup>a time to cast away stones, 
+</div><div class="q2">and a time to gather stones together; 
+</div><div class="q1">a time to embrace, 
+</div><div class="q2">and a time to refrain from embracing; 
+</div><div class="q1">
+<sup>6&#160;</sup>a time to seek, 
+</div><div class="q2">and a time to lose; 
+</div><div class="q1">a time to keep, 
+</div><div class="q2">and a time to cast away; 
+</div><div class="q1">
+<sup>7&#160;</sup>a time to tear, 
+</div><div class="q2">and a time to sew; 
+</div><div class="q1">a time to keep silence, 
+</div><div class="q2">and a time to speak; 
+</div><div class="q1">
+<sup>8&#160;</sup>a time to love, 
+</div><div class="q2">and a time to hate; 
+</div><div class="q1">a time for war, 
+</div><div class="q2">and a time for peace. 
+</div><div class="p">
+<sup>9&#160;</sup>What profit has he who works in that in which he labors? 
+<sup>10&#160;</sup>I have seen the burden which Elohim has given to the sons of men to be afflicted with. 
+<sup>11&#160;</sup>He has made everything beautiful in its time. He has also set eternity in their hearts, yet so that man can’t find out the work that Elohim has done from the beginning even to the end. 
+<sup>12&#160;</sup>I know that there is nothing better for them than to rejoice, and to do good as long as they live. 
+<sup>13&#160;</sup>Also that every man should eat and drink, and enjoy good in all his labor, is the gift of Elohim. 
+<sup>14&#160;</sup>I know that whatever Elohim does, it shall be forever. Nothing can be added to it, nor anything taken from it; and Elohim has done it, that men should fear before him. 
+<sup>15&#160;</sup>That which is has been long ago, and that which is to be has been long ago. Elohim seeks again that which is passed away. 
+</div><div class="p">
+<sup>16&#160;</sup>Moreover I saw under the sun, in the place of justice, that wickedness was there; and in the place of righteousness, that wickedness was there. 
+<sup>17&#160;</sup>I said in my heart, “Elohim will judge the righteous and the wicked; for there is a time there for every purpose and for every work.” 
+<sup>18&#160;</sup>I said in my heart, “As for the sons of men, Elohim tests them, so that they may see that they themselves are like animals. 
+<sup>19&#160;</sup>For that which happens to the sons of men happens to animals. Even one thing happens to them. As the one dies, so the other dies. Yes, they have all one breath; and man has no advantage over the animals, for all is vanity. 
+<sup>20&#160;</sup>All go to one place. All are from the dust, and all turn to dust again. 
+<sup>21&#160;</sup>Who knows the spirit of man, whether it goes upward, and the spirit of the animal, whether it goes downward to the earth?” 
+</div><div class="p">
+<sup>22&#160;</sup>Therefore I saw that there is nothing better than that a man should rejoice in his works, for that is his portion; for who can bring him to see what will be after him? 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Then I returned and saw all the oppressions that are done under the sun: and behold, the tears of those who were oppressed, and they had no comforter; and on the side of their oppressors there was power; but they had no comforter. 
+<sup>2&#160;</sup>Therefore I praised the dead who have been long dead more than the living who are yet alive. 
+<sup>3&#160;</sup>Yes, better than them both is him who has not yet been, who has not seen the evil work that is done under the sun. 
+<sup>4&#160;</sup>Then I saw all the labor and achievement that is the envy of a man’s neighbor. This also is vanity and a striving after wind. 
+</div><div class="p">
+<sup>5&#160;</sup>The fool folds his hands together and ruins himself. 
+<sup>6&#160;</sup>Better is a handful, with quietness, than two handfuls with labor and chasing after wind. 
+</div><div class="p">
+<sup>7&#160;</sup>Then I returned and saw vanity under the sun. 
+<sup>8&#160;</sup>There is one who is alone, and he has neither son nor brother. There is no end to all of his labor, neither are his eyes satisfied with wealth. “For whom then do I labor and deprive my soul of enjoyment?” This also is vanity. Yes, it is a miserable business. 
+</div><div class="p">
+<sup>9&#160;</sup>Two are better than one, because they have a good reward for their labor. 
+<sup>10&#160;</sup>For if they fall, the one will lift up his fellow; but woe to him who is alone when he falls, and doesn’t have another to lift him up. 
+<sup>11&#160;</sup>Again, if two lie together, then they have warmth; but how can one keep warm alone? 
+<sup>12&#160;</sup>If a man prevails against one who is alone, two shall withstand him; and a threefold cord is not quickly broken. 
+</div><div class="p">
+<sup>13&#160;</sup>Better is a poor and wise youth than an old and foolish king who doesn’t know how to receive admonition any more. 
+<sup>14&#160;</sup>For out of prison he came out to be king; yes, even in his kingdom he was born poor. 
+<sup>15&#160;</sup>I saw all the living who walk under the sun, that they were with the youth, the other, who succeeded him. 
+<sup>16&#160;</sup>There was no end of all the people, even of all them over whom he was—yet those who come after shall not rejoice in him. Surely this also is vanity and a chasing after wind. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Guard your steps when you go to Elohim’s house; for to draw near to listen is better than to give the sacrifice of fools, for they don’t know that they do evil. 
+<sup>2&#160;</sup>Don’t be rash with your mouth, and don’t let your heart be hasty to utter anything before Elohim; for Elohim is in heaven, and you on earth. Therefore let your words be few. 
+<sup>3&#160;</sup>For as a dream comes with a multitude of cares, so a fool’s speech with a multitude of words. 
+<sup>4&#160;</sup>When you vow a vow to Elohim, don’t defer to pay it; for he has no pleasure in fools. Pay that which you vow. 
+<sup>5&#160;</sup>It is better that you should not vow, than that you should vow and not pay. 
+<sup>6&#160;</sup>Don’t allow your mouth to lead you into sin. Don’t protest before the messenger that this was a mistake. Why should Elohim be angry at your voice, and destroy the work of your hands? 
+<sup>7&#160;</sup>For in the multitude of dreams there are vanities, as well as in many words; but you must fear Elohim. 
+</div><div class="p">
+<sup>8&#160;</sup>If you see the oppression of the poor, and the violent taking away of justice and righteousness in a district, don’t marvel at the matter, for one official is eyed by a higher one, and there are officials over them. 
+<sup>9&#160;</sup>Moreover the profit of the earth is for all. The king profits from the field. 
+</div><div class="p">
+<sup>10&#160;</sup>He who loves silver shall not be satisfied with silver, nor he who loves abundance, with increase. This also is vanity. 
+<sup>11&#160;</sup>When goods increase, those who eat them are increased; and what advantage is there to its owner, except to feast on them with his eyes? 
+</div><div class="p">
+<sup>12&#160;</sup>The sleep of a laboring man is sweet, whether he eats little or much; but the abundance of the rich will not allow him to sleep. 
+</div><div class="p">
+<sup>13&#160;</sup>There is a grievous evil which I have seen under the sun: wealth kept by its owner to his harm. 
+<sup>14&#160;</sup>Those riches perish by misfortune, and if he has fathered a son, there is nothing in his hand. 
+<sup>15&#160;</sup>As he came out of his mother’s womb, naked shall he go again as he came, and shall take nothing for his labor, which he may carry away in his hand. 
+<sup>16&#160;</sup>This also is a grievous evil, that in all points as he came, so shall he go. And what profit does he have who labors for the wind? 
+<sup>17&#160;</sup>All his days he also eats in darkness, he is frustrated, and has sickness and wrath. 
+</div><div class="p">
+<sup>18&#160;</sup>Behold, that which I have seen to be good and proper is for one to eat and to drink, and to enjoy good in all his labor, in which he labors under the sun, all the days of his life which Elohim has given him; for this is his portion. 
+<sup>19&#160;</sup>Every man also to whom Elohim has given riches and wealth, and has given him power to eat of it, and to take his portion, and to rejoice in his labor—this is the gift of Elohim. 
+<sup>20&#160;</sup>For he shall not often reflect on the days of his life, because Elohim occupies him with the joy of his heart. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>There is an evil which I have seen under the sun, and it is heavy on men: 
+<sup>2&#160;</sup>a man to whom Elohim gives riches, wealth, and honor, so that he lacks nothing for his soul of all that he desires, yet Elohim gives him no power to eat of it, but an alien eats it. This is vanity, and it is an evil disease. 
+</div><div class="p">
+<sup>3&#160;</sup>If a man fathers a hundred children, and lives many years, so that the days of his years are many, but his soul is not filled with good, and moreover he has no burial, I say that a stillborn child is better than he; 
+<sup>4&#160;</sup>for it comes in vanity, and departs in darkness, and its name is covered with darkness. 
+<sup>5&#160;</sup>Moreover it has not seen the sun nor known it. This has rest rather than the other. 
+<sup>6&#160;</sup>Yes, though he live a thousand years twice told, and yet fails to enjoy good, don’t all go to one place? 
+<sup>7&#160;</sup>All the labor of man is for his mouth, and yet the appetite is not filled. 
+<sup>8&#160;</sup>For what advantage has the wise more than the fool? What has the poor man, that knows how to walk before the living? 
+<sup>9&#160;</sup>Better is the sight of the eyes than the wandering of the desire. This also is vanity and a chasing after wind. 
+<sup>10&#160;</sup>Whatever has been, its name was given long ago; and it is known what man is; neither can he contend with him who is mightier than he. 
+<sup>11&#160;</sup>For there are many words that create vanity. What does that profit man? 
+<sup>12&#160;</sup>For who knows what is good for man in life, all the days of his vain life which he spends like a shadow? For who can tell a man what will be after him under the sun? 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>A good name is better than fine perfume; and the day of death better than the day of one’s birth. 
+<sup>2&#160;</sup>It is better to go to the house of mourning than to go to the house of feasting; for that is the end of all men, and the living should take this to heart. 
+<sup>3&#160;</sup>Sorrow is better than laughter; for by the sadness of the face the heart is made good. 
+<sup>4&#160;</sup>The heart of the wise is in the house of mourning; but the heart of fools is in the house of mirth. 
+<sup>5&#160;</sup>It is better to hear the rebuke of the wise than for a man to hear the song of fools. 
+<sup>6&#160;</sup>For as the crackling of thorns under a pot, so is the laughter of the fool. This also is vanity. 
+<sup>7&#160;</sup>Surely extortion makes the wise man foolish; and a bribe destroys the understanding. 
+<sup>8&#160;</sup>Better is the end of a thing than its beginning. 
+</div><div class="p">The patient in spirit is better than the proud in spirit. 
+<sup>9&#160;</sup>Don’t be hasty in your spirit to be angry, for anger rests in the bosom of fools. 
+<sup>10&#160;</sup>Don’t say, “Why were the former days better than these?” For you do not ask wisely about this. 
+</div><div class="p">
+<sup>11&#160;</sup>Wisdom is as good as an inheritance. Yes, it is more excellent for those who see the sun. 
+<sup>12&#160;</sup>For wisdom is a defense, even as money is a defense; but the excellency of knowledge is that wisdom preserves the life of him who has it. 
+</div><div class="p">
+<sup>13&#160;</sup>Consider the work of Elohim, for who can make that straight which he has made crooked? 
+<sup>14&#160;</sup>In the day of prosperity be joyful, and in the day of adversity consider; yes, Elohim has made the one side by side with the other, to the end that man should not find out anything after him. 
+</div><div class="p">
+<sup>15&#160;</sup>All this I have seen in my days of vanity: there is a righteous man who perishes in his righteousness, and there is a wicked man who lives long in his evildoing. 
+<sup>16&#160;</sup>Don’t be overly righteous, neither make yourself overly wise. Why should you destroy yourself? 
+<sup>17&#160;</sup>Don’t be too wicked, neither be foolish. Why should you die before your time? 
+<sup>18&#160;</sup>It is good that you should take hold of this. Yes, also don’t withdraw your hand from that; for he who fears Elohim will come out of them all. 
+<sup>19&#160;</sup>Wisdom is a strength to the wise man more than ten rulers who are in a city. 
+<sup>20&#160;</sup>Surely there is not a righteous man on earth who does good and doesn’t sin. 
+<sup>21&#160;</sup>Also don’t take heed to all words that are spoken, lest you hear your servant curse you; 
+<sup>22&#160;</sup>for often your own heart knows that you yourself have likewise cursed others. 
+<sup>23&#160;</sup>All this I have proved in wisdom. I said, “I will be wise;” but it was far from me. 
+<sup>24&#160;</sup>That which is, is far off and exceedingly deep. Who can find it out? 
+<sup>25&#160;</sup>I turned around, and my heart sought to know and to search out, and to seek wisdom and the scheme of things, and to know that wickedness is stupidity, and that foolishness is madness. 
+</div><div class="p">
+<sup>26&#160;</sup>I find more bitter than death the woman whose heart is snares and traps, whose hands are chains. Whoever pleases Elohim shall escape from her; but the sinner will be ensnared by her. 
+</div><div class="p">
+<sup>27&#160;</sup>“Behold, I have found this,” says the Preacher, “to one another, to find an explanation 
+<sup>28&#160;</sup>which my soul still seeks, but I have not found. I have found one man among a thousand, but I have not found a woman among all those. 
+<sup>29&#160;</sup>Behold, I have only found this: that Elohim made mankind upright; but they search for many inventions.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Who is like the wise man? And who knows the interpretation of a thing? A man’s wisdom makes his face shine, and the hardness of his face is changed. 
+</div><div class="p">
+<sup>2&#160;</sup>I say, “Keep the king’s command!” because of the oath to Elohim. 
+<sup>3&#160;</sup>Don’t be hasty to go out of his presence. Don’t persist in an evil thing, for he does whatever pleases him, 
+<sup>4&#160;</sup>for the king’s word is supreme. Who can say to him, “What are you doing?” 
+<sup>5&#160;</sup>Whoever keeps the commandment shall not come to harm, and his wise heart will know the time and procedure. 
+<sup>6&#160;</sup>For there is a time and procedure for every purpose, although the misery of man is heavy on him. 
+<sup>7&#160;</sup>For he doesn’t know that which will be; for who can tell him how it will be? 
+<sup>8&#160;</sup>There is no man who has power over the spirit to contain the spirit; neither does he have power over the day of death. There is no discharge in war; neither shall wickedness deliver those who practice it. 
+</div><div class="p">
+<sup>9&#160;</sup>All this I have seen, and applied my mind to every work that is done under the sun. There is a time in which one man has power over another to his hurt. 
+<sup>10&#160;</sup>So I saw the wicked buried. Indeed they came also from set-apartness. They went and were forgotten in the city where they did this. This also is vanity. 
+<sup>11&#160;</sup>Because sentence against an evil work is not executed speedily, therefore the heart of the sons of men is fully set in them to do evil. 
+<sup>12&#160;</sup>Though a sinner commits crimes a hundred times, and lives long, yet surely I know that it will be better with those who fear Elohim, who are reverent before him. 
+<sup>13&#160;</sup>But it shall not be well with the wicked, neither shall he lengthen days like a shadow, because he doesn’t fear Elohim. 
+</div><div class="p">
+<sup>14&#160;</sup>There is a vanity which is done on the earth, that there are righteous men to whom it happens according to the work of the wicked. Again, there are wicked men to whom it happens according to the work of the righteous. I said that this also is vanity. 
+<sup>15&#160;</sup>Then I commended mirth, because a man has no better thing under the sun than to eat, to drink, and to be joyful: for that will accompany him in his labor all the days of his life which Elohim has given him under the sun. 
+</div><div class="p">
+<sup>16&#160;</sup>When I applied my heart to know wisdom, and to see the business that is done on the earth (even though eyes see no sleep day or night), 
+<sup>17&#160;</sup>then I saw all the work of Elohim, that man can’t find out the work that is done under the sun, because however much a man labors to seek it out, yet he won’t find it. Yes even though a wise man thinks he can comprehend it, he won’t be able to find it. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>For all this I laid to my heart, even to explore all this: that the righteous, and the wise, and their works, are in the hand of Elohim; whether it is love or hatred, man doesn’t know it; all is before them. 
+<sup>2&#160;</sup>All things come alike to all. There is one event to the righteous and to the wicked; to the good, to the clean, to the unclean, to him who sacrifices, and to him who doesn’t sacrifice. As is the good, so is the sinner; he who takes an oath, as he who fears an oath. 
+<sup>3&#160;</sup>This is an evil in all that is done under the sun, that there is one event to all. Yes also, the heart of the sons of men is full of evil, and madness is in their heart while they live, and after that they go to the dead. 
+<sup>4&#160;</sup>For to him who is joined with all the living there is hope; for a living dog is better than a dead lion. 
+<sup>5&#160;</sup>For the living know that they will die, but the dead don’t know anything, neither do they have any more a reward; for their memory is forgotten. 
+<sup>6&#160;</sup>Also their love, their hatred, and their envy has perished long ago; neither do they any longer have a portion forever in anything that is done under the sun. 
+</div><div class="p">
+<sup>7&#160;</sup>Go your way—eat your bread with joy, and drink your wine with a merry heart; for Elohim has already accepted your works. 
+<sup>8&#160;</sup>Let your garments be always white, and don’t let your head lack oil. 
+<sup>9&#160;</sup>Live joyfully with the woman whom you love all the days of your life of vanity, which he has given you under the sun, all your days of vanity, for that is your portion in life, and in your labor in which you labor under the sun. 
+<sup>10&#160;</sup>Whatever your hand finds to do, do it with your might; for there is no work, nor plan, nor knowledge, nor wisdom, in Sheol, where you are going. 
+</div><div class="p">
+<sup>11&#160;</sup>I returned and saw under the sun that the race is not to the swift, nor the battle to the strong, neither yet bread to the wise, nor yet riches to men of understanding, nor yet favor to men of skill; but time and chance happen to them all. 
+<sup>12&#160;</sup>For man also doesn’t know his time. As the fish that are taken in an evil net, and as the birds that are caught in the snare, even so are the sons of men snared in an evil time, when it falls suddenly on them. 
+</div><div class="p">
+<sup>13&#160;</sup>I have also seen wisdom under the sun in this way, and it seemed great to me. 
+<sup>14&#160;</sup>There was a little city, and few men within it; and a great king came against it, besieged it, and built great bulwarks against it. 
+<sup>15&#160;</sup>Now a poor wise man was found in it, and he by his wisdom delivered the city; yet no man remembered that same poor man. 
+<sup>16&#160;</sup>Then I said, “Wisdom is better than strength.” Nevertheless the poor man’s wisdom is despised, and his words are not heard. 
+<sup>17&#160;</sup>The words of the wise heard in quiet are better than the cry of him who rules among fools. 
+<sup>18&#160;</sup>Wisdom is better than weapons of war; but one sinner destroys much good. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="q1">
+<sup>1&#160;</sup>Dead flies cause the oil of the perfumer to produce an evil odor; 
+</div><div class="q2">so does a little folly outweigh wisdom and honor. 
+</div><div class="q1">
+<sup>2&#160;</sup>A wise man’s heart is at his right hand, 
+</div><div class="q2">but a fool’s heart at his left. 
+<sup>3&#160;</sup>Yes also when the fool walks by the way, his understanding fails him, and he says to everyone that he is a fool. 
+<sup>4&#160;</sup>If the spirit of the ruler rises up against you, don’t leave your place; for gentleness lays great offenses to rest. 
+</div><div class="p">
+<sup>5&#160;</sup>There is an evil which I have seen under the sun, the sort of error which proceeds from the ruler. 
+<sup>6&#160;</sup>Folly is set in great dignity, and the rich sit in a low place. 
+<sup>7&#160;</sup>I have seen servants on horses, and princes walking like servants on the earth. 
+<sup>8&#160;</sup>He who digs a pit may fall into it; and whoever breaks through a wall may be bitten by a snake. 
+<sup>9&#160;</sup>Whoever carves out stones may be injured by them. Whoever splits wood may be endangered by it. 
+<sup>10&#160;</sup>If the ax is blunt, and one doesn’t sharpen the edge, then he must use more strength; but skill brings success. 
+</div><div class="p">
+<sup>11&#160;</sup>If the snake bites before it is charmed, then is there no profit for the charmer’s tongue. 
+<sup>12&#160;</sup>The words of a wise man’s mouth are gracious; but a fool is swallowed by his own lips. 
+<sup>13&#160;</sup>The beginning of the words of his mouth is foolishness; and the end of his talk is mischievous madness. 
+<sup>14&#160;</sup>A fool also multiplies words. 
+</div><div class="p">Man doesn’t know what will be; and that which will be after him, who can tell him? 
+<sup>15&#160;</sup>The labor of fools wearies every one of them; for he doesn’t know how to go to the city. 
+</div><div class="q1">
+<sup>16&#160;</sup>Woe to you, land, when your king is a child, 
+</div><div class="q2">and your princes eat in the morning! 
+</div><div class="q1">
+<sup>17&#160;</sup>Happy are you, land, when your king is the son of nobles, 
+</div><div class="q2">and your princes eat in due season, 
+</div><div class="q2">for strength, and not for drunkenness! 
+</div><div class="q1">
+<sup>18&#160;</sup>By slothfulness the roof sinks in; 
+</div><div class="q2">and through idleness of the hands the house leaks. 
+</div><div class="q1">
+<sup>19&#160;</sup>A feast is made for laughter, 
+</div><div class="q2">and wine makes the life glad; 
+</div><div class="q2">and money is the answer for all things. 
+</div><div class="q1">
+<sup>20&#160;</sup>Don’t curse the king, no, not in your thoughts; 
+</div><div class="q2">and don’t curse the rich in your bedroom, 
+</div><div class="q2">for a bird of the sky may carry your voice, 
+</div><div class="q2">and that which has wings may tell the matter. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Cast your bread on the waters; 
+</div><div class="q2">for you shall find it after many days. 
+</div><div class="q1">
+<sup>2&#160;</sup>Give a portion to seven, yes, even to eight; 
+</div><div class="q2">for you don’t know what evil will be on the earth. 
+</div><div class="q1">
+<sup>3&#160;</sup>If the clouds are full of rain, they empty themselves on the earth; 
+</div><div class="q2">and if a tree falls toward the south, or toward the north, 
+</div><div class="q2">in the place where the tree falls, there shall it be. 
+</div><div class="q1">
+<sup>4&#160;</sup>He who observes the wind won’t sow; 
+</div><div class="q2">and he who regards the clouds won’t reap. 
+</div><div class="q1">
+<sup>5&#160;</sup>As you don’t know what is the way of the wind, 
+</div><div class="q2">nor how the bones grow in the womb of her who is with child; 
+</div><div class="q2">even so you don’t know the work of Elohim who does all. 
+</div><div class="q1">
+<sup>6&#160;</sup>In the morning sow your seed, 
+</div><div class="q2">and in the evening don’t withhold your hand; 
+</div><div class="q2">for you don’t know which will prosper, whether this or that, 
+</div><div class="q2">or whether they both will be equally good. 
+</div><div class="q1">
+<sup>7&#160;</sup>Truly the light is sweet, 
+</div><div class="q2">and it is a pleasant thing for the eyes to see the sun. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yes, if a man lives many years, let him rejoice in them all; 
+</div><div class="q2">but let him remember the days of darkness, for they shall be many. 
+</div><div class="q2">All that comes is vanity. 
+</div><div class="q1">
+<sup>9&#160;</sup>Rejoice, young man, in your youth, 
+</div><div class="q2">and let your heart cheer you in the days of your youth, 
+</div><div class="q2">and walk in the ways of your heart, 
+</div><div class="q2">and in the sight of your eyes; 
+</div><div class="q2">but know that for all these things Elohim will bring you into judgment. 
+</div><div class="q1">
+<sup>10&#160;</sup>Therefore remove sorrow from your heart, 
+</div><div class="q2">and put away evil from your flesh; 
+</div><div class="q2">for youth and the dawn of life are vanity. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Remember also your Creator in the days of your youth, 
+</div><div class="q2">before the evil days come, and the years draw near, 
+</div><div class="q2">when you will say, “I have no pleasure in them;” 
+</div><div class="q1">
+<sup>2&#160;</sup>Before the sun, the light, the moon, and the stars are darkened, 
+</div><div class="q2">and the clouds return after the rain; 
+</div><div class="q1">
+<sup>3&#160;</sup>in the day when the keepers of the house shall tremble, 
+</div><div class="q2">and the strong men shall bow themselves, 
+</div><div class="q2">and the grinders cease because they are few, 
+</div><div class="q2">and those who look out of the windows are darkened, 
+</div><div class="q1">
+<sup>4&#160;</sup>and the doors shall be shut in the street; 
+</div><div class="q2">when the sound of the grinding is low, 
+</div><div class="q2">and one shall rise up at the voice of a bird, 
+</div><div class="q2">and all the daughters of music shall be brought low; 
+</div><div class="q1">
+<sup>5&#160;</sup>yes, they shall be afraid of heights, 
+</div><div class="q2">and terrors will be on the way; 
+</div><div class="q2">and the almond tree shall blossom, 
+</div><div class="q2">and the grasshopper shall be a burden, 
+</div><div class="q2">and desire shall fail; 
+</div><div class="q2">because man goes to his everlasting home, 
+</div><div class="q2">and the mourners go about the streets; 
+</div><div class="q1">
+<sup>6&#160;</sup>before the silver cord is severed, 
+</div><div class="q2">or the golden bowl is broken, 
+</div><div class="q2">or the pitcher is broken at the spring, 
+</div><div class="q2">or the wheel broken at the cistern, 
+</div><div class="q1">
+<sup>7&#160;</sup>and the dust returns to the earth as it was, 
+</div><div class="q2">and the spirit returns to Elohim who gave it. 
+</div><div class="q2">
+<sup>8&#160;</sup>“Vanity of vanities,” says the Preacher. 
+</div><div class="q2">“All is vanity!” 
+</div><div class="p">
+<sup>9&#160;</sup>Further, because the Preacher was wise, he still taught the people knowledge. Yes, he pondered, sought out, and set in order many proverbs. 
+<sup>10&#160;</sup>The Preacher sought to find out acceptable words, and that which was written blamelessly, words of truth. 
+<sup>11&#160;</sup>The words of the wise are like goads; and like nails well fastened are words from the masters of assemblies, which are given from one shepherd. 
+<sup>12&#160;</sup>Furthermore, my son, be admonished: of making many books there is no end; and much study is a weariness of the flesh. 
+</div><div class="p">
+<sup>13&#160;</sup>This is the end of the matter. All has been heard. Fear Elohim and keep his commandments; for this is the whole duty of man. 
+<sup>14&#160;</sup>For Elohim will bring every work into judgment, with every hidden thing, whether it is good, or whether it is evil. </div></div><script src="../main.js"></script></body></html>

--- a/book/esther.html
+++ b/book/esther.html
@@ -3,6 +3,47 @@
 <head>
 <title>Esther</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,246 +53,257 @@
 <div class="main">
 <!-- EST World English Scripture (WES) -->
 <h1 class="booklabel">Esther</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now in the days of Ahasuerus (this is Ahasuerus who reigned from India even to Ethiopia, over one hundred twenty-seven provinces), 
-<span class="v">2&#160;</span>in those days, when the King Ahasuerus sat on the throne of his kingdom, which was in Susa the palace, 
-<span class="v">3&#160;</span>in the third year of his reign, he made a feast for all his princes and his servants; the army of Persia and Media, the nobles and princes of the provinces being before him. 
-<span class="v">4&#160;</span>He displayed the riches of his glorious kingdom and the honor of his excellent majesty many days, even one hundred eighty days. 
-</p><p>
-<span class="v">5&#160;</span>When these days were fulfilled, the king made a seven day feast for all the people who were present in Susa the palace, both great and small, in the court of the garden of the king’s palace. 
-<span class="v">6&#160;</span>There were hangings of white and blue material, fastened with cords of fine linen and purple to silver rings and marble pillars. The couches were of gold and silver, on a pavement of red, white, yellow, and black marble. 
-<span class="v">7&#160;</span>They gave them drinks in golden vessels of various kinds, including royal wine in abundance, according to the bounty of the king. 
-<span class="v">8&#160;</span>In accordance with the law, the drinking was not compulsory; for so the king had instructed all the officials of his house, that they should do according to every man’s pleasure. 
-</p><p>
-<span class="v">9&#160;</span>Also Vashti the queen made a feast for the women in the royal house which belonged to King Ahasuerus. 
-</p><p>
-<span class="v">10&#160;</span>On the seventh day, when the heart of the king was merry with wine, he commanded Mehuman, Biztha, Harbona, Bigtha, and Abagtha, Zethar, and Carcass, the seven eunuchs who served in the presence of Ahasuerus the king, 
-<span class="v">11&#160;</span>to bring Vashti the queen before the king wearing the royal crown, to show the people and the princes her beauty; for she was beautiful. 
-<span class="v">12&#160;</span>But the queen Vashti refused to come at the king’s commandment by the eunuchs. Therefore the king was very angry, and his anger burned in him. 
-</p><p>
-<span class="v">13&#160;</span>Then the king said to the wise men, who knew the times (for it was the king’s custom to consult those who knew law and judgment; 
-<span class="v">14&#160;</span>and next to him were Carshena, Shethar, Admatha, Tarshish, Meres, Marsena, and Memucan, the seven princes of Persia and Media, who saw the king’s face, and sat first in the kingdom), 
-<span class="v">15&#160;</span>“What shall we do to Queen Vashti according to law, because she has not done the bidding of the King Ahasuerus by the eunuchs?” 
-</p><p>
-<span class="v">16&#160;</span>Memucan answered before the king and the princes, “Vashti the queen has not done wrong to just the king, but also to all the princes, and to all the people who are in all the provinces of the King Ahasuerus. 
-<span class="v">17&#160;</span>For this deed of the queen will become known to all women, causing them to show contempt for their owners when it is reported, ‘King Ahasuerus commanded Vashti the queen to be brought in before him, but she didn’t come.’ 
-<span class="v">18&#160;</span>Today, the princesses of Persia and Media who have heard of the queen’s deed will tell all the king’s princes. This will cause much contempt and wrath. 
-</p><p>
-<span class="v">19&#160;</span>“If it pleases the king, let a royal commandment go from him, and let it be written among the laws of the Persians and the Medes, so that it cannot be altered, that Vashti may never again come before King Ahasuerus; and let the king give her royal estate to another who is better than she. 
-<span class="v">20&#160;</span>When the king’s decree which he shall make is published throughout all his kingdom (for it is great), all the women will give their owners honor, both great and small.” 
-</p><p>
-<span class="v">21&#160;</span>This advice pleased the king and the princes, and the king did according to the word of Memucan: 
-<span class="v">22&#160;</span>for he sent letters into all the king’s provinces, into every province according to its writing, and to every people in their language, that every man should rule his own house, speaking in the language of his own people. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>After these things, when the wrath of King Ahasuerus was pacified, he remembered Vashti, and what she had done, and what was decreed against her. 
-<span class="v">2&#160;</span>Then the king’s servants who served him said, “Let beautiful young virgins be sought for the king. 
-<span class="v">3&#160;</span>Let the king appoint officers in all the provinces of his kingdom, that they may gather together all the beautiful young virgins to the citadel of Susa, to the women’s house, to the custody of Hegai the king’s eunuch, keeper of the women. Let cosmetics be given them; 
-<span class="v">4&#160;</span>and let the maiden who pleases the king be queen instead of Vashti.” The thing pleased the king, and he did so. 
-</p><p>
-<span class="v">5&#160;</span>There was a certain Jew in the citadel of Susa whose name was Mordecai, the son of Jair, the son of Shimei, the son of Kish, a Benjamite, 
-<span class="v">6&#160;</span>who had been carried away from Jerusalem with the captives who had been carried away with Jeconiah king of Judah, whom Nebuchadnezzar the king of Babylon had carried away. 
-<span class="v">7&#160;</span>He brought up Hadassah, that is, Esther, his uncle’s daughter; for she had neither father nor mother. The maiden was fair and beautiful; and when her father and mother were dead, Mordecai took her for his own daughter. 
-</p><p>
-<span class="v">8&#160;</span>So, when the king’s commandment and his decree was heard, and when many maidens were gathered together to the citadel of Susa, to the custody of Hegai, Esther was taken into the king’s house, to the custody of Hegai, keeper of the women. 
-<span class="v">9&#160;</span>The maiden pleased him, and she obtained kindness from him. He quickly gave her cosmetics and her portions of food, and the seven choice maidens who were to be given her out of the king’s house. He moved her and her maidens to the best place in the women’s house. 
-<span class="v">10&#160;</span>Esther had not made known her people nor her relatives, because Mordecai had instructed her that she should not make it known. 
-<span class="v">11&#160;</span>Mordecai walked every day in front of the court of the women’s house, to find out how Esther was doing, and what would become of her. 
-</p><p>
-<span class="v">12&#160;</span>Each young woman’s turn came to go in to King Ahasuerus after her purification for twelve months (for so were the days of their purification accomplished, six months with oil of myrrh, and six months with sweet fragrances and with preparations for beautifying women). 
-<span class="v">13&#160;</span>The young woman then came to the king like this: whatever she desired was given her to go with her out of the women’s house to the king’s house. 
-<span class="v">14&#160;</span>In the evening she went, and on the next day she returned into the second women’s house, to the custody of Shaashgaz, the king’s eunuch, who kept the concubines. She came in to the king no more, unless the king delighted in her, and she was called by name. 
-</p><p>
-<span class="v">15&#160;</span>Now when the turn of Esther, the daughter of Abihail the uncle of Mordecai, who had taken her for his daughter, came to go in to the king, she required nothing but what Hegai the king’s eunuch, the keeper of the women, advised. Esther obtained favor in the sight of all those who looked at her. 
-</p><p>
-<span class="v">16&#160;</span>So Esther was taken to King Ahasuerus into his royal house in the tenth month, which is the month Tebeth, in the seventh year of his reign. 
-<span class="v">17&#160;</span>The king loved Esther more than all the women, and she obtained favor and kindness in his sight more than all the virgins; so that he set the royal crown on her head, and made her queen instead of Vashti. 
-</p><p>
-<span class="v">18&#160;</span>Then the king made a great feast for all his princes and his servants, even Esther’s feast; and he proclaimed a set-apart day in the provinces, and gave gifts according to the king’s bounty. 
-</p><p>
-<span class="v">19&#160;</span>When the virgins were gathered together the second time, Mordecai was sitting in the king’s gate. 
-<span class="v">20&#160;</span>Esther had not yet made known her relatives nor her people, as Mordecai had commanded her; for Esther obeyed Mordecai, like she did when she was brought up by him. 
-<span class="v">21&#160;</span>In those days, while Mordecai was sitting in the king’s gate, two of the king’s eunuchs, Bigthan and Teresh, who were doorkeepers, were angry, and sought to lay hands on the King Ahasuerus. 
-<span class="v">22&#160;</span>This thing became known to Mordecai, who informed Esther the queen; and Esther informed the king in Mordecai’s name. 
-<span class="v">23&#160;</span>When this matter was investigated, and it was found to be so, they were both hanged on a gallows; and it was written in the book of the chronicles in the king’s presence. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>After these things King Ahasuerus promoted Haman the son of Hammedatha the Agagite, and advanced him, and set his seat above all the princes who were with him. 
-<span class="v">2&#160;</span>All the king’s servants who were in the king’s gate bowed down and paid homage to Haman, for the king had so commanded concerning him. But Mordecai didn’t bow down or pay him homage. 
-<span class="v">3&#160;</span>Then the king’s servants who were in the king’s gate said to Mordecai, “Why do you disobey the king’s commandment?” 
-<span class="v">4&#160;</span>Now it came to pass, when they spoke daily to him, and he didn’t listen to them, that they told Haman, to see whether Mordecai’s reason would stand; for he had told them that he was a Jew. 
-<span class="v">5&#160;</span>When Haman saw that Mordecai didn’t bow down nor pay him homage, Haman was full of wrath. 
-<span class="v">6&#160;</span>But he scorned the thought of laying hands on Mordecai alone, for they had made known to him Mordecai’s people. Therefore Haman sought to destroy all the Jews who were throughout the whole kingdom of Ahasuerus, even Mordecai’s people. 
-</p><p>
-<span class="v">7&#160;</span>In the first month, which is the month Nisan, in the twelfth year of King Ahasuerus, they cast Pur, that is, the lot, before Haman from day to day, and from month to month, and chose the twelfth month, which is the month Adar. 
-<span class="v">8&#160;</span>Haman said to King Ahasuerus, “There is a certain people scattered abroad and dispersed among the peoples in all the provinces of your kingdom, and their laws are different from other people’s. They don’t keep the king’s laws. Therefore it is not for the king’s profit to allow them to remain. 
-<span class="v">9&#160;</span>If it pleases the king, let it be written that they be destroyed; and I will pay ten thousand talents<span class="f">+ \fr 3:9 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of silver into the hands of those who are in charge of the king’s business, to bring it into the king’s treasuries.” 
-</p><p>
-<span class="v">10&#160;</span>The king took his ring from his hand, and gave it to Haman the son of Hammedatha the Agagite, the Jews’ enemy. 
-<span class="v">11&#160;</span>The king said to Haman, “The silver is given to you, the people also, to do with them as it seems good to you.” 
-</p><p>
-<span class="v">12&#160;</span>Then the king’s scribes were called in on the first month, on the thirteenth day of the month; and all that Haman commanded was written to the king’s local governors, and to the governors who were over every province, and to the princes of every people, to every province according to its writing, and to every people in their language. It was written in the name of King Ahasuerus, and it was sealed with the king’s ring. 
-<span class="v">13&#160;</span>Letters were sent by couriers into all the king’s provinces, to destroy, to kill, and to cause to perish, all Jews, both young and old, little children and women, in one day, even on the thirteenth day of the twelfth month, which is the month Adar, and to plunder their possessions. 
-<span class="v">14&#160;</span>A copy of the letter, that the decree should be given out in every province, was published to all the peoples, that they should be ready against that day. 
-<span class="v">15&#160;</span>The couriers went out in haste by the king’s commandment, and the decree was given out in the citadel of Susa. The king and Haman sat down to drink; but the city of Susa was perplexed. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Now when Mordecai found out all that was done, Mordecai tore his clothes and put on sackcloth with ashes, and went out into the middle of the city, and wailed loudly and bitterly. 
-<span class="v">2&#160;</span>He came even before the king’s gate, for no one is allowed inside the king’s gate clothed with sackcloth. 
-<span class="v">3&#160;</span>In every province, wherever the king’s commandment and his decree came, there was great mourning among the Jews, and fasting, and weeping, and wailing; and many lay in sackcloth and ashes. 
-</p><p>
-<span class="v">4&#160;</span>Esther’s maidens and her eunuchs came and told her this, and the queen was exceedingly grieved. She sent clothing to Mordecai, to replace his sackcloth, but he didn’t receive it. 
-<span class="v">5&#160;</span>Then Esther called for Hathach, one of the king’s eunuchs, whom he had appointed to attend her, and commanded him to go to Mordecai, to find out what this was, and why it was. 
-<span class="v">6&#160;</span>So Hathach went out to Mordecai, to the city square which was before the king’s gate. 
-<span class="v">7&#160;</span>Mordecai told him of all that had happened to him, and the exact sum of the money that Haman had promised to pay to the king’s treasuries for the destruction of the Jews. 
-<span class="v">8&#160;</span>He also gave him the copy of the writing of the decree that was given out in Susa to destroy them, to show it to Esther, and to declare it to her, and to urge her to go in to the king to make supplication to him, and to make request before him for her people. 
-</p><p>
-<span class="v">9&#160;</span>Hathach came and told Esther the words of Mordecai. 
-<span class="v">10&#160;</span>Then Esther spoke to Hathach, and gave him a message to Mordecai: 
-<span class="v">11&#160;</span>“All the king’s servants and the people of the king’s provinces know that whoever, whether man or woman, comes to the king into the inner court without being called, there is one law for him, that he be put to death, except those to whom the king might hold out the golden scepter, that he may live. I have not been called to come in to the king these thirty days.” 
-</p><p>
-<span class="v">12&#160;</span>They told Esther’s words to Mordecai. 
-<span class="v">13&#160;</span>Then Mordecai asked them to return this answer to Esther: “Don’t think to yourself that you will escape in the king’s house any more than all the Jews. 
-<span class="v">14&#160;</span>For if you remain silent now, then relief and deliverance will come to the Jews from another place, but you and your father’s house will perish. Who knows if you haven’t come to the kingdom for such a time as this?” 
-</p><p>
-<span class="v">15&#160;</span>Then Esther asked them to answer Mordecai, 
-<span class="v">16&#160;</span>“Go, gather together all the Jews who are present in Susa, and fast for me, and neither eat nor drink three days, night or day. I and my maidens will also fast the same way. Then I will go in to the king, which is against the law; and if I perish, I perish.” 
-<span class="v">17&#160;</span>So Mordecai went his way, and did according to all that Esther had commanded him. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Now on the third day, Esther put on her royal clothing and stood in the inner court of the king’s house, next to the king’s house. The king sat on his royal throne in the royal house, next to the entrance of the house. 
-<span class="v">2&#160;</span>When the king saw Esther the queen standing in the court, she obtained favor in his sight; and the king held out to Esther the golden scepter that was in his hand. So Esther came near and touched the top of the scepter. 
-</p><p>
-<span class="v">3&#160;</span>Then the king asked her, “What would you like, queen Esther? What is your request? It shall be given you even to the half of the kingdom.” 
-</p><p>
-<span class="v">4&#160;</span>Esther said, “If it seems good to the king, let the king and Haman come today to the banquet that I have prepared for him.” 
-</p><p>
-<span class="v">5&#160;</span>Then the king said, “Bring Haman quickly, so that it may be done as Esther has said.” So the king and Haman came to the banquet that Esther had prepared. 
-</p><p>
-<span class="v">6&#160;</span>The king said to Esther at the banquet of wine, “What is your petition? It shall be granted you. What is your request? Even to the half of the kingdom it shall be performed.” 
-</p><p>
-<span class="v">7&#160;</span>Then Esther answered and said, “My petition and my request is this. 
-<span class="v">8&#160;</span>If I have found favor in the sight of the king, and if it pleases the king to grant my petition and to perform my request, let the king and Haman come to the banquet that I will prepare for them, and I will do tomorrow as the king has said.” 
-</p><p>
-<span class="v">9&#160;</span>Then Haman went out that day joyful and glad of heart, but when Haman saw Mordecai in the king’s gate, that he didn’t stand up nor move for him, he was filled with wrath against Mordecai. 
-<span class="v">10&#160;</span>Nevertheless Haman restrained himself, and went home. There, he sent and called for his friends and Zeresh his woman. 
-<span class="v">11&#160;</span>Haman recounted to them the glory of his riches, the multitude of his children, all the things in which the king had promoted him, and how he had advanced him above the princes and servants of the king. 
-</p><p>
-<span class="v">12&#160;</span>Haman also said, “Yes, Esther the queen let no man come in with the king to the banquet that she had prepared but myself; and tomorrow I am also invited by her together with the king. 
-<span class="v">13&#160;</span>Yet all this avails me nothing, so long as I see Mordecai the Jew sitting at the king’s gate.” 
-</p><p>
-<span class="v">14&#160;</span>Then Zeresh his woman and all his friends said to him, “Let a gallows be made fifty cubits<span class="f">+ \fr 5:14 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> high, and in the morning speak to the king about hanging Mordecai on it. Then go in merrily with the king to the banquet.” This pleased Haman, so he had the gallows made. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>On that night, the king couldn’t sleep. He commanded the book of records of the chronicles to be brought, and they were read to the king. 
-<span class="v">2&#160;</span>It was found written that Mordecai had told of Bigthana and Teresh, two of the king’s eunuchs, who were doorkeepers, who had tried to lay hands on the King Ahasuerus. 
-<span class="v">3&#160;</span>The king said, “What honor and dignity has been given to Mordecai for this?” 
-</p><p>Then the king’s servants who attended him said, “Nothing has been done for him.” 
-</p><p>
-<span class="v">4&#160;</span>The king said, “Who is in the court?” Now Haman had come into the outer court of the king’s house, to speak to the king about hanging Mordecai on the gallows that he had prepared for him. 
-</p><p>
-<span class="v">5&#160;</span>The king’s servants said to him, “Behold,<span class="f">+ \fr 6:5 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> Haman stands in the court.” 
-</p><p>The king said, “Let him come in.” 
-<span class="v">6&#160;</span>So Haman came in. The king said to him, “What shall be done to the man whom the king delights to honor?” 
-</p><p>Now Haman said in his heart, “Who would the king delight to honor more than myself?” 
-<span class="v">7&#160;</span>Haman said to the king, “For the man whom the king delights to honor, 
-<span class="v">8&#160;</span>let royal clothing be brought which the king uses to wear, and the horse that the king rides on, and on the head of which a royal crown is set. 
-<span class="v">9&#160;</span>Let the clothing and the horse be delivered to the hand of one of the king’s most noble princes, that they may array the man whom the king delights to honor with them, and have him ride on horseback through the city square, and proclaim before him, ‘Thus it shall be done to the man whom the king delights to honor!’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Then the king said to Haman, “Hurry and take the clothing and the horse, as you have said, and do this for Mordecai the Jew, who sits at the king’s gate. Let nothing fail of all that you have spoken.” 
-</p><p>
-<span class="v">11&#160;</span>Then Haman took the clothing and the horse, and arrayed Mordecai, and had him ride through the city square, and proclaimed before him, “Thus it shall be done to the man whom the king delights to honor!” 
-</p><p>
-<span class="v">12&#160;</span>Mordecai came back to the king’s gate, but Haman hurried to his house, mourning and having his head covered. 
-<span class="v">13&#160;</span>Haman recounted to Zeresh his woman and all his friends everything that had happened to him. Then his wise men and Zeresh his woman said to him, “If Mordecai, before whom you have begun to fall, is of Jewish descent, you will not prevail against him, but you will surely fall before him.” 
-<span class="v">14&#160;</span>While they were yet talking with him, the king’s eunuchs came, and hurried to bring Haman to the banquet that Esther had prepared. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>So the king and Haman came to banquet with Esther the queen. 
-<span class="v">2&#160;</span>The king said again to Esther on the second day at the banquet of wine, “What is your petition, queen Esther? It shall be granted you. What is your request? Even to the half of the kingdom it shall be performed.” 
-</p><p>
-<span class="v">3&#160;</span>Then Esther the queen answered, “If I have found favor in your sight, O king, and if it pleases the king, let my life be given me at my petition, and my people at my request. 
-<span class="v">4&#160;</span>For we are sold, I and my people, to be destroyed, to be slain, and to perish. But if we had been sold for male and female slaves, I would have held my peace, although the adversary could not have compensated for the king’s loss.” 
-</p><p>
-<span class="v">5&#160;</span>Then King Ahasuerus said to Esther the queen, “Who is he, and where is he who dared presume in his heart to do so?” 
-</p><p>
-<span class="v">6&#160;</span>Esther said, “An adversary and an enemy, even this wicked Haman!” 
-</p><p>Then Haman was afraid before the king and the queen. 
-<span class="v">7&#160;</span>The king arose in his wrath from the banquet of wine and went into the palace garden. Haman stood up to make request for his life to Esther the queen, for he saw that there was evil determined against him by the king. 
-<span class="v">8&#160;</span>Then the king returned out of the palace garden into the place of the banquet of wine; and Haman had fallen on the couch where Esther was. Then the king said, “Will he even assault the queen in front of me in the house?” As the word went out of the king’s mouth, they covered Haman’s face. 
-</p><p>
-<span class="v">9&#160;</span>Then Harbonah, one of the eunuchs who were with the king, said, “Behold, the gallows fifty cubits<span class="f">+ \fr 7:9 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> high, which Haman has made for Mordecai, who spoke good for the king, is standing at Haman’s house.” 
-</p><p>The king said, “Hang him on it!” 
-</p><p>
-<span class="v">10&#160;</span>So they hanged Haman on the gallows that he had prepared for Mordecai. Then the king’s wrath was pacified. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>On that day, King Ahasuerus gave the house of Haman, the Jews’ enemy, to Esther the queen. Mordecai came before the king; for Esther had told what he was to her. 
-<span class="v">2&#160;</span>The king took off his ring, which he had taken from Haman, and gave it to Mordecai. Esther set Mordecai over the house of Haman. 
-</p><p>
-<span class="v">3&#160;</span>Esther spoke yet again before the king, and fell down at his feet and begged him with tears to put away the mischief of Haman the Agagite, and his plan that he had planned against the Jews. 
-<span class="v">4&#160;</span>Then the king held out to Esther the golden scepter. So Esther arose, and stood before the king. 
-<span class="v">5&#160;</span>She said, “If it pleases the king, and if I have found favor in his sight, and the thing seems right to the king, and I am pleasing in his eyes, let it be written to reverse the letters devised by Haman, the son of Hammedatha the Agagite, which he wrote to destroy the Jews who are in all the king’s provinces. 
-<span class="v">6&#160;</span>For how can I endure to see the evil that would come to my people? How can I endure to see the destruction of my relatives?” 
-</p><p>
-<span class="v">7&#160;</span>Then King Ahasuerus said to Esther the queen and to Mordecai the Jew, “See, I have given Esther the house of Haman, and they have hanged him on the gallows because he laid his hand on the Jews. 
-<span class="v">8&#160;</span>Write also to the Jews as it pleases you, in the king’s name, and seal it with the king’s ring; for the writing which is written in the king’s name, and sealed with the king’s ring, may not be reversed by any man.” 
-</p><p>
-<span class="v">9&#160;</span>Then the king’s scribes were called at that time, in the third month, which is the month Sivan, on the twenty-third day of the month; and it was written according to all that Mordecai commanded to the Jews, and to the local governors, and the governors and princes of the provinces which are from India to Ethiopia, one hundred twenty-seven provinces, to every province according to its writing, and to every people in their language, and to the Jews in their writing, and in their language. 
-<span class="v">10&#160;</span>He wrote in the name of King Ahasuerus, and sealed it with the king’s ring, and sent letters by courier on horseback, riding on royal horses that were bred from swift steeds. 
-<span class="v">11&#160;</span>In those letters, the king granted the Jews who were in every city to gather themselves together and to defend their lives—to destroy, to kill, and to cause to perish all the power of the people and province that would assault them, their little ones and women, and to plunder their possessions, 
-<span class="v">12&#160;</span>on one day in all the provinces of King Ahasuerus, on the thirteenth day of the twelfth month, which is the month Adar. 
-<span class="v">13&#160;</span>A copy of the letter, that the decree should be given out in every province, was published to all the peoples, that the Jews should be ready for that day to avenge themselves on their enemies. 
-<span class="v">14&#160;</span>So the couriers who rode on royal horses went out, hastened and pressed on by the king’s commandment. The decree was given out in the citadel of Susa. 
-</p><p>
-<span class="v">15&#160;</span>Mordecai went out of the presence of the king in royal clothing of blue and white, and with a great crown of gold, and with a robe of fine linen and purple; and the city of Susa shouted and was glad. 
-<span class="v">16&#160;</span>The Jews had light, gladness, joy, and honor. 
-<span class="v">17&#160;</span>In every province and in every city, wherever the king’s commandment and his decree came, the Jews had gladness, joy, a feast and a set-apart day. Many from among the peoples of the land became Jews, for the fear of the Jews had fallen on them. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Now in the twelfth month, which is the month Adar, on the thirteenth day of the month, when the king’s commandment and his decree came near to be put in execution, on the day that the enemies of the Jews hoped to conquer them, (but it turned out that the opposite happened, that the Jews conquered those who hated them), 
-<span class="v">2&#160;</span>the Jews gathered themselves together in their cities throughout all the provinces of the King Ahasuerus, to lay hands on those who wanted to harm them. No one could withstand them, because the fear of them had fallen on all the people. 
-<span class="v">3&#160;</span>All the princes of the provinces, the local governors, the governors, and those who did the king’s business helped the Jews, because the fear of Mordecai had fallen on them. 
-<span class="v">4&#160;</span>For Mordecai was great in the king’s house, and his fame went out throughout all the provinces, for the man Mordecai grew greater and greater. 
-<span class="v">5&#160;</span>The Jews struck all their enemies with the stroke of the sword, and with slaughter and destruction, and did what they wanted to those who hated them. 
-<span class="v">6&#160;</span>In the citadel of Susa, the Jews killed and destroyed five hundred men. 
-<span class="v">7&#160;</span>They killed Parshandatha, Dalphon, Aspatha, 
-<span class="v">8&#160;</span>Poratha, Adalia, Aridatha, 
-<span class="v">9&#160;</span>Parmashta, Arisai, Aridai, and Vaizatha, 
-<span class="v">10&#160;</span>the ten sons of Haman the son of Hammedatha, the Jews’ enemy, but they didn’t lay their hand on the plunder. 
-</p><p>
-<span class="v">11&#160;</span>On that day, the number of those who were slain in the citadel of Susa was brought before the king. 
-<span class="v">12&#160;</span>The king said to Esther the queen, “The Jews have slain and destroyed five hundred men in the citadel of Susa, including the ten sons of Haman; what then have they done in the rest of the king’s provinces! Now what is your petition? It shall be granted you. What is your further request? It shall be done.” 
-</p><p>
-<span class="v">13&#160;</span>Then Esther said, “If it pleases the king, let it be granted to the Jews who are in Susa to do tomorrow also according to today’s decree, and let Haman’s ten sons be hanged on the gallows.” 
-</p><p>
-<span class="v">14&#160;</span>The king commanded this to be done. A decree was given out in Susa; and they hanged Haman’s ten sons. 
-<span class="v">15&#160;</span>The Jews who were in Susa gathered themselves together on the fourteenth day also of the month Adar, and killed three hundred men in Susa; but they didn’t lay their hand on the plunder. 
-</p><p>
-<span class="v">16&#160;</span>The other Jews who were in the king’s provinces gathered themselves together, defended their lives, had rest from their enemies, and killed seventy-five thousand of those who hated them; but they didn’t lay their hand on the plunder. 
-<span class="v">17&#160;</span>This was done on the thirteenth day of the month Adar; and on the fourteenth day of that month they rested and made it a day of feasting and gladness. 
-</p><p>
-<span class="v">18&#160;</span>But the Jews who were in Susa assembled together on the thirteenth and on the fourteenth days of the month; and on the fifteenth day of that month, they rested, and made it a day of feasting and gladness. 
-<span class="v">19&#160;</span>Therefore the Jews of the villages, who live in the unwalled towns, make the fourteenth day of the month Adar a day of gladness and feasting, a set-apart day, and a day of sending presents of food to one another. 
-</p><p>
-<span class="v">20&#160;</span>Mordecai wrote these things, and sent letters to all the Jews who were in all the provinces of the King Ahasuerus, both near and far, 
-<span class="v">21&#160;</span>to enjoin them that they should keep the fourteenth and fifteenth days of the month Adar yearly, 
-<span class="v">22&#160;</span>as the days in which the Jews had rest from their enemies, and the month which was turned to them from sorrow to gladness, and from mourning into a set-apart day; that they should make them days of feasting and gladness, and of sending presents of food to one another, and gifts to the needy. 
-<span class="v">23&#160;</span>The Jews accepted the custom that they had begun, as Mordecai had written to them, 
-<span class="v">24&#160;</span>because Haman the son of Hammedatha, the Agagite, the enemy of all the Jews, had plotted against the Jews to destroy them, and had cast “Pur”, that is the lot, to consume them and to destroy them; 
-<span class="v">25&#160;</span>but when this became known to the king, he commanded by letters that his wicked plan, which he had planned against the Jews, should return on his own head, and that he and his sons should be hanged on the gallows. 
-</p><p>
-<span class="v">26&#160;</span>Therefore they called these days “Purim”,<span class="f">+ \fr 9:26 \ft Purim is the Hebrew plural for pur, which means lot.</span> from the word “Pur.” Therefore because of all the words of this letter, and of that which they had seen concerning this matter, and that which had come to them, 
-<span class="v">27&#160;</span>the Jews established and imposed on themselves, on their descendants, and on all those who joined themselves to them, so that it should not fail that they would keep these two days according to what was written and according to its appointed time every year; 
-<span class="v">28&#160;</span>and that these days should be remembered and kept throughout every generation, every family, every province, and every city; and that these days of Purim should not fail from among the Jews, nor their memory perish from their offspring.<span class="f">+ \fr 9:28 \ft or, seed</span> 
-</p><p>
-<span class="v">29&#160;</span>Then Esther the queen, the daughter of Abihail, and Mordecai the Jew wrote with all authority to confirm this second letter of Purim. 
-<span class="v">30&#160;</span>He sent letters to all the Jews in the hundred twenty-seven provinces of the kingdom of Ahasuerus with words of peace and truth, 
-<span class="v">31&#160;</span>to confirm these days of Purim in their appointed times, as Mordecai the Jew and Esther the queen had decreed, and as they had imposed upon themselves and their descendants in the matter of the fastings and their mourning. 
-<span class="v">32&#160;</span>The commandment of Esther confirmed these matters of Purim; and it was written in the book. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>King Ahasuerus laid a tribute on the land and on the islands of the sea. 
-<span class="v">2&#160;</span>Aren’t all the acts of his power and of his might, and the full account of the greatness of Mordecai, to which the king advanced him, written in the book of the chronicles of the kings of Media and Persia? 
-<span class="v">3&#160;</span>For Mordecai the Jew was next to King Ahasuerus, and great among the Jews and accepted by the multitude of his brothers, seeking the good of his people and speaking peace to all his descendants. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now in the days of Ahasuerus (this is Ahasuerus who reigned from India even to Ethiopia, over one hundred twenty-seven provinces), 
+<sup>2&#160;</sup>in those days, when the King Ahasuerus sat on the throne of his kingdom, which was in Susa the palace, 
+<sup>3&#160;</sup>in the third year of his reign, he made a feast for all his princes and his servants; the army of Persia and Media, the nobles and princes of the provinces being before him. 
+<sup>4&#160;</sup>He displayed the riches of his glorious kingdom and the honor of his excellent majesty many days, even one hundred eighty days. 
+</div><div class="p">
+<sup>5&#160;</sup>When these days were fulfilled, the king made a seven day feast for all the people who were present in Susa the palace, both great and small, in the court of the garden of the king’s palace. 
+<sup>6&#160;</sup>There were hangings of white and blue material, fastened with cords of fine linen and purple to silver rings and marble pillars. The couches were of gold and silver, on a pavement of red, white, yellow, and black marble. 
+<sup>7&#160;</sup>They gave them drinks in golden vessels of various kinds, including royal wine in abundance, according to the bounty of the king. 
+<sup>8&#160;</sup>In accordance with the law, the drinking was not compulsory; for so the king had instructed all the officials of his house, that they should do according to every man’s pleasure. 
+</div><div class="p">
+<sup>9&#160;</sup>Also Vashti the queen made a feast for the women in the royal house which belonged to King Ahasuerus. 
+</div><div class="p">
+<sup>10&#160;</sup>On the seventh day, when the heart of the king was merry with wine, he commanded Mehuman, Biztha, Harbona, Bigtha, and Abagtha, Zethar, and Carcass, the seven eunuchs who served in the presence of Ahasuerus the king, 
+<sup>11&#160;</sup>to bring Vashti the queen before the king wearing the royal crown, to show the people and the princes her beauty; for she was beautiful. 
+<sup>12&#160;</sup>But the queen Vashti refused to come at the king’s commandment by the eunuchs. Therefore the king was very angry, and his anger burned in him. 
+</div><div class="p">
+<sup>13&#160;</sup>Then the king said to the wise men, who knew the times (for it was the king’s custom to consult those who knew law and judgment; 
+<sup>14&#160;</sup>and next to him were Carshena, Shethar, Admatha, Tarshish, Meres, Marsena, and Memucan, the seven princes of Persia and Media, who saw the king’s face, and sat first in the kingdom), 
+<sup>15&#160;</sup>“What shall we do to Queen Vashti according to law, because she has not done the bidding of the King Ahasuerus by the eunuchs?” 
+</div><div class="p">
+<sup>16&#160;</sup>Memucan answered before the king and the princes, “Vashti the queen has not done wrong to just the king, but also to all the princes, and to all the people who are in all the provinces of the King Ahasuerus. 
+<sup>17&#160;</sup>For this deed of the queen will become known to all women, causing them to show contempt for their owners when it is reported, ‘King Ahasuerus commanded Vashti the queen to be brought in before him, but she didn’t come.’ 
+<sup>18&#160;</sup>Today, the princesses of Persia and Media who have heard of the queen’s deed will tell all the king’s princes. This will cause much contempt and wrath. 
+</div><div class="p">
+<sup>19&#160;</sup>“If it pleases the king, let a royal commandment go from him, and let it be written among the laws of the Persians and the Medes, so that it cannot be altered, that Vashti may never again come before King Ahasuerus; and let the king give her royal estate to another who is better than she. 
+<sup>20&#160;</sup>When the king’s decree which he shall make is published throughout all his kingdom (for it is great), all the women will give their owners honor, both great and small.” 
+</div><div class="p">
+<sup>21&#160;</sup>This advice pleased the king and the princes, and the king did according to the word of Memucan: 
+<sup>22&#160;</sup>for he sent letters into all the king’s provinces, into every province according to its writing, and to every people in their language, that every man should rule his own house, speaking in the language of his own people. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, when the wrath of King Ahasuerus was pacified, he remembered Vashti, and what she had done, and what was decreed against her. 
+<sup>2&#160;</sup>Then the king’s servants who served him said, “Let beautiful young virgins be sought for the king. 
+<sup>3&#160;</sup>Let the king appoint officers in all the provinces of his kingdom, that they may gather together all the beautiful young virgins to the citadel of Susa, to the women’s house, to the custody of Hegai the king’s eunuch, keeper of the women. Let cosmetics be given them; 
+<sup>4&#160;</sup>and let the maiden who pleases the king be queen instead of Vashti.” The thing pleased the king, and he did so. 
+</div><div class="p">
+<sup>5&#160;</sup>There was a certain Jew in the citadel of Susa whose name was Mordecai, the son of Jair, the son of Shimei, the son of Kish, a Benjamite, 
+<sup>6&#160;</sup>who had been carried away from Jerusalem with the captives who had been carried away with Jeconiah king of Judah, whom Nebuchadnezzar the king of Babylon had carried away. 
+<sup>7&#160;</sup>He brought up Hadassah, that is, Esther, his uncle’s daughter; for she had neither father nor mother. The maiden was fair and beautiful; and when her father and mother were dead, Mordecai took her for his own daughter. 
+</div><div class="p">
+<sup>8&#160;</sup>So, when the king’s commandment and his decree was heard, and when many maidens were gathered together to the citadel of Susa, to the custody of Hegai, Esther was taken into the king’s house, to the custody of Hegai, keeper of the women. 
+<sup>9&#160;</sup>The maiden pleased him, and she obtained kindness from him. He quickly gave her cosmetics and her portions of food, and the seven choice maidens who were to be given her out of the king’s house. He moved her and her maidens to the best place in the women’s house. 
+<sup>10&#160;</sup>Esther had not made known her people nor her relatives, because Mordecai had instructed her that she should not make it known. 
+<sup>11&#160;</sup>Mordecai walked every day in front of the court of the women’s house, to find out how Esther was doing, and what would become of her. 
+</div><div class="p">
+<sup>12&#160;</sup>Each young woman’s turn came to go in to King Ahasuerus after her purification for twelve months (for so were the days of their purification accomplished, six months with oil of myrrh, and six months with sweet fragrances and with preparations for beautifying women). 
+<sup>13&#160;</sup>The young woman then came to the king like this: whatever she desired was given her to go with her out of the women’s house to the king’s house. 
+<sup>14&#160;</sup>In the evening she went, and on the next day she returned into the second women’s house, to the custody of Shaashgaz, the king’s eunuch, who kept the concubines. She came in to the king no more, unless the king delighted in her, and she was called by name. 
+</div><div class="p">
+<sup>15&#160;</sup>Now when the turn of Esther, the daughter of Abihail the uncle of Mordecai, who had taken her for his daughter, came to go in to the king, she required nothing but what Hegai the king’s eunuch, the keeper of the women, advised. Esther obtained favor in the sight of all those who looked at her. 
+</div><div class="p">
+<sup>16&#160;</sup>So Esther was taken to King Ahasuerus into his royal house in the tenth month, which is the month Tebeth, in the seventh year of his reign. 
+<sup>17&#160;</sup>The king loved Esther more than all the women, and she obtained favor and kindness in his sight more than all the virgins; so that he set the royal crown on her head, and made her queen instead of Vashti. 
+</div><div class="p">
+<sup>18&#160;</sup>Then the king made a great feast for all his princes and his servants, even Esther’s feast; and he proclaimed a set-apart day in the provinces, and gave gifts according to the king’s bounty. 
+</div><div class="p">
+<sup>19&#160;</sup>When the virgins were gathered together the second time, Mordecai was sitting in the king’s gate. 
+<sup>20&#160;</sup>Esther had not yet made known her relatives nor her people, as Mordecai had commanded her; for Esther obeyed Mordecai, like she did when she was brought up by him. 
+<sup>21&#160;</sup>In those days, while Mordecai was sitting in the king’s gate, two of the king’s eunuchs, Bigthan and Teresh, who were doorkeepers, were angry, and sought to lay hands on the King Ahasuerus. 
+<sup>22&#160;</sup>This thing became known to Mordecai, who informed Esther the queen; and Esther informed the king in Mordecai’s name. 
+<sup>23&#160;</sup>When this matter was investigated, and it was found to be so, they were both hanged on a gallows; and it was written in the book of the chronicles in the king’s presence. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things King Ahasuerus promoted Haman the son of Hammedatha the Agagite, and advanced him, and set his seat above all the princes who were with him. 
+<sup>2&#160;</sup>All the king’s servants who were in the king’s gate bowed down and paid homage to Haman, for the king had so commanded concerning him. But Mordecai didn’t bow down or pay him homage. 
+<sup>3&#160;</sup>Then the king’s servants who were in the king’s gate said to Mordecai, “Why do you disobey the king’s commandment?” 
+<sup>4&#160;</sup>Now it came to pass, when they spoke daily to him, and he didn’t listen to them, that they told Haman, to see whether Mordecai’s reason would stand; for he had told them that he was a Jew. 
+<sup>5&#160;</sup>When Haman saw that Mordecai didn’t bow down nor pay him homage, Haman was full of wrath. 
+<sup>6&#160;</sup>But he scorned the thought of laying hands on Mordecai alone, for they had made known to him Mordecai’s people. Therefore Haman sought to destroy all the Jews who were throughout the whole kingdom of Ahasuerus, even Mordecai’s people. 
+</div><div class="p">
+<sup>7&#160;</sup>In the first month, which is the month Nisan, in the twelfth year of King Ahasuerus, they cast Pur, that is, the lot, before Haman from day to day, and from month to month, and chose the twelfth month, which is the month Adar. 
+<sup>8&#160;</sup>Haman said to King Ahasuerus, “There is a certain people scattered abroad and dispersed among the peoples in all the provinces of your kingdom, and their laws are different from other people’s. They don’t keep the king’s laws. Therefore it is not for the king’s profit to allow them to remain. 
+<sup>9&#160;</sup>If it pleases the king, let it be written that they be destroyed; and I will pay ten thousand talents of silver into the hands of those who are in charge of the king’s business, to bring it into the king’s treasuries.” 
+</div><div class="p">
+<sup>10&#160;</sup>The king took his ring from his hand, and gave it to Haman the son of Hammedatha the Agagite, the Jews’ enemy. 
+<sup>11&#160;</sup>The king said to Haman, “The silver is given to you, the people also, to do with them as it seems good to you.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then the king’s scribes were called in on the first month, on the thirteenth day of the month; and all that Haman commanded was written to the king’s local governors, and to the governors who were over every province, and to the princes of every people, to every province according to its writing, and to every people in their language. It was written in the name of King Ahasuerus, and it was sealed with the king’s ring. 
+<sup>13&#160;</sup>Letters were sent by couriers into all the king’s provinces, to destroy, to kill, and to cause to perish, all Jews, both young and old, little children and women, in one day, even on the thirteenth day of the twelfth month, which is the month Adar, and to plunder their possessions. 
+<sup>14&#160;</sup>A copy of the letter, that the decree should be given out in every province, was published to all the peoples, that they should be ready against that day. 
+<sup>15&#160;</sup>The couriers went out in haste by the king’s commandment, and the decree was given out in the citadel of Susa. The king and Haman sat down to drink; but the city of Susa was perplexed. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when Mordecai found out all that was done, Mordecai tore his clothes and put on sackcloth with ashes, and went out into the middle of the city, and wailed loudly and bitterly. 
+<sup>2&#160;</sup>He came even before the king’s gate, for no one is allowed inside the king’s gate clothed with sackcloth. 
+<sup>3&#160;</sup>In every province, wherever the king’s commandment and his decree came, there was great mourning among the Jews, and fasting, and weeping, and wailing; and many lay in sackcloth and ashes. 
+</div><div class="p">
+<sup>4&#160;</sup>Esther’s maidens and her eunuchs came and told her this, and the queen was exceedingly grieved. She sent clothing to Mordecai, to replace his sackcloth, but he didn’t receive it. 
+<sup>5&#160;</sup>Then Esther called for Hathach, one of the king’s eunuchs, whom he had appointed to attend her, and commanded him to go to Mordecai, to find out what this was, and why it was. 
+<sup>6&#160;</sup>So Hathach went out to Mordecai, to the city square which was before the king’s gate. 
+<sup>7&#160;</sup>Mordecai told him of all that had happened to him, and the exact sum of the money that Haman had promised to pay to the king’s treasuries for the destruction of the Jews. 
+<sup>8&#160;</sup>He also gave him the copy of the writing of the decree that was given out in Susa to destroy them, to show it to Esther, and to declare it to her, and to urge her to go in to the king to make supplication to him, and to make request before him for her people. 
+</div><div class="p">
+<sup>9&#160;</sup>Hathach came and told Esther the words of Mordecai. 
+<sup>10&#160;</sup>Then Esther spoke to Hathach, and gave him a message to Mordecai: 
+<sup>11&#160;</sup>“All the king’s servants and the people of the king’s provinces know that whoever, whether man or woman, comes to the king into the inner court without being called, there is one law for him, that he be put to death, except those to whom the king might hold out the golden scepter, that he may live. I have not been called to come in to the king these thirty days.” 
+</div><div class="p">
+<sup>12&#160;</sup>They told Esther’s words to Mordecai. 
+<sup>13&#160;</sup>Then Mordecai asked them to return this answer to Esther: “Don’t think to yourself that you will escape in the king’s house any more than all the Jews. 
+<sup>14&#160;</sup>For if you remain silent now, then relief and deliverance will come to the Jews from another place, but you and your father’s house will perish. Who knows if you haven’t come to the kingdom for such a time as this?” 
+</div><div class="p">
+<sup>15&#160;</sup>Then Esther asked them to answer Mordecai, 
+<sup>16&#160;</sup>“Go, gather together all the Jews who are present in Susa, and fast for me, and neither eat nor drink three days, night or day. I and my maidens will also fast the same way. Then I will go in to the king, which is against the law; and if I perish, I perish.” 
+<sup>17&#160;</sup>So Mordecai went his way, and did according to all that Esther had commanded him. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Now on the third day, Esther put on her royal clothing and stood in the inner court of the king’s house, next to the king’s house. The king sat on his royal throne in the royal house, next to the entrance of the house. 
+<sup>2&#160;</sup>When the king saw Esther the queen standing in the court, she obtained favor in his sight; and the king held out to Esther the golden scepter that was in his hand. So Esther came near and touched the top of the scepter. 
+</div><div class="p">
+<sup>3&#160;</sup>Then the king asked her, “What would you like, queen Esther? What is your request? It shall be given you even to the half of the kingdom.” 
+</div><div class="p">
+<sup>4&#160;</sup>Esther said, “If it seems good to the king, let the king and Haman come today to the banquet that I have prepared for him.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then the king said, “Bring Haman quickly, so that it may be done as Esther has said.” So the king and Haman came to the banquet that Esther had prepared. 
+</div><div class="p">
+<sup>6&#160;</sup>The king said to Esther at the banquet of wine, “What is your petition? It shall be granted you. What is your request? Even to the half of the kingdom it shall be performed.” 
+</div><div class="p">
+<sup>7&#160;</sup>Then Esther answered and said, “My petition and my request is this. 
+<sup>8&#160;</sup>If I have found favor in the sight of the king, and if it pleases the king to grant my petition and to perform my request, let the king and Haman come to the banquet that I will prepare for them, and I will do tomorrow as the king has said.” 
+</div><div class="p">
+<sup>9&#160;</sup>Then Haman went out that day joyful and glad of heart, but when Haman saw Mordecai in the king’s gate, that he didn’t stand up nor move for him, he was filled with wrath against Mordecai. 
+<sup>10&#160;</sup>Nevertheless Haman restrained himself, and went home. There, he sent and called for his friends and Zeresh his woman. 
+<sup>11&#160;</sup>Haman recounted to them the glory of his riches, the multitude of his children, all the things in which the king had promoted him, and how he had advanced him above the princes and servants of the king. 
+</div><div class="p">
+<sup>12&#160;</sup>Haman also said, “Yes, Esther the queen let no man come in with the king to the banquet that she had prepared but myself; and tomorrow I am also invited by her together with the king. 
+<sup>13&#160;</sup>Yet all this avails me nothing, so long as I see Mordecai the Jew sitting at the king’s gate.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Zeresh his woman and all his friends said to him, “Let a gallows be made fifty cubits high, and in the morning speak to the king about hanging Mordecai on it. Then go in merrily with the king to the banquet.” This pleased Haman, so he had the gallows made. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>On that night, the king couldn’t sleep. He commanded the book of records of the chronicles to be brought, and they were read to the king. 
+<sup>2&#160;</sup>It was found written that Mordecai had told of Bigthana and Teresh, two of the king’s eunuchs, who were doorkeepers, who had tried to lay hands on the King Ahasuerus. 
+<sup>3&#160;</sup>The king said, “What honor and dignity has been given to Mordecai for this?” 
+</div><div class="p">Then the king’s servants who attended him said, “Nothing has been done for him.” 
+</div><div class="p">
+<sup>4&#160;</sup>The king said, “Who is in the court?” Now Haman had come into the outer court of the king’s house, to speak to the king about hanging Mordecai on the gallows that he had prepared for him. 
+</div><div class="p">
+<sup>5&#160;</sup>The king’s servants said to him, “Behold, Haman stands in the court.” 
+</div><div class="p">The king said, “Let him come in.” 
+<sup>6&#160;</sup>So Haman came in. The king said to him, “What shall be done to the man whom the king delights to honor?” 
+</div><div class="p">Now Haman said in his heart, “Who would the king delight to honor more than myself?” 
+<sup>7&#160;</sup>Haman said to the king, “For the man whom the king delights to honor, 
+<sup>8&#160;</sup>let royal clothing be brought which the king uses to wear, and the horse that the king rides on, and on the head of which a royal crown is set. 
+<sup>9&#160;</sup>Let the clothing and the horse be delivered to the hand of one of the king’s most noble princes, that they may array the man whom the king delights to honor with them, and have him ride on horseback through the city square, and proclaim before him, ‘Thus it shall be done to the man whom the king delights to honor!’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Then the king said to Haman, “Hurry and take the clothing and the horse, as you have said, and do this for Mordecai the Jew, who sits at the king’s gate. Let nothing fail of all that you have spoken.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then Haman took the clothing and the horse, and arrayed Mordecai, and had him ride through the city square, and proclaimed before him, “Thus it shall be done to the man whom the king delights to honor!” 
+</div><div class="p">
+<sup>12&#160;</sup>Mordecai came back to the king’s gate, but Haman hurried to his house, mourning and having his head covered. 
+<sup>13&#160;</sup>Haman recounted to Zeresh his woman and all his friends everything that had happened to him. Then his wise men and Zeresh his woman said to him, “If Mordecai, before whom you have begun to fall, is of Jewish descent, you will not prevail against him, but you will surely fall before him.” 
+<sup>14&#160;</sup>While they were yet talking with him, the king’s eunuchs came, and hurried to bring Haman to the banquet that Esther had prepared. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>So the king and Haman came to banquet with Esther the queen. 
+<sup>2&#160;</sup>The king said again to Esther on the second day at the banquet of wine, “What is your petition, queen Esther? It shall be granted you. What is your request? Even to the half of the kingdom it shall be performed.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then Esther the queen answered, “If I have found favor in your sight, O king, and if it pleases the king, let my life be given me at my petition, and my people at my request. 
+<sup>4&#160;</sup>For we are sold, I and my people, to be destroyed, to be slain, and to perish. But if we had been sold for male and female slaves, I would have held my peace, although the adversary could not have compensated for the king’s loss.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then King Ahasuerus said to Esther the queen, “Who is he, and where is he who dared presume in his heart to do so?” 
+</div><div class="p">
+<sup>6&#160;</sup>Esther said, “An adversary and an enemy, even this wicked Haman!” 
+</div><div class="p">Then Haman was afraid before the king and the queen. 
+<sup>7&#160;</sup>The king arose in his wrath from the banquet of wine and went into the palace garden. Haman stood up to make request for his life to Esther the queen, for he saw that there was evil determined against him by the king. 
+<sup>8&#160;</sup>Then the king returned out of the palace garden into the place of the banquet of wine; and Haman had fallen on the couch where Esther was. Then the king said, “Will he even assault the queen in front of me in the house?” As the word went out of the king’s mouth, they covered Haman’s face. 
+</div><div class="p">
+<sup>9&#160;</sup>Then Harbonah, one of the eunuchs who were with the king, said, “Behold, the gallows fifty cubits high, which Haman has made for Mordecai, who spoke good for the king, is standing at Haman’s house.” 
+</div><div class="p">The king said, “Hang him on it!” 
+</div><div class="p">
+<sup>10&#160;</sup>So they hanged Haman on the gallows that he had prepared for Mordecai. Then the king’s wrath was pacified. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>On that day, King Ahasuerus gave the house of Haman, the Jews’ enemy, to Esther the queen. Mordecai came before the king; for Esther had told what he was to her. 
+<sup>2&#160;</sup>The king took off his ring, which he had taken from Haman, and gave it to Mordecai. Esther set Mordecai over the house of Haman. 
+</div><div class="p">
+<sup>3&#160;</sup>Esther spoke yet again before the king, and fell down at his feet and begged him with tears to put away the mischief of Haman the Agagite, and his plan that he had planned against the Jews. 
+<sup>4&#160;</sup>Then the king held out to Esther the golden scepter. So Esther arose, and stood before the king. 
+<sup>5&#160;</sup>She said, “If it pleases the king, and if I have found favor in his sight, and the thing seems right to the king, and I am pleasing in his eyes, let it be written to reverse the letters devised by Haman, the son of Hammedatha the Agagite, which he wrote to destroy the Jews who are in all the king’s provinces. 
+<sup>6&#160;</sup>For how can I endure to see the evil that would come to my people? How can I endure to see the destruction of my relatives?” 
+</div><div class="p">
+<sup>7&#160;</sup>Then King Ahasuerus said to Esther the queen and to Mordecai the Jew, “See, I have given Esther the house of Haman, and they have hanged him on the gallows because he laid his hand on the Jews. 
+<sup>8&#160;</sup>Write also to the Jews as it pleases you, in the king’s name, and seal it with the king’s ring; for the writing which is written in the king’s name, and sealed with the king’s ring, may not be reversed by any man.” 
+</div><div class="p">
+<sup>9&#160;</sup>Then the king’s scribes were called at that time, in the third month, which is the month Sivan, on the twenty-third day of the month; and it was written according to all that Mordecai commanded to the Jews, and to the local governors, and the governors and princes of the provinces which are from India to Ethiopia, one hundred twenty-seven provinces, to every province according to its writing, and to every people in their language, and to the Jews in their writing, and in their language. 
+<sup>10&#160;</sup>He wrote in the name of King Ahasuerus, and sealed it with the king’s ring, and sent letters by courier on horseback, riding on royal horses that were bred from swift steeds. 
+<sup>11&#160;</sup>In those letters, the king granted the Jews who were in every city to gather themselves together and to defend their lives—to destroy, to kill, and to cause to perish all the power of the people and province that would assault them, their little ones and women, and to plunder their possessions, 
+<sup>12&#160;</sup>on one day in all the provinces of King Ahasuerus, on the thirteenth day of the twelfth month, which is the month Adar. 
+<sup>13&#160;</sup>A copy of the letter, that the decree should be given out in every province, was published to all the peoples, that the Jews should be ready for that day to avenge themselves on their enemies. 
+<sup>14&#160;</sup>So the couriers who rode on royal horses went out, hastened and pressed on by the king’s commandment. The decree was given out in the citadel of Susa. 
+</div><div class="p">
+<sup>15&#160;</sup>Mordecai went out of the presence of the king in royal clothing of blue and white, and with a great crown of gold, and with a robe of fine linen and purple; and the city of Susa shouted and was glad. 
+<sup>16&#160;</sup>The Jews had light, gladness, joy, and honor. 
+<sup>17&#160;</sup>In every province and in every city, wherever the king’s commandment and his decree came, the Jews had gladness, joy, a feast and a set-apart day. Many from among the peoples of the land became Jews, for the fear of the Jews had fallen on them. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Now in the twelfth month, which is the month Adar, on the thirteenth day of the month, when the king’s commandment and his decree came near to be put in execution, on the day that the enemies of the Jews hoped to conquer them, (but it turned out that the opposite happened, that the Jews conquered those who hated them), 
+<sup>2&#160;</sup>the Jews gathered themselves together in their cities throughout all the provinces of the King Ahasuerus, to lay hands on those who wanted to harm them. No one could withstand them, because the fear of them had fallen on all the people. 
+<sup>3&#160;</sup>All the princes of the provinces, the local governors, the governors, and those who did the king’s business helped the Jews, because the fear of Mordecai had fallen on them. 
+<sup>4&#160;</sup>For Mordecai was great in the king’s house, and his fame went out throughout all the provinces, for the man Mordecai grew greater and greater. 
+<sup>5&#160;</sup>The Jews struck all their enemies with the stroke of the sword, and with slaughter and destruction, and did what they wanted to those who hated them. 
+<sup>6&#160;</sup>In the citadel of Susa, the Jews killed and destroyed five hundred men. 
+<sup>7&#160;</sup>They killed Parshandatha, Dalphon, Aspatha, 
+<sup>8&#160;</sup>Poratha, Adalia, Aridatha, 
+<sup>9&#160;</sup>Parmashta, Arisai, Aridai, and Vaizatha, 
+<sup>10&#160;</sup>the ten sons of Haman the son of Hammedatha, the Jews’ enemy, but they didn’t lay their hand on the plunder. 
+</div><div class="p">
+<sup>11&#160;</sup>On that day, the number of those who were slain in the citadel of Susa was brought before the king. 
+<sup>12&#160;</sup>The king said to Esther the queen, “The Jews have slain and destroyed five hundred men in the citadel of Susa, including the ten sons of Haman; what then have they done in the rest of the king’s provinces! Now what is your petition? It shall be granted you. What is your further request? It shall be done.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then Esther said, “If it pleases the king, let it be granted to the Jews who are in Susa to do tomorrow also according to today’s decree, and let Haman’s ten sons be hanged on the gallows.” 
+</div><div class="p">
+<sup>14&#160;</sup>The king commanded this to be done. A decree was given out in Susa; and they hanged Haman’s ten sons. 
+<sup>15&#160;</sup>The Jews who were in Susa gathered themselves together on the fourteenth day also of the month Adar, and killed three hundred men in Susa; but they didn’t lay their hand on the plunder. 
+</div><div class="p">
+<sup>16&#160;</sup>The other Jews who were in the king’s provinces gathered themselves together, defended their lives, had rest from their enemies, and killed seventy-five thousand of those who hated them; but they didn’t lay their hand on the plunder. 
+<sup>17&#160;</sup>This was done on the thirteenth day of the month Adar; and on the fourteenth day of that month they rested and made it a day of feasting and gladness. 
+</div><div class="p">
+<sup>18&#160;</sup>But the Jews who were in Susa assembled together on the thirteenth and on the fourteenth days of the month; and on the fifteenth day of that month, they rested, and made it a day of feasting and gladness. 
+<sup>19&#160;</sup>Therefore the Jews of the villages, who live in the unwalled towns, make the fourteenth day of the month Adar a day of gladness and feasting, a set-apart day, and a day of sending presents of food to one another. 
+</div><div class="p">
+<sup>20&#160;</sup>Mordecai wrote these things, and sent letters to all the Jews who were in all the provinces of the King Ahasuerus, both near and far, 
+<sup>21&#160;</sup>to enjoin them that they should keep the fourteenth and fifteenth days of the month Adar yearly, 
+<sup>22&#160;</sup>as the days in which the Jews had rest from their enemies, and the month which was turned to them from sorrow to gladness, and from mourning into a set-apart day; that they should make them days of feasting and gladness, and of sending presents of food to one another, and gifts to the needy. 
+<sup>23&#160;</sup>The Jews accepted the custom that they had begun, as Mordecai had written to them, 
+<sup>24&#160;</sup>because Haman the son of Hammedatha, the Agagite, the enemy of all the Jews, had plotted against the Jews to destroy them, and had cast “Pur”, that is the lot, to consume them and to destroy them; 
+<sup>25&#160;</sup>but when this became known to the king, he commanded by letters that his wicked plan, which he had planned against the Jews, should return on his own head, and that he and his sons should be hanged on the gallows. 
+</div><div class="p">
+<sup>26&#160;</sup>Therefore they called these days “Purim”, from the word “Pur.” Therefore because of all the words of this letter, and of that which they had seen concerning this matter, and that which had come to them, 
+<sup>27&#160;</sup>the Jews established and imposed on themselves, on their descendants, and on all those who joined themselves to them, so that it should not fail that they would keep these two days according to what was written and according to its appointed time every year; 
+<sup>28&#160;</sup>and that these days should be remembered and kept throughout every generation, every family, every province, and every city; and that these days of Purim should not fail from among the Jews, nor their memory perish from their offspring. 
+</div><div class="p">
+<sup>29&#160;</sup>Then Esther the queen, the daughter of Abihail, and Mordecai the Jew wrote with all authority to confirm this second letter of Purim. 
+<sup>30&#160;</sup>He sent letters to all the Jews in the hundred twenty-seven provinces of the kingdom of Ahasuerus with words of peace and truth, 
+<sup>31&#160;</sup>to confirm these days of Purim in their appointed times, as Mordecai the Jew and Esther the queen had decreed, and as they had imposed upon themselves and their descendants in the matter of the fastings and their mourning. 
+<sup>32&#160;</sup>The commandment of Esther confirmed these matters of Purim; and it was written in the book. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>King Ahasuerus laid a tribute on the land and on the islands of the sea. 
+<sup>2&#160;</sup>Aren’t all the acts of his power and of his might, and the full account of the greatness of Mordecai, to which the king advanced him, written in the book of the chronicles of the kings of Media and Persia? 
+<sup>3&#160;</sup>For Mordecai the Jew was next to King Ahasuerus, and great among the Jews and accepted by the multitude of his brothers, seeking the good of his people and speaking peace to all his descendants. </div></div><script src="../main.js"></script></body></html>

--- a/book/exodus.html
+++ b/book/exodus.html
@@ -3,6 +3,47 @@
 <head>
 <title>Exodus</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1652 +53,1693 @@
 <div class="main">
 <!-- EXO World English Scripture (WES) -->
 <h1 class="booklabel">Exodus</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now these are the names of the sons of Israel, who came into Egypt (every man and his household came with Jacob): 
-<span class="v">2&#160;</span>Reuben, Simeon, Levi, and Judah, 
-<span class="v">3&#160;</span>Issachar, Zebulun, and Benjamin, 
-<span class="v">4&#160;</span>Dan and Naphtali, Gad and Asher. 
-<span class="v">5&#160;</span>All the souls who came out of Jacob’s body were seventy souls, and Joseph was in Egypt already. 
-<span class="v">6&#160;</span>Joseph died, as did all his brothers, and all that generation. 
-<span class="v">7&#160;</span>The children of Israel were fruitful, and increased abundantly, and multiplied, and grew exceedingly mighty; and the land was filled with them. 
-</p><p>
-<span class="v">8&#160;</span>Now there arose a new king over Egypt, who didn’t know Joseph. 
-<span class="v">9&#160;</span>He said to his people, “Behold,<span class="f">+ \fr 1:9 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> the people of the children of Israel are more and mightier than we. 
-<span class="v">10&#160;</span>Come, let’s deal wisely with them, lest they multiply, and it happen that when any war breaks out, they also join themselves to our enemies and fight against us, and escape out of the land.” 
-<span class="v">11&#160;</span>Therefore they set taskmasters over them to afflict them with their burdens. They built storage cities for Pharaoh: Pithom and Raamses. 
-<span class="v">12&#160;</span>But the more they afflicted them, the more they multiplied and the more they spread out. They started to dread the children of Israel. 
-<span class="v">13&#160;</span>The Egyptians ruthlessly made the children of Israel serve, 
-<span class="v">14&#160;</span>and they made their lives bitter with hard service in mortar and in brick, and in all kinds of service in the field, all their service, in which they ruthlessly made them serve. 
-</p><p>
-<span class="v">15&#160;</span>The king of Egypt spoke to the Hebrew midwives, of whom the name of the one was Shiphrah, and the name of the other Puah, 
-<span class="v">16&#160;</span>and he said, “When you perform the duty of a midwife to the Hebrew women, and see them on the birth stool, if it is a son, then you shall kill him; but if it is a daughter, then she shall live.” 
-<span class="v">17&#160;</span>But the midwives feared Elohim,<span class="f">+ \fr 1:17 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> and didn’t do what the king of Egypt commanded them, but saved the baby boys alive. 
-<span class="v">18&#160;</span>The king of Egypt called for the midwives, and said to them, “Why have you done this thing and saved the boys alive?” 
-</p><p>
-<span class="v">19&#160;</span>The midwives said to Pharaoh, “Because the Hebrew women aren’t like the Egyptian women; for they are vigorous and give birth before the midwife comes to them.” 
-</p><p>
-<span class="v">20&#160;</span>Elohim dealt well with the midwives, and the people multiplied, and grew very mighty. 
-<span class="v">21&#160;</span>Because the midwives feared Elohim, he gave them families. 
-<span class="v">22&#160;</span>Pharaoh commanded all his people, saying, “You shall cast every son who is born into the river, and every daughter you shall save alive.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>A man of the house of Levi went and took a daughter of Levi as his woman. 
-<span class="v">2&#160;</span>The woman conceived and bore a son. When she saw that he was a fine child, she hid him three months. 
-<span class="v">3&#160;</span>When she could no longer hide him, she took a papyrus basket for him, and coated it with tar and with pitch. She put the child in it, and laid it in the reeds by the river’s bank. 
-<span class="v">4&#160;</span>His sister stood far off, to see what would be done to him. 
-<span class="v">5&#160;</span>Pharaoh’s daughter came down to bathe at the river. Her maidens walked along by the riverside. She saw the basket among the reeds, and sent her servant to get it. 
-<span class="v">6&#160;</span>She opened it, and saw the child, and behold, the baby cried. She had compassion on him, and said, “This is one of the Hebrews’ children.” 
-</p><p>
-<span class="v">7&#160;</span>Then his sister said to Pharaoh’s daughter, “Should I go and call a nurse for you from the Hebrew women, that she may nurse the child for you?” 
-</p><p>
-<span class="v">8&#160;</span>Pharaoh’s daughter said to her, “Go.” 
-</p><p>The young woman went and called the child’s mother. 
-<span class="v">9&#160;</span>Pharaoh’s daughter said to her, “Take this child away, and nurse him for me, and I will give you your wages.” 
-</p><p>The woman took the child, and nursed it. 
-<span class="v">10&#160;</span>The child grew, and she brought him to Pharaoh’s daughter, and he became her son. She named him Moses,<span class="f">+ \fr 2:10 \ft “Moses” sounds like the Hebrew for “draw out”.</span> and said, “Because I drew him out of the water.” 
-</p><p>
-<span class="v">11&#160;</span>In those days, when Moses had grown up, he went out to his brothers and saw their burdens. He saw an Egyptian striking a Hebrew, one of his brothers. 
-<span class="v">12&#160;</span>He looked this way and that way, and when he saw that there was no one, he killed the Egyptian, and hid him in the sand. 
-</p><p>
-<span class="v">13&#160;</span>He went out the second day, and behold, two men of the Hebrews were fighting with each other. He said to him who did the wrong, “Why do you strike your fellow?” 
-</p><p>
-<span class="v">14&#160;</span>He said, “Who made you a prince and a judge over us? Do you plan to kill me, as you killed the Egyptian?” 
-</p><p>Moses was afraid, and said, “Surely this thing is known.” 
-<span class="v">15&#160;</span>Now when Pharaoh heard this thing, he sought to kill Moses. But Moses fled from the face of Pharaoh, and lived in the land of Midian, and he sat down by a well. 
-</p><p>
-<span class="v">16&#160;</span>Now the priest of Midian had seven daughters. They came and drew water, and filled the troughs to water their father’s flock. 
-<span class="v">17&#160;</span>The shepherds came and drove them away; but Moses stood up and helped them, and watered their flock. 
-<span class="v">18&#160;</span>When they came to Reuel, their father, he said, “How is it that you have returned so early today?” 
-</p><p>
-<span class="v">19&#160;</span>They said, “An Egyptian delivered us out of the hand of the shepherds, and moreover he drew water for us, and watered the flock.” 
-</p><p>
-<span class="v">20&#160;</span>He said to his daughters, “Where is he? Why is it that you have left the man? Call him, that he may eat bread.” 
-</p><p>
-<span class="v">21&#160;</span>Moses was content to dwell with the man. He gave Moses Zipporah, his daughter. 
-<span class="v">22&#160;</span>She bore a son, and he named him Gershom,<span class="f">+ \fr 2:22 \ft “Gershom” sounds like the Hebrew for “an alien there”.</span> for he said, “I have lived as a foreigner in a foreign land.” 
-</p><p>
-<span class="v">23&#160;</span>In the course of those many days, the king of Egypt died, and the children of Israel sighed because of the bondage, and they cried, and their cry came up to Elohim because of the bondage. 
-<span class="v">24&#160;</span>Elohim heard their groaning, and Elohim remembered his covenant with Abraham, with Isaac, and with Jacob. 
-<span class="v">25&#160;</span>Elohim saw the children of Israel, and Elohim understood. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now Moses was keeping the flock of Jethro, his father-in-law, the priest of Midian, and he led the flock to the back of the wilderness, and came to Elohim’s mountain, to Horeb. 
-<span class="v">2&#160;</span>Yahweh’s<span class="f">+ \fr 3:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> angel appeared to him in a flame of fire out of the middle of a bush. He looked, and behold, the bush burned with fire, and the bush was not consumed. 
-<span class="v">3&#160;</span>Moses said, “I will go now, and see this great sight, why the bush is not burned.” 
-</p><p>
-<span class="v">4&#160;</span>When Yahweh saw that he came over to see, Elohim called to him out of the middle of the bush, and said, “Moses! Moses!” 
-</p><p>He said, “Here I am.” 
-</p><p>
-<span class="v">5&#160;</span>He said, “Don’t come close. Take off your sandals, for the place you are standing on is set-apart ground.” 
-<span class="v">6&#160;</span>Moreover he said, “I am the Elohim of your father, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob.” 
-</p><p>Moses hid his face because he was afraid to look at Elohim. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh said, “I have surely seen the affliction of my people who are in Egypt, and have heard their cry because of their taskmasters, for I know their sorrows. 
-<span class="v">8&#160;</span>I have come down to deliver them out of the hand of the Egyptians, and to bring them up out of that land to a good and large land, to a land flowing with milk and honey; to the place of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite. 
-<span class="v">9&#160;</span>Now, behold, the cry of the children of Israel has come to me. Moreover I have seen the oppression with which the Egyptians oppress them. 
-<span class="v">10&#160;</span>Come now therefore, and I will send you to Pharaoh, that you may bring my people, the children of Israel, out of Egypt.” 
-</p><p>
-<span class="v">11&#160;</span>Moses said to Elohim, “Who am I, that I should go to Pharaoh, and that I should bring the children of Israel out of Egypt?” 
-</p><p>
-<span class="v">12&#160;</span>He said, “Certainly I will be with you. This will be the token to you, that I have sent you: when you have brought the people out of Egypt, you shall serve Elohim on this mountain.” 
-</p><p>
-<span class="v">13&#160;</span>Moses said to Elohim, “Behold, when I come to the children of Israel, and tell them, ‘The Elohim of your fathers has sent me to you,’ and they ask me, ‘What is his name?’ what should I tell them?” 
-</p><p>
-<span class="v">14&#160;</span>Elohim said to Moses, “I will be who I will be,” and he said, “You shall tell the children of Israel this: ‘I will be has sent me to you.’&#160;” 
-<span class="v">15&#160;</span>Elohim said moreover to Moses, “You shall tell the children of Israel this, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has sent me to you.’ This is my name forever, and this is my memorial to all generations. 
-<span class="v">16&#160;</span>Go and gather the elders of Israel together, and tell them, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, of Isaac, and of Jacob, has appeared to me, saying, “I have surely visited you, and seen that which is done to you in Egypt. 
-<span class="v">17&#160;</span>I have said, I will bring you up out of the affliction of Egypt to the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite, to a land flowing with milk and honey.”&#160;’ 
-<span class="v">18&#160;</span>They will listen to your voice. You shall come, you and the elders of Israel, to the king of Egypt, and you shall tell him, ‘Yahweh, the Elohim of the Hebrews, has met with us. Now please let us go three days’ journey into the wilderness, that we may sacrifice to Yahweh, our Elohim.’ 
-<span class="v">19&#160;</span>I know that the king of Egypt won’t give you permission to go, no, not by a mighty hand. 
-<span class="v">20&#160;</span>I will reach out my hand and strike Egypt with all my wonders which I will do among them, and after that he will let you go. 
-<span class="v">21&#160;</span>I will give this people favor in the sight of the Egyptians, and it will happen that when you go, you shall not go empty-handed. 
-<span class="v">22&#160;</span>But every woman shall ask of her neighbor, and of her who visits her house, jewels of silver, jewels of gold, and clothing. You shall put them on your sons, and on your daughters. You shall plunder the Egyptians.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Moses answered, “But, behold, they will not believe me, nor listen to my voice; for they will say, ‘Yahweh has not appeared to you.’&#160;” 
-</p><p>
-<span class="v">2&#160;</span>Yahweh said to him, “What is that in your hand?” 
-</p><p>He said, “A rod.” 
-</p><p>
-<span class="v">3&#160;</span>He said, “Throw it on the ground.” 
-</p><p>He threw it on the ground, and it became a snake; and Moses ran away from it. 
-</p><p>
-<span class="v">4&#160;</span>Yahweh said to Moses, “Stretch out your hand, and take it by the tail.” 
-</p><p>He stretched out his hand, and took hold of it, and it became a rod in his hand. 
-</p><p>
-<span class="v">5&#160;</span>“This is so that they may believe that Yahweh, the Elohim of their fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has appeared to you.” 
-<span class="v">6&#160;</span>Yahweh said furthermore to him, “Now put your hand inside your cloak.” 
-</p><p>He put his hand inside his cloak, and when he took it out, behold, his hand was leprous, as white as snow. 
-</p><p>
-<span class="v">7&#160;</span>He said, “Put your hand inside your cloak again.” 
-</p><p>He put his hand inside his cloak again, and when he took it out of his cloak, behold, it had turned again as his other flesh. 
-</p><p>
-<span class="v">8&#160;</span>“It will happen, if they will not believe you or listen to the voice of the first sign, that they will believe the voice of the latter sign. 
-<span class="v">9&#160;</span>It will happen, if they will not believe even these two signs or listen to your voice, that you shall take of the water of the river, and pour it on the dry land. The water which you take out of the river will become blood on the dry land.” 
-</p><p>
-<span class="v">10&#160;</span>Moses said to Yahweh, “O Lord,<span class="f">+ \fr 4:10 \ft The word translated “Lord” is “Adonai”.</span> I am not eloquent, neither before now, nor since you have spoken to your servant; for I am slow of speech, and of a slow tongue.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said to him, “Who made man’s mouth? Or who makes one mute, or deaf, or seeing, or blind? Isn’t it I, Yahweh? 
-<span class="v">12&#160;</span>Now therefore go, and I will be with your mouth, and teach you what you shall speak.” 
-</p><p>
-<span class="v">13&#160;</span>Moses said, “Oh, Lord, please send someone else.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh’s anger burned against Moses, and he said, “What about Aaron, your brother, the Levite? I know that he can speak well. Also, behold, he is coming out to meet you. When he sees you, he will be glad in his heart. 
-<span class="v">15&#160;</span>You shall speak to him, and put the words in his mouth. I will be with your mouth, and with his mouth, and will teach you what you shall do. 
-<span class="v">16&#160;</span>He will be your spokesman to the people. It will happen that he will be to you a mouth, and you will be to him as Elohim. 
-<span class="v">17&#160;</span>You shall take this rod in your hand, with which you shall do the signs.” 
-</p><p>
-<span class="v">18&#160;</span>Moses went and returned to Jethro his father-in-law, and said to him, “Please let me go and return to my brothers who are in Egypt, and see whether they are still alive.” 
-</p><p>Jethro said to Moses, “Go in peace.” 
-</p><p>
-<span class="v">19&#160;</span>Yahweh said to Moses in Midian, “Go, return into Egypt; for all the men who sought your life are dead.” 
-</p><p>
-<span class="v">20&#160;</span>Moses took his woman and his sons, and set them on a donkey, and he returned to the land of Egypt. Moses took Elohim’s rod in his hand. 
-<span class="v">21&#160;</span>Yahweh said to Moses, “When you go back into Egypt, see that you do before Pharaoh all the wonders which I have put in your hand, but I will harden his heart and he will not let the people go. 
-<span class="v">22&#160;</span>You shall tell Pharaoh, ‘Yahweh says, Israel is my son, my firstborn, 
-<span class="v">23&#160;</span>and I have said to you, “Let my son go, that he may serve me;” and you have refused to let him go. Behold, I will kill your firstborn son.’&#160;” 
-</p><p>
-<span class="v">24&#160;</span>On the way at a lodging place, Yahweh met Moses and wanted to kill him. 
-<span class="v">25&#160;</span>Then Zipporah took a flint, and cut off the foreskin of her son, and cast it at his feet; and she said, “Surely you are a bridegroom of blood to me.” 
-</p><p>
-<span class="v">26&#160;</span>So he let him alone. Then she said, “You are a bridegroom of blood,” because of the circumcision. 
-</p><p>
-<span class="v">27&#160;</span>Yahweh said to Aaron, “Go into the wilderness to meet Moses.” 
-</p><p>He went, and met him on Elohim’s mountain, and kissed him. 
-<span class="v">28&#160;</span>Moses told Aaron all Yahweh’s words with which he had sent him, and all the signs with which he had instructed him. 
-<span class="v">29&#160;</span>Moses and Aaron went and gathered together all the elders of the children of Israel. 
-<span class="v">30&#160;</span>Aaron spoke all the words which Yahweh had spoken to Moses, and did the signs in the sight of the people. 
-<span class="v">31&#160;</span>The people believed, and when they heard that Yahweh had visited the children of Israel, and that he had seen their affliction, then they bowed their heads and worshiped. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Afterward Moses and Aaron came, and said to Pharaoh, “This is what Yahweh, the Elohim of Israel, says, ‘Let my people go, that they may hold a feast to me in the wilderness.’&#160;” 
-</p><p>
-<span class="v">2&#160;</span>Pharaoh said, “Who is Yahweh, that I should listen to his voice to let Israel go? I don’t know Yahweh, and moreover I will not let Israel go.” 
-</p><p>
-<span class="v">3&#160;</span>They said, “The Elohim of the Hebrews has met with us. Please let us go three days’ journey into the wilderness, and sacrifice to Yahweh, our Elohim, lest he fall on us with pestilence, or with the sword.” 
-</p><p>
-<span class="v">4&#160;</span>The king of Egypt said to them, “Why do you, Moses and Aaron, take the people from their work? Get back to your burdens!” 
-<span class="v">5&#160;</span>Pharaoh said, “Behold, the people of the land are now many, and you make them rest from their burdens.” 
-<span class="v">6&#160;</span>The same day Pharaoh commanded the taskmasters of the people and their officers, saying, 
-<span class="v">7&#160;</span>“You shall no longer give the people straw to make brick, as before. Let them go and gather straw for themselves. 
-<span class="v">8&#160;</span>You shall require from them the number of the bricks which they made before. You shall not diminish anything of it, for they are idle. Therefore they cry, saying, ‘Let’s go and sacrifice to our Elohim.’ 
-<span class="v">9&#160;</span>Let heavier work be laid on the men, that they may labor in it. Don’t let them pay any attention to lying words.” 
-</p><p>
-<span class="v">10&#160;</span>The taskmasters of the people went out with their officers, and they spoke to the people, saying, “This is what Pharaoh says: ‘I will not give you straw. 
-<span class="v">11&#160;</span>Go yourselves, get straw where you can find it, for nothing of your work shall be diminished.’&#160;” 
-<span class="v">12&#160;</span>So the people were scattered abroad throughout all the land of Egypt to gather stubble for straw. 
-<span class="v">13&#160;</span>The taskmasters were urgent saying, “Fulfill your work quota daily, as when there was straw!” 
-<span class="v">14&#160;</span>The officers of the children of Israel, whom Pharaoh’s taskmasters had set over them, were beaten, and were asked, “Why haven’t you fulfilled your quota both yesterday and today, in making brick as before?” 
-</p><p>
-<span class="v">15&#160;</span>Then the officers of the children of Israel came and cried to Pharaoh, saying, “Why do you deal this way with your servants? 
-<span class="v">16&#160;</span>No straw is given to your servants, and they tell us, ‘Make brick!’ and behold, your servants are beaten; but the fault is in your own people.” 
-</p><p>
-<span class="v">17&#160;</span>But Pharaoh said, “You are idle! You are idle! Therefore you say, ‘Let’s go and sacrifice to Yahweh.’ 
-<span class="v">18&#160;</span>Go therefore now, and work; for no straw shall be given to you; yet you shall deliver the same number of bricks!” 
-</p><p>
-<span class="v">19&#160;</span>The officers of the children of Israel saw that they were in trouble when it was said, “You shall not diminish anything from your daily quota of bricks!” 
-</p><p>
-<span class="v">20&#160;</span>They met Moses and Aaron, who stood along the way, as they came out from Pharaoh. 
-<span class="v">21&#160;</span>They said to them, “May Yahweh look at you and judge, because you have made us a stench to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to kill us!” 
-</p><p>
-<span class="v">22&#160;</span>Moses returned to Yahweh, and said, “Lord, why have you brought trouble on this people? Why is it that you have sent me? 
-<span class="v">23&#160;</span>For since I came to Pharaoh to speak in your name, he has brought trouble on this people. You have not rescued your people at all!” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, “Now you shall see what I will do to Pharaoh, for by a strong hand he shall let them go, and by a strong hand he shall drive them out of his land.” 
-</p><p>
-<span class="v">2&#160;</span>Elohim spoke to Moses, and said to him, “I am Yahweh. 
-<span class="v">3&#160;</span>I appeared to Abraham, to Isaac, and to Jacob, as Elohim Almighty; but by my name Yahweh I was not known to them. 
-<span class="v">4&#160;</span>I have also established my covenant with them, to give them the land of Canaan, the land of their travels, in which they lived as aliens. 
-<span class="v">5&#160;</span>Moreover I have heard the groaning of the children of Israel, whom the Egyptians keep in bondage, and I have remembered my covenant. 
-<span class="v">6&#160;</span>Therefore tell the children of Israel, ‘I am Yahweh, and I will bring you out from under the burdens of the Egyptians, and I will rid you out of their bondage, and I will redeem you with an outstretched arm, and with great judgments. 
-<span class="v">7&#160;</span>I will take you to myself for a people. I will be your Elohim; and you shall know that I am Yahweh your Elohim, who brings you out from under the burdens of the Egyptians. 
-<span class="v">8&#160;</span>I will bring you into the land which I swore to give to Abraham, to Isaac, and to Jacob; and I will give it to you for a heritage: I am Yahweh.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>Moses spoke so to the children of Israel, but they didn’t listen to Moses for anguish of spirit, and for cruel bondage. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">11&#160;</span>“Go in, speak to Pharaoh king of Egypt, that he let the children of Israel go out of his land.” 
-</p><p>
-<span class="v">12&#160;</span>Moses spoke before Yahweh, saying, “Behold, the children of Israel haven’t listened to me. How then shall Pharaoh listen to me, when I have uncircumcised lips?” 
-<span class="v">13&#160;</span>Yahweh spoke to Moses and to Aaron, and gave them a command to the children of Israel, and to Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt. 
-</p><p>
-<span class="v">14&#160;</span>These are the heads of their fathers’ houses. The sons of Reuben the firstborn of Israel: Hanoch, and Pallu, Hezron, and Carmi; these are the families of Reuben. 
-<span class="v">15&#160;</span>The sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanite woman; these are the families of Simeon. 
-<span class="v">16&#160;</span>These are the names of the sons of Levi according to their generations: Gershon, and Kohath, and Merari; and the years of the life of Levi were one hundred thirty-seven years. 
-<span class="v">17&#160;</span>The sons of Gershon: Libni and Shimei, according to their families. 
-<span class="v">18&#160;</span>The sons of Kohath: Amram, and Izhar, and Hebron, and Uzziel; and the years of the life of Kohath were one hundred thirty-three years. 
-<span class="v">19&#160;</span>The sons of Merari: Mahli and Mushi. These are the families of the Levites according to their generations. 
-<span class="v">20&#160;</span>Amram took Jochebed his father’s sister to himself as woman; and she bore him Aaron and Moses. The years of the life of Amram were one hundred thirty-seven years. 
-<span class="v">21&#160;</span>The sons of Izhar: Korah, and Nepheg, and Zichri. 
-<span class="v">22&#160;</span>The sons of Uzziel: Mishael, Elzaphan, and Sithri. 
-<span class="v">23&#160;</span>Aaron took Elisheba, the daughter of Amminadab, the sister of Nahshon, as his woman; and she bore him Nadab and Abihu, Eleazar and Ithamar. 
-<span class="v">24&#160;</span>The sons of Korah: Assir, Elkanah, and Abiasaph; these are the families of the Korahites. 
-<span class="v">25&#160;</span>Eleazar Aaron’s son took one of the daughters of Putiel as his woman; and she bore him Phinehas. These are the heads of the fathers’ houses of the Levites according to their families. 
-<span class="v">26&#160;</span>These are that Aaron and Moses to whom Yahweh said, “Bring out the children of Israel from the land of Egypt according to their armies.” 
-<span class="v">27&#160;</span>These are those who spoke to Pharaoh king of Egypt, to bring out the children of Israel from Egypt. These are that Moses and Aaron. 
-</p><p>
-<span class="v">28&#160;</span>On the day when Yahweh spoke to Moses in the land of Egypt, 
-<span class="v">29&#160;</span>Yahweh said to Moses, “I am Yahweh. Tell Pharaoh king of Egypt all that I tell you.” 
-</p><p>
-<span class="v">30&#160;</span>Moses said before Yahweh, “Behold, I am of uncircumcised lips, and how shall Pharaoh listen to me?” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, “Behold, I have made you as Elohim to Pharaoh; and Aaron your brother shall be your prophet. 
-<span class="v">2&#160;</span>You shall speak all that I command you; and Aaron your brother shall speak to Pharaoh, that he let the children of Israel go out of his land. 
-<span class="v">3&#160;</span>I will harden Pharaoh’s heart, and multiply my signs and my wonders in the land of Egypt. 
-<span class="v">4&#160;</span>But Pharaoh will not listen to you, so I will lay my hand on Egypt, and bring out my armies, my people the children of Israel, out of the land of Egypt by great judgments. 
-<span class="v">5&#160;</span>The Egyptians shall know that I am Yahweh when I stretch out my hand on Egypt, and bring the children of Israel out from among them.” 
-</p><p>
-<span class="v">6&#160;</span>Moses and Aaron did so. As Yahweh commanded them, so they did. 
-<span class="v">7&#160;</span>Moses was eighty years old, and Aaron eighty-three years old, when they spoke to Pharaoh. 
-</p><p>
-<span class="v">8&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">9&#160;</span>“When Pharaoh speaks to you, saying, ‘Perform a miracle!’ then you shall tell Aaron, ‘Take your rod, and cast it down before Pharaoh, and it will become a serpent.’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Moses and Aaron went in to Pharaoh, and they did so, as Yahweh had commanded. Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent. 
-<span class="v">11&#160;</span>Then Pharaoh also called for the wise men and the sorcerers. They also, the magicians of Egypt, did the same thing with their enchantments. 
-<span class="v">12&#160;</span>For they each cast down their rods, and they became serpents; but Aaron’s rod swallowed up their rods. 
-<span class="v">13&#160;</span>Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
-</p><p>
-<span class="v">14&#160;</span>Yahweh said to Moses, “Pharaoh’s heart is stubborn. He refuses to let the people go. 
-<span class="v">15&#160;</span>Go to Pharaoh in the morning. Behold, he is going out to the water. You shall stand by the river’s bank to meet him. You shall take the rod which was turned to a serpent in your hand. 
-<span class="v">16&#160;</span>You shall tell him, ‘Yahweh, the Elohim of the Hebrews, has sent me to you, saying, “Let my people go, that they may serve me in the wilderness. Behold, until now you haven’t listened.” 
-<span class="v">17&#160;</span>Yahweh says, “In this you shall know that I am Yahweh. Behold: I will strike with the rod that is in my hand on the waters which are in the river, and they shall be turned to blood. 
-<span class="v">18&#160;</span>The fish that are in the river will die and the river will become foul. The Egyptians will loathe to drink water from the river.”&#160;’&#160;” 
-<span class="v">19&#160;</span>Yahweh said to Moses, “Tell Aaron, ‘Take your rod, and stretch out your hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood. There will be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>Moses and Aaron did so, as Yahweh commanded; and he lifted up the rod, and struck the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood. 
-<span class="v">21&#160;</span>The fish that were in the river died. The river became foul. The Egyptians couldn’t drink water from the river. The blood was throughout all the land of Egypt. 
-<span class="v">22&#160;</span>The magicians of Egypt did the same thing with their enchantments. So Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
-<span class="v">23&#160;</span>Pharaoh turned and went into his house, and he didn’t even take this to heart. 
-<span class="v">24&#160;</span>All the Egyptians dug around the river for water to drink; for they couldn’t drink the river water. 
-<span class="v">25&#160;</span>Seven days were fulfilled, after Yahweh had struck the river. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
-<span class="v">2&#160;</span>If you refuse to let them go, behold, I will plague all your borders with frogs. 
-<span class="v">3&#160;</span>The river will swarm with frogs, which will go up and come into your house, and into your bedroom, and on your bed, and into the house of your servants, and on your people, and into your ovens, and into your kneading troughs. 
-<span class="v">4&#160;</span>The frogs shall come up both on you, and on your people, and on all your servants.”&#160;’&#160;” 
-<span class="v">5&#160;</span>Yahweh said to Moses, “Tell Aaron, ‘Stretch out your hand with your rod over the rivers, over the streams, and over the pools, and cause frogs to come up on the land of Egypt.’&#160;” 
-<span class="v">6&#160;</span>Aaron stretched out his hand over the waters of Egypt; and the frogs came up, and covered the land of Egypt. 
-<span class="v">7&#160;</span>The magicians did the same thing with their enchantments, and brought up frogs on the land of Egypt. 
-</p><p>
-<span class="v">8&#160;</span>Then Pharaoh called for Moses and Aaron, and said, “Entreat Yahweh, that he take away the frogs from me and from my people; and I will let the people go, that they may sacrifice to Yahweh.” 
-</p><p>
-<span class="v">9&#160;</span>Moses said to Pharaoh, “I give you the honor of setting the time that I should pray for you, and for your servants, and for your people, that the frogs be destroyed from you and your houses, and remain in the river only.” 
-</p><p>
-<span class="v">10&#160;</span>Pharaoh said, “Tomorrow.” 
-</p><p>Moses said, “Let it be according to your word, that you may know that there is no one like Yahweh our Elohim. 
-<span class="v">11&#160;</span>The frogs shall depart from you, and from your houses, and from your servants, and from your people. They shall remain in the river only.” 
-</p><p>
-<span class="v">12&#160;</span>Moses and Aaron went out from Pharaoh, and Moses cried to Yahweh concerning the frogs which he had brought on Pharaoh. 
-<span class="v">13&#160;</span>Yahweh did according to the word of Moses, and the frogs died out of the houses, out of the courts, and out of the fields. 
-<span class="v">14&#160;</span>They gathered them together in heaps, and the land stank. 
-<span class="v">15&#160;</span>But when Pharaoh saw that there was a respite, he hardened his heart, and didn’t listen to them, as Yahweh had spoken. 
-</p><p>
-<span class="v">16&#160;</span>Yahweh said to Moses, “Tell Aaron, ‘Stretch out your rod, and strike the dust of the earth, that it may become lice throughout all the land of Egypt.’&#160;” 
-<span class="v">17&#160;</span>They did so; and Aaron stretched out his hand with his rod, and struck the dust of the earth, and there were lice on man, and on animal; all the dust of the earth became lice throughout all the land of Egypt. 
-<span class="v">18&#160;</span>The magicians tried with their enchantments to produce lice, but they couldn’t. There were lice on man, and on animal. 
-<span class="v">19&#160;</span>Then the magicians said to Pharaoh, “This is Elohim’s finger;” but Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
-</p><p>
-<span class="v">20&#160;</span>Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh; behold, he comes out to the water; and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
-<span class="v">21&#160;</span>Else, if you will not let my people go, behold, I will send swarms of flies on you, and on your servants, and on your people, and into your houses. The houses of the Egyptians shall be full of swarms of flies, and also the ground they are on. 
-<span class="v">22&#160;</span>I will set apart in that day the land of Goshen, in which my people dwell, that no swarms of flies shall be there, to the end you may know that I am Yahweh on the earth. 
-<span class="v">23&#160;</span>I will put a division between my people and your people. This sign shall happen by tomorrow.”&#160;’&#160;” 
-<span class="v">24&#160;</span>Yahweh did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’ houses. In all the land of Egypt the land was corrupted by reason of the swarms of flies. 
-</p><p>
-<span class="v">25&#160;</span>Pharaoh called for Moses and for Aaron, and said, “Go, sacrifice to your Elohim in the land!” 
-</p><p>
-<span class="v">26&#160;</span>Moses said, “It isn’t appropriate to do so; for we shall sacrifice the abomination of the Egyptians to Yahweh our Elohim. Behold, if we sacrifice the abomination of the Egyptians before their eyes, won’t they stone us? 
-<span class="v">27&#160;</span>We will go three days’ journey into the wilderness, and sacrifice to Yahweh our Elohim, as he shall command us.” 
-</p><p>
-<span class="v">28&#160;</span>Pharaoh said, “I will let you go, that you may sacrifice to Yahweh your Elohim in the wilderness, only you shall not go very far away. Pray for me.” 
-</p><p>
-<span class="v">29&#160;</span>Moses said, “Behold, I am going out from you. I will pray to Yahweh that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only don’t let Pharaoh deal deceitfully any more in not letting the people go to sacrifice to Yahweh.” 
-<span class="v">30&#160;</span>Moses went out from Pharaoh, and prayed to Yahweh. 
-<span class="v">31&#160;</span>Yahweh did according to the word of Moses, and he removed the swarms of flies from Pharaoh, from his servants, and from his people. There remained not one. 
-<span class="v">32&#160;</span>Pharaoh hardened his heart this time also, and he didn’t let the people go. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Then Yahweh said to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
-<span class="v">2&#160;</span>For if you refuse to let them go, and hold them still, 
-<span class="v">3&#160;</span>behold, Yahweh’s hand is on your livestock which are in the field, on the horses, on the donkeys, on the camels, on the herds, and on the flocks with a very grievous pestilence. 
-<span class="v">4&#160;</span>Yahweh will make a distinction between the livestock of Israel and the livestock of Egypt; and nothing shall die of all that belongs to the children of Israel.”&#160;’&#160;” 
-<span class="v">5&#160;</span>Yahweh appointed a set time, saying, “Tomorrow Yahweh shall do this thing in the land.” 
-<span class="v">6&#160;</span>Yahweh did that thing on the next day; and all the livestock of Egypt died, but of the livestock of the children of Israel, not one died. 
-<span class="v">7&#160;</span>Pharaoh sent, and, behold, there was not so much as one of the livestock of the Israelites dead. But the heart of Pharaoh was stubborn, and he didn’t let the people go. 
-</p><p>
-<span class="v">8&#160;</span>Yahweh said to Moses and to Aaron, “Take handfuls of ashes of the furnace, and let Moses sprinkle it toward the sky in the sight of Pharaoh. 
-<span class="v">9&#160;</span>It shall become small dust over all the land of Egypt, and shall be boils and blisters breaking out on man and on animal, throughout all the land of Egypt.” 
-</p><p>
-<span class="v">10&#160;</span>They took ashes of the furnace, and stood before Pharaoh; and Moses sprinkled it up toward the sky; and it became boils and blisters breaking out on man and on animal. 
-<span class="v">11&#160;</span>The magicians couldn’t stand before Moses because of the boils; for the boils were on the magicians and on all the Egyptians. 
-<span class="v">12&#160;</span>Yahweh hardened the heart of Pharaoh, and he didn’t listen to them, as Yahweh had spoken to Moses. 
-</p><p>
-<span class="v">13&#160;</span>Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
-<span class="v">14&#160;</span>For this time I will send all my plagues against your heart, against your officials, and against your people; that you may know that there is no one like me in all the earth. 
-<span class="v">15&#160;</span>For now I would have stretched out my hand, and struck you and your people with pestilence, and you would have been cut off from the earth; 
-<span class="v">16&#160;</span>but indeed for this cause I have made you stand: to show you my power, and that my name may be declared throughout all the earth, 
-<span class="v">17&#160;</span>because you still exalt yourself against my people, that you won’t let them go. 
-<span class="v">18&#160;</span>Behold, tomorrow about this time I will cause it to rain a very grievous hail, such as has not been in Egypt since the day it was founded even until now. 
-<span class="v">19&#160;</span>Now therefore command that all of your livestock and all that you have in the field be brought into shelter. The hail will come down on every man and animal that is found in the field, and isn’t brought home, and they will die.”&#160;’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>Those who feared Yahweh’s word among the servants of Pharaoh made their servants and their livestock flee into the houses. 
-<span class="v">21&#160;</span>Whoever didn’t respect Yahweh’s word left his servants and his livestock in the field. 
-</p><p>
-<span class="v">22&#160;</span>Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be hail in all the land of Egypt, on man, and on animal, and on every herb of the field, throughout the land of Egypt.” 
-</p><p>
-<span class="v">23&#160;</span>Moses stretched out his rod toward the heavens, and Yahweh sent thunder and hail; and lightning flashed down to the earth. Yahweh rained hail on the land of Egypt. 
-<span class="v">24&#160;</span>So there was very severe hail, and lightning mixed with the hail, such as had not been in all the land of Egypt since it became a nation. 
-<span class="v">25&#160;</span>The hail struck throughout all the land of Egypt all that was in the field, both man and animal; and the hail struck every herb of the field, and broke every tree of the field. 
-<span class="v">26&#160;</span>Only in the land of Goshen, where the children of Israel were, there was no hail. 
-</p><p>
-<span class="v">27&#160;</span>Pharaoh sent and called for Moses and Aaron, and said to them, “I have sinned this time. Yahweh is righteous, and I and my people are wicked. 
-<span class="v">28&#160;</span>Pray to Yahweh; for there has been enough of mighty thunderings and hail. I will let you go, and you shall stay no longer.” 
-</p><p>
-<span class="v">29&#160;</span>Moses said to him, “As soon as I have gone out of the city, I will spread out my hands to Yahweh. The thunders shall cease, and there will not be any more hail; that you may know that the earth is Yahweh’s. 
-<span class="v">30&#160;</span>But as for you and your servants, I know that you don’t yet fear Yahweh Elohim.” 
-</p><p>
-<span class="v">31&#160;</span>The flax and the barley were struck, for the barley had ripened and the flax was blooming. 
-<span class="v">32&#160;</span>But the wheat and the spelt were not struck, for they had not grown up. 
-<span class="v">33&#160;</span>Moses went out of the city from Pharaoh, and spread out his hands to Yahweh; and the thunders and hail ceased, and the rain was not poured on the earth. 
-<span class="v">34&#160;</span>When Pharaoh saw that the rain and the hail and the thunders had ceased, he sinned yet more, and hardened his heart, he and his servants. 
-<span class="v">35&#160;</span>The heart of Pharaoh was hardened, and he didn’t let the children of Israel go, just as Yahweh had spoken through Moses. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, “Go in to Pharaoh, for I have hardened his heart and the heart of his servants, that I may show these my signs among them; 
-<span class="v">2&#160;</span>and that you may tell in the hearing of your son, and of your son’s son, what things I have done to Egypt, and my signs which I have done among them; that you may know that I am Yahweh.” 
-</p><p>
-<span class="v">3&#160;</span>Moses and Aaron went in to Pharaoh, and said to him, “This is what Yahweh, the Elohim of the Hebrews, says: ‘How long will you refuse to humble yourself before me? Let my people go, that they may serve me. 
-<span class="v">4&#160;</span>Or else, if you refuse to let my people go, behold, tomorrow I will bring locusts into your country, 
-<span class="v">5&#160;</span>and they shall cover the surface of the earth, so that one won’t be able to see the earth. They shall eat the residue of that which has escaped, which remains to you from the hail, and shall eat every tree which grows for you out of the field. 
-<span class="v">6&#160;</span>Your houses shall be filled, and the houses of all your servants, and the houses of all the Egyptians, as neither your fathers nor your fathers’ fathers have seen, since the day that they were on the earth to this day.’&#160;” He turned, and went out from Pharaoh. 
-</p><p>
-<span class="v">7&#160;</span>Pharaoh’s servants said to him, “How long will this man be a snare to us? Let the men go, that they may serve Yahweh, their Elohim. Don’t you yet know that Egypt is destroyed?” 
-</p><p>
-<span class="v">8&#160;</span>Moses and Aaron were brought again to Pharaoh, and he said to them, “Go, serve Yahweh your Elohim; but who are those who will go?” 
-</p><p>
-<span class="v">9&#160;</span>Moses said, “We will go with our young and with our old. We will go with our sons and with our daughters, with our flocks and with our herds; for we must hold a feast to Yahweh.” 
-</p><p>
-<span class="v">10&#160;</span>He said to them, “Yahweh be with you if I let you go with your little ones! See, evil is clearly before your faces. 
-<span class="v">11&#160;</span>Not so! Go now you who are men, and serve Yahweh; for that is what you desire!” Then they were driven out from Pharaoh’s presence. 
-</p><p>
-<span class="v">12&#160;</span>Yahweh said to Moses, “Stretch out your hand over the land of Egypt for the locusts, that they may come up on the land of Egypt, and eat every herb of the land, even all that the hail has left.” 
-<span class="v">13&#160;</span>Moses stretched out his rod over the land of Egypt, and Yahweh brought an east wind on the land all that day, and all night; and when it was morning, the east wind brought the locusts. 
-<span class="v">14&#160;</span>The locusts went up over all the land of Egypt, and rested in all the borders of Egypt. They were very grievous. Before them there were no such locusts as they, nor will there ever be again. 
-<span class="v">15&#160;</span>For they covered the surface of the whole earth, so that the land was darkened, and they ate every herb of the land, and all the fruit of the trees which the hail had left. There remained nothing green, either tree or herb of the field, through all the land of Egypt. 
-<span class="v">16&#160;</span>Then Pharaoh called for Moses and Aaron in haste, and he said, “I have sinned against Yahweh your Elohim, and against you. 
-<span class="v">17&#160;</span>Now therefore please forgive my sin again, and pray to Yahweh your Elohim, that he may also take away from me this death.” 
-</p><p>
-<span class="v">18&#160;</span>Moses went out from Pharaoh, and prayed to Yahweh. 
-<span class="v">19&#160;</span>Yahweh sent an exceedingly strong west wind, which took up the locusts, and drove them into the Red Sea.<span class="f">+ \fr 10:19 \ft “Red Sea” is the translation for the Hebrew “Yam Suf”, which could be more literally translated “Sea of Reeds” or “Sea of Cattails”. It refers to the body of water currently known as the Red Sea, or possibly to one of the bodies of water connected to it or near it.</span> There remained not one locust in all the borders of Egypt. 
-<span class="v">20&#160;</span>But Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go. 
-</p><p>
-<span class="v">21&#160;</span>Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be darkness over the land of Egypt, even darkness which may be felt.” 
-<span class="v">22&#160;</span>Moses stretched out his hand toward the sky, and there was a thick darkness in all the land of Egypt for three days. 
-<span class="v">23&#160;</span>They didn’t see one another, and nobody rose from his place for three days; but all the children of Israel had light in their dwellings. 
-</p><p>
-<span class="v">24&#160;</span>Pharaoh called to Moses, and said, “Go, serve Yahweh. Only let your flocks and your herds stay behind. Let your little ones also go with you.” 
-</p><p>
-<span class="v">25&#160;</span>Moses said, “You must also give into our hand sacrifices and burnt offerings, that we may sacrifice to Yahweh our Elohim. 
-<span class="v">26&#160;</span>Our livestock also shall go with us. Not a hoof shall be left behind, for of it we must take to serve Yahweh our Elohim; and we don’t know with what we must serve Yahweh, until we come there.” 
-</p><p>
-<span class="v">27&#160;</span>But Yahweh hardened Pharaoh’s heart, and he wouldn’t let them go. 
-<span class="v">28&#160;</span>Pharaoh said to him, “Get away from me! Be careful to see my face no more; for in the day you see my face you shall die!” 
-</p><p>
-<span class="v">29&#160;</span>Moses said, “You have spoken well. I will see your face again no more.” 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, “I will bring yet one more plague on Pharaoh, and on Egypt; afterwards he will let you go. When he lets you go, he will surely thrust you out altogether. 
-<span class="v">2&#160;</span>Speak now in the ears of the people, and let every man ask of his neighbor, and every woman of her neighbor, jewels of silver, and jewels of gold.” 
-<span class="v">3&#160;</span>Yahweh gave the people favor in the sight of the Egyptians. Moreover, the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people. 
-</p><p>
-<span class="v">4&#160;</span>Moses said, “This is what Yahweh says: ‘About midnight I will go out into the middle of Egypt, 
-<span class="v">5&#160;</span>and all the firstborn in the land of Egypt shall die, from the firstborn of Pharaoh who sits on his throne, even to the firstborn of the female servant who is behind the mill, and all the firstborn of livestock. 
-<span class="v">6&#160;</span>There will be a great cry throughout all the land of Egypt, such as there has not been, nor will be any more. 
-<span class="v">7&#160;</span>But against any of the children of Israel a dog won’t even bark or move its tongue, against man or animal, that you may know that Yahweh makes a distinction between the Egyptians and Israel. 
-<span class="v">8&#160;</span>All these servants of yours will come down to me, and bow down themselves to me, saying, “Get out, with all the people who follow you;” and after that I will go out.’&#160;” He went out from Pharaoh in hot anger. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh said to Moses, “Pharaoh won’t listen to you, that my wonders may be multiplied in the land of Egypt.” 
-<span class="v">10&#160;</span>Moses and Aaron did all these wonders before Pharaoh, but Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go out of his land. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and Aaron in the land of Egypt, saying, 
-<span class="v">2&#160;</span>“This month shall be to you the beginning of months. It shall be the first month of the year to you. 
-<span class="v">3&#160;</span>Speak to all the congregation of Israel, saying, ‘On the tenth day of this month, they shall take to them every man a lamb, according to their fathers’ houses, a lamb for a household; 
-<span class="v">4&#160;</span>and if the household is too little for a lamb, then he and his neighbor next to his house shall take one according to the number of the souls. You shall make your count for the lamb according to what everyone can eat. 
-<span class="v">5&#160;</span>Your lamb shall be without defect, a male a year old. You shall take it from the sheep or from the goats. 
-<span class="v">6&#160;</span>You shall keep it until the fourteenth day of the same month; and the whole assembly of the congregation of Israel shall kill it at evening. 
-<span class="v">7&#160;</span>They shall take some of the blood, and put it on the two door posts and on the lintel, on the houses in which they shall eat it. 
-<span class="v">8&#160;</span>They shall eat the meat in that night, roasted with fire, with unleavened bread. They shall eat it with bitter herbs. 
-<span class="v">9&#160;</span>Don’t eat it raw, nor boiled at all with water, but roasted with fire; with its head, its legs and its inner parts. 
-<span class="v">10&#160;</span>You shall let nothing of it remain until the morning; but that which remains of it until the morning you shall burn with fire. 
-<span class="v">11&#160;</span>This is how you shall eat it: with your belt on your waist, your sandals on your feet, and your staff in your hand; and you shall eat it in haste: it is Yahweh’s Passover. 
-<span class="v">12&#160;</span>For I will go through the land of Egypt in that night, and will strike all the firstborn in the land of Egypt, both man and animal. I will execute judgments against all the elohims of Egypt. I am Yahweh. 
-<span class="v">13&#160;</span>The blood shall be to you for a token on the houses where you are. When I see the blood, I will pass over you, and no plague will be on you to destroy you when I strike the land of Egypt. 
-<span class="v">14&#160;</span>This day shall be a memorial for you. You shall keep it as a feast to Yahweh. You shall keep it as a feast throughout your generations by an ordinance forever. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘Seven days you shall eat unleavened bread; even the first day you shall put away yeast out of your houses, for whoever eats leavened bread from the first day until the seventh day, that soul shall be cut off from Israel. 
-<span class="v">16&#160;</span>In the first day there shall be to you a set-apart convocation, and in the seventh day a set-apart convocation; no kind of work shall be done in them, except that which every man must eat, only that may be done by you. 
-<span class="v">17&#160;</span>You shall observe the feast of unleavened bread; for in this same day I have brought your armies out of the land of Egypt. Therefore you shall observe this day throughout your generations by an ordinance forever. 
-<span class="v">18&#160;</span>In the first month, on the fourteenth day of the month at evening, you shall eat unleavened bread, until the twenty first day of the month at evening. 
-<span class="v">19&#160;</span>There shall be no yeast found in your houses for seven days, for whoever eats that which is leavened, that soul shall be cut off from the congregation of Israel, whether he is a foreigner, or one who is born in the land. 
-<span class="v">20&#160;</span>You shall eat nothing leavened. In all your habitations you shall eat unleavened bread.’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>Then Moses called for all the elders of Israel, and said to them, “Draw out, and take lambs according to your families, and kill the Passover. 
-<span class="v">22&#160;</span>You shall take a bunch of hyssop, and dip it in the blood that is in the basin, and strike the lintel and the two door posts with the blood that is in the basin. None of you shall go out of the door of his house until the morning. 
-<span class="v">23&#160;</span>For Yahweh will pass through to strike the Egyptians; and when he sees the blood on the lintel, and on the two door posts, Yahweh will pass over the door, and will not allow the destroyer to come in to your houses to strike you. 
-<span class="v">24&#160;</span>You shall observe this thing for an ordinance to you and to your sons forever. 
-<span class="v">25&#160;</span>It shall happen when you have come to the land which Yahweh will give you, as he has promised, that you shall keep this service. 
-<span class="v">26&#160;</span>It will happen, when your children ask you, ‘What do you mean by this service?’ 
-<span class="v">27&#160;</span>that you shall say, ‘It is the sacrifice of Yahweh’s Passover, who passed over the houses of the children of Israel in Egypt, when he struck the Egyptians, and spared our houses.’&#160;” 
-</p><p>The people bowed their heads and worshiped. 
-<span class="v">28&#160;</span>The children of Israel went and did so; as Yahweh had commanded Moses and Aaron, so they did. 
-</p><p>
-<span class="v">29&#160;</span>At midnight, Yahweh struck all the firstborn in the land of Egypt, from the firstborn of Pharaoh who sat on his throne to the firstborn of the captive who was in the dungeon, and all the firstborn of livestock. 
-<span class="v">30&#160;</span>Pharaoh rose up in the night, he, and all his servants, and all the Egyptians; and there was a great cry in Egypt, for there was not a house where there was not one dead. 
-<span class="v">31&#160;</span>He called for Moses and Aaron by night, and said, “Rise up, get out from among my people, both you and the children of Israel; and go, serve Yahweh, as you have said! 
-<span class="v">32&#160;</span>Take both your flocks and your herds, as you have said, and be gone; and bless me also!” 
-</p><p>
-<span class="v">33&#160;</span>The Egyptians were urgent with the people, to send them out of the land in haste, for they said, “We are all dead men.” 
-<span class="v">34&#160;</span>The people took their dough before it was leavened, their kneading troughs being bound up in their clothes on their shoulders. 
-<span class="v">35&#160;</span>The children of Israel did according to the word of Moses; and they asked of the Egyptians jewels of silver, and jewels of gold, and clothing. 
-<span class="v">36&#160;</span>Yahweh gave the people favor in the sight of the Egyptians, so that they let them have what they asked. They plundered the Egyptians. 
-</p><p>
-<span class="v">37&#160;</span>The children of Israel traveled from Rameses to Succoth, about six hundred thousand on foot who were men, in addition to children. 
-<span class="v">38&#160;</span>A mixed multitude went up also with them, with flocks, herds, and even very much livestock. 
-<span class="v">39&#160;</span>They baked unleavened cakes of the dough which they brought out of Egypt; for it wasn’t leavened, because they were thrust out of Egypt, and couldn’t wait, and they had not prepared any food for themselves. 
-<span class="v">40&#160;</span>Now the time that the children of Israel lived in Egypt was four hundred thirty years. 
-<span class="v">41&#160;</span>At the end of four hundred thirty years, to the day, all of Yahweh’s armies went out from the land of Egypt. 
-<span class="v">42&#160;</span>It is a night to be much observed to Yahweh for bringing them out from the land of Egypt. This is that night of Yahweh, to be much observed by all the children of Israel throughout their generations. 
-</p><p>
-<span class="v">43&#160;</span>Yahweh said to Moses and Aaron, “This is the ordinance of the Passover. No foreigner shall eat of it, 
-<span class="v">44&#160;</span>but every man’s servant who is bought for money, when you have circumcised him, then shall he eat of it. 
-<span class="v">45&#160;</span>A foreigner and a hired servant shall not eat of it. 
-<span class="v">46&#160;</span>It must be eaten in one house. You shall not carry any of the meat outside of the house. Do not break any of its bones. 
-<span class="v">47&#160;</span>All the congregation of Israel shall keep it. 
-<span class="v">48&#160;</span>When a stranger lives as a foreigner with you, and would like to keep the Passover to Yahweh, let all his males be circumcised, and then let him come near and keep it. He shall be as one who is born in the land; but no uncircumcised person shall eat of it. 
-<span class="v">49&#160;</span>One law shall be to him who is born at home, and to the stranger who lives as a foreigner among you.” 
-<span class="v">50&#160;</span>All the children of Israel did so. As Yahweh commanded Moses and Aaron, so they did. 
-<span class="v">51&#160;</span>That same day, Yahweh brought the children of Israel out of the land of Egypt by their armies. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Sanctify to me all the firstborn, whatever opens the womb among the children of Israel, both of man and of animal. It is mine.” 
-</p><p>
-<span class="v">3&#160;</span>Moses said to the people, “Remember this day, in which you came out of Egypt, out of the house of bondage; for by strength of hand Yahweh brought you out from this place. No leavened bread shall be eaten. 
-<span class="v">4&#160;</span>Today you go out in the month Abib. 
-<span class="v">5&#160;</span>It shall be, when Yahweh brings you into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which he swore to your fathers to give you, a land flowing with milk and honey, that you shall keep this service in this month. 
-<span class="v">6&#160;</span>Seven days you shall eat unleavened bread, and in the seventh day shall be a feast to Yahweh. 
-<span class="v">7&#160;</span>Unleavened bread shall be eaten throughout the seven days; and no leavened bread shall be seen with you. No yeast shall be seen with you, within all your borders. 
-<span class="v">8&#160;</span>You shall tell your son in that day, saying, ‘It is because of that which Yahweh did for me when I came out of Egypt.’ 
-<span class="v">9&#160;</span>It shall be for a sign to you on your hand, and for a memorial between your eyes, that Yahweh’s law may be in your mouth; for with a strong hand Yahweh has brought you out of Egypt. 
-<span class="v">10&#160;</span>You shall therefore keep this ordinance in its season from year to year. 
-</p><p>
-<span class="v">11&#160;</span>“It shall be, when Yahweh brings you into the land of the Canaanite, as he swore to you and to your fathers, and will give it to you, 
-<span class="v">12&#160;</span>that you shall set apart to Yahweh all that opens the womb, and every firstborn that comes from an animal which you have. The males shall be Yahweh’s. 
-<span class="v">13&#160;</span>Every firstborn of a donkey you shall redeem with a lamb; and if you will not redeem it, then you shall break its neck; and you shall redeem all the firstborn of man among your sons. 
-<span class="v">14&#160;</span>It shall be, when your son asks you in time to come, saying, ‘What is this?’ that you shall tell him, ‘By strength of hand Yahweh brought us out from Egypt, from the house of bondage. 
-<span class="v">15&#160;</span>When Pharaoh stubbornly refused to let us go, Yahweh killed all the firstborn in the land of Egypt, both the firstborn of man, and the firstborn of livestock. Therefore I sacrifice to Yahweh all that opens the womb, being males; but all the firstborn of my sons I redeem.’ 
-<span class="v">16&#160;</span>It shall be for a sign on your hand, and for symbols between your eyes; for by strength of hand Yahweh brought us out of Egypt.” 
-</p><p>
-<span class="v">17&#160;</span>When Pharaoh had let the people go, Elohim didn’t lead them by the way of the land of the Philistines, although that was near; for Elohim said, “Lest perhaps the people change their minds when they see war, and they return to Egypt”; 
-<span class="v">18&#160;</span>but Elohim led the people around by the way of the wilderness by the Red Sea; and the children of Israel went up armed out of the land of Egypt. 
-<span class="v">19&#160;</span>Moses took the bones of Joseph with him, for he had made the children of Israel swear, saying, “Elohim will surely visit you, and you shall carry up my bones away from here with you.” 
-<span class="v">20&#160;</span>They took their journey from Succoth, and encamped in Etham, in the edge of the wilderness. 
-<span class="v">21&#160;</span>Yahweh went before them by day in a pillar of cloud, to lead them on their way, and by night in a pillar of fire, to give them light, that they might go by day and by night: 
-<span class="v">22&#160;</span>the pillar of cloud by day, and the pillar of fire by night, didn’t depart from before the people. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, that they turn back and encamp before Pihahiroth, between Migdol and the sea, before Baal Zephon. You shall encamp opposite it by the sea. 
-<span class="v">3&#160;</span>Pharaoh will say of the children of Israel, ‘They are entangled in the land. The wilderness has shut them in.’ 
-<span class="v">4&#160;</span>I will harden Pharaoh’s heart, and he will follow after them; and I will get honor over Pharaoh, and over all his armies; and the Egyptians shall know that I am Yahweh.” They did so. 
-</p><p>
-<span class="v">5&#160;</span>The king of Egypt was told that the people had fled; and the heart of Pharaoh and of his servants was changed toward the people, and they said, “What is this we have done, that we have let Israel go from serving us?” 
-<span class="v">6&#160;</span>He prepared his chariot, and took his army with him; 
-<span class="v">7&#160;</span>and he took six hundred chosen chariots, and all the chariots of Egypt, with captains over all of them. 
-<span class="v">8&#160;</span>Yahweh hardened the heart of Pharaoh king of Egypt, and he pursued the children of Israel; for the children of Israel went out with a high hand.<span class="f">+ \fr 14:8 \ft or, defiantly.</span> 
-<span class="v">9&#160;</span>The Egyptians pursued them. All the horses and chariots of Pharaoh, his horsemen, and his army overtook them encamping by the sea, beside Pihahiroth, before Baal Zephon. 
-</p><p>
-<span class="v">10&#160;</span>When Pharaoh came near, the children of Israel lifted up their eyes, and behold, the Egyptians were marching after them; and they were very afraid. The children of Israel cried out to Yahweh. 
-<span class="v">11&#160;</span>They said to Moses, “Because there were no graves in Egypt, have you taken us away to die in the wilderness? Why have you treated us this way, to bring us out of Egypt? 
-<span class="v">12&#160;</span>Isn’t this the word that we spoke to you in Egypt, saying, ‘Leave us alone, that we may serve the Egyptians’? For it would have been better for us to serve the Egyptians than to die in the wilderness.” 
-</p><p>
-<span class="v">13&#160;</span>Moses said to the people, “Don’t be afraid. Stand still, and see the salvation of Yahweh, which he will work for you today; for you will never again see the Egyptians whom you have seen today. 
-<span class="v">14&#160;</span>Yahweh will fight for you, and you shall be still.” 
-</p><p>
-<span class="v">15&#160;</span>Yahweh said to Moses, “Why do you cry to me? Speak to the children of Israel, that they go forward. 
-<span class="v">16&#160;</span>Lift up your rod, and stretch out your hand over the sea and divide it. Then the children of Israel shall go into the middle of the sea on dry ground. 
-<span class="v">17&#160;</span>Behold, I myself will harden the hearts of the Egyptians, and they will go in after them. I will get myself honor over Pharaoh, and over all his armies, over his chariots, and over his horsemen. 
-<span class="v">18&#160;</span>The Egyptians shall know that I am Yahweh when I have gotten myself honor over Pharaoh, over his chariots, and over his horsemen.” 
-<span class="v">19&#160;</span>The angel of Elohim, who went before the camp of Israel, moved and went behind them; and the pillar of cloud moved from before them, and stood behind them. 
-<span class="v">20&#160;</span>It came between the camp of Egypt and the camp of Israel. There was the cloud and the darkness, yet it gave light by night. One didn’t come near the other all night. 
-</p><p>
-<span class="v">21&#160;</span>Moses stretched out his hand over the sea, and Yahweh caused the sea to go back by a strong east wind all night, and made the sea dry land, and the waters were divided. 
-<span class="v">22&#160;</span>The children of Israel went into the middle of the sea on the dry ground; and the waters were a wall to them on their right hand and on their left. 
-<span class="v">23&#160;</span>The Egyptians pursued, and went in after them into the middle of the sea: all of Pharaoh’s horses, his chariots, and his horsemen. 
-<span class="v">24&#160;</span>In the morning watch, Yahweh looked out on the Egyptian army through the pillar of fire and of cloud, and confused the Egyptian army. 
-<span class="v">25&#160;</span>He took off their chariot wheels, and they drove them heavily; so that the Egyptians said, “Let’s flee from the face of Israel, for Yahweh fights for them against the Egyptians!” 
-</p><p>
-<span class="v">26&#160;</span>Yahweh said to Moses, “Stretch out your hand over the sea, that the waters may come again on the Egyptians, on their chariots, and on their horsemen.” 
-<span class="v">27&#160;</span>Moses stretched out his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it. Yahweh overthrew the Egyptians in the middle of the sea. 
-<span class="v">28&#160;</span>The waters returned, and covered the chariots and the horsemen, even all Pharaoh’s army that went in after them into the sea. There remained not so much as one of them. 
-<span class="v">29&#160;</span>But the children of Israel walked on dry land in the middle of the sea, and the waters were a wall to them on their right hand and on their left. 
-<span class="v">30&#160;</span>Thus Yahweh saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead on the seashore. 
-<span class="v">31&#160;</span>Israel saw the great work which Yahweh did to the Egyptians, and the people feared Yahweh; and they believed in Yahweh and in his servant Moses. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Then Moses and the children of Israel sang this song to Yahweh, and said, 
-</p><p class="q1">“I will sing to Yahweh, for he has triumphed gloriously. 
-</p><p class="q2">He has thrown the horse and his rider into the sea. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yah is my strength and song. 
-</p><p class="q2">He has become my salvation. 
-</p><p class="q1">This is my Elohim, and I will praise him; 
-</p><p class="q2">my father’s Elohim, and I will exalt him. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh is a man of war. 
-</p><p class="q2">Yahweh is his name. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He has cast Pharaoh’s chariots and his army into the sea. 
-</p><p class="q2">His chosen captains are sunk in the Red Sea. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The deeps cover them. 
-</p><p class="q2">They went down into the depths like a stone. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Your right hand, Yahweh, is glorious in power. 
-</p><p class="q2">Your right hand, Yahweh, dashes the enemy in pieces. 
-</p><p class="q1">
-<span class="v">7&#160;</span>In the greatness of your excellency, you overthrow those who rise up against you. 
-</p><p class="q2">You send out your wrath. It consumes them as stubble. 
-</p><p class="q1">
-<span class="v">8&#160;</span>With the blast of your nostrils, the waters were piled up. 
-</p><p class="q2">The floods stood upright as a heap. 
-</p><p class="q2">The deeps were congealed in the heart of the sea. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The enemy said, ‘I will pursue. I will overtake. I will divide the plunder. 
-</p><p class="q2">My desire will be satisfied on them. 
-</p><p class="q2">I will draw my sword. My hand will destroy them.’ 
-</p><p class="q1">
-<span class="v">10&#160;</span>You blew with your wind. 
-</p><p class="q2">The sea covered them. 
-</p><p class="q2">They sank like lead in the mighty waters. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Who is like you, Yahweh, among the elohims? 
-</p><p class="q2">Who is like you, glorious in set-apartness, 
-</p><p class="q2">fearful in praises, doing wonders? 
-</p><p class="q1">
-<span class="v">12&#160;</span>You stretched out your right hand. 
-</p><p class="q2">The earth swallowed them. 
-</p><p class="q1">
-<span class="v">13&#160;</span>“You, in your loving kindness, have led the people that you have redeemed. 
-</p><p class="q2">You have guided them in your strength to your set-apart habitation. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The peoples have heard. 
-</p><p class="q2">They tremble. 
-</p><p class="q2">Pangs have taken hold of the inhabitants of Philistia. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Then the chiefs of Edom were dismayed. 
-</p><p class="q2">Trembling takes hold of the mighty men of Moab. 
-</p><p class="q2">All the inhabitants of Canaan have melted away. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Terror and dread falls on them. 
-</p><p class="q2">By the greatness of your arm they are as still as a stone, 
-</p><p class="q2">until your people pass over, Yahweh, 
-</p><p class="q2">until the people you have purchased pass over. 
-</p><p class="q2">
-<span class="v">17&#160;</span>You will bring them in, and plant them in the mountain of your inheritance, 
-</p><p class="q2">the place, Yahweh, which you have made for yourself to dwell in: 
-</p><p class="q2">the sanctuary, Lord, which your hands have established. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yahweh will reign forever and ever.” 
-</p><p>
-<span class="v">19&#160;</span>For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and Yahweh brought back the waters of the sea on them; but the children of Israel walked on dry land in the middle of the sea. 
-<span class="v">20&#160;</span>Miriam the prophetess, the sister of Aaron, took a tambourine in her hand; and all the women went out after her with tambourines and with dances. 
-<span class="v">21&#160;</span>Miriam answered them, 
-</p><p class="q1">“Sing to Yahweh, for he has triumphed gloriously. 
-</p><p class="q1">He has thrown the horse and his rider into the sea.” 
-</p><p>
-<span class="v">22&#160;</span>Moses led Israel onward from the Red Sea, and they went out into the wilderness of Shur; and they went three days in the wilderness, and found no water. 
-<span class="v">23&#160;</span>When they came to Marah, they couldn’t drink from the waters of Marah, for they were bitter. Therefore its name was called Marah.<span class="f">+ \fr 15:23 \ft Marah means bitter.</span> 
-<span class="v">24&#160;</span>The people murmured against Moses, saying, “What shall we drink?” 
-<span class="v">25&#160;</span>Then he cried to Yahweh. Yahweh showed him a tree, and he threw it into the waters, and the waters were made sweet. There he made a statute and an ordinance for them, and there he tested them. 
-<span class="v">26&#160;</span>He said, “If you will diligently listen to Yahweh your Elohim’s voice, and will do that which is right in his eyes, and will pay attention to his commandments, and keep all his statutes, I will put none of the diseases on you which I have put on the Egyptians; for I am Yahweh who heals you.” 
-</p><p>
-<span class="v">27&#160;</span>They came to Elim, where there were twelve springs of water and seventy palm trees. They encamped there by the waters. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>They took their journey from Elim, and all the congregation of the children of Israel came to the wilderness of Sin, which is between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt. 
-<span class="v">2&#160;</span>The whole congregation of the children of Israel murmured against Moses and against Aaron in the wilderness; 
-<span class="v">3&#160;</span>and the children of Israel said to them, “We wish that we had died by Yahweh’s hand in the land of Egypt, when we sat by the meat pots, when we ate our fill of bread, for you have brought us out into this wilderness to kill this whole assembly with hunger.” 
-</p><p>
-<span class="v">4&#160;</span>Then Yahweh said to Moses, “Behold, I will rain bread from the sky for you, and the people shall go out and gather a day’s portion every day, that I may test them, whether they will walk in my law or not. 
-<span class="v">5&#160;</span>It shall come to pass on the sixth day, that they shall prepare that which they bring in, and it shall be twice as much as they gather daily.” 
-</p><p>
-<span class="v">6&#160;</span>Moses and Aaron said to all the children of Israel, “At evening, you shall know that Yahweh has brought you out from the land of Egypt. 
-<span class="v">7&#160;</span>In the morning, you shall see Yahweh’s glory; because he hears your murmurings against Yahweh. Who are we, that you murmur against us?” 
-<span class="v">8&#160;</span>Moses said, “Now Yahweh will give you meat to eat in the evening, and in the morning bread to satisfy you, because Yahweh hears your murmurings which you murmur against him. And who are we? Your murmurings are not against us, but against Yahweh.” 
-<span class="v">9&#160;</span>Moses said to Aaron, “Tell all the congregation of the children of Israel, ‘Come close to Yahweh, for he has heard your murmurings.’&#160;” 
-<span class="v">10&#160;</span>As Aaron spoke to the whole congregation of the children of Israel, they looked toward the wilderness, and behold, Yahweh’s glory appeared in the cloud. 
-<span class="v">11&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">12&#160;</span>“I have heard the murmurings of the children of Israel. Speak to them, saying, ‘At evening you shall eat meat, and in the morning you shall be filled with bread. Then you will know that I am Yahweh your Elohim.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>In the evening, quail came up and covered the camp; and in the morning the dew lay around the camp. 
-<span class="v">14&#160;</span>When the dew that lay had gone, behold, on the surface of the wilderness was a small round thing, small as the frost on the ground. 
-<span class="v">15&#160;</span>When the children of Israel saw it, they said to one another, “What is it?” For they didn’t know what it was. Moses said to them, “It is the bread which Yahweh has given you to eat. 
-<span class="v">16&#160;</span>This is the thing which Yahweh has commanded: ‘Gather of it everyone according to his eating; an omer<span class="f">+ \fr 16:16 \ft An omer is about 2.2 liters or about 2.3 quarts</span> a head, according to the number of your persons, you shall take it, every man for those who are in his tent.’&#160;” 
-<span class="v">17&#160;</span>The children of Israel did so, and some gathered more, some less. 
-<span class="v">18&#160;</span>When they measured it with an omer, he who gathered much had nothing over, and he who gathered little had no lack. They each gathered according to his eating. 
-<span class="v">19&#160;</span>Moses said to them, “Let no one leave of it until the morning.” 
-<span class="v">20&#160;</span>Notwithstanding they didn’t listen to Moses, but some of them left of it until the morning, so it bred worms and became foul; and Moses was angry with them. 
-<span class="v">21&#160;</span>They gathered it morning by morning, everyone according to his eating. When the sun grew hot, it melted. 
-<span class="v">22&#160;</span>On the sixth day, they gathered twice as much bread, two omers for each one; and all the rulers of the congregation came and told Moses. 
-<span class="v">23&#160;</span>He said to them, “This is that which Yahweh has spoken, ‘Tomorrow is a solemn rest, a set-apart Sabbath to Yahweh. Bake that which you want to bake, and boil that which you want to boil; and all that remains over lay up for yourselves to be kept until the morning.’&#160;” 
-<span class="v">24&#160;</span>They laid it up until the morning, as Moses ordered, and it didn’t become foul, and there were no worms in it. 
-<span class="v">25&#160;</span>Moses said, “Eat that today, for today is a Sabbath to Yahweh. Today you shall not find it in the field. 
-<span class="v">26&#160;</span>Six days you shall gather it, but on the seventh day is the Sabbath. In it there shall be none.” 
-<span class="v">27&#160;</span>On the seventh day, some of the people went out to gather, and they found none. 
-<span class="v">28&#160;</span>Yahweh said to Moses, “How long do you refuse to keep my commandments and my laws? 
-<span class="v">29&#160;</span>Behold, because Yahweh has given you the Sabbath, therefore he gives you on the sixth day the bread of two days. Everyone stay in his place. Let no one go out of his place on the seventh day.” 
-<span class="v">30&#160;</span>So the people rested on the seventh day. 
-</p><p>
-<span class="v">31&#160;</span>The house of Israel called its name “Manna”,<span class="f">+ \fr 16:31 \ft “Manna” means “What is it?”</span> and it was like coriander seed, white; and its taste was like wafers with honey. 
-<span class="v">32&#160;</span>Moses said, “This is the thing which Yahweh has commanded, ‘Let an omer-full of it be kept throughout your generations, that they may see the bread with which I fed you in the wilderness, when I brought you out of the land of Egypt.’&#160;” 
-<span class="v">33&#160;</span>Moses said to Aaron, “Take a pot, and put an omer-full of manna in it, and lay it up before Yahweh, to be kept throughout your generations.” 
-<span class="v">34&#160;</span>As Yahweh commanded Moses, so Aaron laid it up before the Testimony, to be kept. 
-<span class="v">35&#160;</span>The children of Israel ate the manna forty years, until they came to an inhabited land. They ate the manna until they came to the borders of the land of Canaan. 
-<span class="v">36&#160;</span>Now an omer is one tenth of an ephah.<span class="f">+ \fr 16:36 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>All the congregation of the children of Israel traveled from the wilderness of Sin, starting according to Yahweh’s commandment, and encamped in Rephidim; but there was no water for the people to drink. 
-<span class="v">2&#160;</span>Therefore the people quarreled with Moses, and said, “Give us water to drink.” 
-</p><p>Moses said to them, “Why do you quarrel with me? Why do you test Yahweh?” 
-</p><p>
-<span class="v">3&#160;</span>The people were thirsty for water there; so the people murmured against Moses, and said, “Why have you brought us up out of Egypt, to kill us, our children, and our livestock with thirst?” 
-</p><p>
-<span class="v">4&#160;</span>Moses cried to Yahweh, saying, “What shall I do with these people? They are almost ready to stone me.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh said to Moses, “Walk on before the people, and take the elders of Israel with you, and take the rod in your hand with which you struck the Nile, and go. 
-<span class="v">6&#160;</span>Behold, I will stand before you there on the rock in Horeb. You shall strike the rock, and water will come out of it, that the people may drink.” Moses did so in the sight of the elders of Israel. 
-<span class="v">7&#160;</span>He called the name of the place Massah,<span class="f">+ \fr 17:7 \ft Massah means testing. </span> and Meribah,<span class="f">+ \fr 17:7 \ft Meribah means quarreling.</span> because the children of Israel quarreled, and because they tested Yahweh, saying, “Is Yahweh among us, or not?” 
-</p><p>
-<span class="v">8&#160;</span>Then Amalek came and fought with Israel in Rephidim. 
-<span class="v">9&#160;</span>Moses said to Joshua, “Choose men for us, and go out to fight with Amalek. Tomorrow I will stand on the top of the hill with Elohim’s rod in my hand.” 
-<span class="v">10&#160;</span>So Joshua did as Moses had told him, and fought with Amalek; and Moses, Aaron, and Hur went up to the top of the hill. 
-<span class="v">11&#160;</span>When Moses held up his hand, Israel prevailed. When he let down his hand, Amalek prevailed. 
-<span class="v">12&#160;</span>But Moses’ hands were heavy; so they took a stone, and put it under him, and he sat on it. Aaron and Hur held up his hands, the one on the one side, and the other on the other side. His hands were steady until sunset. 
-<span class="v">13&#160;</span>Joshua defeated Amalek and his people with the edge of the sword. 
-<span class="v">14&#160;</span>Yahweh said to Moses, “Write this for a memorial in a book, and rehearse it in the ears of Joshua: that I will utterly blot out the memory of Amalek from under the sky.” 
-<span class="v">15&#160;</span>Moses built an altar, and called its name “Yahweh our Banner”.<span class="f">+ \fr 17:15 \ft Hebrew, Yahweh Nissi</span> 
-<span class="v">16&#160;</span>He said, “Yah has sworn: ‘Yahweh will have war with Amalek from generation to generation.’&#160;” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Now Jethro, the priest of Midian, Moses’ father-in-law, heard of all that Elohim had done for Moses and for Israel his people, how Yahweh had brought Israel out of Egypt. 
-<span class="v">2&#160;</span>Jethro, Moses’ father-in-law, received Zipporah, Moses’ woman, after he had sent her away, 
-<span class="v">3&#160;</span>and her two sons. The name of one son was Gershom,<span class="f">+ \fr 18:3 \ft “Gershom” sounds like the Hebrew for “an alien there”.</span> for Moses said, “I have lived as a foreigner in a foreign land”. 
-<span class="v">4&#160;</span>The name of the other was Eliezer,<span class="f">+ \fr 18:4 \ft Eliezer means “Elohim is my helper”. </span> for he said, “My father’s Elohim was my help and delivered me from Pharaoh’s sword.” 
-<span class="v">5&#160;</span>Jethro, Moses’ father-in-law, came with Moses’ sons and his woman to Moses into the wilderness where he was encamped, at the Mountain of Elohim. 
-<span class="v">6&#160;</span>He said to Moses, “I, your father-in-law Jethro, have come to you with your woman, and her two sons with her.” 
-</p><p>
-<span class="v">7&#160;</span>Moses went out to meet his father-in-law, and bowed and kissed him. They asked each other of their welfare, and they came into the tent. 
-<span class="v">8&#160;</span>Moses told his father-in-law all that Yahweh had done to Pharaoh and to the Egyptians for Israel’s sake, all the hardships that had come on them on the way, and how Yahweh delivered them. 
-<span class="v">9&#160;</span>Jethro rejoiced for all the goodness which Yahweh had done to Israel, in that he had delivered them out of the hand of the Egyptians. 
-<span class="v">10&#160;</span>Jethro said, “Blessed be Yahweh, who has delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who has delivered the people from under the hand of the Egyptians. 
-<span class="v">11&#160;</span>Now I know that Yahweh is greater than all elohims because of the way that they treated people arrogantly.” 
-<span class="v">12&#160;</span>Jethro, Moses’ father-in-law, took a burnt offering and sacrifices for Elohim. Aaron came with all the elders of Israel, to eat bread with Moses’ father-in-law before Elohim. 
-</p><p>
-<span class="v">13&#160;</span>On the next day, Moses sat to judge the people, and the people stood around Moses from the morning to the evening. 
-<span class="v">14&#160;</span>When Moses’ father-in-law saw all that he did to the people, he said, “What is this thing that you do for the people? Why do you sit alone, and all the people stand around you from morning to evening?” 
-</p><p>
-<span class="v">15&#160;</span>Moses said to his father-in-law, “Because the people come to me to inquire of Elohim. 
-<span class="v">16&#160;</span>When they have a matter, they come to me, and I judge between a man and his neighbor, and I make them know the statutes of Elohim, and his laws.” 
-<span class="v">17&#160;</span>Moses’ father-in-law said to him, “The thing that you do is not good. 
-<span class="v">18&#160;</span>You will surely wear away, both you, and this people that is with you; for the thing is too heavy for you. You are not able to perform it yourself alone. 
-<span class="v">19&#160;</span>Listen now to my voice. I will give you counsel, and Elohim be with you. You represent the people before Elohim, and bring the causes to Elohim. 
-<span class="v">20&#160;</span>You shall teach them the statutes and the laws, and shall show them the way in which they must walk, and the work that they must do. 
-<span class="v">21&#160;</span>Moreover you shall provide out of all the people able men which fear Elohim: men of truth, hating unjust gain; and place such over them, to be rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens. 
-<span class="v">22&#160;</span>Let them judge the people at all times. It shall be that every great matter they shall bring to you, but every small matter they shall judge themselves. So shall it be easier for you, and they shall share the load with you. 
-<span class="v">23&#160;</span>If you will do this thing, and Elohim commands you so, then you will be able to endure, and all these people also will go to their place in peace.” 
-</p><p>
-<span class="v">24&#160;</span>So Moses listened to the voice of his father-in-law, and did all that he had said. 
-<span class="v">25&#160;</span>Moses chose able men out of all Israel, and made them heads over the people, rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens. 
-<span class="v">26&#160;</span>They judged the people at all times. They brought the hard cases to Moses, but every small matter they judged themselves. 
-<span class="v">27&#160;</span>Moses let his father-in-law depart, and he went his way into his own land. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>In the third month after the children of Israel had gone out of the land of Egypt, on that same day they came into the wilderness of Sinai. 
-<span class="v">2&#160;</span>When they had departed from Rephidim, and had come to the wilderness of Sinai, they encamped in the wilderness; and there Israel encamped before the mountain. 
-<span class="v">3&#160;</span>Moses went up to Elohim, and Yahweh called to him out of the mountain, saying, “This is what you shall tell the house of Jacob, and tell the children of Israel: 
-<span class="v">4&#160;</span>‘You have seen what I did to the Egyptians, and how I bore you on eagles’ wings, and brought you to myself. 
-<span class="v">5&#160;</span>Now therefore, if you will indeed obey my voice and keep my covenant, then you shall be my own possession from among all peoples; for all the earth is mine; 
-<span class="v">6&#160;</span>and you shall be to me a kingdom of priests and a set-apart nation.’ These are the words which you shall speak to the children of Israel.” 
-</p><p>
-<span class="v">7&#160;</span>Moses came and called for the elders of the people, and set before them all these words which Yahweh commanded him. 
-<span class="v">8&#160;</span>All the people answered together, and said, “All that Yahweh has spoken we will do.” 
-</p><p>Moses reported the words of the people to Yahweh. 
-<span class="v">9&#160;</span>Yahweh said to Moses, “Behold, I come to you in a thick cloud, that the people may hear when I speak with you, and may also believe you forever.” Moses told the words of the people to Yahweh. 
-<span class="v">10&#160;</span>Yahweh said to Moses, “Go to the people, and sanctify them today and tomorrow, and let them wash their garments, 
-<span class="v">11&#160;</span>and be ready for the third day; for on the third day Yahweh will come down in the sight of all the people on Mount Sinai. 
-<span class="v">12&#160;</span>You shall set bounds to the people all around, saying, ‘Be careful that you don’t go up onto the mountain, or touch its border. Whoever touches the mountain shall be surely put to death. 
-<span class="v">13&#160;</span>No hand shall touch him, but he shall surely be stoned or shot through; whether it is animal or man, he shall not live.’ When the trumpet sounds long, they shall come up to the mountain.” 
-</p><p>
-<span class="v">14&#160;</span>Moses went down from the mountain to the people, and sanctified the people; and they washed their clothes. 
-<span class="v">15&#160;</span>He said to the people, “Be ready by the third day. Don’t have sexual relations with a woman.” 
-</p><p>
-<span class="v">16&#160;</span>On the third day, when it was morning, there were thunders and lightnings, and a thick cloud on the mountain, and the sound of an exceedingly loud trumpet; and all the people who were in the camp trembled. 
-<span class="v">17&#160;</span>Moses led the people out of the camp to meet Elohim; and they stood at the lower part of the mountain. 
-<span class="v">18&#160;</span>All of Mount Sinai smoked, because Yahweh descended on it in fire; and its smoke ascended like the smoke of a furnace, and the whole mountain quaked greatly. 
-<span class="v">19&#160;</span>When the sound of the trumpet grew louder and louder, Moses spoke, and Elohim answered him by a voice. 
-<span class="v">20&#160;</span>Yahweh came down on Mount Sinai, to the top of the mountain. Yahweh called Moses to the top of the mountain, and Moses went up. 
-</p><p>
-<span class="v">21&#160;</span>Yahweh said to Moses, “Go down, warn the people, lest they break through to Yahweh to gaze, and many of them perish. 
-<span class="v">22&#160;</span>Let the priests also, who come near to Yahweh, sanctify themselves, lest Yahweh break out on them.” 
-</p><p>
-<span class="v">23&#160;</span>Moses said to Yahweh, “The people can’t come up to Mount Sinai, for you warned us, saying, ‘Set bounds around the mountain, and sanctify it.’&#160;” 
-</p><p>
-<span class="v">24&#160;</span>Yahweh said to him, “Go down! You shall bring Aaron up with you, but don’t let the priests and the people break through to come up to Yahweh, lest he break out against them.” 
-</p><p>
-<span class="v">25&#160;</span>So Moses went down to the people, and told them. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Elohim<span class="f">+ \fr 20:1 \ft After “Elohim”, the Hebrew has the two letters “Aleph Tav” (the first and last letters of the Hebrew alphabet), not as a word, but as a grammatical marker.</span> spoke all these words, saying, 
-<span class="v">2&#160;</span>“I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
-</p><p>
-<span class="v">3&#160;</span>“You shall have no other elohims before me. 
-</p><p>
-<span class="v">4&#160;</span>“You shall not make for yourselves an idol, nor any image of anything that is in the heavens above, or that is in the earth beneath, or that is in the water under the earth: 
-<span class="v">5&#160;</span>you shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children, on the third and on the fourth generation of those who hate me, 
-<span class="v">6&#160;</span>and showing loving kindness to thousands of those who love me and keep my commandments. 
-</p><p>
-<span class="v">7&#160;</span>“You shall not misuse the name of Yahweh your Elohim,<span class="f">+ \fr 20:7 \ft or, You shall not take the name of Yahweh your Elohim in vain</span> for Yahweh will not hold him guiltless who misuses his name. 
-</p><p>
-<span class="v">8&#160;</span>“Remember the Sabbath day, to keep it set-apart. 
-<span class="v">9&#160;</span>You shall labor six days, and do all your work, 
-<span class="v">10&#160;</span>but the seventh day is a Sabbath to Yahweh your Elohim. You shall not do any work in it, you, nor your son, nor your daughter, your male servant, nor your female servant, nor your livestock, nor your stranger who is within your gates; 
-<span class="v">11&#160;</span>for in six days Yahweh made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore Yahweh blessed the Sabbath day, and made it set-apart. 
-</p><p>
-<span class="v">12&#160;</span>“Honor your father and your mother, that your days may be long in the land which Yahweh your Elohim gives you. 
-</p><p>
-<span class="v">13&#160;</span>“You shall not murder. 
-</p><p>
-<span class="v">14&#160;</span>“You shall not commit adultery. 
-</p><p>
-<span class="v">15&#160;</span>“You shall not steal. 
-</p><p>
-<span class="v">16&#160;</span>“You shall not give false testimony against your neighbor. 
-</p><p>
-<span class="v">17&#160;</span>“You shall not covet your neighbor’s house. You shall not covet your neighbor’s woman, nor his male servant, nor his female servant, nor his ox, nor his donkey, nor anything that is your neighbor’s.” 
-</p><p>
-<span class="v">18&#160;</span>All the people perceived the thunderings, the lightnings, the sound of the trumpet, and the mountain smoking. When the people saw it, they trembled, and stayed at a distance. 
-<span class="v">19&#160;</span>They said to Moses, “Speak with us yourself, and we will listen; but don’t let Elohim speak with us, lest we die.” 
-</p><p>
-<span class="v">20&#160;</span>Moses said to the people, “Don’t be afraid, for Elohim has come to test you, and that his fear may be before you, that you won’t sin.” 
-<span class="v">21&#160;</span>The people stayed at a distance, and Moses came near to the thick darkness where Elohim was. 
-</p><p>
-<span class="v">22&#160;</span>Yahweh said to Moses, “This is what you shall tell the children of Israel: ‘You yourselves have seen that I have talked with you from heaven. 
-<span class="v">23&#160;</span>You shall most certainly not make elohims of silver or elohims of gold for yourselves to be alongside me. 
-<span class="v">24&#160;</span>You shall make an altar of earth for me, and shall sacrifice on it your burnt offerings and your peace offerings, your sheep and your cattle. In every place where I record my name I will come to you and I will bless you. 
-<span class="v">25&#160;</span>If you make me an altar of stone, you shall not build it of cut stones; for if you lift up your tool on it, you have polluted it. 
-<span class="v">26&#160;</span>You shall not go up by steps to my altar, that your nakedness may not be exposed to it.’ 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>“Now these are the ordinances which you shall set before them: 
-</p><p>
-<span class="v">2&#160;</span>“If you buy a Hebrew servant, he shall serve six years, and in the seventh he shall go out free without paying anything. 
-<span class="v">3&#160;</span>If he comes in by himself, he shall go out by himself. If he is the owner of a woman, then his woman shall go out with him. 
-<span class="v">4&#160;</span>If his master gives him a woman and she bears him sons or daughters, the woman and her children shall be her master’s, and he shall go out by himself. 
-<span class="v">5&#160;</span>But if the servant shall plainly say, ‘I love my master, my woman, and my children. I will not go out free;’ 
-<span class="v">6&#160;</span>then his master shall bring him to Elohim, and shall bring him to the door or to the doorpost, and his master shall bore his ear through with an awl, and he shall serve him forever. 
-</p><p>
-<span class="v">7&#160;</span>“If a man sells his daughter to be a female servant, she shall not go out as the male servants do. 
-<span class="v">8&#160;</span>If she doesn’t please her master, who has married her to himself, then he shall let her be redeemed. He shall have no right to sell her to a foreign people, since he has dealt deceitfully with her. 
-<span class="v">9&#160;</span>If he marries her to his son, he shall deal with her as a daughter. 
-<span class="v">10&#160;</span>If he takes another woman to himself, he shall not diminish her food, her clothing, and her marital rights. 
-<span class="v">11&#160;</span>If he doesn’t do these three things for her, she may go free without paying any money. 
-</p><p>
-<span class="v">12&#160;</span>“One who strikes a man so that he dies shall surely be put to death, 
-<span class="v">13&#160;</span>but not if it is unintentional, but Elohim allows it to happen; then I will appoint you a place where he shall flee. 
-<span class="v">14&#160;</span>If a man schemes and comes presumptuously on his neighbor to kill him, you shall take him from my altar, that he may die. 
-</p><p>
-<span class="v">15&#160;</span>“Anyone who attacks his father or his mother shall be surely put to death. 
-</p><p>
-<span class="v">16&#160;</span>“Anyone who kidnaps someone and sells him, or if he is found in his hand, he shall surely be put to death. 
-</p><p>
-<span class="v">17&#160;</span>“Anyone who curses his father or his mother shall surely be put to death. 
-</p><p>
-<span class="v">18&#160;</span>“If men quarrel and one strikes the other with a stone, or with his fist, and he doesn’t die, but is confined to bed; 
-<span class="v">19&#160;</span>if he rises again and walks around with his staff, then he who struck him shall be cleared; only he shall pay for the loss of his time, and shall provide for his healing until he is thoroughly healed. 
-</p><p>
-<span class="v">20&#160;</span>“If a man strikes his servant or his maid with a rod, and he dies under his hand, the man shall surely be punished. 
-<span class="v">21&#160;</span>Notwithstanding, if his servant gets up after a day or two, he shall not be punished, for the servant is his property. 
-</p><p>
-<span class="v">22&#160;</span>“If men fight and hurt a pregnant woman so that she gives birth prematurely, and yet no harm follows, he shall be surely fined as much as the woman’s owner demands and the judges allow. 
-<span class="v">23&#160;</span>But if any harm follows, then you must take life for life, 
-<span class="v">24&#160;</span>eye for eye, tooth for tooth, hand for hand, foot for foot, 
-<span class="v">25&#160;</span>burning for burning, wound for wound, and bruise for bruise. 
-</p><p>
-<span class="v">26&#160;</span>“If a man strikes his servant’s eye, or his maid’s eye, and destroys it, he shall let him go free for his eye’s sake. 
-<span class="v">27&#160;</span>If he strikes out his male servant’s tooth, or his female servant’s tooth, he shall let the servant go free for his tooth’s sake. 
-</p><p>
-<span class="v">28&#160;</span>“If a bull gores a man or a woman to death, the bull shall surely be stoned, and its meat shall not be eaten; but the owner of the bull shall not be held responsible. 
-<span class="v">29&#160;</span>But if the bull had a habit of goring in the past, and this has been testified to its owner, and he has not kept it in, but it has killed a man or a woman, the bull shall be stoned, and its owner shall also be put to death. 
-<span class="v">30&#160;</span>If a ransom is imposed on him, then he shall give for the redemption of his life whatever is imposed. 
-<span class="v">31&#160;</span>Whether it has gored a son or has gored a daughter, according to this judgment it shall be done to him. 
-<span class="v">32&#160;</span>If the bull gores a male servant or a female servant, thirty shekels<span class="f">+ \fr 21:32 \ft A shekel is about 10 grams or about 0.35 ounces, so 30 shekels is about 300 grams or about 10.6 ounces.</span> of silver shall be given to their master, and the ox shall be stoned. 
-</p><p>
-<span class="v">33&#160;</span>“If a man opens a pit, or if a man digs a pit and doesn’t cover it, and a bull or a donkey falls into it, 
-<span class="v">34&#160;</span>the owner of the pit shall make it good. He shall give money to its owner, and the dead animal shall be his. 
-</p><p>
-<span class="v">35&#160;</span>“If one man’s bull injures another’s, so that it dies, then they shall sell the live bull, and divide its price; and they shall also divide the dead animal. 
-<span class="v">36&#160;</span>Or if it is known that the bull was in the habit of goring in the past, and its owner has not kept it in, he shall surely pay bull for bull, and the dead animal shall be his own. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>“If a man steals an ox or a sheep, and kills it or sells it, he shall pay five oxen for an ox, and four sheep for a sheep. 
-<span class="v">2&#160;</span>If the thief is found breaking in, and is struck so that he dies, there shall be no guilt of bloodshed for him. 
-<span class="v">3&#160;</span>If the sun has risen on him, he is guilty of bloodshed. He shall make restitution. If he has nothing, then he shall be sold for his theft. 
-<span class="v">4&#160;</span>If the stolen property is found in his hand alive, whether it is ox, donkey, or sheep, he shall pay double. 
-</p><p>
-<span class="v">5&#160;</span>“If a man causes a field or vineyard to be eaten by letting his animal loose, and it grazes in another man’s field, he shall make restitution from the best of his own field, and from the best of his own vineyard. 
-</p><p>
-<span class="v">6&#160;</span>“If fire breaks out, and catches in thorns so that the shocks of grain, or the standing grain, or the field are consumed; he who kindled the fire shall surely make restitution. 
-</p><p>
-<span class="v">7&#160;</span>“If a man delivers to his neighbor money or stuff to keep, and it is stolen out of the man’s house, if the thief is found, he shall pay double. 
-<span class="v">8&#160;</span>If the thief isn’t found, then the owner of the house shall come near to Elohim, to find out whether or not he has put his hand on his neighbor’s goods. 
-<span class="v">9&#160;</span>For every matter of trespass, whether it is for ox, for donkey, for sheep, for clothing, or for any kind of lost thing, about which one says, ‘This is mine,’ the cause of both parties shall come before Elohim. He whom Elohim condemns shall pay double to his neighbor. 
-</p><p>
-<span class="v">10&#160;</span>“If a man delivers to his neighbor a donkey, an ox, a sheep, or any animal to keep, and it dies or is injured, or driven away, no man seeing it; 
-<span class="v">11&#160;</span>the oath of Yahweh shall be between them both, he has not put his hand on his neighbor’s goods; and its owner shall accept it, and he shall not make restitution. 
-<span class="v">12&#160;</span>But if it is stolen from him, the one who stole shall make restitution to its owner. 
-<span class="v">13&#160;</span>If it is torn in pieces, let him bring it for evidence. He shall not make good that which was torn. 
-</p><p>
-<span class="v">14&#160;</span>“If a man borrows anything of his neighbor’s, and it is injured, or dies, its owner not being with it, he shall surely make restitution. 
-<span class="v">15&#160;</span>If its owner is with it, he shall not make it good. If it is a leased thing, it came for its lease. 
-</p><p>
-<span class="v">16&#160;</span>“If a man entices a virgin who isn’t pledged to be married, and lies with her, he shall surely pay a dowry for her to be his woman. 
-<span class="v">17&#160;</span>If her father utterly refuses to give her to him, he shall pay money according to the dowry of virgins. 
-</p><p>
-<span class="v">18&#160;</span>“You shall not allow a sorceress to live. 
-</p><p>
-<span class="v">19&#160;</span>“Whoever has sex with an animal shall surely be put to death. 
-</p><p>
-<span class="v">20&#160;</span>“He who sacrifices to any elohim, except to Yahweh only, shall be utterly destroyed. 
-</p><p>
-<span class="v">21&#160;</span>“You shall not wrong an alien or oppress him, for you were aliens in the land of Egypt. 
-</p><p>
-<span class="v">22&#160;</span>“You shall not take advantage of any widow or fatherless child. 
-<span class="v">23&#160;</span>If you take advantage of them at all, and they cry at all to me, I will surely hear their cry; 
-<span class="v">24&#160;</span>and my wrath will grow hot, and I will kill you with the sword; and your women shall be widows, and your children fatherless. 
-</p><p>
-<span class="v">25&#160;</span>“If you lend money to any of my people with you who is poor, you shall not be to him as a creditor. You shall not charge him interest. 
-<span class="v">26&#160;</span>If you take your neighbor’s garment as collateral, you shall restore it to him before the sun goes down, 
-<span class="v">27&#160;</span>for that is his only covering, it is his garment for his skin. What would he sleep in? It will happen, when he cries to me, that I will hear, for I am gracious. 
-</p><p>
-<span class="v">28&#160;</span>“You shall not blaspheme Elohim, nor curse a ruler of your people. 
-</p><p>
-<span class="v">29&#160;</span>“You shall not delay to offer from your harvest and from the outflow of your presses. 
-</p><p>“You shall give the firstborn of your sons to me. 
-<span class="v">30&#160;</span>You shall do likewise with your cattle and with your sheep. It shall be with its mother seven days, then on the eighth day you shall give it to me. 
-</p><p>
-<span class="v">31&#160;</span>“You shall be set-apart men to me, therefore you shall not eat any meat that is torn by animals in the field. You shall cast it to the dogs. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>“You shall not spread a false report. Don’t join your hand with the wicked to be a malicious witness. 
-</p><p>
-<span class="v">2&#160;</span>“You shall not follow a crowd to do evil. You shall not testify in court to side with a multitude to pervert justice. 
-<span class="v">3&#160;</span>You shall not favor a poor man in his cause. 
-</p><p>
-<span class="v">4&#160;</span>“If you meet your enemy’s ox or his donkey going astray, you shall surely bring it back to him again. 
-<span class="v">5&#160;</span>If you see the donkey of him who hates you fallen down under his burden, don’t leave him. You shall surely help him with it. 
-</p><p>
-<span class="v">6&#160;</span>“You shall not deny justice to your poor people in their lawsuits. 
-</p><p>
-<span class="v">7&#160;</span>“Keep far from a false charge, and don’t kill the innocent and righteous; for I will not justify the wicked. 
-</p><p>
-<span class="v">8&#160;</span>“You shall take no bribe, for a bribe blinds those who have sight and perverts the words of the righteous. 
-</p><p>
-<span class="v">9&#160;</span>“You shall not oppress an alien, for you know the heart of an alien, since you were aliens in the land of Egypt. 
-</p><p>
-<span class="v">10&#160;</span>“For six years you shall sow your land, and shall gather in its increase, 
-<span class="v">11&#160;</span>but the seventh year you shall let it rest and lie fallow, that the poor of your people may eat; and what they leave the animal of the field shall eat. In the same way, you shall deal with your vineyard and with your olive grove. 
-</p><p>
-<span class="v">12&#160;</span>“Six days you shall do your work, and on the seventh day you shall rest, that your ox and your donkey may have rest, and the son of your servant, and the alien may be refreshed. 
-</p><p>
-<span class="v">13&#160;</span>“Be careful to do all things that I have said to you; and don’t invoke the name of other elohims or even let them be heard out of your mouth. 
-</p><p>
-<span class="v">14&#160;</span>“You shall observe a feast to me three times a year. 
-<span class="v">15&#160;</span>You shall observe the feast of unleavened bread. Seven days you shall eat unleavened bread, as I commanded you, at the time appointed in the month Abib (for in it you came out of Egypt), and no one shall appear before me empty. 
-<span class="v">16&#160;</span>And the feast of harvest, the first fruits of your labors, which you sow in the field; and the feast of ingathering, at the end of the year, when you gather in your labors out of the field. 
-<span class="v">17&#160;</span>Three times in the year all your males shall appear before the Lord Yahweh. 
-</p><p>
-<span class="v">18&#160;</span>“You shall not offer the blood of my sacrifice with leavened bread. The fat of my feast shall not remain all night until the morning. 
-</p><p>
-<span class="v">19&#160;</span>You shall bring the first of the first fruits of your ground into the house of Yahweh your Elohim. 
-</p><p>“You shall not boil a young goat in its mother’s milk. 
-</p><p>
-<span class="v">20&#160;</span>“Behold, I send an angel before you, to keep you by the way, and to bring you into the place which I have prepared. 
-<span class="v">21&#160;</span>Pay attention to him, and listen to his voice. Don’t provoke him, for he will not pardon your disobedience, for my name is in him. 
-<span class="v">22&#160;</span>But if you indeed listen to his voice, and do all that I speak, then I will be an enemy to your enemies, and an adversary to your adversaries. 
-<span class="v">23&#160;</span>For my angel shall go before you, and bring you in to the Amorite, the Hittite, the Perizzite, the Canaanite, the Hivite, and the Jebusite; and I will cut them off. 
-<span class="v">24&#160;</span>You shall not bow down to their elohims, nor serve them, nor follow their practices, but you shall utterly overthrow them and demolish their pillars. 
-<span class="v">25&#160;</span>You shall serve Yahweh your Elohim, and he will bless your bread and your water, and I will take sickness away from among you. 
-<span class="v">26&#160;</span>No one will miscarry or be barren in your land. I will fulfill the number of your days. 
-<span class="v">27&#160;</span>I will send my terror before you, and will confuse all the people to whom you come, and I will make all your enemies turn their backs to you. 
-<span class="v">28&#160;</span>I will send the hornet before you, which will drive out the Hivite, the Canaanite, and the Hittite, from before you. 
-<span class="v">29&#160;</span>I will not drive them out from before you in one year, lest the land become desolate, and the animals of the field multiply against you. 
-<span class="v">30&#160;</span>Little by little I will drive them out from before you, until you have increased and inherit the land. 
-<span class="v">31&#160;</span>I will set your border from the Red Sea even to the sea of the Philistines, and from the wilderness to the River; for I will deliver the inhabitants of the land into your hand, and you shall drive them out before you. 
-<span class="v">32&#160;</span>You shall make no covenant with them, nor with their elohims. 
-<span class="v">33&#160;</span>They shall not dwell in your land, lest they make you sin against me, for if you serve their elohims, it will surely be a snare to you.” 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>He said to Moses, “Come up to Yahweh, you, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship from a distance. 
-<span class="v">2&#160;</span>Moses alone shall come near to Yahweh, but they shall not come near. The people shall not go up with him.” 
-</p><p>
-<span class="v">3&#160;</span>Moses came and told the people all Yahweh’s words, and all the ordinances; and all the people answered with one voice, and said, “All the words which Yahweh has spoken will we do.” 
-</p><p>
-<span class="v">4&#160;</span>Moses wrote all Yahweh’s words, then rose up early in the morning and built an altar at the base of the mountain, with twelve pillars for the twelve tribes of Israel. 
-<span class="v">5&#160;</span>He sent young men of the children of Israel, who offered burnt offerings and sacrificed peace offerings of cattle to Yahweh. 
-<span class="v">6&#160;</span>Moses took half of the blood and put it in basins, and half of the blood he sprinkled on the altar. 
-<span class="v">7&#160;</span>He took the book of the covenant and read it in the hearing of the people, and they said, “We will do all that Yahweh has said, and be obedient.” 
-</p><p>
-<span class="v">8&#160;</span>Moses took the blood, and sprinkled it on the people, and said, “Look, this is the blood of the covenant, which Yahweh has made with you concerning all these words.” 
-</p><p>
-<span class="v">9&#160;</span>Then Moses, Aaron, Nadab, Abihu, and seventy of the elders of Israel went up. 
-<span class="v">10&#160;</span>They saw the Elohim of Israel. Under his feet was like a paved work of sapphire<span class="f">+ \fr 24:10 \ft or, lapis lazuli</span> stone, like the skies for clearness. 
-<span class="v">11&#160;</span>He didn’t lay his hand on the nobles of the children of Israel. They saw Elohim, and ate and drank. 
-</p><p>
-<span class="v">12&#160;</span>Yahweh said to Moses, “Come up to me on the mountain, and stay here, and I will give you the stone tablets with the law and the commands that I have written, that you may teach them.” 
-</p><p>
-<span class="v">13&#160;</span>Moses rose up with Joshua, his servant, and Moses went up onto Elohim’s Mountain. 
-<span class="v">14&#160;</span>He said to the elders, “Wait here for us, until we come again to you. Behold, Aaron and Hur are with you. Whoever is involved in a dispute can go to them.” 
-</p><p>
-<span class="v">15&#160;</span>Moses went up on the mountain, and the cloud covered the mountain. 
-<span class="v">16&#160;</span>Yahweh’s glory settled on Mount Sinai, and the cloud covered it six days. The seventh day he called to Moses out of the middle of the cloud. 
-<span class="v">17&#160;</span>The appearance of Yahweh’s glory was like devouring fire on the top of the mountain in the eyes of the children of Israel. 
-<span class="v">18&#160;</span>Moses entered into the middle of the cloud, and went up on the mountain; and Moses was on the mountain forty days and forty nights. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, that they take an offering for me. From everyone whose heart makes him willing you shall take my offering. 
-<span class="v">3&#160;</span>This is the offering which you shall take from them: gold, silver, bronze, 
-<span class="v">4&#160;</span>blue, purple, scarlet, fine linen, goats’ hair, 
-<span class="v">5&#160;</span>rams’ skins dyed red, sea cow hides,<span class="f">+ \fr 25:5 \ft or, fine leather</span> acacia wood, 
-<span class="v">6&#160;</span>oil for the light, spices for the anointing oil and for the sweet incense, 
-<span class="v">7&#160;</span>onyx stones, and stones to be set for the ephod and for the breastplate. 
-<span class="v">8&#160;</span>Let them make me a sanctuary, that I may dwell among them. 
-<span class="v">9&#160;</span>According to all that I show you, the pattern of the tabernacle, and the pattern of all of its furniture, even so you shall make it. 
-</p><p>
-<span class="v">10&#160;</span>“They shall make an ark of acacia wood. Its length shall be two and a half cubits,<span class="f">+ \fr 25:10 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> its width a cubit and a half, and a cubit and a half its height. 
-<span class="v">11&#160;</span>You shall overlay it with pure gold. You shall overlay it inside and outside, and you shall make a gold molding around it. 
-<span class="v">12&#160;</span>You shall cast four rings of gold for it, and put them in its four feet. Two rings shall be on the one side of it, and two rings on the other side of it. 
-<span class="v">13&#160;</span>You shall make poles of acacia wood, and overlay them with gold. 
-<span class="v">14&#160;</span>You shall put the poles into the rings on the sides of the ark to carry the ark. 
-<span class="v">15&#160;</span>The poles shall be in the rings of the ark. They shall not be taken from it. 
-<span class="v">16&#160;</span>You shall put the covenant which I shall give you into the ark. 
-<span class="v">17&#160;</span>You shall make a mercy seat of pure gold. Two and a half cubits shall be its length, and a cubit and a half its width. 
-<span class="v">18&#160;</span>You shall make two cherubim of hammered gold. You shall make them at the two ends of the mercy seat. 
-<span class="v">19&#160;</span>Make one cherub at the one end, and one cherub at the other end. You shall make the cherubim on its two ends of one piece with the mercy seat. 
-<span class="v">20&#160;</span>The cherubim shall spread out their wings upward, covering the mercy seat with their wings, with their faces toward one another. The faces of the cherubim shall be toward the mercy seat. 
-<span class="v">21&#160;</span>You shall put the mercy seat on top of the ark, and in the ark you shall put the covenant that I will give you. 
-<span class="v">22&#160;</span>There I will meet with you, and I will tell you from above the mercy seat, from between the two cherubim which are on the ark of the covenant, all that I command you for the children of Israel. 
-</p><p>
-<span class="v">23&#160;</span>“You shall make a table of acacia wood. Its length shall be two cubits, and its width a cubit, and its height one and a half cubits. 
-<span class="v">24&#160;</span>You shall overlay it with pure gold, and make a gold molding around it. 
-<span class="v">25&#160;</span>You shall make a rim of a hand width around it. You shall make a golden molding on its rim around it. 
-<span class="v">26&#160;</span>You shall make four rings of gold for it, and put the rings in the four corners that are on its four feet. 
-<span class="v">27&#160;</span>The rings shall be close to the rim, for places for the poles to carry the table. 
-<span class="v">28&#160;</span>You shall make the poles of acacia wood, and overlay them with gold, that the table may be carried with them. 
-<span class="v">29&#160;</span>You shall make its dishes, its spoons, its ladles, and its bowls with which to pour out offerings. You shall make them of pure gold. 
-<span class="v">30&#160;</span>You shall set bread of the presence on the table before me always. 
-</p><p>
-<span class="v">31&#160;</span>“You shall make a lamp stand of pure gold. The lamp stand shall be made of hammered work. Its base, its shaft, its cups, its buds, and its flowers shall be of one piece with it. 
-<span class="v">32&#160;</span>There shall be six branches going out of its sides: three branches of the lamp stand out of its one side, and three branches of the lamp stand out of its other side; 
-<span class="v">33&#160;</span>three cups made like almond blossoms in one branch, a bud and a flower; and three cups made like almond blossoms in the other branch, a bud and a flower, so for the six branches going out of the lamp stand; 
-<span class="v">34&#160;</span>and in the lamp stand four cups made like almond blossoms, its buds and its flowers; 
-<span class="v">35&#160;</span>and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, for the six branches going out of the lamp stand. 
-<span class="v">36&#160;</span>Their buds and their branches shall be of one piece with it, all of it one beaten work of pure gold. 
-<span class="v">37&#160;</span>You shall make its lamps seven, and they shall light its lamps to give light to the space in front of it. 
-<span class="v">38&#160;</span>Its snuffers and its snuff dishes shall be of pure gold. 
-<span class="v">39&#160;</span>It shall be made of a talent<span class="f">+ \fr 25:39 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of pure gold, with all these accessories. 
-<span class="v">40&#160;</span>See that you make them after their pattern, which has been shown to you on the mountain. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>“Moreover you shall make the tabernacle with ten curtains of fine twined linen, and blue, and purple, and scarlet, with cherubim. You shall make them with the work of a skillful workman. 
-<span class="v">2&#160;</span>The length of each curtain shall be twenty-eight cubits,<span class="f">+ \fr 26:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and the width of each curtain four cubits: all the curtains shall have one measure. 
-<span class="v">3&#160;</span>Five curtains shall be coupled together to one another, and the other five curtains shall be coupled to one another. 
-<span class="v">4&#160;</span>You shall make loops of blue on the edge of the one curtain from the edge in the coupling, and you shall do likewise on the edge of the curtain that is outermost in the second coupling. 
-<span class="v">5&#160;</span>You shall make fifty loops in the one curtain, and you shall make fifty loops in the edge of the curtain that is in the second coupling. The loops shall be opposite one another. 
-<span class="v">6&#160;</span>You shall make fifty clasps of gold, and couple the curtains to one another with the clasps. The tabernacle shall be a unit. 
-</p><p>
-<span class="v">7&#160;</span>“You shall make curtains of goats’ hair for a covering over the tabernacle. You shall make eleven curtains. 
-<span class="v">8&#160;</span>The length of each curtain shall be thirty cubits, and the width of each curtain four cubits: the eleven curtains shall have one measure. 
-<span class="v">9&#160;</span>You shall couple five curtains by themselves, and six curtains by themselves, and shall double over the sixth curtain in the forefront of the tent. 
-<span class="v">10&#160;</span>You shall make fifty loops on the edge of the one curtain that is outermost in the coupling, and fifty loops on the edge of the curtain which is outermost in the second coupling. 
-<span class="v">11&#160;</span>You shall make fifty clasps of bronze, and put the clasps into the loops, and couple the tent together, that it may be one. 
-<span class="v">12&#160;</span>The overhanging part that remains of the curtains of the tent—the half curtain that remains—shall hang over the back of the tabernacle. 
-<span class="v">13&#160;</span>The cubit on the one side and the cubit on the other side, of that which remains in the length of the curtains of the tent, shall hang over the sides of the tabernacle on this side and on that side, to cover it. 
-<span class="v">14&#160;</span>You shall make a covering for the tent of rams’ skins dyed red, and a covering of sea cow hides above. 
-</p><p>
-<span class="v">15&#160;</span>“You shall make the boards for the tabernacle of acacia wood, standing upright. 
-<span class="v">16&#160;</span>Ten cubits shall be the length of a board, and one and a half cubits the width of each board. 
-<span class="v">17&#160;</span>There shall be two tenons in each board, joined to one another: thus you shall make for all the boards of the tabernacle. 
-<span class="v">18&#160;</span>You shall make twenty boards for the tabernacle, for the south side southward. 
-<span class="v">19&#160;</span>You shall make forty sockets of silver under the twenty boards; two sockets under one board for its two tenons, and two sockets under another board for its two tenons. 
-<span class="v">20&#160;</span>For the second side of the tabernacle, on the north side, twenty boards, 
-<span class="v">21&#160;</span>and their forty sockets of silver; two sockets under one board, and two sockets under another board. 
-<span class="v">22&#160;</span>For the far side of the tabernacle westward you shall make six boards. 
-<span class="v">23&#160;</span>You shall make two boards for the corners of the tabernacle in the far side. 
-<span class="v">24&#160;</span>They shall be double beneath, and in the same way they shall be whole to its top to one ring: thus shall it be for them both; they shall be for the two corners. 
-<span class="v">25&#160;</span>There shall be eight boards, and their sockets of silver, sixteen sockets; two sockets under one board, and two sockets under another board. 
-</p><p>
-<span class="v">26&#160;</span>“You shall make bars of acacia wood: five for the boards of the one side of the tabernacle, 
-<span class="v">27&#160;</span>and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the side of the tabernacle, for the far side westward. 
-<span class="v">28&#160;</span>The middle bar in the middle of the boards shall pass through from end to end. 
-<span class="v">29&#160;</span>You shall overlay the boards with gold, and make their rings of gold for places for the bars. You shall overlay the bars with gold. 
-<span class="v">30&#160;</span>You shall set up the tabernacle according to the way that it was shown to you on the mountain. 
-</p><p>
-<span class="v">31&#160;</span>“You shall make a veil of blue, and purple, and scarlet, and fine twined linen, with cherubim. It shall be the work of a skillful workman. 
-<span class="v">32&#160;</span>You shall hang it on four pillars of acacia overlaid with gold; their hooks shall be of gold, on four sockets of silver. 
-<span class="v">33&#160;</span>You shall hang up the veil under the clasps, and shall bring the ark of the covenant in there within the veil. The veil shall separate the set-apart place from the most set-apart for you. 
-<span class="v">34&#160;</span>You shall put the mercy seat on the ark of the covenant in the most set-apart place. 
-<span class="v">35&#160;</span>You shall set the table outside the veil, and the lamp stand opposite the table on the side of the tabernacle toward the south. You shall put the table on the north side. 
-</p><p>
-<span class="v">36&#160;</span>“You shall make a screen for the door of the Tent, of blue, and purple, and scarlet, and fine twined linen, the work of the embroiderer. 
-<span class="v">37&#160;</span>You shall make for the screen five pillars of acacia, and overlay them with gold. Their hooks shall be of gold. You shall cast five sockets of bronze for them. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>“You shall make the altar of acacia wood, five cubits<span class="f">+ \fr 27:1 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> long, and five cubits wide. The altar shall be square. Its height shall be three cubits.<span class="f">+ \fr 27:1 \ft The altar was to be about 2.3×2.3×1.4 meters or about 7½×7½×4½ feet.</span> 
-<span class="v">2&#160;</span>You shall make its horns on its four corners. Its horns shall be of one piece with it. You shall overlay it with bronze. 
-<span class="v">3&#160;</span>You shall make its pots to take away its ashes; and its shovels, its basins, its meat hooks, and its fire pans. You shall make all its vessels of bronze. 
-<span class="v">4&#160;</span>You shall make a grating for it of network of bronze. On the net you shall make four bronze rings in its four corners. 
-<span class="v">5&#160;</span>You shall put it under the ledge around the altar beneath, that the net may reach halfway up the altar. 
-<span class="v">6&#160;</span>You shall make poles for the altar, poles of acacia wood, and overlay them with bronze. 
-<span class="v">7&#160;</span>Its poles shall be put into the rings, and the poles shall be on the two sides of the altar when carrying it. 
-<span class="v">8&#160;</span>You shall make it hollow with planks. They shall make it as it has been shown you on the mountain. 
-</p><p>
-<span class="v">9&#160;</span>“You shall make the court of the tabernacle: for the south side southward there shall be hangings for the court of fine twined linen one hundred cubits long for one side. 
-<span class="v">10&#160;</span>Its pillars shall be twenty, and their sockets twenty, of bronze. The hooks of the pillars and their fillets shall be of silver. 
-<span class="v">11&#160;</span>Likewise for the length of the north side, there shall be hangings one hundred cubits long, and its pillars twenty, and their sockets twenty, of bronze; the hooks of the pillars, and their fillets, of silver. 
-<span class="v">12&#160;</span>For the width of the court on the west side shall be hangings of fifty cubits; their pillars ten, and their sockets ten. 
-<span class="v">13&#160;</span>The width of the court on the east side eastward shall be fifty cubits. 
-<span class="v">14&#160;</span>The hangings for the one side of the gate shall be fifteen cubits; their pillars three, and their sockets three. 
-<span class="v">15&#160;</span>For the other side shall be hangings of fifteen cubits; their pillars three, and their sockets three. 
-<span class="v">16&#160;</span>For the gate of the court shall be a screen of twenty cubits, of blue, and purple, and scarlet, and fine twined linen, the work of the embroiderer; their pillars four, and their sockets four. 
-<span class="v">17&#160;</span>All the pillars of the court around shall be filleted with silver; their hooks of silver, and their sockets of bronze. 
-<span class="v">18&#160;</span>The length of the court shall be one hundred cubits, and the width fifty throughout, and the height five cubits, of fine twined linen, and their sockets of bronze. 
-<span class="v">19&#160;</span>All the instruments of the tabernacle in all its service, and all its pins, and all the pins of the court, shall be of bronze. 
-</p><p>
-<span class="v">20&#160;</span>“You shall command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
-<span class="v">21&#160;</span>In the Tent of Meeting, outside the veil which is before the covenant, Aaron and his sons shall keep it in order from evening to morning before Yahweh: it shall be a statute forever throughout their generations on the behalf of the children of Israel. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>“Bring Aaron your brother, and his sons with him, near to you from among the children of Israel, that he may minister to me in the priest’s office: Aaron, with Nadab, Abihu, Eleazar, and Ithamar, Aaron’s sons. 
-<span class="v">2&#160;</span>You shall make set-apart garments for Aaron your brother, for glory and for beauty. 
-<span class="v">3&#160;</span>You shall speak to all who are wise-hearted, whom I have filled with the spirit of wisdom, that they make Aaron’s garments to sanctify him, that he may minister to me in the priest’s office. 
-<span class="v">4&#160;</span>These are the garments which they shall make: a breastplate, an ephod, a robe, a fitted tunic, a turban, and a sash. They shall make set-apart garments for Aaron your brother and his sons, that he may minister to me in the priest’s office. 
-<span class="v">5&#160;</span>They shall use the gold, and the blue, and the purple, and the scarlet, and the fine linen. 
-</p><p>
-<span class="v">6&#160;</span>“They shall make the ephod of gold, blue, purple, scarlet, and fine twined linen, the work of the skillful workman. 
-<span class="v">7&#160;</span>It shall have two shoulder straps joined to the two ends of it, that it may be joined together. 
-<span class="v">8&#160;</span>The skillfully woven band, which is on it, shall be like its work and of the same piece; of gold, blue, purple, scarlet, and fine twined linen. 
-<span class="v">9&#160;</span>You shall take two onyx stones, and engrave on them the names of the children of Israel. 
-<span class="v">10&#160;</span>Six of their names on the one stone, and the names of the six that remain on the other stone, in the order of their birth. 
-<span class="v">11&#160;</span>With the work of an engraver in stone, like the engravings of a signet, you shall engrave the two stones, according to the names of the children of Israel. You shall make them to be enclosed in settings of gold. 
-<span class="v">12&#160;</span>You shall put the two stones on the shoulder straps of the ephod, to be stones of memorial for the children of Israel. Aaron shall bear their names before Yahweh on his two shoulders for a memorial. 
-<span class="v">13&#160;</span>You shall make settings of gold, 
-<span class="v">14&#160;</span>and two chains of pure gold; you shall make them like cords of braided work. You shall put the braided chains on the settings. 
-</p><p>
-<span class="v">15&#160;</span>“You shall make a breastplate of judgment, the work of the skillful workman; like the work of the ephod you shall make it; of gold, of blue, and purple, and scarlet, and fine twined linen, you shall make it. 
-<span class="v">16&#160;</span>It shall be square and folded double; a span<span class="f">+ \fr 28:16 \ft A span is the length from the tip of a man’s thumb to the tip of his little finger when his hand is stretched out (about half a cubit, or 9 inches, or 22.8 cm.)</span> shall be its length, and a span its width. 
-<span class="v">17&#160;</span>You shall set in it settings of stones, four rows of stones: a row of ruby, topaz, and beryl shall be the first row; 
-<span class="v">18&#160;</span>and the second row a turquoise, a sapphire,<span class="f">+ \fr 28:18 \ft or, lapis lazuli </span> and an emerald; 
-<span class="v">19&#160;</span>and the third row a jacinth, an agate, and an amethyst; 
-<span class="v">20&#160;</span>and the fourth row a chrysolite, an onyx, and a jasper. They shall be enclosed in gold in their settings. 
-<span class="v">21&#160;</span>The stones shall be according to the names of the children of Israel, twelve, according to their names; like the engravings of a signet, everyone according to his name, they shall be for the twelve tribes. 
-<span class="v">22&#160;</span>You shall make on the breastplate chains like cords, of braided work of pure gold. 
-<span class="v">23&#160;</span>You shall make on the breastplate two rings of gold, and shall put the two rings on the two ends of the breastplate. 
-<span class="v">24&#160;</span>You shall put the two braided chains of gold in the two rings at the ends of the breastplate. 
-<span class="v">25&#160;</span>The other two ends of the two braided chains you shall put on the two settings, and put them on the shoulder straps of the ephod in its forepart. 
-<span class="v">26&#160;</span>You shall make two rings of gold, and you shall put them on the two ends of the breastplate, on its edge, which is toward the side of the ephod inward. 
-<span class="v">27&#160;</span>You shall make two rings of gold, and shall put them on the two shoulder straps of the ephod underneath, in its forepart, close by its coupling, above the skillfully woven band of the ephod. 
-<span class="v">28&#160;</span>They shall bind the breastplate by its rings to the rings of the ephod with a lace of blue, that it may be on the skillfully woven band of the ephod, and that the breastplate may not swing out from the ephod. 
-<span class="v">29&#160;</span>Aaron shall bear the names of the children of Israel in the breastplate of judgment on his heart, when he goes in to the set-apart place, for a memorial before Yahweh continually. 
-<span class="v">30&#160;</span>You shall put in the breastplate of judgment the Urim and the Thummim; and they shall be on Aaron’s heart, when he goes in before Yahweh. Aaron shall bear the judgment of the children of Israel on his heart before Yahweh continually. 
-</p><p>
-<span class="v">31&#160;</span>“You shall make the robe of the ephod all of blue. 
-<span class="v">32&#160;</span>It shall have a hole for the head in the middle of it. It shall have a binding of woven work around its hole, as it were the hole of a coat of mail, that it not be torn. 
-<span class="v">33&#160;</span>On its hem you shall make pomegranates of blue, and of purple, and of scarlet, all around its hem; with bells of gold between and around them: 
-<span class="v">34&#160;</span>a golden bell and a pomegranate, a golden bell and a pomegranate, around the hem of the robe. 
-<span class="v">35&#160;</span>It shall be on Aaron to minister: and its sound shall be heard when he goes in to the set-apart place before Yahweh, and when he comes out, that he not die. 
-</p><p>
-<span class="v">36&#160;</span>“You shall make a plate of pure gold, and engrave on it, like the engravings of a signet, ‘SET-APART TO YAHWEH.’ 
-<span class="v">37&#160;</span>You shall put it on a lace of blue, and it shall be on the sash. It shall be on the front of the sash. 
-<span class="v">38&#160;</span>It shall be on Aaron’s forehead, and Aaron shall bear the iniquity of the set-apart things, which the children of Israel shall make set-apart in all their set-apart gifts; and it shall be always on his forehead, that they may be accepted before Yahweh. 
-<span class="v">39&#160;</span>You shall weave the tunic with fine linen. You shall make a turban of fine linen. You shall make a sash, the work of the embroiderer. 
-</p><p>
-<span class="v">40&#160;</span>“You shall make tunics for Aaron’s sons. You shall make sashes for them. You shall make headbands for them, for glory and for beauty. 
-<span class="v">41&#160;</span>You shall put them on Aaron your brother, and on his sons with him, and shall anoint them, and consecrate them, and sanctify them, that they may minister to me in the priest’s office. 
-<span class="v">42&#160;</span>You shall make them linen pants to cover their naked flesh. They shall reach from the waist even to the thighs. 
-<span class="v">43&#160;</span>They shall be on Aaron and on his sons, when they go in to the Tent of Meeting, or when they come near to the altar to minister in the set-apart place, that they don’t bear iniquity, and die. This shall be a statute forever to him and to his offspring after him. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>“This is the thing that you shall do to them to make them set-apart, to minister to me in the priest’s office: take one young bull and two rams without defect, 
-<span class="v">2&#160;</span>unleavened bread, unleavened cakes mixed with oil, and unleavened wafers anointed with oil. You shall make them of fine wheat flour. 
-<span class="v">3&#160;</span>You shall put them into one basket, and bring them in the basket, with the bull and the two rams. 
-<span class="v">4&#160;</span>You shall bring Aaron and his sons to the door of the Tent of Meeting, and shall wash them with water. 
-<span class="v">5&#160;</span>You shall take the garments, and put on Aaron the tunic, the robe of the ephod, the ephod, and the breastplate, and clothe him with the skillfully woven band of the ephod. 
-<span class="v">6&#160;</span>You shall set the turban on his head, and put the set-apart crown on the turban. 
-<span class="v">7&#160;</span>Then you shall take the anointing oil, and pour it on his head, and anoint him. 
-<span class="v">8&#160;</span>You shall bring his sons, and put tunics on them. 
-<span class="v">9&#160;</span>You shall clothe them with belts, Aaron and his sons, and bind headbands on them. They shall have the priesthood by a perpetual statute. You shall consecrate Aaron and his sons. 
-</p><p>
-<span class="v">10&#160;</span>“You shall bring the bull before the Tent of Meeting; and Aaron and his sons shall lay their hands on the head of the bull. 
-<span class="v">11&#160;</span>You shall kill the bull before Yahweh at the door of the Tent of Meeting. 
-<span class="v">12&#160;</span>You shall take of the blood of the bull, and put it on the horns of the altar with your finger; and you shall pour out all the blood at the base of the altar. 
-<span class="v">13&#160;</span>You shall take all the fat that covers the innards, the cover of the liver, the two kidneys, and the fat that is on them, and burn them on the altar. 
-<span class="v">14&#160;</span>But the meat of the bull, and its skin, and its dung, you shall burn with fire outside of the camp. It is a sin offering. 
-</p><p>
-<span class="v">15&#160;</span>“You shall also take the one ram, and Aaron and his sons shall lay their hands on the head of the ram. 
-<span class="v">16&#160;</span>You shall kill the ram, and you shall take its blood, and sprinkle it around on the altar. 
-<span class="v">17&#160;</span>You shall cut the ram into its pieces, and wash its innards, and its legs, and put them with its pieces, and with its head. 
-<span class="v">18&#160;</span>You shall burn the whole ram on the altar: it is a burnt offering to Yahweh; it is a pleasant aroma, an offering made by fire to Yahweh. 
-</p><p>
-<span class="v">19&#160;</span>“You shall take the other ram, and Aaron and his sons shall lay their hands on the head of the ram. 
-<span class="v">20&#160;</span>Then you shall kill the ram, and take some of its blood, and put it on the tip of the right ear of Aaron, and on the tip of the right ear of his sons, and on the thumb of their right hand, and on the big toe of their right foot; and sprinkle the blood around on the altar. 
-<span class="v">21&#160;</span>You shall take of the blood that is on the altar, and of the anointing oil, and sprinkle it on Aaron, and on his garments, and on his sons, and on the garments of his sons with him: and he shall be made set-apart, and his garments, and his sons, and his sons’ garments with him. 
-<span class="v">22&#160;</span>Also you shall take some of the ram’s fat, the fat tail, the fat that covers the innards, the cover of the liver, the two kidneys, the fat that is on them, and the right thigh (for it is a ram of consecration), 
-<span class="v">23&#160;</span>and one loaf of bread, one cake of oiled bread, and one wafer out of the basket of unleavened bread that is before Yahweh. 
-<span class="v">24&#160;</span>You shall put all of this in Aaron’s hands, and in his sons’ hands, and shall wave them for a wave offering before Yahweh. 
-<span class="v">25&#160;</span>You shall take them from their hands, and burn them on the altar on the burnt offering, for a pleasant aroma before Yahweh: it is an offering made by fire to Yahweh. 
-</p><p>
-<span class="v">26&#160;</span>“You shall take the breast of Aaron’s ram of consecration, and wave it for a wave offering before Yahweh. It shall be your portion. 
-<span class="v">27&#160;</span>You shall sanctify the breast of the wave offering and the thigh of the wave offering, which is waved, and which is raised up, of the ram of consecration, even of that which is for Aaron, and of that which is for his sons. 
-<span class="v">28&#160;</span>It shall be for Aaron and his sons as their portion forever from the children of Israel; for it is a wave offering. It shall be a wave offering from the children of Israel of the sacrifices of their peace offerings, even their wave offering to Yahweh. 
-</p><p>
-<span class="v">29&#160;</span>“The set-apart garments of Aaron shall be for his sons after him, to be anointed in them, and to be consecrated in them. 
-<span class="v">30&#160;</span>Seven days shall the son who is priest in his place put them on, when he comes into the Tent of Meeting to minister in the set-apart place. 
-</p><p>
-<span class="v">31&#160;</span>“You shall take the ram of consecration and boil its meat in a set-apart place. 
-<span class="v">32&#160;</span>Aaron and his sons shall eat the meat of the ram, and the bread that is in the basket, at the door of the Tent of Meeting. 
-<span class="v">33&#160;</span>They shall eat those things with which atonement was made, to consecrate and sanctify them; but a stranger shall not eat of it, because they are set-apart. 
-<span class="v">34&#160;</span>If anything of the meat of the consecration, or of the bread, remains to the morning, then you shall burn the remainder with fire. It shall not be eaten, because it is set-apart. 
-</p><p>
-<span class="v">35&#160;</span>“You shall do so to Aaron and to his sons, according to all that I have commanded you. You shall consecrate them seven days. 
-<span class="v">36&#160;</span>Every day you shall offer the bull of sin offering for atonement. You shall cleanse the altar when you make atonement for it. You shall anoint it, to sanctify it. 
-<span class="v">37&#160;</span>Seven days you shall make atonement for the altar, and sanctify it; and the altar shall be most set-apart. Whatever touches the altar shall be set-apart. 
-</p><p>
-<span class="v">38&#160;</span>“Now this is that which you shall offer on the altar: two lambs a year old day by day continually. 
-<span class="v">39&#160;</span>The one lamb you shall offer in the morning; and the other lamb you shall offer at evening; 
-<span class="v">40&#160;</span>and with the one lamb a tenth part of an ephah<span class="f">+ \fr 29:40 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour mixed with the fourth part of a hin<span class="f">+ \fr 29:40 \ft A hin is about 6.5 liters or 1.7 gallons, so a fourth of a hin is about 1.6 liters.</span> of beaten oil, and the fourth part of a hin of wine for a drink offering. 
-<span class="v">41&#160;</span>The other lamb you shall offer at evening, and shall do to it according to the meal offering of the morning and according to its drink offering, for a pleasant aroma, an offering made by fire to Yahweh. 
-<span class="v">42&#160;</span>It shall be a continual burnt offering throughout your generations at the door of the Tent of Meeting before Yahweh, where I will meet with you, to speak there to you. 
-<span class="v">43&#160;</span>There I will meet with the children of Israel; and the place shall be sanctified by my glory. 
-<span class="v">44&#160;</span>I will sanctify the Tent of Meeting and the altar. I will also sanctify Aaron and his sons to minister to me in the priest’s office. 
-<span class="v">45&#160;</span>I will dwell among the children of Israel, and will be their Elohim. 
-<span class="v">46&#160;</span>They shall know that I am Yahweh their Elohim, who brought them out of the land of Egypt, that I might dwell among them: I am Yahweh their Elohim. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>“You shall make an altar to burn incense on. You shall make it of acacia wood. 
-<span class="v">2&#160;</span>Its length shall be a cubit,<span class="f">+ \fr 30:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and its width a cubit. It shall be square, and its height shall be two cubits. Its horns shall be of one piece with it. 
-<span class="v">3&#160;</span>You shall overlay it with pure gold, its top, its sides around it, and its horns; and you shall make a gold molding around it. 
-<span class="v">4&#160;</span>You shall make two golden rings for it under its molding; on its two ribs, on its two sides you shall make them; and they shall be for places for poles with which to bear it. 
-<span class="v">5&#160;</span>You shall make the poles of acacia wood, and overlay them with gold. 
-<span class="v">6&#160;</span>You shall put it before the veil that is by the ark of the covenant, before the mercy seat that is over the covenant, where I will meet with you. 
-<span class="v">7&#160;</span>Aaron shall burn incense of sweet spices on it every morning. When he tends the lamps, he shall burn it. 
-<span class="v">8&#160;</span>When Aaron lights the lamps at evening, he shall burn it, a perpetual incense before Yahweh throughout your generations. 
-<span class="v">9&#160;</span>You shall offer no strange incense on it, nor burnt offering, nor meal offering; and you shall pour no drink offering on it. 
-<span class="v">10&#160;</span>Aaron shall make atonement on its horns once in the year; with the blood of the sin offering of atonement once in the year he shall make atonement for it throughout your generations. It is most set-apart to Yahweh.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">12&#160;</span>“When you take a census of the children of Israel, according to those who are counted among them, then each man shall give a ransom for his soul to Yahweh when you count them, that there be no plague among them when you count them. 
-<span class="v">13&#160;</span>They shall give this, everyone who passes over to those who are counted, half a shekel according to the shekel<span class="f">+ \fr 30:13 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of the sanctuary (the shekel is twenty gerahs<span class="f">+ \fr 30:13 \ft a gerah is about 0.5 grams or about 7.7 grains</span>); half a shekel for an offering to Yahweh. 
-<span class="v">14&#160;</span>Everyone who passes over to those who are counted, from twenty years old and upward, shall give the offering to Yahweh. 
-<span class="v">15&#160;</span>The rich shall not give more, and the poor shall not give less, than the half shekel,<span class="f">+ \fr 30:15 \ft A shekel is about 10 grams or about 0.35 ounces.</span> when they give the offering of Yahweh, to make atonement for your souls. 
-<span class="v">16&#160;</span>You shall take the atonement money from the children of Israel, and shall appoint it for the service of the Tent of Meeting; that it may be a memorial for the children of Israel before Yahweh, to make atonement for your souls.” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">18&#160;</span>“You shall also make a basin of bronze, and its base of bronze, in which to wash. You shall put it between the Tent of Meeting and the altar, and you shall put water in it. 
-<span class="v">19&#160;</span>Aaron and his sons shall wash their hands and their feet in it. 
-<span class="v">20&#160;</span>When they go into the Tent of Meeting, they shall wash with water, that they not die; or when they come near to the altar to minister, to burn an offering made by fire to Yahweh. 
-<span class="v">21&#160;</span>So they shall wash their hands and their feet, that they not die. This shall be a statute forever to them, even to him and to his descendants throughout their generations.” 
-</p><p>
-<span class="v">22&#160;</span>Moreover Yahweh spoke to Moses, saying, 
-<span class="v">23&#160;</span>“Also take fine spices: of liquid myrrh, five hundred shekels;<span class="f">+ \fr 30:23 \ft A shekel is about 10 grams or about 0.35 ounces, so 500 shekels is about 5 kilograms or about 11 pounds.</span> and of fragrant cinnamon half as much, even two hundred and fifty; and of fragrant cane, two hundred and fifty; 
-<span class="v">24&#160;</span>and of cassia five hundred, according to the shekel of the sanctuary; and a hin<span class="f">+ \fr 30:24 \ft A hin is about 6.5 liters or 1.7 gallons.</span> of olive oil. 
-<span class="v">25&#160;</span>You shall make it into a set-apart anointing oil, a perfume compounded after the art of the perfumer: it shall be a set-apart anointing oil. 
-<span class="v">26&#160;</span>You shall use it to anoint the Tent of Meeting, the ark of the covenant, 
-<span class="v">27&#160;</span>the table and all its articles, the lamp stand and its accessories, the altar of incense, 
-<span class="v">28&#160;</span>the altar of burnt offering with all its utensils, and the basin with its base. 
-<span class="v">29&#160;</span>You shall sanctify them, that they may be most set-apart. Whatever touches them shall be set-apart. 
-<span class="v">30&#160;</span>You shall anoint Aaron and his sons, and sanctify them, that they may minister to me in the priest’s office. 
-<span class="v">31&#160;</span>You shall speak to the children of Israel, saying, ‘This shall be a set-apart anointing oil to me throughout your generations. 
-<span class="v">32&#160;</span>It shall not be poured on man’s flesh, and do not make any like it, according to its composition. It is set-apart. It shall be set-apart to you. 
-<span class="v">33&#160;</span>Whoever compounds any like it, or whoever puts any of it on a stranger, he shall be cut off from his people.’&#160;” 
-</p><p>
-<span class="v">34&#160;</span>Yahweh said to Moses, “Take to yourself sweet spices, gum resin, onycha, and galbanum: sweet spices with pure frankincense. There shall be an equal weight of each. 
-<span class="v">35&#160;</span>You shall make incense of it, a perfume after the art of the perfumer, seasoned with salt, pure and set-apart. 
-<span class="v">36&#160;</span>You shall beat some of it very small, and put some of it before the covenant in the Tent of Meeting, where I will meet with you. It shall be to you most set-apart. 
-<span class="v">37&#160;</span>You shall not make this incense, according to its composition, for yourselves: it shall be to you set-apart for Yahweh. 
-<span class="v">38&#160;</span>Whoever shall make any like that, to smell of it, he shall be cut off from his people.” 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Behold, I have called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
-<span class="v">3&#160;</span>I have filled him with the Spirit of Elohim, in wisdom, and in understanding, and in knowledge, and in all kinds of workmanship, 
-<span class="v">4&#160;</span>to devise skillful works, to work in gold, and in silver, and in bronze, 
-<span class="v">5&#160;</span>and in cutting of stones for setting, and in carving of wood, to work in all kinds of workmanship. 
-<span class="v">6&#160;</span>Behold, I myself have appointed with him Oholiab, the son of Ahisamach, of the tribe of Dan; and in the heart of all who are wise-hearted I have put wisdom, that they may make all that I have commanded you: 
-<span class="v">7&#160;</span>the Tent of Meeting, the ark of the covenant, the mercy seat that is on it, all the furniture of the Tent, 
-<span class="v">8&#160;</span>the table and its vessels, the pure lamp stand with all its vessels, the altar of incense, 
-<span class="v">9&#160;</span>the altar of burnt offering with all its vessels, the basin and its base, 
-<span class="v">10&#160;</span>the finely worked garments—the set-apart garments for Aaron the priest, the garments of his sons to minister in the priest’s office—<span class="v">11&#160;</span>the anointing oil, and the incense of sweet spices for the set-apart place: according to all that I have commanded you they shall do.” 
-</p><p>
-<span class="v">12&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">13&#160;</span>“Speak also to the children of Israel, saying, ‘Most certainly you shall keep my Sabbaths; for it is a sign between me and you throughout your generations, that you may know that I am Yahweh who sanctifies you. 
-<span class="v">14&#160;</span>You shall keep the Sabbath therefore, for it is set-apart to you. Everyone who profanes it shall surely be put to death; for whoever does any work therein, that soul shall be cut off from among his people. 
-<span class="v">15&#160;</span>Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, set-apart to Yahweh. Whoever does any work on the Sabbath day shall surely be put to death. 
-<span class="v">16&#160;</span>Therefore the children of Israel shall keep the Sabbath, to observe the Sabbath throughout their generations, for a perpetual covenant. 
-<span class="v">17&#160;</span>It is a sign between me and the children of Israel forever; for in six days Yahweh made heaven and earth, and on the seventh day he rested, and was refreshed.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>When he finished speaking with him on Mount Sinai, he gave Moses the two tablets of the covenant, stone tablets, written with Elohim’s finger. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>When the people saw that Moses delayed coming down from the mountain, the people gathered themselves together to Aaron, and said to him, “Come, make us elohims, which shall go before us; for as for this Moses, the man who brought us up out of the land of Egypt, we don’t know what has become of him.” 
-</p><p>
-<span class="v">2&#160;</span>Aaron said to them, “Take off the golden rings, which are in the ears of your women, of your sons, and of your daughters, and bring them to me.” 
-</p><p>
-<span class="v">3&#160;</span>All the people took off the golden rings which were in their ears, and brought them to Aaron. 
-<span class="v">4&#160;</span>He received what they handed him, fashioned it with an engraving tool, and made it a molded calf. Then they said, “These are your elohims, Israel, which brought you up out of the land of Egypt.” 
-</p><p>
-<span class="v">5&#160;</span>When Aaron saw this, he built an altar before it; and Aaron made a proclamation, and said, “Tomorrow shall be a feast to Yahweh.” 
-</p><p>
-<span class="v">6&#160;</span>They rose up early on the next day, and offered burnt offerings, and brought peace offerings; and the people sat down to eat and to drink, and rose up to play. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh spoke to Moses, “Go, get down; for your people, whom you brought up out of the land of Egypt, have corrupted themselves! 
-<span class="v">8&#160;</span>They have turned away quickly out of the way which I commanded them. They have made themselves a molded calf, and have worshiped it, and have sacrificed to it, and said, ‘These are your elohims, Israel, which brought you up out of the land of Egypt.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh said to Moses, “I have seen these people, and behold, they are a stiff-necked people. 
-<span class="v">10&#160;</span>Now therefore leave me alone, that my wrath may burn hot against them, and that I may consume them; and I will make of you a great nation.” 
-</p><p>
-<span class="v">11&#160;</span>Moses begged Yahweh his Elohim, and said, “Yahweh, why does your wrath burn hot against your people, that you have brought out of the land of Egypt with great power and with a mighty hand? 
-<span class="v">12&#160;</span>Why should the Egyptians talk, saying, ‘He brought them out for evil, to kill them in the mountains, and to consume them from the surface of the earth’? Turn from your fierce wrath, and turn away from this evil against your people. 
-<span class="v">13&#160;</span>Remember Abraham, Isaac, and Israel, your servants, to whom you swore by your own self, and said to them, ‘I will multiply your offspring<span class="f">+ \fr 32:13 \ft or, seed</span> as the stars of the sky, and all this land that I have spoken of I will give to your offspring, and they shall inherit it forever.’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>So Yahweh turned away from the evil which he said he would do to his people. 
-</p><p>
-<span class="v">15&#160;</span>Moses turned, and went down from the mountain, with the two tablets of the covenant in his hand; tablets that were written on both their sides. They were written on one side and on the other. 
-<span class="v">16&#160;</span>The tablets were the work of Elohim, and the writing was the writing of Elohim, engraved on the tablets. 
-</p><p>
-<span class="v">17&#160;</span>When Joshua heard the noise of the people as they shouted, he said to Moses, “There is the noise of war in the camp.” 
-</p><p>
-<span class="v">18&#160;</span>He said, “It isn’t the voice of those who shout for victory. It is not the voice of those who cry for being overcome; but the noise of those who sing that I hear.” 
-<span class="v">19&#160;</span>As soon as he came near to the camp, he saw the calf and the dancing. Then Moses’ anger grew hot, and he threw the tablets out of his hands, and broke them beneath the mountain. 
-<span class="v">20&#160;</span>He took the calf which they had made, and burned it with fire, ground it to powder, and scattered it on the water, and made the children of Israel drink it. 
-</p><p>
-<span class="v">21&#160;</span>Moses said to Aaron, “What did these people do to you, that you have brought a great sin on them?” 
-</p><p>
-<span class="v">22&#160;</span>Aaron said, “Don’t let the anger of my lord grow hot. You know the people, that they are set on evil. 
-<span class="v">23&#160;</span>For they said to me, ‘Make us elohims, which shall go before us. As for this Moses, the man who brought us up out of the land of Egypt, we don’t know what has become of him.’ 
-<span class="v">24&#160;</span>I said to them, ‘Whoever has any gold, let them take it off.’ So they gave it to me; and I threw it into the fire, and out came this calf.” 
-</p><p>
-<span class="v">25&#160;</span>When Moses saw that the people were out of control, (for Aaron had let them lose control, causing derision among their enemies), 
-<span class="v">26&#160;</span>then Moses stood in the gate of the camp, and said, “Whoever is on Yahweh’s side, come to me!” 
-</p><p>All the sons of Levi gathered themselves together to him. 
-<span class="v">27&#160;</span>He said to them, “Yahweh, the Elohim of Israel, says, ‘Every man put his sword on his thigh, and go back and forth from gate to gate throughout the camp, and every man kill his brother, and every man his companion, and every man his neighbor.’&#160;” 
-<span class="v">28&#160;</span>The sons of Levi did according to the word of Moses. About three thousand men fell of the people that day. 
-<span class="v">29&#160;</span>Moses said, “Consecrate yourselves today to Yahweh, for every man was against his son and against his brother, that he may give you a blessing today.” 
-</p><p>
-<span class="v">30&#160;</span>On the next day, Moses said to the people, “You have sinned a great sin. Now I will go up to Yahweh. Perhaps I shall make atonement for your sin.” 
-</p><p>
-<span class="v">31&#160;</span>Moses returned to Yahweh, and said, “Oh, this people have sinned a great sin, and have made themselves elohims of gold. 
-<span class="v">32&#160;</span>Yet now, if you will, forgive their sin—and if not, please blot me out of your book which you have written.” 
-</p><p>
-<span class="v">33&#160;</span>Yahweh said to Moses, “Whoever has sinned against me, I will blot him out of my book. 
-<span class="v">34&#160;</span>Now go, lead the people to the place of which I have spoken to you. Behold, my angel shall go before you. Nevertheless, in the day when I punish, I will punish them for their sin.” 
-<span class="v">35&#160;</span>Yahweh struck the people, because of what they did with the calf, which Aaron made. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, “Depart, go up from here, you and the people that you have brought up out of the land of Egypt, to the land of which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ 
-<span class="v">2&#160;</span>I will send an angel before you; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite. 
-<span class="v">3&#160;</span>Go to a land flowing with milk and honey; but I will not go up among you, for you are a stiff-necked people, lest I consume you on the way.” 
-</p><p>
-<span class="v">4&#160;</span>When the people heard this evil news, they mourned; and no one put on his jewelry. 
-</p><p>
-<span class="v">5&#160;</span>Yahweh had said to Moses, “Tell the children of Israel, ‘You are a stiff-necked people. If I were to go up among you for one moment, I would consume you. Therefore now take off your jewelry from you, that I may know what to do to you.’&#160;” 
-</p><p>
-<span class="v">6&#160;</span>The children of Israel stripped themselves of their jewelry from Mount Horeb onward. 
-</p><p>
-<span class="v">7&#160;</span>Now Moses used to take the tent and pitch it outside the camp, far away from the camp, and he called it “The Tent of Meeting.” Everyone who sought Yahweh went out to the Tent of Meeting, which was outside the camp. 
-<span class="v">8&#160;</span>When Moses went out to the Tent, all the people rose up, and stood, everyone at their tent door, and watched Moses, until he had gone into the Tent. 
-<span class="v">9&#160;</span>When Moses entered into the Tent, the pillar of cloud descended, stood at the door of the Tent, and Yahweh spoke with Moses. 
-<span class="v">10&#160;</span>All the people saw the pillar of cloud stand at the door of the Tent, and all the people rose up and worshiped, everyone at their tent door. 
-<span class="v">11&#160;</span>Yahweh spoke to Moses face to face, as a man speaks to his friend. He turned again into the camp, but his servant Joshua, the son of Nun, a young man, didn’t depart from the Tent. 
-</p><p>
-<span class="v">12&#160;</span>Moses said to Yahweh, “Behold, you tell me, ‘Bring up this people;’ and you haven’t let me know whom you will send with me. Yet you have said, ‘I know you by name, and you have also found favor in my sight.’ 
-<span class="v">13&#160;</span>Now therefore, if I have found favor in your sight, please show me your way, now, that I may know you, so that I may find favor in your sight; and consider that this nation is your people.” 
-</p><p>
-<span class="v">14&#160;</span>He said, “My presence will go with you, and I will give you rest.” 
-</p><p>
-<span class="v">15&#160;</span>Moses said to him, “If your presence doesn’t go with me, don’t carry us up from here. 
-<span class="v">16&#160;</span>For how would people know that I have found favor in your sight, I and your people? Isn’t it that you go with us, so that we are separated, I and your people, from all the people who are on the surface of the earth?” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh said to Moses, “I will do this thing also that you have spoken; for you have found favor in my sight, and I know you by name.” 
-</p><p>
-<span class="v">18&#160;</span>Moses said, “Please show me your glory.” 
-</p><p>
-<span class="v">19&#160;</span>He said, “I will make all my goodness pass before you, and will proclaim Yahweh’s name before you. I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.” 
-<span class="v">20&#160;</span>He said, “You cannot see my face, for man may not see me and live.” 
-<span class="v">21&#160;</span>Yahweh also said, “Behold, there is a place by me, and you shall stand on the rock. 
-<span class="v">22&#160;</span>It will happen, while my glory passes by, that I will put you in a cleft of the rock, and will cover you with my hand until I have passed by; 
-<span class="v">23&#160;</span>then I will take away my hand, and you will see my back; but my face shall not be seen.” 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, “Chisel two stone tablets like the first. I will write on the tablets the words that were on the first tablets, which you broke. 
-<span class="v">2&#160;</span>Be ready by the morning, and come up in the morning to Mount Sinai, and present yourself there to me on the top of the mountain. 
-<span class="v">3&#160;</span>No one shall come up with you or be seen anywhere on the mountain. Do not let the flocks or herds graze in front of that mountain.” 
-</p><p>
-<span class="v">4&#160;</span>He chiseled two tablets of stone like the first; then Moses rose up early in the morning, and went up to Mount Sinai, as Yahweh had commanded him, and took in his hand two stone tablets. 
-<span class="v">5&#160;</span>Yahweh descended in the cloud, and stood with him there, and proclaimed Yahweh’s name. 
-<span class="v">6&#160;</span>Yahweh passed by before him, and proclaimed, “Yahweh! Yahweh, a merciful and gracious Elohim, slow to anger, and abundant in loving kindness and truth, 
-<span class="v">7&#160;</span>keeping loving kindness for thousands, forgiving iniquity and disobedience and sin; and who will by no means clear the guilty, visiting the iniquity of the fathers on the children, and on the children’s children, on the third and on the fourth generation.” 
-</p><p>
-<span class="v">8&#160;</span>Moses hurried and bowed his head toward the earth, and worshiped. 
-<span class="v">9&#160;</span>He said, “If now I have found favor in your sight, Lord, please let the Lord go among us, even though this is a stiff-necked people; pardon our iniquity and our sin, and take us for your inheritance.” 
-</p><p>
-<span class="v">10&#160;</span>He said, “Behold, I make a covenant: before all your people I will do marvels, such as have not been worked in all the earth, nor in any nation; and all the people among whom you are shall see the work of Yahweh; for it is an awesome thing that I do with you. 
-<span class="v">11&#160;</span>Observe that which I command you today. Behold, I will drive out before you the Amorite, the Canaanite, the Hittite, the Perizzite, the Hivite, and the Jebusite. 
-<span class="v">12&#160;</span>Be careful, lest you make a covenant with the inhabitants of the land where you are going, lest it be for a snare among you; 
-<span class="v">13&#160;</span>but you shall break down their altars, and dash in pieces their pillars, and you shall cut down their Asherah poles; 
-<span class="v">14&#160;</span>for you shall worship no other elohim; for Yahweh, whose name is Jealous, is a jealous Elohim. 
-</p><p>
-<span class="v">15&#160;</span>“Don’t make a covenant with the inhabitants of the land, lest they play the prostitute after their elohims, and sacrifice to their elohims, and one call you and you eat of his sacrifice; 
-<span class="v">16&#160;</span>and you take of their daughters to your sons, and their daughters play the prostitute after their elohims, and make your sons play the prostitute after their elohims. 
-</p><p>
-<span class="v">17&#160;</span>“You shall make no cast idols for yourselves. 
-</p><p>
-<span class="v">18&#160;</span>“You shall keep the feast of unleavened bread. Seven days you shall eat unleavened bread, as I commanded you, at the time appointed in the month Abib; for in the month Abib you came out of Egypt. 
-</p><p>
-<span class="v">19&#160;</span>“All that opens the womb is mine; and all your livestock that is male, the firstborn of cow and sheep. 
-<span class="v">20&#160;</span>You shall redeem the firstborn of a donkey with a lamb. If you will not redeem it, then you shall break its neck. You shall redeem all the firstborn of your sons. No one shall appear before me empty. 
-</p><p>
-<span class="v">21&#160;</span>“Six days you shall work, but on the seventh day you shall rest: in plowing time and in harvest you shall rest. 
-</p><p>
-<span class="v">22&#160;</span>“You shall observe the feast of weeks with the first fruits of wheat harvest, and the feast of harvest at the year’s end. 
-<span class="v">23&#160;</span>Three times in the year all your males shall appear before the Lord Yahweh, the Elohim of Israel. 
-<span class="v">24&#160;</span>For I will drive out nations before you and enlarge your borders; neither shall any man desire your land when you go up to appear before Yahweh, your Elohim, three times in the year. 
-</p><p>
-<span class="v">25&#160;</span>“You shall not offer the blood of my sacrifice with leavened bread. The sacrifice of the feast of the Passover shall not be left to the morning. 
-</p><p>
-<span class="v">26&#160;</span>“You shall bring the first of the first fruits of your ground to the house of Yahweh your Elohim. 
-</p><p>“You shall not boil a young goat in its mother’s milk.” 
-</p><p>
-<span class="v">27&#160;</span>Yahweh said to Moses, “Write these words; for in accordance with these words I have made a covenant with you and with Israel.” 
-</p><p>
-<span class="v">28&#160;</span>He was there with Yahweh forty days and forty nights; he neither ate bread, nor drank water. He wrote on the tablets the words of the covenant, the ten commandments. 
-</p><p>
-<span class="v">29&#160;</span>When Moses came down from Mount Sinai with the two tablets of the covenant in Moses’ hand, when he came down from the mountain, Moses didn’t know that the skin of his face shone by reason of his speaking with him. 
-<span class="v">30&#160;</span>When Aaron and all the children of Israel saw Moses, behold, the skin of his face shone; and they were afraid to come near him. 
-<span class="v">31&#160;</span>Moses called to them, and Aaron and all the rulers of the congregation returned to him; and Moses spoke to them. 
-<span class="v">32&#160;</span>Afterward all the children of Israel came near, and he gave them all the commandments that Yahweh had spoken with him on Mount Sinai. 
-<span class="v">33&#160;</span>When Moses was done speaking with them, he put a veil on his face. 
-<span class="v">34&#160;</span>But when Moses went in before Yahweh to speak with him, he took the veil off, until he came out; and he came out, and spoke to the children of Israel that which he was commanded. 
-<span class="v">35&#160;</span>The children of Israel saw Moses’ face, that the skin of Moses’ face shone; so Moses put the veil on his face again, until he went in to speak with him. 
-</p><h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>Moses assembled all the congregation of the children of Israel, and said to them, “These are the words which Yahweh has commanded, that you should do them. 
-<span class="v">2&#160;</span>‘Six days shall work be done, but on the seventh day there shall be a set-apart day for you, a Sabbath of solemn rest to Yahweh: whoever does any work in it shall be put to death. 
-<span class="v">3&#160;</span>You shall kindle no fire throughout your habitations on the Sabbath day.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>Moses spoke to all the congregation of the children of Israel, saying, “This is the thing which Yahweh commanded, saying, 
-<span class="v">5&#160;</span>‘Take from among you an offering to Yahweh. Whoever is of a willing heart, let him bring it as Yahweh’s offering: gold, silver, bronze, 
-<span class="v">6&#160;</span>blue, purple, scarlet, fine linen, goats’ hair, 
-<span class="v">7&#160;</span>rams’ skins dyed red, sea cow hides, acacia wood, 
-<span class="v">8&#160;</span>oil for the light, spices for the anointing oil and for the sweet incense, 
-<span class="v">9&#160;</span>onyx stones, and stones to be set for the ephod and for the breastplate. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘Let every wise-hearted man among you come, and make all that Yahweh has commanded: 
-<span class="v">11&#160;</span>the tabernacle, its outer covering, its roof, its clasps, its boards, its bars, its pillars, and its sockets; 
-<span class="v">12&#160;</span>the ark, and its poles, the mercy seat, the veil of the screen; 
-<span class="v">13&#160;</span>the table with its poles and all its vessels, and the show bread; 
-<span class="v">14&#160;</span>the lamp stand also for the light, with its vessels, its lamps, and the oil for the light; 
-<span class="v">15&#160;</span>and the altar of incense with its poles, the anointing oil, the sweet incense, the screen for the door, at the door of the tabernacle; 
-<span class="v">16&#160;</span>the altar of burnt offering, with its grating of bronze, its poles, and all its vessels, the basin and its base; 
-<span class="v">17&#160;</span>the hangings of the court, its pillars, their sockets, and the screen for the gate of the court; 
-<span class="v">18&#160;</span>the pins of the tabernacle, the pins of the court, and their cords; 
-<span class="v">19&#160;</span>the finely worked garments for ministering in the set-apart place—the set-apart garments for Aaron the priest, and the garments of his sons—to minister in the priest’s office.’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>All the congregation of the children of Israel departed from the presence of Moses. 
-<span class="v">21&#160;</span>They came, everyone whose heart stirred him up, and everyone whom his spirit made willing, and brought Yahweh’s offering for the work of the Tent of Meeting, and for all of its service, and for the set-apart garments. 
-<span class="v">22&#160;</span>They came, both men and women, as many as were willing-hearted, and brought brooches, earrings, signet rings, and armlets, all jewels of gold; even every man who offered an offering of gold to Yahweh. 
-<span class="v">23&#160;</span>Everyone with whom was found blue, purple, scarlet, fine linen, goats’ hair, rams’ skins dyed red, and sea cow hides, brought them. 
-<span class="v">24&#160;</span>Everyone who offered an offering of silver and bronze brought Yahweh’s offering; and everyone with whom was found acacia wood for any work of the service, brought it. 
-<span class="v">25&#160;</span>All the women who were wise-hearted spun with their hands, and brought that which they had spun: the blue, the purple, the scarlet, and the fine linen. 
-<span class="v">26&#160;</span>All the women whose heart stirred them up in wisdom spun the goats’ hair. 
-<span class="v">27&#160;</span>The rulers brought the onyx stones and the stones to be set for the ephod and for the breastplate; 
-<span class="v">28&#160;</span>with the spice and the oil for the light, for the anointing oil, and for the sweet incense. 
-<span class="v">29&#160;</span>The children of Israel brought a free will offering to Yahweh; every man and woman whose heart made them willing to bring for all the work, which Yahweh had commanded to be made by Moses. 
-</p><p>
-<span class="v">30&#160;</span>Moses said to the children of Israel, “Behold, Yahweh has called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
-<span class="v">31&#160;</span>He has filled him with the Spirit of Elohim, in wisdom, in understanding, in knowledge, and in all kinds of workmanship; 
-<span class="v">32&#160;</span>and to make skillful works, to work in gold, in silver, in bronze, 
-<span class="v">33&#160;</span>in cutting of stones for setting, and in carving of wood, to work in all kinds of skillful workmanship. 
-<span class="v">34&#160;</span>He has put in his heart that he may teach, both he and Oholiab, the son of Ahisamach, of the tribe of Dan. 
-<span class="v">35&#160;</span>He has filled them with wisdom of heart to work all kinds of workmanship, of the engraver, of the skillful workman, and of the embroiderer, in blue, in purple, in scarlet, and in fine linen, and of the weaver, even of those who do any workmanship, and of those who make skillful works. 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>“Bezalel and Oholiab shall work with every wise-hearted man, in whom Yahweh has put wisdom and understanding to know how to do all the work for the service of the sanctuary, according to all that Yahweh has commanded.” 
-</p><p>
-<span class="v">2&#160;</span>Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart Yahweh had put wisdom, even everyone whose heart stirred him up to come to the work to do it. 
-<span class="v">3&#160;</span>They received from Moses all the offering which the children of Israel had brought for the work of the service of the sanctuary, with which to make it. They kept bringing free will offerings to him every morning. 
-<span class="v">4&#160;</span>All the wise men, who performed all the work of the sanctuary, each came from his work which he did. 
-<span class="v">5&#160;</span>They spoke to Moses, saying, “The people have brought much more than enough for the service of the work which Yahweh commanded to make.” 
-</p><p>
-<span class="v">6&#160;</span>Moses gave a commandment, and they caused it to be proclaimed throughout the camp, saying, “Let neither man nor woman make anything else for the offering for the sanctuary.” So the people were restrained from bringing. 
-<span class="v">7&#160;</span>For the stuff they had was sufficient to do all the work, and too much. 
-</p><p>
-<span class="v">8&#160;</span>All the wise-hearted men among those who did the work made the tabernacle with ten curtains of fine twined linen, blue, purple, and scarlet. They made them with cherubim, the work of a skillful workman. 
-<span class="v">9&#160;</span>The length of each curtain was twenty-eight cubits,<span class="f">+ \fr 36:9 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and the width of each curtain four cubits. All the curtains had one measure. 
-<span class="v">10&#160;</span>He coupled five curtains to one another, and the other five curtains he coupled to one another. 
-<span class="v">11&#160;</span>He made loops of blue on the edge of the one curtain from the edge in the coupling. Likewise he made in the edge of the curtain that was outermost in the second coupling. 
-<span class="v">12&#160;</span>He made fifty loops in the one curtain, and he made fifty loops in the edge of the curtain that was in the second coupling. The loops were opposite to one another. 
-<span class="v">13&#160;</span>He made fifty clasps of gold, and coupled the curtains to one another with the clasps: so the tabernacle was a unit. 
-</p><p>
-<span class="v">14&#160;</span>He made curtains of goats’ hair for a covering over the tabernacle. He made them eleven curtains. 
-<span class="v">15&#160;</span>The length of each curtain was thirty cubits, and four cubits the width of each curtain. The eleven curtains had one measure. 
-<span class="v">16&#160;</span>He coupled five curtains by themselves, and six curtains by themselves. 
-<span class="v">17&#160;</span>He made fifty loops on the edge of the curtain that was outermost in the coupling, and he made fifty loops on the edge of the curtain which was outermost in the second coupling. 
-<span class="v">18&#160;</span>He made fifty clasps of bronze to couple the tent together, that it might be a unit. 
-<span class="v">19&#160;</span>He made a covering for the tent of rams’ skins dyed red, and a covering of sea cow hides above. 
-</p><p>
-<span class="v">20&#160;</span>He made the boards for the tabernacle of acacia wood, standing up. 
-<span class="v">21&#160;</span>Ten cubits was the length of a board, and a cubit and a half the width of each board. 
-<span class="v">22&#160;</span>Each board had two tenons, joined to one another. He made all the boards of the tabernacle this way. 
-<span class="v">23&#160;</span>He made the boards for the tabernacle, twenty boards for the south side southward. 
-<span class="v">24&#160;</span>He made forty sockets of silver under the twenty boards: two sockets under one board for its two tenons, and two sockets under another board for its two tenons. 
-<span class="v">25&#160;</span>For the second side of the tabernacle, on the north side, he made twenty boards 
-<span class="v">26&#160;</span>and their forty sockets of silver: two sockets under one board, and two sockets under another board. 
-<span class="v">27&#160;</span>For the far part of the tabernacle westward he made six boards. 
-<span class="v">28&#160;</span>He made two boards for the corners of the tabernacle in the far part. 
-<span class="v">29&#160;</span>They were double beneath, and in the same way they were all the way to its top to one ring. He did this to both of them in the two corners. 
-<span class="v">30&#160;</span>There were eight boards and their sockets of silver, sixteen sockets—under every board two sockets. 
-</p><p>
-<span class="v">31&#160;</span>He made bars of acacia wood: five for the boards of the one side of the tabernacle, 
-<span class="v">32&#160;</span>and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the tabernacle for the hinder part westward. 
-<span class="v">33&#160;</span>He made the middle bar to pass through in the middle of the boards from the one end to the other. 
-<span class="v">34&#160;</span>He overlaid the boards with gold, and made their rings of gold as places for the bars, and overlaid the bars with gold. 
-</p><p>
-<span class="v">35&#160;</span>He made the veil of blue, purple, scarlet, and fine twined linen, with cherubim. He made it the work of a skillful workman. 
-<span class="v">36&#160;</span>He made four pillars of acacia for it, and overlaid them with gold. Their hooks were of gold. He cast four sockets of silver for them. 
-<span class="v">37&#160;</span>He made a screen for the door of the tent, of blue, purple, scarlet, and fine twined linen, the work of an embroiderer; 
-<span class="v">38&#160;</span>and the five pillars of it with their hooks. He overlaid their capitals and their fillets with gold, and their five sockets were of bronze. 
-</p><h2 class="chapterlabel" id="37">37</h2>
-<p>
-<span class="v">1&#160;</span>Bezalel made the ark of acacia wood. Its length was two and a half cubits,<span class="f">+ \fr 37:1 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and its width a cubit and a half, and a cubit and a half its height. 
-<span class="v">2&#160;</span>He overlaid it with pure gold inside and outside, and made a molding of gold for it around it. 
-<span class="v">3&#160;</span>He cast four rings of gold for it in its four feet—two rings on its one side, and two rings on its other side. 
-<span class="v">4&#160;</span>He made poles of acacia wood and overlaid them with gold. 
-<span class="v">5&#160;</span>He put the poles into the rings on the sides of the ark, to bear the ark. 
-<span class="v">6&#160;</span>He made a mercy seat of pure gold. Its length was two and a half cubits, and a cubit and a half its width. 
-<span class="v">7&#160;</span>He made two cherubim of gold. He made them of beaten work, at the two ends of the mercy seat: 
-<span class="v">8&#160;</span>one cherub at the one end, and one cherub at the other end. He made the cherubim of one piece with the mercy seat at its two ends. 
-<span class="v">9&#160;</span>The cherubim spread out their wings above, covering the mercy seat with their wings, with their faces toward one another. The faces of the cherubim were toward the mercy seat. 
-</p><p>
-<span class="v">10&#160;</span>He made the table of acacia wood. Its length was two cubits, and its width was a cubit, and its height was a cubit and a half. 
-<span class="v">11&#160;</span>He overlaid it with pure gold, and made a gold molding around it. 
-<span class="v">12&#160;</span>He made a border of a hand’s width around it, and made a golden molding on its border around it. 
-<span class="v">13&#160;</span>He cast four rings of gold for it, and put the rings in the four corners that were on its four feet. 
-<span class="v">14&#160;</span>The rings were close by the border, the places for the poles to carry the table. 
-<span class="v">15&#160;</span>He made the poles of acacia wood, and overlaid them with gold, to carry the table. 
-<span class="v">16&#160;</span>He made the vessels which were on the table, its dishes, its spoons, its bowls, and its pitchers with which to pour out, of pure gold. 
-</p><p>
-<span class="v">17&#160;</span>He made the lamp stand of pure gold. He made the lamp stand of beaten work. Its base, its shaft, its cups, its buds, and its flowers were of one piece with it. 
-<span class="v">18&#160;</span>There were six branches going out of its sides: three branches of the lamp stand out of its one side, and three branches of the lamp stand out of its other side: 
-<span class="v">19&#160;</span>three cups made like almond blossoms in one branch, a bud and a flower, and three cups made like almond blossoms in the other branch, a bud and a flower; so for the six branches going out of the lamp stand. 
-<span class="v">20&#160;</span>In the lamp stand were four cups made like almond blossoms, its buds and its flowers; 
-<span class="v">21&#160;</span>and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, for the six branches going out of it. 
-<span class="v">22&#160;</span>Their buds and their branches were of one piece with it. The whole thing was one beaten work of pure gold. 
-<span class="v">23&#160;</span>He made its seven lamps, and its snuffers, and its snuff dishes, of pure gold. 
-<span class="v">24&#160;</span>He made it of a talent<span class="f">+ \fr 37:24 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of pure gold, with all its vessels. 
-</p><p>
-<span class="v">25&#160;</span>He made the altar of incense of acacia wood. It was square: its length was a cubit, and its width a cubit. Its height was two cubits. Its horns were of one piece with it. 
-<span class="v">26&#160;</span>He overlaid it with pure gold: its top, its sides around it, and its horns. He made a gold molding around it. 
-<span class="v">27&#160;</span>He made two golden rings for it under its molding crown, on its two ribs, on its two sides, for places for poles with which to carry it. 
-<span class="v">28&#160;</span>He made the poles of acacia wood, and overlaid them with gold. 
-<span class="v">29&#160;</span>He made the set-apart anointing oil and the pure incense of sweet spices, after the art of the perfumer. 
-</p><h2 class="chapterlabel" id="38">38</h2>
-<p>
-<span class="v">1&#160;</span>He made the altar of burnt offering of acacia wood. It was square. Its length was five cubits,<span class="f">+ \fr 38:1 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> its width was five cubits, and its height was three cubits. 
-<span class="v">2&#160;</span>He made its horns on its four corners. Its horns were of one piece with it, and he overlaid it with bronze. 
-<span class="v">3&#160;</span>He made all the vessels of the altar: the pots, the shovels, the basins, the forks, and the fire pans. He made all its vessels of bronze. 
-<span class="v">4&#160;</span>He made for the altar a grating of a network of bronze, under the ledge around it beneath, reaching halfway up. 
-<span class="v">5&#160;</span>He cast four rings for the four corners of bronze grating, to be places for the poles. 
-<span class="v">6&#160;</span>He made the poles of acacia wood, and overlaid them with bronze. 
-<span class="v">7&#160;</span>He put the poles into the rings on the sides of the altar, with which to carry it. He made it hollow with planks. 
-</p><p>
-<span class="v">8&#160;</span>He made the basin of bronze, and its base of bronze, out of the mirrors of the ministering women who ministered at the door of the Tent of Meeting. 
-</p><p>
-<span class="v">9&#160;</span>He made the court: for the south side southward the hangings of the court were of fine twined linen, one hundred cubits; 
-<span class="v">10&#160;</span>their pillars were twenty, and their sockets twenty, of bronze; the hooks of the pillars and their fillets were of silver. 
-<span class="v">11&#160;</span>For the north side one hundred cubits, their pillars twenty, and their sockets twenty, of bronze; the hooks of the pillars, and their fillets, of silver. 
-<span class="v">12&#160;</span>For the west side were hangings of fifty cubits, their pillars ten, and their sockets ten; the hooks of the pillars, and their fillets, of silver. 
-<span class="v">13&#160;</span>For the east side eastward fifty cubits, 
-<span class="v">14&#160;</span>the hangings for the one side were fifteen cubits; their pillars three, and their sockets three; 
-<span class="v">15&#160;</span>and so for the other side: on this hand and that hand by the gate of the court were hangings of fifteen cubits; their pillars three, and their sockets three. 
-<span class="v">16&#160;</span>All the hangings around the court were of fine twined linen. 
-<span class="v">17&#160;</span>The sockets for the pillars were of bronze. The hooks of the pillars and their fillets were of silver. Their capitals were overlaid with silver. All the pillars of the court had silver bands. 
-<span class="v">18&#160;</span>The screen for the gate of the court was the work of the embroiderer, of blue, purple, scarlet, and fine twined linen. Twenty cubits was the length, and the height along the width was five cubits, like the hangings of the court. 
-<span class="v">19&#160;</span>Their pillars were four, and their sockets four, of bronze; their hooks of silver, and the overlaying of their capitals, and their fillets, of silver. 
-<span class="v">20&#160;</span>All the pins of the tabernacle, and around the court, were of bronze. 
-</p><p>
-<span class="v">21&#160;</span>These are the amounts of materials used for the tabernacle, even the Tabernacle of the Testimony, as they were counted, according to the commandment of Moses, for the service of the Levites, by the hand of Ithamar, the son of Aaron the priest. 
-<span class="v">22&#160;</span>Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that Yahweh commanded Moses. 
-<span class="v">23&#160;</span>With him was Oholiab, the son of Ahisamach, of the tribe of Dan, an engraver, and a skillful workman, and an embroiderer in blue, in purple, in scarlet, and in fine linen. 
-</p><p>
-<span class="v">24&#160;</span>All the gold that was used for the work in all the work of the sanctuary, even the gold of the offering, was twenty-nine talents<span class="f">+ \fr 38:24 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces.</span> and seven hundred thirty shekels, according to the shekel<span class="f">+ \fr 38:24 \ft A shekel is about 10 grams or about 0.32 Troy ounces.</span> of the sanctuary. 
-<span class="v">25&#160;</span>The silver of those who were counted of the congregation was one hundred talents<span class="f">+ \fr 38:25 \ft A talent is about 30 kilograms or 66 pounds</span> and one thousand seven hundred seventy-five shekels,<span class="f">+ \fr 38:25 \ft A shekel is about 10 grams or about 0.35 ounces.</span> according to the shekel of the sanctuary: 
-<span class="v">26&#160;</span>a beka<span class="f">+ \fr 38:26 \ft a beka is about 5 grams or about 0.175 ounces</span> a head, that is, half a shekel, according to the shekel<span class="f">+ \fr 38:26 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of the sanctuary, for everyone who passed over to those who were counted, from twenty years old and upward, for six hundred three thousand five hundred fifty men. 
-<span class="v">27&#160;</span>The one hundred talents<span class="f">+ \fr 38:27 \ft A talent is about 30 kilograms or 66 pounds.</span> of silver were for casting the sockets of the sanctuary and the sockets of the veil: one hundred sockets for the one hundred talents, one talent per socket. 
-<span class="v">28&#160;</span>From the one thousand seven hundred seventy-five shekels<span class="f">+ \fr 38:28 \ft A shekel is about 10 grams or about 0.35 ounces, so 1775 shekels is about 17.75 kilograms or about 39 pounds.</span> he made hooks for the pillars, overlaid their capitals, and made fillets for them. 
-<span class="v">29&#160;</span>The bronze of the offering was seventy talents<span class="f">+ \fr 38:29 \ft A talent is about 30 kilograms or 66 pounds</span> and two thousand four hundred shekels.<span class="f">+ \fr 38:29 \ft 70 talents + 2400 shekels is about 2124 kilograms, or 2.124 metric tons.</span> 
-<span class="v">30&#160;</span>With this he made the sockets to the door of the Tent of Meeting, the bronze altar, the bronze grating for it, all the vessels of the altar, 
-<span class="v">31&#160;</span>the sockets around the court, the sockets of the gate of the court, all the pins of the tabernacle, and all the pins around the court. 
-</p><h2 class="chapterlabel" id="39">39</h2>
-<p>
-<span class="v">1&#160;</span>Of the blue, purple, and scarlet, they made finely worked garments for ministering in the set-apart place, and made the set-apart garments for Aaron, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">2&#160;</span>He made the ephod of gold, blue, purple, scarlet, and fine twined linen. 
-<span class="v">3&#160;</span>They beat the gold into thin plates, and cut it into wires, to work it in with the blue, the purple, the scarlet, and the fine linen, the work of the skillful workman. 
-<span class="v">4&#160;</span>They made shoulder straps for it, joined together. It was joined together at the two ends. 
-<span class="v">5&#160;</span>The skillfully woven band that was on it, with which to fasten it on, was of the same piece, like its work: of gold, of blue, purple, scarlet, and fine twined linen, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">6&#160;</span>They worked the onyx stones, enclosed in settings of gold, engraved with the engravings of a signet, according to the names of the children of Israel. 
-<span class="v">7&#160;</span>He put them on the shoulder straps of the ephod, to be stones of memorial for the children of Israel, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">8&#160;</span>He made the breastplate, the work of a skillful workman, like the work of the ephod: of gold, of blue, purple, scarlet, and fine twined linen. 
-<span class="v">9&#160;</span>It was square. They made the breastplate double. Its length was a span,<span class="f">+ \fr 39:9 \ft A span is the length from the tip of a man’s thumb to the tip of his little finger when his hand is stretched out (about half a cubit, or 9 inches, or 22.8 cm.)</span> and its width a span, being double. 
-<span class="v">10&#160;</span>They set in it four rows of stones. A row of ruby, topaz, and beryl was the first row; 
-<span class="v">11&#160;</span>and the second row, a turquoise, a sapphire,<span class="f">+ \fr 39:11 \ft or, lapis lazuli </span> and an emerald; 
-<span class="v">12&#160;</span>and the third row, a jacinth, an agate, and an amethyst; 
-<span class="v">13&#160;</span>and the fourth row, a chrysolite, an onyx, and a jasper. They were enclosed in gold settings. 
-<span class="v">14&#160;</span>The stones were according to the names of the children of Israel, twelve, according to their names; like the engravings of a signet, everyone according to his name, for the twelve tribes. 
-<span class="v">15&#160;</span>They made on the breastplate chains like cords, of braided work of pure gold. 
-<span class="v">16&#160;</span>They made two settings of gold, and two gold rings, and put the two rings on the two ends of the breastplate. 
-<span class="v">17&#160;</span>They put the two braided chains of gold in the two rings at the ends of the breastplate. 
-<span class="v">18&#160;</span>The other two ends of the two braided chains they put on the two settings, and put them on the shoulder straps of the ephod, in its front. 
-<span class="v">19&#160;</span>They made two rings of gold, and put them on the two ends of the breastplate, on its edge, which was toward the side of the ephod inward. 
-<span class="v">20&#160;</span>They made two more rings of gold, and put them on the two shoulder straps of the ephod underneath, in its front, close by its coupling, above the skillfully woven band of the ephod. 
-<span class="v">21&#160;</span>They bound the breastplate by its rings to the rings of the ephod with a lace of blue, that it might be on the skillfully woven band of the ephod, and that the breastplate might not come loose from the ephod, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">22&#160;</span>He made the robe of the ephod of woven work, all of blue. 
-<span class="v">23&#160;</span>The opening of the robe in the middle of it was like the opening of a coat of mail, with a binding around its opening, that it should not be torn. 
-<span class="v">24&#160;</span>They made on the skirts of the robe pomegranates of blue, purple, scarlet, and twined linen. 
-<span class="v">25&#160;</span>They made bells of pure gold, and put the bells between the pomegranates around the skirts of the robe, between the pomegranates; 
-<span class="v">26&#160;</span>a bell and a pomegranate, a bell and a pomegranate, around the skirts of the robe, to minister in, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">27&#160;</span>They made the tunics of fine linen of woven work for Aaron and for his sons, 
-<span class="v">28&#160;</span>the turban of fine linen, the linen headbands of fine linen, the linen trousers of fine twined linen, 
-<span class="v">29&#160;</span>the sash of fine twined linen, blue, purple, and scarlet, the work of the embroiderer, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">30&#160;</span>They made the plate of the set-apart crown of pure gold, and wrote on it an inscription, like the engravings of a signet: “SET-APART TO YAHWEH”. 
-<span class="v">31&#160;</span>They tied to it a lace of blue, to fasten it on the turban above, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">32&#160;</span>Thus all the work of the tabernacle of the Tent of Meeting was finished. The children of Israel did according to all that Yahweh commanded Moses; so they did. 
-<span class="v">33&#160;</span>They brought the tabernacle to Moses: the tent, with all its furniture, its clasps, its boards, its bars, its pillars, its sockets, 
-<span class="v">34&#160;</span>the covering of rams’ skins dyed red, the covering of sea cow hides, the veil of the screen, 
-<span class="v">35&#160;</span>the ark of the covenant with its poles, the mercy seat, 
-<span class="v">36&#160;</span>the table, all its vessels, the show bread, 
-<span class="v">37&#160;</span>the pure lamp stand, its lamps, even the lamps to be set in order, all its vessels, the oil for the light, 
-<span class="v">38&#160;</span>the golden altar, the anointing oil, the sweet incense, the screen for the door of the Tent, 
-<span class="v">39&#160;</span>the bronze altar, its grating of bronze, its poles, all of its vessels, the basin and its base, 
-<span class="v">40&#160;</span>the hangings of the court, its pillars, its sockets, the screen for the gate of the court, its cords, its pins, and all the instruments of the service of the tabernacle, for the Tent of Meeting, 
-<span class="v">41&#160;</span>the finely worked garments for ministering in the set-apart place, the set-apart garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office. 
-<span class="v">42&#160;</span>According to all that Yahweh commanded Moses, so the children of Israel did all the work. 
-<span class="v">43&#160;</span>Moses saw all the work, and behold, they had done it as Yahweh had commanded. They had done so; and Moses blessed them. 
-</p><h2 class="chapterlabel" id="40">40</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“On the first day of the first month you shall raise up the tabernacle of the Tent of Meeting. 
-<span class="v">3&#160;</span>You shall put the ark of the covenant in it, and you shall screen the ark with the veil. 
-<span class="v">4&#160;</span>You shall bring in the table, and set in order the things that are on it. You shall bring in the lamp stand, and light its lamps. 
-<span class="v">5&#160;</span>You shall set the golden altar for incense before the ark of the covenant, and put the screen of the door to the tabernacle. 
-</p><p>
-<span class="v">6&#160;</span>“You shall set the altar of burnt offering before the door of the tabernacle of the Tent of Meeting. 
-<span class="v">7&#160;</span>You shall set the basin between the Tent of Meeting and the altar, and shall put water therein. 
-<span class="v">8&#160;</span>You shall set up the court around it, and hang up the screen of the gate of the court. 
-</p><p>
-<span class="v">9&#160;</span>“You shall take the anointing oil, and anoint the tabernacle and all that is in it, and shall make it set-apart, and all its furniture, and it will be set-apart. 
-<span class="v">10&#160;</span>You shall anoint the altar of burnt offering, with all its vessels, and sanctify the altar, and the altar will be most set-apart. 
-<span class="v">11&#160;</span>You shall anoint the basin and its base, and sanctify it. 
-</p><p>
-<span class="v">12&#160;</span>“You shall bring Aaron and his sons to the door of the Tent of Meeting, and shall wash them with water. 
-<span class="v">13&#160;</span>You shall put on Aaron the set-apart garments; and you shall anoint him, and sanctify him, that he may minister to me in the priest’s office. 
-<span class="v">14&#160;</span>You shall bring his sons, and put tunics on them. 
-<span class="v">15&#160;</span>You shall anoint them, as you anointed their father, that they may minister to me in the priest’s office. Their anointing shall be to them for an everlasting priesthood throughout their generations.” 
-<span class="v">16&#160;</span>Moses did so. According to all that Yahweh commanded him, so he did. 
-</p><p>
-<span class="v">17&#160;</span>In the first month in the second year, on the first day of the month, the tabernacle was raised up. 
-<span class="v">18&#160;</span>Moses raised up the tabernacle, and laid its sockets, and set up its boards, and put in its bars, and raised up its pillars. 
-<span class="v">19&#160;</span>He spread the covering over the tent, and put the roof of the tabernacle above on it, as Yahweh commanded Moses. 
-<span class="v">20&#160;</span>He took and put the covenant into the ark, and set the poles on the ark, and put the mercy seat above on the ark. 
-<span class="v">21&#160;</span>He brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the covenant, as Yahweh commanded Moses. 
-<span class="v">22&#160;</span>He put the table in the Tent of Meeting, on the north side of the tabernacle, outside of the veil. 
-<span class="v">23&#160;</span>He set the bread in order on it before Yahweh, as Yahweh commanded Moses. 
-<span class="v">24&#160;</span>He put the lamp stand in the Tent of Meeting, opposite the table, on the south side of the tabernacle. 
-<span class="v">25&#160;</span>He lit the lamps before Yahweh, as Yahweh commanded Moses. 
-<span class="v">26&#160;</span>He put the golden altar in the Tent of Meeting before the veil; 
-<span class="v">27&#160;</span>and he burned incense of sweet spices on it, as Yahweh commanded Moses. 
-<span class="v">28&#160;</span>He put up the screen of the door to the tabernacle. 
-<span class="v">29&#160;</span>He set the altar of burnt offering at the door of the tabernacle of the Tent of Meeting, and offered on it the burnt offering and the meal offering, as Yahweh commanded Moses. 
-<span class="v">30&#160;</span>He set the basin between the Tent of Meeting and the altar, and put water therein, with which to wash. 
-<span class="v">31&#160;</span>Moses, Aaron, and his sons washed their hands and their feet there. 
-<span class="v">32&#160;</span>When they went into the Tent of Meeting, and when they came near to the altar, they washed, as Yahweh commanded Moses. 
-<span class="v">33&#160;</span>He raised up the court around the tabernacle and the altar, and set up the screen of the gate of the court. So Moses finished the work. 
-</p><p>
-<span class="v">34&#160;</span>Then the cloud covered the Tent of Meeting, and Yahweh’s glory filled the tabernacle. 
-<span class="v">35&#160;</span>Moses wasn’t able to enter into the Tent of Meeting, because the cloud stayed on it, and Yahweh’s glory filled the tabernacle. 
-<span class="v">36&#160;</span>When the cloud was taken up from over the tabernacle, the children of Israel went onward, throughout all their journeys; 
-<span class="v">37&#160;</span>but if the cloud wasn’t taken up, then they didn’t travel until the day that it was taken up. 
-<span class="v">38&#160;</span>For the cloud of Yahweh was on the tabernacle by day, and there was fire in the cloud by night, in the sight of all the house of Israel, throughout all their journeys. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now these are the names of the sons of Israel, who came into Egypt (every man and his household came with Jacob): 
+<sup>2&#160;</sup>Reuben, Simeon, Levi, and Judah, 
+<sup>3&#160;</sup>Issachar, Zebulun, and Benjamin, 
+<sup>4&#160;</sup>Dan and Naphtali, Gad and Asher. 
+<sup>5&#160;</sup>All the souls who came out of Jacob’s body were seventy souls, and Joseph was in Egypt already. 
+<sup>6&#160;</sup>Joseph died, as did all his brothers, and all that generation. 
+<sup>7&#160;</sup>The children of Israel were fruitful, and increased abundantly, and multiplied, and grew exceedingly mighty; and the land was filled with them. 
+</div><div class="p">
+<sup>8&#160;</sup>Now there arose a new king over Egypt, who didn’t know Joseph. 
+<sup>9&#160;</sup>He said to his people, “Behold, the people of the children of Israel are more and mightier than we. 
+<sup>10&#160;</sup>Come, let’s deal wisely with them, lest they multiply, and it happen that when any war breaks out, they also join themselves to our enemies and fight against us, and escape out of the land.” 
+<sup>11&#160;</sup>Therefore they set taskmasters over them to afflict them with their burdens. They built storage cities for Pharaoh: Pithom and Raamses. 
+<sup>12&#160;</sup>But the more they afflicted them, the more they multiplied and the more they spread out. They started to dread the children of Israel. 
+<sup>13&#160;</sup>The Egyptians ruthlessly made the children of Israel serve, 
+<sup>14&#160;</sup>and they made their lives bitter with hard service in mortar and in brick, and in all kinds of service in the field, all their service, in which they ruthlessly made them serve. 
+</div><div class="p">
+<sup>15&#160;</sup>The king of Egypt spoke to the Hebrew midwives, of whom the name of the one was Shiphrah, and the name of the other Puah, 
+<sup>16&#160;</sup>and he said, “When you perform the duty of a midwife to the Hebrew women, and see them on the birth stool, if it is a son, then you shall kill him; but if it is a daughter, then she shall live.” 
+<sup>17&#160;</sup>But the midwives feared Elohim, and didn’t do what the king of Egypt commanded them, but saved the baby boys alive. 
+<sup>18&#160;</sup>The king of Egypt called for the midwives, and said to them, “Why have you done this thing and saved the boys alive?” 
+</div><div class="p">
+<sup>19&#160;</sup>The midwives said to Pharaoh, “Because the Hebrew women aren’t like the Egyptian women; for they are vigorous and give birth before the midwife comes to them.” 
+</div><div class="p">
+<sup>20&#160;</sup>Elohim dealt well with the midwives, and the people multiplied, and grew very mighty. 
+<sup>21&#160;</sup>Because the midwives feared Elohim, he gave them families. 
+<sup>22&#160;</sup>Pharaoh commanded all his people, saying, “You shall cast every son who is born into the river, and every daughter you shall save alive.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>A man of the house of Levi went and took a daughter of Levi as his woman. 
+<sup>2&#160;</sup>The woman conceived and bore a son. When she saw that he was a fine child, she hid him three months. 
+<sup>3&#160;</sup>When she could no longer hide him, she took a papyrus basket for him, and coated it with tar and with pitch. She put the child in it, and laid it in the reeds by the river’s bank. 
+<sup>4&#160;</sup>His sister stood far off, to see what would be done to him. 
+<sup>5&#160;</sup>Pharaoh’s daughter came down to bathe at the river. Her maidens walked along by the riverside. She saw the basket among the reeds, and sent her servant to get it. 
+<sup>6&#160;</sup>She opened it, and saw the child, and behold, the baby cried. She had compassion on him, and said, “This is one of the Hebrews’ children.” 
+</div><div class="p">
+<sup>7&#160;</sup>Then his sister said to Pharaoh’s daughter, “Should I go and call a nurse for you from the Hebrew women, that she may nurse the child for you?” 
+</div><div class="p">
+<sup>8&#160;</sup>Pharaoh’s daughter said to her, “Go.” 
+</div><div class="p">The young woman went and called the child’s mother. 
+<sup>9&#160;</sup>Pharaoh’s daughter said to her, “Take this child away, and nurse him for me, and I will give you your wages.” 
+</div><div class="p">The woman took the child, and nursed it. 
+<sup>10&#160;</sup>The child grew, and she brought him to Pharaoh’s daughter, and he became her son. She named him Moses, and said, “Because I drew him out of the water.” 
+</div><div class="p">
+<sup>11&#160;</sup>In those days, when Moses had grown up, he went out to his brothers and saw their burdens. He saw an Egyptian striking a Hebrew, one of his brothers. 
+<sup>12&#160;</sup>He looked this way and that way, and when he saw that there was no one, he killed the Egyptian, and hid him in the sand. 
+</div><div class="p">
+<sup>13&#160;</sup>He went out the second day, and behold, two men of the Hebrews were fighting with each other. He said to him who did the wrong, “Why do you strike your fellow?” 
+</div><div class="p">
+<sup>14&#160;</sup>He said, “Who made you a prince and a judge over us? Do you plan to kill me, as you killed the Egyptian?” 
+</div><div class="p">Moses was afraid, and said, “Surely this thing is known.” 
+<sup>15&#160;</sup>Now when Pharaoh heard this thing, he sought to kill Moses. But Moses fled from the face of Pharaoh, and lived in the land of Midian, and he sat down by a well. 
+</div><div class="p">
+<sup>16&#160;</sup>Now the priest of Midian had seven daughters. They came and drew water, and filled the troughs to water their father’s flock. 
+<sup>17&#160;</sup>The shepherds came and drove them away; but Moses stood up and helped them, and watered their flock. 
+<sup>18&#160;</sup>When they came to Reuel, their father, he said, “How is it that you have returned so early today?” 
+</div><div class="p">
+<sup>19&#160;</sup>They said, “An Egyptian delivered us out of the hand of the shepherds, and moreover he drew water for us, and watered the flock.” 
+</div><div class="p">
+<sup>20&#160;</sup>He said to his daughters, “Where is he? Why is it that you have left the man? Call him, that he may eat bread.” 
+</div><div class="p">
+<sup>21&#160;</sup>Moses was content to dwell with the man. He gave Moses Zipporah, his daughter. 
+<sup>22&#160;</sup>She bore a son, and he named him Gershom, for he said, “I have lived as a foreigner in a foreign land.” 
+</div><div class="p">
+<sup>23&#160;</sup>In the course of those many days, the king of Egypt died, and the children of Israel sighed because of the bondage, and they cried, and their cry came up to Elohim because of the bondage. 
+<sup>24&#160;</sup>Elohim heard their groaning, and Elohim remembered his covenant with Abraham, with Isaac, and with Jacob. 
+<sup>25&#160;</sup>Elohim saw the children of Israel, and Elohim understood. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Moses was keeping the flock of Jethro, his father-in-law, the priest of Midian, and he led the flock to the back of the wilderness, and came to Elohim’s mountain, to Horeb. 
+<sup>2&#160;</sup>Yahweh’s angel appeared to him in a flame of fire out of the middle of a bush. He looked, and behold, the bush burned with fire, and the bush was not consumed. 
+<sup>3&#160;</sup>Moses said, “I will go now, and see this great sight, why the bush is not burned.” 
+</div><div class="p">
+<sup>4&#160;</sup>When Yahweh saw that he came over to see, Elohim called to him out of the middle of the bush, and said, “Moses! Moses!” 
+</div><div class="p">He said, “Here I am.” 
+</div><div class="p">
+<sup>5&#160;</sup>He said, “Don’t come close. Take off your sandals, for the place you are standing on is set-apart ground.” 
+<sup>6&#160;</sup>Moreover he said, “I am the Elohim of your father, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob.” 
+</div><div class="p">Moses hid his face because he was afraid to look at Elohim. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh said, “I have surely seen the affliction of my people who are in Egypt, and have heard their cry because of their taskmasters, for I know their sorrows. 
+<sup>8&#160;</sup>I have come down to deliver them out of the hand of the Egyptians, and to bring them up out of that land to a good and large land, to a land flowing with milk and honey; to the place of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite. 
+<sup>9&#160;</sup>Now, behold, the cry of the children of Israel has come to me. Moreover I have seen the oppression with which the Egyptians oppress them. 
+<sup>10&#160;</sup>Come now therefore, and I will send you to Pharaoh, that you may bring my people, the children of Israel, out of Egypt.” 
+</div><div class="p">
+<sup>11&#160;</sup>Moses said to Elohim, “Who am I, that I should go to Pharaoh, and that I should bring the children of Israel out of Egypt?” 
+</div><div class="p">
+<sup>12&#160;</sup>He said, “Certainly I will be with you. This will be the token to you, that I have sent you: when you have brought the people out of Egypt, you shall serve Elohim on this mountain.” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses said to Elohim, “Behold, when I come to the children of Israel, and tell them, ‘The Elohim of your fathers has sent me to you,’ and they ask me, ‘What is his name?’ what should I tell them?” 
+</div><div class="p">
+<sup>14&#160;</sup>Elohim said to Moses, “I will be who I will be,” and he said, “You shall tell the children of Israel this: ‘I will be has sent me to you.’&#160;” 
+<sup>15&#160;</sup>Elohim said moreover to Moses, “You shall tell the children of Israel this, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has sent me to you.’ This is my name forever, and this is my memorial to all generations. 
+<sup>16&#160;</sup>Go and gather the elders of Israel together, and tell them, ‘Yahweh, the Elohim of your fathers, the Elohim of Abraham, of Isaac, and of Jacob, has appeared to me, saying, “I have surely visited you, and seen that which is done to you in Egypt. 
+<sup>17&#160;</sup>I have said, I will bring you up out of the affliction of Egypt to the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Hivite, and the Jebusite, to a land flowing with milk and honey.”&#160;’ 
+<sup>18&#160;</sup>They will listen to your voice. You shall come, you and the elders of Israel, to the king of Egypt, and you shall tell him, ‘Yahweh, the Elohim of the Hebrews, has met with us. Now please let us go three days’ journey into the wilderness, that we may sacrifice to Yahweh, our Elohim.’ 
+<sup>19&#160;</sup>I know that the king of Egypt won’t give you permission to go, no, not by a mighty hand. 
+<sup>20&#160;</sup>I will reach out my hand and strike Egypt with all my wonders which I will do among them, and after that he will let you go. 
+<sup>21&#160;</sup>I will give this people favor in the sight of the Egyptians, and it will happen that when you go, you shall not go empty-handed. 
+<sup>22&#160;</sup>But every woman shall ask of her neighbor, and of her who visits her house, jewels of silver, jewels of gold, and clothing. You shall put them on your sons, and on your daughters. You shall plunder the Egyptians.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses answered, “But, behold, they will not believe me, nor listen to my voice; for they will say, ‘Yahweh has not appeared to you.’&#160;” 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh said to him, “What is that in your hand?” 
+</div><div class="p">He said, “A rod.” 
+</div><div class="p">
+<sup>3&#160;</sup>He said, “Throw it on the ground.” 
+</div><div class="p">He threw it on the ground, and it became a snake; and Moses ran away from it. 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh said to Moses, “Stretch out your hand, and take it by the tail.” 
+</div><div class="p">He stretched out his hand, and took hold of it, and it became a rod in his hand. 
+</div><div class="p">
+<sup>5&#160;</sup>“This is so that they may believe that Yahweh, the Elohim of their fathers, the Elohim of Abraham, the Elohim of Isaac, and the Elohim of Jacob, has appeared to you.” 
+<sup>6&#160;</sup>Yahweh said furthermore to him, “Now put your hand inside your cloak.” 
+</div><div class="p">He put his hand inside his cloak, and when he took it out, behold, his hand was leprous, as white as snow. 
+</div><div class="p">
+<sup>7&#160;</sup>He said, “Put your hand inside your cloak again.” 
+</div><div class="p">He put his hand inside his cloak again, and when he took it out of his cloak, behold, it had turned again as his other flesh. 
+</div><div class="p">
+<sup>8&#160;</sup>“It will happen, if they will not believe you or listen to the voice of the first sign, that they will believe the voice of the latter sign. 
+<sup>9&#160;</sup>It will happen, if they will not believe even these two signs or listen to your voice, that you shall take of the water of the river, and pour it on the dry land. The water which you take out of the river will become blood on the dry land.” 
+</div><div class="p">
+<sup>10&#160;</sup>Moses said to Yahweh, “O Lord, I am not eloquent, neither before now, nor since you have spoken to your servant; for I am slow of speech, and of a slow tongue.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said to him, “Who made man’s mouth? Or who makes one mute, or deaf, or seeing, or blind? Isn’t it I, Yahweh? 
+<sup>12&#160;</sup>Now therefore go, and I will be with your mouth, and teach you what you shall speak.” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses said, “Oh, Lord, please send someone else.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh’s anger burned against Moses, and he said, “What about Aaron, your brother, the Levite? I know that he can speak well. Also, behold, he is coming out to meet you. When he sees you, he will be glad in his heart. 
+<sup>15&#160;</sup>You shall speak to him, and put the words in his mouth. I will be with your mouth, and with his mouth, and will teach you what you shall do. 
+<sup>16&#160;</sup>He will be your spokesman to the people. It will happen that he will be to you a mouth, and you will be to him as Elohim. 
+<sup>17&#160;</sup>You shall take this rod in your hand, with which you shall do the signs.” 
+</div><div class="p">
+<sup>18&#160;</sup>Moses went and returned to Jethro his father-in-law, and said to him, “Please let me go and return to my brothers who are in Egypt, and see whether they are still alive.” 
+</div><div class="p">Jethro said to Moses, “Go in peace.” 
+</div><div class="p">
+<sup>19&#160;</sup>Yahweh said to Moses in Midian, “Go, return into Egypt; for all the men who sought your life are dead.” 
+</div><div class="p">
+<sup>20&#160;</sup>Moses took his woman and his sons, and set them on a donkey, and he returned to the land of Egypt. Moses took Elohim’s rod in his hand. 
+<sup>21&#160;</sup>Yahweh said to Moses, “When you go back into Egypt, see that you do before Pharaoh all the wonders which I have put in your hand, but I will harden his heart and he will not let the people go. 
+<sup>22&#160;</sup>You shall tell Pharaoh, ‘Yahweh says, Israel is my son, my firstborn, 
+<sup>23&#160;</sup>and I have said to you, “Let my son go, that he may serve me;” and you have refused to let him go. Behold, I will kill your firstborn son.’&#160;” 
+</div><div class="p">
+<sup>24&#160;</sup>On the way at a lodging place, Yahweh met Moses and wanted to kill him. 
+<sup>25&#160;</sup>Then Zipporah took a flint, and cut off the foreskin of her son, and cast it at his feet; and she said, “Surely you are a bridegroom of blood to me.” 
+</div><div class="p">
+<sup>26&#160;</sup>So he let him alone. Then she said, “You are a bridegroom of blood,” because of the circumcision. 
+</div><div class="p">
+<sup>27&#160;</sup>Yahweh said to Aaron, “Go into the wilderness to meet Moses.” 
+</div><div class="p">He went, and met him on Elohim’s mountain, and kissed him. 
+<sup>28&#160;</sup>Moses told Aaron all Yahweh’s words with which he had sent him, and all the signs with which he had instructed him. 
+<sup>29&#160;</sup>Moses and Aaron went and gathered together all the elders of the children of Israel. 
+<sup>30&#160;</sup>Aaron spoke all the words which Yahweh had spoken to Moses, and did the signs in the sight of the people. 
+<sup>31&#160;</sup>The people believed, and when they heard that Yahweh had visited the children of Israel, and that he had seen their affliction, then they bowed their heads and worshiped. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Afterward Moses and Aaron came, and said to Pharaoh, “This is what Yahweh, the Elohim of Israel, says, ‘Let my people go, that they may hold a feast to me in the wilderness.’&#160;” 
+</div><div class="p">
+<sup>2&#160;</sup>Pharaoh said, “Who is Yahweh, that I should listen to his voice to let Israel go? I don’t know Yahweh, and moreover I will not let Israel go.” 
+</div><div class="p">
+<sup>3&#160;</sup>They said, “The Elohim of the Hebrews has met with us. Please let us go three days’ journey into the wilderness, and sacrifice to Yahweh, our Elohim, lest he fall on us with pestilence, or with the sword.” 
+</div><div class="p">
+<sup>4&#160;</sup>The king of Egypt said to them, “Why do you, Moses and Aaron, take the people from their work? Get back to your burdens!” 
+<sup>5&#160;</sup>Pharaoh said, “Behold, the people of the land are now many, and you make them rest from their burdens.” 
+<sup>6&#160;</sup>The same day Pharaoh commanded the taskmasters of the people and their officers, saying, 
+<sup>7&#160;</sup>“You shall no longer give the people straw to make brick, as before. Let them go and gather straw for themselves. 
+<sup>8&#160;</sup>You shall require from them the number of the bricks which they made before. You shall not diminish anything of it, for they are idle. Therefore they cry, saying, ‘Let’s go and sacrifice to our Elohim.’ 
+<sup>9&#160;</sup>Let heavier work be laid on the men, that they may labor in it. Don’t let them pay any attention to lying words.” 
+</div><div class="p">
+<sup>10&#160;</sup>The taskmasters of the people went out with their officers, and they spoke to the people, saying, “This is what Pharaoh says: ‘I will not give you straw. 
+<sup>11&#160;</sup>Go yourselves, get straw where you can find it, for nothing of your work shall be diminished.’&#160;” 
+<sup>12&#160;</sup>So the people were scattered abroad throughout all the land of Egypt to gather stubble for straw. 
+<sup>13&#160;</sup>The taskmasters were urgent saying, “Fulfill your work quota daily, as when there was straw!” 
+<sup>14&#160;</sup>The officers of the children of Israel, whom Pharaoh’s taskmasters had set over them, were beaten, and were asked, “Why haven’t you fulfilled your quota both yesterday and today, in making brick as before?” 
+</div><div class="p">
+<sup>15&#160;</sup>Then the officers of the children of Israel came and cried to Pharaoh, saying, “Why do you deal this way with your servants? 
+<sup>16&#160;</sup>No straw is given to your servants, and they tell us, ‘Make brick!’ and behold, your servants are beaten; but the fault is in your own people.” 
+</div><div class="p">
+<sup>17&#160;</sup>But Pharaoh said, “You are idle! You are idle! Therefore you say, ‘Let’s go and sacrifice to Yahweh.’ 
+<sup>18&#160;</sup>Go therefore now, and work; for no straw shall be given to you; yet you shall deliver the same number of bricks!” 
+</div><div class="p">
+<sup>19&#160;</sup>The officers of the children of Israel saw that they were in trouble when it was said, “You shall not diminish anything from your daily quota of bricks!” 
+</div><div class="p">
+<sup>20&#160;</sup>They met Moses and Aaron, who stood along the way, as they came out from Pharaoh. 
+<sup>21&#160;</sup>They said to them, “May Yahweh look at you and judge, because you have made us a stench to be abhorred in the eyes of Pharaoh, and in the eyes of his servants, to put a sword in their hand to kill us!” 
+</div><div class="p">
+<sup>22&#160;</sup>Moses returned to Yahweh, and said, “Lord, why have you brought trouble on this people? Why is it that you have sent me? 
+<sup>23&#160;</sup>For since I came to Pharaoh to speak in your name, he has brought trouble on this people. You have not rescued your people at all!” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, “Now you shall see what I will do to Pharaoh, for by a strong hand he shall let them go, and by a strong hand he shall drive them out of his land.” 
+</div><div class="p">
+<sup>2&#160;</sup>Elohim spoke to Moses, and said to him, “I am Yahweh. 
+<sup>3&#160;</sup>I appeared to Abraham, to Isaac, and to Jacob, as Elohim Almighty; but by my name Yahweh I was not known to them. 
+<sup>4&#160;</sup>I have also established my covenant with them, to give them the land of Canaan, the land of their travels, in which they lived as aliens. 
+<sup>5&#160;</sup>Moreover I have heard the groaning of the children of Israel, whom the Egyptians keep in bondage, and I have remembered my covenant. 
+<sup>6&#160;</sup>Therefore tell the children of Israel, ‘I am Yahweh, and I will bring you out from under the burdens of the Egyptians, and I will rid you out of their bondage, and I will redeem you with an outstretched arm, and with great judgments. 
+<sup>7&#160;</sup>I will take you to myself for a people. I will be your Elohim; and you shall know that I am Yahweh your Elohim, who brings you out from under the burdens of the Egyptians. 
+<sup>8&#160;</sup>I will bring you into the land which I swore to give to Abraham, to Isaac, and to Jacob; and I will give it to you for a heritage: I am Yahweh.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>Moses spoke so to the children of Israel, but they didn’t listen to Moses for anguish of spirit, and for cruel bondage. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>11&#160;</sup>“Go in, speak to Pharaoh king of Egypt, that he let the children of Israel go out of his land.” 
+</div><div class="p">
+<sup>12&#160;</sup>Moses spoke before Yahweh, saying, “Behold, the children of Israel haven’t listened to me. How then shall Pharaoh listen to me, when I have uncircumcised lips?” 
+<sup>13&#160;</sup>Yahweh spoke to Moses and to Aaron, and gave them a command to the children of Israel, and to Pharaoh king of Egypt, to bring the children of Israel out of the land of Egypt. 
+</div><div class="p">
+<sup>14&#160;</sup>These are the heads of their fathers’ houses. The sons of Reuben the firstborn of Israel: Hanoch, and Pallu, Hezron, and Carmi; these are the families of Reuben. 
+<sup>15&#160;</sup>The sons of Simeon: Jemuel, and Jamin, and Ohad, and Jachin, and Zohar, and Shaul the son of a Canaanite woman; these are the families of Simeon. 
+<sup>16&#160;</sup>These are the names of the sons of Levi according to their generations: Gershon, and Kohath, and Merari; and the years of the life of Levi were one hundred thirty-seven years. 
+<sup>17&#160;</sup>The sons of Gershon: Libni and Shimei, according to their families. 
+<sup>18&#160;</sup>The sons of Kohath: Amram, and Izhar, and Hebron, and Uzziel; and the years of the life of Kohath were one hundred thirty-three years. 
+<sup>19&#160;</sup>The sons of Merari: Mahli and Mushi. These are the families of the Levites according to their generations. 
+<sup>20&#160;</sup>Amram took Jochebed his father’s sister to himself as woman; and she bore him Aaron and Moses. The years of the life of Amram were one hundred thirty-seven years. 
+<sup>21&#160;</sup>The sons of Izhar: Korah, and Nepheg, and Zichri. 
+<sup>22&#160;</sup>The sons of Uzziel: Mishael, Elzaphan, and Sithri. 
+<sup>23&#160;</sup>Aaron took Elisheba, the daughter of Amminadab, the sister of Nahshon, as his woman; and she bore him Nadab and Abihu, Eleazar and Ithamar. 
+<sup>24&#160;</sup>The sons of Korah: Assir, Elkanah, and Abiasaph; these are the families of the Korahites. 
+<sup>25&#160;</sup>Eleazar Aaron’s son took one of the daughters of Putiel as his woman; and she bore him Phinehas. These are the heads of the fathers’ houses of the Levites according to their families. 
+<sup>26&#160;</sup>These are that Aaron and Moses to whom Yahweh said, “Bring out the children of Israel from the land of Egypt according to their armies.” 
+<sup>27&#160;</sup>These are those who spoke to Pharaoh king of Egypt, to bring out the children of Israel from Egypt. These are that Moses and Aaron. 
+</div><div class="p">
+<sup>28&#160;</sup>On the day when Yahweh spoke to Moses in the land of Egypt, 
+<sup>29&#160;</sup>Yahweh said to Moses, “I am Yahweh. Tell Pharaoh king of Egypt all that I tell you.” 
+</div><div class="p">
+<sup>30&#160;</sup>Moses said before Yahweh, “Behold, I am of uncircumcised lips, and how shall Pharaoh listen to me?” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, “Behold, I have made you as Elohim to Pharaoh; and Aaron your brother shall be your prophet. 
+<sup>2&#160;</sup>You shall speak all that I command you; and Aaron your brother shall speak to Pharaoh, that he let the children of Israel go out of his land. 
+<sup>3&#160;</sup>I will harden Pharaoh’s heart, and multiply my signs and my wonders in the land of Egypt. 
+<sup>4&#160;</sup>But Pharaoh will not listen to you, so I will lay my hand on Egypt, and bring out my armies, my people the children of Israel, out of the land of Egypt by great judgments. 
+<sup>5&#160;</sup>The Egyptians shall know that I am Yahweh when I stretch out my hand on Egypt, and bring the children of Israel out from among them.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses and Aaron did so. As Yahweh commanded them, so they did. 
+<sup>7&#160;</sup>Moses was eighty years old, and Aaron eighty-three years old, when they spoke to Pharaoh. 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>9&#160;</sup>“When Pharaoh speaks to you, saying, ‘Perform a miracle!’ then you shall tell Aaron, ‘Take your rod, and cast it down before Pharaoh, and it will become a serpent.’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Moses and Aaron went in to Pharaoh, and they did so, as Yahweh had commanded. Aaron cast down his rod before Pharaoh and before his servants, and it became a serpent. 
+<sup>11&#160;</sup>Then Pharaoh also called for the wise men and the sorcerers. They also, the magicians of Egypt, did the same thing with their enchantments. 
+<sup>12&#160;</sup>For they each cast down their rods, and they became serpents; but Aaron’s rod swallowed up their rods. 
+<sup>13&#160;</sup>Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh said to Moses, “Pharaoh’s heart is stubborn. He refuses to let the people go. 
+<sup>15&#160;</sup>Go to Pharaoh in the morning. Behold, he is going out to the water. You shall stand by the river’s bank to meet him. You shall take the rod which was turned to a serpent in your hand. 
+<sup>16&#160;</sup>You shall tell him, ‘Yahweh, the Elohim of the Hebrews, has sent me to you, saying, “Let my people go, that they may serve me in the wilderness. Behold, until now you haven’t listened.” 
+<sup>17&#160;</sup>Yahweh says, “In this you shall know that I am Yahweh. Behold: I will strike with the rod that is in my hand on the waters which are in the river, and they shall be turned to blood. 
+<sup>18&#160;</sup>The fish that are in the river will die and the river will become foul. The Egyptians will loathe to drink water from the river.”&#160;’&#160;” 
+<sup>19&#160;</sup>Yahweh said to Moses, “Tell Aaron, ‘Take your rod, and stretch out your hand over the waters of Egypt, over their rivers, over their streams, and over their pools, and over all their ponds of water, that they may become blood. There will be blood throughout all the land of Egypt, both in vessels of wood and in vessels of stone.’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>Moses and Aaron did so, as Yahweh commanded; and he lifted up the rod, and struck the waters that were in the river, in the sight of Pharaoh, and in the sight of his servants; and all the waters that were in the river were turned to blood. 
+<sup>21&#160;</sup>The fish that were in the river died. The river became foul. The Egyptians couldn’t drink water from the river. The blood was throughout all the land of Egypt. 
+<sup>22&#160;</sup>The magicians of Egypt did the same thing with their enchantments. So Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+<sup>23&#160;</sup>Pharaoh turned and went into his house, and he didn’t even take this to heart. 
+<sup>24&#160;</sup>All the Egyptians dug around the river for water to drink; for they couldn’t drink the river water. 
+<sup>25&#160;</sup>Seven days were fulfilled, after Yahweh had struck the river. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
+<sup>2&#160;</sup>If you refuse to let them go, behold, I will plague all your borders with frogs. 
+<sup>3&#160;</sup>The river will swarm with frogs, which will go up and come into your house, and into your bedroom, and on your bed, and into the house of your servants, and on your people, and into your ovens, and into your kneading troughs. 
+<sup>4&#160;</sup>The frogs shall come up both on you, and on your people, and on all your servants.”&#160;’&#160;” 
+<sup>5&#160;</sup>Yahweh said to Moses, “Tell Aaron, ‘Stretch out your hand with your rod over the rivers, over the streams, and over the pools, and cause frogs to come up on the land of Egypt.’&#160;” 
+<sup>6&#160;</sup>Aaron stretched out his hand over the waters of Egypt; and the frogs came up, and covered the land of Egypt. 
+<sup>7&#160;</sup>The magicians did the same thing with their enchantments, and brought up frogs on the land of Egypt. 
+</div><div class="p">
+<sup>8&#160;</sup>Then Pharaoh called for Moses and Aaron, and said, “Entreat Yahweh, that he take away the frogs from me and from my people; and I will let the people go, that they may sacrifice to Yahweh.” 
+</div><div class="p">
+<sup>9&#160;</sup>Moses said to Pharaoh, “I give you the honor of setting the time that I should pray for you, and for your servants, and for your people, that the frogs be destroyed from you and your houses, and remain in the river only.” 
+</div><div class="p">
+<sup>10&#160;</sup>Pharaoh said, “Tomorrow.” 
+</div><div class="p">Moses said, “Let it be according to your word, that you may know that there is no one like Yahweh our Elohim. 
+<sup>11&#160;</sup>The frogs shall depart from you, and from your houses, and from your servants, and from your people. They shall remain in the river only.” 
+</div><div class="p">
+<sup>12&#160;</sup>Moses and Aaron went out from Pharaoh, and Moses cried to Yahweh concerning the frogs which he had brought on Pharaoh. 
+<sup>13&#160;</sup>Yahweh did according to the word of Moses, and the frogs died out of the houses, out of the courts, and out of the fields. 
+<sup>14&#160;</sup>They gathered them together in heaps, and the land stank. 
+<sup>15&#160;</sup>But when Pharaoh saw that there was a respite, he hardened his heart, and didn’t listen to them, as Yahweh had spoken. 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh said to Moses, “Tell Aaron, ‘Stretch out your rod, and strike the dust of the earth, that it may become lice throughout all the land of Egypt.’&#160;” 
+<sup>17&#160;</sup>They did so; and Aaron stretched out his hand with his rod, and struck the dust of the earth, and there were lice on man, and on animal; all the dust of the earth became lice throughout all the land of Egypt. 
+<sup>18&#160;</sup>The magicians tried with their enchantments to produce lice, but they couldn’t. There were lice on man, and on animal. 
+<sup>19&#160;</sup>Then the magicians said to Pharaoh, “This is Elohim’s finger;” but Pharaoh’s heart was hardened, and he didn’t listen to them, as Yahweh had spoken. 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh; behold, he comes out to the water; and tell him, ‘This is what Yahweh says, “Let my people go, that they may serve me. 
+<sup>21&#160;</sup>Else, if you will not let my people go, behold, I will send swarms of flies on you, and on your servants, and on your people, and into your houses. The houses of the Egyptians shall be full of swarms of flies, and also the ground they are on. 
+<sup>22&#160;</sup>I will set apart in that day the land of Goshen, in which my people dwell, that no swarms of flies shall be there, to the end you may know that I am Yahweh on the earth. 
+<sup>23&#160;</sup>I will put a division between my people and your people. This sign shall happen by tomorrow.”&#160;’&#160;” 
+<sup>24&#160;</sup>Yahweh did so; and there came grievous swarms of flies into the house of Pharaoh, and into his servants’ houses. In all the land of Egypt the land was corrupted by reason of the swarms of flies. 
+</div><div class="p">
+<sup>25&#160;</sup>Pharaoh called for Moses and for Aaron, and said, “Go, sacrifice to your Elohim in the land!” 
+</div><div class="p">
+<sup>26&#160;</sup>Moses said, “It isn’t appropriate to do so; for we shall sacrifice the abomination of the Egyptians to Yahweh our Elohim. Behold, if we sacrifice the abomination of the Egyptians before their eyes, won’t they stone us? 
+<sup>27&#160;</sup>We will go three days’ journey into the wilderness, and sacrifice to Yahweh our Elohim, as he shall command us.” 
+</div><div class="p">
+<sup>28&#160;</sup>Pharaoh said, “I will let you go, that you may sacrifice to Yahweh your Elohim in the wilderness, only you shall not go very far away. Pray for me.” 
+</div><div class="p">
+<sup>29&#160;</sup>Moses said, “Behold, I am going out from you. I will pray to Yahweh that the swarms of flies may depart from Pharaoh, from his servants, and from his people, tomorrow; only don’t let Pharaoh deal deceitfully any more in not letting the people go to sacrifice to Yahweh.” 
+<sup>30&#160;</sup>Moses went out from Pharaoh, and prayed to Yahweh. 
+<sup>31&#160;</sup>Yahweh did according to the word of Moses, and he removed the swarms of flies from Pharaoh, from his servants, and from his people. There remained not one. 
+<sup>32&#160;</sup>Pharaoh hardened his heart this time also, and he didn’t let the people go. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Yahweh said to Moses, “Go in to Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
+<sup>2&#160;</sup>For if you refuse to let them go, and hold them still, 
+<sup>3&#160;</sup>behold, Yahweh’s hand is on your livestock which are in the field, on the horses, on the donkeys, on the camels, on the herds, and on the flocks with a very grievous pestilence. 
+<sup>4&#160;</sup>Yahweh will make a distinction between the livestock of Israel and the livestock of Egypt; and nothing shall die of all that belongs to the children of Israel.”&#160;’&#160;” 
+<sup>5&#160;</sup>Yahweh appointed a set time, saying, “Tomorrow Yahweh shall do this thing in the land.” 
+<sup>6&#160;</sup>Yahweh did that thing on the next day; and all the livestock of Egypt died, but of the livestock of the children of Israel, not one died. 
+<sup>7&#160;</sup>Pharaoh sent, and, behold, there was not so much as one of the livestock of the Israelites dead. But the heart of Pharaoh was stubborn, and he didn’t let the people go. 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh said to Moses and to Aaron, “Take handfuls of ashes of the furnace, and let Moses sprinkle it toward the sky in the sight of Pharaoh. 
+<sup>9&#160;</sup>It shall become small dust over all the land of Egypt, and shall be boils and blisters breaking out on man and on animal, throughout all the land of Egypt.” 
+</div><div class="p">
+<sup>10&#160;</sup>They took ashes of the furnace, and stood before Pharaoh; and Moses sprinkled it up toward the sky; and it became boils and blisters breaking out on man and on animal. 
+<sup>11&#160;</sup>The magicians couldn’t stand before Moses because of the boils; for the boils were on the magicians and on all the Egyptians. 
+<sup>12&#160;</sup>Yahweh hardened the heart of Pharaoh, and he didn’t listen to them, as Yahweh had spoken to Moses. 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh said to Moses, “Rise up early in the morning, and stand before Pharaoh, and tell him, ‘This is what Yahweh, the Elohim of the Hebrews, says: “Let my people go, that they may serve me. 
+<sup>14&#160;</sup>For this time I will send all my plagues against your heart, against your officials, and against your people; that you may know that there is no one like me in all the earth. 
+<sup>15&#160;</sup>For now I would have stretched out my hand, and struck you and your people with pestilence, and you would have been cut off from the earth; 
+<sup>16&#160;</sup>but indeed for this cause I have made you stand: to show you my power, and that my name may be declared throughout all the earth, 
+<sup>17&#160;</sup>because you still exalt yourself against my people, that you won’t let them go. 
+<sup>18&#160;</sup>Behold, tomorrow about this time I will cause it to rain a very grievous hail, such as has not been in Egypt since the day it was founded even until now. 
+<sup>19&#160;</sup>Now therefore command that all of your livestock and all that you have in the field be brought into shelter. The hail will come down on every man and animal that is found in the field, and isn’t brought home, and they will die.”&#160;’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>Those who feared Yahweh’s word among the servants of Pharaoh made their servants and their livestock flee into the houses. 
+<sup>21&#160;</sup>Whoever didn’t respect Yahweh’s word left his servants and his livestock in the field. 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be hail in all the land of Egypt, on man, and on animal, and on every herb of the field, throughout the land of Egypt.” 
+</div><div class="p">
+<sup>23&#160;</sup>Moses stretched out his rod toward the heavens, and Yahweh sent thunder and hail; and lightning flashed down to the earth. Yahweh rained hail on the land of Egypt. 
+<sup>24&#160;</sup>So there was very severe hail, and lightning mixed with the hail, such as had not been in all the land of Egypt since it became a nation. 
+<sup>25&#160;</sup>The hail struck throughout all the land of Egypt all that was in the field, both man and animal; and the hail struck every herb of the field, and broke every tree of the field. 
+<sup>26&#160;</sup>Only in the land of Goshen, where the children of Israel were, there was no hail. 
+</div><div class="p">
+<sup>27&#160;</sup>Pharaoh sent and called for Moses and Aaron, and said to them, “I have sinned this time. Yahweh is righteous, and I and my people are wicked. 
+<sup>28&#160;</sup>Pray to Yahweh; for there has been enough of mighty thunderings and hail. I will let you go, and you shall stay no longer.” 
+</div><div class="p">
+<sup>29&#160;</sup>Moses said to him, “As soon as I have gone out of the city, I will spread out my hands to Yahweh. The thunders shall cease, and there will not be any more hail; that you may know that the earth is Yahweh’s. 
+<sup>30&#160;</sup>But as for you and your servants, I know that you don’t yet fear Yahweh Elohim.” 
+</div><div class="p">
+<sup>31&#160;</sup>The flax and the barley were struck, for the barley had ripened and the flax was blooming. 
+<sup>32&#160;</sup>But the wheat and the spelt were not struck, for they had not grown up. 
+<sup>33&#160;</sup>Moses went out of the city from Pharaoh, and spread out his hands to Yahweh; and the thunders and hail ceased, and the rain was not poured on the earth. 
+<sup>34&#160;</sup>When Pharaoh saw that the rain and the hail and the thunders had ceased, he sinned yet more, and hardened his heart, he and his servants. 
+<sup>35&#160;</sup>The heart of Pharaoh was hardened, and he didn’t let the children of Israel go, just as Yahweh had spoken through Moses. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, “Go in to Pharaoh, for I have hardened his heart and the heart of his servants, that I may show these my signs among them; 
+<sup>2&#160;</sup>and that you may tell in the hearing of your son, and of your son’s son, what things I have done to Egypt, and my signs which I have done among them; that you may know that I am Yahweh.” 
+</div><div class="p">
+<sup>3&#160;</sup>Moses and Aaron went in to Pharaoh, and said to him, “This is what Yahweh, the Elohim of the Hebrews, says: ‘How long will you refuse to humble yourself before me? Let my people go, that they may serve me. 
+<sup>4&#160;</sup>Or else, if you refuse to let my people go, behold, tomorrow I will bring locusts into your country, 
+<sup>5&#160;</sup>and they shall cover the surface of the earth, so that one won’t be able to see the earth. They shall eat the residue of that which has escaped, which remains to you from the hail, and shall eat every tree which grows for you out of the field. 
+<sup>6&#160;</sup>Your houses shall be filled, and the houses of all your servants, and the houses of all the Egyptians, as neither your fathers nor your fathers’ fathers have seen, since the day that they were on the earth to this day.’&#160;” He turned, and went out from Pharaoh. 
+</div><div class="p">
+<sup>7&#160;</sup>Pharaoh’s servants said to him, “How long will this man be a snare to us? Let the men go, that they may serve Yahweh, their Elohim. Don’t you yet know that Egypt is destroyed?” 
+</div><div class="p">
+<sup>8&#160;</sup>Moses and Aaron were brought again to Pharaoh, and he said to them, “Go, serve Yahweh your Elohim; but who are those who will go?” 
+</div><div class="p">
+<sup>9&#160;</sup>Moses said, “We will go with our young and with our old. We will go with our sons and with our daughters, with our flocks and with our herds; for we must hold a feast to Yahweh.” 
+</div><div class="p">
+<sup>10&#160;</sup>He said to them, “Yahweh be with you if I let you go with your little ones! See, evil is clearly before your faces. 
+<sup>11&#160;</sup>Not so! Go now you who are men, and serve Yahweh; for that is what you desire!” Then they were driven out from Pharaoh’s presence. 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh said to Moses, “Stretch out your hand over the land of Egypt for the locusts, that they may come up on the land of Egypt, and eat every herb of the land, even all that the hail has left.” 
+<sup>13&#160;</sup>Moses stretched out his rod over the land of Egypt, and Yahweh brought an east wind on the land all that day, and all night; and when it was morning, the east wind brought the locusts. 
+<sup>14&#160;</sup>The locusts went up over all the land of Egypt, and rested in all the borders of Egypt. They were very grievous. Before them there were no such locusts as they, nor will there ever be again. 
+<sup>15&#160;</sup>For they covered the surface of the whole earth, so that the land was darkened, and they ate every herb of the land, and all the fruit of the trees which the hail had left. There remained nothing green, either tree or herb of the field, through all the land of Egypt. 
+<sup>16&#160;</sup>Then Pharaoh called for Moses and Aaron in haste, and he said, “I have sinned against Yahweh your Elohim, and against you. 
+<sup>17&#160;</sup>Now therefore please forgive my sin again, and pray to Yahweh your Elohim, that he may also take away from me this death.” 
+</div><div class="p">
+<sup>18&#160;</sup>Moses went out from Pharaoh, and prayed to Yahweh. 
+<sup>19&#160;</sup>Yahweh sent an exceedingly strong west wind, which took up the locusts, and drove them into the Red Sea. There remained not one locust in all the borders of Egypt. 
+<sup>20&#160;</sup>But Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go. 
+</div><div class="p">
+<sup>21&#160;</sup>Yahweh said to Moses, “Stretch out your hand toward the sky, that there may be darkness over the land of Egypt, even darkness which may be felt.” 
+<sup>22&#160;</sup>Moses stretched out his hand toward the sky, and there was a thick darkness in all the land of Egypt for three days. 
+<sup>23&#160;</sup>They didn’t see one another, and nobody rose from his place for three days; but all the children of Israel had light in their dwellings. 
+</div><div class="p">
+<sup>24&#160;</sup>Pharaoh called to Moses, and said, “Go, serve Yahweh. Only let your flocks and your herds stay behind. Let your little ones also go with you.” 
+</div><div class="p">
+<sup>25&#160;</sup>Moses said, “You must also give into our hand sacrifices and burnt offerings, that we may sacrifice to Yahweh our Elohim. 
+<sup>26&#160;</sup>Our livestock also shall go with us. Not a hoof shall be left behind, for of it we must take to serve Yahweh our Elohim; and we don’t know with what we must serve Yahweh, until we come there.” 
+</div><div class="p">
+<sup>27&#160;</sup>But Yahweh hardened Pharaoh’s heart, and he wouldn’t let them go. 
+<sup>28&#160;</sup>Pharaoh said to him, “Get away from me! Be careful to see my face no more; for in the day you see my face you shall die!” 
+</div><div class="p">
+<sup>29&#160;</sup>Moses said, “You have spoken well. I will see your face again no more.” 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, “I will bring yet one more plague on Pharaoh, and on Egypt; afterwards he will let you go. When he lets you go, he will surely thrust you out altogether. 
+<sup>2&#160;</sup>Speak now in the ears of the people, and let every man ask of his neighbor, and every woman of her neighbor, jewels of silver, and jewels of gold.” 
+<sup>3&#160;</sup>Yahweh gave the people favor in the sight of the Egyptians. Moreover, the man Moses was very great in the land of Egypt, in the sight of Pharaoh’s servants, and in the sight of the people. 
+</div><div class="p">
+<sup>4&#160;</sup>Moses said, “This is what Yahweh says: ‘About midnight I will go out into the middle of Egypt, 
+<sup>5&#160;</sup>and all the firstborn in the land of Egypt shall die, from the firstborn of Pharaoh who sits on his throne, even to the firstborn of the female servant who is behind the mill, and all the firstborn of livestock. 
+<sup>6&#160;</sup>There will be a great cry throughout all the land of Egypt, such as there has not been, nor will be any more. 
+<sup>7&#160;</sup>But against any of the children of Israel a dog won’t even bark or move its tongue, against man or animal, that you may know that Yahweh makes a distinction between the Egyptians and Israel. 
+<sup>8&#160;</sup>All these servants of yours will come down to me, and bow down themselves to me, saying, “Get out, with all the people who follow you;” and after that I will go out.’&#160;” He went out from Pharaoh in hot anger. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh said to Moses, “Pharaoh won’t listen to you, that my wonders may be multiplied in the land of Egypt.” 
+<sup>10&#160;</sup>Moses and Aaron did all these wonders before Pharaoh, but Yahweh hardened Pharaoh’s heart, and he didn’t let the children of Israel go out of his land. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and Aaron in the land of Egypt, saying, 
+<sup>2&#160;</sup>“This month shall be to you the beginning of months. It shall be the first month of the year to you. 
+<sup>3&#160;</sup>Speak to all the congregation of Israel, saying, ‘On the tenth day of this month, they shall take to them every man a lamb, according to their fathers’ houses, a lamb for a household; 
+<sup>4&#160;</sup>and if the household is too little for a lamb, then he and his neighbor next to his house shall take one according to the number of the souls. You shall make your count for the lamb according to what everyone can eat. 
+<sup>5&#160;</sup>Your lamb shall be without defect, a male a year old. You shall take it from the sheep or from the goats. 
+<sup>6&#160;</sup>You shall keep it until the fourteenth day of the same month; and the whole assembly of the congregation of Israel shall kill it at evening. 
+<sup>7&#160;</sup>They shall take some of the blood, and put it on the two door posts and on the lintel, on the houses in which they shall eat it. 
+<sup>8&#160;</sup>They shall eat the meat in that night, roasted with fire, with unleavened bread. They shall eat it with bitter herbs. 
+<sup>9&#160;</sup>Don’t eat it raw, nor boiled at all with water, but roasted with fire; with its head, its legs and its inner parts. 
+<sup>10&#160;</sup>You shall let nothing of it remain until the morning; but that which remains of it until the morning you shall burn with fire. 
+<sup>11&#160;</sup>This is how you shall eat it: with your belt on your waist, your sandals on your feet, and your staff in your hand; and you shall eat it in haste: it is Yahweh’s Passover. 
+<sup>12&#160;</sup>For I will go through the land of Egypt in that night, and will strike all the firstborn in the land of Egypt, both man and animal. I will execute judgments against all the elohims of Egypt. I am Yahweh. 
+<sup>13&#160;</sup>The blood shall be to you for a token on the houses where you are. When I see the blood, I will pass over you, and no plague will be on you to destroy you when I strike the land of Egypt. 
+<sup>14&#160;</sup>This day shall be a memorial for you. You shall keep it as a feast to Yahweh. You shall keep it as a feast throughout your generations by an ordinance forever. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘Seven days you shall eat unleavened bread; even the first day you shall put away yeast out of your houses, for whoever eats leavened bread from the first day until the seventh day, that soul shall be cut off from Israel. 
+<sup>16&#160;</sup>In the first day there shall be to you a set-apart convocation, and in the seventh day a set-apart convocation; no kind of work shall be done in them, except that which every man must eat, only that may be done by you. 
+<sup>17&#160;</sup>You shall observe the feast of unleavened bread; for in this same day I have brought your armies out of the land of Egypt. Therefore you shall observe this day throughout your generations by an ordinance forever. 
+<sup>18&#160;</sup>In the first month, on the fourteenth day of the month at evening, you shall eat unleavened bread, until the twenty first day of the month at evening. 
+<sup>19&#160;</sup>There shall be no yeast found in your houses for seven days, for whoever eats that which is leavened, that soul shall be cut off from the congregation of Israel, whether he is a foreigner, or one who is born in the land. 
+<sup>20&#160;</sup>You shall eat nothing leavened. In all your habitations you shall eat unleavened bread.’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Moses called for all the elders of Israel, and said to them, “Draw out, and take lambs according to your families, and kill the Passover. 
+<sup>22&#160;</sup>You shall take a bunch of hyssop, and dip it in the blood that is in the basin, and strike the lintel and the two door posts with the blood that is in the basin. None of you shall go out of the door of his house until the morning. 
+<sup>23&#160;</sup>For Yahweh will pass through to strike the Egyptians; and when he sees the blood on the lintel, and on the two door posts, Yahweh will pass over the door, and will not allow the destroyer to come in to your houses to strike you. 
+<sup>24&#160;</sup>You shall observe this thing for an ordinance to you and to your sons forever. 
+<sup>25&#160;</sup>It shall happen when you have come to the land which Yahweh will give you, as he has promised, that you shall keep this service. 
+<sup>26&#160;</sup>It will happen, when your children ask you, ‘What do you mean by this service?’ 
+<sup>27&#160;</sup>that you shall say, ‘It is the sacrifice of Yahweh’s Passover, who passed over the houses of the children of Israel in Egypt, when he struck the Egyptians, and spared our houses.’&#160;” 
+</div><div class="p">The people bowed their heads and worshiped. 
+<sup>28&#160;</sup>The children of Israel went and did so; as Yahweh had commanded Moses and Aaron, so they did. 
+</div><div class="p">
+<sup>29&#160;</sup>At midnight, Yahweh struck all the firstborn in the land of Egypt, from the firstborn of Pharaoh who sat on his throne to the firstborn of the captive who was in the dungeon, and all the firstborn of livestock. 
+<sup>30&#160;</sup>Pharaoh rose up in the night, he, and all his servants, and all the Egyptians; and there was a great cry in Egypt, for there was not a house where there was not one dead. 
+<sup>31&#160;</sup>He called for Moses and Aaron by night, and said, “Rise up, get out from among my people, both you and the children of Israel; and go, serve Yahweh, as you have said! 
+<sup>32&#160;</sup>Take both your flocks and your herds, as you have said, and be gone; and bless me also!” 
+</div><div class="p">
+<sup>33&#160;</sup>The Egyptians were urgent with the people, to send them out of the land in haste, for they said, “We are all dead men.” 
+<sup>34&#160;</sup>The people took their dough before it was leavened, their kneading troughs being bound up in their clothes on their shoulders. 
+<sup>35&#160;</sup>The children of Israel did according to the word of Moses; and they asked of the Egyptians jewels of silver, and jewels of gold, and clothing. 
+<sup>36&#160;</sup>Yahweh gave the people favor in the sight of the Egyptians, so that they let them have what they asked. They plundered the Egyptians. 
+</div><div class="p">
+<sup>37&#160;</sup>The children of Israel traveled from Rameses to Succoth, about six hundred thousand on foot who were men, in addition to children. 
+<sup>38&#160;</sup>A mixed multitude went up also with them, with flocks, herds, and even very much livestock. 
+<sup>39&#160;</sup>They baked unleavened cakes of the dough which they brought out of Egypt; for it wasn’t leavened, because they were thrust out of Egypt, and couldn’t wait, and they had not prepared any food for themselves. 
+<sup>40&#160;</sup>Now the time that the children of Israel lived in Egypt was four hundred thirty years. 
+<sup>41&#160;</sup>At the end of four hundred thirty years, to the day, all of Yahweh’s armies went out from the land of Egypt. 
+<sup>42&#160;</sup>It is a night to be much observed to Yahweh for bringing them out from the land of Egypt. This is that night of Yahweh, to be much observed by all the children of Israel throughout their generations. 
+</div><div class="p">
+<sup>43&#160;</sup>Yahweh said to Moses and Aaron, “This is the ordinance of the Passover. No foreigner shall eat of it, 
+<sup>44&#160;</sup>but every man’s servant who is bought for money, when you have circumcised him, then shall he eat of it. 
+<sup>45&#160;</sup>A foreigner and a hired servant shall not eat of it. 
+<sup>46&#160;</sup>It must be eaten in one house. You shall not carry any of the meat outside of the house. Do not break any of its bones. 
+<sup>47&#160;</sup>All the congregation of Israel shall keep it. 
+<sup>48&#160;</sup>When a stranger lives as a foreigner with you, and would like to keep the Passover to Yahweh, let all his males be circumcised, and then let him come near and keep it. He shall be as one who is born in the land; but no uncircumcised person shall eat of it. 
+<sup>49&#160;</sup>One law shall be to him who is born at home, and to the stranger who lives as a foreigner among you.” 
+<sup>50&#160;</sup>All the children of Israel did so. As Yahweh commanded Moses and Aaron, so they did. 
+<sup>51&#160;</sup>That same day, Yahweh brought the children of Israel out of the land of Egypt by their armies. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Sanctify to me all the firstborn, whatever opens the womb among the children of Israel, both of man and of animal. It is mine.” 
+</div><div class="p">
+<sup>3&#160;</sup>Moses said to the people, “Remember this day, in which you came out of Egypt, out of the house of bondage; for by strength of hand Yahweh brought you out from this place. No leavened bread shall be eaten. 
+<sup>4&#160;</sup>Today you go out in the month Abib. 
+<sup>5&#160;</sup>It shall be, when Yahweh brings you into the land of the Canaanite, and the Hittite, and the Amorite, and the Hivite, and the Jebusite, which he swore to your fathers to give you, a land flowing with milk and honey, that you shall keep this service in this month. 
+<sup>6&#160;</sup>Seven days you shall eat unleavened bread, and in the seventh day shall be a feast to Yahweh. 
+<sup>7&#160;</sup>Unleavened bread shall be eaten throughout the seven days; and no leavened bread shall be seen with you. No yeast shall be seen with you, within all your borders. 
+<sup>8&#160;</sup>You shall tell your son in that day, saying, ‘It is because of that which Yahweh did for me when I came out of Egypt.’ 
+<sup>9&#160;</sup>It shall be for a sign to you on your hand, and for a memorial between your eyes, that Yahweh’s law may be in your mouth; for with a strong hand Yahweh has brought you out of Egypt. 
+<sup>10&#160;</sup>You shall therefore keep this ordinance in its season from year to year. 
+</div><div class="p">
+<sup>11&#160;</sup>“It shall be, when Yahweh brings you into the land of the Canaanite, as he swore to you and to your fathers, and will give it to you, 
+<sup>12&#160;</sup>that you shall set apart to Yahweh all that opens the womb, and every firstborn that comes from an animal which you have. The males shall be Yahweh’s. 
+<sup>13&#160;</sup>Every firstborn of a donkey you shall redeem with a lamb; and if you will not redeem it, then you shall break its neck; and you shall redeem all the firstborn of man among your sons. 
+<sup>14&#160;</sup>It shall be, when your son asks you in time to come, saying, ‘What is this?’ that you shall tell him, ‘By strength of hand Yahweh brought us out from Egypt, from the house of bondage. 
+<sup>15&#160;</sup>When Pharaoh stubbornly refused to let us go, Yahweh killed all the firstborn in the land of Egypt, both the firstborn of man, and the firstborn of livestock. Therefore I sacrifice to Yahweh all that opens the womb, being males; but all the firstborn of my sons I redeem.’ 
+<sup>16&#160;</sup>It shall be for a sign on your hand, and for symbols between your eyes; for by strength of hand Yahweh brought us out of Egypt.” 
+</div><div class="p">
+<sup>17&#160;</sup>When Pharaoh had let the people go, Elohim didn’t lead them by the way of the land of the Philistines, although that was near; for Elohim said, “Lest perhaps the people change their minds when they see war, and they return to Egypt”; 
+<sup>18&#160;</sup>but Elohim led the people around by the way of the wilderness by the Red Sea; and the children of Israel went up armed out of the land of Egypt. 
+<sup>19&#160;</sup>Moses took the bones of Joseph with him, for he had made the children of Israel swear, saying, “Elohim will surely visit you, and you shall carry up my bones away from here with you.” 
+<sup>20&#160;</sup>They took their journey from Succoth, and encamped in Etham, in the edge of the wilderness. 
+<sup>21&#160;</sup>Yahweh went before them by day in a pillar of cloud, to lead them on their way, and by night in a pillar of fire, to give them light, that they might go by day and by night: 
+<sup>22&#160;</sup>the pillar of cloud by day, and the pillar of fire by night, didn’t depart from before the people. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, that they turn back and encamp before Pihahiroth, between Migdol and the sea, before Baal Zephon. You shall encamp opposite it by the sea. 
+<sup>3&#160;</sup>Pharaoh will say of the children of Israel, ‘They are entangled in the land. The wilderness has shut them in.’ 
+<sup>4&#160;</sup>I will harden Pharaoh’s heart, and he will follow after them; and I will get honor over Pharaoh, and over all his armies; and the Egyptians shall know that I am Yahweh.” They did so. 
+</div><div class="p">
+<sup>5&#160;</sup>The king of Egypt was told that the people had fled; and the heart of Pharaoh and of his servants was changed toward the people, and they said, “What is this we have done, that we have let Israel go from serving us?” 
+<sup>6&#160;</sup>He prepared his chariot, and took his army with him; 
+<sup>7&#160;</sup>and he took six hundred chosen chariots, and all the chariots of Egypt, with captains over all of them. 
+<sup>8&#160;</sup>Yahweh hardened the heart of Pharaoh king of Egypt, and he pursued the children of Israel; for the children of Israel went out with a high hand. 
+<sup>9&#160;</sup>The Egyptians pursued them. All the horses and chariots of Pharaoh, his horsemen, and his army overtook them encamping by the sea, beside Pihahiroth, before Baal Zephon. 
+</div><div class="p">
+<sup>10&#160;</sup>When Pharaoh came near, the children of Israel lifted up their eyes, and behold, the Egyptians were marching after them; and they were very afraid. The children of Israel cried out to Yahweh. 
+<sup>11&#160;</sup>They said to Moses, “Because there were no graves in Egypt, have you taken us away to die in the wilderness? Why have you treated us this way, to bring us out of Egypt? 
+<sup>12&#160;</sup>Isn’t this the word that we spoke to you in Egypt, saying, ‘Leave us alone, that we may serve the Egyptians’? For it would have been better for us to serve the Egyptians than to die in the wilderness.” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses said to the people, “Don’t be afraid. Stand still, and see the salvation of Yahweh, which he will work for you today; for you will never again see the Egyptians whom you have seen today. 
+<sup>14&#160;</sup>Yahweh will fight for you, and you shall be still.” 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh said to Moses, “Why do you cry to me? Speak to the children of Israel, that they go forward. 
+<sup>16&#160;</sup>Lift up your rod, and stretch out your hand over the sea and divide it. Then the children of Israel shall go into the middle of the sea on dry ground. 
+<sup>17&#160;</sup>Behold, I myself will harden the hearts of the Egyptians, and they will go in after them. I will get myself honor over Pharaoh, and over all his armies, over his chariots, and over his horsemen. 
+<sup>18&#160;</sup>The Egyptians shall know that I am Yahweh when I have gotten myself honor over Pharaoh, over his chariots, and over his horsemen.” 
+<sup>19&#160;</sup>The angel of Elohim, who went before the camp of Israel, moved and went behind them; and the pillar of cloud moved from before them, and stood behind them. 
+<sup>20&#160;</sup>It came between the camp of Egypt and the camp of Israel. There was the cloud and the darkness, yet it gave light by night. One didn’t come near the other all night. 
+</div><div class="p">
+<sup>21&#160;</sup>Moses stretched out his hand over the sea, and Yahweh caused the sea to go back by a strong east wind all night, and made the sea dry land, and the waters were divided. 
+<sup>22&#160;</sup>The children of Israel went into the middle of the sea on the dry ground; and the waters were a wall to them on their right hand and on their left. 
+<sup>23&#160;</sup>The Egyptians pursued, and went in after them into the middle of the sea: all of Pharaoh’s horses, his chariots, and his horsemen. 
+<sup>24&#160;</sup>In the morning watch, Yahweh looked out on the Egyptian army through the pillar of fire and of cloud, and confused the Egyptian army. 
+<sup>25&#160;</sup>He took off their chariot wheels, and they drove them heavily; so that the Egyptians said, “Let’s flee from the face of Israel, for Yahweh fights for them against the Egyptians!” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahweh said to Moses, “Stretch out your hand over the sea, that the waters may come again on the Egyptians, on their chariots, and on their horsemen.” 
+<sup>27&#160;</sup>Moses stretched out his hand over the sea, and the sea returned to its strength when the morning appeared; and the Egyptians fled against it. Yahweh overthrew the Egyptians in the middle of the sea. 
+<sup>28&#160;</sup>The waters returned, and covered the chariots and the horsemen, even all Pharaoh’s army that went in after them into the sea. There remained not so much as one of them. 
+<sup>29&#160;</sup>But the children of Israel walked on dry land in the middle of the sea, and the waters were a wall to them on their right hand and on their left. 
+<sup>30&#160;</sup>Thus Yahweh saved Israel that day out of the hand of the Egyptians; and Israel saw the Egyptians dead on the seashore. 
+<sup>31&#160;</sup>Israel saw the great work which Yahweh did to the Egyptians, and the people feared Yahweh; and they believed in Yahweh and in his servant Moses. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Moses and the children of Israel sang this song to Yahweh, and said, 
+</div><div class="q1">“I will sing to Yahweh, for he has triumphed gloriously. 
+</div><div class="q2">He has thrown the horse and his rider into the sea. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yah is my strength and song. 
+</div><div class="q2">He has become my salvation. 
+</div><div class="q1">This is my Elohim, and I will praise him; 
+</div><div class="q2">my father’s Elohim, and I will exalt him. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh is a man of war. 
+</div><div class="q2">Yahweh is his name. 
+</div><div class="q1">
+<sup>4&#160;</sup>He has cast Pharaoh’s chariots and his army into the sea. 
+</div><div class="q2">His chosen captains are sunk in the Red Sea. 
+</div><div class="q1">
+<sup>5&#160;</sup>The deeps cover them. 
+</div><div class="q2">They went down into the depths like a stone. 
+</div><div class="q1">
+<sup>6&#160;</sup>Your right hand, Yahweh, is glorious in power. 
+</div><div class="q2">Your right hand, Yahweh, dashes the enemy in pieces. 
+</div><div class="q1">
+<sup>7&#160;</sup>In the greatness of your excellency, you overthrow those who rise up against you. 
+</div><div class="q2">You send out your wrath. It consumes them as stubble. 
+</div><div class="q1">
+<sup>8&#160;</sup>With the blast of your nostrils, the waters were piled up. 
+</div><div class="q2">The floods stood upright as a heap. 
+</div><div class="q2">The deeps were congealed in the heart of the sea. 
+</div><div class="q1">
+<sup>9&#160;</sup>The enemy said, ‘I will pursue. I will overtake. I will divide the plunder. 
+</div><div class="q2">My desire will be satisfied on them. 
+</div><div class="q2">I will draw my sword. My hand will destroy them.’ 
+</div><div class="q1">
+<sup>10&#160;</sup>You blew with your wind. 
+</div><div class="q2">The sea covered them. 
+</div><div class="q2">They sank like lead in the mighty waters. 
+</div><div class="q1">
+<sup>11&#160;</sup>Who is like you, Yahweh, among the elohims? 
+</div><div class="q2">Who is like you, glorious in set-apartness, 
+</div><div class="q2">fearful in praises, doing wonders? 
+</div><div class="q1">
+<sup>12&#160;</sup>You stretched out your right hand. 
+</div><div class="q2">The earth swallowed them. 
+</div><div class="q1">
+<sup>13&#160;</sup>“You, in your loving kindness, have led the people that you have redeemed. 
+</div><div class="q2">You have guided them in your strength to your set-apart habitation. 
+</div><div class="q1">
+<sup>14&#160;</sup>The peoples have heard. 
+</div><div class="q2">They tremble. 
+</div><div class="q2">Pangs have taken hold of the inhabitants of Philistia. 
+</div><div class="q1">
+<sup>15&#160;</sup>Then the chiefs of Edom were dismayed. 
+</div><div class="q2">Trembling takes hold of the mighty men of Moab. 
+</div><div class="q2">All the inhabitants of Canaan have melted away. 
+</div><div class="q1">
+<sup>16&#160;</sup>Terror and dread falls on them. 
+</div><div class="q2">By the greatness of your arm they are as still as a stone, 
+</div><div class="q2">until your people pass over, Yahweh, 
+</div><div class="q2">until the people you have purchased pass over. 
+</div><div class="q2">
+<sup>17&#160;</sup>You will bring them in, and plant them in the mountain of your inheritance, 
+</div><div class="q2">the place, Yahweh, which you have made for yourself to dwell in: 
+</div><div class="q2">the sanctuary, Lord, which your hands have established. 
+</div><div class="q1">
+<sup>18&#160;</sup>Yahweh will reign forever and ever.” 
+</div><div class="p">
+<sup>19&#160;</sup>For the horses of Pharaoh went in with his chariots and with his horsemen into the sea, and Yahweh brought back the waters of the sea on them; but the children of Israel walked on dry land in the middle of the sea. 
+<sup>20&#160;</sup>Miriam the prophetess, the sister of Aaron, took a tambourine in her hand; and all the women went out after her with tambourines and with dances. 
+<sup>21&#160;</sup>Miriam answered them, 
+</div><div class="q1">“Sing to Yahweh, for he has triumphed gloriously. 
+</div><div class="q1">He has thrown the horse and his rider into the sea.” 
+</div><div class="p">
+<sup>22&#160;</sup>Moses led Israel onward from the Red Sea, and they went out into the wilderness of Shur; and they went three days in the wilderness, and found no water. 
+<sup>23&#160;</sup>When they came to Marah, they couldn’t drink from the waters of Marah, for they were bitter. Therefore its name was called Marah. 
+<sup>24&#160;</sup>The people murmured against Moses, saying, “What shall we drink?” 
+<sup>25&#160;</sup>Then he cried to Yahweh. Yahweh showed him a tree, and he threw it into the waters, and the waters were made sweet. There he made a statute and an ordinance for them, and there he tested them. 
+<sup>26&#160;</sup>He said, “If you will diligently listen to Yahweh your Elohim’s voice, and will do that which is right in his eyes, and will pay attention to his commandments, and keep all his statutes, I will put none of the diseases on you which I have put on the Egyptians; for I am Yahweh who heals you.” 
+</div><div class="p">
+<sup>27&#160;</sup>They came to Elim, where there were twelve springs of water and seventy palm trees. They encamped there by the waters. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>They took their journey from Elim, and all the congregation of the children of Israel came to the wilderness of Sin, which is between Elim and Sinai, on the fifteenth day of the second month after their departing out of the land of Egypt. 
+<sup>2&#160;</sup>The whole congregation of the children of Israel murmured against Moses and against Aaron in the wilderness; 
+<sup>3&#160;</sup>and the children of Israel said to them, “We wish that we had died by Yahweh’s hand in the land of Egypt, when we sat by the meat pots, when we ate our fill of bread, for you have brought us out into this wilderness to kill this whole assembly with hunger.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then Yahweh said to Moses, “Behold, I will rain bread from the sky for you, and the people shall go out and gather a day’s portion every day, that I may test them, whether they will walk in my law or not. 
+<sup>5&#160;</sup>It shall come to pass on the sixth day, that they shall prepare that which they bring in, and it shall be twice as much as they gather daily.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses and Aaron said to all the children of Israel, “At evening, you shall know that Yahweh has brought you out from the land of Egypt. 
+<sup>7&#160;</sup>In the morning, you shall see Yahweh’s glory; because he hears your murmurings against Yahweh. Who are we, that you murmur against us?” 
+<sup>8&#160;</sup>Moses said, “Now Yahweh will give you meat to eat in the evening, and in the morning bread to satisfy you, because Yahweh hears your murmurings which you murmur against him. And who are we? Your murmurings are not against us, but against Yahweh.” 
+<sup>9&#160;</sup>Moses said to Aaron, “Tell all the congregation of the children of Israel, ‘Come close to Yahweh, for he has heard your murmurings.’&#160;” 
+<sup>10&#160;</sup>As Aaron spoke to the whole congregation of the children of Israel, they looked toward the wilderness, and behold, Yahweh’s glory appeared in the cloud. 
+<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>12&#160;</sup>“I have heard the murmurings of the children of Israel. Speak to them, saying, ‘At evening you shall eat meat, and in the morning you shall be filled with bread. Then you will know that I am Yahweh your Elohim.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>In the evening, quail came up and covered the camp; and in the morning the dew lay around the camp. 
+<sup>14&#160;</sup>When the dew that lay had gone, behold, on the surface of the wilderness was a small round thing, small as the frost on the ground. 
+<sup>15&#160;</sup>When the children of Israel saw it, they said to one another, “What is it?” For they didn’t know what it was. Moses said to them, “It is the bread which Yahweh has given you to eat. 
+<sup>16&#160;</sup>This is the thing which Yahweh has commanded: ‘Gather of it everyone according to his eating; an omer a head, according to the number of your persons, you shall take it, every man for those who are in his tent.’&#160;” 
+<sup>17&#160;</sup>The children of Israel did so, and some gathered more, some less. 
+<sup>18&#160;</sup>When they measured it with an omer, he who gathered much had nothing over, and he who gathered little had no lack. They each gathered according to his eating. 
+<sup>19&#160;</sup>Moses said to them, “Let no one leave of it until the morning.” 
+<sup>20&#160;</sup>Notwithstanding they didn’t listen to Moses, but some of them left of it until the morning, so it bred worms and became foul; and Moses was angry with them. 
+<sup>21&#160;</sup>They gathered it morning by morning, everyone according to his eating. When the sun grew hot, it melted. 
+<sup>22&#160;</sup>On the sixth day, they gathered twice as much bread, two omers for each one; and all the rulers of the congregation came and told Moses. 
+<sup>23&#160;</sup>He said to them, “This is that which Yahweh has spoken, ‘Tomorrow is a solemn rest, a set-apart Sabbath to Yahweh. Bake that which you want to bake, and boil that which you want to boil; and all that remains over lay up for yourselves to be kept until the morning.’&#160;” 
+<sup>24&#160;</sup>They laid it up until the morning, as Moses ordered, and it didn’t become foul, and there were no worms in it. 
+<sup>25&#160;</sup>Moses said, “Eat that today, for today is a Sabbath to Yahweh. Today you shall not find it in the field. 
+<sup>26&#160;</sup>Six days you shall gather it, but on the seventh day is the Sabbath. In it there shall be none.” 
+<sup>27&#160;</sup>On the seventh day, some of the people went out to gather, and they found none. 
+<sup>28&#160;</sup>Yahweh said to Moses, “How long do you refuse to keep my commandments and my laws? 
+<sup>29&#160;</sup>Behold, because Yahweh has given you the Sabbath, therefore he gives you on the sixth day the bread of two days. Everyone stay in his place. Let no one go out of his place on the seventh day.” 
+<sup>30&#160;</sup>So the people rested on the seventh day. 
+</div><div class="p">
+<sup>31&#160;</sup>The house of Israel called its name “Manna”, and it was like coriander seed, white; and its taste was like wafers with honey. 
+<sup>32&#160;</sup>Moses said, “This is the thing which Yahweh has commanded, ‘Let an omer-full of it be kept throughout your generations, that they may see the bread with which I fed you in the wilderness, when I brought you out of the land of Egypt.’&#160;” 
+<sup>33&#160;</sup>Moses said to Aaron, “Take a pot, and put an omer-full of manna in it, and lay it up before Yahweh, to be kept throughout your generations.” 
+<sup>34&#160;</sup>As Yahweh commanded Moses, so Aaron laid it up before the Testimony, to be kept. 
+<sup>35&#160;</sup>The children of Israel ate the manna forty years, until they came to an inhabited land. They ate the manna until they came to the borders of the land of Canaan. 
+<sup>36&#160;</sup>Now an omer is one tenth of an ephah. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>All the congregation of the children of Israel traveled from the wilderness of Sin, starting according to Yahweh’s commandment, and encamped in Rephidim; but there was no water for the people to drink. 
+<sup>2&#160;</sup>Therefore the people quarreled with Moses, and said, “Give us water to drink.” 
+</div><div class="p">Moses said to them, “Why do you quarrel with me? Why do you test Yahweh?” 
+</div><div class="p">
+<sup>3&#160;</sup>The people were thirsty for water there; so the people murmured against Moses, and said, “Why have you brought us up out of Egypt, to kill us, our children, and our livestock with thirst?” 
+</div><div class="p">
+<sup>4&#160;</sup>Moses cried to Yahweh, saying, “What shall I do with these people? They are almost ready to stone me.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh said to Moses, “Walk on before the people, and take the elders of Israel with you, and take the rod in your hand with which you struck the Nile, and go. 
+<sup>6&#160;</sup>Behold, I will stand before you there on the rock in Horeb. You shall strike the rock, and water will come out of it, that the people may drink.” Moses did so in the sight of the elders of Israel. 
+<sup>7&#160;</sup>He called the name of the place Massah, because the children of Israel quarreled, and because they tested Yahweh, saying, “Is Yahweh among us, or not?” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Amalek came and fought with Israel in Rephidim. 
+<sup>9&#160;</sup>Moses said to Joshua, “Choose men for us, and go out to fight with Amalek. Tomorrow I will stand on the top of the hill with Elohim’s rod in my hand.” 
+<sup>10&#160;</sup>So Joshua did as Moses had told him, and fought with Amalek; and Moses, Aaron, and Hur went up to the top of the hill. 
+<sup>11&#160;</sup>When Moses held up his hand, Israel prevailed. When he let down his hand, Amalek prevailed. 
+<sup>12&#160;</sup>But Moses’ hands were heavy; so they took a stone, and put it under him, and he sat on it. Aaron and Hur held up his hands, the one on the one side, and the other on the other side. His hands were steady until sunset. 
+<sup>13&#160;</sup>Joshua defeated Amalek and his people with the edge of the sword. 
+<sup>14&#160;</sup>Yahweh said to Moses, “Write this for a memorial in a book, and rehearse it in the ears of Joshua: that I will utterly blot out the memory of Amalek from under the sky.” 
+<sup>15&#160;</sup>Moses built an altar, and called its name “Yahweh our Banner”. 
+<sup>16&#160;</sup>He said, “Yah has sworn: ‘Yahweh will have war with Amalek from generation to generation.’&#160;” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Jethro, the priest of Midian, Moses’ father-in-law, heard of all that Elohim had done for Moses and for Israel his people, how Yahweh had brought Israel out of Egypt. 
+<sup>2&#160;</sup>Jethro, Moses’ father-in-law, received Zipporah, Moses’ woman, after he had sent her away, 
+<sup>3&#160;</sup>and her two sons. The name of one son was Gershom, for Moses said, “I have lived as a foreigner in a foreign land”. 
+<sup>4&#160;</sup>The name of the other was Eliezer, for he said, “My father’s Elohim was my help and delivered me from Pharaoh’s sword.” 
+<sup>5&#160;</sup>Jethro, Moses’ father-in-law, came with Moses’ sons and his woman to Moses into the wilderness where he was encamped, at the Mountain of Elohim. 
+<sup>6&#160;</sup>He said to Moses, “I, your father-in-law Jethro, have come to you with your woman, and her two sons with her.” 
+</div><div class="p">
+<sup>7&#160;</sup>Moses went out to meet his father-in-law, and bowed and kissed him. They asked each other of their welfare, and they came into the tent. 
+<sup>8&#160;</sup>Moses told his father-in-law all that Yahweh had done to Pharaoh and to the Egyptians for Israel’s sake, all the hardships that had come on them on the way, and how Yahweh delivered them. 
+<sup>9&#160;</sup>Jethro rejoiced for all the goodness which Yahweh had done to Israel, in that he had delivered them out of the hand of the Egyptians. 
+<sup>10&#160;</sup>Jethro said, “Blessed be Yahweh, who has delivered you out of the hand of the Egyptians, and out of the hand of Pharaoh; who has delivered the people from under the hand of the Egyptians. 
+<sup>11&#160;</sup>Now I know that Yahweh is greater than all elohims because of the way that they treated people arrogantly.” 
+<sup>12&#160;</sup>Jethro, Moses’ father-in-law, took a burnt offering and sacrifices for Elohim. Aaron came with all the elders of Israel, to eat bread with Moses’ father-in-law before Elohim. 
+</div><div class="p">
+<sup>13&#160;</sup>On the next day, Moses sat to judge the people, and the people stood around Moses from the morning to the evening. 
+<sup>14&#160;</sup>When Moses’ father-in-law saw all that he did to the people, he said, “What is this thing that you do for the people? Why do you sit alone, and all the people stand around you from morning to evening?” 
+</div><div class="p">
+<sup>15&#160;</sup>Moses said to his father-in-law, “Because the people come to me to inquire of Elohim. 
+<sup>16&#160;</sup>When they have a matter, they come to me, and I judge between a man and his neighbor, and I make them know the statutes of Elohim, and his laws.” 
+<sup>17&#160;</sup>Moses’ father-in-law said to him, “The thing that you do is not good. 
+<sup>18&#160;</sup>You will surely wear away, both you, and this people that is with you; for the thing is too heavy for you. You are not able to perform it yourself alone. 
+<sup>19&#160;</sup>Listen now to my voice. I will give you counsel, and Elohim be with you. You represent the people before Elohim, and bring the causes to Elohim. 
+<sup>20&#160;</sup>You shall teach them the statutes and the laws, and shall show them the way in which they must walk, and the work that they must do. 
+<sup>21&#160;</sup>Moreover you shall provide out of all the people able men which fear Elohim: men of truth, hating unjust gain; and place such over them, to be rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens. 
+<sup>22&#160;</sup>Let them judge the people at all times. It shall be that every great matter they shall bring to you, but every small matter they shall judge themselves. So shall it be easier for you, and they shall share the load with you. 
+<sup>23&#160;</sup>If you will do this thing, and Elohim commands you so, then you will be able to endure, and all these people also will go to their place in peace.” 
+</div><div class="p">
+<sup>24&#160;</sup>So Moses listened to the voice of his father-in-law, and did all that he had said. 
+<sup>25&#160;</sup>Moses chose able men out of all Israel, and made them heads over the people, rulers of thousands, rulers of hundreds, rulers of fifties, and rulers of tens. 
+<sup>26&#160;</sup>They judged the people at all times. They brought the hard cases to Moses, but every small matter they judged themselves. 
+<sup>27&#160;</sup>Moses let his father-in-law depart, and he went his way into his own land. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>In the third month after the children of Israel had gone out of the land of Egypt, on that same day they came into the wilderness of Sinai. 
+<sup>2&#160;</sup>When they had departed from Rephidim, and had come to the wilderness of Sinai, they encamped in the wilderness; and there Israel encamped before the mountain. 
+<sup>3&#160;</sup>Moses went up to Elohim, and Yahweh called to him out of the mountain, saying, “This is what you shall tell the house of Jacob, and tell the children of Israel: 
+<sup>4&#160;</sup>‘You have seen what I did to the Egyptians, and how I bore you on eagles’ wings, and brought you to myself. 
+<sup>5&#160;</sup>Now therefore, if you will indeed obey my voice and keep my covenant, then you shall be my own possession from among all peoples; for all the earth is mine; 
+<sup>6&#160;</sup>and you shall be to me a kingdom of priests and a set-apart nation.’ These are the words which you shall speak to the children of Israel.” 
+</div><div class="p">
+<sup>7&#160;</sup>Moses came and called for the elders of the people, and set before them all these words which Yahweh commanded him. 
+<sup>8&#160;</sup>All the people answered together, and said, “All that Yahweh has spoken we will do.” 
+</div><div class="p">Moses reported the words of the people to Yahweh. 
+<sup>9&#160;</sup>Yahweh said to Moses, “Behold, I come to you in a thick cloud, that the people may hear when I speak with you, and may also believe you forever.” Moses told the words of the people to Yahweh. 
+<sup>10&#160;</sup>Yahweh said to Moses, “Go to the people, and sanctify them today and tomorrow, and let them wash their garments, 
+<sup>11&#160;</sup>and be ready for the third day; for on the third day Yahweh will come down in the sight of all the people on Mount Sinai. 
+<sup>12&#160;</sup>You shall set bounds to the people all around, saying, ‘Be careful that you don’t go up onto the mountain, or touch its border. Whoever touches the mountain shall be surely put to death. 
+<sup>13&#160;</sup>No hand shall touch him, but he shall surely be stoned or shot through; whether it is animal or man, he shall not live.’ When the trumpet sounds long, they shall come up to the mountain.” 
+</div><div class="p">
+<sup>14&#160;</sup>Moses went down from the mountain to the people, and sanctified the people; and they washed their clothes. 
+<sup>15&#160;</sup>He said to the people, “Be ready by the third day. Don’t have sexual relations with a woman.” 
+</div><div class="p">
+<sup>16&#160;</sup>On the third day, when it was morning, there were thunders and lightnings, and a thick cloud on the mountain, and the sound of an exceedingly loud trumpet; and all the people who were in the camp trembled. 
+<sup>17&#160;</sup>Moses led the people out of the camp to meet Elohim; and they stood at the lower part of the mountain. 
+<sup>18&#160;</sup>All of Mount Sinai smoked, because Yahweh descended on it in fire; and its smoke ascended like the smoke of a furnace, and the whole mountain quaked greatly. 
+<sup>19&#160;</sup>When the sound of the trumpet grew louder and louder, Moses spoke, and Elohim answered him by a voice. 
+<sup>20&#160;</sup>Yahweh came down on Mount Sinai, to the top of the mountain. Yahweh called Moses to the top of the mountain, and Moses went up. 
+</div><div class="p">
+<sup>21&#160;</sup>Yahweh said to Moses, “Go down, warn the people, lest they break through to Yahweh to gaze, and many of them perish. 
+<sup>22&#160;</sup>Let the priests also, who come near to Yahweh, sanctify themselves, lest Yahweh break out on them.” 
+</div><div class="p">
+<sup>23&#160;</sup>Moses said to Yahweh, “The people can’t come up to Mount Sinai, for you warned us, saying, ‘Set bounds around the mountain, and sanctify it.’&#160;” 
+</div><div class="p">
+<sup>24&#160;</sup>Yahweh said to him, “Go down! You shall bring Aaron up with you, but don’t let the priests and the people break through to come up to Yahweh, lest he break out against them.” 
+</div><div class="p">
+<sup>25&#160;</sup>So Moses went down to the people, and told them. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Elohim spoke all these words, saying, 
+<sup>2&#160;</sup>“I am Yahweh your Elohim, who brought you out of the land of Egypt, out of the house of bondage. 
+</div><div class="p">
+<sup>3&#160;</sup>“You shall have no other elohims before me. 
+</div><div class="p">
+<sup>4&#160;</sup>“You shall not make for yourselves an idol, nor any image of anything that is in the heavens above, or that is in the earth beneath, or that is in the water under the earth: 
+<sup>5&#160;</sup>you shall not bow yourself down to them, nor serve them, for I, Yahweh your Elohim, am a jealous Elohim, visiting the iniquity of the fathers on the children, on the third and on the fourth generation of those who hate me, 
+<sup>6&#160;</sup>and showing loving kindness to thousands of those who love me and keep my commandments. 
+</div><div class="p">
+<sup>7&#160;</sup>“You shall not misuse the name of Yahweh your Elohim, for Yahweh will not hold him guiltless who misuses his name. 
+</div><div class="p">
+<sup>8&#160;</sup>“Remember the Sabbath day, to keep it set-apart. 
+<sup>9&#160;</sup>You shall labor six days, and do all your work, 
+<sup>10&#160;</sup>but the seventh day is a Sabbath to Yahweh your Elohim. You shall not do any work in it, you, nor your son, nor your daughter, your male servant, nor your female servant, nor your livestock, nor your stranger who is within your gates; 
+<sup>11&#160;</sup>for in six days Yahweh made heaven and earth, the sea, and all that is in them, and rested the seventh day; therefore Yahweh blessed the Sabbath day, and made it set-apart. 
+</div><div class="p">
+<sup>12&#160;</sup>“Honor your father and your mother, that your days may be long in the land which Yahweh your Elohim gives you. 
+</div><div class="p">
+<sup>13&#160;</sup>“You shall not murder. 
+</div><div class="p">
+<sup>14&#160;</sup>“You shall not commit adultery. 
+</div><div class="p">
+<sup>15&#160;</sup>“You shall not steal. 
+</div><div class="p">
+<sup>16&#160;</sup>“You shall not give false testimony against your neighbor. 
+</div><div class="p">
+<sup>17&#160;</sup>“You shall not covet your neighbor’s house. You shall not covet your neighbor’s woman, nor his male servant, nor his female servant, nor his ox, nor his donkey, nor anything that is your neighbor’s.” 
+</div><div class="p">
+<sup>18&#160;</sup>All the people perceived the thunderings, the lightnings, the sound of the trumpet, and the mountain smoking. When the people saw it, they trembled, and stayed at a distance. 
+<sup>19&#160;</sup>They said to Moses, “Speak with us yourself, and we will listen; but don’t let Elohim speak with us, lest we die.” 
+</div><div class="p">
+<sup>20&#160;</sup>Moses said to the people, “Don’t be afraid, for Elohim has come to test you, and that his fear may be before you, that you won’t sin.” 
+<sup>21&#160;</sup>The people stayed at a distance, and Moses came near to the thick darkness where Elohim was. 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh said to Moses, “This is what you shall tell the children of Israel: ‘You yourselves have seen that I have talked with you from heaven. 
+<sup>23&#160;</sup>You shall most certainly not make elohims of silver or elohims of gold for yourselves to be alongside me. 
+<sup>24&#160;</sup>You shall make an altar of earth for me, and shall sacrifice on it your burnt offerings and your peace offerings, your sheep and your cattle. In every place where I record my name I will come to you and I will bless you. 
+<sup>25&#160;</sup>If you make me an altar of stone, you shall not build it of cut stones; for if you lift up your tool on it, you have polluted it. 
+<sup>26&#160;</sup>You shall not go up by steps to my altar, that your nakedness may not be exposed to it.’ 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>“Now these are the ordinances which you shall set before them: 
+</div><div class="p">
+<sup>2&#160;</sup>“If you buy a Hebrew servant, he shall serve six years, and in the seventh he shall go out free without paying anything. 
+<sup>3&#160;</sup>If he comes in by himself, he shall go out by himself. If he is the owner of a woman, then his woman shall go out with him. 
+<sup>4&#160;</sup>If his master gives him a woman and she bears him sons or daughters, the woman and her children shall be her master’s, and he shall go out by himself. 
+<sup>5&#160;</sup>But if the servant shall plainly say, ‘I love my master, my woman, and my children. I will not go out free;’ 
+<sup>6&#160;</sup>then his master shall bring him to Elohim, and shall bring him to the door or to the doorpost, and his master shall bore his ear through with an awl, and he shall serve him forever. 
+</div><div class="p">
+<sup>7&#160;</sup>“If a man sells his daughter to be a female servant, she shall not go out as the male servants do. 
+<sup>8&#160;</sup>If she doesn’t please her master, who has married her to himself, then he shall let her be redeemed. He shall have no right to sell her to a foreign people, since he has dealt deceitfully with her. 
+<sup>9&#160;</sup>If he marries her to his son, he shall deal with her as a daughter. 
+<sup>10&#160;</sup>If he takes another woman to himself, he shall not diminish her food, her clothing, and her marital rights. 
+<sup>11&#160;</sup>If he doesn’t do these three things for her, she may go free without paying any money. 
+</div><div class="p">
+<sup>12&#160;</sup>“One who strikes a man so that he dies shall surely be put to death, 
+<sup>13&#160;</sup>but not if it is unintentional, but Elohim allows it to happen; then I will appoint you a place where he shall flee. 
+<sup>14&#160;</sup>If a man schemes and comes presumptuously on his neighbor to kill him, you shall take him from my altar, that he may die. 
+</div><div class="p">
+<sup>15&#160;</sup>“Anyone who attacks his father or his mother shall be surely put to death. 
+</div><div class="p">
+<sup>16&#160;</sup>“Anyone who kidnaps someone and sells him, or if he is found in his hand, he shall surely be put to death. 
+</div><div class="p">
+<sup>17&#160;</sup>“Anyone who curses his father or his mother shall surely be put to death. 
+</div><div class="p">
+<sup>18&#160;</sup>“If men quarrel and one strikes the other with a stone, or with his fist, and he doesn’t die, but is confined to bed; 
+<sup>19&#160;</sup>if he rises again and walks around with his staff, then he who struck him shall be cleared; only he shall pay for the loss of his time, and shall provide for his healing until he is thoroughly healed. 
+</div><div class="p">
+<sup>20&#160;</sup>“If a man strikes his servant or his maid with a rod, and he dies under his hand, the man shall surely be punished. 
+<sup>21&#160;</sup>Notwithstanding, if his servant gets up after a day or two, he shall not be punished, for the servant is his property. 
+</div><div class="p">
+<sup>22&#160;</sup>“If men fight and hurt a pregnant woman so that she gives birth prematurely, and yet no harm follows, he shall be surely fined as much as the woman’s owner demands and the judges allow. 
+<sup>23&#160;</sup>But if any harm follows, then you must take life for life, 
+<sup>24&#160;</sup>eye for eye, tooth for tooth, hand for hand, foot for foot, 
+<sup>25&#160;</sup>burning for burning, wound for wound, and bruise for bruise. 
+</div><div class="p">
+<sup>26&#160;</sup>“If a man strikes his servant’s eye, or his maid’s eye, and destroys it, he shall let him go free for his eye’s sake. 
+<sup>27&#160;</sup>If he strikes out his male servant’s tooth, or his female servant’s tooth, he shall let the servant go free for his tooth’s sake. 
+</div><div class="p">
+<sup>28&#160;</sup>“If a bull gores a man or a woman to death, the bull shall surely be stoned, and its meat shall not be eaten; but the owner of the bull shall not be held responsible. 
+<sup>29&#160;</sup>But if the bull had a habit of goring in the past, and this has been testified to its owner, and he has not kept it in, but it has killed a man or a woman, the bull shall be stoned, and its owner shall also be put to death. 
+<sup>30&#160;</sup>If a ransom is imposed on him, then he shall give for the redemption of his life whatever is imposed. 
+<sup>31&#160;</sup>Whether it has gored a son or has gored a daughter, according to this judgment it shall be done to him. 
+<sup>32&#160;</sup>If the bull gores a male servant or a female servant, thirty shekels of silver shall be given to their master, and the ox shall be stoned. 
+</div><div class="p">
+<sup>33&#160;</sup>“If a man opens a pit, or if a man digs a pit and doesn’t cover it, and a bull or a donkey falls into it, 
+<sup>34&#160;</sup>the owner of the pit shall make it good. He shall give money to its owner, and the dead animal shall be his. 
+</div><div class="p">
+<sup>35&#160;</sup>“If one man’s bull injures another’s, so that it dies, then they shall sell the live bull, and divide its price; and they shall also divide the dead animal. 
+<sup>36&#160;</sup>Or if it is known that the bull was in the habit of goring in the past, and its owner has not kept it in, he shall surely pay bull for bull, and the dead animal shall be his own. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>“If a man steals an ox or a sheep, and kills it or sells it, he shall pay five oxen for an ox, and four sheep for a sheep. 
+<sup>2&#160;</sup>If the thief is found breaking in, and is struck so that he dies, there shall be no guilt of bloodshed for him. 
+<sup>3&#160;</sup>If the sun has risen on him, he is guilty of bloodshed. He shall make restitution. If he has nothing, then he shall be sold for his theft. 
+<sup>4&#160;</sup>If the stolen property is found in his hand alive, whether it is ox, donkey, or sheep, he shall pay double. 
+</div><div class="p">
+<sup>5&#160;</sup>“If a man causes a field or vineyard to be eaten by letting his animal loose, and it grazes in another man’s field, he shall make restitution from the best of his own field, and from the best of his own vineyard. 
+</div><div class="p">
+<sup>6&#160;</sup>“If fire breaks out, and catches in thorns so that the shocks of grain, or the standing grain, or the field are consumed; he who kindled the fire shall surely make restitution. 
+</div><div class="p">
+<sup>7&#160;</sup>“If a man delivers to his neighbor money or stuff to keep, and it is stolen out of the man’s house, if the thief is found, he shall pay double. 
+<sup>8&#160;</sup>If the thief isn’t found, then the owner of the house shall come near to Elohim, to find out whether or not he has put his hand on his neighbor’s goods. 
+<sup>9&#160;</sup>For every matter of trespass, whether it is for ox, for donkey, for sheep, for clothing, or for any kind of lost thing, about which one says, ‘This is mine,’ the cause of both parties shall come before Elohim. He whom Elohim condemns shall pay double to his neighbor. 
+</div><div class="p">
+<sup>10&#160;</sup>“If a man delivers to his neighbor a donkey, an ox, a sheep, or any animal to keep, and it dies or is injured, or driven away, no man seeing it; 
+<sup>11&#160;</sup>the oath of Yahweh shall be between them both, he has not put his hand on his neighbor’s goods; and its owner shall accept it, and he shall not make restitution. 
+<sup>12&#160;</sup>But if it is stolen from him, the one who stole shall make restitution to its owner. 
+<sup>13&#160;</sup>If it is torn in pieces, let him bring it for evidence. He shall not make good that which was torn. 
+</div><div class="p">
+<sup>14&#160;</sup>“If a man borrows anything of his neighbor’s, and it is injured, or dies, its owner not being with it, he shall surely make restitution. 
+<sup>15&#160;</sup>If its owner is with it, he shall not make it good. If it is a leased thing, it came for its lease. 
+</div><div class="p">
+<sup>16&#160;</sup>“If a man entices a virgin who isn’t pledged to be married, and lies with her, he shall surely pay a dowry for her to be his woman. 
+<sup>17&#160;</sup>If her father utterly refuses to give her to him, he shall pay money according to the dowry of virgins. 
+</div><div class="p">
+<sup>18&#160;</sup>“You shall not allow a sorceress to live. 
+</div><div class="p">
+<sup>19&#160;</sup>“Whoever has sex with an animal shall surely be put to death. 
+</div><div class="p">
+<sup>20&#160;</sup>“He who sacrifices to any elohim, except to Yahweh only, shall be utterly destroyed. 
+</div><div class="p">
+<sup>21&#160;</sup>“You shall not wrong an alien or oppress him, for you were aliens in the land of Egypt. 
+</div><div class="p">
+<sup>22&#160;</sup>“You shall not take advantage of any widow or fatherless child. 
+<sup>23&#160;</sup>If you take advantage of them at all, and they cry at all to me, I will surely hear their cry; 
+<sup>24&#160;</sup>and my wrath will grow hot, and I will kill you with the sword; and your women shall be widows, and your children fatherless. 
+</div><div class="p">
+<sup>25&#160;</sup>“If you lend money to any of my people with you who is poor, you shall not be to him as a creditor. You shall not charge him interest. 
+<sup>26&#160;</sup>If you take your neighbor’s garment as collateral, you shall restore it to him before the sun goes down, 
+<sup>27&#160;</sup>for that is his only covering, it is his garment for his skin. What would he sleep in? It will happen, when he cries to me, that I will hear, for I am gracious. 
+</div><div class="p">
+<sup>28&#160;</sup>“You shall not blaspheme Elohim, nor curse a ruler of your people. 
+</div><div class="p">
+<sup>29&#160;</sup>“You shall not delay to offer from your harvest and from the outflow of your presses. 
+</div><div class="p">“You shall give the firstborn of your sons to me. 
+<sup>30&#160;</sup>You shall do likewise with your cattle and with your sheep. It shall be with its mother seven days, then on the eighth day you shall give it to me. 
+</div><div class="p">
+<sup>31&#160;</sup>“You shall be set-apart men to me, therefore you shall not eat any meat that is torn by animals in the field. You shall cast it to the dogs. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>“You shall not spread a false report. Don’t join your hand with the wicked to be a malicious witness. 
+</div><div class="p">
+<sup>2&#160;</sup>“You shall not follow a crowd to do evil. You shall not testify in court to side with a multitude to pervert justice. 
+<sup>3&#160;</sup>You shall not favor a poor man in his cause. 
+</div><div class="p">
+<sup>4&#160;</sup>“If you meet your enemy’s ox or his donkey going astray, you shall surely bring it back to him again. 
+<sup>5&#160;</sup>If you see the donkey of him who hates you fallen down under his burden, don’t leave him. You shall surely help him with it. 
+</div><div class="p">
+<sup>6&#160;</sup>“You shall not deny justice to your poor people in their lawsuits. 
+</div><div class="p">
+<sup>7&#160;</sup>“Keep far from a false charge, and don’t kill the innocent and righteous; for I will not justify the wicked. 
+</div><div class="p">
+<sup>8&#160;</sup>“You shall take no bribe, for a bribe blinds those who have sight and perverts the words of the righteous. 
+</div><div class="p">
+<sup>9&#160;</sup>“You shall not oppress an alien, for you know the heart of an alien, since you were aliens in the land of Egypt. 
+</div><div class="p">
+<sup>10&#160;</sup>“For six years you shall sow your land, and shall gather in its increase, 
+<sup>11&#160;</sup>but the seventh year you shall let it rest and lie fallow, that the poor of your people may eat; and what they leave the animal of the field shall eat. In the same way, you shall deal with your vineyard and with your olive grove. 
+</div><div class="p">
+<sup>12&#160;</sup>“Six days you shall do your work, and on the seventh day you shall rest, that your ox and your donkey may have rest, and the son of your servant, and the alien may be refreshed. 
+</div><div class="p">
+<sup>13&#160;</sup>“Be careful to do all things that I have said to you; and don’t invoke the name of other elohims or even let them be heard out of your mouth. 
+</div><div class="p">
+<sup>14&#160;</sup>“You shall observe a feast to me three times a year. 
+<sup>15&#160;</sup>You shall observe the feast of unleavened bread. Seven days you shall eat unleavened bread, as I commanded you, at the time appointed in the month Abib (for in it you came out of Egypt), and no one shall appear before me empty. 
+<sup>16&#160;</sup>And the feast of harvest, the first fruits of your labors, which you sow in the field; and the feast of ingathering, at the end of the year, when you gather in your labors out of the field. 
+<sup>17&#160;</sup>Three times in the year all your males shall appear before the Lord Yahweh. 
+</div><div class="p">
+<sup>18&#160;</sup>“You shall not offer the blood of my sacrifice with leavened bread. The fat of my feast shall not remain all night until the morning. 
+</div><div class="p">
+<sup>19&#160;</sup>You shall bring the first of the first fruits of your ground into the house of Yahweh your Elohim. 
+</div><div class="p">“You shall not boil a young goat in its mother’s milk. 
+</div><div class="p">
+<sup>20&#160;</sup>“Behold, I send an angel before you, to keep you by the way, and to bring you into the place which I have prepared. 
+<sup>21&#160;</sup>Pay attention to him, and listen to his voice. Don’t provoke him, for he will not pardon your disobedience, for my name is in him. 
+<sup>22&#160;</sup>But if you indeed listen to his voice, and do all that I speak, then I will be an enemy to your enemies, and an adversary to your adversaries. 
+<sup>23&#160;</sup>For my angel shall go before you, and bring you in to the Amorite, the Hittite, the Perizzite, the Canaanite, the Hivite, and the Jebusite; and I will cut them off. 
+<sup>24&#160;</sup>You shall not bow down to their elohims, nor serve them, nor follow their practices, but you shall utterly overthrow them and demolish their pillars. 
+<sup>25&#160;</sup>You shall serve Yahweh your Elohim, and he will bless your bread and your water, and I will take sickness away from among you. 
+<sup>26&#160;</sup>No one will miscarry or be barren in your land. I will fulfill the number of your days. 
+<sup>27&#160;</sup>I will send my terror before you, and will confuse all the people to whom you come, and I will make all your enemies turn their backs to you. 
+<sup>28&#160;</sup>I will send the hornet before you, which will drive out the Hivite, the Canaanite, and the Hittite, from before you. 
+<sup>29&#160;</sup>I will not drive them out from before you in one year, lest the land become desolate, and the animals of the field multiply against you. 
+<sup>30&#160;</sup>Little by little I will drive them out from before you, until you have increased and inherit the land. 
+<sup>31&#160;</sup>I will set your border from the Red Sea even to the sea of the Philistines, and from the wilderness to the River; for I will deliver the inhabitants of the land into your hand, and you shall drive them out before you. 
+<sup>32&#160;</sup>You shall make no covenant with them, nor with their elohims. 
+<sup>33&#160;</sup>They shall not dwell in your land, lest they make you sin against me, for if you serve their elohims, it will surely be a snare to you.” 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>He said to Moses, “Come up to Yahweh, you, and Aaron, Nadab, and Abihu, and seventy of the elders of Israel; and worship from a distance. 
+<sup>2&#160;</sup>Moses alone shall come near to Yahweh, but they shall not come near. The people shall not go up with him.” 
+</div><div class="p">
+<sup>3&#160;</sup>Moses came and told the people all Yahweh’s words, and all the ordinances; and all the people answered with one voice, and said, “All the words which Yahweh has spoken will we do.” 
+</div><div class="p">
+<sup>4&#160;</sup>Moses wrote all Yahweh’s words, then rose up early in the morning and built an altar at the base of the mountain, with twelve pillars for the twelve tribes of Israel. 
+<sup>5&#160;</sup>He sent young men of the children of Israel, who offered burnt offerings and sacrificed peace offerings of cattle to Yahweh. 
+<sup>6&#160;</sup>Moses took half of the blood and put it in basins, and half of the blood he sprinkled on the altar. 
+<sup>7&#160;</sup>He took the book of the covenant and read it in the hearing of the people, and they said, “We will do all that Yahweh has said, and be obedient.” 
+</div><div class="p">
+<sup>8&#160;</sup>Moses took the blood, and sprinkled it on the people, and said, “Look, this is the blood of the covenant, which Yahweh has made with you concerning all these words.” 
+</div><div class="p">
+<sup>9&#160;</sup>Then Moses, Aaron, Nadab, Abihu, and seventy of the elders of Israel went up. 
+<sup>10&#160;</sup>They saw the Elohim of Israel. Under his feet was like a paved work of sapphire stone, like the skies for clearness. 
+<sup>11&#160;</sup>He didn’t lay his hand on the nobles of the children of Israel. They saw Elohim, and ate and drank. 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh said to Moses, “Come up to me on the mountain, and stay here, and I will give you the stone tablets with the law and the commands that I have written, that you may teach them.” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses rose up with Joshua, his servant, and Moses went up onto Elohim’s Mountain. 
+<sup>14&#160;</sup>He said to the elders, “Wait here for us, until we come again to you. Behold, Aaron and Hur are with you. Whoever is involved in a dispute can go to them.” 
+</div><div class="p">
+<sup>15&#160;</sup>Moses went up on the mountain, and the cloud covered the mountain. 
+<sup>16&#160;</sup>Yahweh’s glory settled on Mount Sinai, and the cloud covered it six days. The seventh day he called to Moses out of the middle of the cloud. 
+<sup>17&#160;</sup>The appearance of Yahweh’s glory was like devouring fire on the top of the mountain in the eyes of the children of Israel. 
+<sup>18&#160;</sup>Moses entered into the middle of the cloud, and went up on the mountain; and Moses was on the mountain forty days and forty nights. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, that they take an offering for me. From everyone whose heart makes him willing you shall take my offering. 
+<sup>3&#160;</sup>This is the offering which you shall take from them: gold, silver, bronze, 
+<sup>4&#160;</sup>blue, purple, scarlet, fine linen, goats’ hair, 
+<sup>5&#160;</sup>rams’ skins dyed red, sea cow hides, acacia wood, 
+<sup>6&#160;</sup>oil for the light, spices for the anointing oil and for the sweet incense, 
+<sup>7&#160;</sup>onyx stones, and stones to be set for the ephod and for the breastplate. 
+<sup>8&#160;</sup>Let them make me a sanctuary, that I may dwell among them. 
+<sup>9&#160;</sup>According to all that I show you, the pattern of the tabernacle, and the pattern of all of its furniture, even so you shall make it. 
+</div><div class="p">
+<sup>10&#160;</sup>“They shall make an ark of acacia wood. Its length shall be two and a half cubits, its width a cubit and a half, and a cubit and a half its height. 
+<sup>11&#160;</sup>You shall overlay it with pure gold. You shall overlay it inside and outside, and you shall make a gold molding around it. 
+<sup>12&#160;</sup>You shall cast four rings of gold for it, and put them in its four feet. Two rings shall be on the one side of it, and two rings on the other side of it. 
+<sup>13&#160;</sup>You shall make poles of acacia wood, and overlay them with gold. 
+<sup>14&#160;</sup>You shall put the poles into the rings on the sides of the ark to carry the ark. 
+<sup>15&#160;</sup>The poles shall be in the rings of the ark. They shall not be taken from it. 
+<sup>16&#160;</sup>You shall put the covenant which I shall give you into the ark. 
+<sup>17&#160;</sup>You shall make a mercy seat of pure gold. Two and a half cubits shall be its length, and a cubit and a half its width. 
+<sup>18&#160;</sup>You shall make two cherubim of hammered gold. You shall make them at the two ends of the mercy seat. 
+<sup>19&#160;</sup>Make one cherub at the one end, and one cherub at the other end. You shall make the cherubim on its two ends of one piece with the mercy seat. 
+<sup>20&#160;</sup>The cherubim shall spread out their wings upward, covering the mercy seat with their wings, with their faces toward one another. The faces of the cherubim shall be toward the mercy seat. 
+<sup>21&#160;</sup>You shall put the mercy seat on top of the ark, and in the ark you shall put the covenant that I will give you. 
+<sup>22&#160;</sup>There I will meet with you, and I will tell you from above the mercy seat, from between the two cherubim which are on the ark of the covenant, all that I command you for the children of Israel. 
+</div><div class="p">
+<sup>23&#160;</sup>“You shall make a table of acacia wood. Its length shall be two cubits, and its width a cubit, and its height one and a half cubits. 
+<sup>24&#160;</sup>You shall overlay it with pure gold, and make a gold molding around it. 
+<sup>25&#160;</sup>You shall make a rim of a hand width around it. You shall make a golden molding on its rim around it. 
+<sup>26&#160;</sup>You shall make four rings of gold for it, and put the rings in the four corners that are on its four feet. 
+<sup>27&#160;</sup>The rings shall be close to the rim, for places for the poles to carry the table. 
+<sup>28&#160;</sup>You shall make the poles of acacia wood, and overlay them with gold, that the table may be carried with them. 
+<sup>29&#160;</sup>You shall make its dishes, its spoons, its ladles, and its bowls with which to pour out offerings. You shall make them of pure gold. 
+<sup>30&#160;</sup>You shall set bread of the presence on the table before me always. 
+</div><div class="p">
+<sup>31&#160;</sup>“You shall make a lamp stand of pure gold. The lamp stand shall be made of hammered work. Its base, its shaft, its cups, its buds, and its flowers shall be of one piece with it. 
+<sup>32&#160;</sup>There shall be six branches going out of its sides: three branches of the lamp stand out of its one side, and three branches of the lamp stand out of its other side; 
+<sup>33&#160;</sup>three cups made like almond blossoms in one branch, a bud and a flower; and three cups made like almond blossoms in the other branch, a bud and a flower, so for the six branches going out of the lamp stand; 
+<sup>34&#160;</sup>and in the lamp stand four cups made like almond blossoms, its buds and its flowers; 
+<sup>35&#160;</sup>and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, for the six branches going out of the lamp stand. 
+<sup>36&#160;</sup>Their buds and their branches shall be of one piece with it, all of it one beaten work of pure gold. 
+<sup>37&#160;</sup>You shall make its lamps seven, and they shall light its lamps to give light to the space in front of it. 
+<sup>38&#160;</sup>Its snuffers and its snuff dishes shall be of pure gold. 
+<sup>39&#160;</sup>It shall be made of a talent of pure gold, with all these accessories. 
+<sup>40&#160;</sup>See that you make them after their pattern, which has been shown to you on the mountain. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>“Moreover you shall make the tabernacle with ten curtains of fine twined linen, and blue, and purple, and scarlet, with cherubim. You shall make them with the work of a skillful workman. 
+<sup>2&#160;</sup>The length of each curtain shall be twenty-eight cubits, and the width of each curtain four cubits: all the curtains shall have one measure. 
+<sup>3&#160;</sup>Five curtains shall be coupled together to one another, and the other five curtains shall be coupled to one another. 
+<sup>4&#160;</sup>You shall make loops of blue on the edge of the one curtain from the edge in the coupling, and you shall do likewise on the edge of the curtain that is outermost in the second coupling. 
+<sup>5&#160;</sup>You shall make fifty loops in the one curtain, and you shall make fifty loops in the edge of the curtain that is in the second coupling. The loops shall be opposite one another. 
+<sup>6&#160;</sup>You shall make fifty clasps of gold, and couple the curtains to one another with the clasps. The tabernacle shall be a unit. 
+</div><div class="p">
+<sup>7&#160;</sup>“You shall make curtains of goats’ hair for a covering over the tabernacle. You shall make eleven curtains. 
+<sup>8&#160;</sup>The length of each curtain shall be thirty cubits, and the width of each curtain four cubits: the eleven curtains shall have one measure. 
+<sup>9&#160;</sup>You shall couple five curtains by themselves, and six curtains by themselves, and shall double over the sixth curtain in the forefront of the tent. 
+<sup>10&#160;</sup>You shall make fifty loops on the edge of the one curtain that is outermost in the coupling, and fifty loops on the edge of the curtain which is outermost in the second coupling. 
+<sup>11&#160;</sup>You shall make fifty clasps of bronze, and put the clasps into the loops, and couple the tent together, that it may be one. 
+<sup>12&#160;</sup>The overhanging part that remains of the curtains of the tent—the half curtain that remains—shall hang over the back of the tabernacle. 
+<sup>13&#160;</sup>The cubit on the one side and the cubit on the other side, of that which remains in the length of the curtains of the tent, shall hang over the sides of the tabernacle on this side and on that side, to cover it. 
+<sup>14&#160;</sup>You shall make a covering for the tent of rams’ skins dyed red, and a covering of sea cow hides above. 
+</div><div class="p">
+<sup>15&#160;</sup>“You shall make the boards for the tabernacle of acacia wood, standing upright. 
+<sup>16&#160;</sup>Ten cubits shall be the length of a board, and one and a half cubits the width of each board. 
+<sup>17&#160;</sup>There shall be two tenons in each board, joined to one another: thus you shall make for all the boards of the tabernacle. 
+<sup>18&#160;</sup>You shall make twenty boards for the tabernacle, for the south side southward. 
+<sup>19&#160;</sup>You shall make forty sockets of silver under the twenty boards; two sockets under one board for its two tenons, and two sockets under another board for its two tenons. 
+<sup>20&#160;</sup>For the second side of the tabernacle, on the north side, twenty boards, 
+<sup>21&#160;</sup>and their forty sockets of silver; two sockets under one board, and two sockets under another board. 
+<sup>22&#160;</sup>For the far side of the tabernacle westward you shall make six boards. 
+<sup>23&#160;</sup>You shall make two boards for the corners of the tabernacle in the far side. 
+<sup>24&#160;</sup>They shall be double beneath, and in the same way they shall be whole to its top to one ring: thus shall it be for them both; they shall be for the two corners. 
+<sup>25&#160;</sup>There shall be eight boards, and their sockets of silver, sixteen sockets; two sockets under one board, and two sockets under another board. 
+</div><div class="p">
+<sup>26&#160;</sup>“You shall make bars of acacia wood: five for the boards of the one side of the tabernacle, 
+<sup>27&#160;</sup>and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the side of the tabernacle, for the far side westward. 
+<sup>28&#160;</sup>The middle bar in the middle of the boards shall pass through from end to end. 
+<sup>29&#160;</sup>You shall overlay the boards with gold, and make their rings of gold for places for the bars. You shall overlay the bars with gold. 
+<sup>30&#160;</sup>You shall set up the tabernacle according to the way that it was shown to you on the mountain. 
+</div><div class="p">
+<sup>31&#160;</sup>“You shall make a veil of blue, and purple, and scarlet, and fine twined linen, with cherubim. It shall be the work of a skillful workman. 
+<sup>32&#160;</sup>You shall hang it on four pillars of acacia overlaid with gold; their hooks shall be of gold, on four sockets of silver. 
+<sup>33&#160;</sup>You shall hang up the veil under the clasps, and shall bring the ark of the covenant in there within the veil. The veil shall separate the set-apart place from the most set-apart for you. 
+<sup>34&#160;</sup>You shall put the mercy seat on the ark of the covenant in the most set-apart place. 
+<sup>35&#160;</sup>You shall set the table outside the veil, and the lamp stand opposite the table on the side of the tabernacle toward the south. You shall put the table on the north side. 
+</div><div class="p">
+<sup>36&#160;</sup>“You shall make a screen for the door of the Tent, of blue, and purple, and scarlet, and fine twined linen, the work of the embroiderer. 
+<sup>37&#160;</sup>You shall make for the screen five pillars of acacia, and overlay them with gold. Their hooks shall be of gold. You shall cast five sockets of bronze for them. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>“You shall make the altar of acacia wood, five cubits 
+<sup>2&#160;</sup>You shall make its horns on its four corners. Its horns shall be of one piece with it. You shall overlay it with bronze. 
+<sup>3&#160;</sup>You shall make its pots to take away its ashes; and its shovels, its basins, its meat hooks, and its fire pans. You shall make all its vessels of bronze. 
+<sup>4&#160;</sup>You shall make a grating for it of network of bronze. On the net you shall make four bronze rings in its four corners. 
+<sup>5&#160;</sup>You shall put it under the ledge around the altar beneath, that the net may reach halfway up the altar. 
+<sup>6&#160;</sup>You shall make poles for the altar, poles of acacia wood, and overlay them with bronze. 
+<sup>7&#160;</sup>Its poles shall be put into the rings, and the poles shall be on the two sides of the altar when carrying it. 
+<sup>8&#160;</sup>You shall make it hollow with planks. They shall make it as it has been shown you on the mountain. 
+</div><div class="p">
+<sup>9&#160;</sup>“You shall make the court of the tabernacle: for the south side southward there shall be hangings for the court of fine twined linen one hundred cubits long for one side. 
+<sup>10&#160;</sup>Its pillars shall be twenty, and their sockets twenty, of bronze. The hooks of the pillars and their fillets shall be of silver. 
+<sup>11&#160;</sup>Likewise for the length of the north side, there shall be hangings one hundred cubits long, and its pillars twenty, and their sockets twenty, of bronze; the hooks of the pillars, and their fillets, of silver. 
+<sup>12&#160;</sup>For the width of the court on the west side shall be hangings of fifty cubits; their pillars ten, and their sockets ten. 
+<sup>13&#160;</sup>The width of the court on the east side eastward shall be fifty cubits. 
+<sup>14&#160;</sup>The hangings for the one side of the gate shall be fifteen cubits; their pillars three, and their sockets three. 
+<sup>15&#160;</sup>For the other side shall be hangings of fifteen cubits; their pillars three, and their sockets three. 
+<sup>16&#160;</sup>For the gate of the court shall be a screen of twenty cubits, of blue, and purple, and scarlet, and fine twined linen, the work of the embroiderer; their pillars four, and their sockets four. 
+<sup>17&#160;</sup>All the pillars of the court around shall be filleted with silver; their hooks of silver, and their sockets of bronze. 
+<sup>18&#160;</sup>The length of the court shall be one hundred cubits, and the width fifty throughout, and the height five cubits, of fine twined linen, and their sockets of bronze. 
+<sup>19&#160;</sup>All the instruments of the tabernacle in all its service, and all its pins, and all the pins of the court, shall be of bronze. 
+</div><div class="p">
+<sup>20&#160;</sup>“You shall command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
+<sup>21&#160;</sup>In the Tent of Meeting, outside the veil which is before the covenant, Aaron and his sons shall keep it in order from evening to morning before Yahweh: it shall be a statute forever throughout their generations on the behalf of the children of Israel. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>“Bring Aaron your brother, and his sons with him, near to you from among the children of Israel, that he may minister to me in the priest’s office: Aaron, with Nadab, Abihu, Eleazar, and Ithamar, Aaron’s sons. 
+<sup>2&#160;</sup>You shall make set-apart garments for Aaron your brother, for glory and for beauty. 
+<sup>3&#160;</sup>You shall speak to all who are wise-hearted, whom I have filled with the spirit of wisdom, that they make Aaron’s garments to sanctify him, that he may minister to me in the priest’s office. 
+<sup>4&#160;</sup>These are the garments which they shall make: a breastplate, an ephod, a robe, a fitted tunic, a turban, and a sash. They shall make set-apart garments for Aaron your brother and his sons, that he may minister to me in the priest’s office. 
+<sup>5&#160;</sup>They shall use the gold, and the blue, and the purple, and the scarlet, and the fine linen. 
+</div><div class="p">
+<sup>6&#160;</sup>“They shall make the ephod of gold, blue, purple, scarlet, and fine twined linen, the work of the skillful workman. 
+<sup>7&#160;</sup>It shall have two shoulder straps joined to the two ends of it, that it may be joined together. 
+<sup>8&#160;</sup>The skillfully woven band, which is on it, shall be like its work and of the same piece; of gold, blue, purple, scarlet, and fine twined linen. 
+<sup>9&#160;</sup>You shall take two onyx stones, and engrave on them the names of the children of Israel. 
+<sup>10&#160;</sup>Six of their names on the one stone, and the names of the six that remain on the other stone, in the order of their birth. 
+<sup>11&#160;</sup>With the work of an engraver in stone, like the engravings of a signet, you shall engrave the two stones, according to the names of the children of Israel. You shall make them to be enclosed in settings of gold. 
+<sup>12&#160;</sup>You shall put the two stones on the shoulder straps of the ephod, to be stones of memorial for the children of Israel. Aaron shall bear their names before Yahweh on his two shoulders for a memorial. 
+<sup>13&#160;</sup>You shall make settings of gold, 
+<sup>14&#160;</sup>and two chains of pure gold; you shall make them like cords of braided work. You shall put the braided chains on the settings. 
+</div><div class="p">
+<sup>15&#160;</sup>“You shall make a breastplate of judgment, the work of the skillful workman; like the work of the ephod you shall make it; of gold, of blue, and purple, and scarlet, and fine twined linen, you shall make it. 
+<sup>16&#160;</sup>It shall be square and folded double; a span shall be its length, and a span its width. 
+<sup>17&#160;</sup>You shall set in it settings of stones, four rows of stones: a row of ruby, topaz, and beryl shall be the first row; 
+<sup>18&#160;</sup>and the second row a turquoise, a sapphire, and an emerald; 
+<sup>19&#160;</sup>and the third row a jacinth, an agate, and an amethyst; 
+<sup>20&#160;</sup>and the fourth row a chrysolite, an onyx, and a jasper. They shall be enclosed in gold in their settings. 
+<sup>21&#160;</sup>The stones shall be according to the names of the children of Israel, twelve, according to their names; like the engravings of a signet, everyone according to his name, they shall be for the twelve tribes. 
+<sup>22&#160;</sup>You shall make on the breastplate chains like cords, of braided work of pure gold. 
+<sup>23&#160;</sup>You shall make on the breastplate two rings of gold, and shall put the two rings on the two ends of the breastplate. 
+<sup>24&#160;</sup>You shall put the two braided chains of gold in the two rings at the ends of the breastplate. 
+<sup>25&#160;</sup>The other two ends of the two braided chains you shall put on the two settings, and put them on the shoulder straps of the ephod in its forepart. 
+<sup>26&#160;</sup>You shall make two rings of gold, and you shall put them on the two ends of the breastplate, on its edge, which is toward the side of the ephod inward. 
+<sup>27&#160;</sup>You shall make two rings of gold, and shall put them on the two shoulder straps of the ephod underneath, in its forepart, close by its coupling, above the skillfully woven band of the ephod. 
+<sup>28&#160;</sup>They shall bind the breastplate by its rings to the rings of the ephod with a lace of blue, that it may be on the skillfully woven band of the ephod, and that the breastplate may not swing out from the ephod. 
+<sup>29&#160;</sup>Aaron shall bear the names of the children of Israel in the breastplate of judgment on his heart, when he goes in to the set-apart place, for a memorial before Yahweh continually. 
+<sup>30&#160;</sup>You shall put in the breastplate of judgment the Urim and the Thummim; and they shall be on Aaron’s heart, when he goes in before Yahweh. Aaron shall bear the judgment of the children of Israel on his heart before Yahweh continually. 
+</div><div class="p">
+<sup>31&#160;</sup>“You shall make the robe of the ephod all of blue. 
+<sup>32&#160;</sup>It shall have a hole for the head in the middle of it. It shall have a binding of woven work around its hole, as it were the hole of a coat of mail, that it not be torn. 
+<sup>33&#160;</sup>On its hem you shall make pomegranates of blue, and of purple, and of scarlet, all around its hem; with bells of gold between and around them: 
+<sup>34&#160;</sup>a golden bell and a pomegranate, a golden bell and a pomegranate, around the hem of the robe. 
+<sup>35&#160;</sup>It shall be on Aaron to minister: and its sound shall be heard when he goes in to the set-apart place before Yahweh, and when he comes out, that he not die. 
+</div><div class="p">
+<sup>36&#160;</sup>“You shall make a plate of pure gold, and engrave on it, like the engravings of a signet, ‘SET-APART TO YAHWEH.’ 
+<sup>37&#160;</sup>You shall put it on a lace of blue, and it shall be on the sash. It shall be on the front of the sash. 
+<sup>38&#160;</sup>It shall be on Aaron’s forehead, and Aaron shall bear the iniquity of the set-apart things, which the children of Israel shall make set-apart in all their set-apart gifts; and it shall be always on his forehead, that they may be accepted before Yahweh. 
+<sup>39&#160;</sup>You shall weave the tunic with fine linen. You shall make a turban of fine linen. You shall make a sash, the work of the embroiderer. 
+</div><div class="p">
+<sup>40&#160;</sup>“You shall make tunics for Aaron’s sons. You shall make sashes for them. You shall make headbands for them, for glory and for beauty. 
+<sup>41&#160;</sup>You shall put them on Aaron your brother, and on his sons with him, and shall anoint them, and consecrate them, and sanctify them, that they may minister to me in the priest’s office. 
+<sup>42&#160;</sup>You shall make them linen pants to cover their naked flesh. They shall reach from the waist even to the thighs. 
+<sup>43&#160;</sup>They shall be on Aaron and on his sons, when they go in to the Tent of Meeting, or when they come near to the altar to minister in the set-apart place, that they don’t bear iniquity, and die. This shall be a statute forever to him and to his offspring after him. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>“This is the thing that you shall do to them to make them set-apart, to minister to me in the priest’s office: take one young bull and two rams without defect, 
+<sup>2&#160;</sup>unleavened bread, unleavened cakes mixed with oil, and unleavened wafers anointed with oil. You shall make them of fine wheat flour. 
+<sup>3&#160;</sup>You shall put them into one basket, and bring them in the basket, with the bull and the two rams. 
+<sup>4&#160;</sup>You shall bring Aaron and his sons to the door of the Tent of Meeting, and shall wash them with water. 
+<sup>5&#160;</sup>You shall take the garments, and put on Aaron the tunic, the robe of the ephod, the ephod, and the breastplate, and clothe him with the skillfully woven band of the ephod. 
+<sup>6&#160;</sup>You shall set the turban on his head, and put the set-apart crown on the turban. 
+<sup>7&#160;</sup>Then you shall take the anointing oil, and pour it on his head, and anoint him. 
+<sup>8&#160;</sup>You shall bring his sons, and put tunics on them. 
+<sup>9&#160;</sup>You shall clothe them with belts, Aaron and his sons, and bind headbands on them. They shall have the priesthood by a perpetual statute. You shall consecrate Aaron and his sons. 
+</div><div class="p">
+<sup>10&#160;</sup>“You shall bring the bull before the Tent of Meeting; and Aaron and his sons shall lay their hands on the head of the bull. 
+<sup>11&#160;</sup>You shall kill the bull before Yahweh at the door of the Tent of Meeting. 
+<sup>12&#160;</sup>You shall take of the blood of the bull, and put it on the horns of the altar with your finger; and you shall pour out all the blood at the base of the altar. 
+<sup>13&#160;</sup>You shall take all the fat that covers the innards, the cover of the liver, the two kidneys, and the fat that is on them, and burn them on the altar. 
+<sup>14&#160;</sup>But the meat of the bull, and its skin, and its dung, you shall burn with fire outside of the camp. It is a sin offering. 
+</div><div class="p">
+<sup>15&#160;</sup>“You shall also take the one ram, and Aaron and his sons shall lay their hands on the head of the ram. 
+<sup>16&#160;</sup>You shall kill the ram, and you shall take its blood, and sprinkle it around on the altar. 
+<sup>17&#160;</sup>You shall cut the ram into its pieces, and wash its innards, and its legs, and put them with its pieces, and with its head. 
+<sup>18&#160;</sup>You shall burn the whole ram on the altar: it is a burnt offering to Yahweh; it is a pleasant aroma, an offering made by fire to Yahweh. 
+</div><div class="p">
+<sup>19&#160;</sup>“You shall take the other ram, and Aaron and his sons shall lay their hands on the head of the ram. 
+<sup>20&#160;</sup>Then you shall kill the ram, and take some of its blood, and put it on the tip of the right ear of Aaron, and on the tip of the right ear of his sons, and on the thumb of their right hand, and on the big toe of their right foot; and sprinkle the blood around on the altar. 
+<sup>21&#160;</sup>You shall take of the blood that is on the altar, and of the anointing oil, and sprinkle it on Aaron, and on his garments, and on his sons, and on the garments of his sons with him: and he shall be made set-apart, and his garments, and his sons, and his sons’ garments with him. 
+<sup>22&#160;</sup>Also you shall take some of the ram’s fat, the fat tail, the fat that covers the innards, the cover of the liver, the two kidneys, the fat that is on them, and the right thigh (for it is a ram of consecration), 
+<sup>23&#160;</sup>and one loaf of bread, one cake of oiled bread, and one wafer out of the basket of unleavened bread that is before Yahweh. 
+<sup>24&#160;</sup>You shall put all of this in Aaron’s hands, and in his sons’ hands, and shall wave them for a wave offering before Yahweh. 
+<sup>25&#160;</sup>You shall take them from their hands, and burn them on the altar on the burnt offering, for a pleasant aroma before Yahweh: it is an offering made by fire to Yahweh. 
+</div><div class="p">
+<sup>26&#160;</sup>“You shall take the breast of Aaron’s ram of consecration, and wave it for a wave offering before Yahweh. It shall be your portion. 
+<sup>27&#160;</sup>You shall sanctify the breast of the wave offering and the thigh of the wave offering, which is waved, and which is raised up, of the ram of consecration, even of that which is for Aaron, and of that which is for his sons. 
+<sup>28&#160;</sup>It shall be for Aaron and his sons as their portion forever from the children of Israel; for it is a wave offering. It shall be a wave offering from the children of Israel of the sacrifices of their peace offerings, even their wave offering to Yahweh. 
+</div><div class="p">
+<sup>29&#160;</sup>“The set-apart garments of Aaron shall be for his sons after him, to be anointed in them, and to be consecrated in them. 
+<sup>30&#160;</sup>Seven days shall the son who is priest in his place put them on, when he comes into the Tent of Meeting to minister in the set-apart place. 
+</div><div class="p">
+<sup>31&#160;</sup>“You shall take the ram of consecration and boil its meat in a set-apart place. 
+<sup>32&#160;</sup>Aaron and his sons shall eat the meat of the ram, and the bread that is in the basket, at the door of the Tent of Meeting. 
+<sup>33&#160;</sup>They shall eat those things with which atonement was made, to consecrate and sanctify them; but a stranger shall not eat of it, because they are set-apart. 
+<sup>34&#160;</sup>If anything of the meat of the consecration, or of the bread, remains to the morning, then you shall burn the remainder with fire. It shall not be eaten, because it is set-apart. 
+</div><div class="p">
+<sup>35&#160;</sup>“You shall do so to Aaron and to his sons, according to all that I have commanded you. You shall consecrate them seven days. 
+<sup>36&#160;</sup>Every day you shall offer the bull of sin offering for atonement. You shall cleanse the altar when you make atonement for it. You shall anoint it, to sanctify it. 
+<sup>37&#160;</sup>Seven days you shall make atonement for the altar, and sanctify it; and the altar shall be most set-apart. Whatever touches the altar shall be set-apart. 
+</div><div class="p">
+<sup>38&#160;</sup>“Now this is that which you shall offer on the altar: two lambs a year old day by day continually. 
+<sup>39&#160;</sup>The one lamb you shall offer in the morning; and the other lamb you shall offer at evening; 
+<sup>40&#160;</sup>and with the one lamb a tenth part of an ephah of beaten oil, and the fourth part of a hin of wine for a drink offering. 
+<sup>41&#160;</sup>The other lamb you shall offer at evening, and shall do to it according to the meal offering of the morning and according to its drink offering, for a pleasant aroma, an offering made by fire to Yahweh. 
+<sup>42&#160;</sup>It shall be a continual burnt offering throughout your generations at the door of the Tent of Meeting before Yahweh, where I will meet with you, to speak there to you. 
+<sup>43&#160;</sup>There I will meet with the children of Israel; and the place shall be sanctified by my glory. 
+<sup>44&#160;</sup>I will sanctify the Tent of Meeting and the altar. I will also sanctify Aaron and his sons to minister to me in the priest’s office. 
+<sup>45&#160;</sup>I will dwell among the children of Israel, and will be their Elohim. 
+<sup>46&#160;</sup>They shall know that I am Yahweh their Elohim, who brought them out of the land of Egypt, that I might dwell among them: I am Yahweh their Elohim. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>“You shall make an altar to burn incense on. You shall make it of acacia wood. 
+<sup>2&#160;</sup>Its length shall be a cubit, and its width a cubit. It shall be square, and its height shall be two cubits. Its horns shall be of one piece with it. 
+<sup>3&#160;</sup>You shall overlay it with pure gold, its top, its sides around it, and its horns; and you shall make a gold molding around it. 
+<sup>4&#160;</sup>You shall make two golden rings for it under its molding; on its two ribs, on its two sides you shall make them; and they shall be for places for poles with which to bear it. 
+<sup>5&#160;</sup>You shall make the poles of acacia wood, and overlay them with gold. 
+<sup>6&#160;</sup>You shall put it before the veil that is by the ark of the covenant, before the mercy seat that is over the covenant, where I will meet with you. 
+<sup>7&#160;</sup>Aaron shall burn incense of sweet spices on it every morning. When he tends the lamps, he shall burn it. 
+<sup>8&#160;</sup>When Aaron lights the lamps at evening, he shall burn it, a perpetual incense before Yahweh throughout your generations. 
+<sup>9&#160;</sup>You shall offer no strange incense on it, nor burnt offering, nor meal offering; and you shall pour no drink offering on it. 
+<sup>10&#160;</sup>Aaron shall make atonement on its horns once in the year; with the blood of the sin offering of atonement once in the year he shall make atonement for it throughout your generations. It is most set-apart to Yahweh.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>12&#160;</sup>“When you take a census of the children of Israel, according to those who are counted among them, then each man shall give a ransom for his soul to Yahweh when you count them, that there be no plague among them when you count them. 
+<sup>13&#160;</sup>They shall give this, everyone who passes over to those who are counted, half a shekel according to the shekel); half a shekel for an offering to Yahweh. 
+<sup>14&#160;</sup>Everyone who passes over to those who are counted, from twenty years old and upward, shall give the offering to Yahweh. 
+<sup>15&#160;</sup>The rich shall not give more, and the poor shall not give less, than the half shekel, when they give the offering of Yahweh, to make atonement for your souls. 
+<sup>16&#160;</sup>You shall take the atonement money from the children of Israel, and shall appoint it for the service of the Tent of Meeting; that it may be a memorial for the children of Israel before Yahweh, to make atonement for your souls.” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>18&#160;</sup>“You shall also make a basin of bronze, and its base of bronze, in which to wash. You shall put it between the Tent of Meeting and the altar, and you shall put water in it. 
+<sup>19&#160;</sup>Aaron and his sons shall wash their hands and their feet in it. 
+<sup>20&#160;</sup>When they go into the Tent of Meeting, they shall wash with water, that they not die; or when they come near to the altar to minister, to burn an offering made by fire to Yahweh. 
+<sup>21&#160;</sup>So they shall wash their hands and their feet, that they not die. This shall be a statute forever to them, even to him and to his descendants throughout their generations.” 
+</div><div class="p">
+<sup>22&#160;</sup>Moreover Yahweh spoke to Moses, saying, 
+<sup>23&#160;</sup>“Also take fine spices: of liquid myrrh, five hundred shekels; and of fragrant cinnamon half as much, even two hundred and fifty; and of fragrant cane, two hundred and fifty; 
+<sup>24&#160;</sup>and of cassia five hundred, according to the shekel of the sanctuary; and a hin of olive oil. 
+<sup>25&#160;</sup>You shall make it into a set-apart anointing oil, a perfume compounded after the art of the perfumer: it shall be a set-apart anointing oil. 
+<sup>26&#160;</sup>You shall use it to anoint the Tent of Meeting, the ark of the covenant, 
+<sup>27&#160;</sup>the table and all its articles, the lamp stand and its accessories, the altar of incense, 
+<sup>28&#160;</sup>the altar of burnt offering with all its utensils, and the basin with its base. 
+<sup>29&#160;</sup>You shall sanctify them, that they may be most set-apart. Whatever touches them shall be set-apart. 
+<sup>30&#160;</sup>You shall anoint Aaron and his sons, and sanctify them, that they may minister to me in the priest’s office. 
+<sup>31&#160;</sup>You shall speak to the children of Israel, saying, ‘This shall be a set-apart anointing oil to me throughout your generations. 
+<sup>32&#160;</sup>It shall not be poured on man’s flesh, and do not make any like it, according to its composition. It is set-apart. It shall be set-apart to you. 
+<sup>33&#160;</sup>Whoever compounds any like it, or whoever puts any of it on a stranger, he shall be cut off from his people.’&#160;” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahweh said to Moses, “Take to yourself sweet spices, gum resin, onycha, and galbanum: sweet spices with pure frankincense. There shall be an equal weight of each. 
+<sup>35&#160;</sup>You shall make incense of it, a perfume after the art of the perfumer, seasoned with salt, pure and set-apart. 
+<sup>36&#160;</sup>You shall beat some of it very small, and put some of it before the covenant in the Tent of Meeting, where I will meet with you. It shall be to you most set-apart. 
+<sup>37&#160;</sup>You shall not make this incense, according to its composition, for yourselves: it shall be to you set-apart for Yahweh. 
+<sup>38&#160;</sup>Whoever shall make any like that, to smell of it, he shall be cut off from his people.” 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Behold, I have called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
+<sup>3&#160;</sup>I have filled him with the Spirit of Elohim, in wisdom, and in understanding, and in knowledge, and in all kinds of workmanship, 
+<sup>4&#160;</sup>to devise skillful works, to work in gold, and in silver, and in bronze, 
+<sup>5&#160;</sup>and in cutting of stones for setting, and in carving of wood, to work in all kinds of workmanship. 
+<sup>6&#160;</sup>Behold, I myself have appointed with him Oholiab, the son of Ahisamach, of the tribe of Dan; and in the heart of all who are wise-hearted I have put wisdom, that they may make all that I have commanded you: 
+<sup>7&#160;</sup>the Tent of Meeting, the ark of the covenant, the mercy seat that is on it, all the furniture of the Tent, 
+<sup>8&#160;</sup>the table and its vessels, the pure lamp stand with all its vessels, the altar of incense, 
+<sup>9&#160;</sup>the altar of burnt offering with all its vessels, the basin and its base, 
+<sup>10&#160;</sup>the finely worked garments—the set-apart garments for Aaron the priest, the garments of his sons to minister in the priest’s office—<sup>11&#160;</sup>the anointing oil, and the incense of sweet spices for the set-apart place: according to all that I have commanded you they shall do.” 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>13&#160;</sup>“Speak also to the children of Israel, saying, ‘Most certainly you shall keep my Sabbaths; for it is a sign between me and you throughout your generations, that you may know that I am Yahweh who sanctifies you. 
+<sup>14&#160;</sup>You shall keep the Sabbath therefore, for it is set-apart to you. Everyone who profanes it shall surely be put to death; for whoever does any work therein, that soul shall be cut off from among his people. 
+<sup>15&#160;</sup>Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, set-apart to Yahweh. Whoever does any work on the Sabbath day shall surely be put to death. 
+<sup>16&#160;</sup>Therefore the children of Israel shall keep the Sabbath, to observe the Sabbath throughout their generations, for a perpetual covenant. 
+<sup>17&#160;</sup>It is a sign between me and the children of Israel forever; for in six days Yahweh made heaven and earth, and on the seventh day he rested, and was refreshed.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>When he finished speaking with him on Mount Sinai, he gave Moses the two tablets of the covenant, stone tablets, written with Elohim’s finger. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>When the people saw that Moses delayed coming down from the mountain, the people gathered themselves together to Aaron, and said to him, “Come, make us elohims, which shall go before us; for as for this Moses, the man who brought us up out of the land of Egypt, we don’t know what has become of him.” 
+</div><div class="p">
+<sup>2&#160;</sup>Aaron said to them, “Take off the golden rings, which are in the ears of your women, of your sons, and of your daughters, and bring them to me.” 
+</div><div class="p">
+<sup>3&#160;</sup>All the people took off the golden rings which were in their ears, and brought them to Aaron. 
+<sup>4&#160;</sup>He received what they handed him, fashioned it with an engraving tool, and made it a molded calf. Then they said, “These are your elohims, Israel, which brought you up out of the land of Egypt.” 
+</div><div class="p">
+<sup>5&#160;</sup>When Aaron saw this, he built an altar before it; and Aaron made a proclamation, and said, “Tomorrow shall be a feast to Yahweh.” 
+</div><div class="p">
+<sup>6&#160;</sup>They rose up early on the next day, and offered burnt offerings, and brought peace offerings; and the people sat down to eat and to drink, and rose up to play. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh spoke to Moses, “Go, get down; for your people, whom you brought up out of the land of Egypt, have corrupted themselves! 
+<sup>8&#160;</sup>They have turned away quickly out of the way which I commanded them. They have made themselves a molded calf, and have worshiped it, and have sacrificed to it, and said, ‘These are your elohims, Israel, which brought you up out of the land of Egypt.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh said to Moses, “I have seen these people, and behold, they are a stiff-necked people. 
+<sup>10&#160;</sup>Now therefore leave me alone, that my wrath may burn hot against them, and that I may consume them; and I will make of you a great nation.” 
+</div><div class="p">
+<sup>11&#160;</sup>Moses begged Yahweh his Elohim, and said, “Yahweh, why does your wrath burn hot against your people, that you have brought out of the land of Egypt with great power and with a mighty hand? 
+<sup>12&#160;</sup>Why should the Egyptians talk, saying, ‘He brought them out for evil, to kill them in the mountains, and to consume them from the surface of the earth’? Turn from your fierce wrath, and turn away from this evil against your people. 
+<sup>13&#160;</sup>Remember Abraham, Isaac, and Israel, your servants, to whom you swore by your own self, and said to them, ‘I will multiply your offspring as the stars of the sky, and all this land that I have spoken of I will give to your offspring, and they shall inherit it forever.’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>So Yahweh turned away from the evil which he said he would do to his people. 
+</div><div class="p">
+<sup>15&#160;</sup>Moses turned, and went down from the mountain, with the two tablets of the covenant in his hand; tablets that were written on both their sides. They were written on one side and on the other. 
+<sup>16&#160;</sup>The tablets were the work of Elohim, and the writing was the writing of Elohim, engraved on the tablets. 
+</div><div class="p">
+<sup>17&#160;</sup>When Joshua heard the noise of the people as they shouted, he said to Moses, “There is the noise of war in the camp.” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, “It isn’t the voice of those who shout for victory. It is not the voice of those who cry for being overcome; but the noise of those who sing that I hear.” 
+<sup>19&#160;</sup>As soon as he came near to the camp, he saw the calf and the dancing. Then Moses’ anger grew hot, and he threw the tablets out of his hands, and broke them beneath the mountain. 
+<sup>20&#160;</sup>He took the calf which they had made, and burned it with fire, ground it to powder, and scattered it on the water, and made the children of Israel drink it. 
+</div><div class="p">
+<sup>21&#160;</sup>Moses said to Aaron, “What did these people do to you, that you have brought a great sin on them?” 
+</div><div class="p">
+<sup>22&#160;</sup>Aaron said, “Don’t let the anger of my lord grow hot. You know the people, that they are set on evil. 
+<sup>23&#160;</sup>For they said to me, ‘Make us elohims, which shall go before us. As for this Moses, the man who brought us up out of the land of Egypt, we don’t know what has become of him.’ 
+<sup>24&#160;</sup>I said to them, ‘Whoever has any gold, let them take it off.’ So they gave it to me; and I threw it into the fire, and out came this calf.” 
+</div><div class="p">
+<sup>25&#160;</sup>When Moses saw that the people were out of control, (for Aaron had let them lose control, causing derision among their enemies), 
+<sup>26&#160;</sup>then Moses stood in the gate of the camp, and said, “Whoever is on Yahweh’s side, come to me!” 
+</div><div class="p">All the sons of Levi gathered themselves together to him. 
+<sup>27&#160;</sup>He said to them, “Yahweh, the Elohim of Israel, says, ‘Every man put his sword on his thigh, and go back and forth from gate to gate throughout the camp, and every man kill his brother, and every man his companion, and every man his neighbor.’&#160;” 
+<sup>28&#160;</sup>The sons of Levi did according to the word of Moses. About three thousand men fell of the people that day. 
+<sup>29&#160;</sup>Moses said, “Consecrate yourselves today to Yahweh, for every man was against his son and against his brother, that he may give you a blessing today.” 
+</div><div class="p">
+<sup>30&#160;</sup>On the next day, Moses said to the people, “You have sinned a great sin. Now I will go up to Yahweh. Perhaps I shall make atonement for your sin.” 
+</div><div class="p">
+<sup>31&#160;</sup>Moses returned to Yahweh, and said, “Oh, this people have sinned a great sin, and have made themselves elohims of gold. 
+<sup>32&#160;</sup>Yet now, if you will, forgive their sin—and if not, please blot me out of your book which you have written.” 
+</div><div class="p">
+<sup>33&#160;</sup>Yahweh said to Moses, “Whoever has sinned against me, I will blot him out of my book. 
+<sup>34&#160;</sup>Now go, lead the people to the place of which I have spoken to you. Behold, my angel shall go before you. Nevertheless, in the day when I punish, I will punish them for their sin.” 
+<sup>35&#160;</sup>Yahweh struck the people, because of what they did with the calf, which Aaron made. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, “Depart, go up from here, you and the people that you have brought up out of the land of Egypt, to the land of which I swore to Abraham, to Isaac, and to Jacob, saying, ‘I will give it to your offspring.’ 
+<sup>2&#160;</sup>I will send an angel before you; and I will drive out the Canaanite, the Amorite, and the Hittite, and the Perizzite, the Hivite, and the Jebusite. 
+<sup>3&#160;</sup>Go to a land flowing with milk and honey; but I will not go up among you, for you are a stiff-necked people, lest I consume you on the way.” 
+</div><div class="p">
+<sup>4&#160;</sup>When the people heard this evil news, they mourned; and no one put on his jewelry. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh had said to Moses, “Tell the children of Israel, ‘You are a stiff-necked people. If I were to go up among you for one moment, I would consume you. Therefore now take off your jewelry from you, that I may know what to do to you.’&#160;” 
+</div><div class="p">
+<sup>6&#160;</sup>The children of Israel stripped themselves of their jewelry from Mount Horeb onward. 
+</div><div class="p">
+<sup>7&#160;</sup>Now Moses used to take the tent and pitch it outside the camp, far away from the camp, and he called it “The Tent of Meeting.” Everyone who sought Yahweh went out to the Tent of Meeting, which was outside the camp. 
+<sup>8&#160;</sup>When Moses went out to the Tent, all the people rose up, and stood, everyone at their tent door, and watched Moses, until he had gone into the Tent. 
+<sup>9&#160;</sup>When Moses entered into the Tent, the pillar of cloud descended, stood at the door of the Tent, and Yahweh spoke with Moses. 
+<sup>10&#160;</sup>All the people saw the pillar of cloud stand at the door of the Tent, and all the people rose up and worshiped, everyone at their tent door. 
+<sup>11&#160;</sup>Yahweh spoke to Moses face to face, as a man speaks to his friend. He turned again into the camp, but his servant Joshua, the son of Nun, a young man, didn’t depart from the Tent. 
+</div><div class="p">
+<sup>12&#160;</sup>Moses said to Yahweh, “Behold, you tell me, ‘Bring up this people;’ and you haven’t let me know whom you will send with me. Yet you have said, ‘I know you by name, and you have also found favor in my sight.’ 
+<sup>13&#160;</sup>Now therefore, if I have found favor in your sight, please show me your way, now, that I may know you, so that I may find favor in your sight; and consider that this nation is your people.” 
+</div><div class="p">
+<sup>14&#160;</sup>He said, “My presence will go with you, and I will give you rest.” 
+</div><div class="p">
+<sup>15&#160;</sup>Moses said to him, “If your presence doesn’t go with me, don’t carry us up from here. 
+<sup>16&#160;</sup>For how would people know that I have found favor in your sight, I and your people? Isn’t it that you go with us, so that we are separated, I and your people, from all the people who are on the surface of the earth?” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh said to Moses, “I will do this thing also that you have spoken; for you have found favor in my sight, and I know you by name.” 
+</div><div class="p">
+<sup>18&#160;</sup>Moses said, “Please show me your glory.” 
+</div><div class="p">
+<sup>19&#160;</sup>He said, “I will make all my goodness pass before you, and will proclaim Yahweh’s name before you. I will be gracious to whom I will be gracious, and will show mercy on whom I will show mercy.” 
+<sup>20&#160;</sup>He said, “You cannot see my face, for man may not see me and live.” 
+<sup>21&#160;</sup>Yahweh also said, “Behold, there is a place by me, and you shall stand on the rock. 
+<sup>22&#160;</sup>It will happen, while my glory passes by, that I will put you in a cleft of the rock, and will cover you with my hand until I have passed by; 
+<sup>23&#160;</sup>then I will take away my hand, and you will see my back; but my face shall not be seen.” 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, “Chisel two stone tablets like the first. I will write on the tablets the words that were on the first tablets, which you broke. 
+<sup>2&#160;</sup>Be ready by the morning, and come up in the morning to Mount Sinai, and present yourself there to me on the top of the mountain. 
+<sup>3&#160;</sup>No one shall come up with you or be seen anywhere on the mountain. Do not let the flocks or herds graze in front of that mountain.” 
+</div><div class="p">
+<sup>4&#160;</sup>He chiseled two tablets of stone like the first; then Moses rose up early in the morning, and went up to Mount Sinai, as Yahweh had commanded him, and took in his hand two stone tablets. 
+<sup>5&#160;</sup>Yahweh descended in the cloud, and stood with him there, and proclaimed Yahweh’s name. 
+<sup>6&#160;</sup>Yahweh passed by before him, and proclaimed, “Yahweh! Yahweh, a merciful and gracious Elohim, slow to anger, and abundant in loving kindness and truth, 
+<sup>7&#160;</sup>keeping loving kindness for thousands, forgiving iniquity and disobedience and sin; and who will by no means clear the guilty, visiting the iniquity of the fathers on the children, and on the children’s children, on the third and on the fourth generation.” 
+</div><div class="p">
+<sup>8&#160;</sup>Moses hurried and bowed his head toward the earth, and worshiped. 
+<sup>9&#160;</sup>He said, “If now I have found favor in your sight, Lord, please let the Lord go among us, even though this is a stiff-necked people; pardon our iniquity and our sin, and take us for your inheritance.” 
+</div><div class="p">
+<sup>10&#160;</sup>He said, “Behold, I make a covenant: before all your people I will do marvels, such as have not been worked in all the earth, nor in any nation; and all the people among whom you are shall see the work of Yahweh; for it is an awesome thing that I do with you. 
+<sup>11&#160;</sup>Observe that which I command you today. Behold, I will drive out before you the Amorite, the Canaanite, the Hittite, the Perizzite, the Hivite, and the Jebusite. 
+<sup>12&#160;</sup>Be careful, lest you make a covenant with the inhabitants of the land where you are going, lest it be for a snare among you; 
+<sup>13&#160;</sup>but you shall break down their altars, and dash in pieces their pillars, and you shall cut down their Asherah poles; 
+<sup>14&#160;</sup>for you shall worship no other elohim; for Yahweh, whose name is Jealous, is a jealous Elohim. 
+</div><div class="p">
+<sup>15&#160;</sup>“Don’t make a covenant with the inhabitants of the land, lest they play the prostitute after their elohims, and sacrifice to their elohims, and one call you and you eat of his sacrifice; 
+<sup>16&#160;</sup>and you take of their daughters to your sons, and their daughters play the prostitute after their elohims, and make your sons play the prostitute after their elohims. 
+</div><div class="p">
+<sup>17&#160;</sup>“You shall make no cast idols for yourselves. 
+</div><div class="p">
+<sup>18&#160;</sup>“You shall keep the feast of unleavened bread. Seven days you shall eat unleavened bread, as I commanded you, at the time appointed in the month Abib; for in the month Abib you came out of Egypt. 
+</div><div class="p">
+<sup>19&#160;</sup>“All that opens the womb is mine; and all your livestock that is male, the firstborn of cow and sheep. 
+<sup>20&#160;</sup>You shall redeem the firstborn of a donkey with a lamb. If you will not redeem it, then you shall break its neck. You shall redeem all the firstborn of your sons. No one shall appear before me empty. 
+</div><div class="p">
+<sup>21&#160;</sup>“Six days you shall work, but on the seventh day you shall rest: in plowing time and in harvest you shall rest. 
+</div><div class="p">
+<sup>22&#160;</sup>“You shall observe the feast of weeks with the first fruits of wheat harvest, and the feast of harvest at the year’s end. 
+<sup>23&#160;</sup>Three times in the year all your males shall appear before the Lord Yahweh, the Elohim of Israel. 
+<sup>24&#160;</sup>For I will drive out nations before you and enlarge your borders; neither shall any man desire your land when you go up to appear before Yahweh, your Elohim, three times in the year. 
+</div><div class="p">
+<sup>25&#160;</sup>“You shall not offer the blood of my sacrifice with leavened bread. The sacrifice of the feast of the Passover shall not be left to the morning. 
+</div><div class="p">
+<sup>26&#160;</sup>“You shall bring the first of the first fruits of your ground to the house of Yahweh your Elohim. 
+</div><div class="p">“You shall not boil a young goat in its mother’s milk.” 
+</div><div class="p">
+<sup>27&#160;</sup>Yahweh said to Moses, “Write these words; for in accordance with these words I have made a covenant with you and with Israel.” 
+</div><div class="p">
+<sup>28&#160;</sup>He was there with Yahweh forty days and forty nights; he neither ate bread, nor drank water. He wrote on the tablets the words of the covenant, the ten commandments. 
+</div><div class="p">
+<sup>29&#160;</sup>When Moses came down from Mount Sinai with the two tablets of the covenant in Moses’ hand, when he came down from the mountain, Moses didn’t know that the skin of his face shone by reason of his speaking with him. 
+<sup>30&#160;</sup>When Aaron and all the children of Israel saw Moses, behold, the skin of his face shone; and they were afraid to come near him. 
+<sup>31&#160;</sup>Moses called to them, and Aaron and all the rulers of the congregation returned to him; and Moses spoke to them. 
+<sup>32&#160;</sup>Afterward all the children of Israel came near, and he gave them all the commandments that Yahweh had spoken with him on Mount Sinai. 
+<sup>33&#160;</sup>When Moses was done speaking with them, he put a veil on his face. 
+<sup>34&#160;</sup>But when Moses went in before Yahweh to speak with him, he took the veil off, until he came out; and he came out, and spoke to the children of Israel that which he was commanded. 
+<sup>35&#160;</sup>The children of Israel saw Moses’ face, that the skin of Moses’ face shone; so Moses put the veil on his face again, until he went in to speak with him. 
+</div><h2 class="chapterlabel" id="35">35</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses assembled all the congregation of the children of Israel, and said to them, “These are the words which Yahweh has commanded, that you should do them. 
+<sup>2&#160;</sup>‘Six days shall work be done, but on the seventh day there shall be a set-apart day for you, a Sabbath of solemn rest to Yahweh: whoever does any work in it shall be put to death. 
+<sup>3&#160;</sup>You shall kindle no fire throughout your habitations on the Sabbath day.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>Moses spoke to all the congregation of the children of Israel, saying, “This is the thing which Yahweh commanded, saying, 
+<sup>5&#160;</sup>‘Take from among you an offering to Yahweh. Whoever is of a willing heart, let him bring it as Yahweh’s offering: gold, silver, bronze, 
+<sup>6&#160;</sup>blue, purple, scarlet, fine linen, goats’ hair, 
+<sup>7&#160;</sup>rams’ skins dyed red, sea cow hides, acacia wood, 
+<sup>8&#160;</sup>oil for the light, spices for the anointing oil and for the sweet incense, 
+<sup>9&#160;</sup>onyx stones, and stones to be set for the ephod and for the breastplate. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘Let every wise-hearted man among you come, and make all that Yahweh has commanded: 
+<sup>11&#160;</sup>the tabernacle, its outer covering, its roof, its clasps, its boards, its bars, its pillars, and its sockets; 
+<sup>12&#160;</sup>the ark, and its poles, the mercy seat, the veil of the screen; 
+<sup>13&#160;</sup>the table with its poles and all its vessels, and the show bread; 
+<sup>14&#160;</sup>the lamp stand also for the light, with its vessels, its lamps, and the oil for the light; 
+<sup>15&#160;</sup>and the altar of incense with its poles, the anointing oil, the sweet incense, the screen for the door, at the door of the tabernacle; 
+<sup>16&#160;</sup>the altar of burnt offering, with its grating of bronze, its poles, and all its vessels, the basin and its base; 
+<sup>17&#160;</sup>the hangings of the court, its pillars, their sockets, and the screen for the gate of the court; 
+<sup>18&#160;</sup>the pins of the tabernacle, the pins of the court, and their cords; 
+<sup>19&#160;</sup>the finely worked garments for ministering in the set-apart place—the set-apart garments for Aaron the priest, and the garments of his sons—to minister in the priest’s office.’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>All the congregation of the children of Israel departed from the presence of Moses. 
+<sup>21&#160;</sup>They came, everyone whose heart stirred him up, and everyone whom his spirit made willing, and brought Yahweh’s offering for the work of the Tent of Meeting, and for all of its service, and for the set-apart garments. 
+<sup>22&#160;</sup>They came, both men and women, as many as were willing-hearted, and brought brooches, earrings, signet rings, and armlets, all jewels of gold; even every man who offered an offering of gold to Yahweh. 
+<sup>23&#160;</sup>Everyone with whom was found blue, purple, scarlet, fine linen, goats’ hair, rams’ skins dyed red, and sea cow hides, brought them. 
+<sup>24&#160;</sup>Everyone who offered an offering of silver and bronze brought Yahweh’s offering; and everyone with whom was found acacia wood for any work of the service, brought it. 
+<sup>25&#160;</sup>All the women who were wise-hearted spun with their hands, and brought that which they had spun: the blue, the purple, the scarlet, and the fine linen. 
+<sup>26&#160;</sup>All the women whose heart stirred them up in wisdom spun the goats’ hair. 
+<sup>27&#160;</sup>The rulers brought the onyx stones and the stones to be set for the ephod and for the breastplate; 
+<sup>28&#160;</sup>with the spice and the oil for the light, for the anointing oil, and for the sweet incense. 
+<sup>29&#160;</sup>The children of Israel brought a free will offering to Yahweh; every man and woman whose heart made them willing to bring for all the work, which Yahweh had commanded to be made by Moses. 
+</div><div class="p">
+<sup>30&#160;</sup>Moses said to the children of Israel, “Behold, Yahweh has called by name Bezalel the son of Uri, the son of Hur, of the tribe of Judah. 
+<sup>31&#160;</sup>He has filled him with the Spirit of Elohim, in wisdom, in understanding, in knowledge, and in all kinds of workmanship; 
+<sup>32&#160;</sup>and to make skillful works, to work in gold, in silver, in bronze, 
+<sup>33&#160;</sup>in cutting of stones for setting, and in carving of wood, to work in all kinds of skillful workmanship. 
+<sup>34&#160;</sup>He has put in his heart that he may teach, both he and Oholiab, the son of Ahisamach, of the tribe of Dan. 
+<sup>35&#160;</sup>He has filled them with wisdom of heart to work all kinds of workmanship, of the engraver, of the skillful workman, and of the embroiderer, in blue, in purple, in scarlet, and in fine linen, and of the weaver, even of those who do any workmanship, and of those who make skillful works. 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>“Bezalel and Oholiab shall work with every wise-hearted man, in whom Yahweh has put wisdom and understanding to know how to do all the work for the service of the sanctuary, according to all that Yahweh has commanded.” 
+</div><div class="p">
+<sup>2&#160;</sup>Moses called Bezalel and Oholiab, and every wise-hearted man, in whose heart Yahweh had put wisdom, even everyone whose heart stirred him up to come to the work to do it. 
+<sup>3&#160;</sup>They received from Moses all the offering which the children of Israel had brought for the work of the service of the sanctuary, with which to make it. They kept bringing free will offerings to him every morning. 
+<sup>4&#160;</sup>All the wise men, who performed all the work of the sanctuary, each came from his work which he did. 
+<sup>5&#160;</sup>They spoke to Moses, saying, “The people have brought much more than enough for the service of the work which Yahweh commanded to make.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses gave a commandment, and they caused it to be proclaimed throughout the camp, saying, “Let neither man nor woman make anything else for the offering for the sanctuary.” So the people were restrained from bringing. 
+<sup>7&#160;</sup>For the stuff they had was sufficient to do all the work, and too much. 
+</div><div class="p">
+<sup>8&#160;</sup>All the wise-hearted men among those who did the work made the tabernacle with ten curtains of fine twined linen, blue, purple, and scarlet. They made them with cherubim, the work of a skillful workman. 
+<sup>9&#160;</sup>The length of each curtain was twenty-eight cubits, and the width of each curtain four cubits. All the curtains had one measure. 
+<sup>10&#160;</sup>He coupled five curtains to one another, and the other five curtains he coupled to one another. 
+<sup>11&#160;</sup>He made loops of blue on the edge of the one curtain from the edge in the coupling. Likewise he made in the edge of the curtain that was outermost in the second coupling. 
+<sup>12&#160;</sup>He made fifty loops in the one curtain, and he made fifty loops in the edge of the curtain that was in the second coupling. The loops were opposite to one another. 
+<sup>13&#160;</sup>He made fifty clasps of gold, and coupled the curtains to one another with the clasps: so the tabernacle was a unit. 
+</div><div class="p">
+<sup>14&#160;</sup>He made curtains of goats’ hair for a covering over the tabernacle. He made them eleven curtains. 
+<sup>15&#160;</sup>The length of each curtain was thirty cubits, and four cubits the width of each curtain. The eleven curtains had one measure. 
+<sup>16&#160;</sup>He coupled five curtains by themselves, and six curtains by themselves. 
+<sup>17&#160;</sup>He made fifty loops on the edge of the curtain that was outermost in the coupling, and he made fifty loops on the edge of the curtain which was outermost in the second coupling. 
+<sup>18&#160;</sup>He made fifty clasps of bronze to couple the tent together, that it might be a unit. 
+<sup>19&#160;</sup>He made a covering for the tent of rams’ skins dyed red, and a covering of sea cow hides above. 
+</div><div class="p">
+<sup>20&#160;</sup>He made the boards for the tabernacle of acacia wood, standing up. 
+<sup>21&#160;</sup>Ten cubits was the length of a board, and a cubit and a half the width of each board. 
+<sup>22&#160;</sup>Each board had two tenons, joined to one another. He made all the boards of the tabernacle this way. 
+<sup>23&#160;</sup>He made the boards for the tabernacle, twenty boards for the south side southward. 
+<sup>24&#160;</sup>He made forty sockets of silver under the twenty boards: two sockets under one board for its two tenons, and two sockets under another board for its two tenons. 
+<sup>25&#160;</sup>For the second side of the tabernacle, on the north side, he made twenty boards 
+<sup>26&#160;</sup>and their forty sockets of silver: two sockets under one board, and two sockets under another board. 
+<sup>27&#160;</sup>For the far part of the tabernacle westward he made six boards. 
+<sup>28&#160;</sup>He made two boards for the corners of the tabernacle in the far part. 
+<sup>29&#160;</sup>They were double beneath, and in the same way they were all the way to its top to one ring. He did this to both of them in the two corners. 
+<sup>30&#160;</sup>There were eight boards and their sockets of silver, sixteen sockets—under every board two sockets. 
+</div><div class="p">
+<sup>31&#160;</sup>He made bars of acacia wood: five for the boards of the one side of the tabernacle, 
+<sup>32&#160;</sup>and five bars for the boards of the other side of the tabernacle, and five bars for the boards of the tabernacle for the hinder part westward. 
+<sup>33&#160;</sup>He made the middle bar to pass through in the middle of the boards from the one end to the other. 
+<sup>34&#160;</sup>He overlaid the boards with gold, and made their rings of gold as places for the bars, and overlaid the bars with gold. 
+</div><div class="p">
+<sup>35&#160;</sup>He made the veil of blue, purple, scarlet, and fine twined linen, with cherubim. He made it the work of a skillful workman. 
+<sup>36&#160;</sup>He made four pillars of acacia for it, and overlaid them with gold. Their hooks were of gold. He cast four sockets of silver for them. 
+<sup>37&#160;</sup>He made a screen for the door of the tent, of blue, purple, scarlet, and fine twined linen, the work of an embroiderer; 
+<sup>38&#160;</sup>and the five pillars of it with their hooks. He overlaid their capitals and their fillets with gold, and their five sockets were of bronze. 
+</div><h2 class="chapterlabel" id="37">37</h2>
+<div class="p">
+<sup>1&#160;</sup>Bezalel made the ark of acacia wood. Its length was two and a half cubits, and its width a cubit and a half, and a cubit and a half its height. 
+<sup>2&#160;</sup>He overlaid it with pure gold inside and outside, and made a molding of gold for it around it. 
+<sup>3&#160;</sup>He cast four rings of gold for it in its four feet—two rings on its one side, and two rings on its other side. 
+<sup>4&#160;</sup>He made poles of acacia wood and overlaid them with gold. 
+<sup>5&#160;</sup>He put the poles into the rings on the sides of the ark, to bear the ark. 
+<sup>6&#160;</sup>He made a mercy seat of pure gold. Its length was two and a half cubits, and a cubit and a half its width. 
+<sup>7&#160;</sup>He made two cherubim of gold. He made them of beaten work, at the two ends of the mercy seat: 
+<sup>8&#160;</sup>one cherub at the one end, and one cherub at the other end. He made the cherubim of one piece with the mercy seat at its two ends. 
+<sup>9&#160;</sup>The cherubim spread out their wings above, covering the mercy seat with their wings, with their faces toward one another. The faces of the cherubim were toward the mercy seat. 
+</div><div class="p">
+<sup>10&#160;</sup>He made the table of acacia wood. Its length was two cubits, and its width was a cubit, and its height was a cubit and a half. 
+<sup>11&#160;</sup>He overlaid it with pure gold, and made a gold molding around it. 
+<sup>12&#160;</sup>He made a border of a hand’s width around it, and made a golden molding on its border around it. 
+<sup>13&#160;</sup>He cast four rings of gold for it, and put the rings in the four corners that were on its four feet. 
+<sup>14&#160;</sup>The rings were close by the border, the places for the poles to carry the table. 
+<sup>15&#160;</sup>He made the poles of acacia wood, and overlaid them with gold, to carry the table. 
+<sup>16&#160;</sup>He made the vessels which were on the table, its dishes, its spoons, its bowls, and its pitchers with which to pour out, of pure gold. 
+</div><div class="p">
+<sup>17&#160;</sup>He made the lamp stand of pure gold. He made the lamp stand of beaten work. Its base, its shaft, its cups, its buds, and its flowers were of one piece with it. 
+<sup>18&#160;</sup>There were six branches going out of its sides: three branches of the lamp stand out of its one side, and three branches of the lamp stand out of its other side: 
+<sup>19&#160;</sup>three cups made like almond blossoms in one branch, a bud and a flower, and three cups made like almond blossoms in the other branch, a bud and a flower; so for the six branches going out of the lamp stand. 
+<sup>20&#160;</sup>In the lamp stand were four cups made like almond blossoms, its buds and its flowers; 
+<sup>21&#160;</sup>and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, and a bud under two branches of one piece with it, for the six branches going out of it. 
+<sup>22&#160;</sup>Their buds and their branches were of one piece with it. The whole thing was one beaten work of pure gold. 
+<sup>23&#160;</sup>He made its seven lamps, and its snuffers, and its snuff dishes, of pure gold. 
+<sup>24&#160;</sup>He made it of a talent of pure gold, with all its vessels. 
+</div><div class="p">
+<sup>25&#160;</sup>He made the altar of incense of acacia wood. It was square: its length was a cubit, and its width a cubit. Its height was two cubits. Its horns were of one piece with it. 
+<sup>26&#160;</sup>He overlaid it with pure gold: its top, its sides around it, and its horns. He made a gold molding around it. 
+<sup>27&#160;</sup>He made two golden rings for it under its molding crown, on its two ribs, on its two sides, for places for poles with which to carry it. 
+<sup>28&#160;</sup>He made the poles of acacia wood, and overlaid them with gold. 
+<sup>29&#160;</sup>He made the set-apart anointing oil and the pure incense of sweet spices, after the art of the perfumer. 
+</div><h2 class="chapterlabel" id="38">38</h2>
+<div class="p">
+<sup>1&#160;</sup>He made the altar of burnt offering of acacia wood. It was square. Its length was five cubits, its width was five cubits, and its height was three cubits. 
+<sup>2&#160;</sup>He made its horns on its four corners. Its horns were of one piece with it, and he overlaid it with bronze. 
+<sup>3&#160;</sup>He made all the vessels of the altar: the pots, the shovels, the basins, the forks, and the fire pans. He made all its vessels of bronze. 
+<sup>4&#160;</sup>He made for the altar a grating of a network of bronze, under the ledge around it beneath, reaching halfway up. 
+<sup>5&#160;</sup>He cast four rings for the four corners of bronze grating, to be places for the poles. 
+<sup>6&#160;</sup>He made the poles of acacia wood, and overlaid them with bronze. 
+<sup>7&#160;</sup>He put the poles into the rings on the sides of the altar, with which to carry it. He made it hollow with planks. 
+</div><div class="p">
+<sup>8&#160;</sup>He made the basin of bronze, and its base of bronze, out of the mirrors of the ministering women who ministered at the door of the Tent of Meeting. 
+</div><div class="p">
+<sup>9&#160;</sup>He made the court: for the south side southward the hangings of the court were of fine twined linen, one hundred cubits; 
+<sup>10&#160;</sup>their pillars were twenty, and their sockets twenty, of bronze; the hooks of the pillars and their fillets were of silver. 
+<sup>11&#160;</sup>For the north side one hundred cubits, their pillars twenty, and their sockets twenty, of bronze; the hooks of the pillars, and their fillets, of silver. 
+<sup>12&#160;</sup>For the west side were hangings of fifty cubits, their pillars ten, and their sockets ten; the hooks of the pillars, and their fillets, of silver. 
+<sup>13&#160;</sup>For the east side eastward fifty cubits, 
+<sup>14&#160;</sup>the hangings for the one side were fifteen cubits; their pillars three, and their sockets three; 
+<sup>15&#160;</sup>and so for the other side: on this hand and that hand by the gate of the court were hangings of fifteen cubits; their pillars three, and their sockets three. 
+<sup>16&#160;</sup>All the hangings around the court were of fine twined linen. 
+<sup>17&#160;</sup>The sockets for the pillars were of bronze. The hooks of the pillars and their fillets were of silver. Their capitals were overlaid with silver. All the pillars of the court had silver bands. 
+<sup>18&#160;</sup>The screen for the gate of the court was the work of the embroiderer, of blue, purple, scarlet, and fine twined linen. Twenty cubits was the length, and the height along the width was five cubits, like the hangings of the court. 
+<sup>19&#160;</sup>Their pillars were four, and their sockets four, of bronze; their hooks of silver, and the overlaying of their capitals, and their fillets, of silver. 
+<sup>20&#160;</sup>All the pins of the tabernacle, and around the court, were of bronze. 
+</div><div class="p">
+<sup>21&#160;</sup>These are the amounts of materials used for the tabernacle, even the Tabernacle of the Testimony, as they were counted, according to the commandment of Moses, for the service of the Levites, by the hand of Ithamar, the son of Aaron the priest. 
+<sup>22&#160;</sup>Bezalel the son of Uri, the son of Hur, of the tribe of Judah, made all that Yahweh commanded Moses. 
+<sup>23&#160;</sup>With him was Oholiab, the son of Ahisamach, of the tribe of Dan, an engraver, and a skillful workman, and an embroiderer in blue, in purple, in scarlet, and in fine linen. 
+</div><div class="p">
+<sup>24&#160;</sup>All the gold that was used for the work in all the work of the sanctuary, even the gold of the offering, was twenty-nine talents of the sanctuary. 
+<sup>25&#160;</sup>The silver of those who were counted of the congregation was one hundred talents according to the shekel of the sanctuary: 
+<sup>26&#160;</sup>a beka of the sanctuary, for everyone who passed over to those who were counted, from twenty years old and upward, for six hundred three thousand five hundred fifty men. 
+<sup>27&#160;</sup>The one hundred talents of silver were for casting the sockets of the sanctuary and the sockets of the veil: one hundred sockets for the one hundred talents, one talent per socket. 
+<sup>28&#160;</sup>From the one thousand seven hundred seventy-five shekels he made hooks for the pillars, overlaid their capitals, and made fillets for them. 
+<sup>29&#160;</sup>The bronze of the offering was seventy talents 
+<sup>30&#160;</sup>With this he made the sockets to the door of the Tent of Meeting, the bronze altar, the bronze grating for it, all the vessels of the altar, 
+<sup>31&#160;</sup>the sockets around the court, the sockets of the gate of the court, all the pins of the tabernacle, and all the pins around the court. 
+</div><h2 class="chapterlabel" id="39">39</h2>
+<div class="p">
+<sup>1&#160;</sup>Of the blue, purple, and scarlet, they made finely worked garments for ministering in the set-apart place, and made the set-apart garments for Aaron, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>2&#160;</sup>He made the ephod of gold, blue, purple, scarlet, and fine twined linen. 
+<sup>3&#160;</sup>They beat the gold into thin plates, and cut it into wires, to work it in with the blue, the purple, the scarlet, and the fine linen, the work of the skillful workman. 
+<sup>4&#160;</sup>They made shoulder straps for it, joined together. It was joined together at the two ends. 
+<sup>5&#160;</sup>The skillfully woven band that was on it, with which to fasten it on, was of the same piece, like its work: of gold, of blue, purple, scarlet, and fine twined linen, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>6&#160;</sup>They worked the onyx stones, enclosed in settings of gold, engraved with the engravings of a signet, according to the names of the children of Israel. 
+<sup>7&#160;</sup>He put them on the shoulder straps of the ephod, to be stones of memorial for the children of Israel, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>8&#160;</sup>He made the breastplate, the work of a skillful workman, like the work of the ephod: of gold, of blue, purple, scarlet, and fine twined linen. 
+<sup>9&#160;</sup>It was square. They made the breastplate double. Its length was a span, and its width a span, being double. 
+<sup>10&#160;</sup>They set in it four rows of stones. A row of ruby, topaz, and beryl was the first row; 
+<sup>11&#160;</sup>and the second row, a turquoise, a sapphire, and an emerald; 
+<sup>12&#160;</sup>and the third row, a jacinth, an agate, and an amethyst; 
+<sup>13&#160;</sup>and the fourth row, a chrysolite, an onyx, and a jasper. They were enclosed in gold settings. 
+<sup>14&#160;</sup>The stones were according to the names of the children of Israel, twelve, according to their names; like the engravings of a signet, everyone according to his name, for the twelve tribes. 
+<sup>15&#160;</sup>They made on the breastplate chains like cords, of braided work of pure gold. 
+<sup>16&#160;</sup>They made two settings of gold, and two gold rings, and put the two rings on the two ends of the breastplate. 
+<sup>17&#160;</sup>They put the two braided chains of gold in the two rings at the ends of the breastplate. 
+<sup>18&#160;</sup>The other two ends of the two braided chains they put on the two settings, and put them on the shoulder straps of the ephod, in its front. 
+<sup>19&#160;</sup>They made two rings of gold, and put them on the two ends of the breastplate, on its edge, which was toward the side of the ephod inward. 
+<sup>20&#160;</sup>They made two more rings of gold, and put them on the two shoulder straps of the ephod underneath, in its front, close by its coupling, above the skillfully woven band of the ephod. 
+<sup>21&#160;</sup>They bound the breastplate by its rings to the rings of the ephod with a lace of blue, that it might be on the skillfully woven band of the ephod, and that the breastplate might not come loose from the ephod, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>22&#160;</sup>He made the robe of the ephod of woven work, all of blue. 
+<sup>23&#160;</sup>The opening of the robe in the middle of it was like the opening of a coat of mail, with a binding around its opening, that it should not be torn. 
+<sup>24&#160;</sup>They made on the skirts of the robe pomegranates of blue, purple, scarlet, and twined linen. 
+<sup>25&#160;</sup>They made bells of pure gold, and put the bells between the pomegranates around the skirts of the robe, between the pomegranates; 
+<sup>26&#160;</sup>a bell and a pomegranate, a bell and a pomegranate, around the skirts of the robe, to minister in, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>27&#160;</sup>They made the tunics of fine linen of woven work for Aaron and for his sons, 
+<sup>28&#160;</sup>the turban of fine linen, the linen headbands of fine linen, the linen trousers of fine twined linen, 
+<sup>29&#160;</sup>the sash of fine twined linen, blue, purple, and scarlet, the work of the embroiderer, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>30&#160;</sup>They made the plate of the set-apart crown of pure gold, and wrote on it an inscription, like the engravings of a signet: “SET-APART TO YAHWEH”. 
+<sup>31&#160;</sup>They tied to it a lace of blue, to fasten it on the turban above, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>32&#160;</sup>Thus all the work of the tabernacle of the Tent of Meeting was finished. The children of Israel did according to all that Yahweh commanded Moses; so they did. 
+<sup>33&#160;</sup>They brought the tabernacle to Moses: the tent, with all its furniture, its clasps, its boards, its bars, its pillars, its sockets, 
+<sup>34&#160;</sup>the covering of rams’ skins dyed red, the covering of sea cow hides, the veil of the screen, 
+<sup>35&#160;</sup>the ark of the covenant with its poles, the mercy seat, 
+<sup>36&#160;</sup>the table, all its vessels, the show bread, 
+<sup>37&#160;</sup>the pure lamp stand, its lamps, even the lamps to be set in order, all its vessels, the oil for the light, 
+<sup>38&#160;</sup>the golden altar, the anointing oil, the sweet incense, the screen for the door of the Tent, 
+<sup>39&#160;</sup>the bronze altar, its grating of bronze, its poles, all of its vessels, the basin and its base, 
+<sup>40&#160;</sup>the hangings of the court, its pillars, its sockets, the screen for the gate of the court, its cords, its pins, and all the instruments of the service of the tabernacle, for the Tent of Meeting, 
+<sup>41&#160;</sup>the finely worked garments for ministering in the set-apart place, the set-apart garments for Aaron the priest, and the garments of his sons, to minister in the priest’s office. 
+<sup>42&#160;</sup>According to all that Yahweh commanded Moses, so the children of Israel did all the work. 
+<sup>43&#160;</sup>Moses saw all the work, and behold, they had done it as Yahweh had commanded. They had done so; and Moses blessed them. 
+</div><h2 class="chapterlabel" id="40">40</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“On the first day of the first month you shall raise up the tabernacle of the Tent of Meeting. 
+<sup>3&#160;</sup>You shall put the ark of the covenant in it, and you shall screen the ark with the veil. 
+<sup>4&#160;</sup>You shall bring in the table, and set in order the things that are on it. You shall bring in the lamp stand, and light its lamps. 
+<sup>5&#160;</sup>You shall set the golden altar for incense before the ark of the covenant, and put the screen of the door to the tabernacle. 
+</div><div class="p">
+<sup>6&#160;</sup>“You shall set the altar of burnt offering before the door of the tabernacle of the Tent of Meeting. 
+<sup>7&#160;</sup>You shall set the basin between the Tent of Meeting and the altar, and shall put water therein. 
+<sup>8&#160;</sup>You shall set up the court around it, and hang up the screen of the gate of the court. 
+</div><div class="p">
+<sup>9&#160;</sup>“You shall take the anointing oil, and anoint the tabernacle and all that is in it, and shall make it set-apart, and all its furniture, and it will be set-apart. 
+<sup>10&#160;</sup>You shall anoint the altar of burnt offering, with all its vessels, and sanctify the altar, and the altar will be most set-apart. 
+<sup>11&#160;</sup>You shall anoint the basin and its base, and sanctify it. 
+</div><div class="p">
+<sup>12&#160;</sup>“You shall bring Aaron and his sons to the door of the Tent of Meeting, and shall wash them with water. 
+<sup>13&#160;</sup>You shall put on Aaron the set-apart garments; and you shall anoint him, and sanctify him, that he may minister to me in the priest’s office. 
+<sup>14&#160;</sup>You shall bring his sons, and put tunics on them. 
+<sup>15&#160;</sup>You shall anoint them, as you anointed their father, that they may minister to me in the priest’s office. Their anointing shall be to them for an everlasting priesthood throughout their generations.” 
+<sup>16&#160;</sup>Moses did so. According to all that Yahweh commanded him, so he did. 
+</div><div class="p">
+<sup>17&#160;</sup>In the first month in the second year, on the first day of the month, the tabernacle was raised up. 
+<sup>18&#160;</sup>Moses raised up the tabernacle, and laid its sockets, and set up its boards, and put in its bars, and raised up its pillars. 
+<sup>19&#160;</sup>He spread the covering over the tent, and put the roof of the tabernacle above on it, as Yahweh commanded Moses. 
+<sup>20&#160;</sup>He took and put the covenant into the ark, and set the poles on the ark, and put the mercy seat above on the ark. 
+<sup>21&#160;</sup>He brought the ark into the tabernacle, and set up the veil of the screen, and screened the ark of the covenant, as Yahweh commanded Moses. 
+<sup>22&#160;</sup>He put the table in the Tent of Meeting, on the north side of the tabernacle, outside of the veil. 
+<sup>23&#160;</sup>He set the bread in order on it before Yahweh, as Yahweh commanded Moses. 
+<sup>24&#160;</sup>He put the lamp stand in the Tent of Meeting, opposite the table, on the south side of the tabernacle. 
+<sup>25&#160;</sup>He lit the lamps before Yahweh, as Yahweh commanded Moses. 
+<sup>26&#160;</sup>He put the golden altar in the Tent of Meeting before the veil; 
+<sup>27&#160;</sup>and he burned incense of sweet spices on it, as Yahweh commanded Moses. 
+<sup>28&#160;</sup>He put up the screen of the door to the tabernacle. 
+<sup>29&#160;</sup>He set the altar of burnt offering at the door of the tabernacle of the Tent of Meeting, and offered on it the burnt offering and the meal offering, as Yahweh commanded Moses. 
+<sup>30&#160;</sup>He set the basin between the Tent of Meeting and the altar, and put water therein, with which to wash. 
+<sup>31&#160;</sup>Moses, Aaron, and his sons washed their hands and their feet there. 
+<sup>32&#160;</sup>When they went into the Tent of Meeting, and when they came near to the altar, they washed, as Yahweh commanded Moses. 
+<sup>33&#160;</sup>He raised up the court around the tabernacle and the altar, and set up the screen of the gate of the court. So Moses finished the work. 
+</div><div class="p">
+<sup>34&#160;</sup>Then the cloud covered the Tent of Meeting, and Yahweh’s glory filled the tabernacle. 
+<sup>35&#160;</sup>Moses wasn’t able to enter into the Tent of Meeting, because the cloud stayed on it, and Yahweh’s glory filled the tabernacle. 
+<sup>36&#160;</sup>When the cloud was taken up from over the tabernacle, the children of Israel went onward, throughout all their journeys; 
+<sup>37&#160;</sup>but if the cloud wasn’t taken up, then they didn’t travel until the day that it was taken up. 
+<sup>38&#160;</sup>For the cloud of Yahweh was on the tabernacle by day, and there was fire in the cloud by night, in the sight of all the house of Israel, throughout all their journeys. </div></div><script src="../main.js"></script></body></html>

--- a/book/ezekiel.html
+++ b/book/ezekiel.html
@@ -3,6 +3,47 @@
 <head>
 <title>Ezekiel</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,2216 +53,2265 @@
 <div class="main">
 <!-- EZK World English Scripture (WES) -->
 <h1 class="booklabel">Ezekiel</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now in the thirtieth year, in the fourth month, in the fifth day of the month, as I was among the captives by the river Chebar, the heavens were opened, and I saw visions of Elohim.<span class="f">+ \fr 1:1 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p>
-<span class="v">2&#160;</span>In the fifth of the month, which was the fifth year of King Jehoiachin’s captivity, 
-<span class="v">3&#160;</span>Yahweh’s<span class="f">+ \fr 1:3 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word came to Ezekiel the priest, the son of Buzi, in the land of the Chaldeans by the river Chebar; and Yahweh’s hand was there on him. 
-</p><p>
-<span class="v">4&#160;</span>I looked, and behold,<span class="f">+ \fr 1:4 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> a stormy wind came out of the north: a great cloud, with flashing lightning, and a brightness around it, and out of the middle of it as it were glowing metal, out of the middle of the fire. 
-<span class="v">5&#160;</span>Out of its center came the likeness of four living creatures. This was their appearance: They had the likeness of a man. 
-<span class="v">6&#160;</span>Everyone had four faces, and each one of them had four wings. 
-<span class="v">7&#160;</span>Their feet were straight feet. The sole of their feet was like the sole of a calf’s foot; and they sparkled like burnished bronze. 
-<span class="v">8&#160;</span>They had the hands of a man under their wings on their four sides. The four of them had their faces and their wings like this: 
-<span class="v">9&#160;</span>Their wings were joined to one another. They didn’t turn when they went. Each one went straight forward. 
-</p><p>
-<span class="v">10&#160;</span>As for the likeness of their faces, they had the face of a man. The four of them had the face of a lion on the right side. The four of them had the face of an ox on the left side. The four of them also had the face of an eagle. 
-<span class="v">11&#160;</span>Such were their faces. Their wings were spread out above. Two wings of each one touched another, and two covered their bodies. 
-<span class="v">12&#160;</span>Each one went straight forward. Where the spirit was to go, they went. They didn’t turn when they went. 
-<span class="v">13&#160;</span>As for the likeness of the living creatures, their appearance was like burning coals of fire, like the appearance of torches. The fire went up and down among the living creatures. The fire was bright, and lightning went out of the fire. 
-<span class="v">14&#160;</span>The living creatures ran and returned as the appearance of a flash of lightning. 
-</p><p>
-<span class="v">15&#160;</span>Now as I saw the living creatures, behold, there was one wheel on the earth beside the living creatures, for each of the four faces of it. 
-<span class="v">16&#160;</span>The appearance of the wheels and their work was like a beryl. The four of them had one likeness. Their appearance and their work was as it were a wheel within a wheel. 
-<span class="v">17&#160;</span>When they went, they went in their four directions. They didn’t turn when they went. 
-<span class="v">18&#160;</span>As for their rims, they were high and dreadful; and the four of them had their rims full of eyes all around. 
-</p><p>
-<span class="v">19&#160;</span>When the living creatures went, the wheels went beside them. When the living creatures were lifted up from the earth, the wheels were lifted up. 
-<span class="v">20&#160;</span>Wherever the spirit was to go, they went. The spirit was to go there. The wheels were lifted up beside them; for the spirit of the living creature was in the wheels. 
-<span class="v">21&#160;</span>When those went, these went. When those stood, these stood. When those were lifted up from the earth, the wheels were lifted up beside them; for the spirit of the living creature was in the wheels. 
-</p><p>
-<span class="v">22&#160;</span>Over the head of the living creature there was the likeness of an expanse, like an awesome crystal to look at, stretched out over their heads above. 
-<span class="v">23&#160;</span>Under the expanse, their wings were straight, one toward the other. Each one had two which covered on this side, and each one had two which covered their bodies on that side. 
-<span class="v">24&#160;</span>When they went, I heard the noise of their wings like the noise of great waters, like the voice of the Almighty, a noise of tumult like the noise of an army. When they stood, they let down their wings. 
-</p><p>
-<span class="v">25&#160;</span>There was a voice above the expanse that was over their heads. When they stood, they let down their wings. 
-<span class="v">26&#160;</span>Above the expanse that was over their heads was the likeness of a throne, as the appearance of a sapphire<span class="f">+ \fr 1:26 \ft or, lapis lazuli</span> stone. On the likeness of the throne was a likeness as the appearance of a man on it above. 
-<span class="v">27&#160;</span>I saw as it were glowing metal, as the appearance of fire within it all around, from the appearance of his waist and upward; and from the appearance of his waist and downward I saw as it were the appearance of fire, and there was brightness around him. 
-<span class="v">28&#160;</span>As the appearance of the rainbow that is in the cloud in the day of rain, so was the appearance of the brightness all around. 
-</p><p>This was the appearance of the likeness of Yahweh’s glory. When I saw it, I fell on my face, and I heard a voice of one that spoke. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>He said to me, “Son of man, stand on your feet, and I will speak with you.” 
-<span class="v">2&#160;</span>The Spirit entered into me when he spoke to me, and set me on my feet; and I heard him who spoke to me. 
-</p><p>
-<span class="v">3&#160;</span>He said to me, “Son of man, I send you to the children of Israel, to a nation of rebels who have rebelled against me. They and their fathers have transgressed against me even to this very day. 
-<span class="v">4&#160;</span>The children are impudent and stiff-hearted. I am sending you to them, and you shall tell them, ‘This is what the Lord<span class="f">+ \fr 2:4 \ft The word translated “Lord” is “Adonai.”</span> Yahweh says.’ 
-<span class="v">5&#160;</span>They, whether they will hear, or whether they will refuse—for they are a rebellious house—yet they will know that there has been a prophet among them. 
-<span class="v">6&#160;</span>You, son of man, don’t be afraid of them, neither be afraid of their words, though briers and thorns are with you, and you dwell among scorpions. Don’t be afraid of their words, nor be dismayed at their looks, though they are a rebellious house. 
-<span class="v">7&#160;</span>You shall speak my words to them, whether they will hear or whether they will refuse; for they are most rebellious. 
-<span class="v">8&#160;</span>But you, son of man, hear what I tell you. Don’t be rebellious like that rebellious house. Open your mouth, and eat that which I give you.” 
-</p><p>
-<span class="v">9&#160;</span>When I looked, behold, a hand was stretched out to me; and behold, a scroll of a book was in it. 
-<span class="v">10&#160;</span>He spread it before me. It was written within and without; and lamentations, mourning, and woe were written in it. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>He said to me, “Son of man, eat what you find. Eat this scroll, and go, speak to the house of Israel.” 
-</p><p>
-<span class="v">2&#160;</span>So I opened my mouth, and he caused me to eat the scroll. 
-</p><p>
-<span class="v">3&#160;</span>He said to me, “Son of man, eat this scroll that I give you and fill your belly and your bowels with it.” 
-</p><p>Then I ate it. It was as sweet as honey in my mouth. 
-</p><p>
-<span class="v">4&#160;</span>He said to me, “Son of man, go to the house of Israel, and speak my words to them. 
-<span class="v">5&#160;</span>For you are not sent to a people of a strange speech and of a hard language, but to the house of Israel—<span class="v">6&#160;</span>not to many peoples of a strange speech and of a hard language, whose words you can’t understand. Surely, if I sent you to them, they would listen to you. 
-<span class="v">7&#160;</span>But the house of Israel will not listen to you, for they will not listen to me; for all the house of Israel are obstinate<span class="f">+ \fr 3:7 \ft Literally, have a hard forehead</span> and hard-hearted. 
-<span class="v">8&#160;</span>Behold, I have made your face hard against their faces, and your forehead hard against their foreheads. 
-<span class="v">9&#160;</span>I have made your forehead as a diamond, harder than flint. Don’t be afraid of them, neither be dismayed at their looks, though they are a rebellious house.” 
-</p><p>
-<span class="v">10&#160;</span>Moreover he said to me, “Son of man, receive in your heart and hear with your ears all my words that I speak to you. 
-<span class="v">11&#160;</span>Go to them of the captivity, to the children of your people, and speak to them, and tell them, ‘This is what the Lord Yahweh says,’ whether they will hear, or whether they will refuse.” 
-</p><p>
-<span class="v">12&#160;</span>Then the Spirit lifted me up, and I heard behind me the voice of a great rushing, saying, “Blessed be Yahweh’s glory from his place.” 
-<span class="v">13&#160;</span>I heard the noise of the wings of the living creatures as they touched one another, and the noise of the wheels beside them, even the noise of a great rushing. 
-<span class="v">14&#160;</span>So the Spirit lifted me up, and took me away; and I went in bitterness, in the heat of my spirit; and Yahweh’s hand was strong on me. 
-<span class="v">15&#160;</span>Then I came to them of the captivity at Tel Aviv who lived by the river Chebar, and to where they lived; and I sat there overwhelmed among them seven days. 
-</p><p>
-<span class="v">16&#160;</span>At the end of seven days, Yahweh’s word came to me, saying, 
-<span class="v">17&#160;</span>“Son of man, I have made you a watchman to the house of Israel. Therefore hear the word from my mouth, and warn them from me. 
-<span class="v">18&#160;</span>When I tell the wicked, ‘You will surely die;’ and you give him no warning, nor speak to warn the wicked from his wicked way, to save his life, that wicked man will die in his iniquity; but I will require his blood at your hand. 
-<span class="v">19&#160;</span>Yet if you warn the wicked, and he doesn’t turn from his wickedness, nor from his wicked way, he will die in his iniquity; but you have delivered your soul.” 
-</p><p>
-<span class="v">20&#160;</span>“Again, when a righteous man turns from his righteousness and commits iniquity, and I lay a stumbling block before him, he will die. Because you have not given him warning, he will die in his sin, and his righteous deeds which he has done will not be remembered; but I will require his blood at your hand. 
-<span class="v">21&#160;</span>Nevertheless if you warn the righteous man, that the righteous not sin, and he does not sin, he will surely live, because he took warning; and you have delivered your soul.” 
-</p><p>
-<span class="v">22&#160;</span>Yahweh’s hand was there on me; and he said to me, “Arise, go out into the plain, and I will talk with you there.” 
-</p><p>
-<span class="v">23&#160;</span>Then I arose, and went out into the plain, and behold, Yahweh’s glory stood there, like the glory which I saw by the river Chebar. Then I fell on my face. 
-</p><p>
-<span class="v">24&#160;</span>Then the Spirit entered into me and set me on my feet. He spoke with me, and said to me, “Go, shut yourself inside your house. 
-<span class="v">25&#160;</span>But you, son of man, behold, they will put ropes on you, and will bind you with them, and you will not go out among them. 
-<span class="v">26&#160;</span>I will make your tongue stick to the roof of your mouth so that you will be mute and will not be able to correct them, for they are a rebellious house. 
-<span class="v">27&#160;</span>But when I speak with you, I will open your mouth, and you shall tell them, ‘This is what the Lord Yahweh says.’ He who hears, let him hear; and he who refuses, let him refuse; for they are a rebellious house.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>“You also, son of man, take a tile, and lay it before yourself, and portray on it a city, even Jerusalem. 
-<span class="v">2&#160;</span>Lay siege against it, build forts against it, and cast up a mound against it. Also set camps against it and plant battering rams against it all around. 
-<span class="v">3&#160;</span>Take for yourself an iron pan and set it for a wall of iron between you and the city. Then set your face toward it. It will be besieged, and you shall lay siege against it. This shall be a sign to the house of Israel. 
-</p><p>
-<span class="v">4&#160;</span>“Moreover lie on your left side, and lay the iniquity of the house of Israel on it. According to the number of the days that you shall lie on it, you shall bear their iniquity. 
-<span class="v">5&#160;</span>For I have appointed the years of their iniquity to be to you a number of days, even three hundred ninety days. So you shall bear the iniquity of the house of Israel. 
-</p><p>
-<span class="v">6&#160;</span>“Again, when you have accomplished these, you shall lie on your right side, and shall bear the iniquity of the house of Judah. I have appointed forty days, each day for a year, to you. 
-<span class="v">7&#160;</span>You shall set your face toward the siege of Jerusalem, with your arm uncovered; and you shall prophesy against it. 
-<span class="v">8&#160;</span>Behold, I put ropes on you, and you shall not turn yourself from one side to the other, until you have accomplished the days of your siege. 
-</p><p>
-<span class="v">9&#160;</span>“Take for yourself also wheat, barley, beans, lentils, millet, and spelt, and put them in one vessel. Make bread of it. According to the number of the days that you will lie on your side, even three hundred ninety days, you shall eat of it. 
-<span class="v">10&#160;</span>Your food which you shall eat shall be by weight, twenty shekels<span class="f">+ \fr 4:10 \ft A shekel is about 10 grams or about 0.35 ounces.</span> a day. From time to time you shall eat it. 
-<span class="v">11&#160;</span>You shall drink water by measure, the sixth part of a hin.<span class="f">+ \fr 4:11 \ft A hin is about 6.5 liters or 1.7 gallons.</span> From time to time you shall drink. 
-<span class="v">12&#160;</span>You shall eat it as barley cakes, and you shall bake it in their sight with dung that comes out of man.” 
-<span class="v">13&#160;</span>Yahweh said, “Even thus will the children of Israel eat their bread unclean, among the nations where I will drive them.” 
-</p><p>
-<span class="v">14&#160;</span>Then I said, “Ah Lord Yahweh! Behold, my soul has not been polluted; for from my youth up even until now I have not eaten of that which dies of itself, or is torn of animals. No abominable meat has come into my mouth!” 
-</p><p>
-<span class="v">15&#160;</span>Then he said to me, “Behold, I have given you cow’s dung for man’s dung, and you shall prepare your bread on it.” 
-</p><p>
-<span class="v">16&#160;</span>Moreover he said to me, “Son of man, behold, I will break the staff of bread in Jerusalem. They will eat bread by weight, and with fearfulness. They will drink water by measure, and in dismay; 
-<span class="v">17&#160;</span>that they may lack bread and water, be dismayed one with another, and pine away in their iniquity. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>“You, son of man, take a sharp sword. You shall take it as a barber’s razor to yourself, and shall cause it to pass over your head and over your beard. Then take balances to weigh and divide the hair. 
-<span class="v">2&#160;</span>A third part you shall burn in the fire in the middle of the city, when the days of the siege are fulfilled. You shall take a third part, and strike with the sword around it. A third part you shall scatter to the wind, and I will draw out a sword after them. 
-<span class="v">3&#160;</span>You shall take a small number of these and bind them in the folds of your robe. 
-<span class="v">4&#160;</span>Of these again you shall take, and cast them into the middle of the fire, and burn them in the fire. From it a fire will come out into all the house of Israel. 
-</p><p>
-<span class="v">5&#160;</span>“The Lord Yahweh says: ‘This is Jerusalem. I have set her in the middle of the nations, and countries are around her. 
-<span class="v">6&#160;</span>She has rebelled against my ordinances in doing wickedness more than the nations, and against my statutes more than the countries that are around her; for they have rejected my ordinances, and as for my statutes, they have not walked in them.’ 
-</p><p>
-<span class="v">7&#160;</span>“Therefore the Lord Yahweh says: ‘Because you are more turbulent than the nations that are around you, and have not walked in my statutes, neither have kept my ordinances, neither have followed the ordinances of the nations that are around you; 
-<span class="v">8&#160;</span>therefore the Lord Yahweh says: ‘Behold, I, even I, am against you; and I will execute judgments among you in the sight of the nations. 
-<span class="v">9&#160;</span>I will do in you that which I have not done, and which I will not do anything like it any more, because of all your abominations. 
-<span class="v">10&#160;</span>Therefore the fathers will eat the sons within you, and the sons will eat their fathers. I will execute judgments on you; and I will scatter the whole remnant of you to all the winds. 
-<span class="v">11&#160;</span>Therefore as I live,’ says the Lord Yahweh, ‘surely, because you have defiled my sanctuary with all your detestable things, and with all your abominations, therefore I will also diminish you. My eye won’t spare, and I will have no pity. 
-<span class="v">12&#160;</span>A third part of you will die with the pestilence, and they will be consumed with famine within you. A third part will fall by the sword around you. A third part I will scatter to all the winds, and will draw out a sword after them. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘Thus my anger will be accomplished, and I will cause my wrath toward them to rest, and I will be comforted. They will know that I, Yahweh, have spoken in my zeal, when I have accomplished my wrath on them. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘Moreover I will make you a desolation and a reproach among the nations that are around you, in the sight of all that pass by. 
-<span class="v">15&#160;</span>So it will be a reproach and a taunt, an instruction and an astonishment, to the nations that are around you, when I execute judgments on you in anger and in wrath, and in wrathful rebukes—I, Yahweh, have spoken it—<span class="v">16&#160;</span>when I send on them the evil arrows of famine that are for destruction, which I will send to destroy you. I will increase the famine on you and will break your staff of bread. 
-<span class="v">17&#160;</span>I will send on you famine and evil animals, and they will bereave you. Pestilence and blood will pass through you. I will bring the sword on you. I, Yahweh, have spoken it.’&#160;” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, set your face toward the mountains of Israel, and prophesy to them, 
-<span class="v">3&#160;</span>and say, ‘You mountains of Israel, hear the word of the Lord Yahweh! The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys: “Behold, I, even I, will bring a sword on you, and I will destroy your high places. 
-<span class="v">4&#160;</span>Your altars will become desolate, and your incense altars will be broken. I will cast down your slain men before your idols. 
-<span class="v">5&#160;</span>I will lay the dead bodies of the children of Israel before their idols. I will scatter your bones around your altars. 
-<span class="v">6&#160;</span>In all your dwelling places, the cities will be laid waste and the high places will be desolate, so that your altars may be laid waste and made desolate, and your idols may be broken and cease, and your incense altars may be cut down, and your works may be abolished. 
-<span class="v">7&#160;</span>The slain will fall among you, and you will know that I am Yahweh. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘&#160;“Yet I will leave a remnant, in that you will have some that escape the sword among the nations, when you are scattered through the countries. 
-<span class="v">9&#160;</span>Those of you that escape will remember me among the nations where they are carried captive, how I have been broken with their lewd heart, which has departed from me, and with their eyes, which play the prostitute after their idols. Then they will loathe themselves in their own sight for the evils which they have committed in all their abominations. 
-<span class="v">10&#160;</span>They will know that I am Yahweh. I have not said in vain that I would do this evil to them.”&#160;’ 
-</p><p>
-<span class="v">11&#160;</span>“The Lord Yahweh says: ‘Strike with your hand, and stamp with your foot, and say, “Alas!”, because of all the evil abominations of the house of Israel; for they will fall by the sword, by the famine, and by the pestilence. 
-<span class="v">12&#160;</span>He who is far off will die of the pestilence. He who is near will fall by the sword. He who remains and is besieged will die by the famine. Thus I will accomplish my wrath on them. 
-<span class="v">13&#160;</span>You will know that I am Yahweh when their slain men are among their idols around their altars, on every high hill, on all the tops of the mountains, under every green tree, and under every thick oak—the places where they offered pleasant aroma to all their idols. 
-<span class="v">14&#160;</span>I will stretch out my hand on them and make the land desolate and waste, from the wilderness toward Diblah, throughout all their habitations. Then they will know that I am Yahweh.’&#160;” 
-</p><div class="b"> &#160; </div>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+<a href="#41">41</a>
+<a href="#42">42</a>
+<a href="#43">43</a>
+<a href="#44">44</a>
+<a href="#45">45</a>
+<a href="#46">46</a>
+<a href="#47">47</a>
+<a href="#48">48</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now in the thirtieth year, in the fourth month, in the fifth day of the month, as I was among the captives by the river Chebar, the heavens were opened, and I saw visions of Elohim. 
+</div><div class="p">
+<sup>2&#160;</sup>In the fifth of the month, which was the fifth year of King Jehoiachin’s captivity, 
+<sup>3&#160;</sup>Yahweh’s word came to Ezekiel the priest, the son of Buzi, in the land of the Chaldeans by the river Chebar; and Yahweh’s hand was there on him. 
+</div><div class="p">
+<sup>4&#160;</sup>I looked, and behold, a stormy wind came out of the north: a great cloud, with flashing lightning, and a brightness around it, and out of the middle of it as it were glowing metal, out of the middle of the fire. 
+<sup>5&#160;</sup>Out of its center came the likeness of four living creatures. This was their appearance: They had the likeness of a man. 
+<sup>6&#160;</sup>Everyone had four faces, and each one of them had four wings. 
+<sup>7&#160;</sup>Their feet were straight feet. The sole of their feet was like the sole of a calf’s foot; and they sparkled like burnished bronze. 
+<sup>8&#160;</sup>They had the hands of a man under their wings on their four sides. The four of them had their faces and their wings like this: 
+<sup>9&#160;</sup>Their wings were joined to one another. They didn’t turn when they went. Each one went straight forward. 
+</div><div class="p">
+<sup>10&#160;</sup>As for the likeness of their faces, they had the face of a man. The four of them had the face of a lion on the right side. The four of them had the face of an ox on the left side. The four of them also had the face of an eagle. 
+<sup>11&#160;</sup>Such were their faces. Their wings were spread out above. Two wings of each one touched another, and two covered their bodies. 
+<sup>12&#160;</sup>Each one went straight forward. Where the spirit was to go, they went. They didn’t turn when they went. 
+<sup>13&#160;</sup>As for the likeness of the living creatures, their appearance was like burning coals of fire, like the appearance of torches. The fire went up and down among the living creatures. The fire was bright, and lightning went out of the fire. 
+<sup>14&#160;</sup>The living creatures ran and returned as the appearance of a flash of lightning. 
+</div><div class="p">
+<sup>15&#160;</sup>Now as I saw the living creatures, behold, there was one wheel on the earth beside the living creatures, for each of the four faces of it. 
+<sup>16&#160;</sup>The appearance of the wheels and their work was like a beryl. The four of them had one likeness. Their appearance and their work was as it were a wheel within a wheel. 
+<sup>17&#160;</sup>When they went, they went in their four directions. They didn’t turn when they went. 
+<sup>18&#160;</sup>As for their rims, they were high and dreadful; and the four of them had their rims full of eyes all around. 
+</div><div class="p">
+<sup>19&#160;</sup>When the living creatures went, the wheels went beside them. When the living creatures were lifted up from the earth, the wheels were lifted up. 
+<sup>20&#160;</sup>Wherever the spirit was to go, they went. The spirit was to go there. The wheels were lifted up beside them; for the spirit of the living creature was in the wheels. 
+<sup>21&#160;</sup>When those went, these went. When those stood, these stood. When those were lifted up from the earth, the wheels were lifted up beside them; for the spirit of the living creature was in the wheels. 
+</div><div class="p">
+<sup>22&#160;</sup>Over the head of the living creature there was the likeness of an expanse, like an awesome crystal to look at, stretched out over their heads above. 
+<sup>23&#160;</sup>Under the expanse, their wings were straight, one toward the other. Each one had two which covered on this side, and each one had two which covered their bodies on that side. 
+<sup>24&#160;</sup>When they went, I heard the noise of their wings like the noise of great waters, like the voice of the Almighty, a noise of tumult like the noise of an army. When they stood, they let down their wings. 
+</div><div class="p">
+<sup>25&#160;</sup>There was a voice above the expanse that was over their heads. When they stood, they let down their wings. 
+<sup>26&#160;</sup>Above the expanse that was over their heads was the likeness of a throne, as the appearance of a sapphire stone. On the likeness of the throne was a likeness as the appearance of a man on it above. 
+<sup>27&#160;</sup>I saw as it were glowing metal, as the appearance of fire within it all around, from the appearance of his waist and upward; and from the appearance of his waist and downward I saw as it were the appearance of fire, and there was brightness around him. 
+<sup>28&#160;</sup>As the appearance of the rainbow that is in the cloud in the day of rain, so was the appearance of the brightness all around. 
+</div><div class="p">This was the appearance of the likeness of Yahweh’s glory. When I saw it, I fell on my face, and I heard a voice of one that spoke. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>He said to me, “Son of man, stand on your feet, and I will speak with you.” 
+<sup>2&#160;</sup>The Spirit entered into me when he spoke to me, and set me on my feet; and I heard him who spoke to me. 
+</div><div class="p">
+<sup>3&#160;</sup>He said to me, “Son of man, I send you to the children of Israel, to a nation of rebels who have rebelled against me. They and their fathers have transgressed against me even to this very day. 
+<sup>4&#160;</sup>The children are impudent and stiff-hearted. I am sending you to them, and you shall tell them, ‘This is what the Lord Yahweh says.’ 
+<sup>5&#160;</sup>They, whether they will hear, or whether they will refuse—for they are a rebellious house—yet they will know that there has been a prophet among them. 
+<sup>6&#160;</sup>You, son of man, don’t be afraid of them, neither be afraid of their words, though briers and thorns are with you, and you dwell among scorpions. Don’t be afraid of their words, nor be dismayed at their looks, though they are a rebellious house. 
+<sup>7&#160;</sup>You shall speak my words to them, whether they will hear or whether they will refuse; for they are most rebellious. 
+<sup>8&#160;</sup>But you, son of man, hear what I tell you. Don’t be rebellious like that rebellious house. Open your mouth, and eat that which I give you.” 
+</div><div class="p">
+<sup>9&#160;</sup>When I looked, behold, a hand was stretched out to me; and behold, a scroll of a book was in it. 
+<sup>10&#160;</sup>He spread it before me. It was written within and without; and lamentations, mourning, and woe were written in it. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>He said to me, “Son of man, eat what you find. Eat this scroll, and go, speak to the house of Israel.” 
+</div><div class="p">
+<sup>2&#160;</sup>So I opened my mouth, and he caused me to eat the scroll. 
+</div><div class="p">
+<sup>3&#160;</sup>He said to me, “Son of man, eat this scroll that I give you and fill your belly and your bowels with it.” 
+</div><div class="p">Then I ate it. It was as sweet as honey in my mouth. 
+</div><div class="p">
+<sup>4&#160;</sup>He said to me, “Son of man, go to the house of Israel, and speak my words to them. 
+<sup>5&#160;</sup>For you are not sent to a people of a strange speech and of a hard language, but to the house of Israel—<sup>6&#160;</sup>not to many peoples of a strange speech and of a hard language, whose words you can’t understand. Surely, if I sent you to them, they would listen to you. 
+<sup>7&#160;</sup>But the house of Israel will not listen to you, for they will not listen to me; for all the house of Israel are obstinate and hard-hearted. 
+<sup>8&#160;</sup>Behold, I have made your face hard against their faces, and your forehead hard against their foreheads. 
+<sup>9&#160;</sup>I have made your forehead as a diamond, harder than flint. Don’t be afraid of them, neither be dismayed at their looks, though they are a rebellious house.” 
+</div><div class="p">
+<sup>10&#160;</sup>Moreover he said to me, “Son of man, receive in your heart and hear with your ears all my words that I speak to you. 
+<sup>11&#160;</sup>Go to them of the captivity, to the children of your people, and speak to them, and tell them, ‘This is what the Lord Yahweh says,’ whether they will hear, or whether they will refuse.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then the Spirit lifted me up, and I heard behind me the voice of a great rushing, saying, “Blessed be Yahweh’s glory from his place.” 
+<sup>13&#160;</sup>I heard the noise of the wings of the living creatures as they touched one another, and the noise of the wheels beside them, even the noise of a great rushing. 
+<sup>14&#160;</sup>So the Spirit lifted me up, and took me away; and I went in bitterness, in the heat of my spirit; and Yahweh’s hand was strong on me. 
+<sup>15&#160;</sup>Then I came to them of the captivity at Tel Aviv who lived by the river Chebar, and to where they lived; and I sat there overwhelmed among them seven days. 
+</div><div class="p">
+<sup>16&#160;</sup>At the end of seven days, Yahweh’s word came to me, saying, 
+<sup>17&#160;</sup>“Son of man, I have made you a watchman to the house of Israel. Therefore hear the word from my mouth, and warn them from me. 
+<sup>18&#160;</sup>When I tell the wicked, ‘You will surely die;’ and you give him no warning, nor speak to warn the wicked from his wicked way, to save his life, that wicked man will die in his iniquity; but I will require his blood at your hand. 
+<sup>19&#160;</sup>Yet if you warn the wicked, and he doesn’t turn from his wickedness, nor from his wicked way, he will die in his iniquity; but you have delivered your soul.” 
+</div><div class="p">
+<sup>20&#160;</sup>“Again, when a righteous man turns from his righteousness and commits iniquity, and I lay a stumbling block before him, he will die. Because you have not given him warning, he will die in his sin, and his righteous deeds which he has done will not be remembered; but I will require his blood at your hand. 
+<sup>21&#160;</sup>Nevertheless if you warn the righteous man, that the righteous not sin, and he does not sin, he will surely live, because he took warning; and you have delivered your soul.” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh’s hand was there on me; and he said to me, “Arise, go out into the plain, and I will talk with you there.” 
+</div><div class="p">
+<sup>23&#160;</sup>Then I arose, and went out into the plain, and behold, Yahweh’s glory stood there, like the glory which I saw by the river Chebar. Then I fell on my face. 
+</div><div class="p">
+<sup>24&#160;</sup>Then the Spirit entered into me and set me on my feet. He spoke with me, and said to me, “Go, shut yourself inside your house. 
+<sup>25&#160;</sup>But you, son of man, behold, they will put ropes on you, and will bind you with them, and you will not go out among them. 
+<sup>26&#160;</sup>I will make your tongue stick to the roof of your mouth so that you will be mute and will not be able to correct them, for they are a rebellious house. 
+<sup>27&#160;</sup>But when I speak with you, I will open your mouth, and you shall tell them, ‘This is what the Lord Yahweh says.’ He who hears, let him hear; and he who refuses, let him refuse; for they are a rebellious house.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>“You also, son of man, take a tile, and lay it before yourself, and portray on it a city, even Jerusalem. 
+<sup>2&#160;</sup>Lay siege against it, build forts against it, and cast up a mound against it. Also set camps against it and plant battering rams against it all around. 
+<sup>3&#160;</sup>Take for yourself an iron pan and set it for a wall of iron between you and the city. Then set your face toward it. It will be besieged, and you shall lay siege against it. This shall be a sign to the house of Israel. 
+</div><div class="p">
+<sup>4&#160;</sup>“Moreover lie on your left side, and lay the iniquity of the house of Israel on it. According to the number of the days that you shall lie on it, you shall bear their iniquity. 
+<sup>5&#160;</sup>For I have appointed the years of their iniquity to be to you a number of days, even three hundred ninety days. So you shall bear the iniquity of the house of Israel. 
+</div><div class="p">
+<sup>6&#160;</sup>“Again, when you have accomplished these, you shall lie on your right side, and shall bear the iniquity of the house of Judah. I have appointed forty days, each day for a year, to you. 
+<sup>7&#160;</sup>You shall set your face toward the siege of Jerusalem, with your arm uncovered; and you shall prophesy against it. 
+<sup>8&#160;</sup>Behold, I put ropes on you, and you shall not turn yourself from one side to the other, until you have accomplished the days of your siege. 
+</div><div class="p">
+<sup>9&#160;</sup>“Take for yourself also wheat, barley, beans, lentils, millet, and spelt, and put them in one vessel. Make bread of it. According to the number of the days that you will lie on your side, even three hundred ninety days, you shall eat of it. 
+<sup>10&#160;</sup>Your food which you shall eat shall be by weight, twenty shekels a day. From time to time you shall eat it. 
+<sup>11&#160;</sup>You shall drink water by measure, the sixth part of a hin. From time to time you shall drink. 
+<sup>12&#160;</sup>You shall eat it as barley cakes, and you shall bake it in their sight with dung that comes out of man.” 
+<sup>13&#160;</sup>Yahweh said, “Even thus will the children of Israel eat their bread unclean, among the nations where I will drive them.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then I said, “Ah Lord Yahweh! Behold, my soul has not been polluted; for from my youth up even until now I have not eaten of that which dies of itself, or is torn of animals. No abominable meat has come into my mouth!” 
+</div><div class="p">
+<sup>15&#160;</sup>Then he said to me, “Behold, I have given you cow’s dung for man’s dung, and you shall prepare your bread on it.” 
+</div><div class="p">
+<sup>16&#160;</sup>Moreover he said to me, “Son of man, behold, I will break the staff of bread in Jerusalem. They will eat bread by weight, and with fearfulness. They will drink water by measure, and in dismay; 
+<sup>17&#160;</sup>that they may lack bread and water, be dismayed one with another, and pine away in their iniquity. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>“You, son of man, take a sharp sword. You shall take it as a barber’s razor to yourself, and shall cause it to pass over your head and over your beard. Then take balances to weigh and divide the hair. 
+<sup>2&#160;</sup>A third part you shall burn in the fire in the middle of the city, when the days of the siege are fulfilled. You shall take a third part, and strike with the sword around it. A third part you shall scatter to the wind, and I will draw out a sword after them. 
+<sup>3&#160;</sup>You shall take a small number of these and bind them in the folds of your robe. 
+<sup>4&#160;</sup>Of these again you shall take, and cast them into the middle of the fire, and burn them in the fire. From it a fire will come out into all the house of Israel. 
+</div><div class="p">
+<sup>5&#160;</sup>“The Lord Yahweh says: ‘This is Jerusalem. I have set her in the middle of the nations, and countries are around her. 
+<sup>6&#160;</sup>She has rebelled against my ordinances in doing wickedness more than the nations, and against my statutes more than the countries that are around her; for they have rejected my ordinances, and as for my statutes, they have not walked in them.’ 
+</div><div class="p">
+<sup>7&#160;</sup>“Therefore the Lord Yahweh says: ‘Because you are more turbulent than the nations that are around you, and have not walked in my statutes, neither have kept my ordinances, neither have followed the ordinances of the nations that are around you; 
+<sup>8&#160;</sup>therefore the Lord Yahweh says: ‘Behold, I, even I, am against you; and I will execute judgments among you in the sight of the nations. 
+<sup>9&#160;</sup>I will do in you that which I have not done, and which I will not do anything like it any more, because of all your abominations. 
+<sup>10&#160;</sup>Therefore the fathers will eat the sons within you, and the sons will eat their fathers. I will execute judgments on you; and I will scatter the whole remnant of you to all the winds. 
+<sup>11&#160;</sup>Therefore as I live,’ says the Lord Yahweh, ‘surely, because you have defiled my sanctuary with all your detestable things, and with all your abominations, therefore I will also diminish you. My eye won’t spare, and I will have no pity. 
+<sup>12&#160;</sup>A third part of you will die with the pestilence, and they will be consumed with famine within you. A third part will fall by the sword around you. A third part I will scatter to all the winds, and will draw out a sword after them. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘Thus my anger will be accomplished, and I will cause my wrath toward them to rest, and I will be comforted. They will know that I, Yahweh, have spoken in my zeal, when I have accomplished my wrath on them. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘Moreover I will make you a desolation and a reproach among the nations that are around you, in the sight of all that pass by. 
+<sup>15&#160;</sup>So it will be a reproach and a taunt, an instruction and an astonishment, to the nations that are around you, when I execute judgments on you in anger and in wrath, and in wrathful rebukes—I, Yahweh, have spoken it—<sup>16&#160;</sup>when I send on them the evil arrows of famine that are for destruction, which I will send to destroy you. I will increase the famine on you and will break your staff of bread. 
+<sup>17&#160;</sup>I will send on you famine and evil animals, and they will bereave you. Pestilence and blood will pass through you. I will bring the sword on you. I, Yahweh, have spoken it.’&#160;” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, set your face toward the mountains of Israel, and prophesy to them, 
+<sup>3&#160;</sup>and say, ‘You mountains of Israel, hear the word of the Lord Yahweh! The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys: “Behold, I, even I, will bring a sword on you, and I will destroy your high places. 
+<sup>4&#160;</sup>Your altars will become desolate, and your incense altars will be broken. I will cast down your slain men before your idols. 
+<sup>5&#160;</sup>I will lay the dead bodies of the children of Israel before their idols. I will scatter your bones around your altars. 
+<sup>6&#160;</sup>In all your dwelling places, the cities will be laid waste and the high places will be desolate, so that your altars may be laid waste and made desolate, and your idols may be broken and cease, and your incense altars may be cut down, and your works may be abolished. 
+<sup>7&#160;</sup>The slain will fall among you, and you will know that I am Yahweh. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘&#160;“Yet I will leave a remnant, in that you will have some that escape the sword among the nations, when you are scattered through the countries. 
+<sup>9&#160;</sup>Those of you that escape will remember me among the nations where they are carried captive, how I have been broken with their lewd heart, which has departed from me, and with their eyes, which play the prostitute after their idols. Then they will loathe themselves in their own sight for the evils which they have committed in all their abominations. 
+<sup>10&#160;</sup>They will know that I am Yahweh. I have not said in vain that I would do this evil to them.”&#160;’ 
+</div><div class="p">
+<sup>11&#160;</sup>“The Lord Yahweh says: ‘Strike with your hand, and stamp with your foot, and say, “Alas!”, because of all the evil abominations of the house of Israel; for they will fall by the sword, by the famine, and by the pestilence. 
+<sup>12&#160;</sup>He who is far off will die of the pestilence. He who is near will fall by the sword. He who remains and is besieged will die by the famine. Thus I will accomplish my wrath on them. 
+<sup>13&#160;</sup>You will know that I am Yahweh when their slain men are among their idols around their altars, on every high hill, on all the tops of the mountains, under every green tree, and under every thick oak—the places where they offered pleasant aroma to all their idols. 
+<sup>14&#160;</sup>I will stretch out my hand on them and make the land desolate and waste, from the wilderness toward Diblah, throughout all their habitations. Then they will know that I am Yahweh.’&#160;” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“You, son of man, the Lord Yahweh says to the land of Israel, ‘An end! The end has come on the four corners of the land. 
-<span class="v">3&#160;</span>Now the end is on you, and I will send my anger on you, and will judge you according to your ways. I will bring on you all your abominations. 
-<span class="v">4&#160;</span>My eye will not spare you, neither will I have pity; but I will bring your ways on you, and your abominations will be among you. Then you will know that I am Yahweh.’ 
-</p><p>
-<span class="v">5&#160;</span>“The Lord Yahweh says: ‘A disaster! A unique disaster! Behold, it comes. 
-<span class="v">6&#160;</span>An end has come. The end has come! It awakes against you. Behold, it comes. 
-<span class="v">7&#160;</span>Your doom has come to you, inhabitant of the land! The time has come! The day is near, a day of tumult, and not of joyful shouting, on the mountains. 
-<span class="v">8&#160;</span>Now I will shortly pour out my wrath on you, and accomplish my anger against you, and will judge you according to your ways. I will bring on you all your abominations. 
-<span class="v">9&#160;</span>My eye won’t spare, neither will I have pity. I will punish you according to your ways. Your abominations will be among you. Then you will know that I, Yahweh, strike. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘Behold, the day! Behold, it comes! Your doom has gone out. The rod has blossomed. Pride has budded. 
-<span class="v">11&#160;</span>Violence has risen up into a rod of wickedness. None of them will remain, nor of their multitude, nor of their wealth. There will be nothing of value among them. 
-<span class="v">12&#160;</span>The time has come! The day draws near. Don’t let the buyer rejoice, nor the seller mourn; for wrath is on all its multitude. 
-<span class="v">13&#160;</span>For the seller won’t return to that which is sold, although they are still alive; for the vision concerns the whole multitude of it. None will return. None will strengthen himself in the iniquity of his life. 
-<span class="v">14&#160;</span>They have blown the trumpet, and have made all ready; but no one goes to the battle, for my wrath is on all its multitude. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘The sword is outside, and the pestilence and the famine within. He who is in the field will die by the sword. He who is in the city will be devoured by famine and pestilence. 
-<span class="v">16&#160;</span>But of those who escape, they will escape and will be on the mountains like doves of the valleys, all of them moaning, everyone in his iniquity. 
-<span class="v">17&#160;</span>All hands will be feeble, and all knees will be weak as water. 
-<span class="v">18&#160;</span>They will also clothe themselves with sackcloth, and horror will cover them. Shame will be on all faces, and baldness on all their heads. 
-<span class="v">19&#160;</span>They will cast their silver in the streets, and their gold will be as an unclean thing. Their silver and their gold won’t be able to deliver them in the day of Yahweh’s wrath. They won’t satisfy their souls or fill their bellies; because it has been the stumbling block of their iniquity. 
-<span class="v">20&#160;</span>As for the beauty of his ornament, he set it in majesty; but they made the images of their abominations and their detestable things therein. Therefore I have made it to them as an unclean thing. 
-<span class="v">21&#160;</span>I will give it into the hands of the strangers for a prey, and to the wicked of the earth for a plunder; and they will profane it. 
-<span class="v">22&#160;</span>I will also turn my face from them, and they will profane my secret place. Robbers will enter into it, and profane it. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘Make chains, for the land is full of bloody crimes, and the city is full of violence. 
-<span class="v">24&#160;</span>Therefore I will bring the worst of the nations, and they will possess their houses. I will also make the pride of the strong to cease. Their set-apart places will be profaned. 
-<span class="v">25&#160;</span>Destruction comes! They will seek peace, and there will be none. 
-<span class="v">26&#160;</span>Mischief will come on mischief, and rumor will be on rumor. They will seek a vision of the prophet; but the law will perish from the priest, and counsel from the elders. 
-<span class="v">27&#160;</span>The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>In the sixth year, in the sixth month, in the fifth day of the month, as I sat in my house, and the elders of Judah sat before me, the Lord Yahweh’s hand fell on me there. 
-<span class="v">2&#160;</span>Then I saw, and behold, a likeness as the appearance of fire—from the appearance of his waist and downward, fire, and from his waist and upward, as the appearance of brightness, as it were glowing metal. 
-<span class="v">3&#160;</span>He stretched out the form of a hand, and took me by a lock of my head; and the Spirit lifted me up between earth and the sky, and brought me in the visions of Elohim to Jerusalem, to the door of the gate of the inner court that looks toward the north, where there was the seat of the image of jealousy, which provokes to jealousy. 
-<span class="v">4&#160;</span>Behold, the glory of the Elohim of Israel was there, according to the appearance that I saw in the plain. 
-</p><p>
-<span class="v">5&#160;</span>Then he said to me, “Son of man, lift up your eyes now the way toward the north.” 
-</p><p>So I lifted up my eyes the way toward the north, and saw, northward of the gate of the altar this image of jealousy in the entry. 
-</p><p>
-<span class="v">6&#160;</span>He said to me, “Son of man, do you see what they do? Even the great abominations that the house of Israel commit here, that I should go far off from my sanctuary? But you will again see yet other great abominations.” 
-</p><p>
-<span class="v">7&#160;</span>He brought me to the door of the court; and when I looked, behold, a hole in the wall. 
-<span class="v">8&#160;</span>Then he said to me, “Son of man, dig now in the wall.” 
-</p><p>When I had dug in the wall, I saw a door. 
-</p><p>
-<span class="v">9&#160;</span>He said to me, “Go in, and see the wicked abominations that they do here.” 
-</p><p>
-<span class="v">10&#160;</span>So I went in and looked, and saw every form of creeping things, abominable animals, and all the idols of the house of Israel, portrayed around on the wall. 
-<span class="v">11&#160;</span>Seventy men of the elders of the house of Israel stood before them. In the middle of them Jaazaniah the son of Shaphan stood, every man with his censer in his hand; and the smell of the cloud of incense went up. 
-</p><p>
-<span class="v">12&#160;</span>Then he said to me, “Son of man, have you seen what the elders of the house of Israel do in the dark, every man in his rooms of imagery? For they say, ‘Yahweh doesn’t see us. Yahweh has forsaken the land.’&#160;” 
-<span class="v">13&#160;</span>He said also to me, “You will again see more of the great abominations which they do.” 
-</p><p>
-<span class="v">14&#160;</span>Then he brought me to the door of the gate of Yahweh’s house which was toward the north; and I saw the women sit there weeping for Tammuz. 
-<span class="v">15&#160;</span>Then he said to me, “Have you seen this, son of man? You will again see yet greater abominations than these.” 
-</p><p>
-<span class="v">16&#160;</span>He brought me into the inner court of Yahweh’s house; and I saw at the door of Yahweh’s temple, between the porch and the altar, there were about twenty-five men with their backs toward Yahweh’s temple and their faces toward the east. They were worshiping the sun toward the east. 
-</p><p>
-<span class="v">17&#160;</span>Then he said to me, “Have you seen this, son of man? Is it a light thing to the house of Judah that they commit the abominations which they commit here? For they have filled the land with violence, and have turned again to provoke me to anger. Behold, they put the branch to their nose. 
-<span class="v">18&#160;</span>Therefore I will also deal in wrath. My eye won’t spare, neither will I have pity. Though they cry in my ears with a loud voice, yet I will not hear them.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Then he cried in my ears with a loud voice, saying, “Cause those who are in charge of the city to draw near, each man with his destroying weapon in his hand.” 
-<span class="v">2&#160;</span>Behold, six men came from the way of the upper gate, which lies toward the north, every man with his slaughter weapon in his hand. One man in the middle of them was clothed in linen, with a writer’s inkhorn by his side. They went in, and stood beside the bronze altar. 
-</p><p>
-<span class="v">3&#160;</span>The glory of the Elohim of Israel went up from the cherub, whereupon it was, to the threshold of the house; and he called to the man clothed in linen, who had the writer’s inkhorn by his side. 
-<span class="v">4&#160;</span>Yahweh said to him, “Go through the middle of the city, through the middle of Jerusalem, and set a mark on the foreheads of the men that sigh and that cry over all the abominations that are done within it.” 
-</p><p>
-<span class="v">5&#160;</span>To the others he said in my hearing, “Go through the city after him, and strike. Don’t let your eye spare, neither have pity. 
-<span class="v">6&#160;</span>Kill utterly the old man, the young man, the virgin, little children and women; but don’t come near any man on whom is the mark. Begin at my sanctuary.” 
-</p><p>Then they began at the old men who were before the house. 
-</p><p>
-<span class="v">7&#160;</span>He said to them, “Defile the house, and fill the courts with the slain. Go out!” 
-</p><p>They went out, and struck in the city. 
-</p><p>
-<span class="v">8&#160;</span>While they were killing, and I was left, I fell on my face, and cried, and said, “Ah Lord Yahweh! Will you destroy all the residue of Israel in your pouring out of your wrath on Jerusalem?” 
-</p><p>
-<span class="v">9&#160;</span>Then he said to me, “The iniquity of the house of Israel and Judah is exceedingly great, and the land is full of blood, and the city full of perversion; for they say, ‘Yahweh has forsaken the land, and Yahweh doesn’t see.’ 
-<span class="v">10&#160;</span>As for me also, my eye won’t spare, neither will I have pity, but I will bring their way on their head.” 
-</p><p>
-<span class="v">11&#160;</span>Behold, the man clothed in linen, who had the inkhorn by his side, reported the matter, saying, “I have done as you have commanded me.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Then I looked, and see, in the expanse that was over the head of the cherubim there appeared above them as it were a sapphire<span class="f">+ \fr 10:1 \ft or, lapis lazuli </span> stone, as the appearance of the likeness of a throne. 
-<span class="v">2&#160;</span>He spoke to the man clothed in linen, and said, “Go in between the whirling wheels, even under the cherub, and fill both your hands with coals of fire from between the cherubim, and scatter them over the city.” 
-</p><p>He went in as I watched. 
-<span class="v">3&#160;</span>Now the cherubim stood on the right side of the house when the man went in; and the cloud filled the inner court. 
-<span class="v">4&#160;</span>Yahweh’s glory mounted up from the cherub, and stood over the threshold of the house; and the house was filled with the cloud, and the court was full of the brightness of Yahweh’s glory. 
-<span class="v">5&#160;</span>The sound of the wings of the cherubim was heard even to the outer court, as the voice of Elohim Almighty when he speaks. 
-</p><p>
-<span class="v">6&#160;</span>It came to pass, when he commanded the man clothed in linen, saying, “Take fire from between the whirling wheels, from between the cherubim,” that he went in and stood beside a wheel. 
-<span class="v">7&#160;</span>The cherub stretched out his hand from between the cherubim to the fire that was between the cherubim, and took some of it, and put it into the hands of him who was clothed in linen, who took it and went out. 
-<span class="v">8&#160;</span>The form of a man’s hand appeared here in the cherubim under their wings. 
-</p><p>
-<span class="v">9&#160;</span>I looked, and behold, there were four wheels beside the cherubim, one wheel beside one cherub, and another wheel beside another cherub. The appearance of the wheels was like a beryl stone. 
-<span class="v">10&#160;</span>As for their appearance, the four of them had one likeness, like a wheel within a wheel. 
-<span class="v">11&#160;</span>When they went, they went in their four directions. They didn’t turn as they went, but to the place where the head looked they followed it. They didn’t turn as they went. 
-<span class="v">12&#160;</span>Their whole body, including their backs, their hands, their wings, and the wheels, were full of eyes all around, even the wheels that the four of them had. 
-<span class="v">13&#160;</span>As for the wheels, they were called in my hearing, “the whirling wheels”. 
-<span class="v">14&#160;</span>Every one them had four faces. The first face was the face of the cherub. The second face was the face of a man. The third face was the face of a lion. The fourth was the face of an eagle. 
-</p><p>
-<span class="v">15&#160;</span>The cherubim mounted up. This is the living creature that I saw by the river Chebar. 
-<span class="v">16&#160;</span>When the cherubim went, the wheels went beside them; and when the cherubim lifted up their wings to mount up from the earth, the wheels also didn’t turn from beside them. 
-<span class="v">17&#160;</span>When they stood, these stood. When they mounted up, these mounted up with them; for the spirit of the living creature was in them. 
-</p><p>
-<span class="v">18&#160;</span>Yahweh’s glory went out from over the threshold of the house and stood over the cherubim. 
-<span class="v">19&#160;</span>The cherubim lifted up their wings and mounted up from the earth in my sight when they went out, with the wheels beside them. Then they stood at the door of the east gate of Yahweh’s house; and the glory of the Elohim of Israel was over them above. 
-</p><p>
-<span class="v">20&#160;</span>This is the living creature that I saw under the Elohim of Israel by the river Chebar; and I knew that they were cherubim. 
-<span class="v">21&#160;</span>Every one had four faces, and every one four wings. The likeness of the hands of a man was under their wings. 
-<span class="v">22&#160;</span>As for the likeness of their faces, they were the faces which I saw by the river Chebar, their appearances and themselves. They each went straight forward. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Moreover the Spirit lifted me up and brought me to the east gate of Yahweh’s house, which looks eastward. Behold, twenty-five men were at the door of the gate; and I saw among them Jaazaniah the son of Azzur, and Pelatiah the son of Benaiah, princes of the people. 
-<span class="v">2&#160;</span>He said to me, “Son of man, these are the men who devise iniquity, and who give wicked counsel in this city; 
-<span class="v">3&#160;</span>who say, ‘The time is not near to build houses. This is the cauldron, and we are the meat.’ 
-<span class="v">4&#160;</span>Therefore prophesy against them. Prophesy, son of man.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh’s Spirit fell on me, and he said to me, “Speak, ‘Yahweh says: “Thus you have said, house of Israel; for I know the things that come into your mind. 
-<span class="v">6&#160;</span>You have multiplied your slain in this city, and you have filled its streets with the slain.” 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘Therefore the Lord Yahweh says: “Your slain whom you have laid in the middle of it, they are the meat, and this is the cauldron; but you will be brought out of the middle of it. 
-<span class="v">8&#160;</span>You have feared the sword; and I will bring the sword on you,” says the Lord Yahweh. 
-<span class="v">9&#160;</span>“I will bring you out of the middle of it, and deliver you into the hands of strangers, and will execute judgments among you. 
-<span class="v">10&#160;</span>You will fall by the sword. I will judge you in the border of Israel. Then you will know that I am Yahweh. 
-<span class="v">11&#160;</span>This will not be your cauldron, neither will you be the meat in the middle of it. I will judge you in the border of Israel. 
-<span class="v">12&#160;</span>You will know that I am Yahweh, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.”&#160;’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>When I prophesied, Pelatiah the son of Benaiah died. Then I fell down on my face, and cried with a loud voice, and said, “Ah Lord Yahweh! Will you make a full end of the remnant of Israel?” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">15&#160;</span>“Son of man, your brothers, even your brothers, the men of your relatives, and all the house of Israel, all of them, are the ones to whom the inhabitants of Jerusalem have said, ‘Go far away from Yahweh. This land has been given to us for a possession.’ 
-</p><p>
-<span class="v">16&#160;</span>“Therefore say, ‘The Lord Yahweh says: “Whereas I have removed them far off among the nations, and whereas I have scattered them among the countries, yet I will be to them a sanctuary for a little while in the countries where they have come.”&#160;’ 
-</p><p>
-<span class="v">17&#160;</span>“Therefore say, ‘The Lord Yahweh says: “I will gather you from the peoples, and assemble you out of the countries where you have been scattered, and I will give you the land of Israel.” 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘They will come there, and they will take away all its detestable things and all its abominations from there. 
-<span class="v">19&#160;</span>I will give them one heart, and I will put a new spirit within them. I will take the stony heart out of their flesh, and will give them a heart of flesh, 
-<span class="v">20&#160;</span>that they may walk in my statutes, and keep my ordinances, and do them. They will be my people, and I will be their Elohim. 
-<span class="v">21&#160;</span>But as for them whose heart walks after the heart of their detestable things and their abominations, I will bring their way on their own heads,’ says the Lord Yahweh.” 
-</p><p>
-<span class="v">22&#160;</span>Then the cherubim lifted up their wings, and the wheels were beside them. The glory of the Elohim of Israel was over them above. 
-<span class="v">23&#160;</span>Yahweh’s glory went up from the middle of the city, and stood on the mountain which is on the east side of the city. 
-<span class="v">24&#160;</span>The Spirit lifted me up, and brought me in the vision by the Spirit of Elohim into Chaldea, to the captives. 
-</p><p>So the vision that I had seen went up from me. 
-<span class="v">25&#160;</span>Then I spoke to the captives all the things that Yahweh had shown me. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word also came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, you dwell in the middle of the rebellious house, who have eyes to see, and don’t see, who have ears to hear, and don’t hear; for they are a rebellious house. 
-</p><p>
-<span class="v">3&#160;</span>“Therefore, you son of man, prepare your baggage for moving, and move by day in their sight. You shall move from your place to another place in their sight. It may be they will consider, though they are a rebellious house. 
-<span class="v">4&#160;</span>You shall bring out your baggage by day in their sight, as baggage for moving. You shall go out yourself at evening in their sight, as when men go out into exile. 
-<span class="v">5&#160;</span>Dig through the wall in their sight, and carry your baggage out that way. 
-<span class="v">6&#160;</span>In their sight you shall bear it on your shoulder, and carry it out in the dark. You shall cover your face, so that you don’t see the land, for I have set you for a sign to the house of Israel.” 
-</p><p>
-<span class="v">7&#160;</span>I did so as I was commanded. I brought out my baggage by day, as baggage for moving, and in the evening I dug through the wall with my hand. I brought it out in the dark, and bore it on my shoulder in their sight. 
-</p><p>
-<span class="v">8&#160;</span>In the morning, Yahweh’s word came to me, saying, 
-<span class="v">9&#160;</span>“Son of man, hasn’t the house of Israel, the rebellious house, said to you, ‘What are you doing?’ 
-</p><p>
-<span class="v">10&#160;</span>“Say to them, ‘The Lord Yahweh says: “This burden concerns the prince in Jerusalem, and all the house of Israel among whom they are.”&#160;’ 
-</p><p>
-<span class="v">11&#160;</span>“Say, ‘I am your sign. As I have done, so will it be done to them. They will go into exile, into captivity. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘The prince who is among them will bear his baggage on his shoulder in the dark, and will go out. They will dig through the wall to carry things out that way. He will cover his face, because he will not see the land with his eyes. 
-<span class="v">13&#160;</span>I will also spread my net on him, and he will be taken in my snare. I will bring him to Babylon to the land of the Chaldeans; yet he will not see it, though he will die there. 
-<span class="v">14&#160;</span>I will scatter toward every wind all who are around him to help him, and all his bands. I will draw out the sword after them. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘They will know that I am Yahweh when I disperse them among the nations and scatter them through the countries. 
-<span class="v">16&#160;</span>But I will leave a few men of them from the sword, from the famine, and from the pestilence, that they may declare all their abominations among the nations where they come. Then they will know that I am Yahweh.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">18&#160;</span>“Son of man, eat your bread with quaking, and drink your water with trembling and with fearfulness. 
-<span class="v">19&#160;</span>Tell the people of the land, ‘The Lord Yahweh says concerning the inhabitants of Jerusalem and the land of Israel: “They will eat their bread with fearfulness and drink their water in dismay, that her land may be desolate, and all that is therein, because of the violence of all those who dwell therein. 
-<span class="v">20&#160;</span>The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am Yahweh.”&#160;’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">22&#160;</span>“Son of man, what is this proverb that you have in the land of Israel, saying, ‘The days are prolonged, and every vision fails’? 
-<span class="v">23&#160;</span>Tell them therefore, ‘The Lord Yahweh says: “I will make this proverb to cease, and they will no more use it as a proverb in Israel;”&#160;’ but tell them, ‘&#160;“The days are at hand, and the fulfillment of every vision. 
-<span class="v">24&#160;</span>For there will be no more any false vision nor flattering divination within the house of Israel. 
-<span class="v">25&#160;</span>For I am Yahweh. I will speak, and the word that I speak will be performed. It will be no more deferred; for in your days, rebellious house, I will speak the word and will perform it,” says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">26&#160;</span>Again Yahweh’s word came to me, saying, 
-<span class="v">27&#160;</span>“Son of man, behold, they of the house of Israel say, ‘The vision that he sees is for many days to come, and he prophesies of times that are far off.’ 
-</p><p>
-<span class="v">28&#160;</span>“Therefore tell them, ‘The Lord Yahweh says: “None of my words will be deferred any more, but the word which I speak will be performed,” says the Lord Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, prophesy against the prophets of Israel who prophesy, and say to those who prophesy out of their own heart, ‘Hear Yahweh’s word: 
-<span class="v">3&#160;</span>The Lord Yahweh says, “Woe to the foolish prophets, who follow their own spirit, and have seen nothing! 
-<span class="v">4&#160;</span>Israel, your prophets have been like foxes in the waste places. 
-<span class="v">5&#160;</span>You have not gone up into the gaps or built up the wall for the house of Israel, to stand in the battle in Yahweh’s day. 
-<span class="v">6&#160;</span>They have seen falsehood and lying divination, who say, ‘Yahweh says;’ but Yahweh has not sent them. They have made men to hope that the word would be confirmed. 
-<span class="v">7&#160;</span>Haven’t you seen a false vision, and haven’t you spoken a lying divination, in that you say, ‘Yahweh says;’ but I have not spoken?” 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘Therefore the Lord Yahweh says: “Because you have spoken falsehood and seen lies, therefore, behold, I am against you,” says the Lord Yahweh. 
-<span class="v">9&#160;</span>“My hand will be against the prophets who see false visions and who utter lying divinations. They will not be in the council of my people, neither will they be written in the writing of the house of Israel, neither will they enter into the land of Israel. Then you will know that I am the Lord Yahweh.” 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘Because, even because they have seduced my people, saying, “Peace;” and there is no peace. When one builds up a wall, behold, they plaster it with whitewash. 
-<span class="v">11&#160;</span>Tell those who plaster it with whitewash that it will fall. There will be an overflowing shower; and you, great hailstones, will fall. A stormy wind will tear it. 
-<span class="v">12&#160;</span>Behold, when the wall has fallen, won’t it be said to you, “Where is the plaster with which you have plastered it?” 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘Therefore the Lord Yahweh says: “I will even tear it with a stormy wind in my wrath. There will be an overflowing shower in my anger, and great hailstones in wrath to consume it. 
-<span class="v">14&#160;</span>So I will break down the wall that you have plastered with whitewash, and bring it down to the ground, so that its foundation will be uncovered. It will fall, and you will be consumed in the middle of it. Then you will know that I am Yahweh. 
-<span class="v">15&#160;</span>Thus I will accomplish my wrath on the wall, and on those who have plastered it with whitewash. I will tell you, ‘The wall is no more, nor those who plastered it—<span class="v">16&#160;</span>to wit, the prophets of Israel who prophesy concerning Jerusalem, and who see visions of peace for her, and there is no peace,’&#160;” says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>You, son of man, set your face against the daughters of your people, who prophesy out of their own heart; and prophesy against them, 
-<span class="v">18&#160;</span>and say, “The Lord Yahweh says: ‘Woe to the women who sew magic bands on all elbows and make veils for the head of persons of every stature to hunt souls! Will you hunt the souls of my people and save souls alive for yourselves? 
-<span class="v">19&#160;</span>You have profaned me among my people for handfuls of barley and for pieces of bread, to kill the souls who should not die and to save the souls alive who should not live, by your lying to my people who listen to lies.’ 
-</p><p>
-<span class="v">20&#160;</span>“Therefore the Lord Yahweh says: ‘Behold, I am against your magic bands, with which you hunt the souls to make them fly, and I will tear them from your arms. I will let the souls fly free, even the souls whom you ensnare like birds. 
-<span class="v">21&#160;</span>I will also tear your veils and deliver my people out of your hand; and they will no longer be in your hand to be ensnared. Then you will know that I am Yahweh. 
-<span class="v">22&#160;</span>Because with lies you have grieved the heart of the righteous, whom I have not made sad; and strengthened the hands of the wicked, that he should not return from his wicked way, and be saved alive. 
-<span class="v">23&#160;</span>Therefore you shall no more see false visions nor practice divination. I will deliver my people out of your hand. Then you will know that I am Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Then some of the elders of Israel came to me and sat before me. 
-<span class="v">2&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">3&#160;</span>“Son of man, these men have taken their idols into their heart, and put the stumbling block of their iniquity before their face. Should I be inquired of at all by them? 
-<span class="v">4&#160;</span>Therefore speak to them and tell them, ‘The Lord Yahweh says: “Every man of the house of Israel who takes his idols into his heart and puts the stumbling block of his iniquity before his face then comes to the prophet, I Yahweh will answer him there according to the multitude of his idols, 
-<span class="v">5&#160;</span>that I may take the house of Israel in their own heart, because they are all estranged from me through their idols.”&#160;’ 
-</p><p>
-<span class="v">6&#160;</span>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “Return, and turn yourselves from your idols! Turn away your faces from all your abominations. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘&#160;“For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I Yahweh will answer him by myself. 
-<span class="v">8&#160;</span>I will set my face against that man and will make him an astonishment, for a sign and a proverb, and I will cut him off from among my people. Then you will know that I am Yahweh. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘&#160;“If the prophet is deceived and speaks a word, I, Yahweh, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel. 
-<span class="v">10&#160;</span>They will bear their iniquity. The iniquity of the prophet will be even as the iniquity of him who seeks him, 
-<span class="v">11&#160;</span>that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their Elohim,” says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">13&#160;</span>“Son of man, when a land sins against me by committing a trespass, and I stretch out my hand on it, and break the staff of its bread and send famine on it, and cut off from it man and animal—<span class="v">14&#160;</span>though these three men, Noah, Daniel, and Job, were in it, they would deliver only their own souls by their righteousness,” says the Lord Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>“If I cause evil animals to pass through the land, and they ravage it and it is made desolate, so that no man may pass through because of the animals—<span class="v">16&#160;</span>though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters. They only would be delivered, but the land would be desolate. 
-</p><p>
-<span class="v">17&#160;</span>“Or if I bring a sword on that land, and say, ‘Sword, go through the land, so that I cut off from it man and animal’—<span class="v">18&#160;</span>though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters, but they only would be delivered themselves. 
-</p><p>
-<span class="v">19&#160;</span>“Or if I send a pestilence into that land, and pour out my wrath on it in blood, to cut off from it man and animal—<span class="v">20&#160;</span>though Noah, Daniel, and Job, were in it, as I live,” says the Lord Yahweh, “they would deliver neither son nor daughter; they would deliver only their own souls by their righteousness.” 
-</p><p>
-<span class="v">21&#160;</span>For the Lord Yahweh says: “How much more when I send my four severe judgments on Jerusalem—the sword, the famine, the evil animals, and the pestilence—to cut off from it man and animal! 
-<span class="v">22&#160;</span>Yet, behold, there will be left a remnant in it that will be carried out, both sons and daughters. Behold, they will come out to you, and you will see their way and their doings. Then you will be comforted concerning the evil that I have brought on Jerusalem, even concerning all that I have brought on it. 
-<span class="v">23&#160;</span>They will comfort you, when you see their way and their doings; then you will know that I have not done all that I have done in it without cause,” says the Lord Yahweh. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, what is the vine tree more than any tree, the vine branch which is among the trees of the forest? 
-<span class="v">3&#160;</span>Will wood be taken of it to make anything? Will men take a pin of it to hang any vessel on it? 
-<span class="v">4&#160;</span>Behold, it is cast into the fire for fuel; the fire has devoured both its ends, and the middle of it is burned. Is it profitable for any work? 
-<span class="v">5&#160;</span>Behold, when it was whole, it was suitable for no work. How much less, when the fire has devoured it, and it has been burned, will it yet be suitable for any work?” 
-</p><p>
-<span class="v">6&#160;</span>Therefore the Lord Yahweh says: “As the vine wood among the trees of the forest, which I have given to the fire for fuel, so I will give the inhabitants of Jerusalem. 
-<span class="v">7&#160;</span>I will set my face against them. They will go out from the fire, but the fire will still devour them. Then you will know that I am Yahweh, when I set my face against them. 
-<span class="v">8&#160;</span>I will make the land desolate, because they have acted unfaithfully,” says the Lord Yahweh. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Again Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, cause Jerusalem to know her abominations; 
-<span class="v">3&#160;</span>and say, ‘The Lord Yahweh says to Jerusalem: “Your origin and your birth is of the land of the Canaanite. An Amorite was your father, and your mother was a Hittite. 
-<span class="v">4&#160;</span>As for your birth, in the day you were born your navel was not cut. You weren’t washed in water to cleanse you. You weren’t salted at all, nor wrapped in blankets at all. 
-<span class="v">5&#160;</span>No eye pitied you, to do any of these things to you, to have compassion on you; but you were cast out in the open field, because you were abhorred in the day that you were born. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘&#160;“When I passed by you, and saw you wallowing in your blood, I said to you, ‘Though you are in your blood, live!’ Yes, I said to you, ‘Though you are in your blood, live!’ 
-<span class="v">7&#160;</span>I caused you to multiply as that which grows in the field, and you increased and grew great, and you attained to excellent beauty. Your breasts were formed, and your hair grew; yet you were naked and bare. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘&#160;“Now when I passed by you, and looked at you, behold, your time was the time of love; and I spread my garment over you and covered your nakedness. Yes, I pledged myself to you and entered into a covenant with you,” says the Lord Yahweh, “and you became mine. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘&#160;“Then I washed you with water. Yes, I thoroughly washed away your blood from you, and I anointed you with oil. 
-<span class="v">10&#160;</span>I clothed you also with embroidered work and put leather sandals on you. I dressed you with fine linen and covered you with silk. 
-<span class="v">11&#160;</span>I decked you with ornaments, put bracelets on your hands, and put a chain on your neck. 
-<span class="v">12&#160;</span>I put a ring on your nose, earrings in your ears, and a beautiful crown on your head. 
-<span class="v">13&#160;</span>Thus you were decked with gold and silver. Your clothing was of fine linen, silk, and embroidered work. You ate fine flour, honey, and oil. You were exceedingly beautiful, and you prospered to royal estate. 
-<span class="v">14&#160;</span>Your renown went out among the nations for your beauty; for it was perfect, through my majesty which I had put on you,” says the Lord Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘&#160;“But you trusted in your beauty, and played the prostitute because of your renown, and poured out your prostitution on everyone who passed by. It was his. 
-<span class="v">16&#160;</span>You took some of your garments, and made for yourselves high places decked with various colors, and played the prostitute on them. This shouldn’t happen, neither shall it be. 
-<span class="v">17&#160;</span>You also took your beautiful jewels of my gold and of my silver, which I had given you, and made for yourself images of men, and played the prostitute with them. 
-<span class="v">18&#160;</span>You took your embroidered garments, covered them, and set my oil and my incense before them. 
-<span class="v">19&#160;</span>My bread also which I gave you, fine flour, oil, and honey, with which I fed you, you even set it before them for a pleasant aroma; and so it was,” says the Lord Yahweh. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘&#160;“Moreover you have taken your sons and your daughters, whom you have borne to me, and you have sacrificed these to them to be devoured. Was your prostitution a small matter, 
-<span class="v">21&#160;</span>that you have slain my children and delivered them up, in causing them to pass through the fire to them? 
-<span class="v">22&#160;</span>In all your abominations and your prostitution you have not remembered the days of your youth, when you were naked and bare, and were wallowing in your blood. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘&#160;“It has happened after all your wickedness—woe, woe to you!” says the Lord Yahweh—<span class="v">24&#160;</span>“that you have built for yourselves a vaulted place, and have made yourselves a lofty place in every street. 
-<span class="v">25&#160;</span>You have built your lofty place at the head of every way, and have made your beauty an abomination, and have opened your feet to everyone who passed by, and multiplied your prostitution. 
-<span class="v">26&#160;</span>You have also committed sexual immorality with the Egyptians, your neighbors, great of flesh; and have multiplied your prostitution, to provoke me to anger. 
-<span class="v">27&#160;</span>See therefore, I have stretched out my hand over you, and have diminished your portion, and delivered you to the will of those who hate you, the daughters of the Philistines, who are ashamed of your lewd way. 
-<span class="v">28&#160;</span>You have played the prostitute also with the Assyrians, because you were insatiable; yes, you have played the prostitute with them, and yet you weren’t satisfied. 
-<span class="v">29&#160;</span>You have moreover multiplied your prostitution to the land of merchants, to Chaldea; and yet you weren’t satisfied with this. 
-</p><p>
-<span class="v">30&#160;</span>“&#160;‘&#160;“How weak is your heart,” says the Lord Yahweh, “since you do all these things, the work of an impudent prostitute; 
-<span class="v">31&#160;</span>in that you build your vaulted place at the head of every way, and make your lofty place in every street, and have not been as a prostitute, in that you scorn pay. 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘&#160;“Adulterous woman, who takes strangers instead of her man! 
-<span class="v">33&#160;</span>People give gifts to all prostitutes; but you give your gifts to all your lovers, and bribe them, that they may come to you on every side for your prostitution. 
-<span class="v">34&#160;</span>You are different from other women in your prostitution, in that no one follows you to play the prostitute; and whereas you give hire, and no hire is given to you, therefore you are different.”&#160;’ 
-</p><p>
-<span class="v">35&#160;</span>“Therefore, prostitute, hear Yahweh’s word: 
-<span class="v">36&#160;</span>‘The Lord Yahweh says, “Because your filthiness was poured out, and your nakedness uncovered through your prostitution with your lovers; and because of all the idols of your abominations, and for the blood of your children, that you gave to them; 
-<span class="v">37&#160;</span>therefore see, I will gather all your lovers, with whom you have taken pleasure, and all those whom you have loved, with all those whom you have hated. I will even gather them against you on every side, and will uncover your nakedness to them, that they may see all your nakedness. 
-<span class="v">38&#160;</span>I will judge you as women who break wedlock and shed blood are judged; and I will bring on you the blood of wrath and jealousy. 
-<span class="v">39&#160;</span>I will also give you into their hand, and they will throw down your vaulted place, and break down your lofty places. They will strip you of your clothes and take your beautiful jewels. They will leave you naked and bare. 
-<span class="v">40&#160;</span>They will also bring up a company against you, and they will stone you with stones, and thrust you through with their swords. 
-<span class="v">41&#160;</span>They will burn your houses with fire, and execute judgments on you in the sight of many women. I will cause you to cease from playing the prostitute, and you will also give no hire any more. 
-<span class="v">42&#160;</span>So I will cause my wrath toward you to rest, and my jealousy will depart from you. I will be quiet, and will not be angry any more. 
-</p><p>
-<span class="v">43&#160;</span>“&#160;‘&#160;“Because you have not remembered the days of your youth, but have raged against me in all these things; therefore, behold, I also will bring your way on your head,” says the Lord Yahweh: “and you shall not commit this lewdness with all your abominations. 
-</p><p>
-<span class="v">44&#160;</span>“&#160;‘&#160;“Behold, everyone who uses proverbs will use this proverb against you, saying, ‘As is the mother, so is her daughter.’ 
-<span class="v">45&#160;</span>You are the daughter of your mother, who loathes her man and her children; and you are the sister of your sisters, who loathed their men and their children. Your mother was a Hittite, and your father an Amorite. 
-<span class="v">46&#160;</span>Your elder sister is Samaria, who dwells at your left hand, she and her daughters; and your younger sister, who dwells at your right hand, is Sodom with her daughters. 
-<span class="v">47&#160;</span>Yet you have not walked in their ways, nor done their abominations; but soon you were more corrupt than they in all your ways. 
-<span class="v">48&#160;</span>As I live,” says the Lord Yahweh, “Sodom your sister has not done, she nor her daughters, as you have done, you and your daughters. 
-</p><p>
-<span class="v">49&#160;</span>“&#160;‘&#160;“Behold, this was the iniquity of your sister Sodom: pride, fullness of bread, and prosperous ease was in her and in her daughters. She also didn’t strengthen the hand of the poor and needy. 
-<span class="v">50&#160;</span>They were arrogant and committed abomination before me. Therefore I took them away when I saw it. 
-<span class="v">51&#160;</span>Samaria hasn’t committed half of your sins; but you have multiplied your abominations more than they, and have justified your sisters by all your abominations which you have done. 
-<span class="v">52&#160;</span>You also bear your own shame yourself, in that you have given judgment for your sisters; through your sins that you have committed more abominable than they, they are more righteous than you. Yes, be also confounded, and bear your shame, in that you have justified your sisters. 
-</p><p>
-<span class="v">53&#160;</span>“&#160;‘&#160;“I will reverse their captivity, the captivity of Sodom and her daughters, and the captivity of Samaria and her daughters, and the captivity of your captives among them; 
-<span class="v">54&#160;</span>that you may bear your own shame, and may be ashamed because of all that you have done, in that you are a comfort to them. 
-<span class="v">55&#160;</span>Your sisters, Sodom and her daughters, will return to their former estate; and Samaria and her daughters will return to their former estate; and you and your daughters will return to your former estate. 
-<span class="v">56&#160;</span>For your sister Sodom was not mentioned by your mouth in the day of your pride, 
-<span class="v">57&#160;</span>before your wickedness was uncovered, as at the time of the reproach of the daughters of Syria, and of all who are around her, the daughters of the Philistines, who despise you all around. 
-<span class="v">58&#160;</span>You have borne your lewdness and your abominations,” says Yahweh. 
-</p><p>
-<span class="v">59&#160;</span>“&#160;‘For the Lord Yahweh says: “I will also deal with you as you have done, who have despised the oath in breaking the covenant. 
-<span class="v">60&#160;</span>Nevertheless I will remember my covenant with you in the days of your youth, and I will establish an everlasting covenant with you. 
-<span class="v">61&#160;</span>Then you will remember your ways and be ashamed when you receive your sisters, your elder sisters and your younger; and I will give them to you for daughters, but not by your covenant. 
-<span class="v">62&#160;</span>I will establish my covenant with you. Then you will know that I am Yahweh; 
-<span class="v">63&#160;</span>that you may remember, and be confounded, and never open your mouth any more because of your shame, when I have forgiven you all that you have done,” says the Lord Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, tell a riddle, and speak a parable to the house of Israel; 
-<span class="v">3&#160;</span>and say, ‘The Lord Yahweh says: “A great eagle with great wings and long feathers, full of feathers which had various colors, came to Lebanon and took the top of the cedar. 
-<span class="v">4&#160;</span>He cropped off the topmost of its young twigs, and carried it to a land of traffic. He planted it in a city of merchants. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘&#160;“He also took some of the seed of the land and planted it in fruitful soil. He placed it beside many waters. He set it as a willow tree. 
-<span class="v">6&#160;</span>It grew and became a spreading vine of low stature, whose branches turned toward him, and its roots were under him. So it became a vine, produced branches, and shot out sprigs. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘&#160;“There was also another great eagle with great wings and many feathers. Behold, this vine bent its roots toward him, and shot out its branches toward him, from the ground where it was planted, that he might water it. 
-<span class="v">8&#160;</span>It was planted in a good soil by many waters, that it might produce branches and that it might bear fruit, that it might be a good vine.”&#160;’ 
-</p><p>
-<span class="v">9&#160;</span>“Say, ‘The Lord Yahweh says: “Will it prosper? Won’t he pull up its roots and cut off its fruit, that it may wither, that all its fresh springing leaves may wither? It can’t be raised from its roots by a strong arm or many people. 
-<span class="v">10&#160;</span>Yes, behold, being planted, will it prosper? Won’t it utterly wither when the east wind touches it? It will wither in the ground where it grew.”&#160;’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">12&#160;</span>“Say now to the rebellious house, ‘Don’t you know what these things mean?’ Tell them, ‘Behold, the king of Babylon came to Jerusalem, and took its king, and its princes, and brought them to him to Babylon. 
-<span class="v">13&#160;</span>He took one of the royal offspring,<span class="f">+ \fr 17:13 \ft or, seed</span> and made a covenant with him. He also brought him under an oath, and took away the mighty of the land, 
-<span class="v">14&#160;</span>that the kingdom might be brought low, that it might not lift itself up, but that by keeping his covenant it might stand. 
-<span class="v">15&#160;</span>But he rebelled against him in sending his ambassadors into Egypt, that they might give him horses and many people. Will he prosper? Will he who does such things escape? Will he break the covenant, and still escape? 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘As I live,’ says the Lord Yahweh, ‘surely in the place where the king dwells who made him king, whose oath he despised, and whose covenant he broke, even with him in the middle of Babylon he will die. 
-<span class="v">17&#160;</span>Pharaoh with his mighty army and great company won’t help him in the war, when they cast up mounds and build forts to cut off many persons. 
-<span class="v">18&#160;</span>For he has despised the oath by breaking the covenant; and behold, he had given his hand, and yet has done all these things. He won’t escape. 
-</p><p>
-<span class="v">19&#160;</span>“Therefore the Lord Yahweh says: ‘As I live, I will surely bring on his own head my oath that he has despised and my covenant that he has broken. 
-<span class="v">20&#160;</span>I will spread my net on him, and he will be taken in my snare. I will bring him to Babylon, and will enter into judgment with him there for his trespass that he has trespassed against me. 
-<span class="v">21&#160;</span>All his fugitives in all his bands will fall by the sword, and those who remain will be scattered toward every wind. Then you will know that I, Yahweh, have spoken it.’ 
-</p><p>
-<span class="v">22&#160;</span>“The Lord Yahweh says: ‘I will also take some of the lofty top of the cedar, and will plant it. I will crop off from the topmost of its young twigs a tender one, and I will plant it on a high and lofty mountain. 
-<span class="v">23&#160;</span>I will plant it in the mountain of the height of Israel; and it will produce boughs, and bear fruit, and be a good cedar. Birds of every kind will dwell in the shade of its branches. 
-<span class="v">24&#160;</span>All the trees of the field will know that I, Yahweh, have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree flourish. 
-</p><p>“&#160;‘I, Yahweh, have spoken and have done it.’&#160;” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me again, saying, 
-<span class="v">2&#160;</span>“What do you mean, that you use this proverb concerning the land of Israel, saying, 
-</p><p class="q1">‘The fathers have eaten sour grapes, 
-</p><p class="q2">and the children’s teeth are set on edge’? 
-</p><p>
-<span class="v">3&#160;</span>“As I live,” says the Lord Yahweh, “you shall not use this proverb any more in Israel. 
-<span class="v">4&#160;</span>Behold, all souls are mine; as the soul of the father, so also the soul of the son is mine. The soul who sins, he shall die. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“But if a man is just, 
-</p><p class="q2">and does that which is lawful and right, 
-</p><p class="q1">
-<span class="v">6&#160;</span>and has not eaten on the mountains, 
-</p><p class="q2">hasn’t lifted up his eyes to the idols of the house of Israel, 
-</p><p class="q1">hasn’t defiled his neighbor’s woman, 
-</p><p class="q2">hasn’t come near a woman in her impurity, 
-</p><p class="q1">
-<span class="v">7&#160;</span>and has not wronged any, 
-</p><p class="q2">but has restored to the debtor his pledge, 
-</p><p class="q1">has taken nothing by robbery, 
-</p><p class="q2">has given his bread to the hungry, 
-</p><p class="q2">and has covered the naked with a garment; 
-</p><p class="q1">
-<span class="v">8&#160;</span>he who hasn’t lent to them with interest, 
-</p><p class="q2">hasn’t taken any increase from them, 
-</p><p class="q1">who has withdrawn his hand from iniquity, 
-</p><p class="q2">has executed true justice between man and man, 
-</p><p class="q1">
-<span class="v">9&#160;</span>has walked in my statutes, 
-</p><p class="q2">and has kept my ordinances, 
-</p><p class="q2">to deal truly; 
-</p><p class="q1">he is just, 
-</p><p class="q2">he shall surely live,” says the Lord Yahweh. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">10&#160;</span>“If he fathers a son who is a robber who sheds blood, and who does any one of these things, 
-<span class="v">11&#160;</span>or who does not do any of those things 
-</p><p class="q1">but has eaten at the mountain shrines 
-</p><p class="q2">and defiled his neighbor’s woman, 
-</p><p class="q1">
-<span class="v">12&#160;</span>has wronged the poor and needy, 
-</p><p class="q2">has taken by robbery, 
-</p><p class="q1">has not restored the pledge, 
-</p><p class="q2">and has lifted up his eyes to the idols, 
-</p><p class="q2">has committed abomination, 
-</p><p class="q1">
-<span class="v">13&#160;</span>has lent with interest, 
-</p><p class="q2">and has taken increase from the poor, 
-</p><p class="m">shall he then live? He shall not live. He has done all these abominations. He shall surely die. His blood will be on him. 
-</p><p>
-<span class="v">14&#160;</span>“Now, behold, if he fathers a son who sees all his father’s sins which he has done, and fears, and doesn’t do likewise, 
-</p><p class="q1">
-<span class="v">15&#160;</span>who hasn’t eaten on the mountains, 
-</p><p class="q2">hasn’t lifted up his eyes to the idols of the house of Israel, 
-</p><p class="q2">hasn’t defiled his neighbor’s woman, 
-</p><p class="q1">
-<span class="v">16&#160;</span>hasn’t wronged any, 
-</p><p class="q2">hasn’t taken anything to pledge, 
-</p><p class="q1">hasn’t taken by robbery, 
-</p><p class="q2">but has given his bread to the hungry, 
-</p><p class="q2">and has covered the naked with a garment; 
-</p><p class="q1">
-<span class="v">17&#160;</span>who has withdrawn his hand from the poor, 
-</p><p class="q2">who hasn’t received interest or increase, 
-</p><p class="q1">has executed my ordinances, 
-</p><p class="q2">has walked in my statutes; 
-</p><p class="m">he shall not die for the iniquity of his father. He shall surely live. 
-<span class="v">18&#160;</span>As for his father, because he cruelly oppressed, robbed his brother, and did that which is not good among his people, behold, he will die in his iniquity. 
-</p><p>
-<span class="v">19&#160;</span>“Yet you say, ‘Why doesn’t the son bear the iniquity of the father?’ When the son has done that which is lawful and right, and has kept all my statutes, and has done them, he will surely live. 
-<span class="v">20&#160;</span>The soul who sins, he shall die. The son shall not bear the iniquity of the father, neither shall the father bear the iniquity of the son. The righteousness of the righteous shall be on him, and the wickedness of the wicked shall be on him. 
-</p><p>
-<span class="v">21&#160;</span>“But if the wicked turns from all his sins that he has committed, and keeps all my statutes, and does that which is lawful and right, he shall surely live. He shall not die. 
-<span class="v">22&#160;</span>None of his transgressions that he has committed will be remembered against him. In his righteousness that he has done, he shall live. 
-<span class="v">23&#160;</span>Have I any pleasure in the death of the wicked?” says the Lord Yahweh, “and not rather that he should return from his way, and live? 
-</p><p>
-<span class="v">24&#160;</span>“But when the righteous turns away from his righteousness, and commits iniquity, and does according to all the abominations that the wicked man does, should he live? None of his righteous deeds that he has done will be remembered. In his trespass that he has trespassed, and in his sin that he has sinned, in them he shall die. 
-</p><p>
-<span class="v">25&#160;</span>“Yet you say, ‘The way of the Lord is not equal.’ Hear now, house of Israel: Is my way not equal? Aren’t your ways unequal? 
-<span class="v">26&#160;</span>When the righteous man turns away from his righteousness, and commits iniquity, and dies in it, then he dies in his iniquity that he has done. 
-<span class="v">27&#160;</span>Again, when the wicked man turns away from his wickedness that he has committed, and does that which is lawful and right, he will save his soul alive. 
-<span class="v">28&#160;</span>Because he considers, and turns away from all his transgressions that he has committed, he shall surely live. He shall not die. 
-<span class="v">29&#160;</span>Yet the house of Israel says, ‘The way of the Lord is not fair.’ House of Israel, aren’t my ways fair? Aren’t your ways unfair? 
-</p><p>
-<span class="v">30&#160;</span>“Therefore I will judge you, house of Israel, everyone according to his ways,” says the Lord Yahweh. “Return, and turn yourselves from all your transgressions, so iniquity will not be your ruin. 
-<span class="v">31&#160;</span>Cast away from you all your transgressions in which you have transgressed; and make yourself a new heart and a new spirit. For why will you die, house of Israel? 
-<span class="v">32&#160;</span>For I have no pleasure in the death of him who dies,” says the Lord Yahweh. “Therefore turn yourselves, and live! 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>“Moreover, take up a lamentation for the princes of Israel, 
-<span class="v">2&#160;</span>and say, 
-</p><p class="q1">‘What was your mother? 
-</p><p class="q2">A lioness. 
-</p><p class="q1">She couched among lions, 
-</p><p class="q2">in the middle of the young lions she nourished her cubs. 
-</p><p class="q1">
-<span class="v">3&#160;</span>She brought up one of her cubs. 
-</p><p class="q2">He became a young lion. 
-</p><p class="q1">He learned to catch the prey. 
-</p><p class="q2">He devoured men. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The nations also heard of him. 
-</p><p class="q2">He was taken in their pit; 
-</p><p class="q2">and they brought him with hooks to the land of Egypt. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“&#160;‘Now when she saw that she had waited, 
-</p><p class="q2">and her hope was lost, 
-</p><p class="q1">then she took another of her cubs, 
-</p><p class="q2">and made him a young lion. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He went up and down among the lions. 
-</p><p class="q2">He became a young lion. 
-</p><p class="q1">He learned to catch the prey. 
-</p><p class="q2">He devoured men. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He knew their palaces, 
-</p><p class="q2">and laid waste their cities. 
-</p><p class="q1">The land was desolate with its fullness, 
-</p><p class="q2">because of the noise of his roaring. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Then the nations attacked him on every side from the provinces. 
-</p><p class="q2">They spread their net over him. 
-</p><p class="q2">He was taken in their pit. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They put him in a cage with hooks, 
-</p><p class="q2">and brought him to the king of Babylon. 
-</p><p class="q1">They brought him into strongholds, 
-</p><p class="q2">so that his voice should no more be heard on the mountains of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“&#160;‘Your mother was like a vine in your blood, planted by the waters. 
-</p><p class="q2">It was fruitful and full of branches by reason of many waters. 
-</p><p class="q1">
-<span class="v">11&#160;</span>It had strong branches for the scepters of those who ruled. 
-</p><p class="q2">Their stature was exalted among the thick boughs. 
-</p><p class="q1">They were seen in their height 
-</p><p class="q2">with the multitude of their branches. 
-</p><p class="q1">
-<span class="v">12&#160;</span>But it was plucked up in fury. 
-</p><p class="q2">It was cast down to the ground, 
-</p><p class="q1">and the east wind dried up its fruit. 
-</p><p class="q2">Its strong branches were broken off and withered. 
-</p><p class="q2">The fire consumed them. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Now it is planted in the wilderness, 
-</p><p class="q2">in a dry and thirsty land. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Fire has gone out of its branches. 
-</p><p class="q2">It has devoured its fruit, 
-</p><p class="q2">so that there is in it no strong branch to be a scepter to rule.’ 
-</p><p class="m">This is a lamentation, and shall be for a lamentation.” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>In the seventh year, in the fifth month, the tenth day of the month, some of the elders of Israel came to inquire of Yahweh, and sat before me. 
-</p><p>
-<span class="v">2&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">3&#160;</span>“Son of man, speak to the elders of Israel, and tell them, ‘The Lord Yahweh says: “Is it to inquire of me that you have come? As I live,” says the Lord Yahweh, “I will not be inquired of by you.”&#160;’ 
-</p><p>
-<span class="v">4&#160;</span>“Will you judge them, son of man? Will you judge them? Cause them to know the abominations of their fathers. 
-<span class="v">5&#160;</span>Tell them, ‘The Lord Yahweh says: “In the day when I chose Israel, and swore to the offspring of the house of Jacob, and made myself known to them in the land of Egypt, when I swore to them, saying, ‘I am Yahweh your Elohim;’ 
-<span class="v">6&#160;</span>in that day I swore to them to bring them out of the land of Egypt into a land that I had searched out for them, flowing with milk and honey, which is the glory of all lands. 
-<span class="v">7&#160;</span>I said to them, ‘Each of you throw away the abominations of his eyes. Don’t defile yourselves with the idols of Egypt. I am Yahweh your Elohim.’ 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘&#160;“But they rebelled against me and wouldn’t listen to me. They didn’t all throw away the abominations of their eyes. They also didn’t forsake the idols of Egypt. Then I said I would pour out my wrath on them, to accomplish my anger against them in the middle of the land of Egypt. 
-<span class="v">9&#160;</span>But I worked for my name’s sake, that it should not be profaned in the sight of the nations among which they were, in whose sight I made myself known to them in bringing them out of the land of Egypt. 
-<span class="v">10&#160;</span>So I caused them to go out of the land of Egypt and brought them into the wilderness. 
-<span class="v">11&#160;</span>I gave them my statutes and showed them my ordinances, which if a man does, he will live in them. 
-<span class="v">12&#160;</span>Moreover also I gave them my Sabbaths, to be a sign between me and them, that they might know that I am Yahweh who sanctifies them. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘&#160;“But the house of Israel rebelled against me in the wilderness. They didn’t walk in my statutes and they rejected my ordinances, which if a man keeps, he shall live in them. They greatly profaned my Sabbaths. Then I said I would pour out my wrath on them in the wilderness, to consume them. 
-<span class="v">14&#160;</span>But I worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
-<span class="v">15&#160;</span>Moreover also I swore to them in the wilderness that I would not bring them into the land which I had given them, flowing with milk and honey, which is the glory of all lands, 
-<span class="v">16&#160;</span>because they rejected my ordinances, and didn’t walk in my statutes, and profaned my Sabbaths; for their heart went after their idols. 
-<span class="v">17&#160;</span>Nevertheless my eye spared them, and I didn’t destroy them. I didn’t make a full end of them in the wilderness. 
-<span class="v">18&#160;</span>I said to their children in the wilderness, ‘Don’t walk in the statutes of your fathers. Don’t observe their ordinances or defile yourselves with their idols. 
-<span class="v">19&#160;</span>I am Yahweh your Elohim. Walk in my statutes, keep my ordinances, and do them. 
-<span class="v">20&#160;</span>Make my Sabbaths set-apart. They shall be a sign between me and you, that you may know that I am Yahweh your Elohim.’ 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘&#160;“But the children rebelled against me. They didn’t walk in my statutes, and didn’t keep my ordinances to do them, which if a man does, he shall live in them. They profaned my Sabbaths. Then I said I would pour out my wrath on them, to accomplish my anger against them in the wilderness. 
-<span class="v">22&#160;</span>Nevertheless I withdrew my hand and worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
-<span class="v">23&#160;</span>Moreover I swore to them in the wilderness, that I would scatter them among the nations and disperse them through the countries, 
-<span class="v">24&#160;</span>because they had not executed my ordinances, but had rejected my statutes, and had profaned my Sabbaths, and their eyes were after their fathers’ idols. 
-<span class="v">25&#160;</span>Moreover also I gave them statutes that were not good, and ordinances in which they couldn’t live. 
-<span class="v">26&#160;</span>I polluted them in their own gifts, in that they caused all that opens the womb to pass through the fire, that I might make them desolate, to the end that they might know that I am Yahweh.”&#160;’ 
-</p><p>
-<span class="v">27&#160;</span>“Therefore, son of man, speak to the house of Israel, and tell them, ‘The Lord Yahweh says: “Moreover, in this your fathers have blasphemed me, in that they have committed a trespass against me. 
-<span class="v">28&#160;</span>For when I had brought them into the land which I swore to give to them, then they saw every high hill and every thick tree, and they offered there their sacrifices, and there they presented the provocation of their offering. There they also made their pleasant aroma, and there they poured out their drink offerings. 
-<span class="v">29&#160;</span>Then I said to them, ‘What does the high place where you go mean?’ So its name is called Bamah<span class="f">+ \fr 20:29 \ft “Bamah” means “High Place”.</span> to this day.”&#160;’ 
-</p><p>
-<span class="v">30&#160;</span>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “Do you pollute yourselves in the way of your fathers? Do you play the prostitute after their abominations? 
-<span class="v">31&#160;</span>When you offer your gifts, when you make your sons pass through the fire, do you pollute yourselves with all your idols to this day? Should I be inquired of by you, house of Israel? As I live, says the Lord Yahweh, I will not be inquired of by you! 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘&#160;“That which comes into your mind will not be at all, in that you say, ‘We will be as the nations, as the families of the countries, to serve wood and stone.’ 
-<span class="v">33&#160;</span>As I live,” says the Lord Yahweh, “surely with a mighty hand, with an outstretched arm, and with wrath poured out, I will be king over you. 
-<span class="v">34&#160;</span>I will bring you out from the peoples, and will gather you out of the countries in which you are scattered with a mighty hand, with an outstretched arm, and with wrath poured out. 
-<span class="v">35&#160;</span>I will bring you into the wilderness of the peoples, and there I will enter into judgment with you face to face. 
-<span class="v">36&#160;</span>Just as I entered into judgment with your fathers in the wilderness of the land of Egypt, so I will enter into judgment with you,” says the Lord Yahweh. 
-<span class="v">37&#160;</span>“I will cause you to pass under the rod, and I will bring you into the bond of the covenant. 
-<span class="v">38&#160;</span>I will purge out from among you the rebels and those who disobey me. I will bring them out of the land where they live, but they shall not enter into the land of Israel. Then you will know that I am Yahweh.” 
-</p><p>
-<span class="v">39&#160;</span>“&#160;‘As for you, house of Israel, the Lord Yahweh says: “Go, everyone serve his idols, and hereafter also, if you will not listen to me; but you shall no more profane my set-apart name with your gifts and with your idols. 
-<span class="v">40&#160;</span>For in my set-apart mountain, in the mountain of the height of Israel,” says the Lord Yahweh, “there all the house of Israel, all of them, shall serve me in the land. There I will accept them, and there I will require your offerings and the first fruits of your offerings, with all your set-apart things. 
-<span class="v">41&#160;</span>I will accept you as a pleasant aroma when I bring you out from the peoples and gather you out of the countries in which you have been scattered. I will be sanctified in you in the sight of the nations. 
-<span class="v">42&#160;</span>You will know that I am Yahweh when I bring you into the land of Israel, into the country which I swore to give to your fathers. 
-<span class="v">43&#160;</span>There you will remember your ways, and all your deeds in which you have polluted yourselves. Then you will loathe yourselves in your own sight for all your evils that you have committed. 
-<span class="v">44&#160;</span>You will know that I am Yahweh, when I have dealt with you for my name’s sake, not according to your evil ways, nor according to your corrupt doings, you house of Israel,” says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">45&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">46&#160;</span>“Son of man, set your face toward the south, and preach toward the south, and prophesy against the forest of the field in the south. 
-<span class="v">47&#160;</span>Tell the forest of the south, ‘Hear Yahweh’s word: The Lord Yahweh says, “Behold, I will kindle a fire in you, and it will devour every green tree in you, and every dry tree. The burning flame will not be quenched, and all faces from the south to the north will be burned by it. 
-<span class="v">48&#160;</span>All flesh will see that I, Yahweh, have kindled it. It will not be quenched.”&#160;’&#160;” 
-</p><p>
-<span class="v">49&#160;</span>Then I said, “Ah Lord Yahweh! They say of me, ‘Isn’t he a speaker of parables?’&#160;” 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, set your face toward Jerusalem, and preach toward the sanctuaries, and prophesy against the land of Israel. 
-<span class="v">3&#160;</span>Tell the land of Israel, ‘Yahweh says: “Behold, I am against you, and will draw my sword out of its sheath, and will cut off from you the righteous and the wicked. 
-<span class="v">4&#160;</span>Seeing then that I will cut off from you the righteous and the wicked, therefore my sword will go out of its sheath against all flesh from the south to the north. 
-<span class="v">5&#160;</span>All flesh will know that I, Yahweh, have drawn my sword out of its sheath. It will not return any more.”&#160;’ 
-</p><p>
-<span class="v">6&#160;</span>“Therefore sigh, you son of man. You shall sigh before their eyes with a broken heart<span class="f">+ \fr 21:6 \ft literally, the breaking of your thighs</span> and with bitterness. 
-<span class="v">7&#160;</span>It shall be, when they ask you, ‘Why do you sigh?’ that you shall say, ‘Because of the news, for it comes! Every heart will melt, all hands will be feeble, every spirit will faint, and all knees will be weak as water. Behold, it comes, and it shall be done, says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">9&#160;</span>“Son of man, prophesy, and say, ‘Yahweh says: 
-</p><p class="q1">“A sword! A sword! 
-</p><p class="q2">It is sharpened, 
-</p><p class="q2">and also polished. 
-</p><p class="q1">
-<span class="v">10&#160;</span>It is sharpened that it may make a slaughter. 
-</p><p class="q2">It is polished that it may be as lightning. 
-</p><p class="q1">Should we then make mirth? 
-</p><p class="q2">The rod of my son condemns every tree. 
-</p><p class="q1">
-<span class="v">11&#160;</span>It is given to be polished, 
-</p><p class="q2">that it may be handled. 
-</p><p class="q1">The sword is sharpened. 
-</p><p class="q2">Yes, it is polished 
-</p><p class="q2">to give it into the hand of the killer.”&#160;’ 
-</p><p class="q1">
-<span class="v">12&#160;</span>Cry and wail, son of man; 
-</p><p class="q2">for it is on my people. 
-</p><p class="q2">It is on all the princes of Israel. 
-</p><p class="q1">They are delivered over to the sword with my people. 
-</p><p class="q2">Therefore beat your thigh. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">13&#160;</span>“For there is a trial. What if even the rod that condemns will be no more?” says the Lord Yahweh. 
-</p><p class="q1">
-<span class="v">14&#160;</span>“You therefore, son of man, prophesy, 
-</p><p class="q2">and strike your hands together. 
-</p><p class="q1">Let the sword be doubled the third time, 
-</p><p class="q2">the sword of the fatally wounded. 
-</p><p class="q1">It is the sword of the great one who is fatally wounded, 
-</p><p class="q2">which enters into their rooms. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I have set the threatening sword against all their gates, 
-</p><p class="q2">that their heart may melt, 
-</p><p class="q2">and their stumblings be multiplied. 
-</p><p class="q1">Ah! It is made as lightning. 
-</p><p class="q2">It is pointed for slaughter. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Gather yourselves together. 
-</p><p class="q2">Go to the right. 
-</p><p class="q1">Set yourselves in array. 
-</p><p class="q2">Go to the left, 
-</p><p class="q2">wherever your face is set. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will also strike my hands together, 
-</p><p class="q2">and I will cause my wrath to rest. 
-</p><p class="q2">I, Yahweh, have spoken it.” 
-</p><p>
-<span class="v">18&#160;</span>Yahweh’s word came to me again, saying, 
-<span class="v">19&#160;</span>“Also, you son of man, appoint two ways, that the sword of the king of Babylon may come. They both will come out of one land, and mark out a place. Mark it out at the head of the way to the city. 
-<span class="v">20&#160;</span>You shall appoint a way for the sword to come to Rabbah of the children of Ammon, and to Judah in Jerusalem the fortified. 
-<span class="v">21&#160;</span>For the king of Babylon stood at the parting of the way, at the head of the two ways, to use divination. He shook the arrows back and forth. He consulted the teraphim.<span class="f">+ \fr 21:21 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> He looked in the liver. 
-<span class="v">22&#160;</span>In his right hand was the lot for Jerusalem, to set battering rams, to open the mouth in the slaughter, to lift up the voice with shouting, to set battering rams against the gates, to cast up mounds, and to build forts. 
-<span class="v">23&#160;</span>It will be to them as a false divination in their sight, who have sworn oaths to them; but he brings iniquity to memory, that they may be taken. 
-</p><p>
-<span class="v">24&#160;</span>“Therefore the Lord Yahweh says: ‘Because you have caused your iniquity to be remembered, in that your transgressions are uncovered, so that in all your doings your sins appear; because you have come to memory, you will be taken with the hand. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘You, deadly wounded wicked one, the prince of Israel, whose day has come, in the time of the iniquity of the end, 
-<span class="v">26&#160;</span>the Lord Yahweh says: “Remove the turban, and take off the crown. This will not be as it was. Exalt that which is low, and humble that which is high. 
-<span class="v">27&#160;</span>I will overturn, overturn, overturn it. This also will be no more, until he comes whose right it is; and I will give it.”&#160;’ 
-</p><p>
-<span class="v">28&#160;</span>“You, son of man, prophesy and say, ‘The Lord Yahweh says this concerning the children of Ammon, and concerning their reproach: 
-</p><p class="q1">“A sword! A sword is drawn! 
-</p><p class="q2">It is polished for the slaughter, 
-</p><p class="q1">to cause it to devour, 
-</p><p class="q2">that it may be as lightning; 
-</p><p class="q1">
-<span class="v">29&#160;</span>while they see for you false visions, 
-</p><p class="q2">while they divine lies to you, 
-</p><p class="q1">to lay you on the necks of the wicked who are deadly wounded, 
-</p><p class="q2">whose day has come in the time of the iniquity of the end. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Cause it to return into its sheath. 
-</p><p class="q2">In the place where you were created, 
-</p><p class="q2">in the land of your birth, I will judge you. 
-</p><p class="q1">
-<span class="v">31&#160;</span>I will pour out my indignation on you. 
-</p><p class="q2">I will blow on you with the fire of my wrath. 
-</p><p class="q1">I will deliver you into the hand of brutish men, 
-</p><p class="q2">skillful to destroy. 
-</p><p class="q1">
-<span class="v">32&#160;</span>You will be for fuel to the fire. 
-</p><p class="q2">Your blood will be in the middle of the land. 
-</p><p class="q1">You will be remembered no more; 
-</p><p class="q2">for I, Yahweh, have spoken it.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“You, son of man, will you judge? Will you judge the bloody city? Then cause her to know all her abominations. 
-<span class="v">3&#160;</span>You shall say, ‘The Lord Yahweh says: “A city that sheds blood within herself, that her time may come, and that makes idols against herself to defile her! 
-<span class="v">4&#160;</span>You have become guilty in your blood that you have shed, and are defiled in your idols which you have made! You have caused your days to draw near, and have come to the end of your years. Therefore I have made you a reproach to the nations, and a mocking to all the countries. 
-<span class="v">5&#160;</span>Those who are near and those who are far from you will mock you, you infamous one, full of tumult. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘&#160;“Behold, the princes of Israel, everyone according to his power, have been in you to shed blood. 
-<span class="v">7&#160;</span>In you have they treated father and mother with contempt.<span class="f">+ \fr 22:7 \ft Literally, \fqa made light of father and mother.</span> Among you they have oppressed the foreigner. In you they have wronged the fatherless and the widow. 
-<span class="v">8&#160;</span>You have despised my set-apart things, and have profaned my Sabbaths. 
-<span class="v">9&#160;</span>Slanderous men have been in you to shed blood. In you they have eaten on the mountains. They have committed lewdness among you. 
-<span class="v">10&#160;</span>In you have they uncovered their fathers’ nakedness. In you have they humbled her who was unclean in her impurity. 
-<span class="v">11&#160;</span>One has committed abomination with his neighbor’s woman, and another has lewdly defiled his daughter-in-law. Another in you has humbled his sister, his father’s daughter. 
-<span class="v">12&#160;</span>In you have they taken bribes to shed blood. You have taken interest and increase, and you have greedily gained of your neighbors by oppression, and have forgotten me,” says the Lord Yahweh. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘&#160;“Behold, therefore I have struck my hand at your dishonest gain which you have made, and at the blood which has been shed within you. 
-<span class="v">14&#160;</span>Can your heart endure, or can your hands be strong, in the days that I will deal with you? I, Yahweh, have spoken it, and will do it. 
-<span class="v">15&#160;</span>I will scatter you among the nations, and disperse you through the countries. I will purge your filthiness out of you. 
-<span class="v">16&#160;</span>You will be profaned in yourself in the sight of the nations. Then you will know that I am Yahweh.”&#160;’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">18&#160;</span>“Son of man, the house of Israel has become dross to me. All of them are bronze, tin, iron, and lead in the middle of the furnace. They are the dross of silver. 
-<span class="v">19&#160;</span>Therefore the Lord Yahweh says: ‘Because you have all become dross, therefore, behold, I will gather you into the middle of Jerusalem. 
-<span class="v">20&#160;</span>As they gather silver, bronze, iron, lead, and tin into the middle of the furnace, to blow the fire on it, to melt it, so I will gather you in my anger and in my wrath, and I will lay you there and melt you. 
-<span class="v">21&#160;</span>Yes, I will gather you, and blow on you with the fire of my wrath, and you will be melted in the middle of it. 
-<span class="v">22&#160;</span>As silver is melted in the middle of the furnace, so you will be melted in the middle of it; and you will know that I, Yahweh, have poured out my wrath on you.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">24&#160;</span>“Son of man, tell her, ‘You are a land that is not cleansed nor rained on in the day of indignation.’ 
-<span class="v">25&#160;</span>There is a conspiracy of her prophets within it, like a roaring lion ravening the prey. They have devoured souls. They take treasure and precious things. They have made many widows within it. 
-<span class="v">26&#160;</span>Her priests have done violence to my law and have profaned my set-apart things. They have made no distinction between the set-apart and the common, neither have they caused men to discern between the unclean and the clean, and have hidden their eyes from my Sabbaths. So I am profaned among them. 
-<span class="v">27&#160;</span>Her princes within it are like wolves ravening the prey, to shed blood and to destroy souls, that they may get dishonest gain. 
-<span class="v">28&#160;</span>Her prophets have plastered for them with whitewash, seeing false visions, and divining lies to them, saying, ‘The Lord Yahweh says,’ when Yahweh has not spoken. 
-<span class="v">29&#160;</span>The people of the land have used oppression and exercised robbery. Yes, they have troubled the poor and needy, and have oppressed the foreigner wrongfully. 
-</p><p>
-<span class="v">30&#160;</span>“I sought for a man among them who would build up the wall and stand in the gap before me for the land, that I would not destroy it; but I found no one. 
-<span class="v">31&#160;</span>Therefore I have poured out my indignation on them. I have consumed them with the fire of my wrath. I have brought their own way on their heads,” says the Lord Yahweh. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came again to me, saying, 
-<span class="v">2&#160;</span>“Son of man, there were two women, the daughters of one mother. 
-<span class="v">3&#160;</span>They played the prostitute in Egypt. They played the prostitute in their youth. Their breasts were fondled there, and their youthful nipples were caressed there. 
-<span class="v">4&#160;</span>Their names were Oholah the elder, and Oholibah her sister. They became mine, and they bore sons and daughters. As for their names, Samaria is Oholah, and Jerusalem Oholibah. 
-</p><p>
-<span class="v">5&#160;</span>“Oholah played the prostitute when she was mine. She doted on her lovers, on the Assyrians her neighbors, 
-<span class="v">6&#160;</span>who were clothed with blue—governors and rulers, all of them desirable young men, horsemen riding on horses. 
-<span class="v">7&#160;</span>She gave herself as a prostitute to them, all of them the choicest men of Assyria. She defiled herself with the idols of whoever she lusted after. 
-<span class="v">8&#160;</span>She hasn’t left her prostitution since leaving Egypt; for in her youth they lay with her. They caressed her youthful nipples and they poured out their prostitution on her. 
-</p><p>
-<span class="v">9&#160;</span>“Therefore I delivered her into the hand of her lovers, into the hand of the Assyrians on whom she doted. 
-<span class="v">10&#160;</span>These uncovered her nakedness. They took her sons and her daughters, and they killed her with the sword. She became a byword among women; for they executed judgments on her. 
-</p><p>
-<span class="v">11&#160;</span>“Her sister Oholibah saw this, yet she was more corrupt in her lusting than she, and in her prostitution which was more depraved than the prostitution of her sister. 
-<span class="v">12&#160;</span>She lusted after the Assyrians, governors and rulers—her neighbors, clothed most gorgeously, horsemen riding on horses, all of them desirable young men. 
-<span class="v">13&#160;</span>I saw that she was defiled. They both went the same way. 
-</p><p>
-<span class="v">14&#160;</span>“She increased her prostitution; for she saw men portrayed on the wall, the images of the Chaldeans portrayed with red, 
-<span class="v">15&#160;</span>dressed with belts on their waists, with flowing turbans on their heads, all of them looking like princes, after the likeness of the Babylonians in Chaldea, the land of their birth. 
-<span class="v">16&#160;</span>As soon as she saw them, she lusted after them and sent messengers to them into Chaldea. 
-<span class="v">17&#160;</span>The Babylonians came to her into the bed of love, and they defiled her with their prostitution. She was polluted with them, and her soul was alienated from them. 
-<span class="v">18&#160;</span>So she uncovered her prostitution and uncovered her nakedness. Then my soul was alienated from her, just like my soul was alienated from her sister. 
-<span class="v">19&#160;</span>Yet she multiplied her prostitution, remembering the days of her youth, in which she had played the prostitute in the land of Egypt. 
-<span class="v">20&#160;</span>She lusted after their lovers, whose flesh is as the flesh of donkeys, and whose issue is like the issue of horses. 
-<span class="v">21&#160;</span>Thus you called to memory the lewdness of your youth, in the caressing of your nipples by the Egyptians because of your youthful breasts. 
-</p><p>
-<span class="v">22&#160;</span>“Therefore, Oholibah, the Lord Yahweh says: ‘Behold, I will raise up your lovers against you, from whom your soul is alienated, and I will bring them against you on every side: 
-<span class="v">23&#160;</span>the Babylonians and all the Chaldeans, Pekod, Shoa, Koa, and all the Assyrians with them; all of them desirable young men, governors and rulers, princes and men of renown, all of them riding on horses. 
-<span class="v">24&#160;</span>They will come against you with weapons, chariots, and wagons, and with a company of peoples. They will set themselves against you with buckler, shield, and helmet all around. I will commit the judgment to them, and they will judge you according to their judgments. 
-<span class="v">25&#160;</span>I will set my jealousy against you, and they will deal with you in fury. They will take away your nose and your ears. Your remnant will fall by the sword. They will take your sons and your daughters; and the rest of you will be devoured by the fire. 
-<span class="v">26&#160;</span>They will also strip you of your clothes and take away your beautiful jewels. 
-<span class="v">27&#160;</span>Thus I will make your lewdness to cease from you, and remove your prostitution from the land of Egypt, so that you will not lift up your eyes to them, nor remember Egypt any more.’ 
-</p><p>
-<span class="v">28&#160;</span>“For the Lord Yahweh says: ‘Behold, I will deliver you into the hand of them whom you hate, into the hand of them from whom your soul is alienated. 
-<span class="v">29&#160;</span>They will deal with you in hatred, and will take away all your labor, and will leave you naked and bare. The nakedness of your prostitution will be uncovered, both your lewdness and your prostitution. 
-<span class="v">30&#160;</span>These things will be done to you because you have played the prostitute after the nations, and because you are polluted with their idols. 
-<span class="v">31&#160;</span>You have walked in the way of your sister; therefore I will give her cup into your hand.’ 
-</p><p>
-<span class="v">32&#160;</span>“The Lord Yahweh says: 
-</p><p class="q1">‘You will drink of your sister’s cup, 
-</p><p class="q2">which is deep and large. 
-</p><p class="q1">You will be ridiculed and held in derision. 
-</p><p class="q2">It contains much. 
-</p><p class="q1">
-<span class="v">33&#160;</span>You will be filled with drunkenness and sorrow, 
-</p><p class="q2">with the cup of astonishment and desolation, 
-</p><p class="q2">with the cup of your sister Samaria. 
-</p><p class="q1">
-<span class="v">34&#160;</span>You will even drink it and drain it out. 
-</p><p class="q2">You will gnaw the broken pieces of it, 
-</p><p class="q2">and will tear your breasts; 
-</p><p class="m">for I have spoken it,’ says the Lord Yahweh. 
-</p><p>
-<span class="v">35&#160;</span>“Therefore the Lord Yahweh says: ‘Because you have forgotten me and cast me behind your back, therefore you also bear your lewdness and your prostitution.’&#160;” 
-</p><p>
-<span class="v">36&#160;</span>Yahweh said moreover to me: “Son of man, will you judge Oholah and Oholibah? Then declare to them their abominations. 
-<span class="v">37&#160;</span>For they have committed adultery, and blood is in their hands. They have committed adultery with their idols. They have also caused their sons, whom they bore to me, to pass through the fire to them to be devoured. 
-<span class="v">38&#160;</span>Moreover this they have done to me: they have defiled my sanctuary in the same day, and have profaned my Sabbaths. 
-<span class="v">39&#160;</span>For when they had slain their children to their idols, then they came the same day into my sanctuary to profane it; and behold, they have done this in the middle of my house. 
-</p><p>
-<span class="v">40&#160;</span>“Furthermore you sisters have sent for men who come from far away, to whom a messenger was sent, and behold, they came; for whom you washed yourself, painted your eyes, decorated yourself with ornaments, 
-<span class="v">41&#160;</span>and sat on a stately bed, with a table prepared before it, whereupon you set my incense and my oil. 
-</p><p>
-<span class="v">42&#160;</span>“The voice of a multitude being at ease was with her. With men of the common sort were brought drunkards from the wilderness; and they put bracelets on their hands, and beautiful crowns on their heads. 
-<span class="v">43&#160;</span>Then I said of her who was old in adulteries, ‘Now they will play the prostitute with her, and she with them.’ 
-<span class="v">44&#160;</span>They went in to her, as they go in to a prostitute. So they went in to Oholah and to Oholibah, the lewd women. 
-<span class="v">45&#160;</span>Righteous men will judge them with the judgment of adulteresses and with the judgment of women who shed blood, because they are adulteresses, and blood is in their hands. 
-</p><p>
-<span class="v">46&#160;</span>“For the Lord Yahweh says: ‘I will bring up a mob against them, and will give them to be tossed back and forth and robbed. 
-<span class="v">47&#160;</span>The company will stone them with stones and dispatch them with their swords. They will kill their sons and their daughters, and burn up their houses with fire. 
-</p><p>
-<span class="v">48&#160;</span>“&#160;‘Thus I will cause lewdness to cease out of the land, that all women may be taught not to be lewd like you. 
-<span class="v">49&#160;</span>They will recompense your lewdness on you, and you will bear the sins of your idols. Then you will know that I am the Lord Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Again, in the ninth year, in the tenth month, in the tenth day of the month, Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, write the name of the day, this same day. The king of Babylon drew close to Jerusalem this same day. 
-<span class="v">3&#160;</span>Utter a parable to the rebellious house, and tell them, ‘The Lord Yahweh says, 
-</p><p class="q1">“Put the cauldron on the fire. 
-</p><p class="q2">Put it on, 
-</p><p class="q2">and also pour water into it. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Gather its pieces into it, 
-</p><p class="q2">even every good piece: 
-</p><p class="q2">the thigh and the shoulder. 
-</p><p class="q2">Fill it with the choice bones. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Take the choice of the flock, 
-</p><p class="q2">and also a pile of wood for the bones under the cauldron. 
-</p><p class="q1">Make it boil well. 
-</p><p class="q2">Yes, let its bones be boiled within it.” 
-</p><p class="m">
-<span class="v">6&#160;</span>“&#160;‘Therefore the Lord Yahweh says: 
-</p><p class="q1">“Woe to the bloody city, 
-</p><p class="q2">to the cauldron whose rust is in it, 
-</p><p class="q2">and whose rust hasn’t gone out of it! 
-</p><p class="q1">Take out of it piece after piece 
-</p><p class="q2">without casting lots for it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“&#160;‘&#160;“For the blood she shed is in the middle of her. 
-</p><p class="q2">She set it on the bare rock. 
-</p><p class="q1">She didn’t pour it on the ground, 
-</p><p class="q2">to cover it with dust. 
-</p><p class="q1">
-<span class="v">8&#160;</span>That it may cause wrath to come up to take vengeance, 
-</p><p class="q2">I have set her blood on the bare rock, 
-</p><p class="q2">that it should not be covered.” 
-</p><p class="m">
-<span class="v">9&#160;</span>“&#160;‘Therefore the Lord Yahweh says: 
-</p><p class="q1">“Woe to the bloody city! 
-</p><p class="q2">I also will make the pile great. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Heap on the wood. 
-</p><p class="q2">Make the fire hot. 
-</p><p class="q1">Boil the meat well. 
-</p><p class="q2">Make the broth thick, 
-</p><p class="q2">and let the bones be burned. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Then set it empty on its coals, 
-</p><p class="q2">that it may be hot, 
-</p><p class="q1">and its bronze may burn, 
-</p><p class="q2">and that its filthiness may be molten in it, 
-</p><p class="q2">that its rust may be consumed. 
-</p><p class="q1">
-<span class="v">12&#160;</span>She is weary with toil; 
-</p><p class="q2">yet her great rust, 
-</p><p class="q2">rust by fire, doesn’t leave her. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘&#160;“In your filthiness is lewdness. Because I have cleansed you and you weren’t cleansed, you won’t be cleansed from your filthiness any more, until I have caused my wrath toward you to rest. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘&#160;“I, Yahweh, have spoken it. It will happen, and I will do it. I won’t go back. I won’t spare. I won’t repent. According to your ways and according to your doings, they will judge you,” says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">15&#160;</span>Also Yahweh’s word came to me, saying, 
-<span class="v">16&#160;</span>“Son of man, behold, I will take away from you the desire of your eyes with one stroke; yet you shall neither mourn nor weep, neither shall your tears run down. 
-<span class="v">17&#160;</span>Sigh, but not aloud. Make no mourning for the dead. Bind your headdress on you, and put your sandals on your feet. Don’t cover your lips, and don’t eat mourner’s bread.” 
-</p><p>
-<span class="v">18&#160;</span>So I spoke to the people in the morning, and at evening my woman died. So I did in the morning as I was commanded. 
-</p><p>
-<span class="v">19&#160;</span>The people asked me, “Won’t you tell us what these things mean to us, that you act like this?” 
-</p><p>
-<span class="v">20&#160;</span>Then I said to them, “Yahweh’s word came to me, saying, 
-<span class="v">21&#160;</span>‘Speak to the house of Israel, “The Lord Yahweh says: ‘Behold, I will profane my sanctuary, the pride of your power, the desire of your eyes, and that which your soul pities; and your sons and your daughters whom you have left behind will fall by the sword. 
-<span class="v">22&#160;</span>You will do as I have done. You won’t cover your lips or eat mourner’s bread. 
-<span class="v">23&#160;</span>Your turbans will be on your heads, and your sandals on your feet. You won’t mourn or weep; but you will pine away in your iniquities, and moan one toward another. 
-<span class="v">24&#160;</span>Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord Yahweh.’&#160;”&#160;’&#160;” 
-</p><p>
-<span class="v">25&#160;</span>“You, son of man, shouldn’t it be in the day when I take from them their strength, the joy of their glory, the desire of their eyes, and that whereupon they set their heart—their sons and their daughters—<span class="v">26&#160;</span>that in that day he who escapes will come to you, to cause you to hear it with your ears? 
-<span class="v">27&#160;</span>In that day your mouth will be opened to him who has escaped, and you will speak and be no more mute. So you will be a sign to them. Then they will know that I am Yahweh.” 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, set your face toward the children of Ammon, and prophesy against them. 
-<span class="v">3&#160;</span>Tell the children of Ammon, ‘Hear the word of the Lord Yahweh! The Lord Yahweh says, “Because you said, ‘Aha!’ against my sanctuary when it was profaned, and against the land of Israel when it was made desolate, and against the house of Judah when they went into captivity, 
-<span class="v">4&#160;</span>therefore, behold, I will deliver you to the children of the east for a possession. They will set their encampments in you and make their dwellings in you. They will eat your fruit and they will drink your milk. 
-<span class="v">5&#160;</span>I will make Rabbah a stable for camels and the children of Ammon a resting place for flocks. Then you will know that I am Yahweh.” 
-<span class="v">6&#160;</span>For the Lord Yahweh says: “Because you have clapped your hands, stamped with the feet, and rejoiced with all the contempt of your soul against the land of Israel, 
-<span class="v">7&#160;</span>therefore, behold, I have stretched out my hand on you, and will deliver you for a plunder to the nations. I will cut you off from the peoples, and I will cause you to perish out of the countries. I will destroy you. Then you will know that I am Yahweh.” 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘The Lord Yahweh says: “Because Moab and Seir say, ‘Behold, the house of Judah is like all the nations,’ 
-<span class="v">9&#160;</span>therefore, behold, I will open the side of Moab from the cities, from his cities which are on its frontiers, the glory of the country, Beth Jeshimoth, Baal Meon, and Kiriathaim, 
-<span class="v">10&#160;</span>to the children of the east, to go against the children of Ammon; and I will give them for a possession, that the children of Ammon may not be remembered among the nations. 
-<span class="v">11&#160;</span>I will execute judgments on Moab. Then they will know that I am Yahweh.” 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘The Lord Yahweh says: “Because Edom has dealt against the house of Judah by taking vengeance, and has greatly offended, and taken revenge on them,” 
-<span class="v">13&#160;</span>therefore the Lord Yahweh says, “I will stretch out my hand on Edom, and will cut off man and animal from it; and I will make it desolate from Teman. They will fall by the sword even to Dedan. 
-<span class="v">14&#160;</span>I will lay my vengeance on Edom by the hand of my people Israel. They will do in Edom according to my anger and according to my wrath. Then they will know my vengeance,” says the Lord Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘The Lord Yahweh says: “Because the Philistines have taken revenge, and have taken vengeance with contempt of soul to destroy with perpetual hostility,” 
-<span class="v">16&#160;</span>therefore the Lord Yahweh says, “Behold, I will stretch out my hand on the Philistines, and I will cut off the Cherethites, and destroy the remnant of the sea coast. 
-<span class="v">17&#160;</span>I will execute great vengeance on them with wrathful rebukes. Then they will know that I am Yahweh, when I lay my vengeance on them.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>In the eleventh year, in the first of the month, Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, because Tyre has said against Jerusalem, ‘Aha! She is broken! She who was the gateway of the peoples has been returned to me. I will be replenished, now that she is laid waste;’ 
-<span class="v">3&#160;</span>therefore the Lord Yahweh says, ‘Behold, I am against you, Tyre, and will cause many nations to come up against you, as the sea causes its waves to come up. 
-<span class="v">4&#160;</span>They will destroy the walls of Tyre, and break down her towers. I will also scrape her dust from her, and make her a bare rock. 
-<span class="v">5&#160;</span>She will be a place for the spreading of nets in the middle of the sea; for I have spoken it,’ says the Lord Yahweh. ‘She will become plunder for the nations. 
-<span class="v">6&#160;</span>Her daughters who are in the field will be slain with the sword. Then they will know that I am Yahweh.’ 
-</p><p>
-<span class="v">7&#160;</span>“For the Lord Yahweh says: ‘Behold, I will bring on Tyre Nebuchadnezzar king of Babylon, king of kings, from the north, with horses, with chariots, with horsemen, and an army with many people. 
-<span class="v">8&#160;</span>He will kill your daughters in the field with the sword. He will make forts against you, cast up a mound against you, and raise up the buckler against you. 
-<span class="v">9&#160;</span>He will set his battering engines against your walls, and with his axes he will break down your towers. 
-<span class="v">10&#160;</span>By reason of the abundance of his horses, their dust will cover you. Your walls will shake at the noise of the horsemen, of the wagons, and of the chariots, when he enters into your gates, as men enter into a city which is broken open. 
-<span class="v">11&#160;</span>He will tread down all your streets with the hoofs of his horses. He will kill your people with the sword. The pillars of your strength will go down to the ground. 
-<span class="v">12&#160;</span>They will make a plunder of your riches and make a prey of your merchandise. They will break down your walls and destroy your pleasant houses. They will lay your stones, your timber, and your dust in the middle of the waters. 
-<span class="v">13&#160;</span>I will cause the noise of your songs to cease. The sound of your harps won’t be heard any more. 
-<span class="v">14&#160;</span>I will make you a bare rock. You will be a place for the spreading of nets. You will be built no more; for I Yahweh have spoken it,’ says the Lord Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>“The Lord Yahweh says to Tyre: ‘Won’t the islands shake at the sound of your fall, when the wounded groan, when the slaughter is made within you? 
-<span class="v">16&#160;</span>Then all the princes of the sea will come down from their thrones, and lay aside their robes, and strip off their embroidered garments. They will clothe themselves with trembling. They will sit on the ground, and will tremble every moment, and be astonished at you. 
-<span class="v">17&#160;</span>They will take up a lamentation over you, and tell you, 
-</p><p class="q1">“How you are destroyed, 
-</p><p class="q2">who were inhabited by seafaring men, 
-</p><p class="q1">the renowned city, 
-</p><p class="q2">who was strong in the sea, 
-</p><p class="q1">she and her inhabitants, 
-</p><p class="q2">who caused their terror to be on all who lived there!” 
-</p><p class="q1">
-<span class="v">18&#160;</span>Now the islands will tremble in the day of your fall. 
-</p><p class="q2">Yes, the islands that are in the sea will be dismayed at your departure.’ 
-</p><p>
-<span class="v">19&#160;</span>“For the Lord Yahweh says: ‘When I make you a desolate city, like the cities that are not inhabited, when I bring up the deep on you, and the great waters cover you, 
-<span class="v">20&#160;</span>then I will bring you down with those who descend into the pit, to the people of old time, and will make you dwell in the lower parts of the earth, in the places that are desolate of old, with those who go down to the pit, that you be not inhabited; and I will set glory in the land of the living. 
-<span class="v">21&#160;</span>I will make you a terror, and you will no more have any being. Though you are sought for, yet you will never be found again,’ says the Lord Yahweh.” 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came again to me, saying, 
-<span class="v">2&#160;</span>“You, son of man, take up a lamentation over Tyre; 
-<span class="v">3&#160;</span>and tell Tyre, ‘You who dwell at the entry of the sea, who are the merchant of the peoples to many islands, the Lord Yahweh says: 
-</p><p class="q1">“You, Tyre, have said, 
-</p><p class="q2">‘I am perfect in beauty.’ 
-</p><p class="q1">
-<span class="v">4&#160;</span>Your borders are in the heart of the seas. 
-</p><p class="q2">Your builders have perfected your beauty. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They have made all your planks of cypress trees from Senir. 
-</p><p class="q2">They have taken a cedar from Lebanon to make a mast for you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>They have made your oars of the oaks of Bashan. 
-</p><p class="q2">They have made your benches of ivory inlaid in cypress wood from the islands of Kittim. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Your sail was of fine linen with embroidered work from Egypt, 
-</p><p class="q2">that it might be to you for a banner. 
-</p><p class="q2">Blue and purple from the islands of Elishah was your awning. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The inhabitants of Sidon and Arvad were your rowers. 
-</p><p class="q2">Your wise men, Tyre, were in you. 
-</p><p class="q2">They were your pilots. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The old men of Gebal 
-</p><p class="q2">and its wise men were your repairers of ship seams in you. 
-</p><p class="q1">All the ships of the sea with their mariners were in you 
-</p><p class="q2">to deal in your merchandise. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“&#160;‘&#160;“Persia, Lud, and Put were in your army, 
-</p><p class="q2">your men of war. 
-</p><p class="q1">They hung the shield and helmet in you. 
-</p><p class="q2">They showed your beauty. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The men of Arvad with your army were on your walls all around, 
-</p><p class="q2">and valiant men were in your towers. 
-</p><p class="q1">They hung their shields on your walls all around. 
-</p><p class="q2">They have perfected your beauty. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘&#160;“Tarshish was your merchant by reason of the multitude of all kinds of riches. They traded for your wares with silver, iron, tin, and lead. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘&#160;“Javan, Tubal, and Meshech were your traders. They traded the persons of men and vessels of bronze for your merchandise. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘&#160;“They of the house of Togarmah traded for your wares with horses, war horses, and mules. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘&#160;“The men of Dedan traded with you. Many islands were the market of your hand. They brought you horns of ivory and ebony in exchange. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘&#160;“Syria was your merchant by reason of the multitude of your handiworks. They traded for your wares with emeralds, purple, embroidered work, fine linen, coral, and rubies. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘&#160;“Judah and the land of Israel were your traders. They traded wheat of Minnith, confections, honey, oil, and balm for your merchandise. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘&#160;“Damascus was your merchant for the multitude of your handiworks by reason of the multitude of all kinds of riches, with the wine of Helbon, and white wool. 
-</p><p>
-<span class="v">19&#160;</span>“&#160;‘&#160;“Vedan and Javan traded with yarn for your wares; wrought iron, cassia, and calamus were among your merchandise. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘&#160;“Dedan was your merchant in precious saddle blankets for riding. 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘&#160;“Arabia and all the princes of Kedar were your favorite dealers in lambs, rams, and goats. In these, they were your merchants. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘&#160;“The traders of Sheba and Raamah were your traders. They traded for your wares with the best of all spices, all precious stones, and gold. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘&#160;“Haran, Canneh, Eden, the traders of Sheba, Asshur and Chilmad, were your traders. 
-<span class="v">24&#160;</span>These were your traders in choice wares, in wrappings of blue and embroidered work, and in cedar chests of rich clothing bound with cords, among your merchandise. 
-</p><p class="q1">
-<span class="v">25&#160;</span>“&#160;‘&#160;“The ships of Tarshish were your caravans for your merchandise. 
-</p><p class="q2">You were replenished 
-</p><p class="q2">and made very glorious in the heart of the seas. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Your rowers have brought you into great waters. 
-</p><p class="q2">The east wind has broken you in the heart of the seas. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Your riches, your wares, your merchandise, 
-</p><p class="q2">your mariners, your pilots, your repairers of ship seams, 
-</p><p class="q1">the dealers in your merchandise, 
-</p><p class="q2">and all your men of war who are in you, 
-</p><p class="q1">with all your company which is among you, 
-</p><p class="q2">will fall into the heart of the seas in the day of your ruin. 
-</p><p class="q1">
-<span class="v">28&#160;</span>At the sound of the cry of your pilots, 
-</p><p class="q2">the pasture lands will shake. 
-</p><p class="q1">
-<span class="v">29&#160;</span>All who handle the oars, 
-</p><p class="q2">the mariners and all the pilots of the sea, 
-</p><p class="q2">will come down from their ships. 
-</p><p class="q1">They will stand on the land, 
-</p><p class="q2">
-<span class="v">30&#160;</span>and will cause their voice to be heard over you, 
-</p><p class="q2">and will cry bitterly. 
-</p><p class="q1">They will cast up dust on their heads. 
-</p><p class="q2">They will wallow in the ashes. 
-</p><p class="q1">
-<span class="v">31&#160;</span>They will make themselves bald for you, 
-</p><p class="q2">and clothe themselves with sackcloth. 
-</p><p class="q1">They will weep for you in bitterness of soul, 
-</p><p class="q2">with bitter mourning. 
-</p><p class="q1">
-<span class="v">32&#160;</span>In their wailing they will take up a lamentation for you, 
-</p><p class="q2">and lament over you, saying, 
-</p><p class="q1">‘Who is there like Tyre, 
-</p><p class="q2">like her who is brought to silence in the middle of the sea?’ 
-</p><p class="q1">
-<span class="v">33&#160;</span>When your wares came from the seas, 
-</p><p class="q2">you filled many peoples. 
-</p><p class="q1">You enriched the kings of the earth 
-</p><p class="q2">with the multitude of your riches and of your merchandise. 
-</p><p class="q1">
-<span class="v">34&#160;</span>In the time that you were broken by the seas, 
-</p><p class="q2">in the depths of the waters, 
-</p><p class="q2">your merchandise and all your company fell within you. 
-</p><p class="q1">
-<span class="v">35&#160;</span>All the inhabitants of the islands are astonished at you, 
-</p><p class="q2">and their kings are horribly afraid. 
-</p><p class="q2">They are troubled in their face. 
-</p><p class="q1">
-<span class="v">36&#160;</span>The merchants among the peoples hiss at you. 
-</p><p class="q2">You have come to a terrible end, 
-</p><p class="q2">and you will be no more.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came again to me, saying, 
-<span class="v">2&#160;</span>“Son of man, tell the prince of Tyre, ‘The Lord Yahweh says: 
-</p><p class="q1">“Because your heart is lifted up, 
-</p><p class="q2">and you have said, ‘I am an elohim, 
-</p><p class="q1">I sit in the seat of Elohim, 
-</p><p class="q2">in the middle of the seas;’ 
-</p><p class="q1">yet you are man, 
-</p><p class="q2">and no elohim, 
-</p><p class="q2">though you set your heart as the heart of an elohim—</p><p class="q1">
-<span class="v">3&#160;</span>behold, you are wiser than Daniel. 
-</p><p class="q2">There is no secret that is hidden from you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>By your wisdom and by your understanding you have gotten yourself riches, 
-</p><p class="q2">and have gotten gold and silver into your treasuries. 
-</p><p class="q1">
-<span class="v">5&#160;</span>By your great wisdom 
-</p><p class="q2">and by your trading you have increased your riches, 
-</p><p class="q2">and your heart is lifted up because of your riches—” 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘therefore the Lord Yahweh says: 
-</p><p class="q1">“Because you have set your heart as the heart of Elohim, 
-</p><p class="q2">
-<span class="v">7&#160;</span>therefore, behold, I will bring strangers on you, 
-</p><p class="q2">the terrible of the nations. 
-</p><p class="q1">They will draw their swords against the beauty of your wisdom. 
-</p><p class="q2">They will defile your brightness. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They will bring you down to the pit. 
-</p><p class="q2">You will die the death of those who are slain 
-</p><p class="q2">in the heart of the seas. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Will you yet say before him who kills you, ‘I am Elohim’? 
-</p><p class="q2">But you are man, and not Elohim, 
-</p><p class="q2">in the hand of him who wounds you. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You will die the death of the uncircumcised 
-</p><p class="q2">by the hand of strangers; 
-</p><p class="q2">for I have spoken it,” says the Lord Yahweh.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">11&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">12&#160;</span>“Son of man, take up a lamentation over the king of Tyre, and tell him, ‘The Lord Yahweh says: 
-</p><p class="q1">“You were the seal of full measure, 
-</p><p class="q2">full of wisdom, 
-</p><p class="q2">and perfect in beauty. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You were in Eden, 
-</p><p class="q2">the garden of Elohim. 
-</p><p class="q1">Every precious stone adorned you: 
-</p><p class="q2">ruby, topaz, emerald, 
-</p><p class="q2">chrysolite, onyx, jasper, 
-</p><p class="q2">sapphire,<span class="f">+ \fr 28:13 \ft or, lapis lazuli </span> turquoise, and beryl. 
-</p><p class="q1">Gold work of tambourines 
-</p><p class="q2">and of pipes was in you. 
-</p><p class="q2">They were prepared in the day that you were created. 
-</p><p class="q1">
-<span class="v">14&#160;</span>You were the anointed cherub who covers. 
-</p><p class="q2">Then I set you up on the set-apart mountain of Elohim. 
-</p><p class="q2">You have walked up and down in the middle of the stones of fire. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You were perfect in your ways from the day that you were created, 
-</p><p class="q2">until unrighteousness was found in you. 
-</p><p class="q1">
-<span class="v">16&#160;</span>By the abundance of your commerce, your insides were filled with violence, 
-</p><p class="q2">and you have sinned. 
-</p><p class="q1">Therefore I have cast you as profane out of Elohim’s mountain. 
-</p><p class="q2">I have destroyed you, covering cherub, 
-</p><p class="q2">from the middle of the stones of fire. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Your heart was lifted up because of your beauty. 
-</p><p class="q2">You have corrupted your wisdom by reason of your splendor. 
-</p><p class="q1">I have cast you to the ground. 
-</p><p class="q2">I have laid you before kings, 
-</p><p class="q2">that they may see you. 
-</p><p class="q1">
-<span class="v">18&#160;</span>By the multitude of your iniquities, 
-</p><p class="q2">in the unrighteousness of your commerce, 
-</p><p class="q2">you have profaned your sanctuaries. 
-</p><p class="q1">Therefore I have brought out a fire from the middle of you. 
-</p><p class="q2">It has devoured you. 
-</p><p class="q1">I have turned you to ashes on the earth 
-</p><p class="q2">in the sight of all those who see you. 
-</p><p class="q1">
-<span class="v">19&#160;</span>All those who know you among the peoples will be astonished at you. 
-</p><p class="q2">You have become a terror, 
-</p><p class="q2">and you will exist no more.”&#160;’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">20&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">21&#160;</span>“Son of man, set your face toward Sidon, and prophesy against it, 
-<span class="v">22&#160;</span>and say, ‘The Lord Yahweh says: 
-</p><p class="q1">“Behold, I am against you, Sidon. 
-</p><p class="q2">I will be glorified among you. 
-</p><p class="q1">Then they will know that I am Yahweh, 
-</p><p class="q2">when I have executed judgments in her, 
-</p><p class="q2">and am sanctified in her. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For I will send pestilence into her, 
-</p><p class="q2">and blood into her streets. 
-</p><p class="q1">The wounded will fall within her, 
-</p><p class="q2">with the sword on her on every side. 
-</p><p class="q2">Then they will know that I am Yahweh. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘&#160;“There will no longer be a pricking brier to the house of Israel, nor a hurting thorn of any that are around them that scorned them. Then they will know that I am the Lord Yahweh.” 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘The Lord Yahweh says: “When I have gathered the house of Israel from the peoples among whom they are scattered, and am shown as set-apart among them in the sight of the nations, then they will dwell in their own land which I gave to my servant Jacob. 
-<span class="v">26&#160;</span>They will dwell in it securely. Yes, they will build houses, plant vineyards, and will dwell securely when I have executed judgments on all those around them who have treated them with contempt. Then they will know that I am Yahweh their Elohim.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>In the tenth year, in the tenth month, on the twelfth day of the month, Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, set your face against Pharaoh king of Egypt, and prophesy against him and against all Egypt. 
-<span class="v">3&#160;</span>Speak and say, ‘The Lord Yahweh says: 
-</p><p class="q1">“Behold, I am against you, Pharaoh king of Egypt, 
-</p><p class="q2">the great monster that lies in the middle of his rivers, 
-</p><p class="q1">that has said, ‘My river is my own, 
-</p><p class="q2">and I have made it for myself.’ 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will put hooks in your jaws, 
-</p><p class="q2">and I will make the fish of your rivers stick to your scales. 
-</p><p class="q1">I will bring you up out of the middle of your rivers, 
-</p><p class="q2">with all the fish of your rivers which stick to your scales. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I’ll cast you out into the wilderness, 
-</p><p class="q2">you and all the fish of your rivers. 
-</p><p class="q1">You’ll fall on the open field. 
-</p><p class="q2">You won’t be brought together or gathered. 
-</p><p class="q1">I have given you for food to the animals of the earth 
-</p><p class="q2">and to the birds of the sky. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘&#160;“All the inhabitants of Egypt will know that I am Yahweh, because they have been a staff of reed to the house of Israel. 
-<span class="v">7&#160;</span>When they took hold of you by your hand, you broke and tore all their shoulders. When they leaned on you, you broke and paralyzed all of their thighs.” 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘Therefore the Lord Yahweh says: “Behold, I will bring a sword on you, and will cut off man and animal from you. 
-<span class="v">9&#160;</span>The land of Egypt will be a desolation and a waste. Then they will know that I am Yahweh. 
-</p><p>“&#160;‘&#160;“Because he has said, ‘The river is mine, and I have made it,’ 
-<span class="v">10&#160;</span>therefore, behold, I am against you and against your rivers. I will make the land of Egypt an utter waste and desolation, from the tower of Seveneh even to the border of Ethiopia. 
-<span class="v">11&#160;</span>No foot of man will pass through it, nor will any animal foot pass through it. It won’t be inhabited for forty years. 
-<span class="v">12&#160;</span>I will make the land of Egypt a desolation in the middle of the countries that are desolate. Her cities among the cities that are laid waste will be a desolation forty years. I will scatter the Egyptians among the nations, and will disperse them through the countries.” 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘For the Lord Yahweh says: “At the end of forty years I will gather the Egyptians from the peoples where they were scattered. 
-<span class="v">14&#160;</span>I will reverse the captivity of Egypt, and will cause them to return into the land of Pathros, into the land of their birth. There they will be a lowly kingdom. 
-<span class="v">15&#160;</span>It will be the lowest of the kingdoms. It won’t lift itself up above the nations any more. I will diminish them so that they will no longer rule over the nations. 
-<span class="v">16&#160;</span>It will no longer be the confidence of the house of Israel, bringing iniquity to memory, when they turn to look after them. Then they will know that I am the Lord Yahweh.”&#160;’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">17&#160;</span>It came to pass in the twenty-seventh year, in the first month, in the first day of the month, Yahweh’s word came to me, saying, 
-<span class="v">18&#160;</span>“Son of man, Nebuchadnezzar king of Babylon caused his army to serve a great service against Tyre. Every head was made bald, and every shoulder was worn; yet he had no wages, nor did his army, from Tyre, for the service that he had served against it. 
-<span class="v">19&#160;</span>Therefore the Lord Yahweh says: ‘Behold, I will give the land of Egypt to Nebuchadnezzar king of Babylon. He will carry off her multitude, take her plunder, and take her prey. That will be the wages for his army. 
-<span class="v">20&#160;</span>I have given him the land of Egypt as his payment for which he served, because they worked for me,’ says the Lord Yahweh. 
-</p><p>
-<span class="v">21&#160;</span>“In that day I will cause a horn to sprout for the house of Israel, and I will open your mouth among them. Then they will know that I am Yahweh.” 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came again to me, saying, 
-<span class="v">2&#160;</span>“Son of man, prophesy, and say, ‘The Lord Yahweh says: 
-</p><p class="q1">“Wail, ‘Alas for the day!’ 
-</p><p class="q2">
-<span class="v">3&#160;</span>For the day is near, 
-</p><p class="q2">even Yahweh’s day is near. 
-</p><p class="q1">It will be a day of clouds, 
-</p><p class="q2">a time of the nations. 
-</p><p class="q1">
-<span class="v">4&#160;</span>A sword will come on Egypt, 
-</p><p class="q2">and anguish will be in Ethiopia, 
-</p><p class="q2">when the slain fall in Egypt. 
-</p><p class="q1">They take away her multitude, 
-</p><p class="q2">and her foundations are broken down. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘&#160;“Ethiopia, Put, Lud, all the mixed people, Cub, and the children of the land that is allied with them, will fall with them by the sword.” 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘Yahweh says: 
-</p><p class="q1">“They also who uphold Egypt will fall. 
-</p><p class="q2">The pride of her power will come down. 
-</p><p class="q1">They will fall by the sword in it from the tower of Seveneh,” 
-</p><p class="q2">says the Lord Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>“They will be desolate in the middle of the countries that are desolate. 
-</p><p class="q2">Her cities will be among the cities that are wasted. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They will know that I am Yahweh 
-</p><p class="q2">when I have set a fire in Egypt, 
-</p><p class="q2">and all her helpers are destroyed. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘&#160;“In that day messengers will go out from before me in ships to make the careless Ethiopians afraid. There will be anguish on them, as in the day of Egypt; for, behold, it comes.” 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘The Lord Yahweh says: 
-</p><p class="q1">“I will also make the multitude of Egypt to cease, 
-</p><p class="q2">by the hand of Nebuchadnezzar king of Babylon. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He and his people with him, 
-</p><p class="q2">the terrible of the nations, 
-</p><p class="q1">will be brought in to destroy the land. 
-</p><p class="q2">They will draw their swords against Egypt, 
-</p><p class="q2">and fill the land with the slain. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will make the rivers dry, 
-</p><p class="q2">and will sell the land into the hand of evil men. 
-</p><p class="q1">I will make the land desolate, 
-</p><p class="q2">and all that is therein, 
-</p><p class="q2">by the hand of foreigners. 
-</p><p class="q2">I, Yahweh, have spoken it.” 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘The Lord Yahweh says: 
-</p><p class="q1">“I will also destroy the idols, 
-</p><p class="q2">and I will cause the images to cease from Memphis. 
-</p><p class="q1">There will be no more a prince from the land of Egypt. 
-</p><p class="q2">I will put a fear in the land of Egypt. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will make Pathros desolate, 
-</p><p class="q2">and will set a fire in Zoan, 
-</p><p class="q2">and will execute judgments on No. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will pour my wrath on Sin, 
-</p><p class="q2">the stronghold of Egypt. 
-</p><p class="q2">I will cut off the multitude of No. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will set a fire in Egypt 
-</p><p class="q2">Sin will be in great anguish. 
-</p><p class="q1">No will be broken up. 
-</p><p class="q2">Memphis will have adversaries in the daytime. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The young men of Aven and of Pibeseth will fall by the sword. 
-</p><p class="q2">They will go into captivity. 
-</p><p class="q1">
-<span class="v">18&#160;</span>At Tehaphnehes also the day will withdraw itself, 
-</p><p class="q2">when I break the yokes of Egypt there. 
-</p><p class="q1">The pride of her power will cease in her. 
-</p><p class="q2">As for her, a cloud will cover her, 
-</p><p class="q2">and her daughters will go into captivity. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Thus I will execute judgments on Egypt. 
-</p><p class="q2">Then they will know that I am Yahweh.”&#160;’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">20&#160;</span>In the eleventh year, in the first month, in the seventh day of the month, Yahweh’s word came to me, saying, 
-<span class="v">21&#160;</span>“Son of man, I have broken the arm of Pharaoh king of Egypt. Behold, it has not been bound up, to apply medicines, to put a bandage to bind it, that it may become strong to hold the sword. 
-<span class="v">22&#160;</span>Therefore the Lord Yahweh says: ‘Behold, I am against Pharaoh king of Egypt, and will break his arms, the strong arm, and that which was broken. I will cause the sword to fall out of his hand. 
-<span class="v">23&#160;</span>I will scatter the Egyptians among the nations, and will disperse them through the countries. 
-<span class="v">24&#160;</span>I will strengthen the arms of the king of Babylon, and put my sword in his hand; but I will break the arms of Pharaoh, and he will groan before the king of Babylon with the groaning of a mortally wounded man. 
-<span class="v">25&#160;</span>I will hold up the arms of the king of Babylon, but the arms of Pharaoh will fall down. Then they will know that I am Yahweh when I put my sword into the hand of the king of Babylon, and he stretches it out on the land of Egypt. 
-<span class="v">26&#160;</span>I will scatter the Egyptians among the nations and disperse them through the countries. Then they will know that I am Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>In the eleventh year, in the third month, in the first day of the month, Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, tell Pharaoh king of Egypt and his multitude: 
-</p><p class="q1">‘Whom are you like in your greatness? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Behold, the Assyrian was a cedar in Lebanon 
-</p><p class="q2">with beautiful branches, 
-</p><p class="q1">and with a forest-like shade, 
-</p><p class="q2">of high stature; 
-</p><p class="q2">and its top was among the thick boughs. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The waters nourished it. 
-</p><p class="q2">The deep made it to grow. 
-</p><p class="q1">Its rivers ran all around its plantation. 
-</p><p class="q2">It sent out its channels to all the trees of the field. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Therefore its stature was exalted above all the trees of the field; 
-</p><p class="q2">and its boughs were multiplied. 
-</p><p class="q1">Its branches became long by reason of many waters, 
-</p><p class="q2">when it spread them out. 
-</p><p class="q1">
-<span class="v">6&#160;</span>All the birds of the sky made their nests in its boughs. 
-</p><p class="q2">Under its branches, all the animals of the field gave birth to their young. 
-</p><p class="q2">All great nations lived under its shadow. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Thus it was beautiful in its greatness, 
-</p><p class="q2">in the length of its branches; 
-</p><p class="q2">for its root was by many waters. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The cedars in the garden of Elohim could not hide it. 
-</p><p class="q2">The cypress trees were not like its branches. 
-</p><p class="q1">The pine trees were not like its branches; 
-</p><p class="q2">nor was any tree in the garden of Elohim like it in its beauty. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I made it beautiful by the multitude of its branches, 
-</p><p class="q2">so that all the trees of Eden, 
-</p><p class="q2">that were in the garden of Elohim, envied it.’ 
-</p><p>
-<span class="v">10&#160;</span>“Therefore thus said the Lord Yahweh: ‘Because he is exalted in stature, and he has set his top among the thick branches, and his heart is lifted up in his height, 
-<span class="v">11&#160;</span>I will deliver him into the hand of the mighty one of the nations. He will surely deal with him. I have driven him out for his wickedness. 
-<span class="v">12&#160;</span>Foreigners, the tyrants of the nations, have cut him off and have left him. His branches have fallen on the mountains and in all the valleys, and his boughs are broken by all the watercourses of the land. All the peoples of the earth have gone down from his shadow and have left him. 
-<span class="v">13&#160;</span>All the birds of the sky will dwell on his ruin, and all the animals of the field will be on his branches, 
-<span class="v">14&#160;</span>to the end that none of all the trees by the waters exalt themselves in their stature, and don’t set their top among the thick boughs. Their mighty ones don’t stand up on their height, even all who drink water; for they are all delivered to death, to the lower parts of the earth, among the children of men, with those who go down to the pit.’ 
-</p><p>
-<span class="v">15&#160;</span>“The Lord Yahweh says: ‘In the day when he went down to Sheol,<span class="f">+ \fr 31:15 \ft Sheol is the place of the dead.</span> I caused a mourning. I covered the deep for him, and I restrained its rivers. The great waters were stopped. I caused Lebanon to mourn for him, and all the trees of the field fainted for him. 
-<span class="v">16&#160;</span>I made the nations to shake at the sound of his fall, when I cast him down to Sheol<span class="f">+ \fr 31:16 \ft Sheol is the place of the dead.</span> with those who descend into the pit. All the trees of Eden, the choice and best of Lebanon, all that drink water, were comforted in the lower parts of the earth. 
-<span class="v">17&#160;</span>They also went down into Sheol with him to those who are slain by the sword; yes, those who were his arm, who lived under his shadow in the middle of the nations. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘To whom are you thus like in glory and in greatness among the trees of Eden? Yet you will be brought down with the trees of Eden to the lower parts of the earth. You will lie in the middle of the uncircumcised, with those who are slain by the sword. 
-</p><p>“&#160;‘This is Pharaoh and all his multitude,’ says the Lord Yahweh.” 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>In the twelfth year, in the twelfth month, in the first day of the month, “Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>‘Son of man, take up a lamentation over Pharaoh king of Egypt, and tell him, 
-</p><p class="q1">“You were likened to a young lion of the nations; 
-</p><p class="q2">yet you are as a monster in the seas. 
-</p><p class="q1">You broke out with your rivers, 
-</p><p class="q2">and troubled the waters with your feet, 
-</p><p class="q2">and fouled their rivers.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>The Lord Yahweh says: 
-</p><p class="q2">“I will spread out my net on you with a company of many peoples. 
-</p><p class="q2">They will bring you up in my net. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will leave you on the land. 
-</p><p class="q2">I will cast you out on the open field, 
-</p><p class="q1">and will cause all the birds of the sky to settle on you. 
-</p><p class="q2">I will satisfy the animals of the whole earth with you. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I will lay your flesh on the mountains, 
-</p><p class="q2">and fill the valleys with your height. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I will also water the land in which you swim with your blood, 
-</p><p class="q2">even to the mountains. 
-</p><p class="q2">The watercourses will be full of you. 
-</p><p class="q1">
-<span class="v">7&#160;</span>When I extinguish you, I will cover the heavens 
-</p><p class="q2">and make its stars dark. 
-</p><p class="q1">I will cover the sun with a cloud, 
-</p><p class="q2">and the moon won’t give its light. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will make all the bright lights of the sky dark over you, 
-</p><p class="q2">and set darkness on your land,” says the Lord Yahweh. 
-</p><p class="q1">
-<span class="v">9&#160;</span>“I will also trouble the hearts of many peoples, 
-</p><p class="q2">when I bring your destruction among the nations, 
-</p><p class="q2">into the countries which you have not known. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Yes, I will make many peoples amazed at you, 
-</p><p class="q2">and their kings will be horribly afraid for you, 
-</p><p class="q1">when I brandish my sword before them. 
-</p><p class="q2">They will tremble at every moment, 
-</p><p class="q1">every man for his own life, 
-</p><p class="q2">in the day of your fall.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>For the Lord Yahweh says: 
-</p><p class="q2">“The sword of the king of Babylon will come on you. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will cause your multitude to fall by the swords of the mighty. 
-</p><p class="q2">They are all the ruthless of the nations. 
-</p><p class="q1">They will bring the pride of Egypt to nothing, 
-</p><p class="q2">and all its multitude will be destroyed. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I will destroy also all its animals from beside many waters. 
-</p><p class="q2">The foot of man won’t trouble them any more, 
-</p><p class="q2">nor will the hoofs of animals trouble them. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Then I will make their waters clear, 
-</p><p class="q2">and cause their rivers to run like oil,” 
-</p><p class="q2">says the Lord Yahweh. 
-</p><p class="q1">
-<span class="v">15&#160;</span>“When I make the land of Egypt desolate and waste, 
-</p><p class="q2">a land destitute of that of which it was full, 
-</p><p class="q1">when I strike all those who dwell therein, 
-</p><p class="q2">then they will know that I am Yahweh. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘&#160;“This is the lamentation with which they will lament. The daughters of the nations will lament with this. They will lament with it over Egypt, and over all her multitude,” says the Lord Yahweh.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">17&#160;</span>Also in the twelfth year, in the fifteenth day of the month, Yahweh’s word came to me, saying, 
-<span class="v">18&#160;</span>“Son of man, wail for the multitude of Egypt, and cast them down, even her and the daughters of the famous nations, to the lower parts of the earth, with those who go down into the pit. 
-<span class="v">19&#160;</span>Whom do you pass in beauty? Go down, and be laid with the uncircumcised. 
-<span class="v">20&#160;</span>They will fall among those who are slain by the sword. She is delivered to the sword. Draw her away with all her multitudes. 
-<span class="v">21&#160;</span>The strong among the mighty will speak to him out of the middle of Sheol<span class="f">+ \fr 32:21 \ft Sheol is the place of the dead.</span> with those who help him. They have gone down. The uncircumcised lie still, slain by the sword. 
-</p><p>
-<span class="v">22&#160;</span>“Asshur is there with all her company. Her graves are all around her. All of them are slain, fallen by the sword, 
-<span class="v">23&#160;</span>whose graves are set in the uttermost parts of the pit, and her company is around her grave, all of them slain, fallen by the sword, who caused terror in the land of the living. 
-</p><p>
-<span class="v">24&#160;</span>“There is Elam and all her multitude around her grave; all of them slain, fallen by the sword, who have gone down uncircumcised into the lower parts of the earth, who caused their terror in the land of the living, and have borne their shame with those who go down to the pit. 
-<span class="v">25&#160;</span>They have made Elam a bed among the slain with all her multitude. Her graves are around her, all of them uncircumcised, slain by the sword; for their terror was caused in the land of the living, and they have borne their shame with those who go down to the pit. He is put among those who are slain. 
-</p><p>
-<span class="v">26&#160;</span>“There is Meshech, Tubal, and all their multitude. Their graves are around them, all of them uncircumcised, slain by the sword; for they caused their terror in the land of the living. 
-<span class="v">27&#160;</span>They will not lie with the mighty who are fallen of the uncircumcised, who have gone down to Sheol with their weapons of war and have laid their swords under their heads. Their iniquities are on their bones; for they were the terror of the mighty in the land of the living. 
-</p><p>
-<span class="v">28&#160;</span>“But you will be broken among the uncircumcised, and will lie with those who are slain by the sword. 
-</p><p>
-<span class="v">29&#160;</span>“There is Edom, her kings, and all her princes, who in their might are laid with those who are slain by the sword. They will lie with the uncircumcised, and with those who go down to the pit. 
-</p><p>
-<span class="v">30&#160;</span>“There are the princes of the north, all of them, and all the Sidonians, who have gone down with the slain. They are put to shame in the terror which they caused by their might. They lie uncircumcised with those who are slain by the sword, and bear their shame with those who go down to the pit. 
-</p><p>
-<span class="v">31&#160;</span>“Pharaoh will see them and will be comforted over all his multitude, even Pharaoh and all his army, slain by the sword,” says the Lord Yahweh. 
-<span class="v">32&#160;</span>“For I have put his terror in the land of the living. He will be laid among the uncircumcised, with those who are slain by the sword, even Pharaoh and all his multitude,” says the Lord Yahweh. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, speak to the children of your people, and tell them, ‘When I bring the sword on a land, and the people of the land take a man from among them, and set him for their watchman, 
-<span class="v">3&#160;</span>if, when he sees the sword come on the land, he blows the trumpet and warns the people, 
-<span class="v">4&#160;</span>then whoever hears the sound of the trumpet and doesn’t heed the warning, if the sword comes and takes him away, his blood will be on his own head. 
-<span class="v">5&#160;</span>He heard the sound of the trumpet and didn’t take warning. His blood will be on him; whereas if he had heeded the warning, he would have delivered his soul. 
-<span class="v">6&#160;</span>But if the watchman sees the sword come and doesn’t blow the trumpet, and the people aren’t warned, and the sword comes and takes any person from among them, he is taken away in his iniquity, but his blood I will require at the watchman’s hand.’ 
-</p><p>
-<span class="v">7&#160;</span>“So you, son of man, I have set you a watchman to the house of Israel. Therefore hear the word from my mouth, and give them warnings from me. 
-<span class="v">8&#160;</span>When I tell the wicked, ‘O wicked man, you will surely die,’ and you don’t speak to warn the wicked from his way, that wicked man will die in his iniquity, but I will require his blood at your hand. 
-<span class="v">9&#160;</span>Nevertheless, if you warn the wicked of his way to turn from it, and he doesn’t turn from his way; he will die in his iniquity, but you have delivered your soul. 
-</p><p>
-<span class="v">10&#160;</span>“You, son of man, tell the house of Israel: ‘You say this, “Our transgressions and our sins are on us, and we pine away in them. How then can we live?”&#160;’ 
-<span class="v">11&#160;</span>Tell them, ‘&#160;“As I live,” says the Lord Yahweh, “I have no pleasure in the death of the wicked, but that the wicked turn from his way and live. Turn, turn from your evil ways! For why will you die, house of Israel?”&#160;’ 
-</p><p>
-<span class="v">12&#160;</span>“You, son of man, tell the children of your people, ‘The righteousness of the righteous will not deliver him in the day of his disobedience. And as for the wickedness of the wicked, he will not fall by it in the day that he turns from his wickedness; neither will he who is righteous be able to live by it in the day that he sins. 
-<span class="v">13&#160;</span>When I tell the righteous that he will surely live, if he trusts in his righteousness and commits iniquity, none of his righteous deeds will be remembered; but he will die in his iniquity that he has committed. 
-<span class="v">14&#160;</span>Again, when I say to the wicked, “You will surely die,” if he turns from his sin and does that which is lawful and right, 
-<span class="v">15&#160;</span>if the wicked restore the pledge, give again that which he had taken by robbery, walk in the statutes of life, committing no iniquity, he will surely live. He will not die. 
-<span class="v">16&#160;</span>None of his sins that he has committed will be remembered against him. He has done that which is lawful and right. He will surely live. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘Yet the children of your people say, “The way of the Lord is not fair;” but as for them, their way is not fair. 
-<span class="v">18&#160;</span>When the righteous turns from his righteousness and commits iniquity, he will even die therein. 
-<span class="v">19&#160;</span>When the wicked turns from his wickedness and does that which is lawful and right, he will live by it. 
-<span class="v">20&#160;</span>Yet you say, “The way of the Lord is not fair.” House of Israel, I will judge every one of you after his ways.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">21&#160;</span>In the twelfth year of our captivity, in the tenth month, in the fifth day of the month, one who had escaped out of Jerusalem came to me, saying, “The city has been defeated!” 
-<span class="v">22&#160;</span>Now Yahweh’s hand had been on me in the evening, before he who had escaped came; and he had opened my mouth until he came to me in the morning; and my mouth was opened, and I was no longer mute. 
-</p><p>
-<span class="v">23&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">24&#160;</span>“Son of man, those who inhabit the waste places in the land of Israel speak, saying, ‘Abraham was one, and he inherited the land; but we are many. The land is given us for inheritance.’ 
-<span class="v">25&#160;</span>Therefore tell them, ‘The Lord Yahweh says: “You eat with the blood, and lift up your eyes to your idols, and shed blood. So should you possess the land? 
-<span class="v">26&#160;</span>You stand on your sword, you work abomination, and every one of you defiles his neighbor’s woman. So should you possess the land?”&#160;’ 
-</p><p>
-<span class="v">27&#160;</span>“You shall tell them, ‘The Lord Yahweh says: “As I live, surely those who are in the waste places will fall by the sword. I will give whoever is in the open field to the animals to be devoured, and those who are in the strongholds and in the caves will die of the pestilence. 
-<span class="v">28&#160;</span>I will make the land a desolation and an astonishment. The pride of her power will cease. The mountains of Israel will be desolate, so that no one will pass through. 
-<span class="v">29&#160;</span>Then they will know that I am Yahweh, when I have made the land a desolation and an astonishment because of all their abominations which they have committed.”&#160;’ 
-</p><p>
-<span class="v">30&#160;</span>“As for you, son of man, the children of your people talk about you by the walls and in the doors of the houses, and speak to one another, everyone to his brother, saying, ‘Please come and hear what the word is that comes out from Yahweh.’ 
-<span class="v">31&#160;</span>They come to you as the people come, and they sit before you as my people, and they hear your words, but don’t do them; for with their mouth they show much love, but their heart goes after their gain. 
-<span class="v">32&#160;</span>Behold, you are to them as a very lovely song of one who has a pleasant voice, and can play well on an instrument; for they hear your words, but they don’t do them. 
-</p><p>
-<span class="v">33&#160;</span>“When this comes to pass—behold, it comes—then they will know that a prophet has been among them.” 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, prophesy against the shepherds of Israel. Prophesy, and tell them, even the shepherds, ‘The Lord Yahweh says: “Woe to the shepherds of Israel who feed themselves! Shouldn’t the shepherds feed the sheep? 
-<span class="v">3&#160;</span>You eat the fat. You clothe yourself with the wool. You kill the fatlings, but you don’t feed the sheep. 
-<span class="v">4&#160;</span>You haven’t strengthened the diseased. You haven’t healed that which was sick. You haven’t bound up that which was broken. You haven’t brought back that which was driven away. You haven’t sought that which was lost, but you have ruled over them with force and with rigor. 
-<span class="v">5&#160;</span>They were scattered, because there was no shepherd. They became food to all the animals of the field, and were scattered. 
-<span class="v">6&#160;</span>My sheep wandered through all the mountains and on every high hill. Yes, my sheep were scattered on all the surface of the earth. There was no one who searched or sought.” 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘Therefore, you shepherds, hear Yahweh’s word: 
-<span class="v">8&#160;</span>“As I live,” says the Lord Yahweh, “surely because my sheep became a prey, and my sheep became food to all the animals of the field, because there was no shepherd, and my shepherds didn’t search for my sheep, but the shepherds fed themselves, and didn’t feed my sheep, 
-<span class="v">9&#160;</span>therefore, you shepherds, hear Yahweh’s word!” 
-<span class="v">10&#160;</span>The Lord Yahweh says: “Behold, I am against the shepherds. I will require my sheep at their hand, and cause them to cease from feeding the sheep. The shepherds won’t feed themselves any more. I will deliver my sheep from their mouth, that they may not be food for them.” 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘For the Lord Yahweh says: “Behold, I myself, even I, will search for my sheep, and will seek them out. 
-<span class="v">12&#160;</span>As a shepherd seeks out his flock in the day that he is among his sheep that are scattered abroad, so I will seek out my sheep. I will deliver them out of all places where they have been scattered in the cloudy and dark day. 
-<span class="v">13&#160;</span>I will bring them out from the peoples, and gather them from the countries, and will bring them into their own land. I will feed them on the mountains of Israel, by the watercourses, and in all the inhabited places of the country. 
-<span class="v">14&#160;</span>I will feed them with good pasture, and their fold will be on the mountains of the height of Israel. There they will lie down in a good fold. They will feed on rich pasture on the mountains of Israel. 
-<span class="v">15&#160;</span>I myself will be the shepherd of my sheep, and I will cause them to lie down,” says the Lord Yahweh. 
-<span class="v">16&#160;</span>“I will seek that which was lost, and will bring back that which was driven away, and will bind up that which was broken, and will strengthen that which was sick; but I will destroy the fat and the strong. I will feed them in justice.”&#160;’ 
-</p><p>
-<span class="v">17&#160;</span>“As for you, O my flock, the Lord Yahweh says: ‘Behold, I judge between sheep and sheep, the rams and the male goats. 
-<span class="v">18&#160;</span>Does it seem a small thing to you to have fed on the good pasture, but you must tread down with your feet the residue of your pasture? And to have drunk of the clear waters, but must you foul the residue with your feet? 
-<span class="v">19&#160;</span>As for my sheep, they eat that which you have trodden with your feet, and they drink that which you have fouled with your feet.’ 
-</p><p>
-<span class="v">20&#160;</span>“Therefore the Lord Yahweh says to them: ‘Behold, I, even I, will judge between the fat sheep and the lean sheep. 
-<span class="v">21&#160;</span>Because you thrust with side and with shoulder, and push all the diseased with your horns, until you have scattered them abroad, 
-<span class="v">22&#160;</span>therefore I will save my flock, and they will no more be a prey. I will judge between sheep and sheep. 
-<span class="v">23&#160;</span>I will set up one shepherd over them, and he will feed them, even my servant David. He will feed them, and he will be their shepherd. 
-<span class="v">24&#160;</span>I, Yahweh, will be their Elohim, and my servant David prince among them. I, Yahweh, have spoken it. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘I will make with them a covenant of peace, and will cause evil animals to cease out of the land. They will dwell securely in the wilderness and sleep in the woods. 
-<span class="v">26&#160;</span>I will make them and the places around my hill a blessing. I will cause the shower to come down in its season. There will be showers of blessing. 
-<span class="v">27&#160;</span>The tree of the field will yield its fruit, and the earth will yield its increase, and they will be secure in their land. Then they will know that I am Yahweh, when I have broken the bars of their yoke, and have delivered them out of the hand of those who made slaves of them. 
-<span class="v">28&#160;</span>They will no more be a prey to the nations, neither will the animals of the earth devour them; but they will dwell securely, and no one will make them afraid. 
-<span class="v">29&#160;</span>I will raise up to them a plantation for renown, and they will no more be consumed with famine in the land, and not bear the shame of the nations any more. 
-<span class="v">30&#160;</span>They will know that I, Yahweh, their Elohim am with them, and that they, the house of Israel, are my people, says the Lord Yahweh. 
-<span class="v">31&#160;</span>You my sheep, the sheep of my pasture, are men, and I am your Elohim,’ says the Lord Yahweh.” 
-</p><h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, set your face against Mount Seir, and prophesy against it, 
-<span class="v">3&#160;</span>and tell it, ‘The Lord Yahweh says: “Behold, I am against you, Mount Seir, and I will stretch out my hand against you. I will make you a desolation and an astonishment. 
-<span class="v">4&#160;</span>I will lay your cities waste, and you will be desolate. Then you will know that I am Yahweh. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘&#160;“Because you have had a perpetual hostility, and have given over the children of Israel to the power of the sword in the time of their calamity, in the time of the iniquity of the end, 
-<span class="v">6&#160;</span>therefore, as I live,” says the Lord Yahweh, “I will prepare you for blood, and blood will pursue you. Since you have not hated blood, therefore blood will pursue you. 
-<span class="v">7&#160;</span>Thus I will make Mount Seir an astonishment and a desolation. I will cut off from it him who passes through and him who returns. 
-<span class="v">8&#160;</span>I will fill its mountains with its slain. The slain with the sword will fall in your hills and in your valleys and in all your watercourses. 
-<span class="v">9&#160;</span>I will make you a perpetual desolation, and your cities will not be inhabited. Then you will know that I am Yahweh. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘&#160;“Because you have said, ‘These two nations and these two countries will be mine, and we will possess it,’ although Yahweh was there, 
-<span class="v">11&#160;</span>therefore, as I live,” says the Lord Yahweh, “I will do according to your anger, and according to your envy which you have shown out of your hatred against them; and I will make myself known among them when I judge you. 
-<span class="v">12&#160;</span>You will know that I, Yahweh, have heard all your insults which you have spoken against the mountains of Israel, saying, ‘They have been laid desolate. They have been given to us to devour.’ 
-<span class="v">13&#160;</span>You have magnified yourselves against me with your mouth, and have multiplied your words against me. I have heard it.” 
-<span class="v">14&#160;</span>The Lord Yahweh says: “When the whole earth rejoices, I will make you desolate. 
-<span class="v">15&#160;</span>As you rejoiced over the inheritance of the house of Israel because it was desolate, so I will do to you. You will be desolate, Mount Seir, and all Edom, even all of it. Then they will know that I am Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>You, son of man, prophesy to the mountains of Israel, and say, “You mountains of Israel, hear Yahweh’s word. 
-<span class="v">2&#160;</span>The Lord Yahweh says: ‘Because the enemy has said against you, “Aha!” and, “The ancient high places are ours in possession!”&#160;’ 
-<span class="v">3&#160;</span>therefore prophesy, and say, ‘The Lord Yahweh says: “Because, even because they have made you desolate, and swallowed you up on every side, that you might be a possession to the residue of the nations, and you are taken up in the lips of talkers, and the evil report of the people;” 
-<span class="v">4&#160;</span>therefore, you mountains of Israel, hear the word of the Lord Yahweh: The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys, to the desolate wastes and to the cities that are forsaken, which have become a prey and derision to the residue of the nations that are all around; 
-<span class="v">5&#160;</span>therefore the Lord Yahweh says: “Surely in the fire of my jealousy I have spoken against the residue of the nations, and against all Edom, that have appointed my land to themselves for a possession with the joy of all their heart, with despite of soul, to cast it out for a prey.”&#160;’ 
-<span class="v">6&#160;</span>Therefore prophesy concerning the land of Israel, and tell the mountains, the hills, the watercourses and the valleys, ‘The Lord Yahweh says: “Behold, I have spoken in my jealousy and in my wrath, because you have borne the shame of the nations.” 
-<span class="v">7&#160;</span>Therefore the Lord Yahweh says: “I have sworn, ‘Surely the nations that are around you will bear their shame.’ 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘&#160;“But you, mountains of Israel, you shall shoot out your branches and yield your fruit to my people Israel; for they are at hand to come. 
-<span class="v">9&#160;</span>For, behold, I am for you, and I will come to you, and you will be tilled and sown. 
-<span class="v">10&#160;</span>I will multiply men on you, all the house of Israel, even all of it. The cities will be inhabited and the waste places will be built. 
-<span class="v">11&#160;</span>I will multiply man and animal on you. They will increase and be fruitful. I will cause you to be inhabited as you were before, and you will do better than at your beginnings. Then you will know that I am Yahweh. 
-<span class="v">12&#160;</span>Yes, I will cause men to walk on you, even my people Israel. They will possess you, and you will be their inheritance, and you will never again bereave them of their children.” 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘The Lord Yahweh says: “Because they say to you, ‘You are a devourer of men, and have been a bereaver of your nation;’ 
-<span class="v">14&#160;</span>therefore you shall devour men no more, and not bereave your nation any more,” says the Lord Yahweh. 
-<span class="v">15&#160;</span>“I won’t let you hear the shame of the nations any more. You won’t bear the reproach of the peoples any more, and you won’t cause your nation to stumble any more,” says the Lord Yahweh.’&#160;” 
-</p><p>
-<span class="v">16&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">17&#160;</span>“Son of man, when the house of Israel lived in their own land, they defiled it by their ways and by their deeds. Their way before me was as the uncleanness of a woman in her impurity. 
-<span class="v">18&#160;</span>Therefore I poured out my wrath on them for the blood which they had poured out on the land, and because they had defiled it with their idols. 
-<span class="v">19&#160;</span>I scattered them among the nations, and they were dispersed through the countries. I judged them according to their way and according to their deeds. 
-<span class="v">20&#160;</span>When they came to the nations where they went, they profaned my set-apart name, in that men said of them, ‘These are Yahweh’s people, and have left his land.’ 
-<span class="v">21&#160;</span>But I had respect for my set-apart name, which the house of Israel had profaned among the nations where they went. 
-</p><p>
-<span class="v">22&#160;</span>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “I don’t do this for your sake, house of Israel, but for my set-apart name, which you have profaned among the nations where you went. 
-<span class="v">23&#160;</span>I will sanctify my great name, which has been profaned among the nations, which you have profaned among them. Then the nations will know that I am Yahweh,” says the Lord Yahweh, “when I am proven set-apart in you before their eyes. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘&#160;“For I will take you from among the nations and gather you out of all the countries, and will bring you into your own land. 
-<span class="v">25&#160;</span>I will sprinkle clean water on you, and you will be clean. I will cleanse you from all your filthiness and from all your idols. 
-<span class="v">26&#160;</span>I will also give you a new heart, and I will put a new spirit within you. I will take away the stony heart out of your flesh, and I will give you a heart of flesh. 
-<span class="v">27&#160;</span>I will put my Spirit within you, and cause you to walk in my statutes. You will keep my ordinances and do them. 
-<span class="v">28&#160;</span>You will dwell in the land that I gave to your fathers. You will be my people, and I will be your Elohim. 
-<span class="v">29&#160;</span>I will save you from all your uncleanness. I will call for the grain and will multiply it, and lay no famine on you. 
-<span class="v">30&#160;</span>I will multiply the fruit of the tree and the increase of the field, that you may receive no more the reproach of famine among the nations. 
-</p><p>
-<span class="v">31&#160;</span>“&#160;‘&#160;“Then you will remember your evil ways, and your deeds that were not good; and you will loathe yourselves in your own sight for your iniquities and for your abominations. 
-<span class="v">32&#160;</span>I don’t do this for your sake,” says the Lord Yahweh. “Let it be known to you. Be ashamed and confounded for your ways, house of Israel.” 
-</p><p>
-<span class="v">33&#160;</span>“&#160;‘The Lord Yahweh says: “In the day that I cleanse you from all your iniquities, I will cause the cities to be inhabited and the waste places will be built. 
-<span class="v">34&#160;</span>The land that was desolate will be tilled instead of being a desolation in the sight of all who passed by. 
-<span class="v">35&#160;</span>They will say, ‘This land that was desolate has become like the garden of Eden. The waste, desolate, and ruined cities are fortified and inhabited.’ 
-<span class="v">36&#160;</span>Then the nations that are left around you will know that I, Yahweh, have built the ruined places and planted that which was desolate. I, Yahweh, have spoken it, and I will do it.” 
-</p><p>
-<span class="v">37&#160;</span>“&#160;‘The Lord Yahweh says: “For this, moreover, I will be inquired of by the house of Israel, to do it for them: I will increase them with men like a flock. 
-<span class="v">38&#160;</span>As the flock for sacrifice, as the flock of Jerusalem in her appointed feasts, so the waste cities will be filled with flocks of men. Then they will know that I am Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="37">37</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s hand was on me, and he brought me out in Yahweh’s Spirit, and set me down in the middle of the valley; and it was full of bones. 
-<span class="v">2&#160;</span>He caused me to pass by them all around; and behold, there were very many in the open valley, and behold, they were very dry. 
-<span class="v">3&#160;</span>He said to me, “Son of man, can these bones live?” 
-</p><p>I answered, “Lord Yahweh, you know.” 
-</p><p>
-<span class="v">4&#160;</span>Again he said to me, “Prophesy over these bones, and tell them, ‘You dry bones, hear Yahweh’s word. 
-<span class="v">5&#160;</span>The Lord Yahweh says to these bones: “Behold, I will cause breath to enter into you, and you will live. 
-<span class="v">6&#160;</span>I will lay sinews on you, and will bring up flesh on you, and cover you with skin, and put breath in you, and you will live. Then you will know that I am Yahweh.”&#160;’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>So I prophesied as I was commanded. As I prophesied, there was a noise, and behold, there was an earthquake. Then the bones came together, bone to its bone. 
-<span class="v">8&#160;</span>I saw, and, behold, there were sinews on them, and flesh came up, and skin covered them above; but there was no breath in them. 
-</p><p>
-<span class="v">9&#160;</span>Then he said to me, “Prophesy to the wind, prophesy, son of man, and tell the wind, ‘The Lord Yahweh says: “Come from the four winds, breath, and breathe on these slain, that they may live.”&#160;’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>So I prophesied as he commanded me, and the breath came into them, and they lived, and stood up on their feet, an exceedingly great army. 
-</p><p>
-<span class="v">11&#160;</span>Then he said to me, “Son of man, these bones are the whole house of Israel. Behold, they say, ‘Our bones are dried up, and our hope is lost. We are completely cut off.’ 
-<span class="v">12&#160;</span>Therefore prophesy, and tell them, ‘The Lord Yahweh says: “Behold, I will open your graves, and cause you to come up out of your graves, my people; and I will bring you into the land of Israel. 
-<span class="v">13&#160;</span>You will know that I am Yahweh, when I have opened your graves and caused you to come up out of your graves, my people. 
-<span class="v">14&#160;</span>I will put my Spirit in you, and you will live. Then I will place you in your own land; and you will know that I, Yahweh, have spoken it and performed it,” says Yahweh.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">15&#160;</span>Yahweh’s word came again to me, saying, 
-<span class="v">16&#160;</span>“You, son of man, take one stick and write on it, ‘For Judah, and for the children of Israel his companions.’ Then take another stick, and write on it, ‘For Joseph, the stick of Ephraim, and for all the house of Israel his companions.’ 
-<span class="v">17&#160;</span>Then join them for yourself to one another into one stick, that they may become one in your hand. 
-</p><p>
-<span class="v">18&#160;</span>“When the children of your people speak to you, saying, ‘Won’t you show us what you mean by these?’ 
-<span class="v">19&#160;</span>tell them, ‘The Lord Yahweh says: “Behold, I will take the stick of Joseph, which is in the hand of Ephraim, and the tribes of Israel his companions; and I will put them with it, with the stick of Judah, and make them one stick, and they will be one in my hand. 
-<span class="v">20&#160;</span>The sticks on which you write will be in your hand before their eyes.”&#160;’ 
-<span class="v">21&#160;</span>Say to them, ‘The Lord Yahweh says: “Behold, I will take the children of Israel from among the nations where they have gone, and will gather them on every side, and bring them into their own land. 
-<span class="v">22&#160;</span>I will make them one nation in the land, on the mountains of Israel. One king will be king to them all. They will no longer be two nations. They won’t be divided into two kingdoms any more at all. 
-<span class="v">23&#160;</span>They won’t defile themselves any more with their idols, nor with their detestable things, nor with any of their transgressions; but I will save them out of all their dwelling places in which they have sinned, and will cleanse them. So they will be my people, and I will be their Elohim. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘&#160;“My servant David will be king over them. They all will have one shepherd. They will also walk in my ordinances and observe my statutes, and do them. 
-<span class="v">25&#160;</span>They will dwell in the land that I have given to Jacob my servant, in which your fathers lived. They will dwell therein, they, and their children, and their children’s children, forever. David my servant will be their prince forever. 
-<span class="v">26&#160;</span>Moreover I will make a covenant of peace with them. It will be an everlasting covenant with them. I will place them, multiply them, and will set my sanctuary among them forever more. 
-<span class="v">27&#160;</span>My tent also will be with them. I will be their Elohim, and they will be my people. 
-<span class="v">28&#160;</span>The nations will know that I am Yahweh who sanctifies Israel, when my sanctuary is among them forever more.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="38">38</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Son of man, set your face toward Gog, of the land of Magog, the prince of Rosh, Meshech, and Tubal, and prophesy against him, 
-<span class="v">3&#160;</span>and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
-<span class="v">4&#160;</span>I will turn you around, and put hooks into your jaws, and I will bring you out, with all your army, horses and horsemen, all of them clothed in full armor, a great company with buckler and shield, all of them handling swords; 
-<span class="v">5&#160;</span>Persia, Cush, and Put with them, all of them with shield and helmet; 
-<span class="v">6&#160;</span>Gomer, and all his hordes; the house of Togarmah in the uttermost parts of the north, and all his hordes—even many peoples with you. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘&#160;“Be prepared, yes, prepare yourself, you, and all your companies who are assembled to you, and be a guard to them. 
-<span class="v">8&#160;</span>After many days you will be visited. In the latter years you will come into the land that is brought back from the sword, that is gathered out of many peoples, on the mountains of Israel, which have been a continual waste; but it is brought out of the peoples and they will dwell securely, all of them. 
-<span class="v">9&#160;</span>You will ascend. You will come like a storm. You will be like a cloud to cover the land, you and all your hordes, and many peoples with you.” 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘The Lord Yahweh says: “It will happen in that day that things will come into your mind, and you will devise an evil plan. 
-<span class="v">11&#160;</span>You will say, ‘I will go up to the land of unwalled villages. I will go to those who are at rest, who dwell securely, all of them dwelling without walls, and having neither bars nor gates, 
-<span class="v">12&#160;</span>to take the plunder and to take prey; to turn your hand against the waste places that are inhabited, and against the people who are gathered out of the nations, who have gotten livestock and goods, who dwell in the middle of the earth.’ 
-<span class="v">13&#160;</span>Sheba, Dedan, and the merchants of Tarshish, with all its young lions, will ask you, ‘Have you come to take the plunder? Have you assembled your company to take the prey, to carry away silver and gold, to take away livestock and goods, to take great plunder?’&#160;”&#160;’ 
-</p><p>
-<span class="v">14&#160;</span>“Therefore, son of man, prophesy, and tell Gog, ‘The Lord Yahweh says: “In that day when my people Israel dwells securely, will you not know it? 
-<span class="v">15&#160;</span>You will come from your place out of the uttermost parts of the north, you, and many peoples with you, all of them riding on horses, a great company and a mighty army. 
-<span class="v">16&#160;</span>You will come up against my people Israel as a cloud to cover the land. It will happen in the latter days that I will bring you against my land, that the nations may know me when I am sanctified in you, Gog, before their eyes.” 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘The Lord Yahweh says: “Are you he of whom I spoke in old time by my servants the prophets of Israel, who prophesied in those days for years that I would bring you against them? 
-<span class="v">18&#160;</span>It will happen in that day, when Gog comes against the land of Israel,” says the Lord Yahweh, “that my wrath will come up into my nostrils. 
-<span class="v">19&#160;</span>For in my jealousy and in the fire of my wrath I have spoken. Surely in that day there will be a great shaking in the land of Israel, 
-<span class="v">20&#160;</span>so that the fish of the sea, the birds of the sky, the animals of the field, all creeping things who creep on the earth, and all the men who are on the surface of the earth will shake at my presence. Then the mountains will be thrown down, the steep places will fall, and every wall will fall to the ground. 
-<span class="v">21&#160;</span>I will call for a sword against him to all my mountains,” says the Lord Yahweh. “Every man’s sword will be against his brother. 
-<span class="v">22&#160;</span>I will enter into judgment with him with pestilence and with blood. I will rain on him, on his hordes, and on the many peoples who are with him, torrential rains with great hailstones, fire, and sulfur. 
-<span class="v">23&#160;</span>I will magnify myself and sanctify myself, and I will make myself known in the eyes of many nations. Then they will know that I am Yahweh.”&#160;’ 
-</p><h2 class="chapterlabel" id="39">39</h2>
-<p>
-<span class="v">1&#160;</span>“You, son of man, prophesy against Gog, and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
-<span class="v">2&#160;</span>I will turn you around, will lead you on, and will cause you to come up from the uttermost parts of the north; and I will bring you onto the mountains of Israel. 
-<span class="v">3&#160;</span>I will strike your bow out of your left hand, and will cause your arrows to fall out of your right hand. 
-<span class="v">4&#160;</span>You will fall on the mountains of Israel, you, and all your hordes, and the peoples who are with you. I will give you to the ravenous birds of every sort and to the animals of the field to be devoured. 
-<span class="v">5&#160;</span>You will fall on the open field, for I have spoken it,” says the Lord Yahweh. 
-<span class="v">6&#160;</span>“I will send a fire on Magog and on those who dwell securely in the islands. Then they will know that I am Yahweh. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘&#160;“I will make my set-apart name known among my people Israel. I won’t allow my set-apart name to be profaned any more. Then the nations will know that I am Yahweh, the Set-Apart One in Israel. 
-<span class="v">8&#160;</span>Behold, it comes, and it will be done,” says the Lord Yahweh. “This is the day about which I have spoken. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘&#160;“Those who dwell in the cities of Israel will go out and will make fires of the weapons and burn them, both the shields and the bucklers, the bows and the arrows, and the war clubs and the spears, and they will make fires with them for seven years; 
-<span class="v">10&#160;</span>so that they will take no wood out of the field, and not cut down any out of the forests; for they will make fires with the weapons. They will plunder those who plundered them, and rob those who robbed them,” says the Lord Yahweh. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘&#160;“It will happen in that day, that I will give to Gog a place for burial in Israel, the valley of those who pass through on the east of the sea; and it will stop those who pass through. They will bury Gog and all his multitude there, and they will call it ‘The valley of Hamon Gog’. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘&#160;“The house of Israel will be burying them for seven months, that they may cleanse the land. 
-<span class="v">13&#160;</span>Yes, all the people of the land will bury them; and they will become famous in the day that I will be glorified,” says the Lord Yahweh. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘&#160;“They will set apart men of continual employment who will pass through the land. Those who pass through will go with those who bury those who remain on the surface of the land, to cleanse it. After the end of seven months they will search. 
-<span class="v">15&#160;</span>Those who search through the land will pass through; and when anyone sees a man’s bone, then he will set up a sign by it, until the undertakers have buried it in the valley of Hamon Gog. 
-<span class="v">16&#160;</span>Hamonah will also be the name of a city. Thus they will cleanse the land.”&#160;’ 
-</p><p>
-<span class="v">17&#160;</span>“You, son of man, the Lord Yahweh says: ‘Speak to the birds of every sort, and to every animal of the field, “Assemble yourselves, and come; gather yourselves on every side to my sacrifice that I sacrifice for you, even a great sacrifice on the mountains of Israel, that you may eat meat and drink blood. 
-<span class="v">18&#160;</span>You shall eat the flesh of the mighty, and drink the blood of the princes of the earth, of rams, of lambs, and of goats, of bulls, all of them fatlings of Bashan. 
-<span class="v">19&#160;</span>You shall eat fat until you are full, and drink blood until you are drunk, of my sacrifice which I have sacrificed for you. 
-<span class="v">20&#160;</span>You shall be filled at my table with horses and charioteers, with mighty men, and with all men of war,” says the Lord Yahweh.’ 
-</p><p>
-<span class="v">21&#160;</span>“I will set my glory among the nations. Then all the nations will see my judgment that I have executed, and my hand that I have laid on them. 
-<span class="v">22&#160;</span>So the house of Israel will know that I am Yahweh their Elohim, from that day and forward. 
-<span class="v">23&#160;</span>The nations will know that the house of Israel went into captivity for their iniquity, because they trespassed against me, and I hid my face from them; so I gave them into the hand of their adversaries, and they all fell by the sword. 
-<span class="v">24&#160;</span>I did to them according to their uncleanness and according to their transgressions. I hid my face from them. 
-</p><p>
-<span class="v">25&#160;</span>“Therefore the Lord Yahweh says: ‘Now I will reverse the captivity of Jacob and have mercy on the whole house of Israel. I will be jealous for my set-apart name. 
-<span class="v">26&#160;</span>They will forget their shame and all their trespasses by which they have trespassed against me, when they dwell securely in their land. No one will make them afraid 
-<span class="v">27&#160;</span>when I have brought them back from the peoples, gathered them out of their enemies’ lands, and am shown set-apart among them in the sight of many nations. 
-<span class="v">28&#160;</span>They will know that I am Yahweh their Elohim, in that I caused them to go into captivity among the nations, and have gathered them to their own land. Then I will leave none of them captive any more. 
-<span class="v">29&#160;</span>I won’t hide my face from them any more, for I have poured out my Spirit on the house of Israel,’ says the Lord Yahweh.” 
-</p><h2 class="chapterlabel" id="40">40</h2>
-<p>
-<span class="v">1&#160;</span>In the twenty-fifth year of our captivity, in the beginning of the year, in the tenth day of the month, in the fourteenth year after the city was struck, in the same day, Yahweh’s hand was on me, and he brought me there. 
-<span class="v">2&#160;</span>In the visions of Elohim he brought me into the land of Israel, and set me down on a very high mountain, on which was something like the frame of a city to the south. 
-<span class="v">3&#160;</span>He brought me there; and, behold, there was a man whose appearance was like the appearance of bronze, with a line of flax in his hand and a measuring reed; and he stood in the gate. 
-<span class="v">4&#160;</span>The man said to me, “Son of man, see with your eyes, and hear with your ears, and set your heart on all that I will show you; for you have been brought here so that I may show them to you. Declare all that you see to the house of Israel.” 
-</p><p>
-<span class="v">5&#160;</span>Behold, there was a wall on the outside of the house all around, and in the man’s hand a measuring reed six cubits<span class="f">+ \fr 40:5 \ft A normal cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters. A handbreadth is about 4.3 inches or 11 centimeters, so the long cubit described here would be about 22.3 inches or 57 centimeters long. Thus, a 6 long cubit measuring reed would have been about 3 yards 26.6 inches or about 3.42 meters long.</span> long, of a cubit and a hand width each. So he measured the thickness of the building, one reed; and the height, one reed. 
-</p><p>
-<span class="v">6&#160;</span>Then he came to the gate which looks toward the east, and went up its steps. He measured the threshold of the gate, one reed wide; and the other threshold, one reed wide. 
-<span class="v">7&#160;</span>Every lodge was one reed long and one reed wide. Between the lodges was five cubits. The threshold of the gate by the porch of the gate toward the house was one reed. 
-</p><p>
-<span class="v">8&#160;</span>He measured also the porch of the gate toward the house, one reed. 
-<span class="v">9&#160;</span>Then he measured the porch of the gate, eight cubits; and its posts, two cubits; and the porch of the gate was toward the house. 
-</p><p>
-<span class="v">10&#160;</span>The side rooms of the gate eastward were three on this side, and three on that side. The three of them were of one measure. The posts had one measure on this side and on that side. 
-<span class="v">11&#160;</span>He measured the width of the opening of the gate, ten cubits; and the length of the gate, thirteen cubits; 
-<span class="v">12&#160;</span>and a border before the lodges, one cubit on this side, and a border, one cubit on that side; and the side rooms, six cubits on this side, and six cubits on that side. 
-<span class="v">13&#160;</span>He measured the gate from the roof of the one side room to the roof of the other, a width of twenty-five cubits, door against door. 
-<span class="v">14&#160;</span>He also made posts, sixty cubits; and the court reached to the posts, around the gate. 
-<span class="v">15&#160;</span>From the forefront of the gate at the entrance to the forefront of the inner porch of the gate were fifty cubits. 
-<span class="v">16&#160;</span>There were closed windows to the side rooms, and to their posts within the gate all around, and likewise to the arches. Windows were around inward. Palm trees were on each post. 
-</p><p>
-<span class="v">17&#160;</span>Then he brought me into the outer court. Behold, there were rooms and a pavement made for the court all around. Thirty rooms were on the pavement. 
-<span class="v">18&#160;</span>The pavement was by the side of the gates, corresponding to the length of the gates, even the lower pavement. 
-<span class="v">19&#160;</span>Then he measured the width from the forefront of the lower gate to the forefront of the inner court outside, one hundred cubits, both on the east and on the north. 
-</p><p>
-<span class="v">20&#160;</span>He measured the length and width of the gate of the outer court which faces toward the north. 
-<span class="v">21&#160;</span>The lodges of it were three on this side and three on that side. Its posts and its arches were the same as the measure of the first gate: its length was fifty cubits, and the width twenty-five cubits. 
-<span class="v">22&#160;</span>Its windows, its arches, and its palm trees were the same as the measure of the gate which faces toward the east. They went up to it by seven steps. Its arches were before them. 
-<span class="v">23&#160;</span>There was a gate to the inner court facing the other gate, on the north and on the east. He measured one hundred cubits from gate to gate. 
-</p><p>
-<span class="v">24&#160;</span>He led me toward the south; and behold, there was a gate toward the south. He measured its posts and its arches according to these measurements. 
-<span class="v">25&#160;</span>There were windows in it and in its arches all around, like the other windows: the length was fifty cubits, and the width twenty-five cubits. 
-<span class="v">26&#160;</span>There were seven steps to go up to it, and its arches were before them. It had palm trees, one on this side, and another on that side, on its posts. 
-<span class="v">27&#160;</span>There was a gate to the inner court toward the south. He measured one hundred cubits from gate to gate toward the south. 
-</p><p>
-<span class="v">28&#160;</span>Then he brought me to the inner court by the south gate. He measured the south gate according to these measurements; 
-<span class="v">29&#160;</span>with its lodges, its posts, and its arches, according to these measurements. There were windows in it and in its arches all around. It was fifty cubits long, and twenty-five cubits wide. 
-<span class="v">30&#160;</span>There were arches all around, twenty-five cubits long and five cubits wide. 
-<span class="v">31&#160;</span>Its arches were toward the outer court. Palm trees were on its posts. The ascent to it had eight steps. 
-</p><p>
-<span class="v">32&#160;</span>He brought me into the inner court toward the east. He measured the gate according to these measurements; 
-<span class="v">33&#160;</span>with its lodges, its posts, and its arches, according to these measurements. There were windows in it and in its arches all around. It was fifty cubits long, and twenty-five cubits wide. 
-<span class="v">34&#160;</span>Its arches were toward the outer court. Palm trees were on its posts on this side and on that side. The ascent to it had eight steps. 
-</p><p>
-<span class="v">35&#160;</span>He brought me to the north gate, and he measured it according to these measurements—<span class="v">36&#160;</span>its lodges, its posts, and its arches. There were windows in it all around. The length was fifty cubits and the width twenty-five cubits. 
-<span class="v">37&#160;</span>Its posts were toward the outer court. Palm trees were on its posts on this side and on that side. The ascent to it had eight steps. 
-</p><p>
-<span class="v">38&#160;</span>A room with its door was by the posts at the gates. They washed the burnt offering there. 
-<span class="v">39&#160;</span>In the porch of the gate were two tables on this side and two tables on that side, on which to kill the burnt offering, the sin offering, and the trespass offering. 
-<span class="v">40&#160;</span>On the one side outside, as one goes up to the entry of the gate toward the north, were two tables; and on the other side, which belonged to the porch of the gate, were two tables. 
-<span class="v">41&#160;</span>Four tables were on this side, and four tables on that side, by the side of the gate: eight tables, on which they killed the sacrifices. 
-<span class="v">42&#160;</span>There were four cut stone tables for the burnt offering, a cubit and a half long, a cubit and a half wide, and one cubit high. They laid the instruments with which they killed the burnt offering and the sacrifice on them. 
-<span class="v">43&#160;</span>The hooks, a hand width long, were fastened within all around. The meat of the offering was on the tables. 
-</p><p>
-<span class="v">44&#160;</span>Outside of the inner gate were rooms for the singers in the inner court, which was at the side of the north gate. They faced toward the south. One at the side of the east gate faced toward the north. 
-<span class="v">45&#160;</span>He said to me, “This room, which faces toward the south, is for the priests who perform the duty of the house. 
-<span class="v">46&#160;</span>The room which faces toward the north is for the priests who perform the duty of the altar. These are the sons of Zadok, who from among the sons of Levi come near to Yahweh to minister to him.” 
-<span class="v">47&#160;</span>He measured the court, one hundred cubits long and one hundred cubits wide, square. The altar was before the house. 
-</p><p>
-<span class="v">48&#160;</span>Then he brought me to the porch of the house, and measured each post of the porch, five cubits on this side, and five cubits on that side. The width of the gate was three cubits on this side and three cubits on that side. 
-<span class="v">49&#160;</span>The length of the porch was twenty cubits and the width eleven cubits, even by the steps by which they went up to it. There were pillars by the posts, one on this side, and another on that side. 
-</p><h2 class="chapterlabel" id="41">41</h2>
-<p>
-<span class="v">1&#160;</span>He brought me to the nave and measured the posts, six cubits wide on the one side and six cubits wide on the other side, which was the width of the tent. 
-<span class="v">2&#160;</span>The width of the entrance was ten cubits,<span class="f">+ \fr 41:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and the sides of the entrance were five cubits on the one side, and five cubits on the other side. He measured its length, forty cubits, and the width, twenty cubits. 
-</p><p>
-<span class="v">3&#160;</span>Then he went inward and measured each post of the entrance, two cubits; and the entrance, six cubits; and the width of the entrance, seven cubits. 
-<span class="v">4&#160;</span>He measured its length, twenty cubits, and the width, twenty cubits, before the nave. He said to me, “This is the most set-apart place.” 
-</p><p>
-<span class="v">5&#160;</span>Then he measured the wall of the house, six cubits; and the width of every side room, four cubits, all around the house on every side. 
-<span class="v">6&#160;</span>The side rooms were in three stories, one over another, and thirty in each story. They entered into the wall which belonged to the house for the side rooms all around, that they might be supported and not penetrate the wall of the house. 
-<span class="v">7&#160;</span>The side rooms were wider on the higher levels, because the walls were narrower at the higher levels. Therefore the width of the house increased upward; and so one went up from the lowest level to the highest through the middle level. 
-</p><p>
-<span class="v">8&#160;</span>I saw also that the house had a raised base all around. The foundations of the side rooms were a full reed of six great cubits. 
-<span class="v">9&#160;</span>The thickness of the outer wall of the side rooms was five cubits. That which was left was the place of the side rooms that belonged to the house. 
-<span class="v">10&#160;</span>Between the rooms was a width of twenty cubits around the house on every side. 
-<span class="v">11&#160;</span>The doors of the side rooms were toward an open area that was left, one door toward the north, and another door toward the south. The width of the open area was five cubits all around. 
-</p><p>
-<span class="v">12&#160;</span>The building that was before the separate place at the side toward the west was seventy cubits wide; and the wall of the building was five cubits thick all around, and its length ninety cubits. 
-</p><p>
-<span class="v">13&#160;</span>So he measured the temple, one hundred cubits long; and the separate place, and the building, with its walls, one hundred cubits long; 
-<span class="v">14&#160;</span>also the width of the face of the temple, and of the separate place toward the east, one hundred cubits. 
-</p><p>
-<span class="v">15&#160;</span>He measured the length of the building before the separate place which was at its back, and its galleries on the one side and on the other side, one hundred cubits from the inner temple, and the porches of the court, 
-<span class="v">16&#160;</span>the thresholds, and the closed windows, and the galleries around on their three stories, opposite the threshold, with wood ceilings all around, and from the ground up to the windows, (now the windows were covered), 
-<span class="v">17&#160;</span>to the space above the door, even to the inner house, and outside, and by all the wall all around inside and outside, by measure. 
-<span class="v">18&#160;</span>It was made with cherubim and palm trees. A palm tree was between cherub and cherub, and every cherub had two faces, 
-<span class="v">19&#160;</span>so that there was the face of a man toward the palm tree on the one side, and the face of a young lion toward the palm tree on the other side. It was made like this through all the house all around. 
-<span class="v">20&#160;</span>Cherubim and palm trees were made from the ground to above the door. The wall of the temple was like this. 
-</p><p>
-<span class="v">21&#160;</span>The door posts of the nave were squared. As for the face of the nave, its appearance was as the appearance of the temple. 
-<span class="v">22&#160;</span>The altar was of wood, three cubits high, and its length two cubits. Its corners, its base, and its walls were of wood. He said to me, “This is the table that is before Yahweh.” 
-<span class="v">23&#160;</span>The temple and the sanctuary had two doors. 
-<span class="v">24&#160;</span>The doors had two leaves each, two turning leaves: two for the one door, and two leaves for the other. 
-<span class="v">25&#160;</span>There were made on them, on the doors of the nave, cherubim and palm trees, like those made on the walls. There was a threshold of wood on the face of the porch outside. 
-<span class="v">26&#160;</span>There were closed windows and palm trees on the one side and on the other side, on the sides of the porch. This is how the side rooms of the temple and the thresholds were arranged. 
-</p><h2 class="chapterlabel" id="42">42</h2>
-<p>
-<span class="v">1&#160;</span>Then he brought me out into the outer court, the way toward the north. Then he brought me into the room that was opposite the separate place, and which was opposite the building toward the north. 
-<span class="v">2&#160;</span>Facing the length of one hundred cubits<span class="f">+ \fr 42:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> was the north door, and the width was fifty cubits. 
-<span class="v">3&#160;</span>Opposite the twenty cubits which belonged to the inner court, and opposite the pavement which belonged to the outer court, was gallery against gallery in the three stories. 
-<span class="v">4&#160;</span>Before the rooms was a walk of ten cubits’ width inward, a way of one cubit; and their doors were toward the north. 
-<span class="v">5&#160;</span>Now the upper rooms were shorter; for the galleries took away from these more than from the lower and the middle in the building. 
-<span class="v">6&#160;</span>For they were in three stories, and they didn’t have pillars as the pillars of the courts. Therefore the uppermost was set back more than the lowest and the middle from the ground. 
-<span class="v">7&#160;</span>The wall that was outside by the side of the rooms, toward the outer court before the rooms, was fifty cubits long. 
-<span class="v">8&#160;</span>For the length of the rooms that were in the outer court was fifty cubits. Behold, those facing the temple were one hundred cubits. 
-<span class="v">9&#160;</span>From under these rooms was the entry on the east side, as one goes into them from the outer court. 
-</p><p>
-<span class="v">10&#160;</span>In the thickness of the wall of the court toward the east, before the separate place, and before the building, there were rooms. 
-<span class="v">11&#160;</span>The way before them was like the appearance of the rooms which were toward the north. Their length and width were the same. All their exits had the same arrangement and doors. 
-<span class="v">12&#160;</span>Like the doors of the rooms that were toward the south was a door at the head of the way, even the way directly before the wall toward the east, as one enters into them. 
-</p><p>
-<span class="v">13&#160;</span>Then he said to me, “The north rooms and the south rooms, which are opposite the separate place, are the set-apart rooms, where the priests who are near to Yahweh shall eat the most set-apart things. There they shall lay the most set-apart things, with the meal offering, the sin offering, and the trespass offering; for the place is set-apart. 
-<span class="v">14&#160;</span>When the priests enter in, then they shall not go out of the set-apart place into the outer court until they lay their garments in which they minister there; for they are set-apart. Then they shall put on other garments, and shall approach that which is for the people.” 
-</p><p>
-<span class="v">15&#160;</span>Now when he had finished measuring the inner house, he brought me out by the way of the gate which faces toward the east, and measured it all around. 
-<span class="v">16&#160;</span>He measured on the east side with the measuring reed five hundred reeds, with the measuring reed all around. 
-<span class="v">17&#160;</span>He measured on the north side five hundred reeds with the measuring reed all around. 
-<span class="v">18&#160;</span>He measured on the south side five hundred reeds with the measuring reed. 
-<span class="v">19&#160;</span>He turned about to the west side, and measured five hundred reeds with the measuring reed. 
-<span class="v">20&#160;</span>He measured it on the four sides. It had a wall around it, the length five hundred cubits, and the width five hundred cubits, to make a separation between that which was set-apart and that which was common. 
-</p><h2 class="chapterlabel" id="43">43</h2>
-<p>
-<span class="v">1&#160;</span>Afterward he brought me to the gate, even the gate that looks toward the east. 
-<span class="v">2&#160;</span>Behold, the glory of the Elohim of Israel came from the way of the east. His voice was like the sound of many waters; and the earth was illuminated with his glory. 
-<span class="v">3&#160;</span>It was like the appearance of the vision which I saw, even according to the vision that I saw when I came to destroy the city; and the visions were like the vision that I saw by the river Chebar; and I fell on my face. 
-<span class="v">4&#160;</span>Yahweh’s glory came into the house by the way of the gate which faces toward the east. 
-<span class="v">5&#160;</span>The Spirit took me up and brought me into the inner court; and behold, Yahweh’s glory filled the house. 
-</p><p>
-<span class="v">6&#160;</span>I heard one speaking to me out of the house, and a man stood by me. 
-<span class="v">7&#160;</span>He said to me, “Son of man, this is the place of my throne and the place of the soles of my feet, where I will dwell among the children of Israel forever. The house of Israel will no more defile my set-apart name, neither they nor their kings, by their prostitution and by the dead bodies of their kings in their high places; 
-<span class="v">8&#160;</span>in their setting of their threshold by my threshold and their door post beside my door post. There was a wall between me and them; and they have defiled my set-apart name by their abominations which they have committed. Therefore I have consumed them in my anger. 
-<span class="v">9&#160;</span>Now let them put away their prostitution, and the dead bodies of their kings far from me. Then I will dwell among them forever. 
-</p><p>
-<span class="v">10&#160;</span>“You, son of man, show the house to the house of Israel, that they may be ashamed of their iniquities; and let them measure the pattern. 
-<span class="v">11&#160;</span>If they are ashamed of all that they have done, make known to them the form of the house, its fashion, its exits, its entrances, its structure, all its ordinances, all its forms, and all its laws; and write it in their sight, that they may keep the whole form of it, and all its ordinances, and do them. 
-</p><p>
-<span class="v">12&#160;</span>“This is the law of the house. On the top of the mountain the whole limit around it shall be most set-apart. Behold, this is the law of the house. 
-</p><p>
-<span class="v">13&#160;</span>“These are the measurements of the altar by cubits (the cubit<span class="f">+ \fr 43:13 \ft A normal cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters. A hand width is about 4.3 inches or 11 cm.</span> is a cubit and a hand width): the bottom shall be a cubit, and the width a cubit, and its border around its edge a span;<span class="f">+ \fr 43:13 \ft A span is the length from the tip of a man’s thumb to the tip of his little finger when his hand is stretched out (about half a cubit, or 9 inches, or 22.8 cm.)</span> and this shall be the base of the altar. 
-<span class="v">14&#160;</span>From the bottom on the ground to the lower ledge shall be two cubits, and the width one cubit; and from the lesser ledge to the greater ledge shall be four cubits, and the width a cubit. 
-<span class="v">15&#160;</span>The upper altar shall be four cubits; and from the altar hearth and upward there shall be four horns. 
-<span class="v">16&#160;</span>The altar hearth shall be twelve cubits long by twelve wide, square in its four sides. 
-<span class="v">17&#160;</span>The ledge shall be fourteen cubits long by fourteen wide in its four sides; and the border about it shall be half a cubit; and its bottom shall be a cubit around; and its steps shall look toward the east.” 
-</p><p>
-<span class="v">18&#160;</span>He said to me, “Son of man, the Lord Yahweh says: ‘These are the ordinances of the altar in the day when they make it, to offer burnt offerings on it, and to sprinkle blood on it. 
-<span class="v">19&#160;</span>You shall give to the Levitical priests who are of the offspring of Zadok, who are near to me, to minister to me,’ says the Lord Yahweh, ‘a young bull for a sin offering. 
-<span class="v">20&#160;</span>You shall take of its blood and put it on its four horns, and on the four corners of the ledge, and on the border all around. You shall cleanse it and make atonement for it that way. 
-<span class="v">21&#160;</span>You shall also take the bull of the sin offering, and it shall be burned in the appointed place of the house, outside of the sanctuary. 
-</p><p>
-<span class="v">22&#160;</span>“On the second day you shall offer a male goat without defect for a sin offering; and they shall cleanse the altar, as they cleansed it with the bull. 
-<span class="v">23&#160;</span>When you have finished cleansing it, you shall offer a young bull without defect and a ram out of the flock without defect. 
-<span class="v">24&#160;</span>You shall bring them near to Yahweh, and the priests shall cast salt on them, and they shall offer them up for a burnt offering to Yahweh. 
-</p><p>
-<span class="v">25&#160;</span>“Seven days you shall prepare every day a goat for a sin offering. They shall also prepare a young bull and a ram out of the flock, without defect. 
-<span class="v">26&#160;</span>Seven days shall they make atonement for the altar and purify it. So shall they consecrate it. 
-<span class="v">27&#160;</span>When they have accomplished the days, it shall be that on the eighth day and onward, the priests shall make your burnt offerings on the altar and your peace offerings. Then I will accept you,’ says the Lord Yahweh.” 
-</p><h2 class="chapterlabel" id="44">44</h2>
-<p>
-<span class="v">1&#160;</span>Then he brought me back by the way of the outer gate of the sanctuary, which looks toward the east; and it was shut. 
-<span class="v">2&#160;</span>Yahweh said to me, “This gate shall be shut. It shall not be opened, no man shall enter in by it; for Yahweh, the Elohim of Israel, has entered in by it. Therefore it shall be shut. 
-<span class="v">3&#160;</span>As for the prince, he shall sit in it as prince to eat bread before Yahweh. He shall enter by the way of the porch of the gate, and shall go out the same way.” 
-</p><p>
-<span class="v">4&#160;</span>Then he brought me by the way of the north gate before the house; and I looked, and behold, Yahweh’s glory filled Yahweh’s house; so I fell on my face. 
-</p><p>
-<span class="v">5&#160;</span>Yahweh said to me, “Son of man, mark well, and see with your eyes, and hear with your ears all that I tell you concerning all the ordinances of Yahweh’s house and all its laws; and mark well the entrance of the house, with every exit of the sanctuary. 
-<span class="v">6&#160;</span>You shall tell the rebellious, even the house of Israel, ‘The Lord Yahweh says: “You house of Israel, let that be enough of all your abominations, 
-<span class="v">7&#160;</span>in that you have brought in foreigners, uncircumcised in heart and uncircumcised in flesh, to be in my sanctuary, to profane it, even my house, when you offer my bread, the fat and the blood; and they have broken my covenant, to add to all your abominations. 
-<span class="v">8&#160;</span>You have not performed the duty of my set-apart things; but you have set performers of my duty in my sanctuary for yourselves.” 
-<span class="v">9&#160;</span>The Lord Yahweh says, “No foreigner, uncircumcised in heart and uncircumcised in flesh, shall enter into my sanctuary, of any foreigners who are among the children of Israel. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘&#160;“But the Levites who went far from me when Israel went astray, who went astray from me after their idols, they will bear their iniquity. 
-<span class="v">11&#160;</span>Yet they shall be ministers in my sanctuary, having oversight at the gates of the house, and ministering in the house. They shall kill the burnt offering and the sacrifice for the people, and they shall stand before them to minister to them. 
-<span class="v">12&#160;</span>Because they ministered to them before their idols, and became a stumbling block of iniquity to the house of Israel, therefore I have lifted up my hand against them,” says the Lord Yahweh, “and they will bear their iniquity. 
-<span class="v">13&#160;</span>They shall not come near to me, to execute the office of priest to me, nor to come near to any of my set-apart things, to the things that are most set-apart; but they will bear their shame and their abominations which they have committed. 
-<span class="v">14&#160;</span>Yet I will make them performers of the duty of the house, for all its service and for all that will be done therein. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘&#160;“But the Levitical priests, the sons of Zadok, who performed the duty of my sanctuary when the children of Israel went astray from me, shall come near to me to minister to me. They shall stand before me to offer to me the fat and the blood,” says the Lord Yahweh. 
-<span class="v">16&#160;</span>“They shall enter into my sanctuary, and they shall come near to my table, to minister to me, and they shall keep my instruction. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘&#160;“It will be that when they enter in at the gates of the inner court, they shall be clothed with linen garments. No wool shall come on them while they minister in the gates of the inner court, and within. 
-<span class="v">18&#160;</span>They shall have linen turbans on their heads, and shall have linen trousers on their waists. They shall not clothe themselves with anything that makes them sweat. 
-<span class="v">19&#160;</span>When they go out into the outer court, even into the outer court to the people, they shall put off their garments in which they minister and lay them in the set-apart rooms. They shall put on other garments, that they not sanctify the people with their garments. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘&#160;“They shall not shave their heads, or allow their locks to grow long. They shall only cut off the hair of their heads. 
-<span class="v">21&#160;</span>None of the priests shall drink wine when they enter into the inner court. 
-<span class="v">22&#160;</span>They shall not take for their women a widow, or her who is put away; but they shall take virgins of the offspring of the house of Israel, or a widow who is the widow of a priest. 
-<span class="v">23&#160;</span>They shall teach my people the difference between the set-apart and the common, and cause them to discern between the unclean and the clean. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘&#160;“In a controversy they shall stand to judge. They shall judge it according to my ordinances. They shall keep my laws and my statutes in all my appointed feasts. They shall make my Sabbaths set-apart. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘&#160;“They shall go in to no dead person to defile themselves; but for father, or for mother, or for son, or for daughter, for brother, or for sister who has had no man, they may defile themselves. 
-<span class="v">26&#160;</span>After he is cleansed, they shall reckon to him seven days. 
-<span class="v">27&#160;</span>In the day that he goes into the sanctuary, into the inner court, to minister in the sanctuary, he shall offer his sin offering,” says the Lord Yahweh. 
-</p><p>
-<span class="v">28&#160;</span>“&#160;‘They shall have an inheritance: I am their inheritance; and you shall give them no possession in Israel. I am their possession. 
-<span class="v">29&#160;</span>They shall eat the meal offering, and the sin offering, and the trespass offering; and every devoted thing in Israel shall be theirs. 
-<span class="v">30&#160;</span>The first of all the first fruits of every thing, and every offering of everything, of all your offerings, shall be for the priest. You shall also give to the priests the first of your dough, to cause a blessing to rest on your house. 
-<span class="v">31&#160;</span>The priests shall not eat of anything that dies of itself or is torn, whether it is bird or animal. 
-</p><h2 class="chapterlabel" id="45">45</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘&#160;“Moreover, when you divide by lot the land for inheritance, you shall offer an offering to Yahweh, a set-apart portion of the land. The length shall be the length of twenty-five thousand reeds, and the width shall be ten thousand. It shall be set-apart in all its border all around. 
-<span class="v">2&#160;</span>Of this there shall be a five hundred by five hundred square for the set-apart place, and fifty cubits<span class="f">+ \fr 45:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> for its pasture lands all around. 
-<span class="v">3&#160;</span>Of this measure you shall measure a length of twenty-five thousand, and a width of ten thousand. In it shall be the sanctuary, which is most set-apart. 
-<span class="v">4&#160;</span>It is a set-apart portion of the land; it shall be for the priests, the ministers of the sanctuary, who come near to minister to Yahweh. It shall be a place for their houses and a set-apart place for the sanctuary. 
-<span class="v">5&#160;</span>Twenty-five thousand cubits in length and ten thousand in width shall be for the Levites, the ministers of the house, as a possession for themselves, for twenty rooms. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘&#160;“You shall appoint the possession of the city five thousand cubits wide and twenty-five thousand long, side by side with the offering of the set-apart portion. It shall be for the whole house of Israel. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘&#160;“What is for the prince shall be on the one side and on the other side of the set-apart allotment and of the possession of the city, in front of the set-apart allotment and in front of the possession of the city, on the west side westward, and on the east side eastward, and in length corresponding to one of the portions, from the west border to the east border. 
-<span class="v">8&#160;</span>In the land it shall be to him for a possession in Israel. My princes shall no more oppress my people, but they shall give the land to the house of Israel according to their tribes.” 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘The Lord Yahweh says: “Enough you, princes of Israel! Remove violence and plunder, and execute justice and righteousness! Stop dispossessing my people!” says the Lord Yahweh. 
-<span class="v">10&#160;</span>“You shall have just balances, a just ephah,<span class="f">+ \fr 45:10 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> and a just bath. 
-<span class="v">11&#160;</span>The ephah and the bath shall be of one measure, that the bath may contain one tenth of a homer,<span class="f">+ \fr 45:11 \ft 1 homer is about 220 liters or 6 bushels</span> and the ephah one tenth of a homer. Its measure shall be the same as the homer. 
-<span class="v">12&#160;</span>The shekel<span class="f">+ \fr 45:12 \ft A shekel is about 10 grams or about 0.35 ounces.</span> shall be twenty gerahs.<span class="f">+ \fr 45:12 \ft a gerah is about 0.5 grams or about 7.7 grains</span> Twenty shekels plus twenty-five shekels plus fifteen shekels shall be your mina.<span class="f">+ \fr 45:12 \ft A mina is about 600 grams or 1.3 U. S. pounds.</span> 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘&#160;“This is the offering that you shall offer: the sixth part of an ephah from a homer of wheat, and you shall give the sixth part of an ephah from a homer of barley, 
-<span class="v">14&#160;</span>and the set portion of oil, of the bath of oil, one tenth of a bath out of the cor, which is ten baths, even a homer (for ten baths are a homer),<span class="f">+ \fr 45:14 \ft 1 cor is the same as 1 homer in volume, and is about 211 liters, 55.9 gallons, or 6 bushels. 1 bath is about 21.1 liters, 5.59 gallons, or 2.4 pecks.</span> 
-<span class="v">15&#160;</span>and one lamb of the flock out of two hundred, from the well-watered pastures of Israel—for a meal offering, for a burnt offering, and for peace offerings, to make atonement for them,” says the Lord Yahweh. 
-<span class="v">16&#160;</span>“All the people of the land shall give to this offering for the prince in Israel. 
-<span class="v">17&#160;</span>It shall be the prince’s part to give the burnt offerings, the meal offerings, and the drink offerings, in the feasts, and on the new moons, and on the Sabbaths, in all the appointed feasts of the house of Israel. He shall prepare the sin offering, the meal offering, the burnt offering, and the peace offerings, to make atonement for the house of Israel.” 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘The Lord Yahweh says: “In the first month, on the first day of the month, you shall take a young bull without defect, and you shall cleanse the sanctuary. 
-<span class="v">19&#160;</span>The priest shall take of the blood of the sin offering and put it on the door posts of the house, and on the four corners of the ledge of the altar, and on the posts of the gate of the inner court. 
-<span class="v">20&#160;</span>So you shall do on the seventh day of the month for everyone who errs, and for him who is simple. So you shall make atonement for the house. 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘&#160;“In the first month, on the fourteenth day of the month, you shall have the Passover, a feast of seven days; unleavened bread shall be eaten. 
-<span class="v">22&#160;</span>On that day the prince shall prepare for himself and for all the people of the land a bull for a sin offering. 
-<span class="v">23&#160;</span>The seven days of the feast he shall prepare a burnt offering to Yahweh, seven bulls and seven rams without defect daily the seven days; and a male goat daily for a sin offering. 
-<span class="v">24&#160;</span>He shall prepare a meal offering, an ephah<span class="f">+ \fr 45:24 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> for a bull, an ephah for a ram, and a hin<span class="f">+ \fr 45:24 \ft A hin is about 6.5 liters or 1.7 gallons.</span> of oil to an ephah. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘&#160;“In the seventh month, on the fifteenth day of the month, during the feast, he shall do like that for seven days. He shall make the same provision for sin offering, the burnt offering, the meal offering, and the oil.” 
-</p><h2 class="chapterlabel" id="46">46</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘The Lord Yahweh says: “The gate of the inner court that looks toward the east shall be shut the six working days; but on the Sabbath day it shall be opened, and on the day of the new moon it shall be opened. 
-<span class="v">2&#160;</span>The prince shall enter by the way of the porch of the gate outside, and shall stand by the post of the gate; and the priests shall prepare his burnt offering and his peace offerings, and he shall worship at the threshold of the gate. Then he shall go out, but the gate shall not be shut until the evening. 
-<span class="v">3&#160;</span>The people of the land shall worship at the door of that gate before Yahweh on the Sabbaths and on the new moons. 
-<span class="v">4&#160;</span>The burnt offering that the prince shall offer to Yahweh shall be on the Sabbath day, six lambs without defect and a ram without defect; 
-<span class="v">5&#160;</span>and the meal offering shall be an ephah for the ram, and the meal offering for the lambs as he is able to give, and a hin<span class="f">+ \fr 46:5 \ft A hin is about 6.5 liters or 1.7 gallons.</span> of oil to an ephah.<span class="f">+ \fr 46:5 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> 
-<span class="v">6&#160;</span>On the day of the new moon it shall be a young bull without defect, six lambs, and a ram. They shall be without defect. 
-<span class="v">7&#160;</span>He shall prepare a meal offering: an ephah for the bull, and an ephah for the ram, and for the lambs according as he is able, and a hin of oil to an ephah. 
-<span class="v">8&#160;</span>When the prince enters, he shall go in by the way of the porch of the gate, and he shall go out by its way. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘&#160;“But when the people of the land come before Yahweh in the appointed feasts, he who enters by the way of the north gate to worship shall go out by the way of the south gate; and he who enters by the way of the south gate shall go out by the way of the north gate. He shall not return by the way of the gate by which he came in, but shall go out straight before him. 
-<span class="v">10&#160;</span>The prince shall go in with them when they go in. When they go out, he shall go out. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘&#160;“In the feasts and in the appointed set-apart days, the meal offering shall be an ephah<span class="f">+ \fr 46:11 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> for a bull, and an ephah for a ram, and for the lambs as he is able to give, and a hin of oil to an ephah. 
-<span class="v">12&#160;</span>When the prince prepares a free will offering, a burnt offering or peace offerings as a free will offering to Yahweh, one shall open for him the gate that looks toward the east; and he shall prepare his burnt offering and his peace offerings, as he does on the Sabbath day. Then he shall go out; and after his going out one shall shut the gate. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘&#160;“You shall prepare a lamb a year old without defect for a burnt offering to Yahweh daily. Morning by morning you shall prepare it. 
-<span class="v">14&#160;</span>You shall prepare a meal offering with it morning by morning, the sixth part of an ephah,<span class="f">+ \fr 46:14 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> and the third part of a hin of oil to moisten the fine flour; a meal offering to Yahweh continually by a perpetual ordinance. 
-<span class="v">15&#160;</span>Thus they shall prepare the lamb, the meal offering, and the oil, morning by morning, for a continual burnt offering.” 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘The Lord Yahweh says: “If the prince gives a gift to any of his sons, it is his inheritance. It shall belong to his sons. It is their possession by inheritance. 
-<span class="v">17&#160;</span>But if he gives of his inheritance a gift to one of his servants, it shall be his to the year of liberty; then it shall return to the prince; but as for his inheritance, it shall be for his sons. 
-<span class="v">18&#160;</span>Moreover the prince shall not take of the people’s inheritance, to thrust them out of their possession. He shall give inheritance to his sons out of his own possession, that my people not each be scattered from his possession.”&#160;’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>Then he brought me through the entry, which was at the side of the gate, into the set-apart rooms for the priests, which looked toward the north. Behold, there was a place on the back part westward. 
-<span class="v">20&#160;</span>He said to me, “This is the place where the priests shall boil the trespass offering and the sin offering, and where they shall bake the meal offering, that they not bring them out into the outer court, to sanctify the people.” 
-</p><p>
-<span class="v">21&#160;</span>Then he brought me out into the outer court and caused me to pass by the four corners of the court; and behold, in every corner of the court there was a court. 
-<span class="v">22&#160;</span>In the four corners of the court there were courts enclosed, forty cubits<span class="f">+ \fr 46:22 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> long and thirty wide. These four in the corners were the same size. 
-<span class="v">23&#160;</span>There was a wall around in them, around the four, and boiling places were made under the walls all around. 
-<span class="v">24&#160;</span>Then he said to me, “These are the boiling houses, where the ministers of the house shall boil the sacrifice of the people.” 
-</p><h2 class="chapterlabel" id="47">47</h2>
-<p>
-<span class="v">1&#160;</span>He brought me back to the door of the temple; and behold, waters flowed out from under the threshold of the temple eastward, for the front of the temple faced toward the east. The waters came down from underneath, from the right side of the temple, on the south of the altar. 
-<span class="v">2&#160;</span>Then he brought me out by the way of the gate northward, and led me around by the way outside to the outer gate, by the way of the gate that looks toward the east. Behold, waters ran out on the right side. 
-</p><p>
-<span class="v">3&#160;</span>When the man went out eastward with the line in his hand, he measured one thousand cubits,<span class="f">+ \fr 47:3 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and he caused me to pass through the waters, waters that were to the ankles. 
-<span class="v">4&#160;</span>Again he measured one thousand, and caused me to pass through the waters, waters that were to the knees. Again he measured one thousand, and caused me to pass through waters that were to the waist. 
-<span class="v">5&#160;</span>Afterward he measured one thousand; and it was a river that I could not pass through, for the waters had risen, waters to swim in, a river that could not be walked through. 
-</p><p>
-<span class="v">6&#160;</span>He said to me, “Son of man, have you seen this?” 
-</p><p>Then he brought me and caused me to return to the bank of the river. 
-<span class="v">7&#160;</span>Now when I had returned, behold, on the bank of the river were very many trees on the one side and on the other. 
-<span class="v">8&#160;</span>Then he said to me, “These waters flow out toward the eastern region and will go down into the Arabah. Then they will go toward the sea and flow into the sea which will be made to flow out; and the waters will be healed. 
-<span class="v">9&#160;</span>It will happen that every living creature which swarms, in every place where the rivers come, will live. Then there will be a very great multitude of fish; for these waters have come there, and the waters of the sea will be healed, and everything will live wherever the river comes. 
-<span class="v">10&#160;</span>It will happen that fishermen will stand by it. From En Gedi even to En Eglaim will be a place for the spreading of nets. Their fish will be after their kinds, as the fish of the great sea, exceedingly many. 
-<span class="v">11&#160;</span>But its swamps marshes will not be healed. They will be given up to salt. 
-<span class="v">12&#160;</span>By the river banks, on both sides, will grow every tree for food, whose leaf won’t wither, neither will its fruit fail. It will produce new fruit every month, because its waters issue out of the sanctuary. Its fruit will be for food, and its leaf for healing.” 
-</p><p>
-<span class="v">13&#160;</span>The Lord Yahweh says: “This shall be the border by which you shall divide the land for inheritance according to the twelve tribes of Israel. Joseph shall have two portions. 
-<span class="v">14&#160;</span>You shall inherit it, one as well as another; for I swore to give it to your fathers. This land will fall to you for inheritance. 
-</p><p>
-<span class="v">15&#160;</span>“This shall be the border of the land: 
-</p><p>“On the north side, from the great sea, by the way of Hethlon, to the entrance of Zedad; 
-<span class="v">16&#160;</span>Hamath, Berothah, Sibraim (which is between the border of Damascus and the border of Hamath), to Hazer Hatticon, which is by the border of Hauran. 
-<span class="v">17&#160;</span>The border from the sea shall be Hazar Enon at the border of Damascus; and on the north northward is the border of Hamath. This is the north side. 
-</p><p>
-<span class="v">18&#160;</span>“The east side, between Hauran, Damascus, Gilead, and the land of Israel, shall be the Jordan; from the north border to the east sea you shall measure. This is the east side. 
-</p><p>
-<span class="v">19&#160;</span>“The south side southward shall be from Tamar as far as the waters of Meriboth Kadesh, to the brook, to the great sea. This is the south side southward. 
-</p><p>
-<span class="v">20&#160;</span>“The west side shall be the great sea, from the south border as far as opposite the entrance of Hamath. This is the west side. 
-</p><p>
-<span class="v">21&#160;</span>“So you shall divide this land to yourselves according to the tribes of Israel. 
-<span class="v">22&#160;</span>You shall divide it by lot for an inheritance to you and to the aliens who live among you, who will father children among you. Then they shall be to you as the native-born among the children of Israel. They shall have inheritance with you among the tribes of Israel. 
-<span class="v">23&#160;</span>In whatever tribe the stranger lives, there you shall give him his inheritance,” says the Lord Yahweh. 
-</p><h2 class="chapterlabel" id="48">48</h2>
-<p>
-<span class="v">1&#160;</span>“Now these are the names of the tribes: From the north end, beside the way of Hethlon to the entrance of Hamath, Hazar Enan at the border of Damascus, northward beside Hamath (and they shall have their sides east and west), Dan, one portion. 
-</p><p>
-<span class="v">2&#160;</span>“By the border of Dan, from the east side to the west side, Asher, one portion. 
-</p><p>
-<span class="v">3&#160;</span>“By the border of Asher, from the east side even to the west side, Naphtali, one portion. 
-</p><p>
-<span class="v">4&#160;</span>“By the border of Naphtali, from the east side to the west side, Manasseh, one portion. 
-</p><p>
-<span class="v">5&#160;</span>“By the border of Manasseh, from the east side to the west side, Ephraim, one portion. 
-</p><p>
-<span class="v">6&#160;</span>“By the border of Ephraim, from the east side even to the west side, Reuben, one portion. 
-</p><p>
-<span class="v">7&#160;</span>“By the border of Reuben, from the east side to the west side, Judah, one portion. 
-</p><p>
-<span class="v">8&#160;</span>“By the border of Judah, from the east side to the west side, shall be the offering which you shall offer, twenty-five thousand reeds in width, and in length as one of the portions, from the east side to the west side; and the sanctuary shall be in the middle of it. 
-</p><p>
-<span class="v">9&#160;</span>“The offering that you shall offer to Yahweh shall be twenty-five thousand reeds in length, and ten thousand in width. 
-<span class="v">10&#160;</span>For these, even for the priests, shall be the set-apart offering: toward the north twenty-five thousand in length, and toward the west ten thousand in width, and toward the east ten thousand in width, and toward the south twenty-five thousand in length; and the sanctuary of Yahweh shall be in the middle of it. 
-<span class="v">11&#160;</span>It shall be for the priests who are sanctified of the sons of Zadok, who have kept my instruction, who didn’t go astray when the children of Israel went astray, as the Levites went astray. 
-<span class="v">12&#160;</span>It shall be to them an offering from the offering of the land, a most set-apart thing, by the border of the Levites. 
-</p><p>
-<span class="v">13&#160;</span>“Alongside the border of the priests, the Levites shall have twenty-five thousand cubits in length and ten thousand in width. All the length shall be twenty-five thousand, and the width ten thousand. 
-<span class="v">14&#160;</span>They shall sell none of it, nor exchange it, nor shall the first fruits of the land be alienated, for it is set-apart to Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>“The five thousand cubits that are left in the width, in front of the twenty-five thousand, shall be for common use, for the city, for dwelling and for pasture lands; and the city shall be in the middle of it. 
-<span class="v">16&#160;</span>These shall be its measurements: the north side four thousand and five hundred, and the south side four thousand and five hundred, and on the east side four thousand and five hundred, and the west side four thousand and five hundred. 
-<span class="v">17&#160;</span>The city shall have pasture lands: toward the north two hundred fifty, and toward the south two hundred fifty, and toward the east two hundred fifty, and toward the west two hundred fifty. 
-<span class="v">18&#160;</span>The remainder of the length, alongside the set-apart offering, shall be ten thousand eastward and ten thousand westward; and it shall be alongside the set-apart offering. Its increase shall be for food to those who labor in the city. 
-<span class="v">19&#160;</span>Those who labor in the city, out of all the tribes of Israel, shall cultivate it. 
-<span class="v">20&#160;</span>All the offering shall be a square of twenty-five thousand by twenty-five thousand. You shall offer it as a set-apart offering, with the possession of the city. 
-</p><p>
-<span class="v">21&#160;</span>“The remainder shall be for the prince, on the one side and on the other of the set-apart offering and of the possession of the city; in front of the twenty-five thousand of the offering toward the east border, and westward in front of the twenty-five thousand toward the west border, alongside the portions, it shall be for the prince. The set-apart offering and the sanctuary of the house shall be in the middle of it. 
-<span class="v">22&#160;</span>Moreover, from the possession of the Levites, and from the possession of the city, being in the middle of that which is the prince’s, between the border of Judah and the border of Benjamin, shall be for the prince. 
-</p><p>
-<span class="v">23&#160;</span>“As for the rest of the tribes: from the east side to the west side, Benjamin, one portion. 
-</p><p>
-<span class="v">24&#160;</span>“By the border of Benjamin, from the east side to the west side, Simeon, one portion. 
-</p><p>
-<span class="v">25&#160;</span>“By the border of Simeon, from the east side to the west side, Issachar, one portion. 
-</p><p>
-<span class="v">26&#160;</span>“By the border of Issachar, from the east side to the west side, Zebulun, one portion. 
-</p><p>
-<span class="v">27&#160;</span>“By the border of Zebulun, from the east side to the west side, Gad, one portion. 
-</p><p>
-<span class="v">28&#160;</span>“By the border of Gad, at the south side southward, the border shall be even from Tamar to the waters of Meribath Kadesh, to the brook, to the great sea. 
-</p><p>
-<span class="v">29&#160;</span>“This is the land which you shall divide by lot to the tribes of Israel for inheritance, and these are their several portions, says the Lord Yahweh. 
-</p><p>
-<span class="v">30&#160;</span>“These are the exits of the city: On the north side four thousand five hundred reeds by measure; 
-<span class="v">31&#160;</span>and the gates of the city shall be named after the tribes of Israel, three gates northward: the gate of Reuben, one; the gate of Judah, one; the gate of Levi, one. 
-</p><p>
-<span class="v">32&#160;</span>“At the east side four thousand five hundred reeds, and three gates: even the gate of Joseph, one; the gate of Benjamin, one; the gate of Dan, one. 
-</p><p>
-<span class="v">33&#160;</span>“At the south side four thousand five hundred reeds by measure, and three gates: the gate of Simeon, one; the gate of Issachar, one; the gate of Zebulun, one. 
-</p><p>
-<span class="v">34&#160;</span>“At the west side four thousand five hundred reeds, with their three gates: the gate of Gad, one; the gate of Asher, one; the gate of Naphtali, one. 
-</p><p>
-<span class="v">35&#160;</span>“It shall be eighteen thousand reeds in circumference; and the name of the city from that day shall be, ‘Yahweh is there.’ </div><script src="../main.js"></script></body></html>
+<div class="p">
+<sup>1&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“You, son of man, the Lord Yahweh says to the land of Israel, ‘An end! The end has come on the four corners of the land. 
+<sup>3&#160;</sup>Now the end is on you, and I will send my anger on you, and will judge you according to your ways. I will bring on you all your abominations. 
+<sup>4&#160;</sup>My eye will not spare you, neither will I have pity; but I will bring your ways on you, and your abominations will be among you. Then you will know that I am Yahweh.’ 
+</div><div class="p">
+<sup>5&#160;</sup>“The Lord Yahweh says: ‘A disaster! A unique disaster! Behold, it comes. 
+<sup>6&#160;</sup>An end has come. The end has come! It awakes against you. Behold, it comes. 
+<sup>7&#160;</sup>Your doom has come to you, inhabitant of the land! The time has come! The day is near, a day of tumult, and not of joyful shouting, on the mountains. 
+<sup>8&#160;</sup>Now I will shortly pour out my wrath on you, and accomplish my anger against you, and will judge you according to your ways. I will bring on you all your abominations. 
+<sup>9&#160;</sup>My eye won’t spare, neither will I have pity. I will punish you according to your ways. Your abominations will be among you. Then you will know that I, Yahweh, strike. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘Behold, the day! Behold, it comes! Your doom has gone out. The rod has blossomed. Pride has budded. 
+<sup>11&#160;</sup>Violence has risen up into a rod of wickedness. None of them will remain, nor of their multitude, nor of their wealth. There will be nothing of value among them. 
+<sup>12&#160;</sup>The time has come! The day draws near. Don’t let the buyer rejoice, nor the seller mourn; for wrath is on all its multitude. 
+<sup>13&#160;</sup>For the seller won’t return to that which is sold, although they are still alive; for the vision concerns the whole multitude of it. None will return. None will strengthen himself in the iniquity of his life. 
+<sup>14&#160;</sup>They have blown the trumpet, and have made all ready; but no one goes to the battle, for my wrath is on all its multitude. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘The sword is outside, and the pestilence and the famine within. He who is in the field will die by the sword. He who is in the city will be devoured by famine and pestilence. 
+<sup>16&#160;</sup>But of those who escape, they will escape and will be on the mountains like doves of the valleys, all of them moaning, everyone in his iniquity. 
+<sup>17&#160;</sup>All hands will be feeble, and all knees will be weak as water. 
+<sup>18&#160;</sup>They will also clothe themselves with sackcloth, and horror will cover them. Shame will be on all faces, and baldness on all their heads. 
+<sup>19&#160;</sup>They will cast their silver in the streets, and their gold will be as an unclean thing. Their silver and their gold won’t be able to deliver them in the day of Yahweh’s wrath. They won’t satisfy their souls or fill their bellies; because it has been the stumbling block of their iniquity. 
+<sup>20&#160;</sup>As for the beauty of his ornament, he set it in majesty; but they made the images of their abominations and their detestable things therein. Therefore I have made it to them as an unclean thing. 
+<sup>21&#160;</sup>I will give it into the hands of the strangers for a prey, and to the wicked of the earth for a plunder; and they will profane it. 
+<sup>22&#160;</sup>I will also turn my face from them, and they will profane my secret place. Robbers will enter into it, and profane it. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘Make chains, for the land is full of bloody crimes, and the city is full of violence. 
+<sup>24&#160;</sup>Therefore I will bring the worst of the nations, and they will possess their houses. I will also make the pride of the strong to cease. Their set-apart places will be profaned. 
+<sup>25&#160;</sup>Destruction comes! They will seek peace, and there will be none. 
+<sup>26&#160;</sup>Mischief will come on mischief, and rumor will be on rumor. They will seek a vision of the prophet; but the law will perish from the priest, and counsel from the elders. 
+<sup>27&#160;</sup>The king will mourn, and the prince will be clothed with desolation. The hands of the people of the land will be troubled. I will do to them after their way, and according to their own judgments I will judge them. Then they will know that I am Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>In the sixth year, in the sixth month, in the fifth day of the month, as I sat in my house, and the elders of Judah sat before me, the Lord Yahweh’s hand fell on me there. 
+<sup>2&#160;</sup>Then I saw, and behold, a likeness as the appearance of fire—from the appearance of his waist and downward, fire, and from his waist and upward, as the appearance of brightness, as it were glowing metal. 
+<sup>3&#160;</sup>He stretched out the form of a hand, and took me by a lock of my head; and the Spirit lifted me up between earth and the sky, and brought me in the visions of Elohim to Jerusalem, to the door of the gate of the inner court that looks toward the north, where there was the seat of the image of jealousy, which provokes to jealousy. 
+<sup>4&#160;</sup>Behold, the glory of the Elohim of Israel was there, according to the appearance that I saw in the plain. 
+</div><div class="p">
+<sup>5&#160;</sup>Then he said to me, “Son of man, lift up your eyes now the way toward the north.” 
+</div><div class="p">So I lifted up my eyes the way toward the north, and saw, northward of the gate of the altar this image of jealousy in the entry. 
+</div><div class="p">
+<sup>6&#160;</sup>He said to me, “Son of man, do you see what they do? Even the great abominations that the house of Israel commit here, that I should go far off from my sanctuary? But you will again see yet other great abominations.” 
+</div><div class="p">
+<sup>7&#160;</sup>He brought me to the door of the court; and when I looked, behold, a hole in the wall. 
+<sup>8&#160;</sup>Then he said to me, “Son of man, dig now in the wall.” 
+</div><div class="p">When I had dug in the wall, I saw a door. 
+</div><div class="p">
+<sup>9&#160;</sup>He said to me, “Go in, and see the wicked abominations that they do here.” 
+</div><div class="p">
+<sup>10&#160;</sup>So I went in and looked, and saw every form of creeping things, abominable animals, and all the idols of the house of Israel, portrayed around on the wall. 
+<sup>11&#160;</sup>Seventy men of the elders of the house of Israel stood before them. In the middle of them Jaazaniah the son of Shaphan stood, every man with his censer in his hand; and the smell of the cloud of incense went up. 
+</div><div class="p">
+<sup>12&#160;</sup>Then he said to me, “Son of man, have you seen what the elders of the house of Israel do in the dark, every man in his rooms of imagery? For they say, ‘Yahweh doesn’t see us. Yahweh has forsaken the land.’&#160;” 
+<sup>13&#160;</sup>He said also to me, “You will again see more of the great abominations which they do.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then he brought me to the door of the gate of Yahweh’s house which was toward the north; and I saw the women sit there weeping for Tammuz. 
+<sup>15&#160;</sup>Then he said to me, “Have you seen this, son of man? You will again see yet greater abominations than these.” 
+</div><div class="p">
+<sup>16&#160;</sup>He brought me into the inner court of Yahweh’s house; and I saw at the door of Yahweh’s temple, between the porch and the altar, there were about twenty-five men with their backs toward Yahweh’s temple and their faces toward the east. They were worshiping the sun toward the east. 
+</div><div class="p">
+<sup>17&#160;</sup>Then he said to me, “Have you seen this, son of man? Is it a light thing to the house of Judah that they commit the abominations which they commit here? For they have filled the land with violence, and have turned again to provoke me to anger. Behold, they put the branch to their nose. 
+<sup>18&#160;</sup>Therefore I will also deal in wrath. My eye won’t spare, neither will I have pity. Though they cry in my ears with a loud voice, yet I will not hear them.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Then he cried in my ears with a loud voice, saying, “Cause those who are in charge of the city to draw near, each man with his destroying weapon in his hand.” 
+<sup>2&#160;</sup>Behold, six men came from the way of the upper gate, which lies toward the north, every man with his slaughter weapon in his hand. One man in the middle of them was clothed in linen, with a writer’s inkhorn by his side. They went in, and stood beside the bronze altar. 
+</div><div class="p">
+<sup>3&#160;</sup>The glory of the Elohim of Israel went up from the cherub, whereupon it was, to the threshold of the house; and he called to the man clothed in linen, who had the writer’s inkhorn by his side. 
+<sup>4&#160;</sup>Yahweh said to him, “Go through the middle of the city, through the middle of Jerusalem, and set a mark on the foreheads of the men that sigh and that cry over all the abominations that are done within it.” 
+</div><div class="p">
+<sup>5&#160;</sup>To the others he said in my hearing, “Go through the city after him, and strike. Don’t let your eye spare, neither have pity. 
+<sup>6&#160;</sup>Kill utterly the old man, the young man, the virgin, little children and women; but don’t come near any man on whom is the mark. Begin at my sanctuary.” 
+</div><div class="p">Then they began at the old men who were before the house. 
+</div><div class="p">
+<sup>7&#160;</sup>He said to them, “Defile the house, and fill the courts with the slain. Go out!” 
+</div><div class="p">They went out, and struck in the city. 
+</div><div class="p">
+<sup>8&#160;</sup>While they were killing, and I was left, I fell on my face, and cried, and said, “Ah Lord Yahweh! Will you destroy all the residue of Israel in your pouring out of your wrath on Jerusalem?” 
+</div><div class="p">
+<sup>9&#160;</sup>Then he said to me, “The iniquity of the house of Israel and Judah is exceedingly great, and the land is full of blood, and the city full of perversion; for they say, ‘Yahweh has forsaken the land, and Yahweh doesn’t see.’ 
+<sup>10&#160;</sup>As for me also, my eye won’t spare, neither will I have pity, but I will bring their way on their head.” 
+</div><div class="p">
+<sup>11&#160;</sup>Behold, the man clothed in linen, who had the inkhorn by his side, reported the matter, saying, “I have done as you have commanded me.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Then I looked, and see, in the expanse that was over the head of the cherubim there appeared above them as it were a sapphire stone, as the appearance of the likeness of a throne. 
+<sup>2&#160;</sup>He spoke to the man clothed in linen, and said, “Go in between the whirling wheels, even under the cherub, and fill both your hands with coals of fire from between the cherubim, and scatter them over the city.” 
+</div><div class="p">He went in as I watched. 
+<sup>3&#160;</sup>Now the cherubim stood on the right side of the house when the man went in; and the cloud filled the inner court. 
+<sup>4&#160;</sup>Yahweh’s glory mounted up from the cherub, and stood over the threshold of the house; and the house was filled with the cloud, and the court was full of the brightness of Yahweh’s glory. 
+<sup>5&#160;</sup>The sound of the wings of the cherubim was heard even to the outer court, as the voice of Elohim Almighty when he speaks. 
+</div><div class="p">
+<sup>6&#160;</sup>It came to pass, when he commanded the man clothed in linen, saying, “Take fire from between the whirling wheels, from between the cherubim,” that he went in and stood beside a wheel. 
+<sup>7&#160;</sup>The cherub stretched out his hand from between the cherubim to the fire that was between the cherubim, and took some of it, and put it into the hands of him who was clothed in linen, who took it and went out. 
+<sup>8&#160;</sup>The form of a man’s hand appeared here in the cherubim under their wings. 
+</div><div class="p">
+<sup>9&#160;</sup>I looked, and behold, there were four wheels beside the cherubim, one wheel beside one cherub, and another wheel beside another cherub. The appearance of the wheels was like a beryl stone. 
+<sup>10&#160;</sup>As for their appearance, the four of them had one likeness, like a wheel within a wheel. 
+<sup>11&#160;</sup>When they went, they went in their four directions. They didn’t turn as they went, but to the place where the head looked they followed it. They didn’t turn as they went. 
+<sup>12&#160;</sup>Their whole body, including their backs, their hands, their wings, and the wheels, were full of eyes all around, even the wheels that the four of them had. 
+<sup>13&#160;</sup>As for the wheels, they were called in my hearing, “the whirling wheels”. 
+<sup>14&#160;</sup>Every one them had four faces. The first face was the face of the cherub. The second face was the face of a man. The third face was the face of a lion. The fourth was the face of an eagle. 
+</div><div class="p">
+<sup>15&#160;</sup>The cherubim mounted up. This is the living creature that I saw by the river Chebar. 
+<sup>16&#160;</sup>When the cherubim went, the wheels went beside them; and when the cherubim lifted up their wings to mount up from the earth, the wheels also didn’t turn from beside them. 
+<sup>17&#160;</sup>When they stood, these stood. When they mounted up, these mounted up with them; for the spirit of the living creature was in them. 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh’s glory went out from over the threshold of the house and stood over the cherubim. 
+<sup>19&#160;</sup>The cherubim lifted up their wings and mounted up from the earth in my sight when they went out, with the wheels beside them. Then they stood at the door of the east gate of Yahweh’s house; and the glory of the Elohim of Israel was over them above. 
+</div><div class="p">
+<sup>20&#160;</sup>This is the living creature that I saw under the Elohim of Israel by the river Chebar; and I knew that they were cherubim. 
+<sup>21&#160;</sup>Every one had four faces, and every one four wings. The likeness of the hands of a man was under their wings. 
+<sup>22&#160;</sup>As for the likeness of their faces, they were the faces which I saw by the river Chebar, their appearances and themselves. They each went straight forward. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Moreover the Spirit lifted me up and brought me to the east gate of Yahweh’s house, which looks eastward. Behold, twenty-five men were at the door of the gate; and I saw among them Jaazaniah the son of Azzur, and Pelatiah the son of Benaiah, princes of the people. 
+<sup>2&#160;</sup>He said to me, “Son of man, these are the men who devise iniquity, and who give wicked counsel in this city; 
+<sup>3&#160;</sup>who say, ‘The time is not near to build houses. This is the cauldron, and we are the meat.’ 
+<sup>4&#160;</sup>Therefore prophesy against them. Prophesy, son of man.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh’s Spirit fell on me, and he said to me, “Speak, ‘Yahweh says: “Thus you have said, house of Israel; for I know the things that come into your mind. 
+<sup>6&#160;</sup>You have multiplied your slain in this city, and you have filled its streets with the slain.” 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “Your slain whom you have laid in the middle of it, they are the meat, and this is the cauldron; but you will be brought out of the middle of it. 
+<sup>8&#160;</sup>You have feared the sword; and I will bring the sword on you,” says the Lord Yahweh. 
+<sup>9&#160;</sup>“I will bring you out of the middle of it, and deliver you into the hands of strangers, and will execute judgments among you. 
+<sup>10&#160;</sup>You will fall by the sword. I will judge you in the border of Israel. Then you will know that I am Yahweh. 
+<sup>11&#160;</sup>This will not be your cauldron, neither will you be the meat in the middle of it. I will judge you in the border of Israel. 
+<sup>12&#160;</sup>You will know that I am Yahweh, for you have not walked in my statutes. You have not executed my ordinances, but have done after the ordinances of the nations that are around you.”&#160;’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>When I prophesied, Pelatiah the son of Benaiah died. Then I fell down on my face, and cried with a loud voice, and said, “Ah Lord Yahweh! Will you make a full end of the remnant of Israel?” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>15&#160;</sup>“Son of man, your brothers, even your brothers, the men of your relatives, and all the house of Israel, all of them, are the ones to whom the inhabitants of Jerusalem have said, ‘Go far away from Yahweh. This land has been given to us for a possession.’ 
+</div><div class="p">
+<sup>16&#160;</sup>“Therefore say, ‘The Lord Yahweh says: “Whereas I have removed them far off among the nations, and whereas I have scattered them among the countries, yet I will be to them a sanctuary for a little while in the countries where they have come.”&#160;’ 
+</div><div class="p">
+<sup>17&#160;</sup>“Therefore say, ‘The Lord Yahweh says: “I will gather you from the peoples, and assemble you out of the countries where you have been scattered, and I will give you the land of Israel.” 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘They will come there, and they will take away all its detestable things and all its abominations from there. 
+<sup>19&#160;</sup>I will give them one heart, and I will put a new spirit within them. I will take the stony heart out of their flesh, and will give them a heart of flesh, 
+<sup>20&#160;</sup>that they may walk in my statutes, and keep my ordinances, and do them. They will be my people, and I will be their Elohim. 
+<sup>21&#160;</sup>But as for them whose heart walks after the heart of their detestable things and their abominations, I will bring their way on their own heads,’ says the Lord Yahweh.” 
+</div><div class="p">
+<sup>22&#160;</sup>Then the cherubim lifted up their wings, and the wheels were beside them. The glory of the Elohim of Israel was over them above. 
+<sup>23&#160;</sup>Yahweh’s glory went up from the middle of the city, and stood on the mountain which is on the east side of the city. 
+<sup>24&#160;</sup>The Spirit lifted me up, and brought me in the vision by the Spirit of Elohim into Chaldea, to the captives. 
+</div><div class="p">So the vision that I had seen went up from me. 
+<sup>25&#160;</sup>Then I spoke to the captives all the things that Yahweh had shown me. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word also came to me, saying, 
+<sup>2&#160;</sup>“Son of man, you dwell in the middle of the rebellious house, who have eyes to see, and don’t see, who have ears to hear, and don’t hear; for they are a rebellious house. 
+</div><div class="p">
+<sup>3&#160;</sup>“Therefore, you son of man, prepare your baggage for moving, and move by day in their sight. You shall move from your place to another place in their sight. It may be they will consider, though they are a rebellious house. 
+<sup>4&#160;</sup>You shall bring out your baggage by day in their sight, as baggage for moving. You shall go out yourself at evening in their sight, as when men go out into exile. 
+<sup>5&#160;</sup>Dig through the wall in their sight, and carry your baggage out that way. 
+<sup>6&#160;</sup>In their sight you shall bear it on your shoulder, and carry it out in the dark. You shall cover your face, so that you don’t see the land, for I have set you for a sign to the house of Israel.” 
+</div><div class="p">
+<sup>7&#160;</sup>I did so as I was commanded. I brought out my baggage by day, as baggage for moving, and in the evening I dug through the wall with my hand. I brought it out in the dark, and bore it on my shoulder in their sight. 
+</div><div class="p">
+<sup>8&#160;</sup>In the morning, Yahweh’s word came to me, saying, 
+<sup>9&#160;</sup>“Son of man, hasn’t the house of Israel, the rebellious house, said to you, ‘What are you doing?’ 
+</div><div class="p">
+<sup>10&#160;</sup>“Say to them, ‘The Lord Yahweh says: “This burden concerns the prince in Jerusalem, and all the house of Israel among whom they are.”&#160;’ 
+</div><div class="p">
+<sup>11&#160;</sup>“Say, ‘I am your sign. As I have done, so will it be done to them. They will go into exile, into captivity. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘The prince who is among them will bear his baggage on his shoulder in the dark, and will go out. They will dig through the wall to carry things out that way. He will cover his face, because he will not see the land with his eyes. 
+<sup>13&#160;</sup>I will also spread my net on him, and he will be taken in my snare. I will bring him to Babylon to the land of the Chaldeans; yet he will not see it, though he will die there. 
+<sup>14&#160;</sup>I will scatter toward every wind all who are around him to help him, and all his bands. I will draw out the sword after them. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘They will know that I am Yahweh when I disperse them among the nations and scatter them through the countries. 
+<sup>16&#160;</sup>But I will leave a few men of them from the sword, from the famine, and from the pestilence, that they may declare all their abominations among the nations where they come. Then they will know that I am Yahweh.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>18&#160;</sup>“Son of man, eat your bread with quaking, and drink your water with trembling and with fearfulness. 
+<sup>19&#160;</sup>Tell the people of the land, ‘The Lord Yahweh says concerning the inhabitants of Jerusalem and the land of Israel: “They will eat their bread with fearfulness and drink their water in dismay, that her land may be desolate, and all that is therein, because of the violence of all those who dwell therein. 
+<sup>20&#160;</sup>The cities that are inhabited will be laid waste, and the land will be a desolation. Then you will know that I am Yahweh.”&#160;’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>22&#160;</sup>“Son of man, what is this proverb that you have in the land of Israel, saying, ‘The days are prolonged, and every vision fails’? 
+<sup>23&#160;</sup>Tell them therefore, ‘The Lord Yahweh says: “I will make this proverb to cease, and they will no more use it as a proverb in Israel;”&#160;’ but tell them, ‘&#160;“The days are at hand, and the fulfillment of every vision. 
+<sup>24&#160;</sup>For there will be no more any false vision nor flattering divination within the house of Israel. 
+<sup>25&#160;</sup>For I am Yahweh. I will speak, and the word that I speak will be performed. It will be no more deferred; for in your days, rebellious house, I will speak the word and will perform it,” says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>26&#160;</sup>Again Yahweh’s word came to me, saying, 
+<sup>27&#160;</sup>“Son of man, behold, they of the house of Israel say, ‘The vision that he sees is for many days to come, and he prophesies of times that are far off.’ 
+</div><div class="p">
+<sup>28&#160;</sup>“Therefore tell them, ‘The Lord Yahweh says: “None of my words will be deferred any more, but the word which I speak will be performed,” says the Lord Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, prophesy against the prophets of Israel who prophesy, and say to those who prophesy out of their own heart, ‘Hear Yahweh’s word: 
+<sup>3&#160;</sup>The Lord Yahweh says, “Woe to the foolish prophets, who follow their own spirit, and have seen nothing! 
+<sup>4&#160;</sup>Israel, your prophets have been like foxes in the waste places. 
+<sup>5&#160;</sup>You have not gone up into the gaps or built up the wall for the house of Israel, to stand in the battle in Yahweh’s day. 
+<sup>6&#160;</sup>They have seen falsehood and lying divination, who say, ‘Yahweh says;’ but Yahweh has not sent them. They have made men to hope that the word would be confirmed. 
+<sup>7&#160;</sup>Haven’t you seen a false vision, and haven’t you spoken a lying divination, in that you say, ‘Yahweh says;’ but I have not spoken?” 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “Because you have spoken falsehood and seen lies, therefore, behold, I am against you,” says the Lord Yahweh. 
+<sup>9&#160;</sup>“My hand will be against the prophets who see false visions and who utter lying divinations. They will not be in the council of my people, neither will they be written in the writing of the house of Israel, neither will they enter into the land of Israel. Then you will know that I am the Lord Yahweh.” 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘Because, even because they have seduced my people, saying, “Peace;” and there is no peace. When one builds up a wall, behold, they plaster it with whitewash. 
+<sup>11&#160;</sup>Tell those who plaster it with whitewash that it will fall. There will be an overflowing shower; and you, great hailstones, will fall. A stormy wind will tear it. 
+<sup>12&#160;</sup>Behold, when the wall has fallen, won’t it be said to you, “Where is the plaster with which you have plastered it?” 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “I will even tear it with a stormy wind in my wrath. There will be an overflowing shower in my anger, and great hailstones in wrath to consume it. 
+<sup>14&#160;</sup>So I will break down the wall that you have plastered with whitewash, and bring it down to the ground, so that its foundation will be uncovered. It will fall, and you will be consumed in the middle of it. Then you will know that I am Yahweh. 
+<sup>15&#160;</sup>Thus I will accomplish my wrath on the wall, and on those who have plastered it with whitewash. I will tell you, ‘The wall is no more, nor those who plastered it—<sup>16&#160;</sup>to wit, the prophets of Israel who prophesy concerning Jerusalem, and who see visions of peace for her, and there is no peace,’&#160;” says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>You, son of man, set your face against the daughters of your people, who prophesy out of their own heart; and prophesy against them, 
+<sup>18&#160;</sup>and say, “The Lord Yahweh says: ‘Woe to the women who sew magic bands on all elbows and make veils for the head of persons of every stature to hunt souls! Will you hunt the souls of my people and save souls alive for yourselves? 
+<sup>19&#160;</sup>You have profaned me among my people for handfuls of barley and for pieces of bread, to kill the souls who should not die and to save the souls alive who should not live, by your lying to my people who listen to lies.’ 
+</div><div class="p">
+<sup>20&#160;</sup>“Therefore the Lord Yahweh says: ‘Behold, I am against your magic bands, with which you hunt the souls to make them fly, and I will tear them from your arms. I will let the souls fly free, even the souls whom you ensnare like birds. 
+<sup>21&#160;</sup>I will also tear your veils and deliver my people out of your hand; and they will no longer be in your hand to be ensnared. Then you will know that I am Yahweh. 
+<sup>22&#160;</sup>Because with lies you have grieved the heart of the righteous, whom I have not made sad; and strengthened the hands of the wicked, that he should not return from his wicked way, and be saved alive. 
+<sup>23&#160;</sup>Therefore you shall no more see false visions nor practice divination. I will deliver my people out of your hand. Then you will know that I am Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Then some of the elders of Israel came to me and sat before me. 
+<sup>2&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>3&#160;</sup>“Son of man, these men have taken their idols into their heart, and put the stumbling block of their iniquity before their face. Should I be inquired of at all by them? 
+<sup>4&#160;</sup>Therefore speak to them and tell them, ‘The Lord Yahweh says: “Every man of the house of Israel who takes his idols into his heart and puts the stumbling block of his iniquity before his face then comes to the prophet, I Yahweh will answer him there according to the multitude of his idols, 
+<sup>5&#160;</sup>that I may take the house of Israel in their own heart, because they are all estranged from me through their idols.”&#160;’ 
+</div><div class="p">
+<sup>6&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “Return, and turn yourselves from your idols! Turn away your faces from all your abominations. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘&#160;“For everyone of the house of Israel, or of the strangers who live in Israel, who separates himself from me and takes his idols into his heart, and puts the stumbling block of his iniquity before his face, and comes to the prophet to inquire for himself of me, I Yahweh will answer him by myself. 
+<sup>8&#160;</sup>I will set my face against that man and will make him an astonishment, for a sign and a proverb, and I will cut him off from among my people. Then you will know that I am Yahweh. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘&#160;“If the prophet is deceived and speaks a word, I, Yahweh, have deceived that prophet, and I will stretch out my hand on him, and will destroy him from among my people Israel. 
+<sup>10&#160;</sup>They will bear their iniquity. The iniquity of the prophet will be even as the iniquity of him who seeks him, 
+<sup>11&#160;</sup>that the house of Israel may no more go astray from me, neither defile themselves any more with all their transgressions; but that they may be my people, and I may be their Elohim,” says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>13&#160;</sup>“Son of man, when a land sins against me by committing a trespass, and I stretch out my hand on it, and break the staff of its bread and send famine on it, and cut off from it man and animal—<sup>14&#160;</sup>though these three men, Noah, Daniel, and Job, were in it, they would deliver only their own souls by their righteousness,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>“If I cause evil animals to pass through the land, and they ravage it and it is made desolate, so that no man may pass through because of the animals—<sup>16&#160;</sup>though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters. They only would be delivered, but the land would be desolate. 
+</div><div class="p">
+<sup>17&#160;</sup>“Or if I bring a sword on that land, and say, ‘Sword, go through the land, so that I cut off from it man and animal’—<sup>18&#160;</sup>though these three men were in it, as I live,” says the Lord Yahweh, “they would deliver neither sons nor daughters, but they only would be delivered themselves. 
+</div><div class="p">
+<sup>19&#160;</sup>“Or if I send a pestilence into that land, and pour out my wrath on it in blood, to cut off from it man and animal—<sup>20&#160;</sup>though Noah, Daniel, and Job, were in it, as I live,” says the Lord Yahweh, “they would deliver neither son nor daughter; they would deliver only their own souls by their righteousness.” 
+</div><div class="p">
+<sup>21&#160;</sup>For the Lord Yahweh says: “How much more when I send my four severe judgments on Jerusalem—the sword, the famine, the evil animals, and the pestilence—to cut off from it man and animal! 
+<sup>22&#160;</sup>Yet, behold, there will be left a remnant in it that will be carried out, both sons and daughters. Behold, they will come out to you, and you will see their way and their doings. Then you will be comforted concerning the evil that I have brought on Jerusalem, even concerning all that I have brought on it. 
+<sup>23&#160;</sup>They will comfort you, when you see their way and their doings; then you will know that I have not done all that I have done in it without cause,” says the Lord Yahweh. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, what is the vine tree more than any tree, the vine branch which is among the trees of the forest? 
+<sup>3&#160;</sup>Will wood be taken of it to make anything? Will men take a pin of it to hang any vessel on it? 
+<sup>4&#160;</sup>Behold, it is cast into the fire for fuel; the fire has devoured both its ends, and the middle of it is burned. Is it profitable for any work? 
+<sup>5&#160;</sup>Behold, when it was whole, it was suitable for no work. How much less, when the fire has devoured it, and it has been burned, will it yet be suitable for any work?” 
+</div><div class="p">
+<sup>6&#160;</sup>Therefore the Lord Yahweh says: “As the vine wood among the trees of the forest, which I have given to the fire for fuel, so I will give the inhabitants of Jerusalem. 
+<sup>7&#160;</sup>I will set my face against them. They will go out from the fire, but the fire will still devour them. Then you will know that I am Yahweh, when I set my face against them. 
+<sup>8&#160;</sup>I will make the land desolate, because they have acted unfaithfully,” says the Lord Yahweh. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Again Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, cause Jerusalem to know her abominations; 
+<sup>3&#160;</sup>and say, ‘The Lord Yahweh says to Jerusalem: “Your origin and your birth is of the land of the Canaanite. An Amorite was your father, and your mother was a Hittite. 
+<sup>4&#160;</sup>As for your birth, in the day you were born your navel was not cut. You weren’t washed in water to cleanse you. You weren’t salted at all, nor wrapped in blankets at all. 
+<sup>5&#160;</sup>No eye pitied you, to do any of these things to you, to have compassion on you; but you were cast out in the open field, because you were abhorred in the day that you were born. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘&#160;“When I passed by you, and saw you wallowing in your blood, I said to you, ‘Though you are in your blood, live!’ Yes, I said to you, ‘Though you are in your blood, live!’ 
+<sup>7&#160;</sup>I caused you to multiply as that which grows in the field, and you increased and grew great, and you attained to excellent beauty. Your breasts were formed, and your hair grew; yet you were naked and bare. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘&#160;“Now when I passed by you, and looked at you, behold, your time was the time of love; and I spread my garment over you and covered your nakedness. Yes, I pledged myself to you and entered into a covenant with you,” says the Lord Yahweh, “and you became mine. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘&#160;“Then I washed you with water. Yes, I thoroughly washed away your blood from you, and I anointed you with oil. 
+<sup>10&#160;</sup>I clothed you also with embroidered work and put leather sandals on you. I dressed you with fine linen and covered you with silk. 
+<sup>11&#160;</sup>I decked you with ornaments, put bracelets on your hands, and put a chain on your neck. 
+<sup>12&#160;</sup>I put a ring on your nose, earrings in your ears, and a beautiful crown on your head. 
+<sup>13&#160;</sup>Thus you were decked with gold and silver. Your clothing was of fine linen, silk, and embroidered work. You ate fine flour, honey, and oil. You were exceedingly beautiful, and you prospered to royal estate. 
+<sup>14&#160;</sup>Your renown went out among the nations for your beauty; for it was perfect, through my majesty which I had put on you,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘&#160;“But you trusted in your beauty, and played the prostitute because of your renown, and poured out your prostitution on everyone who passed by. It was his. 
+<sup>16&#160;</sup>You took some of your garments, and made for yourselves high places decked with various colors, and played the prostitute on them. This shouldn’t happen, neither shall it be. 
+<sup>17&#160;</sup>You also took your beautiful jewels of my gold and of my silver, which I had given you, and made for yourself images of men, and played the prostitute with them. 
+<sup>18&#160;</sup>You took your embroidered garments, covered them, and set my oil and my incense before them. 
+<sup>19&#160;</sup>My bread also which I gave you, fine flour, oil, and honey, with which I fed you, you even set it before them for a pleasant aroma; and so it was,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘&#160;“Moreover you have taken your sons and your daughters, whom you have borne to me, and you have sacrificed these to them to be devoured. Was your prostitution a small matter, 
+<sup>21&#160;</sup>that you have slain my children and delivered them up, in causing them to pass through the fire to them? 
+<sup>22&#160;</sup>In all your abominations and your prostitution you have not remembered the days of your youth, when you were naked and bare, and were wallowing in your blood. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘&#160;“It has happened after all your wickedness—woe, woe to you!” says the Lord Yahweh—<sup>24&#160;</sup>“that you have built for yourselves a vaulted place, and have made yourselves a lofty place in every street. 
+<sup>25&#160;</sup>You have built your lofty place at the head of every way, and have made your beauty an abomination, and have opened your feet to everyone who passed by, and multiplied your prostitution. 
+<sup>26&#160;</sup>You have also committed sexual immorality with the Egyptians, your neighbors, great of flesh; and have multiplied your prostitution, to provoke me to anger. 
+<sup>27&#160;</sup>See therefore, I have stretched out my hand over you, and have diminished your portion, and delivered you to the will of those who hate you, the daughters of the Philistines, who are ashamed of your lewd way. 
+<sup>28&#160;</sup>You have played the prostitute also with the Assyrians, because you were insatiable; yes, you have played the prostitute with them, and yet you weren’t satisfied. 
+<sup>29&#160;</sup>You have moreover multiplied your prostitution to the land of merchants, to Chaldea; and yet you weren’t satisfied with this. 
+</div><div class="p">
+<sup>30&#160;</sup>“&#160;‘&#160;“How weak is your heart,” says the Lord Yahweh, “since you do all these things, the work of an impudent prostitute; 
+<sup>31&#160;</sup>in that you build your vaulted place at the head of every way, and make your lofty place in every street, and have not been as a prostitute, in that you scorn pay. 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘&#160;“Adulterous woman, who takes strangers instead of her man! 
+<sup>33&#160;</sup>People give gifts to all prostitutes; but you give your gifts to all your lovers, and bribe them, that they may come to you on every side for your prostitution. 
+<sup>34&#160;</sup>You are different from other women in your prostitution, in that no one follows you to play the prostitute; and whereas you give hire, and no hire is given to you, therefore you are different.”&#160;’ 
+</div><div class="p">
+<sup>35&#160;</sup>“Therefore, prostitute, hear Yahweh’s word: 
+<sup>36&#160;</sup>‘The Lord Yahweh says, “Because your filthiness was poured out, and your nakedness uncovered through your prostitution with your lovers; and because of all the idols of your abominations, and for the blood of your children, that you gave to them; 
+<sup>37&#160;</sup>therefore see, I will gather all your lovers, with whom you have taken pleasure, and all those whom you have loved, with all those whom you have hated. I will even gather them against you on every side, and will uncover your nakedness to them, that they may see all your nakedness. 
+<sup>38&#160;</sup>I will judge you as women who break wedlock and shed blood are judged; and I will bring on you the blood of wrath and jealousy. 
+<sup>39&#160;</sup>I will also give you into their hand, and they will throw down your vaulted place, and break down your lofty places. They will strip you of your clothes and take your beautiful jewels. They will leave you naked and bare. 
+<sup>40&#160;</sup>They will also bring up a company against you, and they will stone you with stones, and thrust you through with their swords. 
+<sup>41&#160;</sup>They will burn your houses with fire, and execute judgments on you in the sight of many women. I will cause you to cease from playing the prostitute, and you will also give no hire any more. 
+<sup>42&#160;</sup>So I will cause my wrath toward you to rest, and my jealousy will depart from you. I will be quiet, and will not be angry any more. 
+</div><div class="p">
+<sup>43&#160;</sup>“&#160;‘&#160;“Because you have not remembered the days of your youth, but have raged against me in all these things; therefore, behold, I also will bring your way on your head,” says the Lord Yahweh: “and you shall not commit this lewdness with all your abominations. 
+</div><div class="p">
+<sup>44&#160;</sup>“&#160;‘&#160;“Behold, everyone who uses proverbs will use this proverb against you, saying, ‘As is the mother, so is her daughter.’ 
+<sup>45&#160;</sup>You are the daughter of your mother, who loathes her man and her children; and you are the sister of your sisters, who loathed their men and their children. Your mother was a Hittite, and your father an Amorite. 
+<sup>46&#160;</sup>Your elder sister is Samaria, who dwells at your left hand, she and her daughters; and your younger sister, who dwells at your right hand, is Sodom with her daughters. 
+<sup>47&#160;</sup>Yet you have not walked in their ways, nor done their abominations; but soon you were more corrupt than they in all your ways. 
+<sup>48&#160;</sup>As I live,” says the Lord Yahweh, “Sodom your sister has not done, she nor her daughters, as you have done, you and your daughters. 
+</div><div class="p">
+<sup>49&#160;</sup>“&#160;‘&#160;“Behold, this was the iniquity of your sister Sodom: pride, fullness of bread, and prosperous ease was in her and in her daughters. She also didn’t strengthen the hand of the poor and needy. 
+<sup>50&#160;</sup>They were arrogant and committed abomination before me. Therefore I took them away when I saw it. 
+<sup>51&#160;</sup>Samaria hasn’t committed half of your sins; but you have multiplied your abominations more than they, and have justified your sisters by all your abominations which you have done. 
+<sup>52&#160;</sup>You also bear your own shame yourself, in that you have given judgment for your sisters; through your sins that you have committed more abominable than they, they are more righteous than you. Yes, be also confounded, and bear your shame, in that you have justified your sisters. 
+</div><div class="p">
+<sup>53&#160;</sup>“&#160;‘&#160;“I will reverse their captivity, the captivity of Sodom and her daughters, and the captivity of Samaria and her daughters, and the captivity of your captives among them; 
+<sup>54&#160;</sup>that you may bear your own shame, and may be ashamed because of all that you have done, in that you are a comfort to them. 
+<sup>55&#160;</sup>Your sisters, Sodom and her daughters, will return to their former estate; and Samaria and her daughters will return to their former estate; and you and your daughters will return to your former estate. 
+<sup>56&#160;</sup>For your sister Sodom was not mentioned by your mouth in the day of your pride, 
+<sup>57&#160;</sup>before your wickedness was uncovered, as at the time of the reproach of the daughters of Syria, and of all who are around her, the daughters of the Philistines, who despise you all around. 
+<sup>58&#160;</sup>You have borne your lewdness and your abominations,” says Yahweh. 
+</div><div class="p">
+<sup>59&#160;</sup>“&#160;‘For the Lord Yahweh says: “I will also deal with you as you have done, who have despised the oath in breaking the covenant. 
+<sup>60&#160;</sup>Nevertheless I will remember my covenant with you in the days of your youth, and I will establish an everlasting covenant with you. 
+<sup>61&#160;</sup>Then you will remember your ways and be ashamed when you receive your sisters, your elder sisters and your younger; and I will give them to you for daughters, but not by your covenant. 
+<sup>62&#160;</sup>I will establish my covenant with you. Then you will know that I am Yahweh; 
+<sup>63&#160;</sup>that you may remember, and be confounded, and never open your mouth any more because of your shame, when I have forgiven you all that you have done,” says the Lord Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, tell a riddle, and speak a parable to the house of Israel; 
+<sup>3&#160;</sup>and say, ‘The Lord Yahweh says: “A great eagle with great wings and long feathers, full of feathers which had various colors, came to Lebanon and took the top of the cedar. 
+<sup>4&#160;</sup>He cropped off the topmost of its young twigs, and carried it to a land of traffic. He planted it in a city of merchants. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘&#160;“He also took some of the seed of the land and planted it in fruitful soil. He placed it beside many waters. He set it as a willow tree. 
+<sup>6&#160;</sup>It grew and became a spreading vine of low stature, whose branches turned toward him, and its roots were under him. So it became a vine, produced branches, and shot out sprigs. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘&#160;“There was also another great eagle with great wings and many feathers. Behold, this vine bent its roots toward him, and shot out its branches toward him, from the ground where it was planted, that he might water it. 
+<sup>8&#160;</sup>It was planted in a good soil by many waters, that it might produce branches and that it might bear fruit, that it might be a good vine.”&#160;’ 
+</div><div class="p">
+<sup>9&#160;</sup>“Say, ‘The Lord Yahweh says: “Will it prosper? Won’t he pull up its roots and cut off its fruit, that it may wither, that all its fresh springing leaves may wither? It can’t be raised from its roots by a strong arm or many people. 
+<sup>10&#160;</sup>Yes, behold, being planted, will it prosper? Won’t it utterly wither when the east wind touches it? It will wither in the ground where it grew.”&#160;’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>12&#160;</sup>“Say now to the rebellious house, ‘Don’t you know what these things mean?’ Tell them, ‘Behold, the king of Babylon came to Jerusalem, and took its king, and its princes, and brought them to him to Babylon. 
+<sup>13&#160;</sup>He took one of the royal offspring, and made a covenant with him. He also brought him under an oath, and took away the mighty of the land, 
+<sup>14&#160;</sup>that the kingdom might be brought low, that it might not lift itself up, but that by keeping his covenant it might stand. 
+<sup>15&#160;</sup>But he rebelled against him in sending his ambassadors into Egypt, that they might give him horses and many people. Will he prosper? Will he who does such things escape? Will he break the covenant, and still escape? 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘As I live,’ says the Lord Yahweh, ‘surely in the place where the king dwells who made him king, whose oath he despised, and whose covenant he broke, even with him in the middle of Babylon he will die. 
+<sup>17&#160;</sup>Pharaoh with his mighty army and great company won’t help him in the war, when they cast up mounds and build forts to cut off many persons. 
+<sup>18&#160;</sup>For he has despised the oath by breaking the covenant; and behold, he had given his hand, and yet has done all these things. He won’t escape. 
+</div><div class="p">
+<sup>19&#160;</sup>“Therefore the Lord Yahweh says: ‘As I live, I will surely bring on his own head my oath that he has despised and my covenant that he has broken. 
+<sup>20&#160;</sup>I will spread my net on him, and he will be taken in my snare. I will bring him to Babylon, and will enter into judgment with him there for his trespass that he has trespassed against me. 
+<sup>21&#160;</sup>All his fugitives in all his bands will fall by the sword, and those who remain will be scattered toward every wind. Then you will know that I, Yahweh, have spoken it.’ 
+</div><div class="p">
+<sup>22&#160;</sup>“The Lord Yahweh says: ‘I will also take some of the lofty top of the cedar, and will plant it. I will crop off from the topmost of its young twigs a tender one, and I will plant it on a high and lofty mountain. 
+<sup>23&#160;</sup>I will plant it in the mountain of the height of Israel; and it will produce boughs, and bear fruit, and be a good cedar. Birds of every kind will dwell in the shade of its branches. 
+<sup>24&#160;</sup>All the trees of the field will know that I, Yahweh, have brought down the high tree, have exalted the low tree, have dried up the green tree, and have made the dry tree flourish. 
+</div><div class="p">“&#160;‘I, Yahweh, have spoken and have done it.’&#160;” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me again, saying, 
+<sup>2&#160;</sup>“What do you mean, that you use this proverb concerning the land of Israel, saying, 
+</div><div class="q1">‘The fathers have eaten sour grapes, 
+</div><div class="q2">and the children’s teeth are set on edge’? 
+</div><div class="p">
+<sup>3&#160;</sup>“As I live,” says the Lord Yahweh, “you shall not use this proverb any more in Israel. 
+<sup>4&#160;</sup>Behold, all souls are mine; as the soul of the father, so also the soul of the son is mine. The soul who sins, he shall die. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“But if a man is just, 
+</div><div class="q2">and does that which is lawful and right, 
+</div><div class="q1">
+<sup>6&#160;</sup>and has not eaten on the mountains, 
+</div><div class="q2">hasn’t lifted up his eyes to the idols of the house of Israel, 
+</div><div class="q1">hasn’t defiled his neighbor’s woman, 
+</div><div class="q2">hasn’t come near a woman in her impurity, 
+</div><div class="q1">
+<sup>7&#160;</sup>and has not wronged any, 
+</div><div class="q2">but has restored to the debtor his pledge, 
+</div><div class="q1">has taken nothing by robbery, 
+</div><div class="q2">has given his bread to the hungry, 
+</div><div class="q2">and has covered the naked with a garment; 
+</div><div class="q1">
+<sup>8&#160;</sup>he who hasn’t lent to them with interest, 
+</div><div class="q2">hasn’t taken any increase from them, 
+</div><div class="q1">who has withdrawn his hand from iniquity, 
+</div><div class="q2">has executed true justice between man and man, 
+</div><div class="q1">
+<sup>9&#160;</sup>has walked in my statutes, 
+</div><div class="q2">and has kept my ordinances, 
+</div><div class="q2">to deal truly; 
+</div><div class="q1">he is just, 
+</div><div class="q2">he shall surely live,” says the Lord Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>10&#160;</sup>“If he fathers a son who is a robber who sheds blood, and who does any one of these things, 
+<sup>11&#160;</sup>or who does not do any of those things 
+</div><div class="q1">but has eaten at the mountain shrines 
+</div><div class="q2">and defiled his neighbor’s woman, 
+</div><div class="q1">
+<sup>12&#160;</sup>has wronged the poor and needy, 
+</div><div class="q2">has taken by robbery, 
+</div><div class="q1">has not restored the pledge, 
+</div><div class="q2">and has lifted up his eyes to the idols, 
+</div><div class="q2">has committed abomination, 
+</div><div class="q1">
+<sup>13&#160;</sup>has lent with interest, 
+</div><div class="q2">and has taken increase from the poor, 
+</div><div class="m">shall he then live? He shall not live. He has done all these abominations. He shall surely die. His blood will be on him. 
+</div><div class="p">
+<sup>14&#160;</sup>“Now, behold, if he fathers a son who sees all his father’s sins which he has done, and fears, and doesn’t do likewise, 
+</div><div class="q1">
+<sup>15&#160;</sup>who hasn’t eaten on the mountains, 
+</div><div class="q2">hasn’t lifted up his eyes to the idols of the house of Israel, 
+</div><div class="q2">hasn’t defiled his neighbor’s woman, 
+</div><div class="q1">
+<sup>16&#160;</sup>hasn’t wronged any, 
+</div><div class="q2">hasn’t taken anything to pledge, 
+</div><div class="q1">hasn’t taken by robbery, 
+</div><div class="q2">but has given his bread to the hungry, 
+</div><div class="q2">and has covered the naked with a garment; 
+</div><div class="q1">
+<sup>17&#160;</sup>who has withdrawn his hand from the poor, 
+</div><div class="q2">who hasn’t received interest or increase, 
+</div><div class="q1">has executed my ordinances, 
+</div><div class="q2">has walked in my statutes; 
+</div><div class="m">he shall not die for the iniquity of his father. He shall surely live. 
+<sup>18&#160;</sup>As for his father, because he cruelly oppressed, robbed his brother, and did that which is not good among his people, behold, he will die in his iniquity. 
+</div><div class="p">
+<sup>19&#160;</sup>“Yet you say, ‘Why doesn’t the son bear the iniquity of the father?’ When the son has done that which is lawful and right, and has kept all my statutes, and has done them, he will surely live. 
+<sup>20&#160;</sup>The soul who sins, he shall die. The son shall not bear the iniquity of the father, neither shall the father bear the iniquity of the son. The righteousness of the righteous shall be on him, and the wickedness of the wicked shall be on him. 
+</div><div class="p">
+<sup>21&#160;</sup>“But if the wicked turns from all his sins that he has committed, and keeps all my statutes, and does that which is lawful and right, he shall surely live. He shall not die. 
+<sup>22&#160;</sup>None of his transgressions that he has committed will be remembered against him. In his righteousness that he has done, he shall live. 
+<sup>23&#160;</sup>Have I any pleasure in the death of the wicked?” says the Lord Yahweh, “and not rather that he should return from his way, and live? 
+</div><div class="p">
+<sup>24&#160;</sup>“But when the righteous turns away from his righteousness, and commits iniquity, and does according to all the abominations that the wicked man does, should he live? None of his righteous deeds that he has done will be remembered. In his trespass that he has trespassed, and in his sin that he has sinned, in them he shall die. 
+</div><div class="p">
+<sup>25&#160;</sup>“Yet you say, ‘The way of the Lord is not equal.’ Hear now, house of Israel: Is my way not equal? Aren’t your ways unequal? 
+<sup>26&#160;</sup>When the righteous man turns away from his righteousness, and commits iniquity, and dies in it, then he dies in his iniquity that he has done. 
+<sup>27&#160;</sup>Again, when the wicked man turns away from his wickedness that he has committed, and does that which is lawful and right, he will save his soul alive. 
+<sup>28&#160;</sup>Because he considers, and turns away from all his transgressions that he has committed, he shall surely live. He shall not die. 
+<sup>29&#160;</sup>Yet the house of Israel says, ‘The way of the Lord is not fair.’ House of Israel, aren’t my ways fair? Aren’t your ways unfair? 
+</div><div class="p">
+<sup>30&#160;</sup>“Therefore I will judge you, house of Israel, everyone according to his ways,” says the Lord Yahweh. “Return, and turn yourselves from all your transgressions, so iniquity will not be your ruin. 
+<sup>31&#160;</sup>Cast away from you all your transgressions in which you have transgressed; and make yourself a new heart and a new spirit. For why will you die, house of Israel? 
+<sup>32&#160;</sup>For I have no pleasure in the death of him who dies,” says the Lord Yahweh. “Therefore turn yourselves, and live! 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>“Moreover, take up a lamentation for the princes of Israel, 
+<sup>2&#160;</sup>and say, 
+</div><div class="q1">‘What was your mother? 
+</div><div class="q2">A lioness. 
+</div><div class="q1">She couched among lions, 
+</div><div class="q2">in the middle of the young lions she nourished her cubs. 
+</div><div class="q1">
+<sup>3&#160;</sup>She brought up one of her cubs. 
+</div><div class="q2">He became a young lion. 
+</div><div class="q1">He learned to catch the prey. 
+</div><div class="q2">He devoured men. 
+</div><div class="q1">
+<sup>4&#160;</sup>The nations also heard of him. 
+</div><div class="q2">He was taken in their pit; 
+</div><div class="q2">and they brought him with hooks to the land of Egypt. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“&#160;‘Now when she saw that she had waited, 
+</div><div class="q2">and her hope was lost, 
+</div><div class="q1">then she took another of her cubs, 
+</div><div class="q2">and made him a young lion. 
+</div><div class="q1">
+<sup>6&#160;</sup>He went up and down among the lions. 
+</div><div class="q2">He became a young lion. 
+</div><div class="q1">He learned to catch the prey. 
+</div><div class="q2">He devoured men. 
+</div><div class="q1">
+<sup>7&#160;</sup>He knew their palaces, 
+</div><div class="q2">and laid waste their cities. 
+</div><div class="q1">The land was desolate with its fullness, 
+</div><div class="q2">because of the noise of his roaring. 
+</div><div class="q1">
+<sup>8&#160;</sup>Then the nations attacked him on every side from the provinces. 
+</div><div class="q2">They spread their net over him. 
+</div><div class="q2">He was taken in their pit. 
+</div><div class="q1">
+<sup>9&#160;</sup>They put him in a cage with hooks, 
+</div><div class="q2">and brought him to the king of Babylon. 
+</div><div class="q1">They brought him into strongholds, 
+</div><div class="q2">so that his voice should no more be heard on the mountains of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“&#160;‘Your mother was like a vine in your blood, planted by the waters. 
+</div><div class="q2">It was fruitful and full of branches by reason of many waters. 
+</div><div class="q1">
+<sup>11&#160;</sup>It had strong branches for the scepters of those who ruled. 
+</div><div class="q2">Their stature was exalted among the thick boughs. 
+</div><div class="q1">They were seen in their height 
+</div><div class="q2">with the multitude of their branches. 
+</div><div class="q1">
+<sup>12&#160;</sup>But it was plucked up in fury. 
+</div><div class="q2">It was cast down to the ground, 
+</div><div class="q1">and the east wind dried up its fruit. 
+</div><div class="q2">Its strong branches were broken off and withered. 
+</div><div class="q2">The fire consumed them. 
+</div><div class="q1">
+<sup>13&#160;</sup>Now it is planted in the wilderness, 
+</div><div class="q2">in a dry and thirsty land. 
+</div><div class="q1">
+<sup>14&#160;</sup>Fire has gone out of its branches. 
+</div><div class="q2">It has devoured its fruit, 
+</div><div class="q2">so that there is in it no strong branch to be a scepter to rule.’ 
+</div><div class="m">This is a lamentation, and shall be for a lamentation.” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>In the seventh year, in the fifth month, the tenth day of the month, some of the elders of Israel came to inquire of Yahweh, and sat before me. 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>3&#160;</sup>“Son of man, speak to the elders of Israel, and tell them, ‘The Lord Yahweh says: “Is it to inquire of me that you have come? As I live,” says the Lord Yahweh, “I will not be inquired of by you.”&#160;’ 
+</div><div class="p">
+<sup>4&#160;</sup>“Will you judge them, son of man? Will you judge them? Cause them to know the abominations of their fathers. 
+<sup>5&#160;</sup>Tell them, ‘The Lord Yahweh says: “In the day when I chose Israel, and swore to the offspring of the house of Jacob, and made myself known to them in the land of Egypt, when I swore to them, saying, ‘I am Yahweh your Elohim;’ 
+<sup>6&#160;</sup>in that day I swore to them to bring them out of the land of Egypt into a land that I had searched out for them, flowing with milk and honey, which is the glory of all lands. 
+<sup>7&#160;</sup>I said to them, ‘Each of you throw away the abominations of his eyes. Don’t defile yourselves with the idols of Egypt. I am Yahweh your Elohim.’ 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘&#160;“But they rebelled against me and wouldn’t listen to me. They didn’t all throw away the abominations of their eyes. They also didn’t forsake the idols of Egypt. Then I said I would pour out my wrath on them, to accomplish my anger against them in the middle of the land of Egypt. 
+<sup>9&#160;</sup>But I worked for my name’s sake, that it should not be profaned in the sight of the nations among which they were, in whose sight I made myself known to them in bringing them out of the land of Egypt. 
+<sup>10&#160;</sup>So I caused them to go out of the land of Egypt and brought them into the wilderness. 
+<sup>11&#160;</sup>I gave them my statutes and showed them my ordinances, which if a man does, he will live in them. 
+<sup>12&#160;</sup>Moreover also I gave them my Sabbaths, to be a sign between me and them, that they might know that I am Yahweh who sanctifies them. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘&#160;“But the house of Israel rebelled against me in the wilderness. They didn’t walk in my statutes and they rejected my ordinances, which if a man keeps, he shall live in them. They greatly profaned my Sabbaths. Then I said I would pour out my wrath on them in the wilderness, to consume them. 
+<sup>14&#160;</sup>But I worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
+<sup>15&#160;</sup>Moreover also I swore to them in the wilderness that I would not bring them into the land which I had given them, flowing with milk and honey, which is the glory of all lands, 
+<sup>16&#160;</sup>because they rejected my ordinances, and didn’t walk in my statutes, and profaned my Sabbaths; for their heart went after their idols. 
+<sup>17&#160;</sup>Nevertheless my eye spared them, and I didn’t destroy them. I didn’t make a full end of them in the wilderness. 
+<sup>18&#160;</sup>I said to their children in the wilderness, ‘Don’t walk in the statutes of your fathers. Don’t observe their ordinances or defile yourselves with their idols. 
+<sup>19&#160;</sup>I am Yahweh your Elohim. Walk in my statutes, keep my ordinances, and do them. 
+<sup>20&#160;</sup>Make my Sabbaths set-apart. They shall be a sign between me and you, that you may know that I am Yahweh your Elohim.’ 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘&#160;“But the children rebelled against me. They didn’t walk in my statutes, and didn’t keep my ordinances to do them, which if a man does, he shall live in them. They profaned my Sabbaths. Then I said I would pour out my wrath on them, to accomplish my anger against them in the wilderness. 
+<sup>22&#160;</sup>Nevertheless I withdrew my hand and worked for my name’s sake, that it should not be profaned in the sight of the nations, in whose sight I brought them out. 
+<sup>23&#160;</sup>Moreover I swore to them in the wilderness, that I would scatter them among the nations and disperse them through the countries, 
+<sup>24&#160;</sup>because they had not executed my ordinances, but had rejected my statutes, and had profaned my Sabbaths, and their eyes were after their fathers’ idols. 
+<sup>25&#160;</sup>Moreover also I gave them statutes that were not good, and ordinances in which they couldn’t live. 
+<sup>26&#160;</sup>I polluted them in their own gifts, in that they caused all that opens the womb to pass through the fire, that I might make them desolate, to the end that they might know that I am Yahweh.”&#160;’ 
+</div><div class="p">
+<sup>27&#160;</sup>“Therefore, son of man, speak to the house of Israel, and tell them, ‘The Lord Yahweh says: “Moreover, in this your fathers have blasphemed me, in that they have committed a trespass against me. 
+<sup>28&#160;</sup>For when I had brought them into the land which I swore to give to them, then they saw every high hill and every thick tree, and they offered there their sacrifices, and there they presented the provocation of their offering. There they also made their pleasant aroma, and there they poured out their drink offerings. 
+<sup>29&#160;</sup>Then I said to them, ‘What does the high place where you go mean?’ So its name is called Bamah to this day.”&#160;’ 
+</div><div class="p">
+<sup>30&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “Do you pollute yourselves in the way of your fathers? Do you play the prostitute after their abominations? 
+<sup>31&#160;</sup>When you offer your gifts, when you make your sons pass through the fire, do you pollute yourselves with all your idols to this day? Should I be inquired of by you, house of Israel? As I live, says the Lord Yahweh, I will not be inquired of by you! 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘&#160;“That which comes into your mind will not be at all, in that you say, ‘We will be as the nations, as the families of the countries, to serve wood and stone.’ 
+<sup>33&#160;</sup>As I live,” says the Lord Yahweh, “surely with a mighty hand, with an outstretched arm, and with wrath poured out, I will be king over you. 
+<sup>34&#160;</sup>I will bring you out from the peoples, and will gather you out of the countries in which you are scattered with a mighty hand, with an outstretched arm, and with wrath poured out. 
+<sup>35&#160;</sup>I will bring you into the wilderness of the peoples, and there I will enter into judgment with you face to face. 
+<sup>36&#160;</sup>Just as I entered into judgment with your fathers in the wilderness of the land of Egypt, so I will enter into judgment with you,” says the Lord Yahweh. 
+<sup>37&#160;</sup>“I will cause you to pass under the rod, and I will bring you into the bond of the covenant. 
+<sup>38&#160;</sup>I will purge out from among you the rebels and those who disobey me. I will bring them out of the land where they live, but they shall not enter into the land of Israel. Then you will know that I am Yahweh.” 
+</div><div class="p">
+<sup>39&#160;</sup>“&#160;‘As for you, house of Israel, the Lord Yahweh says: “Go, everyone serve his idols, and hereafter also, if you will not listen to me; but you shall no more profane my set-apart name with your gifts and with your idols. 
+<sup>40&#160;</sup>For in my set-apart mountain, in the mountain of the height of Israel,” says the Lord Yahweh, “there all the house of Israel, all of them, shall serve me in the land. There I will accept them, and there I will require your offerings and the first fruits of your offerings, with all your set-apart things. 
+<sup>41&#160;</sup>I will accept you as a pleasant aroma when I bring you out from the peoples and gather you out of the countries in which you have been scattered. I will be sanctified in you in the sight of the nations. 
+<sup>42&#160;</sup>You will know that I am Yahweh when I bring you into the land of Israel, into the country which I swore to give to your fathers. 
+<sup>43&#160;</sup>There you will remember your ways, and all your deeds in which you have polluted yourselves. Then you will loathe yourselves in your own sight for all your evils that you have committed. 
+<sup>44&#160;</sup>You will know that I am Yahweh, when I have dealt with you for my name’s sake, not according to your evil ways, nor according to your corrupt doings, you house of Israel,” says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>45&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>46&#160;</sup>“Son of man, set your face toward the south, and preach toward the south, and prophesy against the forest of the field in the south. 
+<sup>47&#160;</sup>Tell the forest of the south, ‘Hear Yahweh’s word: The Lord Yahweh says, “Behold, I will kindle a fire in you, and it will devour every green tree in you, and every dry tree. The burning flame will not be quenched, and all faces from the south to the north will be burned by it. 
+<sup>48&#160;</sup>All flesh will see that I, Yahweh, have kindled it. It will not be quenched.”&#160;’&#160;” 
+</div><div class="p">
+<sup>49&#160;</sup>Then I said, “Ah Lord Yahweh! They say of me, ‘Isn’t he a speaker of parables?’&#160;” 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, set your face toward Jerusalem, and preach toward the sanctuaries, and prophesy against the land of Israel. 
+<sup>3&#160;</sup>Tell the land of Israel, ‘Yahweh says: “Behold, I am against you, and will draw my sword out of its sheath, and will cut off from you the righteous and the wicked. 
+<sup>4&#160;</sup>Seeing then that I will cut off from you the righteous and the wicked, therefore my sword will go out of its sheath against all flesh from the south to the north. 
+<sup>5&#160;</sup>All flesh will know that I, Yahweh, have drawn my sword out of its sheath. It will not return any more.”&#160;’ 
+</div><div class="p">
+<sup>6&#160;</sup>“Therefore sigh, you son of man. You shall sigh before their eyes with a broken heart and with bitterness. 
+<sup>7&#160;</sup>It shall be, when they ask you, ‘Why do you sigh?’ that you shall say, ‘Because of the news, for it comes! Every heart will melt, all hands will be feeble, every spirit will faint, and all knees will be weak as water. Behold, it comes, and it shall be done, says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>9&#160;</sup>“Son of man, prophesy, and say, ‘Yahweh says: 
+</div><div class="q1">“A sword! A sword! 
+</div><div class="q2">It is sharpened, 
+</div><div class="q2">and also polished. 
+</div><div class="q1">
+<sup>10&#160;</sup>It is sharpened that it may make a slaughter. 
+</div><div class="q2">It is polished that it may be as lightning. 
+</div><div class="q1">Should we then make mirth? 
+</div><div class="q2">The rod of my son condemns every tree. 
+</div><div class="q1">
+<sup>11&#160;</sup>It is given to be polished, 
+</div><div class="q2">that it may be handled. 
+</div><div class="q1">The sword is sharpened. 
+</div><div class="q2">Yes, it is polished 
+</div><div class="q2">to give it into the hand of the killer.”&#160;’ 
+</div><div class="q1">
+<sup>12&#160;</sup>Cry and wail, son of man; 
+</div><div class="q2">for it is on my people. 
+</div><div class="q2">It is on all the princes of Israel. 
+</div><div class="q1">They are delivered over to the sword with my people. 
+</div><div class="q2">Therefore beat your thigh. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>13&#160;</sup>“For there is a trial. What if even the rod that condemns will be no more?” says the Lord Yahweh. 
+</div><div class="q1">
+<sup>14&#160;</sup>“You therefore, son of man, prophesy, 
+</div><div class="q2">and strike your hands together. 
+</div><div class="q1">Let the sword be doubled the third time, 
+</div><div class="q2">the sword of the fatally wounded. 
+</div><div class="q1">It is the sword of the great one who is fatally wounded, 
+</div><div class="q2">which enters into their rooms. 
+</div><div class="q1">
+<sup>15&#160;</sup>I have set the threatening sword against all their gates, 
+</div><div class="q2">that their heart may melt, 
+</div><div class="q2">and their stumblings be multiplied. 
+</div><div class="q1">Ah! It is made as lightning. 
+</div><div class="q2">It is pointed for slaughter. 
+</div><div class="q1">
+<sup>16&#160;</sup>Gather yourselves together. 
+</div><div class="q2">Go to the right. 
+</div><div class="q1">Set yourselves in array. 
+</div><div class="q2">Go to the left, 
+</div><div class="q2">wherever your face is set. 
+</div><div class="q1">
+<sup>17&#160;</sup>I will also strike my hands together, 
+</div><div class="q2">and I will cause my wrath to rest. 
+</div><div class="q2">I, Yahweh, have spoken it.” 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh’s word came to me again, saying, 
+<sup>19&#160;</sup>“Also, you son of man, appoint two ways, that the sword of the king of Babylon may come. They both will come out of one land, and mark out a place. Mark it out at the head of the way to the city. 
+<sup>20&#160;</sup>You shall appoint a way for the sword to come to Rabbah of the children of Ammon, and to Judah in Jerusalem the fortified. 
+<sup>21&#160;</sup>For the king of Babylon stood at the parting of the way, at the head of the two ways, to use divination. He shook the arrows back and forth. He consulted the teraphim. He looked in the liver. 
+<sup>22&#160;</sup>In his right hand was the lot for Jerusalem, to set battering rams, to open the mouth in the slaughter, to lift up the voice with shouting, to set battering rams against the gates, to cast up mounds, and to build forts. 
+<sup>23&#160;</sup>It will be to them as a false divination in their sight, who have sworn oaths to them; but he brings iniquity to memory, that they may be taken. 
+</div><div class="p">
+<sup>24&#160;</sup>“Therefore the Lord Yahweh says: ‘Because you have caused your iniquity to be remembered, in that your transgressions are uncovered, so that in all your doings your sins appear; because you have come to memory, you will be taken with the hand. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘You, deadly wounded wicked one, the prince of Israel, whose day has come, in the time of the iniquity of the end, 
+<sup>26&#160;</sup>the Lord Yahweh says: “Remove the turban, and take off the crown. This will not be as it was. Exalt that which is low, and humble that which is high. 
+<sup>27&#160;</sup>I will overturn, overturn, overturn it. This also will be no more, until he comes whose right it is; and I will give it.”&#160;’ 
+</div><div class="p">
+<sup>28&#160;</sup>“You, son of man, prophesy and say, ‘The Lord Yahweh says this concerning the children of Ammon, and concerning their reproach: 
+</div><div class="q1">“A sword! A sword is drawn! 
+</div><div class="q2">It is polished for the slaughter, 
+</div><div class="q1">to cause it to devour, 
+</div><div class="q2">that it may be as lightning; 
+</div><div class="q1">
+<sup>29&#160;</sup>while they see for you false visions, 
+</div><div class="q2">while they divine lies to you, 
+</div><div class="q1">to lay you on the necks of the wicked who are deadly wounded, 
+</div><div class="q2">whose day has come in the time of the iniquity of the end. 
+</div><div class="q1">
+<sup>30&#160;</sup>Cause it to return into its sheath. 
+</div><div class="q2">In the place where you were created, 
+</div><div class="q2">in the land of your birth, I will judge you. 
+</div><div class="q1">
+<sup>31&#160;</sup>I will pour out my indignation on you. 
+</div><div class="q2">I will blow on you with the fire of my wrath. 
+</div><div class="q1">I will deliver you into the hand of brutish men, 
+</div><div class="q2">skillful to destroy. 
+</div><div class="q1">
+<sup>32&#160;</sup>You will be for fuel to the fire. 
+</div><div class="q2">Your blood will be in the middle of the land. 
+</div><div class="q1">You will be remembered no more; 
+</div><div class="q2">for I, Yahweh, have spoken it.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“You, son of man, will you judge? Will you judge the bloody city? Then cause her to know all her abominations. 
+<sup>3&#160;</sup>You shall say, ‘The Lord Yahweh says: “A city that sheds blood within herself, that her time may come, and that makes idols against herself to defile her! 
+<sup>4&#160;</sup>You have become guilty in your blood that you have shed, and are defiled in your idols which you have made! You have caused your days to draw near, and have come to the end of your years. Therefore I have made you a reproach to the nations, and a mocking to all the countries. 
+<sup>5&#160;</sup>Those who are near and those who are far from you will mock you, you infamous one, full of tumult. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘&#160;“Behold, the princes of Israel, everyone according to his power, have been in you to shed blood. 
+<sup>7&#160;</sup>In you have they treated father and mother with contempt. Among you they have oppressed the foreigner. In you they have wronged the fatherless and the widow. 
+<sup>8&#160;</sup>You have despised my set-apart things, and have profaned my Sabbaths. 
+<sup>9&#160;</sup>Slanderous men have been in you to shed blood. In you they have eaten on the mountains. They have committed lewdness among you. 
+<sup>10&#160;</sup>In you have they uncovered their fathers’ nakedness. In you have they humbled her who was unclean in her impurity. 
+<sup>11&#160;</sup>One has committed abomination with his neighbor’s woman, and another has lewdly defiled his daughter-in-law. Another in you has humbled his sister, his father’s daughter. 
+<sup>12&#160;</sup>In you have they taken bribes to shed blood. You have taken interest and increase, and you have greedily gained of your neighbors by oppression, and have forgotten me,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘&#160;“Behold, therefore I have struck my hand at your dishonest gain which you have made, and at the blood which has been shed within you. 
+<sup>14&#160;</sup>Can your heart endure, or can your hands be strong, in the days that I will deal with you? I, Yahweh, have spoken it, and will do it. 
+<sup>15&#160;</sup>I will scatter you among the nations, and disperse you through the countries. I will purge your filthiness out of you. 
+<sup>16&#160;</sup>You will be profaned in yourself in the sight of the nations. Then you will know that I am Yahweh.”&#160;’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>18&#160;</sup>“Son of man, the house of Israel has become dross to me. All of them are bronze, tin, iron, and lead in the middle of the furnace. They are the dross of silver. 
+<sup>19&#160;</sup>Therefore the Lord Yahweh says: ‘Because you have all become dross, therefore, behold, I will gather you into the middle of Jerusalem. 
+<sup>20&#160;</sup>As they gather silver, bronze, iron, lead, and tin into the middle of the furnace, to blow the fire on it, to melt it, so I will gather you in my anger and in my wrath, and I will lay you there and melt you. 
+<sup>21&#160;</sup>Yes, I will gather you, and blow on you with the fire of my wrath, and you will be melted in the middle of it. 
+<sup>22&#160;</sup>As silver is melted in the middle of the furnace, so you will be melted in the middle of it; and you will know that I, Yahweh, have poured out my wrath on you.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>24&#160;</sup>“Son of man, tell her, ‘You are a land that is not cleansed nor rained on in the day of indignation.’ 
+<sup>25&#160;</sup>There is a conspiracy of her prophets within it, like a roaring lion ravening the prey. They have devoured souls. They take treasure and precious things. They have made many widows within it. 
+<sup>26&#160;</sup>Her priests have done violence to my law and have profaned my set-apart things. They have made no distinction between the set-apart and the common, neither have they caused men to discern between the unclean and the clean, and have hidden their eyes from my Sabbaths. So I am profaned among them. 
+<sup>27&#160;</sup>Her princes within it are like wolves ravening the prey, to shed blood and to destroy souls, that they may get dishonest gain. 
+<sup>28&#160;</sup>Her prophets have plastered for them with whitewash, seeing false visions, and divining lies to them, saying, ‘The Lord Yahweh says,’ when Yahweh has not spoken. 
+<sup>29&#160;</sup>The people of the land have used oppression and exercised robbery. Yes, they have troubled the poor and needy, and have oppressed the foreigner wrongfully. 
+</div><div class="p">
+<sup>30&#160;</sup>“I sought for a man among them who would build up the wall and stand in the gap before me for the land, that I would not destroy it; but I found no one. 
+<sup>31&#160;</sup>Therefore I have poured out my indignation on them. I have consumed them with the fire of my wrath. I have brought their own way on their heads,” says the Lord Yahweh. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>2&#160;</sup>“Son of man, there were two women, the daughters of one mother. 
+<sup>3&#160;</sup>They played the prostitute in Egypt. They played the prostitute in their youth. Their breasts were fondled there, and their youthful nipples were caressed there. 
+<sup>4&#160;</sup>Their names were Oholah the elder, and Oholibah her sister. They became mine, and they bore sons and daughters. As for their names, Samaria is Oholah, and Jerusalem Oholibah. 
+</div><div class="p">
+<sup>5&#160;</sup>“Oholah played the prostitute when she was mine. She doted on her lovers, on the Assyrians her neighbors, 
+<sup>6&#160;</sup>who were clothed with blue—governors and rulers, all of them desirable young men, horsemen riding on horses. 
+<sup>7&#160;</sup>She gave herself as a prostitute to them, all of them the choicest men of Assyria. She defiled herself with the idols of whoever she lusted after. 
+<sup>8&#160;</sup>She hasn’t left her prostitution since leaving Egypt; for in her youth they lay with her. They caressed her youthful nipples and they poured out their prostitution on her. 
+</div><div class="p">
+<sup>9&#160;</sup>“Therefore I delivered her into the hand of her lovers, into the hand of the Assyrians on whom she doted. 
+<sup>10&#160;</sup>These uncovered her nakedness. They took her sons and her daughters, and they killed her with the sword. She became a byword among women; for they executed judgments on her. 
+</div><div class="p">
+<sup>11&#160;</sup>“Her sister Oholibah saw this, yet she was more corrupt in her lusting than she, and in her prostitution which was more depraved than the prostitution of her sister. 
+<sup>12&#160;</sup>She lusted after the Assyrians, governors and rulers—her neighbors, clothed most gorgeously, horsemen riding on horses, all of them desirable young men. 
+<sup>13&#160;</sup>I saw that she was defiled. They both went the same way. 
+</div><div class="p">
+<sup>14&#160;</sup>“She increased her prostitution; for she saw men portrayed on the wall, the images of the Chaldeans portrayed with red, 
+<sup>15&#160;</sup>dressed with belts on their waists, with flowing turbans on their heads, all of them looking like princes, after the likeness of the Babylonians in Chaldea, the land of their birth. 
+<sup>16&#160;</sup>As soon as she saw them, she lusted after them and sent messengers to them into Chaldea. 
+<sup>17&#160;</sup>The Babylonians came to her into the bed of love, and they defiled her with their prostitution. She was polluted with them, and her soul was alienated from them. 
+<sup>18&#160;</sup>So she uncovered her prostitution and uncovered her nakedness. Then my soul was alienated from her, just like my soul was alienated from her sister. 
+<sup>19&#160;</sup>Yet she multiplied her prostitution, remembering the days of her youth, in which she had played the prostitute in the land of Egypt. 
+<sup>20&#160;</sup>She lusted after their lovers, whose flesh is as the flesh of donkeys, and whose issue is like the issue of horses. 
+<sup>21&#160;</sup>Thus you called to memory the lewdness of your youth, in the caressing of your nipples by the Egyptians because of your youthful breasts. 
+</div><div class="p">
+<sup>22&#160;</sup>“Therefore, Oholibah, the Lord Yahweh says: ‘Behold, I will raise up your lovers against you, from whom your soul is alienated, and I will bring them against you on every side: 
+<sup>23&#160;</sup>the Babylonians and all the Chaldeans, Pekod, Shoa, Koa, and all the Assyrians with them; all of them desirable young men, governors and rulers, princes and men of renown, all of them riding on horses. 
+<sup>24&#160;</sup>They will come against you with weapons, chariots, and wagons, and with a company of peoples. They will set themselves against you with buckler, shield, and helmet all around. I will commit the judgment to them, and they will judge you according to their judgments. 
+<sup>25&#160;</sup>I will set my jealousy against you, and they will deal with you in fury. They will take away your nose and your ears. Your remnant will fall by the sword. They will take your sons and your daughters; and the rest of you will be devoured by the fire. 
+<sup>26&#160;</sup>They will also strip you of your clothes and take away your beautiful jewels. 
+<sup>27&#160;</sup>Thus I will make your lewdness to cease from you, and remove your prostitution from the land of Egypt, so that you will not lift up your eyes to them, nor remember Egypt any more.’ 
+</div><div class="p">
+<sup>28&#160;</sup>“For the Lord Yahweh says: ‘Behold, I will deliver you into the hand of them whom you hate, into the hand of them from whom your soul is alienated. 
+<sup>29&#160;</sup>They will deal with you in hatred, and will take away all your labor, and will leave you naked and bare. The nakedness of your prostitution will be uncovered, both your lewdness and your prostitution. 
+<sup>30&#160;</sup>These things will be done to you because you have played the prostitute after the nations, and because you are polluted with their idols. 
+<sup>31&#160;</sup>You have walked in the way of your sister; therefore I will give her cup into your hand.’ 
+</div><div class="p">
+<sup>32&#160;</sup>“The Lord Yahweh says: 
+</div><div class="q1">‘You will drink of your sister’s cup, 
+</div><div class="q2">which is deep and large. 
+</div><div class="q1">You will be ridiculed and held in derision. 
+</div><div class="q2">It contains much. 
+</div><div class="q1">
+<sup>33&#160;</sup>You will be filled with drunkenness and sorrow, 
+</div><div class="q2">with the cup of astonishment and desolation, 
+</div><div class="q2">with the cup of your sister Samaria. 
+</div><div class="q1">
+<sup>34&#160;</sup>You will even drink it and drain it out. 
+</div><div class="q2">You will gnaw the broken pieces of it, 
+</div><div class="q2">and will tear your breasts; 
+</div><div class="m">for I have spoken it,’ says the Lord Yahweh. 
+</div><div class="p">
+<sup>35&#160;</sup>“Therefore the Lord Yahweh says: ‘Because you have forgotten me and cast me behind your back, therefore you also bear your lewdness and your prostitution.’&#160;” 
+</div><div class="p">
+<sup>36&#160;</sup>Yahweh said moreover to me: “Son of man, will you judge Oholah and Oholibah? Then declare to them their abominations. 
+<sup>37&#160;</sup>For they have committed adultery, and blood is in their hands. They have committed adultery with their idols. They have also caused their sons, whom they bore to me, to pass through the fire to them to be devoured. 
+<sup>38&#160;</sup>Moreover this they have done to me: they have defiled my sanctuary in the same day, and have profaned my Sabbaths. 
+<sup>39&#160;</sup>For when they had slain their children to their idols, then they came the same day into my sanctuary to profane it; and behold, they have done this in the middle of my house. 
+</div><div class="p">
+<sup>40&#160;</sup>“Furthermore you sisters have sent for men who come from far away, to whom a messenger was sent, and behold, they came; for whom you washed yourself, painted your eyes, decorated yourself with ornaments, 
+<sup>41&#160;</sup>and sat on a stately bed, with a table prepared before it, whereupon you set my incense and my oil. 
+</div><div class="p">
+<sup>42&#160;</sup>“The voice of a multitude being at ease was with her. With men of the common sort were brought drunkards from the wilderness; and they put bracelets on their hands, and beautiful crowns on their heads. 
+<sup>43&#160;</sup>Then I said of her who was old in adulteries, ‘Now they will play the prostitute with her, and she with them.’ 
+<sup>44&#160;</sup>They went in to her, as they go in to a prostitute. So they went in to Oholah and to Oholibah, the lewd women. 
+<sup>45&#160;</sup>Righteous men will judge them with the judgment of adulteresses and with the judgment of women who shed blood, because they are adulteresses, and blood is in their hands. 
+</div><div class="p">
+<sup>46&#160;</sup>“For the Lord Yahweh says: ‘I will bring up a mob against them, and will give them to be tossed back and forth and robbed. 
+<sup>47&#160;</sup>The company will stone them with stones and dispatch them with their swords. They will kill their sons and their daughters, and burn up their houses with fire. 
+</div><div class="p">
+<sup>48&#160;</sup>“&#160;‘Thus I will cause lewdness to cease out of the land, that all women may be taught not to be lewd like you. 
+<sup>49&#160;</sup>They will recompense your lewdness on you, and you will bear the sins of your idols. Then you will know that I am the Lord Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Again, in the ninth year, in the tenth month, in the tenth day of the month, Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, write the name of the day, this same day. The king of Babylon drew close to Jerusalem this same day. 
+<sup>3&#160;</sup>Utter a parable to the rebellious house, and tell them, ‘The Lord Yahweh says, 
+</div><div class="q1">“Put the cauldron on the fire. 
+</div><div class="q2">Put it on, 
+</div><div class="q2">and also pour water into it. 
+</div><div class="q1">
+<sup>4&#160;</sup>Gather its pieces into it, 
+</div><div class="q2">even every good piece: 
+</div><div class="q2">the thigh and the shoulder. 
+</div><div class="q2">Fill it with the choice bones. 
+</div><div class="q1">
+<sup>5&#160;</sup>Take the choice of the flock, 
+</div><div class="q2">and also a pile of wood for the bones under the cauldron. 
+</div><div class="q1">Make it boil well. 
+</div><div class="q2">Yes, let its bones be boiled within it.” 
+</div><div class="m">
+<sup>6&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: 
+</div><div class="q1">“Woe to the bloody city, 
+</div><div class="q2">to the cauldron whose rust is in it, 
+</div><div class="q2">and whose rust hasn’t gone out of it! 
+</div><div class="q1">Take out of it piece after piece 
+</div><div class="q2">without casting lots for it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“&#160;‘&#160;“For the blood she shed is in the middle of her. 
+</div><div class="q2">She set it on the bare rock. 
+</div><div class="q1">She didn’t pour it on the ground, 
+</div><div class="q2">to cover it with dust. 
+</div><div class="q1">
+<sup>8&#160;</sup>That it may cause wrath to come up to take vengeance, 
+</div><div class="q2">I have set her blood on the bare rock, 
+</div><div class="q2">that it should not be covered.” 
+</div><div class="m">
+<sup>9&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: 
+</div><div class="q1">“Woe to the bloody city! 
+</div><div class="q2">I also will make the pile great. 
+</div><div class="q1">
+<sup>10&#160;</sup>Heap on the wood. 
+</div><div class="q2">Make the fire hot. 
+</div><div class="q1">Boil the meat well. 
+</div><div class="q2">Make the broth thick, 
+</div><div class="q2">and let the bones be burned. 
+</div><div class="q1">
+<sup>11&#160;</sup>Then set it empty on its coals, 
+</div><div class="q2">that it may be hot, 
+</div><div class="q1">and its bronze may burn, 
+</div><div class="q2">and that its filthiness may be molten in it, 
+</div><div class="q2">that its rust may be consumed. 
+</div><div class="q1">
+<sup>12&#160;</sup>She is weary with toil; 
+</div><div class="q2">yet her great rust, 
+</div><div class="q2">rust by fire, doesn’t leave her. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘&#160;“In your filthiness is lewdness. Because I have cleansed you and you weren’t cleansed, you won’t be cleansed from your filthiness any more, until I have caused my wrath toward you to rest. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘&#160;“I, Yahweh, have spoken it. It will happen, and I will do it. I won’t go back. I won’t spare. I won’t repent. According to your ways and according to your doings, they will judge you,” says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>15&#160;</sup>Also Yahweh’s word came to me, saying, 
+<sup>16&#160;</sup>“Son of man, behold, I will take away from you the desire of your eyes with one stroke; yet you shall neither mourn nor weep, neither shall your tears run down. 
+<sup>17&#160;</sup>Sigh, but not aloud. Make no mourning for the dead. Bind your headdress on you, and put your sandals on your feet. Don’t cover your lips, and don’t eat mourner’s bread.” 
+</div><div class="p">
+<sup>18&#160;</sup>So I spoke to the people in the morning, and at evening my woman died. So I did in the morning as I was commanded. 
+</div><div class="p">
+<sup>19&#160;</sup>The people asked me, “Won’t you tell us what these things mean to us, that you act like this?” 
+</div><div class="p">
+<sup>20&#160;</sup>Then I said to them, “Yahweh’s word came to me, saying, 
+<sup>21&#160;</sup>‘Speak to the house of Israel, “The Lord Yahweh says: ‘Behold, I will profane my sanctuary, the pride of your power, the desire of your eyes, and that which your soul pities; and your sons and your daughters whom you have left behind will fall by the sword. 
+<sup>22&#160;</sup>You will do as I have done. You won’t cover your lips or eat mourner’s bread. 
+<sup>23&#160;</sup>Your turbans will be on your heads, and your sandals on your feet. You won’t mourn or weep; but you will pine away in your iniquities, and moan one toward another. 
+<sup>24&#160;</sup>Thus Ezekiel will be a sign to you; according to all that he has done, you will do. When this comes, then you will know that I am the Lord Yahweh.’&#160;”&#160;’&#160;” 
+</div><div class="p">
+<sup>25&#160;</sup>“You, son of man, shouldn’t it be in the day when I take from them their strength, the joy of their glory, the desire of their eyes, and that whereupon they set their heart—their sons and their daughters—<sup>26&#160;</sup>that in that day he who escapes will come to you, to cause you to hear it with your ears? 
+<sup>27&#160;</sup>In that day your mouth will be opened to him who has escaped, and you will speak and be no more mute. So you will be a sign to them. Then they will know that I am Yahweh.” 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, set your face toward the children of Ammon, and prophesy against them. 
+<sup>3&#160;</sup>Tell the children of Ammon, ‘Hear the word of the Lord Yahweh! The Lord Yahweh says, “Because you said, ‘Aha!’ against my sanctuary when it was profaned, and against the land of Israel when it was made desolate, and against the house of Judah when they went into captivity, 
+<sup>4&#160;</sup>therefore, behold, I will deliver you to the children of the east for a possession. They will set their encampments in you and make their dwellings in you. They will eat your fruit and they will drink your milk. 
+<sup>5&#160;</sup>I will make Rabbah a stable for camels and the children of Ammon a resting place for flocks. Then you will know that I am Yahweh.” 
+<sup>6&#160;</sup>For the Lord Yahweh says: “Because you have clapped your hands, stamped with the feet, and rejoiced with all the contempt of your soul against the land of Israel, 
+<sup>7&#160;</sup>therefore, behold, I have stretched out my hand on you, and will deliver you for a plunder to the nations. I will cut you off from the peoples, and I will cause you to perish out of the countries. I will destroy you. Then you will know that I am Yahweh.” 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘The Lord Yahweh says: “Because Moab and Seir say, ‘Behold, the house of Judah is like all the nations,’ 
+<sup>9&#160;</sup>therefore, behold, I will open the side of Moab from the cities, from his cities which are on its frontiers, the glory of the country, Beth Jeshimoth, Baal Meon, and Kiriathaim, 
+<sup>10&#160;</sup>to the children of the east, to go against the children of Ammon; and I will give them for a possession, that the children of Ammon may not be remembered among the nations. 
+<sup>11&#160;</sup>I will execute judgments on Moab. Then they will know that I am Yahweh.” 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘The Lord Yahweh says: “Because Edom has dealt against the house of Judah by taking vengeance, and has greatly offended, and taken revenge on them,” 
+<sup>13&#160;</sup>therefore the Lord Yahweh says, “I will stretch out my hand on Edom, and will cut off man and animal from it; and I will make it desolate from Teman. They will fall by the sword even to Dedan. 
+<sup>14&#160;</sup>I will lay my vengeance on Edom by the hand of my people Israel. They will do in Edom according to my anger and according to my wrath. Then they will know my vengeance,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘The Lord Yahweh says: “Because the Philistines have taken revenge, and have taken vengeance with contempt of soul to destroy with perpetual hostility,” 
+<sup>16&#160;</sup>therefore the Lord Yahweh says, “Behold, I will stretch out my hand on the Philistines, and I will cut off the Cherethites, and destroy the remnant of the sea coast. 
+<sup>17&#160;</sup>I will execute great vengeance on them with wrathful rebukes. Then they will know that I am Yahweh, when I lay my vengeance on them.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>In the eleventh year, in the first of the month, Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, because Tyre has said against Jerusalem, ‘Aha! She is broken! She who was the gateway of the peoples has been returned to me. I will be replenished, now that she is laid waste;’ 
+<sup>3&#160;</sup>therefore the Lord Yahweh says, ‘Behold, I am against you, Tyre, and will cause many nations to come up against you, as the sea causes its waves to come up. 
+<sup>4&#160;</sup>They will destroy the walls of Tyre, and break down her towers. I will also scrape her dust from her, and make her a bare rock. 
+<sup>5&#160;</sup>She will be a place for the spreading of nets in the middle of the sea; for I have spoken it,’ says the Lord Yahweh. ‘She will become plunder for the nations. 
+<sup>6&#160;</sup>Her daughters who are in the field will be slain with the sword. Then they will know that I am Yahweh.’ 
+</div><div class="p">
+<sup>7&#160;</sup>“For the Lord Yahweh says: ‘Behold, I will bring on Tyre Nebuchadnezzar king of Babylon, king of kings, from the north, with horses, with chariots, with horsemen, and an army with many people. 
+<sup>8&#160;</sup>He will kill your daughters in the field with the sword. He will make forts against you, cast up a mound against you, and raise up the buckler against you. 
+<sup>9&#160;</sup>He will set his battering engines against your walls, and with his axes he will break down your towers. 
+<sup>10&#160;</sup>By reason of the abundance of his horses, their dust will cover you. Your walls will shake at the noise of the horsemen, of the wagons, and of the chariots, when he enters into your gates, as men enter into a city which is broken open. 
+<sup>11&#160;</sup>He will tread down all your streets with the hoofs of his horses. He will kill your people with the sword. The pillars of your strength will go down to the ground. 
+<sup>12&#160;</sup>They will make a plunder of your riches and make a prey of your merchandise. They will break down your walls and destroy your pleasant houses. They will lay your stones, your timber, and your dust in the middle of the waters. 
+<sup>13&#160;</sup>I will cause the noise of your songs to cease. The sound of your harps won’t be heard any more. 
+<sup>14&#160;</sup>I will make you a bare rock. You will be a place for the spreading of nets. You will be built no more; for I Yahweh have spoken it,’ says the Lord Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>“The Lord Yahweh says to Tyre: ‘Won’t the islands shake at the sound of your fall, when the wounded groan, when the slaughter is made within you? 
+<sup>16&#160;</sup>Then all the princes of the sea will come down from their thrones, and lay aside their robes, and strip off their embroidered garments. They will clothe themselves with trembling. They will sit on the ground, and will tremble every moment, and be astonished at you. 
+<sup>17&#160;</sup>They will take up a lamentation over you, and tell you, 
+</div><div class="q1">“How you are destroyed, 
+</div><div class="q2">who were inhabited by seafaring men, 
+</div><div class="q1">the renowned city, 
+</div><div class="q2">who was strong in the sea, 
+</div><div class="q1">she and her inhabitants, 
+</div><div class="q2">who caused their terror to be on all who lived there!” 
+</div><div class="q1">
+<sup>18&#160;</sup>Now the islands will tremble in the day of your fall. 
+</div><div class="q2">Yes, the islands that are in the sea will be dismayed at your departure.’ 
+</div><div class="p">
+<sup>19&#160;</sup>“For the Lord Yahweh says: ‘When I make you a desolate city, like the cities that are not inhabited, when I bring up the deep on you, and the great waters cover you, 
+<sup>20&#160;</sup>then I will bring you down with those who descend into the pit, to the people of old time, and will make you dwell in the lower parts of the earth, in the places that are desolate of old, with those who go down to the pit, that you be not inhabited; and I will set glory in the land of the living. 
+<sup>21&#160;</sup>I will make you a terror, and you will no more have any being. Though you are sought for, yet you will never be found again,’ says the Lord Yahweh.” 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>2&#160;</sup>“You, son of man, take up a lamentation over Tyre; 
+<sup>3&#160;</sup>and tell Tyre, ‘You who dwell at the entry of the sea, who are the merchant of the peoples to many islands, the Lord Yahweh says: 
+</div><div class="q1">“You, Tyre, have said, 
+</div><div class="q2">‘I am perfect in beauty.’ 
+</div><div class="q1">
+<sup>4&#160;</sup>Your borders are in the heart of the seas. 
+</div><div class="q2">Your builders have perfected your beauty. 
+</div><div class="q1">
+<sup>5&#160;</sup>They have made all your planks of cypress trees from Senir. 
+</div><div class="q2">They have taken a cedar from Lebanon to make a mast for you. 
+</div><div class="q1">
+<sup>6&#160;</sup>They have made your oars of the oaks of Bashan. 
+</div><div class="q2">They have made your benches of ivory inlaid in cypress wood from the islands of Kittim. 
+</div><div class="q1">
+<sup>7&#160;</sup>Your sail was of fine linen with embroidered work from Egypt, 
+</div><div class="q2">that it might be to you for a banner. 
+</div><div class="q2">Blue and purple from the islands of Elishah was your awning. 
+</div><div class="q1">
+<sup>8&#160;</sup>The inhabitants of Sidon and Arvad were your rowers. 
+</div><div class="q2">Your wise men, Tyre, were in you. 
+</div><div class="q2">They were your pilots. 
+</div><div class="q1">
+<sup>9&#160;</sup>The old men of Gebal 
+</div><div class="q2">and its wise men were your repairers of ship seams in you. 
+</div><div class="q1">All the ships of the sea with their mariners were in you 
+</div><div class="q2">to deal in your merchandise. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“&#160;‘&#160;“Persia, Lud, and Put were in your army, 
+</div><div class="q2">your men of war. 
+</div><div class="q1">They hung the shield and helmet in you. 
+</div><div class="q2">They showed your beauty. 
+</div><div class="q1">
+<sup>11&#160;</sup>The men of Arvad with your army were on your walls all around, 
+</div><div class="q2">and valiant men were in your towers. 
+</div><div class="q1">They hung their shields on your walls all around. 
+</div><div class="q2">They have perfected your beauty. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘&#160;“Tarshish was your merchant by reason of the multitude of all kinds of riches. They traded for your wares with silver, iron, tin, and lead. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘&#160;“Javan, Tubal, and Meshech were your traders. They traded the persons of men and vessels of bronze for your merchandise. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘&#160;“They of the house of Togarmah traded for your wares with horses, war horses, and mules. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘&#160;“The men of Dedan traded with you. Many islands were the market of your hand. They brought you horns of ivory and ebony in exchange. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘&#160;“Syria was your merchant by reason of the multitude of your handiworks. They traded for your wares with emeralds, purple, embroidered work, fine linen, coral, and rubies. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘&#160;“Judah and the land of Israel were your traders. They traded wheat of Minnith, confections, honey, oil, and balm for your merchandise. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘&#160;“Damascus was your merchant for the multitude of your handiworks by reason of the multitude of all kinds of riches, with the wine of Helbon, and white wool. 
+</div><div class="p">
+<sup>19&#160;</sup>“&#160;‘&#160;“Vedan and Javan traded with yarn for your wares; wrought iron, cassia, and calamus were among your merchandise. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘&#160;“Dedan was your merchant in precious saddle blankets for riding. 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘&#160;“Arabia and all the princes of Kedar were your favorite dealers in lambs, rams, and goats. In these, they were your merchants. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘&#160;“The traders of Sheba and Raamah were your traders. They traded for your wares with the best of all spices, all precious stones, and gold. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘&#160;“Haran, Canneh, Eden, the traders of Sheba, Asshur and Chilmad, were your traders. 
+<sup>24&#160;</sup>These were your traders in choice wares, in wrappings of blue and embroidered work, and in cedar chests of rich clothing bound with cords, among your merchandise. 
+</div><div class="q1">
+<sup>25&#160;</sup>“&#160;‘&#160;“The ships of Tarshish were your caravans for your merchandise. 
+</div><div class="q2">You were replenished 
+</div><div class="q2">and made very glorious in the heart of the seas. 
+</div><div class="q1">
+<sup>26&#160;</sup>Your rowers have brought you into great waters. 
+</div><div class="q2">The east wind has broken you in the heart of the seas. 
+</div><div class="q1">
+<sup>27&#160;</sup>Your riches, your wares, your merchandise, 
+</div><div class="q2">your mariners, your pilots, your repairers of ship seams, 
+</div><div class="q1">the dealers in your merchandise, 
+</div><div class="q2">and all your men of war who are in you, 
+</div><div class="q1">with all your company which is among you, 
+</div><div class="q2">will fall into the heart of the seas in the day of your ruin. 
+</div><div class="q1">
+<sup>28&#160;</sup>At the sound of the cry of your pilots, 
+</div><div class="q2">the pasture lands will shake. 
+</div><div class="q1">
+<sup>29&#160;</sup>All who handle the oars, 
+</div><div class="q2">the mariners and all the pilots of the sea, 
+</div><div class="q2">will come down from their ships. 
+</div><div class="q1">They will stand on the land, 
+</div><div class="q2">
+<sup>30&#160;</sup>and will cause their voice to be heard over you, 
+</div><div class="q2">and will cry bitterly. 
+</div><div class="q1">They will cast up dust on their heads. 
+</div><div class="q2">They will wallow in the ashes. 
+</div><div class="q1">
+<sup>31&#160;</sup>They will make themselves bald for you, 
+</div><div class="q2">and clothe themselves with sackcloth. 
+</div><div class="q1">They will weep for you in bitterness of soul, 
+</div><div class="q2">with bitter mourning. 
+</div><div class="q1">
+<sup>32&#160;</sup>In their wailing they will take up a lamentation for you, 
+</div><div class="q2">and lament over you, saying, 
+</div><div class="q1">‘Who is there like Tyre, 
+</div><div class="q2">like her who is brought to silence in the middle of the sea?’ 
+</div><div class="q1">
+<sup>33&#160;</sup>When your wares came from the seas, 
+</div><div class="q2">you filled many peoples. 
+</div><div class="q1">You enriched the kings of the earth 
+</div><div class="q2">with the multitude of your riches and of your merchandise. 
+</div><div class="q1">
+<sup>34&#160;</sup>In the time that you were broken by the seas, 
+</div><div class="q2">in the depths of the waters, 
+</div><div class="q2">your merchandise and all your company fell within you. 
+</div><div class="q1">
+<sup>35&#160;</sup>All the inhabitants of the islands are astonished at you, 
+</div><div class="q2">and their kings are horribly afraid. 
+</div><div class="q2">They are troubled in their face. 
+</div><div class="q1">
+<sup>36&#160;</sup>The merchants among the peoples hiss at you. 
+</div><div class="q2">You have come to a terrible end, 
+</div><div class="q2">and you will be no more.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>2&#160;</sup>“Son of man, tell the prince of Tyre, ‘The Lord Yahweh says: 
+</div><div class="q1">“Because your heart is lifted up, 
+</div><div class="q2">and you have said, ‘I am an elohim, 
+</div><div class="q1">I sit in the seat of Elohim, 
+</div><div class="q2">in the middle of the seas;’ 
+</div><div class="q1">yet you are man, 
+</div><div class="q2">and no elohim, 
+</div><div class="q2">though you set your heart as the heart of an elohim—</div><div class="q1">
+<sup>3&#160;</sup>behold, you are wiser than Daniel. 
+</div><div class="q2">There is no secret that is hidden from you. 
+</div><div class="q1">
+<sup>4&#160;</sup>By your wisdom and by your understanding you have gotten yourself riches, 
+</div><div class="q2">and have gotten gold and silver into your treasuries. 
+</div><div class="q1">
+<sup>5&#160;</sup>By your great wisdom 
+</div><div class="q2">and by your trading you have increased your riches, 
+</div><div class="q2">and your heart is lifted up because of your riches—” 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘therefore the Lord Yahweh says: 
+</div><div class="q1">“Because you have set your heart as the heart of Elohim, 
+</div><div class="q2">
+<sup>7&#160;</sup>therefore, behold, I will bring strangers on you, 
+</div><div class="q2">the terrible of the nations. 
+</div><div class="q1">They will draw their swords against the beauty of your wisdom. 
+</div><div class="q2">They will defile your brightness. 
+</div><div class="q1">
+<sup>8&#160;</sup>They will bring you down to the pit. 
+</div><div class="q2">You will die the death of those who are slain 
+</div><div class="q2">in the heart of the seas. 
+</div><div class="q1">
+<sup>9&#160;</sup>Will you yet say before him who kills you, ‘I am Elohim’? 
+</div><div class="q2">But you are man, and not Elohim, 
+</div><div class="q2">in the hand of him who wounds you. 
+</div><div class="q1">
+<sup>10&#160;</sup>You will die the death of the uncircumcised 
+</div><div class="q2">by the hand of strangers; 
+</div><div class="q2">for I have spoken it,” says the Lord Yahweh.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>11&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>12&#160;</sup>“Son of man, take up a lamentation over the king of Tyre, and tell him, ‘The Lord Yahweh says: 
+</div><div class="q1">“You were the seal of full measure, 
+</div><div class="q2">full of wisdom, 
+</div><div class="q2">and perfect in beauty. 
+</div><div class="q1">
+<sup>13&#160;</sup>You were in Eden, 
+</div><div class="q2">the garden of Elohim. 
+</div><div class="q1">Every precious stone adorned you: 
+</div><div class="q2">ruby, topaz, emerald, 
+</div><div class="q2">chrysolite, onyx, jasper, 
+</div><div class="q2">sapphire, turquoise, and beryl. 
+</div><div class="q1">Gold work of tambourines 
+</div><div class="q2">and of pipes was in you. 
+</div><div class="q2">They were prepared in the day that you were created. 
+</div><div class="q1">
+<sup>14&#160;</sup>You were the anointed cherub who covers. 
+</div><div class="q2">Then I set you up on the set-apart mountain of Elohim. 
+</div><div class="q2">You have walked up and down in the middle of the stones of fire. 
+</div><div class="q1">
+<sup>15&#160;</sup>You were perfect in your ways from the day that you were created, 
+</div><div class="q2">until unrighteousness was found in you. 
+</div><div class="q1">
+<sup>16&#160;</sup>By the abundance of your commerce, your insides were filled with violence, 
+</div><div class="q2">and you have sinned. 
+</div><div class="q1">Therefore I have cast you as profane out of Elohim’s mountain. 
+</div><div class="q2">I have destroyed you, covering cherub, 
+</div><div class="q2">from the middle of the stones of fire. 
+</div><div class="q1">
+<sup>17&#160;</sup>Your heart was lifted up because of your beauty. 
+</div><div class="q2">You have corrupted your wisdom by reason of your splendor. 
+</div><div class="q1">I have cast you to the ground. 
+</div><div class="q2">I have laid you before kings, 
+</div><div class="q2">that they may see you. 
+</div><div class="q1">
+<sup>18&#160;</sup>By the multitude of your iniquities, 
+</div><div class="q2">in the unrighteousness of your commerce, 
+</div><div class="q2">you have profaned your sanctuaries. 
+</div><div class="q1">Therefore I have brought out a fire from the middle of you. 
+</div><div class="q2">It has devoured you. 
+</div><div class="q1">I have turned you to ashes on the earth 
+</div><div class="q2">in the sight of all those who see you. 
+</div><div class="q1">
+<sup>19&#160;</sup>All those who know you among the peoples will be astonished at you. 
+</div><div class="q2">You have become a terror, 
+</div><div class="q2">and you will exist no more.”&#160;’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>20&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>21&#160;</sup>“Son of man, set your face toward Sidon, and prophesy against it, 
+<sup>22&#160;</sup>and say, ‘The Lord Yahweh says: 
+</div><div class="q1">“Behold, I am against you, Sidon. 
+</div><div class="q2">I will be glorified among you. 
+</div><div class="q1">Then they will know that I am Yahweh, 
+</div><div class="q2">when I have executed judgments in her, 
+</div><div class="q2">and am sanctified in her. 
+</div><div class="q1">
+<sup>23&#160;</sup>For I will send pestilence into her, 
+</div><div class="q2">and blood into her streets. 
+</div><div class="q1">The wounded will fall within her, 
+</div><div class="q2">with the sword on her on every side. 
+</div><div class="q2">Then they will know that I am Yahweh. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘&#160;“There will no longer be a pricking brier to the house of Israel, nor a hurting thorn of any that are around them that scorned them. Then they will know that I am the Lord Yahweh.” 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘The Lord Yahweh says: “When I have gathered the house of Israel from the peoples among whom they are scattered, and am shown as set-apart among them in the sight of the nations, then they will dwell in their own land which I gave to my servant Jacob. 
+<sup>26&#160;</sup>They will dwell in it securely. Yes, they will build houses, plant vineyards, and will dwell securely when I have executed judgments on all those around them who have treated them with contempt. Then they will know that I am Yahweh their Elohim.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>In the tenth year, in the tenth month, on the twelfth day of the month, Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, set your face against Pharaoh king of Egypt, and prophesy against him and against all Egypt. 
+<sup>3&#160;</sup>Speak and say, ‘The Lord Yahweh says: 
+</div><div class="q1">“Behold, I am against you, Pharaoh king of Egypt, 
+</div><div class="q2">the great monster that lies in the middle of his rivers, 
+</div><div class="q1">that has said, ‘My river is my own, 
+</div><div class="q2">and I have made it for myself.’ 
+</div><div class="q1">
+<sup>4&#160;</sup>I will put hooks in your jaws, 
+</div><div class="q2">and I will make the fish of your rivers stick to your scales. 
+</div><div class="q1">I will bring you up out of the middle of your rivers, 
+</div><div class="q2">with all the fish of your rivers which stick to your scales. 
+</div><div class="q1">
+<sup>5&#160;</sup>I’ll cast you out into the wilderness, 
+</div><div class="q2">you and all the fish of your rivers. 
+</div><div class="q1">You’ll fall on the open field. 
+</div><div class="q2">You won’t be brought together or gathered. 
+</div><div class="q1">I have given you for food to the animals of the earth 
+</div><div class="q2">and to the birds of the sky. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘&#160;“All the inhabitants of Egypt will know that I am Yahweh, because they have been a staff of reed to the house of Israel. 
+<sup>7&#160;</sup>When they took hold of you by your hand, you broke and tore all their shoulders. When they leaned on you, you broke and paralyzed all of their thighs.” 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘Therefore the Lord Yahweh says: “Behold, I will bring a sword on you, and will cut off man and animal from you. 
+<sup>9&#160;</sup>The land of Egypt will be a desolation and a waste. Then they will know that I am Yahweh. 
+</div><div class="p">“&#160;‘&#160;“Because he has said, ‘The river is mine, and I have made it,’ 
+<sup>10&#160;</sup>therefore, behold, I am against you and against your rivers. I will make the land of Egypt an utter waste and desolation, from the tower of Seveneh even to the border of Ethiopia. 
+<sup>11&#160;</sup>No foot of man will pass through it, nor will any animal foot pass through it. It won’t be inhabited for forty years. 
+<sup>12&#160;</sup>I will make the land of Egypt a desolation in the middle of the countries that are desolate. Her cities among the cities that are laid waste will be a desolation forty years. I will scatter the Egyptians among the nations, and will disperse them through the countries.” 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘For the Lord Yahweh says: “At the end of forty years I will gather the Egyptians from the peoples where they were scattered. 
+<sup>14&#160;</sup>I will reverse the captivity of Egypt, and will cause them to return into the land of Pathros, into the land of their birth. There they will be a lowly kingdom. 
+<sup>15&#160;</sup>It will be the lowest of the kingdoms. It won’t lift itself up above the nations any more. I will diminish them so that they will no longer rule over the nations. 
+<sup>16&#160;</sup>It will no longer be the confidence of the house of Israel, bringing iniquity to memory, when they turn to look after them. Then they will know that I am the Lord Yahweh.”&#160;’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>17&#160;</sup>It came to pass in the twenty-seventh year, in the first month, in the first day of the month, Yahweh’s word came to me, saying, 
+<sup>18&#160;</sup>“Son of man, Nebuchadnezzar king of Babylon caused his army to serve a great service against Tyre. Every head was made bald, and every shoulder was worn; yet he had no wages, nor did his army, from Tyre, for the service that he had served against it. 
+<sup>19&#160;</sup>Therefore the Lord Yahweh says: ‘Behold, I will give the land of Egypt to Nebuchadnezzar king of Babylon. He will carry off her multitude, take her plunder, and take her prey. That will be the wages for his army. 
+<sup>20&#160;</sup>I have given him the land of Egypt as his payment for which he served, because they worked for me,’ says the Lord Yahweh. 
+</div><div class="p">
+<sup>21&#160;</sup>“In that day I will cause a horn to sprout for the house of Israel, and I will open your mouth among them. Then they will know that I am Yahweh.” 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>2&#160;</sup>“Son of man, prophesy, and say, ‘The Lord Yahweh says: 
+</div><div class="q1">“Wail, ‘Alas for the day!’ 
+</div><div class="q2">
+<sup>3&#160;</sup>For the day is near, 
+</div><div class="q2">even Yahweh’s day is near. 
+</div><div class="q1">It will be a day of clouds, 
+</div><div class="q2">a time of the nations. 
+</div><div class="q1">
+<sup>4&#160;</sup>A sword will come on Egypt, 
+</div><div class="q2">and anguish will be in Ethiopia, 
+</div><div class="q2">when the slain fall in Egypt. 
+</div><div class="q1">They take away her multitude, 
+</div><div class="q2">and her foundations are broken down. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘&#160;“Ethiopia, Put, Lud, all the mixed people, Cub, and the children of the land that is allied with them, will fall with them by the sword.” 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘Yahweh says: 
+</div><div class="q1">“They also who uphold Egypt will fall. 
+</div><div class="q2">The pride of her power will come down. 
+</div><div class="q1">They will fall by the sword in it from the tower of Seveneh,” 
+</div><div class="q2">says the Lord Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>“They will be desolate in the middle of the countries that are desolate. 
+</div><div class="q2">Her cities will be among the cities that are wasted. 
+</div><div class="q1">
+<sup>8&#160;</sup>They will know that I am Yahweh 
+</div><div class="q2">when I have set a fire in Egypt, 
+</div><div class="q2">and all her helpers are destroyed. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘&#160;“In that day messengers will go out from before me in ships to make the careless Ethiopians afraid. There will be anguish on them, as in the day of Egypt; for, behold, it comes.” 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘The Lord Yahweh says: 
+</div><div class="q1">“I will also make the multitude of Egypt to cease, 
+</div><div class="q2">by the hand of Nebuchadnezzar king of Babylon. 
+</div><div class="q1">
+<sup>11&#160;</sup>He and his people with him, 
+</div><div class="q2">the terrible of the nations, 
+</div><div class="q1">will be brought in to destroy the land. 
+</div><div class="q2">They will draw their swords against Egypt, 
+</div><div class="q2">and fill the land with the slain. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will make the rivers dry, 
+</div><div class="q2">and will sell the land into the hand of evil men. 
+</div><div class="q1">I will make the land desolate, 
+</div><div class="q2">and all that is therein, 
+</div><div class="q2">by the hand of foreigners. 
+</div><div class="q2">I, Yahweh, have spoken it.” 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘The Lord Yahweh says: 
+</div><div class="q1">“I will also destroy the idols, 
+</div><div class="q2">and I will cause the images to cease from Memphis. 
+</div><div class="q1">There will be no more a prince from the land of Egypt. 
+</div><div class="q2">I will put a fear in the land of Egypt. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will make Pathros desolate, 
+</div><div class="q2">and will set a fire in Zoan, 
+</div><div class="q2">and will execute judgments on No. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will pour my wrath on Sin, 
+</div><div class="q2">the stronghold of Egypt. 
+</div><div class="q2">I will cut off the multitude of No. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will set a fire in Egypt 
+</div><div class="q2">Sin will be in great anguish. 
+</div><div class="q1">No will be broken up. 
+</div><div class="q2">Memphis will have adversaries in the daytime. 
+</div><div class="q1">
+<sup>17&#160;</sup>The young men of Aven and of Pibeseth will fall by the sword. 
+</div><div class="q2">They will go into captivity. 
+</div><div class="q1">
+<sup>18&#160;</sup>At Tehaphnehes also the day will withdraw itself, 
+</div><div class="q2">when I break the yokes of Egypt there. 
+</div><div class="q1">The pride of her power will cease in her. 
+</div><div class="q2">As for her, a cloud will cover her, 
+</div><div class="q2">and her daughters will go into captivity. 
+</div><div class="q1">
+<sup>19&#160;</sup>Thus I will execute judgments on Egypt. 
+</div><div class="q2">Then they will know that I am Yahweh.”&#160;’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>20&#160;</sup>In the eleventh year, in the first month, in the seventh day of the month, Yahweh’s word came to me, saying, 
+<sup>21&#160;</sup>“Son of man, I have broken the arm of Pharaoh king of Egypt. Behold, it has not been bound up, to apply medicines, to put a bandage to bind it, that it may become strong to hold the sword. 
+<sup>22&#160;</sup>Therefore the Lord Yahweh says: ‘Behold, I am against Pharaoh king of Egypt, and will break his arms, the strong arm, and that which was broken. I will cause the sword to fall out of his hand. 
+<sup>23&#160;</sup>I will scatter the Egyptians among the nations, and will disperse them through the countries. 
+<sup>24&#160;</sup>I will strengthen the arms of the king of Babylon, and put my sword in his hand; but I will break the arms of Pharaoh, and he will groan before the king of Babylon with the groaning of a mortally wounded man. 
+<sup>25&#160;</sup>I will hold up the arms of the king of Babylon, but the arms of Pharaoh will fall down. Then they will know that I am Yahweh when I put my sword into the hand of the king of Babylon, and he stretches it out on the land of Egypt. 
+<sup>26&#160;</sup>I will scatter the Egyptians among the nations and disperse them through the countries. Then they will know that I am Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>In the eleventh year, in the third month, in the first day of the month, Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, tell Pharaoh king of Egypt and his multitude: 
+</div><div class="q1">‘Whom are you like in your greatness? 
+</div><div class="q1">
+<sup>3&#160;</sup>Behold, the Assyrian was a cedar in Lebanon 
+</div><div class="q2">with beautiful branches, 
+</div><div class="q1">and with a forest-like shade, 
+</div><div class="q2">of high stature; 
+</div><div class="q2">and its top was among the thick boughs. 
+</div><div class="q1">
+<sup>4&#160;</sup>The waters nourished it. 
+</div><div class="q2">The deep made it to grow. 
+</div><div class="q1">Its rivers ran all around its plantation. 
+</div><div class="q2">It sent out its channels to all the trees of the field. 
+</div><div class="q1">
+<sup>5&#160;</sup>Therefore its stature was exalted above all the trees of the field; 
+</div><div class="q2">and its boughs were multiplied. 
+</div><div class="q1">Its branches became long by reason of many waters, 
+</div><div class="q2">when it spread them out. 
+</div><div class="q1">
+<sup>6&#160;</sup>All the birds of the sky made their nests in its boughs. 
+</div><div class="q2">Under its branches, all the animals of the field gave birth to their young. 
+</div><div class="q2">All great nations lived under its shadow. 
+</div><div class="q1">
+<sup>7&#160;</sup>Thus it was beautiful in its greatness, 
+</div><div class="q2">in the length of its branches; 
+</div><div class="q2">for its root was by many waters. 
+</div><div class="q1">
+<sup>8&#160;</sup>The cedars in the garden of Elohim could not hide it. 
+</div><div class="q2">The cypress trees were not like its branches. 
+</div><div class="q1">The pine trees were not like its branches; 
+</div><div class="q2">nor was any tree in the garden of Elohim like it in its beauty. 
+</div><div class="q1">
+<sup>9&#160;</sup>I made it beautiful by the multitude of its branches, 
+</div><div class="q2">so that all the trees of Eden, 
+</div><div class="q2">that were in the garden of Elohim, envied it.’ 
+</div><div class="p">
+<sup>10&#160;</sup>“Therefore thus said the Lord Yahweh: ‘Because he is exalted in stature, and he has set his top among the thick branches, and his heart is lifted up in his height, 
+<sup>11&#160;</sup>I will deliver him into the hand of the mighty one of the nations. He will surely deal with him. I have driven him out for his wickedness. 
+<sup>12&#160;</sup>Foreigners, the tyrants of the nations, have cut him off and have left him. His branches have fallen on the mountains and in all the valleys, and his boughs are broken by all the watercourses of the land. All the peoples of the earth have gone down from his shadow and have left him. 
+<sup>13&#160;</sup>All the birds of the sky will dwell on his ruin, and all the animals of the field will be on his branches, 
+<sup>14&#160;</sup>to the end that none of all the trees by the waters exalt themselves in their stature, and don’t set their top among the thick boughs. Their mighty ones don’t stand up on their height, even all who drink water; for they are all delivered to death, to the lower parts of the earth, among the children of men, with those who go down to the pit.’ 
+</div><div class="p">
+<sup>15&#160;</sup>“The Lord Yahweh says: ‘In the day when he went down to Sheol, I caused a mourning. I covered the deep for him, and I restrained its rivers. The great waters were stopped. I caused Lebanon to mourn for him, and all the trees of the field fainted for him. 
+<sup>16&#160;</sup>I made the nations to shake at the sound of his fall, when I cast him down to Sheol with those who descend into the pit. All the trees of Eden, the choice and best of Lebanon, all that drink water, were comforted in the lower parts of the earth. 
+<sup>17&#160;</sup>They also went down into Sheol with him to those who are slain by the sword; yes, those who were his arm, who lived under his shadow in the middle of the nations. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘To whom are you thus like in glory and in greatness among the trees of Eden? Yet you will be brought down with the trees of Eden to the lower parts of the earth. You will lie in the middle of the uncircumcised, with those who are slain by the sword. 
+</div><div class="p">“&#160;‘This is Pharaoh and all his multitude,’ says the Lord Yahweh.” 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>In the twelfth year, in the twelfth month, in the first day of the month, “Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>‘Son of man, take up a lamentation over Pharaoh king of Egypt, and tell him, 
+</div><div class="q1">“You were likened to a young lion of the nations; 
+</div><div class="q2">yet you are as a monster in the seas. 
+</div><div class="q1">You broke out with your rivers, 
+</div><div class="q2">and troubled the waters with your feet, 
+</div><div class="q2">and fouled their rivers.” 
+</div><div class="q1">
+<sup>3&#160;</sup>The Lord Yahweh says: 
+</div><div class="q2">“I will spread out my net on you with a company of many peoples. 
+</div><div class="q2">They will bring you up in my net. 
+</div><div class="q1">
+<sup>4&#160;</sup>I will leave you on the land. 
+</div><div class="q2">I will cast you out on the open field, 
+</div><div class="q1">and will cause all the birds of the sky to settle on you. 
+</div><div class="q2">I will satisfy the animals of the whole earth with you. 
+</div><div class="q1">
+<sup>5&#160;</sup>I will lay your flesh on the mountains, 
+</div><div class="q2">and fill the valleys with your height. 
+</div><div class="q1">
+<sup>6&#160;</sup>I will also water the land in which you swim with your blood, 
+</div><div class="q2">even to the mountains. 
+</div><div class="q2">The watercourses will be full of you. 
+</div><div class="q1">
+<sup>7&#160;</sup>When I extinguish you, I will cover the heavens 
+</div><div class="q2">and make its stars dark. 
+</div><div class="q1">I will cover the sun with a cloud, 
+</div><div class="q2">and the moon won’t give its light. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will make all the bright lights of the sky dark over you, 
+</div><div class="q2">and set darkness on your land,” says the Lord Yahweh. 
+</div><div class="q1">
+<sup>9&#160;</sup>“I will also trouble the hearts of many peoples, 
+</div><div class="q2">when I bring your destruction among the nations, 
+</div><div class="q2">into the countries which you have not known. 
+</div><div class="q1">
+<sup>10&#160;</sup>Yes, I will make many peoples amazed at you, 
+</div><div class="q2">and their kings will be horribly afraid for you, 
+</div><div class="q1">when I brandish my sword before them. 
+</div><div class="q2">They will tremble at every moment, 
+</div><div class="q1">every man for his own life, 
+</div><div class="q2">in the day of your fall.” 
+</div><div class="q1">
+<sup>11&#160;</sup>For the Lord Yahweh says: 
+</div><div class="q2">“The sword of the king of Babylon will come on you. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will cause your multitude to fall by the swords of the mighty. 
+</div><div class="q2">They are all the ruthless of the nations. 
+</div><div class="q1">They will bring the pride of Egypt to nothing, 
+</div><div class="q2">and all its multitude will be destroyed. 
+</div><div class="q1">
+<sup>13&#160;</sup>I will destroy also all its animals from beside many waters. 
+</div><div class="q2">The foot of man won’t trouble them any more, 
+</div><div class="q2">nor will the hoofs of animals trouble them. 
+</div><div class="q1">
+<sup>14&#160;</sup>Then I will make their waters clear, 
+</div><div class="q2">and cause their rivers to run like oil,” 
+</div><div class="q2">says the Lord Yahweh. 
+</div><div class="q1">
+<sup>15&#160;</sup>“When I make the land of Egypt desolate and waste, 
+</div><div class="q2">a land destitute of that of which it was full, 
+</div><div class="q1">when I strike all those who dwell therein, 
+</div><div class="q2">then they will know that I am Yahweh. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘&#160;“This is the lamentation with which they will lament. The daughters of the nations will lament with this. They will lament with it over Egypt, and over all her multitude,” says the Lord Yahweh.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>17&#160;</sup>Also in the twelfth year, in the fifteenth day of the month, Yahweh’s word came to me, saying, 
+<sup>18&#160;</sup>“Son of man, wail for the multitude of Egypt, and cast them down, even her and the daughters of the famous nations, to the lower parts of the earth, with those who go down into the pit. 
+<sup>19&#160;</sup>Whom do you pass in beauty? Go down, and be laid with the uncircumcised. 
+<sup>20&#160;</sup>They will fall among those who are slain by the sword. She is delivered to the sword. Draw her away with all her multitudes. 
+<sup>21&#160;</sup>The strong among the mighty will speak to him out of the middle of Sheol with those who help him. They have gone down. The uncircumcised lie still, slain by the sword. 
+</div><div class="p">
+<sup>22&#160;</sup>“Asshur is there with all her company. Her graves are all around her. All of them are slain, fallen by the sword, 
+<sup>23&#160;</sup>whose graves are set in the uttermost parts of the pit, and her company is around her grave, all of them slain, fallen by the sword, who caused terror in the land of the living. 
+</div><div class="p">
+<sup>24&#160;</sup>“There is Elam and all her multitude around her grave; all of them slain, fallen by the sword, who have gone down uncircumcised into the lower parts of the earth, who caused their terror in the land of the living, and have borne their shame with those who go down to the pit. 
+<sup>25&#160;</sup>They have made Elam a bed among the slain with all her multitude. Her graves are around her, all of them uncircumcised, slain by the sword; for their terror was caused in the land of the living, and they have borne their shame with those who go down to the pit. He is put among those who are slain. 
+</div><div class="p">
+<sup>26&#160;</sup>“There is Meshech, Tubal, and all their multitude. Their graves are around them, all of them uncircumcised, slain by the sword; for they caused their terror in the land of the living. 
+<sup>27&#160;</sup>They will not lie with the mighty who are fallen of the uncircumcised, who have gone down to Sheol with their weapons of war and have laid their swords under their heads. Their iniquities are on their bones; for they were the terror of the mighty in the land of the living. 
+</div><div class="p">
+<sup>28&#160;</sup>“But you will be broken among the uncircumcised, and will lie with those who are slain by the sword. 
+</div><div class="p">
+<sup>29&#160;</sup>“There is Edom, her kings, and all her princes, who in their might are laid with those who are slain by the sword. They will lie with the uncircumcised, and with those who go down to the pit. 
+</div><div class="p">
+<sup>30&#160;</sup>“There are the princes of the north, all of them, and all the Sidonians, who have gone down with the slain. They are put to shame in the terror which they caused by their might. They lie uncircumcised with those who are slain by the sword, and bear their shame with those who go down to the pit. 
+</div><div class="p">
+<sup>31&#160;</sup>“Pharaoh will see them and will be comforted over all his multitude, even Pharaoh and all his army, slain by the sword,” says the Lord Yahweh. 
+<sup>32&#160;</sup>“For I have put his terror in the land of the living. He will be laid among the uncircumcised, with those who are slain by the sword, even Pharaoh and all his multitude,” says the Lord Yahweh. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, speak to the children of your people, and tell them, ‘When I bring the sword on a land, and the people of the land take a man from among them, and set him for their watchman, 
+<sup>3&#160;</sup>if, when he sees the sword come on the land, he blows the trumpet and warns the people, 
+<sup>4&#160;</sup>then whoever hears the sound of the trumpet and doesn’t heed the warning, if the sword comes and takes him away, his blood will be on his own head. 
+<sup>5&#160;</sup>He heard the sound of the trumpet and didn’t take warning. His blood will be on him; whereas if he had heeded the warning, he would have delivered his soul. 
+<sup>6&#160;</sup>But if the watchman sees the sword come and doesn’t blow the trumpet, and the people aren’t warned, and the sword comes and takes any person from among them, he is taken away in his iniquity, but his blood I will require at the watchman’s hand.’ 
+</div><div class="p">
+<sup>7&#160;</sup>“So you, son of man, I have set you a watchman to the house of Israel. Therefore hear the word from my mouth, and give them warnings from me. 
+<sup>8&#160;</sup>When I tell the wicked, ‘O wicked man, you will surely die,’ and you don’t speak to warn the wicked from his way, that wicked man will die in his iniquity, but I will require his blood at your hand. 
+<sup>9&#160;</sup>Nevertheless, if you warn the wicked of his way to turn from it, and he doesn’t turn from his way; he will die in his iniquity, but you have delivered your soul. 
+</div><div class="p">
+<sup>10&#160;</sup>“You, son of man, tell the house of Israel: ‘You say this, “Our transgressions and our sins are on us, and we pine away in them. How then can we live?”&#160;’ 
+<sup>11&#160;</sup>Tell them, ‘&#160;“As I live,” says the Lord Yahweh, “I have no pleasure in the death of the wicked, but that the wicked turn from his way and live. Turn, turn from your evil ways! For why will you die, house of Israel?”&#160;’ 
+</div><div class="p">
+<sup>12&#160;</sup>“You, son of man, tell the children of your people, ‘The righteousness of the righteous will not deliver him in the day of his disobedience. And as for the wickedness of the wicked, he will not fall by it in the day that he turns from his wickedness; neither will he who is righteous be able to live by it in the day that he sins. 
+<sup>13&#160;</sup>When I tell the righteous that he will surely live, if he trusts in his righteousness and commits iniquity, none of his righteous deeds will be remembered; but he will die in his iniquity that he has committed. 
+<sup>14&#160;</sup>Again, when I say to the wicked, “You will surely die,” if he turns from his sin and does that which is lawful and right, 
+<sup>15&#160;</sup>if the wicked restore the pledge, give again that which he had taken by robbery, walk in the statutes of life, committing no iniquity, he will surely live. He will not die. 
+<sup>16&#160;</sup>None of his sins that he has committed will be remembered against him. He has done that which is lawful and right. He will surely live. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘Yet the children of your people say, “The way of the Lord is not fair;” but as for them, their way is not fair. 
+<sup>18&#160;</sup>When the righteous turns from his righteousness and commits iniquity, he will even die therein. 
+<sup>19&#160;</sup>When the wicked turns from his wickedness and does that which is lawful and right, he will live by it. 
+<sup>20&#160;</sup>Yet you say, “The way of the Lord is not fair.” House of Israel, I will judge every one of you after his ways.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>21&#160;</sup>In the twelfth year of our captivity, in the tenth month, in the fifth day of the month, one who had escaped out of Jerusalem came to me, saying, “The city has been defeated!” 
+<sup>22&#160;</sup>Now Yahweh’s hand had been on me in the evening, before he who had escaped came; and he had opened my mouth until he came to me in the morning; and my mouth was opened, and I was no longer mute. 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>24&#160;</sup>“Son of man, those who inhabit the waste places in the land of Israel speak, saying, ‘Abraham was one, and he inherited the land; but we are many. The land is given us for inheritance.’ 
+<sup>25&#160;</sup>Therefore tell them, ‘The Lord Yahweh says: “You eat with the blood, and lift up your eyes to your idols, and shed blood. So should you possess the land? 
+<sup>26&#160;</sup>You stand on your sword, you work abomination, and every one of you defiles his neighbor’s woman. So should you possess the land?”&#160;’ 
+</div><div class="p">
+<sup>27&#160;</sup>“You shall tell them, ‘The Lord Yahweh says: “As I live, surely those who are in the waste places will fall by the sword. I will give whoever is in the open field to the animals to be devoured, and those who are in the strongholds and in the caves will die of the pestilence. 
+<sup>28&#160;</sup>I will make the land a desolation and an astonishment. The pride of her power will cease. The mountains of Israel will be desolate, so that no one will pass through. 
+<sup>29&#160;</sup>Then they will know that I am Yahweh, when I have made the land a desolation and an astonishment because of all their abominations which they have committed.”&#160;’ 
+</div><div class="p">
+<sup>30&#160;</sup>“As for you, son of man, the children of your people talk about you by the walls and in the doors of the houses, and speak to one another, everyone to his brother, saying, ‘Please come and hear what the word is that comes out from Yahweh.’ 
+<sup>31&#160;</sup>They come to you as the people come, and they sit before you as my people, and they hear your words, but don’t do them; for with their mouth they show much love, but their heart goes after their gain. 
+<sup>32&#160;</sup>Behold, you are to them as a very lovely song of one who has a pleasant voice, and can play well on an instrument; for they hear your words, but they don’t do them. 
+</div><div class="p">
+<sup>33&#160;</sup>“When this comes to pass—behold, it comes—then they will know that a prophet has been among them.” 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, prophesy against the shepherds of Israel. Prophesy, and tell them, even the shepherds, ‘The Lord Yahweh says: “Woe to the shepherds of Israel who feed themselves! Shouldn’t the shepherds feed the sheep? 
+<sup>3&#160;</sup>You eat the fat. You clothe yourself with the wool. You kill the fatlings, but you don’t feed the sheep. 
+<sup>4&#160;</sup>You haven’t strengthened the diseased. You haven’t healed that which was sick. You haven’t bound up that which was broken. You haven’t brought back that which was driven away. You haven’t sought that which was lost, but you have ruled over them with force and with rigor. 
+<sup>5&#160;</sup>They were scattered, because there was no shepherd. They became food to all the animals of the field, and were scattered. 
+<sup>6&#160;</sup>My sheep wandered through all the mountains and on every high hill. Yes, my sheep were scattered on all the surface of the earth. There was no one who searched or sought.” 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘Therefore, you shepherds, hear Yahweh’s word: 
+<sup>8&#160;</sup>“As I live,” says the Lord Yahweh, “surely because my sheep became a prey, and my sheep became food to all the animals of the field, because there was no shepherd, and my shepherds didn’t search for my sheep, but the shepherds fed themselves, and didn’t feed my sheep, 
+<sup>9&#160;</sup>therefore, you shepherds, hear Yahweh’s word!” 
+<sup>10&#160;</sup>The Lord Yahweh says: “Behold, I am against the shepherds. I will require my sheep at their hand, and cause them to cease from feeding the sheep. The shepherds won’t feed themselves any more. I will deliver my sheep from their mouth, that they may not be food for them.” 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘For the Lord Yahweh says: “Behold, I myself, even I, will search for my sheep, and will seek them out. 
+<sup>12&#160;</sup>As a shepherd seeks out his flock in the day that he is among his sheep that are scattered abroad, so I will seek out my sheep. I will deliver them out of all places where they have been scattered in the cloudy and dark day. 
+<sup>13&#160;</sup>I will bring them out from the peoples, and gather them from the countries, and will bring them into their own land. I will feed them on the mountains of Israel, by the watercourses, and in all the inhabited places of the country. 
+<sup>14&#160;</sup>I will feed them with good pasture, and their fold will be on the mountains of the height of Israel. There they will lie down in a good fold. They will feed on rich pasture on the mountains of Israel. 
+<sup>15&#160;</sup>I myself will be the shepherd of my sheep, and I will cause them to lie down,” says the Lord Yahweh. 
+<sup>16&#160;</sup>“I will seek that which was lost, and will bring back that which was driven away, and will bind up that which was broken, and will strengthen that which was sick; but I will destroy the fat and the strong. I will feed them in justice.”&#160;’ 
+</div><div class="p">
+<sup>17&#160;</sup>“As for you, O my flock, the Lord Yahweh says: ‘Behold, I judge between sheep and sheep, the rams and the male goats. 
+<sup>18&#160;</sup>Does it seem a small thing to you to have fed on the good pasture, but you must tread down with your feet the residue of your pasture? And to have drunk of the clear waters, but must you foul the residue with your feet? 
+<sup>19&#160;</sup>As for my sheep, they eat that which you have trodden with your feet, and they drink that which you have fouled with your feet.’ 
+</div><div class="p">
+<sup>20&#160;</sup>“Therefore the Lord Yahweh says to them: ‘Behold, I, even I, will judge between the fat sheep and the lean sheep. 
+<sup>21&#160;</sup>Because you thrust with side and with shoulder, and push all the diseased with your horns, until you have scattered them abroad, 
+<sup>22&#160;</sup>therefore I will save my flock, and they will no more be a prey. I will judge between sheep and sheep. 
+<sup>23&#160;</sup>I will set up one shepherd over them, and he will feed them, even my servant David. He will feed them, and he will be their shepherd. 
+<sup>24&#160;</sup>I, Yahweh, will be their Elohim, and my servant David prince among them. I, Yahweh, have spoken it. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘I will make with them a covenant of peace, and will cause evil animals to cease out of the land. They will dwell securely in the wilderness and sleep in the woods. 
+<sup>26&#160;</sup>I will make them and the places around my hill a blessing. I will cause the shower to come down in its season. There will be showers of blessing. 
+<sup>27&#160;</sup>The tree of the field will yield its fruit, and the earth will yield its increase, and they will be secure in their land. Then they will know that I am Yahweh, when I have broken the bars of their yoke, and have delivered them out of the hand of those who made slaves of them. 
+<sup>28&#160;</sup>They will no more be a prey to the nations, neither will the animals of the earth devour them; but they will dwell securely, and no one will make them afraid. 
+<sup>29&#160;</sup>I will raise up to them a plantation for renown, and they will no more be consumed with famine in the land, and not bear the shame of the nations any more. 
+<sup>30&#160;</sup>They will know that I, Yahweh, their Elohim am with them, and that they, the house of Israel, are my people, says the Lord Yahweh. 
+<sup>31&#160;</sup>You my sheep, the sheep of my pasture, are men, and I am your Elohim,’ says the Lord Yahweh.” 
+</div><h2 class="chapterlabel" id="35">35</h2>
+<div class="p">
+<sup>1&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, set your face against Mount Seir, and prophesy against it, 
+<sup>3&#160;</sup>and tell it, ‘The Lord Yahweh says: “Behold, I am against you, Mount Seir, and I will stretch out my hand against you. I will make you a desolation and an astonishment. 
+<sup>4&#160;</sup>I will lay your cities waste, and you will be desolate. Then you will know that I am Yahweh. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘&#160;“Because you have had a perpetual hostility, and have given over the children of Israel to the power of the sword in the time of their calamity, in the time of the iniquity of the end, 
+<sup>6&#160;</sup>therefore, as I live,” says the Lord Yahweh, “I will prepare you for blood, and blood will pursue you. Since you have not hated blood, therefore blood will pursue you. 
+<sup>7&#160;</sup>Thus I will make Mount Seir an astonishment and a desolation. I will cut off from it him who passes through and him who returns. 
+<sup>8&#160;</sup>I will fill its mountains with its slain. The slain with the sword will fall in your hills and in your valleys and in all your watercourses. 
+<sup>9&#160;</sup>I will make you a perpetual desolation, and your cities will not be inhabited. Then you will know that I am Yahweh. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘&#160;“Because you have said, ‘These two nations and these two countries will be mine, and we will possess it,’ although Yahweh was there, 
+<sup>11&#160;</sup>therefore, as I live,” says the Lord Yahweh, “I will do according to your anger, and according to your envy which you have shown out of your hatred against them; and I will make myself known among them when I judge you. 
+<sup>12&#160;</sup>You will know that I, Yahweh, have heard all your insults which you have spoken against the mountains of Israel, saying, ‘They have been laid desolate. They have been given to us to devour.’ 
+<sup>13&#160;</sup>You have magnified yourselves against me with your mouth, and have multiplied your words against me. I have heard it.” 
+<sup>14&#160;</sup>The Lord Yahweh says: “When the whole earth rejoices, I will make you desolate. 
+<sup>15&#160;</sup>As you rejoiced over the inheritance of the house of Israel because it was desolate, so I will do to you. You will be desolate, Mount Seir, and all Edom, even all of it. Then they will know that I am Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>You, son of man, prophesy to the mountains of Israel, and say, “You mountains of Israel, hear Yahweh’s word. 
+<sup>2&#160;</sup>The Lord Yahweh says: ‘Because the enemy has said against you, “Aha!” and, “The ancient high places are ours in possession!”&#160;’ 
+<sup>3&#160;</sup>therefore prophesy, and say, ‘The Lord Yahweh says: “Because, even because they have made you desolate, and swallowed you up on every side, that you might be a possession to the residue of the nations, and you are taken up in the lips of talkers, and the evil report of the people;” 
+<sup>4&#160;</sup>therefore, you mountains of Israel, hear the word of the Lord Yahweh: The Lord Yahweh says to the mountains and to the hills, to the watercourses and to the valleys, to the desolate wastes and to the cities that are forsaken, which have become a prey and derision to the residue of the nations that are all around; 
+<sup>5&#160;</sup>therefore the Lord Yahweh says: “Surely in the fire of my jealousy I have spoken against the residue of the nations, and against all Edom, that have appointed my land to themselves for a possession with the joy of all their heart, with despite of soul, to cast it out for a prey.”&#160;’ 
+<sup>6&#160;</sup>Therefore prophesy concerning the land of Israel, and tell the mountains, the hills, the watercourses and the valleys, ‘The Lord Yahweh says: “Behold, I have spoken in my jealousy and in my wrath, because you have borne the shame of the nations.” 
+<sup>7&#160;</sup>Therefore the Lord Yahweh says: “I have sworn, ‘Surely the nations that are around you will bear their shame.’ 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘&#160;“But you, mountains of Israel, you shall shoot out your branches and yield your fruit to my people Israel; for they are at hand to come. 
+<sup>9&#160;</sup>For, behold, I am for you, and I will come to you, and you will be tilled and sown. 
+<sup>10&#160;</sup>I will multiply men on you, all the house of Israel, even all of it. The cities will be inhabited and the waste places will be built. 
+<sup>11&#160;</sup>I will multiply man and animal on you. They will increase and be fruitful. I will cause you to be inhabited as you were before, and you will do better than at your beginnings. Then you will know that I am Yahweh. 
+<sup>12&#160;</sup>Yes, I will cause men to walk on you, even my people Israel. They will possess you, and you will be their inheritance, and you will never again bereave them of their children.” 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘The Lord Yahweh says: “Because they say to you, ‘You are a devourer of men, and have been a bereaver of your nation;’ 
+<sup>14&#160;</sup>therefore you shall devour men no more, and not bereave your nation any more,” says the Lord Yahweh. 
+<sup>15&#160;</sup>“I won’t let you hear the shame of the nations any more. You won’t bear the reproach of the peoples any more, and you won’t cause your nation to stumble any more,” says the Lord Yahweh.’&#160;” 
+</div><div class="p">
+<sup>16&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>17&#160;</sup>“Son of man, when the house of Israel lived in their own land, they defiled it by their ways and by their deeds. Their way before me was as the uncleanness of a woman in her impurity. 
+<sup>18&#160;</sup>Therefore I poured out my wrath on them for the blood which they had poured out on the land, and because they had defiled it with their idols. 
+<sup>19&#160;</sup>I scattered them among the nations, and they were dispersed through the countries. I judged them according to their way and according to their deeds. 
+<sup>20&#160;</sup>When they came to the nations where they went, they profaned my set-apart name, in that men said of them, ‘These are Yahweh’s people, and have left his land.’ 
+<sup>21&#160;</sup>But I had respect for my set-apart name, which the house of Israel had profaned among the nations where they went. 
+</div><div class="p">
+<sup>22&#160;</sup>“Therefore tell the house of Israel, ‘The Lord Yahweh says: “I don’t do this for your sake, house of Israel, but for my set-apart name, which you have profaned among the nations where you went. 
+<sup>23&#160;</sup>I will sanctify my great name, which has been profaned among the nations, which you have profaned among them. Then the nations will know that I am Yahweh,” says the Lord Yahweh, “when I am proven set-apart in you before their eyes. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘&#160;“For I will take you from among the nations and gather you out of all the countries, and will bring you into your own land. 
+<sup>25&#160;</sup>I will sprinkle clean water on you, and you will be clean. I will cleanse you from all your filthiness and from all your idols. 
+<sup>26&#160;</sup>I will also give you a new heart, and I will put a new spirit within you. I will take away the stony heart out of your flesh, and I will give you a heart of flesh. 
+<sup>27&#160;</sup>I will put my Spirit within you, and cause you to walk in my statutes. You will keep my ordinances and do them. 
+<sup>28&#160;</sup>You will dwell in the land that I gave to your fathers. You will be my people, and I will be your Elohim. 
+<sup>29&#160;</sup>I will save you from all your uncleanness. I will call for the grain and will multiply it, and lay no famine on you. 
+<sup>30&#160;</sup>I will multiply the fruit of the tree and the increase of the field, that you may receive no more the reproach of famine among the nations. 
+</div><div class="p">
+<sup>31&#160;</sup>“&#160;‘&#160;“Then you will remember your evil ways, and your deeds that were not good; and you will loathe yourselves in your own sight for your iniquities and for your abominations. 
+<sup>32&#160;</sup>I don’t do this for your sake,” says the Lord Yahweh. “Let it be known to you. Be ashamed and confounded for your ways, house of Israel.” 
+</div><div class="p">
+<sup>33&#160;</sup>“&#160;‘The Lord Yahweh says: “In the day that I cleanse you from all your iniquities, I will cause the cities to be inhabited and the waste places will be built. 
+<sup>34&#160;</sup>The land that was desolate will be tilled instead of being a desolation in the sight of all who passed by. 
+<sup>35&#160;</sup>They will say, ‘This land that was desolate has become like the garden of Eden. The waste, desolate, and ruined cities are fortified and inhabited.’ 
+<sup>36&#160;</sup>Then the nations that are left around you will know that I, Yahweh, have built the ruined places and planted that which was desolate. I, Yahweh, have spoken it, and I will do it.” 
+</div><div class="p">
+<sup>37&#160;</sup>“&#160;‘The Lord Yahweh says: “For this, moreover, I will be inquired of by the house of Israel, to do it for them: I will increase them with men like a flock. 
+<sup>38&#160;</sup>As the flock for sacrifice, as the flock of Jerusalem in her appointed feasts, so the waste cities will be filled with flocks of men. Then they will know that I am Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="37">37</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s hand was on me, and he brought me out in Yahweh’s Spirit, and set me down in the middle of the valley; and it was full of bones. 
+<sup>2&#160;</sup>He caused me to pass by them all around; and behold, there were very many in the open valley, and behold, they were very dry. 
+<sup>3&#160;</sup>He said to me, “Son of man, can these bones live?” 
+</div><div class="p">I answered, “Lord Yahweh, you know.” 
+</div><div class="p">
+<sup>4&#160;</sup>Again he said to me, “Prophesy over these bones, and tell them, ‘You dry bones, hear Yahweh’s word. 
+<sup>5&#160;</sup>The Lord Yahweh says to these bones: “Behold, I will cause breath to enter into you, and you will live. 
+<sup>6&#160;</sup>I will lay sinews on you, and will bring up flesh on you, and cover you with skin, and put breath in you, and you will live. Then you will know that I am Yahweh.”&#160;’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>So I prophesied as I was commanded. As I prophesied, there was a noise, and behold, there was an earthquake. Then the bones came together, bone to its bone. 
+<sup>8&#160;</sup>I saw, and, behold, there were sinews on them, and flesh came up, and skin covered them above; but there was no breath in them. 
+</div><div class="p">
+<sup>9&#160;</sup>Then he said to me, “Prophesy to the wind, prophesy, son of man, and tell the wind, ‘The Lord Yahweh says: “Come from the four winds, breath, and breathe on these slain, that they may live.”&#160;’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>So I prophesied as he commanded me, and the breath came into them, and they lived, and stood up on their feet, an exceedingly great army. 
+</div><div class="p">
+<sup>11&#160;</sup>Then he said to me, “Son of man, these bones are the whole house of Israel. Behold, they say, ‘Our bones are dried up, and our hope is lost. We are completely cut off.’ 
+<sup>12&#160;</sup>Therefore prophesy, and tell them, ‘The Lord Yahweh says: “Behold, I will open your graves, and cause you to come up out of your graves, my people; and I will bring you into the land of Israel. 
+<sup>13&#160;</sup>You will know that I am Yahweh, when I have opened your graves and caused you to come up out of your graves, my people. 
+<sup>14&#160;</sup>I will put my Spirit in you, and you will live. Then I will place you in your own land; and you will know that I, Yahweh, have spoken it and performed it,” says Yahweh.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>15&#160;</sup>Yahweh’s word came again to me, saying, 
+<sup>16&#160;</sup>“You, son of man, take one stick and write on it, ‘For Judah, and for the children of Israel his companions.’ Then take another stick, and write on it, ‘For Joseph, the stick of Ephraim, and for all the house of Israel his companions.’ 
+<sup>17&#160;</sup>Then join them for yourself to one another into one stick, that they may become one in your hand. 
+</div><div class="p">
+<sup>18&#160;</sup>“When the children of your people speak to you, saying, ‘Won’t you show us what you mean by these?’ 
+<sup>19&#160;</sup>tell them, ‘The Lord Yahweh says: “Behold, I will take the stick of Joseph, which is in the hand of Ephraim, and the tribes of Israel his companions; and I will put them with it, with the stick of Judah, and make them one stick, and they will be one in my hand. 
+<sup>20&#160;</sup>The sticks on which you write will be in your hand before their eyes.”&#160;’ 
+<sup>21&#160;</sup>Say to them, ‘The Lord Yahweh says: “Behold, I will take the children of Israel from among the nations where they have gone, and will gather them on every side, and bring them into their own land. 
+<sup>22&#160;</sup>I will make them one nation in the land, on the mountains of Israel. One king will be king to them all. They will no longer be two nations. They won’t be divided into two kingdoms any more at all. 
+<sup>23&#160;</sup>They won’t defile themselves any more with their idols, nor with their detestable things, nor with any of their transgressions; but I will save them out of all their dwelling places in which they have sinned, and will cleanse them. So they will be my people, and I will be their Elohim. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘&#160;“My servant David will be king over them. They all will have one shepherd. They will also walk in my ordinances and observe my statutes, and do them. 
+<sup>25&#160;</sup>They will dwell in the land that I have given to Jacob my servant, in which your fathers lived. They will dwell therein, they, and their children, and their children’s children, forever. David my servant will be their prince forever. 
+<sup>26&#160;</sup>Moreover I will make a covenant of peace with them. It will be an everlasting covenant with them. I will place them, multiply them, and will set my sanctuary among them forever more. 
+<sup>27&#160;</sup>My tent also will be with them. I will be their Elohim, and they will be my people. 
+<sup>28&#160;</sup>The nations will know that I am Yahweh who sanctifies Israel, when my sanctuary is among them forever more.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="38">38</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Son of man, set your face toward Gog, of the land of Magog, the prince of Rosh, Meshech, and Tubal, and prophesy against him, 
+<sup>3&#160;</sup>and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
+<sup>4&#160;</sup>I will turn you around, and put hooks into your jaws, and I will bring you out, with all your army, horses and horsemen, all of them clothed in full armor, a great company with buckler and shield, all of them handling swords; 
+<sup>5&#160;</sup>Persia, Cush, and Put with them, all of them with shield and helmet; 
+<sup>6&#160;</sup>Gomer, and all his hordes; the house of Togarmah in the uttermost parts of the north, and all his hordes—even many peoples with you. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘&#160;“Be prepared, yes, prepare yourself, you, and all your companies who are assembled to you, and be a guard to them. 
+<sup>8&#160;</sup>After many days you will be visited. In the latter years you will come into the land that is brought back from the sword, that is gathered out of many peoples, on the mountains of Israel, which have been a continual waste; but it is brought out of the peoples and they will dwell securely, all of them. 
+<sup>9&#160;</sup>You will ascend. You will come like a storm. You will be like a cloud to cover the land, you and all your hordes, and many peoples with you.” 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘The Lord Yahweh says: “It will happen in that day that things will come into your mind, and you will devise an evil plan. 
+<sup>11&#160;</sup>You will say, ‘I will go up to the land of unwalled villages. I will go to those who are at rest, who dwell securely, all of them dwelling without walls, and having neither bars nor gates, 
+<sup>12&#160;</sup>to take the plunder and to take prey; to turn your hand against the waste places that are inhabited, and against the people who are gathered out of the nations, who have gotten livestock and goods, who dwell in the middle of the earth.’ 
+<sup>13&#160;</sup>Sheba, Dedan, and the merchants of Tarshish, with all its young lions, will ask you, ‘Have you come to take the plunder? Have you assembled your company to take the prey, to carry away silver and gold, to take away livestock and goods, to take great plunder?’&#160;”&#160;’ 
+</div><div class="p">
+<sup>14&#160;</sup>“Therefore, son of man, prophesy, and tell Gog, ‘The Lord Yahweh says: “In that day when my people Israel dwells securely, will you not know it? 
+<sup>15&#160;</sup>You will come from your place out of the uttermost parts of the north, you, and many peoples with you, all of them riding on horses, a great company and a mighty army. 
+<sup>16&#160;</sup>You will come up against my people Israel as a cloud to cover the land. It will happen in the latter days that I will bring you against my land, that the nations may know me when I am sanctified in you, Gog, before their eyes.” 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘The Lord Yahweh says: “Are you he of whom I spoke in old time by my servants the prophets of Israel, who prophesied in those days for years that I would bring you against them? 
+<sup>18&#160;</sup>It will happen in that day, when Gog comes against the land of Israel,” says the Lord Yahweh, “that my wrath will come up into my nostrils. 
+<sup>19&#160;</sup>For in my jealousy and in the fire of my wrath I have spoken. Surely in that day there will be a great shaking in the land of Israel, 
+<sup>20&#160;</sup>so that the fish of the sea, the birds of the sky, the animals of the field, all creeping things who creep on the earth, and all the men who are on the surface of the earth will shake at my presence. Then the mountains will be thrown down, the steep places will fall, and every wall will fall to the ground. 
+<sup>21&#160;</sup>I will call for a sword against him to all my mountains,” says the Lord Yahweh. “Every man’s sword will be against his brother. 
+<sup>22&#160;</sup>I will enter into judgment with him with pestilence and with blood. I will rain on him, on his hordes, and on the many peoples who are with him, torrential rains with great hailstones, fire, and sulfur. 
+<sup>23&#160;</sup>I will magnify myself and sanctify myself, and I will make myself known in the eyes of many nations. Then they will know that I am Yahweh.”&#160;’ 
+</div><h2 class="chapterlabel" id="39">39</h2>
+<div class="p">
+<sup>1&#160;</sup>“You, son of man, prophesy against Gog, and say, ‘The Lord Yahweh says: “Behold, I am against you, Gog, prince of Rosh, Meshech, and Tubal. 
+<sup>2&#160;</sup>I will turn you around, will lead you on, and will cause you to come up from the uttermost parts of the north; and I will bring you onto the mountains of Israel. 
+<sup>3&#160;</sup>I will strike your bow out of your left hand, and will cause your arrows to fall out of your right hand. 
+<sup>4&#160;</sup>You will fall on the mountains of Israel, you, and all your hordes, and the peoples who are with you. I will give you to the ravenous birds of every sort and to the animals of the field to be devoured. 
+<sup>5&#160;</sup>You will fall on the open field, for I have spoken it,” says the Lord Yahweh. 
+<sup>6&#160;</sup>“I will send a fire on Magog and on those who dwell securely in the islands. Then they will know that I am Yahweh. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘&#160;“I will make my set-apart name known among my people Israel. I won’t allow my set-apart name to be profaned any more. Then the nations will know that I am Yahweh, the Set-Apart One in Israel. 
+<sup>8&#160;</sup>Behold, it comes, and it will be done,” says the Lord Yahweh. “This is the day about which I have spoken. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘&#160;“Those who dwell in the cities of Israel will go out and will make fires of the weapons and burn them, both the shields and the bucklers, the bows and the arrows, and the war clubs and the spears, and they will make fires with them for seven years; 
+<sup>10&#160;</sup>so that they will take no wood out of the field, and not cut down any out of the forests; for they will make fires with the weapons. They will plunder those who plundered them, and rob those who robbed them,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘&#160;“It will happen in that day, that I will give to Gog a place for burial in Israel, the valley of those who pass through on the east of the sea; and it will stop those who pass through. They will bury Gog and all his multitude there, and they will call it ‘The valley of Hamon Gog’. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘&#160;“The house of Israel will be burying them for seven months, that they may cleanse the land. 
+<sup>13&#160;</sup>Yes, all the people of the land will bury them; and they will become famous in the day that I will be glorified,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘&#160;“They will set apart men of continual employment who will pass through the land. Those who pass through will go with those who bury those who remain on the surface of the land, to cleanse it. After the end of seven months they will search. 
+<sup>15&#160;</sup>Those who search through the land will pass through; and when anyone sees a man’s bone, then he will set up a sign by it, until the undertakers have buried it in the valley of Hamon Gog. 
+<sup>16&#160;</sup>Hamonah will also be the name of a city. Thus they will cleanse the land.”&#160;’ 
+</div><div class="p">
+<sup>17&#160;</sup>“You, son of man, the Lord Yahweh says: ‘Speak to the birds of every sort, and to every animal of the field, “Assemble yourselves, and come; gather yourselves on every side to my sacrifice that I sacrifice for you, even a great sacrifice on the mountains of Israel, that you may eat meat and drink blood. 
+<sup>18&#160;</sup>You shall eat the flesh of the mighty, and drink the blood of the princes of the earth, of rams, of lambs, and of goats, of bulls, all of them fatlings of Bashan. 
+<sup>19&#160;</sup>You shall eat fat until you are full, and drink blood until you are drunk, of my sacrifice which I have sacrificed for you. 
+<sup>20&#160;</sup>You shall be filled at my table with horses and charioteers, with mighty men, and with all men of war,” says the Lord Yahweh.’ 
+</div><div class="p">
+<sup>21&#160;</sup>“I will set my glory among the nations. Then all the nations will see my judgment that I have executed, and my hand that I have laid on them. 
+<sup>22&#160;</sup>So the house of Israel will know that I am Yahweh their Elohim, from that day and forward. 
+<sup>23&#160;</sup>The nations will know that the house of Israel went into captivity for their iniquity, because they trespassed against me, and I hid my face from them; so I gave them into the hand of their adversaries, and they all fell by the sword. 
+<sup>24&#160;</sup>I did to them according to their uncleanness and according to their transgressions. I hid my face from them. 
+</div><div class="p">
+<sup>25&#160;</sup>“Therefore the Lord Yahweh says: ‘Now I will reverse the captivity of Jacob and have mercy on the whole house of Israel. I will be jealous for my set-apart name. 
+<sup>26&#160;</sup>They will forget their shame and all their trespasses by which they have trespassed against me, when they dwell securely in their land. No one will make them afraid 
+<sup>27&#160;</sup>when I have brought them back from the peoples, gathered them out of their enemies’ lands, and am shown set-apart among them in the sight of many nations. 
+<sup>28&#160;</sup>They will know that I am Yahweh their Elohim, in that I caused them to go into captivity among the nations, and have gathered them to their own land. Then I will leave none of them captive any more. 
+<sup>29&#160;</sup>I won’t hide my face from them any more, for I have poured out my Spirit on the house of Israel,’ says the Lord Yahweh.” 
+</div><h2 class="chapterlabel" id="40">40</h2>
+<div class="p">
+<sup>1&#160;</sup>In the twenty-fifth year of our captivity, in the beginning of the year, in the tenth day of the month, in the fourteenth year after the city was struck, in the same day, Yahweh’s hand was on me, and he brought me there. 
+<sup>2&#160;</sup>In the visions of Elohim he brought me into the land of Israel, and set me down on a very high mountain, on which was something like the frame of a city to the south. 
+<sup>3&#160;</sup>He brought me there; and, behold, there was a man whose appearance was like the appearance of bronze, with a line of flax in his hand and a measuring reed; and he stood in the gate. 
+<sup>4&#160;</sup>The man said to me, “Son of man, see with your eyes, and hear with your ears, and set your heart on all that I will show you; for you have been brought here so that I may show them to you. Declare all that you see to the house of Israel.” 
+</div><div class="p">
+<sup>5&#160;</sup>Behold, there was a wall on the outside of the house all around, and in the man’s hand a measuring reed six cubits long, of a cubit and a hand width each. So he measured the thickness of the building, one reed; and the height, one reed. 
+</div><div class="p">
+<sup>6&#160;</sup>Then he came to the gate which looks toward the east, and went up its steps. He measured the threshold of the gate, one reed wide; and the other threshold, one reed wide. 
+<sup>7&#160;</sup>Every lodge was one reed long and one reed wide. Between the lodges was five cubits. The threshold of the gate by the porch of the gate toward the house was one reed. 
+</div><div class="p">
+<sup>8&#160;</sup>He measured also the porch of the gate toward the house, one reed. 
+<sup>9&#160;</sup>Then he measured the porch of the gate, eight cubits; and its posts, two cubits; and the porch of the gate was toward the house. 
+</div><div class="p">
+<sup>10&#160;</sup>The side rooms of the gate eastward were three on this side, and three on that side. The three of them were of one measure. The posts had one measure on this side and on that side. 
+<sup>11&#160;</sup>He measured the width of the opening of the gate, ten cubits; and the length of the gate, thirteen cubits; 
+<sup>12&#160;</sup>and a border before the lodges, one cubit on this side, and a border, one cubit on that side; and the side rooms, six cubits on this side, and six cubits on that side. 
+<sup>13&#160;</sup>He measured the gate from the roof of the one side room to the roof of the other, a width of twenty-five cubits, door against door. 
+<sup>14&#160;</sup>He also made posts, sixty cubits; and the court reached to the posts, around the gate. 
+<sup>15&#160;</sup>From the forefront of the gate at the entrance to the forefront of the inner porch of the gate were fifty cubits. 
+<sup>16&#160;</sup>There were closed windows to the side rooms, and to their posts within the gate all around, and likewise to the arches. Windows were around inward. Palm trees were on each post. 
+</div><div class="p">
+<sup>17&#160;</sup>Then he brought me into the outer court. Behold, there were rooms and a pavement made for the court all around. Thirty rooms were on the pavement. 
+<sup>18&#160;</sup>The pavement was by the side of the gates, corresponding to the length of the gates, even the lower pavement. 
+<sup>19&#160;</sup>Then he measured the width from the forefront of the lower gate to the forefront of the inner court outside, one hundred cubits, both on the east and on the north. 
+</div><div class="p">
+<sup>20&#160;</sup>He measured the length and width of the gate of the outer court which faces toward the north. 
+<sup>21&#160;</sup>The lodges of it were three on this side and three on that side. Its posts and its arches were the same as the measure of the first gate: its length was fifty cubits, and the width twenty-five cubits. 
+<sup>22&#160;</sup>Its windows, its arches, and its palm trees were the same as the measure of the gate which faces toward the east. They went up to it by seven steps. Its arches were before them. 
+<sup>23&#160;</sup>There was a gate to the inner court facing the other gate, on the north and on the east. He measured one hundred cubits from gate to gate. 
+</div><div class="p">
+<sup>24&#160;</sup>He led me toward the south; and behold, there was a gate toward the south. He measured its posts and its arches according to these measurements. 
+<sup>25&#160;</sup>There were windows in it and in its arches all around, like the other windows: the length was fifty cubits, and the width twenty-five cubits. 
+<sup>26&#160;</sup>There were seven steps to go up to it, and its arches were before them. It had palm trees, one on this side, and another on that side, on its posts. 
+<sup>27&#160;</sup>There was a gate to the inner court toward the south. He measured one hundred cubits from gate to gate toward the south. 
+</div><div class="p">
+<sup>28&#160;</sup>Then he brought me to the inner court by the south gate. He measured the south gate according to these measurements; 
+<sup>29&#160;</sup>with its lodges, its posts, and its arches, according to these measurements. There were windows in it and in its arches all around. It was fifty cubits long, and twenty-five cubits wide. 
+<sup>30&#160;</sup>There were arches all around, twenty-five cubits long and five cubits wide. 
+<sup>31&#160;</sup>Its arches were toward the outer court. Palm trees were on its posts. The ascent to it had eight steps. 
+</div><div class="p">
+<sup>32&#160;</sup>He brought me into the inner court toward the east. He measured the gate according to these measurements; 
+<sup>33&#160;</sup>with its lodges, its posts, and its arches, according to these measurements. There were windows in it and in its arches all around. It was fifty cubits long, and twenty-five cubits wide. 
+<sup>34&#160;</sup>Its arches were toward the outer court. Palm trees were on its posts on this side and on that side. The ascent to it had eight steps. 
+</div><div class="p">
+<sup>35&#160;</sup>He brought me to the north gate, and he measured it according to these measurements—<sup>36&#160;</sup>its lodges, its posts, and its arches. There were windows in it all around. The length was fifty cubits and the width twenty-five cubits. 
+<sup>37&#160;</sup>Its posts were toward the outer court. Palm trees were on its posts on this side and on that side. The ascent to it had eight steps. 
+</div><div class="p">
+<sup>38&#160;</sup>A room with its door was by the posts at the gates. They washed the burnt offering there. 
+<sup>39&#160;</sup>In the porch of the gate were two tables on this side and two tables on that side, on which to kill the burnt offering, the sin offering, and the trespass offering. 
+<sup>40&#160;</sup>On the one side outside, as one goes up to the entry of the gate toward the north, were two tables; and on the other side, which belonged to the porch of the gate, were two tables. 
+<sup>41&#160;</sup>Four tables were on this side, and four tables on that side, by the side of the gate: eight tables, on which they killed the sacrifices. 
+<sup>42&#160;</sup>There were four cut stone tables for the burnt offering, a cubit and a half long, a cubit and a half wide, and one cubit high. They laid the instruments with which they killed the burnt offering and the sacrifice on them. 
+<sup>43&#160;</sup>The hooks, a hand width long, were fastened within all around. The meat of the offering was on the tables. 
+</div><div class="p">
+<sup>44&#160;</sup>Outside of the inner gate were rooms for the singers in the inner court, which was at the side of the north gate. They faced toward the south. One at the side of the east gate faced toward the north. 
+<sup>45&#160;</sup>He said to me, “This room, which faces toward the south, is for the priests who perform the duty of the house. 
+<sup>46&#160;</sup>The room which faces toward the north is for the priests who perform the duty of the altar. These are the sons of Zadok, who from among the sons of Levi come near to Yahweh to minister to him.” 
+<sup>47&#160;</sup>He measured the court, one hundred cubits long and one hundred cubits wide, square. The altar was before the house. 
+</div><div class="p">
+<sup>48&#160;</sup>Then he brought me to the porch of the house, and measured each post of the porch, five cubits on this side, and five cubits on that side. The width of the gate was three cubits on this side and three cubits on that side. 
+<sup>49&#160;</sup>The length of the porch was twenty cubits and the width eleven cubits, even by the steps by which they went up to it. There were pillars by the posts, one on this side, and another on that side. 
+</div><h2 class="chapterlabel" id="41">41</h2>
+<div class="p">
+<sup>1&#160;</sup>He brought me to the nave and measured the posts, six cubits wide on the one side and six cubits wide on the other side, which was the width of the tent. 
+<sup>2&#160;</sup>The width of the entrance was ten cubits, and the sides of the entrance were five cubits on the one side, and five cubits on the other side. He measured its length, forty cubits, and the width, twenty cubits. 
+</div><div class="p">
+<sup>3&#160;</sup>Then he went inward and measured each post of the entrance, two cubits; and the entrance, six cubits; and the width of the entrance, seven cubits. 
+<sup>4&#160;</sup>He measured its length, twenty cubits, and the width, twenty cubits, before the nave. He said to me, “This is the most set-apart place.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then he measured the wall of the house, six cubits; and the width of every side room, four cubits, all around the house on every side. 
+<sup>6&#160;</sup>The side rooms were in three stories, one over another, and thirty in each story. They entered into the wall which belonged to the house for the side rooms all around, that they might be supported and not penetrate the wall of the house. 
+<sup>7&#160;</sup>The side rooms were wider on the higher levels, because the walls were narrower at the higher levels. Therefore the width of the house increased upward; and so one went up from the lowest level to the highest through the middle level. 
+</div><div class="p">
+<sup>8&#160;</sup>I saw also that the house had a raised base all around. The foundations of the side rooms were a full reed of six great cubits. 
+<sup>9&#160;</sup>The thickness of the outer wall of the side rooms was five cubits. That which was left was the place of the side rooms that belonged to the house. 
+<sup>10&#160;</sup>Between the rooms was a width of twenty cubits around the house on every side. 
+<sup>11&#160;</sup>The doors of the side rooms were toward an open area that was left, one door toward the north, and another door toward the south. The width of the open area was five cubits all around. 
+</div><div class="p">
+<sup>12&#160;</sup>The building that was before the separate place at the side toward the west was seventy cubits wide; and the wall of the building was five cubits thick all around, and its length ninety cubits. 
+</div><div class="p">
+<sup>13&#160;</sup>So he measured the temple, one hundred cubits long; and the separate place, and the building, with its walls, one hundred cubits long; 
+<sup>14&#160;</sup>also the width of the face of the temple, and of the separate place toward the east, one hundred cubits. 
+</div><div class="p">
+<sup>15&#160;</sup>He measured the length of the building before the separate place which was at its back, and its galleries on the one side and on the other side, one hundred cubits from the inner temple, and the porches of the court, 
+<sup>16&#160;</sup>the thresholds, and the closed windows, and the galleries around on their three stories, opposite the threshold, with wood ceilings all around, and from the ground up to the windows, (now the windows were covered), 
+<sup>17&#160;</sup>to the space above the door, even to the inner house, and outside, and by all the wall all around inside and outside, by measure. 
+<sup>18&#160;</sup>It was made with cherubim and palm trees. A palm tree was between cherub and cherub, and every cherub had two faces, 
+<sup>19&#160;</sup>so that there was the face of a man toward the palm tree on the one side, and the face of a young lion toward the palm tree on the other side. It was made like this through all the house all around. 
+<sup>20&#160;</sup>Cherubim and palm trees were made from the ground to above the door. The wall of the temple was like this. 
+</div><div class="p">
+<sup>21&#160;</sup>The door posts of the nave were squared. As for the face of the nave, its appearance was as the appearance of the temple. 
+<sup>22&#160;</sup>The altar was of wood, three cubits high, and its length two cubits. Its corners, its base, and its walls were of wood. He said to me, “This is the table that is before Yahweh.” 
+<sup>23&#160;</sup>The temple and the sanctuary had two doors. 
+<sup>24&#160;</sup>The doors had two leaves each, two turning leaves: two for the one door, and two leaves for the other. 
+<sup>25&#160;</sup>There were made on them, on the doors of the nave, cherubim and palm trees, like those made on the walls. There was a threshold of wood on the face of the porch outside. 
+<sup>26&#160;</sup>There were closed windows and palm trees on the one side and on the other side, on the sides of the porch. This is how the side rooms of the temple and the thresholds were arranged. 
+</div><h2 class="chapterlabel" id="42">42</h2>
+<div class="p">
+<sup>1&#160;</sup>Then he brought me out into the outer court, the way toward the north. Then he brought me into the room that was opposite the separate place, and which was opposite the building toward the north. 
+<sup>2&#160;</sup>Facing the length of one hundred cubits was the north door, and the width was fifty cubits. 
+<sup>3&#160;</sup>Opposite the twenty cubits which belonged to the inner court, and opposite the pavement which belonged to the outer court, was gallery against gallery in the three stories. 
+<sup>4&#160;</sup>Before the rooms was a walk of ten cubits’ width inward, a way of one cubit; and their doors were toward the north. 
+<sup>5&#160;</sup>Now the upper rooms were shorter; for the galleries took away from these more than from the lower and the middle in the building. 
+<sup>6&#160;</sup>For they were in three stories, and they didn’t have pillars as the pillars of the courts. Therefore the uppermost was set back more than the lowest and the middle from the ground. 
+<sup>7&#160;</sup>The wall that was outside by the side of the rooms, toward the outer court before the rooms, was fifty cubits long. 
+<sup>8&#160;</sup>For the length of the rooms that were in the outer court was fifty cubits. Behold, those facing the temple were one hundred cubits. 
+<sup>9&#160;</sup>From under these rooms was the entry on the east side, as one goes into them from the outer court. 
+</div><div class="p">
+<sup>10&#160;</sup>In the thickness of the wall of the court toward the east, before the separate place, and before the building, there were rooms. 
+<sup>11&#160;</sup>The way before them was like the appearance of the rooms which were toward the north. Their length and width were the same. All their exits had the same arrangement and doors. 
+<sup>12&#160;</sup>Like the doors of the rooms that were toward the south was a door at the head of the way, even the way directly before the wall toward the east, as one enters into them. 
+</div><div class="p">
+<sup>13&#160;</sup>Then he said to me, “The north rooms and the south rooms, which are opposite the separate place, are the set-apart rooms, where the priests who are near to Yahweh shall eat the most set-apart things. There they shall lay the most set-apart things, with the meal offering, the sin offering, and the trespass offering; for the place is set-apart. 
+<sup>14&#160;</sup>When the priests enter in, then they shall not go out of the set-apart place into the outer court until they lay their garments in which they minister there; for they are set-apart. Then they shall put on other garments, and shall approach that which is for the people.” 
+</div><div class="p">
+<sup>15&#160;</sup>Now when he had finished measuring the inner house, he brought me out by the way of the gate which faces toward the east, and measured it all around. 
+<sup>16&#160;</sup>He measured on the east side with the measuring reed five hundred reeds, with the measuring reed all around. 
+<sup>17&#160;</sup>He measured on the north side five hundred reeds with the measuring reed all around. 
+<sup>18&#160;</sup>He measured on the south side five hundred reeds with the measuring reed. 
+<sup>19&#160;</sup>He turned about to the west side, and measured five hundred reeds with the measuring reed. 
+<sup>20&#160;</sup>He measured it on the four sides. It had a wall around it, the length five hundred cubits, and the width five hundred cubits, to make a separation between that which was set-apart and that which was common. 
+</div><h2 class="chapterlabel" id="43">43</h2>
+<div class="p">
+<sup>1&#160;</sup>Afterward he brought me to the gate, even the gate that looks toward the east. 
+<sup>2&#160;</sup>Behold, the glory of the Elohim of Israel came from the way of the east. His voice was like the sound of many waters; and the earth was illuminated with his glory. 
+<sup>3&#160;</sup>It was like the appearance of the vision which I saw, even according to the vision that I saw when I came to destroy the city; and the visions were like the vision that I saw by the river Chebar; and I fell on my face. 
+<sup>4&#160;</sup>Yahweh’s glory came into the house by the way of the gate which faces toward the east. 
+<sup>5&#160;</sup>The Spirit took me up and brought me into the inner court; and behold, Yahweh’s glory filled the house. 
+</div><div class="p">
+<sup>6&#160;</sup>I heard one speaking to me out of the house, and a man stood by me. 
+<sup>7&#160;</sup>He said to me, “Son of man, this is the place of my throne and the place of the soles of my feet, where I will dwell among the children of Israel forever. The house of Israel will no more defile my set-apart name, neither they nor their kings, by their prostitution and by the dead bodies of their kings in their high places; 
+<sup>8&#160;</sup>in their setting of their threshold by my threshold and their door post beside my door post. There was a wall between me and them; and they have defiled my set-apart name by their abominations which they have committed. Therefore I have consumed them in my anger. 
+<sup>9&#160;</sup>Now let them put away their prostitution, and the dead bodies of their kings far from me. Then I will dwell among them forever. 
+</div><div class="p">
+<sup>10&#160;</sup>“You, son of man, show the house to the house of Israel, that they may be ashamed of their iniquities; and let them measure the pattern. 
+<sup>11&#160;</sup>If they are ashamed of all that they have done, make known to them the form of the house, its fashion, its exits, its entrances, its structure, all its ordinances, all its forms, and all its laws; and write it in their sight, that they may keep the whole form of it, and all its ordinances, and do them. 
+</div><div class="p">
+<sup>12&#160;</sup>“This is the law of the house. On the top of the mountain the whole limit around it shall be most set-apart. Behold, this is the law of the house. 
+</div><div class="p">
+<sup>13&#160;</sup>“These are the measurements of the altar by cubits (the cubit and this shall be the base of the altar. 
+<sup>14&#160;</sup>From the bottom on the ground to the lower ledge shall be two cubits, and the width one cubit; and from the lesser ledge to the greater ledge shall be four cubits, and the width a cubit. 
+<sup>15&#160;</sup>The upper altar shall be four cubits; and from the altar hearth and upward there shall be four horns. 
+<sup>16&#160;</sup>The altar hearth shall be twelve cubits long by twelve wide, square in its four sides. 
+<sup>17&#160;</sup>The ledge shall be fourteen cubits long by fourteen wide in its four sides; and the border about it shall be half a cubit; and its bottom shall be a cubit around; and its steps shall look toward the east.” 
+</div><div class="p">
+<sup>18&#160;</sup>He said to me, “Son of man, the Lord Yahweh says: ‘These are the ordinances of the altar in the day when they make it, to offer burnt offerings on it, and to sprinkle blood on it. 
+<sup>19&#160;</sup>You shall give to the Levitical priests who are of the offspring of Zadok, who are near to me, to minister to me,’ says the Lord Yahweh, ‘a young bull for a sin offering. 
+<sup>20&#160;</sup>You shall take of its blood and put it on its four horns, and on the four corners of the ledge, and on the border all around. You shall cleanse it and make atonement for it that way. 
+<sup>21&#160;</sup>You shall also take the bull of the sin offering, and it shall be burned in the appointed place of the house, outside of the sanctuary. 
+</div><div class="p">
+<sup>22&#160;</sup>“On the second day you shall offer a male goat without defect for a sin offering; and they shall cleanse the altar, as they cleansed it with the bull. 
+<sup>23&#160;</sup>When you have finished cleansing it, you shall offer a young bull without defect and a ram out of the flock without defect. 
+<sup>24&#160;</sup>You shall bring them near to Yahweh, and the priests shall cast salt on them, and they shall offer them up for a burnt offering to Yahweh. 
+</div><div class="p">
+<sup>25&#160;</sup>“Seven days you shall prepare every day a goat for a sin offering. They shall also prepare a young bull and a ram out of the flock, without defect. 
+<sup>26&#160;</sup>Seven days shall they make atonement for the altar and purify it. So shall they consecrate it. 
+<sup>27&#160;</sup>When they have accomplished the days, it shall be that on the eighth day and onward, the priests shall make your burnt offerings on the altar and your peace offerings. Then I will accept you,’ says the Lord Yahweh.” 
+</div><h2 class="chapterlabel" id="44">44</h2>
+<div class="p">
+<sup>1&#160;</sup>Then he brought me back by the way of the outer gate of the sanctuary, which looks toward the east; and it was shut. 
+<sup>2&#160;</sup>Yahweh said to me, “This gate shall be shut. It shall not be opened, no man shall enter in by it; for Yahweh, the Elohim of Israel, has entered in by it. Therefore it shall be shut. 
+<sup>3&#160;</sup>As for the prince, he shall sit in it as prince to eat bread before Yahweh. He shall enter by the way of the porch of the gate, and shall go out the same way.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then he brought me by the way of the north gate before the house; and I looked, and behold, Yahweh’s glory filled Yahweh’s house; so I fell on my face. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh said to me, “Son of man, mark well, and see with your eyes, and hear with your ears all that I tell you concerning all the ordinances of Yahweh’s house and all its laws; and mark well the entrance of the house, with every exit of the sanctuary. 
+<sup>6&#160;</sup>You shall tell the rebellious, even the house of Israel, ‘The Lord Yahweh says: “You house of Israel, let that be enough of all your abominations, 
+<sup>7&#160;</sup>in that you have brought in foreigners, uncircumcised in heart and uncircumcised in flesh, to be in my sanctuary, to profane it, even my house, when you offer my bread, the fat and the blood; and they have broken my covenant, to add to all your abominations. 
+<sup>8&#160;</sup>You have not performed the duty of my set-apart things; but you have set performers of my duty in my sanctuary for yourselves.” 
+<sup>9&#160;</sup>The Lord Yahweh says, “No foreigner, uncircumcised in heart and uncircumcised in flesh, shall enter into my sanctuary, of any foreigners who are among the children of Israel. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘&#160;“But the Levites who went far from me when Israel went astray, who went astray from me after their idols, they will bear their iniquity. 
+<sup>11&#160;</sup>Yet they shall be ministers in my sanctuary, having oversight at the gates of the house, and ministering in the house. They shall kill the burnt offering and the sacrifice for the people, and they shall stand before them to minister to them. 
+<sup>12&#160;</sup>Because they ministered to them before their idols, and became a stumbling block of iniquity to the house of Israel, therefore I have lifted up my hand against them,” says the Lord Yahweh, “and they will bear their iniquity. 
+<sup>13&#160;</sup>They shall not come near to me, to execute the office of priest to me, nor to come near to any of my set-apart things, to the things that are most set-apart; but they will bear their shame and their abominations which they have committed. 
+<sup>14&#160;</sup>Yet I will make them performers of the duty of the house, for all its service and for all that will be done therein. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘&#160;“But the Levitical priests, the sons of Zadok, who performed the duty of my sanctuary when the children of Israel went astray from me, shall come near to me to minister to me. They shall stand before me to offer to me the fat and the blood,” says the Lord Yahweh. 
+<sup>16&#160;</sup>“They shall enter into my sanctuary, and they shall come near to my table, to minister to me, and they shall keep my instruction. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘&#160;“It will be that when they enter in at the gates of the inner court, they shall be clothed with linen garments. No wool shall come on them while they minister in the gates of the inner court, and within. 
+<sup>18&#160;</sup>They shall have linen turbans on their heads, and shall have linen trousers on their waists. They shall not clothe themselves with anything that makes them sweat. 
+<sup>19&#160;</sup>When they go out into the outer court, even into the outer court to the people, they shall put off their garments in which they minister and lay them in the set-apart rooms. They shall put on other garments, that they not sanctify the people with their garments. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘&#160;“They shall not shave their heads, or allow their locks to grow long. They shall only cut off the hair of their heads. 
+<sup>21&#160;</sup>None of the priests shall drink wine when they enter into the inner court. 
+<sup>22&#160;</sup>They shall not take for their women a widow, or her who is put away; but they shall take virgins of the offspring of the house of Israel, or a widow who is the widow of a priest. 
+<sup>23&#160;</sup>They shall teach my people the difference between the set-apart and the common, and cause them to discern between the unclean and the clean. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘&#160;“In a controversy they shall stand to judge. They shall judge it according to my ordinances. They shall keep my laws and my statutes in all my appointed feasts. They shall make my Sabbaths set-apart. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘&#160;“They shall go in to no dead person to defile themselves; but for father, or for mother, or for son, or for daughter, for brother, or for sister who has had no man, they may defile themselves. 
+<sup>26&#160;</sup>After he is cleansed, they shall reckon to him seven days. 
+<sup>27&#160;</sup>In the day that he goes into the sanctuary, into the inner court, to minister in the sanctuary, he shall offer his sin offering,” says the Lord Yahweh. 
+</div><div class="p">
+<sup>28&#160;</sup>“&#160;‘They shall have an inheritance: I am their inheritance; and you shall give them no possession in Israel. I am their possession. 
+<sup>29&#160;</sup>They shall eat the meal offering, and the sin offering, and the trespass offering; and every devoted thing in Israel shall be theirs. 
+<sup>30&#160;</sup>The first of all the first fruits of every thing, and every offering of everything, of all your offerings, shall be for the priest. You shall also give to the priests the first of your dough, to cause a blessing to rest on your house. 
+<sup>31&#160;</sup>The priests shall not eat of anything that dies of itself or is torn, whether it is bird or animal. 
+</div><h2 class="chapterlabel" id="45">45</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘&#160;“Moreover, when you divide by lot the land for inheritance, you shall offer an offering to Yahweh, a set-apart portion of the land. The length shall be the length of twenty-five thousand reeds, and the width shall be ten thousand. It shall be set-apart in all its border all around. 
+<sup>2&#160;</sup>Of this there shall be a five hundred by five hundred square for the set-apart place, and fifty cubits for its pasture lands all around. 
+<sup>3&#160;</sup>Of this measure you shall measure a length of twenty-five thousand, and a width of ten thousand. In it shall be the sanctuary, which is most set-apart. 
+<sup>4&#160;</sup>It is a set-apart portion of the land; it shall be for the priests, the ministers of the sanctuary, who come near to minister to Yahweh. It shall be a place for their houses and a set-apart place for the sanctuary. 
+<sup>5&#160;</sup>Twenty-five thousand cubits in length and ten thousand in width shall be for the Levites, the ministers of the house, as a possession for themselves, for twenty rooms. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘&#160;“You shall appoint the possession of the city five thousand cubits wide and twenty-five thousand long, side by side with the offering of the set-apart portion. It shall be for the whole house of Israel. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘&#160;“What is for the prince shall be on the one side and on the other side of the set-apart allotment and of the possession of the city, in front of the set-apart allotment and in front of the possession of the city, on the west side westward, and on the east side eastward, and in length corresponding to one of the portions, from the west border to the east border. 
+<sup>8&#160;</sup>In the land it shall be to him for a possession in Israel. My princes shall no more oppress my people, but they shall give the land to the house of Israel according to their tribes.” 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘The Lord Yahweh says: “Enough you, princes of Israel! Remove violence and plunder, and execute justice and righteousness! Stop dispossessing my people!” says the Lord Yahweh. 
+<sup>10&#160;</sup>“You shall have just balances, a just ephah, and a just bath. 
+<sup>11&#160;</sup>The ephah and the bath shall be of one measure, that the bath may contain one tenth of a homer, and the ephah one tenth of a homer. Its measure shall be the same as the homer. 
+<sup>12&#160;</sup>The shekel 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘&#160;“This is the offering that you shall offer: the sixth part of an ephah from a homer of wheat, and you shall give the sixth part of an ephah from a homer of barley, 
+<sup>14&#160;</sup>and the set portion of oil, of the bath of oil, one tenth of a bath out of the cor, which is ten baths, even a homer (for ten baths are a homer), 
+<sup>15&#160;</sup>and one lamb of the flock out of two hundred, from the well-watered pastures of Israel—for a meal offering, for a burnt offering, and for peace offerings, to make atonement for them,” says the Lord Yahweh. 
+<sup>16&#160;</sup>“All the people of the land shall give to this offering for the prince in Israel. 
+<sup>17&#160;</sup>It shall be the prince’s part to give the burnt offerings, the meal offerings, and the drink offerings, in the feasts, and on the new moons, and on the Sabbaths, in all the appointed feasts of the house of Israel. He shall prepare the sin offering, the meal offering, the burnt offering, and the peace offerings, to make atonement for the house of Israel.” 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘The Lord Yahweh says: “In the first month, on the first day of the month, you shall take a young bull without defect, and you shall cleanse the sanctuary. 
+<sup>19&#160;</sup>The priest shall take of the blood of the sin offering and put it on the door posts of the house, and on the four corners of the ledge of the altar, and on the posts of the gate of the inner court. 
+<sup>20&#160;</sup>So you shall do on the seventh day of the month for everyone who errs, and for him who is simple. So you shall make atonement for the house. 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘&#160;“In the first month, on the fourteenth day of the month, you shall have the Passover, a feast of seven days; unleavened bread shall be eaten. 
+<sup>22&#160;</sup>On that day the prince shall prepare for himself and for all the people of the land a bull for a sin offering. 
+<sup>23&#160;</sup>The seven days of the feast he shall prepare a burnt offering to Yahweh, seven bulls and seven rams without defect daily the seven days; and a male goat daily for a sin offering. 
+<sup>24&#160;</sup>He shall prepare a meal offering, an ephah of oil to an ephah. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘&#160;“In the seventh month, on the fifteenth day of the month, during the feast, he shall do like that for seven days. He shall make the same provision for sin offering, the burnt offering, the meal offering, and the oil.” 
+</div><h2 class="chapterlabel" id="46">46</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘The Lord Yahweh says: “The gate of the inner court that looks toward the east shall be shut the six working days; but on the Sabbath day it shall be opened, and on the day of the new moon it shall be opened. 
+<sup>2&#160;</sup>The prince shall enter by the way of the porch of the gate outside, and shall stand by the post of the gate; and the priests shall prepare his burnt offering and his peace offerings, and he shall worship at the threshold of the gate. Then he shall go out, but the gate shall not be shut until the evening. 
+<sup>3&#160;</sup>The people of the land shall worship at the door of that gate before Yahweh on the Sabbaths and on the new moons. 
+<sup>4&#160;</sup>The burnt offering that the prince shall offer to Yahweh shall be on the Sabbath day, six lambs without defect and a ram without defect; 
+<sup>5&#160;</sup>and the meal offering shall be an ephah for the ram, and the meal offering for the lambs as he is able to give, and a hin 
+<sup>6&#160;</sup>On the day of the new moon it shall be a young bull without defect, six lambs, and a ram. They shall be without defect. 
+<sup>7&#160;</sup>He shall prepare a meal offering: an ephah for the bull, and an ephah for the ram, and for the lambs according as he is able, and a hin of oil to an ephah. 
+<sup>8&#160;</sup>When the prince enters, he shall go in by the way of the porch of the gate, and he shall go out by its way. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘&#160;“But when the people of the land come before Yahweh in the appointed feasts, he who enters by the way of the north gate to worship shall go out by the way of the south gate; and he who enters by the way of the south gate shall go out by the way of the north gate. He shall not return by the way of the gate by which he came in, but shall go out straight before him. 
+<sup>10&#160;</sup>The prince shall go in with them when they go in. When they go out, he shall go out. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘&#160;“In the feasts and in the appointed set-apart days, the meal offering shall be an ephah for a bull, and an ephah for a ram, and for the lambs as he is able to give, and a hin of oil to an ephah. 
+<sup>12&#160;</sup>When the prince prepares a free will offering, a burnt offering or peace offerings as a free will offering to Yahweh, one shall open for him the gate that looks toward the east; and he shall prepare his burnt offering and his peace offerings, as he does on the Sabbath day. Then he shall go out; and after his going out one shall shut the gate. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘&#160;“You shall prepare a lamb a year old without defect for a burnt offering to Yahweh daily. Morning by morning you shall prepare it. 
+<sup>14&#160;</sup>You shall prepare a meal offering with it morning by morning, the sixth part of an ephah, and the third part of a hin of oil to moisten the fine flour; a meal offering to Yahweh continually by a perpetual ordinance. 
+<sup>15&#160;</sup>Thus they shall prepare the lamb, the meal offering, and the oil, morning by morning, for a continual burnt offering.” 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘The Lord Yahweh says: “If the prince gives a gift to any of his sons, it is his inheritance. It shall belong to his sons. It is their possession by inheritance. 
+<sup>17&#160;</sup>But if he gives of his inheritance a gift to one of his servants, it shall be his to the year of liberty; then it shall return to the prince; but as for his inheritance, it shall be for his sons. 
+<sup>18&#160;</sup>Moreover the prince shall not take of the people’s inheritance, to thrust them out of their possession. He shall give inheritance to his sons out of his own possession, that my people not each be scattered from his possession.”&#160;’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>Then he brought me through the entry, which was at the side of the gate, into the set-apart rooms for the priests, which looked toward the north. Behold, there was a place on the back part westward. 
+<sup>20&#160;</sup>He said to me, “This is the place where the priests shall boil the trespass offering and the sin offering, and where they shall bake the meal offering, that they not bring them out into the outer court, to sanctify the people.” 
+</div><div class="p">
+<sup>21&#160;</sup>Then he brought me out into the outer court and caused me to pass by the four corners of the court; and behold, in every corner of the court there was a court. 
+<sup>22&#160;</sup>In the four corners of the court there were courts enclosed, forty cubits long and thirty wide. These four in the corners were the same size. 
+<sup>23&#160;</sup>There was a wall around in them, around the four, and boiling places were made under the walls all around. 
+<sup>24&#160;</sup>Then he said to me, “These are the boiling houses, where the ministers of the house shall boil the sacrifice of the people.” 
+</div><h2 class="chapterlabel" id="47">47</h2>
+<div class="p">
+<sup>1&#160;</sup>He brought me back to the door of the temple; and behold, waters flowed out from under the threshold of the temple eastward, for the front of the temple faced toward the east. The waters came down from underneath, from the right side of the temple, on the south of the altar. 
+<sup>2&#160;</sup>Then he brought me out by the way of the gate northward, and led me around by the way outside to the outer gate, by the way of the gate that looks toward the east. Behold, waters ran out on the right side. 
+</div><div class="p">
+<sup>3&#160;</sup>When the man went out eastward with the line in his hand, he measured one thousand cubits, and he caused me to pass through the waters, waters that were to the ankles. 
+<sup>4&#160;</sup>Again he measured one thousand, and caused me to pass through the waters, waters that were to the knees. Again he measured one thousand, and caused me to pass through waters that were to the waist. 
+<sup>5&#160;</sup>Afterward he measured one thousand; and it was a river that I could not pass through, for the waters had risen, waters to swim in, a river that could not be walked through. 
+</div><div class="p">
+<sup>6&#160;</sup>He said to me, “Son of man, have you seen this?” 
+</div><div class="p">Then he brought me and caused me to return to the bank of the river. 
+<sup>7&#160;</sup>Now when I had returned, behold, on the bank of the river were very many trees on the one side and on the other. 
+<sup>8&#160;</sup>Then he said to me, “These waters flow out toward the eastern region and will go down into the Arabah. Then they will go toward the sea and flow into the sea which will be made to flow out; and the waters will be healed. 
+<sup>9&#160;</sup>It will happen that every living creature which swarms, in every place where the rivers come, will live. Then there will be a very great multitude of fish; for these waters have come there, and the waters of the sea will be healed, and everything will live wherever the river comes. 
+<sup>10&#160;</sup>It will happen that fishermen will stand by it. From En Gedi even to En Eglaim will be a place for the spreading of nets. Their fish will be after their kinds, as the fish of the great sea, exceedingly many. 
+<sup>11&#160;</sup>But its swamps marshes will not be healed. They will be given up to salt. 
+<sup>12&#160;</sup>By the river banks, on both sides, will grow every tree for food, whose leaf won’t wither, neither will its fruit fail. It will produce new fruit every month, because its waters issue out of the sanctuary. Its fruit will be for food, and its leaf for healing.” 
+</div><div class="p">
+<sup>13&#160;</sup>The Lord Yahweh says: “This shall be the border by which you shall divide the land for inheritance according to the twelve tribes of Israel. Joseph shall have two portions. 
+<sup>14&#160;</sup>You shall inherit it, one as well as another; for I swore to give it to your fathers. This land will fall to you for inheritance. 
+</div><div class="p">
+<sup>15&#160;</sup>“This shall be the border of the land: 
+</div><div class="p">“On the north side, from the great sea, by the way of Hethlon, to the entrance of Zedad; 
+<sup>16&#160;</sup>Hamath, Berothah, Sibraim (which is between the border of Damascus and the border of Hamath), to Hazer Hatticon, which is by the border of Hauran. 
+<sup>17&#160;</sup>The border from the sea shall be Hazar Enon at the border of Damascus; and on the north northward is the border of Hamath. This is the north side. 
+</div><div class="p">
+<sup>18&#160;</sup>“The east side, between Hauran, Damascus, Gilead, and the land of Israel, shall be the Jordan; from the north border to the east sea you shall measure. This is the east side. 
+</div><div class="p">
+<sup>19&#160;</sup>“The south side southward shall be from Tamar as far as the waters of Meriboth Kadesh, to the brook, to the great sea. This is the south side southward. 
+</div><div class="p">
+<sup>20&#160;</sup>“The west side shall be the great sea, from the south border as far as opposite the entrance of Hamath. This is the west side. 
+</div><div class="p">
+<sup>21&#160;</sup>“So you shall divide this land to yourselves according to the tribes of Israel. 
+<sup>22&#160;</sup>You shall divide it by lot for an inheritance to you and to the aliens who live among you, who will father children among you. Then they shall be to you as the native-born among the children of Israel. They shall have inheritance with you among the tribes of Israel. 
+<sup>23&#160;</sup>In whatever tribe the stranger lives, there you shall give him his inheritance,” says the Lord Yahweh. 
+</div><h2 class="chapterlabel" id="48">48</h2>
+<div class="p">
+<sup>1&#160;</sup>“Now these are the names of the tribes: From the north end, beside the way of Hethlon to the entrance of Hamath, Hazar Enan at the border of Damascus, northward beside Hamath (and they shall have their sides east and west), Dan, one portion. 
+</div><div class="p">
+<sup>2&#160;</sup>“By the border of Dan, from the east side to the west side, Asher, one portion. 
+</div><div class="p">
+<sup>3&#160;</sup>“By the border of Asher, from the east side even to the west side, Naphtali, one portion. 
+</div><div class="p">
+<sup>4&#160;</sup>“By the border of Naphtali, from the east side to the west side, Manasseh, one portion. 
+</div><div class="p">
+<sup>5&#160;</sup>“By the border of Manasseh, from the east side to the west side, Ephraim, one portion. 
+</div><div class="p">
+<sup>6&#160;</sup>“By the border of Ephraim, from the east side even to the west side, Reuben, one portion. 
+</div><div class="p">
+<sup>7&#160;</sup>“By the border of Reuben, from the east side to the west side, Judah, one portion. 
+</div><div class="p">
+<sup>8&#160;</sup>“By the border of Judah, from the east side to the west side, shall be the offering which you shall offer, twenty-five thousand reeds in width, and in length as one of the portions, from the east side to the west side; and the sanctuary shall be in the middle of it. 
+</div><div class="p">
+<sup>9&#160;</sup>“The offering that you shall offer to Yahweh shall be twenty-five thousand reeds in length, and ten thousand in width. 
+<sup>10&#160;</sup>For these, even for the priests, shall be the set-apart offering: toward the north twenty-five thousand in length, and toward the west ten thousand in width, and toward the east ten thousand in width, and toward the south twenty-five thousand in length; and the sanctuary of Yahweh shall be in the middle of it. 
+<sup>11&#160;</sup>It shall be for the priests who are sanctified of the sons of Zadok, who have kept my instruction, who didn’t go astray when the children of Israel went astray, as the Levites went astray. 
+<sup>12&#160;</sup>It shall be to them an offering from the offering of the land, a most set-apart thing, by the border of the Levites. 
+</div><div class="p">
+<sup>13&#160;</sup>“Alongside the border of the priests, the Levites shall have twenty-five thousand cubits in length and ten thousand in width. All the length shall be twenty-five thousand, and the width ten thousand. 
+<sup>14&#160;</sup>They shall sell none of it, nor exchange it, nor shall the first fruits of the land be alienated, for it is set-apart to Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>“The five thousand cubits that are left in the width, in front of the twenty-five thousand, shall be for common use, for the city, for dwelling and for pasture lands; and the city shall be in the middle of it. 
+<sup>16&#160;</sup>These shall be its measurements: the north side four thousand and five hundred, and the south side four thousand and five hundred, and on the east side four thousand and five hundred, and the west side four thousand and five hundred. 
+<sup>17&#160;</sup>The city shall have pasture lands: toward the north two hundred fifty, and toward the south two hundred fifty, and toward the east two hundred fifty, and toward the west two hundred fifty. 
+<sup>18&#160;</sup>The remainder of the length, alongside the set-apart offering, shall be ten thousand eastward and ten thousand westward; and it shall be alongside the set-apart offering. Its increase shall be for food to those who labor in the city. 
+<sup>19&#160;</sup>Those who labor in the city, out of all the tribes of Israel, shall cultivate it. 
+<sup>20&#160;</sup>All the offering shall be a square of twenty-five thousand by twenty-five thousand. You shall offer it as a set-apart offering, with the possession of the city. 
+</div><div class="p">
+<sup>21&#160;</sup>“The remainder shall be for the prince, on the one side and on the other of the set-apart offering and of the possession of the city; in front of the twenty-five thousand of the offering toward the east border, and westward in front of the twenty-five thousand toward the west border, alongside the portions, it shall be for the prince. The set-apart offering and the sanctuary of the house shall be in the middle of it. 
+<sup>22&#160;</sup>Moreover, from the possession of the Levites, and from the possession of the city, being in the middle of that which is the prince’s, between the border of Judah and the border of Benjamin, shall be for the prince. 
+</div><div class="p">
+<sup>23&#160;</sup>“As for the rest of the tribes: from the east side to the west side, Benjamin, one portion. 
+</div><div class="p">
+<sup>24&#160;</sup>“By the border of Benjamin, from the east side to the west side, Simeon, one portion. 
+</div><div class="p">
+<sup>25&#160;</sup>“By the border of Simeon, from the east side to the west side, Issachar, one portion. 
+</div><div class="p">
+<sup>26&#160;</sup>“By the border of Issachar, from the east side to the west side, Zebulun, one portion. 
+</div><div class="p">
+<sup>27&#160;</sup>“By the border of Zebulun, from the east side to the west side, Gad, one portion. 
+</div><div class="p">
+<sup>28&#160;</sup>“By the border of Gad, at the south side southward, the border shall be even from Tamar to the waters of Meribath Kadesh, to the brook, to the great sea. 
+</div><div class="p">
+<sup>29&#160;</sup>“This is the land which you shall divide by lot to the tribes of Israel for inheritance, and these are their several portions, says the Lord Yahweh. 
+</div><div class="p">
+<sup>30&#160;</sup>“These are the exits of the city: On the north side four thousand five hundred reeds by measure; 
+<sup>31&#160;</sup>and the gates of the city shall be named after the tribes of Israel, three gates northward: the gate of Reuben, one; the gate of Judah, one; the gate of Levi, one. 
+</div><div class="p">
+<sup>32&#160;</sup>“At the east side four thousand five hundred reeds, and three gates: even the gate of Joseph, one; the gate of Benjamin, one; the gate of Dan, one. 
+</div><div class="p">
+<sup>33&#160;</sup>“At the south side four thousand five hundred reeds by measure, and three gates: the gate of Simeon, one; the gate of Issachar, one; the gate of Zebulun, one. 
+</div><div class="p">
+<sup>34&#160;</sup>“At the west side four thousand five hundred reeds, with their three gates: the gate of Gad, one; the gate of Asher, one; the gate of Naphtali, one. 
+</div><div class="p">
+<sup>35&#160;</sup>“It shall be eighteen thousand reeds in circumference; and the name of the city from that day shall be, ‘Yahweh is there.’ </div></div><script src="../main.js"></script></body></html>

--- a/book/ezra.html
+++ b/book/ezra.html
@@ -3,6 +3,47 @@
 <head>
 <title>Ezra</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,405 +53,416 @@
 <div class="main">
 <!-- EZR World English Scripture (WES) -->
 <h1 class="booklabel">Ezra</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now in the first year of Cyrus king of Persia, that Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word by Jeremiah’s mouth might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
-</p><p class="mi">
-<span class="v">2&#160;</span>“Cyrus king of Persia says, ‘Yahweh, the Elohim<span class="f">+ \fr 1:2 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> of heaven, has given me all the kingdoms of the earth; and he has commanded me to build him a house in Jerusalem, which is in Judah. 
-<span class="v">3&#160;</span>Whoever there is among you of all his people, may his Elohim be with him, and let him go up to Jerusalem, which is in Judah, and build the house of Yahweh, the Elohim of Israel (he is Elohim), which is in Jerusalem. 
-<span class="v">4&#160;</span>Whoever is left, in any place where he lives, let the men of his place help him with silver, with gold, with goods, and with animals, in addition to the free will offering for Elohim’s house which is in Jerusalem.’&#160;” 
-</p><p>
-<span class="v">5&#160;</span>Then the heads of fathers’ households of Judah and Benjamin, the priests and the Levites, all whose spirit Elohim had stirred to go up, rose up to build Yahweh’s house which is in Jerusalem. 
-<span class="v">6&#160;</span>All those who were around them strengthened their hands with vessels of silver, with gold, with goods, with animals, and with precious things, in addition to all that was willingly offered. 
-<span class="v">7&#160;</span>Also Cyrus the king brought out the vessels of Yahweh’s house, which Nebuchadnezzar had brought out of Jerusalem, and had put in the house of his elohims; 
-<span class="v">8&#160;</span>even those, Cyrus king of Persia brought out by the hand of Mithredath the treasurer, and counted them out to Sheshbazzar the prince of Judah. 
-<span class="v">9&#160;</span>This is the number of them: thirty platters of gold, one thousand platters of silver, twenty-nine knives, 
-<span class="v">10&#160;</span>thirty bowls of gold, four hundred ten silver bowls of a second kind, and one thousand other vessels. 
-<span class="v">11&#160;</span>All the vessels of gold and of silver were five thousand four hundred. Sheshbazzar brought all these up when the captives were brought up from Babylon to Jerusalem. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the children of the province who went up out of the captivity of those who had been carried away, whom Nebuchadnezzar the king of Babylon had carried away to Babylon, and who returned to Jerusalem and Judah, everyone to his city; 
-<span class="v">2&#160;</span>who came with Zerubbabel, Jeshua, Nehemiah, Seraiah, Reelaiah, Mordecai, Bilshan, Mispar, Bigvai, Rehum, and Baanah. 
-</p><p>The number of the men of the people of Israel: 
-<span class="v">3&#160;</span>The children of Parosh, two thousand one hundred seventy-two. 
-<span class="v">4&#160;</span>The children of Shephatiah, three hundred seventy-two. 
-<span class="v">5&#160;</span>The children of Arah, seven hundred seventy-five. 
-<span class="v">6&#160;</span>The children of Pahathmoab, of the children of Jeshua and Joab, two thousand eight hundred twelve. 
-<span class="v">7&#160;</span>The children of Elam, one thousand two hundred fifty-four. 
-<span class="v">8&#160;</span>The children of Zattu, nine hundred forty-five. 
-<span class="v">9&#160;</span>The children of Zaccai, seven hundred sixty. 
-<span class="v">10&#160;</span>The children of Bani, six hundred forty-two. 
-<span class="v">11&#160;</span>The children of Bebai, six hundred twenty-three. 
-<span class="v">12&#160;</span>The children of Azgad, one thousand two hundred twenty-two. 
-<span class="v">13&#160;</span>The children of Adonikam, six hundred sixty-six. 
-<span class="v">14&#160;</span>The children of Bigvai, two thousand fifty-six. 
-<span class="v">15&#160;</span>The children of Adin, four hundred fifty-four. 
-<span class="v">16&#160;</span>The children of Ater, of Hezekiah, ninety-eight. 
-<span class="v">17&#160;</span>The children of Bezai, three hundred twenty-three. 
-<span class="v">18&#160;</span>The children of Jorah, one hundred twelve. 
-<span class="v">19&#160;</span>The children of Hashum, two hundred twenty-three. 
-<span class="v">20&#160;</span>The children of Gibbar, ninety-five. 
-<span class="v">21&#160;</span>The children of Bethlehem, one hundred twenty-three. 
-<span class="v">22&#160;</span>The men of Netophah, fifty-six. 
-<span class="v">23&#160;</span>The men of Anathoth, one hundred twenty-eight. 
-<span class="v">24&#160;</span>The children of Azmaveth, forty-two. 
-<span class="v">25&#160;</span>The children of Kiriath Arim, Chephirah, and Beeroth, seven hundred forty-three. 
-<span class="v">26&#160;</span>The children of Ramah and Geba, six hundred twenty-one. 
-<span class="v">27&#160;</span>The men of Michmas, one hundred twenty-two. 
-<span class="v">28&#160;</span>The men of Bethel and Ai, two hundred twenty-three. 
-<span class="v">29&#160;</span>The children of Nebo, fifty-two. 
-<span class="v">30&#160;</span>The children of Magbish, one hundred fifty-six. 
-<span class="v">31&#160;</span>The children of the other Elam, one thousand two hundred fifty-four. 
-<span class="v">32&#160;</span>The children of Harim, three hundred twenty. 
-<span class="v">33&#160;</span>The children of Lod, Hadid, and Ono, seven hundred twenty-five. 
-<span class="v">34&#160;</span>The children of Jericho, three hundred forty-five. 
-<span class="v">35&#160;</span>The children of Senaah, three thousand six hundred thirty. 
-</p><p>
-<span class="v">36&#160;</span>The priests: the children of Jedaiah, of the house of Jeshua, nine hundred seventy-three. 
-<span class="v">37&#160;</span>The children of Immer, one thousand fifty-two. 
-<span class="v">38&#160;</span>The children of Pashhur, one thousand two hundred forty-seven. 
-<span class="v">39&#160;</span>The children of Harim, one thousand seventeen. 
-</p><p>
-<span class="v">40&#160;</span>The Levites: the children of Jeshua and Kadmiel, of the children of Hodaviah, seventy-four. 
-<span class="v">41&#160;</span>The singers: the children of Asaph, one hundred twenty-eight. 
-<span class="v">42&#160;</span>The children of the gatekeepers: the children of Shallum, the children of Ater, the children of Talmon, the children of Akkub, the children of Hatita, the children of Shobai, in all one hundred thirty-nine. 
-</p><p>
-<span class="v">43&#160;</span>The temple servants: the children of Ziha, the children of Hasupha, the children of Tabbaoth, 
-<span class="v">44&#160;</span>the children of Keros, the children of Siaha, the children of Padon, 
-<span class="v">45&#160;</span>the children of Lebanah, the children of Hagabah, the children of Akkub, 
-<span class="v">46&#160;</span>the children of Hagab, the children of Shamlai, the children of Hanan, 
-<span class="v">47&#160;</span>the children of Giddel, the children of Gahar, the children of Reaiah, 
-<span class="v">48&#160;</span>the children of Rezin, the children of Nekoda, the children of Gazzam, 
-<span class="v">49&#160;</span>the children of Uzza, the children of Paseah, the children of Besai, 
-<span class="v">50&#160;</span>the children of Asnah, the children of Meunim, the children of Nephisim, 
-<span class="v">51&#160;</span>the children of Bakbuk, the children of Hakupha, the children of Harhur, 
-<span class="v">52&#160;</span>the children of Bazluth, the children of Mehida, the children of Harsha, 
-<span class="v">53&#160;</span>the children of Barkos, the children of Sisera, the children of Temah, 
-<span class="v">54&#160;</span>the children of Neziah, the children of Hatipha. 
-</p><p>
-<span class="v">55&#160;</span>The children of Solomon’s servants: the children of Sotai, the children of Hassophereth, the children of Peruda, 
-<span class="v">56&#160;</span>the children of Jaalah, the children of Darkon, the children of Giddel, 
-<span class="v">57&#160;</span>the children of Shephatiah, the children of Hattil, the children of Pochereth Hazzebaim, the children of Ami. 
-<span class="v">58&#160;</span>All the temple servants, and the children of Solomon’s servants, were three hundred ninety-two. 
-</p><p>
-<span class="v">59&#160;</span>These were those who went up from Tel Melah, Tel Harsha, Cherub, Addan, and Immer; but they could not show their fathers’ houses and their offspring,<span class="f">+ \fr 2:59 \ft or, seed</span> whether they were of Israel: 
-<span class="v">60&#160;</span>the children of Delaiah, the children of Tobiah, the children of Nekoda, six hundred fifty-two. 
-<span class="v">61&#160;</span>Of the children of the priests: the children of Habaiah, the children of Hakkoz, and the children of Barzillai, who took a woman of the daughters of Barzillai the Gileadite, and was called after their name. 
-<span class="v">62&#160;</span>These sought their place among those who were registered by genealogy, but they were not found; therefore they were deemed disqualified and removed from the priesthood. 
-<span class="v">63&#160;</span>The governor told them that they should not eat of the most set-apart things until a priest stood up to serve with Urim and with Thummim. 
-</p><p>
-<span class="v">64&#160;</span>The whole assembly together was forty-two thousand three hundred sixty, 
-<span class="v">65&#160;</span>in addition to their male servants and their female servants, of whom there were seven thousand three hundred thirty-seven; and they had two hundred singing men and singing women. 
-<span class="v">66&#160;</span>Their horses were seven hundred thirty-six; their mules, two hundred forty-five; 
-<span class="v">67&#160;</span>their camels, four hundred thirty-five; their donkeys, six thousand seven hundred twenty. 
-</p><p>
-<span class="v">68&#160;</span>Some of the heads of fathers’ households, when they came to Yahweh’s house which is in Jerusalem, offered willingly for Elohim’s house to set it up in its place. 
-<span class="v">69&#160;</span>They gave according to their ability into the treasury of the work sixty-one thousand darics of gold,<span class="f">+ \fr 2:69 \ft a daric was a gold coin issued by a Persian king, weighing about 8.4 grams or about 0.27 troy ounces each.</span> five thousand minas<span class="f">+ \fr 2:69 \ft A mina is about 600 grams or 1.3 U. S. pounds, so 5,000 minas is about 3 metric tons.</span> of silver, and one hundred priests’ garments. 
-</p><p>
-<span class="v">70&#160;</span>So the priests and the Levites, with some of the people, the singers, the gatekeepers, and the temple servants, lived in their cities, and all Israel in their cities. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>When the seventh month had come, and the children of Israel were in the cities, the people gathered themselves together as one man to Jerusalem. 
-<span class="v">2&#160;</span>Then Jeshua the son of Jozadak stood up with his brothers the priests and Zerubbabel the son of Shealtiel and his relatives, and built the altar of the Elohim of Israel, to offer burnt offerings on it, as it is written in the law of Moses the man of Elohim. 
-<span class="v">3&#160;</span>In spite of their fear because of the peoples of the surrounding lands, they set the altar on its base; and they offered burnt offerings on it to Yahweh, even burnt offerings morning and evening. 
-<span class="v">4&#160;</span>They kept the feast of booths, as it is written, and offered the daily burnt offerings by number, according to the ordinance, as the duty of every day required; 
-<span class="v">5&#160;</span>and afterward the continual burnt offering, the offerings of the new moons, of all the set feasts of Yahweh that were consecrated, and of everyone who willingly offered a free will offering to Yahweh. 
-<span class="v">6&#160;</span>From the first day of the seventh month, they began to offer burnt offerings to Yahweh; but the foundation of Yahweh’s temple was not yet laid. 
-<span class="v">7&#160;</span>They also gave money to the masons and to the carpenters. They also gave food, drink, and oil to the people of Sidon and Tyre to bring cedar trees from Lebanon to the sea, to Joppa, according to the grant that they had from Cyrus King of Persia. 
-</p><p>
-<span class="v">8&#160;</span>Now in the second year of their coming to Elohim’s house at Jerusalem, in the second month, Zerubbabel the son of Shealtiel, Jeshua the son of Jozadak, and the rest of their brothers the priests and the Levites, and all those who had come out of the captivity to Jerusalem, began the work and appointed the Levites, from twenty years old and upward, to have the oversight of the work of Yahweh’s house. 
-<span class="v">9&#160;</span>Then Jeshua stood with his sons and his brothers, Kadmiel and his sons, the sons of Judah, together to have the oversight of the workmen in Elohim’s house: the sons of Henadad, with their sons and their brothers the Levites. 
-</p><p>
-<span class="v">10&#160;</span>When the builders laid the foundation of Yahweh’s temple, they set the priests in their vestments with trumpets, with the Levites the sons of Asaph with cymbals, to praise Yahweh, according to the directions of David king of Israel. 
-<span class="v">11&#160;</span>They sang to one another in praising and giving thanks to Yahweh, “For he is good, for his loving kindness endures forever toward Israel.” All the people shouted with a great shout, when they praised Yahweh, because the foundation of Yahweh’s house had been laid. 
-</p><p>
-<span class="v">12&#160;</span>But many of the priests and Levites and heads of fathers’ households, the old men who had seen the first house, when the foundation of this house was laid before their eyes, wept with a loud voice. Many also shouted aloud for joy, 
-<span class="v">13&#160;</span>so that the people could not discern the noise of the shout of joy from the noise of the weeping of the people; for the people shouted with a loud shout, and the noise was heard far away. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Now when the adversaries of Judah and Benjamin heard that the children of the captivity were building a temple to Yahweh, the Elohim of Israel, 
-<span class="v">2&#160;</span>they came near to Zerubbabel, and to the heads of fathers’ households, and said to them, “Let us build with you, for we seek your Elohim as you do; and we have been sacrificing to him since the days of Esar Haddon king of Assyria, who brought us up here.” 
-</p><p>
-<span class="v">3&#160;</span>But Zerubbabel, Jeshua, and the rest of the heads of fathers’ households of Israel said to them, “You have nothing to do with us in building a house to our Elohim; but we ourselves together will build to Yahweh, the Elohim of Israel, as King Cyrus the king of Persia has commanded us.” 
-</p><p>
-<span class="v">4&#160;</span>Then the people of the land weakened the hands of the people of Judah, and troubled them in building. 
-<span class="v">5&#160;</span>They hired counselors against them to frustrate their purpose all the days of Cyrus king of Persia, even until the reign of Darius king of Persia. 
-<span class="v">6&#160;</span>In the reign of Ahasuerus, in the beginning of his reign, they wrote an accusation against the inhabitants of Judah and Jerusalem. 
-</p><p>
-<span class="v">7&#160;</span>In the days of Artaxerxes, Bishlam, Mithredath, Tabeel, and the rest of his companions wrote to Artaxerxes king of Persia; and the writing of the letter was written in Syrian and delivered in the Syrian language. 
-<span class="v">8&#160;</span>Rehum the chancellor and Shimshai the scribe wrote a letter against Jerusalem to Artaxerxes the king as follows. 
-<span class="v">9&#160;</span>Then Rehum the chancellor, Shimshai the scribe, and the rest of their companions, the Dinaites, and the Apharsathchites, the Tarpelites, the Apharsites, the Archevites, the Babylonians, the Shushanchites, the Dehaites, the Elamites, 
-<span class="v">10&#160;</span>and the rest of the nations whom the great and noble Osnappar brought over and settled in the city of Samaria, and in the rest of the country beyond the River, and so forth, wrote. 
-</p><p>
-<span class="v">11&#160;</span>This is the copy of the letter that they sent: 
-</p><div class="b"> &#160; </div>
-<p class="mi">To King Artaxerxes, from your servants, the people beyond the River. 
-</p><p class="pi1">
-<span class="v">12&#160;</span>Be it known to the king that the Jews who came up from you have come to us to Jerusalem. They are building the rebellious and bad city, and have finished the walls and repaired the foundations. 
-<span class="v">13&#160;</span>Be it known now to the king that if this city is built and the walls finished, they will not pay tribute, custom, or toll, and in the end it will be hurtful to the kings. 
-<span class="v">14&#160;</span>Now because we eat the salt of the palace and it is not appropriate for us to see the king’s dishonor, therefore we have sent and informed the king, 
-<span class="v">15&#160;</span>that search may be made in the book of the records of your fathers. You will see in the book of the records, and know that this city is a rebellious city, and hurtful to kings and provinces, and that they have started rebellions within it in the past. That is why this city was destroyed. 
-<span class="v">16&#160;</span>We inform the king that if this city is built and the walls finished, then you will have no possession beyond the River. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">17&#160;</span>Then the king sent an answer to Rehum the chancellor, and to Shimshai the scribe, and to the rest of their companions who live in Samaria, and in the rest of the country beyond the River: 
-</p><div class="b"> &#160; </div>
-<p class="mi">Peace. 
-</p><div class="b"> &#160; </div>
-<p class="pi1">
-<span class="v">18&#160;</span>The letter which you sent to us has been plainly read before me. 
-<span class="v">19&#160;</span>I decreed, and search has been made, and it was found that this city has made insurrection against kings in the past, and that rebellion and revolts have been made in it. 
-<span class="v">20&#160;</span>There have also been mighty kings over Jerusalem who have ruled over all the country beyond the River; and tribute, custom, and toll was paid to them. 
-<span class="v">21&#160;</span>Make a decree now to cause these men to cease, and that this city not be built until a decree is made by me. 
-<span class="v">22&#160;</span>Be careful that you not be slack doing so. Why should damage grow to the hurt of the kings? 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">23&#160;</span>Then when the copy of King Artaxerxes’ letter was read before Rehum, Shimshai the scribe, and their companions, they went in haste to Jerusalem to the Jews, and made them to cease by force of arms. 
-<span class="v">24&#160;</span>Then work stopped on Elohim’s house which is at Jerusalem. It stopped until the second year of the reign of Darius king of Persia. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Now the prophets, Haggai the prophet and Zechariah the son of Iddo, prophesied to the Jews who were in Judah and Jerusalem. They prophesied to them in the name of the Elohim of Israel. 
-<span class="v">2&#160;</span>Then Zerubbabel the son of Shealtiel, and Jeshua the son of Jozadak rose up and began to build Elohim’s house which is at Jerusalem; and with them were the prophets of Elohim, helping them. 
-</p><p>
-<span class="v">3&#160;</span>At the same time Tattenai, the governor beyond the River, came to them, with Shetharbozenai and their companions, and asked them, “Who gave you a decree to build this house and to finish this wall?” 
-<span class="v">4&#160;</span>They also asked for the names of the men who were making this building. 
-<span class="v">5&#160;</span>But the eye of their Elohim was on the elders of the Jews, and they didn’t make them cease until the matter should come to Darius, and an answer should be returned by letter concerning it. 
-</p><p>
-<span class="v">6&#160;</span>The copy of the letter that Tattenai, the governor beyond the River, and Shetharbozenai, and his companions the Apharsachites who were beyond the River, sent to Darius the king follows. 
-<span class="v">7&#160;</span>They sent a letter to him, in which was written: 
-</p><div class="b"> &#160; </div>
-<p class="mi">To Darius the king, all peace. 
-</p><p class="pi1">
-<span class="v">8&#160;</span>Be it known to the king that we went into the province of Judah, to the house of the great Elohim, which is being built with great stones and timber is laid in the walls. This work goes on with diligence and prospers in their hands. 
-<span class="v">9&#160;</span>Then we asked those elders, and said to them thus, “Who gave you a decree to build this house, and to finish this wall?” 
-<span class="v">10&#160;</span>We asked them their names also, to inform you that we might write the names of the men who were at their head. 
-<span class="v">11&#160;</span>Thus they returned us answer, saying, “We are the servants of the Elohim of heaven and earth and are building the house that was built these many years ago, which a great king of Israel built and finished. 
-<span class="v">12&#160;</span>But after our fathers had provoked the Elohim of heaven to wrath, he gave them into the hand of Nebuchadnezzar king of Babylon, the Chaldean, who destroyed this house and carried the people away into Babylon. 
-<span class="v">13&#160;</span>But in the first year of Cyrus king of Babylon, Cyrus the king made a decree to build this house of Elohim. 
-<span class="v">14&#160;</span>The gold and silver vessels of Elohim’s house, which Nebuchadnezzar took out of the temple that was in Jerusalem and brought into the temple of Babylon, those Cyrus the king also took out of the temple of Babylon, and they were delivered to one whose name was Sheshbazzar, whom he had made governor. 
-<span class="v">15&#160;</span>He said to him, ‘Take these vessels, go, put them in the temple that is in Jerusalem, and let Elohim’s house be built in its place.’ 
-<span class="v">16&#160;</span>Then the same Sheshbazzar came and laid the foundations of Elohim’s house which is in Jerusalem. Since that time even until now it has been being built, and yet it is not completed. 
-</p><p class="pi1">
-<span class="v">17&#160;</span>Now therefore, if it seems good to the king, let a search be made in the king’s treasure house, which is there at Babylon, whether it is so that a decree was made by Cyrus the king to build this house of Elohim at Jerusalem; and let the king send his pleasure to us concerning this matter.” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Then Darius the king made a decree, and the house of the archives, where the treasures were laid up in Babylon, was searched. 
-<span class="v">2&#160;</span>A scroll was found at Achmetha, in the palace that is in the province of Media, and in it this was written for a record: 
-</p><div class="b"> &#160; </div>
-<p class="pi1">
-<span class="v">3&#160;</span>In the first year of Cyrus the king, Cyrus the king made a decree: Concerning Elohim’s house at Jerusalem, let the house be built, the place where they offer sacrifices, and let its foundations be strongly laid, with its height sixty cubits<span class="f">+ \fr 6:3 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and its width sixty cubits; 
-<span class="v">4&#160;</span>with three courses of great stones and a course of new timber. Let the expenses be given out of the king’s house. 
-<span class="v">5&#160;</span>Also let the gold and silver vessels of Elohim’s house, which Nebuchadnezzar took out of the temple which is at Jerusalem and brought to Babylon, be restored and brought again to the temple which is at Jerusalem, everything to its place. You shall put them in Elohim’s house. 
-</p><p class="pi1">
-<span class="v">6&#160;</span>Now therefore, Tattenai, governor beyond the River, Shetharbozenai, and your companions the Apharsachites, who are beyond the River, you must stay far from there. 
-<span class="v">7&#160;</span>Leave the work of this house of Elohim alone; let the governor of the Jews and the elders of the Jews build this house of Elohim in its place. 
-<span class="v">8&#160;</span>Moreover I make a decree regarding what you shall do for these elders of the Jews for the building of this house of Elohim: that of the king’s goods, even of the tribute beyond the River, expenses must be given with all diligence to these men, that they not be hindered. 
-<span class="v">9&#160;</span>That which they have need of, including young bulls, rams, and lambs, for burnt offerings to the Elohim of heaven; also wheat, salt, wine, and oil, according to the word of the priests who are at Jerusalem, let it be given them day by day without fail, 
-<span class="v">10&#160;</span>that they may offer sacrifices of pleasant aroma to the Elohim of heaven, and pray for the life of the king and of his sons. 
-<span class="v">11&#160;</span>I have also made a decree that whoever alters this message, let a beam be pulled out from his house, and let him be lifted up and fastened on it; and let his house be made a dunghill for this. 
-<span class="v">12&#160;</span>May the Elohim who has caused his name to dwell there overthrow all kings and peoples who stretch out their hand to alter this, to destroy this house of Elohim which is at Jerusalem. I Darius have made a decree. Let it be done with all diligence. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">13&#160;</span>Then Tattenai, the governor beyond the River, Shetharbozenai, and their companions did accordingly with all diligence, because Darius the king had sent a decree. 
-</p><p>
-<span class="v">14&#160;</span>The elders of the Jews built and prospered, through the prophesying of Haggai the prophet and Zechariah the son of Iddo. They built and finished it, according to the commandment of the Elohim of Israel, and according to the decree of Cyrus, Darius, and Artaxerxes king of Persia. 
-<span class="v">15&#160;</span>This house was finished on the third day of the month Adar, which was in the sixth year of the reign of Darius the king. 
-</p><p>
-<span class="v">16&#160;</span>The children of Israel, the priests, the Levites, and the rest of the children of the captivity, kept the dedication of this house of Elohim with joy. 
-<span class="v">17&#160;</span>They offered at the dedication of this house of Elohim one hundred bulls, two hundred rams, four hundred lambs; and for a sin offering for all Israel, twelve male goats, according to the number of the tribes of Israel. 
-<span class="v">18&#160;</span>They set the priests in their divisions and the Levites in their courses, for the service of Elohim which is at Jerusalem, as it is written in the book of Moses. 
-</p><p>
-<span class="v">19&#160;</span>The children of the captivity kept the Passover on the fourteenth day of the first month. 
-<span class="v">20&#160;</span>Because the priests and the Levites had purified themselves together, all of them were pure. They killed the Passover for all the children of the captivity, for their brothers the priests, and for themselves. 
-<span class="v">21&#160;</span>The children of Israel who had returned out of the captivity, and all who had separated themselves to them from the filthiness of the nations of the land to seek Yahweh, the Elohim of Israel, ate, 
-<span class="v">22&#160;</span>and kept the feast of unleavened bread seven days with joy; because Yahweh had made them joyful, and had turned the heart of the king of Assyria to them, to strengthen their hands in the work of Elohim, the Elohim of Israel’s house. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Now after these things, in the reign of Artaxerxes king of Persia, Ezra the son of Seraiah, the son of Azariah, the son of Hilkiah, 
-<span class="v">2&#160;</span>the son of Shallum, the son of Zadok, the son of Ahitub, 
-<span class="v">3&#160;</span>the son of Amariah, the son of Azariah, the son of Meraioth, 
-<span class="v">4&#160;</span>the son of Zerahiah, the son of Uzzi, the son of Bukki, 
-<span class="v">5&#160;</span>the son of Abishua, the son of Phinehas, the son of Eleazar, the son of Aaron the chief priest—<span class="v">6&#160;</span>this Ezra went up from Babylon. He was a skilled scribe in the law of Moses, which Yahweh, the Elohim of Israel, had given; and the king granted him all his request, according to Yahweh his Elohim’s hand on him. 
-<span class="v">7&#160;</span>Some of the children of Israel, including some of the priests, the Levites, the singers, the gatekeepers, and the temple servants went up to Jerusalem in the seventh year of Artaxerxes the king. 
-<span class="v">8&#160;</span>He came to Jerusalem in the fifth month, which was in the seventh year of the king. 
-<span class="v">9&#160;</span>For on the first day of the first month he began to go up from Babylon; and on the first day of the fifth month he came to Jerusalem, according to the good hand of his Elohim on him. 
-<span class="v">10&#160;</span>For Ezra had set his heart to seek Yahweh’s law, and to do it, and to teach statutes and ordinances in Israel. 
-</p><p>
-<span class="v">11&#160;</span>Now this is the copy of the letter that King Artaxerxes gave to Ezra the priest, the scribe, even the scribe of the words of Yahweh’s commandments, and of his statutes to Israel: 
-</p><div class="b"> &#160; </div>
-<p class="mi">
-<span class="v">12&#160;</span>Artaxerxes, king of kings, 
-</p><p class="mi">To Ezra the priest, the scribe of the law of the perfect Elohim of heaven. 
-</p><p class="pi1">Now 
-<span class="v">13&#160;</span>I make a decree that all those of the people of Israel and their priests and the Levites in my realm, who intend of their own free will to go to Jerusalem, go with you. 
-<span class="v">14&#160;</span>Because you are sent by the king and his seven counselors to inquire concerning Judah and Jerusalem, according to the law of your Elohim which is in your hand, 
-<span class="v">15&#160;</span>and to carry the silver and gold, which the king and his counselors have freely offered to the Elohim of Israel, whose habitation is in Jerusalem, 
-<span class="v">16&#160;</span>and all the silver and gold that you will find in all the province of Babylon, with the free will offering of the people and of the priests, offering willingly for the house of their Elohim which is in Jerusalem. 
-<span class="v">17&#160;</span>Therefore you shall with all diligence buy with this money bulls, rams, and lambs with their meal offerings and their drink offerings, and shall offer them on the altar of the house of your Elohim which is in Jerusalem. 
-<span class="v">18&#160;</span>Whatever seems good to you and to your brothers to do with the rest of the silver and the gold, do that according to the will of your Elohim. 
-<span class="v">19&#160;</span>The vessels that are given to you for the service of the house of your Elohim, deliver before the Elohim of Jerusalem. 
-<span class="v">20&#160;</span>Whatever more will be needed for the house of your Elohim, which you may have occasion to give, give it out of the king’s treasure house. 
-</p><p class="pi1">
-<span class="v">21&#160;</span>I, even I, Artaxerxes the king, make a decree to all the treasurers who are beyond the River, that whatever Ezra the priest, the scribe of the law of the Elohim of heaven, requires of you, it shall be done with all diligence, 
-<span class="v">22&#160;</span>up to one hundred talents<span class="f">+ \fr 7:22 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> of silver, and to one hundred cors<span class="f">+ \fr 7:22 \ft 1 cor is the same as a homer, or about 55.9 U. S. gallons (liquid) or 211 liters or 6 bushels.</span> of wheat, and to one hundred baths<span class="f">+ \fr 7:22 \ft 1 bath is one tenth of a cor, or about 5.6 U. S. gallons or 21 liters or 2.4 pecks. 100 baths would be about 2,100 liters.</span> of wine, and to one hundred baths of oil, and salt without prescribing how much. 
-<span class="v">23&#160;</span>Whatever is commanded by the Elohim of heaven, let it be done exactly for the house of the Elohim of heaven; for why should there be wrath against the realm of the king and his sons? 
-</p><p class="pi1">
-<span class="v">24&#160;</span>Also we inform you that it shall not be lawful to impose tribute, custom, or toll on any of the priests, Levites, singers, gatekeepers, temple servants, or laborers of this house of Elohim. 
-</p><p class="pi1">
-<span class="v">25&#160;</span>You, Ezra, according to the wisdom of your Elohim that is in your hand, appoint magistrates and judges who may judge all the people who are beyond the River, who all know the laws of your Elohim; and teach him who doesn’t know them. 
-<span class="v">26&#160;</span>Whoever will not do the law of your Elohim and the law of the king, let judgment be executed on him with all diligence, whether it is to death, or to banishment, or to confiscation of goods, or to imprisonment. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">27&#160;</span>Blessed be Yahweh, the Elohim of our fathers, who has put such a thing as this in the king’s heart, to beautify Yahweh’s house which is in Jerusalem; 
-<span class="v">28&#160;</span>and has extended loving kindness to me before the king and his counselors, and before all the king’s mighty princes. I was strengthened according to Yahweh my Elohim’s hand on me, and I gathered together chief men out of Israel to go up with me. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the heads of their fathers’ households, and this is the genealogy of those who went up with me from Babylon, in the reign of Artaxerxes the king: 
-</p><p class="li1">
-<span class="v">2&#160;</span>Of the sons of Phinehas, Gershom. 
-</p><p class="li1">Of the sons of Ithamar, Daniel. 
-</p><p class="li1">Of the sons of David, Hattush. 
-</p><p class="li1">
-<span class="v">3&#160;</span>Of the sons of Shecaniah, of the sons of Parosh, Zechariah; and with him were listed by genealogy of the males one hundred fifty. 
-</p><p class="li1">
-<span class="v">4&#160;</span>Of the sons of Pahathmoab, Eliehoenai the son of Zerahiah; and with him two hundred males. 
-</p><p class="li1">
-<span class="v">5&#160;</span>Of the sons of Shecaniah, the son of Jahaziel; and with him three hundred males. 
-</p><p class="li1">
-<span class="v">6&#160;</span>Of the sons of Adin, Ebed the son of Jonathan; and with him fifty males. 
-</p><p class="li1">
-<span class="v">7&#160;</span>Of the sons of Elam, Jeshaiah the son of Athaliah; and with him seventy males. 
-</p><p class="li1">
-<span class="v">8&#160;</span>Of the sons of Shephatiah, Zebadiah the son of Michael; and with him eighty males. 
-</p><p class="li1">
-<span class="v">9&#160;</span>Of the sons of Joab, Obadiah the son of Jehiel; and with him two hundred eighteen males. 
-</p><p class="li1">
-<span class="v">10&#160;</span>Of the sons of Shelomith, the son of Josiphiah; and with him one hundred sixty males. 
-</p><p class="li1">
-<span class="v">11&#160;</span>Of the sons of Bebai, Zechariah the son of Bebai; and with him twenty-eight males. 
-</p><p class="li1">
-<span class="v">12&#160;</span>Of the sons of Azgad, Johanan the son of Hakkatan; and with him one hundred ten males. 
-</p><p class="li1">
-<span class="v">13&#160;</span>Of the sons of Adonikam, who were the last, their names are: Eliphelet, Jeuel, and Shemaiah; and with them sixty males. 
-</p><p class="li1">
-<span class="v">14&#160;</span>Of the sons of Bigvai, Uthai and Zabbud; and with them seventy males. 
-</p><p>
-<span class="v">15&#160;</span>I gathered them together to the river that runs to Ahava; and there we encamped three days. Then I looked around at the people and the priests, and found there were none of the sons of Levi. 
-<span class="v">16&#160;</span>Then I sent for Eliezer, for Ariel, for Shemaiah, for Elnathan, for Jarib, for Elnathan, for Nathan, for Zechariah, and for Meshullam, chief men; also for Joiarib and for Elnathan, who were teachers. 
-<span class="v">17&#160;</span>I sent them out to Iddo the chief at the place Casiphia; and I told them what they should tell Iddo and his brothers the temple servants at the place Casiphia, that they should bring to us ministers for the house of our Elohim. 
-<span class="v">18&#160;</span>According to the good hand of our Elohim on us they brought us a man of discretion, of the sons of Mahli, the son of Levi, the son of Israel, namely Sherebiah, with his sons and his brothers, eighteen; 
-<span class="v">19&#160;</span>and Hashabiah, and with him Jeshaiah of the sons of Merari, his brothers and their sons, twenty; 
-<span class="v">20&#160;</span>and of the temple servants, whom David and the princes had given for the service of the Levites, two hundred twenty temple servants. All of them were mentioned by name. 
-</p><p>
-<span class="v">21&#160;</span>Then I proclaimed a fast there at the river Ahava, that we might humble ourselves before our Elohim, to seek from him a straight way for us, for our little ones, and for all our possessions. 
-<span class="v">22&#160;</span>For I was ashamed to ask of the king a band of soldiers and horsemen to help us against the enemy on the way, because we had spoken to the king, saying, “The hand of our Elohim is on all those who seek him, for good; but his power and his wrath is against all those who forsake him.” 
-<span class="v">23&#160;</span>So we fasted and begged our Elohim for this, and he granted our request. 
-</p><p>
-<span class="v">24&#160;</span>Then I set apart twelve of the chiefs of the priests, even Sherebiah, Hashabiah, and ten of their brothers with them, 
-<span class="v">25&#160;</span>and weighed to them the silver, the gold, and the vessels, even the offering for the house of our Elohim, which the king, his counselors, his princes, and all Israel there present, had offered. 
-<span class="v">26&#160;</span>I weighed into their hand six hundred fifty talents of silver,<span class="f">+ \fr 8:26 \ft A talent is about 30 kilograms or 66 pounds or 965 Troy ounces</span> one hundred talents of silver vessels, one hundred talents of gold, 
-<span class="v">27&#160;</span>twenty bowls of gold weighing one thousand darics,<span class="f">+ \fr 8:27 \ft a daric was a gold coin issued by a Persian king, weighing about 8.4 grams or about 0.27 troy ounces each.</span> and two vessels of fine bright bronze, precious as gold. 
-<span class="v">28&#160;</span>I said to them, “You are set-apart to Yahweh, and the vessels are set-apart. The silver and the gold are a free will offering to Yahweh, the Elohim of your fathers. 
-<span class="v">29&#160;</span>Watch and keep them until you weigh them before the chiefs of the priests, the Levites, and the princes of the fathers’ households of Israel at Jerusalem, in the rooms of Yahweh’s house.” 
-</p><p>
-<span class="v">30&#160;</span>So the priests and the Levites received the weight of the silver, the gold, and the vessels, to bring them to Jerusalem to the house of our Elohim. 
-</p><p>
-<span class="v">31&#160;</span>Then we departed from the river Ahava on the twelfth day of the first month, to go to Jerusalem. The hand of our Elohim was on us, and he delivered us from the hand of the enemy and the bandits by the way. 
-<span class="v">32&#160;</span>We came to Jerusalem, and stayed there three days. 
-<span class="v">33&#160;</span>On the fourth day the silver and the gold and the vessels were weighed in the house of our Elohim into the hand of Meremoth the son of Uriah the priest; and with him was Eleazar the son of Phinehas; and with them were Jozabad the son of Jeshua, and Noadiah the son of Binnui, the Levites. 
-<span class="v">34&#160;</span>Everything was counted and weighed; and all the weight was written at that time. 
-</p><p>
-<span class="v">35&#160;</span>The children of the captivity, who had come out of exile, offered burnt offerings to the Elohim of Israel: twelve bulls for all Israel, ninety-six rams, seventy-seven lambs, and twelve male goats for a sin offering. All this was a burnt offering to Yahweh. 
-<span class="v">36&#160;</span>They delivered the king’s commissions to the king’s local governors and to the governors beyond the River. So they supported the people and Elohim’s house. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Now when these things were done, the princes came near to me, saying, “The people of Israel, the priests, and the Levites have not separated themselves from the peoples of the lands, following their abominations, even those of the Canaanites, the Hittites, the Perizzites, the Jebusites, the Ammonites, the Moabites, the Egyptians, and the Amorites. 
-<span class="v">2&#160;</span>For they have taken of their daughters for themselves and for their sons, so that the set-apart offspring have mixed themselves with the peoples of the lands. Yes, the hand of the princes and rulers has been chief in this trespass.” 
-</p><p>
-<span class="v">3&#160;</span>When I heard this thing, I tore my garment and my robe, and pulled the hair out of my head and of my beard, and sat down confounded. 
-<span class="v">4&#160;</span>Then everyone who trembled at the words of the Elohim of Israel were assembled to me because of the trespass of the exiles; and I sat confounded until the evening offering. 
-</p><p>
-<span class="v">5&#160;</span>At the evening offering I rose up from my humiliation, even with my garment and my robe torn; and I fell on my knees, and spread out my hands to Yahweh my Elohim; 
-<span class="v">6&#160;</span>and I said, “My Elohim, I am ashamed and blush to lift up my face to you, my Elohim, for our iniquities have increased over our head, and our guiltiness has grown up to the heavens. 
-<span class="v">7&#160;</span>Since the days of our fathers we have been exceedingly guilty to this day; and for our iniquities we, our kings, and our priests have been delivered into the hand of the kings of the lands, to the sword, to captivity, to plunder, and to confusion of face, as it is this day. 
-<span class="v">8&#160;</span>Now for a little moment grace has been shown from Yahweh our Elohim, to leave us a remnant to escape, and to give us a stake in his set-apart place, that our Elohim may lighten our eyes, and revive us a little in our bondage. 
-<span class="v">9&#160;</span>For we are bondservants; yet our Elohim has not forsaken us in our bondage, but has extended loving kindness to us in the sight of the kings of Persia, to revive us, to set up the house of our Elohim, and to repair its ruins, and to give us a wall in Judah and in Jerusalem. 
-</p><p>
-<span class="v">10&#160;</span>“Now, our Elohim, what shall we say after this? For we have forsaken your commandments, 
-<span class="v">11&#160;</span>which you have commanded by your servants the prophets, saying, ‘The land to which you go to possess is an unclean land through the uncleanness of the peoples of the lands, through their abominations, which have filled it from one end to another with their filthiness. 
-<span class="v">12&#160;</span>Now therefore don’t give your daughters to their sons. Don’t take their daughters to your sons, nor seek their peace or their prosperity forever, that you may be strong and eat the good of the land, and leave it for an inheritance to your children forever.’ 
-</p><p>
-<span class="v">13&#160;</span>“After all that has come on us for our evil deeds and for our great guilt, since you, our Elohim, have punished us less than our iniquities deserve, and have given us such a remnant, 
-<span class="v">14&#160;</span>shall we again break your commandments, and join ourselves with the peoples that do these abominations? Wouldn’t you be angry with us until you had consumed us, so that there would be no remnant, nor any to escape? 
-<span class="v">15&#160;</span>Yahweh, the Elohim of Israel, you are righteous; for we are left a remnant that has escaped, as it is today. Behold,<span class="f">+ \fr 9:15 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> we are before you in our guiltiness; for no one can stand before you because of this.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Now while Ezra prayed and made confession, weeping and casting himself down before Elohim’s house, there was gathered together to him out of Israel a very great assembly of men and women and children; for the people wept very bitterly. 
-<span class="v">2&#160;</span>Shecaniah the son of Jehiel, one of the sons of Elam, answered Ezra, “We have trespassed against our Elohim, and have married foreign women of the peoples of the land. Yet now there is hope for Israel concerning this thing. 
-<span class="v">3&#160;</span>Now therefore let’s make a covenant with our Elohim to put away all the women and those who are born of them, according to the counsel of my lord and of those who tremble at the commandment of our Elohim. Let it be done according to the law. 
-<span class="v">4&#160;</span>Arise, for the matter belongs to you and we are with you. Be courageous, and do it.” 
-</p><p>
-<span class="v">5&#160;</span>Then Ezra arose, and made the chiefs of the priests, the Levites, and all Israel to swear that they would do according to this word. So they swore. 
-<span class="v">6&#160;</span>Then Ezra rose up from before Elohim’s house, and went into the room of Jehohanan the son of Eliashib. When he came there, he didn’t eat bread or drink water, for he mourned because of the trespass of the exiles. 
-<span class="v">7&#160;</span>They made a proclamation throughout Judah and Jerusalem to all the children of the captivity, that they should gather themselves together to Jerusalem; 
-<span class="v">8&#160;</span>and that whoever didn’t come within three days, according to the counsel of the princes and the elders, all his possessions should be forfeited, and he himself separated from the assembly of the captivity. 
-</p><p>
-<span class="v">9&#160;</span>Then all the men of Judah and Benjamin gathered themselves together to Jerusalem within the three days. It was the ninth month, on the twentieth day of the month; and all the people sat in the wide place in front of Elohim’s house, trembling because of this matter, and because of the great rain. 
-</p><p>
-<span class="v">10&#160;</span>Ezra the priest stood up and said to them, “You have trespassed, and have married foreign women, increasing the guilt of Israel. 
-<span class="v">11&#160;</span>Now therefore make confession to Yahweh, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
-</p><p>
-<span class="v">12&#160;</span>Then all the assembly answered with a loud voice, “We must do as you have said concerning us. 
-<span class="v">13&#160;</span>But the people are many, and it is a time of much rain, and we are not able to stand outside. This is not a work of one day or two, for we have greatly transgressed in this matter. 
-<span class="v">14&#160;</span>Now let our princes be appointed for all the assembly, and let all those who are in our cities who have married foreign women come at appointed times, and with them the elders of every city and its judges, until the fierce wrath of our Elohim is turned from us, until this matter is resolved.” 
-</p><p>
-<span class="v">15&#160;</span>Only Jonathan the son of Asahel and Jahzeiah the son of Tikvah stood up against this; and Meshullam and Shabbethai the Levite helped them. 
-</p><p>
-<span class="v">16&#160;</span>The children of the captivity did so. Ezra the priest, with certain heads of fathers’ households, after their fathers’ houses, and all of them by their names, were set apart; and they sat down in the first day of the tenth month to examine the matter. 
-<span class="v">17&#160;</span>They finished with all the men who had married foreign women by the first day of the first month. 
-</p><p>
-<span class="v">18&#160;</span>Among the sons of the priests there were found who had married foreign women: 
-</p><p class="li1">of the sons of Jeshua, the son of Jozadak, and his brothers: Maaseiah, Eliezer, Jarib, and Gedaliah. 
-<span class="v">19&#160;</span>They gave their hand that they would put away their women; and being guilty, they offered a ram of the flock for their guilt. 
-</p><p class="li1">
-<span class="v">20&#160;</span>Of the sons of Immer: Hanani and Zebadiah. 
-</p><p class="li1">
-<span class="v">21&#160;</span>Of the sons of Harim: Maaseiah, Elijah, Shemaiah, Jehiel, and Uzziah. 
-</p><p class="li1">
-<span class="v">22&#160;</span>Of the sons of Pashhur: Elioenai, Maaseiah, Ishmael, Nethanel, Jozabad, and Elasah. 
-</p><p class="li1">
-<span class="v">23&#160;</span>Of the Levites: Jozabad, Shimei, Kelaiah (also called Kelita), Pethahiah, Judah, and Eliezer. 
-</p><p class="li1">
-<span class="v">24&#160;</span>Of the singers: Eliashib. 
-</p><p class="li1">Of the gatekeepers: Shallum, Telem, and Uri. 
-</p><p class="li1">
-<span class="v">25&#160;</span>Of Israel: Of the sons of Parosh: Ramiah, Izziah, Malchijah, Mijamin, Eleazar, Malchijah, and Benaiah. 
-</p><p class="li1">
-<span class="v">26&#160;</span>Of the sons of Elam: Mattaniah, Zechariah, Jehiel, Abdi, Jeremoth, and Elijah. 
-</p><p class="li1">
-<span class="v">27&#160;</span>Of the sons of Zattu: Elioenai, Eliashib, Mattaniah, Jeremoth, Zabad, and Aziza. 
-</p><p class="li1">
-<span class="v">28&#160;</span>Of the sons of Bebai: Jehohanan, Hananiah, Zabbai, and Athlai. 
-</p><p class="li1">
-<span class="v">29&#160;</span>Of the sons of Bani: Meshullam, Malluch, Adaiah, Jashub, Sheal, and Jeremoth. 
-</p><p class="li1">
-<span class="v">30&#160;</span>Of the sons of Pahathmoab: Adna, Chelal, Benaiah, Maaseiah, Mattaniah, Bezalel, Binnui, and Manasseh. 
-</p><p class="li1">
-<span class="v">31&#160;</span>Of the sons of Harim: Eliezer, Isshijah, Malchijah, Shemaiah, Shimeon, 
-<span class="v">32&#160;</span>Benjamin, Malluch, and Shemariah. 
-</p><p class="li1">
-<span class="v">33&#160;</span>Of the sons of Hashum: Mattenai, Mattattah, Zabad, Eliphelet, Jeremai, Manasseh, and Shimei. 
-</p><p class="li1">
-<span class="v">34&#160;</span>Of the sons of Bani: Maadai, Amram, Uel, 
-<span class="v">35&#160;</span>Benaiah, Bedeiah, Cheluhi, 
-<span class="v">36&#160;</span>Vaniah, Meremoth, Eliashib, 
-<span class="v">37&#160;</span>Mattaniah, Mattenai, Jaasu, 
-<span class="v">38&#160;</span>Bani, Binnui, Shimei, 
-<span class="v">39&#160;</span>Shelemiah, Nathan, Adaiah, 
-<span class="v">40&#160;</span>Machnadebai, Shashai, Sharai, 
-<span class="v">41&#160;</span>Azarel, Shelemiah, Shemariah, 
-<span class="v">42&#160;</span>Shallum, Amariah, and Joseph. 
-</p><p class="li1">
-<span class="v">43&#160;</span>Of the sons of Nebo: Jeiel, Mattithiah, Zabad, Zebina, Iddo, Joel, and Benaiah. 
-</p><p>
-<span class="v">44&#160;</span>All these had taken foreign women. Some of them had women by whom they had children. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now in the first year of Cyrus king of Persia, that Yahweh’s word by Jeremiah’s mouth might be accomplished, Yahweh stirred up the spirit of Cyrus king of Persia, so that he made a proclamation throughout all his kingdom, and put it also in writing, saying, 
+</div><div class="mi">
+<sup>2&#160;</sup>“Cyrus king of Persia says, ‘Yahweh, the Elohim of heaven, has given me all the kingdoms of the earth; and he has commanded me to build him a house in Jerusalem, which is in Judah. 
+<sup>3&#160;</sup>Whoever there is among you of all his people, may his Elohim be with him, and let him go up to Jerusalem, which is in Judah, and build the house of Yahweh, the Elohim of Israel (he is Elohim), which is in Jerusalem. 
+<sup>4&#160;</sup>Whoever is left, in any place where he lives, let the men of his place help him with silver, with gold, with goods, and with animals, in addition to the free will offering for Elohim’s house which is in Jerusalem.’&#160;” 
+</div><div class="p">
+<sup>5&#160;</sup>Then the heads of fathers’ households of Judah and Benjamin, the priests and the Levites, all whose spirit Elohim had stirred to go up, rose up to build Yahweh’s house which is in Jerusalem. 
+<sup>6&#160;</sup>All those who were around them strengthened their hands with vessels of silver, with gold, with goods, with animals, and with precious things, in addition to all that was willingly offered. 
+<sup>7&#160;</sup>Also Cyrus the king brought out the vessels of Yahweh’s house, which Nebuchadnezzar had brought out of Jerusalem, and had put in the house of his elohims; 
+<sup>8&#160;</sup>even those, Cyrus king of Persia brought out by the hand of Mithredath the treasurer, and counted them out to Sheshbazzar the prince of Judah. 
+<sup>9&#160;</sup>This is the number of them: thirty platters of gold, one thousand platters of silver, twenty-nine knives, 
+<sup>10&#160;</sup>thirty bowls of gold, four hundred ten silver bowls of a second kind, and one thousand other vessels. 
+<sup>11&#160;</sup>All the vessels of gold and of silver were five thousand four hundred. Sheshbazzar brought all these up when the captives were brought up from Babylon to Jerusalem. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the children of the province who went up out of the captivity of those who had been carried away, whom Nebuchadnezzar the king of Babylon had carried away to Babylon, and who returned to Jerusalem and Judah, everyone to his city; 
+<sup>2&#160;</sup>who came with Zerubbabel, Jeshua, Nehemiah, Seraiah, Reelaiah, Mordecai, Bilshan, Mispar, Bigvai, Rehum, and Baanah. 
+</div><div class="p">The number of the men of the people of Israel: 
+<sup>3&#160;</sup>The children of Parosh, two thousand one hundred seventy-two. 
+<sup>4&#160;</sup>The children of Shephatiah, three hundred seventy-two. 
+<sup>5&#160;</sup>The children of Arah, seven hundred seventy-five. 
+<sup>6&#160;</sup>The children of Pahathmoab, of the children of Jeshua and Joab, two thousand eight hundred twelve. 
+<sup>7&#160;</sup>The children of Elam, one thousand two hundred fifty-four. 
+<sup>8&#160;</sup>The children of Zattu, nine hundred forty-five. 
+<sup>9&#160;</sup>The children of Zaccai, seven hundred sixty. 
+<sup>10&#160;</sup>The children of Bani, six hundred forty-two. 
+<sup>11&#160;</sup>The children of Bebai, six hundred twenty-three. 
+<sup>12&#160;</sup>The children of Azgad, one thousand two hundred twenty-two. 
+<sup>13&#160;</sup>The children of Adonikam, six hundred sixty-six. 
+<sup>14&#160;</sup>The children of Bigvai, two thousand fifty-six. 
+<sup>15&#160;</sup>The children of Adin, four hundred fifty-four. 
+<sup>16&#160;</sup>The children of Ater, of Hezekiah, ninety-eight. 
+<sup>17&#160;</sup>The children of Bezai, three hundred twenty-three. 
+<sup>18&#160;</sup>The children of Jorah, one hundred twelve. 
+<sup>19&#160;</sup>The children of Hashum, two hundred twenty-three. 
+<sup>20&#160;</sup>The children of Gibbar, ninety-five. 
+<sup>21&#160;</sup>The children of Bethlehem, one hundred twenty-three. 
+<sup>22&#160;</sup>The men of Netophah, fifty-six. 
+<sup>23&#160;</sup>The men of Anathoth, one hundred twenty-eight. 
+<sup>24&#160;</sup>The children of Azmaveth, forty-two. 
+<sup>25&#160;</sup>The children of Kiriath Arim, Chephirah, and Beeroth, seven hundred forty-three. 
+<sup>26&#160;</sup>The children of Ramah and Geba, six hundred twenty-one. 
+<sup>27&#160;</sup>The men of Michmas, one hundred twenty-two. 
+<sup>28&#160;</sup>The men of Bethel and Ai, two hundred twenty-three. 
+<sup>29&#160;</sup>The children of Nebo, fifty-two. 
+<sup>30&#160;</sup>The children of Magbish, one hundred fifty-six. 
+<sup>31&#160;</sup>The children of the other Elam, one thousand two hundred fifty-four. 
+<sup>32&#160;</sup>The children of Harim, three hundred twenty. 
+<sup>33&#160;</sup>The children of Lod, Hadid, and Ono, seven hundred twenty-five. 
+<sup>34&#160;</sup>The children of Jericho, three hundred forty-five. 
+<sup>35&#160;</sup>The children of Senaah, three thousand six hundred thirty. 
+</div><div class="p">
+<sup>36&#160;</sup>The priests: the children of Jedaiah, of the house of Jeshua, nine hundred seventy-three. 
+<sup>37&#160;</sup>The children of Immer, one thousand fifty-two. 
+<sup>38&#160;</sup>The children of Pashhur, one thousand two hundred forty-seven. 
+<sup>39&#160;</sup>The children of Harim, one thousand seventeen. 
+</div><div class="p">
+<sup>40&#160;</sup>The Levites: the children of Jeshua and Kadmiel, of the children of Hodaviah, seventy-four. 
+<sup>41&#160;</sup>The singers: the children of Asaph, one hundred twenty-eight. 
+<sup>42&#160;</sup>The children of the gatekeepers: the children of Shallum, the children of Ater, the children of Talmon, the children of Akkub, the children of Hatita, the children of Shobai, in all one hundred thirty-nine. 
+</div><div class="p">
+<sup>43&#160;</sup>The temple servants: the children of Ziha, the children of Hasupha, the children of Tabbaoth, 
+<sup>44&#160;</sup>the children of Keros, the children of Siaha, the children of Padon, 
+<sup>45&#160;</sup>the children of Lebanah, the children of Hagabah, the children of Akkub, 
+<sup>46&#160;</sup>the children of Hagab, the children of Shamlai, the children of Hanan, 
+<sup>47&#160;</sup>the children of Giddel, the children of Gahar, the children of Reaiah, 
+<sup>48&#160;</sup>the children of Rezin, the children of Nekoda, the children of Gazzam, 
+<sup>49&#160;</sup>the children of Uzza, the children of Paseah, the children of Besai, 
+<sup>50&#160;</sup>the children of Asnah, the children of Meunim, the children of Nephisim, 
+<sup>51&#160;</sup>the children of Bakbuk, the children of Hakupha, the children of Harhur, 
+<sup>52&#160;</sup>the children of Bazluth, the children of Mehida, the children of Harsha, 
+<sup>53&#160;</sup>the children of Barkos, the children of Sisera, the children of Temah, 
+<sup>54&#160;</sup>the children of Neziah, the children of Hatipha. 
+</div><div class="p">
+<sup>55&#160;</sup>The children of Solomon’s servants: the children of Sotai, the children of Hassophereth, the children of Peruda, 
+<sup>56&#160;</sup>the children of Jaalah, the children of Darkon, the children of Giddel, 
+<sup>57&#160;</sup>the children of Shephatiah, the children of Hattil, the children of Pochereth Hazzebaim, the children of Ami. 
+<sup>58&#160;</sup>All the temple servants, and the children of Solomon’s servants, were three hundred ninety-two. 
+</div><div class="p">
+<sup>59&#160;</sup>These were those who went up from Tel Melah, Tel Harsha, Cherub, Addan, and Immer; but they could not show their fathers’ houses and their offspring, whether they were of Israel: 
+<sup>60&#160;</sup>the children of Delaiah, the children of Tobiah, the children of Nekoda, six hundred fifty-two. 
+<sup>61&#160;</sup>Of the children of the priests: the children of Habaiah, the children of Hakkoz, and the children of Barzillai, who took a woman of the daughters of Barzillai the Gileadite, and was called after their name. 
+<sup>62&#160;</sup>These sought their place among those who were registered by genealogy, but they were not found; therefore they were deemed disqualified and removed from the priesthood. 
+<sup>63&#160;</sup>The governor told them that they should not eat of the most set-apart things until a priest stood up to serve with Urim and with Thummim. 
+</div><div class="p">
+<sup>64&#160;</sup>The whole assembly together was forty-two thousand three hundred sixty, 
+<sup>65&#160;</sup>in addition to their male servants and their female servants, of whom there were seven thousand three hundred thirty-seven; and they had two hundred singing men and singing women. 
+<sup>66&#160;</sup>Their horses were seven hundred thirty-six; their mules, two hundred forty-five; 
+<sup>67&#160;</sup>their camels, four hundred thirty-five; their donkeys, six thousand seven hundred twenty. 
+</div><div class="p">
+<sup>68&#160;</sup>Some of the heads of fathers’ households, when they came to Yahweh’s house which is in Jerusalem, offered willingly for Elohim’s house to set it up in its place. 
+<sup>69&#160;</sup>They gave according to their ability into the treasury of the work sixty-one thousand darics of gold, of silver, and one hundred priests’ garments. 
+</div><div class="p">
+<sup>70&#160;</sup>So the priests and the Levites, with some of the people, the singers, the gatekeepers, and the temple servants, lived in their cities, and all Israel in their cities. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>When the seventh month had come, and the children of Israel were in the cities, the people gathered themselves together as one man to Jerusalem. 
+<sup>2&#160;</sup>Then Jeshua the son of Jozadak stood up with his brothers the priests and Zerubbabel the son of Shealtiel and his relatives, and built the altar of the Elohim of Israel, to offer burnt offerings on it, as it is written in the law of Moses the man of Elohim. 
+<sup>3&#160;</sup>In spite of their fear because of the peoples of the surrounding lands, they set the altar on its base; and they offered burnt offerings on it to Yahweh, even burnt offerings morning and evening. 
+<sup>4&#160;</sup>They kept the feast of booths, as it is written, and offered the daily burnt offerings by number, according to the ordinance, as the duty of every day required; 
+<sup>5&#160;</sup>and afterward the continual burnt offering, the offerings of the new moons, of all the set feasts of Yahweh that were consecrated, and of everyone who willingly offered a free will offering to Yahweh. 
+<sup>6&#160;</sup>From the first day of the seventh month, they began to offer burnt offerings to Yahweh; but the foundation of Yahweh’s temple was not yet laid. 
+<sup>7&#160;</sup>They also gave money to the masons and to the carpenters. They also gave food, drink, and oil to the people of Sidon and Tyre to bring cedar trees from Lebanon to the sea, to Joppa, according to the grant that they had from Cyrus King of Persia. 
+</div><div class="p">
+<sup>8&#160;</sup>Now in the second year of their coming to Elohim’s house at Jerusalem, in the second month, Zerubbabel the son of Shealtiel, Jeshua the son of Jozadak, and the rest of their brothers the priests and the Levites, and all those who had come out of the captivity to Jerusalem, began the work and appointed the Levites, from twenty years old and upward, to have the oversight of the work of Yahweh’s house. 
+<sup>9&#160;</sup>Then Jeshua stood with his sons and his brothers, Kadmiel and his sons, the sons of Judah, together to have the oversight of the workmen in Elohim’s house: the sons of Henadad, with their sons and their brothers the Levites. 
+</div><div class="p">
+<sup>10&#160;</sup>When the builders laid the foundation of Yahweh’s temple, they set the priests in their vestments with trumpets, with the Levites the sons of Asaph with cymbals, to praise Yahweh, according to the directions of David king of Israel. 
+<sup>11&#160;</sup>They sang to one another in praising and giving thanks to Yahweh, “For he is good, for his loving kindness endures forever toward Israel.” All the people shouted with a great shout, when they praised Yahweh, because the foundation of Yahweh’s house had been laid. 
+</div><div class="p">
+<sup>12&#160;</sup>But many of the priests and Levites and heads of fathers’ households, the old men who had seen the first house, when the foundation of this house was laid before their eyes, wept with a loud voice. Many also shouted aloud for joy, 
+<sup>13&#160;</sup>so that the people could not discern the noise of the shout of joy from the noise of the weeping of the people; for the people shouted with a loud shout, and the noise was heard far away. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when the adversaries of Judah and Benjamin heard that the children of the captivity were building a temple to Yahweh, the Elohim of Israel, 
+<sup>2&#160;</sup>they came near to Zerubbabel, and to the heads of fathers’ households, and said to them, “Let us build with you, for we seek your Elohim as you do; and we have been sacrificing to him since the days of Esar Haddon king of Assyria, who brought us up here.” 
+</div><div class="p">
+<sup>3&#160;</sup>But Zerubbabel, Jeshua, and the rest of the heads of fathers’ households of Israel said to them, “You have nothing to do with us in building a house to our Elohim; but we ourselves together will build to Yahweh, the Elohim of Israel, as King Cyrus the king of Persia has commanded us.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the people of the land weakened the hands of the people of Judah, and troubled them in building. 
+<sup>5&#160;</sup>They hired counselors against them to frustrate their purpose all the days of Cyrus king of Persia, even until the reign of Darius king of Persia. 
+<sup>6&#160;</sup>In the reign of Ahasuerus, in the beginning of his reign, they wrote an accusation against the inhabitants of Judah and Jerusalem. 
+</div><div class="p">
+<sup>7&#160;</sup>In the days of Artaxerxes, Bishlam, Mithredath, Tabeel, and the rest of his companions wrote to Artaxerxes king of Persia; and the writing of the letter was written in Syrian and delivered in the Syrian language. 
+<sup>8&#160;</sup>Rehum the chancellor and Shimshai the scribe wrote a letter against Jerusalem to Artaxerxes the king as follows. 
+<sup>9&#160;</sup>Then Rehum the chancellor, Shimshai the scribe, and the rest of their companions, the Dinaites, and the Apharsathchites, the Tarpelites, the Apharsites, the Archevites, the Babylonians, the Shushanchites, the Dehaites, the Elamites, 
+<sup>10&#160;</sup>and the rest of the nations whom the great and noble Osnappar brought over and settled in the city of Samaria, and in the rest of the country beyond the River, and so forth, wrote. 
+</div><div class="p">
+<sup>11&#160;</sup>This is the copy of the letter that they sent: 
+</div><div class="b"> &#160; </div>
+<div class="mi">To King Artaxerxes, from your servants, the people beyond the River. 
+</div><div class="pi1">
+<sup>12&#160;</sup>Be it known to the king that the Jews who came up from you have come to us to Jerusalem. They are building the rebellious and bad city, and have finished the walls and repaired the foundations. 
+<sup>13&#160;</sup>Be it known now to the king that if this city is built and the walls finished, they will not pay tribute, custom, or toll, and in the end it will be hurtful to the kings. 
+<sup>14&#160;</sup>Now because we eat the salt of the palace and it is not appropriate for us to see the king’s dishonor, therefore we have sent and informed the king, 
+<sup>15&#160;</sup>that search may be made in the book of the records of your fathers. You will see in the book of the records, and know that this city is a rebellious city, and hurtful to kings and provinces, and that they have started rebellions within it in the past. That is why this city was destroyed. 
+<sup>16&#160;</sup>We inform the king that if this city is built and the walls finished, then you will have no possession beyond the River. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>17&#160;</sup>Then the king sent an answer to Rehum the chancellor, and to Shimshai the scribe, and to the rest of their companions who live in Samaria, and in the rest of the country beyond the River: 
+</div><div class="b"> &#160; </div>
+<div class="mi">Peace. 
+</div><div class="b"> &#160; </div>
+<div class="pi1">
+<sup>18&#160;</sup>The letter which you sent to us has been plainly read before me. 
+<sup>19&#160;</sup>I decreed, and search has been made, and it was found that this city has made insurrection against kings in the past, and that rebellion and revolts have been made in it. 
+<sup>20&#160;</sup>There have also been mighty kings over Jerusalem who have ruled over all the country beyond the River; and tribute, custom, and toll was paid to them. 
+<sup>21&#160;</sup>Make a decree now to cause these men to cease, and that this city not be built until a decree is made by me. 
+<sup>22&#160;</sup>Be careful that you not be slack doing so. Why should damage grow to the hurt of the kings? 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>23&#160;</sup>Then when the copy of King Artaxerxes’ letter was read before Rehum, Shimshai the scribe, and their companions, they went in haste to Jerusalem to the Jews, and made them to cease by force of arms. 
+<sup>24&#160;</sup>Then work stopped on Elohim’s house which is at Jerusalem. It stopped until the second year of the reign of Darius king of Persia. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the prophets, Haggai the prophet and Zechariah the son of Iddo, prophesied to the Jews who were in Judah and Jerusalem. They prophesied to them in the name of the Elohim of Israel. 
+<sup>2&#160;</sup>Then Zerubbabel the son of Shealtiel, and Jeshua the son of Jozadak rose up and began to build Elohim’s house which is at Jerusalem; and with them were the prophets of Elohim, helping them. 
+</div><div class="p">
+<sup>3&#160;</sup>At the same time Tattenai, the governor beyond the River, came to them, with Shetharbozenai and their companions, and asked them, “Who gave you a decree to build this house and to finish this wall?” 
+<sup>4&#160;</sup>They also asked for the names of the men who were making this building. 
+<sup>5&#160;</sup>But the eye of their Elohim was on the elders of the Jews, and they didn’t make them cease until the matter should come to Darius, and an answer should be returned by letter concerning it. 
+</div><div class="p">
+<sup>6&#160;</sup>The copy of the letter that Tattenai, the governor beyond the River, and Shetharbozenai, and his companions the Apharsachites who were beyond the River, sent to Darius the king follows. 
+<sup>7&#160;</sup>They sent a letter to him, in which was written: 
+</div><div class="b"> &#160; </div>
+<div class="mi">To Darius the king, all peace. 
+</div><div class="pi1">
+<sup>8&#160;</sup>Be it known to the king that we went into the province of Judah, to the house of the great Elohim, which is being built with great stones and timber is laid in the walls. This work goes on with diligence and prospers in their hands. 
+<sup>9&#160;</sup>Then we asked those elders, and said to them thus, “Who gave you a decree to build this house, and to finish this wall?” 
+<sup>10&#160;</sup>We asked them their names also, to inform you that we might write the names of the men who were at their head. 
+<sup>11&#160;</sup>Thus they returned us answer, saying, “We are the servants of the Elohim of heaven and earth and are building the house that was built these many years ago, which a great king of Israel built and finished. 
+<sup>12&#160;</sup>But after our fathers had provoked the Elohim of heaven to wrath, he gave them into the hand of Nebuchadnezzar king of Babylon, the Chaldean, who destroyed this house and carried the people away into Babylon. 
+<sup>13&#160;</sup>But in the first year of Cyrus king of Babylon, Cyrus the king made a decree to build this house of Elohim. 
+<sup>14&#160;</sup>The gold and silver vessels of Elohim’s house, which Nebuchadnezzar took out of the temple that was in Jerusalem and brought into the temple of Babylon, those Cyrus the king also took out of the temple of Babylon, and they were delivered to one whose name was Sheshbazzar, whom he had made governor. 
+<sup>15&#160;</sup>He said to him, ‘Take these vessels, go, put them in the temple that is in Jerusalem, and let Elohim’s house be built in its place.’ 
+<sup>16&#160;</sup>Then the same Sheshbazzar came and laid the foundations of Elohim’s house which is in Jerusalem. Since that time even until now it has been being built, and yet it is not completed. 
+</div><div class="pi1">
+<sup>17&#160;</sup>Now therefore, if it seems good to the king, let a search be made in the king’s treasure house, which is there at Babylon, whether it is so that a decree was made by Cyrus the king to build this house of Elohim at Jerusalem; and let the king send his pleasure to us concerning this matter.” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Darius the king made a decree, and the house of the archives, where the treasures were laid up in Babylon, was searched. 
+<sup>2&#160;</sup>A scroll was found at Achmetha, in the palace that is in the province of Media, and in it this was written for a record: 
+</div><div class="b"> &#160; </div>
+<div class="pi1">
+<sup>3&#160;</sup>In the first year of Cyrus the king, Cyrus the king made a decree: Concerning Elohim’s house at Jerusalem, let the house be built, the place where they offer sacrifices, and let its foundations be strongly laid, with its height sixty cubits and its width sixty cubits; 
+<sup>4&#160;</sup>with three courses of great stones and a course of new timber. Let the expenses be given out of the king’s house. 
+<sup>5&#160;</sup>Also let the gold and silver vessels of Elohim’s house, which Nebuchadnezzar took out of the temple which is at Jerusalem and brought to Babylon, be restored and brought again to the temple which is at Jerusalem, everything to its place. You shall put them in Elohim’s house. 
+</div><div class="pi1">
+<sup>6&#160;</sup>Now therefore, Tattenai, governor beyond the River, Shetharbozenai, and your companions the Apharsachites, who are beyond the River, you must stay far from there. 
+<sup>7&#160;</sup>Leave the work of this house of Elohim alone; let the governor of the Jews and the elders of the Jews build this house of Elohim in its place. 
+<sup>8&#160;</sup>Moreover I make a decree regarding what you shall do for these elders of the Jews for the building of this house of Elohim: that of the king’s goods, even of the tribute beyond the River, expenses must be given with all diligence to these men, that they not be hindered. 
+<sup>9&#160;</sup>That which they have need of, including young bulls, rams, and lambs, for burnt offerings to the Elohim of heaven; also wheat, salt, wine, and oil, according to the word of the priests who are at Jerusalem, let it be given them day by day without fail, 
+<sup>10&#160;</sup>that they may offer sacrifices of pleasant aroma to the Elohim of heaven, and pray for the life of the king and of his sons. 
+<sup>11&#160;</sup>I have also made a decree that whoever alters this message, let a beam be pulled out from his house, and let him be lifted up and fastened on it; and let his house be made a dunghill for this. 
+<sup>12&#160;</sup>May the Elohim who has caused his name to dwell there overthrow all kings and peoples who stretch out their hand to alter this, to destroy this house of Elohim which is at Jerusalem. I Darius have made a decree. Let it be done with all diligence. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>13&#160;</sup>Then Tattenai, the governor beyond the River, Shetharbozenai, and their companions did accordingly with all diligence, because Darius the king had sent a decree. 
+</div><div class="p">
+<sup>14&#160;</sup>The elders of the Jews built and prospered, through the prophesying of Haggai the prophet and Zechariah the son of Iddo. They built and finished it, according to the commandment of the Elohim of Israel, and according to the decree of Cyrus, Darius, and Artaxerxes king of Persia. 
+<sup>15&#160;</sup>This house was finished on the third day of the month Adar, which was in the sixth year of the reign of Darius the king. 
+</div><div class="p">
+<sup>16&#160;</sup>The children of Israel, the priests, the Levites, and the rest of the children of the captivity, kept the dedication of this house of Elohim with joy. 
+<sup>17&#160;</sup>They offered at the dedication of this house of Elohim one hundred bulls, two hundred rams, four hundred lambs; and for a sin offering for all Israel, twelve male goats, according to the number of the tribes of Israel. 
+<sup>18&#160;</sup>They set the priests in their divisions and the Levites in their courses, for the service of Elohim which is at Jerusalem, as it is written in the book of Moses. 
+</div><div class="p">
+<sup>19&#160;</sup>The children of the captivity kept the Passover on the fourteenth day of the first month. 
+<sup>20&#160;</sup>Because the priests and the Levites had purified themselves together, all of them were pure. They killed the Passover for all the children of the captivity, for their brothers the priests, and for themselves. 
+<sup>21&#160;</sup>The children of Israel who had returned out of the captivity, and all who had separated themselves to them from the filthiness of the nations of the land to seek Yahweh, the Elohim of Israel, ate, 
+<sup>22&#160;</sup>and kept the feast of unleavened bread seven days with joy; because Yahweh had made them joyful, and had turned the heart of the king of Assyria to them, to strengthen their hands in the work of Elohim, the Elohim of Israel’s house. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Now after these things, in the reign of Artaxerxes king of Persia, Ezra the son of Seraiah, the son of Azariah, the son of Hilkiah, 
+<sup>2&#160;</sup>the son of Shallum, the son of Zadok, the son of Ahitub, 
+<sup>3&#160;</sup>the son of Amariah, the son of Azariah, the son of Meraioth, 
+<sup>4&#160;</sup>the son of Zerahiah, the son of Uzzi, the son of Bukki, 
+<sup>5&#160;</sup>the son of Abishua, the son of Phinehas, the son of Eleazar, the son of Aaron the chief priest—<sup>6&#160;</sup>this Ezra went up from Babylon. He was a skilled scribe in the law of Moses, which Yahweh, the Elohim of Israel, had given; and the king granted him all his request, according to Yahweh his Elohim’s hand on him. 
+<sup>7&#160;</sup>Some of the children of Israel, including some of the priests, the Levites, the singers, the gatekeepers, and the temple servants went up to Jerusalem in the seventh year of Artaxerxes the king. 
+<sup>8&#160;</sup>He came to Jerusalem in the fifth month, which was in the seventh year of the king. 
+<sup>9&#160;</sup>For on the first day of the first month he began to go up from Babylon; and on the first day of the fifth month he came to Jerusalem, according to the good hand of his Elohim on him. 
+<sup>10&#160;</sup>For Ezra had set his heart to seek Yahweh’s law, and to do it, and to teach statutes and ordinances in Israel. 
+</div><div class="p">
+<sup>11&#160;</sup>Now this is the copy of the letter that King Artaxerxes gave to Ezra the priest, the scribe, even the scribe of the words of Yahweh’s commandments, and of his statutes to Israel: 
+</div><div class="b"> &#160; </div>
+<div class="mi">
+<sup>12&#160;</sup>Artaxerxes, king of kings, 
+</div><div class="mi">To Ezra the priest, the scribe of the law of the perfect Elohim of heaven. 
+</div><div class="pi1">Now 
+<sup>13&#160;</sup>I make a decree that all those of the people of Israel and their priests and the Levites in my realm, who intend of their own free will to go to Jerusalem, go with you. 
+<sup>14&#160;</sup>Because you are sent by the king and his seven counselors to inquire concerning Judah and Jerusalem, according to the law of your Elohim which is in your hand, 
+<sup>15&#160;</sup>and to carry the silver and gold, which the king and his counselors have freely offered to the Elohim of Israel, whose habitation is in Jerusalem, 
+<sup>16&#160;</sup>and all the silver and gold that you will find in all the province of Babylon, with the free will offering of the people and of the priests, offering willingly for the house of their Elohim which is in Jerusalem. 
+<sup>17&#160;</sup>Therefore you shall with all diligence buy with this money bulls, rams, and lambs with their meal offerings and their drink offerings, and shall offer them on the altar of the house of your Elohim which is in Jerusalem. 
+<sup>18&#160;</sup>Whatever seems good to you and to your brothers to do with the rest of the silver and the gold, do that according to the will of your Elohim. 
+<sup>19&#160;</sup>The vessels that are given to you for the service of the house of your Elohim, deliver before the Elohim of Jerusalem. 
+<sup>20&#160;</sup>Whatever more will be needed for the house of your Elohim, which you may have occasion to give, give it out of the king’s treasure house. 
+</div><div class="pi1">
+<sup>21&#160;</sup>I, even I, Artaxerxes the king, make a decree to all the treasurers who are beyond the River, that whatever Ezra the priest, the scribe of the law of the Elohim of heaven, requires of you, it shall be done with all diligence, 
+<sup>22&#160;</sup>up to one hundred talents of wine, and to one hundred baths of oil, and salt without prescribing how much. 
+<sup>23&#160;</sup>Whatever is commanded by the Elohim of heaven, let it be done exactly for the house of the Elohim of heaven; for why should there be wrath against the realm of the king and his sons? 
+</div><div class="pi1">
+<sup>24&#160;</sup>Also we inform you that it shall not be lawful to impose tribute, custom, or toll on any of the priests, Levites, singers, gatekeepers, temple servants, or laborers of this house of Elohim. 
+</div><div class="pi1">
+<sup>25&#160;</sup>You, Ezra, according to the wisdom of your Elohim that is in your hand, appoint magistrates and judges who may judge all the people who are beyond the River, who all know the laws of your Elohim; and teach him who doesn’t know them. 
+<sup>26&#160;</sup>Whoever will not do the law of your Elohim and the law of the king, let judgment be executed on him with all diligence, whether it is to death, or to banishment, or to confiscation of goods, or to imprisonment. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>27&#160;</sup>Blessed be Yahweh, the Elohim of our fathers, who has put such a thing as this in the king’s heart, to beautify Yahweh’s house which is in Jerusalem; 
+<sup>28&#160;</sup>and has extended loving kindness to me before the king and his counselors, and before all the king’s mighty princes. I was strengthened according to Yahweh my Elohim’s hand on me, and I gathered together chief men out of Israel to go up with me. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the heads of their fathers’ households, and this is the genealogy of those who went up with me from Babylon, in the reign of Artaxerxes the king: 
+</div><div class="li1">
+<sup>2&#160;</sup>Of the sons of Phinehas, Gershom. 
+</div><div class="li1">Of the sons of Ithamar, Daniel. 
+</div><div class="li1">Of the sons of David, Hattush. 
+</div><div class="li1">
+<sup>3&#160;</sup>Of the sons of Shecaniah, of the sons of Parosh, Zechariah; and with him were listed by genealogy of the males one hundred fifty. 
+</div><div class="li1">
+<sup>4&#160;</sup>Of the sons of Pahathmoab, Eliehoenai the son of Zerahiah; and with him two hundred males. 
+</div><div class="li1">
+<sup>5&#160;</sup>Of the sons of Shecaniah, the son of Jahaziel; and with him three hundred males. 
+</div><div class="li1">
+<sup>6&#160;</sup>Of the sons of Adin, Ebed the son of Jonathan; and with him fifty males. 
+</div><div class="li1">
+<sup>7&#160;</sup>Of the sons of Elam, Jeshaiah the son of Athaliah; and with him seventy males. 
+</div><div class="li1">
+<sup>8&#160;</sup>Of the sons of Shephatiah, Zebadiah the son of Michael; and with him eighty males. 
+</div><div class="li1">
+<sup>9&#160;</sup>Of the sons of Joab, Obadiah the son of Jehiel; and with him two hundred eighteen males. 
+</div><div class="li1">
+<sup>10&#160;</sup>Of the sons of Shelomith, the son of Josiphiah; and with him one hundred sixty males. 
+</div><div class="li1">
+<sup>11&#160;</sup>Of the sons of Bebai, Zechariah the son of Bebai; and with him twenty-eight males. 
+</div><div class="li1">
+<sup>12&#160;</sup>Of the sons of Azgad, Johanan the son of Hakkatan; and with him one hundred ten males. 
+</div><div class="li1">
+<sup>13&#160;</sup>Of the sons of Adonikam, who were the last, their names are: Eliphelet, Jeuel, and Shemaiah; and with them sixty males. 
+</div><div class="li1">
+<sup>14&#160;</sup>Of the sons of Bigvai, Uthai and Zabbud; and with them seventy males. 
+</div><div class="p">
+<sup>15&#160;</sup>I gathered them together to the river that runs to Ahava; and there we encamped three days. Then I looked around at the people and the priests, and found there were none of the sons of Levi. 
+<sup>16&#160;</sup>Then I sent for Eliezer, for Ariel, for Shemaiah, for Elnathan, for Jarib, for Elnathan, for Nathan, for Zechariah, and for Meshullam, chief men; also for Joiarib and for Elnathan, who were teachers. 
+<sup>17&#160;</sup>I sent them out to Iddo the chief at the place Casiphia; and I told them what they should tell Iddo and his brothers the temple servants at the place Casiphia, that they should bring to us ministers for the house of our Elohim. 
+<sup>18&#160;</sup>According to the good hand of our Elohim on us they brought us a man of discretion, of the sons of Mahli, the son of Levi, the son of Israel, namely Sherebiah, with his sons and his brothers, eighteen; 
+<sup>19&#160;</sup>and Hashabiah, and with him Jeshaiah of the sons of Merari, his brothers and their sons, twenty; 
+<sup>20&#160;</sup>and of the temple servants, whom David and the princes had given for the service of the Levites, two hundred twenty temple servants. All of them were mentioned by name. 
+</div><div class="p">
+<sup>21&#160;</sup>Then I proclaimed a fast there at the river Ahava, that we might humble ourselves before our Elohim, to seek from him a straight way for us, for our little ones, and for all our possessions. 
+<sup>22&#160;</sup>For I was ashamed to ask of the king a band of soldiers and horsemen to help us against the enemy on the way, because we had spoken to the king, saying, “The hand of our Elohim is on all those who seek him, for good; but his power and his wrath is against all those who forsake him.” 
+<sup>23&#160;</sup>So we fasted and begged our Elohim for this, and he granted our request. 
+</div><div class="p">
+<sup>24&#160;</sup>Then I set apart twelve of the chiefs of the priests, even Sherebiah, Hashabiah, and ten of their brothers with them, 
+<sup>25&#160;</sup>and weighed to them the silver, the gold, and the vessels, even the offering for the house of our Elohim, which the king, his counselors, his princes, and all Israel there present, had offered. 
+<sup>26&#160;</sup>I weighed into their hand six hundred fifty talents of silver, one hundred talents of silver vessels, one hundred talents of gold, 
+<sup>27&#160;</sup>twenty bowls of gold weighing one thousand darics, and two vessels of fine bright bronze, precious as gold. 
+<sup>28&#160;</sup>I said to them, “You are set-apart to Yahweh, and the vessels are set-apart. The silver and the gold are a free will offering to Yahweh, the Elohim of your fathers. 
+<sup>29&#160;</sup>Watch and keep them until you weigh them before the chiefs of the priests, the Levites, and the princes of the fathers’ households of Israel at Jerusalem, in the rooms of Yahweh’s house.” 
+</div><div class="p">
+<sup>30&#160;</sup>So the priests and the Levites received the weight of the silver, the gold, and the vessels, to bring them to Jerusalem to the house of our Elohim. 
+</div><div class="p">
+<sup>31&#160;</sup>Then we departed from the river Ahava on the twelfth day of the first month, to go to Jerusalem. The hand of our Elohim was on us, and he delivered us from the hand of the enemy and the bandits by the way. 
+<sup>32&#160;</sup>We came to Jerusalem, and stayed there three days. 
+<sup>33&#160;</sup>On the fourth day the silver and the gold and the vessels were weighed in the house of our Elohim into the hand of Meremoth the son of Uriah the priest; and with him was Eleazar the son of Phinehas; and with them were Jozabad the son of Jeshua, and Noadiah the son of Binnui, the Levites. 
+<sup>34&#160;</sup>Everything was counted and weighed; and all the weight was written at that time. 
+</div><div class="p">
+<sup>35&#160;</sup>The children of the captivity, who had come out of exile, offered burnt offerings to the Elohim of Israel: twelve bulls for all Israel, ninety-six rams, seventy-seven lambs, and twelve male goats for a sin offering. All this was a burnt offering to Yahweh. 
+<sup>36&#160;</sup>They delivered the king’s commissions to the king’s local governors and to the governors beyond the River. So they supported the people and Elohim’s house. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when these things were done, the princes came near to me, saying, “The people of Israel, the priests, and the Levites have not separated themselves from the peoples of the lands, following their abominations, even those of the Canaanites, the Hittites, the Perizzites, the Jebusites, the Ammonites, the Moabites, the Egyptians, and the Amorites. 
+<sup>2&#160;</sup>For they have taken of their daughters for themselves and for their sons, so that the set-apart offspring have mixed themselves with the peoples of the lands. Yes, the hand of the princes and rulers has been chief in this trespass.” 
+</div><div class="p">
+<sup>3&#160;</sup>When I heard this thing, I tore my garment and my robe, and pulled the hair out of my head and of my beard, and sat down confounded. 
+<sup>4&#160;</sup>Then everyone who trembled at the words of the Elohim of Israel were assembled to me because of the trespass of the exiles; and I sat confounded until the evening offering. 
+</div><div class="p">
+<sup>5&#160;</sup>At the evening offering I rose up from my humiliation, even with my garment and my robe torn; and I fell on my knees, and spread out my hands to Yahweh my Elohim; 
+<sup>6&#160;</sup>and I said, “My Elohim, I am ashamed and blush to lift up my face to you, my Elohim, for our iniquities have increased over our head, and our guiltiness has grown up to the heavens. 
+<sup>7&#160;</sup>Since the days of our fathers we have been exceedingly guilty to this day; and for our iniquities we, our kings, and our priests have been delivered into the hand of the kings of the lands, to the sword, to captivity, to plunder, and to confusion of face, as it is this day. 
+<sup>8&#160;</sup>Now for a little moment grace has been shown from Yahweh our Elohim, to leave us a remnant to escape, and to give us a stake in his set-apart place, that our Elohim may lighten our eyes, and revive us a little in our bondage. 
+<sup>9&#160;</sup>For we are bondservants; yet our Elohim has not forsaken us in our bondage, but has extended loving kindness to us in the sight of the kings of Persia, to revive us, to set up the house of our Elohim, and to repair its ruins, and to give us a wall in Judah and in Jerusalem. 
+</div><div class="p">
+<sup>10&#160;</sup>“Now, our Elohim, what shall we say after this? For we have forsaken your commandments, 
+<sup>11&#160;</sup>which you have commanded by your servants the prophets, saying, ‘The land to which you go to possess is an unclean land through the uncleanness of the peoples of the lands, through their abominations, which have filled it from one end to another with their filthiness. 
+<sup>12&#160;</sup>Now therefore don’t give your daughters to their sons. Don’t take their daughters to your sons, nor seek their peace or their prosperity forever, that you may be strong and eat the good of the land, and leave it for an inheritance to your children forever.’ 
+</div><div class="p">
+<sup>13&#160;</sup>“After all that has come on us for our evil deeds and for our great guilt, since you, our Elohim, have punished us less than our iniquities deserve, and have given us such a remnant, 
+<sup>14&#160;</sup>shall we again break your commandments, and join ourselves with the peoples that do these abominations? Wouldn’t you be angry with us until you had consumed us, so that there would be no remnant, nor any to escape? 
+<sup>15&#160;</sup>Yahweh, the Elohim of Israel, you are righteous; for we are left a remnant that has escaped, as it is today. Behold, we are before you in our guiltiness; for no one can stand before you because of this.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Now while Ezra prayed and made confession, weeping and casting himself down before Elohim’s house, there was gathered together to him out of Israel a very great assembly of men and women and children; for the people wept very bitterly. 
+<sup>2&#160;</sup>Shecaniah the son of Jehiel, one of the sons of Elam, answered Ezra, “We have trespassed against our Elohim, and have married foreign women of the peoples of the land. Yet now there is hope for Israel concerning this thing. 
+<sup>3&#160;</sup>Now therefore let’s make a covenant with our Elohim to put away all the women and those who are born of them, according to the counsel of my lord and of those who tremble at the commandment of our Elohim. Let it be done according to the law. 
+<sup>4&#160;</sup>Arise, for the matter belongs to you and we are with you. Be courageous, and do it.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then Ezra arose, and made the chiefs of the priests, the Levites, and all Israel to swear that they would do according to this word. So they swore. 
+<sup>6&#160;</sup>Then Ezra rose up from before Elohim’s house, and went into the room of Jehohanan the son of Eliashib. When he came there, he didn’t eat bread or drink water, for he mourned because of the trespass of the exiles. 
+<sup>7&#160;</sup>They made a proclamation throughout Judah and Jerusalem to all the children of the captivity, that they should gather themselves together to Jerusalem; 
+<sup>8&#160;</sup>and that whoever didn’t come within three days, according to the counsel of the princes and the elders, all his possessions should be forfeited, and he himself separated from the assembly of the captivity. 
+</div><div class="p">
+<sup>9&#160;</sup>Then all the men of Judah and Benjamin gathered themselves together to Jerusalem within the three days. It was the ninth month, on the twentieth day of the month; and all the people sat in the wide place in front of Elohim’s house, trembling because of this matter, and because of the great rain. 
+</div><div class="p">
+<sup>10&#160;</sup>Ezra the priest stood up and said to them, “You have trespassed, and have married foreign women, increasing the guilt of Israel. 
+<sup>11&#160;</sup>Now therefore make confession to Yahweh, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then all the assembly answered with a loud voice, “We must do as you have said concerning us. 
+<sup>13&#160;</sup>But the people are many, and it is a time of much rain, and we are not able to stand outside. This is not a work of one day or two, for we have greatly transgressed in this matter. 
+<sup>14&#160;</sup>Now let our princes be appointed for all the assembly, and let all those who are in our cities who have married foreign women come at appointed times, and with them the elders of every city and its judges, until the fierce wrath of our Elohim is turned from us, until this matter is resolved.” 
+</div><div class="p">
+<sup>15&#160;</sup>Only Jonathan the son of Asahel and Jahzeiah the son of Tikvah stood up against this; and Meshullam and Shabbethai the Levite helped them. 
+</div><div class="p">
+<sup>16&#160;</sup>The children of the captivity did so. Ezra the priest, with certain heads of fathers’ households, after their fathers’ houses, and all of them by their names, were set apart; and they sat down in the first day of the tenth month to examine the matter. 
+<sup>17&#160;</sup>They finished with all the men who had married foreign women by the first day of the first month. 
+</div><div class="p">
+<sup>18&#160;</sup>Among the sons of the priests there were found who had married foreign women: 
+</div><div class="li1">of the sons of Jeshua, the son of Jozadak, and his brothers: Maaseiah, Eliezer, Jarib, and Gedaliah. 
+<sup>19&#160;</sup>They gave their hand that they would put away their women; and being guilty, they offered a ram of the flock for their guilt. 
+</div><div class="li1">
+<sup>20&#160;</sup>Of the sons of Immer: Hanani and Zebadiah. 
+</div><div class="li1">
+<sup>21&#160;</sup>Of the sons of Harim: Maaseiah, Elijah, Shemaiah, Jehiel, and Uzziah. 
+</div><div class="li1">
+<sup>22&#160;</sup>Of the sons of Pashhur: Elioenai, Maaseiah, Ishmael, Nethanel, Jozabad, and Elasah. 
+</div><div class="li1">
+<sup>23&#160;</sup>Of the Levites: Jozabad, Shimei, Kelaiah (also called Kelita), Pethahiah, Judah, and Eliezer. 
+</div><div class="li1">
+<sup>24&#160;</sup>Of the singers: Eliashib. 
+</div><div class="li1">Of the gatekeepers: Shallum, Telem, and Uri. 
+</div><div class="li1">
+<sup>25&#160;</sup>Of Israel: Of the sons of Parosh: Ramiah, Izziah, Malchijah, Mijamin, Eleazar, Malchijah, and Benaiah. 
+</div><div class="li1">
+<sup>26&#160;</sup>Of the sons of Elam: Mattaniah, Zechariah, Jehiel, Abdi, Jeremoth, and Elijah. 
+</div><div class="li1">
+<sup>27&#160;</sup>Of the sons of Zattu: Elioenai, Eliashib, Mattaniah, Jeremoth, Zabad, and Aziza. 
+</div><div class="li1">
+<sup>28&#160;</sup>Of the sons of Bebai: Jehohanan, Hananiah, Zabbai, and Athlai. 
+</div><div class="li1">
+<sup>29&#160;</sup>Of the sons of Bani: Meshullam, Malluch, Adaiah, Jashub, Sheal, and Jeremoth. 
+</div><div class="li1">
+<sup>30&#160;</sup>Of the sons of Pahathmoab: Adna, Chelal, Benaiah, Maaseiah, Mattaniah, Bezalel, Binnui, and Manasseh. 
+</div><div class="li1">
+<sup>31&#160;</sup>Of the sons of Harim: Eliezer, Isshijah, Malchijah, Shemaiah, Shimeon, 
+<sup>32&#160;</sup>Benjamin, Malluch, and Shemariah. 
+</div><div class="li1">
+<sup>33&#160;</sup>Of the sons of Hashum: Mattenai, Mattattah, Zabad, Eliphelet, Jeremai, Manasseh, and Shimei. 
+</div><div class="li1">
+<sup>34&#160;</sup>Of the sons of Bani: Maadai, Amram, Uel, 
+<sup>35&#160;</sup>Benaiah, Bedeiah, Cheluhi, 
+<sup>36&#160;</sup>Vaniah, Meremoth, Eliashib, 
+<sup>37&#160;</sup>Mattaniah, Mattenai, Jaasu, 
+<sup>38&#160;</sup>Bani, Binnui, Shimei, 
+<sup>39&#160;</sup>Shelemiah, Nathan, Adaiah, 
+<sup>40&#160;</sup>Machnadebai, Shashai, Sharai, 
+<sup>41&#160;</sup>Azarel, Shelemiah, Shemariah, 
+<sup>42&#160;</sup>Shallum, Amariah, and Joseph. 
+</div><div class="li1">
+<sup>43&#160;</sup>Of the sons of Nebo: Jeiel, Mattithiah, Zabad, Zebina, Iddo, Joel, and Benaiah. 
+</div><div class="p">
+<sup>44&#160;</sup>All these had taken foreign women. Some of them had women by whom they had children. </div></div><script src="../main.js"></script></body></html>

--- a/book/genesis.html
+++ b/book/genesis.html
@@ -3,6 +3,47 @@
 <head>
 <title>Genesis</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,2233 +53,2284 @@
 <div class="main">
 <!-- GEN World English Scripture (WES) -->
 <h1 class="booklabel">Genesis</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>In the beginning, Elohim<span class="f">+ \fr 1:1 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> created the heavens and the earth. 
-<span class="v">2&#160;</span>The earth was formless and empty. Darkness was on the surface of the deep and Elohim’s Spirit was hovering over the surface of the waters. 
-</p><p>
-<span class="v">3&#160;</span>Elohim said, “Let there be light,” and there was light. 
-<span class="v">4&#160;</span>Elohim saw the light, and saw that it was good. Elohim divided the light from the darkness. 
-<span class="v">5&#160;</span>Elohim called the light “day”, and the darkness he called “night”. There was evening and there was morning, the first day. 
-</p><p>
-<span class="v">6&#160;</span>Elohim said, “Let there be an expanse in the middle of the waters, and let it divide the waters from the waters.” 
-<span class="v">7&#160;</span>Elohim made the expanse, and divided the waters which were under the expanse from the waters which were above the expanse; and it was so. 
-<span class="v">8&#160;</span>Elohim called the expanse “sky”. There was evening and there was morning, a second day. 
-</p><p>
-<span class="v">9&#160;</span>Elohim said, “Let the waters under the sky be gathered together to one place, and let the dry land appear;” and it was so. 
-<span class="v">10&#160;</span>Elohim called the dry land “earth”, and the gathering together of the waters he called “seas”. Elohim saw that it was good. 
-<span class="v">11&#160;</span>Elohim said, “Let the earth yield grass, herbs yielding seeds, and fruit trees bearing fruit after their kind, with their seeds in it, on the earth;” and it was so. 
-<span class="v">12&#160;</span>The earth yielded grass, herbs yielding seed after their kind, and trees bearing fruit, with their seeds in it, after their kind; and Elohim saw that it was good. 
-<span class="v">13&#160;</span>There was evening and there was morning, a third day. 
-</p><p>
-<span class="v">14&#160;</span>Elohim said, “Let there be lights in the expanse of the sky to divide the day from the night; and let them be for signs to mark seasons, days, and years; 
-<span class="v">15&#160;</span>and let them be for lights in the expanse of the sky to give light on the earth;” and it was so. 
-<span class="v">16&#160;</span>Elohim made the two great lights: the greater light to rule the day, and the lesser light to rule the night. He also made the stars. 
-<span class="v">17&#160;</span>Elohim set them in the expanse of the sky to give light to the earth, 
-<span class="v">18&#160;</span>and to rule over the day and over the night, and to divide the light from the darkness. Elohim saw that it was good. 
-<span class="v">19&#160;</span>There was evening and there was morning, a fourth day. 
-</p><p>
-<span class="v">20&#160;</span>Elohim said, “Let the waters abound with living creatures, and let birds fly above the earth in the open expanse of the sky.” 
-<span class="v">21&#160;</span>Elohim created the large sea creatures and every living creature that moves, with which the waters swarmed, after their kind, and every winged bird after its kind. Elohim saw that it was good. 
-<span class="v">22&#160;</span>Elohim blessed them, saying, “Be fruitful, and multiply, and fill the waters in the seas, and let birds multiply on the earth.” 
-<span class="v">23&#160;</span>There was evening and there was morning, a fifth day. 
-</p><p>
-<span class="v">24&#160;</span>Elohim said, “Let the earth produce living creatures after their kind, livestock, creeping things, and animals of the earth after their kind;” and it was so. 
-<span class="v">25&#160;</span>Elohim made the animals of the earth after their kind, and the livestock after their kind, and everything that creeps on the ground after its kind. Elohim saw that it was good. 
-</p><p>
-<span class="v">26&#160;</span>Elohim said, “Let’s make man in our image, after our likeness. Let them have dominion over the fish of the sea, and over the birds of the sky, and over the livestock, and over all the earth, and over every creeping thing that creeps on the earth.” 
-<span class="v">27&#160;</span>Elohim created man in his own image. In Elohim’s image he created him; male and female he created them. 
-<span class="v">28&#160;</span>Elohim blessed them. Elohim said to them, “Be fruitful, multiply, fill the earth, and subdue it. Have dominion over the fish of the sea, over the birds of the sky, and over every living thing that moves on the earth.” 
-<span class="v">29&#160;</span>Elohim said, “Behold,<span class="f">+ \fr 1:29 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I have given you every herb yielding seed, which is on the surface of all the earth, and every tree, which bears fruit yielding seed. It will be your food. 
-<span class="v">30&#160;</span>To every animal of the earth, and to every bird of the sky, and to everything that creeps on the earth, in which there is life, I have given every green herb for food;” and it was so. 
-</p><p>
-<span class="v">31&#160;</span>Elohim saw everything that he had made, and, behold, it was very good. There was evening and there was morning, a sixth day. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>The heavens, the earth, and all their vast array were finished. 
-<span class="v">2&#160;</span>On the seventh day Elohim finished his work which he had done; and he rested on the seventh day from all his work which he had done. 
-<span class="v">3&#160;</span>Elohim blessed the seventh day, and made it set-apart, because he rested in it from all his work of creation which he had done. 
-</p><p>
-<span class="v">4&#160;</span>This is the history of the generations of the heavens and of the earth when they were created, in the day that Yahweh<span class="f">+ \fr 2:4 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> Elohim made the earth and the heavens. 
-<span class="v">5&#160;</span>No plant of the field was yet in the earth, and no herb of the field had yet sprung up; for Yahweh Elohim had not caused it to rain on the earth. There was not a man to till the ground, 
-<span class="v">6&#160;</span>but a mist went up from the earth, and watered the whole surface of the ground. 
-<span class="v">7&#160;</span>Yahweh Elohim formed man from the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul. 
-<span class="v">8&#160;</span>Yahweh Elohim planted a garden eastward, in Eden, and there he put the man whom he had formed. 
-<span class="v">9&#160;</span>Out of the ground Yahweh Elohim made every tree to grow that is pleasant to the sight, and good for food, including the tree of life in the middle of the garden and the tree of the knowledge of good and evil. 
-<span class="v">10&#160;</span>A river went out of Eden to water the garden; and from there it was parted, and became the source of four rivers. 
-<span class="v">11&#160;</span>The name of the first is Pishon: it flows through the whole land of Havilah, where there is gold; 
-<span class="v">12&#160;</span>and the gold of that land is good. Bdellium<span class="f">+ \fr 2:12 \ft or, aromatic resin</span> and onyx stone are also there. 
-<span class="v">13&#160;</span>The name of the second river is Gihon. It is the same river that flows through the whole land of Cush. 
-<span class="v">14&#160;</span>The name of the third river is Hiddekel. This is the one which flows in front of Assyria. The fourth river is the Euphrates. 
-<span class="v">15&#160;</span>Yahweh Elohim took the man, and put him into the garden of Eden to cultivate and keep it. 
-<span class="v">16&#160;</span>Yahweh Elohim commanded the man, saying, “You may freely eat of every tree of the garden; 
-<span class="v">17&#160;</span>but you shall not eat of the tree of the knowledge of good and evil; for in the day that you eat of it, you will surely die.” 
-</p><p>
-<span class="v">18&#160;</span>Yahweh Elohim said, “It is not good for the man to be alone. I will make him a helper comparable to<span class="f">+ \fr 2:18 \ft or, suitable for, or appropriate for.</span> him.” 
-<span class="v">19&#160;</span>Out of the ground Yahweh Elohim formed every animal of the field, and every bird of the sky, and brought them to the man to see what he would call them. Whatever the man called every living creature became its name. 
-<span class="v">20&#160;</span>The man gave names to all livestock, and to the birds of the sky, and to every animal of the field; but for man there was not found a helper comparable to him. 
-<span class="v">21&#160;</span>Yahweh Elohim caused the man to fall into a deep sleep. As the man slept, he took one of his ribs, and closed up the flesh in its place. 
-<span class="v">22&#160;</span>Yahweh Elohim made a woman from the rib which he had taken from the man, and brought her to the man. 
-<span class="v">23&#160;</span>The man said, “This is now bone of my bones, and flesh of my flesh. She will be called ‘woman,’ because she was taken out of Man.” 
-<span class="v">24&#160;</span>Therefore a man will leave his father and his mother, and will join with his woman, and they will be one flesh. 
-<span class="v">25&#160;</span>The man and his woman were both naked, and they were not ashamed. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now the serpent was more subtle than any animal of the field which Yahweh Elohim had made. He said to the woman, “Has Elohim really said, ‘You shall not eat of any tree of the garden’?” 
-</p><p>
-<span class="v">2&#160;</span>The woman said to the serpent, “We may eat fruit from the trees of the garden, 
-<span class="v">3&#160;</span>but not the fruit of the tree which is in the middle of the garden. Elohim has said, ‘You shall not eat of it. You shall not touch it, lest you die.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>The serpent said to the woman, “You won’t really die, 
-<span class="v">5&#160;</span>for Elohim knows that in the day you eat it, your eyes will be opened, and you will be like Elohim, knowing good and evil.” 
-</p><p>
-<span class="v">6&#160;</span>When the woman saw that the tree was good for food, and that it was a delight to the eyes, and that the tree was to be desired to make one wise, she took some of its fruit, and ate. Then she gave some to her man with her, and he ate it, too. 
-<span class="v">7&#160;</span>Their eyes were opened, and they both knew that they were naked. They sewed fig leaves together, and made coverings for themselves. 
-<span class="v">8&#160;</span>They heard Yahweh Elohim’s voice walking in the garden in the cool of the day, and the man and his woman hid themselves from the presence of Yahweh Elohim among the trees of the garden. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh Elohim called to the man, and said to him, “Where are you?” 
-</p><p>
-<span class="v">10&#160;</span>The man said, “I heard your voice in the garden, and I was afraid, because I was naked; so I hid myself.” 
-</p><p>
-<span class="v">11&#160;</span>Elohim said, “Who told you that you were naked? Have you eaten from the tree that I commanded you not to eat from?” 
-</p><p>
-<span class="v">12&#160;</span>The man said, “The woman whom you gave to be with me, she gave me fruit from the tree, and I ate it.” 
-</p><p>
-<span class="v">13&#160;</span>Yahweh Elohim said to the woman, “What have you done?” 
-</p><p>The woman said, “The serpent deceived me, and I ate.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh Elohim said to the serpent, 
-</p><p class="q1">“Because you have done this, 
-</p><p class="q2">you are cursed above all livestock, 
-</p><p class="q2">and above every animal of the field. 
-</p><p class="q1">You shall go on your belly 
-</p><p class="q2">and you shall eat dust all the days of your life. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will put hostility between you and the woman, 
-</p><p class="q2">and between your offspring and her offspring. 
-</p><p class="q1">He will bruise your head, 
-</p><p class="q2">and you will bruise his heel.” 
-</p><p>
-<span class="v">16&#160;</span>To the woman he said, 
-</p><p class="q1">“I will greatly multiply your pain in childbirth. 
-</p><p class="q2">You will bear children in pain. 
-</p><p class="q1">Your desire will be for your man, 
-</p><p class="q2">and he will rule over you.” 
-</p><p>
-<span class="v">17&#160;</span>To Adam he said, 
-</p><p class="q1">“Because you have listened to your woman’s voice, 
-</p><p class="q2">and have eaten from the tree, 
-</p><p class="q2">about which I commanded you, saying, ‘You shall not eat of it,’ 
-</p><p class="q2">the ground is cursed for your sake. 
-</p><p class="q1">You will eat from it with much labor all the days of your life. 
-</p><p class="q2">
-<span class="v">18&#160;</span>It will yield thorns and thistles to you; 
-</p><p class="q2">and you will eat the herb of the field. 
-</p><p class="q1">
-<span class="v">19&#160;</span>You will eat bread by the sweat of your face until you return to the ground, 
-</p><p class="q2">for you were taken out of it. 
-</p><p class="q1">For you are dust, 
-</p><p class="q2">and you shall return to dust.” 
-</p><p>
-<span class="v">20&#160;</span>The man called his woman Eve because she would be the mother of all the living. 
-<span class="v">21&#160;</span>Yahweh Elohim made garments of animal skins for Adam and for his woman, and clothed them. 
-</p><p>
-<span class="v">22&#160;</span>Yahweh Elohim said, “Behold, the man has become like one of us, knowing good and evil. Now, lest he reach out his hand, and also take of the tree of life, and eat, and live forever—” 
-<span class="v">23&#160;</span>Therefore Yahweh Elohim sent him out from the garden of Eden, to till the ground from which he was taken. 
-<span class="v">24&#160;</span>So he drove out the man; and he placed cherubim<span class="f">+ \fr 3:24 \ft cherubim are powerful angelic creatures, messengers of Elohim with wings. See Ezekiel 10.</span> at the east of the garden of Eden, and a flaming sword which turned every way, to guard the way to the tree of life. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>The man knew<span class="f">+ \fr 4:1 \ft or, lay with, or, had relations with</span> Eve his woman. She conceived,<span class="f">+ \fr 4:1 \ft or, became pregnant</span> and gave birth to Cain, and said, “I have gotten a man with Yahweh’s help.” 
-<span class="v">2&#160;</span>Again she gave birth, to Cain’s brother Abel. Abel was a keeper of sheep, but Cain was a tiller of the ground. 
-<span class="v">3&#160;</span>As time passed, Cain brought an offering to Yahweh from the fruit of the ground. 
-<span class="v">4&#160;</span>Abel also brought some of the firstborn of his flock and of its fat. Yahweh respected Abel and his offering, 
-<span class="v">5&#160;</span>but he didn’t respect Cain and his offering. Cain was very angry, and the expression on his face fell. 
-<span class="v">6&#160;</span>Yahweh said to Cain, “Why are you angry? Why has the expression of your face fallen? 
-<span class="v">7&#160;</span>If you do well, won’t it be lifted up? If you don’t do well, sin crouches at the door. Its desire is for you, but you are to rule over it.” 
-<span class="v">8&#160;</span>Cain said to Abel, his brother, “Let’s go into the field.” While they were in the field, Cain rose up against Abel, his brother, and killed him. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh said to Cain, “Where is Abel, your brother?” 
-</p><p>He said, “I don’t know. Am I my brother’s keeper?” 
-</p><p>
-<span class="v">10&#160;</span>Yahweh said, “What have you done? The voice of your brother’s blood cries to me from the ground. 
-<span class="v">11&#160;</span>Now you are cursed because of the ground, which has opened its mouth to receive your brother’s blood from your hand. 
-<span class="v">12&#160;</span>From now on, when you till the ground, it won’t yield its strength to you. You will be a fugitive and a wanderer in the earth.” 
-</p><p>
-<span class="v">13&#160;</span>Cain said to Yahweh, “My punishment is greater than I can bear. 
-<span class="v">14&#160;</span>Behold, you have driven me out today from the surface of the ground. I will be hidden from your face, and I will be a fugitive and a wanderer in the earth. Whoever finds me will kill me.” 
-</p><p>
-<span class="v">15&#160;</span>Yahweh said to him, “Therefore whoever slays Cain, vengeance will be taken on him sevenfold.” Yahweh appointed a sign for Cain, so that anyone finding him would not strike him. 
-</p><p>
-<span class="v">16&#160;</span>Cain left Yahweh’s presence, and lived in the land of Nod, east of Eden. 
-<span class="v">17&#160;</span>Cain knew his woman. She conceived, and gave birth to Enoch. He built a city, and named the city after the name of his son, Enoch. 
-<span class="v">18&#160;</span>Irad was born to Enoch. Irad brought forth Mehujael. Mehujael brought forth Methushael. Methushael brought forth Lamech. 
-<span class="v">19&#160;</span>Lamech took two women: the name of the first one was Adah, and the name of the second one was Zillah. 
-<span class="v">20&#160;</span>Adah gave birth to Jabal, who was the father of those who dwell in tents and have livestock. 
-<span class="v">21&#160;</span>His brother’s name was Jubal, who was the father of all who handle the harp and pipe. 
-<span class="v">22&#160;</span>Zillah also gave birth to Tubal Cain, the forger of every cutting instrument of bronze and iron. Tubal Cain’s sister was Naamah. 
-<span class="v">23&#160;</span>Lamech said to his women, 
-</p><p class="q1">“Adah and Zillah, hear my voice. 
-</p><p class="q2">You women of Lamech, listen to my speech, 
-</p><p class="q1">for I have slain a man for wounding me, 
-</p><p class="q2">a young man for bruising me. 
-</p><p class="q1">
-<span class="v">24&#160;</span>If Cain will be avenged seven times, 
-</p><p class="q2">truly Lamech seventy-seven times.” 
-</p><p>
-<span class="v">25&#160;</span>Adam knew his woman again. She gave birth to a son, and named him Seth, saying, “for Elohim has given me another child instead of Abel, for Cain killed him.” 
-<span class="v">26&#160;</span>A son was also born to Seth, and he named him Enosh. At that time men began to call on Yahweh’s name. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>This is the book of the generations of Adam. In the day that Elohim created man, he made him in Elohim’s likeness. 
-<span class="v">2&#160;</span>He created them male and female, and blessed them. On the day they were created, he named them Adam.<span class="f">+ \fr 5:2 \ft “Adam” and “Man” are spelled with the exact same consonants in Hebrew, so this can be correctly translated either way.</span> 
-<span class="v">3&#160;</span>Adam lived two hundred thirty years, and brought forth a son in his own likeness, after his image, and named him Seth. 
-<span class="v">4&#160;</span>The days of Adam after he brought forth Seth were seven hundred years, and he brought forth other sons and daughters. 
-<span class="v">5&#160;</span>All the days that Adam lived were nine hundred thirty years, then he died. 
-</p><p>
-<span class="v">6&#160;</span>Seth lived two hundred five years, then brought forth Enosh. 
-<span class="v">7&#160;</span>Seth lived after he brought forth Enosh seven hundred seven years, and brought forth other sons and daughters. 
-<span class="v">8&#160;</span>All of the days of Seth were nine hundred twelve years, then he died. 
-</p><p>
-<span class="v">9&#160;</span>Enosh lived one hundred ninety years, and brought forth Kenan. 
-<span class="v">10&#160;</span>Enosh lived after he brought forth Kenan seven hundred fifteen years, and brought forth other sons and daughters. 
-<span class="v">11&#160;</span>All of the days of Enosh were nine hundred five years, then he died. 
-</p><p>
-<span class="v">12&#160;</span>Kenan lived one hundred seventy years, then brought forth Mahalalel. 
-<span class="v">13&#160;</span>Kenan lived after he brought forth Mahalalel seven hundred forty years, and brought forth other sons and daughters 
-<span class="v">14&#160;</span>and all of the days of Kenan were nine hundred ten years, then he died. 
-</p><p>
-<span class="v">15&#160;</span>Mahalalel lived one hundred sixty-five years, then brought forth Jared. 
-<span class="v">16&#160;</span>Mahalalel lived after he brought forth Jared seven hundred thirty years, and brought forth other sons and daughters. 
-<span class="v">17&#160;</span>All of the days of Mahalalel were eight hundred ninety-five years, then he died. 
-</p><p>
-<span class="v">18&#160;</span>Jared lived one hundred sixty-two years, then brought forth Enoch. 
-<span class="v">19&#160;</span>Jared lived after he brought forth Enoch eight hundred years, and brought forth other sons and daughters. 
-<span class="v">20&#160;</span>All of the days of Jared were nine hundred sixty-two years, then he died. 
-</p><p>
-<span class="v">21&#160;</span>Enoch lived one hundred sixty-five years, then brought forth Methuselah. 
-<span class="v">22&#160;</span>After Methuselah’s birth, Enoch walked with Elohim for two hundred years, and brought forth more sons and daughters. 
-<span class="v">23&#160;</span>All the days of Enoch were three hundred sixty-five years. 
-<span class="v">24&#160;</span>Enoch walked with Elohim, and he was not found, for Elohim took him. 
-</p><p>
-<span class="v">25&#160;</span>Methuselah lived one hundred eighty-seven years, then brought forth Lamech. 
-<span class="v">26&#160;</span>Methuselah lived after he brought forth Lamech seven hundred eighty-two years, and brought forth other sons and daughters. 
-<span class="v">27&#160;</span>All the days of Methuselah were nine hundred sixty-nine years, then he died. 
-</p><p>
-<span class="v">28&#160;</span>Lamech lived one hundred eighty-two years, then brought forth a son. 
-<span class="v">29&#160;</span>He named him Noah, saying, “This one will comfort us in our work and in the toil of our hands, caused by the ground which Yahweh has cursed.” 
-<span class="v">30&#160;</span>Lamech lived after he brought forth Noah five hundred ninety-five years, and brought forth other sons and daughters. 
-<span class="v">31&#160;</span>All the days of Lamech were seven hundred seventy-seven years, then he died. 
-</p><p>
-<span class="v">32&#160;</span>Noah was five hundred years old, then Noah brought forth Shem, Ham, and Japheth. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>When men began to multiply on the surface of the ground, and daughters were born to them, 
-<span class="v">2&#160;</span>Elohim’s sons saw that men’s daughters were beautiful, and they took any that they wanted for themselves as women. 
-<span class="v">3&#160;</span>Yahweh said, “My Spirit will not strive with man forever, because he also is flesh; so his days will be one hundred twenty years.” 
-<span class="v">4&#160;</span>The Nephilim<span class="f">+ \fr 6:4 \ft or, giants</span> were in the earth in those days, and also after that, when Elohim’s sons came in to men’s daughters and had children with them. Those were the mighty men who were of old, men of renown. 
-</p><p>
-<span class="v">5&#160;</span>Yahweh saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of man’s heart was continually only evil. 
-<span class="v">6&#160;</span>Yahweh was sorry that he had made man on the earth, and it grieved him in his heart. 
-<span class="v">7&#160;</span>Yahweh said, “I will destroy man whom I have created from the surface of the ground—man, along with animals, creeping things, and birds of the sky—for I am sorry that I have made them.” 
-<span class="v">8&#160;</span>But Noah found favor in Yahweh’s eyes. 
-</p><p>
-<span class="v">9&#160;</span>This is the history of the generations of Noah: Noah was a righteous man, blameless among the people of his time. Noah walked with Elohim. 
-<span class="v">10&#160;</span>Noah brought forth three sons: Shem, Ham, and Japheth. 
-<span class="v">11&#160;</span>The earth was corrupt before Elohim, and the earth was filled with violence. 
-<span class="v">12&#160;</span>Elohim saw the earth, and saw that it was corrupt, for all flesh had corrupted their way on the earth. 
-</p><p>
-<span class="v">13&#160;</span>Elohim said to Noah, “I will bring an end to all flesh, for the earth is filled with violence through them. Behold, I will destroy them and the earth. 
-<span class="v">14&#160;</span>Make a ship of gopher wood. You shall make rooms in the ship, and shall seal it inside and outside with pitch. 
-<span class="v">15&#160;</span>This is how you shall make it. The length of the ship shall be three hundred cubits,<span class="f">+ \fr 6:15 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> its width fifty cubits, and its height thirty cubits. 
-<span class="v">16&#160;</span>You shall make a roof in the ship, and you shall finish it to a cubit upward. You shall set the door of the ship in its side. You shall make it with lower, second, and third levels. 
-<span class="v">17&#160;</span>I, even I, will bring the flood of waters on this earth, to destroy all flesh having the breath of life from under the sky. Everything that is in the earth will die. 
-<span class="v">18&#160;</span>But I will establish my covenant with you. You shall come into the ship, you, your sons, your woman, and your sons’ women with you. 
-<span class="v">19&#160;</span>Of every living thing of all flesh, you shall bring two of every sort into the ship, to keep them alive with you. They shall be male and female. 
-<span class="v">20&#160;</span>Of the birds after their kind, of the livestock after their kind, of every creeping thing of the ground after its kind, two of every sort will come to you, to keep them alive. 
-<span class="v">21&#160;</span>Take with you some of all food that is eaten, and gather it to yourself; and it will be for food for you, and for them.” 
-<span class="v">22&#160;</span>Thus Noah did. He did all that Elohim commanded him. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Noah, “Come with all of your household into the ship, for I have seen your righteousness before me in this generation. 
-<span class="v">2&#160;</span>You shall take seven pairs of every clean animal with you, the male and his female. Of the animals that are not clean, take two, the male and his female. 
-<span class="v">3&#160;</span>Also of the birds of the sky, seven and seven, male and female, to keep seed alive on the surface of all the earth. 
-<span class="v">4&#160;</span>In seven days, I will cause it to rain on the earth for forty days and forty nights. I will destroy every living thing that I have made from the surface of the ground.” 
-</p><p>
-<span class="v">5&#160;</span>Noah did everything that Yahweh commanded him. 
-</p><p>
-<span class="v">6&#160;</span>Noah was six hundred years old when the flood of waters came on the earth. 
-<span class="v">7&#160;</span>Noah went into the ship with his sons, his woman, and his sons’ women, because of the floodwaters. 
-<span class="v">8&#160;</span>Clean animals, unclean animals, birds, and everything that creeps on the ground 
-<span class="v">9&#160;</span>went by pairs to Noah into the ship, male and female, as Elohim commanded Noah. 
-<span class="v">10&#160;</span>After the seven days, the floodwaters came on the earth. 
-<span class="v">11&#160;</span>In the six hundredth year of Noah’s life, in the second month, on the seventeenth day of the month, on that day all the fountains of the great deep burst open, and the sky’s windows opened. 
-<span class="v">12&#160;</span>It rained on the earth forty days and forty nights. 
-</p><p>
-<span class="v">13&#160;</span>In the same day Noah, and Shem, Ham, and Japheth—the sons of Noah—and Noah’s woman and the three women of his sons with them, entered into the ship—<span class="v">14&#160;</span>they, and every animal after its kind, all the livestock after their kind, every creeping thing that creeps on the earth after its kind, and every bird after its kind, every bird of every sort. 
-<span class="v">15&#160;</span>Pairs from all flesh with the breath of life in them went into the ship to Noah. 
-<span class="v">16&#160;</span>Those who went in, went in male and female of all flesh, as Elohim commanded him; then Yahweh shut him in. 
-<span class="v">17&#160;</span>The flood was forty days on the earth. The waters increased, and lifted up the ship, and it was lifted up above the earth. 
-<span class="v">18&#160;</span>The waters rose, and increased greatly on the earth; and the ship floated on the surface of the waters. 
-<span class="v">19&#160;</span>The waters rose very high on the earth. All the high mountains that were under the whole sky were covered. 
-<span class="v">20&#160;</span>The waters rose fifteen cubits<span class="f">+ \fr 7:20 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> higher, and the mountains were covered. 
-<span class="v">21&#160;</span>All flesh died that moved on the earth, including birds, livestock, animals, every creeping thing that creeps on the earth, and every man. 
-<span class="v">22&#160;</span>All on the dry land, in whose nostrils was the breath of the spirit of life, died. 
-<span class="v">23&#160;</span>Every living thing was destroyed that was on the surface of the ground, including man, livestock, creeping things, and birds of the sky. They were destroyed from the earth. Only Noah was left, and those who were with him in the ship. 
-<span class="v">24&#160;</span>The waters flooded the earth one hundred fifty days. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Elohim remembered Noah, all the animals, and all the livestock that were with him in the ship; and Elohim made a wind to pass over the earth. The waters subsided. 
-<span class="v">2&#160;</span>The deep’s fountains and the sky’s windows were also stopped, and the rain from the sky was restrained. 
-<span class="v">3&#160;</span>The waters continually receded from the earth. After the end of one hundred fifty days the waters receded. 
-<span class="v">4&#160;</span>The ship rested in the seventh month, on the seventeenth day of the month, on Ararat’s mountains. 
-<span class="v">5&#160;</span>The waters receded continually until the tenth month. In the tenth month, on the first day of the month, the tops of the mountains were visible. 
-</p><p>
-<span class="v">6&#160;</span>At the end of forty days, Noah opened the window of the ship which he had made, 
-<span class="v">7&#160;</span>and he sent out a raven. It went back and forth, until the waters were dried up from the earth. 
-<span class="v">8&#160;</span>He himself sent out a dove to see if the waters were abated from the surface of the ground, 
-<span class="v">9&#160;</span>but the dove found no place to rest her foot, and she returned into the ship to him, for the waters were on the surface of the whole earth. He put out his hand, and took her, and brought her to him into the ship. 
-<span class="v">10&#160;</span>He waited yet another seven days; and again he sent the dove out of the ship. 
-<span class="v">11&#160;</span>The dove came back to him at evening and, behold, in her mouth was a freshly plucked olive leaf. So Noah knew that the waters were abated from the earth. 
-<span class="v">12&#160;</span>He waited yet another seven days, and sent out the dove; and she didn’t return to him any more. 
-</p><p>
-<span class="v">13&#160;</span>In the six hundred first year, in the first month, the first day of the month, the waters were dried up from the earth. Noah removed the covering of the ship, and looked. He saw that the surface of the ground was dry. 
-<span class="v">14&#160;</span>In the second month, on the twenty-seventh day of the month, the earth was dry. 
-</p><p>
-<span class="v">15&#160;</span>Elohim spoke to Noah, saying, 
-<span class="v">16&#160;</span>“Go out of the ship, you, your woman, your sons, and your sons’ women with you. 
-<span class="v">17&#160;</span>Bring out with you every living thing that is with you of all flesh, including birds, livestock, and every creeping thing that creeps on the earth, that they may breed abundantly in the earth, and be fruitful, and multiply on the earth.” 
-</p><p>
-<span class="v">18&#160;</span>Noah went out, with his sons, his woman, and his sons’ women with him. 
-<span class="v">19&#160;</span>Every animal, every creeping thing, and every bird, whatever moves on the earth, after their families, went out of the ship. 
-</p><p>
-<span class="v">20&#160;</span>Noah built an altar to Yahweh, and took of every clean animal, and of every clean bird, and offered burnt offerings on the altar. 
-<span class="v">21&#160;</span>Yahweh smelled the pleasant aroma. Yahweh said in his heart, “I will not again curse the ground any more for man’s sake because the imagination of man’s heart is evil from his youth. I will never again strike every living thing, as I have done. 
-<span class="v">22&#160;</span>While the earth remains, seed time and harvest, and cold and heat, and summer and winter, and day and night will not cease.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Elohim blessed Noah and his sons, and said to them, “Be fruitful, multiply, and replenish the earth. 
-<span class="v">2&#160;</span>The fear of you and the dread of you will be on every animal of the earth, and on every bird of the sky. Everything that moves along the ground, and all the fish of the sea, are delivered into your hand. 
-<span class="v">3&#160;</span>Every moving thing that lives will be food for you. As I gave you the green herb, I have given everything to you. 
-<span class="v">4&#160;</span>But flesh with its life, that is, its blood, you shall not eat. 
-<span class="v">5&#160;</span>I will surely require accounting for your life’s blood. At the hand of every animal I will require it. At the hand of man, even at the hand of every man’s brother, I will require the life of man. 
-<span class="v">6&#160;</span>Whoever sheds man’s blood, his blood will be shed by man, for Elohim made man in his own image. 
-<span class="v">7&#160;</span>Be fruitful and multiply. Increase abundantly in the earth, and multiply in it.” 
-</p><p>
-<span class="v">8&#160;</span>Elohim spoke to Noah and to his sons with him, saying, 
-<span class="v">9&#160;</span>“As for me, behold, I establish my covenant with you, and with your offspring after you, 
-<span class="v">10&#160;</span>and with every living creature that is with you: the birds, the livestock, and every animal of the earth with you, of all that go out of the ship, even every animal of the earth. 
-<span class="v">11&#160;</span>I will establish my covenant with you: All flesh will not be cut off any more by the waters of the flood. There will never again be a flood to destroy the earth.” 
-<span class="v">12&#160;</span>Elohim said, “This is the token of the covenant which I make between me and you and every living creature that is with you, for perpetual generations: 
-<span class="v">13&#160;</span>I set my rainbow in the cloud, and it will be a sign of a covenant between me and the earth. 
-<span class="v">14&#160;</span>When I bring a cloud over the earth, that the rainbow will be seen in the cloud, 
-<span class="v">15&#160;</span>I will remember my covenant, which is between me and you and every living creature of all flesh, and the waters will no more become a flood to destroy all flesh. 
-<span class="v">16&#160;</span>The rainbow will be in the cloud. I will look at it, that I may remember the everlasting covenant between Elohim and every living creature of all flesh that is on the earth.” 
-<span class="v">17&#160;</span>Elohim said to Noah, “This is the token of the covenant which I have established between me and all flesh that is on the earth.” 
-</p><p>
-<span class="v">18&#160;</span>The sons of Noah who went out from the ship were Shem, Ham, and Japheth. Ham is the father of Canaan. 
-<span class="v">19&#160;</span>These three were the sons of Noah, and from these the whole earth was populated. 
-</p><p>
-<span class="v">20&#160;</span>Noah began to be a farmer, and planted a vineyard. 
-<span class="v">21&#160;</span>He drank of the wine and got drunk. He was uncovered within his tent. 
-<span class="v">22&#160;</span>Ham, the father of Canaan, saw the nakedness of his father, and told his two brothers outside. 
-<span class="v">23&#160;</span>Shem and Japheth took a garment, and laid it on both their shoulders, went in backwards, and covered the nakedness of their father. Their faces were backwards, and they didn’t see their father’s nakedness. 
-<span class="v">24&#160;</span>Noah awoke from his wine, and knew what his youngest son had done to him. 
-<span class="v">25&#160;</span>He said, 
-</p><p class="q1">“Canaan is cursed. 
-</p><p class="q2">He will be a servant of servants to his brothers.” 
-</p><p>
-<span class="v">26&#160;</span>He said, 
-</p><p class="q1">“Blessed be Yahweh, the Elohim of Shem. 
-</p><p class="q2">Let Canaan be his servant. 
-</p><p class="q1">
-<span class="v">27&#160;</span>May Elohim enlarge Japheth. 
-</p><p class="q2">Let him dwell in the tents of Shem. 
-</p><p class="q2">Let Canaan be his servant.” 
-</p><p>
-<span class="v">28&#160;</span>Noah lived three hundred fifty years after the flood. 
-<span class="v">29&#160;</span>All the days of Noah were nine hundred fifty years, and then he died. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Now this is the history of the generations of the sons of Noah and of Shem, Ham, and Japheth. Sons were born to them after the flood. 
-</p><p>
-<span class="v">2&#160;</span>The sons of Japheth were: Gomer, Magog, Madai, Javan, Tubal, Meshech, and Tiras. 
-<span class="v">3&#160;</span>The sons of Gomer were: Ashkenaz, Riphath, and Togarmah. 
-<span class="v">4&#160;</span>The sons of Javan were: Elishah, Tarshish, Kittim, and Dodanim. 
-<span class="v">5&#160;</span>Of these were the islands of the nations divided in their lands, everyone after his language, after their families, in their nations. 
-</p><p>
-<span class="v">6&#160;</span>The sons of Ham were: Cush, Mizraim, Put, and Canaan. 
-<span class="v">7&#160;</span>The sons of Cush were: Seba, Havilah, Sabtah, Raamah, and Sabteca. The sons of Raamah were: Sheba and Dedan. 
-<span class="v">8&#160;</span>Cush brought forth Nimrod. He began to be a mighty one in the earth. 
-<span class="v">9&#160;</span>He was a mighty hunter before Yahweh. Therefore it is said, “like Nimrod, a mighty hunter before Yahweh”. 
-<span class="v">10&#160;</span>The beginning of his kingdom was Babel, Erech, Accad, and Calneh, in the land of Shinar. 
-<span class="v">11&#160;</span>Out of that land he went into Assyria, and built Nineveh, Rehoboth Ir, Calah, 
-<span class="v">12&#160;</span>and Resen between Nineveh and the great city Calah. 
-<span class="v">13&#160;</span>Mizraim brought forth Ludim, Anamim, Lehabim, Naphtuhim, 
-<span class="v">14&#160;</span>Pathrusim, Casluhim (which the Philistines descended from), and Caphtorim. 
-</p><p>
-<span class="v">15&#160;</span>Canaan brought forth Sidon (his firstborn), Heth, 
-<span class="v">16&#160;</span>the Jebusites, the Amorites, the Girgashites, 
-<span class="v">17&#160;</span>the Hivites, the Arkites, the Sinites, 
-<span class="v">18&#160;</span>the Arvadites, the Zemarites, and the Hamathites. Afterward the families of the Canaanites were spread abroad. 
-<span class="v">19&#160;</span>The border of the Canaanites was from Sidon—as you go toward Gerar—to Gaza—as you go toward Sodom, Gomorrah, Admah, and Zeboiim—to Lasha. 
-<span class="v">20&#160;</span>These are the sons of Ham, after their families, according to their languages, in their lands and their nations. 
-</p><p>
-<span class="v">21&#160;</span>Children were also born to Shem (the elder brother of Japheth), the father of all the children of Eber. 
-<span class="v">22&#160;</span>The sons of Shem were: Elam, Asshur, Arpachshad, Lud, and Aram. 
-<span class="v">23&#160;</span>The sons of Aram were: Uz, Hul, Gether, and Mash. 
-<span class="v">24&#160;</span>Arpachshad brought forth Cainan. Cainan brought forth Shelah. Shelah brought forth Eber. 
-<span class="v">25&#160;</span>To Eber were born two sons. The name of the one was Peleg, for in his days the earth was divided. His brother’s name was Joktan. 
-<span class="v">26&#160;</span>Joktan brought forth Almodad, Sheleph, Hazarmaveth, Jerah, 
-<span class="v">27&#160;</span>Hadoram, Uzal, Diklah, 
-<span class="v">28&#160;</span>Obal, Abimael, Sheba, 
-<span class="v">29&#160;</span>Ophir, Havilah, and Jobab. All these were the sons of Joktan. 
-<span class="v">30&#160;</span>Their dwelling extended from Mesha, as you go toward Sephar, the mountain of the east. 
-<span class="v">31&#160;</span>These are the sons of Shem, by their families, according to their languages, lands, and nations. 
-</p><p>
-<span class="v">32&#160;</span>These are the families of the sons of Noah, by their generations, according to their nations. The nations divided from these in the earth after the flood. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>The whole earth was of one language and of one speech. 
-<span class="v">2&#160;</span>As they traveled east,<span class="f">+ \fr 11:2 \ft LXX reads “from the east”.</span> they found a plain in the land of Shinar, and they lived there. 
-<span class="v">3&#160;</span>They said to one another, “Come, let’s make bricks, and burn them thoroughly.” They had brick for stone, and they used tar for mortar. 
-<span class="v">4&#160;</span>They said, “Come, let’s build ourselves a city, and a tower whose top reaches to the sky, and let’s make a name for ourselves, lest we be scattered abroad on the surface of the whole earth.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh came down to see the city and the tower, which the children of men built. 
-<span class="v">6&#160;</span>Yahweh said, “Behold, they are one people, and they all have one language, and this is what they begin to do. Now nothing will be withheld from them, which they intend to do. 
-<span class="v">7&#160;</span>Come, let’s go down, and there confuse their language, that they may not understand one another’s speech.” 
-<span class="v">8&#160;</span>So Yahweh scattered them abroad from there on the surface of all the earth. They stopped building the city. 
-<span class="v">9&#160;</span>Therefore its name was called Babel, because there Yahweh confused the language of all the earth. From there, Yahweh scattered them abroad on the surface of all the earth. 
-</p><p>
-<span class="v">10&#160;</span>This is the history of the generations of Shem: Shem was one hundred years old when he brought forth Arpachshad two years after the flood. 
-<span class="v">11&#160;</span>Shem lived five hundred years after he brought forth Arpachshad, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">12&#160;</span>Arpachshad lived one hundred thirty-five years and brought forth Cainan. 
-<span class="v">13&#160;</span>Arpachshad lived four hundred thirty years after he brought forth Cainan, and brought forth more sons and daughters. Cainan lived one hundred thirty years, and brought forth Shelah. Cainan lived three hundred thirty years after he brought forth Shelah, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">14&#160;</span>Shelah lived one hundred thirty years, and brought forth Eber. 
-<span class="v">15&#160;</span>Shelah lived four hundred three years after he brought forth Eber, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">16&#160;</span>Eber lived one hundred thirty-four years, and brought forth Peleg. 
-<span class="v">17&#160;</span>Eber lived three hundred seventy years after he brought forth Peleg, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">18&#160;</span>Peleg lived one hundred thirty years, and brought forth Reu. 
-<span class="v">19&#160;</span>Peleg lived two hundred nine years after he brought forth Reu, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">20&#160;</span>Reu lived one hundred thirty-two years, and brought forth Serug. 
-<span class="v">21&#160;</span>Reu lived two hundred seven years after he brought forth Serug, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">22&#160;</span>Serug lived one hundred thirty years, and brought forth Nahor. 
-<span class="v">23&#160;</span>Serug lived two hundred years after he brought forth Nahor, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">24&#160;</span>Nahor lived seventy-nine years, and brought forth Terah. 
-<span class="v">25&#160;</span>Nahor lived one hundred twenty-nine years after he brought forth Terah, and brought forth more sons and daughters. 
-</p><p>
-<span class="v">26&#160;</span>Terah lived seventy years, and brought forth Abram, Nahor, and Haran. 
-</p><p>
-<span class="v">27&#160;</span>Now this is the history of the generations of Terah. Terah brought forth Abram, Nahor, and Haran. Haran brought forth Lot. 
-<span class="v">28&#160;</span>Haran died in the land of his birth, in Ur of the Chaldees, while his father Terah was still alive. 
-<span class="v">29&#160;</span>Abram and Nahor married women. The name of Abram’s woman was Sarai, and the name of Nahor’s woman was Milcah, the daughter of Haran, who was also the father of Iscah. 
-<span class="v">30&#160;</span>Sarai was barren. She had no child. 
-<span class="v">31&#160;</span>Terah took Abram his son, Lot the son of Haran, his son’s son, and Sarai his daughter-in-law, his son Abram’s woman. They went from Ur of the Chaldees, to go into the land of Canaan. They came to Haran and lived there. 
-<span class="v">32&#160;</span>The days of Terah were two hundred five years. Terah died in Haran. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Now Yahweh said to Abram, “Leave your country, and your relatives, and your father’s house, and go to the land that I will show you. 
-<span class="v">2&#160;</span>I will make of you a great nation. I will bless you and make your name great. You will be a blessing. 
-<span class="v">3&#160;</span>I will bless those who bless you, and I will curse him who treats you with contempt. All the families of the earth will be blessed through you.” 
-</p><p>
-<span class="v">4&#160;</span>So Abram went, as Yahweh had told him. Lot went with him. Abram was seventy-five years old when he departed from Haran. 
-<span class="v">5&#160;</span>Abram took Sarai his woman, Lot his brother’s son, all their possessions that they had gathered, and the people whom they had acquired in Haran, and they went to go into the land of Canaan. They entered into the land of Canaan. 
-<span class="v">6&#160;</span>Abram passed through the land to the place of Shechem, to the oak of Moreh. At that time, Canaanites were in the land. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh appeared to Abram and said, “I will give this land to your offspring.”<span class="f">+ \fr 12:7 \ft or, seed</span> 
-</p><p>He built an altar there to Yahweh, who had appeared to him. 
-<span class="v">8&#160;</span>He left from there to go to the mountain on the east of Bethel and pitched his tent, having Bethel on the west, and Ai on the east. There he built an altar to Yahweh and called on Yahweh’s name. 
-<span class="v">9&#160;</span>Abram traveled, still going on toward the South. 
-</p><p>
-<span class="v">10&#160;</span>There was a famine in the land. Abram went down into Egypt to live as a foreigner there, for the famine was severe in the land. 
-<span class="v">11&#160;</span>When he had come near to enter Egypt, he said to Sarai his woman, “See now, I know that you are a beautiful woman to look at. 
-<span class="v">12&#160;</span>It will happen that when the Egyptians see you, they will say, ‘This is his woman.’ They will kill me, but they will save you alive. 
-<span class="v">13&#160;</span>Please say that you are my sister, that it may be well with me for your sake, and that my soul may live because of you.” 
-</p><p>
-<span class="v">14&#160;</span>When Abram had come into Egypt, Egyptians saw that the woman was very beautiful. 
-<span class="v">15&#160;</span>The princes of Pharaoh saw her, and praised her to Pharaoh; and the woman was taken into Pharaoh’s house. 
-<span class="v">16&#160;</span>He dealt well with Abram for her sake. He had sheep, cattle, male donkeys, male servants, female servants, female donkeys, and camels. 
-<span class="v">17&#160;</span>Yahweh afflicted Pharaoh and his house with great plagues because of Sarai, Abram’s woman. 
-<span class="v">18&#160;</span>Pharaoh called Abram and said, “What is this that you have done to me? Why didn’t you tell me that she was your woman? 
-<span class="v">19&#160;</span>Why did you say, ‘She is my sister,’ so that I took her to be my woman? Now therefore, see your woman, take her, and go your way.” 
-</p><p>
-<span class="v">20&#160;</span>Pharaoh commanded men concerning him, and they escorted him away with his woman and all that he had. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Abram went up out of Egypt—he, his woman, all that he had, and Lot with him—into the South. 
-<span class="v">2&#160;</span>Abram was very rich in livestock, in silver, and in gold. 
-<span class="v">3&#160;</span>He went on his journeys from the South as far as Bethel, to the place where his tent had been at the beginning, between Bethel and Ai, 
-<span class="v">4&#160;</span>to the place of the altar, which he had made there at the first. There Abram called on Yahweh’s name. 
-<span class="v">5&#160;</span>Lot also, who went with Abram, had flocks, herds, and tents. 
-<span class="v">6&#160;</span>The land was not able to bear them, that they might live together; for their possessions were so great that they couldn’t live together. 
-<span class="v">7&#160;</span>There was strife between the herdsmen of Abram’s livestock and the herdsmen of Lot’s livestock. The Canaanites and the Perizzites lived in the land at that time. 
-<span class="v">8&#160;</span>Abram said to Lot, “Please, let there be no strife between you and me, and between your herdsmen and my herdsmen; for we are relatives. 
-<span class="v">9&#160;</span>Isn’t the whole land before you? Please separate yourself from me. If you go to the left hand, then I will go to the right. Or if you go to the right hand, then I will go to the left.” 
-</p><p>
-<span class="v">10&#160;</span>Lot lifted up his eyes, and saw all the plain of the Jordan, that it was well-watered everywhere, before Yahweh destroyed Sodom and Gomorrah, like the garden of Yahweh, like the land of Egypt, as you go to Zoar. 
-<span class="v">11&#160;</span>So Lot chose the Plain of the Jordan for himself. Lot traveled east, and they separated themselves from one other. 
-<span class="v">12&#160;</span>Abram lived in the land of Canaan, and Lot lived in the cities of the plain, and moved his tent as far as Sodom. 
-<span class="v">13&#160;</span>Now the men of Sodom were exceedingly wicked and sinners against Yahweh. 
-</p><p>
-<span class="v">14&#160;</span>Yahweh said to Abram, after Lot was separated from him, “Now, lift up your eyes, and look from the place where you are, northward and southward and eastward and westward, 
-<span class="v">15&#160;</span>for I will give all the land which you see to you and to your offspring forever. 
-<span class="v">16&#160;</span>I will make your offspring as the dust of the earth, so that if a man can count the dust of the earth, then your offspring may also be counted. 
-<span class="v">17&#160;</span>Arise, walk through the land in its length and in its width; for I will give it to you.” 
-</p><p>
-<span class="v">18&#160;</span>Abram moved his tent, and came and lived by the oaks of Mamre, which are in Hebron, and built an altar there to Yahweh. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>In the days of Amraphel, king of Shinar; Arioch, king of Ellasar; Chedorlaomer, king of Elam; and Tidal, king of Goiim, 
-<span class="v">2&#160;</span>they made war with Bera, king of Sodom; Birsha, king of Gomorrah; Shinab, king of Admah; Shemeber, king of Zeboiim; and the king of Bela (also called Zoar). 
-<span class="v">3&#160;</span>All these joined together in the valley of Siddim (also called the Salt Sea). 
-<span class="v">4&#160;</span>They served Chedorlaomer for twelve years, and in the thirteenth year they rebelled. 
-<span class="v">5&#160;</span>In the fourteenth year Chedorlaomer and the kings who were with him came and struck the Rephaim in Ashteroth Karnaim, the Zuzim in Ham, the Emim in Shaveh Kiriathaim, 
-<span class="v">6&#160;</span>and the Horites in their Mount Seir, to El Paran, which is by the wilderness. 
-<span class="v">7&#160;</span>They returned, and came to En Mishpat (also called Kadesh), and struck all the country of the Amalekites, and also the Amorites, that lived in Hazazon Tamar. 
-<span class="v">8&#160;</span>The king of Sodom, and the king of Gomorrah, the king of Admah, the king of Zeboiim, and the king of Bela (also called Zoar) went out; and they set the battle in array against them in the valley of Siddim 
-<span class="v">9&#160;</span>against Chedorlaomer king of Elam, Tidal king of Goiim, Amraphel king of Shinar, and Arioch king of Ellasar; four kings against the five. 
-<span class="v">10&#160;</span>Now the valley of Siddim was full of tar pits; and the kings of Sodom and Gomorrah fled, and some fell there. Those who remained fled to the hills. 
-<span class="v">11&#160;</span>They took all the goods of Sodom and Gomorrah, and all their food, and went their way. 
-<span class="v">12&#160;</span>They took Lot, Abram’s brother’s son, who lived in Sodom, and his goods, and departed. 
-</p><p>
-<span class="v">13&#160;</span>One who had escaped came and told Abram, the Hebrew. At that time, he lived by the oaks of Mamre, the Amorite, brother of Eshcol and brother of Aner. They were allies of Abram. 
-<span class="v">14&#160;</span>When Abram heard that his relative was taken captive, he led out his three hundred eighteen trained men, born in his house, and pursued as far as Dan. 
-<span class="v">15&#160;</span>He divided himself against them by night, he and his servants, and struck them, and pursued them to Hobah, which is on the left hand of Damascus. 
-<span class="v">16&#160;</span>He brought back all the goods, and also brought back his relative Lot and his goods, and the women also, and the other people. 
-</p><p>
-<span class="v">17&#160;</span>The king of Sodom went out to meet him after his return from the slaughter of Chedorlaomer and the kings who were with him, at the valley of Shaveh (that is, the King’s Valley). 
-<span class="v">18&#160;</span>Melchizedek king of Salem brought out bread and wine. He was priest of Elohim Most High. 
-<span class="v">19&#160;</span>He blessed him, and said, “Blessed be Abram of Elohim Most High, possessor of heaven and earth. 
-<span class="v">20&#160;</span>Blessed be Elohim Most High, who has delivered your enemies into your hand.” 
-</p><p>Abram gave him a tenth of all. 
-</p><p>
-<span class="v">21&#160;</span>The king of Sodom said to Abram, “Give me the people, and take the goods for yourself.” 
-</p><p>
-<span class="v">22&#160;</span>Abram said to the king of Sodom, “I have lifted up my hand to Yahweh, Elohim Most High, possessor of heaven and earth, 
-<span class="v">23&#160;</span>that I will not take a thread nor a sandal strap nor anything that is yours, lest you should say, ‘I have made Abram rich.’ 
-<span class="v">24&#160;</span>I will accept nothing from you except that which the young men have eaten, and the portion of the men who went with me: Aner, Eshcol, and Mamre. Let them take their portion.” 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>After these things Yahweh’s word came to Abram in a vision, saying, “Don’t be afraid, Abram. I am your shield, your exceedingly great reward.” 
-</p><p>
-<span class="v">2&#160;</span>Abram said, “Lord<span class="f">+ \fr 15:2 \ft The word translated “Lord” is “Adonai”.</span> Yahweh, what will you give me, since I go childless, and he who will inherit my estate is Eliezer of Damascus?” 
-<span class="v">3&#160;</span>Abram said, “Behold, you have given no children to me: and, behold, one born in my house is my heir.” 
-</p><p>
-<span class="v">4&#160;</span>Behold, Yahweh’s word came to him, saying, “This man will not be your heir, but he who will come out of your own body will be your heir.” 
-<span class="v">5&#160;</span>Yahweh brought him outside, and said, “Look now toward the sky, and count the stars, if you are able to count them.” He said to Abram, “So your offspring will be.” 
-<span class="v">6&#160;</span>He believed in Yahweh, and credited it to him as righteousness. 
-<span class="v">7&#160;</span>He said to Abram, “I am Yahweh who brought you out of Ur of the Chaldees, to give you this land to inherit it.” 
-</p><p>
-<span class="v">8&#160;</span>He said, “Lord Yahweh, how will I know that I will inherit it?” 
-</p><p>
-<span class="v">9&#160;</span>He said to him, “Bring me a heifer three years old, a female goat three years old, a ram three years old, a turtledove, and a young pigeon.” 
-<span class="v">10&#160;</span>He brought him all these, and divided them in the middle, and laid each half opposite the other; but he didn’t divide the birds. 
-<span class="v">11&#160;</span>The birds of prey came down on the carcasses, and Abram drove them away. 
-</p><p>
-<span class="v">12&#160;</span>When the sun was going down, a deep sleep fell on Abram. Now terror and great darkness fell on him. 
-<span class="v">13&#160;</span>He said to Abram, “Know for sure that your offspring will live as foreigners in a land that is not theirs, and will serve them. They will afflict them four hundred years. 
-<span class="v">14&#160;</span>I will also judge that nation, whom they will serve. Afterward they will come out with great wealth; 
-<span class="v">15&#160;</span>but you will go to your fathers in peace. You will be buried at a good old age. 
-<span class="v">16&#160;</span>In the fourth generation they will come here again, for the iniquity of the Amorite is not yet full.” 
-<span class="v">17&#160;</span>It came to pass that, when the sun went down, and it was dark, behold, a smoking furnace and a flaming torch passed between these pieces. 
-<span class="v">18&#160;</span>In that day Yahweh made a covenant with Abram, saying, “I have given this land to your offspring, from the river of Egypt to the great river, the river Euphrates: 
-<span class="v">19&#160;</span>the land of the Kenites, the Kenizzites, the Kadmonites, 
-<span class="v">20&#160;</span>the Hittites, the Perizzites, the Rephaim, 
-<span class="v">21&#160;</span>the Amorites, the Canaanites, the Girgashites, and the Jebusites.” 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Now Sarai, Abram’s woman, bore him no children. She had a servant, an Egyptian, whose name was Hagar. 
-<span class="v">2&#160;</span>Sarai said to Abram, “See now, Yahweh has restrained me from bearing. Please go in to my servant. It may be that I will obtain children by her.” Abram listened to the voice of Sarai. 
-<span class="v">3&#160;</span>Sarai, Abram’s woman, took Hagar the Egyptian, her servant, after Abram had lived ten years in the land of Canaan, and gave her to Abram her man to be his woman. 
-<span class="v">4&#160;</span>He went in to Hagar, and she conceived. When she saw that she had conceived, her mistress was despised in her eyes. 
-<span class="v">5&#160;</span>Sarai said to Abram, “This wrong is your fault. I gave my servant into your bosom, and when she saw that she had conceived, she despised me. May Yahweh judge between me and you.” 
-</p><p>
-<span class="v">6&#160;</span>But Abram said to Sarai, “Behold, your maid is in your hand. Do to her whatever is good in your eyes.” Sarai dealt harshly with her, and she fled from her face. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh’s angel found her by a fountain of water in the wilderness, by the fountain on the way to Shur. 
-<span class="v">8&#160;</span>He said, “Hagar, Sarai’s servant, where did you come from? Where are you going?” 
-</p><p>She said, “I am fleeing from the face of my mistress Sarai.” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh’s angel said to her, “Return to your mistress, and submit yourself under her hands.” 
-<span class="v">10&#160;</span>Yahweh’s angel said to her, “I will greatly multiply your offspring, that they will not be counted for multitude.” 
-<span class="v">11&#160;</span>Yahweh’s angel said to her, “Behold, you are with child, and will bear a son. You shall call his name Ishmael, because Yahweh has heard your affliction. 
-<span class="v">12&#160;</span>He will be like a wild donkey among men. His hand will be against every man, and every man’s hand against him. He will live opposed to all of his brothers.” 
-</p><p>
-<span class="v">13&#160;</span>She called the name of Yahweh who spoke to her, “You are an Elohim who sees,” for she said, “Have I even stayed alive after seeing him?” 
-<span class="v">14&#160;</span>Therefore the well was called Beer Lahai Roi.<span class="f">+ \fr 16:14 \ft Beer Lahai Roi means “well of the one who lives and sees me”.</span> Behold, it is between Kadesh and Bered. 
-</p><p>
-<span class="v">15&#160;</span>Hagar bore a son for Abram. Abram called the name of his son, whom Hagar bore, Ishmael. 
-<span class="v">16&#160;</span>Abram was eighty-six years old when Hagar bore Ishmael to Abram. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>When Abram was ninety-nine years old, Yahweh appeared to Abram and said to him, “I am Elohim Almighty. Walk before me and be blameless. 
-<span class="v">2&#160;</span>I will make my covenant between me and you, and will multiply you exceedingly.” 
-</p><p>
-<span class="v">3&#160;</span>Abram fell on his face. Elohim talked with him, saying, 
-<span class="v">4&#160;</span>“As for me, behold, my covenant is with you. You will be the father of a multitude of nations. 
-<span class="v">5&#160;</span>Your name will no more be called Abram, but your name will be Abraham; for I have made you the father of a multitude of nations. 
-<span class="v">6&#160;</span>I will make you exceedingly fruitful, and I will make nations of you. Kings will come out of you. 
-<span class="v">7&#160;</span>I will establish my covenant between me and you and your offspring after you throughout their generations for an everlasting covenant, to be an Elohim to you and to your offspring after you. 
-<span class="v">8&#160;</span>I will give to you, and to your offspring after you, the land where you are traveling, all the land of Canaan, for an everlasting possession. I will be their Elohim.” 
-</p><p>
-<span class="v">9&#160;</span>Elohim said to Abraham, “As for you, you shall keep my covenant, you and your offspring after you throughout their generations. 
-<span class="v">10&#160;</span>This is my covenant, which you shall keep, between me and you and your offspring after you. Every male among you shall be circumcised. 
-<span class="v">11&#160;</span>You shall be circumcised in the flesh of your foreskin. It will be a token of the covenant between me and you. 
-<span class="v">12&#160;</span>He who is eight days old shall be circumcised among you, every male throughout your generations, he who is born in the house, or bought with money from any foreigner who is not of your offspring. 
-<span class="v">13&#160;</span>He who is born in your house, and he who is bought with your money, must be circumcised. My covenant shall be in your flesh for an everlasting covenant. 
-<span class="v">14&#160;</span>The uncircumcised male who is not circumcised in the flesh of his foreskin, that soul shall be cut off from his people. He has broken my covenant.” 
-</p><p>
-<span class="v">15&#160;</span>Elohim said to Abraham, “As for Sarai your woman, you shall not call her name Sarai, but her name shall be Sarah. 
-<span class="v">16&#160;</span>I will bless her, and moreover I will give you a son by her. Yes, I will bless her, and she will be a mother of nations. Kings of peoples will come from her.” 
-</p><p>
-<span class="v">17&#160;</span>Then Abraham fell on his face, and laughed, and said in his heart, “Will a child be born to him who is one hundred years old? Will Sarah, who is ninety years old, give birth?” 
-<span class="v">18&#160;</span>Abraham said to Elohim, “Oh that Ishmael might live before you!” 
-</p><p>
-<span class="v">19&#160;</span>Elohim said, “No, but Sarah, your woman, will bear you a son. You shall call his name Isaac.<span class="f">+ \fr 17:19 \ft Isaac means “he laughs”.</span> I will establish my covenant with him for an everlasting covenant for his offspring after him. 
-<span class="v">20&#160;</span>As for Ishmael, I have heard you. Behold, I have blessed him, and will make him fruitful, and will multiply him exceedingly. He will become the father of twelve princes, and I will make him a great nation. 
-<span class="v">21&#160;</span>But I will establish my covenant with Isaac, whom Sarah will bear to you at this set time next year.” 
-</p><p>
-<span class="v">22&#160;</span>When he finished talking with him, Elohim went up from Abraham. 
-<span class="v">23&#160;</span>Abraham took Ishmael his son, all who were born in his house, and all who were bought with his money: every male among the men of Abraham’s house, and circumcised the flesh of their foreskin in the same day, as Elohim had said to him. 
-<span class="v">24&#160;</span>Abraham was ninety-nine years old when he was circumcised in the flesh of his foreskin. 
-<span class="v">25&#160;</span>Ishmael, his son, was thirteen years old when he was circumcised in the flesh of his foreskin. 
-<span class="v">26&#160;</span>In the same day both Abraham and Ishmael, his son, were circumcised. 
-<span class="v">27&#160;</span>All the men of his house, those born in the house, and those bought with money from a foreigner, were circumcised with him. 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh appeared to him by the oaks of Mamre, as he sat in the tent door in the heat of the day. 
-<span class="v">2&#160;</span>He lifted up his eyes and looked, and saw that three men stood near him. When he saw them, he ran to meet them from the tent door, and bowed himself to the earth, 
-<span class="v">3&#160;</span>and said, “My lord, if now I have found favor in your sight, please don’t go away from your servant. 
-<span class="v">4&#160;</span>Now let a little water be fetched, wash your feet, and rest yourselves under the tree. 
-<span class="v">5&#160;</span>I will get a piece of bread so you can refresh your heart. After that you may go your way, now that you have come to your servant.” 
-</p><p>They said, “Very well, do as you have said.” 
-</p><p>
-<span class="v">6&#160;</span>Abraham hurried into the tent to Sarah, and said, “Quickly prepare three seahs<span class="f">+ \fr 18:6 \ft 1 seah is about 7 liters or 1.9 gallons or 0.8 pecks</span> of fine meal, knead it, and make cakes.” 
-<span class="v">7&#160;</span>Abraham ran to the herd, and fetched a tender and good calf, and gave it to the servant. He hurried to dress it. 
-<span class="v">8&#160;</span>He took butter, milk, and the calf which he had dressed, and set it before them. He stood by them under the tree, and they ate. 
-</p><p>
-<span class="v">9&#160;</span>They asked him, “Where is Sarah, your woman?” 
-</p><p>He said, “There, in the tent.” 
-</p><p>
-<span class="v">10&#160;</span>He said, “I will certainly return to you at about this time next year; and behold, Sarah your woman will have a son.” 
-</p><p>Sarah heard in the tent door, which was behind him. 
-<span class="v">11&#160;</span>Now Abraham and Sarah were old, well advanced in age. Sarah had passed the age of childbearing. 
-<span class="v">12&#160;</span>Sarah laughed within herself, saying, “After I have grown old will I have pleasure, my lord being old also?” 
-</p><p>
-<span class="v">13&#160;</span>Yahweh said to Abraham, “Why did Sarah laugh, saying, ‘Will I really bear a child when I am old?’ 
-<span class="v">14&#160;</span>Is anything too hard for Yahweh? At the set time I will return to you, when the season comes around, and Sarah will have a son.” 
-</p><p>
-<span class="v">15&#160;</span>Then Sarah denied it, saying, “I didn’t laugh,” for she was afraid. 
-</p><p>He said, “No, but you did laugh.” 
-</p><p>
-<span class="v">16&#160;</span>The men rose up from there, and looked toward Sodom. Abraham went with them to see them on their way. 
-<span class="v">17&#160;</span>Yahweh said, “Will I hide from Abraham what I do, 
-<span class="v">18&#160;</span>since Abraham will surely become a great and mighty nation, and all the nations of the earth will be blessed in him? 
-<span class="v">19&#160;</span>For I have known him, to the end that he may command his children and his household after him, that they may keep the way of Yahweh, to do righteousness and justice; to the end that Yahweh may bring on Abraham that which he has spoken of him.” 
-<span class="v">20&#160;</span>Yahweh said, “Because the cry of Sodom and Gomorrah is great, and because their sin is very grievous, 
-<span class="v">21&#160;</span>I will go down now, and see whether their deeds are as bad as the reports which have come to me. If not, I will know.” 
-</p><p>
-<span class="v">22&#160;</span>The men turned from there, and went toward Sodom, but Abraham stood yet before Yahweh. 
-<span class="v">23&#160;</span>Abraham came near, and said, “Will you consume the righteous with the wicked? 
-<span class="v">24&#160;</span>What if there are fifty righteous within the city? Will you consume and not spare the place for the fifty righteous who are in it? 
-<span class="v">25&#160;</span>May it be far from you to do things like that, to kill the righteous with the wicked, so that the righteous should be like the wicked. May that be far from you. Shouldn’t the Judge of all the earth do right?” 
-</p><p>
-<span class="v">26&#160;</span>Yahweh said, “If I find in Sodom fifty righteous within the city, then I will spare the whole place for their sake.” 
-<span class="v">27&#160;</span>Abraham answered, “See now, I have taken it on myself to speak to the Lord, although I am dust and ashes. 
-<span class="v">28&#160;</span>What if there will lack five of the fifty righteous? Will you destroy all the city for lack of five?” 
-</p><p>He said, “I will not destroy it if I find forty-five there.” 
-</p><p>
-<span class="v">29&#160;</span>He spoke to him yet again, and said, “What if there are forty found there?” 
-</p><p>He said, “I will not do it for the forty’s sake.” 
-</p><p>
-<span class="v">30&#160;</span>He said, “Oh don’t let the Lord be angry, and I will speak. What if there are thirty found there?” 
-</p><p>He said, “I will not do it if I find thirty there.” 
-</p><p>
-<span class="v">31&#160;</span>He said, “See now, I have taken it on myself to speak to the Lord. What if there are twenty found there?” 
-</p><p>He said, “I will not destroy it for the twenty’s sake.” 
-</p><p>
-<span class="v">32&#160;</span>He said, “Oh don’t let the Lord be angry, and I will speak just once more. What if ten are found there?” 
-</p><p>He said, “I will not destroy it for the ten’s sake.” 
-</p><p>
-<span class="v">33&#160;</span>Yahweh went his way as soon as he had finished communing with Abraham, and Abraham returned to his place. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>The two angels came to Sodom at evening. Lot sat in the gate of Sodom. Lot saw them, and rose up to meet them. He bowed himself with his face to the earth, 
-<span class="v">2&#160;</span>and he said, “See now, my lords, please come into your servant’s house, stay all night, wash your feet, and you can rise up early, and go on your way.” 
-</p><p>They said, “No, but we will stay in the street all night.” 
-</p><p>
-<span class="v">3&#160;</span>He urged them greatly, and they came in with him, and entered into his house. He made them a feast, and baked unleavened bread, and they ate. 
-<span class="v">4&#160;</span>But before they lay down, the men of the city, the men of Sodom, surrounded the house, both young and old, all the people from every quarter. 
-<span class="v">5&#160;</span>They called to Lot, and said to him, “Where are the men who came in to you this night? Bring them out to us, that we may have sex with them.” 
-</p><p>
-<span class="v">6&#160;</span>Lot went out to them through the door, and shut the door after himself. 
-<span class="v">7&#160;</span>He said, “Please, my brothers, don’t act so wickedly. 
-<span class="v">8&#160;</span>See now, I have two virgin daughters. Please let me bring them out to you, and you may do to them what seems good to you. Only don’t do anything to these men, because they have come under the shadow of my roof.” 
-</p><p>
-<span class="v">9&#160;</span>They said, “Stand back!” Then they said, “This one fellow came in to live as a foreigner, and he appoints himself a judge. Now we will deal worse with you than with them!” They pressed hard on the man Lot, and came near to break the door. 
-<span class="v">10&#160;</span>But the men reached out their hand, and brought Lot into the house to them, and shut the door. 
-<span class="v">11&#160;</span>They struck the men who were at the door of the house with blindness, both small and great, so that they wearied themselves to find the door. 
-</p><p>
-<span class="v">12&#160;</span>The men said to Lot, “Do you have anybody else here? Sons-in-law, your sons, your daughters, and whomever you have in the city, bring them out of the place: 
-<span class="v">13&#160;</span>for we will destroy this place, because the outcry against them has grown so great before Yahweh that Yahweh has sent us to destroy it.” 
-</p><p>
-<span class="v">14&#160;</span>Lot went out, and spoke to his sons-in-law, who were pledged to marry his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
-</p><p>But he seemed to his sons-in-law to be joking. 
-<span class="v">15&#160;</span>When the morning came, then the angels hurried Lot, saying, “Get up! Take your woman and your two daughters who are here, lest you be consumed in the iniquity of the city.” 
-<span class="v">16&#160;</span>But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahweh being merciful to him; and they took him out, and set him outside of the city. 
-<span class="v">17&#160;</span>It came to pass, when they had taken them out, that he said, “Escape for your life! Don’t look behind you, and don’t stay anywhere in the plain. Escape to the mountains, lest you be consumed!” 
-</p><p>
-<span class="v">18&#160;</span>Lot said to them, “Oh, not so, my lord. 
-<span class="v">19&#160;</span>See now, your servant has found favor in your sight, and you have magnified your loving kindness, which you have shown to me in saving my life. I can’t escape to the mountain, lest evil overtake me, and I die. 
-<span class="v">20&#160;</span>See now, this city is near to flee to, and it is a little one. Oh let me escape there (isn’t it a little one?), and my soul will live.” 
-</p><p>
-<span class="v">21&#160;</span>He said to him, “Behold, I have granted your request concerning this thing also, that I will not overthrow the city of which you have spoken. 
-<span class="v">22&#160;</span>Hurry, escape there, for I can’t do anything until you get there.” Therefore the name of the city was called Zoar.<span class="f">+ \fr 19:22 \ft Zoar means “little”.</span> 
-</p><p>
-<span class="v">23&#160;</span>The sun had risen on the earth when Lot came to Zoar. 
-<span class="v">24&#160;</span>Then Yahweh rained on Sodom and on Gomorrah sulfur and fire from Yahweh out of the sky. 
-<span class="v">25&#160;</span>He overthrew those cities, all the plain, all the inhabitants of the cities, and that which grew on the ground. 
-<span class="v">26&#160;</span>But Lot’s woman looked back from behind him, and she became a pillar of salt. 
-</p><p>
-<span class="v">27&#160;</span>Abraham went up early in the morning to the place where he had stood before Yahweh. 
-<span class="v">28&#160;</span>He looked toward Sodom and Gomorrah, and toward all the land of the plain, and saw that the smoke of the land went up as the smoke of a furnace. 
-</p><p>
-<span class="v">29&#160;</span>When Elohim destroyed the cities of the plain, Elohim remembered Abraham, and sent Lot out of the middle of the overthrow, when he overthrew the cities in which Lot lived. 
-</p><p>
-<span class="v">30&#160;</span>Lot went up out of Zoar, and lived in the mountain, and his two daughters with him; for he was afraid to live in Zoar. He lived in a cave with his two daughters. 
-<span class="v">31&#160;</span>The firstborn said to the younger, “Our father is old, and there is not a man in the earth to come in to us in the way of all the earth. 
-<span class="v">32&#160;</span>Come, let’s make our father drink wine, and we will lie with him, that we may preserve our father’s family line.” 
-<span class="v">33&#160;</span>They made their father drink wine that night: and the firstborn went in, and lay with her father. He didn’t know when she lay down, nor when she arose. 
-<span class="v">34&#160;</span>It came to pass on the next day, that the firstborn said to the younger, “Behold, I lay last night with my father. Let’s make him drink wine again tonight. You go in, and lie with him, that we may preserve our father’s family line.” 
-<span class="v">35&#160;</span>They made their father drink wine that night also. The younger went and lay with him. He didn’t know when she lay down, nor when she got up. 
-<span class="v">36&#160;</span>Thus both of Lot’s daughters were with child by their father. 
-<span class="v">37&#160;</span>The firstborn bore a son, and named him Moab. He is the father of the Moabites to this day. 
-<span class="v">38&#160;</span>The younger also bore a son, and called his name Ben Ammi. He is the father of the children of Ammon to this day. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Abraham traveled from there toward the land of the South, and lived between Kadesh and Shur. He lived as a foreigner in Gerar. 
-<span class="v">2&#160;</span>Abraham said about Sarah his woman, “She is my sister.” Abimelech king of Gerar sent, and took Sarah. 
-<span class="v">3&#160;</span>But Elohim came to Abimelech in a dream of the night, and said to him, “Behold, you are a dead man, because of the woman whom you have taken; for she is owned by an owner.” 
-</p><p>
-<span class="v">4&#160;</span>Now Abimelech had not come near her. He said, “Lord, will you kill even a righteous nation? 
-<span class="v">5&#160;</span>Didn’t he tell me, ‘She is my sister’? She, even she herself, said, ‘He is my brother.’ I have done this in the integrity of my heart and the innocence of my hands.” 
-</p><p>
-<span class="v">6&#160;</span>Elohim said to him in the dream, “Yes, I know that in the integrity of your heart you have done this, and I also withheld you from sinning against me. Therefore I didn’t allow you to touch her. 
-<span class="v">7&#160;</span>Now therefore, restore the man’s woman. For he is a prophet, and he will pray for you, and you will live. If you don’t restore her, know for sure that you will die, you, and all who are yours.” 
-</p><p>
-<span class="v">8&#160;</span>Abimelech rose early in the morning, and called all his servants, and told all these things in their ear. The men were very scared. 
-<span class="v">9&#160;</span>Then Abimelech called Abraham, and said to him, “What have you done to us? How have I sinned against you, that you have brought on me and on my kingdom a great sin? You have done deeds to me that ought not to be done!” 
-<span class="v">10&#160;</span>Abimelech said to Abraham, “What did you see, that you have done this thing?” 
-</p><p>
-<span class="v">11&#160;</span>Abraham said, “Because I thought, ‘Surely the fear of Elohim is not in this place. They will kill me for my woman’s sake.’ 
-<span class="v">12&#160;</span>Besides, she is indeed my sister, the daughter of my father, but not the daughter of my mother; and she became my woman. 
-<span class="v">13&#160;</span>When Elohim caused me to wander from my father’s house, I said to her, ‘This is your kindness which you shall show to me. Everywhere that we go, say of me, “He is my brother.”&#160;’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Abimelech took sheep and cattle, male servants and female servants, and gave them to Abraham, and restored Sarah, his woman, to him. 
-<span class="v">15&#160;</span>Abimelech said, “Behold, my land is before you. Dwell where it pleases you.” 
-<span class="v">16&#160;</span>To Sarah he said, “Behold, I have given your brother a thousand pieces of silver. Behold, it is for you a covering of the eyes to all that are with you. In front of all you are vindicated.” 
-</p><p>
-<span class="v">17&#160;</span>Abraham prayed to Elohim. So Elohim healed Abimelech, his woman, and his female servants, and they bore children. 
-<span class="v">18&#160;</span>For Yahweh had closed up tight all the wombs of the house of Abimelech, because of Sarah, Abraham’s woman. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh visited Sarah as he had said, and Yahweh did to Sarah as he had spoken. 
-<span class="v">2&#160;</span>Sarah conceived, and bore Abraham a son in his old age, at the set time of which Elohim had spoken to him. 
-<span class="v">3&#160;</span>Abraham called his son who was born to him, whom Sarah bore to him, Isaac.<span class="f">+ \fr 21:3 \ft Isaac means “He laughs”.</span> 
-<span class="v">4&#160;</span>Abraham circumcised his son, Isaac, when he was eight days old, as Elohim had commanded him. 
-<span class="v">5&#160;</span>Abraham was one hundred years old when his son, Isaac, was born to him. 
-<span class="v">6&#160;</span>Sarah said, “Elohim has made me laugh. Everyone who hears will laugh with me.” 
-<span class="v">7&#160;</span>She said, “Who would have said to Abraham that Sarah would nurse children? For I have borne him a son in his old age.” 
-</p><p>
-<span class="v">8&#160;</span>The child grew and was weaned. Abraham made a great feast on the day that Isaac was weaned. 
-<span class="v">9&#160;</span>Sarah saw the son of Hagar the Egyptian, whom she had borne to Abraham, mocking. 
-<span class="v">10&#160;</span>Therefore she said to Abraham, “Cast out this servant and her son! For the son of this servant will not be heir with my son, Isaac.” 
-</p><p>
-<span class="v">11&#160;</span>The thing was very grievous in Abraham’s sight on account of his son. 
-<span class="v">12&#160;</span>Elohim said to Abraham, “Don’t let it be grievous in your sight because of the boy, and because of your servant. In all that Sarah says to you, listen to her voice. For your offspring will be named through Isaac. 
-<span class="v">13&#160;</span>I will also make a nation of the son of the servant, because he is your child.” 
-<span class="v">14&#160;</span>Abraham rose up early in the morning, and took bread and a container of water, and gave it to Hagar, putting it on her shoulder; and gave her the child, and sent her away. She departed, and wandered in the wilderness of Beersheba. 
-<span class="v">15&#160;</span>The water in the container was spent, and she put the child under one of the shrubs. 
-<span class="v">16&#160;</span>She went and sat down opposite him, a good way off, about a bow shot away. For she said, “Don’t let me see the death of the child.” She sat opposite him, and lifted up her voice, and wept. 
-<span class="v">17&#160;</span>Elohim heard the voice of the boy. 
-</p><p>The angel of Elohim called to Hagar out of the sky, and said to her, “What troubles you, Hagar? Don’t be afraid. For Elohim has heard the voice of the boy where he is. 
-<span class="v">18&#160;</span>Get up, lift up the boy, and hold him with your hand. For I will make him a great nation.” 
-</p><p>
-<span class="v">19&#160;</span>Elohim opened her eyes, and she saw a well of water. She went, filled the container with water, and gave the boy a drink. 
-</p><p>
-<span class="v">20&#160;</span>Elohim was with the boy, and he grew. He lived in the wilderness, and as he grew up, he became an archer. 
-<span class="v">21&#160;</span>He lived in the wilderness of Paran. His mother got a woman for him out of the land of Egypt. 
-</p><p>
-<span class="v">22&#160;</span>At that time, Abimelech and Phicol the captain of his army spoke to Abraham, saying, “Elohim is with you in all that you do. 
-<span class="v">23&#160;</span>Now, therefore, swear to me here by Elohim that you will not deal falsely with me, nor with my son, nor with my son’s son. But according to the kindness that I have done to you, you shall do to me, and to the land in which you have lived as a foreigner.” 
-</p><p>
-<span class="v">24&#160;</span>Abraham said, “I will swear.” 
-<span class="v">25&#160;</span>Abraham complained to Abimelech because of a water well, which Abimelech’s servants had violently taken away. 
-<span class="v">26&#160;</span>Abimelech said, “I don’t know who has done this thing. You didn’t tell me, and I didn’t hear of it until today.” 
-</p><p>
-<span class="v">27&#160;</span>Abraham took sheep and cattle, and gave them to Abimelech. Those two made a covenant. 
-<span class="v">28&#160;</span>Abraham set seven ewe lambs of the flock by themselves. 
-<span class="v">29&#160;</span>Abimelech said to Abraham, “What do these seven ewe lambs, which you have set by themselves, mean?” 
-</p><p>
-<span class="v">30&#160;</span>He said, “You shall take these seven ewe lambs from my hand, that it may be a witness to me, that I have dug this well.” 
-<span class="v">31&#160;</span>Therefore he called that place Beersheba,<span class="f">+ \fr 21:31 \ft Beersheba can mean “well of the oath” or “well of seven”.</span> because they both swore an oath there. 
-<span class="v">32&#160;</span>So they made a covenant at Beersheba. Abimelech rose up with Phicol, the captain of his army, and they returned into the land of the Philistines. 
-<span class="v">33&#160;</span>Abraham planted a tamarisk tree in Beersheba, and there he called on the name of Yahweh, the Everlasting Elohim. 
-<span class="v">34&#160;</span>Abraham lived as a foreigner in the land of the Philistines many days. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>After these things, Elohim tested Abraham, and said to him, “Abraham!” 
-</p><p>He said, “Here I am.” 
-</p><p>
-<span class="v">2&#160;</span>He said, “Now take your son, your only son, Isaac, whom you love, and go into the land of Moriah. Offer him there as a burnt offering on one of the mountains which I will tell you of.” 
-</p><p>
-<span class="v">3&#160;</span>Abraham rose early in the morning, and saddled his donkey; and took two of his young men with him, and Isaac his son. He split the wood for the burnt offering, and rose up, and went to the place of which Elohim had told him. 
-<span class="v">4&#160;</span>On the third day Abraham lifted up his eyes, and saw the place far off. 
-<span class="v">5&#160;</span>Abraham said to his young men, “Stay here with the donkey. The boy and I will go over there. We will worship, and come back to you.” 
-<span class="v">6&#160;</span>Abraham took the wood of the burnt offering and laid it on Isaac his son. He took in his hand the fire and the knife. They both went together. 
-<span class="v">7&#160;</span>Isaac spoke to Abraham his father, and said, “My father?” 
-</p><p>He said, “Here I am, my son.” 
-</p><p>He said, “Here is the fire and the wood, but where is the lamb for a burnt offering?” 
-</p><p>
-<span class="v">8&#160;</span>Abraham said, “Elohim will provide himself the lamb for a burnt offering, my son.” So they both went together. 
-<span class="v">9&#160;</span>They came to the place which Elohim had told him of. Abraham built the altar there, and laid the wood in order, bound Isaac his son, and laid him on the altar, on the wood. 
-<span class="v">10&#160;</span>Abraham stretched out his hand, and took the knife to kill his son. 
-</p><p>
-<span class="v">11&#160;</span>Yahweh’s angel called to him out of the sky, and said, “Abraham, Abraham!” 
-</p><p>He said, “Here I am.” 
-</p><p>
-<span class="v">12&#160;</span>He said, “Don’t lay your hand on the boy or do anything to him. For now I know that you fear Elohim, since you have not withheld your son, your only son, from me.” 
-</p><p>
-<span class="v">13&#160;</span>Abraham lifted up his eyes, and looked, and saw that behind him was a ram caught in the thicket by his horns. Abraham went and took the ram, and offered him up for a burnt offering instead of his son. 
-<span class="v">14&#160;</span>Abraham called the name of that place “Yahweh Will Provide”.<span class="f">+ \fr 22:14 \ft or, Yahweh-Jireh, or, Yahweh-Seeing</span> As it is said to this day, “On Yahweh’s mountain, it will be provided.” 
-</p><p>
-<span class="v">15&#160;</span>Yahweh’s angel called to Abraham a second time out of the sky, 
-<span class="v">16&#160;</span>and said, “&#160;‘I have sworn by myself,’ says Yahweh, ‘because you have done this thing, and have not withheld your son, your only son, 
-<span class="v">17&#160;</span>that I will bless you greatly, and I will multiply your offspring greatly like the stars of the heavens, and like the sand which is on the seashore. Your offspring will possess the gate of his enemies. 
-<span class="v">18&#160;</span>All the nations of the earth will be blessed by your offspring, because you have obeyed my voice.’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>So Abraham returned to his young men, and they rose up and went together to Beersheba. Abraham lived at Beersheba. 
-</p><p>
-<span class="v">20&#160;</span>After these things, Abraham was told, “Behold, Milcah, she also has borne children to your brother Nahor: 
-<span class="v">21&#160;</span>Uz his firstborn, Buz his brother, Kemuel the father of Aram, 
-<span class="v">22&#160;</span>Chesed, Hazo, Pildash, Jidlaph, and Bethuel.” 
-<span class="v">23&#160;</span>Bethuel brought forth Rebekah. These eight Milcah bore to Nahor, Abraham’s brother. 
-<span class="v">24&#160;</span>His concubine, whose name was Reumah, also bore Tebah, Gaham, Tahash, and Maacah. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Sarah lived one hundred twenty-seven years. This was the length of Sarah’s life. 
-<span class="v">2&#160;</span>Sarah died in Kiriath Arba (also called Hebron), in the land of Canaan. Abraham came to mourn for Sarah, and to weep for her. 
-<span class="v">3&#160;</span>Abraham rose up from before his dead and spoke to the children of Heth, saying, 
-<span class="v">4&#160;</span>“I am a stranger and a foreigner living with you. Give me a possession of a burying-place with you, that I may bury my dead out of my sight.” 
-</p><p>
-<span class="v">5&#160;</span>The children of Heth answered Abraham, saying to him, 
-<span class="v">6&#160;</span>“Hear us, my lord. You are a prince of Elohim among us. Bury your dead in the best of our tombs. None of us will withhold from you his tomb. Bury your dead.” 
-</p><p>
-<span class="v">7&#160;</span>Abraham rose up, and bowed himself to the people of the land, to the children of Heth. 
-<span class="v">8&#160;</span>He talked with them, saying, “If you agree that I should bury my dead out of my sight, hear me, and entreat for me to Ephron the son of Zohar, 
-<span class="v">9&#160;</span>that he may sell me the cave of Machpelah, which he has, which is in the end of his field. For the full price let him sell it to me among you as a possession for a burial place.” 
-</p><p>
-<span class="v">10&#160;</span>Now Ephron was sitting in the middle of the children of Heth. Ephron the Hittite answered Abraham in the hearing of the children of Heth, even of all who went in at the gate of his city, saying, 
-<span class="v">11&#160;</span>“No, my lord, hear me. I give you the field, and I give you the cave that is in it. In the presence of the children of my people I give it to you. Bury your dead.” 
-</p><p>
-<span class="v">12&#160;</span>Abraham bowed himself down before the people of the land. 
-<span class="v">13&#160;</span>He spoke to Ephron in the audience of the people of the land, saying, “But if you will, please hear me. I will give the price of the field. Take it from me, and I will bury my dead there.” 
-</p><p>
-<span class="v">14&#160;</span>Ephron answered Abraham, saying to him, 
-<span class="v">15&#160;</span>“My lord, listen to me. What is a piece of land worth four hundred shekels of silver<span class="f">+ \fr 23:15 \ft A shekel is about 10 grams, so 400 shekels would be about 4 kg. or 8.8 pounds.</span> between me and you? Therefore bury your dead.” 
-</p><p>
-<span class="v">16&#160;</span>Abraham listened to Ephron. Abraham weighed to Ephron the silver which he had named in the hearing of the children of Heth, four hundred shekels of silver, according to the current merchants’ standard. 
-</p><p>
-<span class="v">17&#160;</span>So the field of Ephron, which was in Machpelah, which was before Mamre, the field, the cave which was in it, and all the trees that were in the field, that were in all of its borders, were deeded 
-<span class="v">18&#160;</span>to Abraham for a possession in the presence of the children of Heth, before all who went in at the gate of his city. 
-<span class="v">19&#160;</span>After this, Abraham buried Sarah his woman in the cave of the field of Machpelah before Mamre (that is, Hebron), in the land of Canaan. 
-<span class="v">20&#160;</span>The field, and the cave that is in it, were deeded to Abraham by the children of Heth as a possession for a burial place. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Abraham was old, and well advanced in age. Yahweh had blessed Abraham in all things. 
-<span class="v">2&#160;</span>Abraham said to his servant, the elder of his house, who ruled over all that he had, “Please put your hand under my thigh. 
-<span class="v">3&#160;</span>I will make you swear by Yahweh, the Elohim of heaven and the Elohim of the earth, that you shall not take a woman for my son of the daughters of the Canaanites, among whom I live. 
-<span class="v">4&#160;</span>But you shall go to my country, and to my relatives, and take a woman for my son Isaac.” 
-</p><p>
-<span class="v">5&#160;</span>The servant said to him, “What if the woman isn’t willing to follow me to this land? Must I bring your son again to the land you came from?” 
-</p><p>
-<span class="v">6&#160;</span>Abraham said to him, “Beware that you don’t bring my son there again. 
-<span class="v">7&#160;</span>Yahweh, the Elohim of heaven—who took me from my father’s house, and from the land of my birth, who spoke to me, and who swore to me, saying, ‘I will give this land to your offspring—he will send his angel before you, and you shall take a woman for my son from there. 
-<span class="v">8&#160;</span>If the woman isn’t willing to follow you, then you shall be clear from this oath to me. Only you shall not bring my son there again.” 
-</p><p>
-<span class="v">9&#160;</span>The servant put his hand under the thigh of Abraham his master, and swore to him concerning this matter. 
-<span class="v">10&#160;</span>The servant took ten of his master’s camels, and departed, having a variety of good things of his master’s with him. He arose, and went to Mesopotamia, to the city of Nahor. 
-<span class="v">11&#160;</span>He made the camels kneel down outside the city by the well of water at the time of evening, the time that women go out to draw water. 
-<span class="v">12&#160;</span>He said, “Yahweh, the Elohim of my master Abraham, please give me success today, and show kindness to my master Abraham. 
-<span class="v">13&#160;</span>Behold, I am standing by the spring of water. The daughters of the men of the city are coming out to draw water. 
-<span class="v">14&#160;</span>Let it happen, that the young lady to whom I will say, ‘Please let down your pitcher, that I may drink,’ then she says, ‘Drink, and I will also give your camels a drink,’—let her be the one you have appointed for your servant Isaac. By this I will know that you have shown kindness to my master.” 
-</p><p>
-<span class="v">15&#160;</span>Before he had finished speaking, behold, Rebekah came out, who was born to Bethuel the son of Milcah, the woman of Nahor, Abraham’s brother, with her pitcher on her shoulder. 
-<span class="v">16&#160;</span>The young lady was very beautiful to look at, a virgin. No man had known her. She went down to the spring, filled her pitcher, and came up. 
-<span class="v">17&#160;</span>The servant ran to meet her, and said, “Please give me a drink, a little water from your pitcher.” 
-</p><p>
-<span class="v">18&#160;</span>She said, “Drink, my lord.” She hurried, and let down her pitcher on her hand, and gave him a drink. 
-<span class="v">19&#160;</span>When she had finished giving him a drink, she said, “I will also draw for your camels, until they have finished drinking.” 
-<span class="v">20&#160;</span>She hurried, and emptied her pitcher into the trough, and ran again to the well to draw, and drew for all his camels. 
-</p><p>
-<span class="v">21&#160;</span>The man looked steadfastly at her, remaining silent, to know whether Yahweh had made his journey prosperous or not. 
-<span class="v">22&#160;</span>As the camels had done drinking, the man took a golden ring of half a shekel<span class="f">+ \fr 24:22 \ft A shekel is about 10 grams or about 0.35 ounces.</span> weight, and two bracelets for her hands of ten shekels weight of gold, 
-<span class="v">23&#160;</span>and said, “Whose daughter are you? Please tell me. Is there room in your father’s house for us to stay?” 
-</p><p>
-<span class="v">24&#160;</span>She said to him, “I am the daughter of Bethuel the son of Milcah, whom she bore to Nahor.” 
-<span class="v">25&#160;</span>She said moreover to him, “We have both straw and feed enough, and room to lodge in.” 
-</p><p>
-<span class="v">26&#160;</span>The man bowed his head, and worshiped Yahweh. 
-<span class="v">27&#160;</span>He said, “Blessed be Yahweh, the Elohim of my master Abraham, who has not forsaken his loving kindness and his truth toward my master. As for me, Yahweh has led me on the way to the house of my master’s relatives.” 
-</p><p>
-<span class="v">28&#160;</span>The young lady ran, and told her mother’s house about these words. 
-<span class="v">29&#160;</span>Rebekah had a brother, and his name was Laban. Laban ran out to the man, to the spring. 
-<span class="v">30&#160;</span>When he saw the ring, and the bracelets on his sister’s hands, and when he heard the words of Rebekah his sister, saying, “This is what the man said to me,” he came to the man. Behold, he was standing by the camels at the spring. 
-<span class="v">31&#160;</span>He said, “Come in, you blessed of Yahweh. Why do you stand outside? For I have prepared the house, and room for the camels.” 
-</p><p>
-<span class="v">32&#160;</span>The man came into the house, and he unloaded the camels. He gave straw and feed for the camels, and water to wash his feet and the feet of the men who were with him. 
-<span class="v">33&#160;</span>Food was set before him to eat, but he said, “I will not eat until I have told my message.” 
-</p><p>Laban said, “Speak on.” 
-</p><p>
-<span class="v">34&#160;</span>He said, “I am Abraham’s servant. 
-<span class="v">35&#160;</span>Yahweh has blessed my master greatly. He has become great. Yahweh has given him flocks and herds, silver and gold, male servants and female servants, and camels and donkeys. 
-<span class="v">36&#160;</span>Sarah, my master’s woman, bore a son to my master when she was old. He has given all that he has to him. 
-<span class="v">37&#160;</span>My master made me swear, saying, ‘You shall not take a woman for my son from the daughters of the Canaanites, in whose land I live, 
-<span class="v">38&#160;</span>but you shall go to my father’s house, and to my relatives, and take a woman for my son.’ 
-<span class="v">39&#160;</span>I asked my master, ‘What if the woman will not follow me?’ 
-<span class="v">40&#160;</span>He said to me, ‘Yahweh, before whom I walk, will send his angel with you, and prosper your way. You shall take a woman for my son from my relatives, and of my father’s house. 
-<span class="v">41&#160;</span>Then you will be clear from my oath, when you come to my relatives. If they don’t give her to you, you shall be clear from my oath.’ 
-<span class="v">42&#160;</span>I came today to the spring, and said, ‘Yahweh, the Elohim of my master Abraham, if now you do prosper my way which I go—<span class="v">43&#160;</span>behold, I am standing by this spring of water. Let it happen, that the maiden who comes out to draw, to whom I will say, “Please give me a little water from your pitcher to drink,” 
-<span class="v">44&#160;</span>then she tells me, “Drink, and I will also draw for your camels,”—let her be the woman whom Yahweh has appointed for my master’s son.’ 
-<span class="v">45&#160;</span>Before I had finished speaking in my heart, behold, Rebekah came out with her pitcher on her shoulder. She went down to the spring, and drew. I said to her, ‘Please let me drink.’ 
-<span class="v">46&#160;</span>She hurried and let down her pitcher from her shoulder, and said, ‘Drink, and I will also give your camels a drink.’ So I drank, and she also gave the camels a drink. 
-<span class="v">47&#160;</span>I asked her, and said, ‘Whose daughter are you?’ She said, ‘The daughter of Bethuel, Nahor’s son, whom Milcah bore to him.’ I put the ring on her nose, and the bracelets on her hands. 
-<span class="v">48&#160;</span>I bowed my head, and worshiped Yahweh, and blessed Yahweh, the Elohim of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son. 
-<span class="v">49&#160;</span>Now if you will deal kindly and truly with my master, tell me. If not, tell me, that I may turn to the right hand, or to the left.” 
-</p><p>
-<span class="v">50&#160;</span>Then Laban and Bethuel answered, “The thing proceeds from Yahweh. We can’t speak to you bad or good. 
-<span class="v">51&#160;</span>Behold, Rebekah is before you. Take her, and go, and let her be your master’s son’s woman, as Yahweh has spoken.” 
-</p><p>
-<span class="v">52&#160;</span>When Abraham’s servant heard their words, he bowed himself down to the earth to Yahweh. 
-<span class="v">53&#160;</span>The servant brought out jewels of silver, and jewels of gold, and clothing, and gave them to Rebekah. He also gave precious things to her brother and her mother. 
-<span class="v">54&#160;</span>They ate and drank, he and the men who were with him, and stayed all night. They rose up in the morning, and he said, “Send me away to my master.” 
-</p><p>
-<span class="v">55&#160;</span>Her brother and her mother said, “Let the young lady stay with us a few days, at least ten. After that she will go.” 
-</p><p>
-<span class="v">56&#160;</span>He said to them, “Don’t hinder me, since Yahweh has prospered my way. Send me away that I may go to my master.” 
-</p><p>
-<span class="v">57&#160;</span>They said, “We will call the young lady, and ask her.” 
-<span class="v">58&#160;</span>They called Rebekah, and said to her, “Will you go with this man?” 
-</p><p>She said, “I will go.” 
-</p><p>
-<span class="v">59&#160;</span>They sent away Rebekah, their sister, with her nurse, Abraham’s servant, and his men. 
-<span class="v">60&#160;</span>They blessed Rebekah, and said to her, “Our sister, may you be the mother of thousands of ten thousands, and let your offspring possess the gate of those who hate them.” 
-</p><p>
-<span class="v">61&#160;</span>Rebekah arose with her ladies. They rode on the camels, and followed the man. The servant took Rebekah, and went his way. 
-<span class="v">62&#160;</span>Isaac came from the way of Beer Lahai Roi, for he lived in the land of the South. 
-<span class="v">63&#160;</span>Isaac went out to meditate in the field at the evening. He lifted up his eyes and looked. Behold, there were camels coming. 
-<span class="v">64&#160;</span>Rebekah lifted up her eyes, and when she saw Isaac, she got off the camel. 
-<span class="v">65&#160;</span>She said to the servant, “Who is the man who is walking in the field to meet us?” 
-</p><p>The servant said, “It is my master.” 
-</p><p>She took her veil, and covered herself. 
-<span class="v">66&#160;</span>The servant told Isaac all the things that he had done. 
-<span class="v">67&#160;</span>Isaac brought her into his mother Sarah’s tent, and took Rebekah, and she became his woman. He loved her. So Isaac was comforted after his mother’s death. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Abraham took another woman, and her name was Keturah. 
-<span class="v">2&#160;</span>She bore him Zimran, Jokshan, Medan, Midian, Ishbak, and Shuah. 
-<span class="v">3&#160;</span>Jokshan brought forth Sheba, and Dedan. The sons of Dedan were Asshurim, Letushim, and Leummim. 
-<span class="v">4&#160;</span>The sons of Midian were Ephah, Epher, Hanoch, Abida, and Eldaah. All these were the children of Keturah. 
-<span class="v">5&#160;</span>Abraham gave all that he had to Isaac, 
-<span class="v">6&#160;</span>but Abraham gave gifts to the sons of Abraham’s concubines. While he still lived, he sent them away from Isaac his son, eastward, to the east country. 
-<span class="v">7&#160;</span>These are the days of the years of Abraham’s life which he lived: one hundred seventy-five years. 
-<span class="v">8&#160;</span>Abraham gave up his spirit, and died at a good old age, an old man, and full of years, and was gathered to his people. 
-<span class="v">9&#160;</span>Isaac and Ishmael, his sons, buried him in the cave of Machpelah, in the field of Ephron, the son of Zohar the Hittite, which is near Mamre, 
-<span class="v">10&#160;</span>the field which Abraham purchased from the children of Heth. Abraham was buried there with Sarah, his woman. 
-<span class="v">11&#160;</span>After the death of Abraham, Elohim blessed Isaac, his son. Isaac lived by Beer Lahai Roi. 
-</p><p>
-<span class="v">12&#160;</span>Now this is the history of the generations of Ishmael, Abraham’s son, whom Hagar the Egyptian, Sarah’s servant, bore to Abraham. 
-<span class="v">13&#160;</span>These are the names of the sons of Ishmael, by their names, according to the order of their birth: the firstborn of Ishmael, Nebaioth, then Kedar, Adbeel, Mibsam, 
-<span class="v">14&#160;</span>Mishma, Dumah, Massa, 
-<span class="v">15&#160;</span>Hadad, Tema, Jetur, Naphish, and Kedemah. 
-<span class="v">16&#160;</span>These are the sons of Ishmael, and these are their names, by their villages, and by their encampments: twelve princes, according to their nations. 
-<span class="v">17&#160;</span>These are the years of the life of Ishmael: one hundred thirty-seven years. He gave up his spirit and died, and was gathered to his people. 
-<span class="v">18&#160;</span>They lived from Havilah to Shur that is before Egypt, as you go toward Assyria. He lived opposite all his relatives. 
-</p><p>
-<span class="v">19&#160;</span>This is the history of the generations of Isaac, Abraham’s son. Abraham brought forth Isaac. 
-<span class="v">20&#160;</span>Isaac was forty years old when he took Rebekah, the daughter of Bethuel the Syrian of Paddan Aram, the sister of Laban the Syrian, to be his woman. 
-<span class="v">21&#160;</span>Isaac entreated Yahweh for his woman, because she was barren. Yahweh was entreated by him, and Rebekah his woman conceived. 
-<span class="v">22&#160;</span>The children struggled together within her. She said, “If it is like this, why do I live?” She went to inquire of Yahweh. 
-<span class="v">23&#160;</span>Yahweh said to her, 
-</p><p class="q1">“Two nations are in your womb. 
-</p><p class="q1">Two peoples will be separated from your body. 
-</p><p class="q1">The one people will be stronger than the other people. 
-</p><p class="q1">The elder will serve the younger.” 
-</p><p>
-<span class="v">24&#160;</span>When her days to be delivered were fulfilled, behold, there were twins in her womb. 
-<span class="v">25&#160;</span>The first came out red all over, like a hairy garment. They named him Esau. 
-<span class="v">26&#160;</span>After that, his brother came out, and his hand had hold on Esau’s heel. He was named Jacob. Isaac was sixty years old when she bore them. 
-</p><p>
-<span class="v">27&#160;</span>The boys grew. Esau was a skillful hunter, a man of the field. Jacob was a quiet man, living in tents. 
-<span class="v">28&#160;</span>Now Isaac loved Esau, because he ate his venison. Rebekah loved Jacob. 
-<span class="v">29&#160;</span>Jacob boiled stew. Esau came in from the field, and he was famished. 
-<span class="v">30&#160;</span>Esau said to Jacob, “Please feed me with some of that red stew, for I am famished.” Therefore his name was called Edom.<span class="f">+ \fr 25:30 \ft “Edom” means “red”.</span> 
-</p><p>
-<span class="v">31&#160;</span>Jacob said, “First, sell me your birthright.” 
-</p><p>
-<span class="v">32&#160;</span>Esau said, “Behold, I am about to die. What good is the birthright to me?” 
-</p><p>
-<span class="v">33&#160;</span>Jacob said, “Swear to me first.” 
-</p><p>He swore to him. He sold his birthright to Jacob. 
-<span class="v">34&#160;</span>Jacob gave Esau bread and lentil stew. He ate and drank, rose up, and went his way. So Esau despised his birthright. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>There was a famine in the land, in addition to the first famine that was in the days of Abraham. Isaac went to Abimelech king of the Philistines, to Gerar. 
-<span class="v">2&#160;</span>Yahweh appeared to him, and said, “Don’t go down into Egypt. Live in the land I will tell you about. 
-<span class="v">3&#160;</span>Live in this land, and I will be with you, and will bless you. For I will give to you, and to your offspring, all these lands, and I will establish the oath which I swore to Abraham your father. 
-<span class="v">4&#160;</span>I will multiply your offspring as the stars of the sky, and will give all these lands to your offspring. In your offspring all the nations of the earth will be blessed, 
-<span class="v">5&#160;</span>because Abraham obeyed my voice, and kept my requirements, my commandments, my statutes, and my laws.” 
-</p><p>
-<span class="v">6&#160;</span>Isaac lived in Gerar. 
-<span class="v">7&#160;</span>The men of the place asked him about his woman. He said, “She is my sister,” for he was afraid to say, “My woman”, lest, he thought, “the men of the place might kill me for Rebekah, because she is beautiful to look at.” 
-<span class="v">8&#160;</span>When he had been there a long time, Abimelech king of the Philistines looked out at a window, and saw, and, behold, Isaac was caressing Rebekah, his woman. 
-<span class="v">9&#160;</span>Abimelech called Isaac, and said, “Behold, surely she is your woman. Why did you say, ‘She is my sister’?” 
-</p><p>Isaac said to him, “Because I said, ‘Lest I die because of her.’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Abimelech said, “What is this you have done to us? One of the people might easily have lain with your woman, and you would have brought guilt on us!” 
-</p><p>
-<span class="v">11&#160;</span>Abimelech commanded all the people, saying, “He who touches this man or his woman will surely be put to death.” 
-</p><p>
-<span class="v">12&#160;</span>Isaac sowed in that land, and reaped in the same year one hundred times what he planted. Yahweh blessed him. 
-<span class="v">13&#160;</span>The man grew great, and grew more and more until he became very great. 
-<span class="v">14&#160;</span>He had possessions of flocks, possessions of herds, and a great household. The Philistines envied him. 
-<span class="v">15&#160;</span>Now all the wells which his father’s servants had dug in the days of Abraham his father, the Philistines had stopped, and filled with earth. 
-<span class="v">16&#160;</span>Abimelech said to Isaac, “Go away from us, for you are much mightier than we.” 
-</p><p>
-<span class="v">17&#160;</span>Isaac departed from there, encamped in the valley of Gerar, and lived there. 
-</p><p>
-<span class="v">18&#160;</span>Isaac dug again the wells of water, which they had dug in the days of Abraham his father, for the Philistines had stopped them after the death of Abraham. He called their names after the names by which his father had called them. 
-<span class="v">19&#160;</span>Isaac’s servants dug in the valley, and found there a well of flowing<span class="f">+ \fr 26:19 \ft Or, living. Or, fresh.</span> water. 
-<span class="v">20&#160;</span>The herdsmen of Gerar argued with Isaac’s herdsmen, saying, “The water is ours.” So he called the name of the well Esek,<span class="f">+ \fr 26:20 \ft “Esek” means “contention”.</span> because they contended with him. 
-<span class="v">21&#160;</span>They dug another well, and they argued over that, also. So he called its name Sitnah.<span class="f">+ \fr 26:21 \ft “Sitnah” means “hostility”.</span> 
-<span class="v">22&#160;</span>He left that place, and dug another well. They didn’t argue over that one. So he called it Rehoboth.<span class="f">+ \fr 26:22 \ft “Rehoboth” means “broad places”.</span> He said, “For now Yahweh has made room for us, and we will be fruitful in the land.” 
-</p><p>
-<span class="v">23&#160;</span>He went up from there to Beersheba. 
-<span class="v">24&#160;</span>Yahweh appeared to him the same night, and said, “I am the Elohim of Abraham your father. Don’t be afraid, for I am with you, and will bless you, and multiply your offspring for my servant Abraham’s sake.” 
-</p><p>
-<span class="v">25&#160;</span>He built an altar there, and called on Yahweh’s name, and pitched his tent there. There Isaac’s servants dug a well. 
-</p><p>
-<span class="v">26&#160;</span>Then Abimelech went to him from Gerar with Ahuzzath his friend, and Phicol the captain of his army. 
-<span class="v">27&#160;</span>Isaac said to them, “Why have you come to me, since you hate me, and have sent me away from you?” 
-</p><p>
-<span class="v">28&#160;</span>They said, “We saw plainly that Yahweh was with you. We said, ‘Let there now be an oath between us, even between us and you, and let’s make a covenant with you, 
-<span class="v">29&#160;</span>that you will do us no harm, as we have not touched you, and as we have done to you nothing but good, and have sent you away in peace.’ You are now the blessed of Yahweh.” 
-</p><p>
-<span class="v">30&#160;</span>He made them a feast, and they ate and drank. 
-<span class="v">31&#160;</span>They rose up some time in the morning, and swore an oath to one another. Isaac sent them away, and they departed from him in peace. 
-<span class="v">32&#160;</span>The same day, Isaac’s servants came, and told him concerning the well which they had dug, and said to him, “We have found water.” 
-<span class="v">33&#160;</span>He called it “Shibah”.<span class="f">+ \fr 26:33 \ft Shibah means “oath” or “seven”.</span> Therefore the name of the city is “Beersheba”<span class="f">+ \fr 26:33 \ft Beersheba means “well of the oath” or “well of the seven”</span> to this day. 
-</p><p>
-<span class="v">34&#160;</span>When Esau was forty years old, he took as woman Judith, the daughter of Beeri the Hittite, and Basemath, the daughter of Elon the Hittite. 
-<span class="v">35&#160;</span>They grieved Isaac’s and Rebekah’s spirits. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>When Isaac was old, and his eyes were dim, so that he could not see, he called Esau his elder son, and said to him, “My son?” 
-</p><p>He said to him, “Here I am.” 
-</p><p>
-<span class="v">2&#160;</span>He said, “See now, I am old. I don’t know the day of my death. 
-<span class="v">3&#160;</span>Now therefore, please take your weapons, your quiver and your bow, and go out to the field, and get me venison. 
-<span class="v">4&#160;</span>Make me savory food, such as I love, and bring it to me, that I may eat, and that my soul may bless you before I die.” 
-</p><p>
-<span class="v">5&#160;</span>Rebekah heard when Isaac spoke to Esau his son. Esau went to the field to hunt for venison, and to bring it. 
-<span class="v">6&#160;</span>Rebekah spoke to Jacob her son, saying, “Behold, I heard your father speak to Esau your brother, saying, 
-<span class="v">7&#160;</span>‘Bring me venison, and make me savory food, that I may eat, and bless you before Yahweh before my death.’ 
-<span class="v">8&#160;</span>Now therefore, my son, obey my voice according to that which I command you. 
-<span class="v">9&#160;</span>Go now to the flock and get me two good young goats from there. I will make them savory food for your father, such as he loves. 
-<span class="v">10&#160;</span>You shall bring it to your father, that he may eat, so that he may bless you before his death.” 
-</p><p>
-<span class="v">11&#160;</span>Jacob said to Rebekah his mother, “Behold, Esau my brother is a hairy man, and I am a smooth man. 
-<span class="v">12&#160;</span>What if my father touches me? I will seem to him as a deceiver, and I would bring a curse on myself, and not a blessing.” 
-</p><p>
-<span class="v">13&#160;</span>His mother said to him, “Let your curse be on me, my son. Only obey my voice, and go get them for me.” 
-</p><p>
-<span class="v">14&#160;</span>He went, and got them, and brought them to his mother. His mother made savory food, such as his father loved. 
-<span class="v">15&#160;</span>Rebekah took the good clothes of Esau, her elder son, which were with her in the house, and put them on Jacob, her younger son. 
-<span class="v">16&#160;</span>She put the skins of the young goats on his hands, and on the smooth of his neck. 
-<span class="v">17&#160;</span>She gave the savory food and the bread, which she had prepared, into the hand of her son Jacob. 
-</p><p>
-<span class="v">18&#160;</span>He came to his father, and said, “My father?” 
-</p><p>He said, “Here I am. Who are you, my son?” 
-</p><p>
-<span class="v">19&#160;</span>Jacob said to his father, “I am Esau your firstborn. I have done what you asked me to do. Please arise, sit and eat of my venison, that your soul may bless me.” 
-</p><p>
-<span class="v">20&#160;</span>Isaac said to his son, “How is it that you have found it so quickly, my son?” 
-</p><p>He said, “Because Yahweh your Elohim gave me success.” 
-</p><p>
-<span class="v">21&#160;</span>Isaac said to Jacob, “Please come near, that I may feel you, my son, whether you are really my son Esau or not.” 
-</p><p>
-<span class="v">22&#160;</span>Jacob went near to Isaac his father. He felt him, and said, “The voice is Jacob’s voice, but the hands are the hands of Esau.” 
-<span class="v">23&#160;</span>He didn’t recognize him, because his hands were hairy, like his brother Esau’s hands. So he blessed him. 
-<span class="v">24&#160;</span>He said, “Are you really my son Esau?” 
-</p><p>He said, “I am.” 
-</p><p>
-<span class="v">25&#160;</span>He said, “Bring it near to me, and I will eat of my son’s venison, that my soul may bless you.” 
-</p><p>He brought it near to him, and he ate. He brought him wine, and he drank. 
-<span class="v">26&#160;</span>His father Isaac said to him, “Come near now, and kiss me, my son.” 
-<span class="v">27&#160;</span>He came near, and kissed him. He smelled the smell of his clothing, and blessed him, and said, 
-</p><p class="q1">“Behold, the smell of my son 
-</p><p class="q2">is as the smell of a field which Yahweh has blessed. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Elohim give you of the dew of the sky, 
-</p><p class="q2">of the fatness of the earth, 
-</p><p class="q2">and plenty of grain and new wine. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Let peoples serve you, 
-</p><p class="q2">and nations bow down to you. 
-</p><p class="q1">Be lord over your brothers. 
-</p><p class="q2">Let your mother’s sons bow down to you. 
-</p><p class="q1">Cursed be everyone who curses you. 
-</p><p class="q2">Blessed be everyone who blesses you.” 
-</p><p>
-<span class="v">30&#160;</span>As soon as Isaac had finished blessing Jacob, and Jacob had just gone out from the presence of Isaac his father, Esau his brother came in from his hunting. 
-<span class="v">31&#160;</span>He also made savory food, and brought it to his father. He said to his father, “Let my father arise, and eat of his son’s venison, that your soul may bless me.” 
-</p><p>
-<span class="v">32&#160;</span>Isaac his father said to him, “Who are you?” 
-</p><p>He said, “I am your son, your firstborn, Esau.” 
-</p><p>
-<span class="v">33&#160;</span>Isaac trembled violently, and said, “Who, then, is he who has taken venison, and brought it to me, and I have eaten of all before you came, and have blessed him? Yes, he will be blessed.” 
-</p><p>
-<span class="v">34&#160;</span>When Esau heard the words of his father, he cried with an exceedingly great and bitter cry, and said to his father, “Bless me, even me also, my father.” 
-</p><p>
-<span class="v">35&#160;</span>He said, “Your brother came with deceit, and has taken away your blessing.” 
-</p><p>
-<span class="v">36&#160;</span>He said, “Isn’t he rightly named Jacob? For he has supplanted me these two times. He took away my birthright. See, now he has taken away my blessing.” He said, “Haven’t you reserved a blessing for me?” 
-</p><p>
-<span class="v">37&#160;</span>Isaac answered Esau, “Behold, I have made him your lord, and all his brothers I have given to him for servants. I have sustained him with grain and new wine. What then will I do for you, my son?” 
-</p><p>
-<span class="v">38&#160;</span>Esau said to his father, “Do you have just one blessing, my father? Bless me, even me also, my father.” Esau lifted up his voice, and wept. 
-</p><p>
-<span class="v">39&#160;</span>Isaac his father answered him, 
-</p><p class="q1">“Behold, your dwelling will be of the fatness of the earth, 
-</p><p class="q1">and of the dew of the sky from above. 
-</p><p class="q1">
-<span class="v">40&#160;</span>You will live by your sword, and you will serve your brother. 
-</p><p class="q1">It will happen, when you will break loose, 
-</p><p class="q1">that you will shake his yoke from off your neck.” 
-</p><p>
-<span class="v">41&#160;</span>Esau hated Jacob because of the blessing with which his father blessed him. Esau said in his heart, “The days of mourning for my father are at hand. Then I will kill my brother Jacob.” 
-</p><p>
-<span class="v">42&#160;</span>The words of Esau, her elder son, were told to Rebekah. She sent and called Jacob, her younger son, and said to him, “Behold, your brother Esau comforts himself about you by planning to kill you. 
-<span class="v">43&#160;</span>Now therefore, my son, obey my voice. Arise, flee to Laban, my brother, in Haran. 
-<span class="v">44&#160;</span>Stay with him a few days, until your brother’s fury turns away—<span class="v">45&#160;</span>until your brother’s anger turns away from you, and he forgets what you have done to him. Then I will send, and get you from there. Why should I be bereaved of you both in one day?” 
-</p><p>
-<span class="v">46&#160;</span>Rebekah said to Isaac, “I am weary of my life because of the daughters of Heth. If Jacob takes a woman of the daughters of Heth, such as these, of the daughters of the land, what good will my life do me?” 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>Isaac called Jacob, blessed him, and commanded him, “You shall not take a woman of the daughters of Canaan. 
-<span class="v">2&#160;</span>Arise, go to Paddan Aram, to the house of Bethuel your mother’s father. Take a woman from there from the daughters of Laban, your mother’s brother. 
-<span class="v">3&#160;</span>May Elohim Almighty bless you, and make you fruitful, and multiply you, that you may be a company of peoples, 
-<span class="v">4&#160;</span>and give you the blessing of Abraham, to you and to your offspring with you, that you may inherit the land where you travel, which Elohim gave to Abraham.” 
-</p><p>
-<span class="v">5&#160;</span>Isaac sent Jacob away. He went to Paddan Aram to Laban, son of Bethuel the Syrian, the brother of Rebekah, Jacob’s and Esau’s mother. 
-</p><p>
-<span class="v">6&#160;</span>Now Esau saw that Isaac had blessed Jacob and sent him away to Paddan Aram, to take him a woman from there, and that as he blessed him he gave him a command, saying, “You shall not take a woman of the daughters of Canaan;” 
-<span class="v">7&#160;</span>and that Jacob obeyed his father and his mother, and was gone to Paddan Aram. 
-<span class="v">8&#160;</span>Esau saw that the daughters of Canaan didn’t please Isaac, his father. 
-<span class="v">9&#160;</span>So Esau went to Ishmael, and took, in addition to the women that he had, Mahalath the daughter of Ishmael, Abraham’s son, the sister of Nebaioth, to be his woman. 
-</p><p>
-<span class="v">10&#160;</span>Jacob went out from Beersheba, and went toward Haran. 
-<span class="v">11&#160;</span>He came to a certain place, and stayed there all night, because the sun had set. He took one of the stones of the place, and put it under his head, and lay down in that place to sleep. 
-<span class="v">12&#160;</span>He dreamed and saw a stairway set upon the earth, and its top reached to heaven. Behold, the angels of Elohim were ascending and descending on it. 
-<span class="v">13&#160;</span>Behold, Yahweh stood above it, and said, “I am Yahweh, the Elohim of Abraham your father, and the Elohim of Isaac. I will give the land you lie on to you and to your offspring. 
-<span class="v">14&#160;</span>Your offspring will be as the dust of the earth, and you will spread abroad to the west, and to the east, and to the north, and to the south. In you and in your offspring, all the families of the earth will be blessed. 
-<span class="v">15&#160;</span>Behold, I am with you, and will keep you, wherever you go, and will bring you again into this land. For I will not leave you until I have done that which I have spoken of to you.” 
-</p><p>
-<span class="v">16&#160;</span>Jacob awakened out of his sleep, and he said, “Surely Yahweh is in this place, and I didn’t know it.” 
-<span class="v">17&#160;</span>He was afraid, and said, “How awesome this place is! This is none other than Elohim’s house, and this is the gate of heaven.” 
-</p><p>
-<span class="v">18&#160;</span>Jacob rose up early in the morning, and took the stone that he had put under his head, and set it up for a pillar, and poured oil on its top. 
-<span class="v">19&#160;</span>He called the name of that place Bethel, but the name of the city was Luz at the first. 
-<span class="v">20&#160;</span>Jacob vowed a vow, saying, “If Elohim will be with me, and will keep me in this way that I go, and will give me bread to eat, and clothing to put on, 
-<span class="v">21&#160;</span>so that I come again to my father’s house in peace, and Yahweh will be my Elohim, 
-<span class="v">22&#160;</span>then this stone, which I have set up for a pillar, will be Elohim’s house. Of all that you will give me I will surely give a tenth to you.” 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>Then Jacob went on his journey, and came to the land of the children of the east. 
-<span class="v">2&#160;</span>He looked, and saw a well in the field, and saw three flocks of sheep lying there by it. For out of that well they watered the flocks. The stone on the well’s mouth was large. 
-<span class="v">3&#160;</span>There all the flocks were gathered. They rolled the stone from the well’s mouth, and watered the sheep, and put the stone back on the well’s mouth in its place. 
-<span class="v">4&#160;</span>Jacob said to them, “My relatives, where are you from?” 
-</p><p>They said, “We are from Haran.” 
-</p><p>
-<span class="v">5&#160;</span>He said to them, “Do you know Laban, the son of Nahor?” 
-</p><p>They said, “We know him.” 
-</p><p>
-<span class="v">6&#160;</span>He said to them, “Is it well with him?” 
-</p><p>They said, “It is well. See, Rachel, his daughter, is coming with the sheep.” 
-</p><p>
-<span class="v">7&#160;</span>He said, “Behold, it is still the middle of the day, not time to gather the livestock together. Water the sheep, and go and feed them.” 
-</p><p>
-<span class="v">8&#160;</span>They said, “We can’t, until all the flocks are gathered together, and they roll the stone from the well’s mouth. Then we will water the sheep.” 
-</p><p>
-<span class="v">9&#160;</span>While he was yet speaking with them, Rachel came with her father’s sheep, for she kept them. 
-<span class="v">10&#160;</span>When Jacob saw Rachel the daughter of Laban, his mother’s brother, and the sheep of Laban, his mother’s brother, Jacob went near, and rolled the stone from the well’s mouth, and watered the flock of Laban his mother’s brother. 
-<span class="v">11&#160;</span>Jacob kissed Rachel, and lifted up his voice, and wept. 
-<span class="v">12&#160;</span>Jacob told Rachel that he was her father’s relative, and that he was Rebekah’s son. She ran and told her father. 
-</p><p>
-<span class="v">13&#160;</span>When Laban heard the news of Jacob, his sister’s son, he ran to meet Jacob, and embraced him, and kissed him, and brought him to his house. Jacob told Laban all these things. 
-<span class="v">14&#160;</span>Laban said to him, “Surely you are my bone and my flesh.” Jacob stayed with him for a month. 
-<span class="v">15&#160;</span>Laban said to Jacob, “Because you are my relative, should you therefore serve me for nothing? Tell me, what will your wages be?” 
-</p><p>
-<span class="v">16&#160;</span>Laban had two daughters. The name of the elder was Leah, and the name of the younger was Rachel. 
-<span class="v">17&#160;</span>Leah’s eyes were weak, but Rachel was beautiful in form and attractive. 
-<span class="v">18&#160;</span>Jacob loved Rachel. He said, “I will serve you seven years for Rachel, your younger daughter.” 
-</p><p>
-<span class="v">19&#160;</span>Laban said, “It is better that I give her to you, than that I should give her to another man. Stay with me.” 
-</p><p>
-<span class="v">20&#160;</span>Jacob served seven years for Rachel. They seemed to him but a few days, for the love he had for her. 
-</p><p>
-<span class="v">21&#160;</span>Jacob said to Laban, “Give me my woman, for my days are fulfilled, that I may go in to her.” 
-</p><p>
-<span class="v">22&#160;</span>Laban gathered together all the men of the place, and made a feast. 
-<span class="v">23&#160;</span>In the evening, he took Leah his daughter, and brought her to Jacob. He went in to her. 
-<span class="v">24&#160;</span>Laban gave Zilpah his servant to his daughter Leah for a servant. 
-<span class="v">25&#160;</span>In the morning, behold, it was Leah! He said to Laban, “What is this you have done to me? Didn’t I serve with you for Rachel? Why then have you deceived me?” 
-</p><p>
-<span class="v">26&#160;</span>Laban said, “It is not done so in our place, to give the younger before the firstborn. 
-<span class="v">27&#160;</span>Fulfill the week of this one, and we will give you the other also for the service which you will serve with me for seven more years.” 
-</p><p>
-<span class="v">28&#160;</span>Jacob did so, and fulfilled her week. He gave him Rachel his daughter as woman. 
-<span class="v">29&#160;</span>Laban gave Bilhah, his servant, to his daughter Rachel to be her servant. 
-<span class="v">30&#160;</span>He went in also to Rachel, and he loved also Rachel more than Leah, and served with him seven more years. 
-</p><p>
-<span class="v">31&#160;</span>Yahweh saw that Leah was hated, and he opened her womb, but Rachel was barren. 
-<span class="v">32&#160;</span>Leah conceived, and bore a son, and she named him Reuben. For she said, “Because Yahweh has looked at my affliction; for now my man will love me.” 
-<span class="v">33&#160;</span>She conceived again, and bore a son, and said, “Because Yahweh has heard that I am hated, he has therefore given me this son also.” She named him Simeon. 
-<span class="v">34&#160;</span>She conceived again, and bore a son. She said, “Now this time my man will be joined to me, because I have borne him three sons.” Therefore his name was called Levi. 
-<span class="v">35&#160;</span>She conceived again, and bore a son. She said, “This time I will praise Yahweh.” Therefore she named him Judah. Then she stopped bearing. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>When Rachel saw that she bore Jacob no children, Rachel envied her sister. She said to Jacob, “Give me children, or else I will die.” 
-</p><p>
-<span class="v">2&#160;</span>Jacob’s anger burned against Rachel, and he said, “Am I in Elohim’s place, who has withheld from you the fruit of the womb?” 
-</p><p>
-<span class="v">3&#160;</span>She said, “Behold, my maid Bilhah. Go in to her, that she may bear on my knees, and I also may obtain children by her.” 
-<span class="v">4&#160;</span>She gave him Bilhah her servant as woman, and Jacob went in to her. 
-<span class="v">5&#160;</span>Bilhah conceived, and bore Jacob a son. 
-<span class="v">6&#160;</span>Rachel said, “Elohim has judged me, and has also heard my voice, and has given me a son.” Therefore she called his name Dan. 
-<span class="v">7&#160;</span>Bilhah, Rachel’s servant, conceived again, and bore Jacob a second son. 
-<span class="v">8&#160;</span>Rachel said, “I have wrestled with my sister with mighty wrestlings, and have prevailed.” She named him Naphtali. 
-</p><p>
-<span class="v">9&#160;</span>When Leah saw that she had finished bearing, she took Zilpah, her servant, and gave her to Jacob as a woman. 
-<span class="v">10&#160;</span>Zilpah, Leah’s servant, bore Jacob a son. 
-<span class="v">11&#160;</span>Leah said, “How fortunate!” She named him Gad. 
-<span class="v">12&#160;</span>Zilpah, Leah’s servant, bore Jacob a second son. 
-<span class="v">13&#160;</span>Leah said, “Happy am I, for the daughters will call me happy.” She named him Asher. 
-</p><p>
-<span class="v">14&#160;</span>Reuben went in the days of wheat harvest, and found mandrakes in the field, and brought them to his mother, Leah. Then Rachel said to Leah, “Please give me some of your son’s mandrakes.” 
-</p><p>
-<span class="v">15&#160;</span>Leah said to her, “Is it a small matter that you have taken away my man? Would you take away my son’s mandrakes, also?” 
-</p><p>Rachel said, “Therefore he will lie with you tonight for your son’s mandrakes.” 
-</p><p>
-<span class="v">16&#160;</span>Jacob came from the field in the evening, and Leah went out to meet him, and said, “You must come in to me; for I have surely hired you with my son’s mandrakes.” 
-</p><p>He lay with her that night. 
-<span class="v">17&#160;</span>Elohim listened to Leah, and she conceived, and bore Jacob a fifth son. 
-<span class="v">18&#160;</span>Leah said, “Elohim has given me my hire, because I gave my servant to my man.” She named him Issachar. 
-<span class="v">19&#160;</span>Leah conceived again, and bore a sixth son to Jacob. 
-<span class="v">20&#160;</span>Leah said, “Elohim has endowed me with a good dowry. Now my man will live with me, because I have borne him six sons.” She named him Zebulun. 
-<span class="v">21&#160;</span>Afterwards, she bore a daughter, and named her Dinah. 
-</p><p>
-<span class="v">22&#160;</span>Elohim remembered Rachel, and Elohim listened to her, and opened her womb. 
-<span class="v">23&#160;</span>She conceived, bore a son, and said, “Elohim has taken away my reproach.” 
-<span class="v">24&#160;</span>She named him Joseph,<span class="f">+ \fr 30:24 \ft Joseph means “may he add”.</span> saying, “May Yahweh add another son to me.” 
-</p><p>
-<span class="v">25&#160;</span>When Rachel had borne Joseph, Jacob said to Laban, “Send me away, that I may go to my own place, and to my country. 
-<span class="v">26&#160;</span>Give me my women and my children for whom I have served you, and let me go; for you know my service with which I have served you.” 
-</p><p>
-<span class="v">27&#160;</span>Laban said to him, “If now I have found favor in your eyes, stay here, for I have divined that Yahweh has blessed me for your sake.” 
-<span class="v">28&#160;</span>He said, “Appoint me your wages, and I will give it.” 
-</p><p>
-<span class="v">29&#160;</span>Jacob said to him, “You know how I have served you, and how your livestock have fared with me. 
-<span class="v">30&#160;</span>For it was little which you had before I came, and it has increased to a multitude. Yahweh has blessed you wherever I turned. Now when will I provide for my own house also?” 
-</p><p>
-<span class="v">31&#160;</span>Laban said, “What shall I give you?” 
-</p><p>Jacob said, “You shall not give me anything. If you will do this thing for me, I will again feed your flock and keep it. 
-<span class="v">32&#160;</span>I will pass through all your flock today, removing from there every speckled and spotted one, and every black one among the sheep, and the spotted and speckled among the goats. This will be my hire. 
-<span class="v">33&#160;</span>So my righteousness will answer for me hereafter, when you come concerning my hire that is before you. Every one that is not speckled and spotted among the goats, and black among the sheep, that might be with me, will be considered stolen.” 
-</p><p>
-<span class="v">34&#160;</span>Laban said, “Behold, let it be according to your word.” 
-</p><p>
-<span class="v">35&#160;</span>That day, he removed the male goats that were streaked and spotted, and all the female goats that were speckled and spotted, every one that had white in it, and all the black ones among the sheep, and gave them into the hand of his sons. 
-<span class="v">36&#160;</span>He set three days’ journey between himself and Jacob, and Jacob fed the rest of Laban’s flocks. 
-</p><p>
-<span class="v">37&#160;</span>Jacob took to himself rods of fresh poplar, almond, and plane tree, peeled white streaks in them, and made the white appear which was in the rods. 
-<span class="v">38&#160;</span>He set the rods which he had peeled opposite the flocks in the watering troughs where the flocks came to drink. They conceived when they came to drink. 
-<span class="v">39&#160;</span>The flocks conceived before the rods, and the flocks produced streaked, speckled, and spotted. 
-<span class="v">40&#160;</span>Jacob separated the lambs, and set the faces of the flocks toward the streaked and all the black in Laban’s flock. He put his own droves apart, and didn’t put them into Laban’s flock. 
-<span class="v">41&#160;</span>Whenever the stronger of the flock conceived, Jacob laid the rods in front of the eyes of the flock in the watering troughs, that they might conceive among the rods; 
-<span class="v">42&#160;</span>but when the flock were feeble, he didn’t put them in. So the feebler were Laban’s, and the stronger Jacob’s. 
-<span class="v">43&#160;</span>The man increased exceedingly, and had large flocks, female servants and male servants, and camels and donkeys. 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>Jacob heard Laban’s sons’ words, saying, “Jacob has taken away all that was our father’s. He has obtained all this wealth from that which was our father’s.” 
-<span class="v">2&#160;</span>Jacob saw the expression on Laban’s face, and, behold, it was not toward him as before. 
-<span class="v">3&#160;</span>Yahweh said to Jacob, “Return to the land of your fathers, and to your relatives, and I will be with you.” 
-</p><p>
-<span class="v">4&#160;</span>Jacob sent and called Rachel and Leah to the field to his flock, 
-<span class="v">5&#160;</span>and said to them, “I see the expression on your father’s face, that it is not toward me as before; but the Elohim of my father has been with me. 
-<span class="v">6&#160;</span>You know that I have served your father with all of my strength. 
-<span class="v">7&#160;</span>Your father has deceived me, and changed my wages ten times, but Elohim didn’t allow him to hurt me. 
-<span class="v">8&#160;</span>If he said, ‘The speckled will be your wages,’ then all the flock bore speckled. If he said, ‘The streaked will be your wages,’ then all the flock bore streaked. 
-<span class="v">9&#160;</span>Thus Elohim has taken away your father’s livestock, and given them to me. 
-<span class="v">10&#160;</span>During mating season, I lifted up my eyes, and saw in a dream, and behold, the male goats which leaped on the flock were streaked, speckled, and grizzled. 
-<span class="v">11&#160;</span>The angel of Elohim said to me in the dream, ‘Jacob,’ and I said, ‘Here I am.’ 
-<span class="v">12&#160;</span>He said, ‘Now lift up your eyes, and behold, all the male goats which leap on the flock are streaked, speckled, and grizzled, for I have seen all that Laban does to you. 
-<span class="v">13&#160;</span>I am the Elohim of Bethel, where you anointed a pillar, where you vowed a vow to me. Now arise, get out from this land, and return to the land of your birth.’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Rachel and Leah answered him, “Is there yet any portion or inheritance for us in our father’s house? 
-<span class="v">15&#160;</span>Aren’t we considered as foreigners by him? For he has sold us, and has also used up our money. 
-<span class="v">16&#160;</span>For all the riches which Elohim has taken away from our father are ours and our children’s. Now then, whatever Elohim has said to you, do.” 
-</p><p>
-<span class="v">17&#160;</span>Then Jacob rose up, and set his sons and his women on the camels, 
-<span class="v">18&#160;</span>and he took away all his livestock, and all his possessions which he had gathered, including the livestock which he had gained in Paddan Aram, to go to Isaac his father, to the land of Canaan. 
-<span class="v">19&#160;</span>Now Laban had gone to shear his sheep; and Rachel stole the teraphim<span class="f">+ \fr 31:19 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> that were her father’s. 
-</p><p>
-<span class="v">20&#160;</span>Jacob deceived Laban the Syrian, in that he didn’t tell him that he was running away. 
-<span class="v">21&#160;</span>So he fled with all that he had. He rose up, passed over the River, and set his face toward the mountain of Gilead. 
-</p><p>
-<span class="v">22&#160;</span>Laban was told on the third day that Jacob had fled. 
-<span class="v">23&#160;</span>He took his relatives with him, and pursued him seven days’ journey. He overtook him in the mountain of Gilead. 
-<span class="v">24&#160;</span>Elohim came to Laban the Syrian in a dream of the night, and said to him, “Be careful that you don’t speak to Jacob either good or bad.” 
-</p><p>
-<span class="v">25&#160;</span>Laban caught up with Jacob. Now Jacob had pitched his tent in the mountain, and Laban with his relatives encamped in the mountain of Gilead. 
-<span class="v">26&#160;</span>Laban said to Jacob, “What have you done, that you have deceived me, and carried away my daughters like captives of the sword? 
-<span class="v">27&#160;</span>Why did you flee secretly, and deceive me, and didn’t tell me, that I might have sent you away with mirth and with songs, with tambourine and with harp; 
-<span class="v">28&#160;</span>and didn’t allow me to kiss my sons and my daughters? Now have you done foolishly. 
-<span class="v">29&#160;</span>It is in the power of my hand to hurt you, but the Elohim of your father spoke to me last night, saying, ‘Be careful that you don’t speak to Jacob either good or bad.’ 
-<span class="v">30&#160;</span>Now, you want to be gone, because you greatly longed for your father’s house, but why have you stolen my elohims?” 
-</p><p>
-<span class="v">31&#160;</span>Jacob answered Laban, “Because I was afraid, for I said, ‘Lest you should take your daughters from me by force.’ 
-<span class="v">32&#160;</span>Anyone you find your elohims with shall not live. Before our relatives, discern what is yours with me, and take it.” For Jacob didn’t know that Rachel had stolen them. 
-</p><p>
-<span class="v">33&#160;</span>Laban went into Jacob’s tent, into Leah’s tent, and into the tent of the two female servants; but he didn’t find them. He went out of Leah’s tent, and entered into Rachel’s tent. 
-<span class="v">34&#160;</span>Now Rachel had taken the teraphim, put them in the camel’s saddle, and sat on them. Laban felt around all the tent, but didn’t find them. 
-<span class="v">35&#160;</span>She said to her father, “Don’t let my lord be angry that I can’t rise up before you; for I’m having my period.” He searched, but didn’t find the teraphim. 
-</p><p>
-<span class="v">36&#160;</span>Jacob was angry, and argued with Laban. Jacob answered Laban, “What is my trespass? What is my sin, that you have hotly pursued me? 
-<span class="v">37&#160;</span>Now that you have felt around in all my stuff, what have you found of all your household stuff? Set it here before my relatives and your relatives, that they may judge between us two. 
-</p><p>
-<span class="v">38&#160;</span>“These twenty years I have been with you. Your ewes and your female goats have not cast their young, and I haven’t eaten the rams of your flocks. 
-<span class="v">39&#160;</span>That which was torn of animals, I didn’t bring to you. I bore its loss. Of my hand you required it, whether stolen by day or stolen by night. 
-<span class="v">40&#160;</span>This was my situation: in the day the drought consumed me, and the frost by night; and my sleep fled from my eyes. 
-<span class="v">41&#160;</span>These twenty years I have been in your house. I served you fourteen years for your two daughters, and six years for your flock, and you have changed my wages ten times. 
-<span class="v">42&#160;</span>Unless the Elohim of my father, the Elohim of Abraham, and the fear of Isaac, had been with me, surely now you would have sent me away empty. Elohim has seen my affliction and the labor of my hands, and rebuked you last night.” 
-</p><p>
-<span class="v">43&#160;</span>Laban answered Jacob, “The daughters are my daughters, the children are my children, the flocks are my flocks, and all that you see is mine! What can I do today to these my daughters, or to their children whom they have borne? 
-<span class="v">44&#160;</span>Now come, let’s make a covenant, you and I. Let it be for a witness between me and you.” 
-</p><p>
-<span class="v">45&#160;</span>Jacob took a stone, and set it up for a pillar. 
-<span class="v">46&#160;</span>Jacob said to his relatives, “Gather stones.” They took stones, and made a heap. They ate there by the heap. 
-<span class="v">47&#160;</span>Laban called it Jegar Sahadutha,<span class="f">+ \fr 31:47 \ft “Jegar Sahadutha” means “Witness Heap” in Aramaic.</span> but Jacob called it Galeed.<span class="f">+ \fr 31:47 \ft “Galeed” means “Witness Heap” in Hebrew.</span> 
-<span class="v">48&#160;</span>Laban said, “This heap is witness between me and you today.” Therefore it was named Galeed 
-<span class="v">49&#160;</span>and Mizpah, for he said, “Yahweh watch between me and you, when we are absent one from another. 
-<span class="v">50&#160;</span>If you afflict my daughters, or if you take women in addition to my daughters, no man is with us; behold, Elohim is witness between me and you.” 
-<span class="v">51&#160;</span>Laban said to Jacob, “See this heap, and see the pillar, which I have set between me and you. 
-<span class="v">52&#160;</span>May this heap be a witness, and the pillar be a witness, that I will not pass over this heap to you, and that you will not pass over this heap and this pillar to me, for harm. 
-<span class="v">53&#160;</span>The Elohim of Abraham, and the Elohim of Nahor, the Elohim of their father, judge between us.” Then Jacob swore by the fear of his father, Isaac. 
-<span class="v">54&#160;</span>Jacob offered a sacrifice in the mountain, and called his relatives to eat bread. They ate bread, and stayed all night in the mountain. 
-<span class="v">55&#160;</span>Early in the morning, Laban rose up, and kissed his sons and his daughters, and blessed them. Laban departed and returned to his place. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>Jacob went on his way, and the angels of Elohim met him. 
-<span class="v">2&#160;</span>When he saw them, Jacob said, “This is Elohim’s army.” He called the name of that place Mahanaim.<span class="f">+ \fr 32:2 \ft “Mahanaim” means “two camps”.</span> 
-</p><p>
-<span class="v">3&#160;</span>Jacob sent messengers in front of him to Esau, his brother, to the land of Seir, the field of Edom. 
-<span class="v">4&#160;</span>He commanded them, saying, “This is what you shall tell my lord, Esau: ‘This is what your servant, Jacob, says. I have lived as a foreigner with Laban, and stayed until now. 
-<span class="v">5&#160;</span>I have cattle, donkeys, flocks, male servants, and female servants. I have sent to tell my lord, that I may find favor in your sight.’&#160;” 
-<span class="v">6&#160;</span>The messengers returned to Jacob, saying, “We came to your brother Esau. He is coming to meet you, and four hundred men are with him.” 
-<span class="v">7&#160;</span>Then Jacob was greatly afraid and was distressed. He divided the people who were with him, along with the flocks, the herds, and the camels, into two companies. 
-<span class="v">8&#160;</span>He said, “If Esau comes to the one company, and strikes it, then the company which is left will escape.” 
-<span class="v">9&#160;</span>Jacob said, “Elohim of my father Abraham, and Elohim of my father Isaac, Yahweh, who said to me, ‘Return to your country, and to your relatives, and I will do you good,’ 
-<span class="v">10&#160;</span>I am not worthy of the least of all the loving kindnesses, and of all the truth, which you have shown to your servant; for with just my staff I crossed over this Jordan; and now I have become two companies. 
-<span class="v">11&#160;</span>Please deliver me from the hand of my brother, from the hand of Esau; for I fear him, lest he come and strike me and the mothers with the children. 
-<span class="v">12&#160;</span>You said, ‘I will surely do you good, and make your offspring as the sand of the sea, which can’t be counted because there are so many.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>He stayed there that night, and took from that which he had with him a present for Esau, his brother: 
-<span class="v">14&#160;</span>two hundred female goats and twenty male goats, two hundred ewes and twenty rams, 
-<span class="v">15&#160;</span>thirty milk camels and their colts, forty cows, ten bulls, twenty female donkeys and ten foals. 
-<span class="v">16&#160;</span>He delivered them into the hands of his servants, every herd by itself, and said to his servants, “Pass over before me, and put a space between herd and herd.” 
-<span class="v">17&#160;</span>He commanded the foremost, saying, “When Esau, my brother, meets you, and asks you, saying, ‘Whose are you? Where are you going? Whose are these before you?’ 
-<span class="v">18&#160;</span>Then you shall say, ‘They are your servant, Jacob’s. It is a present sent to my lord, Esau. Behold, he also is behind us.’&#160;” 
-<span class="v">19&#160;</span>He commanded also the second, and the third, and all that followed the herds, saying, “This is how you shall speak to Esau, when you find him. 
-<span class="v">20&#160;</span>You shall say, ‘Not only that, but behold, your servant, Jacob, is behind us.’&#160;” For, he said, “I will appease him with the present that goes before me, and afterward I will see his face. Perhaps he will accept me.” 
-</p><p>
-<span class="v">21&#160;</span>So the present passed over before him, and he himself stayed that night in the camp. 
-</p><p>
-<span class="v">22&#160;</span>He rose up that night, and took his two women, and his two servants, and his eleven sons, and crossed over the ford of the Jabbok. 
-<span class="v">23&#160;</span>He took them, and sent them over the stream, and sent over that which he had. 
-<span class="v">24&#160;</span>Jacob was left alone, and wrestled with a man there until the breaking of the day. 
-<span class="v">25&#160;</span>When he saw that he didn’t prevail against him, the man touched the hollow of his thigh, and the hollow of Jacob’s thigh was strained as he wrestled. 
-<span class="v">26&#160;</span>The man said, “Let me go, for the day breaks.” 
-</p><p>Jacob said, “I won’t let you go unless you bless me.” 
-</p><p>
-<span class="v">27&#160;</span>He said to him, “What is your name?” 
-</p><p>He said, “Jacob”. 
-</p><p>
-<span class="v">28&#160;</span>He said, “Your name will no longer be called Jacob, but Israel; for you have fought with Elohim and with men, and have prevailed.” 
-</p><p>
-<span class="v">29&#160;</span>Jacob asked him, “Please tell me your name.” 
-</p><p>He said, “Why is it that you ask what my name is?” So he blessed him there. 
-</p><p>
-<span class="v">30&#160;</span>Jacob called the name of the place Peniel;<span class="f">+ \fr 32:30 \ft Peniel means “face of Elohim”.</span> for he said, “I have seen Elohim face to face, and my life is preserved.” 
-<span class="v">31&#160;</span>The sun rose on him as he passed over Peniel, and he limped because of his thigh. 
-<span class="v">32&#160;</span>Therefore the children of Israel don’t eat the sinew of the hip, which is on the hollow of the thigh, to this day, because he touched the hollow of Jacob’s thigh in the sinew of the hip. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p>
-<span class="v">1&#160;</span>Jacob lifted up his eyes, and looked, and, behold, Esau was coming, and with him four hundred men. He divided the children between Leah, Rachel, and the two servants. 
-<span class="v">2&#160;</span>He put the servants and their children in front, Leah and her children after, and Rachel and Joseph at the rear. 
-<span class="v">3&#160;</span>He himself passed over in front of them, and bowed himself to the ground seven times, until he came near to his brother. 
-</p><p>
-<span class="v">4&#160;</span>Esau ran to meet him, embraced him, fell on his neck, kissed him, and they wept. 
-<span class="v">5&#160;</span>He lifted up his eyes, and saw the women and the children; and said, “Who are these with you?” 
-</p><p>He said, “The children whom Elohim has graciously given your servant.” 
-<span class="v">6&#160;</span>Then the servants came near with their children, and they bowed themselves. 
-<span class="v">7&#160;</span>Leah also and her children came near, and bowed themselves. After them, Joseph came near with Rachel, and they bowed themselves. 
-</p><p>
-<span class="v">8&#160;</span>Esau said, “What do you mean by all this company which I met?” 
-</p><p>Jacob said, “To find favor in the sight of my lord.” 
-</p><p>
-<span class="v">9&#160;</span>Esau said, “I have enough, my brother; let that which you have be yours.” 
-</p><p>
-<span class="v">10&#160;</span>Jacob said, “Please, no, if I have now found favor in your sight, then receive my present at my hand, because I have seen your face, as one sees the face of Elohim, and you were pleased with me. 
-<span class="v">11&#160;</span>Please take the gift that I brought to you, because Elohim has dealt graciously with me, and because I have enough.” He urged him, and he took it. 
-</p><p>
-<span class="v">12&#160;</span>Esau said, “Let’s take our journey, and let’s go, and I will go before you.” 
-</p><p>
-<span class="v">13&#160;</span>Jacob said to him, “My lord knows that the children are tender, and that the flocks and herds with me have their young, and if they overdrive them one day, all the flocks will die. 
-<span class="v">14&#160;</span>Please let my lord pass over before his servant, and I will lead on gently, according to the pace of the livestock that are before me and according to the pace of the children, until I come to my lord to Seir.” 
-</p><p>
-<span class="v">15&#160;</span>Esau said, “Let me now leave with you some of the people who are with me.” 
-</p><p>He said, “Why? Let me find favor in the sight of my lord.” 
-</p><p>
-<span class="v">16&#160;</span>So Esau returned that day on his way to Seir. 
-<span class="v">17&#160;</span>Jacob traveled to Succoth, built himself a house, and made shelters for his livestock. Therefore the name of the place is called Succoth.<span class="f">+ \fr 33:17 \ft succoth means shelters or booths.</span> 
-</p><p>
-<span class="v">18&#160;</span>Jacob came in peace to the city of Shechem, which is in the land of Canaan, when he came from Paddan Aram; and encamped before the city. 
-<span class="v">19&#160;</span>He bought the parcel of ground where he had spread his tent, at the hand of the children of Hamor, Shechem’s father, for one hundred pieces of money. 
-<span class="v">20&#160;</span>He erected an altar there, and called it El Elohe Israel.<span class="f">+ \fr 33:20 \ft El Elohe Israel means “Elohim, the Elohim of Israel” or “The Elohim of Israel is mighty”.</span> 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Dinah, the daughter of Leah, whom she bore to Jacob, went out to see the daughters of the land. 
-<span class="v">2&#160;</span>Shechem the son of Hamor the Hivite, the prince of the land, saw her. He took her, lay with her, and humbled her. 
-<span class="v">3&#160;</span>His soul joined to Dinah, the daughter of Jacob, and he loved the young lady, and spoke kindly to the young lady. 
-<span class="v">4&#160;</span>Shechem spoke to his father, Hamor, saying, “Get me this young lady as a woman.” 
-</p><p>
-<span class="v">5&#160;</span>Now Jacob heard that he had defiled Dinah, his daughter; and his sons were with his livestock in the field. Jacob held his peace until they came. 
-<span class="v">6&#160;</span>Hamor the father of Shechem went out to Jacob to talk with him. 
-<span class="v">7&#160;</span>The sons of Jacob came in from the field when they heard it. The men were grieved, and they were very angry, because he had done folly in Israel in lying with Jacob’s daughter, a thing that ought not to be done. 
-<span class="v">8&#160;</span>Hamor talked with them, saying, “The soul of my son, Shechem, longs for your daughter. Please give her to him as a woman. 
-<span class="v">9&#160;</span>Make marriages with us. Give your daughters to us, and take our daughters for yourselves. 
-<span class="v">10&#160;</span>You shall dwell with us, and the land will be before you. Live and trade in it, and get possessions in it.” 
-</p><p>
-<span class="v">11&#160;</span>Shechem said to her father and to her brothers, “Let me find favor in your eyes, and whatever you will tell me I will give. 
-<span class="v">12&#160;</span>Ask me a great amount for a dowry, and I will give whatever you ask of me, but give me the young lady as a woman.” 
-</p><p>
-<span class="v">13&#160;</span>The sons of Jacob answered Shechem and Hamor his father with deceit when they spoke, because he had defiled Dinah their sister, 
-<span class="v">14&#160;</span>and said to them, “We can’t do this thing, to give our sister to one who is uncircumcised; for that is a reproach to us. 
-<span class="v">15&#160;</span>Only on this condition will we consent to you. If you will be as we are, that every male of you be circumcised, 
-<span class="v">16&#160;</span>then will we give our daughters to you; and we will take your daughters to us, and we will dwell with you, and we will become one people. 
-<span class="v">17&#160;</span>But if you will not listen to us and be circumcised, then we will take our sister,<span class="f">+ \fr 34:17 \ft Hebrew has, literally, “daughter”</span> and we will be gone.” 
-</p><p>
-<span class="v">18&#160;</span>Their words pleased Hamor and Shechem, Hamor’s son. 
-<span class="v">19&#160;</span>The young man didn’t wait to do this thing, because he had delight in Jacob’s daughter, and he was honored above all the house of his father. 
-<span class="v">20&#160;</span>Hamor and Shechem, his son, came to the gate of their city, and talked with the men of their city, saying, 
-<span class="v">21&#160;</span>“These men are peaceful with us. Therefore let them live in the land and trade in it. For behold, the land is large enough for them. Let’s take their daughters to us for women, and let’s give them our daughters. 
-<span class="v">22&#160;</span>Only on this condition will the men consent to us to live with us, to become one people, if every male among us is circumcised, as they are circumcised. 
-<span class="v">23&#160;</span>Won’t their livestock and their possessions and all their animals be ours? Only let’s give our consent to them, and they will dwell with us.” 
-</p><p>
-<span class="v">24&#160;</span>All who went out of the gate of his city listened to Hamor, and to Shechem his son; and every male was circumcised, all who went out of the gate of his city. 
-<span class="v">25&#160;</span>On the third day, when they were sore, two of Jacob’s sons, Simeon and Levi, Dinah’s brothers, each took his sword, came upon the unsuspecting city, and killed all the males. 
-<span class="v">26&#160;</span>They killed Hamor and Shechem, his son, with the edge of the sword, and took Dinah out of Shechem’s house, and went away. 
-<span class="v">27&#160;</span>Jacob’s sons came on the dead, and plundered the city, because they had defiled their sister. 
-<span class="v">28&#160;</span>They took their flocks, their herds, their donkeys, that which was in the city, that which was in the field, 
-<span class="v">29&#160;</span>and all their wealth. They took captive all their little ones and their women, and took as plunder everything that was in the house. 
-<span class="v">30&#160;</span>Jacob said to Simeon and Levi, “You have troubled me, to make me odious to the inhabitants of the land, among the Canaanites and the Perizzites. I am few in number. They will gather themselves together against me and strike me, and I will be destroyed, I and my house.” 
-</p><p>
-<span class="v">31&#160;</span>They said, “Should he deal with our sister as with a prostitute?” 
-</p><h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>Elohim said to Jacob, “Arise, go up to Bethel, and live there. Make there an altar to Elohim, who appeared to you when you fled from the face of Esau your brother.” 
-</p><p>
-<span class="v">2&#160;</span>Then Jacob said to his household, and to all who were with him, “Put away the foreign elohims that are among you, purify yourselves, and change your garments. 
-<span class="v">3&#160;</span>Let’s arise, and go up to Bethel. I will make there an altar to Elohim, who answered me in the day of my distress, and was with me on the way which I went.” 
-</p><p>
-<span class="v">4&#160;</span>They gave to Jacob all the foreign elohims which were in their hands, and the rings which were in their ears; and Jacob hid them under the oak which was by Shechem. 
-<span class="v">5&#160;</span>They traveled, and a terror of Elohim was on the cities that were around them, and they didn’t pursue the sons of Jacob. 
-<span class="v">6&#160;</span>So Jacob came to Luz (that is, Bethel), which is in the land of Canaan, he and all the people who were with him. 
-<span class="v">7&#160;</span>He built an altar there, and called the place El Beth El; because there Elohim was revealed to him, when he fled from the face of his brother. 
-<span class="v">8&#160;</span>Deborah, Rebekah’s nurse, died, and she was buried below Bethel under the oak; and its name was called Allon Bacuth. 
-</p><p>
-<span class="v">9&#160;</span>Elohim appeared to Jacob again, when he came from Paddan Aram, and blessed him. 
-<span class="v">10&#160;</span>Elohim said to him, “Your name is Jacob. Your name shall not be Jacob any more, but your name will be Israel.” He named him Israel. 
-<span class="v">11&#160;</span>Elohim said to him, “I am Elohim Almighty. Be fruitful and multiply. A nation and a company of nations will be from you, and kings will come out of your body. 
-<span class="v">12&#160;</span>The land which I gave to Abraham and Isaac, I will give it to you, and to your offspring after you I will give the land.” 
-</p><p>
-<span class="v">13&#160;</span>Elohim went up from him in the place where he spoke with him. 
-<span class="v">14&#160;</span>Jacob set up a pillar in the place where he spoke with him, a pillar of stone. He poured out a drink offering on it, and poured oil on it. 
-<span class="v">15&#160;</span>Jacob called the name of the place where Elohim spoke with him “Bethel”. 
-</p><p>
-<span class="v">16&#160;</span>They traveled from Bethel. There was still some distance to come to Ephrath, and Rachel travailed. She had hard labor. 
-<span class="v">17&#160;</span>When she was in hard labor, the midwife said to her, “Don’t be afraid, for now you will have another son.” 
-</p><p>
-<span class="v">18&#160;</span>As her soul was departing (for she died), she named him Benoni,<span class="f">+ \fr 35:18 \ft “Benoni” means “son of my trouble”.</span> but his father named him Benjamin.<span class="f">+ \fr 35:18 \ft “Benjamin” means “son of my right hand”.</span> 
-<span class="v">19&#160;</span>Rachel died, and was buried on the way to Ephrath (also called Bethlehem). 
-<span class="v">20&#160;</span>Jacob set up a pillar on her grave. The same is the Pillar of Rachel’s grave to this day. 
-<span class="v">21&#160;</span>Israel traveled, and spread his tent beyond the tower of Eder. 
-<span class="v">22&#160;</span>While Israel lived in that land, Reuben went and lay with Bilhah, his father’s concubine, and Israel heard of it. 
-</p><p>Now the sons of Jacob were twelve. 
-<span class="v">23&#160;</span>The sons of Leah: Reuben (Jacob’s firstborn), Simeon, Levi, Judah, Issachar, and Zebulun. 
-<span class="v">24&#160;</span>The sons of Rachel: Joseph and Benjamin. 
-<span class="v">25&#160;</span>The sons of Bilhah (Rachel’s servant): Dan and Naphtali. 
-<span class="v">26&#160;</span>The sons of Zilpah (Leah’s servant): Gad and Asher. These are the sons of Jacob, who were born to him in Paddan Aram. 
-<span class="v">27&#160;</span>Jacob came to Isaac his father, to Mamre, to Kiriath Arba (which is Hebron), where Abraham and Isaac lived as foreigners. 
-</p><p>
-<span class="v">28&#160;</span>The days of Isaac were one hundred eighty years. 
-<span class="v">29&#160;</span>Isaac gave up the spirit and died, and was gathered to his people, old and full of days. Esau and Jacob, his sons, buried him. 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>Now this is the history of the generations of Esau (that is, Edom). 
-<span class="v">2&#160;</span>Esau took his women from the daughters of Canaan: Adah the daughter of Elon, the Hittite; and Oholibamah the daughter of Anah, the daughter of Zibeon, the Hivite; 
-<span class="v">3&#160;</span>and Basemath, Ishmael’s daughter, sister of Nebaioth. 
-<span class="v">4&#160;</span>Adah bore to Esau Eliphaz. Basemath bore Reuel. 
-<span class="v">5&#160;</span>Oholibamah bore Jeush, Jalam, and Korah. These are the sons of Esau, who were born to him in the land of Canaan. 
-<span class="v">6&#160;</span>Esau took his women, his sons, his daughters, and all the members of his household, with his livestock, all his animals, and all his possessions, which he had gathered in the land of Canaan, and went into a land away from his brother Jacob. 
-<span class="v">7&#160;</span>For their substance was too great for them to dwell together, and the land of their travels couldn’t bear them because of their livestock. 
-<span class="v">8&#160;</span>Esau lived in the hill country of Seir. Esau is Edom. 
-</p><p>
-<span class="v">9&#160;</span>This is the history of the generations of Esau the father of the Edomites in the hill country of Seir: 
-<span class="v">10&#160;</span>these are the names of Esau’s sons: Eliphaz, the son of Adah, the woman of Esau; and Reuel, the son of Basemath, the woman of Esau. 
-<span class="v">11&#160;</span>The sons of Eliphaz were Teman, Omar, Zepho, and Gatam, and Kenaz. 
-<span class="v">12&#160;</span>Timna was concubine to Eliphaz, Esau’s son; and she bore to Eliphaz Amalek. These are the descendants of Adah, Esau’s woman. 
-<span class="v">13&#160;</span>These are the sons of Reuel: Nahath, Zerah, Shammah, and Mizzah. These were the descendants of Basemath, Esau’s woman. 
-<span class="v">14&#160;</span>These were the sons of Oholibamah, the daughter of Anah, the daughter of Zibeon, Esau’s woman: she bore to Esau Jeush, Jalam, and Korah. 
-</p><p>
-<span class="v">15&#160;</span>These are the chiefs of the sons of Esau: the sons of Eliphaz the firstborn of Esau: chief Teman, chief Omar, chief Zepho, chief Kenaz, 
-<span class="v">16&#160;</span>chief Korah, chief Gatam, chief Amalek. These are the chiefs who came of Eliphaz in the land of Edom. These are the sons of Adah. 
-<span class="v">17&#160;</span>These are the sons of Reuel, Esau’s son: chief Nahath, chief Zerah, chief Shammah, chief Mizzah. These are the chiefs who came of Reuel in the land of Edom. These are the sons of Basemath, Esau’s woman. 
-<span class="v">18&#160;</span>These are the sons of Oholibamah, Esau’s woman: chief Jeush, chief Jalam, chief Korah. These are the chiefs who came of Oholibamah the daughter of Anah, Esau’s woman. 
-<span class="v">19&#160;</span>These are the sons of Esau (that is, Edom), and these are their chiefs. 
-</p><p>
-<span class="v">20&#160;</span>These are the sons of Seir the Horite, the inhabitants of the land: Lotan, Shobal, Zibeon, Anah, 
-<span class="v">21&#160;</span>Dishon, Ezer, and Dishan. These are the chiefs who came of the Horites, the children of Seir in the land of Edom. 
-<span class="v">22&#160;</span>The children of Lotan were Hori and Heman. Lotan’s sister was Timna. 
-<span class="v">23&#160;</span>These are the children of Shobal: Alvan, Manahath, Ebal, Shepho, and Onam. 
-<span class="v">24&#160;</span>These are the children of Zibeon: Aiah and Anah. This is Anah who found the hot springs in the wilderness, as he fed the donkeys of Zibeon his father. 
-<span class="v">25&#160;</span>These are the children of Anah: Dishon and Oholibamah, the daughter of Anah. 
-<span class="v">26&#160;</span>These are the children of Dishon: Hemdan, Eshban, Ithran, and Cheran. 
-<span class="v">27&#160;</span>These are the children of Ezer: Bilhan, Zaavan, and Akan. 
-<span class="v">28&#160;</span>These are the children of Dishan: Uz and Aran. 
-<span class="v">29&#160;</span>These are the chiefs who came of the Horites: chief Lotan, chief Shobal, chief Zibeon, chief Anah, 
-<span class="v">30&#160;</span>chief Dishon, chief Ezer, and chief Dishan. These are the chiefs who came of the Horites, according to their chiefs in the land of Seir. 
-</p><p>
-<span class="v">31&#160;</span>These are the kings who reigned in the land of Edom, before any king reigned over the children of Israel. 
-<span class="v">32&#160;</span>Bela, the son of Beor, reigned in Edom. The name of his city was Dinhabah. 
-<span class="v">33&#160;</span>Bela died, and Jobab, the son of Zerah of Bozrah, reigned in his place. 
-<span class="v">34&#160;</span>Jobab died, and Husham of the land of the Temanites reigned in his place. 
-<span class="v">35&#160;</span>Husham died, and Hadad, the son of Bedad, who struck Midian in the field of Moab, reigned in his place. The name of his city was Avith. 
-<span class="v">36&#160;</span>Hadad died, and Samlah of Masrekah reigned in his place. 
-<span class="v">37&#160;</span>Samlah died, and Shaul of Rehoboth by the river, reigned in his place. 
-<span class="v">38&#160;</span>Shaul died, and Baal Hanan the son of Achbor reigned in his place. 
-<span class="v">39&#160;</span>Baal Hanan the son of Achbor died, and Hadar reigned in his place. The name of his city was Pau. His woman’s name was Mehetabel, the daughter of Matred, the daughter of Mezahab. 
-</p><p>
-<span class="v">40&#160;</span>These are the names of the chiefs who came from Esau, according to their families, after their places, and by their names: chief Timna, chief Alvah, chief Jetheth, 
-<span class="v">41&#160;</span>chief Oholibamah, chief Elah, chief Pinon, 
-<span class="v">42&#160;</span>chief Kenaz, chief Teman, chief Mibzar, 
-<span class="v">43&#160;</span>chief Magdiel, and chief Iram. These are the chiefs of Edom, according to their habitations in the land of their possession. This is Esau, the father of the Edomites. 
-</p><h2 class="chapterlabel" id="37">37</h2>
-<p>
-<span class="v">1&#160;</span>Jacob lived in the land of his father’s travels, in the land of Canaan. 
-<span class="v">2&#160;</span>This is the history of the generations of Jacob. Joseph, being seventeen years old, was feeding the flock with his brothers. He was a boy with the sons of Bilhah and Zilpah, his father’s women. Joseph brought an evil report of them to their father. 
-<span class="v">3&#160;</span>Now Israel loved Joseph more than all his children, because he was the son of his old age, and he made him a tunic of many colors. 
-<span class="v">4&#160;</span>His brothers saw that their father loved him more than all his brothers, and they hated him, and couldn’t speak peaceably to him. 
-</p><p>
-<span class="v">5&#160;</span>Joseph dreamed a dream, and he told it to his brothers, and they hated him all the more. 
-<span class="v">6&#160;</span>He said to them, “Please hear this dream which I have dreamed: 
-<span class="v">7&#160;</span>for behold, we were binding sheaves in the field, and behold, my sheaf arose and also stood upright; and behold, your sheaves came around, and bowed down to my sheaf.” 
-</p><p>
-<span class="v">8&#160;</span>His brothers asked him, “Will you indeed reign over us? Will you indeed have dominion over us?” They hated him all the more for his dreams and for his words. 
-<span class="v">9&#160;</span>He dreamed yet another dream, and told it to his brothers, and said, “Behold, I have dreamed yet another dream: and behold, the sun and the moon and eleven stars bowed down to me.” 
-<span class="v">10&#160;</span>He told it to his father and to his brothers. His father rebuked him, and said to him, “What is this dream that you have dreamed? Will I and your mother and your brothers indeed come to bow ourselves down to the earth before you?” 
-<span class="v">11&#160;</span>His brothers envied him, but his father kept this saying in mind. 
-</p><p>
-<span class="v">12&#160;</span>His brothers went to feed their father’s flock in Shechem. 
-<span class="v">13&#160;</span>Israel said to Joseph, “Aren’t your brothers feeding the flock in Shechem? Come, and I will send you to them.” He said to him, “Here I am.” 
-</p><p>
-<span class="v">14&#160;</span>He said to him, “Go now, see whether it is well with your brothers, and well with the flock; and bring me word again.” So he sent him out of the valley of Hebron, and he came to Shechem. 
-<span class="v">15&#160;</span>A certain man found him, and behold, he was wandering in the field. The man asked him, “What are you looking for?” 
-</p><p>
-<span class="v">16&#160;</span>He said, “I am looking for my brothers. Tell me, please, where they are feeding the flock.” 
-</p><p>
-<span class="v">17&#160;</span>The man said, “They have left here, for I heard them say, ‘Let’s go to Dothan.’&#160;” 
-</p><p>Joseph went after his brothers, and found them in Dothan. 
-<span class="v">18&#160;</span>They saw him afar off, and before he came near to them, they conspired against him to kill him. 
-<span class="v">19&#160;</span>They said to one another, “Behold, this dreamer comes. 
-<span class="v">20&#160;</span>Come now therefore, and let’s kill him, and cast him into one of the pits, and we will say, ‘An evil animal has devoured him.’ We will see what will become of his dreams.” 
-</p><p>
-<span class="v">21&#160;</span>Reuben heard it, and delivered him out of their hand, and said, “Let’s not take his life.” 
-<span class="v">22&#160;</span>Reuben said to them, “Shed no blood. Throw him into this pit that is in the wilderness, but lay no hand on him”—that he might deliver him out of their hand, to restore him to his father. 
-<span class="v">23&#160;</span>When Joseph came to his brothers, they stripped Joseph of his tunic, the tunic of many colors that was on him; 
-<span class="v">24&#160;</span>and they took him, and threw him into the pit. The pit was empty. There was no water in it. 
-</p><p>
-<span class="v">25&#160;</span>They sat down to eat bread, and they lifted up their eyes and looked, and saw a caravan of Ishmaelites was coming from Gilead, with their camels bearing spices and balm and myrrh, going to carry it down to Egypt. 
-<span class="v">26&#160;</span>Judah said to his brothers, “What profit is it if we kill our brother and conceal his blood? 
-<span class="v">27&#160;</span>Come, and let’s sell him to the Ishmaelites, and not let our hand be on him; for he is our brother, our flesh.” His brothers listened to him. 
-<span class="v">28&#160;</span>Midianites who were merchants passed by, and they drew and lifted up Joseph out of the pit, and sold Joseph to the Ishmaelites for twenty pieces of silver. The merchants brought Joseph into Egypt. 
-</p><p>
-<span class="v">29&#160;</span>Reuben returned to the pit, and saw that Joseph wasn’t in the pit; and he tore his clothes. 
-<span class="v">30&#160;</span>He returned to his brothers, and said, “The child is no more; and I, where will I go?” 
-<span class="v">31&#160;</span>They took Joseph’s tunic, and killed a male goat, and dipped the tunic in the blood. 
-<span class="v">32&#160;</span>They took the tunic of many colors, and they brought it to their father, and said, “We have found this. Examine it, now, and see if it is your son’s tunic or not.” 
-</p><p>
-<span class="v">33&#160;</span>He recognized it, and said, “It is my son’s tunic. An evil animal has devoured him. Joseph is without doubt torn in pieces.” 
-<span class="v">34&#160;</span>Jacob tore his clothes, and put sackcloth on his waist, and mourned for his son many days. 
-<span class="v">35&#160;</span>All his sons and all his daughters rose up to comfort him, but he refused to be comforted. He said, “For I will go down to Sheol<span class="f">+ \fr 37:35 \ft Sheol is the place of the dead.</span> to my son, mourning.” His father wept for him. 
-<span class="v">36&#160;</span>The Midianites sold him into Egypt to Potiphar, an officer of Pharaoh’s, the captain of the guard. 
-</p><h2 class="chapterlabel" id="38">38</h2>
-<p>
-<span class="v">1&#160;</span>At that time, Judah went down from his brothers, and visited a certain Adullamite, whose name was Hirah. 
-<span class="v">2&#160;</span>There, Judah saw the daughter of a certain Canaanite man named Shua. He took her, and went in to her. 
-<span class="v">3&#160;</span>She conceived, and bore a son; and he named him Er. 
-<span class="v">4&#160;</span>She conceived again, and bore a son; and she named him Onan. 
-<span class="v">5&#160;</span>She yet again bore a son, and named him Shelah. He was at Chezib when she bore him. 
-<span class="v">6&#160;</span>Judah took a woman for Er, his firstborn, and her name was Tamar. 
-<span class="v">7&#160;</span>Er, Judah’s firstborn, was wicked in Yahweh’s sight. So Yahweh killed him. 
-<span class="v">8&#160;</span>Judah said to Onan, “Go in to your brother’s woman, and perform the duty of a brother-in-law to her, and raise up offspring for your brother.” 
-<span class="v">9&#160;</span>Onan knew that the offspring wouldn’t be his; and when he went in to his brother’s woman, he spilled his semen on the ground, lest he should give offspring to his brother. 
-<span class="v">10&#160;</span>The thing which he did was evil in Yahweh’s sight, and he killed him also. 
-<span class="v">11&#160;</span>Then Judah said to Tamar, his daughter-in-law, “Remain a widow in your father’s house, until Shelah, my son, is grown up;” for he said, “Lest he also die, like his brothers.” Tamar went and lived in her father’s house. 
-</p><p>
-<span class="v">12&#160;</span>After many days, Shua’s daughter, the woman of Judah, died. Judah was comforted, and went up to his sheep shearers to Timnah, he and his friend Hirah, the Adullamite. 
-<span class="v">13&#160;</span>Tamar was told, “Behold, your father-in-law is going up to Timnah to shear his sheep.” 
-<span class="v">14&#160;</span>She took off the garments of her widowhood, and covered herself with her veil, and wrapped herself, and sat in the gate of Enaim, which is on the way to Timnah; for she saw that Shelah was grown up, and she wasn’t given to him as a woman. 
-<span class="v">15&#160;</span>When Judah saw her, he thought that she was a prostitute, for she had covered her face. 
-<span class="v">16&#160;</span>He turned to her by the way, and said, “Please come, let me come in to you,” for he didn’t know that she was his daughter-in-law. 
-</p><p>She said, “What will you give me, that you may come in to me?” 
-</p><p>
-<span class="v">17&#160;</span>He said, “I will send you a young goat from the flock.” 
-</p><p>She said, “Will you give me a pledge, until you send it?” 
-</p><p>
-<span class="v">18&#160;</span>He said, “What pledge will I give you?” 
-</p><p>She said, “Your signet and your cord, and your staff that is in your hand.” 
-</p><p>He gave them to her, and came in to her, and she conceived by him. 
-<span class="v">19&#160;</span>She arose, and went away, and put off her veil from her, and put on the garments of her widowhood. 
-<span class="v">20&#160;</span>Judah sent the young goat by the hand of his friend, the Adullamite, to receive the pledge from the woman’s hand, but he didn’t find her. 
-<span class="v">21&#160;</span>Then he asked the men of her place, saying, “Where is the prostitute, that was at Enaim by the road?” 
-</p><p>They said, “There has been no prostitute here.” 
-</p><p>
-<span class="v">22&#160;</span>He returned to Judah, and said, “I haven’t found her; and also the men of the place said, ‘There has been no prostitute here.’&#160;” 
-<span class="v">23&#160;</span>Judah said, “Let her keep it, lest we be shamed. Behold, I sent this young goat, and you haven’t found her.” 
-</p><p>
-<span class="v">24&#160;</span>About three months later, Judah was told, “Tamar, your daughter-in-law, has played the prostitute. Moreover, behold, she is with child by prostitution.” 
-</p><p>Judah said, “Bring her out, and let her be burned.” 
-<span class="v">25&#160;</span>When she was brought out, she sent to her father-in-law, saying, “I am with child by the man who owns these.” She also said, “Please discern whose these are—the signet, and the cords, and the staff.” 
-</p><p>
-<span class="v">26&#160;</span>Judah acknowledged them, and said, “She is more righteous than I, because I didn’t give her to Shelah, my son.” 
-</p><p>He knew her again no more. 
-<span class="v">27&#160;</span>In the time of her travail, behold, twins were in her womb. 
-<span class="v">28&#160;</span>When she travailed, one put out a hand, and the midwife took and tied a scarlet thread on his hand, saying, “This came out first.” 
-<span class="v">29&#160;</span>As he drew back his hand, behold, his brother came out, and she said, “Why have you made a breach for yourself?” Therefore his name was called Perez.<span class="f">+ \fr 38:29 \ft Perez means “breaking out”.</span> 
-<span class="v">30&#160;</span>Afterward his brother came out, who had the scarlet thread on his hand, and his name was called Zerah.<span class="f">+ \fr 38:30 \ft Zerah means “scarlet” or “brightness”.</span> 
-</p><h2 class="chapterlabel" id="39">39</h2>
-<p>
-<span class="v">1&#160;</span>Joseph was brought down to Egypt. Potiphar, an officer of Pharaoh’s, the captain of the guard, an Egyptian, bought him from the hand of the Ishmaelites that had brought him down there. 
-<span class="v">2&#160;</span>Yahweh was with Joseph, and he was a prosperous man. He was in the house of his master the Egyptian. 
-<span class="v">3&#160;</span>His master saw that Yahweh was with him, and that Yahweh made all that he did prosper in his hand. 
-<span class="v">4&#160;</span>Joseph found favor in his sight. He ministered to him, and Potiphar made him overseer over his house, and all that he had he put into his hand. 
-<span class="v">5&#160;</span>From the time that he made him overseer in his house, and over all that he had, Yahweh blessed the Egyptian’s house for Joseph’s sake. Yahweh’s blessing was on all that he had, in the house and in the field. 
-<span class="v">6&#160;</span>He left all that he had in Joseph’s hand. He didn’t concern himself with anything, except for the food which he ate. 
-</p><p>Joseph was well-built and handsome. 
-<span class="v">7&#160;</span>After these things, his master’s woman set her eyes on Joseph; and she said, “Lie with me.” 
-</p><p>
-<span class="v">8&#160;</span>But he refused, and said to his master’s woman, “Behold, my master doesn’t know what is with me in the house, and he has put all that he has into my hand. 
-<span class="v">9&#160;</span>No one is greater in this house than I am, and he has not kept back anything from me but you, because you are his woman. How then can I do this great wickedness, and sin against Elohim?” 
-</p><p>
-<span class="v">10&#160;</span>As she spoke to Joseph day by day, he didn’t listen to her, to lie by her, or to be with her. 
-<span class="v">11&#160;</span>About this time, he went into the house to do his work, and there were none of the men of the house inside. 
-<span class="v">12&#160;</span>She caught him by his garment, saying, “Lie with me!” 
-</p><p>He left his garment in her hand, and ran outside. 
-<span class="v">13&#160;</span>When she saw that he had left his garment in her hand, and had run outside, 
-<span class="v">14&#160;</span>she called to the men of her house, and spoke to them, saying, “Behold, he has brought a Hebrew in to us to mock us. He came in to me to lie with me, and I cried with a loud voice. 
-<span class="v">15&#160;</span>When he heard that I lifted up my voice and cried, he left his garment by me, and ran outside.” 
-<span class="v">16&#160;</span>She laid up his garment by her, until his master came home. 
-<span class="v">17&#160;</span>She spoke to him according to these words, saying, “The Hebrew servant, whom you have brought to us, came in to me to mock me, 
-<span class="v">18&#160;</span>and as I lifted up my voice and cried, he left his garment by me, and ran outside.” 
-</p><p>
-<span class="v">19&#160;</span>When his master heard the words of his woman, which she spoke to him, saying, “This is what your servant did to me,” his wrath was kindled. 
-<span class="v">20&#160;</span>Joseph’s master took him, and put him into the prison, the place where the king’s prisoners were bound, and he was there in custody. 
-<span class="v">21&#160;</span>But Yahweh was with Joseph, and showed kindness to him, and gave him favor in the sight of the keeper of the prison. 
-<span class="v">22&#160;</span>The keeper of the prison committed to Joseph’s hand all the prisoners who were in the prison. Whatever they did there, he was responsible for it. 
-<span class="v">23&#160;</span>The keeper of the prison didn’t look after anything that was under his hand, because Yahweh was with him; and that which he did, Yahweh made it prosper. 
-</p><h2 class="chapterlabel" id="40">40</h2>
-<p>
-<span class="v">1&#160;</span>After these things, the butler of the king of Egypt and his baker offended their lord, the king of Egypt. 
-<span class="v">2&#160;</span>Pharaoh was angry with his two officers, the chief cup bearer and the chief baker. 
-<span class="v">3&#160;</span>He put them in custody in the house of the captain of the guard, into the prison, the place where Joseph was bound. 
-<span class="v">4&#160;</span>The captain of the guard assigned them to Joseph, and he took care of them. They stayed in prison many days. 
-<span class="v">5&#160;</span>They both dreamed a dream, each man his dream, in one night, each man according to the interpretation of his dream, the cup bearer and the baker of the king of Egypt, who were bound in the prison. 
-<span class="v">6&#160;</span>Joseph came in to them in the morning, and saw them, and saw that they were sad. 
-<span class="v">7&#160;</span>He asked Pharaoh’s officers who were with him in custody in his master’s house, saying, “Why do you look so sad today?” 
-</p><p>
-<span class="v">8&#160;</span>They said to him, “We have dreamed a dream, and there is no one who can interpret it.” 
-</p><p>Joseph said to them, “Don’t interpretations belong to Elohim? Please tell it to me.” 
-</p><p>
-<span class="v">9&#160;</span>The chief cup bearer told his dream to Joseph, and said to him, “In my dream, behold, a vine was in front of me, 
-<span class="v">10&#160;</span>and in the vine were three branches. It was as though it budded, it blossomed, and its clusters produced ripe grapes. 
-<span class="v">11&#160;</span>Pharaoh’s cup was in my hand; and I took the grapes, and pressed them into Pharaoh’s cup, and I gave the cup into Pharaoh’s hand.” 
-</p><p>
-<span class="v">12&#160;</span>Joseph said to him, “This is its interpretation: the three branches are three days. 
-<span class="v">13&#160;</span>Within three more days, Pharaoh will lift up your head, and restore you to your office. You will give Pharaoh’s cup into his hand, the way you did when you were his cup bearer. 
-<span class="v">14&#160;</span>But remember me when it is well with you. Please show kindness to me, and make mention of me to Pharaoh, and bring me out of this house. 
-<span class="v">15&#160;</span>For indeed, I was stolen away out of the land of the Hebrews, and here also I have done nothing that they should put me into the dungeon.” 
-</p><p>
-<span class="v">16&#160;</span>When the chief baker saw that the interpretation was good, he said to Joseph, “I also was in my dream, and behold, three baskets of white bread were on my head. 
-<span class="v">17&#160;</span>In the uppermost basket there were all kinds of baked food for Pharaoh, and the birds ate them out of the basket on my head.” 
-</p><p>
-<span class="v">18&#160;</span>Joseph answered, “This is its interpretation. The three baskets are three days. 
-<span class="v">19&#160;</span>Within three more days, Pharaoh will lift up your head from off you, and will hang you on a tree; and the birds will eat your flesh from off you.” 
-<span class="v">20&#160;</span>On the third day, which was Pharaoh’s birthday, he made a feast for all his servants, and he lifted up the head of the chief cup bearer and the head of the chief baker among his servants. 
-<span class="v">21&#160;</span>He restored the chief cup bearer to his position again, and he gave the cup into Pharaoh’s hand; 
-<span class="v">22&#160;</span>but he hanged the chief baker, as Joseph had interpreted to them. 
-<span class="v">23&#160;</span>Yet the chief cup bearer didn’t remember Joseph, but forgot him. 
-</p><h2 class="chapterlabel" id="41">41</h2>
-<p>
-<span class="v">1&#160;</span>At the end of two full years, Pharaoh dreamed, and behold, he stood by the river. 
-<span class="v">2&#160;</span>Behold, seven cattle came up out of the river. They were sleek and fat, and they fed in the marsh grass. 
-<span class="v">3&#160;</span>Behold, seven other cattle came up after them out of the river, ugly and thin, and stood by the other cattle on the brink of the river. 
-<span class="v">4&#160;</span>The ugly and thin cattle ate up the seven sleek and fat cattle. So Pharaoh awoke. 
-<span class="v">5&#160;</span>He slept and dreamed a second time; and behold, seven heads of grain came up on one stalk, healthy and good. 
-<span class="v">6&#160;</span>Behold, seven heads of grain, thin and blasted with the east wind, sprung up after them. 
-<span class="v">7&#160;</span>The thin heads of grain swallowed up the seven healthy and full ears. Pharaoh awoke, and behold, it was a dream. 
-<span class="v">8&#160;</span>In the morning, his spirit was troubled, and he sent and called for all of Egypt’s magicians and wise men. Pharaoh told them his dreams, but there was no one who could interpret them to Pharaoh. 
-</p><p>
-<span class="v">9&#160;</span>Then the chief cup bearer spoke to Pharaoh, saying, “I remember my faults today. 
-<span class="v">10&#160;</span>Pharaoh was angry with his servants, and put me in custody in the house of the captain of the guard, with the chief baker. 
-<span class="v">11&#160;</span>We dreamed a dream in one night, he and I. Each man dreamed according to the interpretation of his dream. 
-<span class="v">12&#160;</span>There was with us there a young man, a Hebrew, servant to the captain of the guard, and we told him, and he interpreted to us our dreams. He interpreted to each man according to his dream. 
-<span class="v">13&#160;</span>As he interpreted to us, so it was. He restored me to my office, and he hanged him.” 
-</p><p>
-<span class="v">14&#160;</span>Then Pharaoh sent and called Joseph, and they brought him hastily out of the dungeon. He shaved himself, changed his clothing, and came in to Pharaoh. 
-<span class="v">15&#160;</span>Pharaoh said to Joseph, “I have dreamed a dream, and there is no one who can interpret it. I have heard it said of you, that when you hear a dream you can interpret it.” 
-</p><p>
-<span class="v">16&#160;</span>Joseph answered Pharaoh, saying, “It isn’t in me. Elohim will give Pharaoh an answer of peace.” 
-</p><p>
-<span class="v">17&#160;</span>Pharaoh spoke to Joseph, “In my dream, behold, I stood on the brink of the river; 
-<span class="v">18&#160;</span>and behold, seven fat and sleek cattle came up out of the river. They fed in the marsh grass; 
-<span class="v">19&#160;</span>and behold, seven other cattle came up after them, poor and very ugly and thin, such as I never saw in all the land of Egypt for ugliness. 
-<span class="v">20&#160;</span>The thin and ugly cattle ate up the first seven fat cattle; 
-<span class="v">21&#160;</span>and when they had eaten them up, it couldn’t be known that they had eaten them, but they were still ugly, as at the beginning. So I awoke. 
-<span class="v">22&#160;</span>I saw in my dream, and behold, seven heads of grain came up on one stalk, full and good; 
-<span class="v">23&#160;</span>and behold, seven heads of grain, withered, thin, and blasted with the east wind, sprung up after them. 
-<span class="v">24&#160;</span>The thin heads of grain swallowed up the seven good heads of grain. I told it to the magicians, but there was no one who could explain it to me.” 
-</p><p>
-<span class="v">25&#160;</span>Joseph said to Pharaoh, “The dream of Pharaoh is one. What Elohim is about to do he has declared to Pharaoh. 
-<span class="v">26&#160;</span>The seven good cattle are seven years; and the seven good heads of grain are seven years. The dream is one. 
-<span class="v">27&#160;</span>The seven thin and ugly cattle that came up after them are seven years, and also the seven empty heads of grain blasted with the east wind; they will be seven years of famine. 
-<span class="v">28&#160;</span>That is the thing which I have spoken to Pharaoh. Elohim has shown Pharaoh what he is about to do. 
-<span class="v">29&#160;</span>Behold, seven years of great plenty throughout all the land of Egypt are coming. 
-<span class="v">30&#160;</span>Seven years of famine will arise after them, and all the plenty will be forgotten in the land of Egypt. The famine will consume the land, 
-<span class="v">31&#160;</span>and the plenty will not be known in the land by reason of that famine which follows; for it will be very grievous. 
-<span class="v">32&#160;</span>The dream was doubled to Pharaoh, because the thing is established by Elohim, and Elohim will shortly bring it to pass. 
-</p><p>
-<span class="v">33&#160;</span>“Now therefore let Pharaoh look for a discreet and wise man, and set him over the land of Egypt. 
-<span class="v">34&#160;</span>Let Pharaoh do this, and let him appoint overseers over the land, and take up the fifth part of the land of Egypt’s produce in the seven plenteous years. 
-<span class="v">35&#160;</span>Let them gather all the food of these good years that come, and store grain under the hand of Pharaoh for food in the cities, and let them keep it. 
-<span class="v">36&#160;</span>The food will be to supply the land against the seven years of famine, which will be in the land of Egypt; so that the land will not perish through the famine.” 
-</p><p>
-<span class="v">37&#160;</span>The thing was good in the eyes of Pharaoh, and in the eyes of all his servants. 
-<span class="v">38&#160;</span>Pharaoh said to his servants, “Can we find such a one as this, a man in whom is the Spirit of Elohim?” 
-<span class="v">39&#160;</span>Pharaoh said to Joseph, “Because Elohim has shown you all of this, there is no one so discreet and wise as you. 
-<span class="v">40&#160;</span>You shall be over my house. All my people will be ruled according to your word. Only in the throne I will be greater than you.” 
-<span class="v">41&#160;</span>Pharaoh said to Joseph, “Behold, I have set you over all the land of Egypt.” 
-<span class="v">42&#160;</span>Pharaoh took off his signet ring from his hand, and put it on Joseph’s hand, and arrayed him in robes of fine linen, and put a gold chain about his neck. 
-<span class="v">43&#160;</span>He made him ride in the second chariot which he had. They cried before him, “Bow the knee!” He set him over all the land of Egypt. 
-<span class="v">44&#160;</span>Pharaoh said to Joseph, “I am Pharaoh. Without you, no man shall lift up his hand or his foot in all the land of Egypt.” 
-<span class="v">45&#160;</span>Pharaoh called Joseph’s name Zaphenath-Paneah. He gave him Asenath, the daughter of Potiphera priest of On as a woman. Joseph went out over the land of Egypt. 
-</p><p>
-<span class="v">46&#160;</span>Joseph was thirty years old when he stood before Pharaoh king of Egypt. Joseph went out from the presence of Pharaoh, and went throughout all the land of Egypt. 
-<span class="v">47&#160;</span>In the seven plenteous years the earth produced abundantly. 
-<span class="v">48&#160;</span>He gathered up all the food of the seven years which were in the land of Egypt, and laid up the food in the cities. He stored food in each city from the fields around that city. 
-<span class="v">49&#160;</span>Joseph laid up grain as the sand of the sea, very much, until he stopped counting, for it was without number. 
-<span class="v">50&#160;</span>To Joseph were born two sons before the year of famine came, whom Asenath, the daughter of Potiphera priest of On, bore to him. 
-<span class="v">51&#160;</span>Joseph called the name of the firstborn Manasseh,<span class="f">+ \fr 41:51 \ft “Manasseh” sounds like the Hebrew for “forget”.</span> “For”, he said, “Elohim has made me forget all my toil, and all my father’s house.” 
-<span class="v">52&#160;</span>The name of the second, he called Ephraim:<span class="f">+ \fr 41:52 \ft “Ephraim” sounds like the Hebrew for “twice fruitful”.</span> “For Elohim has made me fruitful in the land of my affliction.” 
-</p><p>
-<span class="v">53&#160;</span>The seven years of plenty, that were in the land of Egypt, came to an end. 
-<span class="v">54&#160;</span>The seven years of famine began to come, just as Joseph had said. There was famine in all lands, but in all the land of Egypt there was bread. 
-<span class="v">55&#160;</span>When all the land of Egypt was famished, the people cried to Pharaoh for bread, and Pharaoh said to all the Egyptians, “Go to Joseph. What he says to you, do.” 
-<span class="v">56&#160;</span>The famine was over all the surface of the earth. Joseph opened all the store houses, and sold to the Egyptians. The famine was severe in the land of Egypt. 
-<span class="v">57&#160;</span>All countries came into Egypt, to Joseph, to buy grain, because the famine was severe in all the earth. 
-</p><h2 class="chapterlabel" id="42">42</h2>
-<p>
-<span class="v">1&#160;</span>Now Jacob saw that there was grain in Egypt, and Jacob said to his sons, “Why do you look at one another?” 
-<span class="v">2&#160;</span>He said, “Behold, I have heard that there is grain in Egypt. Go down there, and buy for us from there, so that we may live, and not die.” 
-<span class="v">3&#160;</span>Joseph’s ten brothers went down to buy grain from Egypt. 
-<span class="v">4&#160;</span>But Jacob didn’t send Benjamin, Joseph’s brother, with his brothers; for he said, “Lest perhaps harm happen to him.” 
-<span class="v">5&#160;</span>The sons of Israel came to buy among those who came, for the famine was in the land of Canaan. 
-<span class="v">6&#160;</span>Joseph was the governor over the land. It was he who sold to all the people of the land. Joseph’s brothers came, and bowed themselves down to him with their faces to the earth. 
-<span class="v">7&#160;</span>Joseph saw his brothers, and he recognized them, but acted like a stranger to them, and spoke roughly with them. He said to them, “Where did you come from?” 
-</p><p>They said, “From the land of Canaan, to buy food.” 
-</p><p>
-<span class="v">8&#160;</span>Joseph recognized his brothers, but they didn’t recognize him. 
-<span class="v">9&#160;</span>Joseph remembered the dreams which he dreamed about them, and said to them, “You are spies! You have come to see the nakedness of the land.” 
-</p><p>
-<span class="v">10&#160;</span>They said to him, “No, my lord, but your servants have come to buy food. 
-<span class="v">11&#160;</span>We are all one man’s sons; we are honest men. Your servants are not spies.” 
-</p><p>
-<span class="v">12&#160;</span>He said to them, “No, but you have come to see the nakedness of the land!” 
-</p><p>
-<span class="v">13&#160;</span>They said, “We, your servants, are twelve brothers, the sons of one man in the land of Canaan; and behold, the youngest is today with our father, and one is no more.” 
-</p><p>
-<span class="v">14&#160;</span>Joseph said to them, “It is like I told you, saying, ‘You are spies!’ 
-<span class="v">15&#160;</span>By this you shall be tested. By the life of Pharaoh, you shall not go out from here, unless your youngest brother comes here. 
-<span class="v">16&#160;</span>Send one of you, and let him get your brother, and you shall be bound, that your words may be tested, whether there is truth in you, or else by the life of Pharaoh surely you are spies.” 
-<span class="v">17&#160;</span>He put them all together into custody for three days. 
-</p><p>
-<span class="v">18&#160;</span>Joseph said to them the third day, “Do this, and live, for I fear Elohim. 
-<span class="v">19&#160;</span>If you are honest men, then let one of your brothers be bound in your prison; but you go, carry grain for the famine of your houses. 
-<span class="v">20&#160;</span>Bring your youngest brother to me; so will your words be verified, and you won’t die.” 
-</p><p>They did so. 
-<span class="v">21&#160;</span>They said to one another, “We are certainly guilty concerning our brother, in that we saw the distress of his soul, when he begged us, and we wouldn’t listen. Therefore this distress has come upon us.” 
-<span class="v">22&#160;</span>Reuben answered them, saying, “Didn’t I tell you, saying, ‘Don’t sin against the child,’ and you wouldn’t listen? Therefore also, behold, his blood is required.” 
-<span class="v">23&#160;</span>They didn’t know that Joseph understood them; for there was an interpreter between them. 
-<span class="v">24&#160;</span>He turned himself away from them, and wept. Then he returned to them, and spoke to them, and took Simeon from among them, and bound him before their eyes. 
-<span class="v">25&#160;</span>Then Joseph gave a command to fill their bags with grain, and to restore each man’s money into his sack, and to give them food for the way. So it was done to them. 
-</p><p>
-<span class="v">26&#160;</span>They loaded their donkeys with their grain, and departed from there. 
-<span class="v">27&#160;</span>As one of them opened his sack to give his donkey food in the lodging place, he saw his money. Behold, it was in the mouth of his sack. 
-<span class="v">28&#160;</span>He said to his brothers, “My money is restored! Behold, it is in my sack!” Their hearts failed them, and they turned trembling to one another, saying, “What is this that Elohim has done to us?” 
-<span class="v">29&#160;</span>They came to Jacob their father, to the land of Canaan, and told him all that had happened to them, saying, 
-<span class="v">30&#160;</span>“The man, the lord of the land, spoke roughly with us, and took us for spies of the country. 
-<span class="v">31&#160;</span>We said to him, ‘We are honest men. We are no spies. 
-<span class="v">32&#160;</span>We are twelve brothers, sons of our father; one is no more, and the youngest is today with our father in the land of Canaan.’ 
-<span class="v">33&#160;</span>The man, the lord of the land, said to us, ‘By this I will know that you are honest men: leave one of your brothers with me, and take grain for the famine of your houses, and go your way. 
-<span class="v">34&#160;</span>Bring your youngest brother to me. Then I will know that you are not spies, but that you are honest men. So I will deliver your brother to you, and you shall trade in the land.’&#160;” 
-</p><p>
-<span class="v">35&#160;</span>As they emptied their sacks, behold, each man’s bundle of money was in his sack. When they and their father saw their bundles of money, they were afraid. 
-<span class="v">36&#160;</span>Jacob, their father, said to them, “You have bereaved me of my children! Joseph is no more, Simeon is no more, and you want to take Benjamin away. All these things are against me.” 
-</p><p>
-<span class="v">37&#160;</span>Reuben spoke to his father, saying, “Kill my two sons, if I don’t bring him to you. Entrust him to my care, and I will bring him to you again.” 
-</p><p>
-<span class="v">38&#160;</span>He said, “My son shall not go down with you; for his brother is dead, and he only is left. If harm happens to him along the way in which you go, then you will bring down my gray hairs with sorrow to Sheol.”<span class="f">+ \fr 42:38 \ft Sheol is the place of the dead.</span> 
-</p><h2 class="chapterlabel" id="43">43</h2>
-<p>
-<span class="v">1&#160;</span>The famine was severe in the land. 
-<span class="v">2&#160;</span>When they had eaten up the grain which they had brought out of Egypt, their father said to them, “Go again, buy us a little more food.” 
-</p><p>
-<span class="v">3&#160;</span>Judah spoke to him, saying, “The man solemnly warned us, saying, ‘You shall not see my face, unless your brother is with you.’ 
-<span class="v">4&#160;</span>If you’ll send our brother with us, we’ll go down and buy you food; 
-<span class="v">5&#160;</span>but if you don’t send him, we won’t go down, for the man said to us, ‘You shall not see my face, unless your brother is with you.’&#160;” 
-</p><p>
-<span class="v">6&#160;</span>Israel said, “Why did you treat me so badly, telling the man that you had another brother?” 
-</p><p>
-<span class="v">7&#160;</span>They said, “The man asked directly concerning ourselves, and concerning our relatives, saying, ‘Is your father still alive? Have you another brother?’ We just answered his questions. Is there any way we could know that he would say, ‘Bring your brother down’?” 
-</p><p>
-<span class="v">8&#160;</span>Judah said to Israel, his father, “Send the boy with me, and we’ll get up and go, so that we may live, and not die, both we, and you, and also our little ones. 
-<span class="v">9&#160;</span>I’ll be collateral for him. From my hand will you require him. If I don’t bring him to you, and set him before you, then let me bear the blame forever; 
-<span class="v">10&#160;</span>for if we hadn’t delayed, surely we would have returned a second time by now.” 
-</p><p>
-<span class="v">11&#160;</span>Their father, Israel, said to them, “If it must be so, then do this: Take from the choice fruits of the land in your bags, and carry down a present for the man, a little balm, a little honey, spices and myrrh, nuts, and almonds; 
-<span class="v">12&#160;</span>and take double money in your hand, and take back the money that was returned in the mouth of your sacks. Perhaps it was an oversight. 
-<span class="v">13&#160;</span>Take your brother also, get up, and return to the man. 
-<span class="v">14&#160;</span>May Elohim Almighty give you mercy before the man, that he may release to you your other brother and Benjamin. If I am bereaved of my children, I am bereaved.” 
-</p><p>
-<span class="v">15&#160;</span>The men took that present, and they took double money in their hand, and Benjamin; and got up, went down to Egypt, and stood before Joseph. 
-<span class="v">16&#160;</span>When Joseph saw Benjamin with them, he said to the steward of his house, “Bring the men into the house, and butcher an animal, and prepare; for the men will dine with me at noon.” 
-</p><p>
-<span class="v">17&#160;</span>The man did as Joseph commanded, and the man brought the men to Joseph’s house. 
-<span class="v">18&#160;</span>The men were afraid, because they were brought to Joseph’s house; and they said, “Because of the money that was returned in our sacks the first time, we’re brought in; that he may seek occasion against us, attack us, and seize us as slaves, along with our donkeys.” 
-<span class="v">19&#160;</span>They came near to the steward of Joseph’s house, and they spoke to him at the door of the house, 
-<span class="v">20&#160;</span>and said, “Oh, my lord, we indeed came down the first time to buy food. 
-<span class="v">21&#160;</span>When we came to the lodging place, we opened our sacks, and behold, each man’s money was in the mouth of his sack, our money in full weight. We have brought it back in our hand. 
-<span class="v">22&#160;</span>We have brought down other money in our hand to buy food. We don’t know who put our money in our sacks.” 
-</p><p>
-<span class="v">23&#160;</span>He said, “Peace be to you. Don’t be afraid. Your Elohim, and the Elohim of your father, has given you treasure in your sacks. I received your money.” He brought Simeon out to them. 
-<span class="v">24&#160;</span>The man brought the men into Joseph’s house, and gave them water, and they washed their feet. He gave their donkeys fodder. 
-<span class="v">25&#160;</span>They prepared the present for Joseph’s coming at noon, for they heard that they should eat bread there. 
-</p><p>
-<span class="v">26&#160;</span>When Joseph came home, they brought him the present which was in their hand into the house, and bowed themselves down to the earth before him. 
-<span class="v">27&#160;</span>He asked them of their welfare, and said, “Is your father well, the old man of whom you spoke? Is he yet alive?” 
-</p><p>
-<span class="v">28&#160;</span>They said, “Your servant, our father, is well. He is still alive.” They bowed down humbly. 
-<span class="v">29&#160;</span>He lifted up his eyes, and saw Benjamin, his brother, his mother’s son, and said, “Is this your youngest brother, of whom you spoke to me?” He said, “Elohim be gracious to you, my son.” 
-<span class="v">30&#160;</span>Joseph hurried, for his heart yearned over his brother; and he sought a place to weep. He entered into his room, and wept there. 
-<span class="v">31&#160;</span>He washed his face, and came out. He controlled himself, and said, “Serve the meal.” 
-</p><p>
-<span class="v">32&#160;</span>They served him by himself, and them by themselves, and the Egyptians who ate with him by themselves, because the Egyptians don’t eat with the Hebrews, for that is an abomination to the Egyptians. 
-<span class="v">33&#160;</span>They sat before him, the firstborn according to his birthright, and the youngest according to his youth, and the men marveled with one another. 
-<span class="v">34&#160;</span>He sent portions to them from before him, but Benjamin’s portion was five times as much as any of theirs. They drank, and were merry with him. 
-</p><h2 class="chapterlabel" id="44">44</h2>
-<p>
-<span class="v">1&#160;</span>He commanded the steward of his house, saying, “Fill the men’s sacks with food, as much as they can carry, and put each man’s money in his sack’s mouth. 
-<span class="v">2&#160;</span>Put my cup, the silver cup, in the sack’s mouth of the youngest, with his grain money.” He did according to the word that Joseph had spoken. 
-<span class="v">3&#160;</span>As soon as the morning was light, the men were sent away, they and their donkeys. 
-<span class="v">4&#160;</span>When they had gone out of the city, and were not yet far off, Joseph said to his steward, “Up, follow after the men. When you overtake them, ask them, ‘Why have you rewarded evil for good? 
-<span class="v">5&#160;</span>Isn’t this that from which my lord drinks, and by which he indeed divines? You have done evil in so doing.’&#160;” 
-<span class="v">6&#160;</span>He overtook them, and he spoke these words to them. 
-</p><p>
-<span class="v">7&#160;</span>They said to him, “Why does my lord speak such words as these? Far be it from your servants that they should do such a thing! 
-<span class="v">8&#160;</span>Behold, the money, which we found in our sacks’ mouths, we brought again to you out of the land of Canaan. How then should we steal silver or gold out of your lord’s house? 
-<span class="v">9&#160;</span>With whomever of your servants it is found, let him die, and we also will be my lord’s slaves.” 
-</p><p>
-<span class="v">10&#160;</span>He said, “Now also let it be according to your words. He with whom it is found will be my slave; and you will be blameless.” 
-</p><p>
-<span class="v">11&#160;</span>Then they hurried, and each man took his sack down to the ground, and each man opened his sack. 
-<span class="v">12&#160;</span>He searched, beginning with the oldest, and ending at the youngest. The cup was found in Benjamin’s sack. 
-<span class="v">13&#160;</span>Then they tore their clothes, and each man loaded his donkey, and returned to the city. 
-</p><p>
-<span class="v">14&#160;</span>Judah and his brothers came to Joseph’s house, and he was still there. They fell on the ground before him. 
-<span class="v">15&#160;</span>Joseph said to them, “What deed is this that you have done? Don’t you know that such a man as I can indeed do divination?” 
-</p><p>
-<span class="v">16&#160;</span>Judah said, “What will we tell my lord? What will we speak? How will we clear ourselves? Elohim has found out the iniquity of your servants. Behold, we are my lord’s slaves, both we and he also in whose hand the cup is found.” 
-</p><p>
-<span class="v">17&#160;</span>He said, “Far be it from me that I should do so. The man in whose hand the cup is found, he will be my slave; but as for you, go up in peace to your father.” 
-</p><p>
-<span class="v">18&#160;</span>Then Judah came near to him, and said, “Oh, my lord, please let your servant speak a word in my lord’s ears, and don’t let your anger burn against your servant; for you are even as Pharaoh. 
-<span class="v">19&#160;</span>My lord asked his servants, saying, ‘Have you a father, or a brother?’ 
-<span class="v">20&#160;</span>We said to my lord, ‘We have a father, an old man, and a child of his old age, a little one; and his brother is dead, and he alone is left of his mother; and his father loves him.’ 
-<span class="v">21&#160;</span>You said to your servants, ‘Bring him down to me, that I may set my eyes on him.’ 
-<span class="v">22&#160;</span>We said to my lord, ‘The boy can’t leave his father, for if he should leave his father, his father would die.’ 
-<span class="v">23&#160;</span>You said to your servants, ‘Unless your youngest brother comes down with you, you will see my face no more.’ 
-<span class="v">24&#160;</span>When we came up to your servant my father, we told him the words of my lord. 
-<span class="v">25&#160;</span>Our father said, ‘Go again and buy us a little food.’ 
-<span class="v">26&#160;</span>We said, ‘We can’t go down. If our youngest brother is with us, then we will go down: for we may not see the man’s face, unless our youngest brother is with us.’ 
-<span class="v">27&#160;</span>Your servant, my father, said to us, ‘You know that my woman bore me two sons. 
-<span class="v">28&#160;</span>One went out from me, and I said, “Surely he is torn in pieces;” and I haven’t seen him since. 
-<span class="v">29&#160;</span>If you take this one also from me, and harm happens to him, you will bring down my gray hairs with sorrow to Sheol.’<span class="f">+ \fr 44:29 \ft Sheol is the place of the dead.</span> 
-<span class="v">30&#160;</span>Now therefore when I come to your servant my father, and the boy is not with us; since his life is bound up in the boy’s life; 
-<span class="v">31&#160;</span>it will happen, when he sees that the boy is no more, that he will die. Your servants will bring down the gray hairs of your servant, our father, with sorrow to Sheol.<span class="f">+ \fr 44:31 \ft Sheol is the place of the dead.</span> 
-<span class="v">32&#160;</span>For your servant became collateral for the boy to my father, saying, ‘If I don’t bring him to you, then I will bear the blame to my father forever.’ 
-<span class="v">33&#160;</span>Now therefore, please let your servant stay instead of the boy, my lord’s slave; and let the boy go up with his brothers. 
-<span class="v">34&#160;</span>For how will I go up to my father, if the boy isn’t with me?—lest I see the evil that will come on my father.” 
-</p><h2 class="chapterlabel" id="45">45</h2>
-<p>
-<span class="v">1&#160;</span>Then Joseph couldn’t control himself before all those who stood before him, and he called out, “Cause everyone to go out from me!” No one else stood with him, while Joseph made himself known to his brothers. 
-<span class="v">2&#160;</span>He wept aloud. The Egyptians heard, and the house of Pharaoh heard. 
-<span class="v">3&#160;</span>Joseph said to his brothers, “I am Joseph! Does my father still live?” 
-</p><p>His brothers couldn’t answer him; for they were terrified at his presence. 
-<span class="v">4&#160;</span>Joseph said to his brothers, “Come near to me, please.” 
-</p><p>They came near. He said, “I am Joseph, your brother, whom you sold into Egypt. 
-<span class="v">5&#160;</span>Now don’t be grieved, nor angry with yourselves, that you sold me here, for Elohim sent me before you to preserve life. 
-<span class="v">6&#160;</span>For these two years the famine has been in the land, and there are yet five years, in which there will be no plowing and no harvest. 
-<span class="v">7&#160;</span>Elohim sent me before you to preserve for you a remnant in the earth, and to save you alive by a great deliverance. 
-<span class="v">8&#160;</span>So now it wasn’t you who sent me here, but Elohim, and he has made me a father to Pharaoh, lord of all his house, and ruler over all the land of Egypt. 
-<span class="v">9&#160;</span>Hurry, and go up to my father, and tell him, ‘This is what your son Joseph says, “Elohim has made me lord of all Egypt. Come down to me. Don’t wait. 
-<span class="v">10&#160;</span>You shall dwell in the land of Goshen, and you will be near to me, you, your children, your children’s children, your flocks, your herds, and all that you have. 
-<span class="v">11&#160;</span>There I will provide for you; for there are yet five years of famine; lest you come to poverty, you, and your household, and all that you have.”&#160;’ 
-<span class="v">12&#160;</span>Behold, your eyes see, and the eyes of my brother Benjamin, that it is my mouth that speaks to you. 
-<span class="v">13&#160;</span>You shall tell my father of all my glory in Egypt, and of all that you have seen. You shall hurry and bring my father down here.” 
-<span class="v">14&#160;</span>He fell on his brother Benjamin’s neck and wept, and Benjamin wept on his neck. 
-<span class="v">15&#160;</span>He kissed all his brothers, and wept on them. After that his brothers talked with him. 
-</p><p>
-<span class="v">16&#160;</span>The report of it was heard in Pharaoh’s house, saying, “Joseph’s brothers have come.” It pleased Pharaoh well, and his servants. 
-<span class="v">17&#160;</span>Pharaoh said to Joseph, “Tell your brothers, ‘Do this: Load your animals, and go, travel to the land of Canaan. 
-<span class="v">18&#160;</span>Take your father and your households, and come to me, and I will give you the good of the land of Egypt, and you will eat the fat of the land.’ 
-<span class="v">19&#160;</span>Now you are commanded to do this: Take wagons out of the land of Egypt for your little ones, and for your women, and bring your father, and come. 
-<span class="v">20&#160;</span>Also, don’t concern yourselves about your belongings, for the good of all the land of Egypt is yours.” 
-</p><p>
-<span class="v">21&#160;</span>The sons of Israel did so. Joseph gave them wagons, according to the commandment of Pharaoh, and gave them provision for the way. 
-<span class="v">22&#160;</span>He gave each one of them changes of clothing, but to Benjamin he gave three hundred pieces of silver and five changes of clothing. 
-<span class="v">23&#160;</span>He sent the following to his father: ten donkeys loaded with the good things of Egypt, and ten female donkeys loaded with grain and bread and provision for his father by the way. 
-<span class="v">24&#160;</span>So he sent his brothers away, and they departed. He said to them, “See that you don’t quarrel on the way.” 
-</p><p>
-<span class="v">25&#160;</span>They went up out of Egypt, and came into the land of Canaan, to Jacob their father. 
-<span class="v">26&#160;</span>They told him, saying, “Joseph is still alive, and he is ruler over all the land of Egypt.” His heart fainted, for he didn’t believe them. 
-<span class="v">27&#160;</span>They told him all the words of Joseph, which he had said to them. When he saw the wagons which Joseph had sent to carry him, the spirit of Jacob, their father, revived. 
-<span class="v">28&#160;</span>Israel said, “It is enough. Joseph my son is still alive. I will go and see him before I die.” 
-</p><h2 class="chapterlabel" id="46">46</h2>
-<p>
-<span class="v">1&#160;</span>Israel traveled with all that he had, and came to Beersheba, and offered sacrifices to the Elohim of his father, Isaac. 
-<span class="v">2&#160;</span>Elohim spoke to Israel in the visions of the night, and said, “Jacob, Jacob!” 
-</p><p>He said, “Here I am.” 
-</p><p>
-<span class="v">3&#160;</span>He said, “I am Elohim, the Elohim of your father. Don’t be afraid to go down into Egypt, for there I will make of you a great nation. 
-<span class="v">4&#160;</span>I will go down with you into Egypt. I will also surely bring you up again. Joseph’s hand will close your eyes.” 
-</p><p>
-<span class="v">5&#160;</span>Jacob rose up from Beersheba, and the sons of Israel carried Jacob, their father, their little ones, and their women, in the wagons which Pharaoh had sent to carry him. 
-<span class="v">6&#160;</span>They took their livestock, and their goods, which they had gotten in the land of Canaan, and came into Egypt—Jacob, and all his offspring with him, 
-<span class="v">7&#160;</span>his sons, and his sons’ sons with him, his daughters, and his sons’ daughters, and he brought all his offspring with him into Egypt. 
-</p><p>
-<span class="v">8&#160;</span>These are the names of the children of Israel, who came into Egypt, Jacob and his sons: Reuben, Jacob’s firstborn. 
-<span class="v">9&#160;</span>The sons of Reuben: Hanoch, Pallu, Hezron, and Carmi. 
-<span class="v">10&#160;</span>The sons of Simeon: Jemuel, Jamin, Ohad, Jachin, Zohar, and Shaul the son of a Canaanite woman. 
-<span class="v">11&#160;</span>The sons of Levi: Gershon, Kohath, and Merari. 
-<span class="v">12&#160;</span>The sons of Judah: Er, Onan, Shelah, Perez, and Zerah; but Er and Onan died in the land of Canaan. The sons of Perez were Hezron and Hamul. 
-<span class="v">13&#160;</span>The sons of Issachar: Tola, Puvah, Iob, and Shimron. 
-<span class="v">14&#160;</span>The sons of Zebulun: Sered, Elon, and Jahleel. 
-<span class="v">15&#160;</span>These are the sons of Leah, whom she bore to Jacob in Paddan Aram, with his daughter Dinah. All the souls of his sons and his daughters were thirty-three. 
-<span class="v">16&#160;</span>The sons of Gad: Ziphion, Haggi, Shuni, Ezbon, Eri, Arodi, and Areli. 
-<span class="v">17&#160;</span>The sons of Asher: Imnah, Ishvah, Ishvi, Beriah, and Serah their sister. The sons of Beriah: Heber and Malchiel. 
-<span class="v">18&#160;</span>These are the sons of Zilpah, whom Laban gave to Leah, his daughter, and these she bore to Jacob, even sixteen souls. 
-<span class="v">19&#160;</span>The sons of Rachel, Jacob’s woman: Joseph and Benjamin. 
-<span class="v">20&#160;</span>To Joseph in the land of Egypt were born Manasseh and Ephraim, whom Asenath, the daughter of Potiphera, priest of On, bore to him. 
-<span class="v">21&#160;</span>The sons of Benjamin: Bela, Becher, Ashbel, Gera, Naaman, Ehi, Rosh, Muppim, Huppim, and Ard. 
-<span class="v">22&#160;</span>These are the sons of Rachel, who were born to Jacob: all the souls were fourteen. 
-<span class="v">23&#160;</span>The son of Dan: Hushim. 
-<span class="v">24&#160;</span>The sons of Naphtali: Jahzeel, Guni, Jezer, and Shillem. 
-<span class="v">25&#160;</span>These are the sons of Bilhah, whom Laban gave to Rachel, his daughter, and these she bore to Jacob: all the souls were seven. 
-<span class="v">26&#160;</span>All the souls who came with Jacob into Egypt, who were his direct offspring, in addition to Jacob’s sons’ women, all the souls were sixty-six. 
-<span class="v">27&#160;</span>The sons of Joseph, who were born to him in Egypt, were two souls. All the souls of the house of Jacob, who came into Egypt, were seventy. 
-</p><p>
-<span class="v">28&#160;</span>Jacob sent Judah before him to Joseph, to show the way before him to Goshen, and they came into the land of Goshen. 
-<span class="v">29&#160;</span>Joseph prepared his chariot, and went up to meet Israel, his father, in Goshen. He presented himself to him, and fell on his neck, and wept on his neck a good while. 
-<span class="v">30&#160;</span>Israel said to Joseph, “Now let me die, since I have seen your face, that you are still alive.” 
-</p><p>
-<span class="v">31&#160;</span>Joseph said to his brothers, and to his father’s house, “I will go up, and speak with Pharaoh, and will tell him, ‘My brothers, and my father’s house, who were in the land of Canaan, have come to me. 
-<span class="v">32&#160;</span>These men are shepherds, for they have been keepers of livestock, and they have brought their flocks, and their herds, and all that they have.’ 
-<span class="v">33&#160;</span>It will happen, when Pharaoh summons you, and will say, ‘What is your occupation?’ 
-<span class="v">34&#160;</span>that you shall say, ‘Your servants have been keepers of livestock from our youth even until now, both we, and our fathers:’ that you may dwell in the land of Goshen; for every shepherd is an abomination to the Egyptians.” 
-</p><h2 class="chapterlabel" id="47">47</h2>
-<p>
-<span class="v">1&#160;</span>Then Joseph went in and told Pharaoh, and said, “My father and my brothers, with their flocks, their herds, and all that they own, have come out of the land of Canaan; and behold, they are in the land of Goshen.” 
-<span class="v">2&#160;</span>From among his brothers he took five men, and presented them to Pharaoh. 
-<span class="v">3&#160;</span>Pharaoh said to his brothers, “What is your occupation?” 
-</p><p>They said to Pharaoh, “Your servants are shepherds, both we, and our fathers.” 
-<span class="v">4&#160;</span>They also said to Pharaoh, “We have come to live as foreigners in the land, for there is no pasture for your servants’ flocks. For the famine is severe in the land of Canaan. Now therefore, please let your servants dwell in the land of Goshen.” 
-</p><p>
-<span class="v">5&#160;</span>Pharaoh spoke to Joseph, saying, “Your father and your brothers have come to you. 
-<span class="v">6&#160;</span>The land of Egypt is before you. Make your father and your brothers dwell in the best of the land. Let them dwell in the land of Goshen. If you know any able men among them, then put them in charge of my livestock.” 
-</p><p>
-<span class="v">7&#160;</span>Joseph brought in Jacob, his father, and set him before Pharaoh; and Jacob blessed Pharaoh. 
-<span class="v">8&#160;</span>Pharaoh said to Jacob, “How old are you?” 
-</p><p>
-<span class="v">9&#160;</span>Jacob said to Pharaoh, “The years of my pilgrimage are one hundred thirty years. The days of the years of my life have been few and evil. They have not attained to the days of the years of the life of my fathers in the days of their pilgrimage.” 
-<span class="v">10&#160;</span>Jacob blessed Pharaoh, and went out from the presence of Pharaoh. 
-</p><p>
-<span class="v">11&#160;</span>Joseph placed his father and his brothers, and gave them a possession in the land of Egypt, in the best of the land, in the land of Rameses, as Pharaoh had commanded. 
-<span class="v">12&#160;</span>Joseph provided his father, his brothers, and all of his father’s household with bread, according to the sizes of their families. 
-</p><p>
-<span class="v">13&#160;</span>There was no bread in all the land; for the famine was very severe, so that the land of Egypt and the land of Canaan fainted by reason of the famine. 
-<span class="v">14&#160;</span>Joseph gathered up all the money that was found in the land of Egypt, and in the land of Canaan, for the grain which they bought: and Joseph brought the money into Pharaoh’s house. 
-<span class="v">15&#160;</span>When the money was all spent in the land of Egypt, and in the land of Canaan, all the Egyptians came to Joseph, and said, “Give us bread, for why should we die in your presence? For our money fails.” 
-</p><p>
-<span class="v">16&#160;</span>Joseph said, “Give me your livestock; and I will give you food for your livestock, if your money is gone.” 
-</p><p>
-<span class="v">17&#160;</span>They brought their livestock to Joseph, and Joseph gave them bread in exchange for the horses, and for the flocks, and for the herds, and for the donkeys: and he fed them with bread in exchange for all their livestock for that year. 
-<span class="v">18&#160;</span>When that year was ended, they came to him the second year, and said to him, “We will not hide from my lord how our money is all spent, and the herds of livestock are my lord’s. There is nothing left in the sight of my lord, but our bodies, and our lands. 
-<span class="v">19&#160;</span>Why should we die before your eyes, both we and our land? Buy us and our land for bread, and we and our land will be servants to Pharaoh. Give us seed, that we may live, and not die, and that the land won’t be desolate.” 
-</p><p>
-<span class="v">20&#160;</span>So Joseph bought all the land of Egypt for Pharaoh, for every man of the Egyptians sold his field, because the famine was severe on them, and the land became Pharaoh’s. 
-<span class="v">21&#160;</span>As for the people, he moved them to the cities from one end of the border of Egypt even to the other end of it. 
-<span class="v">22&#160;</span>Only he didn’t buy the land of the priests, for the priests had a portion from Pharaoh, and ate their portion which Pharaoh gave them. That is why they didn’t sell their land. 
-<span class="v">23&#160;</span>Then Joseph said to the people, “Behold, I have bought you and your land today for Pharaoh. Behold, here is seed for you, and you shall sow the land. 
-<span class="v">24&#160;</span>It will happen at the harvests, that you shall give a fifth to Pharaoh, and four parts will be your own, for seed of the field, for your food, for them of your households, and for food for your little ones.” 
-</p><p>
-<span class="v">25&#160;</span>They said, “You have saved our lives! Let us find favor in the sight of my lord, and we will be Pharaoh’s servants.” 
-</p><p>
-<span class="v">26&#160;</span>Joseph made it a statute concerning the land of Egypt to this day, that Pharaoh should have the fifth. Only the land of the priests alone didn’t become Pharaoh’s. 
-</p><p>
-<span class="v">27&#160;</span>Israel lived in the land of Egypt, in the land of Goshen; and they got themselves possessions therein, and were fruitful, and multiplied exceedingly. 
-<span class="v">28&#160;</span>Jacob lived in the land of Egypt seventeen years. So the days of Jacob, the years of his life, were one hundred forty-seven years. 
-<span class="v">29&#160;</span>The time came near that Israel must die, and he called his son Joseph, and said to him, “If now I have found favor in your sight, please put your hand under my thigh, and deal kindly and truly with me. Please don’t bury me in Egypt, 
-<span class="v">30&#160;</span>but when I sleep with my fathers, you shall carry me out of Egypt, and bury me in their burying place.” 
-</p><p>Joseph said, “I will do as you have said.” 
-</p><p>
-<span class="v">31&#160;</span>Israel said, “Swear to me,” and he swore to him. Then Israel bowed himself on the bed’s head. 
-</p><h2 class="chapterlabel" id="48">48</h2>
-<p>
-<span class="v">1&#160;</span>After these things, someone said to Joseph, “Behold, your father is sick.” He took with him his two sons, Manasseh and Ephraim. 
-<span class="v">2&#160;</span>Someone told Jacob, and said, “Behold, your son Joseph comes to you,” and Israel strengthened himself, and sat on the bed. 
-<span class="v">3&#160;</span>Jacob said to Joseph, “Elohim Almighty appeared to me at Luz in the land of Canaan, and blessed me, 
-<span class="v">4&#160;</span>and said to me, ‘Behold, I will make you fruitful, and multiply you, and I will make of you a company of peoples, and will give this land to your offspring after you for an everlasting possession.’ 
-<span class="v">5&#160;</span>Now your two sons, who were born to you in the land of Egypt before I came to you into Egypt, are mine; Ephraim and Manasseh, even as Reuben and Simeon, will be mine. 
-<span class="v">6&#160;</span>Your offspring, whom you become the father of after them, will be yours. They will be called after the name of their brothers in their inheritance. 
-<span class="v">7&#160;</span>As for me, when I came from Paddan, Rachel died beside me in the land of Canaan on the way, when there was still some distance to come to Ephrath, and I buried her there on the way to Ephrath (also called Bethlehem).” 
-</p><p>
-<span class="v">8&#160;</span>Israel saw Joseph’s sons, and said, “Who are these?” 
-</p><p>
-<span class="v">9&#160;</span>Joseph said to his father, “They are my sons, whom Elohim has given me here.” 
-</p><p>He said, “Please bring them to me, and I will bless them.” 
-<span class="v">10&#160;</span>Now the eyes of Israel were dim for age, so that he couldn’t see well. Joseph brought them near to him; and he kissed them, and embraced them. 
-<span class="v">11&#160;</span>Israel said to Joseph, “I didn’t think I would see your face, and behold, Elohim has let me see your offspring also.” 
-<span class="v">12&#160;</span>Joseph brought them out from between his knees, and he bowed himself with his face to the earth. 
-<span class="v">13&#160;</span>Joseph took them both, Ephraim in his right hand toward Israel’s left hand, and Manasseh in his left hand toward Israel’s right hand, and brought them near to him. 
-<span class="v">14&#160;</span>Israel stretched out his right hand, and laid it on Ephraim’s head, who was the younger, and his left hand on Manasseh’s head, guiding his hands knowingly, for Manasseh was the firstborn. 
-<span class="v">15&#160;</span>He blessed Joseph, and said, 
-</p><p class="q1">“The Elohim before whom my fathers Abraham and Isaac walked, 
-</p><p class="q1">the Elohim who has fed me all my life long to this day, 
-</p><p class="q1">
-<span class="v">16&#160;</span>the angel who has redeemed me from all evil, bless the lads, 
-</p><p class="q1">and let my name be named on them, 
-</p><p class="q1">and the name of my fathers Abraham and Isaac. 
-</p><p class="q1">Let them grow into a multitude upon the earth.” 
-</p><p>
-<span class="v">17&#160;</span>When Joseph saw that his father laid his right hand on the head of Ephraim, it displeased him. He held up his father’s hand, to remove it from Ephraim’s head to Manasseh’s head. 
-<span class="v">18&#160;</span>Joseph said to his father, “Not so, my father, for this is the firstborn. Put your right hand on his head.” 
-</p><p>
-<span class="v">19&#160;</span>His father refused, and said, “I know, my son, I know. He also will become a people, and he also will be great. However, his younger brother will be greater than he, and his offspring will become a multitude of nations.” 
-<span class="v">20&#160;</span>He blessed them that day, saying, “Israel will bless in you, saying, ‘Elohim make you as Ephraim and as Manasseh’&#160;” He set Ephraim before Manasseh. 
-<span class="v">21&#160;</span>Israel said to Joseph, “Behold, I am dying, but Elohim will be with you, and bring you again to the land of your fathers. 
-<span class="v">22&#160;</span>Moreover I have given to you one portion above your brothers, which I took out of the hand of the Amorite with my sword and with my bow.” 
-</p><h2 class="chapterlabel" id="49">49</h2>
-<p>
-<span class="v">1&#160;</span>Jacob called to his sons, and said: “Gather yourselves together, that I may tell you that which will happen to you in the days to come. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Assemble yourselves, and hear, you sons of Jacob. 
-</p><p class="q2">Listen to Israel, your father. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Reuben, you are my firstborn, my might, and the beginning of my strength, 
-</p><p class="q2">excelling in dignity, and excelling in power. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Boiling over like water, you shall not excel, 
-</p><p class="q2">because you went up to your father’s bed, 
-</p><p class="q2">then defiled it. He went up to my couch. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Simeon and Levi are brothers. 
-</p><p class="q2">Their swords are weapons of violence. 
-</p><p class="q1">
-<span class="v">6&#160;</span>My soul, don’t come into their council. 
-</p><p class="q2">My glory, don’t be united to their assembly; 
-</p><p class="q1">for in their anger they killed men. 
-</p><p class="q2">In their self-will they hamstrung cattle. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Cursed be their anger, for it was fierce; 
-</p><p class="q2">and their wrath, for it was cruel. 
-</p><p class="q1">I will divide them in Jacob, 
-</p><p class="q2">and scatter them in Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Judah, your brothers will praise you. 
-</p><p class="q2">Your hand will be on the neck of your enemies. 
-</p><p class="q2">Your father’s sons will bow down before you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Judah is a lion’s cub. 
-</p><p class="q2">From the prey, my son, you have gone up. 
-</p><p class="q1">He stooped down, he crouched as a lion, 
-</p><p class="q2">as a lioness. 
-</p><p class="q2">Who will rouse him up? 
-</p><p class="q1">
-<span class="v">10&#160;</span>The scepter will not depart from Judah, 
-</p><p class="q2">nor the ruler’s staff from between his feet, 
-</p><p class="q1">until he comes to whom it belongs. 
-</p><p class="q2">The obedience of the peoples will be to him. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Binding his foal to the vine, 
-</p><p class="q2">his donkey’s colt to the choice vine, 
-</p><p class="q1">he has washed his garments in wine, 
-</p><p class="q2">his robes in the blood of grapes. 
-</p><p class="q1">
-<span class="v">12&#160;</span>His eyes will be red with wine, 
-</p><p class="q2">his teeth white with milk. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“Zebulun will dwell at the haven of the sea. 
-</p><p class="q2">He will be for a haven of ships. 
-</p><p class="q2">His border will be on Sidon. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“Issachar is a strong donkey, 
-</p><p class="q2">lying down between the saddlebags. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He saw a resting place, that it was good, 
-</p><p class="q2">the land, that it was pleasant. 
-</p><p class="q1">He bows his shoulder to the burden, 
-</p><p class="q2">and becomes a servant doing forced labor. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>“Dan will judge his people, 
-</p><p class="q2">as one of the tribes of Israel. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Dan will be a serpent on the trail, 
-</p><p class="q2">an adder in the path, 
-</p><p class="q1">that bites the horse’s heels, 
-</p><p class="q2">so that his rider falls backward. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I have waited for your salvation, Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“A troop will press on Gad, 
-</p><p class="q2">but he will press on their heel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Asher’s food will be rich. 
-</p><p class="q2">He will produce royal dainties. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Naphtali is a doe set free, 
-</p><p class="q2">who bears beautiful fawns. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“Joseph is a fruitful vine, 
-</p><p class="q2">a fruitful vine by a spring. 
-</p><p class="q2">His branches run over the wall. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The archers have severely grieved him, 
-</p><p class="q2">shot at him, and persecuted him: 
-</p><p class="q1">
-<span class="v">24&#160;</span>But his bow remained strong. 
-</p><p class="q2">The arms of his hands were made strong, 
-</p><p class="q2">by the hands of the Mighty One of Jacob, 
-</p><p class="q2">(from there is the shepherd, the stone of Israel), 
-</p><p class="q1">
-<span class="v">25&#160;</span>even by the Elohim of your father, who will help you, 
-</p><p class="q2">by the Almighty, who will bless you, 
-</p><p class="q1">with blessings of heaven above, 
-</p><p class="q2">blessings of the deep that lies below, 
-</p><p class="q2">blessings of the breasts, and of the womb. 
-</p><p class="q1">
-<span class="v">26&#160;</span>The blessings of your father have prevailed above the blessings of my ancestors, 
-</p><p class="q2">above the boundaries of the ancient hills. 
-</p><p class="q1">They will be on the head of Joseph, 
-</p><p class="q2">on the crown of the head of him who is separated from his brothers. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">27&#160;</span>“Benjamin is a ravenous wolf. 
-</p><p class="q2">In the morning he will devour the prey. 
-</p><p class="q2">At evening he will divide the plunder.” 
-</p><p>
-<span class="v">28&#160;</span>All these are the twelve tribes of Israel, and this is what their father spoke to them, and blessed them. He blessed everyone according to his own blessing. 
-<span class="v">29&#160;</span>He instructed them, and said to them, “I am to be gathered to my people. Bury me with my fathers in the cave that is in the field of Ephron the Hittite, 
-<span class="v">30&#160;</span>in the cave that is in the field of Machpelah, which is before Mamre, in the land of Canaan, which Abraham bought with the field from Ephron the Hittite as a burial place. 
-<span class="v">31&#160;</span>There they buried Abraham and Sarah, his woman. There they buried Isaac and Rebekah, his woman, and there I buried Leah: 
-<span class="v">32&#160;</span>the field and the cave that is therein, which was purchased from the children of Heth.” 
-<span class="v">33&#160;</span>When Jacob finished charging his sons, he gathered up his feet into the bed, breathed his last breath, and was gathered to his people. 
-</p><h2 class="chapterlabel" id="50">50</h2>
-<p class="nb">
-<span class="v">1&#160;</span>Joseph fell on his father’s face, wept on him, and kissed him. 
-<span class="v">2&#160;</span>Joseph commanded his servants, the physicians, to embalm his father; and the physicians embalmed Israel. 
-<span class="v">3&#160;</span>Forty days were used for him, for that is how many days it takes to embalm. The Egyptians wept for Israel for seventy days. 
-</p><p>
-<span class="v">4&#160;</span>When the days of weeping for him were past, Joseph spoke to Pharaoh’s staff, saying, “If now I have found favor in your eyes, please speak in the ears of Pharaoh, saying, 
-<span class="v">5&#160;</span>‘My father made me swear, saying, “Behold, I am dying. Bury me in my grave which I have dug for myself in the land of Canaan.” Now therefore, please let me go up and bury my father, and I will come again.’&#160;” 
-</p><p>
-<span class="v">6&#160;</span>Pharaoh said, “Go up, and bury your father, just like he made you swear.” 
-</p><p>
-<span class="v">7&#160;</span>Joseph went up to bury his father; and with him went up all the servants of Pharaoh, the elders of his house, all the elders of the land of Egypt, 
-<span class="v">8&#160;</span>all the house of Joseph, his brothers, and his father’s house. Only their little ones, their flocks, and their herds, they left in the land of Goshen. 
-<span class="v">9&#160;</span>Both chariots and horsemen went up with him. It was a very great company. 
-<span class="v">10&#160;</span>They came to the threshing floor of Atad, which is beyond the Jordan, and there they lamented with a very great and severe lamentation. He mourned for his father seven days. 
-<span class="v">11&#160;</span>When the inhabitants of the land, the Canaanites, saw the mourning in the floor of Atad, they said, “This is a grievous mourning by the Egyptians.” Therefore its name was called Abel Mizraim, which is beyond the Jordan. 
-<span class="v">12&#160;</span>His sons did to him just as he commanded them, 
-<span class="v">13&#160;</span>for his sons carried him into the land of Canaan, and buried him in the cave of the field of Machpelah, which Abraham bought with the field, as a possession for a burial site, from Ephron the Hittite, near Mamre. 
-<span class="v">14&#160;</span>Joseph returned into Egypt—he, and his brothers, and all that went up with him to bury his father, after he had buried his father. 
-</p><p>
-<span class="v">15&#160;</span>When Joseph’s brothers saw that their father was dead, they said, “It may be that Joseph will hate us, and will fully pay us back for all the evil which we did to him.” 
-<span class="v">16&#160;</span>They sent a message to Joseph, saying, “Your father commanded before he died, saying, 
-<span class="v">17&#160;</span>‘You shall tell Joseph, “Now please forgive the disobedience of your brothers, and their sin, because they did evil to you.”&#160;’ Now, please forgive the disobedience of the servants of the Elohim of your father.” Joseph wept when they spoke to him. 
-<span class="v">18&#160;</span>His brothers also went and fell down before his face; and they said, “Behold, we are your servants.” 
-<span class="v">19&#160;</span>Joseph said to them, “Don’t be afraid, for am I in the place of Elohim? 
-<span class="v">20&#160;</span>As for you, you meant evil against me, but Elohim meant it for good, to save many people alive, as is happening today. 
-<span class="v">21&#160;</span>Now therefore don’t be afraid. I will provide for you and your little ones.” He comforted them, and spoke kindly to them. 
-</p><p>
-<span class="v">22&#160;</span>Joseph lived in Egypt, he, and his father’s house. Joseph lived one hundred ten years. 
-<span class="v">23&#160;</span>Joseph saw Ephraim’s children to the third generation. The children also of Machir, the son of Manasseh, were born on Joseph’s knees. 
-<span class="v">24&#160;</span>Joseph said to his brothers, “I am dying, but Elohim will surely visit you, and bring you up out of this land to the land which he swore to Abraham, to Isaac, and to Jacob.” 
-<span class="v">25&#160;</span>Joseph took an oath from the children of Israel, saying, “Elohim will surely visit you, and you shall carry up my bones from here.” 
-<span class="v">26&#160;</span>So Joseph died, being one hundred ten years old, and they embalmed him, and he was put in a coffin in Egypt. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+<a href="#41">41</a>
+<a href="#42">42</a>
+<a href="#43">43</a>
+<a href="#44">44</a>
+<a href="#45">45</a>
+<a href="#46">46</a>
+<a href="#47">47</a>
+<a href="#48">48</a>
+<a href="#49">49</a>
+<a href="#50">50</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>In the beginning, Elohim created the heavens and the earth. 
+<sup>2&#160;</sup>The earth was formless and empty. Darkness was on the surface of the deep and Elohim’s Spirit was hovering over the surface of the waters. 
+</div><div class="p">
+<sup>3&#160;</sup>Elohim said, “Let there be light,” and there was light. 
+<sup>4&#160;</sup>Elohim saw the light, and saw that it was good. Elohim divided the light from the darkness. 
+<sup>5&#160;</sup>Elohim called the light “day”, and the darkness he called “night”. There was evening and there was morning, the first day. 
+</div><div class="p">
+<sup>6&#160;</sup>Elohim said, “Let there be an expanse in the middle of the waters, and let it divide the waters from the waters.” 
+<sup>7&#160;</sup>Elohim made the expanse, and divided the waters which were under the expanse from the waters which were above the expanse; and it was so. 
+<sup>8&#160;</sup>Elohim called the expanse “sky”. There was evening and there was morning, a second day. 
+</div><div class="p">
+<sup>9&#160;</sup>Elohim said, “Let the waters under the sky be gathered together to one place, and let the dry land appear;” and it was so. 
+<sup>10&#160;</sup>Elohim called the dry land “earth”, and the gathering together of the waters he called “seas”. Elohim saw that it was good. 
+<sup>11&#160;</sup>Elohim said, “Let the earth yield grass, herbs yielding seeds, and fruit trees bearing fruit after their kind, with their seeds in it, on the earth;” and it was so. 
+<sup>12&#160;</sup>The earth yielded grass, herbs yielding seed after their kind, and trees bearing fruit, with their seeds in it, after their kind; and Elohim saw that it was good. 
+<sup>13&#160;</sup>There was evening and there was morning, a third day. 
+</div><div class="p">
+<sup>14&#160;</sup>Elohim said, “Let there be lights in the expanse of the sky to divide the day from the night; and let them be for signs to mark seasons, days, and years; 
+<sup>15&#160;</sup>and let them be for lights in the expanse of the sky to give light on the earth;” and it was so. 
+<sup>16&#160;</sup>Elohim made the two great lights: the greater light to rule the day, and the lesser light to rule the night. He also made the stars. 
+<sup>17&#160;</sup>Elohim set them in the expanse of the sky to give light to the earth, 
+<sup>18&#160;</sup>and to rule over the day and over the night, and to divide the light from the darkness. Elohim saw that it was good. 
+<sup>19&#160;</sup>There was evening and there was morning, a fourth day. 
+</div><div class="p">
+<sup>20&#160;</sup>Elohim said, “Let the waters abound with living creatures, and let birds fly above the earth in the open expanse of the sky.” 
+<sup>21&#160;</sup>Elohim created the large sea creatures and every living creature that moves, with which the waters swarmed, after their kind, and every winged bird after its kind. Elohim saw that it was good. 
+<sup>22&#160;</sup>Elohim blessed them, saying, “Be fruitful, and multiply, and fill the waters in the seas, and let birds multiply on the earth.” 
+<sup>23&#160;</sup>There was evening and there was morning, a fifth day. 
+</div><div class="p">
+<sup>24&#160;</sup>Elohim said, “Let the earth produce living creatures after their kind, livestock, creeping things, and animals of the earth after their kind;” and it was so. 
+<sup>25&#160;</sup>Elohim made the animals of the earth after their kind, and the livestock after their kind, and everything that creeps on the ground after its kind. Elohim saw that it was good. 
+</div><div class="p">
+<sup>26&#160;</sup>Elohim said, “Let’s make man in our image, after our likeness. Let them have dominion over the fish of the sea, and over the birds of the sky, and over the livestock, and over all the earth, and over every creeping thing that creeps on the earth.” 
+<sup>27&#160;</sup>Elohim created man in his own image. In Elohim’s image he created him; male and female he created them. 
+<sup>28&#160;</sup>Elohim blessed them. Elohim said to them, “Be fruitful, multiply, fill the earth, and subdue it. Have dominion over the fish of the sea, over the birds of the sky, and over every living thing that moves on the earth.” 
+<sup>29&#160;</sup>Elohim said, “Behold, I have given you every herb yielding seed, which is on the surface of all the earth, and every tree, which bears fruit yielding seed. It will be your food. 
+<sup>30&#160;</sup>To every animal of the earth, and to every bird of the sky, and to everything that creeps on the earth, in which there is life, I have given every green herb for food;” and it was so. 
+</div><div class="p">
+<sup>31&#160;</sup>Elohim saw everything that he had made, and, behold, it was very good. There was evening and there was morning, a sixth day. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>The heavens, the earth, and all their vast array were finished. 
+<sup>2&#160;</sup>On the seventh day Elohim finished his work which he had done; and he rested on the seventh day from all his work which he had done. 
+<sup>3&#160;</sup>Elohim blessed the seventh day, and made it set-apart, because he rested in it from all his work of creation which he had done. 
+</div><div class="p">
+<sup>4&#160;</sup>This is the history of the generations of the heavens and of the earth when they were created, in the day that Yahweh Elohim made the earth and the heavens. 
+<sup>5&#160;</sup>No plant of the field was yet in the earth, and no herb of the field had yet sprung up; for Yahweh Elohim had not caused it to rain on the earth. There was not a man to till the ground, 
+<sup>6&#160;</sup>but a mist went up from the earth, and watered the whole surface of the ground. 
+<sup>7&#160;</sup>Yahweh Elohim formed man from the dust of the ground, and breathed into his nostrils the breath of life; and man became a living soul. 
+<sup>8&#160;</sup>Yahweh Elohim planted a garden eastward, in Eden, and there he put the man whom he had formed. 
+<sup>9&#160;</sup>Out of the ground Yahweh Elohim made every tree to grow that is pleasant to the sight, and good for food, including the tree of life in the middle of the garden and the tree of the knowledge of good and evil. 
+<sup>10&#160;</sup>A river went out of Eden to water the garden; and from there it was parted, and became the source of four rivers. 
+<sup>11&#160;</sup>The name of the first is Pishon: it flows through the whole land of Havilah, where there is gold; 
+<sup>12&#160;</sup>and the gold of that land is good. Bdellium and onyx stone are also there. 
+<sup>13&#160;</sup>The name of the second river is Gihon. It is the same river that flows through the whole land of Cush. 
+<sup>14&#160;</sup>The name of the third river is Hiddekel. This is the one which flows in front of Assyria. The fourth river is the Euphrates. 
+<sup>15&#160;</sup>Yahweh Elohim took the man, and put him into the garden of Eden to cultivate and keep it. 
+<sup>16&#160;</sup>Yahweh Elohim commanded the man, saying, “You may freely eat of every tree of the garden; 
+<sup>17&#160;</sup>but you shall not eat of the tree of the knowledge of good and evil; for in the day that you eat of it, you will surely die.” 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh Elohim said, “It is not good for the man to be alone. I will make him a helper comparable to him.” 
+<sup>19&#160;</sup>Out of the ground Yahweh Elohim formed every animal of the field, and every bird of the sky, and brought them to the man to see what he would call them. Whatever the man called every living creature became its name. 
+<sup>20&#160;</sup>The man gave names to all livestock, and to the birds of the sky, and to every animal of the field; but for man there was not found a helper comparable to him. 
+<sup>21&#160;</sup>Yahweh Elohim caused the man to fall into a deep sleep. As the man slept, he took one of his ribs, and closed up the flesh in its place. 
+<sup>22&#160;</sup>Yahweh Elohim made a woman from the rib which he had taken from the man, and brought her to the man. 
+<sup>23&#160;</sup>The man said, “This is now bone of my bones, and flesh of my flesh. She will be called ‘woman,’ because she was taken out of Man.” 
+<sup>24&#160;</sup>Therefore a man will leave his father and his mother, and will join with his woman, and they will be one flesh. 
+<sup>25&#160;</sup>The man and his woman were both naked, and they were not ashamed. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the serpent was more subtle than any animal of the field which Yahweh Elohim had made. He said to the woman, “Has Elohim really said, ‘You shall not eat of any tree of the garden’?” 
+</div><div class="p">
+<sup>2&#160;</sup>The woman said to the serpent, “We may eat fruit from the trees of the garden, 
+<sup>3&#160;</sup>but not the fruit of the tree which is in the middle of the garden. Elohim has said, ‘You shall not eat of it. You shall not touch it, lest you die.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>The serpent said to the woman, “You won’t really die, 
+<sup>5&#160;</sup>for Elohim knows that in the day you eat it, your eyes will be opened, and you will be like Elohim, knowing good and evil.” 
+</div><div class="p">
+<sup>6&#160;</sup>When the woman saw that the tree was good for food, and that it was a delight to the eyes, and that the tree was to be desired to make one wise, she took some of its fruit, and ate. Then she gave some to her man with her, and he ate it, too. 
+<sup>7&#160;</sup>Their eyes were opened, and they both knew that they were naked. They sewed fig leaves together, and made coverings for themselves. 
+<sup>8&#160;</sup>They heard Yahweh Elohim’s voice walking in the garden in the cool of the day, and the man and his woman hid themselves from the presence of Yahweh Elohim among the trees of the garden. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh Elohim called to the man, and said to him, “Where are you?” 
+</div><div class="p">
+<sup>10&#160;</sup>The man said, “I heard your voice in the garden, and I was afraid, because I was naked; so I hid myself.” 
+</div><div class="p">
+<sup>11&#160;</sup>Elohim said, “Who told you that you were naked? Have you eaten from the tree that I commanded you not to eat from?” 
+</div><div class="p">
+<sup>12&#160;</sup>The man said, “The woman whom you gave to be with me, she gave me fruit from the tree, and I ate it.” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh Elohim said to the woman, “What have you done?” 
+</div><div class="p">The woman said, “The serpent deceived me, and I ate.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh Elohim said to the serpent, 
+</div><div class="q1">“Because you have done this, 
+</div><div class="q2">you are cursed above all livestock, 
+</div><div class="q2">and above every animal of the field. 
+</div><div class="q1">You shall go on your belly 
+</div><div class="q2">and you shall eat dust all the days of your life. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will put hostility between you and the woman, 
+</div><div class="q2">and between your offspring and her offspring. 
+</div><div class="q1">He will bruise your head, 
+</div><div class="q2">and you will bruise his heel.” 
+</div><div class="p">
+<sup>16&#160;</sup>To the woman he said, 
+</div><div class="q1">“I will greatly multiply your pain in childbirth. 
+</div><div class="q2">You will bear children in pain. 
+</div><div class="q1">Your desire will be for your man, 
+</div><div class="q2">and he will rule over you.” 
+</div><div class="p">
+<sup>17&#160;</sup>To Adam he said, 
+</div><div class="q1">“Because you have listened to your woman’s voice, 
+</div><div class="q2">and have eaten from the tree, 
+</div><div class="q2">about which I commanded you, saying, ‘You shall not eat of it,’ 
+</div><div class="q2">the ground is cursed for your sake. 
+</div><div class="q1">You will eat from it with much labor all the days of your life. 
+</div><div class="q2">
+<sup>18&#160;</sup>It will yield thorns and thistles to you; 
+</div><div class="q2">and you will eat the herb of the field. 
+</div><div class="q1">
+<sup>19&#160;</sup>You will eat bread by the sweat of your face until you return to the ground, 
+</div><div class="q2">for you were taken out of it. 
+</div><div class="q1">For you are dust, 
+</div><div class="q2">and you shall return to dust.” 
+</div><div class="p">
+<sup>20&#160;</sup>The man called his woman Eve because she would be the mother of all the living. 
+<sup>21&#160;</sup>Yahweh Elohim made garments of animal skins for Adam and for his woman, and clothed them. 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh Elohim said, “Behold, the man has become like one of us, knowing good and evil. Now, lest he reach out his hand, and also take of the tree of life, and eat, and live forever—” 
+<sup>23&#160;</sup>Therefore Yahweh Elohim sent him out from the garden of Eden, to till the ground from which he was taken. 
+<sup>24&#160;</sup>So he drove out the man; and he placed cherubim at the east of the garden of Eden, and a flaming sword which turned every way, to guard the way to the tree of life. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>The man knew and gave birth to Cain, and said, “I have gotten a man with Yahweh’s help.” 
+<sup>2&#160;</sup>Again she gave birth, to Cain’s brother Abel. Abel was a keeper of sheep, but Cain was a tiller of the ground. 
+<sup>3&#160;</sup>As time passed, Cain brought an offering to Yahweh from the fruit of the ground. 
+<sup>4&#160;</sup>Abel also brought some of the firstborn of his flock and of its fat. Yahweh respected Abel and his offering, 
+<sup>5&#160;</sup>but he didn’t respect Cain and his offering. Cain was very angry, and the expression on his face fell. 
+<sup>6&#160;</sup>Yahweh said to Cain, “Why are you angry? Why has the expression of your face fallen? 
+<sup>7&#160;</sup>If you do well, won’t it be lifted up? If you don’t do well, sin crouches at the door. Its desire is for you, but you are to rule over it.” 
+<sup>8&#160;</sup>Cain said to Abel, his brother, “Let’s go into the field.” While they were in the field, Cain rose up against Abel, his brother, and killed him. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh said to Cain, “Where is Abel, your brother?” 
+</div><div class="p">He said, “I don’t know. Am I my brother’s keeper?” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh said, “What have you done? The voice of your brother’s blood cries to me from the ground. 
+<sup>11&#160;</sup>Now you are cursed because of the ground, which has opened its mouth to receive your brother’s blood from your hand. 
+<sup>12&#160;</sup>From now on, when you till the ground, it won’t yield its strength to you. You will be a fugitive and a wanderer in the earth.” 
+</div><div class="p">
+<sup>13&#160;</sup>Cain said to Yahweh, “My punishment is greater than I can bear. 
+<sup>14&#160;</sup>Behold, you have driven me out today from the surface of the ground. I will be hidden from your face, and I will be a fugitive and a wanderer in the earth. Whoever finds me will kill me.” 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh said to him, “Therefore whoever slays Cain, vengeance will be taken on him sevenfold.” Yahweh appointed a sign for Cain, so that anyone finding him would not strike him. 
+</div><div class="p">
+<sup>16&#160;</sup>Cain left Yahweh’s presence, and lived in the land of Nod, east of Eden. 
+<sup>17&#160;</sup>Cain knew his woman. She conceived, and gave birth to Enoch. He built a city, and named the city after the name of his son, Enoch. 
+<sup>18&#160;</sup>Irad was born to Enoch. Irad brought forth Mehujael. Mehujael brought forth Methushael. Methushael brought forth Lamech. 
+<sup>19&#160;</sup>Lamech took two women: the name of the first one was Adah, and the name of the second one was Zillah. 
+<sup>20&#160;</sup>Adah gave birth to Jabal, who was the father of those who dwell in tents and have livestock. 
+<sup>21&#160;</sup>His brother’s name was Jubal, who was the father of all who handle the harp and pipe. 
+<sup>22&#160;</sup>Zillah also gave birth to Tubal Cain, the forger of every cutting instrument of bronze and iron. Tubal Cain’s sister was Naamah. 
+<sup>23&#160;</sup>Lamech said to his women, 
+</div><div class="q1">“Adah and Zillah, hear my voice. 
+</div><div class="q2">You women of Lamech, listen to my speech, 
+</div><div class="q1">for I have slain a man for wounding me, 
+</div><div class="q2">a young man for bruising me. 
+</div><div class="q1">
+<sup>24&#160;</sup>If Cain will be avenged seven times, 
+</div><div class="q2">truly Lamech seventy-seven times.” 
+</div><div class="p">
+<sup>25&#160;</sup>Adam knew his woman again. She gave birth to a son, and named him Seth, saying, “for Elohim has given me another child instead of Abel, for Cain killed him.” 
+<sup>26&#160;</sup>A son was also born to Seth, and he named him Enosh. At that time men began to call on Yahweh’s name. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>This is the book of the generations of Adam. In the day that Elohim created man, he made him in Elohim’s likeness. 
+<sup>2&#160;</sup>He created them male and female, and blessed them. On the day they were created, he named them Adam. 
+<sup>3&#160;</sup>Adam lived two hundred thirty years, and brought forth a son in his own likeness, after his image, and named him Seth. 
+<sup>4&#160;</sup>The days of Adam after he brought forth Seth were seven hundred years, and he brought forth other sons and daughters. 
+<sup>5&#160;</sup>All the days that Adam lived were nine hundred thirty years, then he died. 
+</div><div class="p">
+<sup>6&#160;</sup>Seth lived two hundred five years, then brought forth Enosh. 
+<sup>7&#160;</sup>Seth lived after he brought forth Enosh seven hundred seven years, and brought forth other sons and daughters. 
+<sup>8&#160;</sup>All of the days of Seth were nine hundred twelve years, then he died. 
+</div><div class="p">
+<sup>9&#160;</sup>Enosh lived one hundred ninety years, and brought forth Kenan. 
+<sup>10&#160;</sup>Enosh lived after he brought forth Kenan seven hundred fifteen years, and brought forth other sons and daughters. 
+<sup>11&#160;</sup>All of the days of Enosh were nine hundred five years, then he died. 
+</div><div class="p">
+<sup>12&#160;</sup>Kenan lived one hundred seventy years, then brought forth Mahalalel. 
+<sup>13&#160;</sup>Kenan lived after he brought forth Mahalalel seven hundred forty years, and brought forth other sons and daughters 
+<sup>14&#160;</sup>and all of the days of Kenan were nine hundred ten years, then he died. 
+</div><div class="p">
+<sup>15&#160;</sup>Mahalalel lived one hundred sixty-five years, then brought forth Jared. 
+<sup>16&#160;</sup>Mahalalel lived after he brought forth Jared seven hundred thirty years, and brought forth other sons and daughters. 
+<sup>17&#160;</sup>All of the days of Mahalalel were eight hundred ninety-five years, then he died. 
+</div><div class="p">
+<sup>18&#160;</sup>Jared lived one hundred sixty-two years, then brought forth Enoch. 
+<sup>19&#160;</sup>Jared lived after he brought forth Enoch eight hundred years, and brought forth other sons and daughters. 
+<sup>20&#160;</sup>All of the days of Jared were nine hundred sixty-two years, then he died. 
+</div><div class="p">
+<sup>21&#160;</sup>Enoch lived one hundred sixty-five years, then brought forth Methuselah. 
+<sup>22&#160;</sup>After Methuselah’s birth, Enoch walked with Elohim for two hundred years, and brought forth more sons and daughters. 
+<sup>23&#160;</sup>All the days of Enoch were three hundred sixty-five years. 
+<sup>24&#160;</sup>Enoch walked with Elohim, and he was not found, for Elohim took him. 
+</div><div class="p">
+<sup>25&#160;</sup>Methuselah lived one hundred eighty-seven years, then brought forth Lamech. 
+<sup>26&#160;</sup>Methuselah lived after he brought forth Lamech seven hundred eighty-two years, and brought forth other sons and daughters. 
+<sup>27&#160;</sup>All the days of Methuselah were nine hundred sixty-nine years, then he died. 
+</div><div class="p">
+<sup>28&#160;</sup>Lamech lived one hundred eighty-two years, then brought forth a son. 
+<sup>29&#160;</sup>He named him Noah, saying, “This one will comfort us in our work and in the toil of our hands, caused by the ground which Yahweh has cursed.” 
+<sup>30&#160;</sup>Lamech lived after he brought forth Noah five hundred ninety-five years, and brought forth other sons and daughters. 
+<sup>31&#160;</sup>All the days of Lamech were seven hundred seventy-seven years, then he died. 
+</div><div class="p">
+<sup>32&#160;</sup>Noah was five hundred years old, then Noah brought forth Shem, Ham, and Japheth. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>When men began to multiply on the surface of the ground, and daughters were born to them, 
+<sup>2&#160;</sup>Elohim’s sons saw that men’s daughters were beautiful, and they took any that they wanted for themselves as women. 
+<sup>3&#160;</sup>Yahweh said, “My Spirit will not strive with man forever, because he also is flesh; so his days will be one hundred twenty years.” 
+<sup>4&#160;</sup>The Nephilim were in the earth in those days, and also after that, when Elohim’s sons came in to men’s daughters and had children with them. Those were the mighty men who were of old, men of renown. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh saw that the wickedness of man was great in the earth, and that every imagination of the thoughts of man’s heart was continually only evil. 
+<sup>6&#160;</sup>Yahweh was sorry that he had made man on the earth, and it grieved him in his heart. 
+<sup>7&#160;</sup>Yahweh said, “I will destroy man whom I have created from the surface of the ground—man, along with animals, creeping things, and birds of the sky—for I am sorry that I have made them.” 
+<sup>8&#160;</sup>But Noah found favor in Yahweh’s eyes. 
+</div><div class="p">
+<sup>9&#160;</sup>This is the history of the generations of Noah: Noah was a righteous man, blameless among the people of his time. Noah walked with Elohim. 
+<sup>10&#160;</sup>Noah brought forth three sons: Shem, Ham, and Japheth. 
+<sup>11&#160;</sup>The earth was corrupt before Elohim, and the earth was filled with violence. 
+<sup>12&#160;</sup>Elohim saw the earth, and saw that it was corrupt, for all flesh had corrupted their way on the earth. 
+</div><div class="p">
+<sup>13&#160;</sup>Elohim said to Noah, “I will bring an end to all flesh, for the earth is filled with violence through them. Behold, I will destroy them and the earth. 
+<sup>14&#160;</sup>Make a ship of gopher wood. You shall make rooms in the ship, and shall seal it inside and outside with pitch. 
+<sup>15&#160;</sup>This is how you shall make it. The length of the ship shall be three hundred cubits, its width fifty cubits, and its height thirty cubits. 
+<sup>16&#160;</sup>You shall make a roof in the ship, and you shall finish it to a cubit upward. You shall set the door of the ship in its side. You shall make it with lower, second, and third levels. 
+<sup>17&#160;</sup>I, even I, will bring the flood of waters on this earth, to destroy all flesh having the breath of life from under the sky. Everything that is in the earth will die. 
+<sup>18&#160;</sup>But I will establish my covenant with you. You shall come into the ship, you, your sons, your woman, and your sons’ women with you. 
+<sup>19&#160;</sup>Of every living thing of all flesh, you shall bring two of every sort into the ship, to keep them alive with you. They shall be male and female. 
+<sup>20&#160;</sup>Of the birds after their kind, of the livestock after their kind, of every creeping thing of the ground after its kind, two of every sort will come to you, to keep them alive. 
+<sup>21&#160;</sup>Take with you some of all food that is eaten, and gather it to yourself; and it will be for food for you, and for them.” 
+<sup>22&#160;</sup>Thus Noah did. He did all that Elohim commanded him. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Noah, “Come with all of your household into the ship, for I have seen your righteousness before me in this generation. 
+<sup>2&#160;</sup>You shall take seven pairs of every clean animal with you, the male and his female. Of the animals that are not clean, take two, the male and his female. 
+<sup>3&#160;</sup>Also of the birds of the sky, seven and seven, male and female, to keep seed alive on the surface of all the earth. 
+<sup>4&#160;</sup>In seven days, I will cause it to rain on the earth for forty days and forty nights. I will destroy every living thing that I have made from the surface of the ground.” 
+</div><div class="p">
+<sup>5&#160;</sup>Noah did everything that Yahweh commanded him. 
+</div><div class="p">
+<sup>6&#160;</sup>Noah was six hundred years old when the flood of waters came on the earth. 
+<sup>7&#160;</sup>Noah went into the ship with his sons, his woman, and his sons’ women, because of the floodwaters. 
+<sup>8&#160;</sup>Clean animals, unclean animals, birds, and everything that creeps on the ground 
+<sup>9&#160;</sup>went by pairs to Noah into the ship, male and female, as Elohim commanded Noah. 
+<sup>10&#160;</sup>After the seven days, the floodwaters came on the earth. 
+<sup>11&#160;</sup>In the six hundredth year of Noah’s life, in the second month, on the seventeenth day of the month, on that day all the fountains of the great deep burst open, and the sky’s windows opened. 
+<sup>12&#160;</sup>It rained on the earth forty days and forty nights. 
+</div><div class="p">
+<sup>13&#160;</sup>In the same day Noah, and Shem, Ham, and Japheth—the sons of Noah—and Noah’s woman and the three women of his sons with them, entered into the ship—<sup>14&#160;</sup>they, and every animal after its kind, all the livestock after their kind, every creeping thing that creeps on the earth after its kind, and every bird after its kind, every bird of every sort. 
+<sup>15&#160;</sup>Pairs from all flesh with the breath of life in them went into the ship to Noah. 
+<sup>16&#160;</sup>Those who went in, went in male and female of all flesh, as Elohim commanded him; then Yahweh shut him in. 
+<sup>17&#160;</sup>The flood was forty days on the earth. The waters increased, and lifted up the ship, and it was lifted up above the earth. 
+<sup>18&#160;</sup>The waters rose, and increased greatly on the earth; and the ship floated on the surface of the waters. 
+<sup>19&#160;</sup>The waters rose very high on the earth. All the high mountains that were under the whole sky were covered. 
+<sup>20&#160;</sup>The waters rose fifteen cubits higher, and the mountains were covered. 
+<sup>21&#160;</sup>All flesh died that moved on the earth, including birds, livestock, animals, every creeping thing that creeps on the earth, and every man. 
+<sup>22&#160;</sup>All on the dry land, in whose nostrils was the breath of the spirit of life, died. 
+<sup>23&#160;</sup>Every living thing was destroyed that was on the surface of the ground, including man, livestock, creeping things, and birds of the sky. They were destroyed from the earth. Only Noah was left, and those who were with him in the ship. 
+<sup>24&#160;</sup>The waters flooded the earth one hundred fifty days. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Elohim remembered Noah, all the animals, and all the livestock that were with him in the ship; and Elohim made a wind to pass over the earth. The waters subsided. 
+<sup>2&#160;</sup>The deep’s fountains and the sky’s windows were also stopped, and the rain from the sky was restrained. 
+<sup>3&#160;</sup>The waters continually receded from the earth. After the end of one hundred fifty days the waters receded. 
+<sup>4&#160;</sup>The ship rested in the seventh month, on the seventeenth day of the month, on Ararat’s mountains. 
+<sup>5&#160;</sup>The waters receded continually until the tenth month. In the tenth month, on the first day of the month, the tops of the mountains were visible. 
+</div><div class="p">
+<sup>6&#160;</sup>At the end of forty days, Noah opened the window of the ship which he had made, 
+<sup>7&#160;</sup>and he sent out a raven. It went back and forth, until the waters were dried up from the earth. 
+<sup>8&#160;</sup>He himself sent out a dove to see if the waters were abated from the surface of the ground, 
+<sup>9&#160;</sup>but the dove found no place to rest her foot, and she returned into the ship to him, for the waters were on the surface of the whole earth. He put out his hand, and took her, and brought her to him into the ship. 
+<sup>10&#160;</sup>He waited yet another seven days; and again he sent the dove out of the ship. 
+<sup>11&#160;</sup>The dove came back to him at evening and, behold, in her mouth was a freshly plucked olive leaf. So Noah knew that the waters were abated from the earth. 
+<sup>12&#160;</sup>He waited yet another seven days, and sent out the dove; and she didn’t return to him any more. 
+</div><div class="p">
+<sup>13&#160;</sup>In the six hundred first year, in the first month, the first day of the month, the waters were dried up from the earth. Noah removed the covering of the ship, and looked. He saw that the surface of the ground was dry. 
+<sup>14&#160;</sup>In the second month, on the twenty-seventh day of the month, the earth was dry. 
+</div><div class="p">
+<sup>15&#160;</sup>Elohim spoke to Noah, saying, 
+<sup>16&#160;</sup>“Go out of the ship, you, your woman, your sons, and your sons’ women with you. 
+<sup>17&#160;</sup>Bring out with you every living thing that is with you of all flesh, including birds, livestock, and every creeping thing that creeps on the earth, that they may breed abundantly in the earth, and be fruitful, and multiply on the earth.” 
+</div><div class="p">
+<sup>18&#160;</sup>Noah went out, with his sons, his woman, and his sons’ women with him. 
+<sup>19&#160;</sup>Every animal, every creeping thing, and every bird, whatever moves on the earth, after their families, went out of the ship. 
+</div><div class="p">
+<sup>20&#160;</sup>Noah built an altar to Yahweh, and took of every clean animal, and of every clean bird, and offered burnt offerings on the altar. 
+<sup>21&#160;</sup>Yahweh smelled the pleasant aroma. Yahweh said in his heart, “I will not again curse the ground any more for man’s sake because the imagination of man’s heart is evil from his youth. I will never again strike every living thing, as I have done. 
+<sup>22&#160;</sup>While the earth remains, seed time and harvest, and cold and heat, and summer and winter, and day and night will not cease.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Elohim blessed Noah and his sons, and said to them, “Be fruitful, multiply, and replenish the earth. 
+<sup>2&#160;</sup>The fear of you and the dread of you will be on every animal of the earth, and on every bird of the sky. Everything that moves along the ground, and all the fish of the sea, are delivered into your hand. 
+<sup>3&#160;</sup>Every moving thing that lives will be food for you. As I gave you the green herb, I have given everything to you. 
+<sup>4&#160;</sup>But flesh with its life, that is, its blood, you shall not eat. 
+<sup>5&#160;</sup>I will surely require accounting for your life’s blood. At the hand of every animal I will require it. At the hand of man, even at the hand of every man’s brother, I will require the life of man. 
+<sup>6&#160;</sup>Whoever sheds man’s blood, his blood will be shed by man, for Elohim made man in his own image. 
+<sup>7&#160;</sup>Be fruitful and multiply. Increase abundantly in the earth, and multiply in it.” 
+</div><div class="p">
+<sup>8&#160;</sup>Elohim spoke to Noah and to his sons with him, saying, 
+<sup>9&#160;</sup>“As for me, behold, I establish my covenant with you, and with your offspring after you, 
+<sup>10&#160;</sup>and with every living creature that is with you: the birds, the livestock, and every animal of the earth with you, of all that go out of the ship, even every animal of the earth. 
+<sup>11&#160;</sup>I will establish my covenant with you: All flesh will not be cut off any more by the waters of the flood. There will never again be a flood to destroy the earth.” 
+<sup>12&#160;</sup>Elohim said, “This is the token of the covenant which I make between me and you and every living creature that is with you, for perpetual generations: 
+<sup>13&#160;</sup>I set my rainbow in the cloud, and it will be a sign of a covenant between me and the earth. 
+<sup>14&#160;</sup>When I bring a cloud over the earth, that the rainbow will be seen in the cloud, 
+<sup>15&#160;</sup>I will remember my covenant, which is between me and you and every living creature of all flesh, and the waters will no more become a flood to destroy all flesh. 
+<sup>16&#160;</sup>The rainbow will be in the cloud. I will look at it, that I may remember the everlasting covenant between Elohim and every living creature of all flesh that is on the earth.” 
+<sup>17&#160;</sup>Elohim said to Noah, “This is the token of the covenant which I have established between me and all flesh that is on the earth.” 
+</div><div class="p">
+<sup>18&#160;</sup>The sons of Noah who went out from the ship were Shem, Ham, and Japheth. Ham is the father of Canaan. 
+<sup>19&#160;</sup>These three were the sons of Noah, and from these the whole earth was populated. 
+</div><div class="p">
+<sup>20&#160;</sup>Noah began to be a farmer, and planted a vineyard. 
+<sup>21&#160;</sup>He drank of the wine and got drunk. He was uncovered within his tent. 
+<sup>22&#160;</sup>Ham, the father of Canaan, saw the nakedness of his father, and told his two brothers outside. 
+<sup>23&#160;</sup>Shem and Japheth took a garment, and laid it on both their shoulders, went in backwards, and covered the nakedness of their father. Their faces were backwards, and they didn’t see their father’s nakedness. 
+<sup>24&#160;</sup>Noah awoke from his wine, and knew what his youngest son had done to him. 
+<sup>25&#160;</sup>He said, 
+</div><div class="q1">“Canaan is cursed. 
+</div><div class="q2">He will be a servant of servants to his brothers.” 
+</div><div class="p">
+<sup>26&#160;</sup>He said, 
+</div><div class="q1">“Blessed be Yahweh, the Elohim of Shem. 
+</div><div class="q2">Let Canaan be his servant. 
+</div><div class="q1">
+<sup>27&#160;</sup>May Elohim enlarge Japheth. 
+</div><div class="q2">Let him dwell in the tents of Shem. 
+</div><div class="q2">Let Canaan be his servant.” 
+</div><div class="p">
+<sup>28&#160;</sup>Noah lived three hundred fifty years after the flood. 
+<sup>29&#160;</sup>All the days of Noah were nine hundred fifty years, and then he died. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Now this is the history of the generations of the sons of Noah and of Shem, Ham, and Japheth. Sons were born to them after the flood. 
+</div><div class="p">
+<sup>2&#160;</sup>The sons of Japheth were: Gomer, Magog, Madai, Javan, Tubal, Meshech, and Tiras. 
+<sup>3&#160;</sup>The sons of Gomer were: Ashkenaz, Riphath, and Togarmah. 
+<sup>4&#160;</sup>The sons of Javan were: Elishah, Tarshish, Kittim, and Dodanim. 
+<sup>5&#160;</sup>Of these were the islands of the nations divided in their lands, everyone after his language, after their families, in their nations. 
+</div><div class="p">
+<sup>6&#160;</sup>The sons of Ham were: Cush, Mizraim, Put, and Canaan. 
+<sup>7&#160;</sup>The sons of Cush were: Seba, Havilah, Sabtah, Raamah, and Sabteca. The sons of Raamah were: Sheba and Dedan. 
+<sup>8&#160;</sup>Cush brought forth Nimrod. He began to be a mighty one in the earth. 
+<sup>9&#160;</sup>He was a mighty hunter before Yahweh. Therefore it is said, “like Nimrod, a mighty hunter before Yahweh”. 
+<sup>10&#160;</sup>The beginning of his kingdom was Babel, Erech, Accad, and Calneh, in the land of Shinar. 
+<sup>11&#160;</sup>Out of that land he went into Assyria, and built Nineveh, Rehoboth Ir, Calah, 
+<sup>12&#160;</sup>and Resen between Nineveh and the great city Calah. 
+<sup>13&#160;</sup>Mizraim brought forth Ludim, Anamim, Lehabim, Naphtuhim, 
+<sup>14&#160;</sup>Pathrusim, Casluhim (which the Philistines descended from), and Caphtorim. 
+</div><div class="p">
+<sup>15&#160;</sup>Canaan brought forth Sidon (his firstborn), Heth, 
+<sup>16&#160;</sup>the Jebusites, the Amorites, the Girgashites, 
+<sup>17&#160;</sup>the Hivites, the Arkites, the Sinites, 
+<sup>18&#160;</sup>the Arvadites, the Zemarites, and the Hamathites. Afterward the families of the Canaanites were spread abroad. 
+<sup>19&#160;</sup>The border of the Canaanites was from Sidon—as you go toward Gerar—to Gaza—as you go toward Sodom, Gomorrah, Admah, and Zeboiim—to Lasha. 
+<sup>20&#160;</sup>These are the sons of Ham, after their families, according to their languages, in their lands and their nations. 
+</div><div class="p">
+<sup>21&#160;</sup>Children were also born to Shem (the elder brother of Japheth), the father of all the children of Eber. 
+<sup>22&#160;</sup>The sons of Shem were: Elam, Asshur, Arpachshad, Lud, and Aram. 
+<sup>23&#160;</sup>The sons of Aram were: Uz, Hul, Gether, and Mash. 
+<sup>24&#160;</sup>Arpachshad brought forth Cainan. Cainan brought forth Shelah. Shelah brought forth Eber. 
+<sup>25&#160;</sup>To Eber were born two sons. The name of the one was Peleg, for in his days the earth was divided. His brother’s name was Joktan. 
+<sup>26&#160;</sup>Joktan brought forth Almodad, Sheleph, Hazarmaveth, Jerah, 
+<sup>27&#160;</sup>Hadoram, Uzal, Diklah, 
+<sup>28&#160;</sup>Obal, Abimael, Sheba, 
+<sup>29&#160;</sup>Ophir, Havilah, and Jobab. All these were the sons of Joktan. 
+<sup>30&#160;</sup>Their dwelling extended from Mesha, as you go toward Sephar, the mountain of the east. 
+<sup>31&#160;</sup>These are the sons of Shem, by their families, according to their languages, lands, and nations. 
+</div><div class="p">
+<sup>32&#160;</sup>These are the families of the sons of Noah, by their generations, according to their nations. The nations divided from these in the earth after the flood. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>The whole earth was of one language and of one speech. 
+<sup>2&#160;</sup>As they traveled east, they found a plain in the land of Shinar, and they lived there. 
+<sup>3&#160;</sup>They said to one another, “Come, let’s make bricks, and burn them thoroughly.” They had brick for stone, and they used tar for mortar. 
+<sup>4&#160;</sup>They said, “Come, let’s build ourselves a city, and a tower whose top reaches to the sky, and let’s make a name for ourselves, lest we be scattered abroad on the surface of the whole earth.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh came down to see the city and the tower, which the children of men built. 
+<sup>6&#160;</sup>Yahweh said, “Behold, they are one people, and they all have one language, and this is what they begin to do. Now nothing will be withheld from them, which they intend to do. 
+<sup>7&#160;</sup>Come, let’s go down, and there confuse their language, that they may not understand one another’s speech.” 
+<sup>8&#160;</sup>So Yahweh scattered them abroad from there on the surface of all the earth. They stopped building the city. 
+<sup>9&#160;</sup>Therefore its name was called Babel, because there Yahweh confused the language of all the earth. From there, Yahweh scattered them abroad on the surface of all the earth. 
+</div><div class="p">
+<sup>10&#160;</sup>This is the history of the generations of Shem: Shem was one hundred years old when he brought forth Arpachshad two years after the flood. 
+<sup>11&#160;</sup>Shem lived five hundred years after he brought forth Arpachshad, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>12&#160;</sup>Arpachshad lived one hundred thirty-five years and brought forth Cainan. 
+<sup>13&#160;</sup>Arpachshad lived four hundred thirty years after he brought forth Cainan, and brought forth more sons and daughters. Cainan lived one hundred thirty years, and brought forth Shelah. Cainan lived three hundred thirty years after he brought forth Shelah, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>14&#160;</sup>Shelah lived one hundred thirty years, and brought forth Eber. 
+<sup>15&#160;</sup>Shelah lived four hundred three years after he brought forth Eber, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>16&#160;</sup>Eber lived one hundred thirty-four years, and brought forth Peleg. 
+<sup>17&#160;</sup>Eber lived three hundred seventy years after he brought forth Peleg, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>18&#160;</sup>Peleg lived one hundred thirty years, and brought forth Reu. 
+<sup>19&#160;</sup>Peleg lived two hundred nine years after he brought forth Reu, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>20&#160;</sup>Reu lived one hundred thirty-two years, and brought forth Serug. 
+<sup>21&#160;</sup>Reu lived two hundred seven years after he brought forth Serug, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>22&#160;</sup>Serug lived one hundred thirty years, and brought forth Nahor. 
+<sup>23&#160;</sup>Serug lived two hundred years after he brought forth Nahor, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>24&#160;</sup>Nahor lived seventy-nine years, and brought forth Terah. 
+<sup>25&#160;</sup>Nahor lived one hundred twenty-nine years after he brought forth Terah, and brought forth more sons and daughters. 
+</div><div class="p">
+<sup>26&#160;</sup>Terah lived seventy years, and brought forth Abram, Nahor, and Haran. 
+</div><div class="p">
+<sup>27&#160;</sup>Now this is the history of the generations of Terah. Terah brought forth Abram, Nahor, and Haran. Haran brought forth Lot. 
+<sup>28&#160;</sup>Haran died in the land of his birth, in Ur of the Chaldees, while his father Terah was still alive. 
+<sup>29&#160;</sup>Abram and Nahor married women. The name of Abram’s woman was Sarai, and the name of Nahor’s woman was Milcah, the daughter of Haran, who was also the father of Iscah. 
+<sup>30&#160;</sup>Sarai was barren. She had no child. 
+<sup>31&#160;</sup>Terah took Abram his son, Lot the son of Haran, his son’s son, and Sarai his daughter-in-law, his son Abram’s woman. They went from Ur of the Chaldees, to go into the land of Canaan. They came to Haran and lived there. 
+<sup>32&#160;</sup>The days of Terah were two hundred five years. Terah died in Haran. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Yahweh said to Abram, “Leave your country, and your relatives, and your father’s house, and go to the land that I will show you. 
+<sup>2&#160;</sup>I will make of you a great nation. I will bless you and make your name great. You will be a blessing. 
+<sup>3&#160;</sup>I will bless those who bless you, and I will curse him who treats you with contempt. All the families of the earth will be blessed through you.” 
+</div><div class="p">
+<sup>4&#160;</sup>So Abram went, as Yahweh had told him. Lot went with him. Abram was seventy-five years old when he departed from Haran. 
+<sup>5&#160;</sup>Abram took Sarai his woman, Lot his brother’s son, all their possessions that they had gathered, and the people whom they had acquired in Haran, and they went to go into the land of Canaan. They entered into the land of Canaan. 
+<sup>6&#160;</sup>Abram passed through the land to the place of Shechem, to the oak of Moreh. At that time, Canaanites were in the land. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh appeared to Abram and said, “I will give this land to your offspring.” 
+</div><div class="p">He built an altar there to Yahweh, who had appeared to him. 
+<sup>8&#160;</sup>He left from there to go to the mountain on the east of Bethel and pitched his tent, having Bethel on the west, and Ai on the east. There he built an altar to Yahweh and called on Yahweh’s name. 
+<sup>9&#160;</sup>Abram traveled, still going on toward the South. 
+</div><div class="p">
+<sup>10&#160;</sup>There was a famine in the land. Abram went down into Egypt to live as a foreigner there, for the famine was severe in the land. 
+<sup>11&#160;</sup>When he had come near to enter Egypt, he said to Sarai his woman, “See now, I know that you are a beautiful woman to look at. 
+<sup>12&#160;</sup>It will happen that when the Egyptians see you, they will say, ‘This is his woman.’ They will kill me, but they will save you alive. 
+<sup>13&#160;</sup>Please say that you are my sister, that it may be well with me for your sake, and that my soul may live because of you.” 
+</div><div class="p">
+<sup>14&#160;</sup>When Abram had come into Egypt, Egyptians saw that the woman was very beautiful. 
+<sup>15&#160;</sup>The princes of Pharaoh saw her, and praised her to Pharaoh; and the woman was taken into Pharaoh’s house. 
+<sup>16&#160;</sup>He dealt well with Abram for her sake. He had sheep, cattle, male donkeys, male servants, female servants, female donkeys, and camels. 
+<sup>17&#160;</sup>Yahweh afflicted Pharaoh and his house with great plagues because of Sarai, Abram’s woman. 
+<sup>18&#160;</sup>Pharaoh called Abram and said, “What is this that you have done to me? Why didn’t you tell me that she was your woman? 
+<sup>19&#160;</sup>Why did you say, ‘She is my sister,’ so that I took her to be my woman? Now therefore, see your woman, take her, and go your way.” 
+</div><div class="p">
+<sup>20&#160;</sup>Pharaoh commanded men concerning him, and they escorted him away with his woman and all that he had. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Abram went up out of Egypt—he, his woman, all that he had, and Lot with him—into the South. 
+<sup>2&#160;</sup>Abram was very rich in livestock, in silver, and in gold. 
+<sup>3&#160;</sup>He went on his journeys from the South as far as Bethel, to the place where his tent had been at the beginning, between Bethel and Ai, 
+<sup>4&#160;</sup>to the place of the altar, which he had made there at the first. There Abram called on Yahweh’s name. 
+<sup>5&#160;</sup>Lot also, who went with Abram, had flocks, herds, and tents. 
+<sup>6&#160;</sup>The land was not able to bear them, that they might live together; for their possessions were so great that they couldn’t live together. 
+<sup>7&#160;</sup>There was strife between the herdsmen of Abram’s livestock and the herdsmen of Lot’s livestock. The Canaanites and the Perizzites lived in the land at that time. 
+<sup>8&#160;</sup>Abram said to Lot, “Please, let there be no strife between you and me, and between your herdsmen and my herdsmen; for we are relatives. 
+<sup>9&#160;</sup>Isn’t the whole land before you? Please separate yourself from me. If you go to the left hand, then I will go to the right. Or if you go to the right hand, then I will go to the left.” 
+</div><div class="p">
+<sup>10&#160;</sup>Lot lifted up his eyes, and saw all the plain of the Jordan, that it was well-watered everywhere, before Yahweh destroyed Sodom and Gomorrah, like the garden of Yahweh, like the land of Egypt, as you go to Zoar. 
+<sup>11&#160;</sup>So Lot chose the Plain of the Jordan for himself. Lot traveled east, and they separated themselves from one other. 
+<sup>12&#160;</sup>Abram lived in the land of Canaan, and Lot lived in the cities of the plain, and moved his tent as far as Sodom. 
+<sup>13&#160;</sup>Now the men of Sodom were exceedingly wicked and sinners against Yahweh. 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh said to Abram, after Lot was separated from him, “Now, lift up your eyes, and look from the place where you are, northward and southward and eastward and westward, 
+<sup>15&#160;</sup>for I will give all the land which you see to you and to your offspring forever. 
+<sup>16&#160;</sup>I will make your offspring as the dust of the earth, so that if a man can count the dust of the earth, then your offspring may also be counted. 
+<sup>17&#160;</sup>Arise, walk through the land in its length and in its width; for I will give it to you.” 
+</div><div class="p">
+<sup>18&#160;</sup>Abram moved his tent, and came and lived by the oaks of Mamre, which are in Hebron, and built an altar there to Yahweh. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>In the days of Amraphel, king of Shinar; Arioch, king of Ellasar; Chedorlaomer, king of Elam; and Tidal, king of Goiim, 
+<sup>2&#160;</sup>they made war with Bera, king of Sodom; Birsha, king of Gomorrah; Shinab, king of Admah; Shemeber, king of Zeboiim; and the king of Bela (also called Zoar). 
+<sup>3&#160;</sup>All these joined together in the valley of Siddim (also called the Salt Sea). 
+<sup>4&#160;</sup>They served Chedorlaomer for twelve years, and in the thirteenth year they rebelled. 
+<sup>5&#160;</sup>In the fourteenth year Chedorlaomer and the kings who were with him came and struck the Rephaim in Ashteroth Karnaim, the Zuzim in Ham, the Emim in Shaveh Kiriathaim, 
+<sup>6&#160;</sup>and the Horites in their Mount Seir, to El Paran, which is by the wilderness. 
+<sup>7&#160;</sup>They returned, and came to En Mishpat (also called Kadesh), and struck all the country of the Amalekites, and also the Amorites, that lived in Hazazon Tamar. 
+<sup>8&#160;</sup>The king of Sodom, and the king of Gomorrah, the king of Admah, the king of Zeboiim, and the king of Bela (also called Zoar) went out; and they set the battle in array against them in the valley of Siddim 
+<sup>9&#160;</sup>against Chedorlaomer king of Elam, Tidal king of Goiim, Amraphel king of Shinar, and Arioch king of Ellasar; four kings against the five. 
+<sup>10&#160;</sup>Now the valley of Siddim was full of tar pits; and the kings of Sodom and Gomorrah fled, and some fell there. Those who remained fled to the hills. 
+<sup>11&#160;</sup>They took all the goods of Sodom and Gomorrah, and all their food, and went their way. 
+<sup>12&#160;</sup>They took Lot, Abram’s brother’s son, who lived in Sodom, and his goods, and departed. 
+</div><div class="p">
+<sup>13&#160;</sup>One who had escaped came and told Abram, the Hebrew. At that time, he lived by the oaks of Mamre, the Amorite, brother of Eshcol and brother of Aner. They were allies of Abram. 
+<sup>14&#160;</sup>When Abram heard that his relative was taken captive, he led out his three hundred eighteen trained men, born in his house, and pursued as far as Dan. 
+<sup>15&#160;</sup>He divided himself against them by night, he and his servants, and struck them, and pursued them to Hobah, which is on the left hand of Damascus. 
+<sup>16&#160;</sup>He brought back all the goods, and also brought back his relative Lot and his goods, and the women also, and the other people. 
+</div><div class="p">
+<sup>17&#160;</sup>The king of Sodom went out to meet him after his return from the slaughter of Chedorlaomer and the kings who were with him, at the valley of Shaveh (that is, the King’s Valley). 
+<sup>18&#160;</sup>Melchizedek king of Salem brought out bread and wine. He was priest of Elohim Most High. 
+<sup>19&#160;</sup>He blessed him, and said, “Blessed be Abram of Elohim Most High, possessor of heaven and earth. 
+<sup>20&#160;</sup>Blessed be Elohim Most High, who has delivered your enemies into your hand.” 
+</div><div class="p">Abram gave him a tenth of all. 
+</div><div class="p">
+<sup>21&#160;</sup>The king of Sodom said to Abram, “Give me the people, and take the goods for yourself.” 
+</div><div class="p">
+<sup>22&#160;</sup>Abram said to the king of Sodom, “I have lifted up my hand to Yahweh, Elohim Most High, possessor of heaven and earth, 
+<sup>23&#160;</sup>that I will not take a thread nor a sandal strap nor anything that is yours, lest you should say, ‘I have made Abram rich.’ 
+<sup>24&#160;</sup>I will accept nothing from you except that which the young men have eaten, and the portion of the men who went with me: Aner, Eshcol, and Mamre. Let them take their portion.” 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things Yahweh’s word came to Abram in a vision, saying, “Don’t be afraid, Abram. I am your shield, your exceedingly great reward.” 
+</div><div class="p">
+<sup>2&#160;</sup>Abram said, “Lord Yahweh, what will you give me, since I go childless, and he who will inherit my estate is Eliezer of Damascus?” 
+<sup>3&#160;</sup>Abram said, “Behold, you have given no children to me: and, behold, one born in my house is my heir.” 
+</div><div class="p">
+<sup>4&#160;</sup>Behold, Yahweh’s word came to him, saying, “This man will not be your heir, but he who will come out of your own body will be your heir.” 
+<sup>5&#160;</sup>Yahweh brought him outside, and said, “Look now toward the sky, and count the stars, if you are able to count them.” He said to Abram, “So your offspring will be.” 
+<sup>6&#160;</sup>He believed in Yahweh, and credited it to him as righteousness. 
+<sup>7&#160;</sup>He said to Abram, “I am Yahweh who brought you out of Ur of the Chaldees, to give you this land to inherit it.” 
+</div><div class="p">
+<sup>8&#160;</sup>He said, “Lord Yahweh, how will I know that I will inherit it?” 
+</div><div class="p">
+<sup>9&#160;</sup>He said to him, “Bring me a heifer three years old, a female goat three years old, a ram three years old, a turtledove, and a young pigeon.” 
+<sup>10&#160;</sup>He brought him all these, and divided them in the middle, and laid each half opposite the other; but he didn’t divide the birds. 
+<sup>11&#160;</sup>The birds of prey came down on the carcasses, and Abram drove them away. 
+</div><div class="p">
+<sup>12&#160;</sup>When the sun was going down, a deep sleep fell on Abram. Now terror and great darkness fell on him. 
+<sup>13&#160;</sup>He said to Abram, “Know for sure that your offspring will live as foreigners in a land that is not theirs, and will serve them. They will afflict them four hundred years. 
+<sup>14&#160;</sup>I will also judge that nation, whom they will serve. Afterward they will come out with great wealth; 
+<sup>15&#160;</sup>but you will go to your fathers in peace. You will be buried at a good old age. 
+<sup>16&#160;</sup>In the fourth generation they will come here again, for the iniquity of the Amorite is not yet full.” 
+<sup>17&#160;</sup>It came to pass that, when the sun went down, and it was dark, behold, a smoking furnace and a flaming torch passed between these pieces. 
+<sup>18&#160;</sup>In that day Yahweh made a covenant with Abram, saying, “I have given this land to your offspring, from the river of Egypt to the great river, the river Euphrates: 
+<sup>19&#160;</sup>the land of the Kenites, the Kenizzites, the Kadmonites, 
+<sup>20&#160;</sup>the Hittites, the Perizzites, the Rephaim, 
+<sup>21&#160;</sup>the Amorites, the Canaanites, the Girgashites, and the Jebusites.” 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Sarai, Abram’s woman, bore him no children. She had a servant, an Egyptian, whose name was Hagar. 
+<sup>2&#160;</sup>Sarai said to Abram, “See now, Yahweh has restrained me from bearing. Please go in to my servant. It may be that I will obtain children by her.” Abram listened to the voice of Sarai. 
+<sup>3&#160;</sup>Sarai, Abram’s woman, took Hagar the Egyptian, her servant, after Abram had lived ten years in the land of Canaan, and gave her to Abram her man to be his woman. 
+<sup>4&#160;</sup>He went in to Hagar, and she conceived. When she saw that she had conceived, her mistress was despised in her eyes. 
+<sup>5&#160;</sup>Sarai said to Abram, “This wrong is your fault. I gave my servant into your bosom, and when she saw that she had conceived, she despised me. May Yahweh judge between me and you.” 
+</div><div class="p">
+<sup>6&#160;</sup>But Abram said to Sarai, “Behold, your maid is in your hand. Do to her whatever is good in your eyes.” Sarai dealt harshly with her, and she fled from her face. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh’s angel found her by a fountain of water in the wilderness, by the fountain on the way to Shur. 
+<sup>8&#160;</sup>He said, “Hagar, Sarai’s servant, where did you come from? Where are you going?” 
+</div><div class="p">She said, “I am fleeing from the face of my mistress Sarai.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh’s angel said to her, “Return to your mistress, and submit yourself under her hands.” 
+<sup>10&#160;</sup>Yahweh’s angel said to her, “I will greatly multiply your offspring, that they will not be counted for multitude.” 
+<sup>11&#160;</sup>Yahweh’s angel said to her, “Behold, you are with child, and will bear a son. You shall call his name Ishmael, because Yahweh has heard your affliction. 
+<sup>12&#160;</sup>He will be like a wild donkey among men. His hand will be against every man, and every man’s hand against him. He will live opposed to all of his brothers.” 
+</div><div class="p">
+<sup>13&#160;</sup>She called the name of Yahweh who spoke to her, “You are an Elohim who sees,” for she said, “Have I even stayed alive after seeing him?” 
+<sup>14&#160;</sup>Therefore the well was called Beer Lahai Roi. Behold, it is between Kadesh and Bered. 
+</div><div class="p">
+<sup>15&#160;</sup>Hagar bore a son for Abram. Abram called the name of his son, whom Hagar bore, Ishmael. 
+<sup>16&#160;</sup>Abram was eighty-six years old when Hagar bore Ishmael to Abram. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>When Abram was ninety-nine years old, Yahweh appeared to Abram and said to him, “I am Elohim Almighty. Walk before me and be blameless. 
+<sup>2&#160;</sup>I will make my covenant between me and you, and will multiply you exceedingly.” 
+</div><div class="p">
+<sup>3&#160;</sup>Abram fell on his face. Elohim talked with him, saying, 
+<sup>4&#160;</sup>“As for me, behold, my covenant is with you. You will be the father of a multitude of nations. 
+<sup>5&#160;</sup>Your name will no more be called Abram, but your name will be Abraham; for I have made you the father of a multitude of nations. 
+<sup>6&#160;</sup>I will make you exceedingly fruitful, and I will make nations of you. Kings will come out of you. 
+<sup>7&#160;</sup>I will establish my covenant between me and you and your offspring after you throughout their generations for an everlasting covenant, to be an Elohim to you and to your offspring after you. 
+<sup>8&#160;</sup>I will give to you, and to your offspring after you, the land where you are traveling, all the land of Canaan, for an everlasting possession. I will be their Elohim.” 
+</div><div class="p">
+<sup>9&#160;</sup>Elohim said to Abraham, “As for you, you shall keep my covenant, you and your offspring after you throughout their generations. 
+<sup>10&#160;</sup>This is my covenant, which you shall keep, between me and you and your offspring after you. Every male among you shall be circumcised. 
+<sup>11&#160;</sup>You shall be circumcised in the flesh of your foreskin. It will be a token of the covenant between me and you. 
+<sup>12&#160;</sup>He who is eight days old shall be circumcised among you, every male throughout your generations, he who is born in the house, or bought with money from any foreigner who is not of your offspring. 
+<sup>13&#160;</sup>He who is born in your house, and he who is bought with your money, must be circumcised. My covenant shall be in your flesh for an everlasting covenant. 
+<sup>14&#160;</sup>The uncircumcised male who is not circumcised in the flesh of his foreskin, that soul shall be cut off from his people. He has broken my covenant.” 
+</div><div class="p">
+<sup>15&#160;</sup>Elohim said to Abraham, “As for Sarai your woman, you shall not call her name Sarai, but her name shall be Sarah. 
+<sup>16&#160;</sup>I will bless her, and moreover I will give you a son by her. Yes, I will bless her, and she will be a mother of nations. Kings of peoples will come from her.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Abraham fell on his face, and laughed, and said in his heart, “Will a child be born to him who is one hundred years old? Will Sarah, who is ninety years old, give birth?” 
+<sup>18&#160;</sup>Abraham said to Elohim, “Oh that Ishmael might live before you!” 
+</div><div class="p">
+<sup>19&#160;</sup>Elohim said, “No, but Sarah, your woman, will bear you a son. You shall call his name Isaac. I will establish my covenant with him for an everlasting covenant for his offspring after him. 
+<sup>20&#160;</sup>As for Ishmael, I have heard you. Behold, I have blessed him, and will make him fruitful, and will multiply him exceedingly. He will become the father of twelve princes, and I will make him a great nation. 
+<sup>21&#160;</sup>But I will establish my covenant with Isaac, whom Sarah will bear to you at this set time next year.” 
+</div><div class="p">
+<sup>22&#160;</sup>When he finished talking with him, Elohim went up from Abraham. 
+<sup>23&#160;</sup>Abraham took Ishmael his son, all who were born in his house, and all who were bought with his money: every male among the men of Abraham’s house, and circumcised the flesh of their foreskin in the same day, as Elohim had said to him. 
+<sup>24&#160;</sup>Abraham was ninety-nine years old when he was circumcised in the flesh of his foreskin. 
+<sup>25&#160;</sup>Ishmael, his son, was thirteen years old when he was circumcised in the flesh of his foreskin. 
+<sup>26&#160;</sup>In the same day both Abraham and Ishmael, his son, were circumcised. 
+<sup>27&#160;</sup>All the men of his house, those born in the house, and those bought with money from a foreigner, were circumcised with him. 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh appeared to him by the oaks of Mamre, as he sat in the tent door in the heat of the day. 
+<sup>2&#160;</sup>He lifted up his eyes and looked, and saw that three men stood near him. When he saw them, he ran to meet them from the tent door, and bowed himself to the earth, 
+<sup>3&#160;</sup>and said, “My lord, if now I have found favor in your sight, please don’t go away from your servant. 
+<sup>4&#160;</sup>Now let a little water be fetched, wash your feet, and rest yourselves under the tree. 
+<sup>5&#160;</sup>I will get a piece of bread so you can refresh your heart. After that you may go your way, now that you have come to your servant.” 
+</div><div class="p">They said, “Very well, do as you have said.” 
+</div><div class="p">
+<sup>6&#160;</sup>Abraham hurried into the tent to Sarah, and said, “Quickly prepare three seahs of fine meal, knead it, and make cakes.” 
+<sup>7&#160;</sup>Abraham ran to the herd, and fetched a tender and good calf, and gave it to the servant. He hurried to dress it. 
+<sup>8&#160;</sup>He took butter, milk, and the calf which he had dressed, and set it before them. He stood by them under the tree, and they ate. 
+</div><div class="p">
+<sup>9&#160;</sup>They asked him, “Where is Sarah, your woman?” 
+</div><div class="p">He said, “There, in the tent.” 
+</div><div class="p">
+<sup>10&#160;</sup>He said, “I will certainly return to you at about this time next year; and behold, Sarah your woman will have a son.” 
+</div><div class="p">Sarah heard in the tent door, which was behind him. 
+<sup>11&#160;</sup>Now Abraham and Sarah were old, well advanced in age. Sarah had passed the age of childbearing. 
+<sup>12&#160;</sup>Sarah laughed within herself, saying, “After I have grown old will I have pleasure, my lord being old also?” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh said to Abraham, “Why did Sarah laugh, saying, ‘Will I really bear a child when I am old?’ 
+<sup>14&#160;</sup>Is anything too hard for Yahweh? At the set time I will return to you, when the season comes around, and Sarah will have a son.” 
+</div><div class="p">
+<sup>15&#160;</sup>Then Sarah denied it, saying, “I didn’t laugh,” for she was afraid. 
+</div><div class="p">He said, “No, but you did laugh.” 
+</div><div class="p">
+<sup>16&#160;</sup>The men rose up from there, and looked toward Sodom. Abraham went with them to see them on their way. 
+<sup>17&#160;</sup>Yahweh said, “Will I hide from Abraham what I do, 
+<sup>18&#160;</sup>since Abraham will surely become a great and mighty nation, and all the nations of the earth will be blessed in him? 
+<sup>19&#160;</sup>For I have known him, to the end that he may command his children and his household after him, that they may keep the way of Yahweh, to do righteousness and justice; to the end that Yahweh may bring on Abraham that which he has spoken of him.” 
+<sup>20&#160;</sup>Yahweh said, “Because the cry of Sodom and Gomorrah is great, and because their sin is very grievous, 
+<sup>21&#160;</sup>I will go down now, and see whether their deeds are as bad as the reports which have come to me. If not, I will know.” 
+</div><div class="p">
+<sup>22&#160;</sup>The men turned from there, and went toward Sodom, but Abraham stood yet before Yahweh. 
+<sup>23&#160;</sup>Abraham came near, and said, “Will you consume the righteous with the wicked? 
+<sup>24&#160;</sup>What if there are fifty righteous within the city? Will you consume and not spare the place for the fifty righteous who are in it? 
+<sup>25&#160;</sup>May it be far from you to do things like that, to kill the righteous with the wicked, so that the righteous should be like the wicked. May that be far from you. Shouldn’t the Judge of all the earth do right?” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahweh said, “If I find in Sodom fifty righteous within the city, then I will spare the whole place for their sake.” 
+<sup>27&#160;</sup>Abraham answered, “See now, I have taken it on myself to speak to the Lord, although I am dust and ashes. 
+<sup>28&#160;</sup>What if there will lack five of the fifty righteous? Will you destroy all the city for lack of five?” 
+</div><div class="p">He said, “I will not destroy it if I find forty-five there.” 
+</div><div class="p">
+<sup>29&#160;</sup>He spoke to him yet again, and said, “What if there are forty found there?” 
+</div><div class="p">He said, “I will not do it for the forty’s sake.” 
+</div><div class="p">
+<sup>30&#160;</sup>He said, “Oh don’t let the Lord be angry, and I will speak. What if there are thirty found there?” 
+</div><div class="p">He said, “I will not do it if I find thirty there.” 
+</div><div class="p">
+<sup>31&#160;</sup>He said, “See now, I have taken it on myself to speak to the Lord. What if there are twenty found there?” 
+</div><div class="p">He said, “I will not destroy it for the twenty’s sake.” 
+</div><div class="p">
+<sup>32&#160;</sup>He said, “Oh don’t let the Lord be angry, and I will speak just once more. What if ten are found there?” 
+</div><div class="p">He said, “I will not destroy it for the ten’s sake.” 
+</div><div class="p">
+<sup>33&#160;</sup>Yahweh went his way as soon as he had finished communing with Abraham, and Abraham returned to his place. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>The two angels came to Sodom at evening. Lot sat in the gate of Sodom. Lot saw them, and rose up to meet them. He bowed himself with his face to the earth, 
+<sup>2&#160;</sup>and he said, “See now, my lords, please come into your servant’s house, stay all night, wash your feet, and you can rise up early, and go on your way.” 
+</div><div class="p">They said, “No, but we will stay in the street all night.” 
+</div><div class="p">
+<sup>3&#160;</sup>He urged them greatly, and they came in with him, and entered into his house. He made them a feast, and baked unleavened bread, and they ate. 
+<sup>4&#160;</sup>But before they lay down, the men of the city, the men of Sodom, surrounded the house, both young and old, all the people from every quarter. 
+<sup>5&#160;</sup>They called to Lot, and said to him, “Where are the men who came in to you this night? Bring them out to us, that we may have sex with them.” 
+</div><div class="p">
+<sup>6&#160;</sup>Lot went out to them through the door, and shut the door after himself. 
+<sup>7&#160;</sup>He said, “Please, my brothers, don’t act so wickedly. 
+<sup>8&#160;</sup>See now, I have two virgin daughters. Please let me bring them out to you, and you may do to them what seems good to you. Only don’t do anything to these men, because they have come under the shadow of my roof.” 
+</div><div class="p">
+<sup>9&#160;</sup>They said, “Stand back!” Then they said, “This one fellow came in to live as a foreigner, and he appoints himself a judge. Now we will deal worse with you than with them!” They pressed hard on the man Lot, and came near to break the door. 
+<sup>10&#160;</sup>But the men reached out their hand, and brought Lot into the house to them, and shut the door. 
+<sup>11&#160;</sup>They struck the men who were at the door of the house with blindness, both small and great, so that they wearied themselves to find the door. 
+</div><div class="p">
+<sup>12&#160;</sup>The men said to Lot, “Do you have anybody else here? Sons-in-law, your sons, your daughters, and whomever you have in the city, bring them out of the place: 
+<sup>13&#160;</sup>for we will destroy this place, because the outcry against them has grown so great before Yahweh that Yahweh has sent us to destroy it.” 
+</div><div class="p">
+<sup>14&#160;</sup>Lot went out, and spoke to his sons-in-law, who were pledged to marry his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
+</div><div class="p">But he seemed to his sons-in-law to be joking. 
+<sup>15&#160;</sup>When the morning came, then the angels hurried Lot, saying, “Get up! Take your woman and your two daughters who are here, lest you be consumed in the iniquity of the city.” 
+<sup>16&#160;</sup>But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahweh being merciful to him; and they took him out, and set him outside of the city. 
+<sup>17&#160;</sup>It came to pass, when they had taken them out, that he said, “Escape for your life! Don’t look behind you, and don’t stay anywhere in the plain. Escape to the mountains, lest you be consumed!” 
+</div><div class="p">
+<sup>18&#160;</sup>Lot said to them, “Oh, not so, my lord. 
+<sup>19&#160;</sup>See now, your servant has found favor in your sight, and you have magnified your loving kindness, which you have shown to me in saving my life. I can’t escape to the mountain, lest evil overtake me, and I die. 
+<sup>20&#160;</sup>See now, this city is near to flee to, and it is a little one. Oh let me escape there (isn’t it a little one?), and my soul will live.” 
+</div><div class="p">
+<sup>21&#160;</sup>He said to him, “Behold, I have granted your request concerning this thing also, that I will not overthrow the city of which you have spoken. 
+<sup>22&#160;</sup>Hurry, escape there, for I can’t do anything until you get there.” Therefore the name of the city was called Zoar. 
+</div><div class="p">
+<sup>23&#160;</sup>The sun had risen on the earth when Lot came to Zoar. 
+<sup>24&#160;</sup>Then Yahweh rained on Sodom and on Gomorrah sulfur and fire from Yahweh out of the sky. 
+<sup>25&#160;</sup>He overthrew those cities, all the plain, all the inhabitants of the cities, and that which grew on the ground. 
+<sup>26&#160;</sup>But Lot’s woman looked back from behind him, and she became a pillar of salt. 
+</div><div class="p">
+<sup>27&#160;</sup>Abraham went up early in the morning to the place where he had stood before Yahweh. 
+<sup>28&#160;</sup>He looked toward Sodom and Gomorrah, and toward all the land of the plain, and saw that the smoke of the land went up as the smoke of a furnace. 
+</div><div class="p">
+<sup>29&#160;</sup>When Elohim destroyed the cities of the plain, Elohim remembered Abraham, and sent Lot out of the middle of the overthrow, when he overthrew the cities in which Lot lived. 
+</div><div class="p">
+<sup>30&#160;</sup>Lot went up out of Zoar, and lived in the mountain, and his two daughters with him; for he was afraid to live in Zoar. He lived in a cave with his two daughters. 
+<sup>31&#160;</sup>The firstborn said to the younger, “Our father is old, and there is not a man in the earth to come in to us in the way of all the earth. 
+<sup>32&#160;</sup>Come, let’s make our father drink wine, and we will lie with him, that we may preserve our father’s family line.” 
+<sup>33&#160;</sup>They made their father drink wine that night: and the firstborn went in, and lay with her father. He didn’t know when she lay down, nor when she arose. 
+<sup>34&#160;</sup>It came to pass on the next day, that the firstborn said to the younger, “Behold, I lay last night with my father. Let’s make him drink wine again tonight. You go in, and lie with him, that we may preserve our father’s family line.” 
+<sup>35&#160;</sup>They made their father drink wine that night also. The younger went and lay with him. He didn’t know when she lay down, nor when she got up. 
+<sup>36&#160;</sup>Thus both of Lot’s daughters were with child by their father. 
+<sup>37&#160;</sup>The firstborn bore a son, and named him Moab. He is the father of the Moabites to this day. 
+<sup>38&#160;</sup>The younger also bore a son, and called his name Ben Ammi. He is the father of the children of Ammon to this day. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Abraham traveled from there toward the land of the South, and lived between Kadesh and Shur. He lived as a foreigner in Gerar. 
+<sup>2&#160;</sup>Abraham said about Sarah his woman, “She is my sister.” Abimelech king of Gerar sent, and took Sarah. 
+<sup>3&#160;</sup>But Elohim came to Abimelech in a dream of the night, and said to him, “Behold, you are a dead man, because of the woman whom you have taken; for she is owned by an owner.” 
+</div><div class="p">
+<sup>4&#160;</sup>Now Abimelech had not come near her. He said, “Lord, will you kill even a righteous nation? 
+<sup>5&#160;</sup>Didn’t he tell me, ‘She is my sister’? She, even she herself, said, ‘He is my brother.’ I have done this in the integrity of my heart and the innocence of my hands.” 
+</div><div class="p">
+<sup>6&#160;</sup>Elohim said to him in the dream, “Yes, I know that in the integrity of your heart you have done this, and I also withheld you from sinning against me. Therefore I didn’t allow you to touch her. 
+<sup>7&#160;</sup>Now therefore, restore the man’s woman. For he is a prophet, and he will pray for you, and you will live. If you don’t restore her, know for sure that you will die, you, and all who are yours.” 
+</div><div class="p">
+<sup>8&#160;</sup>Abimelech rose early in the morning, and called all his servants, and told all these things in their ear. The men were very scared. 
+<sup>9&#160;</sup>Then Abimelech called Abraham, and said to him, “What have you done to us? How have I sinned against you, that you have brought on me and on my kingdom a great sin? You have done deeds to me that ought not to be done!” 
+<sup>10&#160;</sup>Abimelech said to Abraham, “What did you see, that you have done this thing?” 
+</div><div class="p">
+<sup>11&#160;</sup>Abraham said, “Because I thought, ‘Surely the fear of Elohim is not in this place. They will kill me for my woman’s sake.’ 
+<sup>12&#160;</sup>Besides, she is indeed my sister, the daughter of my father, but not the daughter of my mother; and she became my woman. 
+<sup>13&#160;</sup>When Elohim caused me to wander from my father’s house, I said to her, ‘This is your kindness which you shall show to me. Everywhere that we go, say of me, “He is my brother.”&#160;’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Abimelech took sheep and cattle, male servants and female servants, and gave them to Abraham, and restored Sarah, his woman, to him. 
+<sup>15&#160;</sup>Abimelech said, “Behold, my land is before you. Dwell where it pleases you.” 
+<sup>16&#160;</sup>To Sarah he said, “Behold, I have given your brother a thousand pieces of silver. Behold, it is for you a covering of the eyes to all that are with you. In front of all you are vindicated.” 
+</div><div class="p">
+<sup>17&#160;</sup>Abraham prayed to Elohim. So Elohim healed Abimelech, his woman, and his female servants, and they bore children. 
+<sup>18&#160;</sup>For Yahweh had closed up tight all the wombs of the house of Abimelech, because of Sarah, Abraham’s woman. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh visited Sarah as he had said, and Yahweh did to Sarah as he had spoken. 
+<sup>2&#160;</sup>Sarah conceived, and bore Abraham a son in his old age, at the set time of which Elohim had spoken to him. 
+<sup>3&#160;</sup>Abraham called his son who was born to him, whom Sarah bore to him, Isaac. 
+<sup>4&#160;</sup>Abraham circumcised his son, Isaac, when he was eight days old, as Elohim had commanded him. 
+<sup>5&#160;</sup>Abraham was one hundred years old when his son, Isaac, was born to him. 
+<sup>6&#160;</sup>Sarah said, “Elohim has made me laugh. Everyone who hears will laugh with me.” 
+<sup>7&#160;</sup>She said, “Who would have said to Abraham that Sarah would nurse children? For I have borne him a son in his old age.” 
+</div><div class="p">
+<sup>8&#160;</sup>The child grew and was weaned. Abraham made a great feast on the day that Isaac was weaned. 
+<sup>9&#160;</sup>Sarah saw the son of Hagar the Egyptian, whom she had borne to Abraham, mocking. 
+<sup>10&#160;</sup>Therefore she said to Abraham, “Cast out this servant and her son! For the son of this servant will not be heir with my son, Isaac.” 
+</div><div class="p">
+<sup>11&#160;</sup>The thing was very grievous in Abraham’s sight on account of his son. 
+<sup>12&#160;</sup>Elohim said to Abraham, “Don’t let it be grievous in your sight because of the boy, and because of your servant. In all that Sarah says to you, listen to her voice. For your offspring will be named through Isaac. 
+<sup>13&#160;</sup>I will also make a nation of the son of the servant, because he is your child.” 
+<sup>14&#160;</sup>Abraham rose up early in the morning, and took bread and a container of water, and gave it to Hagar, putting it on her shoulder; and gave her the child, and sent her away. She departed, and wandered in the wilderness of Beersheba. 
+<sup>15&#160;</sup>The water in the container was spent, and she put the child under one of the shrubs. 
+<sup>16&#160;</sup>She went and sat down opposite him, a good way off, about a bow shot away. For she said, “Don’t let me see the death of the child.” She sat opposite him, and lifted up her voice, and wept. 
+<sup>17&#160;</sup>Elohim heard the voice of the boy. 
+</div><div class="p">The angel of Elohim called to Hagar out of the sky, and said to her, “What troubles you, Hagar? Don’t be afraid. For Elohim has heard the voice of the boy where he is. 
+<sup>18&#160;</sup>Get up, lift up the boy, and hold him with your hand. For I will make him a great nation.” 
+</div><div class="p">
+<sup>19&#160;</sup>Elohim opened her eyes, and she saw a well of water. She went, filled the container with water, and gave the boy a drink. 
+</div><div class="p">
+<sup>20&#160;</sup>Elohim was with the boy, and he grew. He lived in the wilderness, and as he grew up, he became an archer. 
+<sup>21&#160;</sup>He lived in the wilderness of Paran. His mother got a woman for him out of the land of Egypt. 
+</div><div class="p">
+<sup>22&#160;</sup>At that time, Abimelech and Phicol the captain of his army spoke to Abraham, saying, “Elohim is with you in all that you do. 
+<sup>23&#160;</sup>Now, therefore, swear to me here by Elohim that you will not deal falsely with me, nor with my son, nor with my son’s son. But according to the kindness that I have done to you, you shall do to me, and to the land in which you have lived as a foreigner.” 
+</div><div class="p">
+<sup>24&#160;</sup>Abraham said, “I will swear.” 
+<sup>25&#160;</sup>Abraham complained to Abimelech because of a water well, which Abimelech’s servants had violently taken away. 
+<sup>26&#160;</sup>Abimelech said, “I don’t know who has done this thing. You didn’t tell me, and I didn’t hear of it until today.” 
+</div><div class="p">
+<sup>27&#160;</sup>Abraham took sheep and cattle, and gave them to Abimelech. Those two made a covenant. 
+<sup>28&#160;</sup>Abraham set seven ewe lambs of the flock by themselves. 
+<sup>29&#160;</sup>Abimelech said to Abraham, “What do these seven ewe lambs, which you have set by themselves, mean?” 
+</div><div class="p">
+<sup>30&#160;</sup>He said, “You shall take these seven ewe lambs from my hand, that it may be a witness to me, that I have dug this well.” 
+<sup>31&#160;</sup>Therefore he called that place Beersheba, because they both swore an oath there. 
+<sup>32&#160;</sup>So they made a covenant at Beersheba. Abimelech rose up with Phicol, the captain of his army, and they returned into the land of the Philistines. 
+<sup>33&#160;</sup>Abraham planted a tamarisk tree in Beersheba, and there he called on the name of Yahweh, the Everlasting Elohim. 
+<sup>34&#160;</sup>Abraham lived as a foreigner in the land of the Philistines many days. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, Elohim tested Abraham, and said to him, “Abraham!” 
+</div><div class="p">He said, “Here I am.” 
+</div><div class="p">
+<sup>2&#160;</sup>He said, “Now take your son, your only son, Isaac, whom you love, and go into the land of Moriah. Offer him there as a burnt offering on one of the mountains which I will tell you of.” 
+</div><div class="p">
+<sup>3&#160;</sup>Abraham rose early in the morning, and saddled his donkey; and took two of his young men with him, and Isaac his son. He split the wood for the burnt offering, and rose up, and went to the place of which Elohim had told him. 
+<sup>4&#160;</sup>On the third day Abraham lifted up his eyes, and saw the place far off. 
+<sup>5&#160;</sup>Abraham said to his young men, “Stay here with the donkey. The boy and I will go over there. We will worship, and come back to you.” 
+<sup>6&#160;</sup>Abraham took the wood of the burnt offering and laid it on Isaac his son. He took in his hand the fire and the knife. They both went together. 
+<sup>7&#160;</sup>Isaac spoke to Abraham his father, and said, “My father?” 
+</div><div class="p">He said, “Here I am, my son.” 
+</div><div class="p">He said, “Here is the fire and the wood, but where is the lamb for a burnt offering?” 
+</div><div class="p">
+<sup>8&#160;</sup>Abraham said, “Elohim will provide himself the lamb for a burnt offering, my son.” So they both went together. 
+<sup>9&#160;</sup>They came to the place which Elohim had told him of. Abraham built the altar there, and laid the wood in order, bound Isaac his son, and laid him on the altar, on the wood. 
+<sup>10&#160;</sup>Abraham stretched out his hand, and took the knife to kill his son. 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh’s angel called to him out of the sky, and said, “Abraham, Abraham!” 
+</div><div class="p">He said, “Here I am.” 
+</div><div class="p">
+<sup>12&#160;</sup>He said, “Don’t lay your hand on the boy or do anything to him. For now I know that you fear Elohim, since you have not withheld your son, your only son, from me.” 
+</div><div class="p">
+<sup>13&#160;</sup>Abraham lifted up his eyes, and looked, and saw that behind him was a ram caught in the thicket by his horns. Abraham went and took the ram, and offered him up for a burnt offering instead of his son. 
+<sup>14&#160;</sup>Abraham called the name of that place “Yahweh Will Provide”. As it is said to this day, “On Yahweh’s mountain, it will be provided.” 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh’s angel called to Abraham a second time out of the sky, 
+<sup>16&#160;</sup>and said, “&#160;‘I have sworn by myself,’ says Yahweh, ‘because you have done this thing, and have not withheld your son, your only son, 
+<sup>17&#160;</sup>that I will bless you greatly, and I will multiply your offspring greatly like the stars of the heavens, and like the sand which is on the seashore. Your offspring will possess the gate of his enemies. 
+<sup>18&#160;</sup>All the nations of the earth will be blessed by your offspring, because you have obeyed my voice.’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>So Abraham returned to his young men, and they rose up and went together to Beersheba. Abraham lived at Beersheba. 
+</div><div class="p">
+<sup>20&#160;</sup>After these things, Abraham was told, “Behold, Milcah, she also has borne children to your brother Nahor: 
+<sup>21&#160;</sup>Uz his firstborn, Buz his brother, Kemuel the father of Aram, 
+<sup>22&#160;</sup>Chesed, Hazo, Pildash, Jidlaph, and Bethuel.” 
+<sup>23&#160;</sup>Bethuel brought forth Rebekah. These eight Milcah bore to Nahor, Abraham’s brother. 
+<sup>24&#160;</sup>His concubine, whose name was Reumah, also bore Tebah, Gaham, Tahash, and Maacah. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Sarah lived one hundred twenty-seven years. This was the length of Sarah’s life. 
+<sup>2&#160;</sup>Sarah died in Kiriath Arba (also called Hebron), in the land of Canaan. Abraham came to mourn for Sarah, and to weep for her. 
+<sup>3&#160;</sup>Abraham rose up from before his dead and spoke to the children of Heth, saying, 
+<sup>4&#160;</sup>“I am a stranger and a foreigner living with you. Give me a possession of a burying-place with you, that I may bury my dead out of my sight.” 
+</div><div class="p">
+<sup>5&#160;</sup>The children of Heth answered Abraham, saying to him, 
+<sup>6&#160;</sup>“Hear us, my lord. You are a prince of Elohim among us. Bury your dead in the best of our tombs. None of us will withhold from you his tomb. Bury your dead.” 
+</div><div class="p">
+<sup>7&#160;</sup>Abraham rose up, and bowed himself to the people of the land, to the children of Heth. 
+<sup>8&#160;</sup>He talked with them, saying, “If you agree that I should bury my dead out of my sight, hear me, and entreat for me to Ephron the son of Zohar, 
+<sup>9&#160;</sup>that he may sell me the cave of Machpelah, which he has, which is in the end of his field. For the full price let him sell it to me among you as a possession for a burial place.” 
+</div><div class="p">
+<sup>10&#160;</sup>Now Ephron was sitting in the middle of the children of Heth. Ephron the Hittite answered Abraham in the hearing of the children of Heth, even of all who went in at the gate of his city, saying, 
+<sup>11&#160;</sup>“No, my lord, hear me. I give you the field, and I give you the cave that is in it. In the presence of the children of my people I give it to you. Bury your dead.” 
+</div><div class="p">
+<sup>12&#160;</sup>Abraham bowed himself down before the people of the land. 
+<sup>13&#160;</sup>He spoke to Ephron in the audience of the people of the land, saying, “But if you will, please hear me. I will give the price of the field. Take it from me, and I will bury my dead there.” 
+</div><div class="p">
+<sup>14&#160;</sup>Ephron answered Abraham, saying to him, 
+<sup>15&#160;</sup>“My lord, listen to me. What is a piece of land worth four hundred shekels of silver between me and you? Therefore bury your dead.” 
+</div><div class="p">
+<sup>16&#160;</sup>Abraham listened to Ephron. Abraham weighed to Ephron the silver which he had named in the hearing of the children of Heth, four hundred shekels of silver, according to the current merchants’ standard. 
+</div><div class="p">
+<sup>17&#160;</sup>So the field of Ephron, which was in Machpelah, which was before Mamre, the field, the cave which was in it, and all the trees that were in the field, that were in all of its borders, were deeded 
+<sup>18&#160;</sup>to Abraham for a possession in the presence of the children of Heth, before all who went in at the gate of his city. 
+<sup>19&#160;</sup>After this, Abraham buried Sarah his woman in the cave of the field of Machpelah before Mamre (that is, Hebron), in the land of Canaan. 
+<sup>20&#160;</sup>The field, and the cave that is in it, were deeded to Abraham by the children of Heth as a possession for a burial place. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Abraham was old, and well advanced in age. Yahweh had blessed Abraham in all things. 
+<sup>2&#160;</sup>Abraham said to his servant, the elder of his house, who ruled over all that he had, “Please put your hand under my thigh. 
+<sup>3&#160;</sup>I will make you swear by Yahweh, the Elohim of heaven and the Elohim of the earth, that you shall not take a woman for my son of the daughters of the Canaanites, among whom I live. 
+<sup>4&#160;</sup>But you shall go to my country, and to my relatives, and take a woman for my son Isaac.” 
+</div><div class="p">
+<sup>5&#160;</sup>The servant said to him, “What if the woman isn’t willing to follow me to this land? Must I bring your son again to the land you came from?” 
+</div><div class="p">
+<sup>6&#160;</sup>Abraham said to him, “Beware that you don’t bring my son there again. 
+<sup>7&#160;</sup>Yahweh, the Elohim of heaven—who took me from my father’s house, and from the land of my birth, who spoke to me, and who swore to me, saying, ‘I will give this land to your offspring—he will send his angel before you, and you shall take a woman for my son from there. 
+<sup>8&#160;</sup>If the woman isn’t willing to follow you, then you shall be clear from this oath to me. Only you shall not bring my son there again.” 
+</div><div class="p">
+<sup>9&#160;</sup>The servant put his hand under the thigh of Abraham his master, and swore to him concerning this matter. 
+<sup>10&#160;</sup>The servant took ten of his master’s camels, and departed, having a variety of good things of his master’s with him. He arose, and went to Mesopotamia, to the city of Nahor. 
+<sup>11&#160;</sup>He made the camels kneel down outside the city by the well of water at the time of evening, the time that women go out to draw water. 
+<sup>12&#160;</sup>He said, “Yahweh, the Elohim of my master Abraham, please give me success today, and show kindness to my master Abraham. 
+<sup>13&#160;</sup>Behold, I am standing by the spring of water. The daughters of the men of the city are coming out to draw water. 
+<sup>14&#160;</sup>Let it happen, that the young lady to whom I will say, ‘Please let down your pitcher, that I may drink,’ then she says, ‘Drink, and I will also give your camels a drink,’—let her be the one you have appointed for your servant Isaac. By this I will know that you have shown kindness to my master.” 
+</div><div class="p">
+<sup>15&#160;</sup>Before he had finished speaking, behold, Rebekah came out, who was born to Bethuel the son of Milcah, the woman of Nahor, Abraham’s brother, with her pitcher on her shoulder. 
+<sup>16&#160;</sup>The young lady was very beautiful to look at, a virgin. No man had known her. She went down to the spring, filled her pitcher, and came up. 
+<sup>17&#160;</sup>The servant ran to meet her, and said, “Please give me a drink, a little water from your pitcher.” 
+</div><div class="p">
+<sup>18&#160;</sup>She said, “Drink, my lord.” She hurried, and let down her pitcher on her hand, and gave him a drink. 
+<sup>19&#160;</sup>When she had finished giving him a drink, she said, “I will also draw for your camels, until they have finished drinking.” 
+<sup>20&#160;</sup>She hurried, and emptied her pitcher into the trough, and ran again to the well to draw, and drew for all his camels. 
+</div><div class="p">
+<sup>21&#160;</sup>The man looked steadfastly at her, remaining silent, to know whether Yahweh had made his journey prosperous or not. 
+<sup>22&#160;</sup>As the camels had done drinking, the man took a golden ring of half a shekel weight, and two bracelets for her hands of ten shekels weight of gold, 
+<sup>23&#160;</sup>and said, “Whose daughter are you? Please tell me. Is there room in your father’s house for us to stay?” 
+</div><div class="p">
+<sup>24&#160;</sup>She said to him, “I am the daughter of Bethuel the son of Milcah, whom she bore to Nahor.” 
+<sup>25&#160;</sup>She said moreover to him, “We have both straw and feed enough, and room to lodge in.” 
+</div><div class="p">
+<sup>26&#160;</sup>The man bowed his head, and worshiped Yahweh. 
+<sup>27&#160;</sup>He said, “Blessed be Yahweh, the Elohim of my master Abraham, who has not forsaken his loving kindness and his truth toward my master. As for me, Yahweh has led me on the way to the house of my master’s relatives.” 
+</div><div class="p">
+<sup>28&#160;</sup>The young lady ran, and told her mother’s house about these words. 
+<sup>29&#160;</sup>Rebekah had a brother, and his name was Laban. Laban ran out to the man, to the spring. 
+<sup>30&#160;</sup>When he saw the ring, and the bracelets on his sister’s hands, and when he heard the words of Rebekah his sister, saying, “This is what the man said to me,” he came to the man. Behold, he was standing by the camels at the spring. 
+<sup>31&#160;</sup>He said, “Come in, you blessed of Yahweh. Why do you stand outside? For I have prepared the house, and room for the camels.” 
+</div><div class="p">
+<sup>32&#160;</sup>The man came into the house, and he unloaded the camels. He gave straw and feed for the camels, and water to wash his feet and the feet of the men who were with him. 
+<sup>33&#160;</sup>Food was set before him to eat, but he said, “I will not eat until I have told my message.” 
+</div><div class="p">Laban said, “Speak on.” 
+</div><div class="p">
+<sup>34&#160;</sup>He said, “I am Abraham’s servant. 
+<sup>35&#160;</sup>Yahweh has blessed my master greatly. He has become great. Yahweh has given him flocks and herds, silver and gold, male servants and female servants, and camels and donkeys. 
+<sup>36&#160;</sup>Sarah, my master’s woman, bore a son to my master when she was old. He has given all that he has to him. 
+<sup>37&#160;</sup>My master made me swear, saying, ‘You shall not take a woman for my son from the daughters of the Canaanites, in whose land I live, 
+<sup>38&#160;</sup>but you shall go to my father’s house, and to my relatives, and take a woman for my son.’ 
+<sup>39&#160;</sup>I asked my master, ‘What if the woman will not follow me?’ 
+<sup>40&#160;</sup>He said to me, ‘Yahweh, before whom I walk, will send his angel with you, and prosper your way. You shall take a woman for my son from my relatives, and of my father’s house. 
+<sup>41&#160;</sup>Then you will be clear from my oath, when you come to my relatives. If they don’t give her to you, you shall be clear from my oath.’ 
+<sup>42&#160;</sup>I came today to the spring, and said, ‘Yahweh, the Elohim of my master Abraham, if now you do prosper my way which I go—<sup>43&#160;</sup>behold, I am standing by this spring of water. Let it happen, that the maiden who comes out to draw, to whom I will say, “Please give me a little water from your pitcher to drink,” 
+<sup>44&#160;</sup>then she tells me, “Drink, and I will also draw for your camels,”—let her be the woman whom Yahweh has appointed for my master’s son.’ 
+<sup>45&#160;</sup>Before I had finished speaking in my heart, behold, Rebekah came out with her pitcher on her shoulder. She went down to the spring, and drew. I said to her, ‘Please let me drink.’ 
+<sup>46&#160;</sup>She hurried and let down her pitcher from her shoulder, and said, ‘Drink, and I will also give your camels a drink.’ So I drank, and she also gave the camels a drink. 
+<sup>47&#160;</sup>I asked her, and said, ‘Whose daughter are you?’ She said, ‘The daughter of Bethuel, Nahor’s son, whom Milcah bore to him.’ I put the ring on her nose, and the bracelets on her hands. 
+<sup>48&#160;</sup>I bowed my head, and worshiped Yahweh, and blessed Yahweh, the Elohim of my master Abraham, who had led me in the right way to take my master’s brother’s daughter for his son. 
+<sup>49&#160;</sup>Now if you will deal kindly and truly with my master, tell me. If not, tell me, that I may turn to the right hand, or to the left.” 
+</div><div class="p">
+<sup>50&#160;</sup>Then Laban and Bethuel answered, “The thing proceeds from Yahweh. We can’t speak to you bad or good. 
+<sup>51&#160;</sup>Behold, Rebekah is before you. Take her, and go, and let her be your master’s son’s woman, as Yahweh has spoken.” 
+</div><div class="p">
+<sup>52&#160;</sup>When Abraham’s servant heard their words, he bowed himself down to the earth to Yahweh. 
+<sup>53&#160;</sup>The servant brought out jewels of silver, and jewels of gold, and clothing, and gave them to Rebekah. He also gave precious things to her brother and her mother. 
+<sup>54&#160;</sup>They ate and drank, he and the men who were with him, and stayed all night. They rose up in the morning, and he said, “Send me away to my master.” 
+</div><div class="p">
+<sup>55&#160;</sup>Her brother and her mother said, “Let the young lady stay with us a few days, at least ten. After that she will go.” 
+</div><div class="p">
+<sup>56&#160;</sup>He said to them, “Don’t hinder me, since Yahweh has prospered my way. Send me away that I may go to my master.” 
+</div><div class="p">
+<sup>57&#160;</sup>They said, “We will call the young lady, and ask her.” 
+<sup>58&#160;</sup>They called Rebekah, and said to her, “Will you go with this man?” 
+</div><div class="p">She said, “I will go.” 
+</div><div class="p">
+<sup>59&#160;</sup>They sent away Rebekah, their sister, with her nurse, Abraham’s servant, and his men. 
+<sup>60&#160;</sup>They blessed Rebekah, and said to her, “Our sister, may you be the mother of thousands of ten thousands, and let your offspring possess the gate of those who hate them.” 
+</div><div class="p">
+<sup>61&#160;</sup>Rebekah arose with her ladies. They rode on the camels, and followed the man. The servant took Rebekah, and went his way. 
+<sup>62&#160;</sup>Isaac came from the way of Beer Lahai Roi, for he lived in the land of the South. 
+<sup>63&#160;</sup>Isaac went out to meditate in the field at the evening. He lifted up his eyes and looked. Behold, there were camels coming. 
+<sup>64&#160;</sup>Rebekah lifted up her eyes, and when she saw Isaac, she got off the camel. 
+<sup>65&#160;</sup>She said to the servant, “Who is the man who is walking in the field to meet us?” 
+</div><div class="p">The servant said, “It is my master.” 
+</div><div class="p">She took her veil, and covered herself. 
+<sup>66&#160;</sup>The servant told Isaac all the things that he had done. 
+<sup>67&#160;</sup>Isaac brought her into his mother Sarah’s tent, and took Rebekah, and she became his woman. He loved her. So Isaac was comforted after his mother’s death. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Abraham took another woman, and her name was Keturah. 
+<sup>2&#160;</sup>She bore him Zimran, Jokshan, Medan, Midian, Ishbak, and Shuah. 
+<sup>3&#160;</sup>Jokshan brought forth Sheba, and Dedan. The sons of Dedan were Asshurim, Letushim, and Leummim. 
+<sup>4&#160;</sup>The sons of Midian were Ephah, Epher, Hanoch, Abida, and Eldaah. All these were the children of Keturah. 
+<sup>5&#160;</sup>Abraham gave all that he had to Isaac, 
+<sup>6&#160;</sup>but Abraham gave gifts to the sons of Abraham’s concubines. While he still lived, he sent them away from Isaac his son, eastward, to the east country. 
+<sup>7&#160;</sup>These are the days of the years of Abraham’s life which he lived: one hundred seventy-five years. 
+<sup>8&#160;</sup>Abraham gave up his spirit, and died at a good old age, an old man, and full of years, and was gathered to his people. 
+<sup>9&#160;</sup>Isaac and Ishmael, his sons, buried him in the cave of Machpelah, in the field of Ephron, the son of Zohar the Hittite, which is near Mamre, 
+<sup>10&#160;</sup>the field which Abraham purchased from the children of Heth. Abraham was buried there with Sarah, his woman. 
+<sup>11&#160;</sup>After the death of Abraham, Elohim blessed Isaac, his son. Isaac lived by Beer Lahai Roi. 
+</div><div class="p">
+<sup>12&#160;</sup>Now this is the history of the generations of Ishmael, Abraham’s son, whom Hagar the Egyptian, Sarah’s servant, bore to Abraham. 
+<sup>13&#160;</sup>These are the names of the sons of Ishmael, by their names, according to the order of their birth: the firstborn of Ishmael, Nebaioth, then Kedar, Adbeel, Mibsam, 
+<sup>14&#160;</sup>Mishma, Dumah, Massa, 
+<sup>15&#160;</sup>Hadad, Tema, Jetur, Naphish, and Kedemah. 
+<sup>16&#160;</sup>These are the sons of Ishmael, and these are their names, by their villages, and by their encampments: twelve princes, according to their nations. 
+<sup>17&#160;</sup>These are the years of the life of Ishmael: one hundred thirty-seven years. He gave up his spirit and died, and was gathered to his people. 
+<sup>18&#160;</sup>They lived from Havilah to Shur that is before Egypt, as you go toward Assyria. He lived opposite all his relatives. 
+</div><div class="p">
+<sup>19&#160;</sup>This is the history of the generations of Isaac, Abraham’s son. Abraham brought forth Isaac. 
+<sup>20&#160;</sup>Isaac was forty years old when he took Rebekah, the daughter of Bethuel the Syrian of Paddan Aram, the sister of Laban the Syrian, to be his woman. 
+<sup>21&#160;</sup>Isaac entreated Yahweh for his woman, because she was barren. Yahweh was entreated by him, and Rebekah his woman conceived. 
+<sup>22&#160;</sup>The children struggled together within her. She said, “If it is like this, why do I live?” She went to inquire of Yahweh. 
+<sup>23&#160;</sup>Yahweh said to her, 
+</div><div class="q1">“Two nations are in your womb. 
+</div><div class="q1">Two peoples will be separated from your body. 
+</div><div class="q1">The one people will be stronger than the other people. 
+</div><div class="q1">The elder will serve the younger.” 
+</div><div class="p">
+<sup>24&#160;</sup>When her days to be delivered were fulfilled, behold, there were twins in her womb. 
+<sup>25&#160;</sup>The first came out red all over, like a hairy garment. They named him Esau. 
+<sup>26&#160;</sup>After that, his brother came out, and his hand had hold on Esau’s heel. He was named Jacob. Isaac was sixty years old when she bore them. 
+</div><div class="p">
+<sup>27&#160;</sup>The boys grew. Esau was a skillful hunter, a man of the field. Jacob was a quiet man, living in tents. 
+<sup>28&#160;</sup>Now Isaac loved Esau, because he ate his venison. Rebekah loved Jacob. 
+<sup>29&#160;</sup>Jacob boiled stew. Esau came in from the field, and he was famished. 
+<sup>30&#160;</sup>Esau said to Jacob, “Please feed me with some of that red stew, for I am famished.” Therefore his name was called Edom. 
+</div><div class="p">
+<sup>31&#160;</sup>Jacob said, “First, sell me your birthright.” 
+</div><div class="p">
+<sup>32&#160;</sup>Esau said, “Behold, I am about to die. What good is the birthright to me?” 
+</div><div class="p">
+<sup>33&#160;</sup>Jacob said, “Swear to me first.” 
+</div><div class="p">He swore to him. He sold his birthright to Jacob. 
+<sup>34&#160;</sup>Jacob gave Esau bread and lentil stew. He ate and drank, rose up, and went his way. So Esau despised his birthright. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>There was a famine in the land, in addition to the first famine that was in the days of Abraham. Isaac went to Abimelech king of the Philistines, to Gerar. 
+<sup>2&#160;</sup>Yahweh appeared to him, and said, “Don’t go down into Egypt. Live in the land I will tell you about. 
+<sup>3&#160;</sup>Live in this land, and I will be with you, and will bless you. For I will give to you, and to your offspring, all these lands, and I will establish the oath which I swore to Abraham your father. 
+<sup>4&#160;</sup>I will multiply your offspring as the stars of the sky, and will give all these lands to your offspring. In your offspring all the nations of the earth will be blessed, 
+<sup>5&#160;</sup>because Abraham obeyed my voice, and kept my requirements, my commandments, my statutes, and my laws.” 
+</div><div class="p">
+<sup>6&#160;</sup>Isaac lived in Gerar. 
+<sup>7&#160;</sup>The men of the place asked him about his woman. He said, “She is my sister,” for he was afraid to say, “My woman”, lest, he thought, “the men of the place might kill me for Rebekah, because she is beautiful to look at.” 
+<sup>8&#160;</sup>When he had been there a long time, Abimelech king of the Philistines looked out at a window, and saw, and, behold, Isaac was caressing Rebekah, his woman. 
+<sup>9&#160;</sup>Abimelech called Isaac, and said, “Behold, surely she is your woman. Why did you say, ‘She is my sister’?” 
+</div><div class="p">Isaac said to him, “Because I said, ‘Lest I die because of her.’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Abimelech said, “What is this you have done to us? One of the people might easily have lain with your woman, and you would have brought guilt on us!” 
+</div><div class="p">
+<sup>11&#160;</sup>Abimelech commanded all the people, saying, “He who touches this man or his woman will surely be put to death.” 
+</div><div class="p">
+<sup>12&#160;</sup>Isaac sowed in that land, and reaped in the same year one hundred times what he planted. Yahweh blessed him. 
+<sup>13&#160;</sup>The man grew great, and grew more and more until he became very great. 
+<sup>14&#160;</sup>He had possessions of flocks, possessions of herds, and a great household. The Philistines envied him. 
+<sup>15&#160;</sup>Now all the wells which his father’s servants had dug in the days of Abraham his father, the Philistines had stopped, and filled with earth. 
+<sup>16&#160;</sup>Abimelech said to Isaac, “Go away from us, for you are much mightier than we.” 
+</div><div class="p">
+<sup>17&#160;</sup>Isaac departed from there, encamped in the valley of Gerar, and lived there. 
+</div><div class="p">
+<sup>18&#160;</sup>Isaac dug again the wells of water, which they had dug in the days of Abraham his father, for the Philistines had stopped them after the death of Abraham. He called their names after the names by which his father had called them. 
+<sup>19&#160;</sup>Isaac’s servants dug in the valley, and found there a well of flowing water. 
+<sup>20&#160;</sup>The herdsmen of Gerar argued with Isaac’s herdsmen, saying, “The water is ours.” So he called the name of the well Esek, because they contended with him. 
+<sup>21&#160;</sup>They dug another well, and they argued over that, also. So he called its name Sitnah. 
+<sup>22&#160;</sup>He left that place, and dug another well. They didn’t argue over that one. So he called it Rehoboth. He said, “For now Yahweh has made room for us, and we will be fruitful in the land.” 
+</div><div class="p">
+<sup>23&#160;</sup>He went up from there to Beersheba. 
+<sup>24&#160;</sup>Yahweh appeared to him the same night, and said, “I am the Elohim of Abraham your father. Don’t be afraid, for I am with you, and will bless you, and multiply your offspring for my servant Abraham’s sake.” 
+</div><div class="p">
+<sup>25&#160;</sup>He built an altar there, and called on Yahweh’s name, and pitched his tent there. There Isaac’s servants dug a well. 
+</div><div class="p">
+<sup>26&#160;</sup>Then Abimelech went to him from Gerar with Ahuzzath his friend, and Phicol the captain of his army. 
+<sup>27&#160;</sup>Isaac said to them, “Why have you come to me, since you hate me, and have sent me away from you?” 
+</div><div class="p">
+<sup>28&#160;</sup>They said, “We saw plainly that Yahweh was with you. We said, ‘Let there now be an oath between us, even between us and you, and let’s make a covenant with you, 
+<sup>29&#160;</sup>that you will do us no harm, as we have not touched you, and as we have done to you nothing but good, and have sent you away in peace.’ You are now the blessed of Yahweh.” 
+</div><div class="p">
+<sup>30&#160;</sup>He made them a feast, and they ate and drank. 
+<sup>31&#160;</sup>They rose up some time in the morning, and swore an oath to one another. Isaac sent them away, and they departed from him in peace. 
+<sup>32&#160;</sup>The same day, Isaac’s servants came, and told him concerning the well which they had dug, and said to him, “We have found water.” 
+<sup>33&#160;</sup>He called it “Shibah”. to this day. 
+</div><div class="p">
+<sup>34&#160;</sup>When Esau was forty years old, he took as woman Judith, the daughter of Beeri the Hittite, and Basemath, the daughter of Elon the Hittite. 
+<sup>35&#160;</sup>They grieved Isaac’s and Rebekah’s spirits. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>When Isaac was old, and his eyes were dim, so that he could not see, he called Esau his elder son, and said to him, “My son?” 
+</div><div class="p">He said to him, “Here I am.” 
+</div><div class="p">
+<sup>2&#160;</sup>He said, “See now, I am old. I don’t know the day of my death. 
+<sup>3&#160;</sup>Now therefore, please take your weapons, your quiver and your bow, and go out to the field, and get me venison. 
+<sup>4&#160;</sup>Make me savory food, such as I love, and bring it to me, that I may eat, and that my soul may bless you before I die.” 
+</div><div class="p">
+<sup>5&#160;</sup>Rebekah heard when Isaac spoke to Esau his son. Esau went to the field to hunt for venison, and to bring it. 
+<sup>6&#160;</sup>Rebekah spoke to Jacob her son, saying, “Behold, I heard your father speak to Esau your brother, saying, 
+<sup>7&#160;</sup>‘Bring me venison, and make me savory food, that I may eat, and bless you before Yahweh before my death.’ 
+<sup>8&#160;</sup>Now therefore, my son, obey my voice according to that which I command you. 
+<sup>9&#160;</sup>Go now to the flock and get me two good young goats from there. I will make them savory food for your father, such as he loves. 
+<sup>10&#160;</sup>You shall bring it to your father, that he may eat, so that he may bless you before his death.” 
+</div><div class="p">
+<sup>11&#160;</sup>Jacob said to Rebekah his mother, “Behold, Esau my brother is a hairy man, and I am a smooth man. 
+<sup>12&#160;</sup>What if my father touches me? I will seem to him as a deceiver, and I would bring a curse on myself, and not a blessing.” 
+</div><div class="p">
+<sup>13&#160;</sup>His mother said to him, “Let your curse be on me, my son. Only obey my voice, and go get them for me.” 
+</div><div class="p">
+<sup>14&#160;</sup>He went, and got them, and brought them to his mother. His mother made savory food, such as his father loved. 
+<sup>15&#160;</sup>Rebekah took the good clothes of Esau, her elder son, which were with her in the house, and put them on Jacob, her younger son. 
+<sup>16&#160;</sup>She put the skins of the young goats on his hands, and on the smooth of his neck. 
+<sup>17&#160;</sup>She gave the savory food and the bread, which she had prepared, into the hand of her son Jacob. 
+</div><div class="p">
+<sup>18&#160;</sup>He came to his father, and said, “My father?” 
+</div><div class="p">He said, “Here I am. Who are you, my son?” 
+</div><div class="p">
+<sup>19&#160;</sup>Jacob said to his father, “I am Esau your firstborn. I have done what you asked me to do. Please arise, sit and eat of my venison, that your soul may bless me.” 
+</div><div class="p">
+<sup>20&#160;</sup>Isaac said to his son, “How is it that you have found it so quickly, my son?” 
+</div><div class="p">He said, “Because Yahweh your Elohim gave me success.” 
+</div><div class="p">
+<sup>21&#160;</sup>Isaac said to Jacob, “Please come near, that I may feel you, my son, whether you are really my son Esau or not.” 
+</div><div class="p">
+<sup>22&#160;</sup>Jacob went near to Isaac his father. He felt him, and said, “The voice is Jacob’s voice, but the hands are the hands of Esau.” 
+<sup>23&#160;</sup>He didn’t recognize him, because his hands were hairy, like his brother Esau’s hands. So he blessed him. 
+<sup>24&#160;</sup>He said, “Are you really my son Esau?” 
+</div><div class="p">He said, “I am.” 
+</div><div class="p">
+<sup>25&#160;</sup>He said, “Bring it near to me, and I will eat of my son’s venison, that my soul may bless you.” 
+</div><div class="p">He brought it near to him, and he ate. He brought him wine, and he drank. 
+<sup>26&#160;</sup>His father Isaac said to him, “Come near now, and kiss me, my son.” 
+<sup>27&#160;</sup>He came near, and kissed him. He smelled the smell of his clothing, and blessed him, and said, 
+</div><div class="q1">“Behold, the smell of my son 
+</div><div class="q2">is as the smell of a field which Yahweh has blessed. 
+</div><div class="q1">
+<sup>28&#160;</sup>Elohim give you of the dew of the sky, 
+</div><div class="q2">of the fatness of the earth, 
+</div><div class="q2">and plenty of grain and new wine. 
+</div><div class="q1">
+<sup>29&#160;</sup>Let peoples serve you, 
+</div><div class="q2">and nations bow down to you. 
+</div><div class="q1">Be lord over your brothers. 
+</div><div class="q2">Let your mother’s sons bow down to you. 
+</div><div class="q1">Cursed be everyone who curses you. 
+</div><div class="q2">Blessed be everyone who blesses you.” 
+</div><div class="p">
+<sup>30&#160;</sup>As soon as Isaac had finished blessing Jacob, and Jacob had just gone out from the presence of Isaac his father, Esau his brother came in from his hunting. 
+<sup>31&#160;</sup>He also made savory food, and brought it to his father. He said to his father, “Let my father arise, and eat of his son’s venison, that your soul may bless me.” 
+</div><div class="p">
+<sup>32&#160;</sup>Isaac his father said to him, “Who are you?” 
+</div><div class="p">He said, “I am your son, your firstborn, Esau.” 
+</div><div class="p">
+<sup>33&#160;</sup>Isaac trembled violently, and said, “Who, then, is he who has taken venison, and brought it to me, and I have eaten of all before you came, and have blessed him? Yes, he will be blessed.” 
+</div><div class="p">
+<sup>34&#160;</sup>When Esau heard the words of his father, he cried with an exceedingly great and bitter cry, and said to his father, “Bless me, even me also, my father.” 
+</div><div class="p">
+<sup>35&#160;</sup>He said, “Your brother came with deceit, and has taken away your blessing.” 
+</div><div class="p">
+<sup>36&#160;</sup>He said, “Isn’t he rightly named Jacob? For he has supplanted me these two times. He took away my birthright. See, now he has taken away my blessing.” He said, “Haven’t you reserved a blessing for me?” 
+</div><div class="p">
+<sup>37&#160;</sup>Isaac answered Esau, “Behold, I have made him your lord, and all his brothers I have given to him for servants. I have sustained him with grain and new wine. What then will I do for you, my son?” 
+</div><div class="p">
+<sup>38&#160;</sup>Esau said to his father, “Do you have just one blessing, my father? Bless me, even me also, my father.” Esau lifted up his voice, and wept. 
+</div><div class="p">
+<sup>39&#160;</sup>Isaac his father answered him, 
+</div><div class="q1">“Behold, your dwelling will be of the fatness of the earth, 
+</div><div class="q1">and of the dew of the sky from above. 
+</div><div class="q1">
+<sup>40&#160;</sup>You will live by your sword, and you will serve your brother. 
+</div><div class="q1">It will happen, when you will break loose, 
+</div><div class="q1">that you will shake his yoke from off your neck.” 
+</div><div class="p">
+<sup>41&#160;</sup>Esau hated Jacob because of the blessing with which his father blessed him. Esau said in his heart, “The days of mourning for my father are at hand. Then I will kill my brother Jacob.” 
+</div><div class="p">
+<sup>42&#160;</sup>The words of Esau, her elder son, were told to Rebekah. She sent and called Jacob, her younger son, and said to him, “Behold, your brother Esau comforts himself about you by planning to kill you. 
+<sup>43&#160;</sup>Now therefore, my son, obey my voice. Arise, flee to Laban, my brother, in Haran. 
+<sup>44&#160;</sup>Stay with him a few days, until your brother’s fury turns away—<sup>45&#160;</sup>until your brother’s anger turns away from you, and he forgets what you have done to him. Then I will send, and get you from there. Why should I be bereaved of you both in one day?” 
+</div><div class="p">
+<sup>46&#160;</sup>Rebekah said to Isaac, “I am weary of my life because of the daughters of Heth. If Jacob takes a woman of the daughters of Heth, such as these, of the daughters of the land, what good will my life do me?” 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>Isaac called Jacob, blessed him, and commanded him, “You shall not take a woman of the daughters of Canaan. 
+<sup>2&#160;</sup>Arise, go to Paddan Aram, to the house of Bethuel your mother’s father. Take a woman from there from the daughters of Laban, your mother’s brother. 
+<sup>3&#160;</sup>May Elohim Almighty bless you, and make you fruitful, and multiply you, that you may be a company of peoples, 
+<sup>4&#160;</sup>and give you the blessing of Abraham, to you and to your offspring with you, that you may inherit the land where you travel, which Elohim gave to Abraham.” 
+</div><div class="p">
+<sup>5&#160;</sup>Isaac sent Jacob away. He went to Paddan Aram to Laban, son of Bethuel the Syrian, the brother of Rebekah, Jacob’s and Esau’s mother. 
+</div><div class="p">
+<sup>6&#160;</sup>Now Esau saw that Isaac had blessed Jacob and sent him away to Paddan Aram, to take him a woman from there, and that as he blessed him he gave him a command, saying, “You shall not take a woman of the daughters of Canaan;” 
+<sup>7&#160;</sup>and that Jacob obeyed his father and his mother, and was gone to Paddan Aram. 
+<sup>8&#160;</sup>Esau saw that the daughters of Canaan didn’t please Isaac, his father. 
+<sup>9&#160;</sup>So Esau went to Ishmael, and took, in addition to the women that he had, Mahalath the daughter of Ishmael, Abraham’s son, the sister of Nebaioth, to be his woman. 
+</div><div class="p">
+<sup>10&#160;</sup>Jacob went out from Beersheba, and went toward Haran. 
+<sup>11&#160;</sup>He came to a certain place, and stayed there all night, because the sun had set. He took one of the stones of the place, and put it under his head, and lay down in that place to sleep. 
+<sup>12&#160;</sup>He dreamed and saw a stairway set upon the earth, and its top reached to heaven. Behold, the angels of Elohim were ascending and descending on it. 
+<sup>13&#160;</sup>Behold, Yahweh stood above it, and said, “I am Yahweh, the Elohim of Abraham your father, and the Elohim of Isaac. I will give the land you lie on to you and to your offspring. 
+<sup>14&#160;</sup>Your offspring will be as the dust of the earth, and you will spread abroad to the west, and to the east, and to the north, and to the south. In you and in your offspring, all the families of the earth will be blessed. 
+<sup>15&#160;</sup>Behold, I am with you, and will keep you, wherever you go, and will bring you again into this land. For I will not leave you until I have done that which I have spoken of to you.” 
+</div><div class="p">
+<sup>16&#160;</sup>Jacob awakened out of his sleep, and he said, “Surely Yahweh is in this place, and I didn’t know it.” 
+<sup>17&#160;</sup>He was afraid, and said, “How awesome this place is! This is none other than Elohim’s house, and this is the gate of heaven.” 
+</div><div class="p">
+<sup>18&#160;</sup>Jacob rose up early in the morning, and took the stone that he had put under his head, and set it up for a pillar, and poured oil on its top. 
+<sup>19&#160;</sup>He called the name of that place Bethel, but the name of the city was Luz at the first. 
+<sup>20&#160;</sup>Jacob vowed a vow, saying, “If Elohim will be with me, and will keep me in this way that I go, and will give me bread to eat, and clothing to put on, 
+<sup>21&#160;</sup>so that I come again to my father’s house in peace, and Yahweh will be my Elohim, 
+<sup>22&#160;</sup>then this stone, which I have set up for a pillar, will be Elohim’s house. Of all that you will give me I will surely give a tenth to you.” 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Jacob went on his journey, and came to the land of the children of the east. 
+<sup>2&#160;</sup>He looked, and saw a well in the field, and saw three flocks of sheep lying there by it. For out of that well they watered the flocks. The stone on the well’s mouth was large. 
+<sup>3&#160;</sup>There all the flocks were gathered. They rolled the stone from the well’s mouth, and watered the sheep, and put the stone back on the well’s mouth in its place. 
+<sup>4&#160;</sup>Jacob said to them, “My relatives, where are you from?” 
+</div><div class="p">They said, “We are from Haran.” 
+</div><div class="p">
+<sup>5&#160;</sup>He said to them, “Do you know Laban, the son of Nahor?” 
+</div><div class="p">They said, “We know him.” 
+</div><div class="p">
+<sup>6&#160;</sup>He said to them, “Is it well with him?” 
+</div><div class="p">They said, “It is well. See, Rachel, his daughter, is coming with the sheep.” 
+</div><div class="p">
+<sup>7&#160;</sup>He said, “Behold, it is still the middle of the day, not time to gather the livestock together. Water the sheep, and go and feed them.” 
+</div><div class="p">
+<sup>8&#160;</sup>They said, “We can’t, until all the flocks are gathered together, and they roll the stone from the well’s mouth. Then we will water the sheep.” 
+</div><div class="p">
+<sup>9&#160;</sup>While he was yet speaking with them, Rachel came with her father’s sheep, for she kept them. 
+<sup>10&#160;</sup>When Jacob saw Rachel the daughter of Laban, his mother’s brother, and the sheep of Laban, his mother’s brother, Jacob went near, and rolled the stone from the well’s mouth, and watered the flock of Laban his mother’s brother. 
+<sup>11&#160;</sup>Jacob kissed Rachel, and lifted up his voice, and wept. 
+<sup>12&#160;</sup>Jacob told Rachel that he was her father’s relative, and that he was Rebekah’s son. She ran and told her father. 
+</div><div class="p">
+<sup>13&#160;</sup>When Laban heard the news of Jacob, his sister’s son, he ran to meet Jacob, and embraced him, and kissed him, and brought him to his house. Jacob told Laban all these things. 
+<sup>14&#160;</sup>Laban said to him, “Surely you are my bone and my flesh.” Jacob stayed with him for a month. 
+<sup>15&#160;</sup>Laban said to Jacob, “Because you are my relative, should you therefore serve me for nothing? Tell me, what will your wages be?” 
+</div><div class="p">
+<sup>16&#160;</sup>Laban had two daughters. The name of the elder was Leah, and the name of the younger was Rachel. 
+<sup>17&#160;</sup>Leah’s eyes were weak, but Rachel was beautiful in form and attractive. 
+<sup>18&#160;</sup>Jacob loved Rachel. He said, “I will serve you seven years for Rachel, your younger daughter.” 
+</div><div class="p">
+<sup>19&#160;</sup>Laban said, “It is better that I give her to you, than that I should give her to another man. Stay with me.” 
+</div><div class="p">
+<sup>20&#160;</sup>Jacob served seven years for Rachel. They seemed to him but a few days, for the love he had for her. 
+</div><div class="p">
+<sup>21&#160;</sup>Jacob said to Laban, “Give me my woman, for my days are fulfilled, that I may go in to her.” 
+</div><div class="p">
+<sup>22&#160;</sup>Laban gathered together all the men of the place, and made a feast. 
+<sup>23&#160;</sup>In the evening, he took Leah his daughter, and brought her to Jacob. He went in to her. 
+<sup>24&#160;</sup>Laban gave Zilpah his servant to his daughter Leah for a servant. 
+<sup>25&#160;</sup>In the morning, behold, it was Leah! He said to Laban, “What is this you have done to me? Didn’t I serve with you for Rachel? Why then have you deceived me?” 
+</div><div class="p">
+<sup>26&#160;</sup>Laban said, “It is not done so in our place, to give the younger before the firstborn. 
+<sup>27&#160;</sup>Fulfill the week of this one, and we will give you the other also for the service which you will serve with me for seven more years.” 
+</div><div class="p">
+<sup>28&#160;</sup>Jacob did so, and fulfilled her week. He gave him Rachel his daughter as woman. 
+<sup>29&#160;</sup>Laban gave Bilhah, his servant, to his daughter Rachel to be her servant. 
+<sup>30&#160;</sup>He went in also to Rachel, and he loved also Rachel more than Leah, and served with him seven more years. 
+</div><div class="p">
+<sup>31&#160;</sup>Yahweh saw that Leah was hated, and he opened her womb, but Rachel was barren. 
+<sup>32&#160;</sup>Leah conceived, and bore a son, and she named him Reuben. For she said, “Because Yahweh has looked at my affliction; for now my man will love me.” 
+<sup>33&#160;</sup>She conceived again, and bore a son, and said, “Because Yahweh has heard that I am hated, he has therefore given me this son also.” She named him Simeon. 
+<sup>34&#160;</sup>She conceived again, and bore a son. She said, “Now this time my man will be joined to me, because I have borne him three sons.” Therefore his name was called Levi. 
+<sup>35&#160;</sup>She conceived again, and bore a son. She said, “This time I will praise Yahweh.” Therefore she named him Judah. Then she stopped bearing. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>When Rachel saw that she bore Jacob no children, Rachel envied her sister. She said to Jacob, “Give me children, or else I will die.” 
+</div><div class="p">
+<sup>2&#160;</sup>Jacob’s anger burned against Rachel, and he said, “Am I in Elohim’s place, who has withheld from you the fruit of the womb?” 
+</div><div class="p">
+<sup>3&#160;</sup>She said, “Behold, my maid Bilhah. Go in to her, that she may bear on my knees, and I also may obtain children by her.” 
+<sup>4&#160;</sup>She gave him Bilhah her servant as woman, and Jacob went in to her. 
+<sup>5&#160;</sup>Bilhah conceived, and bore Jacob a son. 
+<sup>6&#160;</sup>Rachel said, “Elohim has judged me, and has also heard my voice, and has given me a son.” Therefore she called his name Dan. 
+<sup>7&#160;</sup>Bilhah, Rachel’s servant, conceived again, and bore Jacob a second son. 
+<sup>8&#160;</sup>Rachel said, “I have wrestled with my sister with mighty wrestlings, and have prevailed.” She named him Naphtali. 
+</div><div class="p">
+<sup>9&#160;</sup>When Leah saw that she had finished bearing, she took Zilpah, her servant, and gave her to Jacob as a woman. 
+<sup>10&#160;</sup>Zilpah, Leah’s servant, bore Jacob a son. 
+<sup>11&#160;</sup>Leah said, “How fortunate!” She named him Gad. 
+<sup>12&#160;</sup>Zilpah, Leah’s servant, bore Jacob a second son. 
+<sup>13&#160;</sup>Leah said, “Happy am I, for the daughters will call me happy.” She named him Asher. 
+</div><div class="p">
+<sup>14&#160;</sup>Reuben went in the days of wheat harvest, and found mandrakes in the field, and brought them to his mother, Leah. Then Rachel said to Leah, “Please give me some of your son’s mandrakes.” 
+</div><div class="p">
+<sup>15&#160;</sup>Leah said to her, “Is it a small matter that you have taken away my man? Would you take away my son’s mandrakes, also?” 
+</div><div class="p">Rachel said, “Therefore he will lie with you tonight for your son’s mandrakes.” 
+</div><div class="p">
+<sup>16&#160;</sup>Jacob came from the field in the evening, and Leah went out to meet him, and said, “You must come in to me; for I have surely hired you with my son’s mandrakes.” 
+</div><div class="p">He lay with her that night. 
+<sup>17&#160;</sup>Elohim listened to Leah, and she conceived, and bore Jacob a fifth son. 
+<sup>18&#160;</sup>Leah said, “Elohim has given me my hire, because I gave my servant to my man.” She named him Issachar. 
+<sup>19&#160;</sup>Leah conceived again, and bore a sixth son to Jacob. 
+<sup>20&#160;</sup>Leah said, “Elohim has endowed me with a good dowry. Now my man will live with me, because I have borne him six sons.” She named him Zebulun. 
+<sup>21&#160;</sup>Afterwards, she bore a daughter, and named her Dinah. 
+</div><div class="p">
+<sup>22&#160;</sup>Elohim remembered Rachel, and Elohim listened to her, and opened her womb. 
+<sup>23&#160;</sup>She conceived, bore a son, and said, “Elohim has taken away my reproach.” 
+<sup>24&#160;</sup>She named him Joseph, saying, “May Yahweh add another son to me.” 
+</div><div class="p">
+<sup>25&#160;</sup>When Rachel had borne Joseph, Jacob said to Laban, “Send me away, that I may go to my own place, and to my country. 
+<sup>26&#160;</sup>Give me my women and my children for whom I have served you, and let me go; for you know my service with which I have served you.” 
+</div><div class="p">
+<sup>27&#160;</sup>Laban said to him, “If now I have found favor in your eyes, stay here, for I have divined that Yahweh has blessed me for your sake.” 
+<sup>28&#160;</sup>He said, “Appoint me your wages, and I will give it.” 
+</div><div class="p">
+<sup>29&#160;</sup>Jacob said to him, “You know how I have served you, and how your livestock have fared with me. 
+<sup>30&#160;</sup>For it was little which you had before I came, and it has increased to a multitude. Yahweh has blessed you wherever I turned. Now when will I provide for my own house also?” 
+</div><div class="p">
+<sup>31&#160;</sup>Laban said, “What shall I give you?” 
+</div><div class="p">Jacob said, “You shall not give me anything. If you will do this thing for me, I will again feed your flock and keep it. 
+<sup>32&#160;</sup>I will pass through all your flock today, removing from there every speckled and spotted one, and every black one among the sheep, and the spotted and speckled among the goats. This will be my hire. 
+<sup>33&#160;</sup>So my righteousness will answer for me hereafter, when you come concerning my hire that is before you. Every one that is not speckled and spotted among the goats, and black among the sheep, that might be with me, will be considered stolen.” 
+</div><div class="p">
+<sup>34&#160;</sup>Laban said, “Behold, let it be according to your word.” 
+</div><div class="p">
+<sup>35&#160;</sup>That day, he removed the male goats that were streaked and spotted, and all the female goats that were speckled and spotted, every one that had white in it, and all the black ones among the sheep, and gave them into the hand of his sons. 
+<sup>36&#160;</sup>He set three days’ journey between himself and Jacob, and Jacob fed the rest of Laban’s flocks. 
+</div><div class="p">
+<sup>37&#160;</sup>Jacob took to himself rods of fresh poplar, almond, and plane tree, peeled white streaks in them, and made the white appear which was in the rods. 
+<sup>38&#160;</sup>He set the rods which he had peeled opposite the flocks in the watering troughs where the flocks came to drink. They conceived when they came to drink. 
+<sup>39&#160;</sup>The flocks conceived before the rods, and the flocks produced streaked, speckled, and spotted. 
+<sup>40&#160;</sup>Jacob separated the lambs, and set the faces of the flocks toward the streaked and all the black in Laban’s flock. He put his own droves apart, and didn’t put them into Laban’s flock. 
+<sup>41&#160;</sup>Whenever the stronger of the flock conceived, Jacob laid the rods in front of the eyes of the flock in the watering troughs, that they might conceive among the rods; 
+<sup>42&#160;</sup>but when the flock were feeble, he didn’t put them in. So the feebler were Laban’s, and the stronger Jacob’s. 
+<sup>43&#160;</sup>The man increased exceedingly, and had large flocks, female servants and male servants, and camels and donkeys. 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>Jacob heard Laban’s sons’ words, saying, “Jacob has taken away all that was our father’s. He has obtained all this wealth from that which was our father’s.” 
+<sup>2&#160;</sup>Jacob saw the expression on Laban’s face, and, behold, it was not toward him as before. 
+<sup>3&#160;</sup>Yahweh said to Jacob, “Return to the land of your fathers, and to your relatives, and I will be with you.” 
+</div><div class="p">
+<sup>4&#160;</sup>Jacob sent and called Rachel and Leah to the field to his flock, 
+<sup>5&#160;</sup>and said to them, “I see the expression on your father’s face, that it is not toward me as before; but the Elohim of my father has been with me. 
+<sup>6&#160;</sup>You know that I have served your father with all of my strength. 
+<sup>7&#160;</sup>Your father has deceived me, and changed my wages ten times, but Elohim didn’t allow him to hurt me. 
+<sup>8&#160;</sup>If he said, ‘The speckled will be your wages,’ then all the flock bore speckled. If he said, ‘The streaked will be your wages,’ then all the flock bore streaked. 
+<sup>9&#160;</sup>Thus Elohim has taken away your father’s livestock, and given them to me. 
+<sup>10&#160;</sup>During mating season, I lifted up my eyes, and saw in a dream, and behold, the male goats which leaped on the flock were streaked, speckled, and grizzled. 
+<sup>11&#160;</sup>The angel of Elohim said to me in the dream, ‘Jacob,’ and I said, ‘Here I am.’ 
+<sup>12&#160;</sup>He said, ‘Now lift up your eyes, and behold, all the male goats which leap on the flock are streaked, speckled, and grizzled, for I have seen all that Laban does to you. 
+<sup>13&#160;</sup>I am the Elohim of Bethel, where you anointed a pillar, where you vowed a vow to me. Now arise, get out from this land, and return to the land of your birth.’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Rachel and Leah answered him, “Is there yet any portion or inheritance for us in our father’s house? 
+<sup>15&#160;</sup>Aren’t we considered as foreigners by him? For he has sold us, and has also used up our money. 
+<sup>16&#160;</sup>For all the riches which Elohim has taken away from our father are ours and our children’s. Now then, whatever Elohim has said to you, do.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Jacob rose up, and set his sons and his women on the camels, 
+<sup>18&#160;</sup>and he took away all his livestock, and all his possessions which he had gathered, including the livestock which he had gained in Paddan Aram, to go to Isaac his father, to the land of Canaan. 
+<sup>19&#160;</sup>Now Laban had gone to shear his sheep; and Rachel stole the teraphim that were her father’s. 
+</div><div class="p">
+<sup>20&#160;</sup>Jacob deceived Laban the Syrian, in that he didn’t tell him that he was running away. 
+<sup>21&#160;</sup>So he fled with all that he had. He rose up, passed over the River, and set his face toward the mountain of Gilead. 
+</div><div class="p">
+<sup>22&#160;</sup>Laban was told on the third day that Jacob had fled. 
+<sup>23&#160;</sup>He took his relatives with him, and pursued him seven days’ journey. He overtook him in the mountain of Gilead. 
+<sup>24&#160;</sup>Elohim came to Laban the Syrian in a dream of the night, and said to him, “Be careful that you don’t speak to Jacob either good or bad.” 
+</div><div class="p">
+<sup>25&#160;</sup>Laban caught up with Jacob. Now Jacob had pitched his tent in the mountain, and Laban with his relatives encamped in the mountain of Gilead. 
+<sup>26&#160;</sup>Laban said to Jacob, “What have you done, that you have deceived me, and carried away my daughters like captives of the sword? 
+<sup>27&#160;</sup>Why did you flee secretly, and deceive me, and didn’t tell me, that I might have sent you away with mirth and with songs, with tambourine and with harp; 
+<sup>28&#160;</sup>and didn’t allow me to kiss my sons and my daughters? Now have you done foolishly. 
+<sup>29&#160;</sup>It is in the power of my hand to hurt you, but the Elohim of your father spoke to me last night, saying, ‘Be careful that you don’t speak to Jacob either good or bad.’ 
+<sup>30&#160;</sup>Now, you want to be gone, because you greatly longed for your father’s house, but why have you stolen my elohims?” 
+</div><div class="p">
+<sup>31&#160;</sup>Jacob answered Laban, “Because I was afraid, for I said, ‘Lest you should take your daughters from me by force.’ 
+<sup>32&#160;</sup>Anyone you find your elohims with shall not live. Before our relatives, discern what is yours with me, and take it.” For Jacob didn’t know that Rachel had stolen them. 
+</div><div class="p">
+<sup>33&#160;</sup>Laban went into Jacob’s tent, into Leah’s tent, and into the tent of the two female servants; but he didn’t find them. He went out of Leah’s tent, and entered into Rachel’s tent. 
+<sup>34&#160;</sup>Now Rachel had taken the teraphim, put them in the camel’s saddle, and sat on them. Laban felt around all the tent, but didn’t find them. 
+<sup>35&#160;</sup>She said to her father, “Don’t let my lord be angry that I can’t rise up before you; for I’m having my period.” He searched, but didn’t find the teraphim. 
+</div><div class="p">
+<sup>36&#160;</sup>Jacob was angry, and argued with Laban. Jacob answered Laban, “What is my trespass? What is my sin, that you have hotly pursued me? 
+<sup>37&#160;</sup>Now that you have felt around in all my stuff, what have you found of all your household stuff? Set it here before my relatives and your relatives, that they may judge between us two. 
+</div><div class="p">
+<sup>38&#160;</sup>“These twenty years I have been with you. Your ewes and your female goats have not cast their young, and I haven’t eaten the rams of your flocks. 
+<sup>39&#160;</sup>That which was torn of animals, I didn’t bring to you. I bore its loss. Of my hand you required it, whether stolen by day or stolen by night. 
+<sup>40&#160;</sup>This was my situation: in the day the drought consumed me, and the frost by night; and my sleep fled from my eyes. 
+<sup>41&#160;</sup>These twenty years I have been in your house. I served you fourteen years for your two daughters, and six years for your flock, and you have changed my wages ten times. 
+<sup>42&#160;</sup>Unless the Elohim of my father, the Elohim of Abraham, and the fear of Isaac, had been with me, surely now you would have sent me away empty. Elohim has seen my affliction and the labor of my hands, and rebuked you last night.” 
+</div><div class="p">
+<sup>43&#160;</sup>Laban answered Jacob, “The daughters are my daughters, the children are my children, the flocks are my flocks, and all that you see is mine! What can I do today to these my daughters, or to their children whom they have borne? 
+<sup>44&#160;</sup>Now come, let’s make a covenant, you and I. Let it be for a witness between me and you.” 
+</div><div class="p">
+<sup>45&#160;</sup>Jacob took a stone, and set it up for a pillar. 
+<sup>46&#160;</sup>Jacob said to his relatives, “Gather stones.” They took stones, and made a heap. They ate there by the heap. 
+<sup>47&#160;</sup>Laban called it Jegar Sahadutha, 
+<sup>48&#160;</sup>Laban said, “This heap is witness between me and you today.” Therefore it was named Galeed 
+<sup>49&#160;</sup>and Mizpah, for he said, “Yahweh watch between me and you, when we are absent one from another. 
+<sup>50&#160;</sup>If you afflict my daughters, or if you take women in addition to my daughters, no man is with us; behold, Elohim is witness between me and you.” 
+<sup>51&#160;</sup>Laban said to Jacob, “See this heap, and see the pillar, which I have set between me and you. 
+<sup>52&#160;</sup>May this heap be a witness, and the pillar be a witness, that I will not pass over this heap to you, and that you will not pass over this heap and this pillar to me, for harm. 
+<sup>53&#160;</sup>The Elohim of Abraham, and the Elohim of Nahor, the Elohim of their father, judge between us.” Then Jacob swore by the fear of his father, Isaac. 
+<sup>54&#160;</sup>Jacob offered a sacrifice in the mountain, and called his relatives to eat bread. They ate bread, and stayed all night in the mountain. 
+<sup>55&#160;</sup>Early in the morning, Laban rose up, and kissed his sons and his daughters, and blessed them. Laban departed and returned to his place. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>Jacob went on his way, and the angels of Elohim met him. 
+<sup>2&#160;</sup>When he saw them, Jacob said, “This is Elohim’s army.” He called the name of that place Mahanaim. 
+</div><div class="p">
+<sup>3&#160;</sup>Jacob sent messengers in front of him to Esau, his brother, to the land of Seir, the field of Edom. 
+<sup>4&#160;</sup>He commanded them, saying, “This is what you shall tell my lord, Esau: ‘This is what your servant, Jacob, says. I have lived as a foreigner with Laban, and stayed until now. 
+<sup>5&#160;</sup>I have cattle, donkeys, flocks, male servants, and female servants. I have sent to tell my lord, that I may find favor in your sight.’&#160;” 
+<sup>6&#160;</sup>The messengers returned to Jacob, saying, “We came to your brother Esau. He is coming to meet you, and four hundred men are with him.” 
+<sup>7&#160;</sup>Then Jacob was greatly afraid and was distressed. He divided the people who were with him, along with the flocks, the herds, and the camels, into two companies. 
+<sup>8&#160;</sup>He said, “If Esau comes to the one company, and strikes it, then the company which is left will escape.” 
+<sup>9&#160;</sup>Jacob said, “Elohim of my father Abraham, and Elohim of my father Isaac, Yahweh, who said to me, ‘Return to your country, and to your relatives, and I will do you good,’ 
+<sup>10&#160;</sup>I am not worthy of the least of all the loving kindnesses, and of all the truth, which you have shown to your servant; for with just my staff I crossed over this Jordan; and now I have become two companies. 
+<sup>11&#160;</sup>Please deliver me from the hand of my brother, from the hand of Esau; for I fear him, lest he come and strike me and the mothers with the children. 
+<sup>12&#160;</sup>You said, ‘I will surely do you good, and make your offspring as the sand of the sea, which can’t be counted because there are so many.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>He stayed there that night, and took from that which he had with him a present for Esau, his brother: 
+<sup>14&#160;</sup>two hundred female goats and twenty male goats, two hundred ewes and twenty rams, 
+<sup>15&#160;</sup>thirty milk camels and their colts, forty cows, ten bulls, twenty female donkeys and ten foals. 
+<sup>16&#160;</sup>He delivered them into the hands of his servants, every herd by itself, and said to his servants, “Pass over before me, and put a space between herd and herd.” 
+<sup>17&#160;</sup>He commanded the foremost, saying, “When Esau, my brother, meets you, and asks you, saying, ‘Whose are you? Where are you going? Whose are these before you?’ 
+<sup>18&#160;</sup>Then you shall say, ‘They are your servant, Jacob’s. It is a present sent to my lord, Esau. Behold, he also is behind us.’&#160;” 
+<sup>19&#160;</sup>He commanded also the second, and the third, and all that followed the herds, saying, “This is how you shall speak to Esau, when you find him. 
+<sup>20&#160;</sup>You shall say, ‘Not only that, but behold, your servant, Jacob, is behind us.’&#160;” For, he said, “I will appease him with the present that goes before me, and afterward I will see his face. Perhaps he will accept me.” 
+</div><div class="p">
+<sup>21&#160;</sup>So the present passed over before him, and he himself stayed that night in the camp. 
+</div><div class="p">
+<sup>22&#160;</sup>He rose up that night, and took his two women, and his two servants, and his eleven sons, and crossed over the ford of the Jabbok. 
+<sup>23&#160;</sup>He took them, and sent them over the stream, and sent over that which he had. 
+<sup>24&#160;</sup>Jacob was left alone, and wrestled with a man there until the breaking of the day. 
+<sup>25&#160;</sup>When he saw that he didn’t prevail against him, the man touched the hollow of his thigh, and the hollow of Jacob’s thigh was strained as he wrestled. 
+<sup>26&#160;</sup>The man said, “Let me go, for the day breaks.” 
+</div><div class="p">Jacob said, “I won’t let you go unless you bless me.” 
+</div><div class="p">
+<sup>27&#160;</sup>He said to him, “What is your name?” 
+</div><div class="p">He said, “Jacob”. 
+</div><div class="p">
+<sup>28&#160;</sup>He said, “Your name will no longer be called Jacob, but Israel; for you have fought with Elohim and with men, and have prevailed.” 
+</div><div class="p">
+<sup>29&#160;</sup>Jacob asked him, “Please tell me your name.” 
+</div><div class="p">He said, “Why is it that you ask what my name is?” So he blessed him there. 
+</div><div class="p">
+<sup>30&#160;</sup>Jacob called the name of the place Peniel; for he said, “I have seen Elohim face to face, and my life is preserved.” 
+<sup>31&#160;</sup>The sun rose on him as he passed over Peniel, and he limped because of his thigh. 
+<sup>32&#160;</sup>Therefore the children of Israel don’t eat the sinew of the hip, which is on the hollow of the thigh, to this day, because he touched the hollow of Jacob’s thigh in the sinew of the hip. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="p">
+<sup>1&#160;</sup>Jacob lifted up his eyes, and looked, and, behold, Esau was coming, and with him four hundred men. He divided the children between Leah, Rachel, and the two servants. 
+<sup>2&#160;</sup>He put the servants and their children in front, Leah and her children after, and Rachel and Joseph at the rear. 
+<sup>3&#160;</sup>He himself passed over in front of them, and bowed himself to the ground seven times, until he came near to his brother. 
+</div><div class="p">
+<sup>4&#160;</sup>Esau ran to meet him, embraced him, fell on his neck, kissed him, and they wept. 
+<sup>5&#160;</sup>He lifted up his eyes, and saw the women and the children; and said, “Who are these with you?” 
+</div><div class="p">He said, “The children whom Elohim has graciously given your servant.” 
+<sup>6&#160;</sup>Then the servants came near with their children, and they bowed themselves. 
+<sup>7&#160;</sup>Leah also and her children came near, and bowed themselves. After them, Joseph came near with Rachel, and they bowed themselves. 
+</div><div class="p">
+<sup>8&#160;</sup>Esau said, “What do you mean by all this company which I met?” 
+</div><div class="p">Jacob said, “To find favor in the sight of my lord.” 
+</div><div class="p">
+<sup>9&#160;</sup>Esau said, “I have enough, my brother; let that which you have be yours.” 
+</div><div class="p">
+<sup>10&#160;</sup>Jacob said, “Please, no, if I have now found favor in your sight, then receive my present at my hand, because I have seen your face, as one sees the face of Elohim, and you were pleased with me. 
+<sup>11&#160;</sup>Please take the gift that I brought to you, because Elohim has dealt graciously with me, and because I have enough.” He urged him, and he took it. 
+</div><div class="p">
+<sup>12&#160;</sup>Esau said, “Let’s take our journey, and let’s go, and I will go before you.” 
+</div><div class="p">
+<sup>13&#160;</sup>Jacob said to him, “My lord knows that the children are tender, and that the flocks and herds with me have their young, and if they overdrive them one day, all the flocks will die. 
+<sup>14&#160;</sup>Please let my lord pass over before his servant, and I will lead on gently, according to the pace of the livestock that are before me and according to the pace of the children, until I come to my lord to Seir.” 
+</div><div class="p">
+<sup>15&#160;</sup>Esau said, “Let me now leave with you some of the people who are with me.” 
+</div><div class="p">He said, “Why? Let me find favor in the sight of my lord.” 
+</div><div class="p">
+<sup>16&#160;</sup>So Esau returned that day on his way to Seir. 
+<sup>17&#160;</sup>Jacob traveled to Succoth, built himself a house, and made shelters for his livestock. Therefore the name of the place is called Succoth. 
+</div><div class="p">
+<sup>18&#160;</sup>Jacob came in peace to the city of Shechem, which is in the land of Canaan, when he came from Paddan Aram; and encamped before the city. 
+<sup>19&#160;</sup>He bought the parcel of ground where he had spread his tent, at the hand of the children of Hamor, Shechem’s father, for one hundred pieces of money. 
+<sup>20&#160;</sup>He erected an altar there, and called it El Elohe Israel. 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>Dinah, the daughter of Leah, whom she bore to Jacob, went out to see the daughters of the land. 
+<sup>2&#160;</sup>Shechem the son of Hamor the Hivite, the prince of the land, saw her. He took her, lay with her, and humbled her. 
+<sup>3&#160;</sup>His soul joined to Dinah, the daughter of Jacob, and he loved the young lady, and spoke kindly to the young lady. 
+<sup>4&#160;</sup>Shechem spoke to his father, Hamor, saying, “Get me this young lady as a woman.” 
+</div><div class="p">
+<sup>5&#160;</sup>Now Jacob heard that he had defiled Dinah, his daughter; and his sons were with his livestock in the field. Jacob held his peace until they came. 
+<sup>6&#160;</sup>Hamor the father of Shechem went out to Jacob to talk with him. 
+<sup>7&#160;</sup>The sons of Jacob came in from the field when they heard it. The men were grieved, and they were very angry, because he had done folly in Israel in lying with Jacob’s daughter, a thing that ought not to be done. 
+<sup>8&#160;</sup>Hamor talked with them, saying, “The soul of my son, Shechem, longs for your daughter. Please give her to him as a woman. 
+<sup>9&#160;</sup>Make marriages with us. Give your daughters to us, and take our daughters for yourselves. 
+<sup>10&#160;</sup>You shall dwell with us, and the land will be before you. Live and trade in it, and get possessions in it.” 
+</div><div class="p">
+<sup>11&#160;</sup>Shechem said to her father and to her brothers, “Let me find favor in your eyes, and whatever you will tell me I will give. 
+<sup>12&#160;</sup>Ask me a great amount for a dowry, and I will give whatever you ask of me, but give me the young lady as a woman.” 
+</div><div class="p">
+<sup>13&#160;</sup>The sons of Jacob answered Shechem and Hamor his father with deceit when they spoke, because he had defiled Dinah their sister, 
+<sup>14&#160;</sup>and said to them, “We can’t do this thing, to give our sister to one who is uncircumcised; for that is a reproach to us. 
+<sup>15&#160;</sup>Only on this condition will we consent to you. If you will be as we are, that every male of you be circumcised, 
+<sup>16&#160;</sup>then will we give our daughters to you; and we will take your daughters to us, and we will dwell with you, and we will become one people. 
+<sup>17&#160;</sup>But if you will not listen to us and be circumcised, then we will take our sister, and we will be gone.” 
+</div><div class="p">
+<sup>18&#160;</sup>Their words pleased Hamor and Shechem, Hamor’s son. 
+<sup>19&#160;</sup>The young man didn’t wait to do this thing, because he had delight in Jacob’s daughter, and he was honored above all the house of his father. 
+<sup>20&#160;</sup>Hamor and Shechem, his son, came to the gate of their city, and talked with the men of their city, saying, 
+<sup>21&#160;</sup>“These men are peaceful with us. Therefore let them live in the land and trade in it. For behold, the land is large enough for them. Let’s take their daughters to us for women, and let’s give them our daughters. 
+<sup>22&#160;</sup>Only on this condition will the men consent to us to live with us, to become one people, if every male among us is circumcised, as they are circumcised. 
+<sup>23&#160;</sup>Won’t their livestock and their possessions and all their animals be ours? Only let’s give our consent to them, and they will dwell with us.” 
+</div><div class="p">
+<sup>24&#160;</sup>All who went out of the gate of his city listened to Hamor, and to Shechem his son; and every male was circumcised, all who went out of the gate of his city. 
+<sup>25&#160;</sup>On the third day, when they were sore, two of Jacob’s sons, Simeon and Levi, Dinah’s brothers, each took his sword, came upon the unsuspecting city, and killed all the males. 
+<sup>26&#160;</sup>They killed Hamor and Shechem, his son, with the edge of the sword, and took Dinah out of Shechem’s house, and went away. 
+<sup>27&#160;</sup>Jacob’s sons came on the dead, and plundered the city, because they had defiled their sister. 
+<sup>28&#160;</sup>They took their flocks, their herds, their donkeys, that which was in the city, that which was in the field, 
+<sup>29&#160;</sup>and all their wealth. They took captive all their little ones and their women, and took as plunder everything that was in the house. 
+<sup>30&#160;</sup>Jacob said to Simeon and Levi, “You have troubled me, to make me odious to the inhabitants of the land, among the Canaanites and the Perizzites. I am few in number. They will gather themselves together against me and strike me, and I will be destroyed, I and my house.” 
+</div><div class="p">
+<sup>31&#160;</sup>They said, “Should he deal with our sister as with a prostitute?” 
+</div><h2 class="chapterlabel" id="35">35</h2>
+<div class="p">
+<sup>1&#160;</sup>Elohim said to Jacob, “Arise, go up to Bethel, and live there. Make there an altar to Elohim, who appeared to you when you fled from the face of Esau your brother.” 
+</div><div class="p">
+<sup>2&#160;</sup>Then Jacob said to his household, and to all who were with him, “Put away the foreign elohims that are among you, purify yourselves, and change your garments. 
+<sup>3&#160;</sup>Let’s arise, and go up to Bethel. I will make there an altar to Elohim, who answered me in the day of my distress, and was with me on the way which I went.” 
+</div><div class="p">
+<sup>4&#160;</sup>They gave to Jacob all the foreign elohims which were in their hands, and the rings which were in their ears; and Jacob hid them under the oak which was by Shechem. 
+<sup>5&#160;</sup>They traveled, and a terror of Elohim was on the cities that were around them, and they didn’t pursue the sons of Jacob. 
+<sup>6&#160;</sup>So Jacob came to Luz (that is, Bethel), which is in the land of Canaan, he and all the people who were with him. 
+<sup>7&#160;</sup>He built an altar there, and called the place El Beth El; because there Elohim was revealed to him, when he fled from the face of his brother. 
+<sup>8&#160;</sup>Deborah, Rebekah’s nurse, died, and she was buried below Bethel under the oak; and its name was called Allon Bacuth. 
+</div><div class="p">
+<sup>9&#160;</sup>Elohim appeared to Jacob again, when he came from Paddan Aram, and blessed him. 
+<sup>10&#160;</sup>Elohim said to him, “Your name is Jacob. Your name shall not be Jacob any more, but your name will be Israel.” He named him Israel. 
+<sup>11&#160;</sup>Elohim said to him, “I am Elohim Almighty. Be fruitful and multiply. A nation and a company of nations will be from you, and kings will come out of your body. 
+<sup>12&#160;</sup>The land which I gave to Abraham and Isaac, I will give it to you, and to your offspring after you I will give the land.” 
+</div><div class="p">
+<sup>13&#160;</sup>Elohim went up from him in the place where he spoke with him. 
+<sup>14&#160;</sup>Jacob set up a pillar in the place where he spoke with him, a pillar of stone. He poured out a drink offering on it, and poured oil on it. 
+<sup>15&#160;</sup>Jacob called the name of the place where Elohim spoke with him “Bethel”. 
+</div><div class="p">
+<sup>16&#160;</sup>They traveled from Bethel. There was still some distance to come to Ephrath, and Rachel travailed. She had hard labor. 
+<sup>17&#160;</sup>When she was in hard labor, the midwife said to her, “Don’t be afraid, for now you will have another son.” 
+</div><div class="p">
+<sup>18&#160;</sup>As her soul was departing (for she died), she named him Benoni, 
+<sup>19&#160;</sup>Rachel died, and was buried on the way to Ephrath (also called Bethlehem). 
+<sup>20&#160;</sup>Jacob set up a pillar on her grave. The same is the Pillar of Rachel’s grave to this day. 
+<sup>21&#160;</sup>Israel traveled, and spread his tent beyond the tower of Eder. 
+<sup>22&#160;</sup>While Israel lived in that land, Reuben went and lay with Bilhah, his father’s concubine, and Israel heard of it. 
+</div><div class="p">Now the sons of Jacob were twelve. 
+<sup>23&#160;</sup>The sons of Leah: Reuben (Jacob’s firstborn), Simeon, Levi, Judah, Issachar, and Zebulun. 
+<sup>24&#160;</sup>The sons of Rachel: Joseph and Benjamin. 
+<sup>25&#160;</sup>The sons of Bilhah (Rachel’s servant): Dan and Naphtali. 
+<sup>26&#160;</sup>The sons of Zilpah (Leah’s servant): Gad and Asher. These are the sons of Jacob, who were born to him in Paddan Aram. 
+<sup>27&#160;</sup>Jacob came to Isaac his father, to Mamre, to Kiriath Arba (which is Hebron), where Abraham and Isaac lived as foreigners. 
+</div><div class="p">
+<sup>28&#160;</sup>The days of Isaac were one hundred eighty years. 
+<sup>29&#160;</sup>Isaac gave up the spirit and died, and was gathered to his people, old and full of days. Esau and Jacob, his sons, buried him. 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>Now this is the history of the generations of Esau (that is, Edom). 
+<sup>2&#160;</sup>Esau took his women from the daughters of Canaan: Adah the daughter of Elon, the Hittite; and Oholibamah the daughter of Anah, the daughter of Zibeon, the Hivite; 
+<sup>3&#160;</sup>and Basemath, Ishmael’s daughter, sister of Nebaioth. 
+<sup>4&#160;</sup>Adah bore to Esau Eliphaz. Basemath bore Reuel. 
+<sup>5&#160;</sup>Oholibamah bore Jeush, Jalam, and Korah. These are the sons of Esau, who were born to him in the land of Canaan. 
+<sup>6&#160;</sup>Esau took his women, his sons, his daughters, and all the members of his household, with his livestock, all his animals, and all his possessions, which he had gathered in the land of Canaan, and went into a land away from his brother Jacob. 
+<sup>7&#160;</sup>For their substance was too great for them to dwell together, and the land of their travels couldn’t bear them because of their livestock. 
+<sup>8&#160;</sup>Esau lived in the hill country of Seir. Esau is Edom. 
+</div><div class="p">
+<sup>9&#160;</sup>This is the history of the generations of Esau the father of the Edomites in the hill country of Seir: 
+<sup>10&#160;</sup>these are the names of Esau’s sons: Eliphaz, the son of Adah, the woman of Esau; and Reuel, the son of Basemath, the woman of Esau. 
+<sup>11&#160;</sup>The sons of Eliphaz were Teman, Omar, Zepho, and Gatam, and Kenaz. 
+<sup>12&#160;</sup>Timna was concubine to Eliphaz, Esau’s son; and she bore to Eliphaz Amalek. These are the descendants of Adah, Esau’s woman. 
+<sup>13&#160;</sup>These are the sons of Reuel: Nahath, Zerah, Shammah, and Mizzah. These were the descendants of Basemath, Esau’s woman. 
+<sup>14&#160;</sup>These were the sons of Oholibamah, the daughter of Anah, the daughter of Zibeon, Esau’s woman: she bore to Esau Jeush, Jalam, and Korah. 
+</div><div class="p">
+<sup>15&#160;</sup>These are the chiefs of the sons of Esau: the sons of Eliphaz the firstborn of Esau: chief Teman, chief Omar, chief Zepho, chief Kenaz, 
+<sup>16&#160;</sup>chief Korah, chief Gatam, chief Amalek. These are the chiefs who came of Eliphaz in the land of Edom. These are the sons of Adah. 
+<sup>17&#160;</sup>These are the sons of Reuel, Esau’s son: chief Nahath, chief Zerah, chief Shammah, chief Mizzah. These are the chiefs who came of Reuel in the land of Edom. These are the sons of Basemath, Esau’s woman. 
+<sup>18&#160;</sup>These are the sons of Oholibamah, Esau’s woman: chief Jeush, chief Jalam, chief Korah. These are the chiefs who came of Oholibamah the daughter of Anah, Esau’s woman. 
+<sup>19&#160;</sup>These are the sons of Esau (that is, Edom), and these are their chiefs. 
+</div><div class="p">
+<sup>20&#160;</sup>These are the sons of Seir the Horite, the inhabitants of the land: Lotan, Shobal, Zibeon, Anah, 
+<sup>21&#160;</sup>Dishon, Ezer, and Dishan. These are the chiefs who came of the Horites, the children of Seir in the land of Edom. 
+<sup>22&#160;</sup>The children of Lotan were Hori and Heman. Lotan’s sister was Timna. 
+<sup>23&#160;</sup>These are the children of Shobal: Alvan, Manahath, Ebal, Shepho, and Onam. 
+<sup>24&#160;</sup>These are the children of Zibeon: Aiah and Anah. This is Anah who found the hot springs in the wilderness, as he fed the donkeys of Zibeon his father. 
+<sup>25&#160;</sup>These are the children of Anah: Dishon and Oholibamah, the daughter of Anah. 
+<sup>26&#160;</sup>These are the children of Dishon: Hemdan, Eshban, Ithran, and Cheran. 
+<sup>27&#160;</sup>These are the children of Ezer: Bilhan, Zaavan, and Akan. 
+<sup>28&#160;</sup>These are the children of Dishan: Uz and Aran. 
+<sup>29&#160;</sup>These are the chiefs who came of the Horites: chief Lotan, chief Shobal, chief Zibeon, chief Anah, 
+<sup>30&#160;</sup>chief Dishon, chief Ezer, and chief Dishan. These are the chiefs who came of the Horites, according to their chiefs in the land of Seir. 
+</div><div class="p">
+<sup>31&#160;</sup>These are the kings who reigned in the land of Edom, before any king reigned over the children of Israel. 
+<sup>32&#160;</sup>Bela, the son of Beor, reigned in Edom. The name of his city was Dinhabah. 
+<sup>33&#160;</sup>Bela died, and Jobab, the son of Zerah of Bozrah, reigned in his place. 
+<sup>34&#160;</sup>Jobab died, and Husham of the land of the Temanites reigned in his place. 
+<sup>35&#160;</sup>Husham died, and Hadad, the son of Bedad, who struck Midian in the field of Moab, reigned in his place. The name of his city was Avith. 
+<sup>36&#160;</sup>Hadad died, and Samlah of Masrekah reigned in his place. 
+<sup>37&#160;</sup>Samlah died, and Shaul of Rehoboth by the river, reigned in his place. 
+<sup>38&#160;</sup>Shaul died, and Baal Hanan the son of Achbor reigned in his place. 
+<sup>39&#160;</sup>Baal Hanan the son of Achbor died, and Hadar reigned in his place. The name of his city was Pau. His woman’s name was Mehetabel, the daughter of Matred, the daughter of Mezahab. 
+</div><div class="p">
+<sup>40&#160;</sup>These are the names of the chiefs who came from Esau, according to their families, after their places, and by their names: chief Timna, chief Alvah, chief Jetheth, 
+<sup>41&#160;</sup>chief Oholibamah, chief Elah, chief Pinon, 
+<sup>42&#160;</sup>chief Kenaz, chief Teman, chief Mibzar, 
+<sup>43&#160;</sup>chief Magdiel, and chief Iram. These are the chiefs of Edom, according to their habitations in the land of their possession. This is Esau, the father of the Edomites. 
+</div><h2 class="chapterlabel" id="37">37</h2>
+<div class="p">
+<sup>1&#160;</sup>Jacob lived in the land of his father’s travels, in the land of Canaan. 
+<sup>2&#160;</sup>This is the history of the generations of Jacob. Joseph, being seventeen years old, was feeding the flock with his brothers. He was a boy with the sons of Bilhah and Zilpah, his father’s women. Joseph brought an evil report of them to their father. 
+<sup>3&#160;</sup>Now Israel loved Joseph more than all his children, because he was the son of his old age, and he made him a tunic of many colors. 
+<sup>4&#160;</sup>His brothers saw that their father loved him more than all his brothers, and they hated him, and couldn’t speak peaceably to him. 
+</div><div class="p">
+<sup>5&#160;</sup>Joseph dreamed a dream, and he told it to his brothers, and they hated him all the more. 
+<sup>6&#160;</sup>He said to them, “Please hear this dream which I have dreamed: 
+<sup>7&#160;</sup>for behold, we were binding sheaves in the field, and behold, my sheaf arose and also stood upright; and behold, your sheaves came around, and bowed down to my sheaf.” 
+</div><div class="p">
+<sup>8&#160;</sup>His brothers asked him, “Will you indeed reign over us? Will you indeed have dominion over us?” They hated him all the more for his dreams and for his words. 
+<sup>9&#160;</sup>He dreamed yet another dream, and told it to his brothers, and said, “Behold, I have dreamed yet another dream: and behold, the sun and the moon and eleven stars bowed down to me.” 
+<sup>10&#160;</sup>He told it to his father and to his brothers. His father rebuked him, and said to him, “What is this dream that you have dreamed? Will I and your mother and your brothers indeed come to bow ourselves down to the earth before you?” 
+<sup>11&#160;</sup>His brothers envied him, but his father kept this saying in mind. 
+</div><div class="p">
+<sup>12&#160;</sup>His brothers went to feed their father’s flock in Shechem. 
+<sup>13&#160;</sup>Israel said to Joseph, “Aren’t your brothers feeding the flock in Shechem? Come, and I will send you to them.” He said to him, “Here I am.” 
+</div><div class="p">
+<sup>14&#160;</sup>He said to him, “Go now, see whether it is well with your brothers, and well with the flock; and bring me word again.” So he sent him out of the valley of Hebron, and he came to Shechem. 
+<sup>15&#160;</sup>A certain man found him, and behold, he was wandering in the field. The man asked him, “What are you looking for?” 
+</div><div class="p">
+<sup>16&#160;</sup>He said, “I am looking for my brothers. Tell me, please, where they are feeding the flock.” 
+</div><div class="p">
+<sup>17&#160;</sup>The man said, “They have left here, for I heard them say, ‘Let’s go to Dothan.’&#160;” 
+</div><div class="p">Joseph went after his brothers, and found them in Dothan. 
+<sup>18&#160;</sup>They saw him afar off, and before he came near to them, they conspired against him to kill him. 
+<sup>19&#160;</sup>They said to one another, “Behold, this dreamer comes. 
+<sup>20&#160;</sup>Come now therefore, and let’s kill him, and cast him into one of the pits, and we will say, ‘An evil animal has devoured him.’ We will see what will become of his dreams.” 
+</div><div class="p">
+<sup>21&#160;</sup>Reuben heard it, and delivered him out of their hand, and said, “Let’s not take his life.” 
+<sup>22&#160;</sup>Reuben said to them, “Shed no blood. Throw him into this pit that is in the wilderness, but lay no hand on him”—that he might deliver him out of their hand, to restore him to his father. 
+<sup>23&#160;</sup>When Joseph came to his brothers, they stripped Joseph of his tunic, the tunic of many colors that was on him; 
+<sup>24&#160;</sup>and they took him, and threw him into the pit. The pit was empty. There was no water in it. 
+</div><div class="p">
+<sup>25&#160;</sup>They sat down to eat bread, and they lifted up their eyes and looked, and saw a caravan of Ishmaelites was coming from Gilead, with their camels bearing spices and balm and myrrh, going to carry it down to Egypt. 
+<sup>26&#160;</sup>Judah said to his brothers, “What profit is it if we kill our brother and conceal his blood? 
+<sup>27&#160;</sup>Come, and let’s sell him to the Ishmaelites, and not let our hand be on him; for he is our brother, our flesh.” His brothers listened to him. 
+<sup>28&#160;</sup>Midianites who were merchants passed by, and they drew and lifted up Joseph out of the pit, and sold Joseph to the Ishmaelites for twenty pieces of silver. The merchants brought Joseph into Egypt. 
+</div><div class="p">
+<sup>29&#160;</sup>Reuben returned to the pit, and saw that Joseph wasn’t in the pit; and he tore his clothes. 
+<sup>30&#160;</sup>He returned to his brothers, and said, “The child is no more; and I, where will I go?” 
+<sup>31&#160;</sup>They took Joseph’s tunic, and killed a male goat, and dipped the tunic in the blood. 
+<sup>32&#160;</sup>They took the tunic of many colors, and they brought it to their father, and said, “We have found this. Examine it, now, and see if it is your son’s tunic or not.” 
+</div><div class="p">
+<sup>33&#160;</sup>He recognized it, and said, “It is my son’s tunic. An evil animal has devoured him. Joseph is without doubt torn in pieces.” 
+<sup>34&#160;</sup>Jacob tore his clothes, and put sackcloth on his waist, and mourned for his son many days. 
+<sup>35&#160;</sup>All his sons and all his daughters rose up to comfort him, but he refused to be comforted. He said, “For I will go down to Sheol to my son, mourning.” His father wept for him. 
+<sup>36&#160;</sup>The Midianites sold him into Egypt to Potiphar, an officer of Pharaoh’s, the captain of the guard. 
+</div><h2 class="chapterlabel" id="38">38</h2>
+<div class="p">
+<sup>1&#160;</sup>At that time, Judah went down from his brothers, and visited a certain Adullamite, whose name was Hirah. 
+<sup>2&#160;</sup>There, Judah saw the daughter of a certain Canaanite man named Shua. He took her, and went in to her. 
+<sup>3&#160;</sup>She conceived, and bore a son; and he named him Er. 
+<sup>4&#160;</sup>She conceived again, and bore a son; and she named him Onan. 
+<sup>5&#160;</sup>She yet again bore a son, and named him Shelah. He was at Chezib when she bore him. 
+<sup>6&#160;</sup>Judah took a woman for Er, his firstborn, and her name was Tamar. 
+<sup>7&#160;</sup>Er, Judah’s firstborn, was wicked in Yahweh’s sight. So Yahweh killed him. 
+<sup>8&#160;</sup>Judah said to Onan, “Go in to your brother’s woman, and perform the duty of a brother-in-law to her, and raise up offspring for your brother.” 
+<sup>9&#160;</sup>Onan knew that the offspring wouldn’t be his; and when he went in to his brother’s woman, he spilled his semen on the ground, lest he should give offspring to his brother. 
+<sup>10&#160;</sup>The thing which he did was evil in Yahweh’s sight, and he killed him also. 
+<sup>11&#160;</sup>Then Judah said to Tamar, his daughter-in-law, “Remain a widow in your father’s house, until Shelah, my son, is grown up;” for he said, “Lest he also die, like his brothers.” Tamar went and lived in her father’s house. 
+</div><div class="p">
+<sup>12&#160;</sup>After many days, Shua’s daughter, the woman of Judah, died. Judah was comforted, and went up to his sheep shearers to Timnah, he and his friend Hirah, the Adullamite. 
+<sup>13&#160;</sup>Tamar was told, “Behold, your father-in-law is going up to Timnah to shear his sheep.” 
+<sup>14&#160;</sup>She took off the garments of her widowhood, and covered herself with her veil, and wrapped herself, and sat in the gate of Enaim, which is on the way to Timnah; for she saw that Shelah was grown up, and she wasn’t given to him as a woman. 
+<sup>15&#160;</sup>When Judah saw her, he thought that she was a prostitute, for she had covered her face. 
+<sup>16&#160;</sup>He turned to her by the way, and said, “Please come, let me come in to you,” for he didn’t know that she was his daughter-in-law. 
+</div><div class="p">She said, “What will you give me, that you may come in to me?” 
+</div><div class="p">
+<sup>17&#160;</sup>He said, “I will send you a young goat from the flock.” 
+</div><div class="p">She said, “Will you give me a pledge, until you send it?” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, “What pledge will I give you?” 
+</div><div class="p">She said, “Your signet and your cord, and your staff that is in your hand.” 
+</div><div class="p">He gave them to her, and came in to her, and she conceived by him. 
+<sup>19&#160;</sup>She arose, and went away, and put off her veil from her, and put on the garments of her widowhood. 
+<sup>20&#160;</sup>Judah sent the young goat by the hand of his friend, the Adullamite, to receive the pledge from the woman’s hand, but he didn’t find her. 
+<sup>21&#160;</sup>Then he asked the men of her place, saying, “Where is the prostitute, that was at Enaim by the road?” 
+</div><div class="p">They said, “There has been no prostitute here.” 
+</div><div class="p">
+<sup>22&#160;</sup>He returned to Judah, and said, “I haven’t found her; and also the men of the place said, ‘There has been no prostitute here.’&#160;” 
+<sup>23&#160;</sup>Judah said, “Let her keep it, lest we be shamed. Behold, I sent this young goat, and you haven’t found her.” 
+</div><div class="p">
+<sup>24&#160;</sup>About three months later, Judah was told, “Tamar, your daughter-in-law, has played the prostitute. Moreover, behold, she is with child by prostitution.” 
+</div><div class="p">Judah said, “Bring her out, and let her be burned.” 
+<sup>25&#160;</sup>When she was brought out, she sent to her father-in-law, saying, “I am with child by the man who owns these.” She also said, “Please discern whose these are—the signet, and the cords, and the staff.” 
+</div><div class="p">
+<sup>26&#160;</sup>Judah acknowledged them, and said, “She is more righteous than I, because I didn’t give her to Shelah, my son.” 
+</div><div class="p">He knew her again no more. 
+<sup>27&#160;</sup>In the time of her travail, behold, twins were in her womb. 
+<sup>28&#160;</sup>When she travailed, one put out a hand, and the midwife took and tied a scarlet thread on his hand, saying, “This came out first.” 
+<sup>29&#160;</sup>As he drew back his hand, behold, his brother came out, and she said, “Why have you made a breach for yourself?” Therefore his name was called Perez. 
+<sup>30&#160;</sup>Afterward his brother came out, who had the scarlet thread on his hand, and his name was called Zerah. 
+</div><h2 class="chapterlabel" id="39">39</h2>
+<div class="p">
+<sup>1&#160;</sup>Joseph was brought down to Egypt. Potiphar, an officer of Pharaoh’s, the captain of the guard, an Egyptian, bought him from the hand of the Ishmaelites that had brought him down there. 
+<sup>2&#160;</sup>Yahweh was with Joseph, and he was a prosperous man. He was in the house of his master the Egyptian. 
+<sup>3&#160;</sup>His master saw that Yahweh was with him, and that Yahweh made all that he did prosper in his hand. 
+<sup>4&#160;</sup>Joseph found favor in his sight. He ministered to him, and Potiphar made him overseer over his house, and all that he had he put into his hand. 
+<sup>5&#160;</sup>From the time that he made him overseer in his house, and over all that he had, Yahweh blessed the Egyptian’s house for Joseph’s sake. Yahweh’s blessing was on all that he had, in the house and in the field. 
+<sup>6&#160;</sup>He left all that he had in Joseph’s hand. He didn’t concern himself with anything, except for the food which he ate. 
+</div><div class="p">Joseph was well-built and handsome. 
+<sup>7&#160;</sup>After these things, his master’s woman set her eyes on Joseph; and she said, “Lie with me.” 
+</div><div class="p">
+<sup>8&#160;</sup>But he refused, and said to his master’s woman, “Behold, my master doesn’t know what is with me in the house, and he has put all that he has into my hand. 
+<sup>9&#160;</sup>No one is greater in this house than I am, and he has not kept back anything from me but you, because you are his woman. How then can I do this great wickedness, and sin against Elohim?” 
+</div><div class="p">
+<sup>10&#160;</sup>As she spoke to Joseph day by day, he didn’t listen to her, to lie by her, or to be with her. 
+<sup>11&#160;</sup>About this time, he went into the house to do his work, and there were none of the men of the house inside. 
+<sup>12&#160;</sup>She caught him by his garment, saying, “Lie with me!” 
+</div><div class="p">He left his garment in her hand, and ran outside. 
+<sup>13&#160;</sup>When she saw that he had left his garment in her hand, and had run outside, 
+<sup>14&#160;</sup>she called to the men of her house, and spoke to them, saying, “Behold, he has brought a Hebrew in to us to mock us. He came in to me to lie with me, and I cried with a loud voice. 
+<sup>15&#160;</sup>When he heard that I lifted up my voice and cried, he left his garment by me, and ran outside.” 
+<sup>16&#160;</sup>She laid up his garment by her, until his master came home. 
+<sup>17&#160;</sup>She spoke to him according to these words, saying, “The Hebrew servant, whom you have brought to us, came in to me to mock me, 
+<sup>18&#160;</sup>and as I lifted up my voice and cried, he left his garment by me, and ran outside.” 
+</div><div class="p">
+<sup>19&#160;</sup>When his master heard the words of his woman, which she spoke to him, saying, “This is what your servant did to me,” his wrath was kindled. 
+<sup>20&#160;</sup>Joseph’s master took him, and put him into the prison, the place where the king’s prisoners were bound, and he was there in custody. 
+<sup>21&#160;</sup>But Yahweh was with Joseph, and showed kindness to him, and gave him favor in the sight of the keeper of the prison. 
+<sup>22&#160;</sup>The keeper of the prison committed to Joseph’s hand all the prisoners who were in the prison. Whatever they did there, he was responsible for it. 
+<sup>23&#160;</sup>The keeper of the prison didn’t look after anything that was under his hand, because Yahweh was with him; and that which he did, Yahweh made it prosper. 
+</div><h2 class="chapterlabel" id="40">40</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, the butler of the king of Egypt and his baker offended their lord, the king of Egypt. 
+<sup>2&#160;</sup>Pharaoh was angry with his two officers, the chief cup bearer and the chief baker. 
+<sup>3&#160;</sup>He put them in custody in the house of the captain of the guard, into the prison, the place where Joseph was bound. 
+<sup>4&#160;</sup>The captain of the guard assigned them to Joseph, and he took care of them. They stayed in prison many days. 
+<sup>5&#160;</sup>They both dreamed a dream, each man his dream, in one night, each man according to the interpretation of his dream, the cup bearer and the baker of the king of Egypt, who were bound in the prison. 
+<sup>6&#160;</sup>Joseph came in to them in the morning, and saw them, and saw that they were sad. 
+<sup>7&#160;</sup>He asked Pharaoh’s officers who were with him in custody in his master’s house, saying, “Why do you look so sad today?” 
+</div><div class="p">
+<sup>8&#160;</sup>They said to him, “We have dreamed a dream, and there is no one who can interpret it.” 
+</div><div class="p">Joseph said to them, “Don’t interpretations belong to Elohim? Please tell it to me.” 
+</div><div class="p">
+<sup>9&#160;</sup>The chief cup bearer told his dream to Joseph, and said to him, “In my dream, behold, a vine was in front of me, 
+<sup>10&#160;</sup>and in the vine were three branches. It was as though it budded, it blossomed, and its clusters produced ripe grapes. 
+<sup>11&#160;</sup>Pharaoh’s cup was in my hand; and I took the grapes, and pressed them into Pharaoh’s cup, and I gave the cup into Pharaoh’s hand.” 
+</div><div class="p">
+<sup>12&#160;</sup>Joseph said to him, “This is its interpretation: the three branches are three days. 
+<sup>13&#160;</sup>Within three more days, Pharaoh will lift up your head, and restore you to your office. You will give Pharaoh’s cup into his hand, the way you did when you were his cup bearer. 
+<sup>14&#160;</sup>But remember me when it is well with you. Please show kindness to me, and make mention of me to Pharaoh, and bring me out of this house. 
+<sup>15&#160;</sup>For indeed, I was stolen away out of the land of the Hebrews, and here also I have done nothing that they should put me into the dungeon.” 
+</div><div class="p">
+<sup>16&#160;</sup>When the chief baker saw that the interpretation was good, he said to Joseph, “I also was in my dream, and behold, three baskets of white bread were on my head. 
+<sup>17&#160;</sup>In the uppermost basket there were all kinds of baked food for Pharaoh, and the birds ate them out of the basket on my head.” 
+</div><div class="p">
+<sup>18&#160;</sup>Joseph answered, “This is its interpretation. The three baskets are three days. 
+<sup>19&#160;</sup>Within three more days, Pharaoh will lift up your head from off you, and will hang you on a tree; and the birds will eat your flesh from off you.” 
+<sup>20&#160;</sup>On the third day, which was Pharaoh’s birthday, he made a feast for all his servants, and he lifted up the head of the chief cup bearer and the head of the chief baker among his servants. 
+<sup>21&#160;</sup>He restored the chief cup bearer to his position again, and he gave the cup into Pharaoh’s hand; 
+<sup>22&#160;</sup>but he hanged the chief baker, as Joseph had interpreted to them. 
+<sup>23&#160;</sup>Yet the chief cup bearer didn’t remember Joseph, but forgot him. 
+</div><h2 class="chapterlabel" id="41">41</h2>
+<div class="p">
+<sup>1&#160;</sup>At the end of two full years, Pharaoh dreamed, and behold, he stood by the river. 
+<sup>2&#160;</sup>Behold, seven cattle came up out of the river. They were sleek and fat, and they fed in the marsh grass. 
+<sup>3&#160;</sup>Behold, seven other cattle came up after them out of the river, ugly and thin, and stood by the other cattle on the brink of the river. 
+<sup>4&#160;</sup>The ugly and thin cattle ate up the seven sleek and fat cattle. So Pharaoh awoke. 
+<sup>5&#160;</sup>He slept and dreamed a second time; and behold, seven heads of grain came up on one stalk, healthy and good. 
+<sup>6&#160;</sup>Behold, seven heads of grain, thin and blasted with the east wind, sprung up after them. 
+<sup>7&#160;</sup>The thin heads of grain swallowed up the seven healthy and full ears. Pharaoh awoke, and behold, it was a dream. 
+<sup>8&#160;</sup>In the morning, his spirit was troubled, and he sent and called for all of Egypt’s magicians and wise men. Pharaoh told them his dreams, but there was no one who could interpret them to Pharaoh. 
+</div><div class="p">
+<sup>9&#160;</sup>Then the chief cup bearer spoke to Pharaoh, saying, “I remember my faults today. 
+<sup>10&#160;</sup>Pharaoh was angry with his servants, and put me in custody in the house of the captain of the guard, with the chief baker. 
+<sup>11&#160;</sup>We dreamed a dream in one night, he and I. Each man dreamed according to the interpretation of his dream. 
+<sup>12&#160;</sup>There was with us there a young man, a Hebrew, servant to the captain of the guard, and we told him, and he interpreted to us our dreams. He interpreted to each man according to his dream. 
+<sup>13&#160;</sup>As he interpreted to us, so it was. He restored me to my office, and he hanged him.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Pharaoh sent and called Joseph, and they brought him hastily out of the dungeon. He shaved himself, changed his clothing, and came in to Pharaoh. 
+<sup>15&#160;</sup>Pharaoh said to Joseph, “I have dreamed a dream, and there is no one who can interpret it. I have heard it said of you, that when you hear a dream you can interpret it.” 
+</div><div class="p">
+<sup>16&#160;</sup>Joseph answered Pharaoh, saying, “It isn’t in me. Elohim will give Pharaoh an answer of peace.” 
+</div><div class="p">
+<sup>17&#160;</sup>Pharaoh spoke to Joseph, “In my dream, behold, I stood on the brink of the river; 
+<sup>18&#160;</sup>and behold, seven fat and sleek cattle came up out of the river. They fed in the marsh grass; 
+<sup>19&#160;</sup>and behold, seven other cattle came up after them, poor and very ugly and thin, such as I never saw in all the land of Egypt for ugliness. 
+<sup>20&#160;</sup>The thin and ugly cattle ate up the first seven fat cattle; 
+<sup>21&#160;</sup>and when they had eaten them up, it couldn’t be known that they had eaten them, but they were still ugly, as at the beginning. So I awoke. 
+<sup>22&#160;</sup>I saw in my dream, and behold, seven heads of grain came up on one stalk, full and good; 
+<sup>23&#160;</sup>and behold, seven heads of grain, withered, thin, and blasted with the east wind, sprung up after them. 
+<sup>24&#160;</sup>The thin heads of grain swallowed up the seven good heads of grain. I told it to the magicians, but there was no one who could explain it to me.” 
+</div><div class="p">
+<sup>25&#160;</sup>Joseph said to Pharaoh, “The dream of Pharaoh is one. What Elohim is about to do he has declared to Pharaoh. 
+<sup>26&#160;</sup>The seven good cattle are seven years; and the seven good heads of grain are seven years. The dream is one. 
+<sup>27&#160;</sup>The seven thin and ugly cattle that came up after them are seven years, and also the seven empty heads of grain blasted with the east wind; they will be seven years of famine. 
+<sup>28&#160;</sup>That is the thing which I have spoken to Pharaoh. Elohim has shown Pharaoh what he is about to do. 
+<sup>29&#160;</sup>Behold, seven years of great plenty throughout all the land of Egypt are coming. 
+<sup>30&#160;</sup>Seven years of famine will arise after them, and all the plenty will be forgotten in the land of Egypt. The famine will consume the land, 
+<sup>31&#160;</sup>and the plenty will not be known in the land by reason of that famine which follows; for it will be very grievous. 
+<sup>32&#160;</sup>The dream was doubled to Pharaoh, because the thing is established by Elohim, and Elohim will shortly bring it to pass. 
+</div><div class="p">
+<sup>33&#160;</sup>“Now therefore let Pharaoh look for a discreet and wise man, and set him over the land of Egypt. 
+<sup>34&#160;</sup>Let Pharaoh do this, and let him appoint overseers over the land, and take up the fifth part of the land of Egypt’s produce in the seven plenteous years. 
+<sup>35&#160;</sup>Let them gather all the food of these good years that come, and store grain under the hand of Pharaoh for food in the cities, and let them keep it. 
+<sup>36&#160;</sup>The food will be to supply the land against the seven years of famine, which will be in the land of Egypt; so that the land will not perish through the famine.” 
+</div><div class="p">
+<sup>37&#160;</sup>The thing was good in the eyes of Pharaoh, and in the eyes of all his servants. 
+<sup>38&#160;</sup>Pharaoh said to his servants, “Can we find such a one as this, a man in whom is the Spirit of Elohim?” 
+<sup>39&#160;</sup>Pharaoh said to Joseph, “Because Elohim has shown you all of this, there is no one so discreet and wise as you. 
+<sup>40&#160;</sup>You shall be over my house. All my people will be ruled according to your word. Only in the throne I will be greater than you.” 
+<sup>41&#160;</sup>Pharaoh said to Joseph, “Behold, I have set you over all the land of Egypt.” 
+<sup>42&#160;</sup>Pharaoh took off his signet ring from his hand, and put it on Joseph’s hand, and arrayed him in robes of fine linen, and put a gold chain about his neck. 
+<sup>43&#160;</sup>He made him ride in the second chariot which he had. They cried before him, “Bow the knee!” He set him over all the land of Egypt. 
+<sup>44&#160;</sup>Pharaoh said to Joseph, “I am Pharaoh. Without you, no man shall lift up his hand or his foot in all the land of Egypt.” 
+<sup>45&#160;</sup>Pharaoh called Joseph’s name Zaphenath-Paneah. He gave him Asenath, the daughter of Potiphera priest of On as a woman. Joseph went out over the land of Egypt. 
+</div><div class="p">
+<sup>46&#160;</sup>Joseph was thirty years old when he stood before Pharaoh king of Egypt. Joseph went out from the presence of Pharaoh, and went throughout all the land of Egypt. 
+<sup>47&#160;</sup>In the seven plenteous years the earth produced abundantly. 
+<sup>48&#160;</sup>He gathered up all the food of the seven years which were in the land of Egypt, and laid up the food in the cities. He stored food in each city from the fields around that city. 
+<sup>49&#160;</sup>Joseph laid up grain as the sand of the sea, very much, until he stopped counting, for it was without number. 
+<sup>50&#160;</sup>To Joseph were born two sons before the year of famine came, whom Asenath, the daughter of Potiphera priest of On, bore to him. 
+<sup>51&#160;</sup>Joseph called the name of the firstborn Manasseh, “For”, he said, “Elohim has made me forget all my toil, and all my father’s house.” 
+<sup>52&#160;</sup>The name of the second, he called Ephraim: “For Elohim has made me fruitful in the land of my affliction.” 
+</div><div class="p">
+<sup>53&#160;</sup>The seven years of plenty, that were in the land of Egypt, came to an end. 
+<sup>54&#160;</sup>The seven years of famine began to come, just as Joseph had said. There was famine in all lands, but in all the land of Egypt there was bread. 
+<sup>55&#160;</sup>When all the land of Egypt was famished, the people cried to Pharaoh for bread, and Pharaoh said to all the Egyptians, “Go to Joseph. What he says to you, do.” 
+<sup>56&#160;</sup>The famine was over all the surface of the earth. Joseph opened all the store houses, and sold to the Egyptians. The famine was severe in the land of Egypt. 
+<sup>57&#160;</sup>All countries came into Egypt, to Joseph, to buy grain, because the famine was severe in all the earth. 
+</div><h2 class="chapterlabel" id="42">42</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Jacob saw that there was grain in Egypt, and Jacob said to his sons, “Why do you look at one another?” 
+<sup>2&#160;</sup>He said, “Behold, I have heard that there is grain in Egypt. Go down there, and buy for us from there, so that we may live, and not die.” 
+<sup>3&#160;</sup>Joseph’s ten brothers went down to buy grain from Egypt. 
+<sup>4&#160;</sup>But Jacob didn’t send Benjamin, Joseph’s brother, with his brothers; for he said, “Lest perhaps harm happen to him.” 
+<sup>5&#160;</sup>The sons of Israel came to buy among those who came, for the famine was in the land of Canaan. 
+<sup>6&#160;</sup>Joseph was the governor over the land. It was he who sold to all the people of the land. Joseph’s brothers came, and bowed themselves down to him with their faces to the earth. 
+<sup>7&#160;</sup>Joseph saw his brothers, and he recognized them, but acted like a stranger to them, and spoke roughly with them. He said to them, “Where did you come from?” 
+</div><div class="p">They said, “From the land of Canaan, to buy food.” 
+</div><div class="p">
+<sup>8&#160;</sup>Joseph recognized his brothers, but they didn’t recognize him. 
+<sup>9&#160;</sup>Joseph remembered the dreams which he dreamed about them, and said to them, “You are spies! You have come to see the nakedness of the land.” 
+</div><div class="p">
+<sup>10&#160;</sup>They said to him, “No, my lord, but your servants have come to buy food. 
+<sup>11&#160;</sup>We are all one man’s sons; we are honest men. Your servants are not spies.” 
+</div><div class="p">
+<sup>12&#160;</sup>He said to them, “No, but you have come to see the nakedness of the land!” 
+</div><div class="p">
+<sup>13&#160;</sup>They said, “We, your servants, are twelve brothers, the sons of one man in the land of Canaan; and behold, the youngest is today with our father, and one is no more.” 
+</div><div class="p">
+<sup>14&#160;</sup>Joseph said to them, “It is like I told you, saying, ‘You are spies!’ 
+<sup>15&#160;</sup>By this you shall be tested. By the life of Pharaoh, you shall not go out from here, unless your youngest brother comes here. 
+<sup>16&#160;</sup>Send one of you, and let him get your brother, and you shall be bound, that your words may be tested, whether there is truth in you, or else by the life of Pharaoh surely you are spies.” 
+<sup>17&#160;</sup>He put them all together into custody for three days. 
+</div><div class="p">
+<sup>18&#160;</sup>Joseph said to them the third day, “Do this, and live, for I fear Elohim. 
+<sup>19&#160;</sup>If you are honest men, then let one of your brothers be bound in your prison; but you go, carry grain for the famine of your houses. 
+<sup>20&#160;</sup>Bring your youngest brother to me; so will your words be verified, and you won’t die.” 
+</div><div class="p">They did so. 
+<sup>21&#160;</sup>They said to one another, “We are certainly guilty concerning our brother, in that we saw the distress of his soul, when he begged us, and we wouldn’t listen. Therefore this distress has come upon us.” 
+<sup>22&#160;</sup>Reuben answered them, saying, “Didn’t I tell you, saying, ‘Don’t sin against the child,’ and you wouldn’t listen? Therefore also, behold, his blood is required.” 
+<sup>23&#160;</sup>They didn’t know that Joseph understood them; for there was an interpreter between them. 
+<sup>24&#160;</sup>He turned himself away from them, and wept. Then he returned to them, and spoke to them, and took Simeon from among them, and bound him before their eyes. 
+<sup>25&#160;</sup>Then Joseph gave a command to fill their bags with grain, and to restore each man’s money into his sack, and to give them food for the way. So it was done to them. 
+</div><div class="p">
+<sup>26&#160;</sup>They loaded their donkeys with their grain, and departed from there. 
+<sup>27&#160;</sup>As one of them opened his sack to give his donkey food in the lodging place, he saw his money. Behold, it was in the mouth of his sack. 
+<sup>28&#160;</sup>He said to his brothers, “My money is restored! Behold, it is in my sack!” Their hearts failed them, and they turned trembling to one another, saying, “What is this that Elohim has done to us?” 
+<sup>29&#160;</sup>They came to Jacob their father, to the land of Canaan, and told him all that had happened to them, saying, 
+<sup>30&#160;</sup>“The man, the lord of the land, spoke roughly with us, and took us for spies of the country. 
+<sup>31&#160;</sup>We said to him, ‘We are honest men. We are no spies. 
+<sup>32&#160;</sup>We are twelve brothers, sons of our father; one is no more, and the youngest is today with our father in the land of Canaan.’ 
+<sup>33&#160;</sup>The man, the lord of the land, said to us, ‘By this I will know that you are honest men: leave one of your brothers with me, and take grain for the famine of your houses, and go your way. 
+<sup>34&#160;</sup>Bring your youngest brother to me. Then I will know that you are not spies, but that you are honest men. So I will deliver your brother to you, and you shall trade in the land.’&#160;” 
+</div><div class="p">
+<sup>35&#160;</sup>As they emptied their sacks, behold, each man’s bundle of money was in his sack. When they and their father saw their bundles of money, they were afraid. 
+<sup>36&#160;</sup>Jacob, their father, said to them, “You have bereaved me of my children! Joseph is no more, Simeon is no more, and you want to take Benjamin away. All these things are against me.” 
+</div><div class="p">
+<sup>37&#160;</sup>Reuben spoke to his father, saying, “Kill my two sons, if I don’t bring him to you. Entrust him to my care, and I will bring him to you again.” 
+</div><div class="p">
+<sup>38&#160;</sup>He said, “My son shall not go down with you; for his brother is dead, and he only is left. If harm happens to him along the way in which you go, then you will bring down my gray hairs with sorrow to Sheol.” 
+</div><h2 class="chapterlabel" id="43">43</h2>
+<div class="p">
+<sup>1&#160;</sup>The famine was severe in the land. 
+<sup>2&#160;</sup>When they had eaten up the grain which they had brought out of Egypt, their father said to them, “Go again, buy us a little more food.” 
+</div><div class="p">
+<sup>3&#160;</sup>Judah spoke to him, saying, “The man solemnly warned us, saying, ‘You shall not see my face, unless your brother is with you.’ 
+<sup>4&#160;</sup>If you’ll send our brother with us, we’ll go down and buy you food; 
+<sup>5&#160;</sup>but if you don’t send him, we won’t go down, for the man said to us, ‘You shall not see my face, unless your brother is with you.’&#160;” 
+</div><div class="p">
+<sup>6&#160;</sup>Israel said, “Why did you treat me so badly, telling the man that you had another brother?” 
+</div><div class="p">
+<sup>7&#160;</sup>They said, “The man asked directly concerning ourselves, and concerning our relatives, saying, ‘Is your father still alive? Have you another brother?’ We just answered his questions. Is there any way we could know that he would say, ‘Bring your brother down’?” 
+</div><div class="p">
+<sup>8&#160;</sup>Judah said to Israel, his father, “Send the boy with me, and we’ll get up and go, so that we may live, and not die, both we, and you, and also our little ones. 
+<sup>9&#160;</sup>I’ll be collateral for him. From my hand will you require him. If I don’t bring him to you, and set him before you, then let me bear the blame forever; 
+<sup>10&#160;</sup>for if we hadn’t delayed, surely we would have returned a second time by now.” 
+</div><div class="p">
+<sup>11&#160;</sup>Their father, Israel, said to them, “If it must be so, then do this: Take from the choice fruits of the land in your bags, and carry down a present for the man, a little balm, a little honey, spices and myrrh, nuts, and almonds; 
+<sup>12&#160;</sup>and take double money in your hand, and take back the money that was returned in the mouth of your sacks. Perhaps it was an oversight. 
+<sup>13&#160;</sup>Take your brother also, get up, and return to the man. 
+<sup>14&#160;</sup>May Elohim Almighty give you mercy before the man, that he may release to you your other brother and Benjamin. If I am bereaved of my children, I am bereaved.” 
+</div><div class="p">
+<sup>15&#160;</sup>The men took that present, and they took double money in their hand, and Benjamin; and got up, went down to Egypt, and stood before Joseph. 
+<sup>16&#160;</sup>When Joseph saw Benjamin with them, he said to the steward of his house, “Bring the men into the house, and butcher an animal, and prepare; for the men will dine with me at noon.” 
+</div><div class="p">
+<sup>17&#160;</sup>The man did as Joseph commanded, and the man brought the men to Joseph’s house. 
+<sup>18&#160;</sup>The men were afraid, because they were brought to Joseph’s house; and they said, “Because of the money that was returned in our sacks the first time, we’re brought in; that he may seek occasion against us, attack us, and seize us as slaves, along with our donkeys.” 
+<sup>19&#160;</sup>They came near to the steward of Joseph’s house, and they spoke to him at the door of the house, 
+<sup>20&#160;</sup>and said, “Oh, my lord, we indeed came down the first time to buy food. 
+<sup>21&#160;</sup>When we came to the lodging place, we opened our sacks, and behold, each man’s money was in the mouth of his sack, our money in full weight. We have brought it back in our hand. 
+<sup>22&#160;</sup>We have brought down other money in our hand to buy food. We don’t know who put our money in our sacks.” 
+</div><div class="p">
+<sup>23&#160;</sup>He said, “Peace be to you. Don’t be afraid. Your Elohim, and the Elohim of your father, has given you treasure in your sacks. I received your money.” He brought Simeon out to them. 
+<sup>24&#160;</sup>The man brought the men into Joseph’s house, and gave them water, and they washed their feet. He gave their donkeys fodder. 
+<sup>25&#160;</sup>They prepared the present for Joseph’s coming at noon, for they heard that they should eat bread there. 
+</div><div class="p">
+<sup>26&#160;</sup>When Joseph came home, they brought him the present which was in their hand into the house, and bowed themselves down to the earth before him. 
+<sup>27&#160;</sup>He asked them of their welfare, and said, “Is your father well, the old man of whom you spoke? Is he yet alive?” 
+</div><div class="p">
+<sup>28&#160;</sup>They said, “Your servant, our father, is well. He is still alive.” They bowed down humbly. 
+<sup>29&#160;</sup>He lifted up his eyes, and saw Benjamin, his brother, his mother’s son, and said, “Is this your youngest brother, of whom you spoke to me?” He said, “Elohim be gracious to you, my son.” 
+<sup>30&#160;</sup>Joseph hurried, for his heart yearned over his brother; and he sought a place to weep. He entered into his room, and wept there. 
+<sup>31&#160;</sup>He washed his face, and came out. He controlled himself, and said, “Serve the meal.” 
+</div><div class="p">
+<sup>32&#160;</sup>They served him by himself, and them by themselves, and the Egyptians who ate with him by themselves, because the Egyptians don’t eat with the Hebrews, for that is an abomination to the Egyptians. 
+<sup>33&#160;</sup>They sat before him, the firstborn according to his birthright, and the youngest according to his youth, and the men marveled with one another. 
+<sup>34&#160;</sup>He sent portions to them from before him, but Benjamin’s portion was five times as much as any of theirs. They drank, and were merry with him. 
+</div><h2 class="chapterlabel" id="44">44</h2>
+<div class="p">
+<sup>1&#160;</sup>He commanded the steward of his house, saying, “Fill the men’s sacks with food, as much as they can carry, and put each man’s money in his sack’s mouth. 
+<sup>2&#160;</sup>Put my cup, the silver cup, in the sack’s mouth of the youngest, with his grain money.” He did according to the word that Joseph had spoken. 
+<sup>3&#160;</sup>As soon as the morning was light, the men were sent away, they and their donkeys. 
+<sup>4&#160;</sup>When they had gone out of the city, and were not yet far off, Joseph said to his steward, “Up, follow after the men. When you overtake them, ask them, ‘Why have you rewarded evil for good? 
+<sup>5&#160;</sup>Isn’t this that from which my lord drinks, and by which he indeed divines? You have done evil in so doing.’&#160;” 
+<sup>6&#160;</sup>He overtook them, and he spoke these words to them. 
+</div><div class="p">
+<sup>7&#160;</sup>They said to him, “Why does my lord speak such words as these? Far be it from your servants that they should do such a thing! 
+<sup>8&#160;</sup>Behold, the money, which we found in our sacks’ mouths, we brought again to you out of the land of Canaan. How then should we steal silver or gold out of your lord’s house? 
+<sup>9&#160;</sup>With whomever of your servants it is found, let him die, and we also will be my lord’s slaves.” 
+</div><div class="p">
+<sup>10&#160;</sup>He said, “Now also let it be according to your words. He with whom it is found will be my slave; and you will be blameless.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then they hurried, and each man took his sack down to the ground, and each man opened his sack. 
+<sup>12&#160;</sup>He searched, beginning with the oldest, and ending at the youngest. The cup was found in Benjamin’s sack. 
+<sup>13&#160;</sup>Then they tore their clothes, and each man loaded his donkey, and returned to the city. 
+</div><div class="p">
+<sup>14&#160;</sup>Judah and his brothers came to Joseph’s house, and he was still there. They fell on the ground before him. 
+<sup>15&#160;</sup>Joseph said to them, “What deed is this that you have done? Don’t you know that such a man as I can indeed do divination?” 
+</div><div class="p">
+<sup>16&#160;</sup>Judah said, “What will we tell my lord? What will we speak? How will we clear ourselves? Elohim has found out the iniquity of your servants. Behold, we are my lord’s slaves, both we and he also in whose hand the cup is found.” 
+</div><div class="p">
+<sup>17&#160;</sup>He said, “Far be it from me that I should do so. The man in whose hand the cup is found, he will be my slave; but as for you, go up in peace to your father.” 
+</div><div class="p">
+<sup>18&#160;</sup>Then Judah came near to him, and said, “Oh, my lord, please let your servant speak a word in my lord’s ears, and don’t let your anger burn against your servant; for you are even as Pharaoh. 
+<sup>19&#160;</sup>My lord asked his servants, saying, ‘Have you a father, or a brother?’ 
+<sup>20&#160;</sup>We said to my lord, ‘We have a father, an old man, and a child of his old age, a little one; and his brother is dead, and he alone is left of his mother; and his father loves him.’ 
+<sup>21&#160;</sup>You said to your servants, ‘Bring him down to me, that I may set my eyes on him.’ 
+<sup>22&#160;</sup>We said to my lord, ‘The boy can’t leave his father, for if he should leave his father, his father would die.’ 
+<sup>23&#160;</sup>You said to your servants, ‘Unless your youngest brother comes down with you, you will see my face no more.’ 
+<sup>24&#160;</sup>When we came up to your servant my father, we told him the words of my lord. 
+<sup>25&#160;</sup>Our father said, ‘Go again and buy us a little food.’ 
+<sup>26&#160;</sup>We said, ‘We can’t go down. If our youngest brother is with us, then we will go down: for we may not see the man’s face, unless our youngest brother is with us.’ 
+<sup>27&#160;</sup>Your servant, my father, said to us, ‘You know that my woman bore me two sons. 
+<sup>28&#160;</sup>One went out from me, and I said, “Surely he is torn in pieces;” and I haven’t seen him since. 
+<sup>29&#160;</sup>If you take this one also from me, and harm happens to him, you will bring down my gray hairs with sorrow to Sheol.’ 
+<sup>30&#160;</sup>Now therefore when I come to your servant my father, and the boy is not with us; since his life is bound up in the boy’s life; 
+<sup>31&#160;</sup>it will happen, when he sees that the boy is no more, that he will die. Your servants will bring down the gray hairs of your servant, our father, with sorrow to Sheol. 
+<sup>32&#160;</sup>For your servant became collateral for the boy to my father, saying, ‘If I don’t bring him to you, then I will bear the blame to my father forever.’ 
+<sup>33&#160;</sup>Now therefore, please let your servant stay instead of the boy, my lord’s slave; and let the boy go up with his brothers. 
+<sup>34&#160;</sup>For how will I go up to my father, if the boy isn’t with me?—lest I see the evil that will come on my father.” 
+</div><h2 class="chapterlabel" id="45">45</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Joseph couldn’t control himself before all those who stood before him, and he called out, “Cause everyone to go out from me!” No one else stood with him, while Joseph made himself known to his brothers. 
+<sup>2&#160;</sup>He wept aloud. The Egyptians heard, and the house of Pharaoh heard. 
+<sup>3&#160;</sup>Joseph said to his brothers, “I am Joseph! Does my father still live?” 
+</div><div class="p">His brothers couldn’t answer him; for they were terrified at his presence. 
+<sup>4&#160;</sup>Joseph said to his brothers, “Come near to me, please.” 
+</div><div class="p">They came near. He said, “I am Joseph, your brother, whom you sold into Egypt. 
+<sup>5&#160;</sup>Now don’t be grieved, nor angry with yourselves, that you sold me here, for Elohim sent me before you to preserve life. 
+<sup>6&#160;</sup>For these two years the famine has been in the land, and there are yet five years, in which there will be no plowing and no harvest. 
+<sup>7&#160;</sup>Elohim sent me before you to preserve for you a remnant in the earth, and to save you alive by a great deliverance. 
+<sup>8&#160;</sup>So now it wasn’t you who sent me here, but Elohim, and he has made me a father to Pharaoh, lord of all his house, and ruler over all the land of Egypt. 
+<sup>9&#160;</sup>Hurry, and go up to my father, and tell him, ‘This is what your son Joseph says, “Elohim has made me lord of all Egypt. Come down to me. Don’t wait. 
+<sup>10&#160;</sup>You shall dwell in the land of Goshen, and you will be near to me, you, your children, your children’s children, your flocks, your herds, and all that you have. 
+<sup>11&#160;</sup>There I will provide for you; for there are yet five years of famine; lest you come to poverty, you, and your household, and all that you have.”&#160;’ 
+<sup>12&#160;</sup>Behold, your eyes see, and the eyes of my brother Benjamin, that it is my mouth that speaks to you. 
+<sup>13&#160;</sup>You shall tell my father of all my glory in Egypt, and of all that you have seen. You shall hurry and bring my father down here.” 
+<sup>14&#160;</sup>He fell on his brother Benjamin’s neck and wept, and Benjamin wept on his neck. 
+<sup>15&#160;</sup>He kissed all his brothers, and wept on them. After that his brothers talked with him. 
+</div><div class="p">
+<sup>16&#160;</sup>The report of it was heard in Pharaoh’s house, saying, “Joseph’s brothers have come.” It pleased Pharaoh well, and his servants. 
+<sup>17&#160;</sup>Pharaoh said to Joseph, “Tell your brothers, ‘Do this: Load your animals, and go, travel to the land of Canaan. 
+<sup>18&#160;</sup>Take your father and your households, and come to me, and I will give you the good of the land of Egypt, and you will eat the fat of the land.’ 
+<sup>19&#160;</sup>Now you are commanded to do this: Take wagons out of the land of Egypt for your little ones, and for your women, and bring your father, and come. 
+<sup>20&#160;</sup>Also, don’t concern yourselves about your belongings, for the good of all the land of Egypt is yours.” 
+</div><div class="p">
+<sup>21&#160;</sup>The sons of Israel did so. Joseph gave them wagons, according to the commandment of Pharaoh, and gave them provision for the way. 
+<sup>22&#160;</sup>He gave each one of them changes of clothing, but to Benjamin he gave three hundred pieces of silver and five changes of clothing. 
+<sup>23&#160;</sup>He sent the following to his father: ten donkeys loaded with the good things of Egypt, and ten female donkeys loaded with grain and bread and provision for his father by the way. 
+<sup>24&#160;</sup>So he sent his brothers away, and they departed. He said to them, “See that you don’t quarrel on the way.” 
+</div><div class="p">
+<sup>25&#160;</sup>They went up out of Egypt, and came into the land of Canaan, to Jacob their father. 
+<sup>26&#160;</sup>They told him, saying, “Joseph is still alive, and he is ruler over all the land of Egypt.” His heart fainted, for he didn’t believe them. 
+<sup>27&#160;</sup>They told him all the words of Joseph, which he had said to them. When he saw the wagons which Joseph had sent to carry him, the spirit of Jacob, their father, revived. 
+<sup>28&#160;</sup>Israel said, “It is enough. Joseph my son is still alive. I will go and see him before I die.” 
+</div><h2 class="chapterlabel" id="46">46</h2>
+<div class="p">
+<sup>1&#160;</sup>Israel traveled with all that he had, and came to Beersheba, and offered sacrifices to the Elohim of his father, Isaac. 
+<sup>2&#160;</sup>Elohim spoke to Israel in the visions of the night, and said, “Jacob, Jacob!” 
+</div><div class="p">He said, “Here I am.” 
+</div><div class="p">
+<sup>3&#160;</sup>He said, “I am Elohim, the Elohim of your father. Don’t be afraid to go down into Egypt, for there I will make of you a great nation. 
+<sup>4&#160;</sup>I will go down with you into Egypt. I will also surely bring you up again. Joseph’s hand will close your eyes.” 
+</div><div class="p">
+<sup>5&#160;</sup>Jacob rose up from Beersheba, and the sons of Israel carried Jacob, their father, their little ones, and their women, in the wagons which Pharaoh had sent to carry him. 
+<sup>6&#160;</sup>They took their livestock, and their goods, which they had gotten in the land of Canaan, and came into Egypt—Jacob, and all his offspring with him, 
+<sup>7&#160;</sup>his sons, and his sons’ sons with him, his daughters, and his sons’ daughters, and he brought all his offspring with him into Egypt. 
+</div><div class="p">
+<sup>8&#160;</sup>These are the names of the children of Israel, who came into Egypt, Jacob and his sons: Reuben, Jacob’s firstborn. 
+<sup>9&#160;</sup>The sons of Reuben: Hanoch, Pallu, Hezron, and Carmi. 
+<sup>10&#160;</sup>The sons of Simeon: Jemuel, Jamin, Ohad, Jachin, Zohar, and Shaul the son of a Canaanite woman. 
+<sup>11&#160;</sup>The sons of Levi: Gershon, Kohath, and Merari. 
+<sup>12&#160;</sup>The sons of Judah: Er, Onan, Shelah, Perez, and Zerah; but Er and Onan died in the land of Canaan. The sons of Perez were Hezron and Hamul. 
+<sup>13&#160;</sup>The sons of Issachar: Tola, Puvah, Iob, and Shimron. 
+<sup>14&#160;</sup>The sons of Zebulun: Sered, Elon, and Jahleel. 
+<sup>15&#160;</sup>These are the sons of Leah, whom she bore to Jacob in Paddan Aram, with his daughter Dinah. All the souls of his sons and his daughters were thirty-three. 
+<sup>16&#160;</sup>The sons of Gad: Ziphion, Haggi, Shuni, Ezbon, Eri, Arodi, and Areli. 
+<sup>17&#160;</sup>The sons of Asher: Imnah, Ishvah, Ishvi, Beriah, and Serah their sister. The sons of Beriah: Heber and Malchiel. 
+<sup>18&#160;</sup>These are the sons of Zilpah, whom Laban gave to Leah, his daughter, and these she bore to Jacob, even sixteen souls. 
+<sup>19&#160;</sup>The sons of Rachel, Jacob’s woman: Joseph and Benjamin. 
+<sup>20&#160;</sup>To Joseph in the land of Egypt were born Manasseh and Ephraim, whom Asenath, the daughter of Potiphera, priest of On, bore to him. 
+<sup>21&#160;</sup>The sons of Benjamin: Bela, Becher, Ashbel, Gera, Naaman, Ehi, Rosh, Muppim, Huppim, and Ard. 
+<sup>22&#160;</sup>These are the sons of Rachel, who were born to Jacob: all the souls were fourteen. 
+<sup>23&#160;</sup>The son of Dan: Hushim. 
+<sup>24&#160;</sup>The sons of Naphtali: Jahzeel, Guni, Jezer, and Shillem. 
+<sup>25&#160;</sup>These are the sons of Bilhah, whom Laban gave to Rachel, his daughter, and these she bore to Jacob: all the souls were seven. 
+<sup>26&#160;</sup>All the souls who came with Jacob into Egypt, who were his direct offspring, in addition to Jacob’s sons’ women, all the souls were sixty-six. 
+<sup>27&#160;</sup>The sons of Joseph, who were born to him in Egypt, were two souls. All the souls of the house of Jacob, who came into Egypt, were seventy. 
+</div><div class="p">
+<sup>28&#160;</sup>Jacob sent Judah before him to Joseph, to show the way before him to Goshen, and they came into the land of Goshen. 
+<sup>29&#160;</sup>Joseph prepared his chariot, and went up to meet Israel, his father, in Goshen. He presented himself to him, and fell on his neck, and wept on his neck a good while. 
+<sup>30&#160;</sup>Israel said to Joseph, “Now let me die, since I have seen your face, that you are still alive.” 
+</div><div class="p">
+<sup>31&#160;</sup>Joseph said to his brothers, and to his father’s house, “I will go up, and speak with Pharaoh, and will tell him, ‘My brothers, and my father’s house, who were in the land of Canaan, have come to me. 
+<sup>32&#160;</sup>These men are shepherds, for they have been keepers of livestock, and they have brought their flocks, and their herds, and all that they have.’ 
+<sup>33&#160;</sup>It will happen, when Pharaoh summons you, and will say, ‘What is your occupation?’ 
+<sup>34&#160;</sup>that you shall say, ‘Your servants have been keepers of livestock from our youth even until now, both we, and our fathers:’ that you may dwell in the land of Goshen; for every shepherd is an abomination to the Egyptians.” 
+</div><h2 class="chapterlabel" id="47">47</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Joseph went in and told Pharaoh, and said, “My father and my brothers, with their flocks, their herds, and all that they own, have come out of the land of Canaan; and behold, they are in the land of Goshen.” 
+<sup>2&#160;</sup>From among his brothers he took five men, and presented them to Pharaoh. 
+<sup>3&#160;</sup>Pharaoh said to his brothers, “What is your occupation?” 
+</div><div class="p">They said to Pharaoh, “Your servants are shepherds, both we, and our fathers.” 
+<sup>4&#160;</sup>They also said to Pharaoh, “We have come to live as foreigners in the land, for there is no pasture for your servants’ flocks. For the famine is severe in the land of Canaan. Now therefore, please let your servants dwell in the land of Goshen.” 
+</div><div class="p">
+<sup>5&#160;</sup>Pharaoh spoke to Joseph, saying, “Your father and your brothers have come to you. 
+<sup>6&#160;</sup>The land of Egypt is before you. Make your father and your brothers dwell in the best of the land. Let them dwell in the land of Goshen. If you know any able men among them, then put them in charge of my livestock.” 
+</div><div class="p">
+<sup>7&#160;</sup>Joseph brought in Jacob, his father, and set him before Pharaoh; and Jacob blessed Pharaoh. 
+<sup>8&#160;</sup>Pharaoh said to Jacob, “How old are you?” 
+</div><div class="p">
+<sup>9&#160;</sup>Jacob said to Pharaoh, “The years of my pilgrimage are one hundred thirty years. The days of the years of my life have been few and evil. They have not attained to the days of the years of the life of my fathers in the days of their pilgrimage.” 
+<sup>10&#160;</sup>Jacob blessed Pharaoh, and went out from the presence of Pharaoh. 
+</div><div class="p">
+<sup>11&#160;</sup>Joseph placed his father and his brothers, and gave them a possession in the land of Egypt, in the best of the land, in the land of Rameses, as Pharaoh had commanded. 
+<sup>12&#160;</sup>Joseph provided his father, his brothers, and all of his father’s household with bread, according to the sizes of their families. 
+</div><div class="p">
+<sup>13&#160;</sup>There was no bread in all the land; for the famine was very severe, so that the land of Egypt and the land of Canaan fainted by reason of the famine. 
+<sup>14&#160;</sup>Joseph gathered up all the money that was found in the land of Egypt, and in the land of Canaan, for the grain which they bought: and Joseph brought the money into Pharaoh’s house. 
+<sup>15&#160;</sup>When the money was all spent in the land of Egypt, and in the land of Canaan, all the Egyptians came to Joseph, and said, “Give us bread, for why should we die in your presence? For our money fails.” 
+</div><div class="p">
+<sup>16&#160;</sup>Joseph said, “Give me your livestock; and I will give you food for your livestock, if your money is gone.” 
+</div><div class="p">
+<sup>17&#160;</sup>They brought their livestock to Joseph, and Joseph gave them bread in exchange for the horses, and for the flocks, and for the herds, and for the donkeys: and he fed them with bread in exchange for all their livestock for that year. 
+<sup>18&#160;</sup>When that year was ended, they came to him the second year, and said to him, “We will not hide from my lord how our money is all spent, and the herds of livestock are my lord’s. There is nothing left in the sight of my lord, but our bodies, and our lands. 
+<sup>19&#160;</sup>Why should we die before your eyes, both we and our land? Buy us and our land for bread, and we and our land will be servants to Pharaoh. Give us seed, that we may live, and not die, and that the land won’t be desolate.” 
+</div><div class="p">
+<sup>20&#160;</sup>So Joseph bought all the land of Egypt for Pharaoh, for every man of the Egyptians sold his field, because the famine was severe on them, and the land became Pharaoh’s. 
+<sup>21&#160;</sup>As for the people, he moved them to the cities from one end of the border of Egypt even to the other end of it. 
+<sup>22&#160;</sup>Only he didn’t buy the land of the priests, for the priests had a portion from Pharaoh, and ate their portion which Pharaoh gave them. That is why they didn’t sell their land. 
+<sup>23&#160;</sup>Then Joseph said to the people, “Behold, I have bought you and your land today for Pharaoh. Behold, here is seed for you, and you shall sow the land. 
+<sup>24&#160;</sup>It will happen at the harvests, that you shall give a fifth to Pharaoh, and four parts will be your own, for seed of the field, for your food, for them of your households, and for food for your little ones.” 
+</div><div class="p">
+<sup>25&#160;</sup>They said, “You have saved our lives! Let us find favor in the sight of my lord, and we will be Pharaoh’s servants.” 
+</div><div class="p">
+<sup>26&#160;</sup>Joseph made it a statute concerning the land of Egypt to this day, that Pharaoh should have the fifth. Only the land of the priests alone didn’t become Pharaoh’s. 
+</div><div class="p">
+<sup>27&#160;</sup>Israel lived in the land of Egypt, in the land of Goshen; and they got themselves possessions therein, and were fruitful, and multiplied exceedingly. 
+<sup>28&#160;</sup>Jacob lived in the land of Egypt seventeen years. So the days of Jacob, the years of his life, were one hundred forty-seven years. 
+<sup>29&#160;</sup>The time came near that Israel must die, and he called his son Joseph, and said to him, “If now I have found favor in your sight, please put your hand under my thigh, and deal kindly and truly with me. Please don’t bury me in Egypt, 
+<sup>30&#160;</sup>but when I sleep with my fathers, you shall carry me out of Egypt, and bury me in their burying place.” 
+</div><div class="p">Joseph said, “I will do as you have said.” 
+</div><div class="p">
+<sup>31&#160;</sup>Israel said, “Swear to me,” and he swore to him. Then Israel bowed himself on the bed’s head. 
+</div><h2 class="chapterlabel" id="48">48</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, someone said to Joseph, “Behold, your father is sick.” He took with him his two sons, Manasseh and Ephraim. 
+<sup>2&#160;</sup>Someone told Jacob, and said, “Behold, your son Joseph comes to you,” and Israel strengthened himself, and sat on the bed. 
+<sup>3&#160;</sup>Jacob said to Joseph, “Elohim Almighty appeared to me at Luz in the land of Canaan, and blessed me, 
+<sup>4&#160;</sup>and said to me, ‘Behold, I will make you fruitful, and multiply you, and I will make of you a company of peoples, and will give this land to your offspring after you for an everlasting possession.’ 
+<sup>5&#160;</sup>Now your two sons, who were born to you in the land of Egypt before I came to you into Egypt, are mine; Ephraim and Manasseh, even as Reuben and Simeon, will be mine. 
+<sup>6&#160;</sup>Your offspring, whom you become the father of after them, will be yours. They will be called after the name of their brothers in their inheritance. 
+<sup>7&#160;</sup>As for me, when I came from Paddan, Rachel died beside me in the land of Canaan on the way, when there was still some distance to come to Ephrath, and I buried her there on the way to Ephrath (also called Bethlehem).” 
+</div><div class="p">
+<sup>8&#160;</sup>Israel saw Joseph’s sons, and said, “Who are these?” 
+</div><div class="p">
+<sup>9&#160;</sup>Joseph said to his father, “They are my sons, whom Elohim has given me here.” 
+</div><div class="p">He said, “Please bring them to me, and I will bless them.” 
+<sup>10&#160;</sup>Now the eyes of Israel were dim for age, so that he couldn’t see well. Joseph brought them near to him; and he kissed them, and embraced them. 
+<sup>11&#160;</sup>Israel said to Joseph, “I didn’t think I would see your face, and behold, Elohim has let me see your offspring also.” 
+<sup>12&#160;</sup>Joseph brought them out from between his knees, and he bowed himself with his face to the earth. 
+<sup>13&#160;</sup>Joseph took them both, Ephraim in his right hand toward Israel’s left hand, and Manasseh in his left hand toward Israel’s right hand, and brought them near to him. 
+<sup>14&#160;</sup>Israel stretched out his right hand, and laid it on Ephraim’s head, who was the younger, and his left hand on Manasseh’s head, guiding his hands knowingly, for Manasseh was the firstborn. 
+<sup>15&#160;</sup>He blessed Joseph, and said, 
+</div><div class="q1">“The Elohim before whom my fathers Abraham and Isaac walked, 
+</div><div class="q1">the Elohim who has fed me all my life long to this day, 
+</div><div class="q1">
+<sup>16&#160;</sup>the angel who has redeemed me from all evil, bless the lads, 
+</div><div class="q1">and let my name be named on them, 
+</div><div class="q1">and the name of my fathers Abraham and Isaac. 
+</div><div class="q1">Let them grow into a multitude upon the earth.” 
+</div><div class="p">
+<sup>17&#160;</sup>When Joseph saw that his father laid his right hand on the head of Ephraim, it displeased him. He held up his father’s hand, to remove it from Ephraim’s head to Manasseh’s head. 
+<sup>18&#160;</sup>Joseph said to his father, “Not so, my father, for this is the firstborn. Put your right hand on his head.” 
+</div><div class="p">
+<sup>19&#160;</sup>His father refused, and said, “I know, my son, I know. He also will become a people, and he also will be great. However, his younger brother will be greater than he, and his offspring will become a multitude of nations.” 
+<sup>20&#160;</sup>He blessed them that day, saying, “Israel will bless in you, saying, ‘Elohim make you as Ephraim and as Manasseh’&#160;” He set Ephraim before Manasseh. 
+<sup>21&#160;</sup>Israel said to Joseph, “Behold, I am dying, but Elohim will be with you, and bring you again to the land of your fathers. 
+<sup>22&#160;</sup>Moreover I have given to you one portion above your brothers, which I took out of the hand of the Amorite with my sword and with my bow.” 
+</div><h2 class="chapterlabel" id="49">49</h2>
+<div class="p">
+<sup>1&#160;</sup>Jacob called to his sons, and said: “Gather yourselves together, that I may tell you that which will happen to you in the days to come. 
+</div><div class="q1">
+<sup>2&#160;</sup>Assemble yourselves, and hear, you sons of Jacob. 
+</div><div class="q2">Listen to Israel, your father. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Reuben, you are my firstborn, my might, and the beginning of my strength, 
+</div><div class="q2">excelling in dignity, and excelling in power. 
+</div><div class="q1">
+<sup>4&#160;</sup>Boiling over like water, you shall not excel, 
+</div><div class="q2">because you went up to your father’s bed, 
+</div><div class="q2">then defiled it. He went up to my couch. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Simeon and Levi are brothers. 
+</div><div class="q2">Their swords are weapons of violence. 
+</div><div class="q1">
+<sup>6&#160;</sup>My soul, don’t come into their council. 
+</div><div class="q2">My glory, don’t be united to their assembly; 
+</div><div class="q1">for in their anger they killed men. 
+</div><div class="q2">In their self-will they hamstrung cattle. 
+</div><div class="q1">
+<sup>7&#160;</sup>Cursed be their anger, for it was fierce; 
+</div><div class="q2">and their wrath, for it was cruel. 
+</div><div class="q1">I will divide them in Jacob, 
+</div><div class="q2">and scatter them in Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Judah, your brothers will praise you. 
+</div><div class="q2">Your hand will be on the neck of your enemies. 
+</div><div class="q2">Your father’s sons will bow down before you. 
+</div><div class="q1">
+<sup>9&#160;</sup>Judah is a lion’s cub. 
+</div><div class="q2">From the prey, my son, you have gone up. 
+</div><div class="q1">He stooped down, he crouched as a lion, 
+</div><div class="q2">as a lioness. 
+</div><div class="q2">Who will rouse him up? 
+</div><div class="q1">
+<sup>10&#160;</sup>The scepter will not depart from Judah, 
+</div><div class="q2">nor the ruler’s staff from between his feet, 
+</div><div class="q1">until he comes to whom it belongs. 
+</div><div class="q2">The obedience of the peoples will be to him. 
+</div><div class="q1">
+<sup>11&#160;</sup>Binding his foal to the vine, 
+</div><div class="q2">his donkey’s colt to the choice vine, 
+</div><div class="q1">he has washed his garments in wine, 
+</div><div class="q2">his robes in the blood of grapes. 
+</div><div class="q1">
+<sup>12&#160;</sup>His eyes will be red with wine, 
+</div><div class="q2">his teeth white with milk. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“Zebulun will dwell at the haven of the sea. 
+</div><div class="q2">He will be for a haven of ships. 
+</div><div class="q2">His border will be on Sidon. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“Issachar is a strong donkey, 
+</div><div class="q2">lying down between the saddlebags. 
+</div><div class="q1">
+<sup>15&#160;</sup>He saw a resting place, that it was good, 
+</div><div class="q2">the land, that it was pleasant. 
+</div><div class="q1">He bows his shoulder to the burden, 
+</div><div class="q2">and becomes a servant doing forced labor. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>“Dan will judge his people, 
+</div><div class="q2">as one of the tribes of Israel. 
+</div><div class="q1">
+<sup>17&#160;</sup>Dan will be a serpent on the trail, 
+</div><div class="q2">an adder in the path, 
+</div><div class="q1">that bites the horse’s heels, 
+</div><div class="q2">so that his rider falls backward. 
+</div><div class="q1">
+<sup>18&#160;</sup>I have waited for your salvation, Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“A troop will press on Gad, 
+</div><div class="q2">but he will press on their heel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Asher’s food will be rich. 
+</div><div class="q2">He will produce royal dainties. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Naphtali is a doe set free, 
+</div><div class="q2">who bears beautiful fawns. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“Joseph is a fruitful vine, 
+</div><div class="q2">a fruitful vine by a spring. 
+</div><div class="q2">His branches run over the wall. 
+</div><div class="q1">
+<sup>23&#160;</sup>The archers have severely grieved him, 
+</div><div class="q2">shot at him, and persecuted him: 
+</div><div class="q1">
+<sup>24&#160;</sup>But his bow remained strong. 
+</div><div class="q2">The arms of his hands were made strong, 
+</div><div class="q2">by the hands of the Mighty One of Jacob, 
+</div><div class="q2">(from there is the shepherd, the stone of Israel), 
+</div><div class="q1">
+<sup>25&#160;</sup>even by the Elohim of your father, who will help you, 
+</div><div class="q2">by the Almighty, who will bless you, 
+</div><div class="q1">with blessings of heaven above, 
+</div><div class="q2">blessings of the deep that lies below, 
+</div><div class="q2">blessings of the breasts, and of the womb. 
+</div><div class="q1">
+<sup>26&#160;</sup>The blessings of your father have prevailed above the blessings of my ancestors, 
+</div><div class="q2">above the boundaries of the ancient hills. 
+</div><div class="q1">They will be on the head of Joseph, 
+</div><div class="q2">on the crown of the head of him who is separated from his brothers. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>27&#160;</sup>“Benjamin is a ravenous wolf. 
+</div><div class="q2">In the morning he will devour the prey. 
+</div><div class="q2">At evening he will divide the plunder.” 
+</div><div class="p">
+<sup>28&#160;</sup>All these are the twelve tribes of Israel, and this is what their father spoke to them, and blessed them. He blessed everyone according to his own blessing. 
+<sup>29&#160;</sup>He instructed them, and said to them, “I am to be gathered to my people. Bury me with my fathers in the cave that is in the field of Ephron the Hittite, 
+<sup>30&#160;</sup>in the cave that is in the field of Machpelah, which is before Mamre, in the land of Canaan, which Abraham bought with the field from Ephron the Hittite as a burial place. 
+<sup>31&#160;</sup>There they buried Abraham and Sarah, his woman. There they buried Isaac and Rebekah, his woman, and there I buried Leah: 
+<sup>32&#160;</sup>the field and the cave that is therein, which was purchased from the children of Heth.” 
+<sup>33&#160;</sup>When Jacob finished charging his sons, he gathered up his feet into the bed, breathed his last breath, and was gathered to his people. 
+</div><h2 class="chapterlabel" id="50">50</h2>
+<div class="nb">
+<sup>1&#160;</sup>Joseph fell on his father’s face, wept on him, and kissed him. 
+<sup>2&#160;</sup>Joseph commanded his servants, the physicians, to embalm his father; and the physicians embalmed Israel. 
+<sup>3&#160;</sup>Forty days were used for him, for that is how many days it takes to embalm. The Egyptians wept for Israel for seventy days. 
+</div><div class="p">
+<sup>4&#160;</sup>When the days of weeping for him were past, Joseph spoke to Pharaoh’s staff, saying, “If now I have found favor in your eyes, please speak in the ears of Pharaoh, saying, 
+<sup>5&#160;</sup>‘My father made me swear, saying, “Behold, I am dying. Bury me in my grave which I have dug for myself in the land of Canaan.” Now therefore, please let me go up and bury my father, and I will come again.’&#160;” 
+</div><div class="p">
+<sup>6&#160;</sup>Pharaoh said, “Go up, and bury your father, just like he made you swear.” 
+</div><div class="p">
+<sup>7&#160;</sup>Joseph went up to bury his father; and with him went up all the servants of Pharaoh, the elders of his house, all the elders of the land of Egypt, 
+<sup>8&#160;</sup>all the house of Joseph, his brothers, and his father’s house. Only their little ones, their flocks, and their herds, they left in the land of Goshen. 
+<sup>9&#160;</sup>Both chariots and horsemen went up with him. It was a very great company. 
+<sup>10&#160;</sup>They came to the threshing floor of Atad, which is beyond the Jordan, and there they lamented with a very great and severe lamentation. He mourned for his father seven days. 
+<sup>11&#160;</sup>When the inhabitants of the land, the Canaanites, saw the mourning in the floor of Atad, they said, “This is a grievous mourning by the Egyptians.” Therefore its name was called Abel Mizraim, which is beyond the Jordan. 
+<sup>12&#160;</sup>His sons did to him just as he commanded them, 
+<sup>13&#160;</sup>for his sons carried him into the land of Canaan, and buried him in the cave of the field of Machpelah, which Abraham bought with the field, as a possession for a burial site, from Ephron the Hittite, near Mamre. 
+<sup>14&#160;</sup>Joseph returned into Egypt—he, and his brothers, and all that went up with him to bury his father, after he had buried his father. 
+</div><div class="p">
+<sup>15&#160;</sup>When Joseph’s brothers saw that their father was dead, they said, “It may be that Joseph will hate us, and will fully pay us back for all the evil which we did to him.” 
+<sup>16&#160;</sup>They sent a message to Joseph, saying, “Your father commanded before he died, saying, 
+<sup>17&#160;</sup>‘You shall tell Joseph, “Now please forgive the disobedience of your brothers, and their sin, because they did evil to you.”&#160;’ Now, please forgive the disobedience of the servants of the Elohim of your father.” Joseph wept when they spoke to him. 
+<sup>18&#160;</sup>His brothers also went and fell down before his face; and they said, “Behold, we are your servants.” 
+<sup>19&#160;</sup>Joseph said to them, “Don’t be afraid, for am I in the place of Elohim? 
+<sup>20&#160;</sup>As for you, you meant evil against me, but Elohim meant it for good, to save many people alive, as is happening today. 
+<sup>21&#160;</sup>Now therefore don’t be afraid. I will provide for you and your little ones.” He comforted them, and spoke kindly to them. 
+</div><div class="p">
+<sup>22&#160;</sup>Joseph lived in Egypt, he, and his father’s house. Joseph lived one hundred ten years. 
+<sup>23&#160;</sup>Joseph saw Ephraim’s children to the third generation. The children also of Machir, the son of Manasseh, were born on Joseph’s knees. 
+<sup>24&#160;</sup>Joseph said to his brothers, “I am dying, but Elohim will surely visit you, and bring you up out of this land to the land which he swore to Abraham, to Isaac, and to Jacob.” 
+<sup>25&#160;</sup>Joseph took an oath from the children of Israel, saying, “Elohim will surely visit you, and you shall carry up my bones from here.” 
+<sup>26&#160;</sup>So Joseph died, being one hundred ten years old, and they embalmed him, and he was put in a coffin in Egypt. </div></div><script src="../main.js"></script></body></html>

--- a/book/habakkuk.html
+++ b/book/habakkuk.html
@@ -3,6 +3,47 @@
 <head>
 <title>Habakkuk</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,137 +53,141 @@
 <div class="main">
 <!-- HAB World English Scripture (WES) -->
 <h1 class="booklabel">Habakkuk</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The revelation which Habakkuk the prophet saw. 
-<span class="v">2&#160;</span>Yahweh,<span class="f">+ \fr 1:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> how long will I cry, and you will not hear? I cry out to you “Violence!” and will you not save? 
-<span class="v">3&#160;</span>Why do you show me iniquity, and look at perversity? For destruction and violence are before me. There is strife, and contention rises up. 
-<span class="v">4&#160;</span>Therefore the law is paralyzed, and justice never prevails; for the wicked surround the righteous; therefore justice comes out perverted. 
-</p><p>
-<span class="v">5&#160;</span>“Look among the nations, watch, and wonder marvelously; for I am working a work in your days which you will not believe though it is told you. 
-<span class="v">6&#160;</span>For, behold,<span class="f">+ \fr 1:6 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I am raising up the Chaldeans, that bitter and hasty nation who march through the width of the earth, to possess dwelling places that are not theirs. 
-<span class="v">7&#160;</span>They are feared and dreaded. Their judgment and their dignity proceed from themselves. 
-<span class="v">8&#160;</span>Their horses also are swifter than leopards, and are more fierce than the evening wolves. Their horsemen press proudly on. Yes, their horsemen come from afar. They fly as an eagle that hurries to devour. 
-<span class="v">9&#160;</span>All of them come for violence. Their hordes face forward. They gather prisoners like sand. 
-<span class="v">10&#160;</span>Yes, they scoff at kings, and princes are a derision to them. They laugh at every stronghold, for they build up an earthen ramp and take it. 
-<span class="v">11&#160;</span>Then they sweep by like the wind and go on. They are indeed guilty, whose strength is their elohim.” 
-</p><p>
-<span class="v">12&#160;</span>Aren’t you from everlasting, Yahweh my Elohim,<span class="f">+ \fr 1:12 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> my Set-Apart One? We will not die. Yahweh, you have appointed them for judgment. You, Rock, have established him to punish. 
-<span class="v">13&#160;</span>You who have purer eyes than to see evil, and who cannot look on perversity, why do you tolerate those who deal treacherously and keep silent when the wicked swallows up the man who is more righteous than he, 
-<span class="v">14&#160;</span>and make men like the fish of the sea, like the creeping things that have no ruler over them? 
-<span class="v">15&#160;</span>He takes up all of them with the hook. He catches them in his net and gathers them in his dragnet. Therefore he rejoices and is glad. 
-<span class="v">16&#160;</span>Therefore he sacrifices to his net and burns incense to his dragnet, because by them his life is luxurious and his food is good. 
-<span class="v">17&#160;</span>Will he therefore continually empty his net, and kill the nations without mercy? 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>I will stand at my watch and set myself on the ramparts, and will look out to see what he will say to me, and what I will answer concerning my complaint. 
-</p><p>
-<span class="v">2&#160;</span>Yahweh answered me, “Write the vision, and make it plain on tablets, that he who runs may read it. 
-<span class="v">3&#160;</span>For the vision is yet for the appointed time, and it hurries toward the end, and won’t prove false. Though it takes time, wait for it, because it will surely come. It won’t delay. 
-<span class="v">4&#160;</span>Behold, his soul is puffed up. It is not upright in him, but the righteous will live by his faith. 
-<span class="v">5&#160;</span>Yes, moreover, wine is treacherous: an arrogant man who doesn’t stay at home, who enlarges his desire as Sheol;<span class="f">+ \fr 2:5 \ft Sheol is the place of the dead. </span> he is like death and can’t be satisfied, but gathers to himself all nations and heaps to himself all peoples. 
-</p><p>
-<span class="v">6&#160;</span>Won’t all these take up a parable against him, and a taunting proverb against him, and say, ‘Woe to him who increases that which is not his, and who enriches himself by extortion! How long?’ 
-<span class="v">7&#160;</span>Won’t your debtors rise up suddenly, and wake up those who make you tremble, and you will be their victim? 
-<span class="v">8&#160;</span>Because you have plundered many nations, all the remnant of the peoples will plunder you because of men’s blood, and for the violence done to the land, to the city and to all who dwell in it. 
-</p><p>
-<span class="v">9&#160;</span>Woe to him who gets an evil gain for his house, that he may set his nest on high, that he may be delivered from the hand of evil! 
-<span class="v">10&#160;</span>You have devised shame to your house by cutting off many peoples, and have sinned against your soul. 
-<span class="v">11&#160;</span>For the stone will cry out of the wall, and the beam out of the woodwork will answer it. 
-</p><p>
-<span class="v">12&#160;</span>Woe to him who builds a town with blood, and establishes a city by iniquity! 
-<span class="v">13&#160;</span>Behold, isn’t it from Yahweh of Armies that the peoples labor for the fire, and the nations weary themselves for vanity? 
-<span class="v">14&#160;</span>For the earth will be filled with the knowledge of Yahweh’s glory, as the waters cover the sea. 
-</p><p>
-<span class="v">15&#160;</span>“Woe to him who gives his neighbor drink, pouring your inflaming wine until they are drunk, so that you may gaze at their naked bodies! 
-<span class="v">16&#160;</span>You are filled with shame, and not glory. You will also drink and be exposed! The cup of Yahweh’s right hand will come around to you, and disgrace will cover your glory. 
-<span class="v">17&#160;</span>For the violence done to Lebanon will overwhelm you, and the destruction of the animals will terrify you, because of men’s blood and for the violence done to the land, to every city and to those who dwell in them. 
-</p><p>
-<span class="v">18&#160;</span>“What value does the engraved image have, that its maker has engraved it; the molten image, even the teacher of lies, that he who fashions its form trusts in it, to make mute idols? 
-<span class="v">19&#160;</span>Woe to him who says to the wood, ‘Awake!’ or to the mute stone, ‘Arise!’ Shall this teach? Behold, it is overlaid with gold and silver, and there is no breath at all within it. 
-<span class="v">20&#160;</span>But Yahweh is in his set-apart temple. Let all the earth be silent before him!” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>A prayer of Habakkuk, the prophet, set to victorious music. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh, I have heard of your fame. 
-</p><p class="q2">I stand in awe of your deeds, Yahweh. 
-</p><p class="q1">Renew your work in the middle of the years. 
-</p><p class="q2">In the middle of the years make it known. 
-</p><p class="q2">In wrath, you remember mercy. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Elohim came from Teman, 
-</p><p class="q2">the Set-Apart One from Mount Paran. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">His glory covered the heavens, 
-</p><p class="q2">and his praise filled the earth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>His splendor is like the sunrise. 
-</p><p class="q2">Rays shine from his hand, where his power is hidden. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Plague went before him, 
-</p><p class="q2">and pestilence followed his feet. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He stood, and shook the earth. 
-</p><p class="q2">He looked, and made the nations tremble. 
-</p><p class="q2">The ancient mountains were crumbled. 
-</p><p class="q2">The age-old hills collapsed. 
-</p><p class="q2">His ways are eternal. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I saw the tents of Cushan in affliction. 
-</p><p class="q2">The dwellings of the land of Midian trembled. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Was Yahweh displeased with the rivers? 
-</p><p class="q2">Was your anger against the rivers, 
-</p><p class="q2">or your wrath against the sea, 
-</p><p class="q2">that you rode on your horses, 
-</p><p class="q2">on your chariots of salvation? 
-</p><p class="q1">
-<span class="v">9&#160;</span>You uncovered your bow. 
-</p><p class="q2">You called for your sworn arrows. </p><p class="qs">Selah.</p> 
-</p><p class="q1">You split the earth with rivers. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The mountains saw you, and were afraid. 
-</p><p class="q2">The storm of waters passed by. 
-</p><p class="q2">The deep roared and lifted up its hands on high. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The sun and moon stood still in the sky 
-</p><p class="q2">at the light of your arrows as they went, 
-</p><p class="q2">at the shining of your glittering spear. 
-</p><p class="q1">
-<span class="v">12&#160;</span>You marched through the land in wrath. 
-</p><p class="q2">You threshed the nations in anger. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You went out for the salvation of your people, 
-</p><p class="q2">for the salvation of your anointed. 
-</p><p class="q1">You crushed the head of the land of wickedness. 
-</p><p class="q2">You stripped them head to foot. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>You pierced the heads of his warriors with their own spears. 
-</p><p class="q2">They came as a whirlwind to scatter me, 
-</p><p class="q2">gloating as if to devour the wretched in secret. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You trampled the sea with your horses, 
-</p><p class="q2">churning mighty waters. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I heard, and my body trembled. 
-</p><p class="q2">My lips quivered at the voice. 
-</p><p class="q1">Rottenness enters into my bones, and I tremble in my place 
-</p><p class="q2">because I must wait quietly for the day of trouble, 
-</p><p class="q2">for the coming up of the people who invade us. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For even though the fig tree doesn’t flourish, 
-</p><p class="q2">nor fruit be in the vines, 
-</p><p class="q2">the labor of the olive fails, 
-</p><p class="q2">the fields yield no food, 
-</p><p class="q2">the flocks are cut off from the fold, 
-</p><p class="q2">and there is no herd in the stalls, 
-</p><p class="q1">
-<span class="v">18&#160;</span>yet I will rejoice in Yahweh. 
-</p><p class="q2">I will be joyful in the Elohim of my salvation! 
-</p><p class="q1">
-<span class="v">19&#160;</span>Yahweh, the Lord,<span class="f">+ \fr 3:19 \ft The word translated “Lord” is “Adonai.”</span> is my strength. 
-</p><p class="q2">He makes my feet like deer’s feet, 
-</p><p class="q2">and enables me to go in high places. 
-</p><p>For the music director, on my stringed instruments. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The revelation which Habakkuk the prophet saw. 
+<sup>2&#160;</sup>Yahweh, how long will I cry, and you will not hear? I cry out to you “Violence!” and will you not save? 
+<sup>3&#160;</sup>Why do you show me iniquity, and look at perversity? For destruction and violence are before me. There is strife, and contention rises up. 
+<sup>4&#160;</sup>Therefore the law is paralyzed, and justice never prevails; for the wicked surround the righteous; therefore justice comes out perverted. 
+</div><div class="p">
+<sup>5&#160;</sup>“Look among the nations, watch, and wonder marvelously; for I am working a work in your days which you will not believe though it is told you. 
+<sup>6&#160;</sup>For, behold, I am raising up the Chaldeans, that bitter and hasty nation who march through the width of the earth, to possess dwelling places that are not theirs. 
+<sup>7&#160;</sup>They are feared and dreaded. Their judgment and their dignity proceed from themselves. 
+<sup>8&#160;</sup>Their horses also are swifter than leopards, and are more fierce than the evening wolves. Their horsemen press proudly on. Yes, their horsemen come from afar. They fly as an eagle that hurries to devour. 
+<sup>9&#160;</sup>All of them come for violence. Their hordes face forward. They gather prisoners like sand. 
+<sup>10&#160;</sup>Yes, they scoff at kings, and princes are a derision to them. They laugh at every stronghold, for they build up an earthen ramp and take it. 
+<sup>11&#160;</sup>Then they sweep by like the wind and go on. They are indeed guilty, whose strength is their elohim.” 
+</div><div class="p">
+<sup>12&#160;</sup>Aren’t you from everlasting, Yahweh my Elohim, my Set-Apart One? We will not die. Yahweh, you have appointed them for judgment. You, Rock, have established him to punish. 
+<sup>13&#160;</sup>You who have purer eyes than to see evil, and who cannot look on perversity, why do you tolerate those who deal treacherously and keep silent when the wicked swallows up the man who is more righteous than he, 
+<sup>14&#160;</sup>and make men like the fish of the sea, like the creeping things that have no ruler over them? 
+<sup>15&#160;</sup>He takes up all of them with the hook. He catches them in his net and gathers them in his dragnet. Therefore he rejoices and is glad. 
+<sup>16&#160;</sup>Therefore he sacrifices to his net and burns incense to his dragnet, because by them his life is luxurious and his food is good. 
+<sup>17&#160;</sup>Will he therefore continually empty his net, and kill the nations without mercy? 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>I will stand at my watch and set myself on the ramparts, and will look out to see what he will say to me, and what I will answer concerning my complaint. 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh answered me, “Write the vision, and make it plain on tablets, that he who runs may read it. 
+<sup>3&#160;</sup>For the vision is yet for the appointed time, and it hurries toward the end, and won’t prove false. Though it takes time, wait for it, because it will surely come. It won’t delay. 
+<sup>4&#160;</sup>Behold, his soul is puffed up. It is not upright in him, but the righteous will live by his faith. 
+<sup>5&#160;</sup>Yes, moreover, wine is treacherous: an arrogant man who doesn’t stay at home, who enlarges his desire as Sheol; he is like death and can’t be satisfied, but gathers to himself all nations and heaps to himself all peoples. 
+</div><div class="p">
+<sup>6&#160;</sup>Won’t all these take up a parable against him, and a taunting proverb against him, and say, ‘Woe to him who increases that which is not his, and who enriches himself by extortion! How long?’ 
+<sup>7&#160;</sup>Won’t your debtors rise up suddenly, and wake up those who make you tremble, and you will be their victim? 
+<sup>8&#160;</sup>Because you have plundered many nations, all the remnant of the peoples will plunder you because of men’s blood, and for the violence done to the land, to the city and to all who dwell in it. 
+</div><div class="p">
+<sup>9&#160;</sup>Woe to him who gets an evil gain for his house, that he may set his nest on high, that he may be delivered from the hand of evil! 
+<sup>10&#160;</sup>You have devised shame to your house by cutting off many peoples, and have sinned against your soul. 
+<sup>11&#160;</sup>For the stone will cry out of the wall, and the beam out of the woodwork will answer it. 
+</div><div class="p">
+<sup>12&#160;</sup>Woe to him who builds a town with blood, and establishes a city by iniquity! 
+<sup>13&#160;</sup>Behold, isn’t it from Yahweh of Armies that the peoples labor for the fire, and the nations weary themselves for vanity? 
+<sup>14&#160;</sup>For the earth will be filled with the knowledge of Yahweh’s glory, as the waters cover the sea. 
+</div><div class="p">
+<sup>15&#160;</sup>“Woe to him who gives his neighbor drink, pouring your inflaming wine until they are drunk, so that you may gaze at their naked bodies! 
+<sup>16&#160;</sup>You are filled with shame, and not glory. You will also drink and be exposed! The cup of Yahweh’s right hand will come around to you, and disgrace will cover your glory. 
+<sup>17&#160;</sup>For the violence done to Lebanon will overwhelm you, and the destruction of the animals will terrify you, because of men’s blood and for the violence done to the land, to every city and to those who dwell in them. 
+</div><div class="p">
+<sup>18&#160;</sup>“What value does the engraved image have, that its maker has engraved it; the molten image, even the teacher of lies, that he who fashions its form trusts in it, to make mute idols? 
+<sup>19&#160;</sup>Woe to him who says to the wood, ‘Awake!’ or to the mute stone, ‘Arise!’ Shall this teach? Behold, it is overlaid with gold and silver, and there is no breath at all within it. 
+<sup>20&#160;</sup>But Yahweh is in his set-apart temple. Let all the earth be silent before him!” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>A prayer of Habakkuk, the prophet, set to victorious music. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh, I have heard of your fame. 
+</div><div class="q2">I stand in awe of your deeds, Yahweh. 
+</div><div class="q1">Renew your work in the middle of the years. 
+</div><div class="q2">In the middle of the years make it known. 
+</div><div class="q2">In wrath, you remember mercy. 
+</div><div class="q1">
+<sup>3&#160;</sup>Elohim came from Teman, 
+</div><div class="q2">the Set-Apart One from Mount Paran. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">His glory covered the heavens, 
+</div><div class="q2">and his praise filled the earth. 
+</div><div class="q1">
+<sup>4&#160;</sup>His splendor is like the sunrise. 
+</div><div class="q2">Rays shine from his hand, where his power is hidden. 
+</div><div class="q1">
+<sup>5&#160;</sup>Plague went before him, 
+</div><div class="q2">and pestilence followed his feet. 
+</div><div class="q1">
+<sup>6&#160;</sup>He stood, and shook the earth. 
+</div><div class="q2">He looked, and made the nations tremble. 
+</div><div class="q2">The ancient mountains were crumbled. 
+</div><div class="q2">The age-old hills collapsed. 
+</div><div class="q2">His ways are eternal. 
+</div><div class="q1">
+<sup>7&#160;</sup>I saw the tents of Cushan in affliction. 
+</div><div class="q2">The dwellings of the land of Midian trembled. 
+</div><div class="q1">
+<sup>8&#160;</sup>Was Yahweh displeased with the rivers? 
+</div><div class="q2">Was your anger against the rivers, 
+</div><div class="q2">or your wrath against the sea, 
+</div><div class="q2">that you rode on your horses, 
+</div><div class="q2">on your chariots of salvation? 
+</div><div class="q1">
+<sup>9&#160;</sup>You uncovered your bow. 
+</div><div class="q2">You called for your sworn arrows. </div><div class="qs">Selah. 
+</div><div class="q1">You split the earth with rivers. 
+</div><div class="q1">
+<sup>10&#160;</sup>The mountains saw you, and were afraid. 
+</div><div class="q2">The storm of waters passed by. 
+</div><div class="q2">The deep roared and lifted up its hands on high. 
+</div><div class="q1">
+<sup>11&#160;</sup>The sun and moon stood still in the sky 
+</div><div class="q2">at the light of your arrows as they went, 
+</div><div class="q2">at the shining of your glittering spear. 
+</div><div class="q1">
+<sup>12&#160;</sup>You marched through the land in wrath. 
+</div><div class="q2">You threshed the nations in anger. 
+</div><div class="q1">
+<sup>13&#160;</sup>You went out for the salvation of your people, 
+</div><div class="q2">for the salvation of your anointed. 
+</div><div class="q1">You crushed the head of the land of wickedness. 
+</div><div class="q2">You stripped them head to foot. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>You pierced the heads of his warriors with their own spears. 
+</div><div class="q2">They came as a whirlwind to scatter me, 
+</div><div class="q2">gloating as if to devour the wretched in secret. 
+</div><div class="q1">
+<sup>15&#160;</sup>You trampled the sea with your horses, 
+</div><div class="q2">churning mighty waters. 
+</div><div class="q1">
+<sup>16&#160;</sup>I heard, and my body trembled. 
+</div><div class="q2">My lips quivered at the voice. 
+</div><div class="q1">Rottenness enters into my bones, and I tremble in my place 
+</div><div class="q2">because I must wait quietly for the day of trouble, 
+</div><div class="q2">for the coming up of the people who invade us. 
+</div><div class="q1">
+<sup>17&#160;</sup>For even though the fig tree doesn’t flourish, 
+</div><div class="q2">nor fruit be in the vines, 
+</div><div class="q2">the labor of the olive fails, 
+</div><div class="q2">the fields yield no food, 
+</div><div class="q2">the flocks are cut off from the fold, 
+</div><div class="q2">and there is no herd in the stalls, 
+</div><div class="q1">
+<sup>18&#160;</sup>yet I will rejoice in Yahweh. 
+</div><div class="q2">I will be joyful in the Elohim of my salvation! 
+</div><div class="q1">
+<sup>19&#160;</sup>Yahweh, the Lord, is my strength. 
+</div><div class="q2">He makes my feet like deer’s feet, 
+</div><div class="q2">and enables me to go in high places. 
+</div><div class="p">For the music director, on my stringed instruments. </div></div><script src="../main.js"></script></body></html>

--- a/book/haggai.html
+++ b/book/haggai.html
@@ -3,6 +3,47 @@
 <head>
 <title>Haggai</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,56 +53,59 @@
 <div class="main">
 <!-- HAG World English Scripture (WES) -->
 <h1 class="booklabel">Haggai</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>In the second year of Darius the king, in the sixth month, in the first day of the month, Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word came by Haggai the prophet, to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, saying, 
-<span class="v">2&#160;</span>“This is what Yahweh of Armies says: These people say, ‘The time hasn’t yet come, the time for Yahweh’s house to be built.’&#160;” 
-</p><p>
-<span class="v">3&#160;</span>Then Yahweh’s word came by Haggai the prophet, saying, 
-<span class="v">4&#160;</span>“Is it a time for you yourselves to dwell in your paneled houses, while this house lies waste? 
-<span class="v">5&#160;</span>Now therefore this is what Yahweh of Armies says: ‘Consider your ways. 
-<span class="v">6&#160;</span>You have sown much, and bring in little. You eat, but you don’t have enough. You drink, but you aren’t filled with drink. You clothe yourselves, but no one is warm; and he who earns wages earns wages to put them into a bag with holes in it.’ 
-</p><p>
-<span class="v">7&#160;</span>“This is what Yahweh of Armies says: ‘Consider your ways. 
-<span class="v">8&#160;</span>Go up to the mountain, bring wood, and build the house. I will take pleasure in it, and I will be glorified,” says Yahweh. 
-<span class="v">9&#160;</span>“You looked for much, and, behold,<span class="f">+ \fr 1:9 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> it came to little; and when you brought it home, I blew it away. Why?” says Yahweh of Armies, “Because of my house that lies waste, while each of you is busy with his own house. 
-<span class="v">10&#160;</span>Therefore for your sake the heavens withhold the dew, and the earth withholds its fruit. 
-<span class="v">11&#160;</span>I called for a drought on the land, on the mountains, on the grain, on the new wine, on the oil, on that which the ground produces, on men, on livestock, and on all the labor of the hands.” 
-</p><p>
-<span class="v">12&#160;</span>Then Zerubbabel the son of Shealtiel and Joshua the son of Jehozadak, the high priest, with all the remnant of the people, obeyed Yahweh their Elohim’s<span class="f">+ \fr 1:12 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> voice, and the words of Haggai the prophet, as Yahweh their Elohim had sent him; and the people feared Yahweh. 
-</p><p>
-<span class="v">13&#160;</span>Then Haggai, Yahweh’s messenger, spoke Yahweh’s message to the people, saying, “I am with you,” says Yahweh. 
-</p><p>
-<span class="v">14&#160;</span>Yahweh stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Jehozadak, the high priest, and the spirit of all the remnant of the people; and they came and worked on the house of Yahweh of Armies, their Elohim, 
-<span class="v">15&#160;</span>in the twenty-fourth day of the month, in the sixth month, in the second year of Darius the king. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>In the seventh month, in the twenty-first day of the month, Yahweh’s word came by Haggai the prophet, saying, 
-<span class="v">2&#160;</span>“Speak now to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, and to the remnant of the people, saying, 
-<span class="v">3&#160;</span>‘Who is left among you who saw this house in its former glory? How do you see it now? Isn’t it in your eyes as nothing? 
-<span class="v">4&#160;</span>Yet now be strong, Zerubbabel,’ says Yahweh. ‘Be strong, Joshua son of Jehozadak, the high priest. Be strong, all you people of the land,’ says Yahweh, ‘and work, for I am with you,’ says Yahweh of Armies. 
-<span class="v">5&#160;</span>This is the word that I covenanted with you when you came out of Egypt, and my Spirit lived among you. ‘Don’t be afraid.’ 
-<span class="v">6&#160;</span>For this is what Yahweh of Armies says: ‘Yet once more, it is a little while, and I will shake the heavens, the earth, the sea, and the dry land; 
-<span class="v">7&#160;</span>and I will shake all nations. The treasure of all nations will come, and I will fill this house with glory, says Yahweh of Armies. 
-<span class="v">8&#160;</span>The silver is mine, and the gold is mine,’ says Yahweh of Armies. 
-<span class="v">9&#160;</span>‘The latter glory of this house will be greater than the former,’ says Yahweh of Armies; ‘and in this place I will give peace,’ says Yahweh of Armies.” 
-</p><p>
-<span class="v">10&#160;</span>In the twenty-fourth day of the ninth month, in the second year of Darius, Yahweh’s word came by Haggai the prophet, saying, 
-<span class="v">11&#160;</span>“Yahweh of Armies says: Ask now the priests concerning the law, saying, 
-<span class="v">12&#160;</span>‘If someone carries set-apart meat in the fold of his garment, and with his fold touches bread, stew, wine, oil, or any food, will it become set-apart?’&#160;” 
-</p><p>The priests answered, “No.” 
-</p><p>
-<span class="v">13&#160;</span>Then Haggai said, “If one who is unclean by reason of a dead body touch any of these, will it be unclean?” 
-</p><p>The priests answered, “It will be unclean.” 
-</p><p>
-<span class="v">14&#160;</span>Then Haggai answered, “&#160;‘So is this people, and so is this nation before me,’ says Yahweh; ‘and so is every work of their hands. That which they offer there is unclean. 
-<span class="v">15&#160;</span>Now, please consider from this day and backward, before a stone was laid on a stone in Yahweh’s temple. 
-<span class="v">16&#160;</span>Through all that time, when one came to a heap of twenty measures, there were only ten. When one came to the wine vat to draw out fifty, there were only twenty. 
-<span class="v">17&#160;</span>I struck you with blight, mildew, and hail in all the work of your hands; yet you didn’t turn to me,’ says Yahweh. 
-<span class="v">18&#160;</span>‘Consider, please, from this day and backward, from the twenty-fourth day of the ninth month, since the day that the foundation of Yahweh’s temple was laid, consider it. 
-<span class="v">19&#160;</span>Is the seed yet in the barn? Yes, the vine, the fig tree, the pomegranate, and the olive tree haven’t produced. From today I will bless you.’&#160;” 
-</p><p>
-<span class="v">20&#160;</span>Yahweh’s word came the second time to Haggai in the twenty-fourth day of the month, saying, 
-<span class="v">21&#160;</span>“Speak to Zerubbabel, governor of Judah, saying, ‘I will shake the heavens and the earth. 
-<span class="v">22&#160;</span>I will overthrow the throne of kingdoms. I will destroy the strength of the kingdoms of the nations. I will overthrow the chariots and those who ride in them. The horses and their riders will come down, everyone by the sword of his brother. 
-<span class="v">23&#160;</span>In that day, says Yahweh of Armies, I will take you, Zerubbabel my servant, the son of Shealtiel,’ says Yahweh, ‘and will make you like a signet ring, for I have chosen you,’ says Yahweh of Armies.” </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>In the second year of Darius the king, in the sixth month, in the first day of the month, Yahweh’s word came by Haggai the prophet, to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, saying, 
+<sup>2&#160;</sup>“This is what Yahweh of Armies says: These people say, ‘The time hasn’t yet come, the time for Yahweh’s house to be built.’&#160;” 
+</div><div class="p">
+<sup>3&#160;</sup>Then Yahweh’s word came by Haggai the prophet, saying, 
+<sup>4&#160;</sup>“Is it a time for you yourselves to dwell in your paneled houses, while this house lies waste? 
+<sup>5&#160;</sup>Now therefore this is what Yahweh of Armies says: ‘Consider your ways. 
+<sup>6&#160;</sup>You have sown much, and bring in little. You eat, but you don’t have enough. You drink, but you aren’t filled with drink. You clothe yourselves, but no one is warm; and he who earns wages earns wages to put them into a bag with holes in it.’ 
+</div><div class="p">
+<sup>7&#160;</sup>“This is what Yahweh of Armies says: ‘Consider your ways. 
+<sup>8&#160;</sup>Go up to the mountain, bring wood, and build the house. I will take pleasure in it, and I will be glorified,” says Yahweh. 
+<sup>9&#160;</sup>“You looked for much, and, behold, it came to little; and when you brought it home, I blew it away. Why?” says Yahweh of Armies, “Because of my house that lies waste, while each of you is busy with his own house. 
+<sup>10&#160;</sup>Therefore for your sake the heavens withhold the dew, and the earth withholds its fruit. 
+<sup>11&#160;</sup>I called for a drought on the land, on the mountains, on the grain, on the new wine, on the oil, on that which the ground produces, on men, on livestock, and on all the labor of the hands.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then Zerubbabel the son of Shealtiel and Joshua the son of Jehozadak, the high priest, with all the remnant of the people, obeyed Yahweh their Elohim’s voice, and the words of Haggai the prophet, as Yahweh their Elohim had sent him; and the people feared Yahweh. 
+</div><div class="p">
+<sup>13&#160;</sup>Then Haggai, Yahweh’s messenger, spoke Yahweh’s message to the people, saying, “I am with you,” says Yahweh. 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh stirred up the spirit of Zerubbabel the son of Shealtiel, governor of Judah, and the spirit of Joshua the son of Jehozadak, the high priest, and the spirit of all the remnant of the people; and they came and worked on the house of Yahweh of Armies, their Elohim, 
+<sup>15&#160;</sup>in the twenty-fourth day of the month, in the sixth month, in the second year of Darius the king. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>In the seventh month, in the twenty-first day of the month, Yahweh’s word came by Haggai the prophet, saying, 
+<sup>2&#160;</sup>“Speak now to Zerubbabel the son of Shealtiel, governor of Judah, and to Joshua the son of Jehozadak, the high priest, and to the remnant of the people, saying, 
+<sup>3&#160;</sup>‘Who is left among you who saw this house in its former glory? How do you see it now? Isn’t it in your eyes as nothing? 
+<sup>4&#160;</sup>Yet now be strong, Zerubbabel,’ says Yahweh. ‘Be strong, Joshua son of Jehozadak, the high priest. Be strong, all you people of the land,’ says Yahweh, ‘and work, for I am with you,’ says Yahweh of Armies. 
+<sup>5&#160;</sup>This is the word that I covenanted with you when you came out of Egypt, and my Spirit lived among you. ‘Don’t be afraid.’ 
+<sup>6&#160;</sup>For this is what Yahweh of Armies says: ‘Yet once more, it is a little while, and I will shake the heavens, the earth, the sea, and the dry land; 
+<sup>7&#160;</sup>and I will shake all nations. The treasure of all nations will come, and I will fill this house with glory, says Yahweh of Armies. 
+<sup>8&#160;</sup>The silver is mine, and the gold is mine,’ says Yahweh of Armies. 
+<sup>9&#160;</sup>‘The latter glory of this house will be greater than the former,’ says Yahweh of Armies; ‘and in this place I will give peace,’ says Yahweh of Armies.” 
+</div><div class="p">
+<sup>10&#160;</sup>In the twenty-fourth day of the ninth month, in the second year of Darius, Yahweh’s word came by Haggai the prophet, saying, 
+<sup>11&#160;</sup>“Yahweh of Armies says: Ask now the priests concerning the law, saying, 
+<sup>12&#160;</sup>‘If someone carries set-apart meat in the fold of his garment, and with his fold touches bread, stew, wine, oil, or any food, will it become set-apart?’&#160;” 
+</div><div class="p">The priests answered, “No.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then Haggai said, “If one who is unclean by reason of a dead body touch any of these, will it be unclean?” 
+</div><div class="p">The priests answered, “It will be unclean.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Haggai answered, “&#160;‘So is this people, and so is this nation before me,’ says Yahweh; ‘and so is every work of their hands. That which they offer there is unclean. 
+<sup>15&#160;</sup>Now, please consider from this day and backward, before a stone was laid on a stone in Yahweh’s temple. 
+<sup>16&#160;</sup>Through all that time, when one came to a heap of twenty measures, there were only ten. When one came to the wine vat to draw out fifty, there were only twenty. 
+<sup>17&#160;</sup>I struck you with blight, mildew, and hail in all the work of your hands; yet you didn’t turn to me,’ says Yahweh. 
+<sup>18&#160;</sup>‘Consider, please, from this day and backward, from the twenty-fourth day of the ninth month, since the day that the foundation of Yahweh’s temple was laid, consider it. 
+<sup>19&#160;</sup>Is the seed yet in the barn? Yes, the vine, the fig tree, the pomegranate, and the olive tree haven’t produced. From today I will bless you.’&#160;” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh’s word came the second time to Haggai in the twenty-fourth day of the month, saying, 
+<sup>21&#160;</sup>“Speak to Zerubbabel, governor of Judah, saying, ‘I will shake the heavens and the earth. 
+<sup>22&#160;</sup>I will overthrow the throne of kingdoms. I will destroy the strength of the kingdoms of the nations. I will overthrow the chariots and those who ride in them. The horses and their riders will come down, everyone by the sword of his brother. 
+<sup>23&#160;</sup>In that day, says Yahweh of Armies, I will take you, Zerubbabel my servant, the son of Shealtiel,’ says Yahweh, ‘and will make you like a signet ring, for I have chosen you,’ says Yahweh of Armies.” </div></div><script src="../main.js"></script></body></html>

--- a/book/hosea.html
+++ b/book/hosea.html
@@ -3,6 +3,47 @@
 <head>
 <title>Hosea</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,843 +53,858 @@
 <div class="main">
 <!-- HOS World English Scripture (WES) -->
 <h1 class="booklabel">Hosea</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word that came to Hosea the son of Beeri, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah, and in the days of Jeroboam the son of Joash, king of Israel. 
-</p><p>
-<span class="v">2&#160;</span>When Yahweh spoke at first by Hosea, Yahweh said to Hosea, “Go, take for yourself a woman of prostitution and children of unfaithfulness; for the land commits great adultery, forsaking Yahweh.” 
-</p><p>
-<span class="v">3&#160;</span>So he went and took Gomer the daughter of Diblaim; and she conceived, and bore him a son. 
-</p><p>
-<span class="v">4&#160;</span>Yahweh said to him, “Call his name Jezreel, for yet a little while, and I will avenge the blood of Jezreel on the house of Jehu, and will cause the kingdom of the house of Israel to cease. 
-<span class="v">5&#160;</span>It will happen in that day that I will break the bow of Israel in the valley of Jezreel.” 
-</p><p>
-<span class="v">6&#160;</span>She conceived again, and bore a daughter. 
-</p><p>Then he said to him, “Call her name Lo-Ruhamah,<span class="f">+ \fr 1:6 \ft Lo-Ruhamah means “not loved”.</span> for I will no longer have mercy on the house of Israel, that I should in any way pardon them. 
-<span class="v">7&#160;</span>But I will have mercy on the house of Judah, and will save them by Yahweh their Elohim,<span class="f">+ \fr 1:7 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> and will not save them by bow, sword, battle, horses, or horsemen.” 
-</p><p>
-<span class="v">8&#160;</span>Now when she had weaned Lo-Ruhamah, she conceived, and bore a son. 
-</p><p>
-<span class="v">9&#160;</span>He said, “Call his name Lo-Ammi,<span class="f">+ \fr 1:9 \ft Lo-Ammi means “not my people”.</span> for you are not my people, and I will not be yours. 
-<span class="v">10&#160;</span>Yet the number of the children of Israel will be as the sand of the sea, which can’t be measured or counted; and it will come to pass that, in the place where it was said to them, ‘You are not my people,’ they will be called ‘sons of the living Elohim.’ 
-<span class="v">11&#160;</span>The children of Judah and the children of Israel will be gathered together, and they will appoint themselves one head, and will go up from the land; for great will be the day of Jezreel. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>“Say to your brothers, ‘My people!’<span class="f">+ \fr 2:1 \ft ‘Ammi’ in Hebrew</span> 
-</p><p class="q2">and to your sisters, ‘My loved one!’<span class="f">+ \fr 2:1 \ft ‘Ruhamah’ in Hebrew</span> 
-</p><p class="q1">
-<span class="v">2&#160;</span>Contend with your mother! 
-</p><p class="q2">Contend, for she is not my woman, 
-</p><p class="q2">neither am I her man; 
-</p><p class="q1">and let her put away her prostitution from her face, 
-</p><p class="q2">and her adulteries from between her breasts; 
-</p><p class="q1">
-<span class="v">3&#160;</span>lest I strip her naked, 
-</p><p class="q2">and make her bare as in the day that she was born, 
-</p><p class="q1">and make her like a wilderness, 
-</p><p class="q2">and set her like a dry land, 
-</p><p class="q2">and kill her with thirst. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Indeed, on her children I will have no mercy, 
-</p><p class="q2">for they are children of unfaithfulness. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For their mother has played the prostitute. 
-</p><p class="q2">She who conceived them has done shamefully; 
-</p><p class="q1">for she said, ‘I will go after my lovers, 
-</p><p class="q2">who give me my bread and my water, 
-</p><p class="q2">my wool and my flax, 
-</p><p class="q2">my oil and my drink.’ 
-</p><p class="q1">
-<span class="v">6&#160;</span>Therefore behold,<span class="f">+ \fr 2:6 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I will hedge up your way with thorns, 
-</p><p class="q2">and I will build a wall against her, 
-</p><p class="q2">that she can’t find her way. 
-</p><p class="q1">
-<span class="v">7&#160;</span>She will follow after her lovers, 
-</p><p class="q2">but she won’t overtake them; 
-</p><p class="q1">and she will seek them, 
-</p><p class="q2">but won’t find them. 
-</p><p class="q1">Then she will say, ‘I will go and return to my first man, 
-</p><p class="q2">for then it was better with me than now.’ 
-</p><p class="q1">
-<span class="v">8&#160;</span>For she didn’t know that I gave her the grain, the new wine, and the oil, 
-</p><p class="q2">and multiplied to her silver and gold, which they used for Baal. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Therefore I will take back my grain in its time, 
-</p><p class="q2">and my new wine in its season, 
-</p><p class="q2">and will pluck away my wool and my flax which should have covered her nakedness. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Now I will uncover her lewdness in the sight of her lovers, 
-</p><p class="q2">and no one will deliver her out of my hand. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I will also cause all her celebrations to cease: 
-</p><p class="q2">her feasts, her new moons, her Sabbaths, and all her solemn assemblies. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will lay waste her vines and her fig trees, 
-</p><p class="q2">about which she has said, ‘These are my wages that my lovers have given me,’ 
-</p><p class="q2">and I will make them a forest, 
-</p><p class="q2">and the animals of the field shall eat them. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I will visit on her the days of the Baals, 
-</p><p class="q2">to which she burned incense 
-</p><p class="q1">when she decked herself with her earrings and her jewels, 
-</p><p class="q2">and went after her lovers 
-</p><p class="q2">and forgot me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">14&#160;</span>“Therefore behold, I will allure her, 
-</p><p class="q2">and bring her into the wilderness, 
-</p><p class="q2">and speak tenderly to her. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will give her vineyards from there, 
-</p><p class="q2">and the valley of Achor for a door of hope; 
-</p><p class="q1">and she will respond there 
-</p><p class="q2">as in the days of her youth, 
-</p><p class="q2">and as in the day when she came up out of the land of Egypt. 
-</p><p class="q1">
-<span class="v">16&#160;</span>It will be in that day,” says Yahweh, 
-</p><p class="q2">“that you will call me ‘my man,’ 
-</p><p class="q2">and no longer call me ‘my owner.’ 
-</p><p class="q1">
-<span class="v">17&#160;</span>For I will take away the names of the Baals out of her mouth, 
-</p><p class="q2">and they will no longer be mentioned by name. 
-</p><p class="q1">
-<span class="v">18&#160;</span>In that day I will make a covenant for them with the animals of the field, 
-</p><p class="q2">and with the birds of the sky, 
-</p><p class="q2">and with the creeping things of the ground. 
-</p><p class="q1">I will break the bow, the sword, and the battle out of the land, 
-</p><p class="q2">and will make them lie down safely. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I will betroth you to me forever. 
-</p><p class="q2">Yes, I will betroth you to me in righteousness, in justice, in loving kindness, and in compassion. 
-</p><p class="q1">
-<span class="v">20&#160;</span>I will even betroth you to me in faithfulness; 
-</p><p class="q2">and you shall know Yahweh. 
-</p><p class="q1">
-<span class="v">21&#160;</span>It will happen in that day, that I will respond,” says Yahweh. 
-</p><p class="q2">“I will respond to the heavens, 
-</p><p class="q2">and they will respond to the earth; 
-</p><p class="q2">
-<span class="v">22&#160;</span>and the earth will respond to the grain, and the new wine, and the oil; 
-</p><p class="q2">and they will respond to Jezreel. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I will sow her to me in the earth; 
-</p><p class="q2">and I will have mercy on her who had not obtained mercy; 
-</p><p class="q2">and I will tell those who were not my people, ‘You are my people;’ 
-</p><p class="q2">and they will say, ‘You are My Elohim!’&#160;” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to me, “Go again, love a woman loved by another, and an adulteress, even as Yahweh loves the children of Israel, though they turn to other elohims, and love cakes of raisins.” 
-</p><p>
-<span class="v">2&#160;</span>So I bought her for myself for fifteen pieces of silver and a homer<span class="f">+ \fr 3:2 \ft 1 homer is about 220 liters or 6 bushels</span> and a half of barley. 
-<span class="v">3&#160;</span>I said to her, “You shall stay with me many days. You shall not play the prostitute, and you shall not be with any other man. I will also be so toward you.” 
-</p><p>
-<span class="v">4&#160;</span>For the children of Israel shall live many days without king, without prince, without sacrifice, without sacred stone, and without ephod or idols. 
-<span class="v">5&#160;</span>Afterward the children of Israel shall return and seek Yahweh their Elohim, and David their king, and shall come with trembling to Yahweh and to his blessings in the last days. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Hear Yahweh’s word, you children of Israel, 
-</p><p class="q2">for Yahweh has a charge against the inhabitants of the land: 
-</p><p class="q1">“Indeed there is no truth, nor goodness, 
-</p><p class="q2">nor knowledge of Elohim in the land. 
-</p><p class="q1">
-<span class="v">2&#160;</span>There is cursing, lying, murder, stealing, and committing adultery; 
-</p><p class="q2">they break boundaries, and bloodshed causes bloodshed. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Therefore the land will mourn, 
-</p><p class="q2">and everyone who dwells in it will waste away, 
-</p><p class="q1">with all living things in her, 
-</p><p class="q2">even the animals of the field and the birds of the sky; 
-</p><p class="q2">yes, the fish of the sea also die. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Yet let no man bring a charge, neither let any man accuse; 
-</p><p class="q2">for your people are like those who bring charges against a priest. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You will stumble in the day, 
-</p><p class="q2">and the prophet will also stumble with you in the night; 
-</p><p class="q2">and I will destroy your mother. 
-</p><p class="q1">
-<span class="v">6&#160;</span>My people are destroyed for lack of knowledge. 
-</p><p class="q2">Because you have rejected knowledge, I will also reject you, 
-</p><p class="q2">that you may be no priest to me. 
-</p><p class="q1">Because you have forgotten your Elohim’s law, 
-</p><p class="q2">I will also forget your children. 
-</p><p class="q1">
-<span class="v">7&#160;</span>As they were multiplied, so they sinned against me. 
-</p><p class="q2">I will change their glory into shame. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They feed on the sin of my people, 
-</p><p class="q2">and set their heart on their iniquity. 
-</p><p class="q1">
-<span class="v">9&#160;</span>It will be like people, like priest; 
-</p><p class="q2">and I will punish them for their ways, 
-</p><p class="q2">and will repay them for their deeds. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They will eat, and not have enough. 
-</p><p class="q2">They will play the prostitute, and will not increase; 
-</p><p class="q2">because they have abandoned listening to Yahweh. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Prostitution, wine, and new wine take away understanding. 
-</p><p class="q2">
-<span class="v">12&#160;</span>My people consult with their wooden idol, 
-</p><p class="q2">and answer to a stick of wood. 
-</p><p class="q1">Indeed the spirit of prostitution has led them astray, 
-</p><p class="q2">and they have been unfaithful to their Elohim. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They sacrifice on the tops of the mountains, 
-</p><p class="q2">and burn incense on the hills, under oaks, poplars, and terebinths, 
-</p><p class="q2">because its shade is good. 
-</p><p class="q1">Therefore your daughters play the prostitute, 
-</p><p class="q2">and your brides commit adultery. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will not punish your daughters when they play the prostitute, 
-</p><p class="q2">nor your brides when they commit adultery; 
-</p><p class="q1">because the men consort with prostitutes, 
-</p><p class="q2">and they sacrifice with the shrine prostitutes; 
-</p><p class="q2">so the people without understanding will come to ruin. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“Though you, Israel, play the prostitute, 
-</p><p class="q2">yet don’t let Judah offend; 
-</p><p class="q2">and don’t come to Gilgal, 
-</p><p class="q2">neither go up to Beth Aven, 
-</p><p class="q2">nor swear, ‘As Yahweh lives.’ 
-</p><p class="q1">
-<span class="v">16&#160;</span>For Israel has behaved extremely stubbornly, like a stubborn heifer. 
-</p><p class="q2">Then how will Yahweh feed them like a lamb in a meadow? 
-</p><p class="q1">
-<span class="v">17&#160;</span>Ephraim is joined to idols. 
-</p><p class="q2">Leave him alone! 
-</p><p class="q1">
-<span class="v">18&#160;</span>Their drink has become sour. 
-</p><p class="q2">They play the prostitute continually. 
-</p><p class="q2">Her rulers dearly love their shameful way. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The wind has wrapped her up in its wings; 
-</p><p class="q2">and they shall be disappointed because of their sacrifices. 
-</p><div class="b"> &#160; </div>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Yahweh’s word that came to Hosea the son of Beeri, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah, and in the days of Jeroboam the son of Joash, king of Israel. 
+</div><div class="p">
+<sup>2&#160;</sup>When Yahweh spoke at first by Hosea, Yahweh said to Hosea, “Go, take for yourself a woman of prostitution and children of unfaithfulness; for the land commits great adultery, forsaking Yahweh.” 
+</div><div class="p">
+<sup>3&#160;</sup>So he went and took Gomer the daughter of Diblaim; and she conceived, and bore him a son. 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh said to him, “Call his name Jezreel, for yet a little while, and I will avenge the blood of Jezreel on the house of Jehu, and will cause the kingdom of the house of Israel to cease. 
+<sup>5&#160;</sup>It will happen in that day that I will break the bow of Israel in the valley of Jezreel.” 
+</div><div class="p">
+<sup>6&#160;</sup>She conceived again, and bore a daughter. 
+</div><div class="p">Then he said to him, “Call her name Lo-Ruhamah, for I will no longer have mercy on the house of Israel, that I should in any way pardon them. 
+<sup>7&#160;</sup>But I will have mercy on the house of Judah, and will save them by Yahweh their Elohim, and will not save them by bow, sword, battle, horses, or horsemen.” 
+</div><div class="p">
+<sup>8&#160;</sup>Now when she had weaned Lo-Ruhamah, she conceived, and bore a son. 
+</div><div class="p">
+<sup>9&#160;</sup>He said, “Call his name Lo-Ammi, for you are not my people, and I will not be yours. 
+<sup>10&#160;</sup>Yet the number of the children of Israel will be as the sand of the sea, which can’t be measured or counted; and it will come to pass that, in the place where it was said to them, ‘You are not my people,’ they will be called ‘sons of the living Elohim.’ 
+<sup>11&#160;</sup>The children of Judah and the children of Israel will be gathered together, and they will appoint themselves one head, and will go up from the land; for great will be the day of Jezreel. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>“Say to your brothers, ‘My people!’ 
+</div><div class="q2">and to your sisters, ‘My loved one!’ 
+</div><div class="q1">
+<sup>2&#160;</sup>Contend with your mother! 
+</div><div class="q2">Contend, for she is not my woman, 
+</div><div class="q2">neither am I her man; 
+</div><div class="q1">and let her put away her prostitution from her face, 
+</div><div class="q2">and her adulteries from between her breasts; 
+</div><div class="q1">
+<sup>3&#160;</sup>lest I strip her naked, 
+</div><div class="q2">and make her bare as in the day that she was born, 
+</div><div class="q1">and make her like a wilderness, 
+</div><div class="q2">and set her like a dry land, 
+</div><div class="q2">and kill her with thirst. 
+</div><div class="q1">
+<sup>4&#160;</sup>Indeed, on her children I will have no mercy, 
+</div><div class="q2">for they are children of unfaithfulness. 
+</div><div class="q1">
+<sup>5&#160;</sup>For their mother has played the prostitute. 
+</div><div class="q2">She who conceived them has done shamefully; 
+</div><div class="q1">for she said, ‘I will go after my lovers, 
+</div><div class="q2">who give me my bread and my water, 
+</div><div class="q2">my wool and my flax, 
+</div><div class="q2">my oil and my drink.’ 
+</div><div class="q1">
+<sup>6&#160;</sup>Therefore behold, I will hedge up your way with thorns, 
+</div><div class="q2">and I will build a wall against her, 
+</div><div class="q2">that she can’t find her way. 
+</div><div class="q1">
+<sup>7&#160;</sup>She will follow after her lovers, 
+</div><div class="q2">but she won’t overtake them; 
+</div><div class="q1">and she will seek them, 
+</div><div class="q2">but won’t find them. 
+</div><div class="q1">Then she will say, ‘I will go and return to my first man, 
+</div><div class="q2">for then it was better with me than now.’ 
+</div><div class="q1">
+<sup>8&#160;</sup>For she didn’t know that I gave her the grain, the new wine, and the oil, 
+</div><div class="q2">and multiplied to her silver and gold, which they used for Baal. 
+</div><div class="q1">
+<sup>9&#160;</sup>Therefore I will take back my grain in its time, 
+</div><div class="q2">and my new wine in its season, 
+</div><div class="q2">and will pluck away my wool and my flax which should have covered her nakedness. 
+</div><div class="q1">
+<sup>10&#160;</sup>Now I will uncover her lewdness in the sight of her lovers, 
+</div><div class="q2">and no one will deliver her out of my hand. 
+</div><div class="q1">
+<sup>11&#160;</sup>I will also cause all her celebrations to cease: 
+</div><div class="q2">her feasts, her new moons, her Sabbaths, and all her solemn assemblies. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will lay waste her vines and her fig trees, 
+</div><div class="q2">about which she has said, ‘These are my wages that my lovers have given me,’ 
+</div><div class="q2">and I will make them a forest, 
+</div><div class="q2">and the animals of the field shall eat them. 
+</div><div class="q1">
+<sup>13&#160;</sup>I will visit on her the days of the Baals, 
+</div><div class="q2">to which she burned incense 
+</div><div class="q1">when she decked herself with her earrings and her jewels, 
+</div><div class="q2">and went after her lovers 
+</div><div class="q2">and forgot me,” says Yahweh. 
+</div><div class="q1">
+<sup>14&#160;</sup>“Therefore behold, I will allure her, 
+</div><div class="q2">and bring her into the wilderness, 
+</div><div class="q2">and speak tenderly to her. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will give her vineyards from there, 
+</div><div class="q2">and the valley of Achor for a door of hope; 
+</div><div class="q1">and she will respond there 
+</div><div class="q2">as in the days of her youth, 
+</div><div class="q2">and as in the day when she came up out of the land of Egypt. 
+</div><div class="q1">
+<sup>16&#160;</sup>It will be in that day,” says Yahweh, 
+</div><div class="q2">“that you will call me ‘my man,’ 
+</div><div class="q2">and no longer call me ‘my owner.’ 
+</div><div class="q1">
+<sup>17&#160;</sup>For I will take away the names of the Baals out of her mouth, 
+</div><div class="q2">and they will no longer be mentioned by name. 
+</div><div class="q1">
+<sup>18&#160;</sup>In that day I will make a covenant for them with the animals of the field, 
+</div><div class="q2">and with the birds of the sky, 
+</div><div class="q2">and with the creeping things of the ground. 
+</div><div class="q1">I will break the bow, the sword, and the battle out of the land, 
+</div><div class="q2">and will make them lie down safely. 
+</div><div class="q1">
+<sup>19&#160;</sup>I will betroth you to me forever. 
+</div><div class="q2">Yes, I will betroth you to me in righteousness, in justice, in loving kindness, and in compassion. 
+</div><div class="q1">
+<sup>20&#160;</sup>I will even betroth you to me in faithfulness; 
+</div><div class="q2">and you shall know Yahweh. 
+</div><div class="q1">
+<sup>21&#160;</sup>It will happen in that day, that I will respond,” says Yahweh. 
+</div><div class="q2">“I will respond to the heavens, 
+</div><div class="q2">and they will respond to the earth; 
+</div><div class="q2">
+<sup>22&#160;</sup>and the earth will respond to the grain, and the new wine, and the oil; 
+</div><div class="q2">and they will respond to Jezreel. 
+</div><div class="q1">
+<sup>23&#160;</sup>I will sow her to me in the earth; 
+</div><div class="q2">and I will have mercy on her who had not obtained mercy; 
+</div><div class="q2">and I will tell those who were not my people, ‘You are my people;’ 
+</div><div class="q2">and they will say, ‘You are My Elohim!’&#160;” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to me, “Go again, love a woman loved by another, and an adulteress, even as Yahweh loves the children of Israel, though they turn to other elohims, and love cakes of raisins.” 
+</div><div class="p">
+<sup>2&#160;</sup>So I bought her for myself for fifteen pieces of silver and a homer and a half of barley. 
+<sup>3&#160;</sup>I said to her, “You shall stay with me many days. You shall not play the prostitute, and you shall not be with any other man. I will also be so toward you.” 
+</div><div class="p">
+<sup>4&#160;</sup>For the children of Israel shall live many days without king, without prince, without sacrifice, without sacred stone, and without ephod or idols. 
+<sup>5&#160;</sup>Afterward the children of Israel shall return and seek Yahweh their Elohim, and David their king, and shall come with trembling to Yahweh and to his blessings in the last days. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Hear Yahweh’s word, you children of Israel, 
+</div><div class="q2">for Yahweh has a charge against the inhabitants of the land: 
+</div><div class="q1">“Indeed there is no truth, nor goodness, 
+</div><div class="q2">nor knowledge of Elohim in the land. 
+</div><div class="q1">
+<sup>2&#160;</sup>There is cursing, lying, murder, stealing, and committing adultery; 
+</div><div class="q2">they break boundaries, and bloodshed causes bloodshed. 
+</div><div class="q1">
+<sup>3&#160;</sup>Therefore the land will mourn, 
+</div><div class="q2">and everyone who dwells in it will waste away, 
+</div><div class="q1">with all living things in her, 
+</div><div class="q2">even the animals of the field and the birds of the sky; 
+</div><div class="q2">yes, the fish of the sea also die. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Yet let no man bring a charge, neither let any man accuse; 
+</div><div class="q2">for your people are like those who bring charges against a priest. 
+</div><div class="q1">
+<sup>5&#160;</sup>You will stumble in the day, 
+</div><div class="q2">and the prophet will also stumble with you in the night; 
+</div><div class="q2">and I will destroy your mother. 
+</div><div class="q1">
+<sup>6&#160;</sup>My people are destroyed for lack of knowledge. 
+</div><div class="q2">Because you have rejected knowledge, I will also reject you, 
+</div><div class="q2">that you may be no priest to me. 
+</div><div class="q1">Because you have forgotten your Elohim’s law, 
+</div><div class="q2">I will also forget your children. 
+</div><div class="q1">
+<sup>7&#160;</sup>As they were multiplied, so they sinned against me. 
+</div><div class="q2">I will change their glory into shame. 
+</div><div class="q1">
+<sup>8&#160;</sup>They feed on the sin of my people, 
+</div><div class="q2">and set their heart on their iniquity. 
+</div><div class="q1">
+<sup>9&#160;</sup>It will be like people, like priest; 
+</div><div class="q2">and I will punish them for their ways, 
+</div><div class="q2">and will repay them for their deeds. 
+</div><div class="q1">
+<sup>10&#160;</sup>They will eat, and not have enough. 
+</div><div class="q2">They will play the prostitute, and will not increase; 
+</div><div class="q2">because they have abandoned listening to Yahweh. 
+</div><div class="q1">
+<sup>11&#160;</sup>Prostitution, wine, and new wine take away understanding. 
+</div><div class="q2">
+<sup>12&#160;</sup>My people consult with their wooden idol, 
+</div><div class="q2">and answer to a stick of wood. 
+</div><div class="q1">Indeed the spirit of prostitution has led them astray, 
+</div><div class="q2">and they have been unfaithful to their Elohim. 
+</div><div class="q1">
+<sup>13&#160;</sup>They sacrifice on the tops of the mountains, 
+</div><div class="q2">and burn incense on the hills, under oaks, poplars, and terebinths, 
+</div><div class="q2">because its shade is good. 
+</div><div class="q1">Therefore your daughters play the prostitute, 
+</div><div class="q2">and your brides commit adultery. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will not punish your daughters when they play the prostitute, 
+</div><div class="q2">nor your brides when they commit adultery; 
+</div><div class="q1">because the men consort with prostitutes, 
+</div><div class="q2">and they sacrifice with the shrine prostitutes; 
+</div><div class="q2">so the people without understanding will come to ruin. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“Though you, Israel, play the prostitute, 
+</div><div class="q2">yet don’t let Judah offend; 
+</div><div class="q2">and don’t come to Gilgal, 
+</div><div class="q2">neither go up to Beth Aven, 
+</div><div class="q2">nor swear, ‘As Yahweh lives.’ 
+</div><div class="q1">
+<sup>16&#160;</sup>For Israel has behaved extremely stubbornly, like a stubborn heifer. 
+</div><div class="q2">Then how will Yahweh feed them like a lamb in a meadow? 
+</div><div class="q1">
+<sup>17&#160;</sup>Ephraim is joined to idols. 
+</div><div class="q2">Leave him alone! 
+</div><div class="q1">
+<sup>18&#160;</sup>Their drink has become sour. 
+</div><div class="q2">They play the prostitute continually. 
+</div><div class="q2">Her rulers dearly love their shameful way. 
+</div><div class="q1">
+<sup>19&#160;</sup>The wind has wrapped her up in its wings; 
+</div><div class="q2">and they shall be disappointed because of their sacrifices. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>“Listen to this, you priests! 
-</p><p class="q2">Listen, house of Israel, 
-</p><p class="q2">and give ear, house of the king! 
-</p><p class="q1">For the judgment is against you; 
-</p><p class="q2">for you have been a snare at Mizpah, 
-</p><p class="q2">and a net spread on Tabor. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The rebels are deep in slaughter, 
-</p><p class="q2">but I discipline all of them. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I know Ephraim, 
-</p><p class="q2">and Israel is not hidden from me; 
-</p><p class="q1">for now, Ephraim, you have played the prostitute. 
-</p><p class="q2">Israel is defiled. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Their deeds won’t allow them to turn to their Elohim, 
-</p><p class="q2">for the spirit of prostitution is within them, 
-</p><p class="q2">and they don’t know Yahweh. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The pride of Israel testifies to his face. 
-</p><p class="q2">Therefore Israel and Ephraim will stumble in their iniquity. 
-</p><p class="q2">Judah also will stumble with them. 
-</p><p class="q1">
-<span class="v">6&#160;</span>They will go with their flocks and with their herds to seek Yahweh, 
-</p><p class="q2">but they won’t find him. 
-</p><p class="q2">He has withdrawn himself from them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They are unfaithful to Yahweh; 
-</p><p class="q2">for they have borne illegitimate children. 
-</p><p class="q2">Now the new moon will devour them with their fields. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Blow the cornet in Gibeah, 
-</p><p class="q2">and the trumpet in Ramah! 
-</p><p class="q2">Sound a battle cry at Beth Aven, behind you, Benjamin! 
-</p><p class="q1">
-<span class="v">9&#160;</span>Ephraim will become a desolation in the day of rebuke. 
-</p><p class="q2">Among the tribes of Israel, I have made known that which will surely be. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The princes of Judah are like those who remove a landmark. 
-</p><p class="q2">I will pour out my wrath on them like water. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Ephraim is oppressed, 
-</p><p class="q2">he is crushed in judgment, 
-</p><p class="q2">because he is intent in his pursuit of idols. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Therefore I am to Ephraim like a moth, 
-</p><p class="q2">and to the house of Judah like rottenness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“When Ephraim saw his sickness, 
-</p><p class="q2">and Judah his wound, 
-</p><p class="q2">then Ephraim went to Assyria, 
-</p><p class="q2">and sent to King Jareb: 
-</p><p class="q1">but he is not able to heal you, 
-</p><p class="q2">neither will he cure you of your wound. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For I will be to Ephraim like a lion, 
-</p><p class="q2">and like a young lion to the house of Judah. 
-</p><p class="q1">I myself will tear in pieces and go away. 
-</p><p class="q2">I will carry off, and there will be no one to deliver. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will go and return to my place, 
-</p><p class="q2">until they acknowledge their offense, 
-</p><p class="q2">and seek my face. 
-</p><p class="q2">In their affliction they will seek me earnestly.” 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>“Listen to this, you priests! 
+</div><div class="q2">Listen, house of Israel, 
+</div><div class="q2">and give ear, house of the king! 
+</div><div class="q1">For the judgment is against you; 
+</div><div class="q2">for you have been a snare at Mizpah, 
+</div><div class="q2">and a net spread on Tabor. 
+</div><div class="q1">
+<sup>2&#160;</sup>The rebels are deep in slaughter, 
+</div><div class="q2">but I discipline all of them. 
+</div><div class="q1">
+<sup>3&#160;</sup>I know Ephraim, 
+</div><div class="q2">and Israel is not hidden from me; 
+</div><div class="q1">for now, Ephraim, you have played the prostitute. 
+</div><div class="q2">Israel is defiled. 
+</div><div class="q1">
+<sup>4&#160;</sup>Their deeds won’t allow them to turn to their Elohim, 
+</div><div class="q2">for the spirit of prostitution is within them, 
+</div><div class="q2">and they don’t know Yahweh. 
+</div><div class="q1">
+<sup>5&#160;</sup>The pride of Israel testifies to his face. 
+</div><div class="q2">Therefore Israel and Ephraim will stumble in their iniquity. 
+</div><div class="q2">Judah also will stumble with them. 
+</div><div class="q1">
+<sup>6&#160;</sup>They will go with their flocks and with their herds to seek Yahweh, 
+</div><div class="q2">but they won’t find him. 
+</div><div class="q2">He has withdrawn himself from them. 
+</div><div class="q1">
+<sup>7&#160;</sup>They are unfaithful to Yahweh; 
+</div><div class="q2">for they have borne illegitimate children. 
+</div><div class="q2">Now the new moon will devour them with their fields. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Blow the cornet in Gibeah, 
+</div><div class="q2">and the trumpet in Ramah! 
+</div><div class="q2">Sound a battle cry at Beth Aven, behind you, Benjamin! 
+</div><div class="q1">
+<sup>9&#160;</sup>Ephraim will become a desolation in the day of rebuke. 
+</div><div class="q2">Among the tribes of Israel, I have made known that which will surely be. 
+</div><div class="q1">
+<sup>10&#160;</sup>The princes of Judah are like those who remove a landmark. 
+</div><div class="q2">I will pour out my wrath on them like water. 
+</div><div class="q1">
+<sup>11&#160;</sup>Ephraim is oppressed, 
+</div><div class="q2">he is crushed in judgment, 
+</div><div class="q2">because he is intent in his pursuit of idols. 
+</div><div class="q1">
+<sup>12&#160;</sup>Therefore I am to Ephraim like a moth, 
+</div><div class="q2">and to the house of Judah like rottenness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“When Ephraim saw his sickness, 
+</div><div class="q2">and Judah his wound, 
+</div><div class="q2">then Ephraim went to Assyria, 
+</div><div class="q2">and sent to King Jareb: 
+</div><div class="q1">but he is not able to heal you, 
+</div><div class="q2">neither will he cure you of your wound. 
+</div><div class="q1">
+<sup>14&#160;</sup>For I will be to Ephraim like a lion, 
+</div><div class="q2">and like a young lion to the house of Judah. 
+</div><div class="q1">I myself will tear in pieces and go away. 
+</div><div class="q2">I will carry off, and there will be no one to deliver. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will go and return to my place, 
+</div><div class="q2">until they acknowledge their offense, 
+</div><div class="q2">and seek my face. 
+</div><div class="q2">In their affliction they will seek me earnestly.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>“Come! Let’s return to Yahweh; 
-</p><p class="q2">for he has torn us to pieces, 
-</p><p class="q2">and he will heal us; 
-</p><p class="q1">he has injured us, 
-</p><p class="q2">and he will bind up our wounds. 
-</p><p class="q1">
-<span class="v">2&#160;</span>After two days he will revive us. 
-</p><p class="q2">On the third day he will raise us up, 
-</p><p class="q2">and we will live before him. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Let’s acknowledge Yahweh. 
-</p><p class="q2">Let’s press on to know Yahweh. 
-</p><p class="q1">As surely as the sun rises, 
-</p><p class="q2">Yahweh will appear. 
-</p><p class="q1">He will come to us like the rain, 
-</p><p class="q2">like the spring rain that waters the earth.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Ephraim, what shall I do to you? 
-</p><p class="q2">Judah, what shall I do to you? 
-</p><p class="q2">For your love is like a morning cloud, 
-</p><p class="q2">and like the dew that disappears early. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Therefore I have cut them to pieces with the prophets; 
-</p><p class="q2">I killed them with the words of my mouth. 
-</p><p class="q2">Your judgments are like a flash of lightning. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For I desire mercy, and not sacrifice; 
-</p><p class="q2">and the knowledge of Elohim more than burnt offerings. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But they, like Adam, have broken the covenant. 
-</p><p class="q2">They were unfaithful to me there. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Gilead is a city of those who work iniquity; 
-</p><p class="q2">it is stained with blood. 
-</p><p class="q1">
-<span class="v">9&#160;</span>As gangs of robbers wait to ambush a man, 
-</p><p class="q2">so the company of priests murder on the path toward Shechem, 
-</p><p class="q2">committing shameful crimes. 
-</p><p class="q1">
-<span class="v">10&#160;</span>In the house of Israel I have seen a horrible thing. 
-</p><p class="q2">There is prostitution in Ephraim. 
-</p><p class="q2">Israel is defiled. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Also, Judah, there is a harvest appointed for you, 
-</p><p class="q2">when I restore the fortunes of my people. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>When I would heal Israel, 
-</p><p class="q2">then the iniquity of Ephraim is uncovered, 
-</p><p class="q2">also the wickedness of Samaria; 
-</p><p class="q2">for they commit falsehood, 
-</p><p class="q2">and the thief enters in, 
-</p><p class="q2">and the gang of robbers ravages outside. 
-</p><p class="q1">
-<span class="v">2&#160;</span>They don’t consider in their hearts that I remember all their wickedness. 
-</p><p class="q2">Now their own deeds have engulfed them. 
-</p><p class="q2">They are before my face. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They make the king glad with their wickedness, 
-</p><p class="q2">and the princes with their lies. 
-</p><p class="q1">
-<span class="v">4&#160;</span>They are all adulterers. 
-</p><p class="q2">They are burning like an oven that the baker stops stirring, 
-</p><p class="q2">from the kneading of the dough, until it is leavened. 
-</p><p class="q1">
-<span class="v">5&#160;</span>On the day of our king, the princes made themselves sick with the heat of wine. 
-</p><p class="q2">He joined his hand with mockers. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For they have prepared their heart like an oven, 
-</p><p class="q2">while they lie in wait. 
-</p><p class="q2">Their anger smolders all night. 
-</p><p class="q2">In the morning it burns as a flaming fire. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They are all hot as an oven, 
-</p><p class="q2">and devour their judges. 
-</p><p class="q1">All their kings have fallen. 
-</p><p class="q2">There is no one among them who calls to me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Ephraim mixes himself among the nations. 
-</p><p class="q2">Ephraim is a pancake not turned over. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Strangers have devoured his strength, 
-</p><p class="q2">and he doesn’t realize it. 
-</p><p class="q1">Indeed, gray hairs are here and there on him, 
-</p><p class="q2">and he doesn’t realize it. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The pride of Israel testifies to his face; 
-</p><p class="q2">yet they haven’t returned to Yahweh their Elohim, 
-</p><p class="q2">nor sought him, for all this. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Ephraim is like an easily deceived dove, without understanding. 
-</p><p class="q2">They call to Egypt. 
-</p><p class="q2">They go to Assyria. 
-</p><p class="q1">
-<span class="v">12&#160;</span>When they go, I will spread my net on them. 
-</p><p class="q2">I will bring them down like the birds of the sky. 
-</p><p class="q2">I will chastise them, as their congregation has heard. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Woe to them! 
-</p><p class="q2">For they have wandered from me. 
-</p><p class="q1">Destruction to them! 
-</p><p class="q2">For they have trespassed against me. 
-</p><p class="q1">Though I would redeem them, 
-</p><p class="q2">yet they have spoken lies against me. 
-</p><p class="q1">
-<span class="v">14&#160;</span>They haven’t cried to me with their heart, 
-</p><p class="q2">but they howl on their beds. 
-</p><p class="q1">They assemble themselves for grain and new wine. 
-</p><p class="q2">They turn away from me. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Though I have taught and strengthened their arms, 
-</p><p class="q2">yet they plot evil against me. 
-</p><p class="q1">
-<span class="v">16&#160;</span>They return, but not to the Most High. 
-</p><p class="q2">They are like a faulty bow. 
-</p><p class="q2">Their princes will fall by the sword for the rage of their tongue. 
-</p><p class="q2">This will be their derision in the land of Egypt. 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>“Come! Let’s return to Yahweh; 
+</div><div class="q2">for he has torn us to pieces, 
+</div><div class="q2">and he will heal us; 
+</div><div class="q1">he has injured us, 
+</div><div class="q2">and he will bind up our wounds. 
+</div><div class="q1">
+<sup>2&#160;</sup>After two days he will revive us. 
+</div><div class="q2">On the third day he will raise us up, 
+</div><div class="q2">and we will live before him. 
+</div><div class="q1">
+<sup>3&#160;</sup>Let’s acknowledge Yahweh. 
+</div><div class="q2">Let’s press on to know Yahweh. 
+</div><div class="q1">As surely as the sun rises, 
+</div><div class="q2">Yahweh will appear. 
+</div><div class="q1">He will come to us like the rain, 
+</div><div class="q2">like the spring rain that waters the earth.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Ephraim, what shall I do to you? 
+</div><div class="q2">Judah, what shall I do to you? 
+</div><div class="q2">For your love is like a morning cloud, 
+</div><div class="q2">and like the dew that disappears early. 
+</div><div class="q1">
+<sup>5&#160;</sup>Therefore I have cut them to pieces with the prophets; 
+</div><div class="q2">I killed them with the words of my mouth. 
+</div><div class="q2">Your judgments are like a flash of lightning. 
+</div><div class="q1">
+<sup>6&#160;</sup>For I desire mercy, and not sacrifice; 
+</div><div class="q2">and the knowledge of Elohim more than burnt offerings. 
+</div><div class="q1">
+<sup>7&#160;</sup>But they, like Adam, have broken the covenant. 
+</div><div class="q2">They were unfaithful to me there. 
+</div><div class="q1">
+<sup>8&#160;</sup>Gilead is a city of those who work iniquity; 
+</div><div class="q2">it is stained with blood. 
+</div><div class="q1">
+<sup>9&#160;</sup>As gangs of robbers wait to ambush a man, 
+</div><div class="q2">so the company of priests murder on the path toward Shechem, 
+</div><div class="q2">committing shameful crimes. 
+</div><div class="q1">
+<sup>10&#160;</sup>In the house of Israel I have seen a horrible thing. 
+</div><div class="q2">There is prostitution in Ephraim. 
+</div><div class="q2">Israel is defiled. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Also, Judah, there is a harvest appointed for you, 
+</div><div class="q2">when I restore the fortunes of my people. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>When I would heal Israel, 
+</div><div class="q2">then the iniquity of Ephraim is uncovered, 
+</div><div class="q2">also the wickedness of Samaria; 
+</div><div class="q2">for they commit falsehood, 
+</div><div class="q2">and the thief enters in, 
+</div><div class="q2">and the gang of robbers ravages outside. 
+</div><div class="q1">
+<sup>2&#160;</sup>They don’t consider in their hearts that I remember all their wickedness. 
+</div><div class="q2">Now their own deeds have engulfed them. 
+</div><div class="q2">They are before my face. 
+</div><div class="q1">
+<sup>3&#160;</sup>They make the king glad with their wickedness, 
+</div><div class="q2">and the princes with their lies. 
+</div><div class="q1">
+<sup>4&#160;</sup>They are all adulterers. 
+</div><div class="q2">They are burning like an oven that the baker stops stirring, 
+</div><div class="q2">from the kneading of the dough, until it is leavened. 
+</div><div class="q1">
+<sup>5&#160;</sup>On the day of our king, the princes made themselves sick with the heat of wine. 
+</div><div class="q2">He joined his hand with mockers. 
+</div><div class="q1">
+<sup>6&#160;</sup>For they have prepared their heart like an oven, 
+</div><div class="q2">while they lie in wait. 
+</div><div class="q2">Their anger smolders all night. 
+</div><div class="q2">In the morning it burns as a flaming fire. 
+</div><div class="q1">
+<sup>7&#160;</sup>They are all hot as an oven, 
+</div><div class="q2">and devour their judges. 
+</div><div class="q1">All their kings have fallen. 
+</div><div class="q2">There is no one among them who calls to me. 
+</div><div class="q1">
+<sup>8&#160;</sup>Ephraim mixes himself among the nations. 
+</div><div class="q2">Ephraim is a pancake not turned over. 
+</div><div class="q1">
+<sup>9&#160;</sup>Strangers have devoured his strength, 
+</div><div class="q2">and he doesn’t realize it. 
+</div><div class="q1">Indeed, gray hairs are here and there on him, 
+</div><div class="q2">and he doesn’t realize it. 
+</div><div class="q1">
+<sup>10&#160;</sup>The pride of Israel testifies to his face; 
+</div><div class="q2">yet they haven’t returned to Yahweh their Elohim, 
+</div><div class="q2">nor sought him, for all this. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Ephraim is like an easily deceived dove, without understanding. 
+</div><div class="q2">They call to Egypt. 
+</div><div class="q2">They go to Assyria. 
+</div><div class="q1">
+<sup>12&#160;</sup>When they go, I will spread my net on them. 
+</div><div class="q2">I will bring them down like the birds of the sky. 
+</div><div class="q2">I will chastise them, as their congregation has heard. 
+</div><div class="q1">
+<sup>13&#160;</sup>Woe to them! 
+</div><div class="q2">For they have wandered from me. 
+</div><div class="q1">Destruction to them! 
+</div><div class="q2">For they have trespassed against me. 
+</div><div class="q1">Though I would redeem them, 
+</div><div class="q2">yet they have spoken lies against me. 
+</div><div class="q1">
+<sup>14&#160;</sup>They haven’t cried to me with their heart, 
+</div><div class="q2">but they howl on their beds. 
+</div><div class="q1">They assemble themselves for grain and new wine. 
+</div><div class="q2">They turn away from me. 
+</div><div class="q1">
+<sup>15&#160;</sup>Though I have taught and strengthened their arms, 
+</div><div class="q2">yet they plot evil against me. 
+</div><div class="q1">
+<sup>16&#160;</sup>They return, but not to the Most High. 
+</div><div class="q2">They are like a faulty bow. 
+</div><div class="q2">Their princes will fall by the sword for the rage of their tongue. 
+</div><div class="q2">This will be their derision in the land of Egypt. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>“Put the trumpet to your lips! 
-</p><p class="q2">Something like an eagle is over Yahweh’s house, 
-</p><p class="q2">because they have broken my covenant 
-</p><p class="q2">and rebelled against my law. 
-</p><p class="q1">
-<span class="v">2&#160;</span>They cry to me, ‘My Elohim, we, Israel, acknowledge you!’ 
-</p><p class="q2">
-<span class="v">3&#160;</span>Israel has cast off that which is good. 
-</p><p class="q2">The enemy will pursue him. 
-</p><p class="q1">
-<span class="v">4&#160;</span>They have set up kings, but not by me. 
-</p><p class="q2">They have made princes, and I didn’t approve. 
-</p><p class="q2">Of their silver and their gold they have made themselves idols, 
-</p><p class="q2">that they may be cut off. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let Samaria throw out his calf idol! 
-</p><p class="q2">My anger burns against them! 
-</p><p class="q2">How long will it be until they are capable of purity? 
-</p><p class="q1">
-<span class="v">6&#160;</span>For this is even from Israel! 
-</p><p class="q2">The workman made it, and it is no Elohim; 
-</p><p class="q2">indeed, the calf of Samaria shall be broken in pieces. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For they sow the wind, 
-</p><p class="q2">and they will reap the whirlwind. 
-</p><p class="q1">He has no standing grain. 
-</p><p class="q2">The stalk will yield no head. 
-</p><p class="q2">If it does yield, strangers will swallow it up. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Israel is swallowed up. 
-</p><p class="q2">Now they are among the nations like a worthless thing. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For they have gone up to Assyria, 
-</p><p class="q2">like a wild donkey wandering alone. 
-</p><p class="q2">Ephraim has hired lovers for himself. 
-</p><p class="q1">
-<span class="v">10&#160;</span>But although they sold themselves among the nations, 
-</p><p class="q2">I will now gather them; 
-</p><p class="q2">and they begin to waste away because of the oppression of the king of mighty ones. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Because Ephraim has multiplied altars for sinning, 
-</p><p class="q2">they became for him altars for sinning. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I wrote for him the many things of my law, 
-</p><p class="q2">but they were regarded as a strange thing. 
-</p><p class="q1">
-<span class="v">13&#160;</span>As for the sacrifices of my offerings, 
-</p><p class="q2">they sacrifice meat and eat it, 
-</p><p class="q2">but Yahweh doesn’t accept them. 
-</p><p class="q1">Now he will remember their iniquity, 
-</p><p class="q2">and punish their sins. 
-</p><p class="q2">They will return to Egypt. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For Israel has forgotten his Maker and built palaces; 
-</p><p class="q2">and Judah has multiplied fortified cities; 
-</p><p class="q2">but I will send a fire on his cities, 
-</p><p class="q2">and it will devour its fortresses.” 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>“Put the trumpet to your lips! 
+</div><div class="q2">Something like an eagle is over Yahweh’s house, 
+</div><div class="q2">because they have broken my covenant 
+</div><div class="q2">and rebelled against my law. 
+</div><div class="q1">
+<sup>2&#160;</sup>They cry to me, ‘My Elohim, we, Israel, acknowledge you!’ 
+</div><div class="q2">
+<sup>3&#160;</sup>Israel has cast off that which is good. 
+</div><div class="q2">The enemy will pursue him. 
+</div><div class="q1">
+<sup>4&#160;</sup>They have set up kings, but not by me. 
+</div><div class="q2">They have made princes, and I didn’t approve. 
+</div><div class="q2">Of their silver and their gold they have made themselves idols, 
+</div><div class="q2">that they may be cut off. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let Samaria throw out his calf idol! 
+</div><div class="q2">My anger burns against them! 
+</div><div class="q2">How long will it be until they are capable of purity? 
+</div><div class="q1">
+<sup>6&#160;</sup>For this is even from Israel! 
+</div><div class="q2">The workman made it, and it is no Elohim; 
+</div><div class="q2">indeed, the calf of Samaria shall be broken in pieces. 
+</div><div class="q1">
+<sup>7&#160;</sup>For they sow the wind, 
+</div><div class="q2">and they will reap the whirlwind. 
+</div><div class="q1">He has no standing grain. 
+</div><div class="q2">The stalk will yield no head. 
+</div><div class="q2">If it does yield, strangers will swallow it up. 
+</div><div class="q1">
+<sup>8&#160;</sup>Israel is swallowed up. 
+</div><div class="q2">Now they are among the nations like a worthless thing. 
+</div><div class="q1">
+<sup>9&#160;</sup>For they have gone up to Assyria, 
+</div><div class="q2">like a wild donkey wandering alone. 
+</div><div class="q2">Ephraim has hired lovers for himself. 
+</div><div class="q1">
+<sup>10&#160;</sup>But although they sold themselves among the nations, 
+</div><div class="q2">I will now gather them; 
+</div><div class="q2">and they begin to waste away because of the oppression of the king of mighty ones. 
+</div><div class="q1">
+<sup>11&#160;</sup>Because Ephraim has multiplied altars for sinning, 
+</div><div class="q2">they became for him altars for sinning. 
+</div><div class="q1">
+<sup>12&#160;</sup>I wrote for him the many things of my law, 
+</div><div class="q2">but they were regarded as a strange thing. 
+</div><div class="q1">
+<sup>13&#160;</sup>As for the sacrifices of my offerings, 
+</div><div class="q2">they sacrifice meat and eat it, 
+</div><div class="q2">but Yahweh doesn’t accept them. 
+</div><div class="q1">Now he will remember their iniquity, 
+</div><div class="q2">and punish their sins. 
+</div><div class="q2">They will return to Egypt. 
+</div><div class="q1">
+<sup>14&#160;</sup>For Israel has forgotten his Maker and built palaces; 
+</div><div class="q2">and Judah has multiplied fortified cities; 
+</div><div class="q2">but I will send a fire on his cities, 
+</div><div class="q2">and it will devour its fortresses.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Don’t rejoice, Israel, to jubilation like the nations; 
-</p><p class="q2">for you were unfaithful to your Elohim. 
-</p><p class="q2">You love the wages of a prostitute at every grain threshing floor. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The threshing floor and the wine press won’t feed them, 
-</p><p class="q2">and the new wine will fail her. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They won’t dwell in Yahweh’s land; 
-</p><p class="q2">but Ephraim will return to Egypt, 
-</p><p class="q2">and they will eat unclean food in Assyria. 
-</p><p class="q1">
-<span class="v">4&#160;</span>They won’t pour out wine offerings to Yahweh, 
-</p><p class="q2">neither will they be pleasing to him. 
-</p><p class="q2">Their sacrifices will be to them like the bread of mourners; 
-</p><p class="q2">all who eat of it will be polluted; 
-</p><p class="q2">for their bread will be for their appetite. 
-</p><p class="q2">It will not come into Yahweh’s house. 
-</p><p class="q1">
-<span class="v">5&#160;</span>What will you do in the day of solemn assembly, 
-</p><p class="q2">and in the day of the feast of Yahweh? 
-</p><p class="q1">
-<span class="v">6&#160;</span>For, behold, when they flee destruction, 
-</p><p class="q2">Egypt will gather them up. 
-</p><p class="q2">Memphis will bury them. 
-</p><p class="q2">Nettles will possess their pleasant things of silver. 
-</p><p class="q2">Thorns will be in their tents. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The days of visitation have come. 
-</p><p class="q2">The days of reckoning have come. 
-</p><p class="q1">Israel will consider the prophet to be a fool, 
-</p><p class="q2">and the man who is inspired to be insane, 
-</p><p class="q2">because of the abundance of your sins, 
-</p><p class="q2">and because your hostility is great. 
-</p><p class="q1">
-<span class="v">8&#160;</span>A prophet watches over Ephraim with my Elohim. 
-</p><p class="q2">A fowler’s snare is on all of his paths, 
-</p><p class="q2">and hostility in the house of his Elohim. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They have deeply corrupted themselves, 
-</p><p class="q2">as in the days of Gibeah. 
-</p><p class="q2">He will remember their iniquity. 
-</p><p class="q2">He will punish them for their sins. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I found Israel like grapes in the wilderness. 
-</p><p class="q2">I saw your fathers as the first ripe in the fig tree at its first season; 
-</p><p class="q2">but they came to Baal Peor, and consecrated themselves to the shameful thing, 
-</p><p class="q2">and became abominable like that which they loved. 
-</p><p class="q1">
-<span class="v">11&#160;</span>As for Ephraim, their glory will fly away like a bird. 
-</p><p class="q2">There will be no birth, no one with child, and no conception. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Though they bring up their children, 
-</p><p class="q2">yet I will bereave them, so that not a man shall be left. 
-</p><p class="q2">Indeed, woe also to them when I depart from them! 
-</p><p class="q1">
-<span class="v">13&#160;</span>I have seen Ephraim, like Tyre, planted in a pleasant place; 
-</p><p class="q2">but Ephraim will bring out his children to the murderer. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Give them—Yahweh what will you give? 
-</p><p class="q2">Give them a miscarrying womb and dry breasts. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“All their wickedness is in Gilgal; 
-</p><p class="q2">for there I hated them. 
-</p><p class="q2">Because of the wickedness of their deeds, I will drive them out of my house! 
-</p><p class="q2">I will love them no more. 
-</p><p class="q2">All their princes are rebels. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Ephraim is struck. 
-</p><p class="q2">Their root has dried up. 
-</p><p class="q2">They will bear no fruit. 
-</p><p class="q2">Even though they give birth, yet I will kill the beloved ones of their womb.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>My Elohim will cast them away, because they didn’t listen to him; 
-</p><p class="q2">and they will be wanderers among the nations. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Israel is a luxuriant vine that produces his fruit. 
-</p><p class="q2">According to the abundance of his fruit he has multiplied his altars. 
-</p><p class="q2">As their land has prospered, they have adorned their sacred stones. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Their heart is divided. 
-</p><p class="q2">Now they will be found guilty. 
-</p><p class="q2">He will demolish their altars. 
-</p><p class="q2">He will destroy their sacred stones. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Surely now they will say, “We have no king; for we don’t fear Yahweh; 
-</p><p class="q2">and the king, what can he do for us?” 
-</p><p class="q1">
-<span class="v">4&#160;</span>They make promises, swearing falsely in making covenants. 
-</p><p class="q2">Therefore judgment springs up like poisonous weeds in the furrows of the field. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The inhabitants of Samaria will be in terror for the calves of Beth Aven, 
-</p><p class="q2">for its people will mourn over it, 
-</p><p class="q2">along with its priests who rejoiced over it, 
-</p><p class="q2">for its glory, because it has departed from it. 
-</p><p class="q1">
-<span class="v">6&#160;</span>It also will be carried to Assyria for a present to a great king. 
-</p><p class="q2">Ephraim will receive shame, 
-</p><p class="q2">and Israel will be ashamed of his own counsel. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Samaria and her king float away 
-</p><p class="q2">like a twig on the water. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The high places also of Aven, the sin of Israel, will be destroyed. 
-</p><p class="q2">The thorn and the thistle will come up on their altars. 
-</p><p class="q2">They will tell the mountains, “Cover us!” and the hills, “Fall on us!” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“Israel, you have sinned from the days of Gibeah. 
-</p><p class="q2">There they remained. 
-</p><p class="q2">The battle against the children of iniquity doesn’t overtake them in Gibeah. 
-</p><p class="q1">
-<span class="v">10&#160;</span>When it is my desire, I will chastise them; 
-</p><p class="q2">and the nations will be gathered against them 
-</p><p class="q2">when they are bound to their two transgressions. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Ephraim is a trained heifer that loves to thresh, 
-</p><p class="q2">so I will put a yoke on her beautiful neck. 
-</p><p class="q2">I will set a rider on Ephraim. 
-</p><p class="q2">Judah will plow. 
-</p><p class="q2">Jacob will break his clods. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Sow to yourselves in righteousness, 
-</p><p class="q2">reap according to kindness. 
-</p><p class="q1">Break up your fallow ground, 
-</p><p class="q2">for it is time to seek Yahweh, 
-</p><p class="q2">until he comes and rains righteousness on you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You have plowed wickedness. 
-</p><p class="q2">You have reaped iniquity. 
-</p><p class="q2">You have eaten the fruit of lies, 
-</p><p class="q2">for you trusted in your way, in the multitude of your mighty men. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Therefore a battle roar will arise among your people, 
-</p><p class="q2">and all your fortresses will be destroyed, 
-</p><p class="q2">as Shalman destroyed Beth Arbel in the day of battle. 
-</p><p class="q2">The mother was dashed in pieces with her children. 
-</p><p class="q1">
-<span class="v">15&#160;</span>So Bethel will do to you because of your great wickedness. 
-</p><p class="q2">At daybreak the king of Israel will be destroyed. 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Don’t rejoice, Israel, to jubilation like the nations; 
+</div><div class="q2">for you were unfaithful to your Elohim. 
+</div><div class="q2">You love the wages of a prostitute at every grain threshing floor. 
+</div><div class="q1">
+<sup>2&#160;</sup>The threshing floor and the wine press won’t feed them, 
+</div><div class="q2">and the new wine will fail her. 
+</div><div class="q1">
+<sup>3&#160;</sup>They won’t dwell in Yahweh’s land; 
+</div><div class="q2">but Ephraim will return to Egypt, 
+</div><div class="q2">and they will eat unclean food in Assyria. 
+</div><div class="q1">
+<sup>4&#160;</sup>They won’t pour out wine offerings to Yahweh, 
+</div><div class="q2">neither will they be pleasing to him. 
+</div><div class="q2">Their sacrifices will be to them like the bread of mourners; 
+</div><div class="q2">all who eat of it will be polluted; 
+</div><div class="q2">for their bread will be for their appetite. 
+</div><div class="q2">It will not come into Yahweh’s house. 
+</div><div class="q1">
+<sup>5&#160;</sup>What will you do in the day of solemn assembly, 
+</div><div class="q2">and in the day of the feast of Yahweh? 
+</div><div class="q1">
+<sup>6&#160;</sup>For, behold, when they flee destruction, 
+</div><div class="q2">Egypt will gather them up. 
+</div><div class="q2">Memphis will bury them. 
+</div><div class="q2">Nettles will possess their pleasant things of silver. 
+</div><div class="q2">Thorns will be in their tents. 
+</div><div class="q1">
+<sup>7&#160;</sup>The days of visitation have come. 
+</div><div class="q2">The days of reckoning have come. 
+</div><div class="q1">Israel will consider the prophet to be a fool, 
+</div><div class="q2">and the man who is inspired to be insane, 
+</div><div class="q2">because of the abundance of your sins, 
+</div><div class="q2">and because your hostility is great. 
+</div><div class="q1">
+<sup>8&#160;</sup>A prophet watches over Ephraim with my Elohim. 
+</div><div class="q2">A fowler’s snare is on all of his paths, 
+</div><div class="q2">and hostility in the house of his Elohim. 
+</div><div class="q1">
+<sup>9&#160;</sup>They have deeply corrupted themselves, 
+</div><div class="q2">as in the days of Gibeah. 
+</div><div class="q2">He will remember their iniquity. 
+</div><div class="q2">He will punish them for their sins. 
+</div><div class="q1">
+<sup>10&#160;</sup>I found Israel like grapes in the wilderness. 
+</div><div class="q2">I saw your fathers as the first ripe in the fig tree at its first season; 
+</div><div class="q2">but they came to Baal Peor, and consecrated themselves to the shameful thing, 
+</div><div class="q2">and became abominable like that which they loved. 
+</div><div class="q1">
+<sup>11&#160;</sup>As for Ephraim, their glory will fly away like a bird. 
+</div><div class="q2">There will be no birth, no one with child, and no conception. 
+</div><div class="q1">
+<sup>12&#160;</sup>Though they bring up their children, 
+</div><div class="q2">yet I will bereave them, so that not a man shall be left. 
+</div><div class="q2">Indeed, woe also to them when I depart from them! 
+</div><div class="q1">
+<sup>13&#160;</sup>I have seen Ephraim, like Tyre, planted in a pleasant place; 
+</div><div class="q2">but Ephraim will bring out his children to the murderer. 
+</div><div class="q1">
+<sup>14&#160;</sup>Give them—Yahweh what will you give? 
+</div><div class="q2">Give them a miscarrying womb and dry breasts. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“All their wickedness is in Gilgal; 
+</div><div class="q2">for there I hated them. 
+</div><div class="q2">Because of the wickedness of their deeds, I will drive them out of my house! 
+</div><div class="q2">I will love them no more. 
+</div><div class="q2">All their princes are rebels. 
+</div><div class="q1">
+<sup>16&#160;</sup>Ephraim is struck. 
+</div><div class="q2">Their root has dried up. 
+</div><div class="q2">They will bear no fruit. 
+</div><div class="q2">Even though they give birth, yet I will kill the beloved ones of their womb.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>My Elohim will cast them away, because they didn’t listen to him; 
+</div><div class="q2">and they will be wanderers among the nations. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Israel is a luxuriant vine that produces his fruit. 
+</div><div class="q2">According to the abundance of his fruit he has multiplied his altars. 
+</div><div class="q2">As their land has prospered, they have adorned their sacred stones. 
+</div><div class="q1">
+<sup>2&#160;</sup>Their heart is divided. 
+</div><div class="q2">Now they will be found guilty. 
+</div><div class="q2">He will demolish their altars. 
+</div><div class="q2">He will destroy their sacred stones. 
+</div><div class="q1">
+<sup>3&#160;</sup>Surely now they will say, “We have no king; for we don’t fear Yahweh; 
+</div><div class="q2">and the king, what can he do for us?” 
+</div><div class="q1">
+<sup>4&#160;</sup>They make promises, swearing falsely in making covenants. 
+</div><div class="q2">Therefore judgment springs up like poisonous weeds in the furrows of the field. 
+</div><div class="q1">
+<sup>5&#160;</sup>The inhabitants of Samaria will be in terror for the calves of Beth Aven, 
+</div><div class="q2">for its people will mourn over it, 
+</div><div class="q2">along with its priests who rejoiced over it, 
+</div><div class="q2">for its glory, because it has departed from it. 
+</div><div class="q1">
+<sup>6&#160;</sup>It also will be carried to Assyria for a present to a great king. 
+</div><div class="q2">Ephraim will receive shame, 
+</div><div class="q2">and Israel will be ashamed of his own counsel. 
+</div><div class="q1">
+<sup>7&#160;</sup>Samaria and her king float away 
+</div><div class="q2">like a twig on the water. 
+</div><div class="q1">
+<sup>8&#160;</sup>The high places also of Aven, the sin of Israel, will be destroyed. 
+</div><div class="q2">The thorn and the thistle will come up on their altars. 
+</div><div class="q2">They will tell the mountains, “Cover us!” and the hills, “Fall on us!” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“Israel, you have sinned from the days of Gibeah. 
+</div><div class="q2">There they remained. 
+</div><div class="q2">The battle against the children of iniquity doesn’t overtake them in Gibeah. 
+</div><div class="q1">
+<sup>10&#160;</sup>When it is my desire, I will chastise them; 
+</div><div class="q2">and the nations will be gathered against them 
+</div><div class="q2">when they are bound to their two transgressions. 
+</div><div class="q1">
+<sup>11&#160;</sup>Ephraim is a trained heifer that loves to thresh, 
+</div><div class="q2">so I will put a yoke on her beautiful neck. 
+</div><div class="q2">I will set a rider on Ephraim. 
+</div><div class="q2">Judah will plow. 
+</div><div class="q2">Jacob will break his clods. 
+</div><div class="q1">
+<sup>12&#160;</sup>Sow to yourselves in righteousness, 
+</div><div class="q2">reap according to kindness. 
+</div><div class="q1">Break up your fallow ground, 
+</div><div class="q2">for it is time to seek Yahweh, 
+</div><div class="q2">until he comes and rains righteousness on you. 
+</div><div class="q1">
+<sup>13&#160;</sup>You have plowed wickedness. 
+</div><div class="q2">You have reaped iniquity. 
+</div><div class="q2">You have eaten the fruit of lies, 
+</div><div class="q2">for you trusted in your way, in the multitude of your mighty men. 
+</div><div class="q1">
+<sup>14&#160;</sup>Therefore a battle roar will arise among your people, 
+</div><div class="q2">and all your fortresses will be destroyed, 
+</div><div class="q2">as Shalman destroyed Beth Arbel in the day of battle. 
+</div><div class="q2">The mother was dashed in pieces with her children. 
+</div><div class="q1">
+<sup>15&#160;</sup>So Bethel will do to you because of your great wickedness. 
+</div><div class="q2">At daybreak the king of Israel will be destroyed. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>“When Israel was a child, then I loved him, 
-</p><p class="q2">and called my son out of Egypt. 
-</p><p class="q1">
-<span class="v">2&#160;</span>They called to them, so they went from them. 
-</p><p class="q2">They sacrificed to the Baals, 
-</p><p class="q2">and burned incense to engraved images. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yet I taught Ephraim to walk. 
-</p><p class="q2">I took them by their arms, 
-</p><p class="q2">but they didn’t know that I healed them. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I drew them with cords of a man, with ties of love; 
-</p><p class="q2">and I was to them like those who lift up the yoke on their necks; 
-</p><p class="q2">and I bent down to him and I fed him. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“They won’t return into the land of Egypt; 
-</p><p class="q2">but the Assyrian will be their king, 
-</p><p class="q2">because they refused to repent. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The sword will fall on their cities, 
-</p><p class="q2">and will destroy the bars of their gates, 
-</p><p class="q2">and will put an end to their plans. 
-</p><p class="q1">
-<span class="v">7&#160;</span>My people are determined to turn from me. 
-</p><p class="q2">Though they call to the Most High, 
-</p><p class="q2">he certainly won’t exalt them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“How can I give you up, Ephraim? 
-</p><p class="q2">How can I hand you over, Israel? 
-</p><p class="q2">How can I make you like Admah? 
-</p><p class="q2">How can I make you like Zeboiim? 
-</p><p class="q1">My heart is turned within me, 
-</p><p class="q2">my compassion is aroused. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will not execute the fierceness of my anger. 
-</p><p class="q2">I will not return to destroy Ephraim, 
-</p><p class="q2">for I am Elohim, and not man—the Set-Apart One among you. 
-</p><p class="q2">I will not come in wrath. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They will walk after Yahweh, 
-</p><p class="q2">who will roar like a lion; 
-</p><p class="q2">for he will roar, and the children will come trembling from the west. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They will come trembling like a bird out of Egypt, 
-</p><p class="q2">and like a dove out of the land of Assyria; 
-</p><p class="q1">and I will settle them in their houses,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Ephraim surrounds me with falsehood, 
-</p><p class="q2">and the house of Israel with deceit. 
-</p><p class="q2">Judah still strays from Elohim, 
-</p><p class="q2">and is unfaithful to the Set-Apart One. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Ephraim feeds on wind, 
-</p><p class="q2">and chases the east wind. 
-</p><p class="q2">He continually multiplies lies and desolation. 
-</p><p class="q2">They make a covenant with Assyria, 
-</p><p class="q2">and oil is carried into Egypt. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh also has a controversy with Judah, 
-</p><p class="q2">and will punish Jacob according to his ways; 
-</p><p class="q2">according to his deeds he will repay him. 
-</p><p class="q1">
-<span class="v">3&#160;</span>In the womb he took his brother by the heel, 
-</p><p class="q2">and in his manhood he contended with Elohim. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Indeed, he struggled with the angel, and prevailed; 
-</p><p class="q2">he wept, and made supplication to him. 
-</p><p class="q2">He found him at Bethel, and there he spoke with us—</p><p class="q2">
-<span class="v">5&#160;</span>even Yahweh, the Elohim of Armies. 
-</p><p class="q2">Yahweh is his name of renown! 
-</p><p class="q1">
-<span class="v">6&#160;</span>Therefore turn to your Elohim. 
-</p><p class="q2">Keep kindness and justice, 
-</p><p class="q2">and wait continually for your Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>A merchant has dishonest scales in his hand. 
-</p><p class="q2">He loves to defraud. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Ephraim said, “Surely I have become rich. 
-</p><p class="q2">I have found myself wealth. 
-</p><p class="q2">In all my wealth they won’t find in me any iniquity that is sin.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“But I am Yahweh your Elohim from the land of Egypt. 
-</p><p class="q2">I will yet again make you dwell in tents, 
-</p><p class="q2">as in the days of the solemn feast. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I have also spoken to the prophets, 
-</p><p class="q2">and I have multiplied visions; 
-</p><p class="q2">and by the ministry of the prophets I have used parables. 
-</p><p class="q1">
-<span class="v">11&#160;</span>If Gilead is wicked, 
-</p><p class="q2">surely they are worthless. 
-</p><p class="q1">In Gilgal they sacrifice bulls. 
-</p><p class="q2">Indeed, their altars are like heaps in the furrows of the field. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Jacob fled into the country of Aram. 
-</p><p class="q2">Israel served to get a woman. 
-</p><p class="q2">For a woman he tended flocks and herds. 
-</p><p class="q1">
-<span class="v">13&#160;</span>By a prophet Yahweh brought Israel up out of Egypt, 
-</p><p class="q2">and by a prophet he was preserved. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Ephraim has bitterly provoked anger. 
-</p><p class="q2">Therefore his blood will be left on him, 
-</p><p class="q2">and his Lord<span class="f">+ \fr 12:14 \ft The word translated “Lord” is “Adonai.”</span> will repay his contempt. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>When Ephraim spoke, there was trembling. 
-</p><p class="q2">He exalted himself in Israel, 
-</p><p class="q2">but when he became guilty through Baal, he died. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Now they sin more and more, 
-</p><p class="q2">and have made themselves molten images of their silver, 
-</p><p class="q2">even idols according to their own understanding, 
-</p><p class="q2">all of them the work of the craftsmen. 
-</p><p class="q2">They say of them, ‘They offer human sacrifice and kiss the calves.’ 
-</p><p class="q1">
-<span class="v">3&#160;</span>Therefore they will be like the morning mist, 
-</p><p class="q2">like the dew that passes away early, 
-</p><p class="q2">like the chaff that is driven with the whirlwind out of the threshing floor, 
-</p><p class="q2">and like the smoke out of the chimney. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Yet I am Yahweh your Elohim from the land of Egypt; 
-</p><p class="q2">and you shall acknowledge no elohim but me, 
-</p><p class="q2">and besides me there is no savior. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I knew you in the wilderness, 
-</p><p class="q2">in the land of great drought. 
-</p><p class="q1">
-<span class="v">6&#160;</span>According to their pasture, so were they filled; 
-</p><p class="q2">they were filled, and their heart was exalted. 
-</p><p class="q2">Therefore they have forgotten me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Therefore I am like a lion to them. 
-</p><p class="q2">Like a leopard, I will lurk by the path. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will meet them like a bear that is bereaved of her cubs, 
-</p><p class="q2">and will tear the covering of their heart. 
-</p><p class="q2">There I will devour them like a lioness. 
-</p><p class="q2">The wild animal will tear them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You are destroyed, Israel, because you are against me, 
-</p><p class="q2">against your helper. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Where is your king now, that he may save you in all your cities? 
-</p><p class="q2">And your judges, of whom you said, ‘Give me a king and princes’? 
-</p><p class="q1">
-<span class="v">11&#160;</span>I have given you a king in my anger, 
-</p><p class="q2">and have taken him away in my wrath. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The guilt of Ephraim is stored up. 
-</p><p class="q2">His sin is stored up. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The sorrows of a travailing woman will come on him. 
-</p><p class="q2">He is an unwise son, 
-</p><p class="q2">for when it is time, he doesn’t come to the opening of the womb. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will ransom them from the power of Sheol.<span class="f">+ \fr 13:14 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">I will redeem them from death! 
-</p><p class="q2">Death, where are your plagues? 
-</p><p class="q2">Sheol, where is your destruction? 
-</p><div class="b"> &#160; </div>
-<p class="q1">“Compassion will be hidden from my eyes. 
-</p><p class="q2">
-<span class="v">15&#160;</span>Though he is fruitful among his brothers, an east wind will come, 
-</p><p class="q2">the breath of Yahweh coming up from the wilderness; 
-</p><p class="q2">and his spring will become dry, 
-</p><p class="q2">and his fountain will be dried up. 
-</p><p class="q2">He will plunder the storehouse of treasure. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Samaria will bear her guilt, 
-</p><p class="q2">for she has rebelled against her Elohim. 
-</p><p class="q2">They will fall by the sword. 
-</p><p class="q2">Their infants will be dashed in pieces, 
-</p><p class="q2">and their pregnant women will be ripped open.” 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>“When Israel was a child, then I loved him, 
+</div><div class="q2">and called my son out of Egypt. 
+</div><div class="q1">
+<sup>2&#160;</sup>They called to them, so they went from them. 
+</div><div class="q2">They sacrificed to the Baals, 
+</div><div class="q2">and burned incense to engraved images. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yet I taught Ephraim to walk. 
+</div><div class="q2">I took them by their arms, 
+</div><div class="q2">but they didn’t know that I healed them. 
+</div><div class="q1">
+<sup>4&#160;</sup>I drew them with cords of a man, with ties of love; 
+</div><div class="q2">and I was to them like those who lift up the yoke on their necks; 
+</div><div class="q2">and I bent down to him and I fed him. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“They won’t return into the land of Egypt; 
+</div><div class="q2">but the Assyrian will be their king, 
+</div><div class="q2">because they refused to repent. 
+</div><div class="q1">
+<sup>6&#160;</sup>The sword will fall on their cities, 
+</div><div class="q2">and will destroy the bars of their gates, 
+</div><div class="q2">and will put an end to their plans. 
+</div><div class="q1">
+<sup>7&#160;</sup>My people are determined to turn from me. 
+</div><div class="q2">Though they call to the Most High, 
+</div><div class="q2">he certainly won’t exalt them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“How can I give you up, Ephraim? 
+</div><div class="q2">How can I hand you over, Israel? 
+</div><div class="q2">How can I make you like Admah? 
+</div><div class="q2">How can I make you like Zeboiim? 
+</div><div class="q1">My heart is turned within me, 
+</div><div class="q2">my compassion is aroused. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will not execute the fierceness of my anger. 
+</div><div class="q2">I will not return to destroy Ephraim, 
+</div><div class="q2">for I am Elohim, and not man—the Set-Apart One among you. 
+</div><div class="q2">I will not come in wrath. 
+</div><div class="q1">
+<sup>10&#160;</sup>They will walk after Yahweh, 
+</div><div class="q2">who will roar like a lion; 
+</div><div class="q2">for he will roar, and the children will come trembling from the west. 
+</div><div class="q1">
+<sup>11&#160;</sup>They will come trembling like a bird out of Egypt, 
+</div><div class="q2">and like a dove out of the land of Assyria; 
+</div><div class="q1">and I will settle them in their houses,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Ephraim surrounds me with falsehood, 
+</div><div class="q2">and the house of Israel with deceit. 
+</div><div class="q2">Judah still strays from Elohim, 
+</div><div class="q2">and is unfaithful to the Set-Apart One. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Ephraim feeds on wind, 
+</div><div class="q2">and chases the east wind. 
+</div><div class="q2">He continually multiplies lies and desolation. 
+</div><div class="q2">They make a covenant with Assyria, 
+</div><div class="q2">and oil is carried into Egypt. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh also has a controversy with Judah, 
+</div><div class="q2">and will punish Jacob according to his ways; 
+</div><div class="q2">according to his deeds he will repay him. 
+</div><div class="q1">
+<sup>3&#160;</sup>In the womb he took his brother by the heel, 
+</div><div class="q2">and in his manhood he contended with Elohim. 
+</div><div class="q1">
+<sup>4&#160;</sup>Indeed, he struggled with the angel, and prevailed; 
+</div><div class="q2">he wept, and made supplication to him. 
+</div><div class="q2">He found him at Bethel, and there he spoke with us—</div><div class="q2">
+<sup>5&#160;</sup>even Yahweh, the Elohim of Armies. 
+</div><div class="q2">Yahweh is his name of renown! 
+</div><div class="q1">
+<sup>6&#160;</sup>Therefore turn to your Elohim. 
+</div><div class="q2">Keep kindness and justice, 
+</div><div class="q2">and wait continually for your Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>A merchant has dishonest scales in his hand. 
+</div><div class="q2">He loves to defraud. 
+</div><div class="q1">
+<sup>8&#160;</sup>Ephraim said, “Surely I have become rich. 
+</div><div class="q2">I have found myself wealth. 
+</div><div class="q2">In all my wealth they won’t find in me any iniquity that is sin.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“But I am Yahweh your Elohim from the land of Egypt. 
+</div><div class="q2">I will yet again make you dwell in tents, 
+</div><div class="q2">as in the days of the solemn feast. 
+</div><div class="q1">
+<sup>10&#160;</sup>I have also spoken to the prophets, 
+</div><div class="q2">and I have multiplied visions; 
+</div><div class="q2">and by the ministry of the prophets I have used parables. 
+</div><div class="q1">
+<sup>11&#160;</sup>If Gilead is wicked, 
+</div><div class="q2">surely they are worthless. 
+</div><div class="q1">In Gilgal they sacrifice bulls. 
+</div><div class="q2">Indeed, their altars are like heaps in the furrows of the field. 
+</div><div class="q1">
+<sup>12&#160;</sup>Jacob fled into the country of Aram. 
+</div><div class="q2">Israel served to get a woman. 
+</div><div class="q2">For a woman he tended flocks and herds. 
+</div><div class="q1">
+<sup>13&#160;</sup>By a prophet Yahweh brought Israel up out of Egypt, 
+</div><div class="q2">and by a prophet he was preserved. 
+</div><div class="q1">
+<sup>14&#160;</sup>Ephraim has bitterly provoked anger. 
+</div><div class="q2">Therefore his blood will be left on him, 
+</div><div class="q2">and his Lord will repay his contempt. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>When Ephraim spoke, there was trembling. 
+</div><div class="q2">He exalted himself in Israel, 
+</div><div class="q2">but when he became guilty through Baal, he died. 
+</div><div class="q1">
+<sup>2&#160;</sup>Now they sin more and more, 
+</div><div class="q2">and have made themselves molten images of their silver, 
+</div><div class="q2">even idols according to their own understanding, 
+</div><div class="q2">all of them the work of the craftsmen. 
+</div><div class="q2">They say of them, ‘They offer human sacrifice and kiss the calves.’ 
+</div><div class="q1">
+<sup>3&#160;</sup>Therefore they will be like the morning mist, 
+</div><div class="q2">like the dew that passes away early, 
+</div><div class="q2">like the chaff that is driven with the whirlwind out of the threshing floor, 
+</div><div class="q2">and like the smoke out of the chimney. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Yet I am Yahweh your Elohim from the land of Egypt; 
+</div><div class="q2">and you shall acknowledge no elohim but me, 
+</div><div class="q2">and besides me there is no savior. 
+</div><div class="q1">
+<sup>5&#160;</sup>I knew you in the wilderness, 
+</div><div class="q2">in the land of great drought. 
+</div><div class="q1">
+<sup>6&#160;</sup>According to their pasture, so were they filled; 
+</div><div class="q2">they were filled, and their heart was exalted. 
+</div><div class="q2">Therefore they have forgotten me. 
+</div><div class="q1">
+<sup>7&#160;</sup>Therefore I am like a lion to them. 
+</div><div class="q2">Like a leopard, I will lurk by the path. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will meet them like a bear that is bereaved of her cubs, 
+</div><div class="q2">and will tear the covering of their heart. 
+</div><div class="q2">There I will devour them like a lioness. 
+</div><div class="q2">The wild animal will tear them. 
+</div><div class="q1">
+<sup>9&#160;</sup>You are destroyed, Israel, because you are against me, 
+</div><div class="q2">against your helper. 
+</div><div class="q1">
+<sup>10&#160;</sup>Where is your king now, that he may save you in all your cities? 
+</div><div class="q2">And your judges, of whom you said, ‘Give me a king and princes’? 
+</div><div class="q1">
+<sup>11&#160;</sup>I have given you a king in my anger, 
+</div><div class="q2">and have taken him away in my wrath. 
+</div><div class="q1">
+<sup>12&#160;</sup>The guilt of Ephraim is stored up. 
+</div><div class="q2">His sin is stored up. 
+</div><div class="q1">
+<sup>13&#160;</sup>The sorrows of a travailing woman will come on him. 
+</div><div class="q2">He is an unwise son, 
+</div><div class="q2">for when it is time, he doesn’t come to the opening of the womb. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will ransom them from the power of Sheol. 
+</div><div class="q2">I will redeem them from death! 
+</div><div class="q2">Death, where are your plagues? 
+</div><div class="q2">Sheol, where is your destruction? 
+</div><div class="b"> &#160; </div>
+<div class="q1">“Compassion will be hidden from my eyes. 
+</div><div class="q2">
+<sup>15&#160;</sup>Though he is fruitful among his brothers, an east wind will come, 
+</div><div class="q2">the breath of Yahweh coming up from the wilderness; 
+</div><div class="q2">and his spring will become dry, 
+</div><div class="q2">and his fountain will be dried up. 
+</div><div class="q2">He will plunder the storehouse of treasure. 
+</div><div class="q1">
+<sup>16&#160;</sup>Samaria will bear her guilt, 
+</div><div class="q2">for she has rebelled against her Elohim. 
+</div><div class="q2">They will fall by the sword. 
+</div><div class="q2">Their infants will be dashed in pieces, 
+</div><div class="q2">and their pregnant women will be ripped open.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="14">14</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Israel, return to Yahweh your Elohim; 
-</p><p class="q2">for you have fallen because of your sin. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Take words with you, and return to Yahweh. 
-</p><p class="q2">Tell him, “Forgive all our sins, 
-</p><p class="q2">and accept that which is good; 
-</p><p class="q2">so we offer bulls as we vowed of our lips. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Assyria can’t save us. 
-</p><p class="q2">We won’t ride on horses; 
-</p><p class="q2">neither will we say any more to the work of our hands, ‘Our elohims!’ 
-</p><p class="q2">for in you the fatherless finds mercy.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“I will heal their waywardness. 
-</p><p class="q2">I will love them freely; 
-</p><p class="q2">for my anger is turned away from them. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I will be like the dew to Israel. 
-</p><p class="q2">He will blossom like the lily, 
-</p><p class="q2">and send down his roots like Lebanon. 
-</p><p class="q1">
-<span class="v">6&#160;</span>His branches will spread, 
-</p><p class="q2">and his beauty will be like the olive tree, 
-</p><p class="q2">and his fragrance like Lebanon. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Men will dwell in his shade. 
-</p><p class="q2">They will revive like the grain, 
-</p><p class="q2">and blossom like the vine. 
-</p><p class="q2">Their fragrance will be like the wine of Lebanon. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Ephraim, what have I to do any more with idols? 
-</p><p class="q2">I answer, and will take care of him. 
-</p><p class="q2">I am like a green cypress tree; 
-</p><p class="q2">from me your fruit is found.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Who is wise, that he may understand these things? 
-</p><p class="q2">Who is prudent, that he may know them? 
-</p><p class="q2">For the ways of Yahweh are right, 
-</p><p class="q2">and the righteous walk in them, 
-</p><p class="q2">but the rebellious stumble in them. </div><script src="../main.js"></script></body></html>
+<div class="q1">
+<sup>1&#160;</sup>Israel, return to Yahweh your Elohim; 
+</div><div class="q2">for you have fallen because of your sin. 
+</div><div class="q1">
+<sup>2&#160;</sup>Take words with you, and return to Yahweh. 
+</div><div class="q2">Tell him, “Forgive all our sins, 
+</div><div class="q2">and accept that which is good; 
+</div><div class="q2">so we offer bulls as we vowed of our lips. 
+</div><div class="q1">
+<sup>3&#160;</sup>Assyria can’t save us. 
+</div><div class="q2">We won’t ride on horses; 
+</div><div class="q2">neither will we say any more to the work of our hands, ‘Our elohims!’ 
+</div><div class="q2">for in you the fatherless finds mercy.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“I will heal their waywardness. 
+</div><div class="q2">I will love them freely; 
+</div><div class="q2">for my anger is turned away from them. 
+</div><div class="q1">
+<sup>5&#160;</sup>I will be like the dew to Israel. 
+</div><div class="q2">He will blossom like the lily, 
+</div><div class="q2">and send down his roots like Lebanon. 
+</div><div class="q1">
+<sup>6&#160;</sup>His branches will spread, 
+</div><div class="q2">and his beauty will be like the olive tree, 
+</div><div class="q2">and his fragrance like Lebanon. 
+</div><div class="q1">
+<sup>7&#160;</sup>Men will dwell in his shade. 
+</div><div class="q2">They will revive like the grain, 
+</div><div class="q2">and blossom like the vine. 
+</div><div class="q2">Their fragrance will be like the wine of Lebanon. 
+</div><div class="q1">
+<sup>8&#160;</sup>Ephraim, what have I to do any more with idols? 
+</div><div class="q2">I answer, and will take care of him. 
+</div><div class="q2">I am like a green cypress tree; 
+</div><div class="q2">from me your fruit is found.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Who is wise, that he may understand these things? 
+</div><div class="q2">Who is prudent, that he may know them? 
+</div><div class="q2">For the ways of Yahweh are right, 
+</div><div class="q2">and the righteous walk in them, 
+</div><div class="q2">but the rebellious stumble in them. </div></div><script src="../main.js"></script></body></html>

--- a/book/isaiah.html
+++ b/book/isaiah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Isaiah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,4422 +53,4489 @@
 <div class="main">
 <!-- ISA World English Scripture (WES) -->
 <h1 class="booklabel">Isaiah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The vision of Isaiah the son of Amoz, which he saw concerning Judah and Jerusalem, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear, heavens, 
-</p><p class="q2">and listen, earth; for Yahweh<span class="f">+ \fr 1:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> has spoken: 
-</p><p class="q1">“I have nourished and brought up children 
-</p><p class="q2">and they have rebelled against me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The ox knows his owner, 
-</p><p class="q2">and the donkey his master’s crib; 
-</p><p class="q2">but Israel doesn’t know. 
-</p><p class="q2">My people don’t consider.” 
-</p><p class="q1">
-<span class="v">4&#160;</span>Ah sinful nation, 
-</p><p class="q2">a people loaded with iniquity, 
-</p><p class="q2">offspring<span class="f">+ \fr 1:4 \ft or, seed</span> of evildoers, 
-</p><p class="q2">children who deal corruptly! 
-</p><p class="q1">They have forsaken Yahweh. 
-</p><p class="q2">They have despised the Set-Apart One of Israel. 
-</p><p class="q2">They are estranged and backward. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why should you be beaten more, 
-</p><p class="q2">that you revolt more and more? 
-</p><p class="q1">The whole head is sick, 
-</p><p class="q2">and the whole heart faint. 
-</p><p class="q1">
-<span class="v">6&#160;</span>From the sole of the foot even to the head there is no soundness in it, 
-</p><p class="q2">but wounds, welts, and open sores. 
-</p><p class="q2">They haven’t been closed, bandaged, or soothed with oil. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Your country is desolate. 
-</p><p class="q2">Your cities are burned with fire. 
-</p><p class="q2">Strangers devour your land in your presence 
-</p><p class="q2">and it is desolate, 
-</p><p class="q2">as overthrown by strangers. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The daughter of Zion is left like a shelter in a vineyard, 
-</p><p class="q2">like a hut in a field of melons, 
-</p><p class="q2">like a besieged city. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Unless Yahweh of Armies had left to us a very small remnant, 
-</p><p class="q2">we would have been as Sodom. 
-</p><p class="q2">We would have been like Gomorrah. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Hear Yahweh’s word, you rulers of Sodom! 
-</p><p class="q2">Listen to the law of our Elohim,<span class="f">+ \fr 1:10 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> you people of Gomorrah! 
-</p><p class="q1">
-<span class="v">11&#160;</span>“What are the multitude of your sacrifices to me?”, says Yahweh. 
-</p><p class="q2">“I have had enough of the burnt offerings of rams 
-</p><p class="q2">and the fat of fed animals. 
-</p><p class="q2">I don’t delight in the blood of bulls, 
-</p><p class="q2">or of lambs, 
-</p><p class="q2">or of male goats. 
-</p><p class="q1">
-<span class="v">12&#160;</span>When you come to appear before me, 
-</p><p class="q2">who has required this at your hand, to trample my courts? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Bring no more vain offerings. 
-</p><p class="q2">Incense is an abomination to me. 
-</p><p class="q2">New moons, Sabbaths, and convocations—</p><p class="q2">I can’t stand evil assemblies. 
-</p><p class="q1">
-<span class="v">14&#160;</span>My soul hates your New Moons and your appointed feasts. 
-</p><p class="q2">They are a burden to me. 
-</p><p class="q2">I am weary of bearing them. 
-</p><p class="q1">
-<span class="v">15&#160;</span>When you spread out your hands, I will hide my eyes from you. 
-</p><p class="q2">Yes, when you make many prayers, I will not hear. 
-</p><p class="q2">Your hands are full of blood. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Wash yourselves. Make yourself clean. 
-</p><p class="q2">Put away the evil of your doings from before my eyes. 
-</p><p class="q2">Cease to do evil. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Learn to do well. 
-</p><p class="q2">Seek justice. 
-</p><p class="q2">Relieve the oppressed. 
-</p><p class="q1">Defend the fatherless. 
-</p><p class="q2">Plead for the widow.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“Come now, and let’s reason together,” says Yahweh: 
-</p><p class="q2">“Though your sins are as scarlet, they shall be as white as snow. 
-</p><p class="q2">Though they are red like crimson, they shall be as wool. 
-</p><p class="q1">
-<span class="v">19&#160;</span>If you are willing and obedient, 
-</p><p class="q2">you will eat the good of the land; 
-</p><p class="q2">
-<span class="v">20&#160;</span>but if you refuse and rebel, you will be devoured with the sword; 
-</p><p class="q2">for Yahweh’s mouth has spoken it.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>How the faithful city has become a prostitute! 
-</p><p class="q2">She was full of justice. 
-</p><p class="q1">Righteousness lodged in her, 
-</p><p class="q2">but now there are murderers. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Your silver has become dross, 
-</p><p class="q2">your wine mixed with water. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Your princes are rebellious and companions of thieves. 
-</p><p class="q2">Everyone loves bribes and follows after rewards. 
-</p><p class="q2">They don’t defend the fatherless, 
-</p><p class="q2">neither does the cause of the widow come to them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>Therefore the Lord,<span class="f">+ \fr 1:24 \ft The word translated “Lord” is “Adonai.” </span> Yahweh of Armies, 
-</p><p class="q2">the Mighty One of Israel, says: 
-</p><p class="q1">“Ah, I will get relief from my adversaries, 
-</p><p class="q2">and avenge myself on my enemies. 
-</p><p class="q1">
-<span class="v">25&#160;</span>I will turn my hand on you, 
-</p><p class="q2">thoroughly purge away your dross, 
-</p><p class="q2">and will take away all your tin.<span class="f">+ \fr 1:25 \ft tin is a metal that is separated from silver during the refining and purification process.</span> 
-</p><p class="q1">
-<span class="v">26&#160;</span>I will restore your judges as at the first, 
-</p><p class="q2">and your counselors as at the beginning. 
-</p><p class="q1">Afterward you shall be called ‘The city of righteousness, 
-</p><p class="q2">a faithful town.’ 
-</p><p class="q1">
-<span class="v">27&#160;</span>Zion shall be redeemed with justice, 
-</p><p class="q2">and her converts with righteousness. 
-</p><p class="q1">
-<span class="v">28&#160;</span>But the destruction of transgressors and sinners shall be together, 
-</p><p class="q2">and those who forsake Yahweh shall be consumed. 
-</p><p class="q1">
-<span class="v">29&#160;</span>For they shall be ashamed of the oaks which you have desired, 
-</p><p class="q2">and you shall be confounded for the gardens that you have chosen. 
-</p><p class="q1">
-<span class="v">30&#160;</span>For you shall be as an oak whose leaf fades, 
-</p><p class="q2">and as a garden that has no water. 
-</p><p class="q1">
-<span class="v">31&#160;</span>The strong will be like tinder, 
-</p><p class="q2">and his work like a spark. 
-</p><p class="q1">They will both burn together, 
-</p><p class="q2">and no one will quench them.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>This is what Isaiah the son of Amoz saw concerning Judah and Jerusalem. 
-</p><p class="q1">
-<span class="v">2&#160;</span>It shall happen in the latter days, that the mountain of Yahweh’s house shall be established on the top of the mountains, 
-</p><p class="q2">and shall be raised above the hills; 
-</p><p class="q2">and all nations shall flow to it. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Many peoples shall go and say, 
-</p><p class="q2">“Come, let’s go up to the mountain of Yahweh, 
-</p><p class="q2">to the house of the Elohim of Jacob; 
-</p><p class="q2">and he will teach us of his ways, 
-</p><p class="q2">and we will walk in his paths.” 
-</p><p class="q1">For the law shall go out of Zion, 
-</p><p class="q2">and Yahweh’s word from Jerusalem. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He will judge between the nations, 
-</p><p class="q2">and will decide concerning many peoples. 
-</p><p class="q2">They shall beat their swords into plowshares, 
-</p><p class="q2">and their spears into pruning hooks. 
-</p><p class="q1">Nation shall not lift up sword against nation, 
-</p><p class="q2">neither shall they learn war any more. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>House of Jacob, come, and let’s walk in the light of Yahweh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For you have forsaken your people, the house of Jacob, 
-</p><p class="q2">because they are filled from the east, 
-</p><p class="q2">with those who practice divination like the Philistines, 
-</p><p class="q2">and they clasp hands with the children of foreigners. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Their land is full of silver and gold, 
-</p><p class="q2">neither is there any end of their treasures. 
-</p><p class="q1">Their land also is full of horses, 
-</p><p class="q2">neither is there any end of their chariots. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Their land also is full of idols. 
-</p><p class="q2">They worship the work of their own hands, 
-</p><p class="q2">that which their own fingers have made. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Man is brought low, 
-</p><p class="q2">and mankind is humbled; 
-</p><p class="q2">therefore don’t forgive them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Enter into the rock, 
-</p><p class="q2">and hide in the dust, 
-</p><p class="q1">from before the terror of Yahweh, 
-</p><p class="q2">and from the glory of his majesty. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The lofty looks of man will be brought low, 
-</p><p class="q2">the arrogance of men will be bowed down, 
-</p><p class="q2">and Yahweh alone will be exalted in that day. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>For there will be a day of Yahweh of Armies for all that is proud and arrogant, 
-</p><p class="q2">and for all that is lifted up, 
-</p><p class="q2">and it shall be brought low—</p><p class="q2">
-<span class="v">13&#160;</span>for all the cedars of Lebanon, that are high and lifted up, 
-</p><p class="q2">for all the oaks of Bashan, 
-</p><p class="q2">
-<span class="v">14&#160;</span>for all the high mountains, 
-</p><p class="q2">for all the hills that are lifted up, 
-</p><p class="q2">
-<span class="v">15&#160;</span>for every lofty tower, 
-</p><p class="q2">for every fortified wall, 
-</p><p class="q2">
-<span class="v">16&#160;</span>for all the ships of Tarshish, 
-</p><p class="q2">and for all pleasant imagery. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The loftiness of man shall be bowed down, 
-</p><p class="q2">and the arrogance of men shall be brought low; 
-</p><p class="q2">and Yahweh alone shall be exalted in that day. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The idols shall utterly pass away. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Men shall go into the caves of the rocks, 
-</p><p class="q2">and into the holes of the earth, 
-</p><p class="q2">from before the terror of Yahweh, 
-</p><p class="q2">and from the glory of his majesty, 
-</p><p class="q2">when he arises to shake the earth mightily. 
-</p><p class="q1">
-<span class="v">20&#160;</span>In that day, men shall cast away their idols of silver 
-</p><p class="q2">and their idols of gold, 
-</p><p class="q2">which have been made for themselves to worship, 
-</p><p class="q2">to the moles and to the bats, 
-</p><p class="q2">
-<span class="v">21&#160;</span>to go into the caverns of the rocks, 
-</p><p class="q2">and into the clefts of the ragged rocks, 
-</p><p class="q2">from before the terror of Yahweh, 
-</p><p class="q2">and from the glory of his majesty, 
-</p><p class="q2">when he arises to shake the earth mightily. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Stop trusting in man, whose breath is in his nostrils; 
-</p><p class="q2">for of what account is he? 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p class="q1">
-<span class="v">1&#160;</span>For, behold,<span class="f">+ \fr 3:1 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> the Lord, Yahweh of Armies, takes away from Jerusalem and from Judah supply and support, 
-</p><p class="q2">the whole supply of bread, 
-</p><p class="q2">and the whole supply of water; 
-</p><p class="q2">
-<span class="v">2&#160;</span>the mighty man, 
-</p><p class="q2">the man of war, 
-</p><p class="q2">the judge, 
-</p><p class="q2">the prophet, 
-</p><p class="q2">the diviner, 
-</p><p class="q2">the elder, 
-</p><p class="q2">
-<span class="v">3&#160;</span>the captain of fifty, 
-</p><p class="q2">the honorable man, 
-</p><p class="q2">the counselor, 
-</p><p class="q2">the skilled craftsman, 
-</p><p class="q2">and the clever enchanter. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will give boys to be their princes, 
-</p><p class="q2">and children shall rule over them. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The people will be oppressed, 
-</p><p class="q2">everyone by another, 
-</p><p class="q2">and everyone by his neighbor. 
-</p><p class="q1">The child will behave himself proudly against the old man, 
-</p><p class="q2">and the wicked against the honorable. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Indeed a man shall take hold of his brother in the house of his father, saying, 
-</p><p class="q2">“You have clothing, you be our ruler, 
-</p><p class="q2">and let this ruin be under your hand.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>In that day he will cry out, saying, “I will not be a healer; 
-</p><p class="q2">for in my house is neither bread nor clothing. 
-</p><p class="q2">You shall not make me ruler of the people.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>For Jerusalem is ruined, and Judah is fallen; 
-</p><p class="q2">because their tongue and their doings are against Yahweh, 
-</p><p class="q1">to provoke the eyes of his glory. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The look of their faces testify against them. 
-</p><p class="q2">They parade their sin like Sodom. 
-</p><p class="q2">They don’t hide it. 
-</p><p class="q2">Woe to their soul! 
-</p><p class="q2">For they have brought disaster upon themselves. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Tell the righteous that it will be well with them, 
-</p><p class="q2">for they will eat the fruit of their deeds. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Woe to the wicked! 
-</p><p class="q2">Disaster is upon them, 
-</p><p class="q2">for the deeds of their hands will be paid back to them. 
-</p><p class="q1">
-<span class="v">12&#160;</span>As for my people, children are their oppressors, 
-</p><p class="q2">and women rule over them. 
-</p><p class="q2">My people, those who lead you cause you to err, 
-</p><p class="q2">and destroy the way of your paths. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Yahweh stands up to contend, 
-</p><p class="q2">and stands to judge the peoples. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yahweh will enter into judgment with the elders of his people 
-</p><p class="q2">and their leaders: 
-</p><p class="q2">“It is you who have eaten up the vineyard. 
-</p><p class="q2">The plunder of the poor is in your houses. 
-</p><p class="q2">
-<span class="v">15&#160;</span>What do you mean that you crush my people, 
-</p><p class="q2">and grind the face of the poor?” says the Lord, Yahweh of Armies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Moreover Yahweh said, “Because the daughters of Zion are arrogant, 
-</p><p class="q2">and walk with outstretched necks and flirting eyes, 
-</p><p class="q2">walking daintily as they go, 
-</p><p class="q2">jingling ornaments on their feet; 
-</p><p class="q1">
-<span class="v">17&#160;</span>therefore the Lord brings sores on the crown of the head of the women of Zion, 
-</p><p class="q2">and Yahweh will make their scalps bald.” 
-</p><p>
-<span class="v">18&#160;</span>In that day the Lord will take away the beauty of their anklets, the headbands, the crescent necklaces, 
-<span class="v">19&#160;</span>the earrings, the bracelets, the veils, 
-<span class="v">20&#160;</span>the headdresses, the ankle chains, the sashes, the perfume containers, the charms, 
-<span class="v">21&#160;</span>the signet rings, the nose rings, 
-<span class="v">22&#160;</span>the fine robes, the capes, the cloaks, the purses, 
-<span class="v">23&#160;</span>the hand mirrors, the fine linen garments, the tiaras, and the shawls. 
-</p><p class="q1">
-<span class="v">24&#160;</span>It shall happen that instead of sweet spices, there shall be rottenness; 
-</p><p class="q2">instead of a belt, a rope; 
-</p><p class="q2">instead of well set hair, baldness; 
-</p><p class="q2">instead of a robe, a wearing of sackcloth; 
-</p><p class="q2">and branding instead of beauty. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Your men shall fall by the sword, 
-</p><p class="q2">and your mighty in the war. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Her gates shall lament and mourn. 
-</p><p class="q2">She shall be desolate and sit on the ground. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Seven women shall take hold of one man in that day, saying, “We will eat our own bread, and wear our own clothing. Just let us be called by your name. Take away our reproach.” 
-</p><p>
-<span class="v">2&#160;</span>In that day, Yahweh’s branch will be beautiful and glorious, and the fruit of the land will be the beauty and glory of the survivors of Israel. 
-<span class="v">3&#160;</span>It will happen that he who is left in Zion and he who remains in Jerusalem shall be called set-apart, even everyone who is written among the living in Jerusalem, 
-<span class="v">4&#160;</span>when the Lord shall have washed away the filth of the daughters of Zion, and shall have purged the blood of Jerusalem from within it, by the spirit of justice and by the spirit of burning. 
-<span class="v">5&#160;</span>Yahweh will create over the whole habitation of Mount Zion and over her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night, for over all the glory will be a canopy. 
-<span class="v">6&#160;</span>There will be a pavilion for a shade in the daytime from the heat, and for a refuge and for a shelter from storm and from rain. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Let me sing for my well beloved a song of my beloved about his vineyard. 
-</p><p class="q2">My beloved had a vineyard on a very fruitful hill. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He dug it up, 
-</p><p class="q2">gathered out its stones, 
-</p><p class="q2">planted it with the choicest vine, 
-</p><p class="q2">built a tower in the middle of it, 
-</p><p class="q2">and also cut out a wine press in it. 
-</p><p class="q1">He looked for it to yield grapes, 
-</p><p class="q2">but it yielded wild grapes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Now, inhabitants of Jerusalem and men of Judah, 
-</p><p class="q2">please judge between me and my vineyard. 
-</p><p class="q1">
-<span class="v">4&#160;</span>What could have been done more to my vineyard, that I have not done in it? 
-</p><p class="q2">Why, when I looked for it to yield grapes, did it yield wild grapes? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Now I will tell you what I will do to my vineyard. 
-</p><p class="q2">I will take away its hedge, and it will be eaten up. 
-</p><p class="q2">I will break down its wall, and it will be trampled down. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I will lay it a wasteland. 
-</p><p class="q2">It won’t be pruned or hoed, 
-</p><p class="q2">but it will grow briers and thorns. 
-</p><p class="q2">I will also command the clouds that they rain no rain on it.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>For the vineyard of Yahweh of Armies is the house of Israel, 
-</p><p class="q2">and the men of Judah his pleasant plant. 
-</p><p class="q2">He looked for justice, but behold, oppression, 
-</p><p class="q2">for righteousness, but behold, a cry of distress. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Woe to those who join house to house, 
-</p><p class="q2">who lay field to field, until there is no room, 
-</p><p class="q2">and you are made to dwell alone in the middle of the land! 
-</p><p class="q1">
-<span class="v">9&#160;</span>In my ears, Yahweh of Armies says: “Surely many houses will be desolate, 
-</p><p class="q2">even great and beautiful, unoccupied. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For ten acres<span class="f">+ \fr 5:10 \ft literally, ten yokes, or the amount of land that ten yokes of oxen can plow in one day, which is about 10 acres or 4 hectares.</span> of vineyard shall yield one bath,<span class="f">+ \fr 5:10 \ft 1 bath is about 22 liters or 5.8 U. S. gallons</span> 
-</p><p class="q2">and a homer<span class="f">+ \fr 5:10 \ft 1 homer is about 220 liters or 6 bushels</span> of seed shall yield an ephah.”<span class="f">+ \fr 5:10 \ft 1 ephah is about 22 liters or 0.6 bushels or about 2 pecks—only one tenth of what was sown.</span> 
-</p><p class="q1">
-<span class="v">11&#160;</span>Woe to those who rise up early in the morning, that they may follow strong drink, 
-</p><p class="q2">who stay late into the night, until wine inflames them! 
-</p><p class="q1">
-<span class="v">12&#160;</span>The harp, lyre, tambourine, and flute, with wine, are at their feasts; 
-</p><p class="q2">but they don’t respect the work of Yahweh, 
-</p><p class="q2">neither have they considered the operation of his hands. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Therefore my people go into captivity for lack of knowledge. 
-</p><p class="q2">Their honorable men are famished, 
-</p><p class="q2">and their multitudes are parched with thirst. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Therefore Sheol<span class="f">+ \fr 5:14 \ft Sheol is the place of the dead.</span> has enlarged its desire, 
-</p><p class="q2">and opened its mouth without measure; 
-</p><p class="q2">and their glory, their multitude, their pomp, and he who rejoices among them, descend into it. 
-</p><p class="q1">
-<span class="v">15&#160;</span>So man is brought low, 
-</p><p class="q2">mankind is humbled, 
-</p><p class="q2">and the eyes of the arrogant ones are humbled; 
-</p><p class="q1">
-<span class="v">16&#160;</span>but Yahweh of Armies is exalted in justice, 
-</p><p class="q2">and Elohim the Set-Apart One is sanctified in righteousness. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Then the lambs will graze as in their pasture, 
-</p><p class="q2">and strangers will eat the ruins of the rich. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>Woe to those who draw iniquity with cords of falsehood, 
-</p><p class="q2">and wickedness as with cart rope, 
-</p><p class="q1">
-<span class="v">19&#160;</span>who say, “Let him make haste, let him hasten his work, that we may see it; 
-</p><p class="q2">let the counsel of the Set-Apart One of Israel draw near and come, 
-</p><p class="q2">that we may know it!” 
-</p><p class="q1">
-<span class="v">20&#160;</span>Woe to those who call evil good, and good evil; 
-</p><p class="q2">who put darkness for light, 
-</p><p class="q2">and light for darkness; 
-</p><p class="q1">who put bitter for sweet, 
-</p><p class="q2">and sweet for bitter! 
-</p><p class="q1">
-<span class="v">21&#160;</span>Woe to those who are wise in their own eyes, 
-</p><p class="q2">and prudent in their own sight! 
-</p><p class="q1">
-<span class="v">22&#160;</span>Woe to those who are mighty to drink wine, 
-</p><p class="q2">and champions at mixing strong drink; 
-</p><p class="q1">
-<span class="v">23&#160;</span>who acquit the guilty for a bribe, 
-</p><p class="q2">but deny justice for the innocent! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>Therefore as the tongue of fire devours the stubble, 
-</p><p class="q2">and as the dry grass sinks down in the flame, 
-</p><p class="q2">so their root shall be as rottenness, 
-</p><p class="q2">and their blossom shall go up as dust, 
-</p><p class="q1">because they have rejected the law of Yahweh of Armies, 
-</p><p class="q2">and despised the word of the Set-Apart One of Israel. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Therefore Yahweh’s anger burns against his people, 
-</p><p class="q2">and he has stretched out his hand against them and has struck them. 
-</p><p class="q1">The mountains tremble, 
-</p><p class="q2">and their dead bodies are as refuse in the middle of the streets. 
-</p><p class="q1">For all this, his anger is not turned away, 
-</p><p class="q2">but his hand is still stretched out. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">26&#160;</span>He will lift up a banner to the nations from far away, 
-</p><p class="q2">and he will whistle for them from the end of the earth. 
-</p><p class="q2">Behold, they will come speedily and swiftly. 
-</p><p class="q1">
-<span class="v">27&#160;</span>No one shall be weary nor stumble among them; 
-</p><p class="q2">no one shall slumber nor sleep, 
-</p><p class="q2">neither shall the belt of their waist be untied, 
-</p><p class="q2">nor the strap of their sandals be broken, 
-</p><p class="q1">
-<span class="v">28&#160;</span>whose arrows are sharp, 
-</p><p class="q2">and all their bows bent. 
-</p><p class="q1">Their horses’ hoofs will be like flint, 
-</p><p class="q2">and their wheels like a whirlwind. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Their roaring will be like a lioness. 
-</p><p class="q2">They will roar like young lions. 
-</p><p class="q1">Yes, they shall roar, 
-</p><p class="q2">and seize their prey and carry it off, 
-</p><p class="q2">and there will be no one to deliver. 
-</p><p class="q1">
-<span class="v">30&#160;</span>They will roar against them in that day like the roaring of the sea. 
-</p><p class="q2">If one looks to the land, behold, darkness and distress. 
-</p><p class="q2">The light is darkened in its clouds. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>In the year that King Uzziah died, I saw the Lord sitting on a throne, high and lifted up; and his train filled the temple. 
-<span class="v">2&#160;</span>Above him stood the seraphim. Each one had six wings. With two he covered his face. With two he covered his feet. With two he flew. 
-<span class="v">3&#160;</span>One called to another, and said, 
-</p><p class="q1">“Set-Apart, set-apart, set-apart, is Yahweh of Armies! 
-</p><p class="q2">The whole earth is full of his glory!” 
-</p><p>
-<span class="v">4&#160;</span>The foundations of the thresholds shook at the voice of him who called, and the house was filled with smoke. 
-<span class="v">5&#160;</span>Then I said, “Woe is me! For I am undone, because I am a man of unclean lips and I live among a people of unclean lips, for my eyes have seen the King, Yahweh of Armies!” 
-</p><p>
-<span class="v">6&#160;</span>Then one of the seraphim flew to me, having a live coal in his hand, which he had taken with the tongs from off the altar. 
-<span class="v">7&#160;</span>He touched my mouth with it, and said, “Behold, this has touched your lips; and your iniquity is taken away, and your sin forgiven.” 
-</p><p>
-<span class="v">8&#160;</span>I heard the Lord’s voice, saying, “Whom shall I send, and who will go for us?” 
-</p><p>Then I said, “Here I am. Send me!” 
-</p><p>
-<span class="v">9&#160;</span>He said, “Go, and tell this people, 
-</p><p class="q1">‘You hear indeed, 
-</p><p class="q2">but don’t understand. 
-</p><p class="q1">You see indeed, 
-</p><p class="q2">but don’t perceive.’ 
-</p><p class="q1">
-<span class="v">10&#160;</span>Make the heart of this people fat. 
-</p><p class="q2">Make their ears heavy, and shut their eyes; 
-</p><p class="q1">lest they see with their eyes, 
-</p><p class="q2">hear with their ears, 
-</p><p class="q2">understand with their heart, 
-</p><p class="q2">and turn again, and be healed.” 
-</p><p>
-<span class="v">11&#160;</span>Then I said, “Lord, how long?” 
-</p><p>He answered, 
-</p><p class="q1">“Until cities are waste without inhabitant, 
-</p><p class="q2">houses without man, 
-</p><p class="q2">the land becomes utterly waste, 
-</p><p class="q2">
-<span class="v">12&#160;</span>and Yahweh has removed men far away, 
-</p><p class="q2">and the forsaken places are many within the land. 
-</p><p class="q1">
-<span class="v">13&#160;</span>If there is a tenth left in it, 
-</p><p class="q2">that also will in turn be consumed, 
-</p><p class="q1">as a terebinth, and as an oak whose stump remains when they are cut down, 
-</p><p class="q2">so the set-apart seed is its stump.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>In the days of Ahaz the son of Jotham, the son of Uzziah, king of Judah, Rezin the king of Syria and Pekah the son of Remaliah, king of Israel, went up to Jerusalem to war against it, but could not prevail against it. 
-<span class="v">2&#160;</span>David’s house was told, “Syria is allied with Ephraim.” His heart trembled, and the heart of his people, as the trees of the forest tremble with the wind. 
-</p><p>
-<span class="v">3&#160;</span>Then Yahweh said to Isaiah, “Go out now to meet Ahaz, you, and Shearjashub your son, at the end of the conduit of the upper pool, on the highway of the fuller’s field. 
-<span class="v">4&#160;</span>Tell him, ‘Be careful, and keep calm. Don’t be afraid, neither let your heart be faint because of these two tails of smoking torches, for the fierce anger of Rezin and Syria, and of the son of Remaliah. 
-<span class="v">5&#160;</span>Because Syria, Ephraim, and the son of Remaliah, have plotted evil against you, saying, 
-<span class="v">6&#160;</span>“Let’s go up against Judah, and tear it apart, and let’s divide it among ourselves, and set up a king within it, even the son of Tabeel.” 
-<span class="v">7&#160;</span>This is what the Lord Yahweh says: “It shall not stand, neither shall it happen.” 
-<span class="v">8&#160;</span>For the head of Syria is Damascus, and the head of Damascus is Rezin. Within sixty-five years Ephraim shall be broken in pieces, so that it shall not be a people. 
-<span class="v">9&#160;</span>The head of Ephraim is Samaria, and the head of Samaria is Remaliah’s son. If you will not believe, surely you shall not be established.’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Yahweh spoke again to Ahaz, saying, 
-<span class="v">11&#160;</span>“Ask a sign of Yahweh your Elohim; ask it either in the depth, or in the height above.” 
-</p><p>
-<span class="v">12&#160;</span>But Ahaz said, “I won’t ask. I won’t tempt Yahweh.” 
-</p><p>
-<span class="v">13&#160;</span>He said, “Listen now, house of David. Is it not enough for you to try the patience of men, that you will try the patience of my Elohim also? 
-<span class="v">14&#160;</span>Therefore the Lord himself will give you a sign. Behold, the young woman will conceive, and bear a son, and shall call his name Immanuel.<span class="f">+ \fr 7:14 \ft “Immanuel” means “Elohim with us”.</span> 
-<span class="v">15&#160;</span>He shall eat butter and honey when he knows to refuse the evil and choose the good. 
-<span class="v">16&#160;</span>For before the child knows to refuse the evil and choose the good, the land whose two kings you abhor shall be forsaken. 
-<span class="v">17&#160;</span>Yahweh will bring on you, on your people, and on your father’s house days that have not come, from the day that Ephraim departed from Judah, even the king of Assyria. 
-</p><p>
-<span class="v">18&#160;</span>It will happen in that day that Yahweh will whistle for the fly that is in the uttermost part of the rivers of Egypt, and for the bee that is in the land of Assyria. 
-<span class="v">19&#160;</span>They shall come, and shall all rest in the desolate valleys, in the clefts of the rocks, on all thorn hedges, and on all pastures. 
-</p><p>
-<span class="v">20&#160;</span>In that day the Lord will shave with a razor that is hired in the parts beyond the River, even with the king of Assyria, the head and the hair of the feet; and it shall also consume the beard. 
-</p><p>
-<span class="v">21&#160;</span>It shall happen in that day that a man shall keep alive a young cow, and two sheep. 
-<span class="v">22&#160;</span>It shall happen, that because of the abundance of milk which they shall give he shall eat butter, for everyone will eat butter and honey that is left within the land. 
-</p><p>
-<span class="v">23&#160;</span>It will happen in that day that every place where there were a thousand vines worth a thousand silver shekels,<span class="f">+ \fr 7:23 \ft A shekel is about 10 grams or about 0.35 ounces, so 1000 shekels is about 10 kilograms or 22 pounds.</span> will be for briers and thorns. 
-<span class="v">24&#160;</span>People will go there with arrows and with bow, because all the land will be briers and thorns. 
-<span class="v">25&#160;</span>All the hills that were cultivated with the hoe, you shall not come there for fear of briers and thorns; but it shall be for the sending out of oxen, and for sheep to tread on.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to me, “Take a large tablet, and write on it with a man’s pen, ‘For Maher Shalal Hash Baz’;<span class="f">+ \fr 8:1 \ft “Maher Shalal Hash Baz” means “quick to the plunder, swift to the prey”.</span> 
-<span class="v">2&#160;</span>and I will take for myself faithful witnesses to testify: Uriah the priest, and Zechariah the son of Jeberechiah.” 
-</p><p>
-<span class="v">3&#160;</span>I went to the prophetess, and she conceived, and bore a son. Then Yahweh said to me, “Call his name ‘Maher Shalal Hash Baz.’ 
-<span class="v">4&#160;</span>For before the child knows how to say, ‘My father’ and ‘My mother,’ the riches of Damascus and the plunder of Samaria will be carried away by the king of Assyria.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh spoke to me yet again, saying, 
-<span class="v">6&#160;</span>“Because this people has refused the waters of Shiloah that go softly, and rejoice in Rezin and Remaliah’s son; 
-<span class="v">7&#160;</span>now therefore, behold, the Lord brings upon them the mighty flood waters of the River: the king of Assyria and all his glory. It will come up over all its channels, and go over all its banks. 
-<span class="v">8&#160;</span>It will sweep onward into Judah. It will overflow and pass through. It will reach even to the neck. The stretching out of its wings will fill the width of your land, O Immanuel. 
-</p><p>
-<span class="v">9&#160;</span>Make an uproar, you peoples, and be broken in pieces! Listen, all you from far countries: dress for battle, and be shattered! Dress for battle, and be shattered! 
-<span class="v">10&#160;</span>Take counsel together, and it will be brought to nothing; speak the word, and it will not stand, for Elohim is with us.” 
-</p><p>
-<span class="v">11&#160;</span>For Yahweh spoke this to me with a strong hand, and instructed me not to walk in the way of this people, saying, 
-<span class="v">12&#160;</span>“Don’t call a conspiracy all that this people call a conspiracy. Don’t fear their threats or be terrorized. 
-<span class="v">13&#160;</span>Yahweh of Armies is who you must respect as set-apart. He is the one you must fear. He is the one you must dread. 
-<span class="v">14&#160;</span>He will be a sanctuary, but for both houses of Israel, he will be a stumbling stone and a rock that makes them fall. For the people of Jerusalem, he will be a trap and a snare. 
-<span class="v">15&#160;</span>Many will stumble over it, fall, be broken, be snared, and be captured.” 
-</p><p>
-<span class="v">16&#160;</span>Wrap up the covenant. Seal the law among my disciples. 
-<span class="v">17&#160;</span>I will wait for Yahweh, who hides his face from the house of Jacob, and I will look for him. 
-<span class="v">18&#160;</span>Behold, I and the children whom Yahweh has given me are for signs and for wonders in Israel from Yahweh of Armies, who dwells in Mount Zion. 
-</p><p>
-<span class="v">19&#160;</span>When they tell you, “Consult with those who have familiar spirits and with the wizards, who chirp and who mutter,” shouldn’t a people consult with their Elohim? Should they consult the dead on behalf of the living? 
-<span class="v">20&#160;</span>Turn to the law and to the covenant! If they don’t speak according to this word, surely there is no morning for them. 
-<span class="v">21&#160;</span>They will pass through it, very distressed and hungry. It will happen that when they are hungry, they will worry, and curse their king and their Elohim. They will turn their faces upward, 
-<span class="v">22&#160;</span>then look to the earth and see distress, darkness, and the gloom of anguish. They will be driven into thick darkness. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>But there shall be no more gloom for her who was in anguish. In the former time, he brought into contempt the land of Zebulun and the land of Naphtali; but in the latter time he has made it glorious, by the way of the sea, beyond the Jordan, Galilee of the nations. 
-</p><p>
-<span class="v">2&#160;</span>The people who walked in darkness have seen a great light. 
-</p><p class="q2">The light has shined on those who lived in the land of the shadow of death. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You have multiplied the nation. 
-</p><p class="q2">You have increased their joy. 
-</p><p>They rejoice before you according to the joy in harvest, as men rejoice when they divide the plunder. 
-<span class="v">4&#160;</span>For the yoke of his burden, and the staff of his shoulder, the rod of his oppressor, you have broken as in the day of Midian. 
-<span class="v">5&#160;</span>For all the armor of the armed man in the noisy battle, and the garments rolled in blood, will be for burning, fuel for the fire. 
-<span class="v">6&#160;</span>For a child is born to us. A son is given to us; and the government will be on his shoulders. His name will be called Wonderful Counselor, Mighty Elohim, Everlasting Father, Prince of Peace. 
-<span class="v">7&#160;</span>Of the increase of his government and of peace there shall be no end, on David’s throne, and on his kingdom, to establish it, and to uphold it with justice and with righteousness from that time on, even forever. The zeal of Yahweh of Armies will perform this. 
-</p><p>
-<span class="v">8&#160;</span>The Lord sent a word into Jacob, 
-</p><p class="q2">and it falls on Israel. 
-</p><p class="q1">
-<span class="v">9&#160;</span>All the people will know, 
-</p><p class="q2">including Ephraim and the inhabitants of Samaria, who say in pride and in arrogance of heart, 
-</p><p class="q1">
-<span class="v">10&#160;</span>“The bricks have fallen, 
-</p><p class="q2">but we will build with cut stone. 
-</p><p class="q1">The sycamore fig trees have been cut down, 
-</p><p class="q2">but we will put cedars in their place.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>Therefore Yahweh will set up on high against him the adversaries of Rezin, 
-</p><p class="q2">and will stir up his enemies, 
-</p><p class="q2">
-<span class="v">12&#160;</span>The Syrians in front, 
-</p><p class="q2">and the Philistines behind; 
-</p><p class="q2">and they will devour Israel with open mouth. 
-</p><p class="q1">For all this, his anger is not turned away, 
-</p><p class="q2">but his hand is stretched out still. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Yet the people have not turned to him who struck them, 
-</p><p class="q2">neither have they sought Yahweh of Armies. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Therefore Yahweh will cut off from Israel head and tail, 
-</p><p class="q2">palm branch and reed, in one day. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The elder and the honorable man is the head, 
-</p><p class="q2">and the prophet who teaches lies is the tail. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For those who lead this people lead them astray; 
-</p><p class="q2">and those who are led by them are destroyed. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Therefore the Lord will not rejoice over their young men, 
-</p><p class="q2">neither will he have compassion on their fatherless and widows; 
-</p><p class="q1">for everyone is profane and an evildoer, 
-</p><p class="q2">and every mouth speaks folly. 
-</p><p class="q1">For all this his anger is not turned away, 
-</p><p class="q2">but his hand is stretched out still. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>For wickedness burns like a fire. 
-</p><p class="q2">It devours the briers and thorns; 
-</p><p class="q2">yes, it kindles in the thickets of the forest, 
-</p><p class="q2">and they roll upward in a column of smoke. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Through Yahweh of Armies’ wrath, the land is burned up; 
-</p><p class="q2">and the people are the fuel for the fire. 
-</p><p class="q2">No one spares his brother. 
-</p><p class="q1">
-<span class="v">20&#160;</span>One will devour on the right hand, and be hungry; 
-</p><p class="q2">and he will eat on the left hand, and they will not be satisfied. 
-</p><p class="q1">Everyone will eat the flesh of his own arm: 
-</p><p class="q2">
-<span class="v">21&#160;</span>Manasseh eating Ephraim and Ephraim eating Manasseh, and they together will be against Judah. 
-</p><p class="q1">For all this his anger is not turned away, 
-</p><p class="q2">but his hand is stretched out still. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Woe to those who decree unrighteous decrees, and to the writers who write oppressive decrees 
-<span class="v">2&#160;</span>to deprive the needy of justice, and to rob the poor among my people of their rights, that widows may be their plunder, and that they may make the fatherless their prey! 
-<span class="v">3&#160;</span>What will you do in the day of visitation, and in the desolation which will come from afar? To whom will you flee for help? Where will you leave your wealth? 
-</p><p>
-<span class="v">4&#160;</span>They will only bow down under the prisoners, 
-</p><p class="q2">and will fall under the slain. 
-</p><p class="q1">For all this his anger is not turned away, 
-</p><p class="q2">but his hand is stretched out still. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">5&#160;</span>Alas Assyrian, the rod of my anger, the staff in whose hand is my indignation! 
-<span class="v">6&#160;</span>I will send him against a profane nation, and against the people who anger me I will give him a command to take the plunder and to take the prey, and to tread them down like the mire of the streets. 
-<span class="v">7&#160;</span>However, he doesn’t mean so, neither does his heart think so; but it is in his heart to destroy, and to cut off not a few nations. 
-<span class="v">8&#160;</span>For he says, “Aren’t all of my princes kings? 
-<span class="v">9&#160;</span>Isn’t Calno like Carchemish? Isn’t Hamath like Arpad? Isn’t Samaria like Damascus?” 
-<span class="v">10&#160;</span>As my hand has found the kingdoms of the idols, whose engraved images exceeded those of Jerusalem and of Samaria, 
-<span class="v">11&#160;</span>shall I not, as I have done to Samaria and her idols, so do to Jerusalem and her idols? 
-</p><p>
-<span class="v">12&#160;</span>Therefore it will happen that when the Lord has performed his whole work on Mount Zion and on Jerusalem, I will punish the fruit of the willful proud heart of the king of Assyria, and the insolence of his arrogant looks. 
-<span class="v">13&#160;</span>For he has said, “By the strength of my hand I have done it, and by my wisdom, for I have understanding. I have removed the boundaries of the peoples, and have robbed their treasures. Like a valiant man I have brought down their rulers. 
-<span class="v">14&#160;</span>My hand has found the riches of the peoples like a nest, and like one gathers eggs that are abandoned, I have gathered all the earth. There was no one who moved their wing, or that opened their mouth, or chirped.” 
-</p><p>
-<span class="v">15&#160;</span>Should an ax brag against him who chops with it? Should a saw exalt itself above him who saws with it? As if a rod should lift those who lift it up, or as if a staff should lift up someone who is not wood. 
-<span class="v">16&#160;</span>Therefore the Lord, Yahweh of Armies, will send among his fat ones leanness; and under his glory a burning will be kindled like the burning of fire. 
-<span class="v">17&#160;</span>The light of Israel will be for a fire, and his Set-Apart One for a flame; and it will burn and devour his thorns and his briers in one day. 
-<span class="v">18&#160;</span>He will consume the glory of his forest and of his fruitful field, both soul and body. It will be as when a standard bearer faints. 
-<span class="v">19&#160;</span>The remnant of the trees of his forest shall be few, so that a child could write their number. 
-</p><p>
-<span class="v">20&#160;</span>It will come to pass in that day that the remnant of Israel, and those who have escaped from the house of Jacob will no more again lean on him who struck them, but shall lean on Yahweh, the Set-Apart One of Israel, in truth. 
-<span class="v">21&#160;</span>A remnant will return, even the remnant of Jacob, to the mighty Elohim. 
-<span class="v">22&#160;</span>For though your people, Israel, are like the sand of the sea, only a remnant of them will return. A destruction is determined, overflowing with righteousness. 
-<span class="v">23&#160;</span>For the Lord, Yahweh of Armies, will make a full end, and that determined, throughout all the earth. 
-</p><p>
-<span class="v">24&#160;</span>Therefore the Lord, Yahweh of Armies, says, “My people who dwell in Zion, don’t be afraid of the Assyrian, though he strike you with the rod, and lift up his staff against you, as Egypt did. 
-<span class="v">25&#160;</span>For yet a very little while, and the indignation against you will be accomplished, and my anger will be directed to his destruction.” 
-<span class="v">26&#160;</span>Yahweh of Armies will stir up a scourge against him, as in the slaughter of Midian at the rock of Oreb. His rod will be over the sea, and he will lift it up like he did against Egypt. 
-<span class="v">27&#160;</span>It will happen in that day that his burden will depart from off your shoulder, and his yoke from off your neck, and the yoke shall be destroyed because of the anointing oil. 
-</p><p>
-<span class="v">28&#160;</span>He has come to Aiath. He has passed through Migron. At Michmash he stores his baggage. 
-<span class="v">29&#160;</span>They have gone over the pass. They have taken up their lodging at Geba. Ramah trembles. Gibeah of Saul has fled. 
-<span class="v">30&#160;</span>Cry aloud with your voice, daughter of Gallim! Listen, Laishah! You poor Anathoth! 
-<span class="v">31&#160;</span>Madmenah is a fugitive. The inhabitants of Gebim flee for safety. 
-<span class="v">32&#160;</span>This very day he will halt at Nob. He shakes his hand at the mountain of the daughter of Zion, the hill of Jerusalem. 
-</p><p>
-<span class="v">33&#160;</span>Behold, the Lord, Yahweh of Armies, will lop the boughs with terror. The tall will be cut down, and the lofty will be brought low. 
-<span class="v">34&#160;</span>He will cut down the thickets of the forest with iron, and Lebanon will fall by the Mighty One. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p class="q1">
-<span class="v">1&#160;</span>A shoot will come out of the stock of Jesse, 
-</p><p class="q2">and a branch out of his roots will bear fruit. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh’s Spirit will rest on him: 
-</p><p class="q2">the spirit of wisdom and understanding, 
-</p><p class="q2">the spirit of counsel and might, 
-</p><p class="q2">the spirit of knowledge and of the fear of Yahweh. 
-</p><p class="q1">
-<span class="v">3&#160;</span>His delight will be in the fear of Yahweh. 
-</p><p class="q1">He will not judge by the sight of his eyes, 
-</p><p class="q2">neither decide by the hearing of his ears; 
-</p><p class="q1">
-<span class="v">4&#160;</span>but he will judge the poor with righteousness, 
-</p><p class="q2">and decide with equity for the humble of the earth. 
-</p><p class="q1">He will strike the earth with the rod of his mouth; 
-</p><p class="q2">and with the breath of his lips he will kill the wicked. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Righteousness will be the belt around his waist, 
-</p><p class="q2">and faithfulness the belt around his waist. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>The wolf will live with the lamb, 
-</p><p class="q2">and the leopard will lie down with the young goat, 
-</p><p class="q2">the calf, the young lion, and the fattened calf together; 
-</p><p class="q2">and a little child will lead them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The cow and the bear will graze. 
-</p><p class="q2">Their young ones will lie down together. 
-</p><p class="q2">The lion will eat straw like the ox. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The nursing child will play near a cobra’s hole, 
-</p><p class="q2">and the weaned child will put his hand on the viper’s den. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They will not hurt nor destroy in all my set-apart mountain; 
-</p><p class="q2">for the earth will be full of the knowledge of Yahweh, 
-</p><p class="q2">as the waters cover the sea. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">10&#160;</span>It will happen in that day that the nations will seek the root of Jesse, who stands as a banner of the peoples; and his resting place will be glorious. 
-</p><p>
-<span class="v">11&#160;</span>It will happen in that day that the Lord will set his hand again the second time to recover the remnant that is left of his people from Assyria, from Egypt, from Pathros, from Cush, from Elam, from Shinar, from Hamath, and from the islands of the sea. 
-<span class="v">12&#160;</span>He will set up a banner for the nations, and will assemble the outcasts of Israel, and gather together the dispersed of Judah from the four corners of the earth. 
-<span class="v">13&#160;</span>The envy also of Ephraim will depart, and those who persecute Judah will be cut off. Ephraim won’t envy Judah, and Judah won’t persecute Ephraim. 
-<span class="v">14&#160;</span>They will fly down on the shoulders of the Philistines on the west. Together they will plunder the children of the east. They will extend their power over Edom and Moab, and the children of Ammon will obey them. 
-<span class="v">15&#160;</span>Yahweh will utterly destroy the tongue of the Egyptian sea; and with his scorching wind he will wave his hand over the River, and will split it into seven streams, and cause men to march over in sandals. 
-<span class="v">16&#160;</span>There will be a highway for the remnant that is left of his people from Assyria, like there was for Israel in the day that he came up out of the land of Egypt. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>In that day you will say, “I will give thanks to you, Yahweh; for though you were angry with me, your anger has turned away and you comfort me. 
-<span class="v">2&#160;</span>Behold, Elohim is my salvation. I will trust, and will not be afraid; for Yah, Yahweh, is my strength and song; and he has become my salvation.” 
-<span class="v">3&#160;</span>Therefore with joy you will draw water out of the wells of salvation. 
-<span class="v">4&#160;</span>In that day you will say, “Give thanks to Yahweh! Call on his name! Declare his doings among the peoples! Proclaim that his name is exalted! 
-<span class="v">5&#160;</span>Sing to Yahweh, for he has done excellent things! Let this be known in all the earth! 
-<span class="v">6&#160;</span>Cry aloud and shout, you inhabitant of Zion, for the Set-Apart One of Israel is great among you!” 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>The burden of Babylon, which Isaiah the son of Amoz saw. 
-</p><p>
-<span class="v">2&#160;</span>Set up a banner on the bare mountain! Lift up your voice to them! Wave your hand, that they may go into the gates of the nobles. 
-<span class="v">3&#160;</span>I have commanded my consecrated ones; yes, I have called my mighty men for my anger, even my proudly exulting ones. 
-<span class="v">4&#160;</span>The noise of a multitude is in the mountains, as of a great people; the noise of an uproar of the kingdoms of the nations gathered together! Yahweh of Armies is mustering the army for the battle. 
-<span class="v">5&#160;</span>They come from a far country, from the uttermost part of heaven, even Yahweh, and the weapons of his indignation, to destroy the whole land. 
-</p><p>
-<span class="v">6&#160;</span>Wail, for Yahweh’s day is at hand! It will come as destruction from the Almighty. 
-<span class="v">7&#160;</span>Therefore all hands will be feeble, and everyone’s heart will melt. 
-<span class="v">8&#160;</span>They will be dismayed. Pangs and sorrows will seize them. They will be in pain like a woman in labor. They will look in amazement one at another. Their faces will be faces of flame. 
-<span class="v">9&#160;</span>Behold, the day of Yahweh comes, cruel, with wrath and fierce anger; to make the land a desolation, and to destroy its sinners out of it. 
-<span class="v">10&#160;</span>For the stars of the sky and its constellations will not give their light. The sun will be darkened in its going out, and the moon will not cause its light to shine. 
-<span class="v">11&#160;</span>I will punish the world for their evil, and the wicked for their iniquity. I will cause the arrogance of the proud to cease, and will humble the arrogance of the terrible. 
-<span class="v">12&#160;</span>I will make people more rare than fine gold, even a person than the pure gold of Ophir. 
-<span class="v">13&#160;</span>Therefore I will make the heavens tremble, and the earth will be shaken out of its place in Yahweh of Armies’ wrath, and in the day of his fierce anger. 
-<span class="v">14&#160;</span>It will happen that like a hunted gazelle and like sheep that no one gathers, they will each turn to their own people, and will each flee to their own land. 
-<span class="v">15&#160;</span>Everyone who is found will be thrust through. Everyone who is captured will fall by the sword. 
-<span class="v">16&#160;</span>Their infants also will be dashed in pieces before their eyes. Their houses will be ransacked, and their women raped. 
-</p><p>
-<span class="v">17&#160;</span>Behold, I will stir up the Medes against them, who will not value silver, and as for gold, they will not delight in it. 
-<span class="v">18&#160;</span>Their bows will dash the young men in pieces; and they shall have no pity on the fruit of the womb. Their eyes will not spare children. 
-<span class="v">19&#160;</span>Babylon, the glory of kingdoms, the beauty of the Chaldeans’ pride, will be like when Elohim overthrew Sodom and Gomorrah. 
-<span class="v">20&#160;</span>It will never be inhabited, neither will it be lived in from generation to generation. The Arabian will not pitch a tent there, neither will shepherds make their flocks lie down there. 
-<span class="v">21&#160;</span>But wild animals of the desert will lie there, and their houses will be full of jackals. Ostriches will dwell there, and wild goats will frolic there. 
-<span class="v">22&#160;</span>Hyenas will cry in their fortresses, and jackals in the pleasant palaces. Her time is near to come, and her days will not be prolonged. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>For Yahweh will have compassion on Jacob, and will yet choose Israel, and set them in their own land. The foreigner will join himself with them, and they will unite with the house of Jacob. 
-<span class="v">2&#160;</span>The peoples will take them, and bring them to their place. The house of Israel will possess them in Yahweh’s land for servants and for handmaids. They will take as captives those whose captives they were; and they shall rule over their oppressors. 
-</p><p>
-<span class="v">3&#160;</span>It will happen in the day that Yahweh will give you rest from your sorrow, from your trouble, and from the hard service in which you were made to serve, 
-<span class="v">4&#160;</span>that you will take up this parable against the king of Babylon, and say, “How the oppressor has ceased! The golden city has ceased!” 
-<span class="v">5&#160;</span>Yahweh has broken the staff of the wicked, the scepter of the rulers, 
-<span class="v">6&#160;</span>who struck the peoples in wrath with a continual stroke, who ruled the nations in anger, with a persecution that no one restrained. 
-<span class="v">7&#160;</span>The whole earth is at rest, and is quiet. They break out in song. 
-<span class="v">8&#160;</span>Yes, the cypress trees rejoice with you, with the cedars of Lebanon, saying, “Since you are humbled, no lumberjack has come up against us.” 
-<span class="v">9&#160;</span>Sheol<span class="f">+ \fr 14:9 \ft Sheol is the place of the dead.</span> from beneath has moved for you to meet you at your coming. It stirs up the departed spirits for you, even all the rulers of the earth. It has raised up from their thrones all the kings of the nations. 
-<span class="v">10&#160;</span>They all will answer and ask you, “Have you also become as weak as we are? Have you become like us?” 
-<span class="v">11&#160;</span>Your pomp is brought down to Sheol,<span class="f">+ \fr 14:11 \ft Sheol is the place of the dead. </span> with the sound of your stringed instruments. Maggots are spread out under you, and worms cover you. 
-</p><p>
-<span class="v">12&#160;</span>How you have fallen from heaven, shining one, son of the dawn! How you are cut down to the ground, who laid the nations low! 
-<span class="v">13&#160;</span>You said in your heart, “I will ascend into heaven! I will exalt my throne above the stars of Elohim! I will sit on the mountain of assembly, in the far north! 
-<span class="v">14&#160;</span>I will ascend above the heights of the clouds! I will make myself like the Most High!” 
-<span class="v">15&#160;</span>Yet you shall be brought down to Sheol,<span class="f">+ \fr 14:15 \ft Sheol is the place of the dead.</span> to the depths of the pit. 
-<span class="v">16&#160;</span>Those who see you will stare at you. They will ponder you, saying, “Is this the man who made the earth to tremble, who shook kingdoms, 
-<span class="v">17&#160;</span>who made the world like a wilderness, and overthrew its cities, who didn’t release his prisoners to their home?” 
-</p><p>
-<span class="v">18&#160;</span>All the kings of the nations sleep in glory, everyone in his own house. 
-<span class="v">19&#160;</span>But you are cast away from your tomb like an abominable branch, clothed with the slain who are thrust through with the sword, who go down to the stones of the pit; like a dead body trodden under foot. 
-<span class="v">20&#160;</span>You will not join them in burial, because you have destroyed your land. You have killed your people. The offspring of evildoers will not be named forever. 
-</p><p>
-<span class="v">21&#160;</span>Prepare for slaughter of his children because of the iniquity of their fathers, that they not rise up and possess the earth, and fill the surface of the world with cities. 
-<span class="v">22&#160;</span>“I will rise up against them,” says Yahweh of Armies, “and cut off from Babylon name and remnant, and son and son’s son,” says Yahweh. 
-<span class="v">23&#160;</span>“I will also make it a possession for the porcupine, and pools of water. I will sweep it with the broom of destruction,” says Yahweh of Armies. 
-</p><p>
-<span class="v">24&#160;</span>Yahweh of Armies has sworn, saying, “Surely, as I have thought, so shall it happen; and as I have purposed, so shall it stand: 
-<span class="v">25&#160;</span>that I will break the Assyrian in my land, and tread him under foot on my mountains. Then his yoke will leave them, and his burden leave their shoulders. 
-<span class="v">26&#160;</span>This is the plan that is determined for the whole earth. This is the hand that is stretched out over all the nations. 
-<span class="v">27&#160;</span>For Yahweh of Armies has planned, and who can stop it? His hand is stretched out, and who can turn it back?” 
-</p><p>
-<span class="v">28&#160;</span>This burden was in the year that King Ahaz died. 
-</p><p>
-<span class="v">29&#160;</span>Don’t rejoice, O Philistia, all of you, because the rod that struck you is broken; for out of the serpent’s root an adder will emerge, and his fruit will be a fiery flying serpent. 
-<span class="v">30&#160;</span>The firstborn of the poor will eat, and the needy will lie down in safety; and I will kill your root with famine, and your remnant will be killed. 
-</p><p>
-<span class="v">31&#160;</span>Howl, gate! Cry, city! You are melted away, Philistia, all of you; for smoke comes out of the north, and there is no straggler in his ranks. 
-</p><p>
-<span class="v">32&#160;</span>What will they answer the messengers of the nation? That Yahweh has founded Zion, and in her the afflicted of his people will take refuge. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>The burden of Moab. 
-</p><p>For in a night, Ar of Moab is laid waste, and brought to nothing. For in a night Kir of Moab is laid waste, and brought to nothing. 
-<span class="v">2&#160;</span>They have gone up to Bayith, and to Dibon, to the high places, to weep. Moab wails over Nebo and over Medeba. Baldness is on all of their heads. Every beard is cut off. 
-<span class="v">3&#160;</span>In their streets, they clothe themselves in sackcloth. In their streets and on their housetops, everyone wails, weeping abundantly. 
-<span class="v">4&#160;</span>Heshbon cries out with Elealeh. Their voice is heard even to Jahaz. Therefore the armed men of Moab cry aloud. Their souls tremble within them. 
-<span class="v">5&#160;</span>My heart cries out for Moab! Her nobles flee to Zoar, to Eglath Shelishiyah; for they go up by the ascent of Luhith with weeping; for on the way to Horonaim, they raise up a cry of destruction. 
-<span class="v">6&#160;</span>For the waters of Nimrim will be desolate; for the grass has withered away, the tender grass fails, there is no green thing. 
-<span class="v">7&#160;</span>Therefore they will carry away the abundance they have gotten, and that which they have stored up, over the brook of the willows. 
-<span class="v">8&#160;</span>For the cry has gone around the borders of Moab, its wailing to Eglaim, and its wailing to Beer Elim. 
-<span class="v">9&#160;</span>For the waters of Dimon are full of blood; for I will bring yet more on Dimon, a lion on those of Moab who escape, and on the remnant of the land. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Send the lambs for the ruler of the land from Selah to the wilderness, to the mountain of the daughter of Zion. 
-<span class="v">2&#160;</span>For it will be that as wandering birds, as a scattered nest, so will the daughters of Moab be at the fords of the Arnon. 
-<span class="v">3&#160;</span>Give counsel! Execute justice! Make your shade like the night in the middle of the noonday! Hide the outcasts! Don’t betray the fugitive! 
-<span class="v">4&#160;</span>Let my outcasts dwell with you! As for Moab, be a hiding place for him from the face of the destroyer. For the extortionist is brought to nothing. Destruction ceases. The oppressors are consumed out of the land. 
-<span class="v">5&#160;</span>A throne will be established in loving kindness. One will sit on it in truth, in the tent of David, judging, seeking justice, and swift to do righteousness. 
-</p><p>
-<span class="v">6&#160;</span>We have heard of the pride of Moab, that he is very proud; even of his arrogance, his pride, and his wrath. His boastings are nothing. 
-<span class="v">7&#160;</span>Therefore Moab will wail for Moab. Everyone will wail. You will mourn for the raisin cakes of Kir Hareseth, utterly stricken. 
-<span class="v">8&#160;</span>For the fields of Heshbon languish with the vine of Sibmah. The owners of the nations have broken down its choice branches, which reached even to Jazer, which wandered into the wilderness. Its shoots were spread abroad. They passed over the sea. 
-<span class="v">9&#160;</span>Therefore I will weep with the weeping of Jazer for the vine of Sibmah. I will water you with my tears, Heshbon, and Elealeh: for on your summer fruits and on your harvest the battle shout has fallen. 
-<span class="v">10&#160;</span>Gladness is taken away, and joy out of the fruitful field; and in the vineyards there will be no singing, neither joyful noise. Nobody will tread out wine in the presses. I have made the shouting stop. 
-<span class="v">11&#160;</span>Therefore my heart sounds like a harp for Moab, and my inward parts for Kir Heres. 
-<span class="v">12&#160;</span>It will happen that when Moab presents himself, when he wearies himself on the high place, and comes to his sanctuary to pray, that he will not prevail. 
-</p><p>
-<span class="v">13&#160;</span>This is the word that Yahweh spoke concerning Moab in time past. 
-<span class="v">14&#160;</span>But now Yahweh has spoken, saying, “Within three years, as a worker bound by contract would count them, the glory of Moab shall be brought into contempt, with all his great multitude; and the remnant will be very small and feeble.” 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>The burden of Damascus. 
-</p><p>“Behold, Damascus is taken away from being a city, and it will be a ruinous heap. 
-<span class="v">2&#160;</span>The cities of Aroer are forsaken. They will be for flocks, which shall lie down, and no one shall make them afraid. 
-<span class="v">3&#160;</span>The fortress shall cease from Ephraim, and the kingdom from Damascus, and the remnant of Syria. They will be as the glory of the children of Israel,” says Yahweh of Armies. 
-</p><p>
-<span class="v">4&#160;</span>“It will happen in that day that the glory of Jacob will be made thin, and the fatness of his flesh will become lean. 
-<span class="v">5&#160;</span>It will be like when the harvester gathers the wheat, and his arm reaps the grain. Yes, it will be like when one gleans grain in the valley of Rephaim. 
-<span class="v">6&#160;</span>Yet gleanings will be left there, like the shaking of an olive tree, two or three olives in the top of the uppermost bough, four or five in the outermost branches of a fruitful tree,” says Yahweh, the Elohim of Israel. 
-<span class="v">7&#160;</span>In that day, people will look to their Maker, and their eyes will have respect for the Set-Apart One of Israel. 
-<span class="v">8&#160;</span>They will not look to the altars, the work of their hands; neither shall they respect that which their fingers have made, either the Asherah poles or the incense altars. 
-<span class="v">9&#160;</span>In that day, their strong cities will be like the forsaken places in the woods and on the mountain top, which were forsaken from before the children of Israel; and it will be a desolation. 
-<span class="v">10&#160;</span>For you have forgotten the Elohim of your salvation, and have not remembered the rock of your strength. Therefore you plant pleasant plants, and set out foreign seedlings. 
-<span class="v">11&#160;</span>In the day of your planting, you hedge it in. In the morning, you make your seed blossom, but the harvest flees away in the day of grief and of desperate sorrow. 
-</p><p>
-<span class="v">12&#160;</span>Ah, the uproar of many peoples who roar like the roaring of the seas; and the rushing of nations that rush like the rushing of mighty waters! 
-<span class="v">13&#160;</span>The nations will rush like the rushing of many waters, but he will rebuke them, and they will flee far off, and will be chased like the chaff of the mountains before the wind, and like the whirling dust before the storm. 
-<span class="v">14&#160;</span>At evening, behold, terror! Before the morning, they are no more. This is the portion of those who plunder us, and the lot of those who rob us. 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Ah, the land of the rustling of wings, which is beyond the rivers of Ethiopia; 
-<span class="v">2&#160;</span>that sends ambassadors by the sea, even in vessels of papyrus on the waters, saying, “Go, you swift messengers, to a nation tall and smooth, to a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide!” 
-<span class="v">3&#160;</span>All you inhabitants of the world, and you dwellers on the earth, when a banner is lifted up on the mountains, look! When the trumpet is blown, listen! 
-</p><p>
-<span class="v">4&#160;</span>For Yahweh said to me, “I will be still, and I will see in my dwelling place, like clear heat in sunshine, like a cloud of dew in the heat of harvest.” 
-<span class="v">5&#160;</span>For before the harvest, when the blossom is over, and the flower becomes a ripening grape, he will cut off the sprigs with pruning hooks, and he will cut down and take away the spreading branches. 
-<span class="v">6&#160;</span>They will be left together for the ravenous birds of the mountains, and for the animals of the earth. The ravenous birds will eat them in the summer, and all the animals of the earth will eat them in the winter. 
-<span class="v">7&#160;</span>In that time, a present will be brought to Yahweh of Armies from a people tall and smooth, even from a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide, to the place of the name of Yahweh of Armies, Mount Zion. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>The burden of Egypt. 
-</p><p>“Behold, Yahweh rides on a swift cloud, and comes to Egypt. The idols of Egypt will tremble at his presence; and the heart of Egypt will melt within it. 
-<span class="v">2&#160;</span>I will stir up the Egyptians against the Egyptians, and they will fight everyone against his brother, and everyone against his neighbor; city against city, and kingdom against kingdom. 
-<span class="v">3&#160;</span>The spirit of the Egyptians will fail within them. I will destroy their counsel. They will seek the idols, the charmers, those who have familiar spirits, and the wizards. 
-<span class="v">4&#160;</span>I will give over the Egyptians into the hand of a cruel lord. A fierce king will rule over them,” says the Lord, Yahweh of Armies. 
-</p><p>
-<span class="v">5&#160;</span>The waters will fail from the sea, and the river will be wasted and become dry. 
-<span class="v">6&#160;</span>The rivers will become foul. The streams of Egypt will be diminished and dried up. The reeds and flags will wither away. 
-<span class="v">7&#160;</span>The meadows by the Nile, by the brink of the Nile, and all the sown fields of the Nile, will become dry, be driven away, and be no more. 
-<span class="v">8&#160;</span>The fishermen will lament, and all those who fish in the Nile will mourn, and those who spread nets on the waters will languish. 
-<span class="v">9&#160;</span>Moreover those who work in combed flax, and those who weave white cloth, will be confounded. 
-<span class="v">10&#160;</span>The pillars will be broken in pieces. All those who work for hire will be grieved in soul. 
-</p><p>
-<span class="v">11&#160;</span>The princes of Zoan are utterly foolish. The counsel of the wisest counselors of Pharaoh has become stupid. How do you say to Pharaoh, “I am the son of the wise, the son of ancient kings”? 
-<span class="v">12&#160;</span>Where then are your wise men? Let them tell you now; and let them know what Yahweh of Armies has purposed concerning Egypt. 
-<span class="v">13&#160;</span>The princes of Zoan have become fools. The princes of Memphis are deceived. They have caused Egypt to go astray, those who are the cornerstone of her tribes. 
-<span class="v">14&#160;</span>Yahweh has mixed a spirit of perverseness in the middle of her; and they have caused Egypt to go astray in all of its works, like a drunken man staggers in his vomit. 
-<span class="v">15&#160;</span>Neither shall there be any work for Egypt, which head or tail, palm branch or rush, may do. 
-<span class="v">16&#160;</span>In that day the Egyptians will be like women. They will tremble and fear because of the shaking of Yahweh of Armies’s hand, which he shakes over them. 
-<span class="v">17&#160;</span>The land of Judah will become a terror to Egypt. Everyone to whom mention is made of it will be afraid, because of the plans of Yahweh of Armies, which he determines against it. 
-<span class="v">18&#160;</span>In that day, there will be five cities in the land of Egypt that speak the language of Canaan, and swear to Yahweh of Armies. One will be called “The city of destruction.” 
-</p><p>
-<span class="v">19&#160;</span>In that day, there will be an altar to Yahweh in the middle of the land of Egypt, and a pillar to Yahweh at its border. 
-<span class="v">20&#160;</span>It will be for a sign and for a witness to Yahweh of Armies in the land of Egypt; for they will cry to Yahweh because of oppressors, and he will send them a savior and a defender, and he will deliver them. 
-<span class="v">21&#160;</span>Yahweh will be known to Egypt, and the Egyptians will know Yahweh in that day. Yes, they will worship with sacrifice and offering, and will vow a vow to Yahweh, and will perform it. 
-<span class="v">22&#160;</span>Yahweh will strike Egypt, striking and healing. They will return to Yahweh, and he will be entreated by them, and will heal them. 
-</p><p>
-<span class="v">23&#160;</span>In that day there will be a highway out of Egypt to Assyria, and the Assyrian shall come into Egypt, and the Egyptian into Assyria; and the Egyptians will worship with the Assyrians. 
-</p><p>
-<span class="v">24&#160;</span>In that day, Israel will be the third with Egypt and with Assyria, a blessing within the earth; 
-<span class="v">25&#160;</span>because Yahweh of Armies has blessed them, saying, “Blessed be Egypt my people, Assyria the work of my hands, and Israel my inheritance.” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>In the year that Tartan came to Ashdod, when Sargon the king of Assyria sent him, and he fought against Ashdod and took it; 
-<span class="v">2&#160;</span>at that time Yahweh spoke by Isaiah the son of Amoz, saying, “Go, and loosen the sackcloth from off your waist, and take your sandals from off your feet.” He did so, walking naked and barefoot. 
-<span class="v">3&#160;</span>Yahweh said, “As my servant Isaiah has walked naked and barefoot three years for a sign and a wonder concerning Egypt and concerning Ethiopia, 
-<span class="v">4&#160;</span>so the king of Assyria will lead away the captives of Egypt and the exiles of Ethiopia, young and old, naked and barefoot, and with buttocks uncovered, to the shame of Egypt. 
-<span class="v">5&#160;</span>They will be dismayed and confounded, because of Ethiopia their expectation, and of Egypt their glory. 
-<span class="v">6&#160;</span>The inhabitants of this coast land will say in that day, ‘Behold, this is our expectation, where we fled for help to be delivered from the king of Assyria. And we, how will we escape?’&#160;” 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>The burden of the wilderness of the sea. 
-</p><p>As whirlwinds in the South sweep through, it comes from the wilderness, from an awesome land. 
-<span class="v">2&#160;</span>A grievous vision is declared to me. The treacherous man deals treacherously, and the destroyer destroys. Go up, Elam; attack! I have stopped all of Media’s sighing. 
-<span class="v">3&#160;</span>Therefore my thighs are filled with anguish. Pains have seized me, like the pains of a woman in labor. I am in so much pain that I can’t hear. I am so dismayed that I can’t see. 
-<span class="v">4&#160;</span>My heart flutters. Horror has frightened me. The twilight that I desired has been turned into trembling for me. 
-<span class="v">5&#160;</span>They prepare the table. They set the watch. They eat. They drink. Rise up, you princes, oil the shield! 
-<span class="v">6&#160;</span>For the Lord said to me, “Go, set a watchman. Let him declare what he sees. 
-<span class="v">7&#160;</span>When he sees a troop, horsemen in pairs, a troop of donkeys, a troop of camels, he shall listen diligently with great attentiveness.” 
-<span class="v">8&#160;</span>He cried like a lion: “Lord, I stand continually on the watchtower in the daytime, and every night I stay at my post. 
-<span class="v">9&#160;</span>Behold, here comes a troop of men, horsemen in pairs.” He answered, “Fallen, fallen is Babylon; and all the engraved images of her elohims are broken to the ground. 
-</p><p>
-<span class="v">10&#160;</span>You are my threshing, and the grain of my floor!” That which I have heard from Yahweh of Armies, the Elohim of Israel, I have declared to you. 
-</p><p>
-<span class="v">11&#160;</span>The burden of Dumah. 
-</p><p>One calls to me out of Seir, “Watchman, what of the night? Watchman, what of the night?” 
-<span class="v">12&#160;</span>The watchman said, “The morning comes, and also the night. If you will inquire, inquire. Come back again.” 
-</p><p>
-<span class="v">13&#160;</span>The burden on Arabia. 
-</p><p>You will lodge in the thickets in Arabia, you caravans of Dedanites. 
-<span class="v">14&#160;</span>They brought water to him who was thirsty. The inhabitants of the land of Tema met the fugitives with their bread. 
-<span class="v">15&#160;</span>For they fled away from the swords, from the drawn sword, from the bent bow, and from the heat of battle. 
-<span class="v">16&#160;</span>For the Lord said to me, “Within a year, as a worker bound by contract would count it, all the glory of Kedar will fail, 
-<span class="v">17&#160;</span>and the residue of the number of the archers, the mighty men of the children of Kedar, will be few; for Yahweh, the Elohim of Israel, has spoken it.” 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>The burden of the valley of vision. 
-</p><p>What ails you now, that you have all gone up to the housetops? 
-<span class="v">2&#160;</span>You that are full of shouting, a tumultuous city, a joyous town, your slain are not slain with the sword, neither are they dead in battle. 
-<span class="v">3&#160;</span>All your rulers fled away together. They were bound by the archers. All who were found by you were bound together. They fled far away. 
-<span class="v">4&#160;</span>Therefore I said, “Look away from me. I will weep bitterly. Don’t labor to comfort me for the destruction of the daughter of my people. 
-</p><p>
-<span class="v">5&#160;</span>For it is a day of confusion, and of treading down, and of perplexity from the Lord, Yahweh of Armies, in the valley of vision, a breaking down of the walls, and a crying to the mountains.” 
-<span class="v">6&#160;</span>Elam carried his quiver, with chariots of men and horsemen; and Kir uncovered the shield. 
-<span class="v">7&#160;</span>Your choicest valleys were full of chariots, and the horsemen set themselves in array at the gate. 
-<span class="v">8&#160;</span>He took away the covering of Judah; and you looked in that day to the armor in the house of the forest. 
-<span class="v">9&#160;</span>You saw the breaches of David’s city, that they were many; and you gathered together the waters of the lower pool. 
-<span class="v">10&#160;</span>You counted the houses of Jerusalem, and you broke down the houses to fortify the wall. 
-<span class="v">11&#160;</span>You also made a reservoir between the two walls for the water of the old pool. But you didn’t look to him who had done this, neither did you have respect for him who planned it long ago. 
-</p><p>
-<span class="v">12&#160;</span>In that day, the Lord, Yahweh of Armies, called to weeping, to mourning, to baldness, and to dressing in sackcloth; 
-<span class="v">13&#160;</span>and behold, there is joy and gladness, killing cattle and killing sheep, eating meat and drinking wine: “Let’s eat and drink, for tomorrow we will die.” 
-<span class="v">14&#160;</span>Yahweh of Armies revealed himself in my ears, “Surely this iniquity will not be forgiven you until you die,” says the Lord, Yahweh of Armies. 
-</p><p>
-<span class="v">15&#160;</span>The Lord, Yahweh of Armies says, “Go, get yourself to this treasurer, even to Shebna, who is over the house, and say, 
-<span class="v">16&#160;</span>‘What are you doing here? Who has you here, that you have dug out a tomb here?’ Cutting himself out a tomb on high, chiseling a habitation for himself in the rock!” 
-<span class="v">17&#160;</span>Behold, Yahweh will overcome you and hurl you away violently. Yes, he will grasp you firmly. 
-<span class="v">18&#160;</span>He will surely wind you around and around, and throw you like a ball into a large country. There you will die, and there the chariots of your glory will be, you disgrace of your lord’s house. 
-<span class="v">19&#160;</span>I will thrust you from your office. You will be pulled down from your station. 
-</p><p>
-<span class="v">20&#160;</span>It will happen in that day that I will call my servant Eliakim the son of Hilkiah, 
-<span class="v">21&#160;</span>and I will clothe him with your robe, and strengthen him with your belt. I will commit your government into his hand; and he will be a father to the inhabitants of Jerusalem, and to the house of Judah. 
-<span class="v">22&#160;</span>I will lay the key of David’s house on his shoulder. He will open, and no one will shut. He will shut, and no one will open. 
-<span class="v">23&#160;</span>I will fasten him like a nail in a sure place. He will be for a throne of glory to his father’s house. 
-<span class="v">24&#160;</span>They will hang on him all the glory of his father’s house, the offspring and the issue, every small vessel, from the cups even to all the pitchers. 
-<span class="v">25&#160;</span>“In that day,” says Yahweh of Armies, “the nail that was fastened in a sure place will give way. It will be cut down and fall. The burden that was on it will be cut off, for Yahweh has spoken it.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>The burden of Tyre. 
-</p><p>Howl, you ships of Tarshish! For it is laid waste, so that there is no house, no entering in. From the land of Kittim it is revealed to them. 
-<span class="v">2&#160;</span>Be still, you inhabitants of the coast, you whom the merchants of Sidon that pass over the sea have replenished. 
-<span class="v">3&#160;</span>On great waters, the seed of the Shihor, the harvest of the Nile, was her revenue. She was the market of nations. 
-<span class="v">4&#160;</span>Be ashamed, Sidon; for the sea has spoken, the stronghold of the sea, saying, “I have not travailed, nor given birth, neither have I nourished young men, nor brought up virgins.” 
-<span class="v">5&#160;</span>When the report comes to Egypt, they will be in anguish at the report of Tyre. 
-<span class="v">6&#160;</span>Pass over to Tarshish! Wail, you inhabitants of the coast! 
-<span class="v">7&#160;</span>Is this your joyous city, whose antiquity is of ancient days, whose feet carried her far away to travel? 
-</p><p>
-<span class="v">8&#160;</span>Who has planned this against Tyre, the giver of crowns, whose merchants are princes, whose traders are the honorable of the earth? 
-<span class="v">9&#160;</span>Yahweh of Armies has planned it, to stain the pride of all glory, to bring into contempt all the honorable of the earth. 
-<span class="v">10&#160;</span>Pass through your land like the Nile, daughter of Tarshish. There is no restraint any more. 
-<span class="v">11&#160;</span>He has stretched out his hand over the sea. He has shaken the kingdoms. Yahweh has ordered the destruction of Canaan’s strongholds. 
-<span class="v">12&#160;</span>He said, “You shall rejoice no more, you oppressed virgin daughter of Sidon. Arise, pass over to Kittim. Even there you will have no rest.” 
-</p><p>
-<span class="v">13&#160;</span>Behold, the land of the Chaldeans. This people didn’t exist. The Assyrians founded it for those who dwell in the wilderness. They set up their towers. They overthrew its palaces. They made it a ruin. 
-<span class="v">14&#160;</span>Howl, you ships of Tarshish, for your stronghold is laid waste! 
-<span class="v">15&#160;</span>It will come to pass in that day that Tyre will be forgotten seventy years, according to the days of one king. After the end of seventy years it will be to Tyre like in the song of the prostitute. 
-<span class="v">16&#160;</span>Take a harp; go about the city, you prostitute that has been forgotten. Make sweet melody. Sing many songs, that you may be remembered. 
-<span class="v">17&#160;</span>It will happen after the end of seventy years that Yahweh will visit Tyre. She will return to her wages, and will play the prostitute with all the kingdoms of the world on the surface of the earth. 
-<span class="v">18&#160;</span>Her merchandise and her wages will be set-apartness to Yahweh. It will not be treasured nor laid up; for her merchandise will be for those who dwell before Yahweh, to eat sufficiently, and for durable clothing. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Behold, Yahweh makes the earth empty, makes it waste, turns it upside down, and scatters its inhabitants. 
-<span class="v">2&#160;</span>It will be as with the people, so with the priest; as with the servant, so with his master; as with the maid, so with her mistress; as with the buyer, so with the seller; as with the creditor, so with the debtor; as with the taker of interest, so with the giver of interest. 
-<span class="v">3&#160;</span>The earth will be utterly emptied and utterly laid waste; for Yahweh has spoken this word. 
-<span class="v">4&#160;</span>The earth mourns and fades away. The world languishes and fades away. The lofty people of the earth languish. 
-<span class="v">5&#160;</span>The earth also is polluted under its inhabitants, because they have transgressed the laws, violated the statutes, and broken the everlasting covenant. 
-<span class="v">6&#160;</span>Therefore the curse has devoured the earth, and those who dwell therein are found guilty. Therefore the inhabitants of the earth are burned, and few men are left. 
-<span class="v">7&#160;</span>The new wine mourns. The vine languishes. All the merry-hearted sigh. 
-<span class="v">8&#160;</span>The mirth of tambourines ceases. The sound of those who rejoice ends. The joy of the harp ceases. 
-<span class="v">9&#160;</span>They will not drink wine with a song. Strong drink will be bitter to those who drink it. 
-<span class="v">10&#160;</span>The confused city is broken down. Every house is shut up, that no man may come in. 
-<span class="v">11&#160;</span>There is a crying in the streets because of the wine. All joy is darkened. The mirth of the land is gone. 
-<span class="v">12&#160;</span>The city is left in desolation, and the gate is struck with destruction. 
-<span class="v">13&#160;</span>For it will be so within the earth among the peoples, as the shaking of an olive tree, as the gleanings when the vintage is done. 
-</p><p>
-<span class="v">14&#160;</span>These shall lift up their voice. They will shout for the majesty of Yahweh. They cry aloud from the sea. 
-<span class="v">15&#160;</span>Therefore glorify Yahweh in the east, even the name of Yahweh, the Elohim of Israel, in the islands of the sea! 
-<span class="v">16&#160;</span>From the uttermost part of the earth have we heard songs. Glory to the righteous! 
-</p><p>But I said, “I pine away! I pine away! woe is me!” The treacherous have dealt treacherously. Yes, the treacherous have dealt very treacherously. 
-<span class="v">17&#160;</span>Fear, the pit, and the snare are on you who inhabit the earth. 
-<span class="v">18&#160;</span>It will happen that he who flees from the noise of the fear will fall into the pit; and he who comes up out of the middle of the pit will be taken in the snare; for the windows on high are opened, and the foundations of the earth tremble. 
-<span class="v">19&#160;</span>The earth is utterly broken. The earth is torn apart. The earth is shaken violently. 
-<span class="v">20&#160;</span>The earth will stagger like a drunken man, and will sway back and forth like a hammock. Its disobedience will be heavy on it, and it will fall and not rise again. 
-</p><p>
-<span class="v">21&#160;</span>It will happen in that day that Yahweh will punish the army of the high ones on high, and the kings of the earth on the earth. 
-<span class="v">22&#160;</span>They will be gathered together, as prisoners are gathered in the pit, and will be shut up in the prison; and after many days they will be visited. 
-<span class="v">23&#160;</span>Then the moon will be confounded, and the sun ashamed; for Yahweh of Armies will reign on Mount Zion and in Jerusalem; and glory will be before his elders. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh, you are my Elohim. I will exalt you! I will praise your name, for you have done wonderful things, things planned long ago, in complete faithfulness and truth. 
-<span class="v">2&#160;</span>For you have made a city into a heap, a fortified city into a ruin, a palace of strangers to be no city. It will never be built. 
-<span class="v">3&#160;</span>Therefore a strong people will glorify you. A city of awesome nations will fear you. 
-<span class="v">4&#160;</span>For you have been a stronghold to the poor, a stronghold to the needy in his distress, a refuge from the storm, a shade from the heat, when the blast of the dreaded ones is like a storm against the wall. 
-<span class="v">5&#160;</span>As the heat in a dry place you will bring down the noise of strangers; as the heat by the shade of a cloud, the song of the dreaded ones will be brought low. 
-</p><p>
-<span class="v">6&#160;</span>In this mountain, Yahweh of Armies will make all peoples a feast of choice meat,<span class="f">+ \fr 25:6 \ft literally, fat things</span> a feast of choice wines, of choice meat full of marrow, of well refined choice wines. 
-<span class="v">7&#160;</span>He will destroy in this mountain the surface of the covering that covers all peoples, and the veil that is spread over all nations. 
-<span class="v">8&#160;</span>He has swallowed up death forever! The Lord Yahweh will wipe away tears from off all faces. He will take the reproach of his people away from off all the earth, for Yahweh has spoken it. 
-</p><p>
-<span class="v">9&#160;</span>It shall be said in that day, “Behold, this is our Elohim! We have waited for him, and he will save us! This is Yahweh! We have waited for him. We will be glad and rejoice in his salvation!” 
-<span class="v">10&#160;</span>For Yahweh’s hand will rest in this mountain. 
-</p><p>Moab will be trodden down in his place, even like straw is trodden down in the water of the dunghill. 
-<span class="v">11&#160;</span>He will spread out his hands in the middle of it, like one who swims spreads out hands to swim, but his pride will be humbled together with the craft of his hands. 
-<span class="v">12&#160;</span>He has brought the high fortress of your walls down, laid low, and brought to the ground, even to the dust. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>In that day, this song will be sung in the land of Judah: 
-</p><p class="q1">“We have a strong city. 
-</p><p class="q2">Elohim appoints salvation for walls and bulwarks. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Open the gates, that the righteous nation may enter: 
-</p><p class="q2">the one which keeps faith. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You will keep whoever’s mind is steadfast in perfect peace, 
-</p><p class="q2">because he trusts in you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Trust in Yahweh forever; 
-</p><p class="q2">for in Yah, Yahweh, is an everlasting Rock. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For he has brought down those who dwell on high, the lofty city. 
-</p><p class="q2">He lays it low. 
-</p><p class="q2">He lays it low even to the ground. 
-</p><p class="q2">He brings it even to the dust. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The foot shall tread it down, 
-</p><p class="q2">even the feet of the poor 
-</p><p class="q2">and the steps of the needy.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>The way of the just is uprightness. 
-</p><p class="q2">You who are upright make the path of the righteous level. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Yes, in the way of your judgments, Yahweh, we have waited for you. 
-</p><p class="q2">Your name and your renown are the desire of our soul. 
-</p><p class="q1">
-<span class="v">9&#160;</span>With my soul I have desired you in the night. 
-</p><p class="q2">Yes, with my spirit within me I will seek you earnestly; 
-</p><p class="q2">for when your judgments are in the earth, the inhabitants of the world learn righteousness. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Let favor be shown to the wicked, 
-</p><p class="q2">yet he will not learn righteousness. 
-</p><p class="q1">In the land of uprightness he will deal wrongfully, 
-</p><p class="q2">and will not see Yahweh’s majesty. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Yahweh, your hand is lifted up, yet they don’t see; 
-</p><p class="q2">but they will see your zeal for the people and be disappointed. 
-</p><p class="q2">Yes, fire will consume your adversaries. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yahweh, you will ordain peace for us, 
-</p><p class="q2">for you have also done all our work for us. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yahweh our Elohim, other lords besides you have had dominion over us, 
-</p><p class="q2">but we will only acknowledge your name. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The dead shall not live. 
-</p><p class="q2">The departed spirits shall not rise. 
-</p><p class="q1">Therefore you have visited and destroyed them, 
-</p><p class="q2">and caused all memory of them to perish. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You have increased the nation, O Yahweh. 
-</p><p class="q2">You have increased the nation! 
-</p><p class="q1">You are glorified! 
-</p><p class="q2">You have enlarged all the borders of the land. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Yahweh, in trouble they have visited you. 
-</p><p class="q2">They poured out a prayer when your chastening was on them. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Just as a woman with child, who draws near the time of her delivery, 
-</p><p class="q2">is in pain and cries out in her pangs, 
-</p><p class="q2">so we have been before you, Yahweh. 
-</p><p class="q1">
-<span class="v">18&#160;</span>We have been with child. 
-</p><p class="q2">We have been in pain. 
-</p><p class="q1">We gave birth, it seems, only to wind. 
-</p><p class="q2">We have not worked any deliverance in the earth; 
-</p><p class="q2">neither have the inhabitants of the world fallen. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Your dead shall live. 
-</p><p class="q2">Their dead bodies shall arise. 
-</p><p class="q1">Awake and sing, you who dwell in the dust; 
-</p><p class="q2">for your dew is like the dew of herbs, 
-</p><p class="q2">and the earth will cast out the departed spirits. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>Come, my people, enter into your rooms, 
-</p><p class="q2">and shut your doors behind you. 
-</p><p class="q1">Hide yourself for a little moment, 
-</p><p class="q2">until the indignation is past. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For, behold, Yahweh comes out of his place to punish the inhabitants of the earth for their iniquity. 
-</p><p class="q2">The earth also will disclose her blood, and will no longer cover her slain. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>In that day, Yahweh with his hard and great and strong sword will punish leviathan, the fleeing serpent, and leviathan, the twisted serpent; and he will kill the dragon that is in the sea. 
-</p><p>
-<span class="v">2&#160;</span>In that day, sing to her, “A pleasant vineyard! 
-<span class="v">3&#160;</span>I, Yahweh, am its keeper. I will water it every moment. Lest anyone damage it, I will keep it night and day. 
-<span class="v">4&#160;</span>Wrath is not in me, but if I should find briers and thorns, I would do battle! I would march on them and I would burn them together. 
-<span class="v">5&#160;</span>Or else let him take hold of my strength, that he may make peace with me. Let him make peace with me.” 
-</p><p>
-<span class="v">6&#160;</span>In days to come, Jacob will take root. Israel will blossom and bud. They will fill the surface of the world with fruit. 
-<span class="v">7&#160;</span>Has he struck them as he struck those who struck them? Or are they killed like those who killed them were killed? 
-<span class="v">8&#160;</span>In measure, when you send them away, you contend with them. He has removed them with his rough blast in the day of the east wind. 
-<span class="v">9&#160;</span>Therefore by this the iniquity of Jacob will be forgiven, and this is all the fruit of taking away his sin: that he makes all the stones of the altar as chalk stones that are beaten in pieces, so that the Asherah poles and the incense altars shall rise no more. 
-<span class="v">10&#160;</span>For the fortified city is solitary, a habitation deserted and forsaken, like the wilderness. The calf will feed there, and there he will lie down, and consume its branches. 
-<span class="v">11&#160;</span>When its boughs are withered, they will be broken off. The women will come and set them on fire, for they are a people of no understanding. Therefore he who made them will not have compassion on them, and he who formed them will show them no favor. 
-</p><p>
-<span class="v">12&#160;</span>It will happen in that day that Yahweh will thresh from the flowing stream of the Euphrates to the brook of Egypt; and you will be gathered one by one, children of Israel. 
-</p><p>
-<span class="v">13&#160;</span>It will happen in that day that a great trumpet will be blown; and those who were ready to perish in the land of Assyria, and those who were outcasts in the land of Egypt, shall come; and they will worship Yahweh in the set-apart mountain at Jerusalem. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>Woe to the crown of pride of the drunkards of Ephraim, and to the fading flower of his glorious beauty, which is on the head of the fertile valley of those who are overcome with wine! 
-<span class="v">2&#160;</span>Behold, the Lord has one who is mighty and strong. Like a storm of hail, a destroying storm, and like a storm of mighty waters overflowing, he will cast them down to the earth with his hand. 
-<span class="v">3&#160;</span>The crown of pride of the drunkards of Ephraim will be trodden under foot. 
-<span class="v">4&#160;</span>The fading flower of his glorious beauty, which is on the head of the fertile valley, shall be like the first-ripe fig before the summer, which someone picks and eats as soon as he sees it. 
-<span class="v">5&#160;</span>In that day, Yahweh of Armies will become a crown of glory and a diadem of beauty to the residue of his people, 
-<span class="v">6&#160;</span>and a spirit of justice to him who sits in judgment, and strength to those who turn back the battle at the gate. 
-</p><p>
-<span class="v">7&#160;</span>They also reel with wine, and stagger with strong drink. The priest and the prophet reel with strong drink. They are swallowed up by wine. They stagger with strong drink. They err in vision. They stumble in judgment. 
-<span class="v">8&#160;</span>For all tables are completely full of filthy vomit and filthiness. 
-</p><p>
-<span class="v">9&#160;</span>Whom will he teach knowledge? To whom will he explain the message? Those who are weaned from the milk, and drawn from the breasts? 
-<span class="v">10&#160;</span>For it is precept on precept, precept on precept; line on line, line on line; here a little, there a little. 
-</p><p>
-<span class="v">11&#160;</span>But he will speak to this nation with stammering lips and in another language, 
-<span class="v">12&#160;</span>to whom he said, “This is the resting place. Give rest to the weary,” and “This is the refreshing;” yet they would not hear. 
-<span class="v">13&#160;</span>Therefore Yahweh’s word will be to them precept on precept, precept on precept; line on line, line on line; here a little, there a little; that they may go, fall backward, be broken, be snared, and be taken. 
-</p><p>
-<span class="v">14&#160;</span>Therefore hear Yahweh’s word, you scoffers, that rule this people in Jerusalem: 
-<span class="v">15&#160;</span>“Because you have said, ‘We have made a covenant with death, and we are in agreement with Sheol.<span class="f">+ \fr 28:15 \ft Sheol is the place of the dead.</span> When the overflowing scourge passes through, it won’t come to us; for we have made lies our refuge, and we have hidden ourselves under falsehood.’&#160;” 
-<span class="v">16&#160;</span>Therefore the Lord Yahweh says, “Behold, I lay in Zion for a foundation a stone, a tried stone, a precious cornerstone of a sure foundation. He who believes shall not act hastily. 
-<span class="v">17&#160;</span>I will make justice the measuring line, and righteousness the plumb line. The hail will sweep away the refuge of lies, and the waters will overflow the hiding place. 
-<span class="v">18&#160;</span>Your covenant with death shall be annulled, and your agreement with Sheol<span class="f">+ \fr 28:18 \ft Sheol is the place of the dead.</span> shall not stand. When the overflowing scourge passes through, then you will be trampled down by it. 
-<span class="v">19&#160;</span>As often as it passes through, it will seize you; for morning by morning it will pass through, by day and by night; and it will be nothing but terror to understand the message.” 
-<span class="v">20&#160;</span>For the bed is too short to stretch out on, and the blanket is too narrow to wrap oneself in. 
-<span class="v">21&#160;</span>For Yahweh will rise up as on Mount Perazim. He will be angry as in the valley of Gibeon; that he may do his work, his unusual work, and bring to pass his act, his extraordinary act. 
-<span class="v">22&#160;</span>Now therefore don’t be scoffers, lest your bonds be made strong; for I have heard a decree of destruction from the Lord, Yahweh of Armies, on the whole earth. 
-</p><p>
-<span class="v">23&#160;</span>Give ear, and hear my voice! Listen, and hear my speech! 
-<span class="v">24&#160;</span>Does he who plows to sow plow continually? Does he keep turning the soil and breaking the clods? 
-<span class="v">25&#160;</span>When he has leveled its surface, doesn’t he plant the dill, and scatter the cumin seed, and put in the wheat in rows, the barley in the appointed place, and the spelt in its place? 
-<span class="v">26&#160;</span>For his Elohim instructs him in right judgment and teaches him. 
-<span class="v">27&#160;</span>For the dill isn’t threshed with a sharp instrument, neither is a cart wheel turned over the cumin; but the dill is beaten out with a stick, and the cumin with a rod. 
-<span class="v">28&#160;</span>Bread flour must be ground; so he will not always be threshing it. Although he drives the wheel of his threshing cart over it, his horses don’t grind it. 
-<span class="v">29&#160;</span>This also comes out from Yahweh of Armies, who is wonderful in counsel, and excellent in wisdom. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>Woe to Ariel! Ariel, the city where David encamped! Add year to year; let the feasts come around; 
-<span class="v">2&#160;</span>then I will distress Ariel, and there will be mourning and lamentation. She shall be to me as an altar hearth.<span class="f">+ \fr 29:2 \ft or, Ariel</span> 
-<span class="v">3&#160;</span>I will encamp against you all around you, and will lay siege against you with posted troops. I will raise siege works against you. 
-<span class="v">4&#160;</span>You will be brought down, and will speak out of the ground. Your speech will mumble out of the dust. Your voice will be as of one who has a familiar spirit, out of the ground, and your speech will whisper out of the dust. 
-</p><p>
-<span class="v">5&#160;</span>But the multitude of your foes will be like fine dust, and the multitude of the ruthless ones like chaff that blows away. Yes, it will be in an instant, suddenly. 
-<span class="v">6&#160;</span>She will be visited by Yahweh of Armies with thunder, with earthquake, with great noise, with whirlwind and storm, and with the flame of a devouring fire. 
-<span class="v">7&#160;</span>The multitude of all the nations that fight against Ariel, even all who fight against her and her stronghold, and who distress her, will be like a dream, a vision of the night. 
-<span class="v">8&#160;</span>It will be like when a hungry man dreams, and behold, he eats; but he awakes, and his hunger isn’t satisfied; or like when a thirsty man dreams, and behold, he drinks; but he awakes, and behold, he is faint, and he is still thirsty. The multitude of all the nations that fight against Mount Zion will be like that. 
-</p><p>
-<span class="v">9&#160;</span>Pause and wonder! Blind yourselves and be blind! They are drunken, but not with wine; they stagger, but not with strong drink. 
-<span class="v">10&#160;</span>For Yahweh has poured out on you a spirit of deep sleep, and has closed your eyes, the prophets; and he has covered your heads, the seers. 
-<span class="v">11&#160;</span>All vision has become to you like the words of a book that is sealed, which men deliver to one who is educated, saying, “Read this, please;” and he says, “I can’t, for it is sealed;” 
-<span class="v">12&#160;</span>and the book is delivered to one who is not educated, saying, “Read this, please;” and he says, “I can’t read.” 
-</p><p>
-<span class="v">13&#160;</span>The Lord said, “Because this people draws near with their mouth and honors me with their lips, but they have removed their heart far from me, and their fear of me is a commandment of men which has been taught; 
-<span class="v">14&#160;</span>therefore, behold, I will proceed to do a marvelous work among this people, even a marvelous work and a wonder; and the wisdom of their wise men will perish, and the understanding of their prudent men will be hidden.” 
-</p><p>
-<span class="v">15&#160;</span>Woe to those who deeply hide their counsel from Yahweh, and whose deeds are in the dark, and who say, “Who sees us?” and “Who knows us?” 
-<span class="v">16&#160;</span>You turn things upside down! Should the potter be thought to be like clay, that the thing made should say about him who made it, “He didn’t make me;” or the thing formed say of him who formed it, “He has no understanding”? 
-</p><p>
-<span class="v">17&#160;</span>Isn’t it yet a very little while, and Lebanon will be turned into a fruitful field, and the fruitful field will be regarded as a forest? 
-<span class="v">18&#160;</span>In that day, the deaf will hear the words of the book, and the eyes of the blind will see out of obscurity and out of darkness. 
-<span class="v">19&#160;</span>The humble also will increase their joy in Yahweh, and the poor among men will rejoice in the Set-Apart One of Israel. 
-<span class="v">20&#160;</span>For the ruthless is brought to nothing, and the scoffer ceases, and all those who are alert to do evil are cut off—<span class="v">21&#160;</span>who cause a person to be indicted by a word, and lay a snare for one who reproves in the gate, and who deprive the innocent of justice with false testimony. 
-</p><p>
-<span class="v">22&#160;</span>Therefore Yahweh, who redeemed Abraham, says concerning the house of Jacob: “Jacob shall no longer be ashamed, neither shall his face grow pale. 
-<span class="v">23&#160;</span>But when he sees his children, the work of my hands, in the middle of him, they will sanctify my name. Yes, they will sanctify the Set-Apart One of Jacob, and will stand in awe of the Elohim of Israel. 
-<span class="v">24&#160;</span>They also who err in spirit will come to understanding, and those who grumble will receive instruction.” 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>“Woe to the rebellious children”, says Yahweh, “who take counsel, but not from me; and who make an alliance, but not with my Spirit, that they may add sin to sin; 
-<span class="v">2&#160;</span>who set out to go down into Egypt without asking for my advice, to strengthen themselves in the strength of Pharaoh, and to take refuge in the shadow of Egypt! 
-<span class="v">3&#160;</span>Therefore the strength of Pharaoh will be your shame, and the refuge in the shadow of Egypt your confusion. 
-<span class="v">4&#160;</span>For their princes are at Zoan, and their ambassadors have come to Hanes. 
-<span class="v">5&#160;</span>They shall all be ashamed because of a people that can’t profit them, that are not a help nor profit, but a shame, and also a reproach.” 
-</p><p>
-<span class="v">6&#160;</span>The burden of the animals of the South. 
-</p><p>Through the land of trouble and anguish, of the lioness and the lion, the viper and fiery flying serpent, they carry their riches on the shoulders of young donkeys, and their treasures on the humps of camels, to an unprofitable people. 
-<span class="v">7&#160;</span>For Egypt helps in vain, and to no purpose; therefore I have called her Rahab who sits still. 
-<span class="v">8&#160;</span>Now go, write it before them on a tablet, and inscribe it in a book, that it may be for the time to come forever and ever. 
-<span class="v">9&#160;</span>For it is a rebellious people, lying children, children who will not hear Yahweh’s law; 
-<span class="v">10&#160;</span>who tell the seers, “Don’t see!” and the prophets, “Don’t prophesy to us right things. Tell us pleasant things. Prophesy deceits. 
-<span class="v">11&#160;</span>Get out of the way. Turn away from the path. Cause the Set-Apart One of Israel to cease from before us.” 
-<span class="v">12&#160;</span>Therefore the Set-Apart One of Israel says, “Because you despise this word, and trust in oppression and perverseness, and rely on it, 
-<span class="v">13&#160;</span>therefore this iniquity shall be to you like a breach ready to fall, swelling out in a high wall, whose breaking comes suddenly in an instant. 
-<span class="v">14&#160;</span>He will break it as a potter’s vessel is broken, breaking it in pieces without sparing, so that there won’t be found among the broken pieces a piece good enough to take fire from the hearth, or to dip up water out of the cistern.” 
-</p><p>
-<span class="v">15&#160;</span>For thus said the Lord Yahweh, the Set-Apart One of Israel, “You will be saved in returning and rest. Your strength will be in quietness and in confidence.” You refused, 
-<span class="v">16&#160;</span>but you said, “No, for we will flee on horses;” therefore you will flee; and, “We will ride on the swift;” therefore those who pursue you will be swift. 
-<span class="v">17&#160;</span>One thousand will flee at the threat of one. At the threat of five, you will flee until you are left like a beacon on the top of a mountain, and like a banner on a hill. 
-</p><p>
-<span class="v">18&#160;</span>Therefore Yahweh will wait, that he may be gracious to you; and therefore he will be exalted, that he may have mercy on you, for Yahweh is an Elohim of justice. Blessed are all those who wait for him. 
-<span class="v">19&#160;</span>For the people will dwell in Zion at Jerusalem. You will weep no more. He will surely be gracious to you at the voice of your cry. When he hears you, he will answer you. 
-<span class="v">20&#160;</span>Though the Lord may give you the bread of adversity and the water of affliction, yet your teachers won’t be hidden any more, but your eyes will see your teachers; 
-<span class="v">21&#160;</span>and when you turn to the right hand, and when you turn to the left, your ears will hear a voice behind you, saying, “This is the way. Walk in it.” 
-<span class="v">22&#160;</span>You shall defile the overlaying of your engraved images of silver, and the plating of your molten images of gold. You shall cast them away as an unclean thing. You shall tell it, “Go away!” 
-</p><p>
-<span class="v">23&#160;</span>He will give the rain for your seed, with which you will sow the ground; and bread of the increase of the ground will be rich and plentiful. In that day, your livestock will feed in large pastures. 
-<span class="v">24&#160;</span>The oxen likewise and the young donkeys that till the ground will eat savory feed, which has been winnowed with the shovel and with the fork. 
-<span class="v">25&#160;</span>There will be brooks and streams of water on every lofty mountain and on every high hill in the day of the great slaughter, when the towers fall. 
-<span class="v">26&#160;</span>Moreover the light of the moon will be like the light of the sun, and the light of the sun will be seven times brighter, like the light of seven days, in the day that Yahweh binds up the fracture of his people, and heals the wound they were struck with. 
-</p><p>
-<span class="v">27&#160;</span>Behold, Yahweh’s name comes from far away, burning with his anger, and in thick rising smoke. His lips are full of indignation. His tongue is as a devouring fire. 
-<span class="v">28&#160;</span>His breath is as an overflowing stream that reaches even to the neck, to sift the nations with the sieve of destruction. A bridle that leads to ruin will be in the jaws of the peoples. 
-<span class="v">29&#160;</span>You will have a song, as in the night when a set-apart feast is kept, and gladness of heart, as when one goes with a flute to come to Yahweh’s mountain, to Israel’s Rock. 
-<span class="v">30&#160;</span>Yahweh will cause his glorious voice to be heard, and will show the descent of his arm, with the indignation of his anger and the flame of a devouring fire, with a blast, storm, and hailstones. 
-<span class="v">31&#160;</span>For through Yahweh’s voice the Assyrian will be dismayed. He will strike him with his rod. 
-<span class="v">32&#160;</span>Every stroke of the rod of punishment, which Yahweh will lay on him, will be with the sound of tambourines and harps. He will fight with them in battles, brandishing weapons. 
-<span class="v">33&#160;</span>For his burning place has long been ready. Yes, it is prepared for the king. He has made its pyre deep and large with fire and much wood. Yahweh’s breath, like a stream of sulfur, kindles it. 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Woe to those who go down to Egypt for help, 
-</p><p class="q2">and rely on horses, 
-</p><p class="q2">and trust in chariots because they are many, 
-</p><p class="q2">and in horsemen because they are very strong, 
-</p><p class="q2">but they don’t look to the Set-Apart One of Israel, 
-</p><p class="q2">and they don’t seek Yahweh! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yet he also is wise, and will bring disaster, 
-</p><p class="q2">and will not call back his words, but will arise against the house of the evildoers, 
-</p><p class="q2">and against the help of those who work iniquity. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Now the Egyptians are men, and not Elohim; 
-</p><p class="q2">and their horses flesh, and not spirit. 
-</p><p class="q1">When Yahweh stretches out his hand, both he who helps shall stumble, 
-</p><p class="q2">and he who is helped shall fall, 
-</p><p class="q2">and they all shall be consumed together. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>For Yahweh says to me, 
-</p><p class="q1">“As the lion and the young lion growling over his prey, 
-</p><p class="q2">if a multitude of shepherds is called together against him, 
-</p><p class="q2">will not be dismayed at their voice, 
-</p><p class="q2">nor abase himself for their noise, 
-</p><p class="q2">so Yahweh of Armies will come down to fight on Mount Zion and on its heights. 
-</p><p class="q1">
-<span class="v">5&#160;</span>As birds hovering, so Yahweh of Armies will protect Jerusalem. 
-</p><p class="q2">He will protect and deliver it. 
-</p><p class="q2">He will pass over and preserve it.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>Return to him from whom you have deeply revolted, children of Israel. 
-<span class="v">7&#160;</span>For in that day everyone shall cast away his idols of silver and his idols of gold—sin which your own hands have made for you. 
-</p><p>
-<span class="v">8&#160;</span>“The Assyrian will fall by the sword, not of man; 
-</p><p class="q2">and the sword, not of mankind, shall devour him. 
-</p><p class="q1">He will flee from the sword, 
-</p><p class="q2">and his young men will become subject to forced labor. 
-</p><p class="q1">
-<span class="v">9&#160;</span>His rock will pass away by reason of terror, 
-</p><p class="q2">and his princes will be afraid of the banner,” 
-</p><p class="q1">says Yahweh, whose fire is in Zion, 
-</p><p class="q2">and his furnace in Jerusalem. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Behold, a king shall reign in righteousness, 
-</p><p class="q2">and princes shall rule in justice. 
-</p><p class="q1">
-<span class="v">2&#160;</span>A man shall be as a hiding place from the wind, 
-</p><p class="q2">and a covert from the storm, 
-</p><p class="q2">as streams of water in a dry place, 
-</p><p class="q2">as the shade of a large rock in a weary land. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The eyes of those who see will not be dim, 
-</p><p class="q2">and the ears of those who hear will listen. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The heart of the rash will understand knowledge, 
-</p><p class="q2">and the tongue of the stammerers will be ready to speak plainly. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The fool will no longer be called noble, 
-</p><p class="q2">nor the scoundrel be highly respected. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For the fool will speak folly, 
-</p><p class="q2">and his heart will work iniquity, 
-</p><p class="q2">to practice profanity, 
-</p><p class="q2">and to utter error against Yahweh, 
-</p><p class="q2">to make empty the soul of the hungry, 
-</p><p class="q2">and to cause the drink of the thirsty to fail. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The ways of the scoundrel are evil. 
-</p><p class="q2">He devises wicked plans to destroy the humble with lying words, 
-</p><p class="q2">even when the needy speaks right. 
-</p><p class="q1">
-<span class="v">8&#160;</span>But the noble devises noble things, 
-</p><p class="q2">and he will continue in noble things. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Rise up, you women who are at ease! Hear my voice! 
-</p><p class="q2">You careless daughters, give ear to my speech! 
-</p><p class="q1">
-<span class="v">10&#160;</span>For days beyond a year you will be troubled, you careless women; 
-</p><p class="q2">for the vintage will fail. 
-</p><p class="q2">The harvest won’t come. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Tremble, you women who are at ease! 
-</p><p class="q2">Be troubled, you careless ones! 
-</p><p class="q2">Strip yourselves, make yourselves naked, 
-</p><p class="q2">and put sackcloth on your waist. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Beat your breasts for the pleasant fields, 
-</p><p class="q2">for the fruitful vine. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Thorns and briers will come up on my people’s land; 
-</p><p class="q2">yes, on all the houses of joy in the joyous city. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For the palace will be forsaken. 
-</p><p class="q2">The populous city will be deserted. 
-</p><p class="q2">The hill and the watchtower will be for dens forever, 
-</p><p class="q2">a delight for wild donkeys, 
-</p><p class="q2">a pasture of flocks, 
-</p><p class="q1">
-<span class="v">15&#160;</span>until the Spirit is poured on us from on high, 
-</p><p class="q2">and the wilderness becomes a fruitful field, 
-</p><p class="q2">and the fruitful field is considered a forest. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Then justice will dwell in the wilderness; 
-</p><p class="q2">and righteousness will remain in the fruitful field. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The work of righteousness will be peace, 
-</p><p class="q2">and the effect of righteousness, quietness and confidence forever. 
-</p><p class="q1">
-<span class="v">18&#160;</span>My people will live in a peaceful habitation, 
-</p><p class="q2">in safe dwellings, 
-</p><p class="q2">and in quiet resting places, 
-</p><p class="q1">
-<span class="v">19&#160;</span>though hail flattens the forest, 
-</p><p class="q2">and the city is leveled completely. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Blessed are you who sow beside all waters, 
-</p><p class="q2">who send out the feet of the ox and the donkey. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Woe to you who destroy, but you weren’t destroyed, 
-</p><p class="q2">and who betray, but nobody betrayed you! 
-</p><p class="q1">When you have finished destroying, you will be destroyed; 
-</p><p class="q2">and when you have finished betrayal, you will be betrayed. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">2&#160;</span>Yahweh, be gracious to us. We have waited for you. 
-</p><p class="q2">Be our strength every morning, 
-</p><p class="q2">our salvation also in the time of trouble. 
-</p><p class="q1">
-<span class="v">3&#160;</span>At the noise of the thunder, the peoples have fled. 
-</p><p class="q2">When you lift yourself up, the nations are scattered. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Your plunder will be gathered as the caterpillar gathers. 
-</p><p class="q2">Men will leap on it as locusts leap. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh is exalted, for he dwells on high. 
-</p><p class="q2">He has filled Zion with justice and righteousness. 
-</p><p class="q1">
-<span class="v">6&#160;</span>There will be stability in your times, abundance of salvation, wisdom, and knowledge. 
-</p><p class="q2">The fear of Yahweh is your treasure. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Behold, their valiant ones cry outside; 
-</p><p class="q2">the ambassadors of peace weep bitterly. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The highways are desolate. 
-</p><p class="q2">The traveling man ceases. 
-</p><p class="q2">The covenant is broken. 
-</p><p class="q2">He has despised the cities. 
-</p><p class="q2">He doesn’t respect man. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The land mourns and languishes. 
-</p><p class="q2">Lebanon is confounded and withers away. 
-</p><p class="q2">Sharon is like a desert, and Bashan and Carmel are stripped bare. 
-</p><p class="q1">
-<span class="v">10&#160;</span>“Now I will arise,” says Yahweh. 
-</p><p class="q2">“Now I will lift myself up. 
-</p><p class="q2">Now I will be exalted. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You will conceive chaff. 
-</p><p class="q2">You will give birth to stubble. 
-</p><p class="q2">Your breath is a fire that will devour you. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The peoples will be like the burning of lime, 
-</p><p class="q2">like thorns that are cut down and burned in the fire. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Hear, you who are far off, what I have done; 
-</p><p class="q2">and, you who are near, acknowledge my might.” 
-</p><p class="q1">
-<span class="v">14&#160;</span>The sinners in Zion are afraid. 
-</p><p class="q2">Trembling has seized the elohimless ones. 
-</p><p class="q1">Who among us can live with the devouring fire? 
-</p><p class="q2">Who among us can live with everlasting burning? 
-</p><p class="q1">
-<span class="v">15&#160;</span>He who walks righteously 
-</p><p class="q2">and speaks blamelessly, 
-</p><p class="q2">he who despises the gain of oppressions, 
-</p><p class="q2">who gestures with his hands, refusing to take a bribe, 
-</p><p class="q2">who stops his ears from hearing of bloodshed, 
-</p><p class="q2">and shuts his eyes from looking at evil—</p><p class="q1">
-<span class="v">16&#160;</span>he will dwell on high. 
-</p><p class="q2">His place of defense will be the fortress of rocks. 
-</p><p class="q2">His bread will be supplied. 
-</p><p class="q2">His waters will be sure. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Your eyes will see the king in his beauty. 
-</p><p class="q2">They will see a distant land. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Your heart will meditate on the terror. 
-</p><p class="q2">Where is he who counted? 
-</p><p class="q2">Where is he who weighed? 
-</p><p class="q2">Where is he who counted the towers? 
-</p><p class="q1">
-<span class="v">19&#160;</span>You will no longer see the fierce people, 
-</p><p class="q2">a people of a deep speech that you can’t comprehend, 
-</p><p class="q2">with a strange language that you can’t understand. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Look at Zion, the city of our appointed festivals. 
-</p><p class="q2">Your eyes will see Jerusalem, a quiet habitation, 
-</p><p class="q2">a tent that won’t be removed. 
-</p><p class="q1">Its stakes will never be plucked up, 
-</p><p class="q2">nor will any of its cords be broken. 
-</p><p class="q1">
-<span class="v">21&#160;</span>But there Yahweh will be with us in majesty, 
-</p><p class="q2">a place of wide rivers and streams, 
-</p><p class="q2">in which no galley with oars will go, 
-</p><p class="q2">neither will any gallant ship pass by there. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For Yahweh is our judge. 
-</p><p class="q2">Yahweh is our lawgiver. 
-</p><p class="q2">Yahweh is our king. 
-</p><p class="q2">He will save us. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>Your rigging is untied. 
-</p><p class="q2">They couldn’t strengthen the foot of their mast. 
-</p><p class="q2">They couldn’t spread the sail. 
-</p><p class="q1">Then the prey of a great plunder was divided. 
-</p><p class="q2">The lame took the prey. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>The inhabitant won’t say, “I am sick.” 
-</p><p class="q2">The people who dwell therein will be forgiven their iniquity. 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Come near, you nations, to hear! 
-</p><p class="q2">Listen, you peoples. 
-</p><p class="q2">Let the earth and all it contains hear, 
-</p><p class="q2">the world, and everything that comes from it. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For Yahweh is enraged against all the nations, 
-</p><p class="q2">and angry with all their armies. 
-</p><p class="q1">He has utterly destroyed them. 
-</p><p class="q2">He has given them over for slaughter. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Their slain will also be cast out, 
-</p><p class="q2">and the stench of their dead bodies will come up. 
-</p><p class="q2">The mountains will melt in their blood. 
-</p><p class="q1">
-<span class="v">4&#160;</span>All of the army of the sky will be dissolved. 
-</p><p class="q2">The sky will be rolled up like a scroll, 
-</p><p class="q2">and all its armies will fade away, 
-</p><p class="q2">as a leaf fades from off a vine or a fig tree. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For my sword has drunk its fill in the sky. 
-</p><p class="q2">Behold, it will come down on Edom, 
-</p><p class="q2">and on the people of my curse, for judgment. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh’s sword is filled with blood. 
-</p><p class="q2">It is covered with fat, with the blood of lambs and goats, 
-</p><p class="q2">with the fat of the kidneys of rams; 
-</p><p class="q2">for Yahweh has a sacrifice in Bozrah, 
-</p><p class="q2">and a great slaughter in the land of Edom. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The wild oxen will come down with them, 
-</p><p class="q2">and the young bulls with the mighty bulls; 
-</p><p class="q2">and their land will be drunken with blood, 
-</p><p class="q2">and their dust made greasy with fat. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>For Yahweh has a day of vengeance, 
-</p><p class="q2">a year of recompense for the cause of Zion. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Its streams will be turned into pitch, 
-</p><p class="q2">its dust into sulfur, 
-</p><p class="q2">and its land will become burning pitch. 
-</p><p class="q1">
-<span class="v">10&#160;</span>It won’t be quenched night or day. 
-</p><p class="q2">Its smoke will go up forever. 
-</p><p class="q2">From generation to generation, it will lie waste. 
-</p><p class="q2">No one will pass through it forever and ever. 
-</p><p class="q1">
-<span class="v">11&#160;</span>But the pelican and the porcupine will possess it. 
-</p><p class="q2">The owl and the raven will dwell in it. 
-</p><p class="q1">He will stretch the line of confusion over it, 
-</p><p class="q2">and the plumb line of emptiness. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They shall call its nobles to the kingdom, but none shall be there; 
-</p><p class="q2">and all its princes shall be nothing. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Thorns will come up in its palaces, 
-</p><p class="q2">nettles and thistles in its fortresses; 
-</p><p class="q2">and it will be a habitation of jackals, 
-</p><p class="q2">a court for ostriches. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The wild animals of the desert will meet with the wolves, 
-</p><p class="q2">and the wild goat will cry to his fellow. 
-</p><p class="q1">Yes, the night creature<span class="f">+ \fr 34:14 \ft literally, lilith, which could also be a night demon or night monster</span> shall settle there, 
-</p><p class="q2">and shall find herself a place of rest. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The arrow snake will make her nest there, 
-</p><p class="q2">and lay, hatch, and gather under her shade. 
-</p><p class="q2">Yes, the kites will be gathered there, every one with her mate. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Search in the book of Yahweh, and read: 
-</p><p class="q2">not one of these will be missing. 
-</p><p class="q2">None will lack her mate. 
-</p><p class="q2">For my mouth has commanded, 
-</p><p class="q2">and his Spirit has gathered them. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He has cast the lot for them, 
-</p><p class="q2">and his hand has divided it to them with a measuring line. 
-</p><p class="q2">They shall possess it forever. 
-</p><p class="q2">From generation to generation they will dwell in it. 
-</p><div class="b"> &#160; </div>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+<a href="#41">41</a>
+<a href="#42">42</a>
+<a href="#43">43</a>
+<a href="#44">44</a>
+<a href="#45">45</a>
+<a href="#46">46</a>
+<a href="#47">47</a>
+<a href="#48">48</a>
+<a href="#49">49</a>
+<a href="#50">50</a>
+<a href="#51">51</a>
+<a href="#52">52</a>
+<a href="#53">53</a>
+<a href="#54">54</a>
+<a href="#55">55</a>
+<a href="#56">56</a>
+<a href="#57">57</a>
+<a href="#58">58</a>
+<a href="#59">59</a>
+<a href="#60">60</a>
+<a href="#61">61</a>
+<a href="#62">62</a>
+<a href="#63">63</a>
+<a href="#64">64</a>
+<a href="#65">65</a>
+<a href="#66">66</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The vision of Isaiah the son of Amoz, which he saw concerning Judah and Jerusalem, in the days of Uzziah, Jotham, Ahaz, and Hezekiah, kings of Judah. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear, heavens, 
+</div><div class="q2">and listen, earth; for Yahweh has spoken: 
+</div><div class="q1">“I have nourished and brought up children 
+</div><div class="q2">and they have rebelled against me. 
+</div><div class="q1">
+<sup>3&#160;</sup>The ox knows his owner, 
+</div><div class="q2">and the donkey his master’s crib; 
+</div><div class="q2">but Israel doesn’t know. 
+</div><div class="q2">My people don’t consider.” 
+</div><div class="q1">
+<sup>4&#160;</sup>Ah sinful nation, 
+</div><div class="q2">a people loaded with iniquity, 
+</div><div class="q2">offspring of evildoers, 
+</div><div class="q2">children who deal corruptly! 
+</div><div class="q1">They have forsaken Yahweh. 
+</div><div class="q2">They have despised the Set-Apart One of Israel. 
+</div><div class="q2">They are estranged and backward. 
+</div><div class="q1">
+<sup>5&#160;</sup>Why should you be beaten more, 
+</div><div class="q2">that you revolt more and more? 
+</div><div class="q1">The whole head is sick, 
+</div><div class="q2">and the whole heart faint. 
+</div><div class="q1">
+<sup>6&#160;</sup>From the sole of the foot even to the head there is no soundness in it, 
+</div><div class="q2">but wounds, welts, and open sores. 
+</div><div class="q2">They haven’t been closed, bandaged, or soothed with oil. 
+</div><div class="q1">
+<sup>7&#160;</sup>Your country is desolate. 
+</div><div class="q2">Your cities are burned with fire. 
+</div><div class="q2">Strangers devour your land in your presence 
+</div><div class="q2">and it is desolate, 
+</div><div class="q2">as overthrown by strangers. 
+</div><div class="q1">
+<sup>8&#160;</sup>The daughter of Zion is left like a shelter in a vineyard, 
+</div><div class="q2">like a hut in a field of melons, 
+</div><div class="q2">like a besieged city. 
+</div><div class="q1">
+<sup>9&#160;</sup>Unless Yahweh of Armies had left to us a very small remnant, 
+</div><div class="q2">we would have been as Sodom. 
+</div><div class="q2">We would have been like Gomorrah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Hear Yahweh’s word, you rulers of Sodom! 
+</div><div class="q2">Listen to the law of our Elohim, you people of Gomorrah! 
+</div><div class="q1">
+<sup>11&#160;</sup>“What are the multitude of your sacrifices to me?”, says Yahweh. 
+</div><div class="q2">“I have had enough of the burnt offerings of rams 
+</div><div class="q2">and the fat of fed animals. 
+</div><div class="q2">I don’t delight in the blood of bulls, 
+</div><div class="q2">or of lambs, 
+</div><div class="q2">or of male goats. 
+</div><div class="q1">
+<sup>12&#160;</sup>When you come to appear before me, 
+</div><div class="q2">who has required this at your hand, to trample my courts? 
+</div><div class="q1">
+<sup>13&#160;</sup>Bring no more vain offerings. 
+</div><div class="q2">Incense is an abomination to me. 
+</div><div class="q2">New moons, Sabbaths, and convocations—</div><div class="q2">I can’t stand evil assemblies. 
+</div><div class="q1">
+<sup>14&#160;</sup>My soul hates your New Moons and your appointed feasts. 
+</div><div class="q2">They are a burden to me. 
+</div><div class="q2">I am weary of bearing them. 
+</div><div class="q1">
+<sup>15&#160;</sup>When you spread out your hands, I will hide my eyes from you. 
+</div><div class="q2">Yes, when you make many prayers, I will not hear. 
+</div><div class="q2">Your hands are full of blood. 
+</div><div class="q1">
+<sup>16&#160;</sup>Wash yourselves. Make yourself clean. 
+</div><div class="q2">Put away the evil of your doings from before my eyes. 
+</div><div class="q2">Cease to do evil. 
+</div><div class="q1">
+<sup>17&#160;</sup>Learn to do well. 
+</div><div class="q2">Seek justice. 
+</div><div class="q2">Relieve the oppressed. 
+</div><div class="q1">Defend the fatherless. 
+</div><div class="q2">Plead for the widow.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“Come now, and let’s reason together,” says Yahweh: 
+</div><div class="q2">“Though your sins are as scarlet, they shall be as white as snow. 
+</div><div class="q2">Though they are red like crimson, they shall be as wool. 
+</div><div class="q1">
+<sup>19&#160;</sup>If you are willing and obedient, 
+</div><div class="q2">you will eat the good of the land; 
+</div><div class="q2">
+<sup>20&#160;</sup>but if you refuse and rebel, you will be devoured with the sword; 
+</div><div class="q2">for Yahweh’s mouth has spoken it.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>How the faithful city has become a prostitute! 
+</div><div class="q2">She was full of justice. 
+</div><div class="q1">Righteousness lodged in her, 
+</div><div class="q2">but now there are murderers. 
+</div><div class="q1">
+<sup>22&#160;</sup>Your silver has become dross, 
+</div><div class="q2">your wine mixed with water. 
+</div><div class="q1">
+<sup>23&#160;</sup>Your princes are rebellious and companions of thieves. 
+</div><div class="q2">Everyone loves bribes and follows after rewards. 
+</div><div class="q2">They don’t defend the fatherless, 
+</div><div class="q2">neither does the cause of the widow come to them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>Therefore the Lord, Yahweh of Armies, 
+</div><div class="q2">the Mighty One of Israel, says: 
+</div><div class="q1">“Ah, I will get relief from my adversaries, 
+</div><div class="q2">and avenge myself on my enemies. 
+</div><div class="q1">
+<sup>25&#160;</sup>I will turn my hand on you, 
+</div><div class="q2">thoroughly purge away your dross, 
+</div><div class="q2">and will take away all your tin. 
+</div><div class="q1">
+<sup>26&#160;</sup>I will restore your judges as at the first, 
+</div><div class="q2">and your counselors as at the beginning. 
+</div><div class="q1">Afterward you shall be called ‘The city of righteousness, 
+</div><div class="q2">a faithful town.’ 
+</div><div class="q1">
+<sup>27&#160;</sup>Zion shall be redeemed with justice, 
+</div><div class="q2">and her converts with righteousness. 
+</div><div class="q1">
+<sup>28&#160;</sup>But the destruction of transgressors and sinners shall be together, 
+</div><div class="q2">and those who forsake Yahweh shall be consumed. 
+</div><div class="q1">
+<sup>29&#160;</sup>For they shall be ashamed of the oaks which you have desired, 
+</div><div class="q2">and you shall be confounded for the gardens that you have chosen. 
+</div><div class="q1">
+<sup>30&#160;</sup>For you shall be as an oak whose leaf fades, 
+</div><div class="q2">and as a garden that has no water. 
+</div><div class="q1">
+<sup>31&#160;</sup>The strong will be like tinder, 
+</div><div class="q2">and his work like a spark. 
+</div><div class="q1">They will both burn together, 
+</div><div class="q2">and no one will quench them.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>This is what Isaiah the son of Amoz saw concerning Judah and Jerusalem. 
+</div><div class="q1">
+<sup>2&#160;</sup>It shall happen in the latter days, that the mountain of Yahweh’s house shall be established on the top of the mountains, 
+</div><div class="q2">and shall be raised above the hills; 
+</div><div class="q2">and all nations shall flow to it. 
+</div><div class="q1">
+<sup>3&#160;</sup>Many peoples shall go and say, 
+</div><div class="q2">“Come, let’s go up to the mountain of Yahweh, 
+</div><div class="q2">to the house of the Elohim of Jacob; 
+</div><div class="q2">and he will teach us of his ways, 
+</div><div class="q2">and we will walk in his paths.” 
+</div><div class="q1">For the law shall go out of Zion, 
+</div><div class="q2">and Yahweh’s word from Jerusalem. 
+</div><div class="q1">
+<sup>4&#160;</sup>He will judge between the nations, 
+</div><div class="q2">and will decide concerning many peoples. 
+</div><div class="q2">They shall beat their swords into plowshares, 
+</div><div class="q2">and their spears into pruning hooks. 
+</div><div class="q1">Nation shall not lift up sword against nation, 
+</div><div class="q2">neither shall they learn war any more. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>House of Jacob, come, and let’s walk in the light of Yahweh. 
+</div><div class="q1">
+<sup>6&#160;</sup>For you have forsaken your people, the house of Jacob, 
+</div><div class="q2">because they are filled from the east, 
+</div><div class="q2">with those who practice divination like the Philistines, 
+</div><div class="q2">and they clasp hands with the children of foreigners. 
+</div><div class="q1">
+<sup>7&#160;</sup>Their land is full of silver and gold, 
+</div><div class="q2">neither is there any end of their treasures. 
+</div><div class="q1">Their land also is full of horses, 
+</div><div class="q2">neither is there any end of their chariots. 
+</div><div class="q1">
+<sup>8&#160;</sup>Their land also is full of idols. 
+</div><div class="q2">They worship the work of their own hands, 
+</div><div class="q2">that which their own fingers have made. 
+</div><div class="q1">
+<sup>9&#160;</sup>Man is brought low, 
+</div><div class="q2">and mankind is humbled; 
+</div><div class="q2">therefore don’t forgive them. 
+</div><div class="q1">
+<sup>10&#160;</sup>Enter into the rock, 
+</div><div class="q2">and hide in the dust, 
+</div><div class="q1">from before the terror of Yahweh, 
+</div><div class="q2">and from the glory of his majesty. 
+</div><div class="q1">
+<sup>11&#160;</sup>The lofty looks of man will be brought low, 
+</div><div class="q2">the arrogance of men will be bowed down, 
+</div><div class="q2">and Yahweh alone will be exalted in that day. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>For there will be a day of Yahweh of Armies for all that is proud and arrogant, 
+</div><div class="q2">and for all that is lifted up, 
+</div><div class="q2">and it shall be brought low—</div><div class="q2">
+<sup>13&#160;</sup>for all the cedars of Lebanon, that are high and lifted up, 
+</div><div class="q2">for all the oaks of Bashan, 
+</div><div class="q2">
+<sup>14&#160;</sup>for all the high mountains, 
+</div><div class="q2">for all the hills that are lifted up, 
+</div><div class="q2">
+<sup>15&#160;</sup>for every lofty tower, 
+</div><div class="q2">for every fortified wall, 
+</div><div class="q2">
+<sup>16&#160;</sup>for all the ships of Tarshish, 
+</div><div class="q2">and for all pleasant imagery. 
+</div><div class="q1">
+<sup>17&#160;</sup>The loftiness of man shall be bowed down, 
+</div><div class="q2">and the arrogance of men shall be brought low; 
+</div><div class="q2">and Yahweh alone shall be exalted in that day. 
+</div><div class="q1">
+<sup>18&#160;</sup>The idols shall utterly pass away. 
+</div><div class="q1">
+<sup>19&#160;</sup>Men shall go into the caves of the rocks, 
+</div><div class="q2">and into the holes of the earth, 
+</div><div class="q2">from before the terror of Yahweh, 
+</div><div class="q2">and from the glory of his majesty, 
+</div><div class="q2">when he arises to shake the earth mightily. 
+</div><div class="q1">
+<sup>20&#160;</sup>In that day, men shall cast away their idols of silver 
+</div><div class="q2">and their idols of gold, 
+</div><div class="q2">which have been made for themselves to worship, 
+</div><div class="q2">to the moles and to the bats, 
+</div><div class="q2">
+<sup>21&#160;</sup>to go into the caverns of the rocks, 
+</div><div class="q2">and into the clefts of the ragged rocks, 
+</div><div class="q2">from before the terror of Yahweh, 
+</div><div class="q2">and from the glory of his majesty, 
+</div><div class="q2">when he arises to shake the earth mightily. 
+</div><div class="q1">
+<sup>22&#160;</sup>Stop trusting in man, whose breath is in his nostrils; 
+</div><div class="q2">for of what account is he? 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="q1">
+<sup>1&#160;</sup>For, behold, the Lord, Yahweh of Armies, takes away from Jerusalem and from Judah supply and support, 
+</div><div class="q2">the whole supply of bread, 
+</div><div class="q2">and the whole supply of water; 
+</div><div class="q2">
+<sup>2&#160;</sup>the mighty man, 
+</div><div class="q2">the man of war, 
+</div><div class="q2">the judge, 
+</div><div class="q2">the prophet, 
+</div><div class="q2">the diviner, 
+</div><div class="q2">the elder, 
+</div><div class="q2">
+<sup>3&#160;</sup>the captain of fifty, 
+</div><div class="q2">the honorable man, 
+</div><div class="q2">the counselor, 
+</div><div class="q2">the skilled craftsman, 
+</div><div class="q2">and the clever enchanter. 
+</div><div class="q1">
+<sup>4&#160;</sup>I will give boys to be their princes, 
+</div><div class="q2">and children shall rule over them. 
+</div><div class="q1">
+<sup>5&#160;</sup>The people will be oppressed, 
+</div><div class="q2">everyone by another, 
+</div><div class="q2">and everyone by his neighbor. 
+</div><div class="q1">The child will behave himself proudly against the old man, 
+</div><div class="q2">and the wicked against the honorable. 
+</div><div class="q1">
+<sup>6&#160;</sup>Indeed a man shall take hold of his brother in the house of his father, saying, 
+</div><div class="q2">“You have clothing, you be our ruler, 
+</div><div class="q2">and let this ruin be under your hand.” 
+</div><div class="q1">
+<sup>7&#160;</sup>In that day he will cry out, saying, “I will not be a healer; 
+</div><div class="q2">for in my house is neither bread nor clothing. 
+</div><div class="q2">You shall not make me ruler of the people.” 
+</div><div class="q1">
+<sup>8&#160;</sup>For Jerusalem is ruined, and Judah is fallen; 
+</div><div class="q2">because their tongue and their doings are against Yahweh, 
+</div><div class="q1">to provoke the eyes of his glory. 
+</div><div class="q1">
+<sup>9&#160;</sup>The look of their faces testify against them. 
+</div><div class="q2">They parade their sin like Sodom. 
+</div><div class="q2">They don’t hide it. 
+</div><div class="q2">Woe to their soul! 
+</div><div class="q2">For they have brought disaster upon themselves. 
+</div><div class="q1">
+<sup>10&#160;</sup>Tell the righteous that it will be well with them, 
+</div><div class="q2">for they will eat the fruit of their deeds. 
+</div><div class="q1">
+<sup>11&#160;</sup>Woe to the wicked! 
+</div><div class="q2">Disaster is upon them, 
+</div><div class="q2">for the deeds of their hands will be paid back to them. 
+</div><div class="q1">
+<sup>12&#160;</sup>As for my people, children are their oppressors, 
+</div><div class="q2">and women rule over them. 
+</div><div class="q2">My people, those who lead you cause you to err, 
+</div><div class="q2">and destroy the way of your paths. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Yahweh stands up to contend, 
+</div><div class="q2">and stands to judge the peoples. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yahweh will enter into judgment with the elders of his people 
+</div><div class="q2">and their leaders: 
+</div><div class="q2">“It is you who have eaten up the vineyard. 
+</div><div class="q2">The plunder of the poor is in your houses. 
+</div><div class="q2">
+<sup>15&#160;</sup>What do you mean that you crush my people, 
+</div><div class="q2">and grind the face of the poor?” says the Lord, Yahweh of Armies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Moreover Yahweh said, “Because the daughters of Zion are arrogant, 
+</div><div class="q2">and walk with outstretched necks and flirting eyes, 
+</div><div class="q2">walking daintily as they go, 
+</div><div class="q2">jingling ornaments on their feet; 
+</div><div class="q1">
+<sup>17&#160;</sup>therefore the Lord brings sores on the crown of the head of the women of Zion, 
+</div><div class="q2">and Yahweh will make their scalps bald.” 
+</div><div class="p">
+<sup>18&#160;</sup>In that day the Lord will take away the beauty of their anklets, the headbands, the crescent necklaces, 
+<sup>19&#160;</sup>the earrings, the bracelets, the veils, 
+<sup>20&#160;</sup>the headdresses, the ankle chains, the sashes, the perfume containers, the charms, 
+<sup>21&#160;</sup>the signet rings, the nose rings, 
+<sup>22&#160;</sup>the fine robes, the capes, the cloaks, the purses, 
+<sup>23&#160;</sup>the hand mirrors, the fine linen garments, the tiaras, and the shawls. 
+</div><div class="q1">
+<sup>24&#160;</sup>It shall happen that instead of sweet spices, there shall be rottenness; 
+</div><div class="q2">instead of a belt, a rope; 
+</div><div class="q2">instead of well set hair, baldness; 
+</div><div class="q2">instead of a robe, a wearing of sackcloth; 
+</div><div class="q2">and branding instead of beauty. 
+</div><div class="q1">
+<sup>25&#160;</sup>Your men shall fall by the sword, 
+</div><div class="q2">and your mighty in the war. 
+</div><div class="q1">
+<sup>26&#160;</sup>Her gates shall lament and mourn. 
+</div><div class="q2">She shall be desolate and sit on the ground. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Seven women shall take hold of one man in that day, saying, “We will eat our own bread, and wear our own clothing. Just let us be called by your name. Take away our reproach.” 
+</div><div class="p">
+<sup>2&#160;</sup>In that day, Yahweh’s branch will be beautiful and glorious, and the fruit of the land will be the beauty and glory of the survivors of Israel. 
+<sup>3&#160;</sup>It will happen that he who is left in Zion and he who remains in Jerusalem shall be called set-apart, even everyone who is written among the living in Jerusalem, 
+<sup>4&#160;</sup>when the Lord shall have washed away the filth of the daughters of Zion, and shall have purged the blood of Jerusalem from within it, by the spirit of justice and by the spirit of burning. 
+<sup>5&#160;</sup>Yahweh will create over the whole habitation of Mount Zion and over her assemblies, a cloud and smoke by day, and the shining of a flaming fire by night, for over all the glory will be a canopy. 
+<sup>6&#160;</sup>There will be a pavilion for a shade in the daytime from the heat, and for a refuge and for a shelter from storm and from rain. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="q1">
+<sup>1&#160;</sup>Let me sing for my well beloved a song of my beloved about his vineyard. 
+</div><div class="q2">My beloved had a vineyard on a very fruitful hill. 
+</div><div class="q1">
+<sup>2&#160;</sup>He dug it up, 
+</div><div class="q2">gathered out its stones, 
+</div><div class="q2">planted it with the choicest vine, 
+</div><div class="q2">built a tower in the middle of it, 
+</div><div class="q2">and also cut out a wine press in it. 
+</div><div class="q1">He looked for it to yield grapes, 
+</div><div class="q2">but it yielded wild grapes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Now, inhabitants of Jerusalem and men of Judah, 
+</div><div class="q2">please judge between me and my vineyard. 
+</div><div class="q1">
+<sup>4&#160;</sup>What could have been done more to my vineyard, that I have not done in it? 
+</div><div class="q2">Why, when I looked for it to yield grapes, did it yield wild grapes? 
+</div><div class="q1">
+<sup>5&#160;</sup>Now I will tell you what I will do to my vineyard. 
+</div><div class="q2">I will take away its hedge, and it will be eaten up. 
+</div><div class="q2">I will break down its wall, and it will be trampled down. 
+</div><div class="q1">
+<sup>6&#160;</sup>I will lay it a wasteland. 
+</div><div class="q2">It won’t be pruned or hoed, 
+</div><div class="q2">but it will grow briers and thorns. 
+</div><div class="q2">I will also command the clouds that they rain no rain on it.” 
+</div><div class="q1">
+<sup>7&#160;</sup>For the vineyard of Yahweh of Armies is the house of Israel, 
+</div><div class="q2">and the men of Judah his pleasant plant. 
+</div><div class="q2">He looked for justice, but behold, oppression, 
+</div><div class="q2">for righteousness, but behold, a cry of distress. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Woe to those who join house to house, 
+</div><div class="q2">who lay field to field, until there is no room, 
+</div><div class="q2">and you are made to dwell alone in the middle of the land! 
+</div><div class="q1">
+<sup>9&#160;</sup>In my ears, Yahweh of Armies says: “Surely many houses will be desolate, 
+</div><div class="q2">even great and beautiful, unoccupied. 
+</div><div class="q1">
+<sup>10&#160;</sup>For ten acres 
+</div><div class="q2">and a homer 
+</div><div class="q1">
+<sup>11&#160;</sup>Woe to those who rise up early in the morning, that they may follow strong drink, 
+</div><div class="q2">who stay late into the night, until wine inflames them! 
+</div><div class="q1">
+<sup>12&#160;</sup>The harp, lyre, tambourine, and flute, with wine, are at their feasts; 
+</div><div class="q2">but they don’t respect the work of Yahweh, 
+</div><div class="q2">neither have they considered the operation of his hands. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Therefore my people go into captivity for lack of knowledge. 
+</div><div class="q2">Their honorable men are famished, 
+</div><div class="q2">and their multitudes are parched with thirst. 
+</div><div class="q1">
+<sup>14&#160;</sup>Therefore Sheol has enlarged its desire, 
+</div><div class="q2">and opened its mouth without measure; 
+</div><div class="q2">and their glory, their multitude, their pomp, and he who rejoices among them, descend into it. 
+</div><div class="q1">
+<sup>15&#160;</sup>So man is brought low, 
+</div><div class="q2">mankind is humbled, 
+</div><div class="q2">and the eyes of the arrogant ones are humbled; 
+</div><div class="q1">
+<sup>16&#160;</sup>but Yahweh of Armies is exalted in justice, 
+</div><div class="q2">and Elohim the Set-Apart One is sanctified in righteousness. 
+</div><div class="q1">
+<sup>17&#160;</sup>Then the lambs will graze as in their pasture, 
+</div><div class="q2">and strangers will eat the ruins of the rich. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>Woe to those who draw iniquity with cords of falsehood, 
+</div><div class="q2">and wickedness as with cart rope, 
+</div><div class="q1">
+<sup>19&#160;</sup>who say, “Let him make haste, let him hasten his work, that we may see it; 
+</div><div class="q2">let the counsel of the Set-Apart One of Israel draw near and come, 
+</div><div class="q2">that we may know it!” 
+</div><div class="q1">
+<sup>20&#160;</sup>Woe to those who call evil good, and good evil; 
+</div><div class="q2">who put darkness for light, 
+</div><div class="q2">and light for darkness; 
+</div><div class="q1">who put bitter for sweet, 
+</div><div class="q2">and sweet for bitter! 
+</div><div class="q1">
+<sup>21&#160;</sup>Woe to those who are wise in their own eyes, 
+</div><div class="q2">and prudent in their own sight! 
+</div><div class="q1">
+<sup>22&#160;</sup>Woe to those who are mighty to drink wine, 
+</div><div class="q2">and champions at mixing strong drink; 
+</div><div class="q1">
+<sup>23&#160;</sup>who acquit the guilty for a bribe, 
+</div><div class="q2">but deny justice for the innocent! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>Therefore as the tongue of fire devours the stubble, 
+</div><div class="q2">and as the dry grass sinks down in the flame, 
+</div><div class="q2">so their root shall be as rottenness, 
+</div><div class="q2">and their blossom shall go up as dust, 
+</div><div class="q1">because they have rejected the law of Yahweh of Armies, 
+</div><div class="q2">and despised the word of the Set-Apart One of Israel. 
+</div><div class="q1">
+<sup>25&#160;</sup>Therefore Yahweh’s anger burns against his people, 
+</div><div class="q2">and he has stretched out his hand against them and has struck them. 
+</div><div class="q1">The mountains tremble, 
+</div><div class="q2">and their dead bodies are as refuse in the middle of the streets. 
+</div><div class="q1">For all this, his anger is not turned away, 
+</div><div class="q2">but his hand is still stretched out. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>26&#160;</sup>He will lift up a banner to the nations from far away, 
+</div><div class="q2">and he will whistle for them from the end of the earth. 
+</div><div class="q2">Behold, they will come speedily and swiftly. 
+</div><div class="q1">
+<sup>27&#160;</sup>No one shall be weary nor stumble among them; 
+</div><div class="q2">no one shall slumber nor sleep, 
+</div><div class="q2">neither shall the belt of their waist be untied, 
+</div><div class="q2">nor the strap of their sandals be broken, 
+</div><div class="q1">
+<sup>28&#160;</sup>whose arrows are sharp, 
+</div><div class="q2">and all their bows bent. 
+</div><div class="q1">Their horses’ hoofs will be like flint, 
+</div><div class="q2">and their wheels like a whirlwind. 
+</div><div class="q1">
+<sup>29&#160;</sup>Their roaring will be like a lioness. 
+</div><div class="q2">They will roar like young lions. 
+</div><div class="q1">Yes, they shall roar, 
+</div><div class="q2">and seize their prey and carry it off, 
+</div><div class="q2">and there will be no one to deliver. 
+</div><div class="q1">
+<sup>30&#160;</sup>They will roar against them in that day like the roaring of the sea. 
+</div><div class="q2">If one looks to the land, behold, darkness and distress. 
+</div><div class="q2">The light is darkened in its clouds. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>In the year that King Uzziah died, I saw the Lord sitting on a throne, high and lifted up; and his train filled the temple. 
+<sup>2&#160;</sup>Above him stood the seraphim. Each one had six wings. With two he covered his face. With two he covered his feet. With two he flew. 
+<sup>3&#160;</sup>One called to another, and said, 
+</div><div class="q1">“Set-Apart, set-apart, set-apart, is Yahweh of Armies! 
+</div><div class="q2">The whole earth is full of his glory!” 
+</div><div class="p">
+<sup>4&#160;</sup>The foundations of the thresholds shook at the voice of him who called, and the house was filled with smoke. 
+<sup>5&#160;</sup>Then I said, “Woe is me! For I am undone, because I am a man of unclean lips and I live among a people of unclean lips, for my eyes have seen the King, Yahweh of Armies!” 
+</div><div class="p">
+<sup>6&#160;</sup>Then one of the seraphim flew to me, having a live coal in his hand, which he had taken with the tongs from off the altar. 
+<sup>7&#160;</sup>He touched my mouth with it, and said, “Behold, this has touched your lips; and your iniquity is taken away, and your sin forgiven.” 
+</div><div class="p">
+<sup>8&#160;</sup>I heard the Lord’s voice, saying, “Whom shall I send, and who will go for us?” 
+</div><div class="p">Then I said, “Here I am. Send me!” 
+</div><div class="p">
+<sup>9&#160;</sup>He said, “Go, and tell this people, 
+</div><div class="q1">‘You hear indeed, 
+</div><div class="q2">but don’t understand. 
+</div><div class="q1">You see indeed, 
+</div><div class="q2">but don’t perceive.’ 
+</div><div class="q1">
+<sup>10&#160;</sup>Make the heart of this people fat. 
+</div><div class="q2">Make their ears heavy, and shut their eyes; 
+</div><div class="q1">lest they see with their eyes, 
+</div><div class="q2">hear with their ears, 
+</div><div class="q2">understand with their heart, 
+</div><div class="q2">and turn again, and be healed.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then I said, “Lord, how long?” 
+</div><div class="p">He answered, 
+</div><div class="q1">“Until cities are waste without inhabitant, 
+</div><div class="q2">houses without man, 
+</div><div class="q2">the land becomes utterly waste, 
+</div><div class="q2">
+<sup>12&#160;</sup>and Yahweh has removed men far away, 
+</div><div class="q2">and the forsaken places are many within the land. 
+</div><div class="q1">
+<sup>13&#160;</sup>If there is a tenth left in it, 
+</div><div class="q2">that also will in turn be consumed, 
+</div><div class="q1">as a terebinth, and as an oak whose stump remains when they are cut down, 
+</div><div class="q2">so the set-apart seed is its stump.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>In the days of Ahaz the son of Jotham, the son of Uzziah, king of Judah, Rezin the king of Syria and Pekah the son of Remaliah, king of Israel, went up to Jerusalem to war against it, but could not prevail against it. 
+<sup>2&#160;</sup>David’s house was told, “Syria is allied with Ephraim.” His heart trembled, and the heart of his people, as the trees of the forest tremble with the wind. 
+</div><div class="p">
+<sup>3&#160;</sup>Then Yahweh said to Isaiah, “Go out now to meet Ahaz, you, and Shearjashub your son, at the end of the conduit of the upper pool, on the highway of the fuller’s field. 
+<sup>4&#160;</sup>Tell him, ‘Be careful, and keep calm. Don’t be afraid, neither let your heart be faint because of these two tails of smoking torches, for the fierce anger of Rezin and Syria, and of the son of Remaliah. 
+<sup>5&#160;</sup>Because Syria, Ephraim, and the son of Remaliah, have plotted evil against you, saying, 
+<sup>6&#160;</sup>“Let’s go up against Judah, and tear it apart, and let’s divide it among ourselves, and set up a king within it, even the son of Tabeel.” 
+<sup>7&#160;</sup>This is what the Lord Yahweh says: “It shall not stand, neither shall it happen.” 
+<sup>8&#160;</sup>For the head of Syria is Damascus, and the head of Damascus is Rezin. Within sixty-five years Ephraim shall be broken in pieces, so that it shall not be a people. 
+<sup>9&#160;</sup>The head of Ephraim is Samaria, and the head of Samaria is Remaliah’s son. If you will not believe, surely you shall not be established.’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh spoke again to Ahaz, saying, 
+<sup>11&#160;</sup>“Ask a sign of Yahweh your Elohim; ask it either in the depth, or in the height above.” 
+</div><div class="p">
+<sup>12&#160;</sup>But Ahaz said, “I won’t ask. I won’t tempt Yahweh.” 
+</div><div class="p">
+<sup>13&#160;</sup>He said, “Listen now, house of David. Is it not enough for you to try the patience of men, that you will try the patience of my Elohim also? 
+<sup>14&#160;</sup>Therefore the Lord himself will give you a sign. Behold, the young woman will conceive, and bear a son, and shall call his name Immanuel. 
+<sup>15&#160;</sup>He shall eat butter and honey when he knows to refuse the evil and choose the good. 
+<sup>16&#160;</sup>For before the child knows to refuse the evil and choose the good, the land whose two kings you abhor shall be forsaken. 
+<sup>17&#160;</sup>Yahweh will bring on you, on your people, and on your father’s house days that have not come, from the day that Ephraim departed from Judah, even the king of Assyria. 
+</div><div class="p">
+<sup>18&#160;</sup>It will happen in that day that Yahweh will whistle for the fly that is in the uttermost part of the rivers of Egypt, and for the bee that is in the land of Assyria. 
+<sup>19&#160;</sup>They shall come, and shall all rest in the desolate valleys, in the clefts of the rocks, on all thorn hedges, and on all pastures. 
+</div><div class="p">
+<sup>20&#160;</sup>In that day the Lord will shave with a razor that is hired in the parts beyond the River, even with the king of Assyria, the head and the hair of the feet; and it shall also consume the beard. 
+</div><div class="p">
+<sup>21&#160;</sup>It shall happen in that day that a man shall keep alive a young cow, and two sheep. 
+<sup>22&#160;</sup>It shall happen, that because of the abundance of milk which they shall give he shall eat butter, for everyone will eat butter and honey that is left within the land. 
+</div><div class="p">
+<sup>23&#160;</sup>It will happen in that day that every place where there were a thousand vines worth a thousand silver shekels, will be for briers and thorns. 
+<sup>24&#160;</sup>People will go there with arrows and with bow, because all the land will be briers and thorns. 
+<sup>25&#160;</sup>All the hills that were cultivated with the hoe, you shall not come there for fear of briers and thorns; but it shall be for the sending out of oxen, and for sheep to tread on.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to me, “Take a large tablet, and write on it with a man’s pen, ‘For Maher Shalal Hash Baz’; 
+<sup>2&#160;</sup>and I will take for myself faithful witnesses to testify: Uriah the priest, and Zechariah the son of Jeberechiah.” 
+</div><div class="p">
+<sup>3&#160;</sup>I went to the prophetess, and she conceived, and bore a son. Then Yahweh said to me, “Call his name ‘Maher Shalal Hash Baz.’ 
+<sup>4&#160;</sup>For before the child knows how to say, ‘My father’ and ‘My mother,’ the riches of Damascus and the plunder of Samaria will be carried away by the king of Assyria.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh spoke to me yet again, saying, 
+<sup>6&#160;</sup>“Because this people has refused the waters of Shiloah that go softly, and rejoice in Rezin and Remaliah’s son; 
+<sup>7&#160;</sup>now therefore, behold, the Lord brings upon them the mighty flood waters of the River: the king of Assyria and all his glory. It will come up over all its channels, and go over all its banks. 
+<sup>8&#160;</sup>It will sweep onward into Judah. It will overflow and pass through. It will reach even to the neck. The stretching out of its wings will fill the width of your land, O Immanuel. 
+</div><div class="p">
+<sup>9&#160;</sup>Make an uproar, you peoples, and be broken in pieces! Listen, all you from far countries: dress for battle, and be shattered! Dress for battle, and be shattered! 
+<sup>10&#160;</sup>Take counsel together, and it will be brought to nothing; speak the word, and it will not stand, for Elohim is with us.” 
+</div><div class="p">
+<sup>11&#160;</sup>For Yahweh spoke this to me with a strong hand, and instructed me not to walk in the way of this people, saying, 
+<sup>12&#160;</sup>“Don’t call a conspiracy all that this people call a conspiracy. Don’t fear their threats or be terrorized. 
+<sup>13&#160;</sup>Yahweh of Armies is who you must respect as set-apart. He is the one you must fear. He is the one you must dread. 
+<sup>14&#160;</sup>He will be a sanctuary, but for both houses of Israel, he will be a stumbling stone and a rock that makes them fall. For the people of Jerusalem, he will be a trap and a snare. 
+<sup>15&#160;</sup>Many will stumble over it, fall, be broken, be snared, and be captured.” 
+</div><div class="p">
+<sup>16&#160;</sup>Wrap up the covenant. Seal the law among my disciples. 
+<sup>17&#160;</sup>I will wait for Yahweh, who hides his face from the house of Jacob, and I will look for him. 
+<sup>18&#160;</sup>Behold, I and the children whom Yahweh has given me are for signs and for wonders in Israel from Yahweh of Armies, who dwells in Mount Zion. 
+</div><div class="p">
+<sup>19&#160;</sup>When they tell you, “Consult with those who have familiar spirits and with the wizards, who chirp and who mutter,” shouldn’t a people consult with their Elohim? Should they consult the dead on behalf of the living? 
+<sup>20&#160;</sup>Turn to the law and to the covenant! If they don’t speak according to this word, surely there is no morning for them. 
+<sup>21&#160;</sup>They will pass through it, very distressed and hungry. It will happen that when they are hungry, they will worry, and curse their king and their Elohim. They will turn their faces upward, 
+<sup>22&#160;</sup>then look to the earth and see distress, darkness, and the gloom of anguish. They will be driven into thick darkness. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>But there shall be no more gloom for her who was in anguish. In the former time, he brought into contempt the land of Zebulun and the land of Naphtali; but in the latter time he has made it glorious, by the way of the sea, beyond the Jordan, Galilee of the nations. 
+</div><div class="p">
+<sup>2&#160;</sup>The people who walked in darkness have seen a great light. 
+</div><div class="q2">The light has shined on those who lived in the land of the shadow of death. 
+</div><div class="q1">
+<sup>3&#160;</sup>You have multiplied the nation. 
+</div><div class="q2">You have increased their joy. 
+</div><div class="p">They rejoice before you according to the joy in harvest, as men rejoice when they divide the plunder. 
+<sup>4&#160;</sup>For the yoke of his burden, and the staff of his shoulder, the rod of his oppressor, you have broken as in the day of Midian. 
+<sup>5&#160;</sup>For all the armor of the armed man in the noisy battle, and the garments rolled in blood, will be for burning, fuel for the fire. 
+<sup>6&#160;</sup>For a child is born to us. A son is given to us; and the government will be on his shoulders. His name will be called Wonderful Counselor, Mighty Elohim, Everlasting Father, Prince of Peace. 
+<sup>7&#160;</sup>Of the increase of his government and of peace there shall be no end, on David’s throne, and on his kingdom, to establish it, and to uphold it with justice and with righteousness from that time on, even forever. The zeal of Yahweh of Armies will perform this. 
+</div><div class="p">
+<sup>8&#160;</sup>The Lord sent a word into Jacob, 
+</div><div class="q2">and it falls on Israel. 
+</div><div class="q1">
+<sup>9&#160;</sup>All the people will know, 
+</div><div class="q2">including Ephraim and the inhabitants of Samaria, who say in pride and in arrogance of heart, 
+</div><div class="q1">
+<sup>10&#160;</sup>“The bricks have fallen, 
+</div><div class="q2">but we will build with cut stone. 
+</div><div class="q1">The sycamore fig trees have been cut down, 
+</div><div class="q2">but we will put cedars in their place.” 
+</div><div class="q1">
+<sup>11&#160;</sup>Therefore Yahweh will set up on high against him the adversaries of Rezin, 
+</div><div class="q2">and will stir up his enemies, 
+</div><div class="q2">
+<sup>12&#160;</sup>The Syrians in front, 
+</div><div class="q2">and the Philistines behind; 
+</div><div class="q2">and they will devour Israel with open mouth. 
+</div><div class="q1">For all this, his anger is not turned away, 
+</div><div class="q2">but his hand is stretched out still. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Yet the people have not turned to him who struck them, 
+</div><div class="q2">neither have they sought Yahweh of Armies. 
+</div><div class="q1">
+<sup>14&#160;</sup>Therefore Yahweh will cut off from Israel head and tail, 
+</div><div class="q2">palm branch and reed, in one day. 
+</div><div class="q1">
+<sup>15&#160;</sup>The elder and the honorable man is the head, 
+</div><div class="q2">and the prophet who teaches lies is the tail. 
+</div><div class="q1">
+<sup>16&#160;</sup>For those who lead this people lead them astray; 
+</div><div class="q2">and those who are led by them are destroyed. 
+</div><div class="q1">
+<sup>17&#160;</sup>Therefore the Lord will not rejoice over their young men, 
+</div><div class="q2">neither will he have compassion on their fatherless and widows; 
+</div><div class="q1">for everyone is profane and an evildoer, 
+</div><div class="q2">and every mouth speaks folly. 
+</div><div class="q1">For all this his anger is not turned away, 
+</div><div class="q2">but his hand is stretched out still. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>For wickedness burns like a fire. 
+</div><div class="q2">It devours the briers and thorns; 
+</div><div class="q2">yes, it kindles in the thickets of the forest, 
+</div><div class="q2">and they roll upward in a column of smoke. 
+</div><div class="q1">
+<sup>19&#160;</sup>Through Yahweh of Armies’ wrath, the land is burned up; 
+</div><div class="q2">and the people are the fuel for the fire. 
+</div><div class="q2">No one spares his brother. 
+</div><div class="q1">
+<sup>20&#160;</sup>One will devour on the right hand, and be hungry; 
+</div><div class="q2">and he will eat on the left hand, and they will not be satisfied. 
+</div><div class="q1">Everyone will eat the flesh of his own arm: 
+</div><div class="q2">
+<sup>21&#160;</sup>Manasseh eating Ephraim and Ephraim eating Manasseh, and they together will be against Judah. 
+</div><div class="q1">For all this his anger is not turned away, 
+</div><div class="q2">but his hand is stretched out still. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Woe to those who decree unrighteous decrees, and to the writers who write oppressive decrees 
+<sup>2&#160;</sup>to deprive the needy of justice, and to rob the poor among my people of their rights, that widows may be their plunder, and that they may make the fatherless their prey! 
+<sup>3&#160;</sup>What will you do in the day of visitation, and in the desolation which will come from afar? To whom will you flee for help? Where will you leave your wealth? 
+</div><div class="p">
+<sup>4&#160;</sup>They will only bow down under the prisoners, 
+</div><div class="q2">and will fall under the slain. 
+</div><div class="q1">For all this his anger is not turned away, 
+</div><div class="q2">but his hand is stretched out still. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>5&#160;</sup>Alas Assyrian, the rod of my anger, the staff in whose hand is my indignation! 
+<sup>6&#160;</sup>I will send him against a profane nation, and against the people who anger me I will give him a command to take the plunder and to take the prey, and to tread them down like the mire of the streets. 
+<sup>7&#160;</sup>However, he doesn’t mean so, neither does his heart think so; but it is in his heart to destroy, and to cut off not a few nations. 
+<sup>8&#160;</sup>For he says, “Aren’t all of my princes kings? 
+<sup>9&#160;</sup>Isn’t Calno like Carchemish? Isn’t Hamath like Arpad? Isn’t Samaria like Damascus?” 
+<sup>10&#160;</sup>As my hand has found the kingdoms of the idols, whose engraved images exceeded those of Jerusalem and of Samaria, 
+<sup>11&#160;</sup>shall I not, as I have done to Samaria and her idols, so do to Jerusalem and her idols? 
+</div><div class="p">
+<sup>12&#160;</sup>Therefore it will happen that when the Lord has performed his whole work on Mount Zion and on Jerusalem, I will punish the fruit of the willful proud heart of the king of Assyria, and the insolence of his arrogant looks. 
+<sup>13&#160;</sup>For he has said, “By the strength of my hand I have done it, and by my wisdom, for I have understanding. I have removed the boundaries of the peoples, and have robbed their treasures. Like a valiant man I have brought down their rulers. 
+<sup>14&#160;</sup>My hand has found the riches of the peoples like a nest, and like one gathers eggs that are abandoned, I have gathered all the earth. There was no one who moved their wing, or that opened their mouth, or chirped.” 
+</div><div class="p">
+<sup>15&#160;</sup>Should an ax brag against him who chops with it? Should a saw exalt itself above him who saws with it? As if a rod should lift those who lift it up, or as if a staff should lift up someone who is not wood. 
+<sup>16&#160;</sup>Therefore the Lord, Yahweh of Armies, will send among his fat ones leanness; and under his glory a burning will be kindled like the burning of fire. 
+<sup>17&#160;</sup>The light of Israel will be for a fire, and his Set-Apart One for a flame; and it will burn and devour his thorns and his briers in one day. 
+<sup>18&#160;</sup>He will consume the glory of his forest and of his fruitful field, both soul and body. It will be as when a standard bearer faints. 
+<sup>19&#160;</sup>The remnant of the trees of his forest shall be few, so that a child could write their number. 
+</div><div class="p">
+<sup>20&#160;</sup>It will come to pass in that day that the remnant of Israel, and those who have escaped from the house of Jacob will no more again lean on him who struck them, but shall lean on Yahweh, the Set-Apart One of Israel, in truth. 
+<sup>21&#160;</sup>A remnant will return, even the remnant of Jacob, to the mighty Elohim. 
+<sup>22&#160;</sup>For though your people, Israel, are like the sand of the sea, only a remnant of them will return. A destruction is determined, overflowing with righteousness. 
+<sup>23&#160;</sup>For the Lord, Yahweh of Armies, will make a full end, and that determined, throughout all the earth. 
+</div><div class="p">
+<sup>24&#160;</sup>Therefore the Lord, Yahweh of Armies, says, “My people who dwell in Zion, don’t be afraid of the Assyrian, though he strike you with the rod, and lift up his staff against you, as Egypt did. 
+<sup>25&#160;</sup>For yet a very little while, and the indignation against you will be accomplished, and my anger will be directed to his destruction.” 
+<sup>26&#160;</sup>Yahweh of Armies will stir up a scourge against him, as in the slaughter of Midian at the rock of Oreb. His rod will be over the sea, and he will lift it up like he did against Egypt. 
+<sup>27&#160;</sup>It will happen in that day that his burden will depart from off your shoulder, and his yoke from off your neck, and the yoke shall be destroyed because of the anointing oil. 
+</div><div class="p">
+<sup>28&#160;</sup>He has come to Aiath. He has passed through Migron. At Michmash he stores his baggage. 
+<sup>29&#160;</sup>They have gone over the pass. They have taken up their lodging at Geba. Ramah trembles. Gibeah of Saul has fled. 
+<sup>30&#160;</sup>Cry aloud with your voice, daughter of Gallim! Listen, Laishah! You poor Anathoth! 
+<sup>31&#160;</sup>Madmenah is a fugitive. The inhabitants of Gebim flee for safety. 
+<sup>32&#160;</sup>This very day he will halt at Nob. He shakes his hand at the mountain of the daughter of Zion, the hill of Jerusalem. 
+</div><div class="p">
+<sup>33&#160;</sup>Behold, the Lord, Yahweh of Armies, will lop the boughs with terror. The tall will be cut down, and the lofty will be brought low. 
+<sup>34&#160;</sup>He will cut down the thickets of the forest with iron, and Lebanon will fall by the Mighty One. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="q1">
+<sup>1&#160;</sup>A shoot will come out of the stock of Jesse, 
+</div><div class="q2">and a branch out of his roots will bear fruit. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh’s Spirit will rest on him: 
+</div><div class="q2">the spirit of wisdom and understanding, 
+</div><div class="q2">the spirit of counsel and might, 
+</div><div class="q2">the spirit of knowledge and of the fear of Yahweh. 
+</div><div class="q1">
+<sup>3&#160;</sup>His delight will be in the fear of Yahweh. 
+</div><div class="q1">He will not judge by the sight of his eyes, 
+</div><div class="q2">neither decide by the hearing of his ears; 
+</div><div class="q1">
+<sup>4&#160;</sup>but he will judge the poor with righteousness, 
+</div><div class="q2">and decide with equity for the humble of the earth. 
+</div><div class="q1">He will strike the earth with the rod of his mouth; 
+</div><div class="q2">and with the breath of his lips he will kill the wicked. 
+</div><div class="q1">
+<sup>5&#160;</sup>Righteousness will be the belt around his waist, 
+</div><div class="q2">and faithfulness the belt around his waist. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>The wolf will live with the lamb, 
+</div><div class="q2">and the leopard will lie down with the young goat, 
+</div><div class="q2">the calf, the young lion, and the fattened calf together; 
+</div><div class="q2">and a little child will lead them. 
+</div><div class="q1">
+<sup>7&#160;</sup>The cow and the bear will graze. 
+</div><div class="q2">Their young ones will lie down together. 
+</div><div class="q2">The lion will eat straw like the ox. 
+</div><div class="q1">
+<sup>8&#160;</sup>The nursing child will play near a cobra’s hole, 
+</div><div class="q2">and the weaned child will put his hand on the viper’s den. 
+</div><div class="q1">
+<sup>9&#160;</sup>They will not hurt nor destroy in all my set-apart mountain; 
+</div><div class="q2">for the earth will be full of the knowledge of Yahweh, 
+</div><div class="q2">as the waters cover the sea. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>10&#160;</sup>It will happen in that day that the nations will seek the root of Jesse, who stands as a banner of the peoples; and his resting place will be glorious. 
+</div><div class="p">
+<sup>11&#160;</sup>It will happen in that day that the Lord will set his hand again the second time to recover the remnant that is left of his people from Assyria, from Egypt, from Pathros, from Cush, from Elam, from Shinar, from Hamath, and from the islands of the sea. 
+<sup>12&#160;</sup>He will set up a banner for the nations, and will assemble the outcasts of Israel, and gather together the dispersed of Judah from the four corners of the earth. 
+<sup>13&#160;</sup>The envy also of Ephraim will depart, and those who persecute Judah will be cut off. Ephraim won’t envy Judah, and Judah won’t persecute Ephraim. 
+<sup>14&#160;</sup>They will fly down on the shoulders of the Philistines on the west. Together they will plunder the children of the east. They will extend their power over Edom and Moab, and the children of Ammon will obey them. 
+<sup>15&#160;</sup>Yahweh will utterly destroy the tongue of the Egyptian sea; and with his scorching wind he will wave his hand over the River, and will split it into seven streams, and cause men to march over in sandals. 
+<sup>16&#160;</sup>There will be a highway for the remnant that is left of his people from Assyria, like there was for Israel in the day that he came up out of the land of Egypt. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>In that day you will say, “I will give thanks to you, Yahweh; for though you were angry with me, your anger has turned away and you comfort me. 
+<sup>2&#160;</sup>Behold, Elohim is my salvation. I will trust, and will not be afraid; for Yah, Yahweh, is my strength and song; and he has become my salvation.” 
+<sup>3&#160;</sup>Therefore with joy you will draw water out of the wells of salvation. 
+<sup>4&#160;</sup>In that day you will say, “Give thanks to Yahweh! Call on his name! Declare his doings among the peoples! Proclaim that his name is exalted! 
+<sup>5&#160;</sup>Sing to Yahweh, for he has done excellent things! Let this be known in all the earth! 
+<sup>6&#160;</sup>Cry aloud and shout, you inhabitant of Zion, for the Set-Apart One of Israel is great among you!” 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of Babylon, which Isaiah the son of Amoz saw. 
+</div><div class="p">
+<sup>2&#160;</sup>Set up a banner on the bare mountain! Lift up your voice to them! Wave your hand, that they may go into the gates of the nobles. 
+<sup>3&#160;</sup>I have commanded my consecrated ones; yes, I have called my mighty men for my anger, even my proudly exulting ones. 
+<sup>4&#160;</sup>The noise of a multitude is in the mountains, as of a great people; the noise of an uproar of the kingdoms of the nations gathered together! Yahweh of Armies is mustering the army for the battle. 
+<sup>5&#160;</sup>They come from a far country, from the uttermost part of heaven, even Yahweh, and the weapons of his indignation, to destroy the whole land. 
+</div><div class="p">
+<sup>6&#160;</sup>Wail, for Yahweh’s day is at hand! It will come as destruction from the Almighty. 
+<sup>7&#160;</sup>Therefore all hands will be feeble, and everyone’s heart will melt. 
+<sup>8&#160;</sup>They will be dismayed. Pangs and sorrows will seize them. They will be in pain like a woman in labor. They will look in amazement one at another. Their faces will be faces of flame. 
+<sup>9&#160;</sup>Behold, the day of Yahweh comes, cruel, with wrath and fierce anger; to make the land a desolation, and to destroy its sinners out of it. 
+<sup>10&#160;</sup>For the stars of the sky and its constellations will not give their light. The sun will be darkened in its going out, and the moon will not cause its light to shine. 
+<sup>11&#160;</sup>I will punish the world for their evil, and the wicked for their iniquity. I will cause the arrogance of the proud to cease, and will humble the arrogance of the terrible. 
+<sup>12&#160;</sup>I will make people more rare than fine gold, even a person than the pure gold of Ophir. 
+<sup>13&#160;</sup>Therefore I will make the heavens tremble, and the earth will be shaken out of its place in Yahweh of Armies’ wrath, and in the day of his fierce anger. 
+<sup>14&#160;</sup>It will happen that like a hunted gazelle and like sheep that no one gathers, they will each turn to their own people, and will each flee to their own land. 
+<sup>15&#160;</sup>Everyone who is found will be thrust through. Everyone who is captured will fall by the sword. 
+<sup>16&#160;</sup>Their infants also will be dashed in pieces before their eyes. Their houses will be ransacked, and their women raped. 
+</div><div class="p">
+<sup>17&#160;</sup>Behold, I will stir up the Medes against them, who will not value silver, and as for gold, they will not delight in it. 
+<sup>18&#160;</sup>Their bows will dash the young men in pieces; and they shall have no pity on the fruit of the womb. Their eyes will not spare children. 
+<sup>19&#160;</sup>Babylon, the glory of kingdoms, the beauty of the Chaldeans’ pride, will be like when Elohim overthrew Sodom and Gomorrah. 
+<sup>20&#160;</sup>It will never be inhabited, neither will it be lived in from generation to generation. The Arabian will not pitch a tent there, neither will shepherds make their flocks lie down there. 
+<sup>21&#160;</sup>But wild animals of the desert will lie there, and their houses will be full of jackals. Ostriches will dwell there, and wild goats will frolic there. 
+<sup>22&#160;</sup>Hyenas will cry in their fortresses, and jackals in the pleasant palaces. Her time is near to come, and her days will not be prolonged. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>For Yahweh will have compassion on Jacob, and will yet choose Israel, and set them in their own land. The foreigner will join himself with them, and they will unite with the house of Jacob. 
+<sup>2&#160;</sup>The peoples will take them, and bring them to their place. The house of Israel will possess them in Yahweh’s land for servants and for handmaids. They will take as captives those whose captives they were; and they shall rule over their oppressors. 
+</div><div class="p">
+<sup>3&#160;</sup>It will happen in the day that Yahweh will give you rest from your sorrow, from your trouble, and from the hard service in which you were made to serve, 
+<sup>4&#160;</sup>that you will take up this parable against the king of Babylon, and say, “How the oppressor has ceased! The golden city has ceased!” 
+<sup>5&#160;</sup>Yahweh has broken the staff of the wicked, the scepter of the rulers, 
+<sup>6&#160;</sup>who struck the peoples in wrath with a continual stroke, who ruled the nations in anger, with a persecution that no one restrained. 
+<sup>7&#160;</sup>The whole earth is at rest, and is quiet. They break out in song. 
+<sup>8&#160;</sup>Yes, the cypress trees rejoice with you, with the cedars of Lebanon, saying, “Since you are humbled, no lumberjack has come up against us.” 
+<sup>9&#160;</sup>Sheol from beneath has moved for you to meet you at your coming. It stirs up the departed spirits for you, even all the rulers of the earth. It has raised up from their thrones all the kings of the nations. 
+<sup>10&#160;</sup>They all will answer and ask you, “Have you also become as weak as we are? Have you become like us?” 
+<sup>11&#160;</sup>Your pomp is brought down to Sheol, with the sound of your stringed instruments. Maggots are spread out under you, and worms cover you. 
+</div><div class="p">
+<sup>12&#160;</sup>How you have fallen from heaven, shining one, son of the dawn! How you are cut down to the ground, who laid the nations low! 
+<sup>13&#160;</sup>You said in your heart, “I will ascend into heaven! I will exalt my throne above the stars of Elohim! I will sit on the mountain of assembly, in the far north! 
+<sup>14&#160;</sup>I will ascend above the heights of the clouds! I will make myself like the Most High!” 
+<sup>15&#160;</sup>Yet you shall be brought down to Sheol, to the depths of the pit. 
+<sup>16&#160;</sup>Those who see you will stare at you. They will ponder you, saying, “Is this the man who made the earth to tremble, who shook kingdoms, 
+<sup>17&#160;</sup>who made the world like a wilderness, and overthrew its cities, who didn’t release his prisoners to their home?” 
+</div><div class="p">
+<sup>18&#160;</sup>All the kings of the nations sleep in glory, everyone in his own house. 
+<sup>19&#160;</sup>But you are cast away from your tomb like an abominable branch, clothed with the slain who are thrust through with the sword, who go down to the stones of the pit; like a dead body trodden under foot. 
+<sup>20&#160;</sup>You will not join them in burial, because you have destroyed your land. You have killed your people. The offspring of evildoers will not be named forever. 
+</div><div class="p">
+<sup>21&#160;</sup>Prepare for slaughter of his children because of the iniquity of their fathers, that they not rise up and possess the earth, and fill the surface of the world with cities. 
+<sup>22&#160;</sup>“I will rise up against them,” says Yahweh of Armies, “and cut off from Babylon name and remnant, and son and son’s son,” says Yahweh. 
+<sup>23&#160;</sup>“I will also make it a possession for the porcupine, and pools of water. I will sweep it with the broom of destruction,” says Yahweh of Armies. 
+</div><div class="p">
+<sup>24&#160;</sup>Yahweh of Armies has sworn, saying, “Surely, as I have thought, so shall it happen; and as I have purposed, so shall it stand: 
+<sup>25&#160;</sup>that I will break the Assyrian in my land, and tread him under foot on my mountains. Then his yoke will leave them, and his burden leave their shoulders. 
+<sup>26&#160;</sup>This is the plan that is determined for the whole earth. This is the hand that is stretched out over all the nations. 
+<sup>27&#160;</sup>For Yahweh of Armies has planned, and who can stop it? His hand is stretched out, and who can turn it back?” 
+</div><div class="p">
+<sup>28&#160;</sup>This burden was in the year that King Ahaz died. 
+</div><div class="p">
+<sup>29&#160;</sup>Don’t rejoice, O Philistia, all of you, because the rod that struck you is broken; for out of the serpent’s root an adder will emerge, and his fruit will be a fiery flying serpent. 
+<sup>30&#160;</sup>The firstborn of the poor will eat, and the needy will lie down in safety; and I will kill your root with famine, and your remnant will be killed. 
+</div><div class="p">
+<sup>31&#160;</sup>Howl, gate! Cry, city! You are melted away, Philistia, all of you; for smoke comes out of the north, and there is no straggler in his ranks. 
+</div><div class="p">
+<sup>32&#160;</sup>What will they answer the messengers of the nation? That Yahweh has founded Zion, and in her the afflicted of his people will take refuge. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of Moab. 
+</div><div class="p">For in a night, Ar of Moab is laid waste, and brought to nothing. For in a night Kir of Moab is laid waste, and brought to nothing. 
+<sup>2&#160;</sup>They have gone up to Bayith, and to Dibon, to the high places, to weep. Moab wails over Nebo and over Medeba. Baldness is on all of their heads. Every beard is cut off. 
+<sup>3&#160;</sup>In their streets, they clothe themselves in sackcloth. In their streets and on their housetops, everyone wails, weeping abundantly. 
+<sup>4&#160;</sup>Heshbon cries out with Elealeh. Their voice is heard even to Jahaz. Therefore the armed men of Moab cry aloud. Their souls tremble within them. 
+<sup>5&#160;</sup>My heart cries out for Moab! Her nobles flee to Zoar, to Eglath Shelishiyah; for they go up by the ascent of Luhith with weeping; for on the way to Horonaim, they raise up a cry of destruction. 
+<sup>6&#160;</sup>For the waters of Nimrim will be desolate; for the grass has withered away, the tender grass fails, there is no green thing. 
+<sup>7&#160;</sup>Therefore they will carry away the abundance they have gotten, and that which they have stored up, over the brook of the willows. 
+<sup>8&#160;</sup>For the cry has gone around the borders of Moab, its wailing to Eglaim, and its wailing to Beer Elim. 
+<sup>9&#160;</sup>For the waters of Dimon are full of blood; for I will bring yet more on Dimon, a lion on those of Moab who escape, and on the remnant of the land. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Send the lambs for the ruler of the land from Selah to the wilderness, to the mountain of the daughter of Zion. 
+<sup>2&#160;</sup>For it will be that as wandering birds, as a scattered nest, so will the daughters of Moab be at the fords of the Arnon. 
+<sup>3&#160;</sup>Give counsel! Execute justice! Make your shade like the night in the middle of the noonday! Hide the outcasts! Don’t betray the fugitive! 
+<sup>4&#160;</sup>Let my outcasts dwell with you! As for Moab, be a hiding place for him from the face of the destroyer. For the extortionist is brought to nothing. Destruction ceases. The oppressors are consumed out of the land. 
+<sup>5&#160;</sup>A throne will be established in loving kindness. One will sit on it in truth, in the tent of David, judging, seeking justice, and swift to do righteousness. 
+</div><div class="p">
+<sup>6&#160;</sup>We have heard of the pride of Moab, that he is very proud; even of his arrogance, his pride, and his wrath. His boastings are nothing. 
+<sup>7&#160;</sup>Therefore Moab will wail for Moab. Everyone will wail. You will mourn for the raisin cakes of Kir Hareseth, utterly stricken. 
+<sup>8&#160;</sup>For the fields of Heshbon languish with the vine of Sibmah. The owners of the nations have broken down its choice branches, which reached even to Jazer, which wandered into the wilderness. Its shoots were spread abroad. They passed over the sea. 
+<sup>9&#160;</sup>Therefore I will weep with the weeping of Jazer for the vine of Sibmah. I will water you with my tears, Heshbon, and Elealeh: for on your summer fruits and on your harvest the battle shout has fallen. 
+<sup>10&#160;</sup>Gladness is taken away, and joy out of the fruitful field; and in the vineyards there will be no singing, neither joyful noise. Nobody will tread out wine in the presses. I have made the shouting stop. 
+<sup>11&#160;</sup>Therefore my heart sounds like a harp for Moab, and my inward parts for Kir Heres. 
+<sup>12&#160;</sup>It will happen that when Moab presents himself, when he wearies himself on the high place, and comes to his sanctuary to pray, that he will not prevail. 
+</div><div class="p">
+<sup>13&#160;</sup>This is the word that Yahweh spoke concerning Moab in time past. 
+<sup>14&#160;</sup>But now Yahweh has spoken, saying, “Within three years, as a worker bound by contract would count them, the glory of Moab shall be brought into contempt, with all his great multitude; and the remnant will be very small and feeble.” 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of Damascus. 
+</div><div class="p">“Behold, Damascus is taken away from being a city, and it will be a ruinous heap. 
+<sup>2&#160;</sup>The cities of Aroer are forsaken. They will be for flocks, which shall lie down, and no one shall make them afraid. 
+<sup>3&#160;</sup>The fortress shall cease from Ephraim, and the kingdom from Damascus, and the remnant of Syria. They will be as the glory of the children of Israel,” says Yahweh of Armies. 
+</div><div class="p">
+<sup>4&#160;</sup>“It will happen in that day that the glory of Jacob will be made thin, and the fatness of his flesh will become lean. 
+<sup>5&#160;</sup>It will be like when the harvester gathers the wheat, and his arm reaps the grain. Yes, it will be like when one gleans grain in the valley of Rephaim. 
+<sup>6&#160;</sup>Yet gleanings will be left there, like the shaking of an olive tree, two or three olives in the top of the uppermost bough, four or five in the outermost branches of a fruitful tree,” says Yahweh, the Elohim of Israel. 
+<sup>7&#160;</sup>In that day, people will look to their Maker, and their eyes will have respect for the Set-Apart One of Israel. 
+<sup>8&#160;</sup>They will not look to the altars, the work of their hands; neither shall they respect that which their fingers have made, either the Asherah poles or the incense altars. 
+<sup>9&#160;</sup>In that day, their strong cities will be like the forsaken places in the woods and on the mountain top, which were forsaken from before the children of Israel; and it will be a desolation. 
+<sup>10&#160;</sup>For you have forgotten the Elohim of your salvation, and have not remembered the rock of your strength. Therefore you plant pleasant plants, and set out foreign seedlings. 
+<sup>11&#160;</sup>In the day of your planting, you hedge it in. In the morning, you make your seed blossom, but the harvest flees away in the day of grief and of desperate sorrow. 
+</div><div class="p">
+<sup>12&#160;</sup>Ah, the uproar of many peoples who roar like the roaring of the seas; and the rushing of nations that rush like the rushing of mighty waters! 
+<sup>13&#160;</sup>The nations will rush like the rushing of many waters, but he will rebuke them, and they will flee far off, and will be chased like the chaff of the mountains before the wind, and like the whirling dust before the storm. 
+<sup>14&#160;</sup>At evening, behold, terror! Before the morning, they are no more. This is the portion of those who plunder us, and the lot of those who rob us. 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Ah, the land of the rustling of wings, which is beyond the rivers of Ethiopia; 
+<sup>2&#160;</sup>that sends ambassadors by the sea, even in vessels of papyrus on the waters, saying, “Go, you swift messengers, to a nation tall and smooth, to a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide!” 
+<sup>3&#160;</sup>All you inhabitants of the world, and you dwellers on the earth, when a banner is lifted up on the mountains, look! When the trumpet is blown, listen! 
+</div><div class="p">
+<sup>4&#160;</sup>For Yahweh said to me, “I will be still, and I will see in my dwelling place, like clear heat in sunshine, like a cloud of dew in the heat of harvest.” 
+<sup>5&#160;</sup>For before the harvest, when the blossom is over, and the flower becomes a ripening grape, he will cut off the sprigs with pruning hooks, and he will cut down and take away the spreading branches. 
+<sup>6&#160;</sup>They will be left together for the ravenous birds of the mountains, and for the animals of the earth. The ravenous birds will eat them in the summer, and all the animals of the earth will eat them in the winter. 
+<sup>7&#160;</sup>In that time, a present will be brought to Yahweh of Armies from a people tall and smooth, even from a people awesome from their beginning onward, a nation that measures out and treads down, whose land the rivers divide, to the place of the name of Yahweh of Armies, Mount Zion. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of Egypt. 
+</div><div class="p">“Behold, Yahweh rides on a swift cloud, and comes to Egypt. The idols of Egypt will tremble at his presence; and the heart of Egypt will melt within it. 
+<sup>2&#160;</sup>I will stir up the Egyptians against the Egyptians, and they will fight everyone against his brother, and everyone against his neighbor; city against city, and kingdom against kingdom. 
+<sup>3&#160;</sup>The spirit of the Egyptians will fail within them. I will destroy their counsel. They will seek the idols, the charmers, those who have familiar spirits, and the wizards. 
+<sup>4&#160;</sup>I will give over the Egyptians into the hand of a cruel lord. A fierce king will rule over them,” says the Lord, Yahweh of Armies. 
+</div><div class="p">
+<sup>5&#160;</sup>The waters will fail from the sea, and the river will be wasted and become dry. 
+<sup>6&#160;</sup>The rivers will become foul. The streams of Egypt will be diminished and dried up. The reeds and flags will wither away. 
+<sup>7&#160;</sup>The meadows by the Nile, by the brink of the Nile, and all the sown fields of the Nile, will become dry, be driven away, and be no more. 
+<sup>8&#160;</sup>The fishermen will lament, and all those who fish in the Nile will mourn, and those who spread nets on the waters will languish. 
+<sup>9&#160;</sup>Moreover those who work in combed flax, and those who weave white cloth, will be confounded. 
+<sup>10&#160;</sup>The pillars will be broken in pieces. All those who work for hire will be grieved in soul. 
+</div><div class="p">
+<sup>11&#160;</sup>The princes of Zoan are utterly foolish. The counsel of the wisest counselors of Pharaoh has become stupid. How do you say to Pharaoh, “I am the son of the wise, the son of ancient kings”? 
+<sup>12&#160;</sup>Where then are your wise men? Let them tell you now; and let them know what Yahweh of Armies has purposed concerning Egypt. 
+<sup>13&#160;</sup>The princes of Zoan have become fools. The princes of Memphis are deceived. They have caused Egypt to go astray, those who are the cornerstone of her tribes. 
+<sup>14&#160;</sup>Yahweh has mixed a spirit of perverseness in the middle of her; and they have caused Egypt to go astray in all of its works, like a drunken man staggers in his vomit. 
+<sup>15&#160;</sup>Neither shall there be any work for Egypt, which head or tail, palm branch or rush, may do. 
+<sup>16&#160;</sup>In that day the Egyptians will be like women. They will tremble and fear because of the shaking of Yahweh of Armies’s hand, which he shakes over them. 
+<sup>17&#160;</sup>The land of Judah will become a terror to Egypt. Everyone to whom mention is made of it will be afraid, because of the plans of Yahweh of Armies, which he determines against it. 
+<sup>18&#160;</sup>In that day, there will be five cities in the land of Egypt that speak the language of Canaan, and swear to Yahweh of Armies. One will be called “The city of destruction.” 
+</div><div class="p">
+<sup>19&#160;</sup>In that day, there will be an altar to Yahweh in the middle of the land of Egypt, and a pillar to Yahweh at its border. 
+<sup>20&#160;</sup>It will be for a sign and for a witness to Yahweh of Armies in the land of Egypt; for they will cry to Yahweh because of oppressors, and he will send them a savior and a defender, and he will deliver them. 
+<sup>21&#160;</sup>Yahweh will be known to Egypt, and the Egyptians will know Yahweh in that day. Yes, they will worship with sacrifice and offering, and will vow a vow to Yahweh, and will perform it. 
+<sup>22&#160;</sup>Yahweh will strike Egypt, striking and healing. They will return to Yahweh, and he will be entreated by them, and will heal them. 
+</div><div class="p">
+<sup>23&#160;</sup>In that day there will be a highway out of Egypt to Assyria, and the Assyrian shall come into Egypt, and the Egyptian into Assyria; and the Egyptians will worship with the Assyrians. 
+</div><div class="p">
+<sup>24&#160;</sup>In that day, Israel will be the third with Egypt and with Assyria, a blessing within the earth; 
+<sup>25&#160;</sup>because Yahweh of Armies has blessed them, saying, “Blessed be Egypt my people, Assyria the work of my hands, and Israel my inheritance.” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>In the year that Tartan came to Ashdod, when Sargon the king of Assyria sent him, and he fought against Ashdod and took it; 
+<sup>2&#160;</sup>at that time Yahweh spoke by Isaiah the son of Amoz, saying, “Go, and loosen the sackcloth from off your waist, and take your sandals from off your feet.” He did so, walking naked and barefoot. 
+<sup>3&#160;</sup>Yahweh said, “As my servant Isaiah has walked naked and barefoot three years for a sign and a wonder concerning Egypt and concerning Ethiopia, 
+<sup>4&#160;</sup>so the king of Assyria will lead away the captives of Egypt and the exiles of Ethiopia, young and old, naked and barefoot, and with buttocks uncovered, to the shame of Egypt. 
+<sup>5&#160;</sup>They will be dismayed and confounded, because of Ethiopia their expectation, and of Egypt their glory. 
+<sup>6&#160;</sup>The inhabitants of this coast land will say in that day, ‘Behold, this is our expectation, where we fled for help to be delivered from the king of Assyria. And we, how will we escape?’&#160;” 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of the wilderness of the sea. 
+</div><div class="p">As whirlwinds in the South sweep through, it comes from the wilderness, from an awesome land. 
+<sup>2&#160;</sup>A grievous vision is declared to me. The treacherous man deals treacherously, and the destroyer destroys. Go up, Elam; attack! I have stopped all of Media’s sighing. 
+<sup>3&#160;</sup>Therefore my thighs are filled with anguish. Pains have seized me, like the pains of a woman in labor. I am in so much pain that I can’t hear. I am so dismayed that I can’t see. 
+<sup>4&#160;</sup>My heart flutters. Horror has frightened me. The twilight that I desired has been turned into trembling for me. 
+<sup>5&#160;</sup>They prepare the table. They set the watch. They eat. They drink. Rise up, you princes, oil the shield! 
+<sup>6&#160;</sup>For the Lord said to me, “Go, set a watchman. Let him declare what he sees. 
+<sup>7&#160;</sup>When he sees a troop, horsemen in pairs, a troop of donkeys, a troop of camels, he shall listen diligently with great attentiveness.” 
+<sup>8&#160;</sup>He cried like a lion: “Lord, I stand continually on the watchtower in the daytime, and every night I stay at my post. 
+<sup>9&#160;</sup>Behold, here comes a troop of men, horsemen in pairs.” He answered, “Fallen, fallen is Babylon; and all the engraved images of her elohims are broken to the ground. 
+</div><div class="p">
+<sup>10&#160;</sup>You are my threshing, and the grain of my floor!” That which I have heard from Yahweh of Armies, the Elohim of Israel, I have declared to you. 
+</div><div class="p">
+<sup>11&#160;</sup>The burden of Dumah. 
+</div><div class="p">One calls to me out of Seir, “Watchman, what of the night? Watchman, what of the night?” 
+<sup>12&#160;</sup>The watchman said, “The morning comes, and also the night. If you will inquire, inquire. Come back again.” 
+</div><div class="p">
+<sup>13&#160;</sup>The burden on Arabia. 
+</div><div class="p">You will lodge in the thickets in Arabia, you caravans of Dedanites. 
+<sup>14&#160;</sup>They brought water to him who was thirsty. The inhabitants of the land of Tema met the fugitives with their bread. 
+<sup>15&#160;</sup>For they fled away from the swords, from the drawn sword, from the bent bow, and from the heat of battle. 
+<sup>16&#160;</sup>For the Lord said to me, “Within a year, as a worker bound by contract would count it, all the glory of Kedar will fail, 
+<sup>17&#160;</sup>and the residue of the number of the archers, the mighty men of the children of Kedar, will be few; for Yahweh, the Elohim of Israel, has spoken it.” 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of the valley of vision. 
+</div><div class="p">What ails you now, that you have all gone up to the housetops? 
+<sup>2&#160;</sup>You that are full of shouting, a tumultuous city, a joyous town, your slain are not slain with the sword, neither are they dead in battle. 
+<sup>3&#160;</sup>All your rulers fled away together. They were bound by the archers. All who were found by you were bound together. They fled far away. 
+<sup>4&#160;</sup>Therefore I said, “Look away from me. I will weep bitterly. Don’t labor to comfort me for the destruction of the daughter of my people. 
+</div><div class="p">
+<sup>5&#160;</sup>For it is a day of confusion, and of treading down, and of perplexity from the Lord, Yahweh of Armies, in the valley of vision, a breaking down of the walls, and a crying to the mountains.” 
+<sup>6&#160;</sup>Elam carried his quiver, with chariots of men and horsemen; and Kir uncovered the shield. 
+<sup>7&#160;</sup>Your choicest valleys were full of chariots, and the horsemen set themselves in array at the gate. 
+<sup>8&#160;</sup>He took away the covering of Judah; and you looked in that day to the armor in the house of the forest. 
+<sup>9&#160;</sup>You saw the breaches of David’s city, that they were many; and you gathered together the waters of the lower pool. 
+<sup>10&#160;</sup>You counted the houses of Jerusalem, and you broke down the houses to fortify the wall. 
+<sup>11&#160;</sup>You also made a reservoir between the two walls for the water of the old pool. But you didn’t look to him who had done this, neither did you have respect for him who planned it long ago. 
+</div><div class="p">
+<sup>12&#160;</sup>In that day, the Lord, Yahweh of Armies, called to weeping, to mourning, to baldness, and to dressing in sackcloth; 
+<sup>13&#160;</sup>and behold, there is joy and gladness, killing cattle and killing sheep, eating meat and drinking wine: “Let’s eat and drink, for tomorrow we will die.” 
+<sup>14&#160;</sup>Yahweh of Armies revealed himself in my ears, “Surely this iniquity will not be forgiven you until you die,” says the Lord, Yahweh of Armies. 
+</div><div class="p">
+<sup>15&#160;</sup>The Lord, Yahweh of Armies says, “Go, get yourself to this treasurer, even to Shebna, who is over the house, and say, 
+<sup>16&#160;</sup>‘What are you doing here? Who has you here, that you have dug out a tomb here?’ Cutting himself out a tomb on high, chiseling a habitation for himself in the rock!” 
+<sup>17&#160;</sup>Behold, Yahweh will overcome you and hurl you away violently. Yes, he will grasp you firmly. 
+<sup>18&#160;</sup>He will surely wind you around and around, and throw you like a ball into a large country. There you will die, and there the chariots of your glory will be, you disgrace of your lord’s house. 
+<sup>19&#160;</sup>I will thrust you from your office. You will be pulled down from your station. 
+</div><div class="p">
+<sup>20&#160;</sup>It will happen in that day that I will call my servant Eliakim the son of Hilkiah, 
+<sup>21&#160;</sup>and I will clothe him with your robe, and strengthen him with your belt. I will commit your government into his hand; and he will be a father to the inhabitants of Jerusalem, and to the house of Judah. 
+<sup>22&#160;</sup>I will lay the key of David’s house on his shoulder. He will open, and no one will shut. He will shut, and no one will open. 
+<sup>23&#160;</sup>I will fasten him like a nail in a sure place. He will be for a throne of glory to his father’s house. 
+<sup>24&#160;</sup>They will hang on him all the glory of his father’s house, the offspring and the issue, every small vessel, from the cups even to all the pitchers. 
+<sup>25&#160;</sup>“In that day,” says Yahweh of Armies, “the nail that was fastened in a sure place will give way. It will be cut down and fall. The burden that was on it will be cut off, for Yahweh has spoken it.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>The burden of Tyre. 
+</div><div class="p">Howl, you ships of Tarshish! For it is laid waste, so that there is no house, no entering in. From the land of Kittim it is revealed to them. 
+<sup>2&#160;</sup>Be still, you inhabitants of the coast, you whom the merchants of Sidon that pass over the sea have replenished. 
+<sup>3&#160;</sup>On great waters, the seed of the Shihor, the harvest of the Nile, was her revenue. She was the market of nations. 
+<sup>4&#160;</sup>Be ashamed, Sidon; for the sea has spoken, the stronghold of the sea, saying, “I have not travailed, nor given birth, neither have I nourished young men, nor brought up virgins.” 
+<sup>5&#160;</sup>When the report comes to Egypt, they will be in anguish at the report of Tyre. 
+<sup>6&#160;</sup>Pass over to Tarshish! Wail, you inhabitants of the coast! 
+<sup>7&#160;</sup>Is this your joyous city, whose antiquity is of ancient days, whose feet carried her far away to travel? 
+</div><div class="p">
+<sup>8&#160;</sup>Who has planned this against Tyre, the giver of crowns, whose merchants are princes, whose traders are the honorable of the earth? 
+<sup>9&#160;</sup>Yahweh of Armies has planned it, to stain the pride of all glory, to bring into contempt all the honorable of the earth. 
+<sup>10&#160;</sup>Pass through your land like the Nile, daughter of Tarshish. There is no restraint any more. 
+<sup>11&#160;</sup>He has stretched out his hand over the sea. He has shaken the kingdoms. Yahweh has ordered the destruction of Canaan’s strongholds. 
+<sup>12&#160;</sup>He said, “You shall rejoice no more, you oppressed virgin daughter of Sidon. Arise, pass over to Kittim. Even there you will have no rest.” 
+</div><div class="p">
+<sup>13&#160;</sup>Behold, the land of the Chaldeans. This people didn’t exist. The Assyrians founded it for those who dwell in the wilderness. They set up their towers. They overthrew its palaces. They made it a ruin. 
+<sup>14&#160;</sup>Howl, you ships of Tarshish, for your stronghold is laid waste! 
+<sup>15&#160;</sup>It will come to pass in that day that Tyre will be forgotten seventy years, according to the days of one king. After the end of seventy years it will be to Tyre like in the song of the prostitute. 
+<sup>16&#160;</sup>Take a harp; go about the city, you prostitute that has been forgotten. Make sweet melody. Sing many songs, that you may be remembered. 
+<sup>17&#160;</sup>It will happen after the end of seventy years that Yahweh will visit Tyre. She will return to her wages, and will play the prostitute with all the kingdoms of the world on the surface of the earth. 
+<sup>18&#160;</sup>Her merchandise and her wages will be set-apartness to Yahweh. It will not be treasured nor laid up; for her merchandise will be for those who dwell before Yahweh, to eat sufficiently, and for durable clothing. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Behold, Yahweh makes the earth empty, makes it waste, turns it upside down, and scatters its inhabitants. 
+<sup>2&#160;</sup>It will be as with the people, so with the priest; as with the servant, so with his master; as with the maid, so with her mistress; as with the buyer, so with the seller; as with the creditor, so with the debtor; as with the taker of interest, so with the giver of interest. 
+<sup>3&#160;</sup>The earth will be utterly emptied and utterly laid waste; for Yahweh has spoken this word. 
+<sup>4&#160;</sup>The earth mourns and fades away. The world languishes and fades away. The lofty people of the earth languish. 
+<sup>5&#160;</sup>The earth also is polluted under its inhabitants, because they have transgressed the laws, violated the statutes, and broken the everlasting covenant. 
+<sup>6&#160;</sup>Therefore the curse has devoured the earth, and those who dwell therein are found guilty. Therefore the inhabitants of the earth are burned, and few men are left. 
+<sup>7&#160;</sup>The new wine mourns. The vine languishes. All the merry-hearted sigh. 
+<sup>8&#160;</sup>The mirth of tambourines ceases. The sound of those who rejoice ends. The joy of the harp ceases. 
+<sup>9&#160;</sup>They will not drink wine with a song. Strong drink will be bitter to those who drink it. 
+<sup>10&#160;</sup>The confused city is broken down. Every house is shut up, that no man may come in. 
+<sup>11&#160;</sup>There is a crying in the streets because of the wine. All joy is darkened. The mirth of the land is gone. 
+<sup>12&#160;</sup>The city is left in desolation, and the gate is struck with destruction. 
+<sup>13&#160;</sup>For it will be so within the earth among the peoples, as the shaking of an olive tree, as the gleanings when the vintage is done. 
+</div><div class="p">
+<sup>14&#160;</sup>These shall lift up their voice. They will shout for the majesty of Yahweh. They cry aloud from the sea. 
+<sup>15&#160;</sup>Therefore glorify Yahweh in the east, even the name of Yahweh, the Elohim of Israel, in the islands of the sea! 
+<sup>16&#160;</sup>From the uttermost part of the earth have we heard songs. Glory to the righteous! 
+</div><div class="p">But I said, “I pine away! I pine away! woe is me!” The treacherous have dealt treacherously. Yes, the treacherous have dealt very treacherously. 
+<sup>17&#160;</sup>Fear, the pit, and the snare are on you who inhabit the earth. 
+<sup>18&#160;</sup>It will happen that he who flees from the noise of the fear will fall into the pit; and he who comes up out of the middle of the pit will be taken in the snare; for the windows on high are opened, and the foundations of the earth tremble. 
+<sup>19&#160;</sup>The earth is utterly broken. The earth is torn apart. The earth is shaken violently. 
+<sup>20&#160;</sup>The earth will stagger like a drunken man, and will sway back and forth like a hammock. Its disobedience will be heavy on it, and it will fall and not rise again. 
+</div><div class="p">
+<sup>21&#160;</sup>It will happen in that day that Yahweh will punish the army of the high ones on high, and the kings of the earth on the earth. 
+<sup>22&#160;</sup>They will be gathered together, as prisoners are gathered in the pit, and will be shut up in the prison; and after many days they will be visited. 
+<sup>23&#160;</sup>Then the moon will be confounded, and the sun ashamed; for Yahweh of Armies will reign on Mount Zion and in Jerusalem; and glory will be before his elders. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh, you are my Elohim. I will exalt you! I will praise your name, for you have done wonderful things, things planned long ago, in complete faithfulness and truth. 
+<sup>2&#160;</sup>For you have made a city into a heap, a fortified city into a ruin, a palace of strangers to be no city. It will never be built. 
+<sup>3&#160;</sup>Therefore a strong people will glorify you. A city of awesome nations will fear you. 
+<sup>4&#160;</sup>For you have been a stronghold to the poor, a stronghold to the needy in his distress, a refuge from the storm, a shade from the heat, when the blast of the dreaded ones is like a storm against the wall. 
+<sup>5&#160;</sup>As the heat in a dry place you will bring down the noise of strangers; as the heat by the shade of a cloud, the song of the dreaded ones will be brought low. 
+</div><div class="p">
+<sup>6&#160;</sup>In this mountain, Yahweh of Armies will make all peoples a feast of choice meat, a feast of choice wines, of choice meat full of marrow, of well refined choice wines. 
+<sup>7&#160;</sup>He will destroy in this mountain the surface of the covering that covers all peoples, and the veil that is spread over all nations. 
+<sup>8&#160;</sup>He has swallowed up death forever! The Lord Yahweh will wipe away tears from off all faces. He will take the reproach of his people away from off all the earth, for Yahweh has spoken it. 
+</div><div class="p">
+<sup>9&#160;</sup>It shall be said in that day, “Behold, this is our Elohim! We have waited for him, and he will save us! This is Yahweh! We have waited for him. We will be glad and rejoice in his salvation!” 
+<sup>10&#160;</sup>For Yahweh’s hand will rest in this mountain. 
+</div><div class="p">Moab will be trodden down in his place, even like straw is trodden down in the water of the dunghill. 
+<sup>11&#160;</sup>He will spread out his hands in the middle of it, like one who swims spreads out hands to swim, but his pride will be humbled together with the craft of his hands. 
+<sup>12&#160;</sup>He has brought the high fortress of your walls down, laid low, and brought to the ground, even to the dust. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>In that day, this song will be sung in the land of Judah: 
+</div><div class="q1">“We have a strong city. 
+</div><div class="q2">Elohim appoints salvation for walls and bulwarks. 
+</div><div class="q1">
+<sup>2&#160;</sup>Open the gates, that the righteous nation may enter: 
+</div><div class="q2">the one which keeps faith. 
+</div><div class="q1">
+<sup>3&#160;</sup>You will keep whoever’s mind is steadfast in perfect peace, 
+</div><div class="q2">because he trusts in you. 
+</div><div class="q1">
+<sup>4&#160;</sup>Trust in Yahweh forever; 
+</div><div class="q2">for in Yah, Yahweh, is an everlasting Rock. 
+</div><div class="q1">
+<sup>5&#160;</sup>For he has brought down those who dwell on high, the lofty city. 
+</div><div class="q2">He lays it low. 
+</div><div class="q2">He lays it low even to the ground. 
+</div><div class="q2">He brings it even to the dust. 
+</div><div class="q1">
+<sup>6&#160;</sup>The foot shall tread it down, 
+</div><div class="q2">even the feet of the poor 
+</div><div class="q2">and the steps of the needy.” 
+</div><div class="q1">
+<sup>7&#160;</sup>The way of the just is uprightness. 
+</div><div class="q2">You who are upright make the path of the righteous level. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Yes, in the way of your judgments, Yahweh, we have waited for you. 
+</div><div class="q2">Your name and your renown are the desire of our soul. 
+</div><div class="q1">
+<sup>9&#160;</sup>With my soul I have desired you in the night. 
+</div><div class="q2">Yes, with my spirit within me I will seek you earnestly; 
+</div><div class="q2">for when your judgments are in the earth, the inhabitants of the world learn righteousness. 
+</div><div class="q1">
+<sup>10&#160;</sup>Let favor be shown to the wicked, 
+</div><div class="q2">yet he will not learn righteousness. 
+</div><div class="q1">In the land of uprightness he will deal wrongfully, 
+</div><div class="q2">and will not see Yahweh’s majesty. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Yahweh, your hand is lifted up, yet they don’t see; 
+</div><div class="q2">but they will see your zeal for the people and be disappointed. 
+</div><div class="q2">Yes, fire will consume your adversaries. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yahweh, you will ordain peace for us, 
+</div><div class="q2">for you have also done all our work for us. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yahweh our Elohim, other lords besides you have had dominion over us, 
+</div><div class="q2">but we will only acknowledge your name. 
+</div><div class="q1">
+<sup>14&#160;</sup>The dead shall not live. 
+</div><div class="q2">The departed spirits shall not rise. 
+</div><div class="q1">Therefore you have visited and destroyed them, 
+</div><div class="q2">and caused all memory of them to perish. 
+</div><div class="q1">
+<sup>15&#160;</sup>You have increased the nation, O Yahweh. 
+</div><div class="q2">You have increased the nation! 
+</div><div class="q1">You are glorified! 
+</div><div class="q2">You have enlarged all the borders of the land. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Yahweh, in trouble they have visited you. 
+</div><div class="q2">They poured out a prayer when your chastening was on them. 
+</div><div class="q1">
+<sup>17&#160;</sup>Just as a woman with child, who draws near the time of her delivery, 
+</div><div class="q2">is in pain and cries out in her pangs, 
+</div><div class="q2">so we have been before you, Yahweh. 
+</div><div class="q1">
+<sup>18&#160;</sup>We have been with child. 
+</div><div class="q2">We have been in pain. 
+</div><div class="q1">We gave birth, it seems, only to wind. 
+</div><div class="q2">We have not worked any deliverance in the earth; 
+</div><div class="q2">neither have the inhabitants of the world fallen. 
+</div><div class="q1">
+<sup>19&#160;</sup>Your dead shall live. 
+</div><div class="q2">Their dead bodies shall arise. 
+</div><div class="q1">Awake and sing, you who dwell in the dust; 
+</div><div class="q2">for your dew is like the dew of herbs, 
+</div><div class="q2">and the earth will cast out the departed spirits. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>Come, my people, enter into your rooms, 
+</div><div class="q2">and shut your doors behind you. 
+</div><div class="q1">Hide yourself for a little moment, 
+</div><div class="q2">until the indignation is past. 
+</div><div class="q1">
+<sup>21&#160;</sup>For, behold, Yahweh comes out of his place to punish the inhabitants of the earth for their iniquity. 
+</div><div class="q2">The earth also will disclose her blood, and will no longer cover her slain. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>In that day, Yahweh with his hard and great and strong sword will punish leviathan, the fleeing serpent, and leviathan, the twisted serpent; and he will kill the dragon that is in the sea. 
+</div><div class="p">
+<sup>2&#160;</sup>In that day, sing to her, “A pleasant vineyard! 
+<sup>3&#160;</sup>I, Yahweh, am its keeper. I will water it every moment. Lest anyone damage it, I will keep it night and day. 
+<sup>4&#160;</sup>Wrath is not in me, but if I should find briers and thorns, I would do battle! I would march on them and I would burn them together. 
+<sup>5&#160;</sup>Or else let him take hold of my strength, that he may make peace with me. Let him make peace with me.” 
+</div><div class="p">
+<sup>6&#160;</sup>In days to come, Jacob will take root. Israel will blossom and bud. They will fill the surface of the world with fruit. 
+<sup>7&#160;</sup>Has he struck them as he struck those who struck them? Or are they killed like those who killed them were killed? 
+<sup>8&#160;</sup>In measure, when you send them away, you contend with them. He has removed them with his rough blast in the day of the east wind. 
+<sup>9&#160;</sup>Therefore by this the iniquity of Jacob will be forgiven, and this is all the fruit of taking away his sin: that he makes all the stones of the altar as chalk stones that are beaten in pieces, so that the Asherah poles and the incense altars shall rise no more. 
+<sup>10&#160;</sup>For the fortified city is solitary, a habitation deserted and forsaken, like the wilderness. The calf will feed there, and there he will lie down, and consume its branches. 
+<sup>11&#160;</sup>When its boughs are withered, they will be broken off. The women will come and set them on fire, for they are a people of no understanding. Therefore he who made them will not have compassion on them, and he who formed them will show them no favor. 
+</div><div class="p">
+<sup>12&#160;</sup>It will happen in that day that Yahweh will thresh from the flowing stream of the Euphrates to the brook of Egypt; and you will be gathered one by one, children of Israel. 
+</div><div class="p">
+<sup>13&#160;</sup>It will happen in that day that a great trumpet will be blown; and those who were ready to perish in the land of Assyria, and those who were outcasts in the land of Egypt, shall come; and they will worship Yahweh in the set-apart mountain at Jerusalem. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>Woe to the crown of pride of the drunkards of Ephraim, and to the fading flower of his glorious beauty, which is on the head of the fertile valley of those who are overcome with wine! 
+<sup>2&#160;</sup>Behold, the Lord has one who is mighty and strong. Like a storm of hail, a destroying storm, and like a storm of mighty waters overflowing, he will cast them down to the earth with his hand. 
+<sup>3&#160;</sup>The crown of pride of the drunkards of Ephraim will be trodden under foot. 
+<sup>4&#160;</sup>The fading flower of his glorious beauty, which is on the head of the fertile valley, shall be like the first-ripe fig before the summer, which someone picks and eats as soon as he sees it. 
+<sup>5&#160;</sup>In that day, Yahweh of Armies will become a crown of glory and a diadem of beauty to the residue of his people, 
+<sup>6&#160;</sup>and a spirit of justice to him who sits in judgment, and strength to those who turn back the battle at the gate. 
+</div><div class="p">
+<sup>7&#160;</sup>They also reel with wine, and stagger with strong drink. The priest and the prophet reel with strong drink. They are swallowed up by wine. They stagger with strong drink. They err in vision. They stumble in judgment. 
+<sup>8&#160;</sup>For all tables are completely full of filthy vomit and filthiness. 
+</div><div class="p">
+<sup>9&#160;</sup>Whom will he teach knowledge? To whom will he explain the message? Those who are weaned from the milk, and drawn from the breasts? 
+<sup>10&#160;</sup>For it is precept on precept, precept on precept; line on line, line on line; here a little, there a little. 
+</div><div class="p">
+<sup>11&#160;</sup>But he will speak to this nation with stammering lips and in another language, 
+<sup>12&#160;</sup>to whom he said, “This is the resting place. Give rest to the weary,” and “This is the refreshing;” yet they would not hear. 
+<sup>13&#160;</sup>Therefore Yahweh’s word will be to them precept on precept, precept on precept; line on line, line on line; here a little, there a little; that they may go, fall backward, be broken, be snared, and be taken. 
+</div><div class="p">
+<sup>14&#160;</sup>Therefore hear Yahweh’s word, you scoffers, that rule this people in Jerusalem: 
+<sup>15&#160;</sup>“Because you have said, ‘We have made a covenant with death, and we are in agreement with Sheol. When the overflowing scourge passes through, it won’t come to us; for we have made lies our refuge, and we have hidden ourselves under falsehood.’&#160;” 
+<sup>16&#160;</sup>Therefore the Lord Yahweh says, “Behold, I lay in Zion for a foundation a stone, a tried stone, a precious cornerstone of a sure foundation. He who believes shall not act hastily. 
+<sup>17&#160;</sup>I will make justice the measuring line, and righteousness the plumb line. The hail will sweep away the refuge of lies, and the waters will overflow the hiding place. 
+<sup>18&#160;</sup>Your covenant with death shall be annulled, and your agreement with Sheol shall not stand. When the overflowing scourge passes through, then you will be trampled down by it. 
+<sup>19&#160;</sup>As often as it passes through, it will seize you; for morning by morning it will pass through, by day and by night; and it will be nothing but terror to understand the message.” 
+<sup>20&#160;</sup>For the bed is too short to stretch out on, and the blanket is too narrow to wrap oneself in. 
+<sup>21&#160;</sup>For Yahweh will rise up as on Mount Perazim. He will be angry as in the valley of Gibeon; that he may do his work, his unusual work, and bring to pass his act, his extraordinary act. 
+<sup>22&#160;</sup>Now therefore don’t be scoffers, lest your bonds be made strong; for I have heard a decree of destruction from the Lord, Yahweh of Armies, on the whole earth. 
+</div><div class="p">
+<sup>23&#160;</sup>Give ear, and hear my voice! Listen, and hear my speech! 
+<sup>24&#160;</sup>Does he who plows to sow plow continually? Does he keep turning the soil and breaking the clods? 
+<sup>25&#160;</sup>When he has leveled its surface, doesn’t he plant the dill, and scatter the cumin seed, and put in the wheat in rows, the barley in the appointed place, and the spelt in its place? 
+<sup>26&#160;</sup>For his Elohim instructs him in right judgment and teaches him. 
+<sup>27&#160;</sup>For the dill isn’t threshed with a sharp instrument, neither is a cart wheel turned over the cumin; but the dill is beaten out with a stick, and the cumin with a rod. 
+<sup>28&#160;</sup>Bread flour must be ground; so he will not always be threshing it. Although he drives the wheel of his threshing cart over it, his horses don’t grind it. 
+<sup>29&#160;</sup>This also comes out from Yahweh of Armies, who is wonderful in counsel, and excellent in wisdom. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>Woe to Ariel! Ariel, the city where David encamped! Add year to year; let the feasts come around; 
+<sup>2&#160;</sup>then I will distress Ariel, and there will be mourning and lamentation. She shall be to me as an altar hearth. 
+<sup>3&#160;</sup>I will encamp against you all around you, and will lay siege against you with posted troops. I will raise siege works against you. 
+<sup>4&#160;</sup>You will be brought down, and will speak out of the ground. Your speech will mumble out of the dust. Your voice will be as of one who has a familiar spirit, out of the ground, and your speech will whisper out of the dust. 
+</div><div class="p">
+<sup>5&#160;</sup>But the multitude of your foes will be like fine dust, and the multitude of the ruthless ones like chaff that blows away. Yes, it will be in an instant, suddenly. 
+<sup>6&#160;</sup>She will be visited by Yahweh of Armies with thunder, with earthquake, with great noise, with whirlwind and storm, and with the flame of a devouring fire. 
+<sup>7&#160;</sup>The multitude of all the nations that fight against Ariel, even all who fight against her and her stronghold, and who distress her, will be like a dream, a vision of the night. 
+<sup>8&#160;</sup>It will be like when a hungry man dreams, and behold, he eats; but he awakes, and his hunger isn’t satisfied; or like when a thirsty man dreams, and behold, he drinks; but he awakes, and behold, he is faint, and he is still thirsty. The multitude of all the nations that fight against Mount Zion will be like that. 
+</div><div class="p">
+<sup>9&#160;</sup>Pause and wonder! Blind yourselves and be blind! They are drunken, but not with wine; they stagger, but not with strong drink. 
+<sup>10&#160;</sup>For Yahweh has poured out on you a spirit of deep sleep, and has closed your eyes, the prophets; and he has covered your heads, the seers. 
+<sup>11&#160;</sup>All vision has become to you like the words of a book that is sealed, which men deliver to one who is educated, saying, “Read this, please;” and he says, “I can’t, for it is sealed;” 
+<sup>12&#160;</sup>and the book is delivered to one who is not educated, saying, “Read this, please;” and he says, “I can’t read.” 
+</div><div class="p">
+<sup>13&#160;</sup>The Lord said, “Because this people draws near with their mouth and honors me with their lips, but they have removed their heart far from me, and their fear of me is a commandment of men which has been taught; 
+<sup>14&#160;</sup>therefore, behold, I will proceed to do a marvelous work among this people, even a marvelous work and a wonder; and the wisdom of their wise men will perish, and the understanding of their prudent men will be hidden.” 
+</div><div class="p">
+<sup>15&#160;</sup>Woe to those who deeply hide their counsel from Yahweh, and whose deeds are in the dark, and who say, “Who sees us?” and “Who knows us?” 
+<sup>16&#160;</sup>You turn things upside down! Should the potter be thought to be like clay, that the thing made should say about him who made it, “He didn’t make me;” or the thing formed say of him who formed it, “He has no understanding”? 
+</div><div class="p">
+<sup>17&#160;</sup>Isn’t it yet a very little while, and Lebanon will be turned into a fruitful field, and the fruitful field will be regarded as a forest? 
+<sup>18&#160;</sup>In that day, the deaf will hear the words of the book, and the eyes of the blind will see out of obscurity and out of darkness. 
+<sup>19&#160;</sup>The humble also will increase their joy in Yahweh, and the poor among men will rejoice in the Set-Apart One of Israel. 
+<sup>20&#160;</sup>For the ruthless is brought to nothing, and the scoffer ceases, and all those who are alert to do evil are cut off—<sup>21&#160;</sup>who cause a person to be indicted by a word, and lay a snare for one who reproves in the gate, and who deprive the innocent of justice with false testimony. 
+</div><div class="p">
+<sup>22&#160;</sup>Therefore Yahweh, who redeemed Abraham, says concerning the house of Jacob: “Jacob shall no longer be ashamed, neither shall his face grow pale. 
+<sup>23&#160;</sup>But when he sees his children, the work of my hands, in the middle of him, they will sanctify my name. Yes, they will sanctify the Set-Apart One of Jacob, and will stand in awe of the Elohim of Israel. 
+<sup>24&#160;</sup>They also who err in spirit will come to understanding, and those who grumble will receive instruction.” 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>“Woe to the rebellious children”, says Yahweh, “who take counsel, but not from me; and who make an alliance, but not with my Spirit, that they may add sin to sin; 
+<sup>2&#160;</sup>who set out to go down into Egypt without asking for my advice, to strengthen themselves in the strength of Pharaoh, and to take refuge in the shadow of Egypt! 
+<sup>3&#160;</sup>Therefore the strength of Pharaoh will be your shame, and the refuge in the shadow of Egypt your confusion. 
+<sup>4&#160;</sup>For their princes are at Zoan, and their ambassadors have come to Hanes. 
+<sup>5&#160;</sup>They shall all be ashamed because of a people that can’t profit them, that are not a help nor profit, but a shame, and also a reproach.” 
+</div><div class="p">
+<sup>6&#160;</sup>The burden of the animals of the South. 
+</div><div class="p">Through the land of trouble and anguish, of the lioness and the lion, the viper and fiery flying serpent, they carry their riches on the shoulders of young donkeys, and their treasures on the humps of camels, to an unprofitable people. 
+<sup>7&#160;</sup>For Egypt helps in vain, and to no purpose; therefore I have called her Rahab who sits still. 
+<sup>8&#160;</sup>Now go, write it before them on a tablet, and inscribe it in a book, that it may be for the time to come forever and ever. 
+<sup>9&#160;</sup>For it is a rebellious people, lying children, children who will not hear Yahweh’s law; 
+<sup>10&#160;</sup>who tell the seers, “Don’t see!” and the prophets, “Don’t prophesy to us right things. Tell us pleasant things. Prophesy deceits. 
+<sup>11&#160;</sup>Get out of the way. Turn away from the path. Cause the Set-Apart One of Israel to cease from before us.” 
+<sup>12&#160;</sup>Therefore the Set-Apart One of Israel says, “Because you despise this word, and trust in oppression and perverseness, and rely on it, 
+<sup>13&#160;</sup>therefore this iniquity shall be to you like a breach ready to fall, swelling out in a high wall, whose breaking comes suddenly in an instant. 
+<sup>14&#160;</sup>He will break it as a potter’s vessel is broken, breaking it in pieces without sparing, so that there won’t be found among the broken pieces a piece good enough to take fire from the hearth, or to dip up water out of the cistern.” 
+</div><div class="p">
+<sup>15&#160;</sup>For thus said the Lord Yahweh, the Set-Apart One of Israel, “You will be saved in returning and rest. Your strength will be in quietness and in confidence.” You refused, 
+<sup>16&#160;</sup>but you said, “No, for we will flee on horses;” therefore you will flee; and, “We will ride on the swift;” therefore those who pursue you will be swift. 
+<sup>17&#160;</sup>One thousand will flee at the threat of one. At the threat of five, you will flee until you are left like a beacon on the top of a mountain, and like a banner on a hill. 
+</div><div class="p">
+<sup>18&#160;</sup>Therefore Yahweh will wait, that he may be gracious to you; and therefore he will be exalted, that he may have mercy on you, for Yahweh is an Elohim of justice. Blessed are all those who wait for him. 
+<sup>19&#160;</sup>For the people will dwell in Zion at Jerusalem. You will weep no more. He will surely be gracious to you at the voice of your cry. When he hears you, he will answer you. 
+<sup>20&#160;</sup>Though the Lord may give you the bread of adversity and the water of affliction, yet your teachers won’t be hidden any more, but your eyes will see your teachers; 
+<sup>21&#160;</sup>and when you turn to the right hand, and when you turn to the left, your ears will hear a voice behind you, saying, “This is the way. Walk in it.” 
+<sup>22&#160;</sup>You shall defile the overlaying of your engraved images of silver, and the plating of your molten images of gold. You shall cast them away as an unclean thing. You shall tell it, “Go away!” 
+</div><div class="p">
+<sup>23&#160;</sup>He will give the rain for your seed, with which you will sow the ground; and bread of the increase of the ground will be rich and plentiful. In that day, your livestock will feed in large pastures. 
+<sup>24&#160;</sup>The oxen likewise and the young donkeys that till the ground will eat savory feed, which has been winnowed with the shovel and with the fork. 
+<sup>25&#160;</sup>There will be brooks and streams of water on every lofty mountain and on every high hill in the day of the great slaughter, when the towers fall. 
+<sup>26&#160;</sup>Moreover the light of the moon will be like the light of the sun, and the light of the sun will be seven times brighter, like the light of seven days, in the day that Yahweh binds up the fracture of his people, and heals the wound they were struck with. 
+</div><div class="p">
+<sup>27&#160;</sup>Behold, Yahweh’s name comes from far away, burning with his anger, and in thick rising smoke. His lips are full of indignation. His tongue is as a devouring fire. 
+<sup>28&#160;</sup>His breath is as an overflowing stream that reaches even to the neck, to sift the nations with the sieve of destruction. A bridle that leads to ruin will be in the jaws of the peoples. 
+<sup>29&#160;</sup>You will have a song, as in the night when a set-apart feast is kept, and gladness of heart, as when one goes with a flute to come to Yahweh’s mountain, to Israel’s Rock. 
+<sup>30&#160;</sup>Yahweh will cause his glorious voice to be heard, and will show the descent of his arm, with the indignation of his anger and the flame of a devouring fire, with a blast, storm, and hailstones. 
+<sup>31&#160;</sup>For through Yahweh’s voice the Assyrian will be dismayed. He will strike him with his rod. 
+<sup>32&#160;</sup>Every stroke of the rod of punishment, which Yahweh will lay on him, will be with the sound of tambourines and harps. He will fight with them in battles, brandishing weapons. 
+<sup>33&#160;</sup>For his burning place has long been ready. Yes, it is prepared for the king. He has made its pyre deep and large with fire and much wood. Yahweh’s breath, like a stream of sulfur, kindles it. 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="q1">
+<sup>1&#160;</sup>Woe to those who go down to Egypt for help, 
+</div><div class="q2">and rely on horses, 
+</div><div class="q2">and trust in chariots because they are many, 
+</div><div class="q2">and in horsemen because they are very strong, 
+</div><div class="q2">but they don’t look to the Set-Apart One of Israel, 
+</div><div class="q2">and they don’t seek Yahweh! 
+</div><div class="q1">
+<sup>2&#160;</sup>Yet he also is wise, and will bring disaster, 
+</div><div class="q2">and will not call back his words, but will arise against the house of the evildoers, 
+</div><div class="q2">and against the help of those who work iniquity. 
+</div><div class="q1">
+<sup>3&#160;</sup>Now the Egyptians are men, and not Elohim; 
+</div><div class="q2">and their horses flesh, and not spirit. 
+</div><div class="q1">When Yahweh stretches out his hand, both he who helps shall stumble, 
+</div><div class="q2">and he who is helped shall fall, 
+</div><div class="q2">and they all shall be consumed together. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>For Yahweh says to me, 
+</div><div class="q1">“As the lion and the young lion growling over his prey, 
+</div><div class="q2">if a multitude of shepherds is called together against him, 
+</div><div class="q2">will not be dismayed at their voice, 
+</div><div class="q2">nor abase himself for their noise, 
+</div><div class="q2">so Yahweh of Armies will come down to fight on Mount Zion and on its heights. 
+</div><div class="q1">
+<sup>5&#160;</sup>As birds hovering, so Yahweh of Armies will protect Jerusalem. 
+</div><div class="q2">He will protect and deliver it. 
+</div><div class="q2">He will pass over and preserve it.” 
+</div><div class="q1">
+<sup>6&#160;</sup>Return to him from whom you have deeply revolted, children of Israel. 
+<sup>7&#160;</sup>For in that day everyone shall cast away his idols of silver and his idols of gold—sin which your own hands have made for you. 
+</div><div class="p">
+<sup>8&#160;</sup>“The Assyrian will fall by the sword, not of man; 
+</div><div class="q2">and the sword, not of mankind, shall devour him. 
+</div><div class="q1">He will flee from the sword, 
+</div><div class="q2">and his young men will become subject to forced labor. 
+</div><div class="q1">
+<sup>9&#160;</sup>His rock will pass away by reason of terror, 
+</div><div class="q2">and his princes will be afraid of the banner,” 
+</div><div class="q1">says Yahweh, whose fire is in Zion, 
+</div><div class="q2">and his furnace in Jerusalem. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="q1">
+<sup>1&#160;</sup>Behold, a king shall reign in righteousness, 
+</div><div class="q2">and princes shall rule in justice. 
+</div><div class="q1">
+<sup>2&#160;</sup>A man shall be as a hiding place from the wind, 
+</div><div class="q2">and a covert from the storm, 
+</div><div class="q2">as streams of water in a dry place, 
+</div><div class="q2">as the shade of a large rock in a weary land. 
+</div><div class="q1">
+<sup>3&#160;</sup>The eyes of those who see will not be dim, 
+</div><div class="q2">and the ears of those who hear will listen. 
+</div><div class="q1">
+<sup>4&#160;</sup>The heart of the rash will understand knowledge, 
+</div><div class="q2">and the tongue of the stammerers will be ready to speak plainly. 
+</div><div class="q1">
+<sup>5&#160;</sup>The fool will no longer be called noble, 
+</div><div class="q2">nor the scoundrel be highly respected. 
+</div><div class="q1">
+<sup>6&#160;</sup>For the fool will speak folly, 
+</div><div class="q2">and his heart will work iniquity, 
+</div><div class="q2">to practice profanity, 
+</div><div class="q2">and to utter error against Yahweh, 
+</div><div class="q2">to make empty the soul of the hungry, 
+</div><div class="q2">and to cause the drink of the thirsty to fail. 
+</div><div class="q1">
+<sup>7&#160;</sup>The ways of the scoundrel are evil. 
+</div><div class="q2">He devises wicked plans to destroy the humble with lying words, 
+</div><div class="q2">even when the needy speaks right. 
+</div><div class="q1">
+<sup>8&#160;</sup>But the noble devises noble things, 
+</div><div class="q2">and he will continue in noble things. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Rise up, you women who are at ease! Hear my voice! 
+</div><div class="q2">You careless daughters, give ear to my speech! 
+</div><div class="q1">
+<sup>10&#160;</sup>For days beyond a year you will be troubled, you careless women; 
+</div><div class="q2">for the vintage will fail. 
+</div><div class="q2">The harvest won’t come. 
+</div><div class="q1">
+<sup>11&#160;</sup>Tremble, you women who are at ease! 
+</div><div class="q2">Be troubled, you careless ones! 
+</div><div class="q2">Strip yourselves, make yourselves naked, 
+</div><div class="q2">and put sackcloth on your waist. 
+</div><div class="q1">
+<sup>12&#160;</sup>Beat your breasts for the pleasant fields, 
+</div><div class="q2">for the fruitful vine. 
+</div><div class="q1">
+<sup>13&#160;</sup>Thorns and briers will come up on my people’s land; 
+</div><div class="q2">yes, on all the houses of joy in the joyous city. 
+</div><div class="q1">
+<sup>14&#160;</sup>For the palace will be forsaken. 
+</div><div class="q2">The populous city will be deserted. 
+</div><div class="q2">The hill and the watchtower will be for dens forever, 
+</div><div class="q2">a delight for wild donkeys, 
+</div><div class="q2">a pasture of flocks, 
+</div><div class="q1">
+<sup>15&#160;</sup>until the Spirit is poured on us from on high, 
+</div><div class="q2">and the wilderness becomes a fruitful field, 
+</div><div class="q2">and the fruitful field is considered a forest. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Then justice will dwell in the wilderness; 
+</div><div class="q2">and righteousness will remain in the fruitful field. 
+</div><div class="q1">
+<sup>17&#160;</sup>The work of righteousness will be peace, 
+</div><div class="q2">and the effect of righteousness, quietness and confidence forever. 
+</div><div class="q1">
+<sup>18&#160;</sup>My people will live in a peaceful habitation, 
+</div><div class="q2">in safe dwellings, 
+</div><div class="q2">and in quiet resting places, 
+</div><div class="q1">
+<sup>19&#160;</sup>though hail flattens the forest, 
+</div><div class="q2">and the city is leveled completely. 
+</div><div class="q1">
+<sup>20&#160;</sup>Blessed are you who sow beside all waters, 
+</div><div class="q2">who send out the feet of the ox and the donkey. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="q1">
+<sup>1&#160;</sup>Woe to you who destroy, but you weren’t destroyed, 
+</div><div class="q2">and who betray, but nobody betrayed you! 
+</div><div class="q1">When you have finished destroying, you will be destroyed; 
+</div><div class="q2">and when you have finished betrayal, you will be betrayed. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>2&#160;</sup>Yahweh, be gracious to us. We have waited for you. 
+</div><div class="q2">Be our strength every morning, 
+</div><div class="q2">our salvation also in the time of trouble. 
+</div><div class="q1">
+<sup>3&#160;</sup>At the noise of the thunder, the peoples have fled. 
+</div><div class="q2">When you lift yourself up, the nations are scattered. 
+</div><div class="q1">
+<sup>4&#160;</sup>Your plunder will be gathered as the caterpillar gathers. 
+</div><div class="q2">Men will leap on it as locusts leap. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh is exalted, for he dwells on high. 
+</div><div class="q2">He has filled Zion with justice and righteousness. 
+</div><div class="q1">
+<sup>6&#160;</sup>There will be stability in your times, abundance of salvation, wisdom, and knowledge. 
+</div><div class="q2">The fear of Yahweh is your treasure. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Behold, their valiant ones cry outside; 
+</div><div class="q2">the ambassadors of peace weep bitterly. 
+</div><div class="q1">
+<sup>8&#160;</sup>The highways are desolate. 
+</div><div class="q2">The traveling man ceases. 
+</div><div class="q2">The covenant is broken. 
+</div><div class="q2">He has despised the cities. 
+</div><div class="q2">He doesn’t respect man. 
+</div><div class="q1">
+<sup>9&#160;</sup>The land mourns and languishes. 
+</div><div class="q2">Lebanon is confounded and withers away. 
+</div><div class="q2">Sharon is like a desert, and Bashan and Carmel are stripped bare. 
+</div><div class="q1">
+<sup>10&#160;</sup>“Now I will arise,” says Yahweh. 
+</div><div class="q2">“Now I will lift myself up. 
+</div><div class="q2">Now I will be exalted. 
+</div><div class="q1">
+<sup>11&#160;</sup>You will conceive chaff. 
+</div><div class="q2">You will give birth to stubble. 
+</div><div class="q2">Your breath is a fire that will devour you. 
+</div><div class="q1">
+<sup>12&#160;</sup>The peoples will be like the burning of lime, 
+</div><div class="q2">like thorns that are cut down and burned in the fire. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Hear, you who are far off, what I have done; 
+</div><div class="q2">and, you who are near, acknowledge my might.” 
+</div><div class="q1">
+<sup>14&#160;</sup>The sinners in Zion are afraid. 
+</div><div class="q2">Trembling has seized the elohimless ones. 
+</div><div class="q1">Who among us can live with the devouring fire? 
+</div><div class="q2">Who among us can live with everlasting burning? 
+</div><div class="q1">
+<sup>15&#160;</sup>He who walks righteously 
+</div><div class="q2">and speaks blamelessly, 
+</div><div class="q2">he who despises the gain of oppressions, 
+</div><div class="q2">who gestures with his hands, refusing to take a bribe, 
+</div><div class="q2">who stops his ears from hearing of bloodshed, 
+</div><div class="q2">and shuts his eyes from looking at evil—</div><div class="q1">
+<sup>16&#160;</sup>he will dwell on high. 
+</div><div class="q2">His place of defense will be the fortress of rocks. 
+</div><div class="q2">His bread will be supplied. 
+</div><div class="q2">His waters will be sure. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Your eyes will see the king in his beauty. 
+</div><div class="q2">They will see a distant land. 
+</div><div class="q1">
+<sup>18&#160;</sup>Your heart will meditate on the terror. 
+</div><div class="q2">Where is he who counted? 
+</div><div class="q2">Where is he who weighed? 
+</div><div class="q2">Where is he who counted the towers? 
+</div><div class="q1">
+<sup>19&#160;</sup>You will no longer see the fierce people, 
+</div><div class="q2">a people of a deep speech that you can’t comprehend, 
+</div><div class="q2">with a strange language that you can’t understand. 
+</div><div class="q1">
+<sup>20&#160;</sup>Look at Zion, the city of our appointed festivals. 
+</div><div class="q2">Your eyes will see Jerusalem, a quiet habitation, 
+</div><div class="q2">a tent that won’t be removed. 
+</div><div class="q1">Its stakes will never be plucked up, 
+</div><div class="q2">nor will any of its cords be broken. 
+</div><div class="q1">
+<sup>21&#160;</sup>But there Yahweh will be with us in majesty, 
+</div><div class="q2">a place of wide rivers and streams, 
+</div><div class="q2">in which no galley with oars will go, 
+</div><div class="q2">neither will any gallant ship pass by there. 
+</div><div class="q1">
+<sup>22&#160;</sup>For Yahweh is our judge. 
+</div><div class="q2">Yahweh is our lawgiver. 
+</div><div class="q2">Yahweh is our king. 
+</div><div class="q2">He will save us. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>Your rigging is untied. 
+</div><div class="q2">They couldn’t strengthen the foot of their mast. 
+</div><div class="q2">They couldn’t spread the sail. 
+</div><div class="q1">Then the prey of a great plunder was divided. 
+</div><div class="q2">The lame took the prey. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>The inhabitant won’t say, “I am sick.” 
+</div><div class="q2">The people who dwell therein will be forgiven their iniquity. 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="q1">
+<sup>1&#160;</sup>Come near, you nations, to hear! 
+</div><div class="q2">Listen, you peoples. 
+</div><div class="q2">Let the earth and all it contains hear, 
+</div><div class="q2">the world, and everything that comes from it. 
+</div><div class="q1">
+<sup>2&#160;</sup>For Yahweh is enraged against all the nations, 
+</div><div class="q2">and angry with all their armies. 
+</div><div class="q1">He has utterly destroyed them. 
+</div><div class="q2">He has given them over for slaughter. 
+</div><div class="q1">
+<sup>3&#160;</sup>Their slain will also be cast out, 
+</div><div class="q2">and the stench of their dead bodies will come up. 
+</div><div class="q2">The mountains will melt in their blood. 
+</div><div class="q1">
+<sup>4&#160;</sup>All of the army of the sky will be dissolved. 
+</div><div class="q2">The sky will be rolled up like a scroll, 
+</div><div class="q2">and all its armies will fade away, 
+</div><div class="q2">as a leaf fades from off a vine or a fig tree. 
+</div><div class="q1">
+<sup>5&#160;</sup>For my sword has drunk its fill in the sky. 
+</div><div class="q2">Behold, it will come down on Edom, 
+</div><div class="q2">and on the people of my curse, for judgment. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh’s sword is filled with blood. 
+</div><div class="q2">It is covered with fat, with the blood of lambs and goats, 
+</div><div class="q2">with the fat of the kidneys of rams; 
+</div><div class="q2">for Yahweh has a sacrifice in Bozrah, 
+</div><div class="q2">and a great slaughter in the land of Edom. 
+</div><div class="q1">
+<sup>7&#160;</sup>The wild oxen will come down with them, 
+</div><div class="q2">and the young bulls with the mighty bulls; 
+</div><div class="q2">and their land will be drunken with blood, 
+</div><div class="q2">and their dust made greasy with fat. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>For Yahweh has a day of vengeance, 
+</div><div class="q2">a year of recompense for the cause of Zion. 
+</div><div class="q1">
+<sup>9&#160;</sup>Its streams will be turned into pitch, 
+</div><div class="q2">its dust into sulfur, 
+</div><div class="q2">and its land will become burning pitch. 
+</div><div class="q1">
+<sup>10&#160;</sup>It won’t be quenched night or day. 
+</div><div class="q2">Its smoke will go up forever. 
+</div><div class="q2">From generation to generation, it will lie waste. 
+</div><div class="q2">No one will pass through it forever and ever. 
+</div><div class="q1">
+<sup>11&#160;</sup>But the pelican and the porcupine will possess it. 
+</div><div class="q2">The owl and the raven will dwell in it. 
+</div><div class="q1">He will stretch the line of confusion over it, 
+</div><div class="q2">and the plumb line of emptiness. 
+</div><div class="q1">
+<sup>12&#160;</sup>They shall call its nobles to the kingdom, but none shall be there; 
+</div><div class="q2">and all its princes shall be nothing. 
+</div><div class="q1">
+<sup>13&#160;</sup>Thorns will come up in its palaces, 
+</div><div class="q2">nettles and thistles in its fortresses; 
+</div><div class="q2">and it will be a habitation of jackals, 
+</div><div class="q2">a court for ostriches. 
+</div><div class="q1">
+<sup>14&#160;</sup>The wild animals of the desert will meet with the wolves, 
+</div><div class="q2">and the wild goat will cry to his fellow. 
+</div><div class="q1">Yes, the night creature shall settle there, 
+</div><div class="q2">and shall find herself a place of rest. 
+</div><div class="q1">
+<sup>15&#160;</sup>The arrow snake will make her nest there, 
+</div><div class="q2">and lay, hatch, and gather under her shade. 
+</div><div class="q2">Yes, the kites will be gathered there, every one with her mate. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Search in the book of Yahweh, and read: 
+</div><div class="q2">not one of these will be missing. 
+</div><div class="q2">None will lack her mate. 
+</div><div class="q2">For my mouth has commanded, 
+</div><div class="q2">and his Spirit has gathered them. 
+</div><div class="q1">
+<sup>17&#160;</sup>He has cast the lot for them, 
+</div><div class="q2">and his hand has divided it to them with a measuring line. 
+</div><div class="q2">They shall possess it forever. 
+</div><div class="q2">From generation to generation they will dwell in it. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="35">35</h2>
-<p class="q1">
-<span class="v">1&#160;</span>The wilderness and the dry land will be glad. 
-</p><p class="q2">The desert will rejoice and blossom like a rose. 
-</p><p class="q1">
-<span class="v">2&#160;</span>It will blossom abundantly, 
-</p><p class="q2">and rejoice even with joy and singing. 
-</p><p class="q2">Lebanon’s glory will be given to it, 
-</p><p class="q2">the excellence of Carmel and Sharon. 
-</p><p class="q2">They will see Yahweh’s glory, 
-</p><p class="q2">the excellence of our Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>Strengthen the weak hands, 
-</p><p class="q2">and make the feeble knees firm. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Tell those who have a fearful heart, “Be strong! 
-</p><p class="q2">Don’t be afraid! 
-</p><p class="q1">Behold, your Elohim will come with vengeance, Elohim’s retribution. 
-</p><p class="q2">He will come and save you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Then the eyes of the blind will be opened, 
-</p><p class="q2">and the ears of the deaf will be unstopped. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Then the lame man will leap like a deer, 
-</p><p class="q2">and the tongue of the mute will sing; 
-</p><p class="q2">for waters will break out in the wilderness, 
-</p><p class="q2">and streams in the desert. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The burning sand will become a pool, 
-</p><p class="q2">and the thirsty ground springs of water. 
-</p><p class="q2">Grass with reeds and rushes will be in the habitation of jackals, where they lay. 
-</p><p class="q1">
-<span class="v">8&#160;</span>A highway will be there, a road, 
-</p><p class="q2">and it will be called “The Set-Apart Way”. 
-</p><p class="q1">The unclean shall not pass over it, 
-</p><p class="q2">but it will be for those who walk in the Way. 
-</p><p class="q2">Wicked fools shall not go there. 
-</p><p class="q1">
-<span class="v">9&#160;</span>No lion will be there, 
-</p><p class="q2">nor will any ravenous animal go up on it. 
-</p><p class="q2">They will not be found there; 
-</p><p class="q2">but the redeemed will walk there. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Then Yahweh’s ransomed ones will return, 
-</p><p class="q2">and come with singing to Zion; 
-</p><p class="q2">and everlasting joy will be on their heads. 
-</p><p class="q1">They will obtain gladness and joy, 
-</p><p class="q2">and sorrow and sighing will flee away.” 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>Now in the fourteenth year of King Hezekiah, Sennacherib king of Assyria attacked all of the fortified cities of Judah and captured them. 
-<span class="v">2&#160;</span>The king of Assyria sent Rabshakeh from Lachish to Jerusalem to King Hezekiah with a large army. He stood by the aqueduct from the upper pool in the fuller’s field highway. 
-<span class="v">3&#160;</span>Then Eliakim the son of Hilkiah, who was over the household, and Shebna the scribe, and Joah, the son of Asaph the recorder came out to him. 
-</p><p>
-<span class="v">4&#160;</span>Rabshakeh said to them, “Now tell Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
-<span class="v">5&#160;</span>I say that your counsel and strength for the war are only vain words. Now in whom do you trust, that you have rebelled against me? 
-<span class="v">6&#160;</span>Behold, you trust in the staff of this bruised reed, even in Egypt, which if a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust in him. 
-<span class="v">7&#160;</span>But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar’?” 
-<span class="v">8&#160;</span>Now therefore, please make a pledge to my master the king of Assyria, and I will give you two thousand horses, if you are able on your part to set riders on them. 
-<span class="v">9&#160;</span>How then can you turn away the face of one captain of the least of my master’s servants, and put your trust in Egypt for chariots and for horsemen? 
-<span class="v">10&#160;</span>Have I come up now without Yahweh against this land to destroy it? Yahweh said to me, “Go up against this land, and destroy it.”&#160;’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>Then Eliakim, Shebna and Joah said to Rabshakeh, “Please speak to your servants in Aramaic, for we understand it. Don’t speak to us in the Jews’ language in the hearing of the people who are on the wall.” 
-</p><p>
-<span class="v">12&#160;</span>But Rabshakeh said, “Has my master sent me only to your master and to you, to speak these words, and not to the men who sit on the wall, who will eat their own dung and drink their own urine with you?” 
-<span class="v">13&#160;</span>Then Rabshakeh stood, and called out with a loud voice in the Jews’ language, and said, “Hear the words of the great king, the king of Assyria! 
-<span class="v">14&#160;</span>The king says, ‘Don’t let Hezekiah deceive you; for he will not be able to deliver you. 
-<span class="v">15&#160;</span>Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us. This city won’t be given into the hand of the king of Assyria.”&#160;’ 
-<span class="v">16&#160;</span>Don’t listen to Hezekiah, for the king of Assyria says, ‘Make your peace with me, and come out to me; and each of you eat from his vine, and each one from his fig tree, and each one of you drink the waters of his own cistern; 
-<span class="v">17&#160;</span>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards. 
-<span class="v">18&#160;</span>Beware lest Hezekiah persuade you, saying, “Yahweh will deliver us.” Have any of the elohims of the nations delivered their lands from the hand of the king of Assyria? 
-<span class="v">19&#160;</span>Where are the elohims of Hamath and Arpad? Where are the elohims of Sepharvaim? Have they delivered Samaria from my hand? 
-<span class="v">20&#160;</span>Who are they among all the elohims of these countries that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>But they remained silent, and said nothing in reply, for the king’s commandment was, “Don’t answer him.” 
-</p><p>
-<span class="v">22&#160;</span>Then Eliakim the son of Hilkiah, who was over the household, and Shebna the scribe, and Joah, the son of Asaph the recorder, came to Hezekiah with their clothes torn, and told him the words of Rabshakeh. 
-</p><h2 class="chapterlabel" id="37">37</h2>
-<p>
-<span class="v">1&#160;</span>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
-<span class="v">2&#160;</span>He sent Eliakim, who was over the household, and Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet, the son of Amoz. 
-<span class="v">3&#160;</span>They said to him, “Hezekiah says, ‘Today is a day of trouble, and of rebuke, and of rejection; for the children have come to the birth, and there is no strength to give birth. 
-<span class="v">4&#160;</span>It may be Yahweh your Elohim will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
-</p><p>
-<span class="v">5&#160;</span>So the servants of King Hezekiah came to Isaiah. 
-</p><p>
-<span class="v">6&#160;</span>Isaiah said to them, “Tell your master, ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
-<span class="v">7&#160;</span>Behold, I will put a spirit in him and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.”&#160;’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>So Rabshakeh returned, and found the king of Assyria warring against Libnah, for he heard that he had departed from Lachish. 
-<span class="v">9&#160;</span>He heard news concerning Tirhakah king of Ethiopia, “He has come out to fight against you.” When he heard it, he sent messengers to Hezekiah, saying, 
-<span class="v">10&#160;</span>“Thus you shall speak to Hezekiah king of Judah, saying, ‘Don’t let your Elohim in whom you trust deceive you, saying, “Jerusalem won’t be given into the hand of the king of Assyria.” 
-<span class="v">11&#160;</span>Behold, you have heard what the kings of Assyria have done to all lands, by destroying them utterly. Shall you be delivered? 
-<span class="v">12&#160;</span>Have the elohims of the nations delivered them, which my fathers have destroyed, Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
-<span class="v">13&#160;</span>Where is the king of Hamath, and the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
-<span class="v">15&#160;</span>Hezekiah prayed to Yahweh, saying, 
-<span class="v">16&#160;</span>“Yahweh of Armies, the Elohim of Israel, who is enthroned among the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
-<span class="v">17&#160;</span>Turn your ear, Yahweh, and hear. Open your eyes, Yahweh, and behold. Hear all of the words of Sennacherib, who has sent to defy the living Elohim. 
-<span class="v">18&#160;</span>Truly, Yahweh, the kings of Assyria have destroyed all the countries and their land, 
-<span class="v">19&#160;</span>and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone; therefore they have destroyed them. 
-<span class="v">20&#160;</span>Now therefore, Yahweh our Elohim, save us from his hand, that all the kingdoms of the earth may know that you are Yahweh, even you only.” 
-</p><p>
-<span class="v">21&#160;</span>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel says, ‘Because you have prayed to me against Sennacherib king of Assyria, 
-<span class="v">22&#160;</span>this is the word which Yahweh has spoken concerning him: The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
-<span class="v">23&#160;</span>Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel. 
-<span class="v">24&#160;</span>By your servants, you have defied the Lord, and have said, “With the multitude of my chariots I have come up to the height of the mountains, to the innermost parts of Lebanon. I will cut down its tall cedars and its choice cypress trees. I will enter into its farthest height, the forest of its fruitful field. 
-<span class="v">25&#160;</span>I have dug and drunk water, and with the sole of my feet I will dry up all the rivers of Egypt.” 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘Have you not heard how I have done it long ago, and formed it in ancient times? Now I have brought it to pass, that it should be yours to destroy fortified cities, turning them into ruinous heaps. 
-<span class="v">27&#160;</span>Therefore their inhabitants had little power. They were dismayed and confounded. They were like the grass of the field, and like the green herb, like the grass on the housetops, and like a field before its crop has grown. 
-<span class="v">28&#160;</span>But I know your sitting down, your going out, your coming in, and your raging against me. 
-<span class="v">29&#160;</span>Because of your raging against me, and because your arrogance has come up into my ears, therefore I will put my hook in your nose and my bridle in your lips, and I will turn you back by the way by which you came. 
-</p><p>
-<span class="v">30&#160;</span>“&#160;‘This shall be the sign to you: You will eat this year that which grows of itself, and in the second year that which springs from it; and in the third year sow and reap and plant vineyards, and eat their fruit. 
-<span class="v">31&#160;</span>The remnant that is escaped of the house of Judah will again take root downward, and bear fruit upward. 
-<span class="v">32&#160;</span>For out of Jerusalem a remnant will go out, and survivors will escape from Mount Zion. The zeal of Yahweh of Armies will perform this.’ 
-</p><p>
-<span class="v">33&#160;</span>“Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there, neither will he come before it with shield, nor cast up a mound against it. 
-<span class="v">34&#160;</span>He will return the way that he came, and he won’t come to this city,’ says Yahweh. 
-<span class="v">35&#160;</span>‘For I will defend this city to save it, for my own sake, and for my servant David’s sake.’&#160;” 
-</p><p>
-<span class="v">36&#160;</span>Then Yahweh’s angel went out and struck one hundred and eighty-five thousand men in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
-<span class="v">37&#160;</span>So Sennacherib king of Assyria departed, went away, returned to Nineveh, and stayed there. 
-<span class="v">38&#160;</span>As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer his sons struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
-</p><h2 class="chapterlabel" id="38">38</h2>
-<p>
-<span class="v">1&#160;</span>In those days Hezekiah was sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him, “Yahweh says, ‘Set your house in order, for you will die, and not live.’&#160;” 
-</p><p>
-<span class="v">2&#160;</span>Then Hezekiah turned his face to the wall and prayed to Yahweh, 
-<span class="v">3&#160;</span>and said, “Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” Then Hezekiah wept bitterly. 
-</p><p>
-<span class="v">4&#160;</span>Then Yahweh’s word came to Isaiah, saying, 
-<span class="v">5&#160;</span>“Go, and tell Hezekiah, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will add fifteen years to your life. 
-<span class="v">6&#160;</span>I will deliver you and this city out of the hand of the king of Assyria, and I will defend this city. 
-<span class="v">7&#160;</span>This shall be the sign to you from Yahweh, that Yahweh will do this thing that he has spoken. 
-<span class="v">8&#160;</span>Behold, I will cause the shadow on the sundial, which has gone down on the sundial of Ahaz with the sun, to return backward ten steps.”&#160;’&#160;” So the sun returned ten steps on the sundial on which it had gone down. 
-</p><p>
-<span class="v">9&#160;</span>The writing of Hezekiah king of Judah, when he had been sick, and had recovered of his sickness: 
-</p><p class="q1">
-<span class="v">10&#160;</span>I said, “In the middle of my life I go into the gates of Sheol.<span class="f">+ \fr 38:10 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">I am deprived of the residue of my years.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>I said, “I won’t see Yah, 
-</p><p class="q2">Yah in the land of the living. 
-</p><p class="q2">I will see man no more with the inhabitants of the world. 
-</p><p class="q1">
-<span class="v">12&#160;</span>My dwelling is removed, 
-</p><p class="q2">and is carried away from me like a shepherd’s tent. 
-</p><p class="q1">I have rolled up my life like a weaver. 
-</p><p class="q2">He will cut me off from the loom. 
-</p><p class="q2">From day even to night you will make an end of me. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I waited patiently until morning. 
-</p><p class="q2">He breaks all my bones like a lion. 
-</p><p class="q2">From day even to night you will make an end of me. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I chattered like a swallow or a crane. 
-</p><p class="q2">I moaned like a dove. 
-</p><p class="q2">My eyes weaken looking upward. 
-</p><p class="q2">Lord, I am oppressed. 
-</p><p class="q2">Be my security.” 
-</p><p class="q1">
-<span class="v">15&#160;</span>What will I say? 
-</p><p class="q2">He has both spoken to me, and himself has done it. 
-</p><p class="q2">I will walk carefully all my years because of the anguish of my soul. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Lord, men live by these things; 
-</p><p class="q2">and my spirit finds life in all of them. 
-</p><p class="q2">You restore me, and cause me to live. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Behold, for peace I had great anguish, 
-</p><p class="q2">but you have in love for my soul delivered it from the pit of corruption; 
-</p><p class="q2">for you have cast all my sins behind your back. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For Sheol<span class="f">+ \fr 38:18 \ft Sheol is the place of the dead.</span> can’t praise you. 
-</p><p class="q2">Death can’t celebrate you. 
-</p><p class="q1">Those who go down into the pit can’t hope for your truth. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The living, the living, he shall praise you, as I do today. 
-</p><p class="q2">The father shall make known your truth to the children. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Yahweh will save me. 
-</p><p class="q2">Therefore we will sing my songs with stringed instruments all the days of our life in Yahweh’s house. 
-</p><p>
-<span class="v">21&#160;</span>Now Isaiah had said, “Let them take a cake of figs, and lay it for a poultice on the boil, and he shall recover.” 
-<span class="v">22&#160;</span>Hezekiah also had said, “What is the sign that I will go up to Yahweh’s house?” 
-</p><h2 class="chapterlabel" id="39">39</h2>
-<p>
-<span class="v">1&#160;</span>At that time, Merodach-baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he heard that he had been sick, and had recovered. 
-<span class="v">2&#160;</span>Hezekiah was pleased with them, and showed them the house of his precious things, the silver, the gold, the spices, and the precious oil, and all the house of his armor, and all that was found in his treasures. There was nothing in his house, nor in all his dominion, that Hezekiah didn’t show them. 
-<span class="v">3&#160;</span>Then Isaiah the prophet came to King Hezekiah, and asked him, “What did these men say? From where did they come to you?” 
-</p><p>Hezekiah said, “They have come from a country far from me, even from Babylon.” 
-</p><p>
-<span class="v">4&#160;</span>Then he asked, “What have they seen in your house?” 
-</p><p>Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
-</p><p>
-<span class="v">5&#160;</span>Then Isaiah said to Hezekiah, “Hear the word of Yahweh of Armies: 
-<span class="v">6&#160;</span>‘Behold, the days are coming when all that is in your house, and that which your fathers have stored up until today, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
-<span class="v">7&#160;</span>‘They will take away your sons who will issue from you, whom you shall father, and they will be eunuchs in the king of Babylon’s palace.’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “For there will be peace and truth in my days.” 
-</p><h2 class="chapterlabel" id="40">40</h2>
-<p>
-<span class="v">1&#160;</span>“Comfort, comfort my people,” says your Elohim. 
-<span class="v">2&#160;</span>“Speak comfortably to Jerusalem, and call out to her that her warfare is accomplished, that her iniquity is pardoned, that she has received of Yahweh’s hand double for all her sins.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>The voice of one who calls out, 
-</p><p class="q2">“Prepare the way of Yahweh in the wilderness! 
-</p><p class="q2">Make a level highway in the desert for our Elohim. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Every valley shall be exalted, 
-</p><p class="q2">and every mountain and hill shall be made low. 
-</p><p class="q2">The uneven shall be made level, 
-</p><p class="q2">and the rough places a plain. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh’s glory shall be revealed, 
-</p><p class="q2">and all flesh shall see it together; 
-</p><p class="q2">for the mouth of Yahweh has spoken it.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>The voice of one saying, “Cry out!” 
-</p><p class="q2">One said, “What shall I cry?” 
-</p><p class="q1">“All flesh is like grass, 
-</p><p class="q2">and all its glory is like the flower of the field. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The grass withers, 
-</p><p class="q2">the flower fades, 
-</p><p class="q2">because Yahweh’s breath blows on it. 
-</p><p class="q2">Surely the people are like grass. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The grass withers, 
-</p><p class="q2">the flower fades; 
-</p><p class="q2">but the word of our Elohim stands forever.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>You who tell good news to Zion, go up on a high mountain. 
-</p><p class="q2">You who tell good news to Jerusalem, lift up your voice with strength! 
-</p><p class="q2">Lift it up! Don’t be afraid! 
-</p><p class="q2">Say to the cities of Judah, “Behold, your Elohim!” 
-</p><p class="q1">
-<span class="v">10&#160;</span>Behold, the Lord Yahweh will come as a mighty one, 
-</p><p class="q2">and his arm will rule for him. 
-</p><p class="q2">Behold, his reward is with him, 
-</p><p class="q2">and his recompense before him. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He will feed his flock like a shepherd. 
-</p><p class="q2">He will gather the lambs in his arm, 
-</p><p class="q2">and carry them in his bosom. 
-</p><p class="q2">He will gently lead those who have their young. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Who has measured the waters in the hollow of his hand, 
-</p><p class="q2">and marked off the sky with his span, 
-</p><p class="q2">and calculated the dust of the earth in a measuring basket, 
-</p><p class="q2">and weighed the mountains in scales, 
-</p><p class="q2">and the hills in a balance? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Who has directed Yahweh’s Spirit, 
-</p><p class="q2">or has taught him as his counselor? 
-</p><p class="q1">
-<span class="v">14&#160;</span>Who did he take counsel with, 
-</p><p class="q2">and who instructed him, 
-</p><p class="q2">and taught him in the path of justice, 
-</p><p class="q2">and taught him knowledge, 
-</p><p class="q2">and showed him the way of understanding? 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, the nations are like a drop in a bucket, 
-</p><p class="q2">and are regarded as a speck of dust on a balance. 
-</p><p class="q2">Behold, he lifts up the islands like a very little thing. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Lebanon is not sufficient to burn, 
-</p><p class="q2">nor its animals sufficient for a burnt offering. 
-</p><p class="q1">
-<span class="v">17&#160;</span>All the nations are like nothing before him. 
-</p><p class="q2">They are regarded by him as less than nothing, and vanity. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>To whom then will you liken Elohim? 
-</p><p class="q2">Or what likeness will you compare to him? 
-</p><p class="q1">
-<span class="v">19&#160;</span>A workman has cast an image, 
-</p><p class="q2">and the goldsmith overlays it with gold, 
-</p><p class="q2">and casts silver chains for it. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He who is too impoverished for such an offering chooses a tree that will not rot. 
-</p><p class="q2">He seeks a skillful workman to set up a carved image for him that will not be moved. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Haven’t you known? 
-</p><p class="q2">Haven’t you heard? 
-</p><p class="q2">Haven’t you been told from the beginning? 
-</p><p class="q2">Haven’t you understood from the foundations of the earth? 
-</p><p class="q1">
-<span class="v">22&#160;</span>It is he who sits above the circle of the earth, 
-</p><p class="q2">and its inhabitants are like grasshoppers; 
-</p><p class="q2">who stretches out the heavens like a curtain, 
-</p><p class="q2">and spreads them out like a tent to dwell in, 
-</p><p class="q2">
-<span class="v">23&#160;</span>who brings princes to nothing, 
-</p><p class="q2">who makes the judges of the earth meaningless. 
-</p><p class="q1">
-<span class="v">24&#160;</span>They are planted scarcely. 
-</p><p class="q2">They are sown scarcely. 
-</p><p class="q2">Their stock has scarcely taken root in the ground. 
-</p><p class="q2">He merely blows on them, and they wither, 
-</p><p class="q2">and the whirlwind takes them away as stubble. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>“To whom then will you liken me? 
-</p><p class="q2">Who is my equal?” says the Set-Apart One. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Lift up your eyes on high, 
-</p><p class="q2">and see who has created these, 
-</p><p class="q2">who brings out their army by number. 
-</p><p class="q2">He calls them all by name. 
-</p><p class="q2">By the greatness of his might, 
-</p><p class="q2">and because he is strong in power, 
-</p><p class="q2">not one is lacking. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">27&#160;</span>Why do you say, Jacob, 
-</p><p class="q2">and speak, Israel, 
-</p><p class="q2">“My way is hidden from Yahweh, 
-</p><p class="q2">and the justice due me is disregarded by my Elohim”? 
-</p><p class="q1">
-<span class="v">28&#160;</span>Haven’t you known? 
-</p><p class="q2">Haven’t you heard? 
-</p><p class="q2">The everlasting Elohim, Yahweh, 
-</p><p class="q2">the Creator of the ends of the earth, doesn’t faint. 
-</p><p class="q2">He isn’t weary. 
-</p><p class="q2">His understanding is unsearchable. 
-</p><p class="q1">
-<span class="v">29&#160;</span>He gives power to the weak. 
-</p><p class="q2">He increases the strength of him who has no might. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Even the youths faint and get weary, 
-</p><p class="q2">and the young men utterly fall; 
-</p><p class="q2">
-<span class="v">31&#160;</span>but those who wait for Yahweh will renew their strength. 
-</p><p class="q2">They will mount up with wings like eagles. 
-</p><p class="q2">They will run, and not be weary. 
-</p><p class="q2">They will walk, and not faint. 
-</p><h2 class="chapterlabel" id="41">41</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Keep silent before me, islands, 
-</p><p class="q2">and let the peoples renew their strength. 
-</p><p class="q1">Let them come near, 
-</p><p class="q2">then let them speak. 
-</p><p class="q2">Let’s meet together for judgment. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Who has raised up one from the east? 
-</p><p class="q2">Who called him to his feet in righteousness? 
-</p><p class="q2">He hands over nations to him 
-</p><p class="q2">and makes him rule over kings. 
-</p><p class="q2">He gives them like the dust to his sword, 
-</p><p class="q2">like the driven stubble to his bow. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He pursues them 
-</p><p class="q2">and passes by safely, 
-</p><p class="q2">even by a way that he had not gone with his feet. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Who has worked and done it, 
-</p><p class="q2">calling the generations from the beginning? 
-</p><p class="q2">I, Yahweh, the first, and with the last, I am he.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>The islands have seen, and fear. 
-</p><p class="q2">The ends of the earth tremble. 
-</p><p class="q2">They approach, and come. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Everyone helps his neighbor. 
-</p><p class="q2">They say to their brothers, “Be strong!” 
-</p><p class="q1">
-<span class="v">7&#160;</span>So the carpenter encourages the goldsmith. 
-</p><p class="q2">He who smooths with the hammer encourages him who strikes the anvil, 
-</p><p class="q2">saying of the soldering, “It is good;” 
-</p><p class="q2">and he fastens it with nails, that it might not totter. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“But you, Israel, my servant, 
-</p><p class="q2">Jacob whom I have chosen, 
-</p><p class="q2">the offspring of Abraham my friend, 
-</p><p class="q2">
-<span class="v">9&#160;</span>you whom I have taken hold of from the ends of the earth, 
-</p><p class="q2">and called from its corners, 
-</p><p class="q2">and said to you, ‘You are my servant. I have chosen you and have not cast you away.’ 
-</p><p class="q1">
-<span class="v">10&#160;</span>Don’t you be afraid, for I am with you. 
-</p><p class="q2">Don’t be dismayed, for I am your Elohim. 
-</p><p class="q2">I will strengthen you. 
-</p><p class="q2">Yes, I will help you. 
-</p><p class="q2">Yes, I will uphold you with the right hand of my righteousness. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Behold, all those who are incensed against you will be disappointed and confounded. 
-</p><p class="q2">Those who strive with you will be like nothing, and shall perish. 
-</p><p class="q1">
-<span class="v">12&#160;</span>You will seek them, and won’t find them, 
-</p><p class="q2">even those who contend with you. 
-</p><p class="q2">Those who war against you will be as nothing, 
-</p><p class="q2">as a nonexistent thing. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For I, Yahweh your Elohim, will hold your right hand, 
-</p><p class="q2">saying to you, ‘Don’t be afraid. 
-</p><p class="q2">I will help you.’ 
-</p><p class="q1">
-<span class="v">14&#160;</span>Don’t be afraid, you worm Jacob, 
-</p><p class="q2">and you men of Israel. 
-</p><p class="q2">I will help you,” says Yahweh. 
-</p><p class="q2">“Your Redeemer is the Set-Apart One of Israel. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, I have made you into a new sharp threshing instrument with teeth. 
-</p><p class="q2">You will thresh the mountains, 
-</p><p class="q2">and beat them small, 
-</p><p class="q2">and will make the hills like chaff. 
-</p><p class="q1">
-<span class="v">16&#160;</span>You will winnow them, 
-</p><p class="q2">and the wind will carry them away, 
-</p><p class="q2">and the whirlwind will scatter them. 
-</p><p class="q1">You will rejoice in Yahweh. 
-</p><p class="q2">You will glory in the Set-Apart One of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>The poor and needy seek water, and there is none. 
-</p><p class="q2">Their tongue fails for thirst. 
-</p><p class="q1">I, Yahweh, will answer them. 
-</p><p class="q2">I, the Elohim of Israel, will not forsake them. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I will open rivers on the bare heights, 
-</p><p class="q2">and springs in the middle of the valleys. 
-</p><p class="q2">I will make the wilderness a pool of water, 
-</p><p class="q2">and the dry land springs of water. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I will put cedar, acacia, myrtle, and oil trees in the wilderness. 
-</p><p class="q2">I will set cypress trees, pine, and box trees together in the desert; 
-</p><p class="q2">
-<span class="v">20&#160;</span>that they may see, know, consider, and understand together, 
-</p><p class="q2">that Yahweh’s hand has done this, 
-</p><p class="q2">and the Set-Apart One of Israel has created it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Produce your cause,” says Yahweh. 
-</p><p class="q2">“Bring out your strong reasons!” says the King of Jacob. 
-</p><p class="q1">
-<span class="v">22&#160;</span>“Let them announce and declare to us what will happen! 
-</p><p class="q2">Declare the former things, what they are, 
-</p><p class="q2">that we may consider them, and know the latter end of them; 
-</p><p class="q2">or show us things to come. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Declare the things that are to come hereafter, 
-</p><p class="q2">that we may know that you are elohims. 
-</p><p class="q1">Yes, do good, or do evil, 
-</p><p class="q2">that we may be dismayed, 
-</p><p class="q2">and see it together. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Behold, you are nothing, 
-</p><p class="q2">and your work is nothing. 
-</p><p class="q2">He who chooses you is an abomination. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>“I have raised up one from the north, and he has come, 
-</p><p class="q2">from the rising of the sun, one who calls on my name, 
-</p><p class="q2">and he shall come on rulers as on mortar, 
-</p><p class="q2">and as the potter treads clay. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Who has declared it from the beginning, that we may know? 
-</p><p class="q2">and before, that we may say, ‘He is right’? 
-</p><p class="q1">Surely, there is no one who declares. 
-</p><p class="q2">Surely, there is no one who shows. 
-</p><p class="q2">Surely, there is no one who hears your words. 
-</p><p class="q1">
-<span class="v">27&#160;</span>I am the first to say to Zion, ‘Behold, look at them;’ 
-</p><p class="q2">and I will give one who brings good news to Jerusalem. 
-</p><p class="q1">
-<span class="v">28&#160;</span>When I look, there is no man, 
-</p><p class="q2">even among them there is no counselor who, when I ask, can answer a word. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Behold, all of their deeds are vanity and nothing. 
-</p><p class="q2">Their molten images are wind and confusion. 
-</p><h2 class="chapterlabel" id="42">42</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Behold, my servant, whom I uphold, 
-</p><p class="q2">my chosen, in whom my soul delights: 
-</p><p class="q2">I have put my Spirit on him. 
-</p><p class="q2">He will bring justice to the nations. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He will not shout, 
-</p><p class="q2">nor raise his voice, 
-</p><p class="q2">nor cause it to be heard in the street. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He won’t break a bruised reed. 
-</p><p class="q2">He won’t quench a dimly burning wick. 
-</p><p class="q2">He will faithfully bring justice. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He will not fail nor be discouraged, 
-</p><p class="q2">until he has set justice in the earth, 
-</p><p class="q2">and the islands wait for his law.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Elohim Yahweh, 
-</p><p class="q2">he who created the heavens and stretched them out, 
-</p><p class="q2">he who spread out the earth and that which comes out of it, 
-</p><p class="q2">he who gives breath to its people and spirit to those who walk in it, says: 
-</p><p class="q1">
-<span class="v">6&#160;</span>“I, Yahweh, have called you in righteousness. 
-</p><p class="q2">I will hold your hand. 
-</p><p class="q2">I will keep you, 
-</p><p class="q2">and make you a covenant for the people, 
-</p><p class="q2">as a light for the nations, 
-</p><p class="q2">
-<span class="v">7&#160;</span>to open the blind eyes, 
-</p><p class="q2">to bring the prisoners out of the dungeon, 
-</p><p class="q2">and those who sit in darkness out of the prison. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“I am Yahweh. 
-</p><p class="q2">That is my name. 
-</p><p class="q2">I will not give my glory to another, 
-</p><p class="q2">nor my praise to engraved images. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Behold, the former things have happened 
-</p><p class="q2">and I declare new things. 
-</p><p class="q2">I tell you about them before they come up.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Sing to Yahweh a new song, 
-</p><p class="q2">and his praise from the end of the earth, 
-</p><p class="q2">you who go down to the sea, 
-</p><p class="q2">and all that is therein, 
-</p><p class="q2">the islands and their inhabitants. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Let the wilderness and its cities raise their voices, 
-</p><p class="q2">with the villages that Kedar inhabits. 
-</p><p class="q2">Let the inhabitants of Sela sing. 
-</p><p class="q2">Let them shout from the top of the mountains! 
-</p><p class="q1">
-<span class="v">12&#160;</span>Let them give glory to Yahweh, 
-</p><p class="q2">and declare his praise in the islands. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yahweh will go out like a mighty man. 
-</p><p class="q2">He will stir up zeal like a man of war. 
-</p><p class="q2">He will raise a war cry. 
-</p><p class="q2">Yes, he will shout aloud. 
-</p><p class="q2">He will triumph over his enemies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“I have been silent a long time. 
-</p><p class="q2">I have been quiet and restrained myself. 
-</p><p class="q2">Now I will cry out like a travailing woman. I will both gasp and pant. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will destroy mountains and hills, 
-</p><p class="q2">and dry up all their herbs. 
-</p><p class="q2">I will make the rivers islands, 
-</p><p class="q2">and will dry up the pools. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will bring the blind by a way that they don’t know. 
-</p><p class="q2">I will lead them in paths that they don’t know. 
-</p><p class="q2">I will make darkness light before them, 
-</p><p class="q2">and crooked places straight. 
-</p><p class="q2">I will do these things, 
-</p><p class="q2">and I will not forsake them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“Those who trust in engraved images, 
-</p><p class="q2">who tell molten images, 
-</p><p class="q2">‘You are our elohims,’ 
-</p><p class="q2">will be turned back. 
-</p><p class="q2">They will be utterly disappointed. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“Hear, you deaf, 
-</p><p class="q2">and look, you blind, 
-</p><p class="q2">that you may see. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Who is blind, but my servant? 
-</p><p class="q2">Or who is as deaf as my messenger whom I send? 
-</p><p class="q1">Who is as blind as he who is at peace, 
-</p><p class="q2">and as blind as Yahweh’s servant? 
-</p><p class="q1">
-<span class="v">20&#160;</span>You see many things, but don’t observe. 
-</p><p class="q2">His ears are open, but he doesn’t listen. 
-</p><p class="q1">
-<span class="v">21&#160;</span>It pleased Yahweh, for his righteousness’ sake, to magnify the law 
-</p><p class="q2">and make it honorable. 
-</p><p class="q1">
-<span class="v">22&#160;</span>But this is a robbed and plundered people. 
-</p><p class="q2">All of them are snared in holes, 
-</p><p class="q2">and they are hidden in prisons. 
-</p><p class="q1">They have become captives, and no one delivers, 
-</p><p class="q2">and a plunder, and no one says, ‘Restore them!’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>Who is there among you who will give ear to this? 
-</p><p class="q2">Who will listen and hear for the time to come? 
-</p><p class="q1">
-<span class="v">24&#160;</span>Who gave Jacob as plunder, 
-</p><p class="q2">and Israel to the robbers? 
-</p><p class="q2">Didn’t Yahweh, he against whom we have sinned? 
-</p><p class="q2">For they would not walk in his ways, 
-</p><p class="q2">and they disobeyed his law. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Therefore he poured the fierceness of his anger on him, 
-</p><p class="q2">and the strength of battle. 
-</p><p class="q1">It set him on fire all around, but he didn’t know. 
-</p><p class="q2">It burned him, but he didn’t take it to heart.” 
-</p><h2 class="chapterlabel" id="43">43</h2>
-<p class="q1">
-<span class="v">1&#160;</span>But now Yahweh who created you, Jacob, 
-</p><p class="q2">and he who formed you, Israel, says: 
-</p><p class="q1">“Don’t be afraid, for I have redeemed you. 
-</p><p class="q2">I have called you by your name. 
-</p><p class="q2">You are mine. 
-</p><p class="q1">
-<span class="v">2&#160;</span>When you pass through the waters, I will be with you, 
-</p><p class="q2">and through the rivers, they will not overflow you. 
-</p><p class="q1">When you walk through the fire, you will not be burned, 
-</p><p class="q2">and flame will not scorch you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For I am Yahweh your Elohim, 
-</p><p class="q2">the Set-Apart One of Israel, 
-</p><p class="q2">your Savior. 
-</p><p class="q1">I have given Egypt as your ransom, 
-</p><p class="q2">Ethiopia and Seba in your place. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Since you have been precious and honored in my sight, 
-</p><p class="q2">and I have loved you, 
-</p><p class="q2">therefore I will give people in your place, 
-</p><p class="q2">and nations instead of your life. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Don’t be afraid, for I am with you. 
-</p><p class="q2">I will bring your offspring from the east, 
-</p><p class="q2">and gather you from the west. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I will tell the north, ‘Give them up!’ 
-</p><p class="q2">and tell the south, ‘Don’t hold them back! 
-</p><p class="q2">Bring my sons from far away, 
-</p><p class="q2">and my daughters from the ends of the earth—</p><p class="q1">
-<span class="v">7&#160;</span>everyone who is called by my name, 
-</p><p class="q2">and whom I have created for my glory, 
-</p><p class="q2">whom I have formed, 
-</p><p class="q2">yes, whom I have made.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Bring out the blind people who have eyes, 
-</p><p class="q2">and the deaf who have ears. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Let all the nations be gathered together, 
-</p><p class="q2">and let the peoples be assembled. 
-</p><p class="q1">Who among them can declare this, 
-</p><p class="q2">and show us former things? 
-</p><p class="q1">Let them bring their witnesses, that they may be justified, 
-</p><p class="q2">or let them hear, and say, “That is true.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“You are my witnesses,” says Yahweh, 
-</p><p class="q2">“With my servant whom I have chosen; 
-</p><p class="q2">that you may know and believe me, 
-</p><p class="q2">and understand that I am he. 
-</p><p class="q1">Before me there was no Elohim formed, 
-</p><p class="q2">neither will there be after me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I myself am Yahweh. 
-</p><p class="q2">Besides me, there is no savior. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I have declared, I have saved, and I have shown, 
-</p><p class="q2">and there was no strange elohim among you. 
-</p><p class="q1">Therefore you are my witnesses”, 
-</p><p class="q2">says Yahweh, “and I am Elohim. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yes, since the day was, I am he. 
-</p><p class="q2">There is no one who can deliver out of my hand. 
-</p><p class="q2">I will work, and who can hinder it?” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh, your Redeemer, the Set-Apart One of Israel says: “For your sake, I have sent to Babylon, and I will bring all of them down as fugitives, even the Chaldeans, in the ships of their rejoicing. 
-<span class="v">15&#160;</span>I am Yahweh, your Set-Apart One, the Creator of Israel, your King.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh, who makes a way in the sea, 
-</p><p class="q2">and a path in the mighty waters, 
-</p><p class="q1">
-<span class="v">17&#160;</span>who brings out the chariot and horse, 
-</p><p class="q2">the army and the mighty man 
-</p><p class="q2">(they lie down together, they shall not rise; 
-</p><p class="q2">they are extinct, they are quenched like a wick) says: 
-</p><p class="q1">
-<span class="v">18&#160;</span>“Don’t remember the former things, 
-</p><p class="q2">and don’t consider the things of old. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Behold, I will do a new thing. 
-</p><p class="q2">It springs out now. 
-</p><p class="q2">Don’t you know it? 
-</p><p class="q1">I will even make a way in the wilderness, 
-</p><p class="q2">and rivers in the desert. 
-</p><p class="q1">
-<span class="v">20&#160;</span>The animals of the field, the jackals and the ostriches, shall honor me, 
-</p><p class="q2">because I give water in the wilderness and rivers in the desert, 
-</p><p class="q2">to give drink to my people, my chosen, 
-</p><p class="q2">
-<span class="v">21&#160;</span>the people which I formed for myself, 
-</p><p class="q2">that they might declare my praise. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>Yet you have not called on me, Jacob; 
-</p><p class="q2">but you have been weary of me, Israel. 
-</p><p class="q1">
-<span class="v">23&#160;</span>You have not brought me any of your sheep for burnt offerings, 
-</p><p class="q2">neither have you honored me with your sacrifices. 
-</p><p class="q1">I have not burdened you with offerings, 
-</p><p class="q2">nor wearied you with frankincense. 
-</p><p class="q1">
-<span class="v">24&#160;</span>You have bought me no sweet cane with money, 
-</p><p class="q2">nor have you filled me with the fat of your sacrifices, 
-</p><p class="q1">but you have burdened me with your sins. 
-</p><p class="q2">You have wearied me with your iniquities. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>I, even I, am he who blots out your transgressions for my own sake; 
-</p><p class="q2">and I will not remember your sins. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Put me in remembrance. 
-</p><p class="q2">Let us plead together. 
-</p><p class="q1">Declare your case, 
-</p><p class="q2">that you may be justified. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Your first father sinned, 
-</p><p class="q2">and your teachers have transgressed against me. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Therefore I will profane the princes of the sanctuary; 
-</p><p class="q2">and I will make Jacob a curse, 
-</p><p class="q2">and Israel an insult.” 
-</p><h2 class="chapterlabel" id="44">44</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Yet listen now, Jacob my servant, 
-</p><p class="q2">and Israel, whom I have chosen. 
-</p><p class="q1">
-<span class="v">2&#160;</span>This is what Yahweh who made you, 
-</p><p class="q2">and formed you from the womb, 
-</p><p class="q2">who will help you says: 
-</p><p class="q1">“Don’t be afraid, Jacob my servant; 
-</p><p class="q2">and you, Jeshurun, whom I have chosen. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For I will pour water on him who is thirsty, 
-</p><p class="q2">and streams on the dry ground. 
-</p><p class="q1">I will pour my Spirit on your descendants, 
-</p><p class="q2">and my blessing on your offspring; 
-</p><p class="q1">
-<span class="v">4&#160;</span>and they will spring up among the grass, 
-</p><p class="q2">as willows by the watercourses. 
-</p><p class="q1">
-<span class="v">5&#160;</span>One will say, ‘I am Yahweh’s.’ 
-</p><p class="q2">Another will be called by the name of Jacob; 
-</p><p class="q2">and another will write with his hand ‘to Yahweh,’ 
-</p><p class="q2">and honor the name of Israel.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>This is what Yahweh, the King of Israel, 
-</p><p class="q2">and his Redeemer, Yahweh of Armies, says: 
-</p><p class="q1">“I am the first, and I am the last; 
-</p><p class="q2">and besides me there is no Elohim. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Who is like me? 
-</p><p class="q2">Who will call, 
-</p><p class="q2">and will declare it, 
-</p><p class="q2">and set it in order for me, 
-</p><p class="q2">since I established the ancient people? 
-</p><p class="q1">Let them declare the things that are coming, 
-</p><p class="q2">and that will happen. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Don’t fear, 
-</p><p class="q2">neither be afraid. 
-</p><p class="q1">Haven’t I declared it to you long ago, 
-</p><p class="q2">and shown it? 
-</p><p class="q1">You are my witnesses. 
-</p><p class="q2">Is there an Elohim besides me? 
-</p><p class="q1">Indeed, there is not. 
-</p><p class="q2">I don’t know any other Rock.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Everyone who makes a carved image is vain. 
-</p><p class="q2">The things that they delight in will not profit. 
-</p><p class="q2">Their own witnesses don’t see, nor know, that they may be disappointed. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Who has fashioned an elohim, 
-</p><p class="q2">or molds an image that is profitable for nothing? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Behold, all his fellows will be disappointed; 
-</p><p class="q2">and the workmen are mere men. 
-</p><p class="q1">Let them all be gathered together. 
-</p><p class="q2">Let them stand up. 
-</p><p class="q2">They will fear. 
-</p><p class="q2">They will be put to shame together. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>The blacksmith takes an ax, 
-</p><p class="q2">works in the coals, 
-</p><p class="q2">fashions it with hammers, 
-</p><p class="q2">and works it with his strong arm. 
-</p><p class="q1">He is hungry, 
-</p><p class="q2">and his strength fails; 
-</p><p class="q1">he drinks no water, 
-</p><p class="q2">and is faint. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The carpenter stretches out a line. 
-</p><p class="q2">He marks it out with a pencil. 
-</p><p class="q2">He shapes it with planes. 
-</p><p class="q2">He marks it out with compasses, 
-</p><p class="q2">and shapes it like the figure of a man, 
-</p><p class="q2">with the beauty of a man, 
-</p><p class="q2">to reside in a house. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He cuts down cedars for himself, 
-</p><p class="q2">and takes the cypress and the oak, 
-</p><p class="q2">and strengthens for himself one among the trees of the forest. 
-</p><p class="q1">He plants a cypress tree, 
-</p><p class="q2">and the rain nourishes it. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Then it will be for a man to burn; 
-</p><p class="q2">and he takes some of it and warms himself. 
-</p><p class="q2">Yes, he burns it and bakes bread. 
-</p><p class="q1">Yes, he makes an elohim and worships it; 
-</p><p class="q2">he makes it a carved image, and falls down to it. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He burns part of it in the fire. 
-</p><p class="q2">With part of it, he eats meat. 
-</p><p class="q2">He roasts a roast and is satisfied. 
-</p><p class="q1">Yes, he warms himself 
-</p><p class="q2">and says, “Aha! I am warm. I have seen the fire.” 
-</p><p class="q1">
-<span class="v">17&#160;</span>The rest of it he makes into an elohim, 
-</p><p class="q2">even his engraved image. 
-</p><p class="q1">He bows down to it and worships, 
-</p><p class="q2">and prays to it, and says, “Deliver me, for you are my elohim!” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>They don’t know, neither do they consider, 
-</p><p class="q2">for he has shut their eyes, that they can’t see, 
-</p><p class="q2">and their hearts, that they can’t understand. 
-</p><p class="q1">
-<span class="v">19&#160;</span>No one thinks, 
-</p><p class="q2">neither is there knowledge nor understanding to say, 
-</p><p class="q2">“I have burned part of it in the fire. 
-</p><p class="q2">Yes, I have also baked bread on its coals. 
-</p><p class="q2">I have roasted meat and eaten it. 
-</p><p class="q2">Shall I make the rest of it into an abomination? 
-</p><p class="q2">Shall I bow down to a tree trunk?” 
-</p><p class="q1">
-<span class="v">20&#160;</span>He feeds on ashes. 
-</p><p class="q2">A deceived heart has turned him aside; 
-</p><p class="q2">and he can’t deliver his soul, 
-</p><p class="q2">nor say, “Isn’t there a lie in my right hand?” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Remember these things, Jacob and Israel, 
-</p><p class="q2">for you are my servant. 
-</p><p class="q2">I have formed you. 
-</p><p class="q2">You are my servant. 
-</p><p class="q2">Israel, you will not be forgotten by me. 
-</p><p class="q1">
-<span class="v">22&#160;</span>I have blotted out, as a thick cloud, your transgressions, 
-</p><p class="q2">and, as a cloud, your sins. 
-</p><p class="q2">Return to me, for I have redeemed you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>Sing, you heavens, for Yahweh has done it! 
-</p><p class="q2">Shout, you lower parts of the earth! 
-</p><p class="q2">Break out into singing, you mountains, O forest, all of your trees, 
-</p><p class="q2">for Yahweh has redeemed Jacob, 
-</p><p class="q2">and will glorify himself in Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>Yahweh, your Redeemer, 
-</p><p class="q2">and he who formed you from the womb says: 
-</p><p class="q1">“I am Yahweh, who makes all things; 
-</p><p class="q2">who alone stretches out the heavens; 
-</p><p class="q2">who spreads out the earth by myself; 
-</p><p class="q1">
-<span class="v">25&#160;</span>who frustrates the signs of the liars, 
-</p><p class="q2">and makes diviners mad; 
-</p><p class="q1">who turns wise men backward, 
-</p><p class="q2">and makes their knowledge foolish; 
-</p><p class="q1">
-<span class="v">26&#160;</span>who confirms the word of his servant, 
-</p><p class="q2">and performs the counsel of his messengers; 
-</p><p class="q1">who says of Jerusalem, ‘She will be inhabited;’ 
-</p><p class="q2">and of the cities of Judah, ‘They will be built,’ 
-</p><p class="q2">and ‘I will raise up its waste places;’ 
-</p><p class="q1">
-<span class="v">27&#160;</span>who says to the deep, ‘Be dry,’ 
-</p><p class="q2">and ‘I will dry up your rivers,’ 
-</p><p class="q1">
-<span class="v">28&#160;</span>who says of Cyrus, ‘He is my shepherd, and shall perform all my pleasure,’ 
-</p><p class="q2">even saying of Jerusalem, ‘She will be built;’ 
-</p><p class="q2">and of the temple, ‘Your foundation will be laid.’&#160;” 
-</p><h2 class="chapterlabel" id="45">45</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh says to his anointed, to Cyrus, whose right hand I have held to subdue nations before him and strip kings of their armor, to open the doors before him, and the gates shall not be shut: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“I will go before you 
-</p><p class="q2">and make the rough places smooth. 
-</p><p class="q1">I will break the doors of bronze in pieces 
-</p><p class="q2">and cut apart the bars of iron. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I will give you the treasures of darkness 
-</p><p class="q2">and hidden riches of secret places, 
-</p><p class="q1">that you may know that it is I, Yahweh, who calls you by your name, 
-</p><p class="q2">even the Elohim of Israel. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For Jacob my servant’s sake, 
-</p><p class="q2">and Israel my chosen, 
-</p><p class="q1">I have called you by your name. 
-</p><p class="q2">I have given you a title, 
-</p><p class="q2">though you have not known me. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I am Yahweh, and there is no one else. 
-</p><p class="q2">Besides me, there is no Elohim. 
-</p><p class="q1">I will strengthen<span class="f">+ \fr 45:5 \ft or, equip</span> you, 
-</p><p class="q2">though you have not known me, 
-</p><p class="q1">
-<span class="v">6&#160;</span>that they may know from the rising of the sun, 
-</p><p class="q2">and from the west, 
-</p><p class="q1">that there is no one besides me. 
-</p><p class="q2">I am Yahweh, and there is no one else. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I form the light 
-</p><p class="q2">and create darkness. 
-</p><p class="q1">I make peace 
-</p><p class="q2">and create calamity. 
-</p><p class="q1">I am Yahweh, 
-</p><p class="q2">who does all these things. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Rain, you heavens, from above, 
-</p><p class="q2">and let the skies pour down righteousness. 
-</p><p class="q1">Let the earth open, that it may produce salvation, 
-</p><p class="q2">and let it cause righteousness to spring up with it. 
-</p><p class="q1">I, Yahweh, have created it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Woe to him who strives with his Maker—</p><p class="q2">a clay pot among the clay pots of the earth! 
-</p><p class="q1">Shall the clay ask him who fashions it, ‘What are you making?’ 
-</p><p class="q2">or your work, ‘He has no hands’? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Woe to him who says to a father, ‘What have you become the father of?’ 
-</p><p class="q2">or to a mother, ‘What have you given birth to?’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Yahweh, the Set-Apart One of Israel 
-</p><p class="q2">and his Maker says: 
-</p><p class="q1">“You ask me about the things that are to come, concerning my sons, 
-</p><p class="q2">and you command me concerning the work of my hands! 
-</p><p class="q1">
-<span class="v">12&#160;</span>I have made the earth, and created man on it. 
-</p><p class="q2">I, even my hands, have stretched out the heavens. 
-</p><p class="q2">I have commanded all their army. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I have raised him up in righteousness, 
-</p><p class="q2">and I will make all his ways straight. 
-</p><p class="q1">He shall build my city, 
-</p><p class="q2">and he shall let my exiles go free, 
-</p><p class="q2">not for price nor reward,” says Yahweh of Armies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>Yahweh says: “The labor of Egypt, 
-</p><p class="q2">and the merchandise of Ethiopia, 
-</p><p class="q2">and the Sabeans, men of stature, will come over to you, 
-</p><p class="q2">and they will be yours. 
-</p><p class="q1">They will go after you. 
-</p><p class="q2">They shall come over in chains. 
-</p><p class="q2">They will bow down to you. 
-</p><p class="q1">They will make supplication to you: 
-</p><p class="q2">‘Surely Elohim is in you; and there is no one else. 
-</p><p class="q2">There is no other elohim. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Most certainly you are an Elohim who has hidden yourself, 
-</p><p class="q2">Elohim of Israel, the Savior.’&#160;” 
-</p><p class="q1">
-<span class="v">16&#160;</span>They will be disappointed, 
-</p><p class="q2">yes, confounded, all of them. 
-</p><p class="q2">Those who are makers of idols will go into confusion together. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Israel will be saved by Yahweh with an everlasting salvation. 
-</p><p class="q2">You will not be disappointed nor confounded to ages everlasting. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>For Yahweh who created the heavens, 
-</p><p class="q2">the Elohim who formed the earth and made it, 
-</p><p class="q2">who established it and didn’t create it a waste, 
-</p><p class="q2">who formed it to be inhabited says: 
-</p><p class="q1">“I am Yahweh. 
-</p><p class="q2">There is no other. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I have not spoken in secret, 
-</p><p class="q2">in a place of the land of darkness. 
-</p><p class="q1">I didn’t say to the offspring of Jacob, ‘Seek me in vain.’ 
-</p><p class="q2">I, Yahweh, speak righteousness. 
-</p><p class="q2">I declare things that are right. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Assemble yourselves and come. 
-</p><p class="q2">Draw near together, you who have escaped from the nations. 
-</p><p class="q1">Those have no knowledge who carry the wood of their engraved image, 
-</p><p class="q2">and pray to an elohim that can’t save. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Declare and present it. 
-</p><p class="q2">Yes, let them take counsel together. 
-</p><p class="q1">Who has shown this from ancient time? 
-</p><p class="q2">Who has declared it of old? 
-</p><p class="q2">Haven’t I, Yahweh? 
-</p><p class="q1">There is no other Elohim besides me, a just Elohim and a Savior. 
-</p><p class="q2">There is no one besides me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“Look to me, and be saved, all the ends of the earth; 
-</p><p class="q2">for I am Elohim, and there is no other. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I have sworn by myself. 
-</p><p class="q2">The word has gone out of my mouth in righteousness, and will not be revoked, 
-</p><p class="q1">that to me every knee shall bow, 
-</p><p class="q2">every tongue shall take an oath. 
-</p><p class="q1">
-<span class="v">24&#160;</span>They will say of me, 
-</p><p class="q2">‘There is righteousness and strength only in Yahweh.’&#160;” 
-</p><p class="q1">Even to him will men come. 
-</p><p class="q2">All those who raged against him will be disappointed. 
-</p><p class="q1">
-<span class="v">25&#160;</span>All the offspring of Israel will be justified in Yahweh, 
-</p><p class="q2">and will rejoice! 
-</p><h2 class="chapterlabel" id="46">46</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Bel bows down. 
-</p><p class="q2">Nebo stoops. 
-</p><p class="q1">Their idols are carried by animals, 
-</p><p class="q2">and on the livestock. 
-</p><p class="q1">The things that you carried around are heavy loads, 
-</p><p class="q2">a burden for the weary. 
-</p><p class="q1">
-<span class="v">2&#160;</span>They stoop and they bow down together. 
-</p><p class="q2">They could not deliver the burden, 
-</p><p class="q2">but they have gone into captivity. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Listen to me, house of Jacob, 
-</p><p class="q2">and all the remnant of the house of Israel, 
-</p><p class="q2">that have been carried from their birth, 
-</p><p class="q2">that have been carried from the womb. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Even to old age I am he, 
-</p><p class="q2">and even to gray hairs I will carry you. 
-</p><p class="q1">I have made, and I will bear. 
-</p><p class="q2">Yes, I will carry, and will deliver. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“To whom will you compare me, and consider my equal, 
-</p><p class="q2">and compare me, as if we were the same? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Some pour out gold from the bag, 
-</p><p class="q2">and weigh silver in the balance. 
-</p><p class="q1">They hire a goldsmith, 
-</p><p class="q2">and he makes it an elohim. 
-</p><p class="q1">They fall down—</p><p class="q2">yes, they worship. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They bear it on their shoulder. 
-</p><p class="q2">They carry it, and set it in its place, and it stands there. 
-</p><p class="q2">It cannot move from its place. 
-</p><p class="q1">Yes, one may cry to it, yet it can not answer. 
-</p><p class="q2">It cannot save him out of his trouble. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Remember this, and show yourselves men. 
-</p><p class="q2">Bring it to mind again, you transgressors. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Remember the former things of old; 
-</p><p class="q2">for I am Elohim, and there is no other. 
-</p><p class="q2">I am Elohim, and there is none like me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I declare the end from the beginning, 
-</p><p class="q2">and from ancient times things that are not yet done. 
-</p><p class="q1">I say: My counsel will stand, 
-</p><p class="q2">and I will do all that I please. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I call a ravenous bird from the east, 
-</p><p class="q2">the man of my counsel from a far country. 
-</p><p class="q1">Yes, I have spoken. 
-</p><p class="q2">I will also bring it to pass. 
-</p><p class="q1">I have planned. 
-</p><p class="q2">I will also do it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Listen to me, you stubborn-hearted, 
-</p><p class="q2">who are far from righteousness! 
-</p><p class="q1">
-<span class="v">13&#160;</span>I bring my righteousness near. 
-</p><p class="q2">It is not far off, 
-</p><p class="q2">and my salvation will not wait. 
-</p><p class="q1">I will grant salvation to Zion, 
-</p><p class="q2">my glory to Israel. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>The wilderness and the dry land will be glad. 
+</div><div class="q2">The desert will rejoice and blossom like a rose. 
+</div><div class="q1">
+<sup>2&#160;</sup>It will blossom abundantly, 
+</div><div class="q2">and rejoice even with joy and singing. 
+</div><div class="q2">Lebanon’s glory will be given to it, 
+</div><div class="q2">the excellence of Carmel and Sharon. 
+</div><div class="q2">They will see Yahweh’s glory, 
+</div><div class="q2">the excellence of our Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>Strengthen the weak hands, 
+</div><div class="q2">and make the feeble knees firm. 
+</div><div class="q1">
+<sup>4&#160;</sup>Tell those who have a fearful heart, “Be strong! 
+</div><div class="q2">Don’t be afraid! 
+</div><div class="q1">Behold, your Elohim will come with vengeance, Elohim’s retribution. 
+</div><div class="q2">He will come and save you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Then the eyes of the blind will be opened, 
+</div><div class="q2">and the ears of the deaf will be unstopped. 
+</div><div class="q1">
+<sup>6&#160;</sup>Then the lame man will leap like a deer, 
+</div><div class="q2">and the tongue of the mute will sing; 
+</div><div class="q2">for waters will break out in the wilderness, 
+</div><div class="q2">and streams in the desert. 
+</div><div class="q1">
+<sup>7&#160;</sup>The burning sand will become a pool, 
+</div><div class="q2">and the thirsty ground springs of water. 
+</div><div class="q2">Grass with reeds and rushes will be in the habitation of jackals, where they lay. 
+</div><div class="q1">
+<sup>8&#160;</sup>A highway will be there, a road, 
+</div><div class="q2">and it will be called “The Set-Apart Way”. 
+</div><div class="q1">The unclean shall not pass over it, 
+</div><div class="q2">but it will be for those who walk in the Way. 
+</div><div class="q2">Wicked fools shall not go there. 
+</div><div class="q1">
+<sup>9&#160;</sup>No lion will be there, 
+</div><div class="q2">nor will any ravenous animal go up on it. 
+</div><div class="q2">They will not be found there; 
+</div><div class="q2">but the redeemed will walk there. 
+</div><div class="q1">
+<sup>10&#160;</sup>Then Yahweh’s ransomed ones will return, 
+</div><div class="q2">and come with singing to Zion; 
+</div><div class="q2">and everlasting joy will be on their heads. 
+</div><div class="q1">They will obtain gladness and joy, 
+</div><div class="q2">and sorrow and sighing will flee away.” 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>Now in the fourteenth year of King Hezekiah, Sennacherib king of Assyria attacked all of the fortified cities of Judah and captured them. 
+<sup>2&#160;</sup>The king of Assyria sent Rabshakeh from Lachish to Jerusalem to King Hezekiah with a large army. He stood by the aqueduct from the upper pool in the fuller’s field highway. 
+<sup>3&#160;</sup>Then Eliakim the son of Hilkiah, who was over the household, and Shebna the scribe, and Joah, the son of Asaph the recorder came out to him. 
+</div><div class="p">
+<sup>4&#160;</sup>Rabshakeh said to them, “Now tell Hezekiah, ‘The great king, the king of Assyria, says, “What confidence is this in which you trust? 
+<sup>5&#160;</sup>I say that your counsel and strength for the war are only vain words. Now in whom do you trust, that you have rebelled against me? 
+<sup>6&#160;</sup>Behold, you trust in the staff of this bruised reed, even in Egypt, which if a man leans on it, it will go into his hand and pierce it. So is Pharaoh king of Egypt to all who trust in him. 
+<sup>7&#160;</sup>But if you tell me, ‘We trust in Yahweh our Elohim,’ isn’t that he whose high places and whose altars Hezekiah has taken away, and has said to Judah and to Jerusalem, ‘You shall worship before this altar’?” 
+<sup>8&#160;</sup>Now therefore, please make a pledge to my master the king of Assyria, and I will give you two thousand horses, if you are able on your part to set riders on them. 
+<sup>9&#160;</sup>How then can you turn away the face of one captain of the least of my master’s servants, and put your trust in Egypt for chariots and for horsemen? 
+<sup>10&#160;</sup>Have I come up now without Yahweh against this land to destroy it? Yahweh said to me, “Go up against this land, and destroy it.”&#160;’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>Then Eliakim, Shebna and Joah said to Rabshakeh, “Please speak to your servants in Aramaic, for we understand it. Don’t speak to us in the Jews’ language in the hearing of the people who are on the wall.” 
+</div><div class="p">
+<sup>12&#160;</sup>But Rabshakeh said, “Has my master sent me only to your master and to you, to speak these words, and not to the men who sit on the wall, who will eat their own dung and drink their own urine with you?” 
+<sup>13&#160;</sup>Then Rabshakeh stood, and called out with a loud voice in the Jews’ language, and said, “Hear the words of the great king, the king of Assyria! 
+<sup>14&#160;</sup>The king says, ‘Don’t let Hezekiah deceive you; for he will not be able to deliver you. 
+<sup>15&#160;</sup>Don’t let Hezekiah make you trust in Yahweh, saying, “Yahweh will surely deliver us. This city won’t be given into the hand of the king of Assyria.”&#160;’ 
+<sup>16&#160;</sup>Don’t listen to Hezekiah, for the king of Assyria says, ‘Make your peace with me, and come out to me; and each of you eat from his vine, and each one from his fig tree, and each one of you drink the waters of his own cistern; 
+<sup>17&#160;</sup>until I come and take you away to a land like your own land, a land of grain and new wine, a land of bread and vineyards. 
+<sup>18&#160;</sup>Beware lest Hezekiah persuade you, saying, “Yahweh will deliver us.” Have any of the elohims of the nations delivered their lands from the hand of the king of Assyria? 
+<sup>19&#160;</sup>Where are the elohims of Hamath and Arpad? Where are the elohims of Sepharvaim? Have they delivered Samaria from my hand? 
+<sup>20&#160;</sup>Who are they among all the elohims of these countries that have delivered their country out of my hand, that Yahweh should deliver Jerusalem out of my hand?’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>But they remained silent, and said nothing in reply, for the king’s commandment was, “Don’t answer him.” 
+</div><div class="p">
+<sup>22&#160;</sup>Then Eliakim the son of Hilkiah, who was over the household, and Shebna the scribe, and Joah, the son of Asaph the recorder, came to Hezekiah with their clothes torn, and told him the words of Rabshakeh. 
+</div><h2 class="chapterlabel" id="37">37</h2>
+<div class="p">
+<sup>1&#160;</sup>When King Hezekiah heard it, he tore his clothes, covered himself with sackcloth, and went into Yahweh’s house. 
+<sup>2&#160;</sup>He sent Eliakim, who was over the household, and Shebna the scribe, and the elders of the priests, covered with sackcloth, to Isaiah the prophet, the son of Amoz. 
+<sup>3&#160;</sup>They said to him, “Hezekiah says, ‘Today is a day of trouble, and of rebuke, and of rejection; for the children have come to the birth, and there is no strength to give birth. 
+<sup>4&#160;</sup>It may be Yahweh your Elohim will hear the words of Rabshakeh, whom the king of Assyria his master has sent to defy the living Elohim, and will rebuke the words which Yahweh your Elohim has heard. Therefore lift up your prayer for the remnant that is left.’&#160;” 
+</div><div class="p">
+<sup>5&#160;</sup>So the servants of King Hezekiah came to Isaiah. 
+</div><div class="p">
+<sup>6&#160;</sup>Isaiah said to them, “Tell your master, ‘Yahweh says, “Don’t be afraid of the words that you have heard, with which the servants of the king of Assyria have blasphemed me. 
+<sup>7&#160;</sup>Behold, I will put a spirit in him and he will hear news, and will return to his own land. I will cause him to fall by the sword in his own land.”&#160;’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>So Rabshakeh returned, and found the king of Assyria warring against Libnah, for he heard that he had departed from Lachish. 
+<sup>9&#160;</sup>He heard news concerning Tirhakah king of Ethiopia, “He has come out to fight against you.” When he heard it, he sent messengers to Hezekiah, saying, 
+<sup>10&#160;</sup>“Thus you shall speak to Hezekiah king of Judah, saying, ‘Don’t let your Elohim in whom you trust deceive you, saying, “Jerusalem won’t be given into the hand of the king of Assyria.” 
+<sup>11&#160;</sup>Behold, you have heard what the kings of Assyria have done to all lands, by destroying them utterly. Shall you be delivered? 
+<sup>12&#160;</sup>Have the elohims of the nations delivered them, which my fathers have destroyed, Gozan, Haran, Rezeph, and the children of Eden who were in Telassar? 
+<sup>13&#160;</sup>Where is the king of Hamath, and the king of Arpad, and the king of the city of Sepharvaim, of Hena, and Ivvah?’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Hezekiah received the letter from the hand of the messengers and read it. Then Hezekiah went up to Yahweh’s house, and spread it before Yahweh. 
+<sup>15&#160;</sup>Hezekiah prayed to Yahweh, saying, 
+<sup>16&#160;</sup>“Yahweh of Armies, the Elohim of Israel, who is enthroned among the cherubim, you are the Elohim, even you alone, of all the kingdoms of the earth. You have made heaven and earth. 
+<sup>17&#160;</sup>Turn your ear, Yahweh, and hear. Open your eyes, Yahweh, and behold. Hear all of the words of Sennacherib, who has sent to defy the living Elohim. 
+<sup>18&#160;</sup>Truly, Yahweh, the kings of Assyria have destroyed all the countries and their land, 
+<sup>19&#160;</sup>and have cast their elohims into the fire; for they were no elohims, but the work of men’s hands, wood and stone; therefore they have destroyed them. 
+<sup>20&#160;</sup>Now therefore, Yahweh our Elohim, save us from his hand, that all the kingdoms of the earth may know that you are Yahweh, even you only.” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Isaiah the son of Amoz sent to Hezekiah, saying, “Yahweh, the Elohim of Israel says, ‘Because you have prayed to me against Sennacherib king of Assyria, 
+<sup>22&#160;</sup>this is the word which Yahweh has spoken concerning him: The virgin daughter of Zion has despised you and ridiculed you. The daughter of Jerusalem has shaken her head at you. 
+<sup>23&#160;</sup>Whom have you defied and blasphemed? Against whom have you exalted your voice and lifted up your eyes on high? Against the Set-Apart One of Israel. 
+<sup>24&#160;</sup>By your servants, you have defied the Lord, and have said, “With the multitude of my chariots I have come up to the height of the mountains, to the innermost parts of Lebanon. I will cut down its tall cedars and its choice cypress trees. I will enter into its farthest height, the forest of its fruitful field. 
+<sup>25&#160;</sup>I have dug and drunk water, and with the sole of my feet I will dry up all the rivers of Egypt.” 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘Have you not heard how I have done it long ago, and formed it in ancient times? Now I have brought it to pass, that it should be yours to destroy fortified cities, turning them into ruinous heaps. 
+<sup>27&#160;</sup>Therefore their inhabitants had little power. They were dismayed and confounded. They were like the grass of the field, and like the green herb, like the grass on the housetops, and like a field before its crop has grown. 
+<sup>28&#160;</sup>But I know your sitting down, your going out, your coming in, and your raging against me. 
+<sup>29&#160;</sup>Because of your raging against me, and because your arrogance has come up into my ears, therefore I will put my hook in your nose and my bridle in your lips, and I will turn you back by the way by which you came. 
+</div><div class="p">
+<sup>30&#160;</sup>“&#160;‘This shall be the sign to you: You will eat this year that which grows of itself, and in the second year that which springs from it; and in the third year sow and reap and plant vineyards, and eat their fruit. 
+<sup>31&#160;</sup>The remnant that is escaped of the house of Judah will again take root downward, and bear fruit upward. 
+<sup>32&#160;</sup>For out of Jerusalem a remnant will go out, and survivors will escape from Mount Zion. The zeal of Yahweh of Armies will perform this.’ 
+</div><div class="p">
+<sup>33&#160;</sup>“Therefore Yahweh says concerning the king of Assyria, ‘He will not come to this city, nor shoot an arrow there, neither will he come before it with shield, nor cast up a mound against it. 
+<sup>34&#160;</sup>He will return the way that he came, and he won’t come to this city,’ says Yahweh. 
+<sup>35&#160;</sup>‘For I will defend this city to save it, for my own sake, and for my servant David’s sake.’&#160;” 
+</div><div class="p">
+<sup>36&#160;</sup>Then Yahweh’s angel went out and struck one hundred and eighty-five thousand men in the camp of the Assyrians. When men arose early in the morning, behold, these were all dead bodies. 
+<sup>37&#160;</sup>So Sennacherib king of Assyria departed, went away, returned to Nineveh, and stayed there. 
+<sup>38&#160;</sup>As he was worshiping in the house of Nisroch his elohim, Adrammelech and Sharezer his sons struck him with the sword; and they escaped into the land of Ararat. Esar Haddon his son reigned in his place. 
+</div><h2 class="chapterlabel" id="38">38</h2>
+<div class="p">
+<sup>1&#160;</sup>In those days Hezekiah was sick and near death. Isaiah the prophet, the son of Amoz, came to him, and said to him, “Yahweh says, ‘Set your house in order, for you will die, and not live.’&#160;” 
+</div><div class="p">
+<sup>2&#160;</sup>Then Hezekiah turned his face to the wall and prayed to Yahweh, 
+<sup>3&#160;</sup>and said, “Remember now, Yahweh, I beg you, how I have walked before you in truth and with a perfect heart, and have done that which is good in your sight.” Then Hezekiah wept bitterly. 
+</div><div class="p">
+<sup>4&#160;</sup>Then Yahweh’s word came to Isaiah, saying, 
+<sup>5&#160;</sup>“Go, and tell Hezekiah, ‘Yahweh, the Elohim of David your father, says, “I have heard your prayer. I have seen your tears. Behold, I will add fifteen years to your life. 
+<sup>6&#160;</sup>I will deliver you and this city out of the hand of the king of Assyria, and I will defend this city. 
+<sup>7&#160;</sup>This shall be the sign to you from Yahweh, that Yahweh will do this thing that he has spoken. 
+<sup>8&#160;</sup>Behold, I will cause the shadow on the sundial, which has gone down on the sundial of Ahaz with the sun, to return backward ten steps.”&#160;’&#160;” So the sun returned ten steps on the sundial on which it had gone down. 
+</div><div class="p">
+<sup>9&#160;</sup>The writing of Hezekiah king of Judah, when he had been sick, and had recovered of his sickness: 
+</div><div class="q1">
+<sup>10&#160;</sup>I said, “In the middle of my life I go into the gates of Sheol. 
+</div><div class="q2">I am deprived of the residue of my years.” 
+</div><div class="q1">
+<sup>11&#160;</sup>I said, “I won’t see Yah, 
+</div><div class="q2">Yah in the land of the living. 
+</div><div class="q2">I will see man no more with the inhabitants of the world. 
+</div><div class="q1">
+<sup>12&#160;</sup>My dwelling is removed, 
+</div><div class="q2">and is carried away from me like a shepherd’s tent. 
+</div><div class="q1">I have rolled up my life like a weaver. 
+</div><div class="q2">He will cut me off from the loom. 
+</div><div class="q2">From day even to night you will make an end of me. 
+</div><div class="q1">
+<sup>13&#160;</sup>I waited patiently until morning. 
+</div><div class="q2">He breaks all my bones like a lion. 
+</div><div class="q2">From day even to night you will make an end of me. 
+</div><div class="q1">
+<sup>14&#160;</sup>I chattered like a swallow or a crane. 
+</div><div class="q2">I moaned like a dove. 
+</div><div class="q2">My eyes weaken looking upward. 
+</div><div class="q2">Lord, I am oppressed. 
+</div><div class="q2">Be my security.” 
+</div><div class="q1">
+<sup>15&#160;</sup>What will I say? 
+</div><div class="q2">He has both spoken to me, and himself has done it. 
+</div><div class="q2">I will walk carefully all my years because of the anguish of my soul. 
+</div><div class="q1">
+<sup>16&#160;</sup>Lord, men live by these things; 
+</div><div class="q2">and my spirit finds life in all of them. 
+</div><div class="q2">You restore me, and cause me to live. 
+</div><div class="q1">
+<sup>17&#160;</sup>Behold, for peace I had great anguish, 
+</div><div class="q2">but you have in love for my soul delivered it from the pit of corruption; 
+</div><div class="q2">for you have cast all my sins behind your back. 
+</div><div class="q1">
+<sup>18&#160;</sup>For Sheol can’t praise you. 
+</div><div class="q2">Death can’t celebrate you. 
+</div><div class="q1">Those who go down into the pit can’t hope for your truth. 
+</div><div class="q1">
+<sup>19&#160;</sup>The living, the living, he shall praise you, as I do today. 
+</div><div class="q2">The father shall make known your truth to the children. 
+</div><div class="q1">
+<sup>20&#160;</sup>Yahweh will save me. 
+</div><div class="q2">Therefore we will sing my songs with stringed instruments all the days of our life in Yahweh’s house. 
+</div><div class="p">
+<sup>21&#160;</sup>Now Isaiah had said, “Let them take a cake of figs, and lay it for a poultice on the boil, and he shall recover.” 
+<sup>22&#160;</sup>Hezekiah also had said, “What is the sign that I will go up to Yahweh’s house?” 
+</div><h2 class="chapterlabel" id="39">39</h2>
+<div class="p">
+<sup>1&#160;</sup>At that time, Merodach-baladan the son of Baladan, king of Babylon, sent letters and a present to Hezekiah, for he heard that he had been sick, and had recovered. 
+<sup>2&#160;</sup>Hezekiah was pleased with them, and showed them the house of his precious things, the silver, the gold, the spices, and the precious oil, and all the house of his armor, and all that was found in his treasures. There was nothing in his house, nor in all his dominion, that Hezekiah didn’t show them. 
+<sup>3&#160;</sup>Then Isaiah the prophet came to King Hezekiah, and asked him, “What did these men say? From where did they come to you?” 
+</div><div class="p">Hezekiah said, “They have come from a country far from me, even from Babylon.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then he asked, “What have they seen in your house?” 
+</div><div class="p">Hezekiah answered, “They have seen all that is in my house. There is nothing among my treasures that I have not shown them.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then Isaiah said to Hezekiah, “Hear the word of Yahweh of Armies: 
+<sup>6&#160;</sup>‘Behold, the days are coming when all that is in your house, and that which your fathers have stored up until today, will be carried to Babylon. Nothing will be left,’ says Yahweh. 
+<sup>7&#160;</sup>‘They will take away your sons who will issue from you, whom you shall father, and they will be eunuchs in the king of Babylon’s palace.’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Hezekiah said to Isaiah, “Yahweh’s word which you have spoken is good.” He said moreover, “For there will be peace and truth in my days.” 
+</div><h2 class="chapterlabel" id="40">40</h2>
+<div class="p">
+<sup>1&#160;</sup>“Comfort, comfort my people,” says your Elohim. 
+<sup>2&#160;</sup>“Speak comfortably to Jerusalem, and call out to her that her warfare is accomplished, that her iniquity is pardoned, that she has received of Yahweh’s hand double for all her sins.” 
+</div><div class="q1">
+<sup>3&#160;</sup>The voice of one who calls out, 
+</div><div class="q2">“Prepare the way of Yahweh in the wilderness! 
+</div><div class="q2">Make a level highway in the desert for our Elohim. 
+</div><div class="q1">
+<sup>4&#160;</sup>Every valley shall be exalted, 
+</div><div class="q2">and every mountain and hill shall be made low. 
+</div><div class="q2">The uneven shall be made level, 
+</div><div class="q2">and the rough places a plain. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh’s glory shall be revealed, 
+</div><div class="q2">and all flesh shall see it together; 
+</div><div class="q2">for the mouth of Yahweh has spoken it.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>The voice of one saying, “Cry out!” 
+</div><div class="q2">One said, “What shall I cry?” 
+</div><div class="q1">“All flesh is like grass, 
+</div><div class="q2">and all its glory is like the flower of the field. 
+</div><div class="q1">
+<sup>7&#160;</sup>The grass withers, 
+</div><div class="q2">the flower fades, 
+</div><div class="q2">because Yahweh’s breath blows on it. 
+</div><div class="q2">Surely the people are like grass. 
+</div><div class="q1">
+<sup>8&#160;</sup>The grass withers, 
+</div><div class="q2">the flower fades; 
+</div><div class="q2">but the word of our Elohim stands forever.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>You who tell good news to Zion, go up on a high mountain. 
+</div><div class="q2">You who tell good news to Jerusalem, lift up your voice with strength! 
+</div><div class="q2">Lift it up! Don’t be afraid! 
+</div><div class="q2">Say to the cities of Judah, “Behold, your Elohim!” 
+</div><div class="q1">
+<sup>10&#160;</sup>Behold, the Lord Yahweh will come as a mighty one, 
+</div><div class="q2">and his arm will rule for him. 
+</div><div class="q2">Behold, his reward is with him, 
+</div><div class="q2">and his recompense before him. 
+</div><div class="q1">
+<sup>11&#160;</sup>He will feed his flock like a shepherd. 
+</div><div class="q2">He will gather the lambs in his arm, 
+</div><div class="q2">and carry them in his bosom. 
+</div><div class="q2">He will gently lead those who have their young. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Who has measured the waters in the hollow of his hand, 
+</div><div class="q2">and marked off the sky with his span, 
+</div><div class="q2">and calculated the dust of the earth in a measuring basket, 
+</div><div class="q2">and weighed the mountains in scales, 
+</div><div class="q2">and the hills in a balance? 
+</div><div class="q1">
+<sup>13&#160;</sup>Who has directed Yahweh’s Spirit, 
+</div><div class="q2">or has taught him as his counselor? 
+</div><div class="q1">
+<sup>14&#160;</sup>Who did he take counsel with, 
+</div><div class="q2">and who instructed him, 
+</div><div class="q2">and taught him in the path of justice, 
+</div><div class="q2">and taught him knowledge, 
+</div><div class="q2">and showed him the way of understanding? 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, the nations are like a drop in a bucket, 
+</div><div class="q2">and are regarded as a speck of dust on a balance. 
+</div><div class="q2">Behold, he lifts up the islands like a very little thing. 
+</div><div class="q1">
+<sup>16&#160;</sup>Lebanon is not sufficient to burn, 
+</div><div class="q2">nor its animals sufficient for a burnt offering. 
+</div><div class="q1">
+<sup>17&#160;</sup>All the nations are like nothing before him. 
+</div><div class="q2">They are regarded by him as less than nothing, and vanity. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>To whom then will you liken Elohim? 
+</div><div class="q2">Or what likeness will you compare to him? 
+</div><div class="q1">
+<sup>19&#160;</sup>A workman has cast an image, 
+</div><div class="q2">and the goldsmith overlays it with gold, 
+</div><div class="q2">and casts silver chains for it. 
+</div><div class="q1">
+<sup>20&#160;</sup>He who is too impoverished for such an offering chooses a tree that will not rot. 
+</div><div class="q2">He seeks a skillful workman to set up a carved image for him that will not be moved. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Haven’t you known? 
+</div><div class="q2">Haven’t you heard? 
+</div><div class="q2">Haven’t you been told from the beginning? 
+</div><div class="q2">Haven’t you understood from the foundations of the earth? 
+</div><div class="q1">
+<sup>22&#160;</sup>It is he who sits above the circle of the earth, 
+</div><div class="q2">and its inhabitants are like grasshoppers; 
+</div><div class="q2">who stretches out the heavens like a curtain, 
+</div><div class="q2">and spreads them out like a tent to dwell in, 
+</div><div class="q2">
+<sup>23&#160;</sup>who brings princes to nothing, 
+</div><div class="q2">who makes the judges of the earth meaningless. 
+</div><div class="q1">
+<sup>24&#160;</sup>They are planted scarcely. 
+</div><div class="q2">They are sown scarcely. 
+</div><div class="q2">Their stock has scarcely taken root in the ground. 
+</div><div class="q2">He merely blows on them, and they wither, 
+</div><div class="q2">and the whirlwind takes them away as stubble. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>“To whom then will you liken me? 
+</div><div class="q2">Who is my equal?” says the Set-Apart One. 
+</div><div class="q1">
+<sup>26&#160;</sup>Lift up your eyes on high, 
+</div><div class="q2">and see who has created these, 
+</div><div class="q2">who brings out their army by number. 
+</div><div class="q2">He calls them all by name. 
+</div><div class="q2">By the greatness of his might, 
+</div><div class="q2">and because he is strong in power, 
+</div><div class="q2">not one is lacking. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>27&#160;</sup>Why do you say, Jacob, 
+</div><div class="q2">and speak, Israel, 
+</div><div class="q2">“My way is hidden from Yahweh, 
+</div><div class="q2">and the justice due me is disregarded by my Elohim”? 
+</div><div class="q1">
+<sup>28&#160;</sup>Haven’t you known? 
+</div><div class="q2">Haven’t you heard? 
+</div><div class="q2">The everlasting Elohim, Yahweh, 
+</div><div class="q2">the Creator of the ends of the earth, doesn’t faint. 
+</div><div class="q2">He isn’t weary. 
+</div><div class="q2">His understanding is unsearchable. 
+</div><div class="q1">
+<sup>29&#160;</sup>He gives power to the weak. 
+</div><div class="q2">He increases the strength of him who has no might. 
+</div><div class="q1">
+<sup>30&#160;</sup>Even the youths faint and get weary, 
+</div><div class="q2">and the young men utterly fall; 
+</div><div class="q2">
+<sup>31&#160;</sup>but those who wait for Yahweh will renew their strength. 
+</div><div class="q2">They will mount up with wings like eagles. 
+</div><div class="q2">They will run, and not be weary. 
+</div><div class="q2">They will walk, and not faint. 
+</div><h2 class="chapterlabel" id="41">41</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Keep silent before me, islands, 
+</div><div class="q2">and let the peoples renew their strength. 
+</div><div class="q1">Let them come near, 
+</div><div class="q2">then let them speak. 
+</div><div class="q2">Let’s meet together for judgment. 
+</div><div class="q1">
+<sup>2&#160;</sup>Who has raised up one from the east? 
+</div><div class="q2">Who called him to his feet in righteousness? 
+</div><div class="q2">He hands over nations to him 
+</div><div class="q2">and makes him rule over kings. 
+</div><div class="q2">He gives them like the dust to his sword, 
+</div><div class="q2">like the driven stubble to his bow. 
+</div><div class="q1">
+<sup>3&#160;</sup>He pursues them 
+</div><div class="q2">and passes by safely, 
+</div><div class="q2">even by a way that he had not gone with his feet. 
+</div><div class="q1">
+<sup>4&#160;</sup>Who has worked and done it, 
+</div><div class="q2">calling the generations from the beginning? 
+</div><div class="q2">I, Yahweh, the first, and with the last, I am he.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>The islands have seen, and fear. 
+</div><div class="q2">The ends of the earth tremble. 
+</div><div class="q2">They approach, and come. 
+</div><div class="q1">
+<sup>6&#160;</sup>Everyone helps his neighbor. 
+</div><div class="q2">They say to their brothers, “Be strong!” 
+</div><div class="q1">
+<sup>7&#160;</sup>So the carpenter encourages the goldsmith. 
+</div><div class="q2">He who smooths with the hammer encourages him who strikes the anvil, 
+</div><div class="q2">saying of the soldering, “It is good;” 
+</div><div class="q2">and he fastens it with nails, that it might not totter. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“But you, Israel, my servant, 
+</div><div class="q2">Jacob whom I have chosen, 
+</div><div class="q2">the offspring of Abraham my friend, 
+</div><div class="q2">
+<sup>9&#160;</sup>you whom I have taken hold of from the ends of the earth, 
+</div><div class="q2">and called from its corners, 
+</div><div class="q2">and said to you, ‘You are my servant. I have chosen you and have not cast you away.’ 
+</div><div class="q1">
+<sup>10&#160;</sup>Don’t you be afraid, for I am with you. 
+</div><div class="q2">Don’t be dismayed, for I am your Elohim. 
+</div><div class="q2">I will strengthen you. 
+</div><div class="q2">Yes, I will help you. 
+</div><div class="q2">Yes, I will uphold you with the right hand of my righteousness. 
+</div><div class="q1">
+<sup>11&#160;</sup>Behold, all those who are incensed against you will be disappointed and confounded. 
+</div><div class="q2">Those who strive with you will be like nothing, and shall perish. 
+</div><div class="q1">
+<sup>12&#160;</sup>You will seek them, and won’t find them, 
+</div><div class="q2">even those who contend with you. 
+</div><div class="q2">Those who war against you will be as nothing, 
+</div><div class="q2">as a nonexistent thing. 
+</div><div class="q1">
+<sup>13&#160;</sup>For I, Yahweh your Elohim, will hold your right hand, 
+</div><div class="q2">saying to you, ‘Don’t be afraid. 
+</div><div class="q2">I will help you.’ 
+</div><div class="q1">
+<sup>14&#160;</sup>Don’t be afraid, you worm Jacob, 
+</div><div class="q2">and you men of Israel. 
+</div><div class="q2">I will help you,” says Yahweh. 
+</div><div class="q2">“Your Redeemer is the Set-Apart One of Israel. 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, I have made you into a new sharp threshing instrument with teeth. 
+</div><div class="q2">You will thresh the mountains, 
+</div><div class="q2">and beat them small, 
+</div><div class="q2">and will make the hills like chaff. 
+</div><div class="q1">
+<sup>16&#160;</sup>You will winnow them, 
+</div><div class="q2">and the wind will carry them away, 
+</div><div class="q2">and the whirlwind will scatter them. 
+</div><div class="q1">You will rejoice in Yahweh. 
+</div><div class="q2">You will glory in the Set-Apart One of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>The poor and needy seek water, and there is none. 
+</div><div class="q2">Their tongue fails for thirst. 
+</div><div class="q1">I, Yahweh, will answer them. 
+</div><div class="q2">I, the Elohim of Israel, will not forsake them. 
+</div><div class="q1">
+<sup>18&#160;</sup>I will open rivers on the bare heights, 
+</div><div class="q2">and springs in the middle of the valleys. 
+</div><div class="q2">I will make the wilderness a pool of water, 
+</div><div class="q2">and the dry land springs of water. 
+</div><div class="q1">
+<sup>19&#160;</sup>I will put cedar, acacia, myrtle, and oil trees in the wilderness. 
+</div><div class="q2">I will set cypress trees, pine, and box trees together in the desert; 
+</div><div class="q2">
+<sup>20&#160;</sup>that they may see, know, consider, and understand together, 
+</div><div class="q2">that Yahweh’s hand has done this, 
+</div><div class="q2">and the Set-Apart One of Israel has created it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Produce your cause,” says Yahweh. 
+</div><div class="q2">“Bring out your strong reasons!” says the King of Jacob. 
+</div><div class="q1">
+<sup>22&#160;</sup>“Let them announce and declare to us what will happen! 
+</div><div class="q2">Declare the former things, what they are, 
+</div><div class="q2">that we may consider them, and know the latter end of them; 
+</div><div class="q2">or show us things to come. 
+</div><div class="q1">
+<sup>23&#160;</sup>Declare the things that are to come hereafter, 
+</div><div class="q2">that we may know that you are elohims. 
+</div><div class="q1">Yes, do good, or do evil, 
+</div><div class="q2">that we may be dismayed, 
+</div><div class="q2">and see it together. 
+</div><div class="q1">
+<sup>24&#160;</sup>Behold, you are nothing, 
+</div><div class="q2">and your work is nothing. 
+</div><div class="q2">He who chooses you is an abomination. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>“I have raised up one from the north, and he has come, 
+</div><div class="q2">from the rising of the sun, one who calls on my name, 
+</div><div class="q2">and he shall come on rulers as on mortar, 
+</div><div class="q2">and as the potter treads clay. 
+</div><div class="q1">
+<sup>26&#160;</sup>Who has declared it from the beginning, that we may know? 
+</div><div class="q2">and before, that we may say, ‘He is right’? 
+</div><div class="q1">Surely, there is no one who declares. 
+</div><div class="q2">Surely, there is no one who shows. 
+</div><div class="q2">Surely, there is no one who hears your words. 
+</div><div class="q1">
+<sup>27&#160;</sup>I am the first to say to Zion, ‘Behold, look at them;’ 
+</div><div class="q2">and I will give one who brings good news to Jerusalem. 
+</div><div class="q1">
+<sup>28&#160;</sup>When I look, there is no man, 
+</div><div class="q2">even among them there is no counselor who, when I ask, can answer a word. 
+</div><div class="q1">
+<sup>29&#160;</sup>Behold, all of their deeds are vanity and nothing. 
+</div><div class="q2">Their molten images are wind and confusion. 
+</div><h2 class="chapterlabel" id="42">42</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Behold, my servant, whom I uphold, 
+</div><div class="q2">my chosen, in whom my soul delights: 
+</div><div class="q2">I have put my Spirit on him. 
+</div><div class="q2">He will bring justice to the nations. 
+</div><div class="q1">
+<sup>2&#160;</sup>He will not shout, 
+</div><div class="q2">nor raise his voice, 
+</div><div class="q2">nor cause it to be heard in the street. 
+</div><div class="q1">
+<sup>3&#160;</sup>He won’t break a bruised reed. 
+</div><div class="q2">He won’t quench a dimly burning wick. 
+</div><div class="q2">He will faithfully bring justice. 
+</div><div class="q1">
+<sup>4&#160;</sup>He will not fail nor be discouraged, 
+</div><div class="q2">until he has set justice in the earth, 
+</div><div class="q2">and the islands wait for his law.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Elohim Yahweh, 
+</div><div class="q2">he who created the heavens and stretched them out, 
+</div><div class="q2">he who spread out the earth and that which comes out of it, 
+</div><div class="q2">he who gives breath to its people and spirit to those who walk in it, says: 
+</div><div class="q1">
+<sup>6&#160;</sup>“I, Yahweh, have called you in righteousness. 
+</div><div class="q2">I will hold your hand. 
+</div><div class="q2">I will keep you, 
+</div><div class="q2">and make you a covenant for the people, 
+</div><div class="q2">as a light for the nations, 
+</div><div class="q2">
+<sup>7&#160;</sup>to open the blind eyes, 
+</div><div class="q2">to bring the prisoners out of the dungeon, 
+</div><div class="q2">and those who sit in darkness out of the prison. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“I am Yahweh. 
+</div><div class="q2">That is my name. 
+</div><div class="q2">I will not give my glory to another, 
+</div><div class="q2">nor my praise to engraved images. 
+</div><div class="q1">
+<sup>9&#160;</sup>Behold, the former things have happened 
+</div><div class="q2">and I declare new things. 
+</div><div class="q2">I tell you about them before they come up.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Sing to Yahweh a new song, 
+</div><div class="q2">and his praise from the end of the earth, 
+</div><div class="q2">you who go down to the sea, 
+</div><div class="q2">and all that is therein, 
+</div><div class="q2">the islands and their inhabitants. 
+</div><div class="q1">
+<sup>11&#160;</sup>Let the wilderness and its cities raise their voices, 
+</div><div class="q2">with the villages that Kedar inhabits. 
+</div><div class="q2">Let the inhabitants of Sela sing. 
+</div><div class="q2">Let them shout from the top of the mountains! 
+</div><div class="q1">
+<sup>12&#160;</sup>Let them give glory to Yahweh, 
+</div><div class="q2">and declare his praise in the islands. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yahweh will go out like a mighty man. 
+</div><div class="q2">He will stir up zeal like a man of war. 
+</div><div class="q2">He will raise a war cry. 
+</div><div class="q2">Yes, he will shout aloud. 
+</div><div class="q2">He will triumph over his enemies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“I have been silent a long time. 
+</div><div class="q2">I have been quiet and restrained myself. 
+</div><div class="q2">Now I will cry out like a travailing woman. I will both gasp and pant. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will destroy mountains and hills, 
+</div><div class="q2">and dry up all their herbs. 
+</div><div class="q2">I will make the rivers islands, 
+</div><div class="q2">and will dry up the pools. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will bring the blind by a way that they don’t know. 
+</div><div class="q2">I will lead them in paths that they don’t know. 
+</div><div class="q2">I will make darkness light before them, 
+</div><div class="q2">and crooked places straight. 
+</div><div class="q2">I will do these things, 
+</div><div class="q2">and I will not forsake them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“Those who trust in engraved images, 
+</div><div class="q2">who tell molten images, 
+</div><div class="q2">‘You are our elohims,’ 
+</div><div class="q2">will be turned back. 
+</div><div class="q2">They will be utterly disappointed. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“Hear, you deaf, 
+</div><div class="q2">and look, you blind, 
+</div><div class="q2">that you may see. 
+</div><div class="q1">
+<sup>19&#160;</sup>Who is blind, but my servant? 
+</div><div class="q2">Or who is as deaf as my messenger whom I send? 
+</div><div class="q1">Who is as blind as he who is at peace, 
+</div><div class="q2">and as blind as Yahweh’s servant? 
+</div><div class="q1">
+<sup>20&#160;</sup>You see many things, but don’t observe. 
+</div><div class="q2">His ears are open, but he doesn’t listen. 
+</div><div class="q1">
+<sup>21&#160;</sup>It pleased Yahweh, for his righteousness’ sake, to magnify the law 
+</div><div class="q2">and make it honorable. 
+</div><div class="q1">
+<sup>22&#160;</sup>But this is a robbed and plundered people. 
+</div><div class="q2">All of them are snared in holes, 
+</div><div class="q2">and they are hidden in prisons. 
+</div><div class="q1">They have become captives, and no one delivers, 
+</div><div class="q2">and a plunder, and no one says, ‘Restore them!’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>Who is there among you who will give ear to this? 
+</div><div class="q2">Who will listen and hear for the time to come? 
+</div><div class="q1">
+<sup>24&#160;</sup>Who gave Jacob as plunder, 
+</div><div class="q2">and Israel to the robbers? 
+</div><div class="q2">Didn’t Yahweh, he against whom we have sinned? 
+</div><div class="q2">For they would not walk in his ways, 
+</div><div class="q2">and they disobeyed his law. 
+</div><div class="q1">
+<sup>25&#160;</sup>Therefore he poured the fierceness of his anger on him, 
+</div><div class="q2">and the strength of battle. 
+</div><div class="q1">It set him on fire all around, but he didn’t know. 
+</div><div class="q2">It burned him, but he didn’t take it to heart.” 
+</div><h2 class="chapterlabel" id="43">43</h2>
+<div class="q1">
+<sup>1&#160;</sup>But now Yahweh who created you, Jacob, 
+</div><div class="q2">and he who formed you, Israel, says: 
+</div><div class="q1">“Don’t be afraid, for I have redeemed you. 
+</div><div class="q2">I have called you by your name. 
+</div><div class="q2">You are mine. 
+</div><div class="q1">
+<sup>2&#160;</sup>When you pass through the waters, I will be with you, 
+</div><div class="q2">and through the rivers, they will not overflow you. 
+</div><div class="q1">When you walk through the fire, you will not be burned, 
+</div><div class="q2">and flame will not scorch you. 
+</div><div class="q1">
+<sup>3&#160;</sup>For I am Yahweh your Elohim, 
+</div><div class="q2">the Set-Apart One of Israel, 
+</div><div class="q2">your Savior. 
+</div><div class="q1">I have given Egypt as your ransom, 
+</div><div class="q2">Ethiopia and Seba in your place. 
+</div><div class="q1">
+<sup>4&#160;</sup>Since you have been precious and honored in my sight, 
+</div><div class="q2">and I have loved you, 
+</div><div class="q2">therefore I will give people in your place, 
+</div><div class="q2">and nations instead of your life. 
+</div><div class="q1">
+<sup>5&#160;</sup>Don’t be afraid, for I am with you. 
+</div><div class="q2">I will bring your offspring from the east, 
+</div><div class="q2">and gather you from the west. 
+</div><div class="q1">
+<sup>6&#160;</sup>I will tell the north, ‘Give them up!’ 
+</div><div class="q2">and tell the south, ‘Don’t hold them back! 
+</div><div class="q2">Bring my sons from far away, 
+</div><div class="q2">and my daughters from the ends of the earth—</div><div class="q1">
+<sup>7&#160;</sup>everyone who is called by my name, 
+</div><div class="q2">and whom I have created for my glory, 
+</div><div class="q2">whom I have formed, 
+</div><div class="q2">yes, whom I have made.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Bring out the blind people who have eyes, 
+</div><div class="q2">and the deaf who have ears. 
+</div><div class="q1">
+<sup>9&#160;</sup>Let all the nations be gathered together, 
+</div><div class="q2">and let the peoples be assembled. 
+</div><div class="q1">Who among them can declare this, 
+</div><div class="q2">and show us former things? 
+</div><div class="q1">Let them bring their witnesses, that they may be justified, 
+</div><div class="q2">or let them hear, and say, “That is true.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“You are my witnesses,” says Yahweh, 
+</div><div class="q2">“With my servant whom I have chosen; 
+</div><div class="q2">that you may know and believe me, 
+</div><div class="q2">and understand that I am he. 
+</div><div class="q1">Before me there was no Elohim formed, 
+</div><div class="q2">neither will there be after me. 
+</div><div class="q1">
+<sup>11&#160;</sup>I myself am Yahweh. 
+</div><div class="q2">Besides me, there is no savior. 
+</div><div class="q1">
+<sup>12&#160;</sup>I have declared, I have saved, and I have shown, 
+</div><div class="q2">and there was no strange elohim among you. 
+</div><div class="q1">Therefore you are my witnesses”, 
+</div><div class="q2">says Yahweh, “and I am Elohim. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yes, since the day was, I am he. 
+</div><div class="q2">There is no one who can deliver out of my hand. 
+</div><div class="q2">I will work, and who can hinder it?” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh, your Redeemer, the Set-Apart One of Israel says: “For your sake, I have sent to Babylon, and I will bring all of them down as fugitives, even the Chaldeans, in the ships of their rejoicing. 
+<sup>15&#160;</sup>I am Yahweh, your Set-Apart One, the Creator of Israel, your King.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh, who makes a way in the sea, 
+</div><div class="q2">and a path in the mighty waters, 
+</div><div class="q1">
+<sup>17&#160;</sup>who brings out the chariot and horse, 
+</div><div class="q2">the army and the mighty man 
+</div><div class="q2">(they lie down together, they shall not rise; 
+</div><div class="q2">they are extinct, they are quenched like a wick) says: 
+</div><div class="q1">
+<sup>18&#160;</sup>“Don’t remember the former things, 
+</div><div class="q2">and don’t consider the things of old. 
+</div><div class="q1">
+<sup>19&#160;</sup>Behold, I will do a new thing. 
+</div><div class="q2">It springs out now. 
+</div><div class="q2">Don’t you know it? 
+</div><div class="q1">I will even make a way in the wilderness, 
+</div><div class="q2">and rivers in the desert. 
+</div><div class="q1">
+<sup>20&#160;</sup>The animals of the field, the jackals and the ostriches, shall honor me, 
+</div><div class="q2">because I give water in the wilderness and rivers in the desert, 
+</div><div class="q2">to give drink to my people, my chosen, 
+</div><div class="q2">
+<sup>21&#160;</sup>the people which I formed for myself, 
+</div><div class="q2">that they might declare my praise. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>Yet you have not called on me, Jacob; 
+</div><div class="q2">but you have been weary of me, Israel. 
+</div><div class="q1">
+<sup>23&#160;</sup>You have not brought me any of your sheep for burnt offerings, 
+</div><div class="q2">neither have you honored me with your sacrifices. 
+</div><div class="q1">I have not burdened you with offerings, 
+</div><div class="q2">nor wearied you with frankincense. 
+</div><div class="q1">
+<sup>24&#160;</sup>You have bought me no sweet cane with money, 
+</div><div class="q2">nor have you filled me with the fat of your sacrifices, 
+</div><div class="q1">but you have burdened me with your sins. 
+</div><div class="q2">You have wearied me with your iniquities. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>I, even I, am he who blots out your transgressions for my own sake; 
+</div><div class="q2">and I will not remember your sins. 
+</div><div class="q1">
+<sup>26&#160;</sup>Put me in remembrance. 
+</div><div class="q2">Let us plead together. 
+</div><div class="q1">Declare your case, 
+</div><div class="q2">that you may be justified. 
+</div><div class="q1">
+<sup>27&#160;</sup>Your first father sinned, 
+</div><div class="q2">and your teachers have transgressed against me. 
+</div><div class="q1">
+<sup>28&#160;</sup>Therefore I will profane the princes of the sanctuary; 
+</div><div class="q2">and I will make Jacob a curse, 
+</div><div class="q2">and Israel an insult.” 
+</div><h2 class="chapterlabel" id="44">44</h2>
+<div class="q1">
+<sup>1&#160;</sup>Yet listen now, Jacob my servant, 
+</div><div class="q2">and Israel, whom I have chosen. 
+</div><div class="q1">
+<sup>2&#160;</sup>This is what Yahweh who made you, 
+</div><div class="q2">and formed you from the womb, 
+</div><div class="q2">who will help you says: 
+</div><div class="q1">“Don’t be afraid, Jacob my servant; 
+</div><div class="q2">and you, Jeshurun, whom I have chosen. 
+</div><div class="q1">
+<sup>3&#160;</sup>For I will pour water on him who is thirsty, 
+</div><div class="q2">and streams on the dry ground. 
+</div><div class="q1">I will pour my Spirit on your descendants, 
+</div><div class="q2">and my blessing on your offspring; 
+</div><div class="q1">
+<sup>4&#160;</sup>and they will spring up among the grass, 
+</div><div class="q2">as willows by the watercourses. 
+</div><div class="q1">
+<sup>5&#160;</sup>One will say, ‘I am Yahweh’s.’ 
+</div><div class="q2">Another will be called by the name of Jacob; 
+</div><div class="q2">and another will write with his hand ‘to Yahweh,’ 
+</div><div class="q2">and honor the name of Israel.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>This is what Yahweh, the King of Israel, 
+</div><div class="q2">and his Redeemer, Yahweh of Armies, says: 
+</div><div class="q1">“I am the first, and I am the last; 
+</div><div class="q2">and besides me there is no Elohim. 
+</div><div class="q1">
+<sup>7&#160;</sup>Who is like me? 
+</div><div class="q2">Who will call, 
+</div><div class="q2">and will declare it, 
+</div><div class="q2">and set it in order for me, 
+</div><div class="q2">since I established the ancient people? 
+</div><div class="q1">Let them declare the things that are coming, 
+</div><div class="q2">and that will happen. 
+</div><div class="q1">
+<sup>8&#160;</sup>Don’t fear, 
+</div><div class="q2">neither be afraid. 
+</div><div class="q1">Haven’t I declared it to you long ago, 
+</div><div class="q2">and shown it? 
+</div><div class="q1">You are my witnesses. 
+</div><div class="q2">Is there an Elohim besides me? 
+</div><div class="q1">Indeed, there is not. 
+</div><div class="q2">I don’t know any other Rock.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Everyone who makes a carved image is vain. 
+</div><div class="q2">The things that they delight in will not profit. 
+</div><div class="q2">Their own witnesses don’t see, nor know, that they may be disappointed. 
+</div><div class="q1">
+<sup>10&#160;</sup>Who has fashioned an elohim, 
+</div><div class="q2">or molds an image that is profitable for nothing? 
+</div><div class="q1">
+<sup>11&#160;</sup>Behold, all his fellows will be disappointed; 
+</div><div class="q2">and the workmen are mere men. 
+</div><div class="q1">Let them all be gathered together. 
+</div><div class="q2">Let them stand up. 
+</div><div class="q2">They will fear. 
+</div><div class="q2">They will be put to shame together. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>The blacksmith takes an ax, 
+</div><div class="q2">works in the coals, 
+</div><div class="q2">fashions it with hammers, 
+</div><div class="q2">and works it with his strong arm. 
+</div><div class="q1">He is hungry, 
+</div><div class="q2">and his strength fails; 
+</div><div class="q1">he drinks no water, 
+</div><div class="q2">and is faint. 
+</div><div class="q1">
+<sup>13&#160;</sup>The carpenter stretches out a line. 
+</div><div class="q2">He marks it out with a pencil. 
+</div><div class="q2">He shapes it with planes. 
+</div><div class="q2">He marks it out with compasses, 
+</div><div class="q2">and shapes it like the figure of a man, 
+</div><div class="q2">with the beauty of a man, 
+</div><div class="q2">to reside in a house. 
+</div><div class="q1">
+<sup>14&#160;</sup>He cuts down cedars for himself, 
+</div><div class="q2">and takes the cypress and the oak, 
+</div><div class="q2">and strengthens for himself one among the trees of the forest. 
+</div><div class="q1">He plants a cypress tree, 
+</div><div class="q2">and the rain nourishes it. 
+</div><div class="q1">
+<sup>15&#160;</sup>Then it will be for a man to burn; 
+</div><div class="q2">and he takes some of it and warms himself. 
+</div><div class="q2">Yes, he burns it and bakes bread. 
+</div><div class="q1">Yes, he makes an elohim and worships it; 
+</div><div class="q2">he makes it a carved image, and falls down to it. 
+</div><div class="q1">
+<sup>16&#160;</sup>He burns part of it in the fire. 
+</div><div class="q2">With part of it, he eats meat. 
+</div><div class="q2">He roasts a roast and is satisfied. 
+</div><div class="q1">Yes, he warms himself 
+</div><div class="q2">and says, “Aha! I am warm. I have seen the fire.” 
+</div><div class="q1">
+<sup>17&#160;</sup>The rest of it he makes into an elohim, 
+</div><div class="q2">even his engraved image. 
+</div><div class="q1">He bows down to it and worships, 
+</div><div class="q2">and prays to it, and says, “Deliver me, for you are my elohim!” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>They don’t know, neither do they consider, 
+</div><div class="q2">for he has shut their eyes, that they can’t see, 
+</div><div class="q2">and their hearts, that they can’t understand. 
+</div><div class="q1">
+<sup>19&#160;</sup>No one thinks, 
+</div><div class="q2">neither is there knowledge nor understanding to say, 
+</div><div class="q2">“I have burned part of it in the fire. 
+</div><div class="q2">Yes, I have also baked bread on its coals. 
+</div><div class="q2">I have roasted meat and eaten it. 
+</div><div class="q2">Shall I make the rest of it into an abomination? 
+</div><div class="q2">Shall I bow down to a tree trunk?” 
+</div><div class="q1">
+<sup>20&#160;</sup>He feeds on ashes. 
+</div><div class="q2">A deceived heart has turned him aside; 
+</div><div class="q2">and he can’t deliver his soul, 
+</div><div class="q2">nor say, “Isn’t there a lie in my right hand?” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Remember these things, Jacob and Israel, 
+</div><div class="q2">for you are my servant. 
+</div><div class="q2">I have formed you. 
+</div><div class="q2">You are my servant. 
+</div><div class="q2">Israel, you will not be forgotten by me. 
+</div><div class="q1">
+<sup>22&#160;</sup>I have blotted out, as a thick cloud, your transgressions, 
+</div><div class="q2">and, as a cloud, your sins. 
+</div><div class="q2">Return to me, for I have redeemed you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>Sing, you heavens, for Yahweh has done it! 
+</div><div class="q2">Shout, you lower parts of the earth! 
+</div><div class="q2">Break out into singing, you mountains, O forest, all of your trees, 
+</div><div class="q2">for Yahweh has redeemed Jacob, 
+</div><div class="q2">and will glorify himself in Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>Yahweh, your Redeemer, 
+</div><div class="q2">and he who formed you from the womb says: 
+</div><div class="q1">“I am Yahweh, who makes all things; 
+</div><div class="q2">who alone stretches out the heavens; 
+</div><div class="q2">who spreads out the earth by myself; 
+</div><div class="q1">
+<sup>25&#160;</sup>who frustrates the signs of the liars, 
+</div><div class="q2">and makes diviners mad; 
+</div><div class="q1">who turns wise men backward, 
+</div><div class="q2">and makes their knowledge foolish; 
+</div><div class="q1">
+<sup>26&#160;</sup>who confirms the word of his servant, 
+</div><div class="q2">and performs the counsel of his messengers; 
+</div><div class="q1">who says of Jerusalem, ‘She will be inhabited;’ 
+</div><div class="q2">and of the cities of Judah, ‘They will be built,’ 
+</div><div class="q2">and ‘I will raise up its waste places;’ 
+</div><div class="q1">
+<sup>27&#160;</sup>who says to the deep, ‘Be dry,’ 
+</div><div class="q2">and ‘I will dry up your rivers,’ 
+</div><div class="q1">
+<sup>28&#160;</sup>who says of Cyrus, ‘He is my shepherd, and shall perform all my pleasure,’ 
+</div><div class="q2">even saying of Jerusalem, ‘She will be built;’ 
+</div><div class="q2">and of the temple, ‘Your foundation will be laid.’&#160;” 
+</div><h2 class="chapterlabel" id="45">45</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh says to his anointed, to Cyrus, whose right hand I have held to subdue nations before him and strip kings of their armor, to open the doors before him, and the gates shall not be shut: 
+</div><div class="q1">
+<sup>2&#160;</sup>“I will go before you 
+</div><div class="q2">and make the rough places smooth. 
+</div><div class="q1">I will break the doors of bronze in pieces 
+</div><div class="q2">and cut apart the bars of iron. 
+</div><div class="q1">
+<sup>3&#160;</sup>I will give you the treasures of darkness 
+</div><div class="q2">and hidden riches of secret places, 
+</div><div class="q1">that you may know that it is I, Yahweh, who calls you by your name, 
+</div><div class="q2">even the Elohim of Israel. 
+</div><div class="q1">
+<sup>4&#160;</sup>For Jacob my servant’s sake, 
+</div><div class="q2">and Israel my chosen, 
+</div><div class="q1">I have called you by your name. 
+</div><div class="q2">I have given you a title, 
+</div><div class="q2">though you have not known me. 
+</div><div class="q1">
+<sup>5&#160;</sup>I am Yahweh, and there is no one else. 
+</div><div class="q2">Besides me, there is no Elohim. 
+</div><div class="q1">I will strengthen you, 
+</div><div class="q2">though you have not known me, 
+</div><div class="q1">
+<sup>6&#160;</sup>that they may know from the rising of the sun, 
+</div><div class="q2">and from the west, 
+</div><div class="q1">that there is no one besides me. 
+</div><div class="q2">I am Yahweh, and there is no one else. 
+</div><div class="q1">
+<sup>7&#160;</sup>I form the light 
+</div><div class="q2">and create darkness. 
+</div><div class="q1">I make peace 
+</div><div class="q2">and create calamity. 
+</div><div class="q1">I am Yahweh, 
+</div><div class="q2">who does all these things. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Rain, you heavens, from above, 
+</div><div class="q2">and let the skies pour down righteousness. 
+</div><div class="q1">Let the earth open, that it may produce salvation, 
+</div><div class="q2">and let it cause righteousness to spring up with it. 
+</div><div class="q1">I, Yahweh, have created it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Woe to him who strives with his Maker—</div><div class="q2">a clay pot among the clay pots of the earth! 
+</div><div class="q1">Shall the clay ask him who fashions it, ‘What are you making?’ 
+</div><div class="q2">or your work, ‘He has no hands’? 
+</div><div class="q1">
+<sup>10&#160;</sup>Woe to him who says to a father, ‘What have you become the father of?’ 
+</div><div class="q2">or to a mother, ‘What have you given birth to?’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Yahweh, the Set-Apart One of Israel 
+</div><div class="q2">and his Maker says: 
+</div><div class="q1">“You ask me about the things that are to come, concerning my sons, 
+</div><div class="q2">and you command me concerning the work of my hands! 
+</div><div class="q1">
+<sup>12&#160;</sup>I have made the earth, and created man on it. 
+</div><div class="q2">I, even my hands, have stretched out the heavens. 
+</div><div class="q2">I have commanded all their army. 
+</div><div class="q1">
+<sup>13&#160;</sup>I have raised him up in righteousness, 
+</div><div class="q2">and I will make all his ways straight. 
+</div><div class="q1">He shall build my city, 
+</div><div class="q2">and he shall let my exiles go free, 
+</div><div class="q2">not for price nor reward,” says Yahweh of Armies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>Yahweh says: “The labor of Egypt, 
+</div><div class="q2">and the merchandise of Ethiopia, 
+</div><div class="q2">and the Sabeans, men of stature, will come over to you, 
+</div><div class="q2">and they will be yours. 
+</div><div class="q1">They will go after you. 
+</div><div class="q2">They shall come over in chains. 
+</div><div class="q2">They will bow down to you. 
+</div><div class="q1">They will make supplication to you: 
+</div><div class="q2">‘Surely Elohim is in you; and there is no one else. 
+</div><div class="q2">There is no other elohim. 
+</div><div class="q1">
+<sup>15&#160;</sup>Most certainly you are an Elohim who has hidden yourself, 
+</div><div class="q2">Elohim of Israel, the Savior.’&#160;” 
+</div><div class="q1">
+<sup>16&#160;</sup>They will be disappointed, 
+</div><div class="q2">yes, confounded, all of them. 
+</div><div class="q2">Those who are makers of idols will go into confusion together. 
+</div><div class="q1">
+<sup>17&#160;</sup>Israel will be saved by Yahweh with an everlasting salvation. 
+</div><div class="q2">You will not be disappointed nor confounded to ages everlasting. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>For Yahweh who created the heavens, 
+</div><div class="q2">the Elohim who formed the earth and made it, 
+</div><div class="q2">who established it and didn’t create it a waste, 
+</div><div class="q2">who formed it to be inhabited says: 
+</div><div class="q1">“I am Yahweh. 
+</div><div class="q2">There is no other. 
+</div><div class="q1">
+<sup>19&#160;</sup>I have not spoken in secret, 
+</div><div class="q2">in a place of the land of darkness. 
+</div><div class="q1">I didn’t say to the offspring of Jacob, ‘Seek me in vain.’ 
+</div><div class="q2">I, Yahweh, speak righteousness. 
+</div><div class="q2">I declare things that are right. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Assemble yourselves and come. 
+</div><div class="q2">Draw near together, you who have escaped from the nations. 
+</div><div class="q1">Those have no knowledge who carry the wood of their engraved image, 
+</div><div class="q2">and pray to an elohim that can’t save. 
+</div><div class="q1">
+<sup>21&#160;</sup>Declare and present it. 
+</div><div class="q2">Yes, let them take counsel together. 
+</div><div class="q1">Who has shown this from ancient time? 
+</div><div class="q2">Who has declared it of old? 
+</div><div class="q2">Haven’t I, Yahweh? 
+</div><div class="q1">There is no other Elohim besides me, a just Elohim and a Savior. 
+</div><div class="q2">There is no one besides me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“Look to me, and be saved, all the ends of the earth; 
+</div><div class="q2">for I am Elohim, and there is no other. 
+</div><div class="q1">
+<sup>23&#160;</sup>I have sworn by myself. 
+</div><div class="q2">The word has gone out of my mouth in righteousness, and will not be revoked, 
+</div><div class="q1">that to me every knee shall bow, 
+</div><div class="q2">every tongue shall take an oath. 
+</div><div class="q1">
+<sup>24&#160;</sup>They will say of me, 
+</div><div class="q2">‘There is righteousness and strength only in Yahweh.’&#160;” 
+</div><div class="q1">Even to him will men come. 
+</div><div class="q2">All those who raged against him will be disappointed. 
+</div><div class="q1">
+<sup>25&#160;</sup>All the offspring of Israel will be justified in Yahweh, 
+</div><div class="q2">and will rejoice! 
+</div><h2 class="chapterlabel" id="46">46</h2>
+<div class="q1">
+<sup>1&#160;</sup>Bel bows down. 
+</div><div class="q2">Nebo stoops. 
+</div><div class="q1">Their idols are carried by animals, 
+</div><div class="q2">and on the livestock. 
+</div><div class="q1">The things that you carried around are heavy loads, 
+</div><div class="q2">a burden for the weary. 
+</div><div class="q1">
+<sup>2&#160;</sup>They stoop and they bow down together. 
+</div><div class="q2">They could not deliver the burden, 
+</div><div class="q2">but they have gone into captivity. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Listen to me, house of Jacob, 
+</div><div class="q2">and all the remnant of the house of Israel, 
+</div><div class="q2">that have been carried from their birth, 
+</div><div class="q2">that have been carried from the womb. 
+</div><div class="q1">
+<sup>4&#160;</sup>Even to old age I am he, 
+</div><div class="q2">and even to gray hairs I will carry you. 
+</div><div class="q1">I have made, and I will bear. 
+</div><div class="q2">Yes, I will carry, and will deliver. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“To whom will you compare me, and consider my equal, 
+</div><div class="q2">and compare me, as if we were the same? 
+</div><div class="q1">
+<sup>6&#160;</sup>Some pour out gold from the bag, 
+</div><div class="q2">and weigh silver in the balance. 
+</div><div class="q1">They hire a goldsmith, 
+</div><div class="q2">and he makes it an elohim. 
+</div><div class="q1">They fall down—</div><div class="q2">yes, they worship. 
+</div><div class="q1">
+<sup>7&#160;</sup>They bear it on their shoulder. 
+</div><div class="q2">They carry it, and set it in its place, and it stands there. 
+</div><div class="q2">It cannot move from its place. 
+</div><div class="q1">Yes, one may cry to it, yet it can not answer. 
+</div><div class="q2">It cannot save him out of his trouble. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Remember this, and show yourselves men. 
+</div><div class="q2">Bring it to mind again, you transgressors. 
+</div><div class="q1">
+<sup>9&#160;</sup>Remember the former things of old; 
+</div><div class="q2">for I am Elohim, and there is no other. 
+</div><div class="q2">I am Elohim, and there is none like me. 
+</div><div class="q1">
+<sup>10&#160;</sup>I declare the end from the beginning, 
+</div><div class="q2">and from ancient times things that are not yet done. 
+</div><div class="q1">I say: My counsel will stand, 
+</div><div class="q2">and I will do all that I please. 
+</div><div class="q1">
+<sup>11&#160;</sup>I call a ravenous bird from the east, 
+</div><div class="q2">the man of my counsel from a far country. 
+</div><div class="q1">Yes, I have spoken. 
+</div><div class="q2">I will also bring it to pass. 
+</div><div class="q1">I have planned. 
+</div><div class="q2">I will also do it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Listen to me, you stubborn-hearted, 
+</div><div class="q2">who are far from righteousness! 
+</div><div class="q1">
+<sup>13&#160;</sup>I bring my righteousness near. 
+</div><div class="q2">It is not far off, 
+</div><div class="q2">and my salvation will not wait. 
+</div><div class="q1">I will grant salvation to Zion, 
+</div><div class="q2">my glory to Israel. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="47">47</h2>
-<p>
-<span class="v">1&#160;</span>“Come down and sit in the dust, virgin daughter of Babylon. 
-</p><p class="q2">Sit on the ground without a throne, daughter of the Chaldeans. 
-</p><p class="q2">For you will no longer be called tender and delicate. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Take the millstones and grind flour. 
-</p><p class="q2">Remove your veil, lift up your skirt, uncover your legs, 
-</p><p class="q2">and wade through the rivers. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Your nakedness will be uncovered. 
-</p><p class="q2">Yes, your shame will be seen. 
-</p><p class="q1">I will take vengeance, 
-</p><p class="q2">and will spare no one.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>Our Redeemer, Yahweh of Armies is his name, 
-</p><p class="q2">is the Set-Apart One of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Sit in silence, and go into darkness, 
-</p><p class="q2">daughter of the Chaldeans. 
-</p><p class="q1">For you shall no longer be called 
-</p><p class="q2">the mistress of kingdoms. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I was angry with my people. 
-</p><p class="q2">I profaned my inheritance 
-</p><p class="q2">and gave them into your hand. 
-</p><p class="q1">You showed them no mercy. 
-</p><p class="q2">You laid a very heavy yoke on the aged. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You said, ‘I will be a princess forever,’ 
-</p><p class="q2">so that you didn’t lay these things to your heart, 
-</p><p class="q2">nor did you remember the results. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Now therefore hear this, you who are given to pleasures, 
-</p><p class="q2">who sit securely, 
-</p><p class="q1">who say in your heart, 
-</p><p class="q2">‘I am, and there is no one else besides me. 
-</p><p class="q1">I won’t sit as a widow, 
-</p><p class="q2">neither will I know the loss of children.’ 
-</p><p class="q1">
-<span class="v">9&#160;</span>But these two things will come to you in a moment in one day: 
-</p><p class="q2">the loss of children and widowhood. 
-</p><p class="q1">They will come on you in their full measure, 
-</p><p class="q2">in the multitude of your sorceries, 
-</p><p class="q2">and the great abundance of your enchantments. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For you have trusted in your wickedness. 
-</p><p class="q2">You have said, ‘No one sees me.’ 
-</p><p class="q1">Your wisdom and your knowledge has perverted you. 
-</p><p class="q2">You have said in your heart, ‘I am, and there is no one else besides me.’ 
-</p><p class="q1">
-<span class="v">11&#160;</span>Therefore disaster will come on you. 
-</p><p class="q2">You won’t know when it dawns. 
-</p><p class="q1">Mischief will fall on you. 
-</p><p class="q2">You won’t be able to put it away. 
-</p><p class="q1">Desolation will come on you suddenly, 
-</p><p class="q2">which you don’t understand. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Stand now with your enchantments 
-</p><p class="q2">and with the multitude of your sorceries, 
-</p><p class="q2">in which you have labored from your youth, 
-</p><p class="q1">as if you might profit, 
-</p><p class="q2">as if you might prevail. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You are wearied in the multitude of your counsels. 
-</p><p class="q2">Now let the astrologers, the stargazers, and the monthly prognosticators stand up and save you from the things that will happen to you. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Behold, they are like stubble. 
-</p><p class="q2">The fire will burn them. 
-</p><p class="q2">They won’t deliver themselves from the power of the flame. 
-</p><p class="q1">It won’t be a coal to warm at 
-</p><p class="q2">or a fire to sit by. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The things that you labored in will be like this: 
-</p><p class="q2">those who have trafficked with you from your youth will each wander in his own way. 
-</p><p class="q2">There will be no one to save you. 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>“Come down and sit in the dust, virgin daughter of Babylon. 
+</div><div class="q2">Sit on the ground without a throne, daughter of the Chaldeans. 
+</div><div class="q2">For you will no longer be called tender and delicate. 
+</div><div class="q1">
+<sup>2&#160;</sup>Take the millstones and grind flour. 
+</div><div class="q2">Remove your veil, lift up your skirt, uncover your legs, 
+</div><div class="q2">and wade through the rivers. 
+</div><div class="q1">
+<sup>3&#160;</sup>Your nakedness will be uncovered. 
+</div><div class="q2">Yes, your shame will be seen. 
+</div><div class="q1">I will take vengeance, 
+</div><div class="q2">and will spare no one.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>Our Redeemer, Yahweh of Armies is his name, 
+</div><div class="q2">is the Set-Apart One of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Sit in silence, and go into darkness, 
+</div><div class="q2">daughter of the Chaldeans. 
+</div><div class="q1">For you shall no longer be called 
+</div><div class="q2">the mistress of kingdoms. 
+</div><div class="q1">
+<sup>6&#160;</sup>I was angry with my people. 
+</div><div class="q2">I profaned my inheritance 
+</div><div class="q2">and gave them into your hand. 
+</div><div class="q1">You showed them no mercy. 
+</div><div class="q2">You laid a very heavy yoke on the aged. 
+</div><div class="q1">
+<sup>7&#160;</sup>You said, ‘I will be a princess forever,’ 
+</div><div class="q2">so that you didn’t lay these things to your heart, 
+</div><div class="q2">nor did you remember the results. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Now therefore hear this, you who are given to pleasures, 
+</div><div class="q2">who sit securely, 
+</div><div class="q1">who say in your heart, 
+</div><div class="q2">‘I am, and there is no one else besides me. 
+</div><div class="q1">I won’t sit as a widow, 
+</div><div class="q2">neither will I know the loss of children.’ 
+</div><div class="q1">
+<sup>9&#160;</sup>But these two things will come to you in a moment in one day: 
+</div><div class="q2">the loss of children and widowhood. 
+</div><div class="q1">They will come on you in their full measure, 
+</div><div class="q2">in the multitude of your sorceries, 
+</div><div class="q2">and the great abundance of your enchantments. 
+</div><div class="q1">
+<sup>10&#160;</sup>For you have trusted in your wickedness. 
+</div><div class="q2">You have said, ‘No one sees me.’ 
+</div><div class="q1">Your wisdom and your knowledge has perverted you. 
+</div><div class="q2">You have said in your heart, ‘I am, and there is no one else besides me.’ 
+</div><div class="q1">
+<sup>11&#160;</sup>Therefore disaster will come on you. 
+</div><div class="q2">You won’t know when it dawns. 
+</div><div class="q1">Mischief will fall on you. 
+</div><div class="q2">You won’t be able to put it away. 
+</div><div class="q1">Desolation will come on you suddenly, 
+</div><div class="q2">which you don’t understand. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Stand now with your enchantments 
+</div><div class="q2">and with the multitude of your sorceries, 
+</div><div class="q2">in which you have labored from your youth, 
+</div><div class="q1">as if you might profit, 
+</div><div class="q2">as if you might prevail. 
+</div><div class="q1">
+<sup>13&#160;</sup>You are wearied in the multitude of your counsels. 
+</div><div class="q2">Now let the astrologers, the stargazers, and the monthly prognosticators stand up and save you from the things that will happen to you. 
+</div><div class="q1">
+<sup>14&#160;</sup>Behold, they are like stubble. 
+</div><div class="q2">The fire will burn them. 
+</div><div class="q2">They won’t deliver themselves from the power of the flame. 
+</div><div class="q1">It won’t be a coal to warm at 
+</div><div class="q2">or a fire to sit by. 
+</div><div class="q1">
+<sup>15&#160;</sup>The things that you labored in will be like this: 
+</div><div class="q2">those who have trafficked with you from your youth will each wander in his own way. 
+</div><div class="q2">There will be no one to save you. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="48">48</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Hear this, house of Jacob, 
-</p><p class="q2">you who are called by the name of Israel, 
-</p><p class="q2">and have come out of the waters of Judah. 
-</p><p class="q1">You swear by Yahweh’s name, 
-</p><p class="q2">and make mention of the Elohim of Israel, 
-</p><p class="q2">but not in truth, nor in righteousness—</p><p class="q1">
-<span class="v">2&#160;</span>for they call themselves citizens of the set-apart city, 
-</p><p class="q2">and rely on the Elohim of Israel; 
-</p><p class="q2">Yahweh of Armies is his name. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I have declared the former things from of old. 
-</p><p class="q2">Yes, they went out of my mouth, and I revealed them. 
-</p><p class="q2">I did them suddenly, and they happened. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Because I knew that you are obstinate, 
-</p><p class="q2">and your neck is an iron sinew, 
-</p><p class="q2">and your brow bronze; 
-</p><p class="q1">
-<span class="v">5&#160;</span>therefore I have declared it to you from of old; 
-</p><p class="q2">before it came to pass I showed it to you; 
-</p><p class="q2">lest you should say, ‘My idol has done them. 
-</p><p class="q2">My engraved image and my molten image has commanded them.’ 
-</p><p class="q1">
-<span class="v">6&#160;</span>You have heard it. 
-</p><p class="q2">Now see all this. 
-</p><p class="q2">And you, won’t you declare it? 
-</p><div class="b"> &#160; </div>
-<p class="q1">“I have shown you new things from this time, 
-</p><p class="q2">even hidden things, which you have not known. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They are created now, and not from of old. 
-</p><p class="q2">Before today, you didn’t hear them, 
-</p><p class="q2">lest you should say, ‘Behold, I knew them.’ 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yes, you didn’t hear. 
-</p><p class="q2">Yes, you didn’t know. 
-</p><p class="q2">Yes, from of old your ear was not opened, 
-</p><p class="q1">for I knew that you dealt very treacherously, 
-</p><p class="q2">and were called a transgressor from the womb. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For my name’s sake, I will defer my anger, 
-</p><p class="q2">and for my praise, I hold it back for you 
-</p><p class="q2">so that I don’t cut you off. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Behold, I have refined you, 
-</p><p class="q2">but not as silver. 
-</p><p class="q2">I have chosen you in the furnace of affliction. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For my own sake, 
-</p><p class="q2">for my own sake, I will do it; 
-</p><p class="q1">for how would my name be profaned? 
-</p><p class="q2">I will not give my glory to another. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Listen to me, O Jacob, 
-</p><p class="q2">and Israel my called: 
-</p><p class="q1">I am he. 
-</p><p class="q2">I am the first. 
-</p><p class="q2">I am also the last. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yes, my hand has laid the foundation of the earth, 
-</p><p class="q2">and my right hand has spread out the heavens. 
-</p><p class="q2">when I call to them, they stand up together. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“Assemble yourselves, all of you, and hear! 
-</p><p class="q2">Who among them has declared these things? 
-</p><p class="q1">He whom Yahweh loves will do what he likes to Babylon, 
-</p><p class="q2">and his arm will be against the Chaldeans. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I, even I, have spoken. 
-</p><p class="q2">Yes, I have called him. 
-</p><p class="q1">I have brought him 
-</p><p class="q2">and he shall make his way prosperous. 
-</p><p>
-<span class="v">16&#160;</span>“Come near to me and hear this: 
-</p><div class="b"> &#160; </div>
-<p class="q1">“From the beginning I have not spoken in secret; 
-</p><p class="q2">from the time that it happened, I was there.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">Now the Lord Yahweh has sent me 
-</p><p class="q2">with his Spirit. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Yahweh, 
-</p><p class="q2">your Redeemer, 
-</p><p class="q2">the Set-Apart One of Israel, says: 
-</p><p class="q1">“I am Yahweh your Elohim, 
-</p><p class="q2">who teaches you to profit, 
-</p><p class="q2">who leads you by the way that you should go. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Oh that you had listened to my commandments! 
-</p><p class="q2">Then your peace would have been like a river 
-</p><p class="q2">and your righteousness like the waves of the sea. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Your offspring also would have been as the sand 
-</p><p class="q2">and the descendants of your body like its grains. 
-</p><p class="q2">His name would not be cut off nor destroyed from before me.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>Leave Babylon! 
-</p><p class="q2">Flee from the Chaldeans! 
-</p><p class="q1">With the sound of joyful shouting announce this, 
-</p><p class="q2">tell it even to the end of the earth; 
-</p><p class="q2">say, “Yahweh has redeemed his servant Jacob!” 
-</p><p class="q1">
-<span class="v">21&#160;</span>They didn’t thirst when he led them through the deserts. 
-</p><p class="q2">He caused the waters to flow out of the rock for them. 
-</p><p class="q2">He also split the rock and the waters gushed out. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“There is no peace”, says Yahweh, “for the wicked.” 
-</p><h2 class="chapterlabel" id="49">49</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Listen, islands, to me. 
-</p><p class="q2">Listen, you peoples, from afar: 
-</p><p class="q1">Yahweh has called me from the womb; 
-</p><p class="q2">from the inside of my mother, he has mentioned my name. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He has made my mouth like a sharp sword. 
-</p><p class="q2">He has hidden me in the shadow of his hand. 
-</p><p class="q1">He has made me a polished shaft. 
-</p><p class="q2">He has kept me close in his quiver. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He said to me, “You are my servant, 
-</p><p class="q2">Israel, in whom I will be glorified.” 
-</p><p class="q1">
-<span class="v">4&#160;</span>But I said, “I have labored in vain. 
-</p><p class="q2">I have spent my strength in vain for nothing; 
-</p><p class="q1">yet surely the justice due to me is with Yahweh, 
-</p><p class="q2">and my reward with my Elohim.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Now Yahweh, he who formed me from the womb to be his servant, 
-</p><p class="q2">says to bring Jacob again to him, 
-</p><p class="q2">and to gather Israel to him, 
-</p><p class="q2">for I am honorable in Yahweh’s eyes, 
-</p><p class="q2">and my Elohim has become my strength. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Indeed, he says, “It is too light a thing that you should be my servant to raise up the tribes of Jacob, 
-</p><p class="q2">and to restore the preserved of Israel. 
-</p><p class="q1">I will also give you as a light to the nations, 
-</p><p class="q2">that you may be my salvation to the end of the earth.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh, the Redeemer of Israel, and his Set-Apart One, 
-</p><p class="q2">says to him whom man despises, to him whom the nation abhors, to a servant of rulers: 
-</p><p class="q1">“Kings shall see and rise up, 
-</p><p class="q2">princes, and they shall worship, 
-</p><p class="q2">because of Yahweh who is faithful, even the Set-Apart One of Israel, who has chosen you.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Yahweh says, “I have answered you in an acceptable time. 
-</p><p class="q2">I have helped you in a day of salvation. 
-</p><p class="q1">I will preserve you and give you for a covenant of the people, 
-</p><p class="q2">to raise up the land, to make them inherit the desolate heritage, 
-</p><p class="q1">
-<span class="v">9&#160;</span>saying to those who are bound, ‘Come out!’; 
-</p><p class="q2">to those who are in darkness, ‘Show yourselves!’ 
-</p><p class="q1">“They shall feed along the paths, 
-</p><p class="q2">and their pasture shall be on all treeless heights. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They shall not hunger nor thirst; 
-</p><p class="q2">neither shall the heat nor sun strike them, 
-</p><p class="q2">for he who has mercy on them will lead them. 
-</p><p class="q2">He will guide them by springs of water. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I will make all my mountains a road, 
-</p><p class="q2">and my highways shall be exalted. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Behold, these shall come from afar, 
-</p><p class="q2">and behold, these from the north and from the west, 
-</p><p class="q2">and these from the land of Sinim.” 
-</p><p class="q1">
-<span class="v">13&#160;</span>Sing, heavens, and be joyful, earth! 
-</p><p class="q2">Break out into singing, mountains! 
-</p><p class="q1">For Yahweh has comforted his people, 
-</p><p class="q2">and will have compassion on his afflicted. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>But Zion said, “Yahweh has forsaken me, 
-</p><p class="q2">and the Lord has forgotten me.” 
-</p><p class="q1">
-<span class="v">15&#160;</span>“Can a woman forget her nursing child, 
-</p><p class="q2">that she should not have compassion on the son of her womb? 
-</p><p class="q1">Yes, these may forget, 
-</p><p class="q2">yet I will not forget you! 
-</p><p class="q1">
-<span class="v">16&#160;</span>Behold, I have engraved you on the palms of my hands. 
-</p><p class="q2">Your walls are continually before me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Your children hurry. 
-</p><p class="q2">Your destroyers and those who devastated you will leave you. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Lift up your eyes all around, and see: 
-</p><p class="q2">all these gather themselves together, and come to you. 
-</p><p class="q1">As I live,” says Yahweh, “you shall surely clothe yourself with them all as with an ornament, 
-</p><p class="q2">and dress yourself with them, like a bride. 
-</p><p class="q1">
-<span class="v">19&#160;</span>“For, as for your waste and your desolate places, 
-</p><p class="q2">and your land that has been destroyed, 
-</p><p class="q1">surely now that land will be too small for the inhabitants, 
-</p><p class="q2">and those who swallowed you up will be far away. 
-</p><p class="q1">
-<span class="v">20&#160;</span>The children of your bereavement will say in your ears, 
-</p><p class="q2">‘This place is too small for me. 
-</p><p class="q2">Give me a place to live in.’ 
-</p><p class="q1">
-<span class="v">21&#160;</span>Then you will say in your heart, ‘Who has conceived these for me, since I have been bereaved of my children 
-</p><p class="q2">and am alone, an exile, and wandering back and forth? 
-</p><p class="q1">Who has brought these up? 
-</p><p class="q2">Behold, I was left alone. Where were these?’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>The Lord Yahweh says, “Behold, I will lift up my hand to the nations, 
-</p><p class="q2">and lift up my banner to the peoples. 
-</p><p class="q1">They shall bring your sons in their bosom, 
-</p><p class="q2">and your daughters shall be carried on their shoulders. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Kings shall be your foster fathers, 
-</p><p class="q2">and their queens your nursing mothers. 
-</p><p class="q1">They will bow down to you with their faces to the earth, 
-</p><p class="q2">and lick the dust of your feet. 
-</p><p class="q1">Then you will know that I am Yahweh; 
-</p><p class="q2">and those who wait for me won’t be disappointed.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>Shall the plunder be taken from the mighty, 
-</p><p class="q2">or the lawful captives be delivered? 
-</p><p class="q1">
-<span class="v">25&#160;</span>But Yahweh says, “Even the captives of the mighty shall be taken away, 
-</p><p class="q2">and the plunder retrieved from the fierce, 
-</p><p class="q1">for I will contend with him who contends with you 
-</p><p class="q2">and I will save your children. 
-</p><p class="q1">
-<span class="v">26&#160;</span>I will feed those who oppress you with their own flesh; 
-</p><p class="q2">and they will be drunk on their own blood, as with sweet wine. 
-</p><p class="q1">Then all flesh shall know that I, Yahweh, am your Savior 
-</p><p class="q2">and your Redeemer, the Mighty One of Jacob.” 
-</p><h2 class="chapterlabel" id="50">50</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Yahweh says, “Where is the bill of your mother’s divorce, with which I have put her away? 
-</p><p class="q2">Or to which of my creditors have I sold you? 
-</p><p class="q1">Behold, you were sold for your iniquities, 
-</p><p class="q2">and your mother was put away for your transgressions. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Why, when I came, was there no one? 
-</p><p class="q2">When I called, why was there no one to answer? 
-</p><p class="q1">Is my hand shortened at all, that it can’t redeem? 
-</p><p class="q2">Or have I no power to deliver? 
-</p><p class="q1">Behold, at my rebuke I dry up the sea. 
-</p><p class="q2">I make the rivers a wilderness. 
-</p><p class="q2">Their fish stink because there is no water, and die of thirst. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I clothe the heavens with blackness. 
-</p><p class="q2">I make sackcloth their covering.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>The Lord Yahweh has given me the tongue of those who are taught, 
-</p><p class="q2">that I may know how to sustain with words him who is weary. 
-</p><p class="q1">He awakens morning by morning, 
-</p><p class="q2">he awakens my ear to hear as those who are taught. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The Lord Yahweh has opened my ear. 
-</p><p class="q2">I was not rebellious. 
-</p><p class="q2">I have not turned back. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I gave my back to those who beat me, 
-</p><p class="q2">and my cheeks to those who plucked off the hair. 
-</p><p class="q2">I didn’t hide my face from shame and spitting. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For the Lord Yahweh will help me. 
-</p><p class="q2">Therefore I have not been confounded. 
-</p><p class="q1">Therefore I have set my face like a flint, 
-</p><p class="q2">and I know that I won’t be disappointed. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He who justifies me is near. 
-</p><p class="q2">Who will bring charges against me? 
-</p><p class="q1">Let us stand up together. 
-</p><p class="q2">Who is my adversary? 
-</p><p class="q2">Let him come near to me. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Behold, the Lord Yahweh will help me! 
-</p><p class="q2">Who is he who will condemn me? 
-</p><p class="q1">Behold, they will all grow old like a garment. 
-</p><p class="q2">The moths will eat them up. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Who among you fears Yahweh 
-</p><p class="q2">and obeys the voice of his servant? 
-</p><p class="q1">He who walks in darkness 
-</p><p class="q2">and has no light, 
-</p><p class="q1">let him trust in Yahweh’s name, 
-</p><p class="q2">and rely on his Elohim. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Behold, all you who kindle a fire, 
-</p><p class="q2">who adorn yourselves with torches around yourselves, 
-</p><p class="q1">walk in the flame of your fire, 
-</p><p class="q2">and among the torches that you have kindled. 
-</p><p class="q1">You will have this from my hand: 
-</p><p class="q2">you will lie down in sorrow. 
-</p><h2 class="chapterlabel" id="51">51</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Listen to me, you who follow after righteousness, 
-</p><p class="q2">you who seek Yahweh. 
-</p><p class="q1">Look to the rock you were cut from, 
-</p><p class="q2">and to the quarry you were dug from. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Look to Abraham your father, 
-</p><p class="q2">and to Sarah who bore you; 
-</p><p class="q1">for when he was but one I called him, 
-</p><p class="q2">I blessed him, 
-</p><p class="q2">and made him many. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For Yahweh has comforted Zion. 
-</p><p class="q2">He has comforted all her waste places, 
-</p><p class="q2">and has made her wilderness like Eden, 
-</p><p class="q2">and her desert like the garden of Yahweh. 
-</p><p class="q1">Joy and gladness will be found in them, 
-</p><p class="q2">thanksgiving, and the voice of melody. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Listen to me, my people; 
-</p><p class="q2">and hear me, my nation, 
-</p><p class="q1">for a law will go out from me, 
-</p><p class="q2">and I will establish my justice for a light to the peoples. 
-</p><p class="q1">
-<span class="v">5&#160;</span>My righteousness is near. 
-</p><p class="q2">My salvation has gone out, 
-</p><p class="q2">and my arms will judge the peoples. 
-</p><p class="q1">The islands will wait for me, 
-</p><p class="q2">and they will trust my arm. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Lift up your eyes to the heavens, 
-</p><p class="q2">and look at the earth beneath; 
-</p><p class="q1">for the heavens will vanish away like smoke, 
-</p><p class="q2">and the earth will wear out like a garment. 
-</p><p class="q1">Its inhabitants will die in the same way, 
-</p><p class="q2">but my salvation will be forever, 
-</p><p class="q2">and my righteousness will not be abolished. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Listen to me, you who know righteousness, 
-</p><p class="q2">the people in whose heart is my law. 
-</p><p class="q1">Don’t fear the reproach of men, 
-</p><p class="q2">and don’t be dismayed at their insults. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For the moth will eat them up like a garment, 
-</p><p class="q2">and the worm will eat them like wool; 
-</p><p class="q1">but my righteousness will be forever, 
-</p><p class="q2">and my salvation to all generations.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Awake, awake, put on strength, arm of Yahweh! 
-</p><p class="q2">Awake, as in the days of old, 
-</p><p class="q2">the generations of ancient times. 
-</p><p class="q1">Isn’t it you who cut Rahab in pieces, 
-</p><p class="q2">who pierced the monster? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Isn’t it you who dried up the sea, 
-</p><p class="q2">the waters of the great deep; 
-</p><p class="q2">who made the depths of the sea a way for the redeemed to pass over? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Those ransomed by Yahweh will return, 
-</p><p class="q2">and come with singing to Zion. 
-</p><p class="q2">Everlasting joy shall be on their heads. 
-</p><p class="q1">They will obtain gladness and joy. 
-</p><p class="q2">Sorrow and sighing shall flee away. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“I, even I, am he who comforts you. 
-</p><p class="q2">Who are you, that you are afraid of man who shall die, 
-</p><p class="q2">and of the son of man who will be made as grass? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Have you forgotten Yahweh your Maker, 
-</p><p class="q2">who stretched out the heavens, 
-</p><p class="q2">and laid the foundations of the earth? 
-</p><p class="q1">Do you live in fear continually all day because of the fury of the oppressor, 
-</p><p class="q2">when he prepares to destroy? 
-</p><p class="q2">Where is the fury of the oppressor? 
-</p><p class="q1">
-<span class="v">14&#160;</span>The captive exile will speedily be freed. 
-</p><p class="q2">He will not die and go down into the pit. 
-</p><p class="q2">His bread won’t fail. 
-</p><p class="q1">
-<span class="v">15&#160;</span>For I am Yahweh your Elohim, who stirs up the sea 
-</p><p class="q2">so that its waves roar. 
-</p><p class="q2">Yahweh of Armies is his name. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I have put my words in your mouth 
-</p><p class="q2">and have covered you in the shadow of my hand, 
-</p><p class="q1">that I may plant the heavens, 
-</p><p class="q2">and lay the foundations of the earth, 
-</p><p class="q2">and tell Zion, ‘You are my people.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Awake, awake! 
-</p><p class="q2">Stand up, Jerusalem, 
-</p><p class="q2">you who have drunk from Yahweh’s hand the cup of his wrath. 
-</p><p class="q1">You have drunken the bowl of the cup of staggering, 
-</p><p class="q2">and drained it. 
-</p><p class="q1">
-<span class="v">18&#160;</span>There is no one to guide her among all the sons to whom she has given birth; 
-</p><p class="q2">and there is no one who takes her by the hand among all the sons whom she has brought up. 
-</p><p class="q1">
-<span class="v">19&#160;</span>These two things have happened to you—</p><p class="q2">who will grieve with you?—</p><p class="q1">desolation and destruction, 
-</p><p class="q2">and famine and the sword. 
-</p><p class="q2">How can I comfort you? 
-</p><p class="q1">
-<span class="v">20&#160;</span>Your sons have fainted. 
-</p><p class="q2">They lie at the head of all the streets, 
-</p><p class="q2">like an antelope in a net. 
-</p><p class="q1">They are full of Yahweh’s wrath, 
-</p><p class="q2">the rebuke of your Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Therefore now hear this, you afflicted, 
-</p><p class="q2">and drunken, but not with wine: 
-</p><p class="q1">
-<span class="v">22&#160;</span>Your Lord Yahweh, 
-</p><p class="q2">your Elohim who pleads the cause of his people, says, 
-</p><p class="q1">“Behold, I have taken out of your hand the cup of staggering, 
-</p><p class="q2">even the bowl of the cup of my wrath. 
-</p><p class="q2">You will not drink it any more. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I will put it into the hand of those who afflict you, 
-</p><p class="q2">who have said to your soul, ‘Bow down, that we may walk over you;’ 
-</p><p class="q2">and you have laid your back as the ground, 
-</p><p class="q2">like a street to those who walk over.” 
-</p><h2 class="chapterlabel" id="52">52</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Awake, awake! Put on your strength, Zion. 
-</p><p class="q2">Put on your beautiful garments, Jerusalem, the set-apart city, 
-</p><p class="q2">for from now on the uncircumcised and the unclean will no more come into you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Shake yourself from the dust! 
-</p><p class="q2">Arise, sit up, Jerusalem! 
-</p><p class="q2">Release yourself from the bonds of your neck, captive daughter of Zion! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>For Yahweh says, “You were sold for nothing; 
-</p><p class="q2">and you will be redeemed without money.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">4&#160;</span>For the Lord Yahweh says: 
-</p><p class="q1">“My people went down at the first into Egypt to live there; 
-</p><p class="q2">and the Assyrian has oppressed them without cause. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Now therefore, what do I do here,” says Yahweh, 
-</p><p class="q2">“seeing that my people are taken away for nothing? 
-</p><p class="q1">Those who rule over them mock,” says Yahweh, 
-</p><p class="q2">“and my name is blasphemed continually all day long. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Therefore my people shall know my name. 
-</p><p class="q2">Therefore they shall know in that day that I am he who speaks. 
-</p><p class="q2">Behold, it is I.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>How beautiful on the mountains are the feet of him who brings good news, 
-</p><p class="q2">who publishes peace, 
-</p><p class="q2">who brings good news, 
-</p><p class="q2">who proclaims salvation, 
-</p><p class="q2">who says to Zion, “Your Elohim reigns!” 
-</p><p class="q1">
-<span class="v">8&#160;</span>Your watchmen lift up their voice. 
-</p><p class="q2">Together they sing; 
-</p><p class="q2">for they shall see eye to eye when Yahweh returns to Zion. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Break out into joy! 
-</p><p class="q2">Sing together, you waste places of Jerusalem; 
-</p><p class="q2">for Yahweh has comforted his people. 
-</p><p class="q2">He has redeemed Jerusalem. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Yahweh has made his set-apart arm bare in the eyes of all the nations. 
-</p><p class="q2">All the ends of the earth have seen the salvation of our Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Depart! Depart! Go out from there! Touch no unclean thing! 
-</p><p class="q2">Go out from among her! 
-</p><p class="q2">Cleanse yourselves, you who carry Yahweh’s vessels. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For you shall not go out in haste, 
-</p><p class="q2">neither shall you go by flight; 
-</p><p class="q1">for Yahweh will go before you, 
-</p><p class="q2">and the Elohim of Israel will be your rear guard. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Behold, my servant will deal wisely. 
-</p><p class="q2">He will be exalted and lifted up, 
-</p><p class="q2">and will be very high. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Just as many were astonished at you—</p><p class="q2">his appearance was marred more than any man, and his form more than the sons of men—</p><p class="q1">
-<span class="v">15&#160;</span>so he will cleanse<span class="f">+ \fr 52:15 \ft or, sprinkle</span> many nations. 
-</p><p class="q2">Kings will shut their mouths at him; 
-</p><p class="q2">for they will see that which had not been told them, 
-</p><p class="q2">and they will understand that which they had not heard. 
-</p><h2 class="chapterlabel" id="53">53</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Who has believed our message? 
-</p><p class="q2">To whom has Yahweh’s arm been revealed? 
-</p><p class="q1">
-<span class="v">2&#160;</span>For he grew up before him as a tender plant, 
-</p><p class="q2">and as a root out of dry ground. 
-</p><p class="q1">He has no good looks or majesty. 
-</p><p class="q2">When we see him, there is no beauty that we should desire him. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He was despised 
-</p><p class="q2">and rejected by men, 
-</p><p class="q1">a man of suffering 
-</p><p class="q2">and acquainted with disease. 
-</p><p class="q1">He was despised as one from whom men hide their face; 
-</p><p class="q2">and we didn’t respect him. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>Surely he has borne our sickness 
-</p><p class="q2">and carried our suffering; 
-</p><p class="q1">yet we considered him plagued, 
-</p><p class="q2">struck by Elohim, and afflicted. 
-</p><p class="q1">
-<span class="v">5&#160;</span>But he was pierced for our transgressions. 
-</p><p class="q2">He was crushed for our iniquities. 
-</p><p class="q1">The punishment that brought our peace was on him; 
-</p><p class="q2">and by his wounds we are healed. 
-</p><p class="q1">
-<span class="v">6&#160;</span>All we like sheep have gone astray. 
-</p><p class="q2">Everyone has turned to his own way; 
-</p><p class="q2">and Yahweh has laid on him the iniquity of us all. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>He was oppressed, 
-</p><p class="q2">yet when he was afflicted he didn’t open his mouth. 
-</p><p class="q1">As a lamb that is led to the slaughter, 
-</p><p class="q2">and as a sheep that before its shearers is silent, 
-</p><p class="q2">so he didn’t open his mouth. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He was taken away by oppression and judgment. 
-</p><p class="q2">As for his generation, 
-</p><p class="q2">who considered that he was cut off out of the land of the living 
-</p><p class="q2">and stricken for the disobedience of my people? 
-</p><p class="q1">
-<span class="v">9&#160;</span>They made his grave with the wicked, 
-</p><p class="q2">and with a rich man in his death, 
-</p><p class="q1">although he had done no violence, 
-</p><p class="q2">nor was any deceit in his mouth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Yet it pleased Yahweh to bruise him. 
-</p><p class="q2">He has caused him to suffer. 
-</p><p class="q1">When you make his soul an offering for sin, 
-</p><p class="q2">he will see his offspring. 
-</p><p class="q1">He will prolong his days 
-</p><p class="q2">and Yahweh’s pleasure will prosper in his hand. 
-</p><p class="q1">
-<span class="v">11&#160;</span>After the suffering of his soul, 
-</p><p class="q2">he will see the light<span class="f">+ \fr 53:11 \ft So read the Dead Sea Scrolls and Septuagint. Masoretic Text omits “the light”.</span> and be satisfied. 
-</p><p class="q1">My righteous servant will justify many by the knowledge of himself; 
-</p><p class="q2">and he will bear their iniquities. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Therefore I will give him a portion with the great. 
-</p><p class="q2">He will divide the plunder with the strong, 
-</p><p class="q1">because he poured out his soul to death 
-</p><p class="q2">and was counted with the transgressors; 
-</p><p class="q1">yet he bore the sins of many 
-</p><p class="q2">and made intercession for the transgressors. 
-</p><h2 class="chapterlabel" id="54">54</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Sing, barren, you who didn’t give birth! 
-</p><p class="q2">Break out into singing, and cry aloud, you who didn’t travail with child! 
-</p><p class="q2">For more are the children of the desolate than the children of the owned woman,” says Yahweh. 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Enlarge the place of your tent, 
-</p><p class="q2">and let them stretch out the curtains of your habitations; 
-</p><p class="q2">don’t spare; lengthen your cords, and strengthen your stakes. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For you will spread out on the right hand and on the left; 
-</p><p class="q2">and your offspring will possess the nations 
-</p><p class="q2">and settle in desolate cities. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Don’t be afraid, for you will not be ashamed. 
-</p><p class="q2">Don’t be confounded, for you will not be disappointed. 
-</p><p class="q1">For you will forget the shame of your youth. 
-</p><p class="q2">You will remember the reproach of your widowhood no more. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For your Maker is your owner; Yahweh of Armies is his name. 
-</p><p class="q2">The Set-Apart One of Israel is your Redeemer. 
-</p><p class="q2">He will be called the Elohim of the whole earth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For Yahweh has called you as a woman forsaken and grieved in spirit, 
-</p><p class="q2">even a woman of youth, when she is cast off,” says your Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“For a small moment I have forsaken you, 
-</p><p class="q2">but I will gather you with great mercies. 
-</p><p class="q1">
-<span class="v">8&#160;</span>In overflowing wrath I hid my face from you for a moment, 
-</p><p class="q2">but with everlasting loving kindness I will have mercy on you,” says Yahweh your Redeemer. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“For this is like the waters of Noah to me; 
-</p><p class="q2">for as I have sworn that the waters of Noah will no more go over the earth, 
-</p><p class="q2">so I have sworn that I will not be angry with you, nor rebuke you. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For the mountains may depart, 
-</p><p class="q2">and the hills be removed, 
-</p><p class="q1">but my loving kindness will not depart from you, 
-</p><p class="q2">and my covenant of peace will not be removed,” 
-</p><p class="q2">says Yahweh who has mercy on you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“You afflicted, tossed with storms, and not comforted, 
-</p><p class="q2">behold, I will set your stones in beautiful colors, 
-</p><p class="q2">and lay your foundations with sapphires. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will make your pinnacles of rubies, 
-</p><p class="q2">your gates of sparkling jewels, 
-</p><p class="q2">and all your walls of precious stones. 
-</p><p class="q1">
-<span class="v">13&#160;</span>All your children will be taught by Yahweh, 
-</p><p class="q2">and your children’s peace will be great. 
-</p><p class="q1">
-<span class="v">14&#160;</span>You will be established in righteousness. 
-</p><p class="q2">You will be far from oppression, 
-</p><p class="q2">for you will not be afraid, 
-</p><p class="q2">and far from terror, 
-</p><p class="q2">for it shall not come near you. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, they may gather together, but not by me. 
-</p><p class="q2">Whoever gathers together against you will fall because of you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>“Behold, I have created the blacksmith who fans the coals into flame, 
-</p><p class="q2">and forges a weapon for his work; 
-</p><p class="q2">and I have created the destroyer to destroy. 
-</p><p class="q1">
-<span class="v">17&#160;</span>No weapon that is formed against you will prevail; 
-</p><p class="q2">and you will condemn every tongue that rises against you in judgment. 
-</p><p class="q1">This is the heritage of Yahweh’s servants, 
-</p><p class="q2">and their righteousness is of me,” says Yahweh. 
-</p><h2 class="chapterlabel" id="55">55</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Hey! Come, everyone who thirsts, to the waters! 
-</p><p class="q2">Come, he who has no money, buy, and eat! 
-</p><p class="q2">Yes, come, buy wine and milk without money and without price. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Why do you spend money for that which is not bread, 
-</p><p class="q2">and your labor for that which doesn’t satisfy? 
-</p><p class="q1">Listen diligently to me, and eat that which is good, 
-</p><p class="q2">and let your soul delight itself in richness. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Turn your ear, and come to me. 
-</p><p class="q2">Hear, and your soul will live. 
-</p><p class="q2">I will make an everlasting covenant with you, even the sure mercies of David. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Behold, I have given him for a witness to the peoples, 
-</p><p class="q2">a leader and commander to the peoples. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Behold, you shall call a nation that you don’t know; 
-</p><p class="q2">and a nation that didn’t know you shall run to you, 
-</p><p class="q2">because of Yahweh your Elohim, 
-</p><p class="q2">and for the Set-Apart One of Israel; 
-</p><p class="q2">for he has glorified you.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Seek Yahweh while he may be found. 
-</p><p class="q2">Call on him while he is near. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Let the wicked forsake his way, 
-</p><p class="q2">and the unrighteous man his thoughts. 
-</p><p class="q1">Let him return to Yahweh, and he will have mercy on him, 
-</p><p class="q2">to our Elohim, for he will freely pardon. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“For my thoughts are not your thoughts, 
-</p><p class="q2">and your ways are not my ways,” says Yahweh. 
-</p><p class="q1">
-<span class="v">9&#160;</span>“For as the heavens are higher than the earth, 
-</p><p class="q2">so are my ways higher than your ways, 
-</p><p class="q2">and my thoughts than your thoughts. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For as the rain comes down and the snow from the sky, 
-</p><p class="q2">and doesn’t return there, but waters the earth, 
-</p><p class="q2">and makes it grow and bud, 
-</p><p class="q2">and gives seed to the sower and bread to the eater; 
-</p><p class="q1">
-<span class="v">11&#160;</span>so is my word that goes out of my mouth: 
-</p><p class="q2">it will not return to me void, 
-</p><p class="q2">but it will accomplish that which I please, 
-</p><p class="q2">and it will prosper in the thing I sent it to do. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For you shall go out with joy, 
-</p><p class="q2">and be led out with peace. 
-</p><p class="q1">The mountains and the hills will break out before you into singing; 
-</p><p class="q2">and all the trees of the fields will clap their hands. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Instead of the thorn the cypress tree will come up; 
-</p><p class="q2">and instead of the brier the myrtle tree will come up. 
-</p><p class="q1">It will make a name for Yahweh, 
-</p><p class="q2">for an everlasting sign that will not be cut off.” 
-</p><h2 class="chapterlabel" id="56">56</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh says: 
-</p><p class="q1">“Maintain justice 
-</p><p class="q2">and do what is right, 
-</p><p class="q1">for my salvation is near 
-</p><p class="q2">and my righteousness will soon be revealed. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Blessed is the man who does this, 
-</p><p class="q2">and the son of man who holds it fast; 
-</p><p class="q1">who keeps the Sabbath without profaning it 
-</p><p class="q2">and keeps his hand from doing any evil.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>Let no foreigner who has joined himself to Yahweh speak, saying, 
-</p><p class="q2">“Yahweh will surely separate me from his people.” 
-</p><p class="q2">Do not let the eunuch say, “Behold, I am a dry tree.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>For Yahweh says, “To the eunuchs who keep my Sabbaths, 
-</p><p class="q2">choose the things that please me, 
-</p><p class="q2">and hold fast to my covenant, 
-</p><p class="q1">
-<span class="v">5&#160;</span>I will give them in my house and within my walls a memorial and a name better than of sons and of daughters. 
-</p><p class="q2">I will give them an everlasting name that will not be cut off. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Also the foreigners who join themselves to Yahweh 
-</p><p class="q2">to serve him, 
-</p><p class="q1">and to love Yahweh’s name, 
-</p><p class="q2">to be his servants, 
-</p><p class="q1">everyone who keeps the Sabbath from profaning it, 
-</p><p class="q2">and holds fast my covenant, 
-</p><p class="q1">
-<span class="v">7&#160;</span>I will bring these to my set-apart mountain, 
-</p><p class="q2">and make them joyful in my house of prayer. 
-</p><p class="q1">Their burnt offerings and their sacrifices will be accepted on my altar; 
-</p><p class="q2">for my house will be called a house of prayer for all peoples.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>The Lord Yahweh, who gathers the outcasts of Israel, says, 
-</p><p class="q2">“I will yet gather others to him, 
-</p><p class="q2">in addition to his own who are gathered.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>All you animals of the field, 
-</p><p class="q2">come to devour, 
-</p><p class="q2">all you animals in the forest. 
-</p><p class="q1">
-<span class="v">10&#160;</span>His watchmen are blind. 
-</p><p class="q2">They are all without knowledge. 
-</p><p class="q1">They are all mute dogs. 
-</p><p class="q2">They can’t bark—</p><p class="q2">dreaming, lying down, loving to slumber. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yes, the dogs are greedy. 
-</p><p class="q2">They can never have enough. 
-</p><p class="q1">They are shepherds who can’t understand. 
-</p><p class="q2">They have all turned to their own way, 
-</p><p class="q2">each one to his gain, from every quarter. 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Come,” they say, “I will get wine, 
-</p><p class="q2">and we will fill ourselves with strong drink; 
-</p><p class="q2">and tomorrow will be as today, 
-</p><p class="q2">great beyond measure.” 
-</p><h2 class="chapterlabel" id="57">57</h2>
-<p class="q1">
-<span class="v">1&#160;</span>The righteous perish, 
-</p><p class="q2">and no one lays it to heart. 
-</p><p class="q1">Merciful men are taken away, 
-</p><p class="q2">and no one considers that the righteous is taken away from the evil. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He enters into peace. 
-</p><p class="q2">They rest in their beds, 
-</p><p class="q2">each one who walks in his uprightness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“But draw near here, you sons of a sorceress, 
-</p><p class="q2">you offspring of adulterers and prostitutes. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Whom do you mock? 
-</p><p class="q2">Against whom do you make a wide mouth 
-</p><p class="q2">and stick out your tongue? 
-</p><p class="q1">Aren’t you children of disobedience 
-</p><p class="q2">and offspring of falsehood, 
-</p><p class="q1">
-<span class="v">5&#160;</span>you who inflame yourselves among the oaks, 
-</p><p class="q2">under every green tree; 
-</p><p class="q1">who kill the children in the valleys, 
-</p><p class="q2">under the clefts of the rocks? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Among the smooth stones of the valley is your portion. 
-</p><p class="q2">They, they are your lot. 
-</p><p class="q1">You have even poured a drink offering to them. 
-</p><p class="q2">You have offered an offering. 
-</p><p class="q2">Shall I be appeased for these things? 
-</p><p class="q1">
-<span class="v">7&#160;</span>On a high and lofty mountain you have set your bed. 
-</p><p class="q2">You also went up there to offer sacrifice. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You have set up your memorial behind the doors and the posts, 
-</p><p class="q2">for you have exposed yourself to someone besides me, 
-</p><p class="q2">and have gone up. 
-</p><p class="q1">You have enlarged your bed 
-</p><p class="q2">and made you a covenant with them. 
-</p><p class="q2">You loved what you saw on their bed. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You went to the king with oil, 
-</p><p class="q2">increased your perfumes, 
-</p><p class="q2">sent your ambassadors far off, 
-</p><p class="q2">and degraded yourself even to Sheol.<span class="f">+ \fr 57:9 \ft Sheol is the place of the dead.</span> 
-</p><p class="q1">
-<span class="v">10&#160;</span>You were wearied with the length of your ways; 
-</p><p class="q2">yet you didn’t say, ‘It is in vain.’ 
-</p><p class="q1">You found a reviving of your strength; 
-</p><p class="q2">therefore you weren’t faint. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Whom have you dreaded and feared, 
-</p><p class="q2">so that you lie, 
-</p><p class="q2">and have not remembered me, nor laid it to your heart? 
-</p><p class="q1">Haven’t I held my peace for a long time, 
-</p><p class="q2">and you don’t fear me? 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will declare your righteousness; 
-</p><p class="q2">and as for your works, they will not benefit you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>When you cry, 
-</p><p class="q2">let those whom you have gathered deliver you, 
-</p><p class="q1">but the wind will take them. 
-</p><p class="q2">A breath will carry them all away, 
-</p><p class="q1">but he who takes refuge in me will possess the land, 
-</p><p class="q2">and will inherit my set-apart mountain.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>He will say, “Build up, build up, prepare the way! 
-</p><p class="q2">Remove the stumbling-block out of the way of my people.” 
-</p><p class="q1">
-<span class="v">15&#160;</span>For the high and lofty One who inhabits eternity, 
-</p><p class="q2">whose name is Set-Apart, says: 
-</p><p class="q1">“I dwell in the high and set-apart place, with him also who is of a contrite and humble spirit, 
-</p><p class="q2">to revive the spirit of the humble, 
-</p><p class="q2">and to revive the heart of the contrite. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For I will not contend forever, neither will I always be angry; 
-</p><p class="q2">for the spirit would faint before me, 
-</p><p class="q2">and the souls whom I have made. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I was angry because of the iniquity of his covetousness and struck him. 
-</p><p class="q2">I hid myself and was angry; 
-</p><p class="q2">and he went on backsliding in the way of his heart. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I have seen his ways, and will heal him. 
-</p><p class="q2">I will lead him also, 
-</p><p class="q2">and restore comforts to him and to his mourners. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I create the fruit of the lips: 
-</p><p class="q2">Peace, peace, to him who is far off and to him who is near,” 
-</p><p class="q2">says Yahweh; “and I will heal them.” 
-</p><p class="q1">
-<span class="v">20&#160;</span>But the wicked are like the troubled sea; 
-</p><p class="q2">for it can’t rest and its waters cast up mire and mud. 
-</p><p class="q1">
-<span class="v">21&#160;</span>“There is no peace”, says my Elohim, 
-</p><p class="q2">“for the wicked.” 
-</p><h2 class="chapterlabel" id="58">58</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Cry aloud! Don’t spare! 
-</p><p class="q2">Lift up your voice like a trumpet! 
-</p><p class="q1">Declare to my people their disobedience, 
-</p><p class="q2">and to the house of Jacob their sins. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yet they seek me daily, 
-</p><p class="q2">and delight to know my ways. 
-</p><p class="q1">As a nation that did righteousness, 
-</p><p class="q2">and didn’t forsake the ordinance of their Elohim, 
-</p><p class="q1">they ask of me righteous judgments. 
-</p><p class="q2">They delight to draw near to Elohim. 
-</p><p class="q1">
-<span class="v">3&#160;</span>‘Why have we fasted,’ they say, ‘and you don’t see? 
-</p><p class="q2">Why have we afflicted our soul, and you don’t notice?’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">“Behold, in the day of your fast you find pleasure, 
-</p><p class="q2">and oppress all your laborers. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Behold, you fast for strife and contention, 
-</p><p class="q2">and to strike with the fist of wickedness. 
-</p><p class="q2">You don’t fast today so as to make your voice to be heard on high. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Is this the fast that I have chosen? 
-</p><p class="q2">A day for a man to humble his soul? 
-</p><p class="q1">Is it to bow down his head like a reed, 
-</p><p class="q2">and to spread sackcloth and ashes under himself? 
-</p><p class="q1">Will you call this a fast, 
-</p><p class="q2">and an acceptable day to Yahweh? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“Isn’t this the fast that I have chosen: 
-</p><p class="q2">to release the bonds of wickedness, 
-</p><p class="q2">to undo the straps of the yoke, 
-</p><p class="q2">to let the oppressed go free, 
-</p><p class="q2">and that you break every yoke? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Isn’t it to distribute your bread to the hungry, 
-</p><p class="q2">and that you bring the poor who are cast out to your house? 
-</p><p class="q1">When you see the naked, 
-</p><p class="q2">that you cover him; 
-</p><p class="q2">and that you not hide yourself from your own flesh? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Then your light will break out as the morning, 
-</p><p class="q2">and your healing will appear quickly; 
-</p><p class="q1">then your righteousness shall go before you, 
-</p><p class="q2">and Yahweh’s glory will be your rear guard. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Then you will call, and Yahweh will answer. 
-</p><p class="q2">You will cry for help, and he will say, ‘Here I am.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">“If you take away from among you the yoke, 
-</p><p class="q2">finger pointing, 
-</p><p class="q2">and speaking wickedly; 
-</p><p class="q1">
-<span class="v">10&#160;</span>and if you pour out your soul to the hungry, 
-</p><p class="q2">and satisfy the afflicted soul, 
-</p><p class="q1">then your light will rise in darkness, 
-</p><p class="q2">and your obscurity will be as the noonday; 
-</p><p class="q1">
-<span class="v">11&#160;</span>and Yahweh will guide you continually, 
-</p><p class="q2">satisfy your soul in dry places, 
-</p><p class="q2">and make your bones strong. 
-</p><p class="q1">You will be like a watered garden, 
-</p><p class="q2">and like a spring of water 
-</p><p class="q2">whose waters don’t fail. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Those who will be of you will build the old waste places. 
-</p><p class="q2">You will raise up the foundations of many generations. 
-</p><p class="q1">You will be called Repairer of the Breach, 
-</p><p class="q2">Restorer of Paths with Dwellings. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“If you turn away your foot from the Sabbath, 
-</p><p class="q2">from doing your pleasure on my set-apart day, 
-</p><p class="q1">and call the Sabbath a delight, 
-</p><p class="q2">and the set-apart of Yahweh honorable, 
-</p><p class="q2">and honor it, 
-</p><p class="q2">not doing your own ways, 
-</p><p class="q2">nor finding your own pleasure, 
-</p><p class="q2">nor speaking your own words, 
-</p><p class="q1">
-<span class="v">14&#160;</span>then you will delight yourself in Yahweh, 
-</p><p class="q2">and I will make you to ride on the high places of the earth, 
-</p><p class="q2">and I will feed you with the heritage of Jacob your father;” 
-</p><p class="q2">for Yahweh’s mouth has spoken it. 
-</p><h2 class="chapterlabel" id="59">59</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Behold, Yahweh’s hand is not shortened, that it can’t save; 
-</p><p class="q2">nor his ear dull, that it can’t hear. 
-</p><p class="q1">
-<span class="v">2&#160;</span>But your iniquities have separated you and your Elohim, 
-</p><p class="q2">and your sins have hidden his face from you, 
-</p><p class="q2">so that he will not hear. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For your hands are defiled with blood, 
-</p><p class="q2">and your fingers with iniquity. 
-</p><p class="q1">Your lips have spoken lies. 
-</p><p class="q2">Your tongue mutters wickedness. 
-</p><p class="q1">
-<span class="v">4&#160;</span>No one sues in righteousness, 
-</p><p class="q2">and no one pleads in truth. 
-</p><p class="q1">They trust in vanity 
-</p><p class="q2">and speak lies. 
-</p><p class="q1">They conceive mischief 
-</p><p class="q2">and give birth to iniquity. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They hatch adders’ eggs 
-</p><p class="q2">and weave the spider’s web. 
-</p><p class="q1">He who eats of their eggs dies; 
-</p><p class="q2">and that which is crushed breaks out into a viper. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Their webs won’t become garments. 
-</p><p class="q2">They won’t cover themselves with their works. 
-</p><p class="q1">Their works are works of iniquity, 
-</p><p class="q2">and acts of violence are in their hands. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Their feet run to evil, 
-</p><p class="q2">and they hurry to shed innocent blood. 
-</p><p class="q1">Their thoughts are thoughts of iniquity. 
-</p><p class="q2">Desolation and destruction are in their paths. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They don’t know the way of peace; 
-</p><p class="q2">and there is no justice in their ways. 
-</p><p class="q1">They have made crooked paths for themselves; 
-</p><p class="q2">whoever goes in them doesn’t know peace. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Therefore justice is far from us, 
-</p><p class="q2">and righteousness doesn’t overtake us. 
-</p><p class="q1">We look for light, but see darkness; 
-</p><p class="q2">for brightness, but we walk in obscurity. 
-</p><p class="q1">
-<span class="v">10&#160;</span>We grope for the wall like the blind. 
-</p><p class="q2">Yes, we grope as those who have no eyes. 
-</p><p class="q1">We stumble at noon as if it were twilight. 
-</p><p class="q2">Among those who are strong, we are like dead men. 
-</p><p class="q1">
-<span class="v">11&#160;</span>We all roar like bears 
-</p><p class="q2">and moan sadly like doves. 
-</p><p class="q1">We look for justice, but there is none, 
-</p><p class="q2">for salvation, but it is far off from us. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>For our transgressions are multiplied before you, 
-</p><p class="q2">and our sins testify against us; 
-</p><p class="q1">for our transgressions are with us, 
-</p><p class="q2">and as for our iniquities, we know them: 
-</p><p class="q1">
-<span class="v">13&#160;</span>transgressing and denying Yahweh, 
-</p><p class="q2">and turning away from following our Elohim, 
-</p><p class="q2">speaking oppression and revolt, 
-</p><p class="q2">conceiving and uttering from the heart words of falsehood. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Justice is turned away backward, 
-</p><p class="q2">and righteousness stands far away; 
-</p><p class="q1">for truth has fallen in the street, 
-</p><p class="q2">and uprightness can’t enter. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Yes, truth is lacking; 
-</p><p class="q2">and he who departs from evil makes himself a prey. 
-</p><div class="b"> &#160; </div>
-<p class="q1">Yahweh saw it, 
-</p><p class="q2">and it displeased him that there was no justice. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He saw that there was no man, 
-</p><p class="q2">and wondered that there was no intercessor. 
-</p><p class="q1">Therefore his own arm brought salvation to him; 
-</p><p class="q2">and his righteousness sustained him. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He put on righteousness as a breastplate, 
-</p><p class="q2">and a helmet of salvation on his head. 
-</p><p class="q1">He put on garments of vengeance for clothing, 
-</p><p class="q2">and was clad with zeal as a mantle. 
-</p><p class="q1">
-<span class="v">18&#160;</span>According to their deeds, 
-</p><p class="q2">he will repay as appropriate: 
-</p><p class="q2">wrath to his adversaries, 
-</p><p class="q2">recompense to his enemies. 
-</p><p class="q2">He will repay the islands their due. 
-</p><p class="q1">
-<span class="v">19&#160;</span>So they will fear Yahweh’s name from the west, 
-</p><p class="q2">and his glory from the rising of the sun; 
-</p><p class="q1">for he will come as a rushing stream, 
-</p><p class="q2">which Yahweh’s breath drives. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“A Redeemer will come to Zion, 
-</p><p class="q2">and to those who turn from disobedience in Jacob,” says Yahweh. 
-</p><p>
-<span class="v">21&#160;</span>“As for me, this is my covenant with them,” says Yahweh. “My Spirit who is on you, and my words which I have put in your mouth shall not depart out of your mouth, nor out of the mouth of your offspring, nor out of the mouth of your offspring’s offspring,” says Yahweh, “from now on and forever.” 
-</p><h2 class="chapterlabel" id="60">60</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Arise, shine; for your light has come, 
-</p><p class="q2">and Yahweh’s glory has risen on you! 
-</p><p class="q1">
-<span class="v">2&#160;</span>For behold, darkness will cover the earth, 
-</p><p class="q2">and thick darkness the peoples; 
-</p><p class="q1">but Yahweh will arise on you, 
-</p><p class="q2">and his glory shall be seen on you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Nations will come to your light, 
-</p><p class="q2">and kings to the brightness of your rising. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Lift up your eyes all around, and see: 
-</p><p class="q2">they all gather themselves together. 
-</p><p class="q2">They come to you. 
-</p><p class="q1">Your sons will come from far away, 
-</p><p class="q2">and your daughters will be carried in arms. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Then you shall see and be radiant, 
-</p><p class="q2">and your heart will thrill and be enlarged; 
-</p><p class="q1">because the abundance of the sea will be turned to you. 
-</p><p class="q2">The wealth of the nations will come to you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>A multitude of camels will cover you, 
-</p><p class="q2">the dromedaries of Midian and Ephah. 
-</p><p class="q1">All from Sheba will come. 
-</p><p class="q2">They will bring gold and frankincense, 
-</p><p class="q2">and will proclaim the praises of Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>All the flocks of Kedar will be gathered together to you. 
-</p><p class="q2">The rams of Nebaioth will serve you. 
-</p><p class="q1">They will be accepted as offerings on my altar; 
-</p><p class="q2">and I will beautify my glorious house. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Who are these who fly as a cloud, 
-</p><p class="q2">and as the doves to their windows? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Surely the islands will wait for me, 
-</p><p class="q2">and the ships of Tarshish first, 
-</p><p class="q1">to bring your sons from far away, 
-</p><p class="q2">their silver and their gold with them, 
-</p><p class="q1">for the name of Yahweh your Elohim, 
-</p><p class="q2">and for the Set-Apart One of Israel, 
-</p><p class="q2">because he has glorified you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Foreigners will build up your walls, 
-</p><p class="q2">and their kings will serve you; 
-</p><p class="q1">for in my wrath I struck you, 
-</p><p class="q2">but in my favor I have had mercy on you. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Your gates also shall be open continually; they shall not be shut day nor night, that men may bring to you the wealth of the nations, and their kings led captive. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For that nation and kingdom that will not serve you shall perish; yes, those nations shall be utterly wasted. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“The glory of Lebanon shall come to you, the cypress tree, the pine, and the box tree together, to beautify the place of my sanctuary; and I will make the place of my feet glorious. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The sons of those who afflicted you will come bowing to you; 
-</p><p class="q2">and all those who despised you will bow themselves down at the soles of your feet. 
-</p><p class="q1">They will call you Yahweh’s City, 
-</p><p class="q2">the Zion of the Set-Apart One of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“Whereas you have been forsaken and hated, 
-</p><p class="q2">so that no one passed through you, 
-</p><p class="q1">I will make you an eternal excellency, 
-</p><p class="q2">a joy of many generations. 
-</p><p class="q1">
-<span class="v">16&#160;</span>You will also drink the milk of the nations, 
-</p><p class="q2">and will nurse from royal breasts. 
-</p><p class="q1">Then you will know that I, Yahweh, am your Savior, 
-</p><p class="q2">your Redeemer, 
-</p><p class="q2">the Mighty One of Jacob. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For bronze I will bring gold; 
-</p><p class="q2">for iron I will bring silver; 
-</p><p class="q2">for wood, bronze, 
-</p><p class="q2">and for stones, iron. 
-</p><p class="q1">I will also make peace your governor, 
-</p><p class="q2">and righteousness your ruler. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Violence shall no more be heard in your land, 
-</p><p class="q2">nor desolation or destruction within your borders; 
-</p><p class="q1">but you will call your walls Salvation, 
-</p><p class="q2">and your gates Praise. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The sun will be no more your light by day, 
-</p><p class="q2">nor will the brightness of the moon give light to you, 
-</p><p class="q1">but Yahweh will be your everlasting light, 
-</p><p class="q2">and your Elohim will be your glory. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Your sun will not go down any more, 
-</p><p class="q2">nor will your moon withdraw itself; 
-</p><p class="q1">for Yahweh will be your everlasting light, 
-</p><p class="q2">and the days of your mourning will end. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Then your people will all be righteous. 
-</p><p class="q2">They will inherit the land forever, 
-</p><p class="q2">the branch of my planting, 
-</p><p class="q2">the work of my hands, 
-</p><p class="q2">that I may be glorified. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The little one will become a thousand, 
-</p><p class="q2">and the small one a strong nation. 
-</p><p class="q2">I, Yahweh, will do this quickly in its time.” 
-</p><h2 class="chapterlabel" id="61">61</h2>
-<p class="q1">
-<span class="v">1&#160;</span>The Lord Yahweh’s Spirit is on me, 
-</p><p class="q2">because Yahweh has anointed me to preach good news to the humble. 
-</p><p class="q1">He has sent me to bind up the broken hearted, 
-</p><p class="q2">to proclaim liberty to the captives 
-</p><p class="q2">and release to those who are bound,<span class="f">+ \fr 61:1 \ft LXX and DSS add: recovery of sight to the blind</span> 
-</p><p class="q1">
-<span class="v">2&#160;</span>to proclaim the year of Yahweh’s favor 
-</p><p class="q2">and the day of vengeance of our Elohim, 
-</p><p class="q2">to comfort all who mourn, 
-</p><p class="q1">
-<span class="v">3&#160;</span>to provide for those who mourn in Zion, 
-</p><p class="q2">to give to them a garland for ashes, 
-</p><p class="q2">the oil of joy for mourning, 
-</p><p class="q2">the garment of praise for the spirit of heaviness, 
-</p><p class="q1">that they may be called trees of righteousness, 
-</p><p class="q2">the planting of Yahweh, 
-</p><p class="q2">that he may be glorified. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>They will rebuild the old ruins. 
-</p><p class="q2">They will raise up the former devastated places. 
-</p><p class="q1">They will repair the ruined cities 
-</p><p class="q2">that have been devastated for many generations. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Strangers will stand and feed your flocks. 
-</p><p class="q2">Foreigners will work your fields and your vineyards. 
-</p><p class="q1">
-<span class="v">6&#160;</span>But you will be called Yahweh’s priests. 
-</p><p class="q2">Men will call you the servants of our Elohim. 
-</p><p class="q1">You will eat the wealth of the nations. 
-</p><p class="q2">You will boast in their glory. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Instead of your shame you will have double. 
-</p><p class="q2">Instead of dishonor, they will rejoice in their portion. 
-</p><p class="q1">Therefore in their land they will possess double. 
-</p><p class="q2">Everlasting joy will be to them. 
-</p><p class="q1">
-<span class="v">8&#160;</span>“For I, Yahweh, love justice. 
-</p><p class="q2">I hate robbery and iniquity. 
-</p><p class="q1">I will give them their reward in truth 
-</p><p class="q2">and I will make an everlasting covenant with them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Their offspring will be known among the nations, 
-</p><p class="q2">and their offspring among the peoples. 
-</p><p class="q1">All who see them will acknowledge them, 
-</p><p class="q2">that they are the offspring which Yahweh has blessed.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>I will greatly rejoice in Yahweh! 
-</p><p class="q2">My soul will be joyful in my Elohim, 
-</p><p class="q1">for he has clothed me with the garments of salvation. 
-</p><p class="q2">He has covered me with the robe of righteousness, 
-</p><p class="q2">as a bridegroom decks himself with a garland 
-</p><p class="q2">and as a bride adorns herself with her jewels. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For as the earth produces its bud, 
-</p><p class="q2">and as the garden causes the things that are sown in it to spring up, 
-</p><p class="q2">so the Lord Yahweh will cause righteousness and praise to spring up before all the nations. 
-</p><h2 class="chapterlabel" id="62">62</h2>
-<p class="q1">
-<span class="v">1&#160;</span>For Zion’s sake I will not hold my peace, 
-</p><p class="q2">and for Jerusalem’s sake I will not rest, 
-</p><p class="q1">until her righteousness shines out like the dawn, 
-</p><p class="q2">and her salvation like a burning lamp. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The nations will see your righteousness, 
-</p><p class="q2">and all kings your glory. 
-</p><p class="q1">You will be called by a new name, 
-</p><p class="q2">which Yahweh’s mouth will name. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You will also be a crown of beauty in Yahweh’s hand, 
-</p><p class="q2">and a royal diadem in your Elohim’s hand. 
-</p><p class="q1">
-<span class="v">4&#160;</span>You will not be called Forsaken any more, 
-</p><p class="q2">nor will your land be called Desolate any more; 
-</p><p class="q1">but you will be called Hephzibah,<span class="f">+ \fr 62:4 \ft Hephzibah means “I delight in her”.</span> 
-</p><p class="q2">and your land Beulah;<span class="f">+ \fr 62:4 \ft Beulah means “married”</span> 
-</p><p class="q1">for Yahweh delights in you, 
-</p><p class="q2">and your land will be owned. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For as a young man owns a virgin, 
-</p><p class="q2">so your sons will own you. 
-</p><p class="q1">As a bridegroom rejoices over his bride, 
-</p><p class="q2">so your Elohim will rejoice over you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>I have set watchmen on your walls, Jerusalem. 
-</p><p class="q2">They will never be silent day nor night. 
-</p><p class="q1">You who call on Yahweh, take no rest, 
-</p><p class="q2">
-<span class="v">7&#160;</span>and give him no rest until he establishes, 
-</p><p class="q2">and until he makes Jerusalem a praise in the earth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Yahweh has sworn by his right hand, 
-</p><p class="q2">and by the arm of his strength, 
-</p><p class="q1">“Surely I will no more give your grain to be food for your enemies, 
-</p><p class="q2">and foreigners will not drink your new wine, for which you have labored, 
-</p><p class="q1">
-<span class="v">9&#160;</span>but those who have harvested it will eat it, and praise Yahweh. 
-</p><p class="q2">Those who have gathered it will drink it in the courts of my sanctuary.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Go through, go through the gates! 
-</p><p class="q2">Prepare the way of the people! 
-</p><p class="q1">Build up, build up the highway! 
-</p><p class="q2">Gather out the stones! 
-</p><p class="q2">Lift up a banner for the peoples. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Behold, Yahweh has proclaimed to the end of the earth: 
-</p><p class="q2">“Say to the daughter of Zion, 
-</p><p class="q2">‘Behold, your salvation comes! 
-</p><p class="q1">Behold, his reward is with him, 
-</p><p class="q2">and his recompense before him!’&#160;” 
-</p><p class="q1">
-<span class="v">12&#160;</span>They will call them “The Set-Apart People, 
-</p><p class="q2">Yahweh’s Redeemed”. 
-</p><p class="q1">You will be called “Sought Out, 
-</p><p class="q2">A City Not Forsaken”. 
-</p><h2 class="chapterlabel" id="63">63</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Who is this who comes from Edom, 
-</p><p class="q2">with dyed garments from Bozrah? 
-</p><p class="q1">Who is this who is glorious in his clothing, 
-</p><p class="q2">marching in the greatness of his strength? 
-</p><p class="q1">“It is I who speak in righteousness, 
-</p><p class="q2">mighty to save.” 
-</p><p class="q1">
-<span class="v">2&#160;</span>Why is your clothing red, 
-</p><p class="q2">and your garments like him who treads in the wine vat? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“I have trodden the wine press alone. 
-</p><p class="q2">Of the peoples, no one was with me. 
-</p><p class="q1">Yes, I trod them in my anger 
-</p><p class="q2">and trampled them in my wrath. 
-</p><p class="q1">Their lifeblood is sprinkled on my garments, 
-</p><p class="q2">and I have stained all my clothing. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For the day of vengeance was in my heart, 
-</p><p class="q2">and the year of my redeemed has come. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I looked, and there was no one to help; 
-</p><p class="q2">and I wondered that there was no one to uphold. 
-</p><p class="q1">Therefore my own arm brought salvation to me. 
-</p><p class="q2">My own wrath upheld me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I trod down the peoples in my anger 
-</p><p class="q2">and made them drunk in my wrath. 
-</p><p class="q2">I poured their lifeblood out on the earth.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>I will tell of the loving kindnesses of Yahweh 
-</p><p class="q2">and the praises of Yahweh, 
-</p><p class="q2">according to all that Yahweh has given to us, 
-</p><p class="q1">and the great goodness toward the house of Israel, 
-</p><p class="q2">which he has given to them according to his mercies, 
-</p><p class="q2">and according to the multitude of his loving kindnesses. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For he said, “Surely, they are my people, 
-</p><p class="q2">children who will not deal falsely;” 
-</p><p class="q2">so he became their Savior. 
-</p><p class="q1">
-<span class="v">9&#160;</span>In all their affliction he was afflicted, 
-</p><p class="q2">and the angel of his presence saved them. 
-</p><p class="q1">In his love and in his pity he redeemed them. 
-</p><p class="q2">He bore them, 
-</p><p class="q2">and carried them all the days of old. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>But they rebelled 
-</p><p class="q2">and grieved his Set-Apart Spirit. 
-</p><p class="q1">Therefore he turned and became their enemy, 
-</p><p class="q2">and he himself fought against them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Then he remembered the days of old, 
-</p><p class="q2">Moses and his people, saying, 
-</p><p class="q1">“Where is he who brought them up out of the sea with the shepherds of his flock? 
-</p><p class="q2">Where is he who put his Set-Apart Spirit among them?” 
-</p><p class="q1">
-<span class="v">12&#160;</span>Who caused his glorious arm to be at Moses’ right hand? 
-</p><p class="q2">Who divided the waters before them, to make himself an everlasting name? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Who led them through the depths, 
-</p><p class="q2">like a horse in the wilderness, 
-</p><p class="q2">so that they didn’t stumble? 
-</p><p class="q1">
-<span class="v">14&#160;</span>As the livestock that go down into the valley, 
-</p><p class="q2">Yahweh’s Spirit caused them to rest. 
-</p><p class="q2">So you led your people to make yourself a glorious name. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>Look down from heaven, 
-</p><p class="q2">and see from the habitation of your set-apartness and of your glory. 
-</p><p class="q1">Where are your zeal and your mighty acts? 
-</p><p class="q2">The yearning of your heart and your compassion is restrained toward me. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For you are our Father, 
-</p><p class="q2">though Abraham doesn’t know us, 
-</p><p class="q2">and Israel does not acknowledge us. 
-</p><p class="q1">You, Yahweh, are our Father. 
-</p><p class="q2">Our Redeemer from everlasting is your name. 
-</p><p class="q1">
-<span class="v">17&#160;</span>O Yahweh, why do you make us wander from your ways, 
-</p><p class="q2">and harden our heart from your fear? 
-</p><p class="q1">Return for your servants’ sake, 
-</p><p class="q2">the tribes of your inheritance. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Your set-apart people possessed it but a little while. 
-</p><p class="q2">Our adversaries have trodden down your sanctuary. 
-</p><p class="q1">
-<span class="v">19&#160;</span>We have become like those over whom you never ruled, 
-</p><p class="q2">like those who were not called by your name. 
-</p><h2 class="chapterlabel" id="64">64</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Oh that you would tear the heavens, 
-</p><p class="q2">that you would come down, 
-</p><p class="q2">that the mountains might quake at your presence—</p><p class="q1">
-<span class="v">2&#160;</span>as when fire kindles the brushwood, 
-</p><p class="q2">and the fire causes the water to boil. 
-</p><p class="q1">Make your name known to your adversaries, 
-</p><p class="q2">that the nations may tremble at your presence! 
-</p><p class="q1">
-<span class="v">3&#160;</span>When you did awesome things which we didn’t look for, 
-</p><p class="q2">you came down, and the mountains quaked at your presence. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For from of old men have not heard, 
-</p><p class="q2">nor perceived by the ear, 
-</p><p class="q2">nor has the eye seen an Elohim besides you, 
-</p><p class="q2">who works for him who waits for him. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You meet him who rejoices and does righteousness, 
-</p><p class="q2">those who remember you in your ways. 
-</p><p class="q1">Behold, you were angry, and we sinned. 
-</p><p class="q2">We have been in sin for a long time. 
-</p><p class="q2">Shall we be saved? 
-</p><p class="q1">
-<span class="v">6&#160;</span>For we have all become like one who is unclean, 
-</p><p class="q2">and all our righteousness is like a polluted garment. 
-</p><p class="q1">We all fade like a leaf; 
-</p><p class="q2">and our iniquities, like the wind, take us away. 
-</p><p class="q1">
-<span class="v">7&#160;</span>There is no one who calls on your name, 
-</p><p class="q2">who stirs himself up to take hold of you; 
-</p><p class="q1">for you have hidden your face from us, 
-</p><p class="q2">and have consumed us by means of our iniquities. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>But now, Yahweh, you are our Father. 
-</p><p class="q2">We are the clay and you our potter. 
-</p><p class="q2">We all are the work of your hand. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Don’t be furious, Yahweh. 
-</p><p class="q2">Don’t remember iniquity forever. 
-</p><p class="q1">Look and see, we beg you, 
-</p><p class="q2">we are all your people. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Your set-apart cities have become a wilderness. 
-</p><p class="q2">Zion has become a wilderness, 
-</p><p class="q2">Jerusalem a desolation. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Our set-apart and our beautiful house where our fathers praised you 
-</p><p class="q2">is burned with fire. 
-</p><p class="q2">All our pleasant places are laid waste. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Will you hold yourself back for these things, Yahweh? 
-</p><p class="q2">Will you keep silent and punish us very severely? 
-</p><h2 class="chapterlabel" id="65">65</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“I am inquired of by those who didn’t ask. 
-</p><p class="q2">I am found by those who didn’t seek me. 
-</p><p class="q2">I said, ‘See me, see me,’ to a nation that was not called by my name. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I have spread out my hands all day to a rebellious people, 
-</p><p class="q2">who walk in a way that is not good, 
-</p><p class="q2">after their own thoughts; 
-</p><p class="q1">
-<span class="v">3&#160;</span>a people who provoke me to my face continually, 
-</p><p class="q2">sacrificing in gardens, 
-</p><p class="q2">and burning incense on bricks; 
-</p><p class="q1">
-<span class="v">4&#160;</span>who sit among the graves, 
-</p><p class="q2">and spend nights in secret places; 
-</p><p class="q1">who eat pig’s meat, 
-</p><p class="q2">and broth of abominable things is in their vessels; 
-</p><p class="q1">
-<span class="v">5&#160;</span>who say, ‘Stay by yourself, 
-</p><p class="q2">don’t come near to me, 
-</p><p class="q2">for I am more set-apart than you.’ 
-</p><p class="q1">These are smoke in my nose, 
-</p><p class="q2">a fire that burns all day. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“Behold, it is written before me: 
-</p><p class="q2">I will not keep silence, 
-</p><p class="q2">but will repay, 
-</p><p class="q2">yes, I will repay into their bosom 
-</p><p class="q1">
-<span class="v">7&#160;</span>your own iniquities and the iniquities of your fathers together”, says Yahweh, 
-</p><p class="q2">“who have burned incense on the mountains, 
-</p><p class="q2">and blasphemed me on the hills. 
-</p><p class="q2">Therefore I will first measure their work into their bosom.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">8&#160;</span>Yahweh says, 
-</p><p class="q1">“As the new wine is found in the cluster, 
-</p><p class="q2">and one says, ‘Don’t destroy it, for a blessing is in it:’ 
-</p><p class="q1">so I will do for my servants’ sake, 
-</p><p class="q2">that I may not destroy them all. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will bring offspring out of Jacob, 
-</p><p class="q2">and out of Judah an inheritor of my mountains. 
-</p><p class="q1">My chosen will inherit it, 
-</p><p class="q2">and my servants will dwell there. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Sharon will be a fold of flocks, 
-</p><p class="q2">and the valley of Achor a place for herds to lie down in, 
-</p><p class="q2">for my people who have sought me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“But you who forsake Yahweh, 
-</p><p class="q2">who forget my set-apart mountain, 
-</p><p class="q2">who prepare a table for Fortune, 
-</p><p class="q2">and who fill up mixed wine to Destiny; 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will destine you to the sword, 
-</p><p class="q2">and you will all bow down to the slaughter; 
-</p><p class="q1">because when I called, you didn’t answer. 
-</p><p class="q2">When I spoke, you didn’t listen; 
-</p><p class="q1">but you did that which was evil in my eyes, 
-</p><p class="q2">and chose that in which I didn’t delight.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">13&#160;</span>Therefore the Lord Yahweh says, 
-</p><p class="q1">“Behold, my servants will eat, 
-</p><p class="q2">but you will be hungry; 
-</p><p class="q1">behold, my servants will drink, 
-</p><p class="q2">but you will be thirsty. 
-</p><p class="q1">Behold, my servants will rejoice, 
-</p><p class="q2">but you will be disappointed. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Behold, my servants will sing for joy of heart, 
-</p><p class="q2">but you will cry for sorrow of heart, 
-</p><p class="q2">and will wail for anguish of spirit. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You will leave your name for a curse to my chosen, 
-</p><p class="q2">and the Lord Yahweh will kill you. 
-</p><p class="q1">He will call his servants by another name, 
-</p><p class="q2">
-<span class="v">16&#160;</span>so that he who blesses himself in the earth will bless himself in the Elohim of truth; 
-</p><p class="q2">and he who swears in the earth will swear by the Elohim of truth; 
-</p><p class="q1">because the former troubles are forgotten, 
-</p><p class="q2">and because they are hidden from my eyes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“For, behold, I create new heavens and a new earth; 
-</p><p class="q2">and the former things will not be remembered, 
-</p><p class="q2">nor come into mind. 
-</p><p class="q1">
-<span class="v">18&#160;</span>But be glad and rejoice forever in that which I create; 
-</p><p class="q2">for, behold, I create Jerusalem to be a delight, 
-</p><p class="q2">and her people a joy. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I will rejoice in Jerusalem, 
-</p><p class="q2">and delight in my people; 
-</p><p class="q1">and the voice of weeping and the voice of crying 
-</p><p class="q2">will be heard in her no more. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“No more will there be an infant who only lives a few days, 
-</p><p class="q2">nor an old man who has not filled his days; 
-</p><p class="q1">for the child will die one hundred years old, 
-</p><p class="q2">and the sinner being one hundred years old will be accursed. 
-</p><p class="q1">
-<span class="v">21&#160;</span>They will build houses and inhabit them. 
-</p><p class="q2">They will plant vineyards and eat their fruit. 
-</p><p class="q1">
-<span class="v">22&#160;</span>They will not build and another inhabit. 
-</p><p class="q2">They will not plant and another eat; 
-</p><p class="q1">for the days of my people will be like the days of a tree, 
-</p><p class="q2">and my chosen will long enjoy the work of their hands. 
-</p><p class="q1">
-<span class="v">23&#160;</span>They will not labor in vain 
-</p><p class="q2">nor give birth for calamity; 
-</p><p class="q1">for they are the offspring of Yahweh’s blessed 
-</p><p class="q2">and their descendants with them. 
-</p><p class="q1">
-<span class="v">24&#160;</span>It will happen that before they call, I will answer; 
-</p><p class="q2">and while they are yet speaking, I will hear. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The wolf and the lamb will feed together. 
-</p><p class="q2">The lion will eat straw like the ox. 
-</p><p class="q2">Dust will be the serpent’s food. 
-</p><p class="q1">They will not hurt nor destroy in all my set-apart mountain,” 
-</p><p class="q2">says Yahweh. 
-</p><h2 class="chapterlabel" id="66">66</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh says: 
-</p><p class="q1">“Heaven is my throne, and the earth is my footstool. 
-</p><p class="q2">What kind of house will you build to me? 
-</p><p class="q2">Where will I rest? 
-</p><p class="q1">
-<span class="v">2&#160;</span>For my hand has made all these things, 
-</p><p class="q2">and so all these things came to be,” says Yahweh: 
-</p><p class="q1">“but I will look to this man, 
-</p><p class="q2">even to he who is poor and of a contrite spirit, 
-</p><p class="q2">and who trembles at my word. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He who kills an ox is as he who kills a man; 
-</p><p class="q2">he who sacrifices a lamb, as he who breaks a dog’s neck; 
-</p><p class="q2">he who offers an offering, as he who offers pig’s blood; 
-</p><p class="q2">he who burns frankincense, as he who blesses an idol. 
-</p><p class="q1">Yes, they have chosen their own ways, 
-</p><p class="q2">and their soul delights in their abominations. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I also will choose their delusions, 
-</p><p class="q2">and will bring their fears on them, 
-</p><p class="q1">because when I called, no one answered; 
-</p><p class="q2">when I spoke, they didn’t listen, 
-</p><p class="q1">but they did that which was evil in my eyes, 
-</p><p class="q2">and chose that in which I didn’t delight.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Hear Yahweh’s word, 
-</p><p class="q2">you who tremble at his word: 
-</p><p class="q1">“Your brothers who hate you, 
-</p><p class="q2">who cast you out for my name’s sake, have said, 
-</p><p class="q1">‘Let Yahweh be glorified, 
-</p><p class="q2">that we may see your joy;’ 
-</p><p class="q2">but it is those who shall be disappointed. 
-</p><p class="q1">
-<span class="v">6&#160;</span>A voice of tumult from the city, 
-</p><p class="q2">a voice from the temple, 
-</p><p class="q2">a voice of Yahweh that repays his enemies what they deserve. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Before she travailed, she gave birth. 
-</p><p class="q2">Before her pain came, she delivered a son. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Who has heard of such a thing? 
-</p><p class="q2">Who has seen such things? 
-</p><p class="q1">Shall a land be born in one day? 
-</p><p class="q2">Shall a nation be born at once? 
-</p><p class="q1">For as soon as Zion travailed, 
-</p><p class="q2">she gave birth to her children. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Shall I bring to the birth, and not cause to be delivered?” says Yahweh. 
-</p><p class="q2">“Shall I who cause to give birth shut the womb?” says your Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Rejoice with Jerusalem, and be glad for her, all you who love her. 
-</p><p class="q2">Rejoice for joy with her, all you who mourn over her; 
-</p><p class="q1">
-<span class="v">11&#160;</span>that you may nurse and be satisfied at the comforting breasts; 
-</p><p class="q2">that you may drink deeply, 
-</p><p class="q2">and be delighted with the abundance of her glory.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>For Yahweh says, “Behold, I will extend peace to her like a river, 
-</p><p class="q2">and the glory of the nations like an overflowing stream, 
-</p><p class="q2">and you will nurse. 
-</p><p class="q1">You will be carried on her side, 
-</p><p class="q2">and will be dandled on her knees. 
-</p><p class="q1">
-<span class="v">13&#160;</span>As one whom his mother comforts, 
-</p><p class="q2">so I will comfort you. 
-</p><p class="q2">You will be comforted in Jerusalem.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>You will see it, and your heart shall rejoice, 
-</p><p class="q2">and your bones will flourish like the tender grass. 
-</p><p class="q1">Yahweh’s hand will be known among his servants; 
-</p><p class="q2">and he will have indignation against his enemies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>For, behold, Yahweh will come with fire, 
-</p><p class="q2">and his chariots will be like the whirlwind; 
-</p><p class="q1">to render his anger with fierceness, 
-</p><p class="q2">and his rebuke with flames of fire. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For Yahweh will execute judgment by fire and by his sword on all flesh; 
-</p><p class="q2">and those slain by Yahweh will be many. 
-</p><p>
-<span class="v">17&#160;</span>“Those who sanctify themselves and purify themselves to go to the gardens, following one in the middle, eating pig’s meat, abominable things, and the mouse, they shall come to an end together,” says Yahweh. 
-</p><p>
-<span class="v">18&#160;</span>“For I know their works and their thoughts. The time comes that I will gather all nations and languages, and they will come, and will see my glory. 
-</p><p>
-<span class="v">19&#160;</span>“I will set a sign among them, and I will send those who escape of them to the nations, to Tarshish, Pul, and Lud, who draw the bow, to Tubal and Javan, to far-away islands, who have not heard my fame, nor have seen my glory; and they shall declare my glory among the nations. 
-<span class="v">20&#160;</span>They shall bring all your brothers out of all the nations for an offering to Yahweh, on horses, in chariots, in litters, on mules, and on camels, to my set-apart mountain Jerusalem, says Yahweh, as the children of Israel bring their offering in a clean vessel into Yahweh’s house. 
-<span class="v">21&#160;</span>Of them I will also select priests and Levites,” says Yahweh. 
-</p><p>
-<span class="v">22&#160;</span>“For as the new heavens and the new earth, which I will make, shall remain before me,” says Yahweh, “so your offspring and your name shall remain. 
-<span class="v">23&#160;</span>It shall happen that from one new moon to another, and from one Sabbath to another, all flesh will come to worship before me,” says Yahweh. 
-<span class="v">24&#160;</span>“They will go out, and look at the dead bodies of the men who have transgressed against me; for their worm will not die, nor will their fire be quenched, and they will be loathsome to all mankind.” </div><script src="../main.js"></script></body></html>
+<div class="q1">
+<sup>1&#160;</sup>“Hear this, house of Jacob, 
+</div><div class="q2">you who are called by the name of Israel, 
+</div><div class="q2">and have come out of the waters of Judah. 
+</div><div class="q1">You swear by Yahweh’s name, 
+</div><div class="q2">and make mention of the Elohim of Israel, 
+</div><div class="q2">but not in truth, nor in righteousness—</div><div class="q1">
+<sup>2&#160;</sup>for they call themselves citizens of the set-apart city, 
+</div><div class="q2">and rely on the Elohim of Israel; 
+</div><div class="q2">Yahweh of Armies is his name. 
+</div><div class="q1">
+<sup>3&#160;</sup>I have declared the former things from of old. 
+</div><div class="q2">Yes, they went out of my mouth, and I revealed them. 
+</div><div class="q2">I did them suddenly, and they happened. 
+</div><div class="q1">
+<sup>4&#160;</sup>Because I knew that you are obstinate, 
+</div><div class="q2">and your neck is an iron sinew, 
+</div><div class="q2">and your brow bronze; 
+</div><div class="q1">
+<sup>5&#160;</sup>therefore I have declared it to you from of old; 
+</div><div class="q2">before it came to pass I showed it to you; 
+</div><div class="q2">lest you should say, ‘My idol has done them. 
+</div><div class="q2">My engraved image and my molten image has commanded them.’ 
+</div><div class="q1">
+<sup>6&#160;</sup>You have heard it. 
+</div><div class="q2">Now see all this. 
+</div><div class="q2">And you, won’t you declare it? 
+</div><div class="b"> &#160; </div>
+<div class="q1">“I have shown you new things from this time, 
+</div><div class="q2">even hidden things, which you have not known. 
+</div><div class="q1">
+<sup>7&#160;</sup>They are created now, and not from of old. 
+</div><div class="q2">Before today, you didn’t hear them, 
+</div><div class="q2">lest you should say, ‘Behold, I knew them.’ 
+</div><div class="q1">
+<sup>8&#160;</sup>Yes, you didn’t hear. 
+</div><div class="q2">Yes, you didn’t know. 
+</div><div class="q2">Yes, from of old your ear was not opened, 
+</div><div class="q1">for I knew that you dealt very treacherously, 
+</div><div class="q2">and were called a transgressor from the womb. 
+</div><div class="q1">
+<sup>9&#160;</sup>For my name’s sake, I will defer my anger, 
+</div><div class="q2">and for my praise, I hold it back for you 
+</div><div class="q2">so that I don’t cut you off. 
+</div><div class="q1">
+<sup>10&#160;</sup>Behold, I have refined you, 
+</div><div class="q2">but not as silver. 
+</div><div class="q2">I have chosen you in the furnace of affliction. 
+</div><div class="q1">
+<sup>11&#160;</sup>For my own sake, 
+</div><div class="q2">for my own sake, I will do it; 
+</div><div class="q1">for how would my name be profaned? 
+</div><div class="q2">I will not give my glory to another. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Listen to me, O Jacob, 
+</div><div class="q2">and Israel my called: 
+</div><div class="q1">I am he. 
+</div><div class="q2">I am the first. 
+</div><div class="q2">I am also the last. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yes, my hand has laid the foundation of the earth, 
+</div><div class="q2">and my right hand has spread out the heavens. 
+</div><div class="q2">when I call to them, they stand up together. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“Assemble yourselves, all of you, and hear! 
+</div><div class="q2">Who among them has declared these things? 
+</div><div class="q1">He whom Yahweh loves will do what he likes to Babylon, 
+</div><div class="q2">and his arm will be against the Chaldeans. 
+</div><div class="q1">
+<sup>15&#160;</sup>I, even I, have spoken. 
+</div><div class="q2">Yes, I have called him. 
+</div><div class="q1">I have brought him 
+</div><div class="q2">and he shall make his way prosperous. 
+</div><div class="p">
+<sup>16&#160;</sup>“Come near to me and hear this: 
+</div><div class="b"> &#160; </div>
+<div class="q1">“From the beginning I have not spoken in secret; 
+</div><div class="q2">from the time that it happened, I was there.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">Now the Lord Yahweh has sent me 
+</div><div class="q2">with his Spirit. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Yahweh, 
+</div><div class="q2">your Redeemer, 
+</div><div class="q2">the Set-Apart One of Israel, says: 
+</div><div class="q1">“I am Yahweh your Elohim, 
+</div><div class="q2">who teaches you to profit, 
+</div><div class="q2">who leads you by the way that you should go. 
+</div><div class="q1">
+<sup>18&#160;</sup>Oh that you had listened to my commandments! 
+</div><div class="q2">Then your peace would have been like a river 
+</div><div class="q2">and your righteousness like the waves of the sea. 
+</div><div class="q1">
+<sup>19&#160;</sup>Your offspring also would have been as the sand 
+</div><div class="q2">and the descendants of your body like its grains. 
+</div><div class="q2">His name would not be cut off nor destroyed from before me.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>Leave Babylon! 
+</div><div class="q2">Flee from the Chaldeans! 
+</div><div class="q1">With the sound of joyful shouting announce this, 
+</div><div class="q2">tell it even to the end of the earth; 
+</div><div class="q2">say, “Yahweh has redeemed his servant Jacob!” 
+</div><div class="q1">
+<sup>21&#160;</sup>They didn’t thirst when he led them through the deserts. 
+</div><div class="q2">He caused the waters to flow out of the rock for them. 
+</div><div class="q2">He also split the rock and the waters gushed out. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“There is no peace”, says Yahweh, “for the wicked.” 
+</div><h2 class="chapterlabel" id="49">49</h2>
+<div class="q1">
+<sup>1&#160;</sup>Listen, islands, to me. 
+</div><div class="q2">Listen, you peoples, from afar: 
+</div><div class="q1">Yahweh has called me from the womb; 
+</div><div class="q2">from the inside of my mother, he has mentioned my name. 
+</div><div class="q1">
+<sup>2&#160;</sup>He has made my mouth like a sharp sword. 
+</div><div class="q2">He has hidden me in the shadow of his hand. 
+</div><div class="q1">He has made me a polished shaft. 
+</div><div class="q2">He has kept me close in his quiver. 
+</div><div class="q1">
+<sup>3&#160;</sup>He said to me, “You are my servant, 
+</div><div class="q2">Israel, in whom I will be glorified.” 
+</div><div class="q1">
+<sup>4&#160;</sup>But I said, “I have labored in vain. 
+</div><div class="q2">I have spent my strength in vain for nothing; 
+</div><div class="q1">yet surely the justice due to me is with Yahweh, 
+</div><div class="q2">and my reward with my Elohim.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Now Yahweh, he who formed me from the womb to be his servant, 
+</div><div class="q2">says to bring Jacob again to him, 
+</div><div class="q2">and to gather Israel to him, 
+</div><div class="q2">for I am honorable in Yahweh’s eyes, 
+</div><div class="q2">and my Elohim has become my strength. 
+</div><div class="q1">
+<sup>6&#160;</sup>Indeed, he says, “It is too light a thing that you should be my servant to raise up the tribes of Jacob, 
+</div><div class="q2">and to restore the preserved of Israel. 
+</div><div class="q1">I will also give you as a light to the nations, 
+</div><div class="q2">that you may be my salvation to the end of the earth.” 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh, the Redeemer of Israel, and his Set-Apart One, 
+</div><div class="q2">says to him whom man despises, to him whom the nation abhors, to a servant of rulers: 
+</div><div class="q1">“Kings shall see and rise up, 
+</div><div class="q2">princes, and they shall worship, 
+</div><div class="q2">because of Yahweh who is faithful, even the Set-Apart One of Israel, who has chosen you.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Yahweh says, “I have answered you in an acceptable time. 
+</div><div class="q2">I have helped you in a day of salvation. 
+</div><div class="q1">I will preserve you and give you for a covenant of the people, 
+</div><div class="q2">to raise up the land, to make them inherit the desolate heritage, 
+</div><div class="q1">
+<sup>9&#160;</sup>saying to those who are bound, ‘Come out!’; 
+</div><div class="q2">to those who are in darkness, ‘Show yourselves!’ 
+</div><div class="q1">“They shall feed along the paths, 
+</div><div class="q2">and their pasture shall be on all treeless heights. 
+</div><div class="q1">
+<sup>10&#160;</sup>They shall not hunger nor thirst; 
+</div><div class="q2">neither shall the heat nor sun strike them, 
+</div><div class="q2">for he who has mercy on them will lead them. 
+</div><div class="q2">He will guide them by springs of water. 
+</div><div class="q1">
+<sup>11&#160;</sup>I will make all my mountains a road, 
+</div><div class="q2">and my highways shall be exalted. 
+</div><div class="q1">
+<sup>12&#160;</sup>Behold, these shall come from afar, 
+</div><div class="q2">and behold, these from the north and from the west, 
+</div><div class="q2">and these from the land of Sinim.” 
+</div><div class="q1">
+<sup>13&#160;</sup>Sing, heavens, and be joyful, earth! 
+</div><div class="q2">Break out into singing, mountains! 
+</div><div class="q1">For Yahweh has comforted his people, 
+</div><div class="q2">and will have compassion on his afflicted. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>But Zion said, “Yahweh has forsaken me, 
+</div><div class="q2">and the Lord has forgotten me.” 
+</div><div class="q1">
+<sup>15&#160;</sup>“Can a woman forget her nursing child, 
+</div><div class="q2">that she should not have compassion on the son of her womb? 
+</div><div class="q1">Yes, these may forget, 
+</div><div class="q2">yet I will not forget you! 
+</div><div class="q1">
+<sup>16&#160;</sup>Behold, I have engraved you on the palms of my hands. 
+</div><div class="q2">Your walls are continually before me. 
+</div><div class="q1">
+<sup>17&#160;</sup>Your children hurry. 
+</div><div class="q2">Your destroyers and those who devastated you will leave you. 
+</div><div class="q1">
+<sup>18&#160;</sup>Lift up your eyes all around, and see: 
+</div><div class="q2">all these gather themselves together, and come to you. 
+</div><div class="q1">As I live,” says Yahweh, “you shall surely clothe yourself with them all as with an ornament, 
+</div><div class="q2">and dress yourself with them, like a bride. 
+</div><div class="q1">
+<sup>19&#160;</sup>“For, as for your waste and your desolate places, 
+</div><div class="q2">and your land that has been destroyed, 
+</div><div class="q1">surely now that land will be too small for the inhabitants, 
+</div><div class="q2">and those who swallowed you up will be far away. 
+</div><div class="q1">
+<sup>20&#160;</sup>The children of your bereavement will say in your ears, 
+</div><div class="q2">‘This place is too small for me. 
+</div><div class="q2">Give me a place to live in.’ 
+</div><div class="q1">
+<sup>21&#160;</sup>Then you will say in your heart, ‘Who has conceived these for me, since I have been bereaved of my children 
+</div><div class="q2">and am alone, an exile, and wandering back and forth? 
+</div><div class="q1">Who has brought these up? 
+</div><div class="q2">Behold, I was left alone. Where were these?’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>The Lord Yahweh says, “Behold, I will lift up my hand to the nations, 
+</div><div class="q2">and lift up my banner to the peoples. 
+</div><div class="q1">They shall bring your sons in their bosom, 
+</div><div class="q2">and your daughters shall be carried on their shoulders. 
+</div><div class="q1">
+<sup>23&#160;</sup>Kings shall be your foster fathers, 
+</div><div class="q2">and their queens your nursing mothers. 
+</div><div class="q1">They will bow down to you with their faces to the earth, 
+</div><div class="q2">and lick the dust of your feet. 
+</div><div class="q1">Then you will know that I am Yahweh; 
+</div><div class="q2">and those who wait for me won’t be disappointed.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>Shall the plunder be taken from the mighty, 
+</div><div class="q2">or the lawful captives be delivered? 
+</div><div class="q1">
+<sup>25&#160;</sup>But Yahweh says, “Even the captives of the mighty shall be taken away, 
+</div><div class="q2">and the plunder retrieved from the fierce, 
+</div><div class="q1">for I will contend with him who contends with you 
+</div><div class="q2">and I will save your children. 
+</div><div class="q1">
+<sup>26&#160;</sup>I will feed those who oppress you with their own flesh; 
+</div><div class="q2">and they will be drunk on their own blood, as with sweet wine. 
+</div><div class="q1">Then all flesh shall know that I, Yahweh, am your Savior 
+</div><div class="q2">and your Redeemer, the Mighty One of Jacob.” 
+</div><h2 class="chapterlabel" id="50">50</h2>
+<div class="q1">
+<sup>1&#160;</sup>Yahweh says, “Where is the bill of your mother’s divorce, with which I have put her away? 
+</div><div class="q2">Or to which of my creditors have I sold you? 
+</div><div class="q1">Behold, you were sold for your iniquities, 
+</div><div class="q2">and your mother was put away for your transgressions. 
+</div><div class="q1">
+<sup>2&#160;</sup>Why, when I came, was there no one? 
+</div><div class="q2">When I called, why was there no one to answer? 
+</div><div class="q1">Is my hand shortened at all, that it can’t redeem? 
+</div><div class="q2">Or have I no power to deliver? 
+</div><div class="q1">Behold, at my rebuke I dry up the sea. 
+</div><div class="q2">I make the rivers a wilderness. 
+</div><div class="q2">Their fish stink because there is no water, and die of thirst. 
+</div><div class="q1">
+<sup>3&#160;</sup>I clothe the heavens with blackness. 
+</div><div class="q2">I make sackcloth their covering.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>The Lord Yahweh has given me the tongue of those who are taught, 
+</div><div class="q2">that I may know how to sustain with words him who is weary. 
+</div><div class="q1">He awakens morning by morning, 
+</div><div class="q2">he awakens my ear to hear as those who are taught. 
+</div><div class="q1">
+<sup>5&#160;</sup>The Lord Yahweh has opened my ear. 
+</div><div class="q2">I was not rebellious. 
+</div><div class="q2">I have not turned back. 
+</div><div class="q1">
+<sup>6&#160;</sup>I gave my back to those who beat me, 
+</div><div class="q2">and my cheeks to those who plucked off the hair. 
+</div><div class="q2">I didn’t hide my face from shame and spitting. 
+</div><div class="q1">
+<sup>7&#160;</sup>For the Lord Yahweh will help me. 
+</div><div class="q2">Therefore I have not been confounded. 
+</div><div class="q1">Therefore I have set my face like a flint, 
+</div><div class="q2">and I know that I won’t be disappointed. 
+</div><div class="q1">
+<sup>8&#160;</sup>He who justifies me is near. 
+</div><div class="q2">Who will bring charges against me? 
+</div><div class="q1">Let us stand up together. 
+</div><div class="q2">Who is my adversary? 
+</div><div class="q2">Let him come near to me. 
+</div><div class="q1">
+<sup>9&#160;</sup>Behold, the Lord Yahweh will help me! 
+</div><div class="q2">Who is he who will condemn me? 
+</div><div class="q1">Behold, they will all grow old like a garment. 
+</div><div class="q2">The moths will eat them up. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Who among you fears Yahweh 
+</div><div class="q2">and obeys the voice of his servant? 
+</div><div class="q1">He who walks in darkness 
+</div><div class="q2">and has no light, 
+</div><div class="q1">let him trust in Yahweh’s name, 
+</div><div class="q2">and rely on his Elohim. 
+</div><div class="q1">
+<sup>11&#160;</sup>Behold, all you who kindle a fire, 
+</div><div class="q2">who adorn yourselves with torches around yourselves, 
+</div><div class="q1">walk in the flame of your fire, 
+</div><div class="q2">and among the torches that you have kindled. 
+</div><div class="q1">You will have this from my hand: 
+</div><div class="q2">you will lie down in sorrow. 
+</div><h2 class="chapterlabel" id="51">51</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Listen to me, you who follow after righteousness, 
+</div><div class="q2">you who seek Yahweh. 
+</div><div class="q1">Look to the rock you were cut from, 
+</div><div class="q2">and to the quarry you were dug from. 
+</div><div class="q1">
+<sup>2&#160;</sup>Look to Abraham your father, 
+</div><div class="q2">and to Sarah who bore you; 
+</div><div class="q1">for when he was but one I called him, 
+</div><div class="q2">I blessed him, 
+</div><div class="q2">and made him many. 
+</div><div class="q1">
+<sup>3&#160;</sup>For Yahweh has comforted Zion. 
+</div><div class="q2">He has comforted all her waste places, 
+</div><div class="q2">and has made her wilderness like Eden, 
+</div><div class="q2">and her desert like the garden of Yahweh. 
+</div><div class="q1">Joy and gladness will be found in them, 
+</div><div class="q2">thanksgiving, and the voice of melody. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Listen to me, my people; 
+</div><div class="q2">and hear me, my nation, 
+</div><div class="q1">for a law will go out from me, 
+</div><div class="q2">and I will establish my justice for a light to the peoples. 
+</div><div class="q1">
+<sup>5&#160;</sup>My righteousness is near. 
+</div><div class="q2">My salvation has gone out, 
+</div><div class="q2">and my arms will judge the peoples. 
+</div><div class="q1">The islands will wait for me, 
+</div><div class="q2">and they will trust my arm. 
+</div><div class="q1">
+<sup>6&#160;</sup>Lift up your eyes to the heavens, 
+</div><div class="q2">and look at the earth beneath; 
+</div><div class="q1">for the heavens will vanish away like smoke, 
+</div><div class="q2">and the earth will wear out like a garment. 
+</div><div class="q1">Its inhabitants will die in the same way, 
+</div><div class="q2">but my salvation will be forever, 
+</div><div class="q2">and my righteousness will not be abolished. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Listen to me, you who know righteousness, 
+</div><div class="q2">the people in whose heart is my law. 
+</div><div class="q1">Don’t fear the reproach of men, 
+</div><div class="q2">and don’t be dismayed at their insults. 
+</div><div class="q1">
+<sup>8&#160;</sup>For the moth will eat them up like a garment, 
+</div><div class="q2">and the worm will eat them like wool; 
+</div><div class="q1">but my righteousness will be forever, 
+</div><div class="q2">and my salvation to all generations.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Awake, awake, put on strength, arm of Yahweh! 
+</div><div class="q2">Awake, as in the days of old, 
+</div><div class="q2">the generations of ancient times. 
+</div><div class="q1">Isn’t it you who cut Rahab in pieces, 
+</div><div class="q2">who pierced the monster? 
+</div><div class="q1">
+<sup>10&#160;</sup>Isn’t it you who dried up the sea, 
+</div><div class="q2">the waters of the great deep; 
+</div><div class="q2">who made the depths of the sea a way for the redeemed to pass over? 
+</div><div class="q1">
+<sup>11&#160;</sup>Those ransomed by Yahweh will return, 
+</div><div class="q2">and come with singing to Zion. 
+</div><div class="q2">Everlasting joy shall be on their heads. 
+</div><div class="q1">They will obtain gladness and joy. 
+</div><div class="q2">Sorrow and sighing shall flee away. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“I, even I, am he who comforts you. 
+</div><div class="q2">Who are you, that you are afraid of man who shall die, 
+</div><div class="q2">and of the son of man who will be made as grass? 
+</div><div class="q1">
+<sup>13&#160;</sup>Have you forgotten Yahweh your Maker, 
+</div><div class="q2">who stretched out the heavens, 
+</div><div class="q2">and laid the foundations of the earth? 
+</div><div class="q1">Do you live in fear continually all day because of the fury of the oppressor, 
+</div><div class="q2">when he prepares to destroy? 
+</div><div class="q2">Where is the fury of the oppressor? 
+</div><div class="q1">
+<sup>14&#160;</sup>The captive exile will speedily be freed. 
+</div><div class="q2">He will not die and go down into the pit. 
+</div><div class="q2">His bread won’t fail. 
+</div><div class="q1">
+<sup>15&#160;</sup>For I am Yahweh your Elohim, who stirs up the sea 
+</div><div class="q2">so that its waves roar. 
+</div><div class="q2">Yahweh of Armies is his name. 
+</div><div class="q1">
+<sup>16&#160;</sup>I have put my words in your mouth 
+</div><div class="q2">and have covered you in the shadow of my hand, 
+</div><div class="q1">that I may plant the heavens, 
+</div><div class="q2">and lay the foundations of the earth, 
+</div><div class="q2">and tell Zion, ‘You are my people.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Awake, awake! 
+</div><div class="q2">Stand up, Jerusalem, 
+</div><div class="q2">you who have drunk from Yahweh’s hand the cup of his wrath. 
+</div><div class="q1">You have drunken the bowl of the cup of staggering, 
+</div><div class="q2">and drained it. 
+</div><div class="q1">
+<sup>18&#160;</sup>There is no one to guide her among all the sons to whom she has given birth; 
+</div><div class="q2">and there is no one who takes her by the hand among all the sons whom she has brought up. 
+</div><div class="q1">
+<sup>19&#160;</sup>These two things have happened to you—</div><div class="q2">who will grieve with you?—</div><div class="q1">desolation and destruction, 
+</div><div class="q2">and famine and the sword. 
+</div><div class="q2">How can I comfort you? 
+</div><div class="q1">
+<sup>20&#160;</sup>Your sons have fainted. 
+</div><div class="q2">They lie at the head of all the streets, 
+</div><div class="q2">like an antelope in a net. 
+</div><div class="q1">They are full of Yahweh’s wrath, 
+</div><div class="q2">the rebuke of your Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Therefore now hear this, you afflicted, 
+</div><div class="q2">and drunken, but not with wine: 
+</div><div class="q1">
+<sup>22&#160;</sup>Your Lord Yahweh, 
+</div><div class="q2">your Elohim who pleads the cause of his people, says, 
+</div><div class="q1">“Behold, I have taken out of your hand the cup of staggering, 
+</div><div class="q2">even the bowl of the cup of my wrath. 
+</div><div class="q2">You will not drink it any more. 
+</div><div class="q1">
+<sup>23&#160;</sup>I will put it into the hand of those who afflict you, 
+</div><div class="q2">who have said to your soul, ‘Bow down, that we may walk over you;’ 
+</div><div class="q2">and you have laid your back as the ground, 
+</div><div class="q2">like a street to those who walk over.” 
+</div><h2 class="chapterlabel" id="52">52</h2>
+<div class="q1">
+<sup>1&#160;</sup>Awake, awake! Put on your strength, Zion. 
+</div><div class="q2">Put on your beautiful garments, Jerusalem, the set-apart city, 
+</div><div class="q2">for from now on the uncircumcised and the unclean will no more come into you. 
+</div><div class="q1">
+<sup>2&#160;</sup>Shake yourself from the dust! 
+</div><div class="q2">Arise, sit up, Jerusalem! 
+</div><div class="q2">Release yourself from the bonds of your neck, captive daughter of Zion! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>For Yahweh says, “You were sold for nothing; 
+</div><div class="q2">and you will be redeemed without money.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>4&#160;</sup>For the Lord Yahweh says: 
+</div><div class="q1">“My people went down at the first into Egypt to live there; 
+</div><div class="q2">and the Assyrian has oppressed them without cause. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Now therefore, what do I do here,” says Yahweh, 
+</div><div class="q2">“seeing that my people are taken away for nothing? 
+</div><div class="q1">Those who rule over them mock,” says Yahweh, 
+</div><div class="q2">“and my name is blasphemed continually all day long. 
+</div><div class="q1">
+<sup>6&#160;</sup>Therefore my people shall know my name. 
+</div><div class="q2">Therefore they shall know in that day that I am he who speaks. 
+</div><div class="q2">Behold, it is I.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>How beautiful on the mountains are the feet of him who brings good news, 
+</div><div class="q2">who publishes peace, 
+</div><div class="q2">who brings good news, 
+</div><div class="q2">who proclaims salvation, 
+</div><div class="q2">who says to Zion, “Your Elohim reigns!” 
+</div><div class="q1">
+<sup>8&#160;</sup>Your watchmen lift up their voice. 
+</div><div class="q2">Together they sing; 
+</div><div class="q2">for they shall see eye to eye when Yahweh returns to Zion. 
+</div><div class="q1">
+<sup>9&#160;</sup>Break out into joy! 
+</div><div class="q2">Sing together, you waste places of Jerusalem; 
+</div><div class="q2">for Yahweh has comforted his people. 
+</div><div class="q2">He has redeemed Jerusalem. 
+</div><div class="q1">
+<sup>10&#160;</sup>Yahweh has made his set-apart arm bare in the eyes of all the nations. 
+</div><div class="q2">All the ends of the earth have seen the salvation of our Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Depart! Depart! Go out from there! Touch no unclean thing! 
+</div><div class="q2">Go out from among her! 
+</div><div class="q2">Cleanse yourselves, you who carry Yahweh’s vessels. 
+</div><div class="q1">
+<sup>12&#160;</sup>For you shall not go out in haste, 
+</div><div class="q2">neither shall you go by flight; 
+</div><div class="q1">for Yahweh will go before you, 
+</div><div class="q2">and the Elohim of Israel will be your rear guard. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Behold, my servant will deal wisely. 
+</div><div class="q2">He will be exalted and lifted up, 
+</div><div class="q2">and will be very high. 
+</div><div class="q1">
+<sup>14&#160;</sup>Just as many were astonished at you—</div><div class="q2">his appearance was marred more than any man, and his form more than the sons of men—</div><div class="q1">
+<sup>15&#160;</sup>so he will cleanse many nations. 
+</div><div class="q2">Kings will shut their mouths at him; 
+</div><div class="q2">for they will see that which had not been told them, 
+</div><div class="q2">and they will understand that which they had not heard. 
+</div><h2 class="chapterlabel" id="53">53</h2>
+<div class="q1">
+<sup>1&#160;</sup>Who has believed our message? 
+</div><div class="q2">To whom has Yahweh’s arm been revealed? 
+</div><div class="q1">
+<sup>2&#160;</sup>For he grew up before him as a tender plant, 
+</div><div class="q2">and as a root out of dry ground. 
+</div><div class="q1">He has no good looks or majesty. 
+</div><div class="q2">When we see him, there is no beauty that we should desire him. 
+</div><div class="q1">
+<sup>3&#160;</sup>He was despised 
+</div><div class="q2">and rejected by men, 
+</div><div class="q1">a man of suffering 
+</div><div class="q2">and acquainted with disease. 
+</div><div class="q1">He was despised as one from whom men hide their face; 
+</div><div class="q2">and we didn’t respect him. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>Surely he has borne our sickness 
+</div><div class="q2">and carried our suffering; 
+</div><div class="q1">yet we considered him plagued, 
+</div><div class="q2">struck by Elohim, and afflicted. 
+</div><div class="q1">
+<sup>5&#160;</sup>But he was pierced for our transgressions. 
+</div><div class="q2">He was crushed for our iniquities. 
+</div><div class="q1">The punishment that brought our peace was on him; 
+</div><div class="q2">and by his wounds we are healed. 
+</div><div class="q1">
+<sup>6&#160;</sup>All we like sheep have gone astray. 
+</div><div class="q2">Everyone has turned to his own way; 
+</div><div class="q2">and Yahweh has laid on him the iniquity of us all. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>He was oppressed, 
+</div><div class="q2">yet when he was afflicted he didn’t open his mouth. 
+</div><div class="q1">As a lamb that is led to the slaughter, 
+</div><div class="q2">and as a sheep that before its shearers is silent, 
+</div><div class="q2">so he didn’t open his mouth. 
+</div><div class="q1">
+<sup>8&#160;</sup>He was taken away by oppression and judgment. 
+</div><div class="q2">As for his generation, 
+</div><div class="q2">who considered that he was cut off out of the land of the living 
+</div><div class="q2">and stricken for the disobedience of my people? 
+</div><div class="q1">
+<sup>9&#160;</sup>They made his grave with the wicked, 
+</div><div class="q2">and with a rich man in his death, 
+</div><div class="q1">although he had done no violence, 
+</div><div class="q2">nor was any deceit in his mouth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Yet it pleased Yahweh to bruise him. 
+</div><div class="q2">He has caused him to suffer. 
+</div><div class="q1">When you make his soul an offering for sin, 
+</div><div class="q2">he will see his offspring. 
+</div><div class="q1">He will prolong his days 
+</div><div class="q2">and Yahweh’s pleasure will prosper in his hand. 
+</div><div class="q1">
+<sup>11&#160;</sup>After the suffering of his soul, 
+</div><div class="q2">he will see the light and be satisfied. 
+</div><div class="q1">My righteous servant will justify many by the knowledge of himself; 
+</div><div class="q2">and he will bear their iniquities. 
+</div><div class="q1">
+<sup>12&#160;</sup>Therefore I will give him a portion with the great. 
+</div><div class="q2">He will divide the plunder with the strong, 
+</div><div class="q1">because he poured out his soul to death 
+</div><div class="q2">and was counted with the transgressors; 
+</div><div class="q1">yet he bore the sins of many 
+</div><div class="q2">and made intercession for the transgressors. 
+</div><h2 class="chapterlabel" id="54">54</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Sing, barren, you who didn’t give birth! 
+</div><div class="q2">Break out into singing, and cry aloud, you who didn’t travail with child! 
+</div><div class="q2">For more are the children of the desolate than the children of the owned woman,” says Yahweh. 
+</div><div class="q1">
+<sup>2&#160;</sup>“Enlarge the place of your tent, 
+</div><div class="q2">and let them stretch out the curtains of your habitations; 
+</div><div class="q2">don’t spare; lengthen your cords, and strengthen your stakes. 
+</div><div class="q1">
+<sup>3&#160;</sup>For you will spread out on the right hand and on the left; 
+</div><div class="q2">and your offspring will possess the nations 
+</div><div class="q2">and settle in desolate cities. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Don’t be afraid, for you will not be ashamed. 
+</div><div class="q2">Don’t be confounded, for you will not be disappointed. 
+</div><div class="q1">For you will forget the shame of your youth. 
+</div><div class="q2">You will remember the reproach of your widowhood no more. 
+</div><div class="q1">
+<sup>5&#160;</sup>For your Maker is your owner; Yahweh of Armies is his name. 
+</div><div class="q2">The Set-Apart One of Israel is your Redeemer. 
+</div><div class="q2">He will be called the Elohim of the whole earth. 
+</div><div class="q1">
+<sup>6&#160;</sup>For Yahweh has called you as a woman forsaken and grieved in spirit, 
+</div><div class="q2">even a woman of youth, when she is cast off,” says your Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“For a small moment I have forsaken you, 
+</div><div class="q2">but I will gather you with great mercies. 
+</div><div class="q1">
+<sup>8&#160;</sup>In overflowing wrath I hid my face from you for a moment, 
+</div><div class="q2">but with everlasting loving kindness I will have mercy on you,” says Yahweh your Redeemer. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“For this is like the waters of Noah to me; 
+</div><div class="q2">for as I have sworn that the waters of Noah will no more go over the earth, 
+</div><div class="q2">so I have sworn that I will not be angry with you, nor rebuke you. 
+</div><div class="q1">
+<sup>10&#160;</sup>For the mountains may depart, 
+</div><div class="q2">and the hills be removed, 
+</div><div class="q1">but my loving kindness will not depart from you, 
+</div><div class="q2">and my covenant of peace will not be removed,” 
+</div><div class="q2">says Yahweh who has mercy on you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“You afflicted, tossed with storms, and not comforted, 
+</div><div class="q2">behold, I will set your stones in beautiful colors, 
+</div><div class="q2">and lay your foundations with sapphires. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will make your pinnacles of rubies, 
+</div><div class="q2">your gates of sparkling jewels, 
+</div><div class="q2">and all your walls of precious stones. 
+</div><div class="q1">
+<sup>13&#160;</sup>All your children will be taught by Yahweh, 
+</div><div class="q2">and your children’s peace will be great. 
+</div><div class="q1">
+<sup>14&#160;</sup>You will be established in righteousness. 
+</div><div class="q2">You will be far from oppression, 
+</div><div class="q2">for you will not be afraid, 
+</div><div class="q2">and far from terror, 
+</div><div class="q2">for it shall not come near you. 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, they may gather together, but not by me. 
+</div><div class="q2">Whoever gathers together against you will fall because of you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>“Behold, I have created the blacksmith who fans the coals into flame, 
+</div><div class="q2">and forges a weapon for his work; 
+</div><div class="q2">and I have created the destroyer to destroy. 
+</div><div class="q1">
+<sup>17&#160;</sup>No weapon that is formed against you will prevail; 
+</div><div class="q2">and you will condemn every tongue that rises against you in judgment. 
+</div><div class="q1">This is the heritage of Yahweh’s servants, 
+</div><div class="q2">and their righteousness is of me,” says Yahweh. 
+</div><h2 class="chapterlabel" id="55">55</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Hey! Come, everyone who thirsts, to the waters! 
+</div><div class="q2">Come, he who has no money, buy, and eat! 
+</div><div class="q2">Yes, come, buy wine and milk without money and without price. 
+</div><div class="q1">
+<sup>2&#160;</sup>Why do you spend money for that which is not bread, 
+</div><div class="q2">and your labor for that which doesn’t satisfy? 
+</div><div class="q1">Listen diligently to me, and eat that which is good, 
+</div><div class="q2">and let your soul delight itself in richness. 
+</div><div class="q1">
+<sup>3&#160;</sup>Turn your ear, and come to me. 
+</div><div class="q2">Hear, and your soul will live. 
+</div><div class="q2">I will make an everlasting covenant with you, even the sure mercies of David. 
+</div><div class="q1">
+<sup>4&#160;</sup>Behold, I have given him for a witness to the peoples, 
+</div><div class="q2">a leader and commander to the peoples. 
+</div><div class="q1">
+<sup>5&#160;</sup>Behold, you shall call a nation that you don’t know; 
+</div><div class="q2">and a nation that didn’t know you shall run to you, 
+</div><div class="q2">because of Yahweh your Elohim, 
+</div><div class="q2">and for the Set-Apart One of Israel; 
+</div><div class="q2">for he has glorified you.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Seek Yahweh while he may be found. 
+</div><div class="q2">Call on him while he is near. 
+</div><div class="q1">
+<sup>7&#160;</sup>Let the wicked forsake his way, 
+</div><div class="q2">and the unrighteous man his thoughts. 
+</div><div class="q1">Let him return to Yahweh, and he will have mercy on him, 
+</div><div class="q2">to our Elohim, for he will freely pardon. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“For my thoughts are not your thoughts, 
+</div><div class="q2">and your ways are not my ways,” says Yahweh. 
+</div><div class="q1">
+<sup>9&#160;</sup>“For as the heavens are higher than the earth, 
+</div><div class="q2">so are my ways higher than your ways, 
+</div><div class="q2">and my thoughts than your thoughts. 
+</div><div class="q1">
+<sup>10&#160;</sup>For as the rain comes down and the snow from the sky, 
+</div><div class="q2">and doesn’t return there, but waters the earth, 
+</div><div class="q2">and makes it grow and bud, 
+</div><div class="q2">and gives seed to the sower and bread to the eater; 
+</div><div class="q1">
+<sup>11&#160;</sup>so is my word that goes out of my mouth: 
+</div><div class="q2">it will not return to me void, 
+</div><div class="q2">but it will accomplish that which I please, 
+</div><div class="q2">and it will prosper in the thing I sent it to do. 
+</div><div class="q1">
+<sup>12&#160;</sup>For you shall go out with joy, 
+</div><div class="q2">and be led out with peace. 
+</div><div class="q1">The mountains and the hills will break out before you into singing; 
+</div><div class="q2">and all the trees of the fields will clap their hands. 
+</div><div class="q1">
+<sup>13&#160;</sup>Instead of the thorn the cypress tree will come up; 
+</div><div class="q2">and instead of the brier the myrtle tree will come up. 
+</div><div class="q1">It will make a name for Yahweh, 
+</div><div class="q2">for an everlasting sign that will not be cut off.” 
+</div><h2 class="chapterlabel" id="56">56</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh says: 
+</div><div class="q1">“Maintain justice 
+</div><div class="q2">and do what is right, 
+</div><div class="q1">for my salvation is near 
+</div><div class="q2">and my righteousness will soon be revealed. 
+</div><div class="q1">
+<sup>2&#160;</sup>Blessed is the man who does this, 
+</div><div class="q2">and the son of man who holds it fast; 
+</div><div class="q1">who keeps the Sabbath without profaning it 
+</div><div class="q2">and keeps his hand from doing any evil.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>Let no foreigner who has joined himself to Yahweh speak, saying, 
+</div><div class="q2">“Yahweh will surely separate me from his people.” 
+</div><div class="q2">Do not let the eunuch say, “Behold, I am a dry tree.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>For Yahweh says, “To the eunuchs who keep my Sabbaths, 
+</div><div class="q2">choose the things that please me, 
+</div><div class="q2">and hold fast to my covenant, 
+</div><div class="q1">
+<sup>5&#160;</sup>I will give them in my house and within my walls a memorial and a name better than of sons and of daughters. 
+</div><div class="q2">I will give them an everlasting name that will not be cut off. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Also the foreigners who join themselves to Yahweh 
+</div><div class="q2">to serve him, 
+</div><div class="q1">and to love Yahweh’s name, 
+</div><div class="q2">to be his servants, 
+</div><div class="q1">everyone who keeps the Sabbath from profaning it, 
+</div><div class="q2">and holds fast my covenant, 
+</div><div class="q1">
+<sup>7&#160;</sup>I will bring these to my set-apart mountain, 
+</div><div class="q2">and make them joyful in my house of prayer. 
+</div><div class="q1">Their burnt offerings and their sacrifices will be accepted on my altar; 
+</div><div class="q2">for my house will be called a house of prayer for all peoples.” 
+</div><div class="q1">
+<sup>8&#160;</sup>The Lord Yahweh, who gathers the outcasts of Israel, says, 
+</div><div class="q2">“I will yet gather others to him, 
+</div><div class="q2">in addition to his own who are gathered.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>All you animals of the field, 
+</div><div class="q2">come to devour, 
+</div><div class="q2">all you animals in the forest. 
+</div><div class="q1">
+<sup>10&#160;</sup>His watchmen are blind. 
+</div><div class="q2">They are all without knowledge. 
+</div><div class="q1">They are all mute dogs. 
+</div><div class="q2">They can’t bark—</div><div class="q2">dreaming, lying down, loving to slumber. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yes, the dogs are greedy. 
+</div><div class="q2">They can never have enough. 
+</div><div class="q1">They are shepherds who can’t understand. 
+</div><div class="q2">They have all turned to their own way, 
+</div><div class="q2">each one to his gain, from every quarter. 
+</div><div class="q1">
+<sup>12&#160;</sup>“Come,” they say, “I will get wine, 
+</div><div class="q2">and we will fill ourselves with strong drink; 
+</div><div class="q2">and tomorrow will be as today, 
+</div><div class="q2">great beyond measure.” 
+</div><h2 class="chapterlabel" id="57">57</h2>
+<div class="q1">
+<sup>1&#160;</sup>The righteous perish, 
+</div><div class="q2">and no one lays it to heart. 
+</div><div class="q1">Merciful men are taken away, 
+</div><div class="q2">and no one considers that the righteous is taken away from the evil. 
+</div><div class="q1">
+<sup>2&#160;</sup>He enters into peace. 
+</div><div class="q2">They rest in their beds, 
+</div><div class="q2">each one who walks in his uprightness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“But draw near here, you sons of a sorceress, 
+</div><div class="q2">you offspring of adulterers and prostitutes. 
+</div><div class="q1">
+<sup>4&#160;</sup>Whom do you mock? 
+</div><div class="q2">Against whom do you make a wide mouth 
+</div><div class="q2">and stick out your tongue? 
+</div><div class="q1">Aren’t you children of disobedience 
+</div><div class="q2">and offspring of falsehood, 
+</div><div class="q1">
+<sup>5&#160;</sup>you who inflame yourselves among the oaks, 
+</div><div class="q2">under every green tree; 
+</div><div class="q1">who kill the children in the valleys, 
+</div><div class="q2">under the clefts of the rocks? 
+</div><div class="q1">
+<sup>6&#160;</sup>Among the smooth stones of the valley is your portion. 
+</div><div class="q2">They, they are your lot. 
+</div><div class="q1">You have even poured a drink offering to them. 
+</div><div class="q2">You have offered an offering. 
+</div><div class="q2">Shall I be appeased for these things? 
+</div><div class="q1">
+<sup>7&#160;</sup>On a high and lofty mountain you have set your bed. 
+</div><div class="q2">You also went up there to offer sacrifice. 
+</div><div class="q1">
+<sup>8&#160;</sup>You have set up your memorial behind the doors and the posts, 
+</div><div class="q2">for you have exposed yourself to someone besides me, 
+</div><div class="q2">and have gone up. 
+</div><div class="q1">You have enlarged your bed 
+</div><div class="q2">and made you a covenant with them. 
+</div><div class="q2">You loved what you saw on their bed. 
+</div><div class="q1">
+<sup>9&#160;</sup>You went to the king with oil, 
+</div><div class="q2">increased your perfumes, 
+</div><div class="q2">sent your ambassadors far off, 
+</div><div class="q2">and degraded yourself even to Sheol. 
+</div><div class="q1">
+<sup>10&#160;</sup>You were wearied with the length of your ways; 
+</div><div class="q2">yet you didn’t say, ‘It is in vain.’ 
+</div><div class="q1">You found a reviving of your strength; 
+</div><div class="q2">therefore you weren’t faint. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Whom have you dreaded and feared, 
+</div><div class="q2">so that you lie, 
+</div><div class="q2">and have not remembered me, nor laid it to your heart? 
+</div><div class="q1">Haven’t I held my peace for a long time, 
+</div><div class="q2">and you don’t fear me? 
+</div><div class="q1">
+<sup>12&#160;</sup>I will declare your righteousness; 
+</div><div class="q2">and as for your works, they will not benefit you. 
+</div><div class="q1">
+<sup>13&#160;</sup>When you cry, 
+</div><div class="q2">let those whom you have gathered deliver you, 
+</div><div class="q1">but the wind will take them. 
+</div><div class="q2">A breath will carry them all away, 
+</div><div class="q1">but he who takes refuge in me will possess the land, 
+</div><div class="q2">and will inherit my set-apart mountain.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>He will say, “Build up, build up, prepare the way! 
+</div><div class="q2">Remove the stumbling-block out of the way of my people.” 
+</div><div class="q1">
+<sup>15&#160;</sup>For the high and lofty One who inhabits eternity, 
+</div><div class="q2">whose name is Set-Apart, says: 
+</div><div class="q1">“I dwell in the high and set-apart place, with him also who is of a contrite and humble spirit, 
+</div><div class="q2">to revive the spirit of the humble, 
+</div><div class="q2">and to revive the heart of the contrite. 
+</div><div class="q1">
+<sup>16&#160;</sup>For I will not contend forever, neither will I always be angry; 
+</div><div class="q2">for the spirit would faint before me, 
+</div><div class="q2">and the souls whom I have made. 
+</div><div class="q1">
+<sup>17&#160;</sup>I was angry because of the iniquity of his covetousness and struck him. 
+</div><div class="q2">I hid myself and was angry; 
+</div><div class="q2">and he went on backsliding in the way of his heart. 
+</div><div class="q1">
+<sup>18&#160;</sup>I have seen his ways, and will heal him. 
+</div><div class="q2">I will lead him also, 
+</div><div class="q2">and restore comforts to him and to his mourners. 
+</div><div class="q1">
+<sup>19&#160;</sup>I create the fruit of the lips: 
+</div><div class="q2">Peace, peace, to him who is far off and to him who is near,” 
+</div><div class="q2">says Yahweh; “and I will heal them.” 
+</div><div class="q1">
+<sup>20&#160;</sup>But the wicked are like the troubled sea; 
+</div><div class="q2">for it can’t rest and its waters cast up mire and mud. 
+</div><div class="q1">
+<sup>21&#160;</sup>“There is no peace”, says my Elohim, 
+</div><div class="q2">“for the wicked.” 
+</div><h2 class="chapterlabel" id="58">58</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Cry aloud! Don’t spare! 
+</div><div class="q2">Lift up your voice like a trumpet! 
+</div><div class="q1">Declare to my people their disobedience, 
+</div><div class="q2">and to the house of Jacob their sins. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yet they seek me daily, 
+</div><div class="q2">and delight to know my ways. 
+</div><div class="q1">As a nation that did righteousness, 
+</div><div class="q2">and didn’t forsake the ordinance of their Elohim, 
+</div><div class="q1">they ask of me righteous judgments. 
+</div><div class="q2">They delight to draw near to Elohim. 
+</div><div class="q1">
+<sup>3&#160;</sup>‘Why have we fasted,’ they say, ‘and you don’t see? 
+</div><div class="q2">Why have we afflicted our soul, and you don’t notice?’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">“Behold, in the day of your fast you find pleasure, 
+</div><div class="q2">and oppress all your laborers. 
+</div><div class="q1">
+<sup>4&#160;</sup>Behold, you fast for strife and contention, 
+</div><div class="q2">and to strike with the fist of wickedness. 
+</div><div class="q2">You don’t fast today so as to make your voice to be heard on high. 
+</div><div class="q1">
+<sup>5&#160;</sup>Is this the fast that I have chosen? 
+</div><div class="q2">A day for a man to humble his soul? 
+</div><div class="q1">Is it to bow down his head like a reed, 
+</div><div class="q2">and to spread sackcloth and ashes under himself? 
+</div><div class="q1">Will you call this a fast, 
+</div><div class="q2">and an acceptable day to Yahweh? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“Isn’t this the fast that I have chosen: 
+</div><div class="q2">to release the bonds of wickedness, 
+</div><div class="q2">to undo the straps of the yoke, 
+</div><div class="q2">to let the oppressed go free, 
+</div><div class="q2">and that you break every yoke? 
+</div><div class="q1">
+<sup>7&#160;</sup>Isn’t it to distribute your bread to the hungry, 
+</div><div class="q2">and that you bring the poor who are cast out to your house? 
+</div><div class="q1">When you see the naked, 
+</div><div class="q2">that you cover him; 
+</div><div class="q2">and that you not hide yourself from your own flesh? 
+</div><div class="q1">
+<sup>8&#160;</sup>Then your light will break out as the morning, 
+</div><div class="q2">and your healing will appear quickly; 
+</div><div class="q1">then your righteousness shall go before you, 
+</div><div class="q2">and Yahweh’s glory will be your rear guard. 
+</div><div class="q1">
+<sup>9&#160;</sup>Then you will call, and Yahweh will answer. 
+</div><div class="q2">You will cry for help, and he will say, ‘Here I am.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">“If you take away from among you the yoke, 
+</div><div class="q2">finger pointing, 
+</div><div class="q2">and speaking wickedly; 
+</div><div class="q1">
+<sup>10&#160;</sup>and if you pour out your soul to the hungry, 
+</div><div class="q2">and satisfy the afflicted soul, 
+</div><div class="q1">then your light will rise in darkness, 
+</div><div class="q2">and your obscurity will be as the noonday; 
+</div><div class="q1">
+<sup>11&#160;</sup>and Yahweh will guide you continually, 
+</div><div class="q2">satisfy your soul in dry places, 
+</div><div class="q2">and make your bones strong. 
+</div><div class="q1">You will be like a watered garden, 
+</div><div class="q2">and like a spring of water 
+</div><div class="q2">whose waters don’t fail. 
+</div><div class="q1">
+<sup>12&#160;</sup>Those who will be of you will build the old waste places. 
+</div><div class="q2">You will raise up the foundations of many generations. 
+</div><div class="q1">You will be called Repairer of the Breach, 
+</div><div class="q2">Restorer of Paths with Dwellings. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“If you turn away your foot from the Sabbath, 
+</div><div class="q2">from doing your pleasure on my set-apart day, 
+</div><div class="q1">and call the Sabbath a delight, 
+</div><div class="q2">and the set-apart of Yahweh honorable, 
+</div><div class="q2">and honor it, 
+</div><div class="q2">not doing your own ways, 
+</div><div class="q2">nor finding your own pleasure, 
+</div><div class="q2">nor speaking your own words, 
+</div><div class="q1">
+<sup>14&#160;</sup>then you will delight yourself in Yahweh, 
+</div><div class="q2">and I will make you to ride on the high places of the earth, 
+</div><div class="q2">and I will feed you with the heritage of Jacob your father;” 
+</div><div class="q2">for Yahweh’s mouth has spoken it. 
+</div><h2 class="chapterlabel" id="59">59</h2>
+<div class="q1">
+<sup>1&#160;</sup>Behold, Yahweh’s hand is not shortened, that it can’t save; 
+</div><div class="q2">nor his ear dull, that it can’t hear. 
+</div><div class="q1">
+<sup>2&#160;</sup>But your iniquities have separated you and your Elohim, 
+</div><div class="q2">and your sins have hidden his face from you, 
+</div><div class="q2">so that he will not hear. 
+</div><div class="q1">
+<sup>3&#160;</sup>For your hands are defiled with blood, 
+</div><div class="q2">and your fingers with iniquity. 
+</div><div class="q1">Your lips have spoken lies. 
+</div><div class="q2">Your tongue mutters wickedness. 
+</div><div class="q1">
+<sup>4&#160;</sup>No one sues in righteousness, 
+</div><div class="q2">and no one pleads in truth. 
+</div><div class="q1">They trust in vanity 
+</div><div class="q2">and speak lies. 
+</div><div class="q1">They conceive mischief 
+</div><div class="q2">and give birth to iniquity. 
+</div><div class="q1">
+<sup>5&#160;</sup>They hatch adders’ eggs 
+</div><div class="q2">and weave the spider’s web. 
+</div><div class="q1">He who eats of their eggs dies; 
+</div><div class="q2">and that which is crushed breaks out into a viper. 
+</div><div class="q1">
+<sup>6&#160;</sup>Their webs won’t become garments. 
+</div><div class="q2">They won’t cover themselves with their works. 
+</div><div class="q1">Their works are works of iniquity, 
+</div><div class="q2">and acts of violence are in their hands. 
+</div><div class="q1">
+<sup>7&#160;</sup>Their feet run to evil, 
+</div><div class="q2">and they hurry to shed innocent blood. 
+</div><div class="q1">Their thoughts are thoughts of iniquity. 
+</div><div class="q2">Desolation and destruction are in their paths. 
+</div><div class="q1">
+<sup>8&#160;</sup>They don’t know the way of peace; 
+</div><div class="q2">and there is no justice in their ways. 
+</div><div class="q1">They have made crooked paths for themselves; 
+</div><div class="q2">whoever goes in them doesn’t know peace. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Therefore justice is far from us, 
+</div><div class="q2">and righteousness doesn’t overtake us. 
+</div><div class="q1">We look for light, but see darkness; 
+</div><div class="q2">for brightness, but we walk in obscurity. 
+</div><div class="q1">
+<sup>10&#160;</sup>We grope for the wall like the blind. 
+</div><div class="q2">Yes, we grope as those who have no eyes. 
+</div><div class="q1">We stumble at noon as if it were twilight. 
+</div><div class="q2">Among those who are strong, we are like dead men. 
+</div><div class="q1">
+<sup>11&#160;</sup>We all roar like bears 
+</div><div class="q2">and moan sadly like doves. 
+</div><div class="q1">We look for justice, but there is none, 
+</div><div class="q2">for salvation, but it is far off from us. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>For our transgressions are multiplied before you, 
+</div><div class="q2">and our sins testify against us; 
+</div><div class="q1">for our transgressions are with us, 
+</div><div class="q2">and as for our iniquities, we know them: 
+</div><div class="q1">
+<sup>13&#160;</sup>transgressing and denying Yahweh, 
+</div><div class="q2">and turning away from following our Elohim, 
+</div><div class="q2">speaking oppression and revolt, 
+</div><div class="q2">conceiving and uttering from the heart words of falsehood. 
+</div><div class="q1">
+<sup>14&#160;</sup>Justice is turned away backward, 
+</div><div class="q2">and righteousness stands far away; 
+</div><div class="q1">for truth has fallen in the street, 
+</div><div class="q2">and uprightness can’t enter. 
+</div><div class="q1">
+<sup>15&#160;</sup>Yes, truth is lacking; 
+</div><div class="q2">and he who departs from evil makes himself a prey. 
+</div><div class="b"> &#160; </div>
+<div class="q1">Yahweh saw it, 
+</div><div class="q2">and it displeased him that there was no justice. 
+</div><div class="q1">
+<sup>16&#160;</sup>He saw that there was no man, 
+</div><div class="q2">and wondered that there was no intercessor. 
+</div><div class="q1">Therefore his own arm brought salvation to him; 
+</div><div class="q2">and his righteousness sustained him. 
+</div><div class="q1">
+<sup>17&#160;</sup>He put on righteousness as a breastplate, 
+</div><div class="q2">and a helmet of salvation on his head. 
+</div><div class="q1">He put on garments of vengeance for clothing, 
+</div><div class="q2">and was clad with zeal as a mantle. 
+</div><div class="q1">
+<sup>18&#160;</sup>According to their deeds, 
+</div><div class="q2">he will repay as appropriate: 
+</div><div class="q2">wrath to his adversaries, 
+</div><div class="q2">recompense to his enemies. 
+</div><div class="q2">He will repay the islands their due. 
+</div><div class="q1">
+<sup>19&#160;</sup>So they will fear Yahweh’s name from the west, 
+</div><div class="q2">and his glory from the rising of the sun; 
+</div><div class="q1">for he will come as a rushing stream, 
+</div><div class="q2">which Yahweh’s breath drives. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“A Redeemer will come to Zion, 
+</div><div class="q2">and to those who turn from disobedience in Jacob,” says Yahweh. 
+</div><div class="p">
+<sup>21&#160;</sup>“As for me, this is my covenant with them,” says Yahweh. “My Spirit who is on you, and my words which I have put in your mouth shall not depart out of your mouth, nor out of the mouth of your offspring, nor out of the mouth of your offspring’s offspring,” says Yahweh, “from now on and forever.” 
+</div><h2 class="chapterlabel" id="60">60</h2>
+<div class="q1">
+<sup>1&#160;</sup>“Arise, shine; for your light has come, 
+</div><div class="q2">and Yahweh’s glory has risen on you! 
+</div><div class="q1">
+<sup>2&#160;</sup>For behold, darkness will cover the earth, 
+</div><div class="q2">and thick darkness the peoples; 
+</div><div class="q1">but Yahweh will arise on you, 
+</div><div class="q2">and his glory shall be seen on you. 
+</div><div class="q1">
+<sup>3&#160;</sup>Nations will come to your light, 
+</div><div class="q2">and kings to the brightness of your rising. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Lift up your eyes all around, and see: 
+</div><div class="q2">they all gather themselves together. 
+</div><div class="q2">They come to you. 
+</div><div class="q1">Your sons will come from far away, 
+</div><div class="q2">and your daughters will be carried in arms. 
+</div><div class="q1">
+<sup>5&#160;</sup>Then you shall see and be radiant, 
+</div><div class="q2">and your heart will thrill and be enlarged; 
+</div><div class="q1">because the abundance of the sea will be turned to you. 
+</div><div class="q2">The wealth of the nations will come to you. 
+</div><div class="q1">
+<sup>6&#160;</sup>A multitude of camels will cover you, 
+</div><div class="q2">the dromedaries of Midian and Ephah. 
+</div><div class="q1">All from Sheba will come. 
+</div><div class="q2">They will bring gold and frankincense, 
+</div><div class="q2">and will proclaim the praises of Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>All the flocks of Kedar will be gathered together to you. 
+</div><div class="q2">The rams of Nebaioth will serve you. 
+</div><div class="q1">They will be accepted as offerings on my altar; 
+</div><div class="q2">and I will beautify my glorious house. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Who are these who fly as a cloud, 
+</div><div class="q2">and as the doves to their windows? 
+</div><div class="q1">
+<sup>9&#160;</sup>Surely the islands will wait for me, 
+</div><div class="q2">and the ships of Tarshish first, 
+</div><div class="q1">to bring your sons from far away, 
+</div><div class="q2">their silver and their gold with them, 
+</div><div class="q1">for the name of Yahweh your Elohim, 
+</div><div class="q2">and for the Set-Apart One of Israel, 
+</div><div class="q2">because he has glorified you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Foreigners will build up your walls, 
+</div><div class="q2">and their kings will serve you; 
+</div><div class="q1">for in my wrath I struck you, 
+</div><div class="q2">but in my favor I have had mercy on you. 
+</div><div class="q1">
+<sup>11&#160;</sup>Your gates also shall be open continually; they shall not be shut day nor night, that men may bring to you the wealth of the nations, and their kings led captive. 
+</div><div class="q1">
+<sup>12&#160;</sup>For that nation and kingdom that will not serve you shall perish; yes, those nations shall be utterly wasted. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“The glory of Lebanon shall come to you, the cypress tree, the pine, and the box tree together, to beautify the place of my sanctuary; and I will make the place of my feet glorious. 
+</div><div class="q1">
+<sup>14&#160;</sup>The sons of those who afflicted you will come bowing to you; 
+</div><div class="q2">and all those who despised you will bow themselves down at the soles of your feet. 
+</div><div class="q1">They will call you Yahweh’s City, 
+</div><div class="q2">the Zion of the Set-Apart One of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“Whereas you have been forsaken and hated, 
+</div><div class="q2">so that no one passed through you, 
+</div><div class="q1">I will make you an eternal excellency, 
+</div><div class="q2">a joy of many generations. 
+</div><div class="q1">
+<sup>16&#160;</sup>You will also drink the milk of the nations, 
+</div><div class="q2">and will nurse from royal breasts. 
+</div><div class="q1">Then you will know that I, Yahweh, am your Savior, 
+</div><div class="q2">your Redeemer, 
+</div><div class="q2">the Mighty One of Jacob. 
+</div><div class="q1">
+<sup>17&#160;</sup>For bronze I will bring gold; 
+</div><div class="q2">for iron I will bring silver; 
+</div><div class="q2">for wood, bronze, 
+</div><div class="q2">and for stones, iron. 
+</div><div class="q1">I will also make peace your governor, 
+</div><div class="q2">and righteousness your ruler. 
+</div><div class="q1">
+<sup>18&#160;</sup>Violence shall no more be heard in your land, 
+</div><div class="q2">nor desolation or destruction within your borders; 
+</div><div class="q1">but you will call your walls Salvation, 
+</div><div class="q2">and your gates Praise. 
+</div><div class="q1">
+<sup>19&#160;</sup>The sun will be no more your light by day, 
+</div><div class="q2">nor will the brightness of the moon give light to you, 
+</div><div class="q1">but Yahweh will be your everlasting light, 
+</div><div class="q2">and your Elohim will be your glory. 
+</div><div class="q1">
+<sup>20&#160;</sup>Your sun will not go down any more, 
+</div><div class="q2">nor will your moon withdraw itself; 
+</div><div class="q1">for Yahweh will be your everlasting light, 
+</div><div class="q2">and the days of your mourning will end. 
+</div><div class="q1">
+<sup>21&#160;</sup>Then your people will all be righteous. 
+</div><div class="q2">They will inherit the land forever, 
+</div><div class="q2">the branch of my planting, 
+</div><div class="q2">the work of my hands, 
+</div><div class="q2">that I may be glorified. 
+</div><div class="q1">
+<sup>22&#160;</sup>The little one will become a thousand, 
+</div><div class="q2">and the small one a strong nation. 
+</div><div class="q2">I, Yahweh, will do this quickly in its time.” 
+</div><h2 class="chapterlabel" id="61">61</h2>
+<div class="q1">
+<sup>1&#160;</sup>The Lord Yahweh’s Spirit is on me, 
+</div><div class="q2">because Yahweh has anointed me to preach good news to the humble. 
+</div><div class="q1">He has sent me to bind up the broken hearted, 
+</div><div class="q2">to proclaim liberty to the captives 
+</div><div class="q2">and release to those who are bound, 
+</div><div class="q1">
+<sup>2&#160;</sup>to proclaim the year of Yahweh’s favor 
+</div><div class="q2">and the day of vengeance of our Elohim, 
+</div><div class="q2">to comfort all who mourn, 
+</div><div class="q1">
+<sup>3&#160;</sup>to provide for those who mourn in Zion, 
+</div><div class="q2">to give to them a garland for ashes, 
+</div><div class="q2">the oil of joy for mourning, 
+</div><div class="q2">the garment of praise for the spirit of heaviness, 
+</div><div class="q1">that they may be called trees of righteousness, 
+</div><div class="q2">the planting of Yahweh, 
+</div><div class="q2">that he may be glorified. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>They will rebuild the old ruins. 
+</div><div class="q2">They will raise up the former devastated places. 
+</div><div class="q1">They will repair the ruined cities 
+</div><div class="q2">that have been devastated for many generations. 
+</div><div class="q1">
+<sup>5&#160;</sup>Strangers will stand and feed your flocks. 
+</div><div class="q2">Foreigners will work your fields and your vineyards. 
+</div><div class="q1">
+<sup>6&#160;</sup>But you will be called Yahweh’s priests. 
+</div><div class="q2">Men will call you the servants of our Elohim. 
+</div><div class="q1">You will eat the wealth of the nations. 
+</div><div class="q2">You will boast in their glory. 
+</div><div class="q1">
+<sup>7&#160;</sup>Instead of your shame you will have double. 
+</div><div class="q2">Instead of dishonor, they will rejoice in their portion. 
+</div><div class="q1">Therefore in their land they will possess double. 
+</div><div class="q2">Everlasting joy will be to them. 
+</div><div class="q1">
+<sup>8&#160;</sup>“For I, Yahweh, love justice. 
+</div><div class="q2">I hate robbery and iniquity. 
+</div><div class="q1">I will give them their reward in truth 
+</div><div class="q2">and I will make an everlasting covenant with them. 
+</div><div class="q1">
+<sup>9&#160;</sup>Their offspring will be known among the nations, 
+</div><div class="q2">and their offspring among the peoples. 
+</div><div class="q1">All who see them will acknowledge them, 
+</div><div class="q2">that they are the offspring which Yahweh has blessed.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>I will greatly rejoice in Yahweh! 
+</div><div class="q2">My soul will be joyful in my Elohim, 
+</div><div class="q1">for he has clothed me with the garments of salvation. 
+</div><div class="q2">He has covered me with the robe of righteousness, 
+</div><div class="q2">as a bridegroom decks himself with a garland 
+</div><div class="q2">and as a bride adorns herself with her jewels. 
+</div><div class="q1">
+<sup>11&#160;</sup>For as the earth produces its bud, 
+</div><div class="q2">and as the garden causes the things that are sown in it to spring up, 
+</div><div class="q2">so the Lord Yahweh will cause righteousness and praise to spring up before all the nations. 
+</div><h2 class="chapterlabel" id="62">62</h2>
+<div class="q1">
+<sup>1&#160;</sup>For Zion’s sake I will not hold my peace, 
+</div><div class="q2">and for Jerusalem’s sake I will not rest, 
+</div><div class="q1">until her righteousness shines out like the dawn, 
+</div><div class="q2">and her salvation like a burning lamp. 
+</div><div class="q1">
+<sup>2&#160;</sup>The nations will see your righteousness, 
+</div><div class="q2">and all kings your glory. 
+</div><div class="q1">You will be called by a new name, 
+</div><div class="q2">which Yahweh’s mouth will name. 
+</div><div class="q1">
+<sup>3&#160;</sup>You will also be a crown of beauty in Yahweh’s hand, 
+</div><div class="q2">and a royal diadem in your Elohim’s hand. 
+</div><div class="q1">
+<sup>4&#160;</sup>You will not be called Forsaken any more, 
+</div><div class="q2">nor will your land be called Desolate any more; 
+</div><div class="q1">but you will be called Hephzibah, 
+</div><div class="q2">and your land Beulah; 
+</div><div class="q1">for Yahweh delights in you, 
+</div><div class="q2">and your land will be owned. 
+</div><div class="q1">
+<sup>5&#160;</sup>For as a young man owns a virgin, 
+</div><div class="q2">so your sons will own you. 
+</div><div class="q1">As a bridegroom rejoices over his bride, 
+</div><div class="q2">so your Elohim will rejoice over you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>I have set watchmen on your walls, Jerusalem. 
+</div><div class="q2">They will never be silent day nor night. 
+</div><div class="q1">You who call on Yahweh, take no rest, 
+</div><div class="q2">
+<sup>7&#160;</sup>and give him no rest until he establishes, 
+</div><div class="q2">and until he makes Jerusalem a praise in the earth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Yahweh has sworn by his right hand, 
+</div><div class="q2">and by the arm of his strength, 
+</div><div class="q1">“Surely I will no more give your grain to be food for your enemies, 
+</div><div class="q2">and foreigners will not drink your new wine, for which you have labored, 
+</div><div class="q1">
+<sup>9&#160;</sup>but those who have harvested it will eat it, and praise Yahweh. 
+</div><div class="q2">Those who have gathered it will drink it in the courts of my sanctuary.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Go through, go through the gates! 
+</div><div class="q2">Prepare the way of the people! 
+</div><div class="q1">Build up, build up the highway! 
+</div><div class="q2">Gather out the stones! 
+</div><div class="q2">Lift up a banner for the peoples. 
+</div><div class="q1">
+<sup>11&#160;</sup>Behold, Yahweh has proclaimed to the end of the earth: 
+</div><div class="q2">“Say to the daughter of Zion, 
+</div><div class="q2">‘Behold, your salvation comes! 
+</div><div class="q1">Behold, his reward is with him, 
+</div><div class="q2">and his recompense before him!’&#160;” 
+</div><div class="q1">
+<sup>12&#160;</sup>They will call them “The Set-Apart People, 
+</div><div class="q2">Yahweh’s Redeemed”. 
+</div><div class="q1">You will be called “Sought Out, 
+</div><div class="q2">A City Not Forsaken”. 
+</div><h2 class="chapterlabel" id="63">63</h2>
+<div class="q1">
+<sup>1&#160;</sup>Who is this who comes from Edom, 
+</div><div class="q2">with dyed garments from Bozrah? 
+</div><div class="q1">Who is this who is glorious in his clothing, 
+</div><div class="q2">marching in the greatness of his strength? 
+</div><div class="q1">“It is I who speak in righteousness, 
+</div><div class="q2">mighty to save.” 
+</div><div class="q1">
+<sup>2&#160;</sup>Why is your clothing red, 
+</div><div class="q2">and your garments like him who treads in the wine vat? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“I have trodden the wine press alone. 
+</div><div class="q2">Of the peoples, no one was with me. 
+</div><div class="q1">Yes, I trod them in my anger 
+</div><div class="q2">and trampled them in my wrath. 
+</div><div class="q1">Their lifeblood is sprinkled on my garments, 
+</div><div class="q2">and I have stained all my clothing. 
+</div><div class="q1">
+<sup>4&#160;</sup>For the day of vengeance was in my heart, 
+</div><div class="q2">and the year of my redeemed has come. 
+</div><div class="q1">
+<sup>5&#160;</sup>I looked, and there was no one to help; 
+</div><div class="q2">and I wondered that there was no one to uphold. 
+</div><div class="q1">Therefore my own arm brought salvation to me. 
+</div><div class="q2">My own wrath upheld me. 
+</div><div class="q1">
+<sup>6&#160;</sup>I trod down the peoples in my anger 
+</div><div class="q2">and made them drunk in my wrath. 
+</div><div class="q2">I poured their lifeblood out on the earth.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>I will tell of the loving kindnesses of Yahweh 
+</div><div class="q2">and the praises of Yahweh, 
+</div><div class="q2">according to all that Yahweh has given to us, 
+</div><div class="q1">and the great goodness toward the house of Israel, 
+</div><div class="q2">which he has given to them according to his mercies, 
+</div><div class="q2">and according to the multitude of his loving kindnesses. 
+</div><div class="q1">
+<sup>8&#160;</sup>For he said, “Surely, they are my people, 
+</div><div class="q2">children who will not deal falsely;” 
+</div><div class="q2">so he became their Savior. 
+</div><div class="q1">
+<sup>9&#160;</sup>In all their affliction he was afflicted, 
+</div><div class="q2">and the angel of his presence saved them. 
+</div><div class="q1">In his love and in his pity he redeemed them. 
+</div><div class="q2">He bore them, 
+</div><div class="q2">and carried them all the days of old. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>But they rebelled 
+</div><div class="q2">and grieved his Set-Apart Spirit. 
+</div><div class="q1">Therefore he turned and became their enemy, 
+</div><div class="q2">and he himself fought against them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Then he remembered the days of old, 
+</div><div class="q2">Moses and his people, saying, 
+</div><div class="q1">“Where is he who brought them up out of the sea with the shepherds of his flock? 
+</div><div class="q2">Where is he who put his Set-Apart Spirit among them?” 
+</div><div class="q1">
+<sup>12&#160;</sup>Who caused his glorious arm to be at Moses’ right hand? 
+</div><div class="q2">Who divided the waters before them, to make himself an everlasting name? 
+</div><div class="q1">
+<sup>13&#160;</sup>Who led them through the depths, 
+</div><div class="q2">like a horse in the wilderness, 
+</div><div class="q2">so that they didn’t stumble? 
+</div><div class="q1">
+<sup>14&#160;</sup>As the livestock that go down into the valley, 
+</div><div class="q2">Yahweh’s Spirit caused them to rest. 
+</div><div class="q2">So you led your people to make yourself a glorious name. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>Look down from heaven, 
+</div><div class="q2">and see from the habitation of your set-apartness and of your glory. 
+</div><div class="q1">Where are your zeal and your mighty acts? 
+</div><div class="q2">The yearning of your heart and your compassion is restrained toward me. 
+</div><div class="q1">
+<sup>16&#160;</sup>For you are our Father, 
+</div><div class="q2">though Abraham doesn’t know us, 
+</div><div class="q2">and Israel does not acknowledge us. 
+</div><div class="q1">You, Yahweh, are our Father. 
+</div><div class="q2">Our Redeemer from everlasting is your name. 
+</div><div class="q1">
+<sup>17&#160;</sup>O Yahweh, why do you make us wander from your ways, 
+</div><div class="q2">and harden our heart from your fear? 
+</div><div class="q1">Return for your servants’ sake, 
+</div><div class="q2">the tribes of your inheritance. 
+</div><div class="q1">
+<sup>18&#160;</sup>Your set-apart people possessed it but a little while. 
+</div><div class="q2">Our adversaries have trodden down your sanctuary. 
+</div><div class="q1">
+<sup>19&#160;</sup>We have become like those over whom you never ruled, 
+</div><div class="q2">like those who were not called by your name. 
+</div><h2 class="chapterlabel" id="64">64</h2>
+<div class="q1">
+<sup>1&#160;</sup>Oh that you would tear the heavens, 
+</div><div class="q2">that you would come down, 
+</div><div class="q2">that the mountains might quake at your presence—</div><div class="q1">
+<sup>2&#160;</sup>as when fire kindles the brushwood, 
+</div><div class="q2">and the fire causes the water to boil. 
+</div><div class="q1">Make your name known to your adversaries, 
+</div><div class="q2">that the nations may tremble at your presence! 
+</div><div class="q1">
+<sup>3&#160;</sup>When you did awesome things which we didn’t look for, 
+</div><div class="q2">you came down, and the mountains quaked at your presence. 
+</div><div class="q1">
+<sup>4&#160;</sup>For from of old men have not heard, 
+</div><div class="q2">nor perceived by the ear, 
+</div><div class="q2">nor has the eye seen an Elohim besides you, 
+</div><div class="q2">who works for him who waits for him. 
+</div><div class="q1">
+<sup>5&#160;</sup>You meet him who rejoices and does righteousness, 
+</div><div class="q2">those who remember you in your ways. 
+</div><div class="q1">Behold, you were angry, and we sinned. 
+</div><div class="q2">We have been in sin for a long time. 
+</div><div class="q2">Shall we be saved? 
+</div><div class="q1">
+<sup>6&#160;</sup>For we have all become like one who is unclean, 
+</div><div class="q2">and all our righteousness is like a polluted garment. 
+</div><div class="q1">We all fade like a leaf; 
+</div><div class="q2">and our iniquities, like the wind, take us away. 
+</div><div class="q1">
+<sup>7&#160;</sup>There is no one who calls on your name, 
+</div><div class="q2">who stirs himself up to take hold of you; 
+</div><div class="q1">for you have hidden your face from us, 
+</div><div class="q2">and have consumed us by means of our iniquities. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>But now, Yahweh, you are our Father. 
+</div><div class="q2">We are the clay and you our potter. 
+</div><div class="q2">We all are the work of your hand. 
+</div><div class="q1">
+<sup>9&#160;</sup>Don’t be furious, Yahweh. 
+</div><div class="q2">Don’t remember iniquity forever. 
+</div><div class="q1">Look and see, we beg you, 
+</div><div class="q2">we are all your people. 
+</div><div class="q1">
+<sup>10&#160;</sup>Your set-apart cities have become a wilderness. 
+</div><div class="q2">Zion has become a wilderness, 
+</div><div class="q2">Jerusalem a desolation. 
+</div><div class="q1">
+<sup>11&#160;</sup>Our set-apart and our beautiful house where our fathers praised you 
+</div><div class="q2">is burned with fire. 
+</div><div class="q2">All our pleasant places are laid waste. 
+</div><div class="q1">
+<sup>12&#160;</sup>Will you hold yourself back for these things, Yahweh? 
+</div><div class="q2">Will you keep silent and punish us very severely? 
+</div><h2 class="chapterlabel" id="65">65</h2>
+<div class="q1">
+<sup>1&#160;</sup>“I am inquired of by those who didn’t ask. 
+</div><div class="q2">I am found by those who didn’t seek me. 
+</div><div class="q2">I said, ‘See me, see me,’ to a nation that was not called by my name. 
+</div><div class="q1">
+<sup>2&#160;</sup>I have spread out my hands all day to a rebellious people, 
+</div><div class="q2">who walk in a way that is not good, 
+</div><div class="q2">after their own thoughts; 
+</div><div class="q1">
+<sup>3&#160;</sup>a people who provoke me to my face continually, 
+</div><div class="q2">sacrificing in gardens, 
+</div><div class="q2">and burning incense on bricks; 
+</div><div class="q1">
+<sup>4&#160;</sup>who sit among the graves, 
+</div><div class="q2">and spend nights in secret places; 
+</div><div class="q1">who eat pig’s meat, 
+</div><div class="q2">and broth of abominable things is in their vessels; 
+</div><div class="q1">
+<sup>5&#160;</sup>who say, ‘Stay by yourself, 
+</div><div class="q2">don’t come near to me, 
+</div><div class="q2">for I am more set-apart than you.’ 
+</div><div class="q1">These are smoke in my nose, 
+</div><div class="q2">a fire that burns all day. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“Behold, it is written before me: 
+</div><div class="q2">I will not keep silence, 
+</div><div class="q2">but will repay, 
+</div><div class="q2">yes, I will repay into their bosom 
+</div><div class="q1">
+<sup>7&#160;</sup>your own iniquities and the iniquities of your fathers together”, says Yahweh, 
+</div><div class="q2">“who have burned incense on the mountains, 
+</div><div class="q2">and blasphemed me on the hills. 
+</div><div class="q2">Therefore I will first measure their work into their bosom.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>8&#160;</sup>Yahweh says, 
+</div><div class="q1">“As the new wine is found in the cluster, 
+</div><div class="q2">and one says, ‘Don’t destroy it, for a blessing is in it:’ 
+</div><div class="q1">so I will do for my servants’ sake, 
+</div><div class="q2">that I may not destroy them all. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will bring offspring out of Jacob, 
+</div><div class="q2">and out of Judah an inheritor of my mountains. 
+</div><div class="q1">My chosen will inherit it, 
+</div><div class="q2">and my servants will dwell there. 
+</div><div class="q1">
+<sup>10&#160;</sup>Sharon will be a fold of flocks, 
+</div><div class="q2">and the valley of Achor a place for herds to lie down in, 
+</div><div class="q2">for my people who have sought me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“But you who forsake Yahweh, 
+</div><div class="q2">who forget my set-apart mountain, 
+</div><div class="q2">who prepare a table for Fortune, 
+</div><div class="q2">and who fill up mixed wine to Destiny; 
+</div><div class="q1">
+<sup>12&#160;</sup>I will destine you to the sword, 
+</div><div class="q2">and you will all bow down to the slaughter; 
+</div><div class="q1">because when I called, you didn’t answer. 
+</div><div class="q2">When I spoke, you didn’t listen; 
+</div><div class="q1">but you did that which was evil in my eyes, 
+</div><div class="q2">and chose that in which I didn’t delight.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>13&#160;</sup>Therefore the Lord Yahweh says, 
+</div><div class="q1">“Behold, my servants will eat, 
+</div><div class="q2">but you will be hungry; 
+</div><div class="q1">behold, my servants will drink, 
+</div><div class="q2">but you will be thirsty. 
+</div><div class="q1">Behold, my servants will rejoice, 
+</div><div class="q2">but you will be disappointed. 
+</div><div class="q1">
+<sup>14&#160;</sup>Behold, my servants will sing for joy of heart, 
+</div><div class="q2">but you will cry for sorrow of heart, 
+</div><div class="q2">and will wail for anguish of spirit. 
+</div><div class="q1">
+<sup>15&#160;</sup>You will leave your name for a curse to my chosen, 
+</div><div class="q2">and the Lord Yahweh will kill you. 
+</div><div class="q1">He will call his servants by another name, 
+</div><div class="q2">
+<sup>16&#160;</sup>so that he who blesses himself in the earth will bless himself in the Elohim of truth; 
+</div><div class="q2">and he who swears in the earth will swear by the Elohim of truth; 
+</div><div class="q1">because the former troubles are forgotten, 
+</div><div class="q2">and because they are hidden from my eyes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“For, behold, I create new heavens and a new earth; 
+</div><div class="q2">and the former things will not be remembered, 
+</div><div class="q2">nor come into mind. 
+</div><div class="q1">
+<sup>18&#160;</sup>But be glad and rejoice forever in that which I create; 
+</div><div class="q2">for, behold, I create Jerusalem to be a delight, 
+</div><div class="q2">and her people a joy. 
+</div><div class="q1">
+<sup>19&#160;</sup>I will rejoice in Jerusalem, 
+</div><div class="q2">and delight in my people; 
+</div><div class="q1">and the voice of weeping and the voice of crying 
+</div><div class="q2">will be heard in her no more. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“No more will there be an infant who only lives a few days, 
+</div><div class="q2">nor an old man who has not filled his days; 
+</div><div class="q1">for the child will die one hundred years old, 
+</div><div class="q2">and the sinner being one hundred years old will be accursed. 
+</div><div class="q1">
+<sup>21&#160;</sup>They will build houses and inhabit them. 
+</div><div class="q2">They will plant vineyards and eat their fruit. 
+</div><div class="q1">
+<sup>22&#160;</sup>They will not build and another inhabit. 
+</div><div class="q2">They will not plant and another eat; 
+</div><div class="q1">for the days of my people will be like the days of a tree, 
+</div><div class="q2">and my chosen will long enjoy the work of their hands. 
+</div><div class="q1">
+<sup>23&#160;</sup>They will not labor in vain 
+</div><div class="q2">nor give birth for calamity; 
+</div><div class="q1">for they are the offspring of Yahweh’s blessed 
+</div><div class="q2">and their descendants with them. 
+</div><div class="q1">
+<sup>24&#160;</sup>It will happen that before they call, I will answer; 
+</div><div class="q2">and while they are yet speaking, I will hear. 
+</div><div class="q1">
+<sup>25&#160;</sup>The wolf and the lamb will feed together. 
+</div><div class="q2">The lion will eat straw like the ox. 
+</div><div class="q2">Dust will be the serpent’s food. 
+</div><div class="q1">They will not hurt nor destroy in all my set-apart mountain,” 
+</div><div class="q2">says Yahweh. 
+</div><h2 class="chapterlabel" id="66">66</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh says: 
+</div><div class="q1">“Heaven is my throne, and the earth is my footstool. 
+</div><div class="q2">What kind of house will you build to me? 
+</div><div class="q2">Where will I rest? 
+</div><div class="q1">
+<sup>2&#160;</sup>For my hand has made all these things, 
+</div><div class="q2">and so all these things came to be,” says Yahweh: 
+</div><div class="q1">“but I will look to this man, 
+</div><div class="q2">even to he who is poor and of a contrite spirit, 
+</div><div class="q2">and who trembles at my word. 
+</div><div class="q1">
+<sup>3&#160;</sup>He who kills an ox is as he who kills a man; 
+</div><div class="q2">he who sacrifices a lamb, as he who breaks a dog’s neck; 
+</div><div class="q2">he who offers an offering, as he who offers pig’s blood; 
+</div><div class="q2">he who burns frankincense, as he who blesses an idol. 
+</div><div class="q1">Yes, they have chosen their own ways, 
+</div><div class="q2">and their soul delights in their abominations. 
+</div><div class="q1">
+<sup>4&#160;</sup>I also will choose their delusions, 
+</div><div class="q2">and will bring their fears on them, 
+</div><div class="q1">because when I called, no one answered; 
+</div><div class="q2">when I spoke, they didn’t listen, 
+</div><div class="q1">but they did that which was evil in my eyes, 
+</div><div class="q2">and chose that in which I didn’t delight.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Hear Yahweh’s word, 
+</div><div class="q2">you who tremble at his word: 
+</div><div class="q1">“Your brothers who hate you, 
+</div><div class="q2">who cast you out for my name’s sake, have said, 
+</div><div class="q1">‘Let Yahweh be glorified, 
+</div><div class="q2">that we may see your joy;’ 
+</div><div class="q2">but it is those who shall be disappointed. 
+</div><div class="q1">
+<sup>6&#160;</sup>A voice of tumult from the city, 
+</div><div class="q2">a voice from the temple, 
+</div><div class="q2">a voice of Yahweh that repays his enemies what they deserve. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Before she travailed, she gave birth. 
+</div><div class="q2">Before her pain came, she delivered a son. 
+</div><div class="q1">
+<sup>8&#160;</sup>Who has heard of such a thing? 
+</div><div class="q2">Who has seen such things? 
+</div><div class="q1">Shall a land be born in one day? 
+</div><div class="q2">Shall a nation be born at once? 
+</div><div class="q1">For as soon as Zion travailed, 
+</div><div class="q2">she gave birth to her children. 
+</div><div class="q1">
+<sup>9&#160;</sup>Shall I bring to the birth, and not cause to be delivered?” says Yahweh. 
+</div><div class="q2">“Shall I who cause to give birth shut the womb?” says your Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Rejoice with Jerusalem, and be glad for her, all you who love her. 
+</div><div class="q2">Rejoice for joy with her, all you who mourn over her; 
+</div><div class="q1">
+<sup>11&#160;</sup>that you may nurse and be satisfied at the comforting breasts; 
+</div><div class="q2">that you may drink deeply, 
+</div><div class="q2">and be delighted with the abundance of her glory.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>For Yahweh says, “Behold, I will extend peace to her like a river, 
+</div><div class="q2">and the glory of the nations like an overflowing stream, 
+</div><div class="q2">and you will nurse. 
+</div><div class="q1">You will be carried on her side, 
+</div><div class="q2">and will be dandled on her knees. 
+</div><div class="q1">
+<sup>13&#160;</sup>As one whom his mother comforts, 
+</div><div class="q2">so I will comfort you. 
+</div><div class="q2">You will be comforted in Jerusalem.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>You will see it, and your heart shall rejoice, 
+</div><div class="q2">and your bones will flourish like the tender grass. 
+</div><div class="q1">Yahweh’s hand will be known among his servants; 
+</div><div class="q2">and he will have indignation against his enemies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>For, behold, Yahweh will come with fire, 
+</div><div class="q2">and his chariots will be like the whirlwind; 
+</div><div class="q1">to render his anger with fierceness, 
+</div><div class="q2">and his rebuke with flames of fire. 
+</div><div class="q1">
+<sup>16&#160;</sup>For Yahweh will execute judgment by fire and by his sword on all flesh; 
+</div><div class="q2">and those slain by Yahweh will be many. 
+</div><div class="p">
+<sup>17&#160;</sup>“Those who sanctify themselves and purify themselves to go to the gardens, following one in the middle, eating pig’s meat, abominable things, and the mouse, they shall come to an end together,” says Yahweh. 
+</div><div class="p">
+<sup>18&#160;</sup>“For I know their works and their thoughts. The time comes that I will gather all nations and languages, and they will come, and will see my glory. 
+</div><div class="p">
+<sup>19&#160;</sup>“I will set a sign among them, and I will send those who escape of them to the nations, to Tarshish, Pul, and Lud, who draw the bow, to Tubal and Javan, to far-away islands, who have not heard my fame, nor have seen my glory; and they shall declare my glory among the nations. 
+<sup>20&#160;</sup>They shall bring all your brothers out of all the nations for an offering to Yahweh, on horses, in chariots, in litters, on mules, and on camels, to my set-apart mountain Jerusalem, says Yahweh, as the children of Israel bring their offering in a clean vessel into Yahweh’s house. 
+<sup>21&#160;</sup>Of them I will also select priests and Levites,” says Yahweh. 
+</div><div class="p">
+<sup>22&#160;</sup>“For as the new heavens and the new earth, which I will make, shall remain before me,” says Yahweh, “so your offspring and your name shall remain. 
+<sup>23&#160;</sup>It shall happen that from one new moon to another, and from one Sabbath to another, all flesh will come to worship before me,” says Yahweh. 
+<sup>24&#160;</sup>“They will go out, and look at the dead bodies of the men who have transgressed against me; for their worm will not die, nor will their fire be quenched, and they will be loathsome to all mankind.” </div></div><script src="../main.js"></script></body></html>

--- a/book/james.html
+++ b/book/james.html
@@ -3,6 +3,47 @@
 <head>
 <title>James</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,140 +53,146 @@
 <div class="main">
 <!-- JAS World English Scripture (WES) -->
 <h1 class="booklabel">James</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>James, a servant of Elohim and of the Lord Yahushua Christ,<span class="f">+ \fr 1:1 \ft “Christ” means “Anointed One”.</span> to the twelve tribes which are in the Dispersion: Greetings. 
-</p><p>
-<span class="v">2&#160;</span>Count it all joy, my brothers,<span class="f">+ \fr 1:2 \ft The word for “brothers” here and where context allows may also be correctly translated “brothers and sisters” or “siblings.”</span> when you fall into various temptations, 
-<span class="v">3&#160;</span>knowing that the testing of your faith produces endurance. 
-<span class="v">4&#160;</span>Let endurance have its perfect work, that you may be perfect and complete, lacking in nothing. 
-</p><p>
-<span class="v">5&#160;</span>But if any of you lacks wisdom, let him ask of Elohim, who gives to all liberally and without reproach, and it will be given to him. 
-<span class="v">6&#160;</span>But let him ask in faith, without any doubting, for he who doubts is like a wave of the sea, driven by the wind and tossed. 
-<span class="v">7&#160;</span>For that man shouldn’t think that he will receive anything from the Lord. 
-<span class="v">8&#160;</span>He is a double-minded man, unstable in all his ways. 
-</p><p>
-<span class="v">9&#160;</span>Let the brother in humble circumstances glory in his high position; 
-<span class="v">10&#160;</span>and the rich, in that he is made humble, because like the flower in the grass, he will pass away. 
-<span class="v">11&#160;</span>For the sun arises with the scorching wind and withers the grass; and the flower in it falls, and the beauty of its appearance perishes. So the rich man will also fade away in his pursuits. 
-</p><p>
-<span class="v">12&#160;</span>Blessed is a person who endures temptation, for when he has been approved, he will receive the crown of life which the Lord promised to those who love him. 
-</p><p>
-<span class="v">13&#160;</span>Let no man say when he is tempted, “I am tempted by Elohim,” for Elohim can’t be tempted by evil, and he himself tempts no one. 
-<span class="v">14&#160;</span>But each one is tempted when he is drawn away by his own lust and enticed. 
-<span class="v">15&#160;</span>Then the lust, when it has conceived, bears sin. The sin, when it is full grown, produces death. 
-<span class="v">16&#160;</span>Don’t be deceived, my beloved brothers. 
-<span class="v">17&#160;</span>Every good gift and every perfect gift is from above, coming down from the Father of lights, with whom can be no variation nor turning shadow. 
-<span class="v">18&#160;</span>Of his own will he gave birth to us by the word of truth, that we should be a kind of first fruits of his creatures. 
-</p><p>
-<span class="v">19&#160;</span>So, then, my beloved brothers, let every man be swift to hear, slow to speak, and slow to anger; 
-<span class="v">20&#160;</span>for the anger of man doesn’t produce the righteousness of Elohim. 
-<span class="v">21&#160;</span>Therefore, putting away all filthiness and overflowing of wickedness, receive with humility the implanted word, which is able to save your souls.<span class="f">+ \fr 1:21 \ft or, preserve your life.</span> 
-</p><p>
-<span class="v">22&#160;</span>But be doers of the word, and not only hearers, deluding your own selves. 
-<span class="v">23&#160;</span>For if anyone is a hearer of the word and not a doer, he is like a man looking at his natural face in a mirror; 
-<span class="v">24&#160;</span>for he sees himself, and goes away, and immediately forgets what kind of man he was. 
-<span class="v">25&#160;</span>But he who looks into the perfect law of freedom and continues, not being a hearer who forgets but a doer of the work, this man will be blessed in what he does. 
-</p><p>
-<span class="v">26&#160;</span>If anyone among you thinks himself to be religious while he doesn’t bridle his tongue, but deceives his heart, this man’s religion is worthless. 
-<span class="v">27&#160;</span>Pure religion and undefiled before our Elohim and Father is this: to visit the fatherless and widows in their affliction, and to keep oneself unstained by the world. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>My brothers, don’t hold the faith of our glorious Lord Yahushua Christ with partiality. 
-<span class="v">2&#160;</span>For if a man with a gold ring, in fine clothing, comes into your synagogue,<span class="f">+ \fr 2:2 \ft or, meeting</span> and a poor man in filthy clothing also comes in, 
-<span class="v">3&#160;</span>and you pay special attention to him who wears the fine clothing and say, “Sit here in a good place;” and you tell the poor man, “Stand there,” or “Sit by my footstool” 
-<span class="v">4&#160;</span>haven’t you shown partiality among yourselves, and become judges with evil thoughts? 
-<span class="v">5&#160;</span>Listen, my beloved brothers. Didn’t Elohim choose those who are poor in this world to be rich in faith and heirs of the Kingdom which he promised to those who love him? 
-<span class="v">6&#160;</span>But you have dishonored the poor man. Don’t the rich oppress you and personally drag you before the courts? 
-<span class="v">7&#160;</span>Don’t they blaspheme the honorable name by which you are called? 
-</p><p>
-<span class="v">8&#160;</span>However, if you fulfill the royal law according to the Scripture, “You shall love your neighbor as yourself,”<span class="x">+ \xo 2:8 \xt Leviticus 19:18</span> you do well. 
-<span class="v">9&#160;</span>But if you show partiality, you commit sin, being convicted by the law as transgressors. 
-<span class="v">10&#160;</span>For whoever keeps the whole law, and yet stumbles in one point, he has become guilty of all. 
-<span class="v">11&#160;</span>For he who said, “Do not commit adultery,”<span class="x">+ \xo 2:11 \xt Exodus 20:14; Deuteronomy 5:18</span> also said, “Do not commit murder.”<span class="x">+ \xo 2:11 \xt Exodus 20:13; Deuteronomy 5:17 </span> Now if you do not commit adultery but do murder, you have become a transgressor of the law. 
-<span class="v">12&#160;</span>So speak and so do as men who are to be judged by the law of freedom. 
-<span class="v">13&#160;</span>For judgment is without mercy to him who has shown no mercy. Mercy triumphs over judgment. 
-</p><p>
-<span class="v">14&#160;</span>What good is it, my brothers, if a man says he has faith, but has no works? Can faith save him? 
-<span class="v">15&#160;</span>And if a brother or sister is naked and in lack of daily food, 
-<span class="v">16&#160;</span>and one of you tells them, “Go in peace. Be warmed and filled;” yet you didn’t give them the things the body needs, what good is it? 
-<span class="v">17&#160;</span>Even so faith, if it has no works, is dead in itself. 
-<span class="v">18&#160;</span>Yes, a man will say, “You have faith, and I have works.” Show me your faith without works, and I will show you my faith by my works. 
-</p><p>
-<span class="v">19&#160;</span>You believe that Elohim is one. You do well. The demons also believe—and shudder. 
-<span class="v">20&#160;</span>But do you want to know, vain man, that faith apart from works is dead? 
-<span class="v">21&#160;</span>Wasn’t Abraham our father justified by works, in that he offered up Isaac his son on the altar? 
-<span class="v">22&#160;</span>You see that faith worked with his works, and by works faith was perfected. 
-<span class="v">23&#160;</span>So the Scripture was fulfilled which says, “Abraham believed Elohim, and it was accounted to him as righteousness,”<span class="x">+ \xo 2:23 \xt Genesis 15:6</span> and he was called the friend of Elohim. 
-<span class="v">24&#160;</span>You see then that by works a man is justified, and not only by faith. 
-<span class="v">25&#160;</span>In the same way, wasn’t Rahab the prostitute also justified by works when she received the messengers and sent them out another way? 
-<span class="v">26&#160;</span>For as the body apart from the spirit is dead, even so faith apart from works is dead. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Let not many of you be teachers, my brothers, knowing that we will receive heavier judgment. 
-<span class="v">2&#160;</span>For we all stumble in many things. Anyone who doesn’t stumble in word is a perfect person, able to bridle the whole body also. 
-<span class="v">3&#160;</span>Indeed, we put bits into the horses’ mouths so that they may obey us, and we guide their whole body. 
-<span class="v">4&#160;</span>Behold,<span class="f">+ \fr 3:4 \ft “Behold”, from “ἰδοὺ”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> the ships also, though they are so big and are driven by fierce winds, are yet guided by a very small rudder, wherever the pilot desires. 
-<span class="v">5&#160;</span>So the tongue is also a little member, and boasts great things. See how a small fire can spread to a large forest! 
-<span class="v">6&#160;</span>And the tongue is a fire. The world of iniquity among our members is the tongue, which defiles the whole body, and sets on fire the course of nature, and is set on fire by Gehenna.<span class="f">+ \fr 3:6 \ft or, Hell</span> 
-<span class="v">7&#160;</span>For every kind of animal, bird, creeping thing, and sea creature is tamed, and has been tamed by mankind; 
-<span class="v">8&#160;</span>but nobody can tame the tongue. It is a restless evil, full of deadly poison. 
-<span class="v">9&#160;</span>With it we bless our Elohim and Father, and with it we curse men who are made in the image of Elohim. 
-<span class="v">10&#160;</span>Out of the same mouth comes blessing and cursing. My brothers, these things ought not to be so. 
-<span class="v">11&#160;</span>Does a spring send out from the same opening fresh and bitter water? 
-<span class="v">12&#160;</span>Can a fig tree, my brothers, yield olives, or a vine figs? Thus no spring yields both salt water and fresh water. 
-</p><p>
-<span class="v">13&#160;</span>Who is wise and understanding among you? Let him show by his good conduct that his deeds are done in gentleness of wisdom. 
-<span class="v">14&#160;</span>But if you have bitter jealousy and selfish ambition in your heart, don’t boast and don’t lie against the truth. 
-<span class="v">15&#160;</span>This wisdom is not that which comes down from above, but is earthly, sensual, and demonic. 
-<span class="v">16&#160;</span>For where jealousy and selfish ambition are, there is confusion and every evil deed. 
-<span class="v">17&#160;</span>But the wisdom that is from above is first pure, then peaceful, gentle, reasonable, full of mercy and good fruits, without partiality, and without hypocrisy. 
-<span class="v">18&#160;</span>Now the fruit of righteousness is sown in peace by those who make peace. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Where do wars and fightings among you come from? Don’t they come from your pleasures that war in your members? 
-<span class="v">2&#160;</span>You lust, and don’t have. You murder and covet, and can’t obtain. You fight and make war. You don’t have, because you don’t ask. 
-<span class="v">3&#160;</span>You ask, and don’t receive, because you ask with wrong motives, so that you may spend it on your pleasures. 
-<span class="v">4&#160;</span>You adulterers and adulteresses, don’t you know that friendship with the world is hostility toward Elohim? Whoever therefore wants to be a friend of the world makes himself an enemy of Elohim. 
-<span class="v">5&#160;</span>Or do you think that the Scripture says in vain, “The Spirit who lives in us yearns jealously”? 
-<span class="v">6&#160;</span>But he gives more grace. Therefore it says, “Elohim resists the proud, but gives grace to the humble.”<span class="x">+ \xo 4:6 \xt Proverbs 3:34</span> 
-<span class="v">7&#160;</span>Be subject therefore to Elohim. Resist the devil, and he will flee from you. 
-<span class="v">8&#160;</span>Draw near to Elohim, and he will draw near to you. Cleanse your hands, you sinners. Purify your hearts, you double-minded. 
-<span class="v">9&#160;</span>Lament, mourn, and weep. Let your laughter be turned to mourning and your joy to gloom. 
-<span class="v">10&#160;</span>Humble yourselves in the sight of the Lord, and he will exalt you. 
-</p><p>
-<span class="v">11&#160;</span>Don’t speak against one another, brothers. He who speaks against a brother and judges his brother, speaks against the law and judges the law. But if you judge the law, you are not a doer of the law but a judge. 
-<span class="v">12&#160;</span>Only one is the lawgiver, who is able to save and to destroy. But who are you to judge another? 
-</p><p>
-<span class="v">13&#160;</span>Come now, you who say, “Today or tomorrow let’s go into this city and spend a year there, trade, and make a profit.” 
-<span class="v">14&#160;</span>Yet you don’t know what your life will be like tomorrow. For what is your life? For you are a vapor that appears for a little time and then vanishes away. 
-<span class="v">15&#160;</span>For you ought to say, “If the Lord wills, we will both live, and do this or that.” 
-<span class="v">16&#160;</span>But now you glory in your boasting. All such boasting is evil. 
-<span class="v">17&#160;</span>To him therefore who knows to do good and doesn’t do it, to him it is sin. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Come now, you rich, weep and howl for your miseries that are coming on you. 
-<span class="v">2&#160;</span>Your riches are corrupted and your garments are moth-eaten. 
-<span class="v">3&#160;</span>Your gold and your silver are corroded, and their corrosion will be for a testimony against you and will eat your flesh like fire. You have laid up your treasure in the last days. 
-<span class="v">4&#160;</span>Behold, the wages of the laborers who mowed your fields, which you have kept back by fraud, cry out; and the cries of those who reaped have entered into the ears of the Lord of Armies.<span class="f">+ \fr 5:4 \ft Greek: Sabaoth (for Hebrew: Tze’va’ot)</span> 
-<span class="v">5&#160;</span>You have lived in luxury on the earth, and taken your pleasure. You have nourished your hearts as in a day of slaughter. 
-<span class="v">6&#160;</span>You have condemned and you have murdered the righteous one. He doesn’t resist you. 
-</p><p>
-<span class="v">7&#160;</span>Be patient therefore, brothers, until the coming of the Lord. Behold, the farmer waits for the precious fruit of the earth, being patient over it, until it receives the early and late rain. 
-<span class="v">8&#160;</span>You also be patient. Establish your hearts, for the coming of the Lord is at hand. 
-</p><p>
-<span class="v">9&#160;</span>Don’t grumble, brothers, against one another, so that you won’t be judged. Behold, the judge stands at the door. 
-<span class="v">10&#160;</span>Take, brothers, for an example of suffering and of perseverance, the prophets who spoke in the name of the Lord. 
-<span class="v">11&#160;</span>Behold, we call them blessed who endured. You have heard of the perseverance of Job and have seen the Lord in the outcome, and how the Lord is full of compassion and mercy. 
-</p><p>
-<span class="v">12&#160;</span>But above all things, my brothers, don’t swear—not by heaven, or by the earth, or by any other oath; but let your “yes” be “yes”, and your “no”, “no”, so that you don’t fall into hypocrisy.<span class="f">+ \fr 5:12 \ft TR reads “under judgment” instead of “into hypocrisy”</span> 
-</p><p>
-<span class="v">13&#160;</span>Is any among you suffering? Let him pray. Is any cheerful? Let him sing praises. 
-<span class="v">14&#160;</span>Is any among you sick? Let him call for the elders of the assembly, and let them pray over him, anointing him with oil in the name of the Lord; 
-<span class="v">15&#160;</span>and the prayer of faith will heal him who is sick, and the Lord will raise him up. If he has committed sins, he will be forgiven. 
-<span class="v">16&#160;</span>Confess your sins to one another and pray for one another, that you may be healed. The insistent prayer of a righteous person is powerfully effective. 
-<span class="v">17&#160;</span>Elijah was a man with a nature like ours, and he prayed earnestly that it might not rain, and it didn’t rain on the earth for three years and six months. 
-<span class="v">18&#160;</span>He prayed again, and the sky gave rain, and the earth produced its fruit. 
-</p><p>
-<span class="v">19&#160;</span>Brothers, if any among you wanders from the truth and someone turns him back, 
-<span class="v">20&#160;</span>let him know that he who turns a sinner from the error of his way will save a soul from death and will cover a multitude of sins. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>James, a servant of Elohim and of the Lord Yahushua Christ, to the twelve tribes which are in the Dispersion: Greetings. 
+</div><div class="p">
+<sup>2&#160;</sup>Count it all joy, my brothers, when you fall into various temptations, 
+<sup>3&#160;</sup>knowing that the testing of your faith produces endurance. 
+<sup>4&#160;</sup>Let endurance have its perfect work, that you may be perfect and complete, lacking in nothing. 
+</div><div class="p">
+<sup>5&#160;</sup>But if any of you lacks wisdom, let him ask of Elohim, who gives to all liberally and without reproach, and it will be given to him. 
+<sup>6&#160;</sup>But let him ask in faith, without any doubting, for he who doubts is like a wave of the sea, driven by the wind and tossed. 
+<sup>7&#160;</sup>For that man shouldn’t think that he will receive anything from the Lord. 
+<sup>8&#160;</sup>He is a double-minded man, unstable in all his ways. 
+</div><div class="p">
+<sup>9&#160;</sup>Let the brother in humble circumstances glory in his high position; 
+<sup>10&#160;</sup>and the rich, in that he is made humble, because like the flower in the grass, he will pass away. 
+<sup>11&#160;</sup>For the sun arises with the scorching wind and withers the grass; and the flower in it falls, and the beauty of its appearance perishes. So the rich man will also fade away in his pursuits. 
+</div><div class="p">
+<sup>12&#160;</sup>Blessed is a person who endures temptation, for when he has been approved, he will receive the crown of life which the Lord promised to those who love him. 
+</div><div class="p">
+<sup>13&#160;</sup>Let no man say when he is tempted, “I am tempted by Elohim,” for Elohim can’t be tempted by evil, and he himself tempts no one. 
+<sup>14&#160;</sup>But each one is tempted when he is drawn away by his own lust and enticed. 
+<sup>15&#160;</sup>Then the lust, when it has conceived, bears sin. The sin, when it is full grown, produces death. 
+<sup>16&#160;</sup>Don’t be deceived, my beloved brothers. 
+<sup>17&#160;</sup>Every good gift and every perfect gift is from above, coming down from the Father of lights, with whom can be no variation nor turning shadow. 
+<sup>18&#160;</sup>Of his own will he gave birth to us by the word of truth, that we should be a kind of first fruits of his creatures. 
+</div><div class="p">
+<sup>19&#160;</sup>So, then, my beloved brothers, let every man be swift to hear, slow to speak, and slow to anger; 
+<sup>20&#160;</sup>for the anger of man doesn’t produce the righteousness of Elohim. 
+<sup>21&#160;</sup>Therefore, putting away all filthiness and overflowing of wickedness, receive with humility the implanted word, which is able to save your souls. 
+</div><div class="p">
+<sup>22&#160;</sup>But be doers of the word, and not only hearers, deluding your own selves. 
+<sup>23&#160;</sup>For if anyone is a hearer of the word and not a doer, he is like a man looking at his natural face in a mirror; 
+<sup>24&#160;</sup>for he sees himself, and goes away, and immediately forgets what kind of man he was. 
+<sup>25&#160;</sup>But he who looks into the perfect law of freedom and continues, not being a hearer who forgets but a doer of the work, this man will be blessed in what he does. 
+</div><div class="p">
+<sup>26&#160;</sup>If anyone among you thinks himself to be religious while he doesn’t bridle his tongue, but deceives his heart, this man’s religion is worthless. 
+<sup>27&#160;</sup>Pure religion and undefiled before our Elohim and Father is this: to visit the fatherless and widows in their affliction, and to keep oneself unstained by the world. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>My brothers, don’t hold the faith of our glorious Lord Yahushua Christ with partiality. 
+<sup>2&#160;</sup>For if a man with a gold ring, in fine clothing, comes into your synagogue, and a poor man in filthy clothing also comes in, 
+<sup>3&#160;</sup>and you pay special attention to him who wears the fine clothing and say, “Sit here in a good place;” and you tell the poor man, “Stand there,” or “Sit by my footstool” 
+<sup>4&#160;</sup>haven’t you shown partiality among yourselves, and become judges with evil thoughts? 
+<sup>5&#160;</sup>Listen, my beloved brothers. Didn’t Elohim choose those who are poor in this world to be rich in faith and heirs of the Kingdom which he promised to those who love him? 
+<sup>6&#160;</sup>But you have dishonored the poor man. Don’t the rich oppress you and personally drag you before the courts? 
+<sup>7&#160;</sup>Don’t they blaspheme the honorable name by which you are called? 
+</div><div class="p">
+<sup>8&#160;</sup>However, if you fulfill the royal law according to the Scripture, “You shall love your neighbor as yourself,” you do well. 
+<sup>9&#160;</sup>But if you show partiality, you commit sin, being convicted by the law as transgressors. 
+<sup>10&#160;</sup>For whoever keeps the whole law, and yet stumbles in one point, he has become guilty of all. 
+<sup>11&#160;</sup>For he who said, “Do not commit adultery,” Now if you do not commit adultery but do murder, you have become a transgressor of the law. 
+<sup>12&#160;</sup>So speak and so do as men who are to be judged by the law of freedom. 
+<sup>13&#160;</sup>For judgment is without mercy to him who has shown no mercy. Mercy triumphs over judgment. 
+</div><div class="p">
+<sup>14&#160;</sup>What good is it, my brothers, if a man says he has faith, but has no works? Can faith save him? 
+<sup>15&#160;</sup>And if a brother or sister is naked and in lack of daily food, 
+<sup>16&#160;</sup>and one of you tells them, “Go in peace. Be warmed and filled;” yet you didn’t give them the things the body needs, what good is it? 
+<sup>17&#160;</sup>Even so faith, if it has no works, is dead in itself. 
+<sup>18&#160;</sup>Yes, a man will say, “You have faith, and I have works.” Show me your faith without works, and I will show you my faith by my works. 
+</div><div class="p">
+<sup>19&#160;</sup>You believe that Elohim is one. You do well. The demons also believe—and shudder. 
+<sup>20&#160;</sup>But do you want to know, vain man, that faith apart from works is dead? 
+<sup>21&#160;</sup>Wasn’t Abraham our father justified by works, in that he offered up Isaac his son on the altar? 
+<sup>22&#160;</sup>You see that faith worked with his works, and by works faith was perfected. 
+<sup>23&#160;</sup>So the Scripture was fulfilled which says, “Abraham believed Elohim, and it was accounted to him as righteousness,” and he was called the friend of Elohim. 
+<sup>24&#160;</sup>You see then that by works a man is justified, and not only by faith. 
+<sup>25&#160;</sup>In the same way, wasn’t Rahab the prostitute also justified by works when she received the messengers and sent them out another way? 
+<sup>26&#160;</sup>For as the body apart from the spirit is dead, even so faith apart from works is dead. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Let not many of you be teachers, my brothers, knowing that we will receive heavier judgment. 
+<sup>2&#160;</sup>For we all stumble in many things. Anyone who doesn’t stumble in word is a perfect person, able to bridle the whole body also. 
+<sup>3&#160;</sup>Indeed, we put bits into the horses’ mouths so that they may obey us, and we guide their whole body. 
+<sup>4&#160;</sup>Behold, the ships also, though they are so big and are driven by fierce winds, are yet guided by a very small rudder, wherever the pilot desires. 
+<sup>5&#160;</sup>So the tongue is also a little member, and boasts great things. See how a small fire can spread to a large forest! 
+<sup>6&#160;</sup>And the tongue is a fire. The world of iniquity among our members is the tongue, which defiles the whole body, and sets on fire the course of nature, and is set on fire by Gehenna. 
+<sup>7&#160;</sup>For every kind of animal, bird, creeping thing, and sea creature is tamed, and has been tamed by mankind; 
+<sup>8&#160;</sup>but nobody can tame the tongue. It is a restless evil, full of deadly poison. 
+<sup>9&#160;</sup>With it we bless our Elohim and Father, and with it we curse men who are made in the image of Elohim. 
+<sup>10&#160;</sup>Out of the same mouth comes blessing and cursing. My brothers, these things ought not to be so. 
+<sup>11&#160;</sup>Does a spring send out from the same opening fresh and bitter water? 
+<sup>12&#160;</sup>Can a fig tree, my brothers, yield olives, or a vine figs? Thus no spring yields both salt water and fresh water. 
+</div><div class="p">
+<sup>13&#160;</sup>Who is wise and understanding among you? Let him show by his good conduct that his deeds are done in gentleness of wisdom. 
+<sup>14&#160;</sup>But if you have bitter jealousy and selfish ambition in your heart, don’t boast and don’t lie against the truth. 
+<sup>15&#160;</sup>This wisdom is not that which comes down from above, but is earthly, sensual, and demonic. 
+<sup>16&#160;</sup>For where jealousy and selfish ambition are, there is confusion and every evil deed. 
+<sup>17&#160;</sup>But the wisdom that is from above is first pure, then peaceful, gentle, reasonable, full of mercy and good fruits, without partiality, and without hypocrisy. 
+<sup>18&#160;</sup>Now the fruit of righteousness is sown in peace by those who make peace. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Where do wars and fightings among you come from? Don’t they come from your pleasures that war in your members? 
+<sup>2&#160;</sup>You lust, and don’t have. You murder and covet, and can’t obtain. You fight and make war. You don’t have, because you don’t ask. 
+<sup>3&#160;</sup>You ask, and don’t receive, because you ask with wrong motives, so that you may spend it on your pleasures. 
+<sup>4&#160;</sup>You adulterers and adulteresses, don’t you know that friendship with the world is hostility toward Elohim? Whoever therefore wants to be a friend of the world makes himself an enemy of Elohim. 
+<sup>5&#160;</sup>Or do you think that the Scripture says in vain, “The Spirit who lives in us yearns jealously”? 
+<sup>6&#160;</sup>But he gives more grace. Therefore it says, “Elohim resists the proud, but gives grace to the humble.” 
+<sup>7&#160;</sup>Be subject therefore to Elohim. Resist the devil, and he will flee from you. 
+<sup>8&#160;</sup>Draw near to Elohim, and he will draw near to you. Cleanse your hands, you sinners. Purify your hearts, you double-minded. 
+<sup>9&#160;</sup>Lament, mourn, and weep. Let your laughter be turned to mourning and your joy to gloom. 
+<sup>10&#160;</sup>Humble yourselves in the sight of the Lord, and he will exalt you. 
+</div><div class="p">
+<sup>11&#160;</sup>Don’t speak against one another, brothers. He who speaks against a brother and judges his brother, speaks against the law and judges the law. But if you judge the law, you are not a doer of the law but a judge. 
+<sup>12&#160;</sup>Only one is the lawgiver, who is able to save and to destroy. But who are you to judge another? 
+</div><div class="p">
+<sup>13&#160;</sup>Come now, you who say, “Today or tomorrow let’s go into this city and spend a year there, trade, and make a profit.” 
+<sup>14&#160;</sup>Yet you don’t know what your life will be like tomorrow. For what is your life? For you are a vapor that appears for a little time and then vanishes away. 
+<sup>15&#160;</sup>For you ought to say, “If the Lord wills, we will both live, and do this or that.” 
+<sup>16&#160;</sup>But now you glory in your boasting. All such boasting is evil. 
+<sup>17&#160;</sup>To him therefore who knows to do good and doesn’t do it, to him it is sin. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Come now, you rich, weep and howl for your miseries that are coming on you. 
+<sup>2&#160;</sup>Your riches are corrupted and your garments are moth-eaten. 
+<sup>3&#160;</sup>Your gold and your silver are corroded, and their corrosion will be for a testimony against you and will eat your flesh like fire. You have laid up your treasure in the last days. 
+<sup>4&#160;</sup>Behold, the wages of the laborers who mowed your fields, which you have kept back by fraud, cry out; and the cries of those who reaped have entered into the ears of the Lord of Armies. 
+<sup>5&#160;</sup>You have lived in luxury on the earth, and taken your pleasure. You have nourished your hearts as in a day of slaughter. 
+<sup>6&#160;</sup>You have condemned and you have murdered the righteous one. He doesn’t resist you. 
+</div><div class="p">
+<sup>7&#160;</sup>Be patient therefore, brothers, until the coming of the Lord. Behold, the farmer waits for the precious fruit of the earth, being patient over it, until it receives the early and late rain. 
+<sup>8&#160;</sup>You also be patient. Establish your hearts, for the coming of the Lord is at hand. 
+</div><div class="p">
+<sup>9&#160;</sup>Don’t grumble, brothers, against one another, so that you won’t be judged. Behold, the judge stands at the door. 
+<sup>10&#160;</sup>Take, brothers, for an example of suffering and of perseverance, the prophets who spoke in the name of the Lord. 
+<sup>11&#160;</sup>Behold, we call them blessed who endured. You have heard of the perseverance of Job and have seen the Lord in the outcome, and how the Lord is full of compassion and mercy. 
+</div><div class="p">
+<sup>12&#160;</sup>But above all things, my brothers, don’t swear—not by heaven, or by the earth, or by any other oath; but let your “yes” be “yes”, and your “no”, “no”, so that you don’t fall into hypocrisy. 
+</div><div class="p">
+<sup>13&#160;</sup>Is any among you suffering? Let him pray. Is any cheerful? Let him sing praises. 
+<sup>14&#160;</sup>Is any among you sick? Let him call for the elders of the assembly, and let them pray over him, anointing him with oil in the name of the Lord; 
+<sup>15&#160;</sup>and the prayer of faith will heal him who is sick, and the Lord will raise him up. If he has committed sins, he will be forgiven. 
+<sup>16&#160;</sup>Confess your sins to one another and pray for one another, that you may be healed. The insistent prayer of a righteous person is powerfully effective. 
+<sup>17&#160;</sup>Elijah was a man with a nature like ours, and he prayed earnestly that it might not rain, and it didn’t rain on the earth for three years and six months. 
+<sup>18&#160;</sup>He prayed again, and the sky gave rain, and the earth produced its fruit. 
+</div><div class="p">
+<sup>19&#160;</sup>Brothers, if any among you wanders from the truth and someone turns him back, 
+<sup>20&#160;</sup>let him know that he who turns a sinner from the error of his way will save a soul from death and will cover a multitude of sins. </div></div><script src="../main.js"></script></body></html>

--- a/book/jeremiah.html
+++ b/book/jeremiah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Jeremiah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,3806 +53,3859 @@
 <div class="main">
 <!-- JER World English Scripture (WES) -->
 <h1 class="booklabel">Jeremiah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The words of Jeremiah the son of Hilkiah, one of the priests who were in Anathoth in the land of Benjamin. 
-<span class="v">2&#160;</span>Yahweh’s<span class="f">+ \fr 1:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word came to him in the days of Josiah the son of Amon, king of Judah, in the thirteenth year of his reign. 
-<span class="v">3&#160;</span>It came also in the days of Jehoiakim the son of Josiah, king of Judah, to the end of the eleventh year of Zedekiah, the son of Josiah, king of Judah, to the carrying away of Jerusalem captive in the fifth month. 
-<span class="v">4&#160;</span>Now Yahweh’s word came to me, saying, 
-</p><p class="q1">
-<span class="v">5&#160;</span>“Before I formed you in the womb, I knew you. 
-</p><p class="q2">Before you were born, I sanctified you. 
-</p><p class="q2">I have appointed you a prophet to the nations.” 
-</p><p>
-<span class="v">6&#160;</span>Then I said, “Ah, Lord<span class="f">+ \fr 1:6 \ft The word translated “Lord” is “Adonai.” </span> Yahweh! Behold,<span class="f">+ \fr 1:6 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I don’t know how to speak; for I am a child.” 
-</p><p>
-<span class="v">7&#160;</span>But Yahweh said to me, “Don’t say, ‘I am a child;’ for you must go to whomever I send you, and you must say whatever I command you. 
-<span class="v">8&#160;</span>Don’t be afraid because of them, for I am with you to rescue you,” says Yahweh. 
-</p><p>
-<span class="v">9&#160;</span>Then Yahweh stretched out his hand and touched my mouth. Then Yahweh said to me, “Behold, I have put my words in your mouth. 
-<span class="v">10&#160;</span>Behold, I have today set you over the nations and over the kingdoms, to uproot and to tear down, to destroy and to overthrow, to build and to plant.” 
-</p><p>
-<span class="v">11&#160;</span>Moreover Yahweh’s word came to me, saying, “Jeremiah, what do you see?” 
-</p><p>I said, “I see a branch of an almond tree.” 
-</p><p>
-<span class="v">12&#160;</span>Then Yahweh said to me, “You have seen well; for I watch over my word to perform it.” 
-</p><p>
-<span class="v">13&#160;</span>Yahweh’s word came to me the second time, saying, “What do you see?” 
-</p><p>I said, “I see a boiling cauldron; and it is tipping away from the north.” 
-</p><p>
-<span class="v">14&#160;</span>Then Yahweh said to me, “Out of the north, evil will break out on all the inhabitants of the land. 
-<span class="v">15&#160;</span>For behold, I will call all the families of the kingdoms of the north,” says Yahweh. 
-</p><p class="q1">“They will come, and they will each set his throne at the entrance of the gates of Jerusalem, 
-</p><p class="q2">and against all its walls all around, and against all the cities of Judah. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will utter my judgments against them concerning all their wickedness, 
-</p><p class="q2">in that they have forsaken me, 
-</p><p class="q2">and have burned incense to other elohims, 
-</p><p class="q2">and worshiped the works of their own hands. 
-</p><p>
-<span class="v">17&#160;</span>“You therefore put your belt on your waist, arise, and say to them all that I command you. Don’t be dismayed at them, lest I dismay you before them. 
-<span class="v">18&#160;</span>For behold, I have made you today a fortified city, an iron pillar, and bronze walls against the whole land—against the kings of Judah, against its princes, against its priests, and against the people of the land. 
-<span class="v">19&#160;</span>They will fight against you, but they will not prevail against you; for I am with you”, says Yahweh, “to rescue you.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“Go and proclaim in the ears of Jerusalem, saying, ‘Yahweh says, 
-</p><p class="q1">“I remember for you the kindness of your youth, 
-</p><p class="q2">your love as a bride, 
-</p><p class="q1">how you went after me in the wilderness, 
-</p><p class="q2">in a land that was not sown. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Israel was set-apartness to Yahweh, 
-</p><p class="q2">the first fruits of his increase. 
-</p><p class="q1">All who devour him will be held guilty. 
-</p><p class="q2">Evil will come on them,”&#160;’ says Yahweh.” 
-</p><p>
-<span class="v">4&#160;</span>Hear Yahweh’s word, O house of Jacob, and all the families of the house of Israel! 
-<span class="v">5&#160;</span>Yahweh says, 
-</p><p class="q1">“What unrighteousness have your fathers found in me, 
-</p><p class="q2">that they have gone far from me, 
-</p><p class="q1">and have walked after worthless vanity, 
-</p><p class="q2">and have become worthless? 
-</p><p class="q1">
-<span class="v">6&#160;</span>They didn’t say, ‘Where is Yahweh who brought us up out of the land of Egypt, 
-</p><p class="q2">who led us through the wilderness, 
-</p><p class="q2">through a land of deserts and of pits, 
-</p><p class="q2">through a land of drought and of the shadow of death, 
-</p><p class="q2">through a land that no one passed through, 
-</p><p class="q2">and where no man lived?’ 
-</p><p class="q1">
-<span class="v">7&#160;</span>I brought you into a plentiful land 
-</p><p class="q2">to eat its fruit and its goodness; 
-</p><p class="q1">but when you entered, you defiled my land, 
-</p><p class="q2">and made my heritage an abomination. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The priests didn’t say, ‘Where is Yahweh?’ 
-</p><p class="q2">and those who handle the law didn’t know me. 
-</p><p class="q1">The rulers also transgressed against me, 
-</p><p class="q2">and the prophets prophesied by Baal 
-</p><p class="q2">and followed things that do not profit. 
-</p><p class="q1">
-<span class="v">9&#160;</span>“Therefore I will yet contend with you,” says Yahweh, 
-</p><p class="q2">“and I will contend with your children’s children. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For pass over to the islands of Kittim, and see. 
-</p><p class="q2">Send to Kedar, and consider diligently, 
-</p><p class="q2">and see if there has been such a thing. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Has a nation changed its elohims, 
-</p><p class="q2">which really are no elohims? 
-</p><p class="q2">But my people have changed their glory for that which doesn’t profit. 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Be astonished, you heavens, at this 
-</p><p class="q2">and be horribly afraid. 
-</p><p class="q2">Be very desolate,” says Yahweh. 
-</p><p class="q1">
-<span class="v">13&#160;</span>“For my people have committed two evils: 
-</p><p class="q2">they have forsaken me, the spring of living waters, 
-</p><p class="q2">and cut out cisterns for themselves: broken cisterns that can’t hold water. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Is Israel a slave? 
-</p><p class="q2">Is he born into slavery? 
-</p><p class="q2">Why has he become a captive? 
-</p><p class="q1">
-<span class="v">15&#160;</span>The young lions have roared at him and raised their voices. 
-</p><p class="q2">They have made his land waste. 
-</p><p class="q2">His cities are burned up, without inhabitant. 
-</p><p class="q2">
-<span class="v">16&#160;</span>The children also of Memphis and Tahpanhes have broken the crown of your head. 
-</p><p class="q1">
-<span class="v">17&#160;</span>“Haven’t you brought this on yourself, 
-</p><p class="q2">in that you have forsaken Yahweh your Elohim,<span class="f">+ \fr 2:17 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> when he led you by the way? 
-</p><p class="q1">
-<span class="v">18&#160;</span>Now what do you gain by going to Egypt, to drink the waters of the Shihor? 
-</p><p class="q2">Or why do you go on the way to Assyria, to drink the waters of the River?<span class="f">+ \fr 2:18 \ft i.e., the Euphrates River</span> 
-</p><p class="q1">
-<span class="v">19&#160;</span>“Your own wickedness will correct you, 
-</p><p class="q2">and your backsliding will rebuke you. 
-</p><p class="q1">Know therefore and see that it is an evil and bitter thing, 
-</p><p class="q2">that you have forsaken Yahweh your Elohim, 
-</p><p class="q2">and that my fear is not in you,” says the Lord, Yahweh of Armies. 
-</p><p class="q1">
-<span class="v">20&#160;</span>“For long ago I broke off your yoke, 
-</p><p class="q2">and burst your bonds. 
-</p><p class="q1">You said, ‘I will not serve;’ 
-</p><p class="q2">for on every high hill and under every green tree you bowed yourself, 
-</p><p class="q2">playing the prostitute. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Yet I had planted you a noble vine, 
-</p><p class="q2">a pure and faithful seed. 
-</p><p class="q2">How then have you turned into the degenerate branches of a foreign vine to me? 
-</p><p class="q1">
-<span class="v">22&#160;</span>For though you wash yourself with lye, 
-</p><p class="q2">and use much soap, 
-</p><p class="q2">yet your iniquity is marked before me,” says the Lord Yahweh. 
-</p><p class="q1">
-<span class="v">23&#160;</span>“How can you say, ‘I am not defiled. 
-</p><p class="q2">I have not gone after the Baals’? 
-</p><p class="q1">See your way in the valley. 
-</p><p class="q2">Know what you have done. 
-</p><p class="q1">You are a swift dromedary traversing her ways, 
-<span class="v">24&#160;</span>a wild donkey used to the wilderness, that sniffs the wind in her craving. 
-</p><p class="q2">When she is in heat, who can turn her away? 
-</p><p class="q2">All those who seek her will not weary themselves. In her month, they will find her. 
-</p><p class="q1">
-<span class="v">25&#160;</span>“Keep your feet from being bare, 
-</p><p class="q2">and your throat from thirst. 
-</p><p class="q1">But you said, ‘It is in vain. 
-</p><p class="q2">No, for I have loved strangers, 
-</p><p class="q2">and I will go after them.’ 
-</p><p class="q1">
-<span class="v">26&#160;</span>As the thief is ashamed when he is found, 
-</p><p class="q2">so the house of Israel is ashamed—</p><p class="q2">they, their kings, their princes, their priests, and their prophets, 
-</p><p class="q1">
-<span class="v">27&#160;</span>who tell wood, ‘You are my father,’ 
-</p><p class="q2">and a stone, ‘You have given birth to me,’ 
-</p><p class="q1">for they have turned their back to me, 
-</p><p class="q2">and not their face, 
-</p><p class="q2">but in the time of their trouble they will say, ‘Arise, and save us!’ 
-</p><p class="q1">
-<span class="v">28&#160;</span>“But where are your elohims that you have made for yourselves? 
-</p><p class="q2">Let them arise, if they can save you in the time of your trouble, 
-</p><p class="q2">for you have as many elohims as you have towns, O Judah. 
-</p><p class="q1">
-<span class="v">29&#160;</span>“Why will you contend with me? 
-</p><p class="q2">You all have transgressed against me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">30&#160;</span>“I have struck your children in vain. 
-</p><p class="q2">They received no correction. 
-</p><p class="q1">Your own sword has devoured your prophets, 
-</p><p class="q2">like a destroying lion. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Generation, consider Yahweh’s word. 
-</p><p class="q2">Have I been a wilderness to Israel? 
-</p><p class="q2">Or a land of thick darkness? 
-</p><p class="q1">Why do my people say, ‘We have broken loose. 
-</p><p class="q2">We will come to you no more’? 
-</p><p class="q1">
-<span class="v">32&#160;</span>“Can a virgin forget her ornaments, 
-</p><p class="q2">or a bride her attire? 
-</p><p class="q2">Yet my people have forgotten me for days without number. 
-</p><p class="q1">
-<span class="v">33&#160;</span>How well you prepare your way to seek love! 
-</p><p class="q2">Therefore you have even taught the wicked women your ways. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Also the blood of the souls of the innocent poor is found in your skirts. 
-</p><p class="q2">You didn’t find them breaking in, 
-</p><p class="q2">but it is because of all these things. 
-</p><p class="q1">
-<span class="v">35&#160;</span>“Yet you said, ‘I am innocent. 
-</p><p class="q2">Surely his anger has turned away from me.’ 
-</p><p class="q1">“Behold, I will judge you, 
-</p><p class="q2">because you say, ‘I have not sinned.’ 
-</p><p class="q1">
-<span class="v">36&#160;</span>Why do you go about so much to change your ways? 
-</p><p class="q2">You will be ashamed of Egypt also, 
-</p><p class="q2">as you were ashamed of Assyria. 
-</p><p class="q1">
-<span class="v">37&#160;</span>You will also leave that place with your hands on your head; 
-</p><p class="q2">for Yahweh has rejected those in whom you trust, 
-</p><p class="q2">and you won’t prosper with them. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>“They say, ‘If a man puts away his woman, and she goes from him, and becomes another man’s, should he return to her again?’ Wouldn’t that land be greatly polluted? But you have played the prostitute with many lovers; yet return again to me,” says Yahweh. 
-</p><p>
-<span class="v">2&#160;</span>“Lift up your eyes to the bare heights, and see! Where have you not been lain with? You have sat waiting for them by the road, as an Arabian in the wilderness. You have polluted the land with your prostitution and with your wickedness. 
-<span class="v">3&#160;</span>Therefore the showers have been withheld and there has been no latter rain; yet you have had a prostitute’s forehead and you refused to be ashamed. 
-<span class="v">4&#160;</span>Will you not from this time cry to me, ‘My Father, you are the guide of my youth!’? 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘Will he retain his anger forever? Will he keep it to the end?’ Behold, you have spoken and have done evil things, and have had your way.” 
-</p><p>
-<span class="v">6&#160;</span>Moreover, Yahweh said to me in the days of Josiah the king, “Have you seen that which backsliding Israel has done? She has gone up on every high mountain and under every green tree, and has played the prostitute there. 
-<span class="v">7&#160;</span>I said after she had done all these things, ‘She will return to me;’ but she didn’t return, and her treacherous sister Judah saw it. 
-<span class="v">8&#160;</span>I saw when, for this very cause, that backsliding Israel had committed adultery, I had put her away and given her a certificate of divorce, yet treacherous Judah, her sister, had no fear, but she also went and played the prostitute. 
-<span class="v">9&#160;</span>Because she took her prostitution lightly, the land was polluted, and she committed adultery with stones and with wood. 
-<span class="v">10&#160;</span>Yet for all this her treacherous sister, Judah, has not returned to me with her whole heart, but only in pretense,” says Yahweh. 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said to me, “Backsliding Israel has shown herself more righteous than treacherous Judah. 
-<span class="v">12&#160;</span>Go, and proclaim these words toward the north, and say, ‘Return, you backsliding Israel,’ says Yahweh; ‘I will not look in anger on you, for I am merciful,’ says Yahweh. ‘I will not keep anger forever. 
-<span class="v">13&#160;</span>Only acknowledge your iniquity, that you have transgressed against Yahweh your Elohim, and have scattered your ways to the strangers under every green tree, and you have not obeyed my voice,’&#160;” says Yahweh. 
-<span class="v">14&#160;</span>“Return, backsliding children,” says Yahweh, “for I am an owner to you. I will take one of you from a city, and two from a family, and I will bring you to Zion. 
-<span class="v">15&#160;</span>I will give you shepherds according to my heart, who will feed you with knowledge and understanding. 
-<span class="v">16&#160;</span>It will come to pass, when you are multiplied and increased in the land in those days,” says Yahweh, “they will no longer say, ‘the ark of Yahweh’s covenant!’ It will not come to mind. They won’t remember it. They won’t miss it, nor will another be made. 
-<span class="v">17&#160;</span>At that time they will call Jerusalem ‘Yahweh’s Throne;’ and all the nations will be gathered to it, to Yahweh’s name, to Jerusalem. They will no longer walk after the stubbornness of their evil heart. 
-<span class="v">18&#160;</span>In those days the house of Judah will walk with the house of Israel, and they will come together out of the land of the north to the land that I gave for an inheritance to your fathers. 
-</p><p>
-<span class="v">19&#160;</span>“But I said, ‘How I desire to put you among the children, and give you a pleasant land, a goodly heritage of the armies of the nations!’ and I said, ‘You shall call me “My Father”, and shall not turn away from following me.’ 
-</p><p>
-<span class="v">20&#160;</span>“Surely as a woman treacherously departs from her friend, so you have dealt treacherously with me, house of Israel,” says Yahweh. 
-<span class="v">21&#160;</span>A voice is heard on the bare heights, the weeping and the petitions of the children of Israel; because they have perverted their way, they have forgotten Yahweh their Elohim. 
-<span class="v">22&#160;</span>Return, you backsliding children, and I will heal your backsliding. 
-</p><p>“Behold, we have come to you; for you are Yahweh our Elohim. 
-<span class="v">23&#160;</span>Truly help from the hills, the tumult on the mountains, is in vain. Truly the salvation of Israel is in Yahweh our Elohim. 
-<span class="v">24&#160;</span>But the shameful thing has devoured the labor of our fathers from our youth, their flocks and their herds, their sons and their daughters. 
-<span class="v">25&#160;</span>Let us lie down in our shame, and let our confusion cover us; for we have sinned against Yahweh our Elohim, we and our fathers, from our youth even to this day. We have not obeyed Yahweh our Elohim’s voice.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>“If you will return, Israel,” says Yahweh, “if you will return to me, and if you will put away your abominations out of my sight; then you will not be removed; 
-<span class="v">2&#160;</span>and you will swear, ‘As Yahweh lives,’ in truth, in justice, and in righteousness. The nations will bless themselves in him, and they will glory in him.” 
-</p><p>
-<span class="v">3&#160;</span>For Yahweh says to the men of Judah and to Jerusalem, “Break up your fallow ground, and don’t sow among thorns. 
-<span class="v">4&#160;</span>Circumcise yourselves to Yahweh, and take away the foreskins of your heart, you men of Judah and inhabitants of Jerusalem; lest my wrath go out like fire, and burn so that no one can quench it, because of the evil of your doings. 
-<span class="v">5&#160;</span>Declare in Judah, and publish in Jerusalem; and say, ‘Blow the trumpet in the land!’ Cry aloud and say, ‘Assemble yourselves! Let’s go into the fortified cities!’ 
-<span class="v">6&#160;</span>Set up a standard toward Zion. Flee for safety! Don’t wait; for I will bring evil from the north, and a great destruction.” 
-</p><p>
-<span class="v">7&#160;</span>A lion has gone up from his thicket, and a destroyer of nations. He is on his way. He has gone out from his place, to make your land desolate, that your cities be laid waste, without inhabitant. 
-<span class="v">8&#160;</span>For this, clothe yourself with sackcloth, lament and wail; for the fierce anger of Yahweh hasn’t turned back from us. 
-<span class="v">9&#160;</span>“It will happen at that day,” says Yahweh, “that the heart of the king will perish, along with the heart of the princes. The priests will be astonished, and the prophets will wonder.” 
-</p><p>
-<span class="v">10&#160;</span>Then I said, “Ah, Lord Yahweh! Surely you have greatly deceived this people and Jerusalem, saying, ‘You will have peace;’ whereas the sword reaches to the heart.” 
-</p><p>
-<span class="v">11&#160;</span>At that time it will be said to this people and to Jerusalem, “A hot wind blows from the bare heights in the wilderness toward the daughter of my people, not to winnow, nor to cleanse. 
-<span class="v">12&#160;</span>A full wind from these will come for me. Now I will also utter judgments against them.” 
-</p><p>
-<span class="v">13&#160;</span>Behold, he will come up as clouds, and his chariots will be as the whirlwind. His horses are swifter than eagles. Woe to us! For we are ruined. 
-<span class="v">14&#160;</span>Jerusalem, wash your heart from wickedness, that you may be saved. How long will your evil thoughts lodge within you? 
-<span class="v">15&#160;</span>For a voice declares from Dan, and publishes evil from the hills of Ephraim: 
-<span class="v">16&#160;</span>“Tell the nations, behold, publish against Jerusalem, ‘Watchers come from a far country, and raise their voice against the cities of Judah. 
-<span class="v">17&#160;</span>As keepers of a field, they are against her all around, because she has been rebellious against me,’&#160;” says Yahweh. 
-<span class="v">18&#160;</span>“Your way and your doings have brought these things to you. This is your wickedness, for it is bitter, for it reaches to your heart.” 
-</p><p>
-<span class="v">19&#160;</span>My anguish, my anguish! I am pained at my very heart! My heart trembles within me. I can’t hold my peace, because you have heard, O my soul, the sound of the trumpet, the alarm of war. 
-<span class="v">20&#160;</span>Destruction on destruction is decreed, for the whole land is laid waste. Suddenly my tents are destroyed, and my curtains gone in a moment. 
-<span class="v">21&#160;</span>How long will I see the standard and hear the sound of the trumpet? 
-</p><p>
-<span class="v">22&#160;</span>“For my people are foolish. They don’t know me. They are foolish children, and they have no understanding. They are skillful in doing evil, but they don’t know how to do good.” 
-<span class="v">23&#160;</span>I saw the earth and, behold, it was waste and void, and the heavens, and they had no light. 
-<span class="v">24&#160;</span>I saw the mountains, and behold, they trembled, and all the hills moved back and forth. 
-<span class="v">25&#160;</span>I saw, and behold, there was no man, and all the birds of the sky had fled. 
-<span class="v">26&#160;</span>I saw, and behold, the fruitful field was a wilderness, and all its cities were broken down at the presence of Yahweh, before his fierce anger. 
-<span class="v">27&#160;</span>For Yahweh says, “The whole land will be a desolation; yet I will not make a full end. 
-<span class="v">28&#160;</span>For this the earth will mourn, and the heavens above be black, because I have spoken it. I have planned it, and I have not repented, neither will I turn back from it.” 
-</p><p>
-<span class="v">29&#160;</span>Every city flees for the noise of the horsemen and archers. They go into the thickets and climb up on the rocks. Every city is forsaken, and not a man dwells therein. 
-<span class="v">30&#160;</span>You, when you are made desolate, what will you do? Though you clothe yourself with scarlet, though you deck yourself with ornaments of gold, though you enlarge your eyes with makeup, you make yourself beautiful in vain. Your lovers despise you. They seek your life. 
-<span class="v">31&#160;</span>For I have heard a voice as of a woman in travail, the anguish as of her who gives birth to her first child, the voice of the daughter of Zion, who gasps for breath, who spreads her hands, saying, “Woe is me now! For my soul faints before the murderers.” 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>“Run back and forth through the streets of Jerusalem, and see now, and know, and seek in its wide places, if you can find a man, if there is anyone who does justly, who seeks truth, then I will pardon her. 
-<span class="v">2&#160;</span>Though they say, ‘As Yahweh lives,’ surely they swear falsely.” 
-</p><p>
-<span class="v">3&#160;</span>O Yahweh, don’t your eyes look on truth? You have stricken them, but they were not grieved. You have consumed them, but they have refused to receive correction. They have made their faces harder than a rock. They have refused to return. 
-</p><p>
-<span class="v">4&#160;</span>Then I said, “Surely these are poor. They are foolish; for they don’t know Yahweh’s way, nor the law of their Elohim. 
-<span class="v">5&#160;</span>I will go to the great men and will speak to them, for they know the way of Yahweh, and the law of their Elohim.” But these with one accord have broken the yoke, and burst the bonds. 
-<span class="v">6&#160;</span>Therefore a lion out of the forest will kill them. A wolf of the evenings will destroy them. A leopard will watch against their cities. Everyone who goes out there will be torn in pieces, because their transgressions are many and their backsliding has increased. 
-</p><p>
-<span class="v">7&#160;</span>“How can I pardon you? Your children have forsaken me, and sworn by what are no elohims. When I had fed them to the full, they committed adultery, and assembled themselves in troops at the prostitutes’ houses. 
-<span class="v">8&#160;</span>They were as fed horses roaming at large. Everyone neighed after his neighbor’s woman. 
-<span class="v">9&#160;</span>Shouldn’t I punish them for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
-</p><p>
-<span class="v">10&#160;</span>“Go up on her walls, and destroy, but don’t make a full end. Take away her branches, for they are not Yahweh’s. 
-<span class="v">11&#160;</span>For the house of Israel and the house of Judah have dealt very treacherously against me,” says Yahweh. 
-</p><p>
-<span class="v">12&#160;</span>They have denied Yahweh, and said, “It is not he. Evil won’t come on us. We won’t see sword or famine. 
-<span class="v">13&#160;</span>The prophets will become wind, and the word is not in them. Thus it will be done to them.” 
-</p><p>
-<span class="v">14&#160;</span>Therefore Yahweh, the Elohim of Armies says, “Because you speak this word, behold, I will make my words in your mouth fire, and this people wood, and it will devour them. 
-<span class="v">15&#160;</span>Behold, I will bring a nation on you from far away, house of Israel,” says Yahweh. “It is a mighty nation. It is an ancient nation, a nation whose language you don’t know and don’t understand what they say. 
-<span class="v">16&#160;</span>Their quiver is an open tomb. They are all mighty men. 
-<span class="v">17&#160;</span>They will eat up your harvest and your bread, which your sons and your daughters should eat. They will eat up your flocks and your herds. They will eat up your vines and your fig trees. They will beat down your fortified cities in which you trust with the sword. 
-</p><p>
-<span class="v">18&#160;</span>“But even in those days,” says Yahweh, “I will not make a full end of you. 
-<span class="v">19&#160;</span>It will happen when you say, ‘Why has Yahweh our Elohim done all these things to us?’ Then you shall say to them, ‘Just as you have forsaken me and served foreign elohims in your land, so you will serve strangers in a land that is not yours.’ 
-</p><p>
-<span class="v">20&#160;</span>“Declare this in the house of Jacob, and publish it in Judah, saying, 
-<span class="v">21&#160;</span>‘Hear this now, foolish people without understanding, who have eyes, and don’t see, who have ears, and don’t hear: 
-<span class="v">22&#160;</span>Don’t you fear me?’ says Yahweh; ‘Won’t you tremble at my presence, who have placed the sand for the bound of the sea by a perpetual decree, that it can’t pass it? Though its waves toss themselves, yet they can’t prevail. Though they roar, they still can’t pass over it.’ 
-</p><p>
-<span class="v">23&#160;</span>“But this people has a revolting and a rebellious heart. They have revolted and gone. 
-<span class="v">24&#160;</span>They don’t say in their heart, ‘Let’s now fear Yahweh our Elohim, who gives rain, both the former and the latter, in its season, who preserves to us the appointed weeks of the harvest.’ 
-</p><p>
-<span class="v">25&#160;</span>“Your iniquities have turned away these things, and your sins have withheld good from you. 
-<span class="v">26&#160;</span>For wicked men are found among my people. They watch, as fowlers lie in wait. They set a trap. They catch men. 
-<span class="v">27&#160;</span>As a cage is full of birds, so are their houses full of deceit. Therefore they have become great, and grew rich. 
-<span class="v">28&#160;</span>They have grown fat. They shine; yes, they excel in deeds of wickedness. They don’t plead the cause, the cause of the fatherless, that they may prosper; and they don’t defend the rights of the needy. 
-</p><p>
-<span class="v">29&#160;</span>“Shouldn’t I punish for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
-</p><p>
-<span class="v">30&#160;</span>“An astonishing and horrible thing has happened in the land. 
-<span class="v">31&#160;</span>The prophets prophesy falsely, and the priests rule by their own authority; and my people love to have it so. What will you do in the end of it? 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>“Flee for safety, you children of Benjamin, out of the middle of Jerusalem! Blow the trumpet in Tekoa and raise up a signal on Beth Haccherem, for evil looks out from the north with a great destruction. 
-<span class="v">2&#160;</span>I will cut off the beautiful and delicate one, the daughter of Zion. 
-<span class="v">3&#160;</span>Shepherds with their flocks will come to her. They will pitch their tents against her all around. They will feed everyone in his place.” 
-</p><p>
-<span class="v">4&#160;</span>“Prepare war against her! Arise! Let’s go up at noon. Woe to us! For the day declines, for the shadows of the evening are stretched out. 
-<span class="v">5&#160;</span>Arise! Let’s go up by night, and let’s destroy her palaces.” 
-<span class="v">6&#160;</span>For Yahweh of Armies said, “Cut down trees, and cast up a mound against Jerusalem. This is the city to be visited. She is filled with oppression within herself. 
-<span class="v">7&#160;</span>As a well produces its waters, so she produces her wickedness. Violence and destruction is heard in her. Sickness and wounds are continually before me. 
-<span class="v">8&#160;</span>Be instructed, Jerusalem, lest my soul be alienated from you, lest I make you a desolation, an uninhabited land.” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh of Armies says, “They will thoroughly glean the remnant of Israel like a vine. Turn again your hand as a grape gatherer into the baskets.” 
-</p><p>
-<span class="v">10&#160;</span>To whom should I speak and testify, that they may hear? Behold, their ear is uncircumcised, and they can’t listen. Behold, Yahweh’s word has become a reproach to them. They have no delight in it. 
-<span class="v">11&#160;</span>Therefore I am full of Yahweh’s wrath. I am weary with holding it in. 
-</p><p class="q1">“Pour it out on the children in the street, 
-</p><p class="q2">and on the assembly of young men together; 
-</p><p class="q1">for even the man with the woman will be taken, 
-</p><p class="q2">the aged with him who is full of days. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Their houses will be turned to others, 
-</p><p class="q2">their fields and their women together; 
-</p><p class="q1">for I will stretch out my hand on the inhabitants of the land, says Yahweh.” 
-</p><p class="q1">
-<span class="v">13&#160;</span>“For from their least even to their greatest, everyone is given to covetousness. 
-</p><p class="q2">From the prophet even to the priest, everyone deals falsely. 
-</p><p class="q1">
-<span class="v">14&#160;</span>They have healed also the hurt of my people superficially, 
-</p><p class="q2">saying, ‘Peace, peace!’ when there is no peace. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Were they ashamed when they had committed abomination? 
-</p><p class="q2">No, they were not at all ashamed, neither could they blush. 
-</p><p class="q1">Therefore they will fall among those who fall. 
-</p><p class="q2">When I visit them, they will be cast down,” says Yahweh. 
-</p><p>
-<span class="v">16&#160;</span>Yahweh says, “Stand in the ways and see, and ask for the old paths, ‘Where is the good way?’ and walk in it, and you will find rest for your souls. But they said, ‘We will not walk in it.’ 
-<span class="v">17&#160;</span>I set watchmen over you, saying, ‘Listen to the sound of the trumpet!’ But they said, ‘We will not listen!’ 
-<span class="v">18&#160;</span>Therefore hear, you nations, and know, congregation, what is among them. 
-<span class="v">19&#160;</span>Hear, earth! Behold, I will bring evil on this people, even the fruit of their thoughts, because they have not listened to my words; and as for my law, they have rejected it. 
-<span class="v">20&#160;</span>To what purpose does frankincense from Sheba come to me, and the sweet cane from a far country? Your burnt offerings are not acceptable, and your sacrifices are not pleasing to me.” 
-</p><p>
-<span class="v">21&#160;</span>Therefore Yahweh says, “Behold, I will lay stumbling blocks before this people. The fathers and the sons together will stumble against them. The neighbor and his friend will perish.” 
-<span class="v">22&#160;</span>Yahweh says, “Behold, a people comes from the north country. A great nation will be stirred up from the uttermost parts of the earth. 
-<span class="v">23&#160;</span>They take hold of bow and spear. They are cruel, and have no mercy. Their voice roars like the sea, and they ride on horses, everyone set in array, as a man to the battle, against you, daughter of Zion.” 
-</p><p>
-<span class="v">24&#160;</span>We have heard its report. Our hands become feeble. Anguish has taken hold of us, and pains as of a woman in labor. 
-<span class="v">25&#160;</span>Don’t go out into the field or walk by the way; for the sword of the enemy and terror are on every side. 
-<span class="v">26&#160;</span>Daughter of my people, clothe yourself with sackcloth, and wallow in ashes! Mourn, as for an only son, most bitter lamentation, for the destroyer will suddenly come on us. 
-</p><p>
-<span class="v">27&#160;</span>“I have made you a tester of metals and a fortress among my people, that you may know and try their way. 
-<span class="v">28&#160;</span>They are all grievous rebels, going around to slander. They are bronze and iron. All of them deal corruptly. 
-<span class="v">29&#160;</span>The bellows blow fiercely. The lead is consumed in the fire. In vain they go on refining, for the wicked are not plucked away. 
-<span class="v">30&#160;</span>Men will call them rejected silver, because Yahweh has rejected them.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>The word that came to Jeremiah from Yahweh, saying, 
-<span class="v">2&#160;</span>“Stand in the gate of Yahweh’s house, and proclaim this word there, and say, ‘Hear Yahweh’s word, all you of Judah, who enter in at these gates to worship Yahweh.’&#160;” 
-</p><p>
-<span class="v">3&#160;</span>Yahweh of Armies, the Elohim of Israel says, “Amend your ways and your doings, and I will cause you to dwell in this place. 
-<span class="v">4&#160;</span>Don’t trust in lying words, saying, ‘Yahweh’s temple, Yahweh’s temple, Yahweh’s temple, are these.’ 
-<span class="v">5&#160;</span>For if you thoroughly amend your ways and your doings, if you thoroughly execute justice between a man and his neighbor; 
-<span class="v">6&#160;</span>if you don’t oppress the foreigner, the fatherless, and the widow, and don’t shed innocent blood in this place, and don’t walk after other elohims to your own hurt, 
-<span class="v">7&#160;</span>then I will cause you to dwell in this place, in the land that I gave to your fathers, from of old even forever more. 
-<span class="v">8&#160;</span>Behold, you trust in lying words that can’t profit. 
-<span class="v">9&#160;</span>Will you steal, murder, commit adultery, swear falsely, burn incense to Baal, and walk after other elohims that you have not known, 
-<span class="v">10&#160;</span>then come and stand before me in this house, which is called by my name, and say, ‘We are delivered,’ that you may do all these abominations? 
-<span class="v">11&#160;</span>Has this house, which is called by my name, become a den of robbers in your eyes? Behold, I myself have seen it,” says Yahweh. 
-</p><p>
-<span class="v">12&#160;</span>“But go now to my place which was in Shiloh, where I caused my name to dwell at the first, and see what I did to it for the wickedness of my people Israel. 
-<span class="v">13&#160;</span>Now, because you have done all these works,” says Yahweh, “and I spoke to you, rising up early and speaking, but you didn’t hear; and I called you, but you didn’t answer; 
-<span class="v">14&#160;</span>therefore I will do to the house which is called by my name, in which you trust, and to the place which I gave to you and to your fathers, as I did to Shiloh. 
-<span class="v">15&#160;</span>I will cast you out of my sight, as I have cast out all your brothers, even the whole offspring<span class="f">+ \fr 7:15 \ft or, seed</span> of Ephraim. 
-</p><p>
-<span class="v">16&#160;</span>“Therefore don’t pray for this people. Don’t lift up a cry or prayer for them or make intercession to me; for I will not hear you. 
-<span class="v">17&#160;</span>Don’t you see what they do in the cities of Judah and in the streets of Jerusalem? 
-<span class="v">18&#160;</span>The children gather wood, and the fathers kindle the fire, and the women knead the dough, to make cakes to the queen of the sky, and to pour out drink offerings to other elohims, that they may provoke me to anger. 
-<span class="v">19&#160;</span>Do they provoke me to anger?” says Yahweh. “Don’t they provoke themselves, to the confusion of their own faces?” 
-</p><p>
-<span class="v">20&#160;</span>Therefore the Lord Yahweh says: “Behold, my anger and my wrath will be poured out on this place, on man, on animal, on the trees of the field, and on the fruit of the ground; and it will burn and will not be quenched.” 
-</p><p>
-<span class="v">21&#160;</span>Yahweh of Armies, the Elohim of Israel says: “Add your burnt offerings to your sacrifices and eat meat. 
-<span class="v">22&#160;</span>For I didn’t speak to your fathers or command them in the day that I brought them out of the land of Egypt concerning burnt offerings or sacrifices; 
-<span class="v">23&#160;</span>but this thing I commanded them, saying, ‘Listen to my voice, and I will be your Elohim, and you shall be my people. Walk in all the way that I command you, that it may be well with you.’ 
-<span class="v">24&#160;</span>But they didn’t listen or turn their ear, but walked in their own counsels and in the stubbornness of their evil heart, and went backward, and not forward. 
-<span class="v">25&#160;</span>Since the day that your fathers came out of the land of Egypt to this day, I have sent to you all my servants the prophets, daily rising up early and sending them. 
-<span class="v">26&#160;</span>Yet they didn’t listen to me or incline their ear, but made their neck stiff. They did worse than their fathers. 
-</p><p>
-<span class="v">27&#160;</span>“You shall speak all these words to them, but they will not listen to you. You shall also call to them, but they will not answer you. 
-<span class="v">28&#160;</span>You shall tell them, ‘This is the nation that has not listened to Yahweh their Elohim’s voice, nor received instruction. Truth has perished, and is cut off from their mouth.’ 
-<span class="v">29&#160;</span>Cut off your hair, and throw it away, and take up a lamentation on the bare heights; for Yahweh has rejected and forsaken the generation of his wrath. 
-</p><p>
-<span class="v">30&#160;</span>“For the children of Judah have done that which is evil in my sight,” says Yahweh. “They have set their abominations in the house which is called by my name, to defile it. 
-<span class="v">31&#160;</span>They have built the high places of Topheth, which is in the valley of the son of Hinnom, to burn their sons and their daughters in the fire, which I didn’t command, nor did it come into my mind. 
-<span class="v">32&#160;</span>Therefore behold, the days come”, says Yahweh, “that it will no more be called ‘Topheth’ or ‘The valley of the son of Hinnom’, but ‘The valley of Slaughter’; for they will bury in Topheth until there is no place to bury. 
-<span class="v">33&#160;</span>The dead bodies of this people will be food for the birds of the sky, and for the animals of the earth. No one will frighten them away. 
-<span class="v">34&#160;</span>Then I will cause to cease from the cities of Judah and from the streets of Jerusalem the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride; for the land will become a waste.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>“At that time,” says Yahweh, “they will bring the bones of the kings of Judah, the bones of his princes, the bones of the priests, the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves. 
-<span class="v">2&#160;</span>They will spread them before the sun, the moon, and all the army of the sky, which they have loved, which they have served, after which they have walked, which they have sought, and which they have worshiped. They will not be gathered or be buried. They will be like dung on the surface of the earth. 
-<span class="v">3&#160;</span>Death will be chosen rather than life by all the residue that remain of this evil family, that remain in all the places where I have driven them,” says Yahweh of Armies. 
-<span class="v">4&#160;</span>“Moreover you shall tell them, ‘Yahweh says: 
-</p><p class="q1">“&#160;‘Do men fall, and not rise up again? 
-</p><p class="q2">Does one turn away, and not return? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why then have the people of Jerusalem fallen back by a perpetual backsliding? 
-</p><p class="q2">They cling to deceit. 
-</p><p class="q2">They refuse to return. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I listened and heard, but they didn’t say what is right. 
-</p><p class="q2">No one repents of his wickedness, saying, “What have I done?” 
-</p><p class="q1">Everyone turns to his course, 
-</p><p class="q2">as a horse that rushes headlong in the battle. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yes, the stork in the sky knows her appointed times. 
-</p><p class="q2">The turtledove, the swallow, and the crane observe the time of their coming; 
-</p><p class="q2">but my people don’t know Yahweh’s law. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“&#160;‘How do you say, “We are wise, and Yahweh’s law is with us”? 
-</p><p class="q2">But, behold, the false pen of the scribes has made that a lie. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The wise men are disappointed. 
-</p><p class="q2">They are dismayed and trapped. 
-</p><p class="q1">Behold, they have rejected Yahweh’s word. 
-</p><p class="q2">What kind of wisdom is in them? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Therefore I will give their women to others 
-</p><p class="q2">and their fields to those who will possess them. 
-</p><p class="q1">For everyone from the least even to the greatest is given to covetousness; 
-</p><p class="q2">from the prophet even to the priest everyone deals falsely. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They have healed the hurt of the daughter of my people slightly, saying, 
-</p><p class="q2">“Peace, peace,” when there is no peace. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Were they ashamed when they had committed abomination? 
-</p><p class="q2">No, they were not at all ashamed. 
-</p><p class="q2">They couldn’t blush. 
-</p><p class="q1">Therefore they will fall among those who fall. 
-</p><p class="q2">In the time of their visitation they will be cast down, says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“&#160;‘I will utterly consume them, says Yahweh. 
-</p><p class="q2">No grapes will be on the vine, 
-</p><p class="q2">no figs on the fig tree, 
-</p><p class="q2">and the leaf will fade. 
-</p><p class="q1">The things that I have given them 
-</p><p class="q2">will pass away from them.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“Why do we sit still? 
-</p><p class="q2">Assemble yourselves! 
-</p><p class="q2">Let’s enter into the fortified cities, 
-</p><p class="q2">and let’s be silent there; 
-</p><p class="q1">for Yahweh our Elohim has put us to silence, 
-</p><p class="q2">and given us poisoned water to drink, 
-</p><p class="q2">because we have sinned against Yahweh. 
-</p><p class="q1">
-<span class="v">15&#160;</span>We looked for peace, but no good came; 
-</p><p class="q2">and for a time of healing, and behold, dismay! 
-</p><p class="q1">
-<span class="v">16&#160;</span>The snorting of his horses is heard from Dan. 
-</p><p class="q2">The whole land trembles at the sound of the neighing of his strong ones; 
-</p><p class="q1">for they have come, and have devoured the land and all that is in it, 
-</p><p class="q2">the city and those who dwell therein.” 
-</p><p class="q1">
-<span class="v">17&#160;</span>“For, behold, I will send serpents, 
-</p><p class="q2">adders among you, 
-</p><p class="q2">which will not be charmed; 
-</p><p class="q2">and they will bite you,” says Yahweh. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Oh that I could comfort myself against sorrow! 
-</p><p class="q2">My heart is faint within me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Behold, the voice of the cry of the daughter of my people from a land that is very far off: 
-</p><p class="q2">“Isn’t Yahweh in Zion? 
-</p><p class="q2">Isn’t her King in her?” 
-</p><div class="b"> &#160; </div>
-<p class="q1">“Why have they provoked me to anger with their engraved images, 
-</p><p class="q2">and with foreign idols?” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“The harvest is past. 
-</p><p class="q2">The summer has ended, 
-</p><p class="q2">and we are not saved.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>For the hurt of the daughter of my people, I am hurt. 
-</p><p class="q2">I mourn. 
-</p><p class="q2">Dismay has taken hold of me. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Is there no balm in Gilead? 
-</p><p class="q2">Is there no physician there? 
-</p><p class="q1">Why then isn’t the health of the daughter of my people recovered? 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Oh that my head were waters, 
-</p><p class="q2">and my eyes a spring of tears, 
-</p><p class="q1">that I might weep day and night 
-</p><p class="q2">for the slain of the daughter of my people! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Oh that I had in the wilderness 
-</p><p class="q2">a lodging place of wayfaring men, 
-</p><p class="q1">that I might leave my people 
-</p><p class="q2">and go from them! 
-</p><p class="q1">For they are all adulterers, 
-</p><p class="q2">an assembly of treacherous men. 
-</p><p class="q1">
-<span class="v">3&#160;</span>“They bend their tongue, 
-</p><p class="q2">as their bow, for falsehood. 
-</p><p class="q1">They have grown strong in the land, 
-</p><p class="q2">but not for truth; 
-</p><p class="q1">for they proceed from evil to evil, 
-</p><p class="q2">and they don’t know me,” says Yahweh. 
-</p><p class="q1">
-<span class="v">4&#160;</span>“Everyone beware of his neighbor, 
-</p><p class="q2">and don’t trust in any brother; 
-</p><p class="q1">for every brother will utterly supplant, 
-</p><p class="q2">and every neighbor will go around like a slanderer. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Friends deceive each other, 
-</p><p class="q2">and will not speak the truth. 
-</p><p class="q1">They have taught their tongue to speak lies. 
-</p><p class="q2">They weary themselves committing iniquity. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Your habitation is in the middle of deceit. 
-</p><p class="q2">Through deceit, they refuse to know me,” says Yahweh. 
-</p><p>
-<span class="v">7&#160;</span>Therefore Yahweh of Armies says, 
-</p><p class="q1">“Behold, I will melt them and test them; 
-</p><p class="q2">for how should I deal with the daughter of my people? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Their tongue is a deadly arrow. 
-</p><p class="q2">It speaks deceit. 
-</p><p class="q1">One speaks peaceably to his neighbor with his mouth, 
-</p><p class="q2">but in his heart, he waits to ambush him. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Shouldn’t I punish them for these things?” says Yahweh. 
-</p><p class="q2">“Shouldn’t my soul be avenged on a nation such as this? 
-</p><p class="q1">
-<span class="v">10&#160;</span>I will weep and wail for the mountains, 
-</p><p class="q2">and lament for the pastures of the wilderness, 
-</p><p class="q1">because they are burned up, so that no one passes through; 
-</p><p class="q2">Men can’t hear the voice of the livestock. 
-</p><p class="q1">Both the birds of the sky and the animals have fled. 
-</p><p class="q2">They are gone. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“I will make Jerusalem heaps, 
-</p><p class="q2">a dwelling place of jackals. 
-</p><p class="q1">I will make the cities of Judah a desolation, 
-</p><p class="q2">without inhabitant.” 
-</p><p>
-<span class="v">12&#160;</span>Who is wise enough to understand this? Who is he to whom the mouth of Yahweh has spoken, that he may declare it? Why has the land perished and burned up like a wilderness, so that no one passes through? 
-</p><p>
-<span class="v">13&#160;</span>Yahweh says, “Because they have forsaken my law which I set before them, and have not obeyed my voice or walked in my ways, 
-<span class="v">14&#160;</span>but have walked after the stubbornness of their own heart and after the Baals, which their fathers taught them.” 
-<span class="v">15&#160;</span>Therefore Yahweh of Armies, the Elohim of Israel, says, “Behold, I will feed them, even this people, with wormwood and give them poisoned water to drink. 
-<span class="v">16&#160;</span>I will scatter them also among the nations, whom neither they nor their fathers have known. I will send the sword after them, until I have consumed them.” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh of Armies says, 
-</p><p class="q1">“Consider, and call for the mourning women, that they may come. 
-</p><p class="q2">Send for the skillful women, that they may come. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Let them make haste 
-</p><p class="q2">and take up a wailing for us, 
-</p><p class="q1">that our eyes may run down with tears 
-</p><p class="q2">and our eyelids gush out with waters. 
-</p><p class="q1">
-<span class="v">19&#160;</span>For a voice of wailing is heard out of Zion, 
-</p><p class="q2">‘How we are ruined! 
-</p><p class="q1">We are greatly confounded 
-</p><p class="q2">because we have forsaken the land, 
-</p><p class="q2">because they have cast down our dwellings.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>Yet hear Yahweh’s word, you women. 
-</p><p class="q2">Let your ear receive the word of his mouth. 
-</p><p class="q1">Teach your daughters wailing. 
-</p><p class="q2">Everyone teach her neighbor a lamentation. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For death has come up into our windows. 
-</p><p class="q2">It has entered into our palaces 
-</p><p class="q1">to cut off the children from outside, 
-</p><p class="q2">and the young men from the streets. 
-</p><p>
-<span class="v">22&#160;</span>Speak, “Yahweh says, 
-</p><p class="q1">“&#160;‘The dead bodies of men will fall as dung on the open field, 
-</p><p class="q2">and as the handful after the harvester. 
-</p><p class="q2">No one will gather them.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh says, 
-</p><p class="q1">“Don’t let the wise man glory in his wisdom. 
-</p><p class="q2">Don’t let the mighty man glory in his might. 
-</p><p class="q2">Don’t let the rich man glory in his riches. 
-</p><p class="q1">
-<span class="v">24&#160;</span>But let him who glories glory in this, 
-</p><p class="q2">that he has understanding, and knows me, 
-</p><p class="q1">that I am Yahweh who exercises loving kindness, justice, and righteousness in the earth, 
-</p><p class="q2">for I delight in these things,” says Yahweh. 
-</p><p>
-<span class="v">25&#160;</span>“Behold, the days come,” says Yahweh, “that I will punish all those who are circumcised only in their flesh: 
-<span class="v">26&#160;</span>Egypt, Judah, Edom, the children of Ammon, Moab, and all who have the corners of their hair cut off, who dwell in the wilderness, for all the nations are uncircumcised, and all the house of Israel are uncircumcised in heart.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Hear the word which Yahweh speaks to you, house of Israel! 
-<span class="v">2&#160;</span>Yahweh says, 
-</p><p class="q1">“Don’t learn the way of the nations, 
-</p><p class="q2">and don’t be dismayed at the signs of the sky; 
-</p><p class="q2">for the nations are dismayed at them. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For the customs of the peoples are vanity; 
-</p><p class="q2">for one cuts a tree out of the forest, 
-</p><p class="q2">the work of the hands of the workman with the ax. 
-</p><p class="q1">
-<span class="v">4&#160;</span>They deck it with silver and with gold. 
-</p><p class="q2">They fasten it with nails and with hammers, 
-</p><p class="q2">so that it can’t move. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They are like a palm tree, of turned work, 
-</p><p class="q2">and don’t speak. 
-</p><p class="q1">They must be carried, 
-</p><p class="q2">because they can’t move. 
-</p><p class="q1">Don’t be afraid of them; 
-</p><p class="q2">for they can’t do evil, 
-</p><p class="q2">neither is it in them to do good.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>There is no one like you, Yahweh. 
-</p><p class="q2">You are great, 
-</p><p class="q2">and your name is great in might. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Who shouldn’t fear you, 
-</p><p class="q2">King of the nations? 
-</p><p class="q2">For it belongs to you. 
-</p><p class="q1">Because among all the wise men of the nations, 
-</p><p class="q2">and in all their royal estate, 
-</p><p class="q2">there is no one like you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>But they are together brutish and foolish, 
-</p><p class="q2">instructed by idols! 
-</p><p class="q2">It is just wood. 
-</p><p class="q1">
-<span class="v">9&#160;</span>There is silver beaten into plates, which is brought from Tarshish, 
-</p><p class="q2">and gold from Uphaz, 
-</p><p class="q2">the work of the engraver and of the hands of the goldsmith. 
-</p><p class="q1">Their clothing is blue and purple. 
-</p><p class="q2">They are all the work of skillful men. 
-</p><p class="q1">
-<span class="v">10&#160;</span>But Yahweh is the true Elohim. 
-</p><p class="q2">He is the living Elohim, 
-</p><p class="q2">and an everlasting King. 
-</p><p class="q1">At his wrath, the earth trembles. 
-</p><p class="q2">The nations aren’t able to withstand his indignation. 
-</p><p>
-<span class="v">11&#160;</span>“You shall say this to them: ‘The elohims that have not made the heavens and the earth will perish from the earth, and from under the heavens.’&#160;” 
-</p><p class="q1">
-<span class="v">12&#160;</span>Elohim has made the earth by his power. 
-</p><p class="q2">He has established the world by his wisdom, 
-</p><p class="q2">and by his understanding has he stretched out the heavens. 
-</p><p class="q1">
-<span class="v">13&#160;</span>When he utters his voice, 
-</p><p class="q2">the waters in the heavens roar, 
-</p><p class="q2">and he causes the vapors to ascend from the ends of the earth. 
-</p><p class="q1">He makes lightnings for the rain, 
-</p><p class="q2">and brings the wind out of his treasuries. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Every man has become brutish and without knowledge. 
-</p><p class="q2">Every goldsmith is disappointed by his engraved image; 
-</p><p class="q1">for his molten image is falsehood, 
-</p><p class="q2">and there is no breath in them. 
-</p><p class="q1">
-<span class="v">15&#160;</span>They are vanity, a work of delusion. 
-</p><p class="q2">In the time of their visitation they will perish. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The portion of Jacob is not like these; 
-</p><p class="q2">for he is the maker of all things; 
-</p><p class="q1">and Israel is the tribe of his inheritance. 
-</p><p class="q2">Yahweh of Armies is his name. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Gather up your wares out of the land, 
-</p><p class="q2">you who live under siege. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For Yahweh says, 
-</p><p class="q2">“Behold, I will sling out the inhabitants of the land at this time, 
-</p><p class="q2">and will distress them, that they may feel it.” 
-</p><p class="q1">
-<span class="v">19&#160;</span>Woe is me because of my injury! 
-</p><p class="q2">My wound is serious; 
-</p><p class="q1">but I said, 
-</p><p class="q2">“Truly this is my grief, and I must bear it.” 
-</p><p class="q1">
-<span class="v">20&#160;</span>My tent has been destroyed, 
-</p><p class="q2">and all my cords are broken. 
-</p><p class="q1">My children have gone away from me, and they are no more. 
-</p><p class="q2">There is no one to spread my tent any more, 
-</p><p class="q2">to set up my curtains. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For the shepherds have become brutish, 
-</p><p class="q2">and have not inquired of Yahweh. 
-</p><p class="q1">Therefore they have not prospered, 
-</p><p class="q2">and all their flocks have scattered. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The voice of news, behold, it comes, 
-</p><p class="q2">and a great commotion out of the north country, 
-</p><p class="q1">to make the cities of Judah a desolation, 
-</p><p class="q2">a dwelling place of jackals. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Yahweh, I know that the way of man is not in himself. 
-</p><p class="q2">It is not in man who walks to direct his steps. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Yahweh, correct me, but gently; 
-</p><p class="q2">not in your anger, 
-</p><p class="q2">lest you reduce me to nothing. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Pour out your wrath on the nations that don’t know you, 
-</p><p class="q2">and on the families that don’t call on your name; 
-</p><p class="q1">for they have devoured Jacob. 
-</p><p class="q2">Yes, they have devoured him, consumed him, 
-</p><p class="q2">and have laid waste his habitation. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>The word that came to Jeremiah from Yahweh, saying, 
-<span class="v">2&#160;</span>“Hear the words of this covenant, and speak to the men of Judah, and to the inhabitants of Jerusalem; 
-<span class="v">3&#160;</span>and say to them, Yahweh, the Elohim of Israel says: ‘Cursed is the man who doesn’t hear the words of this covenant, 
-<span class="v">4&#160;</span>which I commanded your fathers in the day that I brought them out of the land of Egypt, out of the iron furnace,’ saying, ‘Obey my voice and do them, according to all which I command you; so you shall be my people, and I will be your Elohim; 
-<span class="v">5&#160;</span>that I may establish the oath which I swore to your fathers, to give them a land flowing with milk and honey,’ as it is today.” 
-</p><p>Then I answered, and said, “Amen, Yahweh.” 
-</p><p>
-<span class="v">6&#160;</span>Yahweh said to me, “Proclaim all these words in the cities of Judah, and in the streets of Jerusalem, saying, ‘Hear the words of this covenant, and do them. 
-<span class="v">7&#160;</span>For I earnestly protested to your fathers in the day that I brought them up out of the land of Egypt, even to this day, rising early and protesting, saying, “Obey my voice.” 
-<span class="v">8&#160;</span>Yet they didn’t obey, nor turn their ear, but everyone walked in the stubbornness of their evil heart. Therefore I brought on them all the words of this covenant, which I commanded them to do, but they didn’t do them.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh said to me, “A conspiracy is found among the men of Judah, and among the inhabitants of Jerusalem. 
-<span class="v">10&#160;</span>They have turned back to the iniquities of their forefathers, who refused to hear my words. They have gone after other elohims to serve them. The house of Israel and the house of Judah have broken my covenant which I made with their fathers. 
-<span class="v">11&#160;</span>Therefore Yahweh says, ‘Behold, I will bring evil on them which they will not be able to escape; and they will cry to me, but I will not listen to them. 
-<span class="v">12&#160;</span>Then the cities of Judah and the inhabitants of Jerusalem will go and cry to the elohims to which they offer incense, but they will not save them at all in the time of their trouble. 
-<span class="v">13&#160;</span>For according to the number of your cities are your elohims, Judah; and according to the number of the streets of Jerusalem you have set up altars to the shameful thing, even altars to burn incense to Baal.’ 
-</p><p>
-<span class="v">14&#160;</span>“Therefore don’t pray for this people. Don’t lift up cry or prayer for them; for I will not hear them in the time that they cry to me because of their trouble. 
-</p><p class="q1">
-<span class="v">15&#160;</span>What has my beloved to do in my house, 
-</p><p class="q2">since she has behaved lewdly with many, 
-</p><p class="q2">and the set-apart flesh has passed from you? 
-</p><p class="q1">When you do evil, 
-</p><p class="q2">then you rejoice.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Yahweh called your name, “A green olive tree, 
-</p><p class="q2">beautiful with goodly fruit.” 
-</p><p class="q1">With the noise of a great roar he has kindled fire on it, 
-</p><p class="q2">and its branches are broken. 
-</p><p class="m">
-<span class="v">17&#160;</span>For Yahweh of Armies, who planted you, has pronounced evil against you, because of the evil of the house of Israel and of the house of Judah, which they have done to themselves in provoking me to anger by offering incense to Baal. 
-</p><p>
-<span class="v">18&#160;</span>Yahweh gave me knowledge of it, and I knew it. Then you showed me their doings. 
-<span class="v">19&#160;</span>But I was like a gentle lamb that is led to the slaughter. I didn’t know that they had devised plans against me, saying, 
-</p><p class="q1">“Let’s destroy the tree with its fruit, 
-</p><p class="q2">and let’s cut him off from the land of the living, 
-</p><p class="q2">that his name may be no more remembered.” 
-</p><p class="q1">
-<span class="v">20&#160;</span>But, Yahweh of Armies, who judges righteously, 
-</p><p class="q2">who tests the heart and the mind, 
-</p><p class="q1">I will see your vengeance on them; 
-</p><p class="q2">for to you I have revealed my cause. 
-</p><p>
-<span class="v">21&#160;</span>“Therefore Yahweh says concerning the men of Anathoth, who seek your life, saying, ‘You shall not prophesy in Yahweh’s name, that you not die by our hand’—<span class="v">22&#160;</span>therefore Yahweh of Armies says, ‘Behold, I will punish them. The young men will die by the sword. Their sons and their daughters will die by famine. 
-<span class="v">23&#160;</span>There will be no remnant to them, for I will bring evil on the men of Anathoth, even the year of their visitation.’&#160;” 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p class="q1">
-<span class="v">1&#160;</span>You are righteous, Yahweh, 
-</p><p class="q2">when I contend with you; 
-</p><p class="q1">yet I would like to plead a case with you. 
-</p><p class="q2">Why does the way of the wicked prosper? 
-</p><p class="q2">Why are they all at ease who deal very treacherously? 
-</p><p class="q1">
-<span class="v">2&#160;</span>You have planted them. Yes, they have taken root. 
-</p><p class="q2">They grow. Yes, they produce fruit. 
-</p><p class="q1">You are near in their mouth, 
-</p><p class="q2">and far from their heart. 
-</p><p class="q1">
-<span class="v">3&#160;</span>But you, Yahweh, know me. 
-</p><p class="q2">You see me, and test my heart toward you. 
-</p><p class="q1">Pull them out like sheep for the slaughter, 
-</p><p class="q2">and prepare them for the day of slaughter. 
-</p><p class="q1">
-<span class="v">4&#160;</span>How long will the land mourn, 
-</p><p class="q2">and the herbs of the whole country wither? 
-</p><p class="q1">Because of the wickedness of those who dwell therein, 
-</p><p class="q2">the animals and birds are consumed; 
-</p><p class="q1">because they said, 
-</p><p class="q2">“He won’t see our latter end.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>“If you have run with the footmen, 
-</p><p class="q2">and they have wearied you, 
-</p><p class="q2">then how can you contend with horses? 
-</p><p class="q1">Though in a land of peace you are secure, 
-</p><p class="q2">yet how will you do in the pride of the Jordan? 
-</p><p class="q1">
-<span class="v">6&#160;</span>For even your brothers, and the house of your father, 
-</p><p class="q2">even they have dealt treacherously with you! 
-</p><p class="q2">Even they have cried aloud after you! 
-</p><p class="q1">Don’t believe them, 
-</p><p class="q2">though they speak beautiful words to you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“I have forsaken my house. 
-</p><p class="q2">I have cast off my heritage. 
-</p><p class="q2">I have given the dearly beloved of my soul into the hand of her enemies. 
-</p><p class="q1">
-<span class="v">8&#160;</span>My heritage has become to me as a lion in the forest. 
-</p><p class="q2">She has uttered her voice against me. 
-</p><p class="q2">Therefore I have hated her. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Is my heritage to me as a speckled bird of prey? 
-</p><p class="q2">Are the birds of prey against her all around? 
-</p><p class="q1">Go, assemble all the animals of the field. 
-</p><p class="q2">Bring them to devour. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Many shepherds have destroyed my vineyard. 
-</p><p class="q2">They have trodden my portion under foot. 
-</p><p class="q2">They have made my pleasant portion a desolate wilderness. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They have made it a desolation. 
-</p><p class="q2">It mourns to me, being desolate. 
-</p><p class="q1">The whole land is made desolate, 
-</p><p class="q2">because no one cares. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Destroyers have come on all the bare heights in the wilderness; 
-</p><p class="q2">for the sword of Yahweh devours from the one end of the land even to the other end of the land. 
-</p><p class="q2">No flesh has peace. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They have sown wheat, 
-</p><p class="q2">and have reaped thorns. 
-</p><p class="q1">They have exhausted themselves, 
-</p><p class="q2">and profit nothing. 
-</p><p class="q1">You will be ashamed of your fruits, 
-</p><p class="q2">because of Yahweh’s fierce anger.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">14&#160;</span>Yahweh says, “Concerning all my evil neighbors, who touch the inheritance which I have caused my people Israel to inherit: Behold, I will pluck them up from off their land, and will pluck up the house of Judah from among them. 
-<span class="v">15&#160;</span>It will happen that after I have plucked them up, I will return and have compassion on them. I will bring them again, every man to his heritage, and every man to his land. 
-<span class="v">16&#160;</span>It will happen, if they will diligently learn the ways of my people, to swear by my name, ‘As Yahweh lives;’ even as they taught my people to swear by Baal, then they will be built up in the middle of my people. 
-<span class="v">17&#160;</span>But if they will not hear, then I will pluck up that nation, plucking up and destroying it,” says Yahweh. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to me, “Go, and buy yourself a linen belt, and put it on your waist, and don’t put it in water.” 
-</p><p>
-<span class="v">2&#160;</span>So I bought a belt according to Yahweh’s word, and put it on my waist. 
-</p><p>
-<span class="v">3&#160;</span>Yahweh’s word came to me the second time, saying, 
-<span class="v">4&#160;</span>“Take the belt that you have bought, which is on your waist, and arise, go to the Euphrates, and hide it there in a cleft of the rock.” 
-</p><p>
-<span class="v">5&#160;</span>So I went and hid it by the Euphrates, as Yahweh commanded me. 
-</p><p>
-<span class="v">6&#160;</span>After many days, Yahweh said to me, “Arise, go to the Euphrates, and take the belt from there, which I commanded you to hide there.” 
-</p><p>
-<span class="v">7&#160;</span>Then I went to the Euphrates, and dug, and took the belt from the place where I had hidden it; and behold, the belt was ruined. It was profitable for nothing. 
-</p><p>
-<span class="v">8&#160;</span>Then Yahweh’s word came to me, saying, 
-<span class="v">9&#160;</span>“Yahweh says, ‘In this way I will ruin the pride of Judah, and the great pride of Jerusalem. 
-<span class="v">10&#160;</span>This evil people, who refuse to hear my words, who walk in the stubbornness of their heart, and have gone after other elohims to serve them and to worship them, will even be as this belt, which is profitable for nothing. 
-<span class="v">11&#160;</span>For as the belt clings to the waist of a man, so I have caused the whole house of Israel and the whole house of Judah to cling to me,’ says Yahweh; ‘that they may be to me for a people, for a name, for praise, and for glory; but they would not hear.’ 
-</p><p>
-<span class="v">12&#160;</span>“Therefore you shall speak to them this word: ‘Yahweh, the Elohim of Israel says, “Every container should be filled with wine.”&#160;’ They will tell you, ‘Do we not certainly know that every container should be filled with wine?’ 
-<span class="v">13&#160;</span>Then tell them, ‘Yahweh says, “Behold, I will fill all the inhabitants of this land, even the kings who sit on David’s throne, the priests, the prophets, and all the inhabitants of Jerusalem, with drunkenness. 
-<span class="v">14&#160;</span>I will dash them one against another, even the fathers and the sons together,” says Yahweh: “I will not pity, spare, or have compassion, that I should not destroy them.”&#160;’&#160;” 
-</p><p class="q1">
-<span class="v">15&#160;</span>Hear, and give ear. 
-</p><p class="q2">Don’t be proud, 
-</p><p class="q2">for Yahweh has spoken. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Give glory to Yahweh your Elohim, 
-</p><p class="q2">before he causes darkness, 
-</p><p class="q2">and before your feet stumble on the dark mountains, 
-</p><p class="q1">and while you look for light, 
-</p><p class="q2">he turns it into the shadow of death, 
-</p><p class="q2">and makes it deep darkness. 
-</p><p class="q1">
-<span class="v">17&#160;</span>But if you will not hear it, 
-</p><p class="q2">my soul will weep in secret for your pride. 
-</p><p class="q1">My eye will weep bitterly, 
-</p><p class="q2">and run down with tears, 
-</p><p class="q2">because Yahweh’s flock has been taken captive. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Say to the king and to the queen mother, 
-</p><p class="q2">“Humble yourselves. 
-</p><p class="q1">Sit down, for your crowns have come down, 
-</p><p class="q2">even the crown of your glory. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The cities of the South are shut up, 
-</p><p class="q2">and there is no one to open them. 
-</p><p class="q1">Judah is carried away captive: all of them. 
-</p><p class="q2">They are wholly carried away captive. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Lift up your eyes, 
-</p><p class="q2">and see those who come from the north. 
-</p><p class="q1">Where is the flock that was given to you, 
-</p><p class="q2">your beautiful flock? 
-</p><p class="q1">
-<span class="v">21&#160;</span>What will you say when he sets over you as head those whom you have yourself taught to be friends to you? 
-</p><p class="q2">Won’t sorrows take hold of you, as of a woman in travail? 
-</p><p class="q1">
-<span class="v">22&#160;</span>If you say in your heart, 
-</p><p class="q2">“Why have these things come on me?” 
-</p><p class="q1">Your skirts are uncovered because of the greatness of your iniquity, 
-</p><p class="q2">and your heels suffer violence. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Can the Ethiopian change his skin, 
-</p><p class="q2">or the leopard his spots? 
-</p><p class="q1">Then may you also do good, 
-</p><p class="q2">who are accustomed to do evil. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>“Therefore I will scatter them 
-</p><p class="q2">as the stubble that passes away 
-</p><p class="q2">by the wind of the wilderness. 
-</p><p class="q1">
-<span class="v">25&#160;</span>This is your lot, 
-</p><p class="q2">the portion measured to you from me,” says Yahweh, 
-</p><p class="q1">“because you have forgotten me, 
-</p><p class="q2">and trusted in falsehood.” 
-</p><p class="q1">
-<span class="v">26&#160;</span>Therefore I will also uncover your skirts on your face, 
-</p><p class="q2">and your shame will appear. 
-</p><p class="q1">
-<span class="v">27&#160;</span>I have seen your abominations, even your adulteries 
-</p><p class="q2">and your neighing, the lewdness of your prostitution, 
-</p><p class="q2">on the hills in the field. 
-</p><p class="q1">Woe to you, Jerusalem! 
-</p><p class="q2">You will not be made clean. 
-</p><p class="q2">How long will it yet be?” 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>This is Yahweh’s word that came to Jeremiah concerning the drought: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Judah mourns, 
-</p><p class="q2">and its gates languish. 
-</p><p class="q1">They sit in black on the ground. 
-</p><p class="q2">The cry of Jerusalem goes up. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Their nobles send their little ones to the waters. 
-</p><p class="q2">They come to the cisterns, 
-</p><p class="q2">and find no water. 
-</p><p class="q1">They return with their vessels empty. 
-</p><p class="q2">They are disappointed and confounded, 
-</p><p class="q2">and cover their heads. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Because of the ground which is cracked, 
-</p><p class="q2">because no rain has been in the land, 
-</p><p class="q1">the plowmen are disappointed. 
-</p><p class="q2">They cover their heads. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yes, the doe in the field also calves and forsakes her young, 
-</p><p class="q2">because there is no grass. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The wild donkeys stand on the bare heights. 
-</p><p class="q2">They pant for air like jackals. 
-</p><p class="q1">Their eyes fail, 
-</p><p class="q2">because there is no vegetation. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Though our iniquities testify against us, 
-</p><p class="q2">work for your name’s sake, Yahweh; 
-</p><p class="q1">for our rebellions are many. 
-</p><p class="q2">We have sinned against you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You hope of Israel, 
-</p><p class="q2">its Savior in the time of trouble, 
-</p><p class="q1">why should you be as a foreigner in the land, 
-</p><p class="q2">and as a wayfaring man who turns aside to stay for a night? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Why should you be like a scared man, 
-</p><p class="q2">as a mighty man who can’t save? 
-</p><p class="q1">Yet you, Yahweh, are in the middle of us, 
-</p><p class="q2">and we are called by your name. 
-</p><p class="q2">Don’t leave us. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh says to this people: 
-</p><p class="q1">“Even so they have loved to wander. 
-</p><p class="q2">They have not restrained their feet. 
-</p><p class="q1">Therefore Yahweh does not accept them. 
-</p><p class="q2">Now he will remember their iniquity, 
-</p><p class="q2">and punish them for their sins.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said to me, “Don’t pray for this people for their good. 
-<span class="v">12&#160;</span>When they fast, I will not hear their cry; and when they offer burnt offering and meal offering, I will not accept them; but I will consume them by the sword, by famine, and by pestilence.” 
-</p><p>
-<span class="v">13&#160;</span>Then I said, “Ah, Lord Yahweh! Behold, the prophets tell them, ‘You will not see the sword, neither will you have famine; but I will give you assured peace in this place.’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Then Yahweh said to me, “The prophets prophesy lies in my name. I didn’t send them. I didn’t command them. I didn’t speak to them. They prophesy to you a lying vision, divination, and a thing of nothing, and the deceit of their own heart. 
-<span class="v">15&#160;</span>Therefore Yahweh says concerning the prophets who prophesy in my name, but I didn’t send them, yet they say, ‘Sword and famine will not be in this land.’ Those prophets will be consumed by sword and famine. 
-<span class="v">16&#160;</span>The people to whom they prophesy will be cast out in the streets of Jerusalem because of the famine and the sword. They will have no one to bury them—them, their women, their sons, or their daughters, for I will pour their wickedness on them. 
-</p><p>
-<span class="v">17&#160;</span>“You shall say this word to them: 
-</p><p class="q1">“&#160;‘Let my eyes run down with tears night and day, 
-</p><p class="q2">and let them not cease; 
-</p><p class="q1">for the virgin daughter of my people is broken with a great breach, 
-</p><p class="q2">with a very grievous wound. 
-</p><p class="q1">
-<span class="v">18&#160;</span>If I go out into the field, 
-</p><p class="q2">then behold, the slain with the sword! 
-</p><p class="q1">If I enter into the city, 
-</p><p class="q2">then behold, those who are sick with famine! 
-</p><p class="q1">For both the prophet and the priest go about in the land, 
-</p><p class="q2">and have no knowledge.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Have you utterly rejected Judah? 
-</p><p class="q2">Has your soul loathed Zion? 
-</p><p class="q1">Why have you struck us, and there is no healing for us? 
-</p><p class="q2">We looked for peace, but no good came; 
-</p><p class="q2">and for a time of healing, and behold, dismay! 
-</p><p class="q1">
-<span class="v">20&#160;</span>We acknowledge, Yahweh, our wickedness, 
-</p><p class="q2">and the iniquity of our fathers; 
-</p><p class="q2">for we have sinned against you. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Do not abhor us, for your name’s sake. 
-</p><p class="q2">Do not disgrace the throne of your glory. 
-</p><p class="q2">Remember, and don’t break your covenant with us. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Are there any among the vanities of the nations that can cause rain? 
-</p><p class="q2">Or can the sky give showers? 
-</p><p class="q2">Aren’t you he, Yahweh our Elohim? 
-</p><p class="q1">Therefore we will wait for you; 
-</p><p class="q2">for you have made all these things. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Then Yahweh said to me, “Though Moses and Samuel stood before me, yet my mind would not turn toward this people. Cast them out of my sight, and let them go out! 
-<span class="v">2&#160;</span>It will happen when they ask you, ‘Where shall we go out?’ then you shall tell them, ‘Yahweh says: 
-</p><p class="q1">“Such as are for death, to death; 
-</p><p class="q1">such as are for the sword, to the sword; 
-</p><p class="q1">such as are for the famine, to the famine; 
-</p><p class="q1">and such as are for captivity, to captivity.”&#160;’ 
-</p><p>
-<span class="v">3&#160;</span>“I will appoint over them four kinds,” says Yahweh: “the sword to kill, the dogs to tear, the birds of the sky, and the animals of the earth, to devour and to destroy. 
-<span class="v">4&#160;</span>I will cause them to be tossed back and forth among all the kingdoms of the earth, because of Manasseh, the son of Hezekiah, king of Judah, for that which he did in Jerusalem. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For who will have pity on you, Jerusalem? 
-</p><p class="q2">Who will mourn you? 
-</p><p class="q2">Who will come to ask of your welfare? 
-</p><p class="q1">
-<span class="v">6&#160;</span>You have rejected me,” says Yahweh. 
-</p><p class="q2">“You have gone backward. 
-</p><p class="q1">Therefore I have stretched out my hand against you 
-</p><p class="q2">and destroyed you. 
-</p><p class="q2">I am weary of showing compassion. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I have winnowed them with a fan in the gates of the land. 
-</p><p class="q2">I have bereaved them of children. 
-</p><p class="q1">I have destroyed my people. 
-</p><p class="q2">They didn’t return from their ways. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Their widows are increased more than the sand of the seas. 
-</p><p class="q2">I have brought on them against the mother of the young men a destroyer at noonday. 
-</p><p class="q2">I have caused anguish and terrors to fall on her suddenly. 
-</p><p class="q1">
-<span class="v">9&#160;</span>She who has borne seven languishes. 
-</p><p class="q2">She has given up the spirit. 
-</p><p class="q1">Her sun has gone down while it was yet day. 
-</p><p class="q2">She has been disappointed and confounded. 
-</p><p class="q2">I will deliver their residue to the sword before their enemies,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Woe is me, my mother, that you have borne me, a man of strife, 
-</p><p class="q2">and a man of contention to the whole earth! 
-</p><p class="q1">I have not lent, neither have men lent to me; 
-</p><p class="q2">yet every one of them curses me. 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said, 
-</p><p class="q1">“Most certainly I will strengthen you for good. 
-</p><p class="q2">Most certainly I will cause the enemy to make supplication to you in the time of evil 
-</p><p class="q2">and in the time of affliction. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Can one break iron, 
-</p><p class="q2">even iron from the north, and bronze? 
-</p><p class="q1">
-<span class="v">13&#160;</span>I will give your substance and your treasures for a plunder without price, 
-</p><p class="q2">and that for all your sins, 
-</p><p class="q2">even in all your borders. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will make them to pass with your enemies into a land which you don’t know; 
-</p><p class="q2">for a fire is kindled in my anger, 
-</p><p class="q2">which will burn on you.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>Yahweh, you know. 
-</p><p class="q2">Remember me, visit me, 
-</p><p class="q2">and avenge me of my persecutors. 
-</p><p class="q1">You are patient, so don’t take me away. 
-</p><p class="q2">Know that for your sake I have suffered reproach. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Your words were found, 
-</p><p class="q2">and I ate them. 
-</p><p class="q1">Your words were to me a joy and the rejoicing of my heart, 
-</p><p class="q2">for I am called by your name, Yahweh, Elohim of Armies. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I didn’t sit in the assembly of those who make merry and rejoice. 
-</p><p class="q2">I sat alone because of your hand, 
-</p><p class="q2">for you have filled me with indignation. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Why is my pain perpetual, 
-</p><p class="q2">and my wound incurable, 
-</p><p class="q2">which refuses to be healed? 
-</p><p class="q1">Will you indeed be to me as a deceitful brook, 
-</p><p class="q2">like waters that fail? 
-</p><p>
-<span class="v">19&#160;</span>Therefore Yahweh says, 
-</p><p class="q1">“If you return, then I will bring you again, 
-</p><p class="q2">that you may stand before me; 
-</p><p class="q1">and if you take out the precious from the vile, 
-</p><p class="q2">you will be as my mouth. 
-</p><p class="q1">They will return to you, 
-</p><p class="q2">but you will not return to them. 
-</p><p class="q1">
-<span class="v">20&#160;</span>I will make you to this people a fortified bronze wall. 
-</p><p class="q2">They will fight against you, 
-</p><p class="q2">but they will not prevail against you; 
-</p><p class="q1">for I am with you to save you 
-</p><p class="q2">and to deliver you,” says Yahweh. 
-</p><p class="q1">
-<span class="v">21&#160;</span>“I will deliver you out of the hand of the wicked, 
-</p><p class="q2">and I will redeem you out of the hand of the terrible.” 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Then Yahweh’s word came to me, saying, 
-<span class="v">2&#160;</span>“You shall not take a woman, neither shall you have sons or daughters, in this place.” 
-<span class="v">3&#160;</span>For Yahweh says concerning the sons and concerning the daughters who are born in this place, and concerning their mothers who bore them, and concerning their fathers who became their father in this land: 
-<span class="v">4&#160;</span>“They will die grievous deaths. They will not be lamented, neither will they be buried. They will be as dung on the surface of the ground. They will be consumed by the sword and by famine. Their dead bodies will be food for the birds of the sky and for the animals of the earth.” 
-</p><p>
-<span class="v">5&#160;</span>For Yahweh says, “Don’t enter into the house of mourning. Don’t go to lament. Don’t bemoan them, for I have taken away my peace from this people,” says Yahweh, “even loving kindness and tender mercies. 
-<span class="v">6&#160;</span>Both great and small will die in this land. They will not be buried. Men won’t lament for them, cut themselves, or make themselves bald for them. 
-<span class="v">7&#160;</span>Men won’t break bread for them in mourning, to comfort them for the dead. Men won’t give them the cup of consolation to drink for their father or for their mother. 
-</p><p>
-<span class="v">8&#160;</span>“You shall not go into the house of feasting to sit with them, to eat and to drink.” 
-<span class="v">9&#160;</span>For Yahweh of Armies, the Elohim of Israel says: “Behold, I will cause to cease out of this place, before your eyes and in your days, the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride. 
-<span class="v">10&#160;</span>It will happen, when you tell this people all these words, and they ask you, ‘Why has Yahweh pronounced all this great evil against us?’ or ‘What is our iniquity?’ or ‘What is our sin that we have committed against Yahweh our Elohim?’ 
-<span class="v">11&#160;</span>then you shall tell them, ‘Because your fathers have forsaken me,’ says Yahweh, ‘and have walked after other elohims, have served them, have worshiped them, have forsaken me, and have not kept my law. 
-<span class="v">12&#160;</span>You have done evil more than your fathers, for behold, you each walk after the stubbornness of his evil heart, so that you don’t listen to me. 
-<span class="v">13&#160;</span>Therefore I will cast you out of this land into the land that you have not known, neither you nor your fathers. There you will serve other elohims day and night, for I will show you no favor.’ 
-</p><p>
-<span class="v">14&#160;</span>“Therefore behold, the days come,” says Yahweh, “that it will no more be said, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
-<span class="v">15&#160;</span>but, ‘As Yahweh lives, who brought up the children of Israel from the land of the north, and from all the countries where he had driven them.’ I will bring them again into their land that I gave to their fathers. 
-</p><p>
-<span class="v">16&#160;</span>“Behold, I will send for many fishermen,” says Yahweh, “and they will fish them up. Afterward I will send for many hunters, and they will hunt them from every mountain, from every hill, and out of the clefts of the rocks. 
-<span class="v">17&#160;</span>For my eyes are on all their ways. They are not hidden from my face. Their iniquity isn’t concealed from my eyes. 
-<span class="v">18&#160;</span>First I will recompense their iniquity and their sin double, because they have polluted my land with the carcasses of their detestable things, and have filled my inheritance with their abominations.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Yahweh, my strength, my stronghold, 
-</p><p class="q2">and my refuge in the day of affliction, 
-</p><p class="q1">the nations will come to you from the ends of the earth, 
-</p><p class="q2">and will say, 
-</p><p class="q1">“Our fathers have inherited nothing but lies, 
-</p><p class="q2">vanity and things in which there is no profit. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Should a man make to himself elohims 
-</p><p class="q2">which yet are no elohims?” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Therefore behold, I will cause them to know, 
-</p><p class="q2">this once I will cause them to know my hand and my might. 
-</p><p class="q2">Then they will know that my name is Yahweh.” 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“The sin of Judah is written with a pen of iron, 
-</p><p class="q2">and with the point of a diamond. 
-</p><p class="q1">It is engraved on the tablet of their heart, 
-</p><p class="q2">and on the horns of your altars. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Even their children remember their altars 
-</p><p class="q2">and their Asherah poles by the green trees on the high hills. 
-</p><p class="q1">
-<span class="v">3&#160;</span>My mountain in the field, 
-</p><p class="q2">I will give your substance and all your treasures for a plunder, 
-</p><p class="q2">and your high places, because of sin, throughout all your borders. 
-</p><p class="q1">
-<span class="v">4&#160;</span>You, even of yourself, will discontinue from your heritage that I gave you. 
-</p><p class="q2">I will cause you to serve your enemies in the land which you don’t know, 
-</p><p class="q2">for you have kindled a fire in my anger which will burn forever.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh says: 
-</p><p class="q1">“Cursed is the man who trusts in man, 
-</p><p class="q2">relies on strength of flesh, 
-</p><p class="q2">and whose heart departs from Yahweh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For he will be like a bush in the desert, 
-</p><p class="q2">and will not see when good comes, 
-</p><p class="q1">but will inhabit the parched places in the wilderness, 
-</p><p class="q2">an uninhabited salt land. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Blessed is the man who trusts in Yahweh, 
-</p><p class="q2">and whose confidence is in Yahweh. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For he will be as a tree planted by the waters, 
-</p><p class="q2">who spreads out its roots by the river, 
-</p><p class="q1">and will not fear when heat comes, 
-</p><p class="q2">but its leaf will be green, 
-</p><p class="q1">and will not be concerned in the year of drought. 
-</p><p class="q2">It won’t cease from yielding fruit. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The heart is deceitful above all things 
-</p><p class="q2">and it is exceedingly corrupt. 
-</p><p class="q2">Who can know it? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“I, Yahweh, search the mind. 
-</p><p class="q2">I try the heart, 
-</p><p class="q1">even to give every man according to his ways, 
-</p><p class="q2">according to the fruit of his doings.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>As the partridge that sits on eggs which she has not laid, 
-</p><p class="q2">so is he who gets riches, and not by right. 
-</p><p class="q1">In the middle of his days, they will leave him. 
-</p><p class="q2">At his end, he will be a fool. 
-</p><p class="q1">
-<span class="v">12&#160;</span>A glorious throne, set on high from the beginning, 
-</p><p class="q2">is the place of our sanctuary. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yahweh, the hope of Israel, 
-</p><p class="q2">all who forsake you will be disappointed. 
-</p><p class="q1">Those who depart from me will be written in the earth, 
-</p><p class="q2">because they have forsaken Yahweh, 
-</p><p class="q2">the spring of living waters. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Heal me, O Yahweh, and I will be healed. 
-</p><p class="q2">Save me, and I will be saved; 
-</p><p class="q2">for you are my praise. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, they ask me, 
-</p><p class="q2">“Where is Yahweh’s word? 
-</p><p class="q2">Let it be fulfilled now.” 
-</p><p class="q1">
-<span class="v">16&#160;</span>As for me, I have not hurried from being a shepherd after you. 
-</p><p class="q2">I haven’t desired the woeful day. You know. 
-</p><p class="q2">That which came out of my lips was before your face. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Don’t be a terror to me. 
-</p><p class="q2">You are my refuge in the day of evil. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Let them be disappointed who persecute me, 
-</p><p class="q2">but don’t let me be disappointed. 
-</p><p class="q1">Let them be dismayed, 
-</p><p class="q2">but don’t let me be dismayed. 
-</p><p class="q1">Bring on them the day of evil, 
-</p><p class="q2">and destroy them with double destruction. 
-</p><p>
-<span class="v">19&#160;</span>Yahweh said this to me: “Go and stand in the gate of the children of the people, through which the kings of Judah come in and by which they go out, and in all the gates of Jerusalem. 
-<span class="v">20&#160;</span>Tell them, ‘Hear Yahweh’s word, you kings of Judah, all Judah, and all the inhabitants of Jerusalem, that enter in by these gates: 
-<span class="v">21&#160;</span>Yahweh says, “Be careful, and bear no burden on the Sabbath day, nor bring it in by the gates of Jerusalem. 
-<span class="v">22&#160;</span>Don’t carry a burden out of your houses on the Sabbath day. Don’t do any work, but make the Sabbath day set-apart, as I commanded your fathers. 
-<span class="v">23&#160;</span>But they didn’t listen. They didn’t turn their ear, but made their neck stiff, that they might not hear, and might not receive instruction. 
-<span class="v">24&#160;</span>It will happen, if you diligently listen to me,” says Yahweh, “to bring in no burden through the gates of this city on the Sabbath day, but to make the Sabbath day set-apart, to do no work therein; 
-<span class="v">25&#160;</span>then there will enter in by the gates of this city kings and princes sitting on David’s throne, riding in chariots and on horses, they and their princes, the men of Judah and the inhabitants of Jerusalem; and this city will remain forever. 
-<span class="v">26&#160;</span>They will come from the cities of Judah, and from the places around Jerusalem, from the land of Benjamin, from the lowland, from the hill country, and from the South, bringing burnt offerings, sacrifices, meal offerings, and frankincense, and bringing sacrifices of thanksgiving to Yahweh’s house. 
-<span class="v">27&#160;</span>But if you will not listen to me to make the Sabbath day set-apart, and not to bear a burden and enter in at the gates of Jerusalem on the Sabbath day, then I will kindle a fire in its gates, and it will devour the palaces of Jerusalem. It will not be quenched.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>The word which came to Jeremiah from Yahweh, saying, 
-<span class="v">2&#160;</span>“Arise, and go down to the potter’s house, and there I will cause you to hear my words.” 
-</p><p>
-<span class="v">3&#160;</span>Then I went down to the potter’s house, and behold, he was making something on the wheels. 
-<span class="v">4&#160;</span>When the vessel that he made of the clay was marred in the hand of the potter, he made it again another vessel, as seemed good to the potter to make it. 
-</p><p>
-<span class="v">5&#160;</span>Then Yahweh’s word came to me, saying, 
-<span class="v">6&#160;</span>“House of Israel, can’t I do with you as this potter?” says Yahweh. “Behold, as the clay in the potter’s hand, so are you in my hand, house of Israel. 
-<span class="v">7&#160;</span>At the instant I speak concerning a nation, and concerning a kingdom, to pluck up and to break down and to destroy it, 
-<span class="v">8&#160;</span>if that nation, concerning which I have spoken, turns from their evil, I will repent of the evil that I thought to do to them. 
-<span class="v">9&#160;</span>At the instant I speak concerning a nation, and concerning a kingdom, to build and to plant it, 
-<span class="v">10&#160;</span>if they do that which is evil in my sight, that they not obey my voice, then I will repent of the good with which I said I would benefit them. 
-</p><p>
-<span class="v">11&#160;</span>“Now therefore, speak to the men of Judah, and to the inhabitants of Jerusalem, saying, ‘Yahweh says: “Behold, I frame evil against you, and devise a plan against you. Everyone return from his evil way now, and amend your ways and your doings.”&#160;’ 
-<span class="v">12&#160;</span>But they say, ‘It is in vain; for we will walk after our own plans, and we will each follow the stubbornness of his evil heart.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>Therefore Yahweh says: 
-</p><p class="q1">“Ask now among the nations, 
-</p><p class="q2">‘Who has heard such things?’ 
-</p><p class="q2">The virgin of Israel has done a very horrible thing. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Will the snow of Lebanon fail from the rock of the field? 
-</p><p class="q2">Will the cold waters that flow down from afar be dried up? 
-</p><p class="q1">
-<span class="v">15&#160;</span>For my people have forgotten me. 
-</p><p class="q2">They have burned incense to false elohims. 
-</p><p class="q1">They have been made to stumble in their ways 
-</p><p class="q2">in the ancient paths, 
-</p><p class="q2">to walk in byways, in a way not built up, 
-</p><p class="q1">
-<span class="v">16&#160;</span>to make their land an astonishment, 
-</p><p class="q2">and a perpetual hissing. 
-</p><p class="q1">Everyone who passes by it will be astonished, 
-</p><p class="q2">and shake his head. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will scatter them as with an east wind before the enemy. 
-</p><p class="q2">I will show them the back, and not the face, 
-</p><p class="q2">in the day of their calamity. 
-</p><p>
-<span class="v">18&#160;</span>Then they said, “Come! Let’s devise plans against Jeremiah; for the law won’t perish from the priest, nor counsel from the wise, nor the word from the prophet. Come, and let’s strike him with the tongue, and let’s not give heed to any of his words.” 
-</p><p class="q1">
-<span class="v">19&#160;</span>Give heed to me, Yahweh, 
-</p><p class="q2">and listen to the voice of those who contend with me. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Should evil be recompensed for good? 
-</p><p class="q2">For they have dug a pit for my soul. 
-</p><p class="q1">Remember how I stood before you to speak good for them, 
-</p><p class="q2">to turn away your wrath from them. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Therefore deliver up their children to the famine, 
-</p><p class="q2">and give them over to the power of the sword. 
-</p><p class="q1">Let their women become childless and widows. 
-</p><p class="q2">Let their men be killed 
-</p><p class="q2">and their young men struck by the sword in battle. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Let a cry be heard from their houses 
-</p><p class="q2">when you bring a troop suddenly on them; 
-</p><p class="q1">for they have dug a pit to take me 
-</p><p class="q2">and hidden snares for my feet. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Yet, Yahweh, you know all their counsel against me to kill me. 
-</p><p class="q2">Don’t forgive their iniquity. 
-</p><p class="q2">Don’t blot out their sin from your sight, 
-</p><p class="q1">Let them be overthrown before you. 
-</p><p class="q2">Deal with them in the time of your anger. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Thus said Yahweh, “Go, and buy a potter’s earthen container, and take some of the elders of the people and of the elders of the priests; 
-<span class="v">2&#160;</span>and go out to the valley of the son of Hinnom, which is by the entry of the gate Harsith, and proclaim there the words that I will tell you. 
-<span class="v">3&#160;</span>Say, ‘Hear Yahweh’s word, kings of Judah and inhabitants of Jerusalem: Yahweh of Armies, the Elohim of Israel says, “Behold, I will bring evil on this place, which whoever hears, his ears will tingle. 
-<span class="v">4&#160;</span>Because they have forsaken me, and have defiled this place, and have burned incense in it to other elohims that they didn’t know—they, their fathers, and the kings of Judah—and have filled this place with the blood of innocents, 
-<span class="v">5&#160;</span>and have built the high places of Baal to burn their children in the fire for burnt offerings to Baal, which I didn’t command, nor speak, which didn’t even enter into my mind. 
-<span class="v">6&#160;</span>Therefore, behold, the days come,” says Yahweh, “that this place will no more be called ‘Topheth’, nor ‘The Valley of the son of Hinnom’, but ‘The valley of Slaughter’. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘&#160;“I will make the counsel of Judah and Jerusalem void in this place. I will cause them to fall by the sword before their enemies, and by the hand of those who seek their life. I will give their dead bodies to be food for the birds of the sky and for the animals of the earth. 
-<span class="v">8&#160;</span>I will make this city an astonishment and a hissing. Everyone who passes by it will be astonished and hiss because of all its plagues. 
-<span class="v">9&#160;</span>I will cause them to eat the flesh of their sons and the flesh of their daughters. They will each eat the flesh of his friend in the siege and in the distress with which their enemies, and those who seek their life, will distress them.”&#160;’ 
-</p><p>
-<span class="v">10&#160;</span>“Then you shall break the container in the sight of the men who go with you, 
-<span class="v">11&#160;</span>and shall tell them, ‘Yahweh of Armies says: “Even so I will break this people and this city as one breaks a potter’s vessel, that can’t be made whole again. They will bury in Topheth until there is no place to bury. 
-<span class="v">12&#160;</span>This is what I will do to this place,” says Yahweh, “and to its inhabitants, even making this city as Topheth. 
-<span class="v">13&#160;</span>The houses of Jerusalem and the houses of the kings of Judah, which are defiled, will be as the place of Topheth, even all the houses on whose roofs they have burned incense to all the army of the sky and have poured out drink offerings to other elohims.”&#160;’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Then Jeremiah came from Topheth, where Yahweh had sent him to prophesy, and he stood in the court of Yahweh’s house, and said to all the people: 
-<span class="v">15&#160;</span>“Yahweh of Armies, the Elohim of Israel says, ‘Behold, I will bring on this city and on all its towns all the evil that I have pronounced against it, because they have made their neck stiff, that they may not hear my words.’&#160;” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Now Pashhur, the son of Immer the priest, who was chief officer in Yahweh’s house, heard Jeremiah prophesying these things. 
-<span class="v">2&#160;</span>Then Pashhur struck Jeremiah the prophet and put him in the stocks that were in the upper gate of Benjamin, which was in Yahweh’s house. 
-<span class="v">3&#160;</span>On the next day, Pashhur released Jeremiah out of the stocks. Then Jeremiah said to him, “Yahweh has not called your name Pashhur, but Magormissabib.<span class="f">+ \fr 20:3 \ft “Magormissabib” means “surrounded by terror”</span> 
-<span class="v">4&#160;</span>For Yahweh says, ‘Behold, I will make you a terror to yourself and to all your friends. They will fall by the sword of their enemies, and your eyes will see it. I will give all Judah into the hand of the king of Babylon, and he will carry them captive to Babylon, and will kill them with the sword. 
-<span class="v">5&#160;</span>Moreover I will give all the riches of this city, and all its gains, and all its precious things, yes, I will give all the treasures of the kings of Judah into the hand of their enemies. They will make them captives, take them, and carry them to Babylon. 
-<span class="v">6&#160;</span>You, Pashhur, and all who dwell in your house will go into captivity. You will come to Babylon, and there you will die, and there you will be buried, you, and all your friends, to whom you have prophesied falsely.’&#160;” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Yahweh, you have persuaded me, and I was persuaded. 
-</p><p class="q2">You are stronger than I, and have prevailed. 
-</p><p class="q1">I have become a laughingstock all day. 
-</p><p class="q2">Everyone mocks me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For as often as I speak, I cry out; 
-</p><p class="q2">I cry, “Violence and destruction!” 
-</p><p class="q1">because Yahweh’s word has been made a reproach to me, 
-</p><p class="q2">and a derision, all day. 
-</p><p class="q1">
-<span class="v">9&#160;</span>If I say that I will not make mention of him, 
-</p><p class="q2">or speak any more in his name, 
-</p><p class="q1">then there is in my heart as it were a burning fire shut up in my bones. 
-</p><p class="q2">I am weary with holding it in. 
-</p><p class="q2">I can’t. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For I have heard the defaming of many: 
-</p><p class="q2">“Terror on every side! 
-</p><p class="q2">Denounce, and we will denounce him!” 
-</p><p class="q1">say all my familiar friends, 
-</p><p class="q2">those who watch for my fall. 
-</p><p class="q1">“Perhaps he will be persuaded, 
-</p><p class="q2">and we will prevail against him, 
-</p><p class="q2">and we will take our revenge on him.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>But Yahweh is with me as an awesome mighty one. 
-</p><p class="q2">Therefore my persecutors will stumble, 
-</p><p class="q2">and they won’t prevail. 
-</p><p class="q1">They will be utterly disappointed 
-</p><p class="q2">because they have not dealt wisely, 
-</p><p class="q2">even with an everlasting dishonor which will never be forgotten. 
-</p><p class="q1">
-<span class="v">12&#160;</span>But Yahweh of Armies, who tests the righteous, 
-</p><p class="q2">who sees the heart and the mind, 
-</p><p class="q1">let me see your vengeance on them, 
-</p><p class="q2">for I have revealed my cause to you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Sing to Yahweh! 
-</p><p class="q2">Praise Yahweh, 
-</p><p class="q2">for he has delivered the soul of the needy from the hand of evildoers. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Cursed is the day in which I was born. 
-</p><p class="q2">Don’t let the day in which my mother bore me be blessed. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Cursed is the man who brought news to my father, saying, 
-</p><p class="q2">“A boy is born to you,” making him very glad. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Let that man be as the cities which Yahweh overthrew, 
-</p><p class="q2">and didn’t repent. 
-</p><p class="q1">Let him hear a cry in the morning, 
-</p><p class="q2">and shouting at noontime, 
-</p><p class="q1">
-<span class="v">17&#160;</span>because he didn’t kill me from the womb. 
-</p><p class="q2">So my mother would have been my grave, 
-</p><p class="q2">and her womb always great. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Why did I come out of the womb to see labor and sorrow, 
-</p><p class="q2">that my days should be consumed with shame? 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>The word which came to Jeremiah from Yahweh, when King Zedekiah sent to him Pashhur the son of Malchijah, and Zephaniah the son of Maaseiah, the priest, saying, 
-<span class="v">2&#160;</span>“Please inquire of Yahweh for us; for Nebuchadnezzar king of Babylon makes war against us. Perhaps Yahweh will deal with us according to all his wondrous works, that he may withdraw from us.” 
-</p><p>
-<span class="v">3&#160;</span>Then Jeremiah said to them, “Tell Zedekiah: 
-<span class="v">4&#160;</span>‘Yahweh, the Elohim of Israel says, “Behold, I will turn back the weapons of war that are in your hands, with which you fight against the king of Babylon, and against the Chaldeans who besiege you outside the walls; and I will gather them into the middle of this city. 
-<span class="v">5&#160;</span>I myself will fight against you with an outstretched hand and with a strong arm, even in anger, in wrath, and in great indignation. 
-<span class="v">6&#160;</span>I will strike the inhabitants of this city, both man and animal. They will die of a great pestilence. 
-<span class="v">7&#160;</span>Afterward,” says Yahweh, “I will deliver Zedekiah king of Judah, his servants, and the people, even those who are left in this city from the pestilence, from the sword, and from the famine, into the hand of Nebuchadnezzar king of Babylon, and into the hand of their enemies, and into the hand of those who seek their life. He will strike them with the edge of the sword. He will not spare them, have pity, or have mercy.”&#160;’ 
-</p><p>
-<span class="v">8&#160;</span>“You shall say to this people, ‘Yahweh says: “Behold, I set before you the way of life and the way of death. 
-<span class="v">9&#160;</span>He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out and passes over to the Chaldeans who besiege you, he will live, and he will escape with his life. 
-<span class="v">10&#160;</span>For I have set my face on this city for evil, and not for good,” says Yahweh. “It will be given into the hand of the king of Babylon, and he will burn it with fire.”&#160;’ 
-</p><p>
-<span class="v">11&#160;</span>“Concerning the house of the king of Judah, hear Yahweh’s word: 
-<span class="v">12&#160;</span>House of David, Yahweh says, 
-</p><p class="q1">‘Execute justice in the morning, 
-</p><p class="q2">and deliver him who is robbed out of the hand of the oppressor, 
-</p><p class="q1">lest my wrath go out like fire, 
-</p><p class="q2">and burn so that no one can quench it, 
-</p><p class="q2">because of the evil of your doings. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Behold, I am against you, O inhabitant of the valley, 
-</p><p class="q2">and of the rock of the plain,’ says Yahweh. 
-</p><p class="q1">‘You that say, “Who would come down against us?” 
-</p><p class="q2">or, “Who would enter into our homes?” 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will punish you according to the fruit of your doings,’ says Yahweh; 
-</p><p class="q2">‘and I will kindle a fire in her forest, 
-</p><p class="q2">and it will devour all that is around her.’&#160;” 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said, “Go down to the house of the king of Judah, and speak this word there: 
-<span class="v">2&#160;</span>‘Hear Yahweh’s word, king of Judah, who sits on David’s throne—you, your servants, and your people who enter in by these gates. 
-<span class="v">3&#160;</span>Yahweh says: “Execute justice and righteousness, and deliver him who is robbed out of the hand of the oppressor. Do no wrong. Do no violence to the foreigner, the fatherless, or the widow. Don’t shed innocent blood in this place. 
-<span class="v">4&#160;</span>For if you do this thing indeed, then kings sitting on David’s throne will enter in by the gates of this house, riding in chariots and on horses—they, their servants, and their people. 
-<span class="v">5&#160;</span>But if you will not hear these words, I swear by myself,” says Yahweh, “that this house will become a desolation.”&#160;’&#160;” 
-</p><p>
-<span class="v">6&#160;</span>For Yahweh says concerning the house of the king of Judah: 
-</p><p class="q1">“You are Gilead to me, 
-</p><p class="q2">the head of Lebanon. 
-</p><p class="q1">Yet surely I will make you a wilderness, 
-</p><p class="q2">cities which are not inhabited. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I will prepare destroyers against you, 
-</p><p class="q2">everyone with his weapons, 
-</p><p class="q1">and they will cut down your choice cedars, 
-</p><p class="q2">and cast them into the fire. 
-</p><p>
-<span class="v">8&#160;</span>“Many nations will pass by this city, and they will each ask his neighbor, ‘Why has Yahweh done this to this great city?’ 
-<span class="v">9&#160;</span>Then they will answer, ‘Because they abandoned the covenant of Yahweh their Elohim, worshiped other elohims, and served them.’&#160;” 
-</p><p class="q1">
-<span class="v">10&#160;</span>Don’t weep for the dead. 
-</p><p class="q2">Don’t bemoan him; 
-</p><p class="q1">but weep bitterly for him who goes away, 
-</p><p class="q2">for he will return no more, 
-</p><p class="q2">and not see his native country. 
-</p><p class="m">
-<span class="v">11&#160;</span>For Yahweh says touching Shallum the son of Josiah, king of Judah, who reigned instead of Josiah his father, and who went out of this place: “He won’t return there any more. 
-<span class="v">12&#160;</span>But he will die in the place where they have led him captive. He will see this land no more.” 
-</p><p class="q1">
-<span class="v">13&#160;</span>“Woe to him who builds his house by unrighteousness, 
-</p><p class="q2">and his rooms by injustice; 
-</p><p class="q1">who uses his neighbor’s service without wages, 
-</p><p class="q2">and doesn’t give him his hire; 
-</p><p class="q1">
-<span class="v">14&#160;</span>who says, ‘I will build myself a wide house and spacious rooms,’ 
-</p><p class="q2">and cuts out windows for himself, 
-</p><p class="q1">with a cedar ceiling, 
-</p><p class="q2">and painted with red. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“Should you reign because you strive to excel in cedar? 
-</p><p class="q2">Didn’t your father eat and drink, 
-</p><p class="q2">and do justice and righteousness? 
-</p><p class="q2">Then it was well with him. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He judged the cause of the poor and needy; 
-</p><p class="q2">so then it was well. 
-</p><p class="q1">Wasn’t this to know me?” 
-</p><p class="q2">says Yahweh. 
-</p><p class="q1">
-<span class="v">17&#160;</span>But your eyes and your heart are only for your covetousness, 
-</p><p class="q2">for shedding innocent blood, 
-</p><p class="q2">for oppression, and for doing violence.” 
-</p><p class="m">
-<span class="v">18&#160;</span>Therefore Yahweh says concerning Jehoiakim the son of Josiah, king of Judah: 
-</p><p class="q1">“They won’t lament for him, 
-</p><p class="q2">saying, ‘Ah my brother!’ or, ‘Ah sister!’ 
-</p><p class="q1">They won’t lament for him, 
-</p><p class="q2">saying ‘Ah lord!’ or, ‘Ah his glory!’ 
-</p><p class="q1">
-<span class="v">19&#160;</span>He will be buried with the burial of a donkey, 
-</p><p class="q2">drawn and cast out beyond the gates of Jerusalem.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Go up to Lebanon, and cry out. 
-</p><p class="q2">Lift up your voice in Bashan, 
-</p><p class="q1">and cry from Abarim; 
-</p><p class="q2">for all your lovers have been destroyed. 
-</p><p class="q1">
-<span class="v">21&#160;</span>I spoke to you in your prosperity, 
-</p><p class="q2">but you said, ‘I will not listen.’ 
-</p><p class="q1">This has been your way from your youth, 
-</p><p class="q2">that you didn’t obey my voice. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The wind will feed all your shepherds, 
-</p><p class="q2">and your lovers will go into captivity. 
-</p><p class="q1">Surely then you will be ashamed 
-</p><p class="q2">and confounded for all your wickedness. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Inhabitant of Lebanon, 
-</p><p class="q2">who makes your nest in the cedars, 
-</p><p class="q1">how greatly to be pitied you will be when pangs come on you, 
-</p><p class="q2">the pain as of a woman in travail! 
-</p><p>
-<span class="v">24&#160;</span>“As I live,” says Yahweh, “though Coniah the son of Jehoiakim king of Judah were the signet on my right hand, I would still pluck you from there. 
-<span class="v">25&#160;</span>I would give you into the hand of those who seek your life, and into the hand of them of whom you are afraid, even into the hand of Nebuchadnezzar king of Babylon, and into the hand of the Chaldeans. 
-<span class="v">26&#160;</span>I will cast you out with your mother who bore you into another country, where you were not born; and there you will die. 
-<span class="v">27&#160;</span>But to the land to which their soul longs to return, there they will not return.” 
-</p><p class="q1">
-<span class="v">28&#160;</span>Is this man Coniah a despised broken vessel? 
-</p><p class="q2">Is he a vessel in which no one delights? 
-</p><p class="q1">Why are they cast out, he and his offspring, 
-</p><p class="q2">and cast into a land which they don’t know? 
-</p><p class="q1">
-<span class="v">29&#160;</span>O earth, earth, earth, 
-</p><p class="q2">hear Yahweh’s word! 
-</p><p class="q1">
-<span class="v">30&#160;</span>Yahweh says, 
-</p><p class="q2">“Record this man as childless, 
-</p><p class="q2">a man who will not prosper in his days; 
-</p><p class="q1">for no more will a man of his offspring prosper, 
-</p><p class="q2">sitting on David’s throne 
-</p><p class="q2">and ruling in Judah.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>“Woe to the shepherds who destroy and scatter the sheep of my pasture!” says Yahweh. 
-<span class="v">2&#160;</span>Therefore Yahweh, the Elohim of Israel, says against the shepherds who feed my people: “You have scattered my flock, driven them away, and have not visited them. Behold, I will visit on you the evil of your doings,” says Yahweh. 
-<span class="v">3&#160;</span>“I will gather the remnant of my flock out of all the countries where I have driven them, and will bring them again to their folds; and they will be fruitful and multiply. 
-<span class="v">4&#160;</span>I will set up shepherds over them who will feed them. They will no longer be afraid or dismayed, neither will any be lacking,” says Yahweh. 
-</p><p class="q1">
-<span class="v">5&#160;</span>“Behold, the days come,” says Yahweh, 
-</p><p class="q2">“that I will raise to David a righteous Branch; 
-</p><p class="q1">and he will reign as king and deal wisely, 
-</p><p class="q2">and will execute justice and righteousness in the land. 
-</p><p class="q1">
-<span class="v">6&#160;</span>In his days Judah will be saved, 
-</p><p class="q2">and Israel will dwell safely. 
-</p><p class="q1">This is his name by which he will be called: 
-</p><p class="q2">Yahweh our righteousness. 
-</p><p class="m">
-<span class="v">7&#160;</span>“Therefore, behold, the days come,” says Yahweh, “that they will no more say, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
-<span class="v">8&#160;</span>but, ‘As Yahweh lives, who brought up and who led the offspring of the house of Israel out of the north country, and from all the countries where I had driven them.’ Then they will dwell in their own land.” 
-</p><p>
-<span class="v">9&#160;</span>Concerning the prophets: 
-</p><p class="q1">My heart within me is broken. 
-</p><p class="q2">All my bones shake. 
-</p><p class="q1">I am like a drunken man, 
-</p><p class="q2">and like a man whom wine has overcome, 
-</p><p class="q1">because of Yahweh, 
-</p><p class="q2">and because of his set-apart words. 
-</p><p class="q1">
-<span class="v">10&#160;</span>“For the land is full of adulterers; 
-</p><p class="q2">for because of the curse the land mourns. 
-</p><p class="q1">The pastures of the wilderness have dried up. 
-</p><p class="q2">Their course is evil, 
-</p><p class="q2">and their might is not right; 
-</p><p class="q1">
-<span class="v">11&#160;</span>for both prophet and priest are profane. 
-</p><p class="q2">Yes, in my house I have found their wickedness,” says Yahweh. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Therefore their way will be to them as slippery places in the darkness. 
-</p><p class="q2">They will be driven on, 
-</p><p class="q2">and fall therein; 
-</p><p class="q1">for I will bring evil on them, 
-</p><p class="q2">even the year of their visitation,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“I have seen folly in the prophets of Samaria. 
-</p><p class="q2">They prophesied by Baal, 
-</p><p class="q2">and caused my people Israel to err. 
-</p><p class="q1">
-<span class="v">14&#160;</span>In the prophets of Jerusalem I have also seen a horrible thing: 
-</p><p class="q2">they commit adultery and walk in lies. 
-</p><p class="q1">They strengthen the hands of evildoers, 
-</p><p class="q2">so that no one returns from his wickedness. 
-</p><p class="q1">They have all become to me as Sodom, 
-</p><p class="q2">and its inhabitants as Gomorrah.” 
-</p><p>
-<span class="v">15&#160;</span>Therefore Yahweh of Armies says concerning the prophets: 
-</p><p class="q1">“Behold, I will feed them with wormwood, 
-</p><p class="q2">and make them drink poisoned water; 
-</p><p class="q2">for from the prophets of Jerusalem unelohimliness has gone out into all the land.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh of Armies says, 
-</p><p class="q1">“Don’t listen to the words of the prophets who prophesy to you. 
-</p><p class="q2">They teach you vanity. 
-</p><p class="q2">They speak a vision of their own heart, 
-</p><p class="q2">and not out of the mouth of Yahweh. 
-</p><p class="q1">
-<span class="v">17&#160;</span>They say continually to those who despise me, 
-</p><p class="q2">‘Yahweh has said, “You will have peace;”&#160;’ 
-</p><p class="q1">and to everyone who walks in the stubbornness of his own heart they say, 
-</p><p class="q2">‘No evil will come on you.’ 
-</p><p class="q1">
-<span class="v">18&#160;</span>For who has stood in the council of Yahweh, 
-</p><p class="q2">that he should perceive and hear his word? 
-</p><p class="q2">Who has listened to my word, and heard it? 
-</p><p class="q1">
-<span class="v">19&#160;</span>Behold, Yahweh’s storm, his wrath, has gone out. 
-</p><p class="q2">Yes, a whirling storm! 
-</p><p class="q2">It will burst on the head of the wicked. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Yahweh’s anger will not return until he has executed 
-</p><p class="q2">and performed the intents of his heart. 
-</p><p class="q2">In the latter days, you will understand it perfectly. 
-</p><p class="q1">
-<span class="v">21&#160;</span>I didn’t send these prophets, yet they ran. 
-</p><p class="q2">I didn’t speak to them, yet they prophesied. 
-</p><p class="q1">
-<span class="v">22&#160;</span>But if they had stood in my council, 
-</p><p class="q2">then they would have caused my people to hear my words, 
-</p><p class="q1">and would have turned them from their evil way, 
-</p><p class="q2">and from the evil of their doings. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>“Am I an Elohim at hand,” says Yahweh, 
-</p><p class="q2">“and not an Elohim afar off? 
-</p><p class="q1">
-<span class="v">24&#160;</span>Can anyone hide himself in secret places 
-</p><p class="q2">so that I can’t see him?” says Yahweh. 
-</p><p class="q2">“Don’t I fill heaven and earth?” says Yahweh. 
-</p><p>
-<span class="v">25&#160;</span>“I have heard what the prophets have said, who prophesy lies in my name, saying, ‘I had a dream! I had a dream!’ 
-<span class="v">26&#160;</span>How long will this be in the heart of the prophets who prophesy lies, even the prophets of the deceit of their own heart? 
-<span class="v">27&#160;</span>They intend to cause my people to forget my name by their dreams which they each tell his neighbor, as their fathers forgot my name because of Baal. 
-<span class="v">28&#160;</span>The prophet who has a dream, let him tell a dream; and he who has my word, let him speak my word faithfully. What is the straw to the wheat?” says Yahweh. 
-<span class="v">29&#160;</span>“Isn’t my word like fire?” says Yahweh; “and like a hammer that breaks the rock in pieces? 
-</p><p>
-<span class="v">30&#160;</span>“Therefore behold, I am against the prophets,” says Yahweh, “who each steal my words from his neighbor. 
-<span class="v">31&#160;</span>Behold, I am against the prophets,” says Yahweh, “who use their tongues, and say, ‘He says.’ 
-<span class="v">32&#160;</span>Behold, I am against those who prophesy lying dreams,” says Yahweh, “who tell them, and cause my people to err by their lies, and by their vain boasting; yet I didn’t send them or command them. They don’t profit this people at all,” says Yahweh. 
-</p><p>
-<span class="v">33&#160;</span>“When this people, or the prophet, or a priest, asks you, saying, ‘What is the message from Yahweh?’ Then you shall tell them, ‘&#160;“What message? I will cast you off,” says Yahweh.’ 
-<span class="v">34&#160;</span>As for the prophet, the priest, and the people, who say, ‘The message from Yahweh,’ I will even punish that man and his household. 
-<span class="v">35&#160;</span>You will say everyone to his neighbor, and everyone to his brother, ‘What has Yahweh answered?’ and, ‘What has Yahweh said?’ 
-<span class="v">36&#160;</span>You will mention the message from Yahweh no more, for every man’s own word has become his message; for you have perverted the words of the living Elohim, of Yahweh of Armies, our Elohim. 
-<span class="v">37&#160;</span>You will say to the prophet, ‘What has Yahweh answered you?’ and, ‘What has Yahweh spoken?’ 
-<span class="v">38&#160;</span>Although you say, ‘The message from Yahweh,’ therefore Yahweh says: ‘Because you say this word, “The message from Yahweh,” and I have sent to you, telling you not to say, “The message from Yahweh,” 
-<span class="v">39&#160;</span>therefore behold, I will utterly forget you, and I will cast you off with the city that I gave to you and to your fathers, away from my presence. 
-<span class="v">40&#160;</span>I will bring an everlasting reproach on you, and a perpetual shame, which will not be forgotten.’&#160;” 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh showed me, and behold, two baskets of figs were set before Yahweh’s temple, after Nebuchadnezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim, king of Judah, and the princes of Judah, with the craftsmen and smiths, from Jerusalem, and had brought them to Babylon. 
-<span class="v">2&#160;</span>One basket had very good figs, like the figs that are first-ripe; and the other basket had very bad figs, which could not be eaten, they were so bad. 
-</p><p>
-<span class="v">3&#160;</span>Then Yahweh asked me, “What do you see, Jeremiah?” 
-</p><p>I said, “Figs. The good figs are very good, and the bad are very bad, so bad that they can’t be eaten.” 
-</p><p>
-<span class="v">4&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">5&#160;</span>“Yahweh, the Elohim of Israel says: ‘Like these good figs, so I will regard the captives of Judah, whom I have sent out of this place into the land of the Chaldeans, as good. 
-<span class="v">6&#160;</span>For I will set my eyes on them for good, and I will bring them again to this land. I will build them, and not pull them down. I will plant them, and not pluck them up. 
-<span class="v">7&#160;</span>I will give them a heart to know me, that I am Yahweh. They will be my people, and I will be their Elohim; for they will return to me with their whole heart. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘As the bad figs, which can’t be eaten, they are so bad,’ surely Yahweh says, ‘So I will give up Zedekiah the king of Judah, and his princes, and the remnant of Jerusalem who remain in this land, and those who dwell in the land of Egypt. 
-<span class="v">9&#160;</span>I will even give them up to be tossed back and forth among all the kingdoms of the earth for evil, to be a reproach and a proverb, a taunt and a curse, in all places where I will drive them. 
-<span class="v">10&#160;</span>I will send the sword, the famine, and the pestilence among them, until they are consumed from off the land that I gave to them and to their fathers.’&#160;” 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>The word that came to Jeremiah concerning all the people of Judah, in the fourth year of Jehoiakim the son of Josiah, king of Judah (this was the first year of Nebuchadnezzar king of Babylon), 
-<span class="v">2&#160;</span>which Jeremiah the prophet spoke to all the people of Judah, and to all the inhabitants of Jerusalem: 
-<span class="v">3&#160;</span>From the thirteenth year of Josiah the son of Amon, king of Judah, even to this day, these twenty-three years, Yahweh’s word has come to me, and I have spoken to you, rising up early and speaking; but you have not listened. 
-</p><p>
-<span class="v">4&#160;</span>Yahweh has sent to you all his servants the prophets, rising up early and sending them (but you have not listened or inclined your ear to hear), 
-<span class="v">5&#160;</span>saying, “Return now everyone from his evil way, and from the evil of your doings, and dwell in the land that Yahweh has given to you and to your fathers, from of old and even forever more. 
-<span class="v">6&#160;</span>Don’t go after other elohims to serve them or worship them, and don’t provoke me to anger with the work of your hands; then I will do you no harm.” 
-</p><p>
-<span class="v">7&#160;</span>“Yet you have not listened to me,” says Yahweh, “that you may provoke me to anger with the work of your hands to your own hurt.” 
-</p><p>
-<span class="v">8&#160;</span>Therefore Yahweh of Armies says: “Because you have not heard my words, 
-<span class="v">9&#160;</span>behold, I will send and take all the families of the north,” says Yahweh, “and I will send to Nebuchadnezzar the king of Babylon, my servant, and will bring them against this land, and against its inhabitants, and against all these nations around. I will utterly destroy them, and make them an astonishment, and a hissing, and perpetual desolations. 
-<span class="v">10&#160;</span>Moreover I will take from them the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride, the sound of the millstones, and the light of the lamp. 
-<span class="v">11&#160;</span>This whole land will be a desolation, and an astonishment; and these nations will serve the king of Babylon seventy years. 
-</p><p>
-<span class="v">12&#160;</span>“It will happen, when seventy years are accomplished, that I will punish the king of Babylon and that nation,” says Yahweh, “for their iniquity. I will make the land of the Chaldeans desolate forever. 
-<span class="v">13&#160;</span>I will bring on that land all my words which I have pronounced against it, even all that is written in this book, which Jeremiah has prophesied against all the nations. 
-<span class="v">14&#160;</span>For many nations and great kings will make bondservants of them, even of them. I will recompense them according to their deeds, and according to the work of their hands.” 
-</p><p>
-<span class="v">15&#160;</span>For Yahweh, the Elohim of Israel, says to me: “Take this cup of the wine of wrath from my hand, and cause all the nations to whom I send you to drink it. 
-<span class="v">16&#160;</span>They will drink, and reel back and forth, and be insane, because of the sword that I will send among them.” 
-</p><p>
-<span class="v">17&#160;</span>Then I took the cup at Yahweh’s hand, and made all the nations to drink, to whom Yahweh had sent me: 
-<span class="v">18&#160;</span>Jerusalem, and the cities of Judah, with its kings and its princes, to make them a desolation, an astonishment, a hissing, and a curse, as it is today; 
-<span class="v">19&#160;</span>Pharaoh king of Egypt, with his servants, his princes, and all his people; 
-<span class="v">20&#160;</span>and all the mixed people, and all the kings of the land of Uz, all the kings of the Philistines, Ashkelon, Gaza, Ekron, and the remnant of Ashdod; 
-<span class="v">21&#160;</span>Edom, Moab, and the children of Ammon; 
-<span class="v">22&#160;</span>and all the kings of Tyre, all the kings of Sidon, and the kings of the isle which is beyond the sea; 
-<span class="v">23&#160;</span>Dedan, Tema, Buz, and all who have the corners of their beard cut off; 
-<span class="v">24&#160;</span>and all the kings of Arabia, all the kings of the mixed people who dwell in the wilderness; 
-<span class="v">25&#160;</span>and all the kings of Zimri, all the kings of Elam, and all the kings of the Medes; 
-<span class="v">26&#160;</span>and all the kings of the north, far and near, one with another; and all the kingdoms of the world, which are on the surface of the earth. The king of Sheshach will drink after them. 
-</p><p>
-<span class="v">27&#160;</span>“You shall tell them, ‘Yahweh of Armies, the Elohim of Israel says: “Drink, and be drunk, vomit, fall, and rise no more, because of the sword which I will send among you.”&#160;’ 
-<span class="v">28&#160;</span>It shall be, if they refuse to take the cup at your hand to drink, then you shall tell them, ‘Yahweh of Armies says: “You shall surely drink. 
-<span class="v">29&#160;</span>For, behold, I begin to work evil at the city which is called by my name; and should you be utterly unpunished? You will not be unpunished; for I will call for a sword on all the inhabitants of the earth, says Yahweh of Armies.”&#160;’ 
-</p><p>
-<span class="v">30&#160;</span>“Therefore prophesy against them all these words, and tell them, 
-</p><p class="q1">“&#160;‘Yahweh will roar from on high, 
-</p><p class="q2">and utter his voice from his set-apart habitation. 
-</p><p class="q2">He will mightily roar against his fold. 
-</p><p class="q1">He will give a shout, as those who tread grapes, 
-</p><p class="q2">against all the inhabitants of the earth. 
-</p><p class="q1">
-<span class="v">31&#160;</span>A noise will come even to the end of the earth; 
-</p><p class="q2">for Yahweh has a controversy with the nations. 
-</p><p class="q1">He will enter into judgment with all flesh. 
-</p><p class="q2">As for the wicked, he will give them to the sword,”&#160;’ says Yahweh.” 
-</p><p>
-<span class="v">32&#160;</span>Yahweh of Armies says, 
-</p><p class="q1">“Behold, evil will go out from nation to nation, 
-</p><p class="q2">and a great storm will be raised up from the uttermost parts of the earth.” 
-</p><p class="m">
-<span class="v">33&#160;</span>The slain of Yahweh will be at that day from one end of the earth even to the other end of the earth. They won’t be lamented. They won’t be gathered or buried. They will be dung on the surface of the ground. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Wail, you shepherds, and cry. 
-</p><p class="q2">Wallow in dust, you leader of the flock; 
-</p><p class="q1">for the days of your slaughter and of your dispersions have fully come, 
-</p><p class="q2">and you will fall like fine pottery. 
-</p><p class="q1">
-<span class="v">35&#160;</span>The shepherds will have no way to flee. 
-</p><p class="q2">The leader of the flock will have no escape. 
-</p><p class="q1">
-<span class="v">36&#160;</span>A voice of the cry of the shepherds, 
-</p><p class="q2">and the wailing of the leader of the flock, 
-</p><p class="q2">for Yahweh destroys their pasture. 
-</p><p class="q1">
-<span class="v">37&#160;</span>The peaceful folds are brought to silence 
-</p><p class="q2">because of the fierce anger of Yahweh. 
-</p><p class="q1">
-<span class="v">38&#160;</span>He has left his covert, as the lion; 
-</p><p class="q2">for their land has become an astonishment because of the fierceness of the oppression, 
-</p><p class="q2">and because of his fierce anger. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came from Yahweh: 
-<span class="v">2&#160;</span>“Yahweh says: ‘Stand in the court of Yahweh’s house, and speak to all the cities of Judah which come to worship in Yahweh’s house, all the words that I command you to speak to them. Don’t omit a word. 
-<span class="v">3&#160;</span>It may be they will listen, and every man turn from his evil way, that I may relent from the evil which I intend to do to them because of the evil of their doings.’&#160;” 
-<span class="v">4&#160;</span>You shall tell them, “Yahweh says: ‘If you will not listen to me, to walk in my law which I have set before you, 
-<span class="v">5&#160;</span>to listen to the words of my servants the prophets whom I send to you, even rising up early and sending them—but you have not listened—<span class="v">6&#160;</span>then I will make this house like Shiloh, and will make this city a curse to all the nations of the earth.’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>The priests and the prophets and all the people heard Jeremiah speaking these words in Yahweh’s house. 
-<span class="v">8&#160;</span>When Jeremiah had finished speaking all that Yahweh had commanded him to speak to all the people, the priests and the prophets and all the people seized him, saying, “You shall surely die! 
-<span class="v">9&#160;</span>Why have you prophesied in Yahweh’s name, saying, ‘This house will be like Shiloh, and this city will be desolate, without inhabitant’?” All the people were crowded around Jeremiah in Yahweh’s house. 
-</p><p>
-<span class="v">10&#160;</span>When the princes of Judah heard these things, they came up from the king’s house to Yahweh’s house; and they sat in the entry of the new gate of Yahweh’s house. 
-<span class="v">11&#160;</span>Then the priests and the prophets spoke to the princes and to all the people, saying, “This man is worthy of death, for he has prophesied against this city, as you have heard with your ears.” 
-</p><p>
-<span class="v">12&#160;</span>Then Jeremiah spoke to all the princes and to all the people, saying, “Yahweh sent me to prophesy against this house and against this city all the words that you have heard. 
-<span class="v">13&#160;</span>Now therefore amend your ways and your doings, and obey Yahweh your Elohim’s voice; then Yahweh will relent from the evil that he has pronounced against you. 
-<span class="v">14&#160;</span>But as for me, behold, I am in your hand. Do with me what is good and right in your eyes. 
-<span class="v">15&#160;</span>Only know for certain that if you put me to death, you will bring innocent blood on yourselves, on this city, and on its inhabitants; for in truth Yahweh has sent me to you to speak all these words in your ears.” 
-</p><p>
-<span class="v">16&#160;</span>Then the princes and all the people said to the priests and to the prophets: “This man is not worthy of death; for he has spoken to us in the name of Yahweh our Elohim.” 
-</p><p>
-<span class="v">17&#160;</span>Then certain of the elders of the land rose up, and spoke to all the assembly of the people, saying, 
-<span class="v">18&#160;</span>“Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying, ‘Yahweh of Armies says: 
-</p><p class="q1">“&#160;‘Zion will be plowed as a field, 
-</p><p class="q2">and Jerusalem will become heaps, 
-</p><p class="q2">and the mountain of the house as the high places of a forest.’ 
-</p><p class="m">
-<span class="v">19&#160;</span>Did Hezekiah king of Judah and all Judah put him to death? Didn’t he fear Yahweh, and entreat the favor of Yahweh, and Yahweh relented of the disaster which he had pronounced against them? We would commit great evil against our own souls that way!” 
-</p><p>
-<span class="v">20&#160;</span>There was also a man who prophesied in Yahweh’s name, Uriah the son of Shemaiah of Kiriath Jearim; and he prophesied against this city and against this land according to all the words of Jeremiah. 
-<span class="v">21&#160;</span>When Jehoiakim the king, with all his mighty men and all the princes heard his words, the king sought to put him to death; but when Uriah heard it, he was afraid, and fled, and went into Egypt. 
-<span class="v">22&#160;</span>Then Jehoiakim the king sent Elnathan the son of Achbor and certain men with him into Egypt. 
-<span class="v">23&#160;</span>They fetched Uriah out of Egypt and brought him to Jehoiakim the king, who killed him with the sword and cast his dead body into the graves of the common people. 
-</p><p>
-<span class="v">24&#160;</span>But the hand of Ahikam the son of Shaphan was with Jeremiah, so that they didn’t give him into the hand of the people to put him to death. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
-<span class="v">2&#160;</span>Yahweh says to me: “Make bonds and bars, and put them on your neck. 
-<span class="v">3&#160;</span>Then send them to the king of Edom, to the king of Moab, to the king of the children of Ammon, to the king of Tyre, and to the king of Sidon, by the hand of the messengers who come to Jerusalem to Zedekiah king of Judah. 
-<span class="v">4&#160;</span>Give them a command to their masters, saying, ‘Yahweh of Armies, the Elohim of Israel says, “You shall tell your masters: 
-<span class="v">5&#160;</span>‘I have made the earth, the men, and the animals that are on the surface of the earth by my great power and by my outstretched arm. I give it to whom it seems right to me. 
-<span class="v">6&#160;</span>Now I have given all these lands into the hand of Nebuchadnezzar the king of Babylon, my servant. I have also given the animals of the field to him to serve him. 
-<span class="v">7&#160;</span>All the nations will serve him, his son, and his son’s son, until the time of his own land comes. Then many nations and great kings will make him their bondservant. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘&#160;“&#160;‘It will happen that I will punish the nation and the kingdom which will not serve the same Nebuchadnezzar king of Babylon, and that will not put their neck under the yoke of the king of Babylon,’ says Yahweh, ‘with the sword, with famine, and with pestilence, until I have consumed them by his hand. 
-<span class="v">9&#160;</span>But as for you, don’t listen to your prophets, to your diviners, to your dreams, to your soothsayers, or to your sorcerers, who speak to you, saying, “You shall not serve the king of Babylon;” 
-<span class="v">10&#160;</span>for they prophesy a lie to you, to remove you far from your land, so that I would drive you out, and you would perish. 
-<span class="v">11&#160;</span>But the nation that brings their neck under the yoke of the king of Babylon and serves him, that nation I will let remain in their own land,’ says Yahweh; ‘and they will till it and dwell in it.’&#160;”&#160;’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>I spoke to Zedekiah king of Judah according to all these words, saying, “Bring your necks under the yoke of the king of Babylon, and serve him and his people, and live. 
-<span class="v">13&#160;</span>Why will you die, you and your people, by the sword, by the famine, and by the pestilence, as Yahweh has spoken concerning the nation that will not serve the king of Babylon? 
-<span class="v">14&#160;</span>Don’t listen to the words of the prophets who speak to you, saying, ‘You shall not serve the king of Babylon;’ for they prophesy a lie to you. 
-<span class="v">15&#160;</span>For I have not sent them,” says Yahweh, “but they prophesy falsely in my name; that I may drive you out, and that you may perish, you, and the prophets who prophesy to you.” 
-</p><p>
-<span class="v">16&#160;</span>Also I spoke to the priests and to all this people, saying, Yahweh says, “Don’t listen to the words of your prophets who prophesy to you, saying, ‘Behold, the vessels of Yahweh’s house will now shortly be brought again from Babylon;’ for they prophesy a lie to you. 
-<span class="v">17&#160;</span>Don’t listen to them. Serve the king of Babylon, and live. Why should this city become a desolation? 
-<span class="v">18&#160;</span>But if they are prophets, and if Yahweh’s word is with them, let them now make intercession to Yahweh of Armies, that the vessels which are left in Yahweh’s house, in the house of the king of Judah, and at Jerusalem, don’t go to Babylon. 
-<span class="v">19&#160;</span>For Yahweh of Armies says concerning the pillars, concerning the sea, concerning the bases, and concerning the rest of the vessels that are left in this city, 
-<span class="v">20&#160;</span>which Nebuchadnezzar king of Babylon didn’t take when he carried away captive Jeconiah the son of Jehoiakim, king of Judah, from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem—<span class="v">21&#160;</span>yes, Yahweh of Armies, the Elohim of Israel, says concerning the vessels that are left in Yahweh’s house, and in the house of the king of Judah, and at Jerusalem: 
-<span class="v">22&#160;</span>‘They will be carried to Babylon, and there they will be, until the day that I visit them,’ says Yahweh; ‘then I will bring them up, and restore them to this place.’&#160;” 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>That same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, in the fifth month, Hananiah the son of Azzur, the prophet, who was of Gibeon, spoke to me in Yahweh’s house, in the presence of the priests and of all the people, saying, 
-<span class="v">2&#160;</span>“Yahweh of Armies, the Elohim of Israel, says, ‘I have broken the yoke of the king of Babylon. 
-<span class="v">3&#160;</span>Within two full years I will bring again into this place all the vessels of Yahweh’s house that Nebuchadnezzar king of Babylon took away from this place and carried to Babylon. 
-<span class="v">4&#160;</span>I will bring again to this place Jeconiah the son of Jehoiakim, king of Judah, with all the captives of Judah, who went to Babylon,’ says Yahweh; ‘for I will break the yoke of the king of Babylon.’&#160;” 
-</p><p>
-<span class="v">5&#160;</span>Then the prophet Jeremiah said to the prophet Hananiah in the presence of the priests, and in the presence of all the people who stood in Yahweh’s house, 
-<span class="v">6&#160;</span>even the prophet Jeremiah said, “Amen! May Yahweh do so. May Yahweh perform your words which you have prophesied, to bring again the vessels of Yahweh’s house, and all those who are captives, from Babylon to this place. 
-<span class="v">7&#160;</span>Nevertheless listen now to this word that I speak in your ears, and in the ears of all the people: 
-<span class="v">8&#160;</span>The prophets who have been before me and before you of old prophesied against many countries, and against great kingdoms, of war, of evil, and of pestilence. 
-<span class="v">9&#160;</span>As for the prophet who prophesies of peace, when the word of the prophet happens, then the prophet will be known, that Yahweh has truly sent him.” 
-</p><p>
-<span class="v">10&#160;</span>Then Hananiah the prophet took the bar from off the prophet Jeremiah’s neck, and broke it. 
-<span class="v">11&#160;</span>Hananiah spoke in the presence of all the people, saying, “Yahweh says: ‘Even so I will break the yoke of Nebuchadnezzar king of Babylon from off the neck of all the nations within two full years.’&#160;” Then the prophet Jeremiah went his way. 
-</p><p>
-<span class="v">12&#160;</span>Then Yahweh’s word came to Jeremiah, after Hananiah the prophet had broken the bar from off the neck of the prophet Jeremiah, saying, 
-<span class="v">13&#160;</span>“Go, and tell Hananiah, saying, ‘Yahweh says, “You have broken the bars of wood, but you have made in their place bars of iron.” 
-<span class="v">14&#160;</span>For Yahweh of Armies, the Elohim of Israel says, “I have put a yoke of iron on the neck of all these nations, that they may serve Nebuchadnezzar king of Babylon; and they will serve him. I have also given him the animals of the field.”&#160;’&#160;” 
-</p><p>
-<span class="v">15&#160;</span>Then the prophet Jeremiah said to Hananiah the prophet, “Listen, Hananiah! Yahweh has not sent you, but you make this people trust in a lie. 
-<span class="v">16&#160;</span>Therefore Yahweh says, ‘Behold, I will send you away from off the surface of the earth. This year you will die, because you have spoken rebellion against Yahweh.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>So Hananiah the prophet died the same year in the seventh month. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the words of the letter that Jeremiah the prophet sent from Jerusalem to the residue of the elders of the captivity, and to the priests, to the prophets, and to all the people whom Nebuchadnezzar had carried away captive from Jerusalem to Babylon, 
-<span class="v">2&#160;</span>(after Jeconiah the king, the queen mother, the eunuchs, the princes of Judah and Jerusalem, the craftsmen, and the smiths had departed from Jerusalem), 
-<span class="v">3&#160;</span>by the hand of Elasah the son of Shaphan and Gemariah the son of Hilkiah, (whom Zedekiah king of Judah sent to Babylon to Nebuchadnezzar king of Babylon). It said: 
-</p><p class="pi1">
-<span class="v">4&#160;</span>Yahweh of Armies, the Elohim of Israel, says to all the captives whom I have caused to be carried away captive from Jerusalem to Babylon: 
-<span class="v">5&#160;</span>“Build houses and dwell in them. Plant gardens and eat their fruit. 
-<span class="v">6&#160;</span>Take women and father sons and daughters. Take women for your sons, and give your daughters to men, that they may bear sons and daughters. Multiply there, and don’t be diminished. 
-<span class="v">7&#160;</span>Seek the peace of the city where I have caused you to be carried away captive, and pray to Yahweh for it; for in its peace you will have peace.” 
-<span class="v">8&#160;</span>For Yahweh of Armies, the Elohim of Israel says: “Don’t let your prophets who are among you and your diviners deceive you. Don’t listen to your dreams which you cause to be dreamed. 
-<span class="v">9&#160;</span>For they prophesy falsely to you in my name. I have not sent them,” says Yahweh. 
-<span class="v">10&#160;</span>For Yahweh says, “After seventy years are accomplished for Babylon, I will visit you and perform my good word toward you, in causing you to return to this place. 
-<span class="v">11&#160;</span>For I know the thoughts that I think toward you,” says Yahweh, “thoughts of peace, and not of evil, to give you hope and a future. 
-<span class="v">12&#160;</span>You shall call on me, and you shall go and pray to me, and I will listen to you. 
-<span class="v">13&#160;</span>You shall seek me and find me, when you search for me with all your heart. 
-<span class="v">14&#160;</span>I will be found by you,” says Yahweh, “and I will turn again your captivity, and I will gather you from all the nations, and from all the places where I have driven you, says Yahweh. I will bring you again to the place from where I caused you to be carried away captive.” 
-</p><p class="pi1">
-<span class="v">15&#160;</span>Because you have said, “Yahweh has raised us up prophets in Babylon,” 
-<span class="v">16&#160;</span>Yahweh says concerning the king who sits on David’s throne, and concerning all the people who dwell in this city, your brothers who haven’t gone with you into captivity, 
-<span class="v">17&#160;</span>Yahweh of Armies says: “Behold, I will send on them the sword, the famine, and the pestilence, and will make them like rotten figs that can’t be eaten, they are so bad. 
-<span class="v">18&#160;</span>I will pursue after them with the sword, with the famine, and with the pestilence, and will deliver them to be tossed back and forth among all the kingdoms of the earth, to be an object of horror, an astonishment, a hissing, and a reproach among all the nations where I have driven them, 
-<span class="v">19&#160;</span>because they have not listened to my words,” says Yahweh, “with which I sent to them my servants the prophets, rising up early and sending them; but you would not hear,” says Yahweh. 
-</p><p class="pi1">
-<span class="v">20&#160;</span>Hear therefore Yahweh’s word, all you captives whom I have sent away from Jerusalem to Babylon. 
-<span class="v">21&#160;</span>Yahweh of Armies, the Elohim of Israel, says concerning Ahab the son of Kolaiah, and concerning Zedekiah the son of Maaseiah, who prophesy a lie to you in my name: “Behold, I will deliver them into the hand of Nebuchadnezzar king of Babylon; and he will kill them before your eyes. 
-<span class="v">22&#160;</span>A curse will be taken up about them by all the captives of Judah who are in Babylon, saying, ‘Yahweh make you like Zedekiah and like Ahab, whom the king of Babylon roasted in the fire;’ 
-<span class="v">23&#160;</span>because they have done foolish things in Israel, and have committed adultery with their neighbors’ women, and have spoken words in my name falsely, which I didn’t command them. I am he who knows, and am witness,” says Yahweh. 
-</p><p>
-<span class="v">24&#160;</span>Concerning Shemaiah the Nehelamite you shall speak, saying, 
-<span class="v">25&#160;</span>“Yahweh of Armies, the Elohim of Israel, says, ‘Because you have sent letters in your own name to all the people who are at Jerusalem, and to Zephaniah the son of Maaseiah, the priest, and to all the priests, saying, 
-<span class="v">26&#160;</span>“Yahweh has made you priest in the place of Jehoiada the priest, that there may be officers in Yahweh’s house, for every man who is crazy and makes himself a prophet, that you should put him in the stocks and in shackles. 
-<span class="v">27&#160;</span>Now therefore, why have you not rebuked Jeremiah of Anathoth, who makes himself a prophet to you, 
-<span class="v">28&#160;</span>because he has sent to us in Babylon, saying, The captivity is long. Build houses, and dwell in them. Plant gardens, and eat their fruit?”&#160;’&#160;” 
-</p><p>
-<span class="v">29&#160;</span>Zephaniah the priest read this letter in the hearing of Jeremiah the prophet. 
-<span class="v">30&#160;</span>Then Yahweh’s word came to Jeremiah, saying, 
-<span class="v">31&#160;</span>“Send to all of the captives, saying, ‘Yahweh says concerning Shemaiah the Nehelamite: “Because Shemaiah has prophesied to you, and I didn’t send him, and he has caused you to trust in a lie,” 
-<span class="v">32&#160;</span>therefore Yahweh says, “Behold, I will punish Shemaiah the Nehelamite and his offspring. He will not have a man to dwell among this people. He won’t see the good that I will do to my people,” says Yahweh, “because he has spoken rebellion against Yahweh.”&#160;’&#160;” 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>The word that came to Jeremiah from Yahweh, saying, 
-<span class="v">2&#160;</span>“Yahweh, the Elohim of Israel, says, ‘Write all the words that I have spoken to you in a book. 
-<span class="v">3&#160;</span>For, behold, the days come,’ says Yahweh, ‘that I will reverse the captivity of my people Israel and Judah,’ says Yahweh. ‘I will cause them to return to the land that I gave to their fathers, and they will possess it.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>These are the words that Yahweh spoke concerning Israel and concerning Judah. 
-<span class="v">5&#160;</span>For Yahweh says: 
-</p><p class="q1">“We have heard a voice of trembling; 
-</p><p class="q2">a voice of fear, and not of peace. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Ask now, and see whether a man travails with child. 
-</p><p class="q2">Why do I see every man with his hands on his waist, as a woman in travail, 
-</p><p class="q2">and all faces are turned pale? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Alas, for that day is great, so that none is like it! 
-</p><p class="q2">It is even the time of Jacob’s trouble; 
-</p><p class="q2">but he will be saved out of it. 
-</p><p class="q1">
-<span class="v">8&#160;</span>It will come to pass in that day, says Yahweh of Armies, that I will break his yoke from off your neck, 
-</p><p class="q2">and will burst your bonds. 
-</p><p class="q2">Strangers will no more make them their bondservants; 
-</p><p class="q1">
-<span class="v">9&#160;</span>but they will serve Yahweh their Elohim, 
-</p><p class="q2">and David their king, 
-</p><p class="q2">whom I will raise up to them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Therefore don’t be afraid, O Jacob my servant, says Yahweh. 
-</p><p class="q2">Don’t be dismayed, Israel. 
-</p><p class="q1">For, behold, I will save you from afar, 
-</p><p class="q2">and save your offspring from the land of their captivity. 
-</p><p class="q1">Jacob will return, 
-</p><p class="q2">and will be quiet and at ease. 
-</p><p class="q2">No one will make him afraid. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For I am with you, says Yahweh, to save you; 
-</p><p class="q2">for I will make a full end of all the nations where I have scattered you, 
-</p><p class="q2">but I will not make a full end of you; 
-</p><p class="q1">but I will correct you in measure, 
-</p><p class="q2">and will in no way leave you unpunished.” 
-</p><p>
-<span class="v">12&#160;</span>For Yahweh says, 
-</p><p class="q1">“Your hurt is incurable. 
-</p><p class="q2">Your wound is grievous. 
-</p><p class="q1">
-<span class="v">13&#160;</span>There is no one to plead your cause, 
-</p><p class="q2">that you may be bound up. 
-</p><p class="q2">You have no healing medicines. 
-</p><p class="q1">
-<span class="v">14&#160;</span>All your lovers have forgotten you. 
-</p><p class="q2">They don’t seek you. 
-</p><p class="q1">For I have wounded you with the wound of an enemy, 
-</p><p class="q2">with the chastisement of a cruel one, 
-</p><p class="q1">for the greatness of your iniquity, 
-</p><p class="q2">because your sins were increased. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Why do you cry over your injury? 
-</p><p class="q2">Your pain is incurable. 
-</p><p class="q1">For the greatness of your iniquity, 
-</p><p class="q2">because your sins have increased, 
-</p><p class="q2">I have done these things to you. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Therefore all those who devour you will be devoured. 
-</p><p class="q2">All your adversaries, everyone of them, will go into captivity. 
-</p><p class="q1">Those who plunder you will be plunder. 
-</p><p class="q2">I will make all who prey on you become prey. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For I will restore health to you, 
-</p><p class="q2">and I will heal you of your wounds,” says Yahweh, 
-</p><p class="q1">“because they have called you an outcast, 
-</p><p class="q2">saying, ‘It is Zion, whom no man seeks after.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Yahweh says: 
-</p><p class="q1">“Behold, I will reverse the captivity of Jacob’s tents, 
-</p><p class="q2">and have compassion on his dwelling places. 
-</p><p class="q1">The city will be built on its own hill, 
-</p><p class="q2">and the palace will be inhabited in its own place. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Thanksgiving will proceed out of them 
-</p><p class="q2">with the voice of those who make merry. 
-</p><p class="q1">I will multiply them, 
-</p><p class="q2">and they will not be few; 
-</p><p class="q1">I will also glorify them, 
-</p><p class="q2">and they will not be small. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Their children also will be as before, 
-</p><p class="q2">and their congregation will be established before me. 
-</p><p class="q2">I will punish all who oppress them. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Their prince will be one of them, 
-</p><p class="q2">and their ruler will proceed from among them. 
-</p><p class="q1">I will cause him to draw near, 
-</p><p class="q2">and he will approach me; 
-</p><p class="q2">for who is he who has had boldness to approach me?” says Yahweh. 
-</p><p class="q1">
-<span class="v">22&#160;</span>“You shall be my people, 
-</p><p class="q2">and I will be your Elohim. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Behold, Yahweh’s storm, his wrath, has gone out, 
-</p><p class="q2">a sweeping storm; 
-</p><p class="q2">it will burst on the head of the wicked. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The fierce anger of Yahweh will not return until he has accomplished, 
-</p><p class="q2">and until he has performed the intentions of his heart. 
-</p><p class="q2">In the latter days you will understand it.” 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>“At that time,” says Yahweh, “I will be the Elohim of all the families of Israel, and they will be my people.” 
-</p><p>
-<span class="v">2&#160;</span>Yahweh says, “The people who survive the sword found favor in the wilderness; even Israel, when I went to cause him to rest.” 
-</p><p>
-<span class="v">3&#160;</span>Yahweh appeared of old to me, saying, 
-</p><p class="q1">“Yes, I have loved you with an everlasting love. 
-</p><p class="q2">Therefore I have drawn you with loving kindness. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will build you again, 
-</p><p class="q2">and you will be built, O virgin of Israel. 
-</p><p class="q1">You will again be adorned with your tambourines, 
-</p><p class="q2">and will go out in the dances of those who make merry. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Again you will plant vineyards on the mountains of Samaria. 
-</p><p class="q2">The planters will plant, 
-</p><p class="q2">and will enjoy its fruit. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For there will be a day that the watchmen on the hills of Ephraim cry, 
-</p><p class="q2">‘Arise! Let’s go up to Zion to Yahweh our Elohim.’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>For Yahweh says, 
-</p><p class="q1">“Sing with gladness for Jacob, 
-</p><p class="q2">and shout for the chief of the nations. 
-</p><p class="q1">Publish, praise, and say, 
-</p><p class="q2">‘Yahweh, save your people, 
-</p><p class="q2">the remnant of Israel!’ 
-</p><p class="q1">
-<span class="v">8&#160;</span>Behold, I will bring them from the north country, 
-</p><p class="q2">and gather them from the uttermost parts of the earth, 
-</p><p class="q1">along with the blind and the lame, 
-</p><p class="q2">the woman with child and her who travails with child together. 
-</p><p class="q2">They will return as a great company. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They will come with weeping. 
-</p><p class="q2">I will lead them with petitions. 
-</p><p class="q1">I will cause them to walk by rivers of waters, 
-</p><p class="q2">in a straight way in which they won’t stumble; 
-</p><p class="q1">for I am a father to Israel. 
-</p><p class="q2">Ephraim is my firstborn. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Hear Yahweh’s word, you nations, 
-</p><p class="q2">and declare it in the distant islands. Say, 
-</p><p class="q1">‘He who scattered Israel will gather him, 
-</p><p class="q2">and keep him, as a shepherd does his flock.’ 
-</p><p class="q1">
-<span class="v">11&#160;</span>For Yahweh has ransomed Jacob, 
-</p><p class="q2">and redeemed him from the hand of him who was stronger than he. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They will come and sing in the height of Zion, 
-</p><p class="q2">and will flow to the goodness of Yahweh, 
-</p><p class="q1">to the grain, to the new wine, to the oil, 
-</p><p class="q2">and to the young of the flock and of the herd. 
-</p><p class="q1">Their soul will be as a watered garden. 
-</p><p class="q2">They will not sorrow any more at all. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Then the virgin will rejoice in the dance, 
-</p><p class="q2">the young men and the old together; 
-</p><p class="q1">for I will turn their mourning into joy, 
-</p><p class="q2">and will comfort them, and make them rejoice from their sorrow. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will satiate the soul of the priests with fatness, 
-</p><p class="q2">and my people will be satisfied with my goodness,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">15&#160;</span>Yahweh says: 
-</p><p class="q1">“A voice is heard in Ramah, 
-</p><p class="q2">lamentation and bitter weeping, 
-</p><p class="q1">Rachel weeping for her children. 
-</p><p class="q2">She refuses to be comforted for her children, 
-</p><p class="q2">because they are no more.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh says: 
-</p><p class="q1">“Refrain your voice from weeping, 
-</p><p class="q2">and your eyes from tears, 
-</p><p class="q2">for your work will be rewarded,” says Yahweh. 
-</p><p class="q2">“They will come again from the land of the enemy. 
-</p><p class="q1">
-<span class="v">17&#160;</span>There is hope for your latter end,” says Yahweh. 
-</p><p class="q2">“Your children will come again to their own territory. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“I have surely heard Ephraim grieving thus, 
-</p><p class="q2">‘You have chastised me, 
-</p><p class="q2">and I was chastised, as an untrained calf. 
-</p><p class="q1">Turn me, and I will be turned, 
-</p><p class="q2">for you are Yahweh my Elohim. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Surely after that I was turned. 
-</p><p class="q2">I repented. 
-</p><p class="q1">After that I was instructed. 
-</p><p class="q2">I struck my thigh. 
-</p><p class="q1">I was ashamed, yes, even confounded, 
-</p><p class="q2">because I bore the reproach of my youth.’ 
-</p><p class="q1">
-<span class="v">20&#160;</span>Is Ephraim my dear son? 
-</p><p class="q2">Is he a darling child? 
-</p><p class="q1">For as often as I speak against him, 
-</p><p class="q2">I still earnestly remember him. 
-</p><p class="q1">Therefore my heart yearns for him. 
-</p><p class="q2">I will surely have mercy on him,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Set up road signs. 
-</p><p class="q2">Make guideposts. 
-</p><p class="q1">Set your heart toward the highway, 
-</p><p class="q2">even the way by which you went. 
-</p><p class="q1">Turn again, virgin of Israel. 
-</p><p class="q2">Turn again to these your cities. 
-</p><p class="q1">
-<span class="v">22&#160;</span>How long will you go here and there, 
-</p><p class="q2">you backsliding daughter? 
-</p><p class="q1">For Yahweh has created a new thing in the earth: 
-</p><p class="q2">a woman will encompass a man.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">23&#160;</span>Yahweh of Armies, the Elohim of Israel, says: “Yet again they will use this speech in the land of Judah and in its cities, when I reverse their captivity: ‘Yahweh bless you, habitation of righteousness, mountain of set-apartness.’ 
-<span class="v">24&#160;</span>Judah and all its cities will dwell therein together, the farmers, and those who go about with flocks. 
-<span class="v">25&#160;</span>For I have satiated the weary soul, and I have replenished every sorrowful soul.” 
-</p><p>
-<span class="v">26&#160;</span>On this I awakened, and saw; and my sleep was sweet to me. 
-</p><p>
-<span class="v">27&#160;</span>“Behold, the days come,” says Yahweh, “that I will sow the house of Israel and the house of Judah with the seed of man and with the seed of animal. 
-<span class="v">28&#160;</span>It will happen that, like as I have watched over them to pluck up and to break down and to overthrow and to destroy and to afflict, so I will watch over them to build and to plant,” says Yahweh. 
-<span class="v">29&#160;</span>“In those days they will say no more, 
-</p><p class="q1">“&#160;‘The fathers have eaten sour grapes, 
-</p><p class="q2">and the children’s teeth are set on edge.’ 
-</p><p class="m">
-<span class="v">30&#160;</span>But everyone will die for his own iniquity. Every man who eats the sour grapes, his teeth will be set on edge. 
-</p><p>
-<span class="v">31&#160;</span>“Behold, the days come,” says Yahweh, “that I will make a new covenant with the house of Israel, and with the house of Judah, 
-<span class="v">32&#160;</span>not according to the covenant that I made with their fathers in the day that I took them by the hand to bring them out of the land of Egypt, which covenant of mine they broke, although I was an owner to them,” says Yahweh. 
-<span class="v">33&#160;</span>“But this is the covenant that I will make with the house of Israel after those days,” says Yahweh: 
-</p><p class="q1">“I will put my law in their inward parts, 
-</p><p class="q2">and I will write it in their heart. 
-</p><p class="q1">I will be their Elohim, 
-</p><p class="q2">and they shall be my people. 
-</p><p class="q1">
-<span class="v">34&#160;</span>They will no longer each teach his neighbor, 
-</p><p class="q2">and every man teach his brother, saying, ‘Know Yahweh;’ 
-</p><p class="q1">for they will all know me, 
-</p><p class="q2">from their least to their greatest,” says Yahweh, 
-</p><p class="q1">“for I will forgive their iniquity, 
-</p><p class="q2">and I will remember their sin no more.” 
-</p><p class="q1">
-<span class="v">35&#160;</span>Yahweh, who gives the sun for a light by day, 
-</p><p class="q2">and the ordinances of the moon and of the stars for a light by night, 
-</p><p class="q1">who stirs up the sea, so that its waves roar—</p><p class="q2">Yahweh of Armies is his name, says: 
-</p><p class="q1">
-<span class="v">36&#160;</span>“If these ordinances depart from before me,” says Yahweh, 
-</p><p class="q2">“then the offspring of Israel also will cease from being a nation before me forever.” 
-</p><p class="q1">
-<span class="v">37&#160;</span>Yahweh says: “If heaven above can be measured, 
-</p><p class="q2">and the foundations of the earth searched out beneath, 
-</p><p class="q2">then I will also cast off all the offspring of Israel for all that they have done,” says Yahweh. 
-</p><p>
-<span class="v">38&#160;</span>“Behold, the days come,” says Yahweh, “that the city will be built to Yahweh from the tower of Hananel to the gate of the corner. 
-<span class="v">39&#160;</span>The measuring line will go out further straight onward to the hill Gareb, and will turn toward Goah. 
-<span class="v">40&#160;</span>The whole valley of the dead bodies and of the ashes, and all the fields to the brook Kidron, to the corner of the horse gate toward the east, will be set-apart to Yahweh. It will not be plucked up or thrown down any more forever.” 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>This is the word that came to Jeremiah from Yahweh in the tenth year of Zedekiah king of Judah, which was the eighteenth year of Nebuchadnezzar. 
-<span class="v">2&#160;</span>Now at that time the king of Babylon’s army was besieging Jerusalem. Jeremiah the prophet was shut up in the court of the guard, which was in the king of Judah’s house. 
-</p><p>
-<span class="v">3&#160;</span>For Zedekiah king of Judah had shut him up, saying, “Why do you prophesy, and say, ‘Yahweh says, “Behold, I will give this city into the hand of the king of Babylon, and he will take it; 
-<span class="v">4&#160;</span>and Zedekiah king of Judah won’t escape out of the hand of the Chaldeans, but will surely be delivered into the hand of the king of Babylon, and will speak with him mouth to mouth, and his eyes will see his eyes; 
-<span class="v">5&#160;</span>and he will bring Zedekiah to Babylon, and he will be there until I visit him,” says Yahweh, “though you fight with the Chaldeans, you will not prosper”&#160;’?” 
-</p><p>
-<span class="v">6&#160;</span>Jeremiah said, “Yahweh’s word came to me, saying, 
-<span class="v">7&#160;</span>‘Behold, Hanamel the son of Shallum your uncle will come to you, saying, “Buy my field that is in Anathoth; for the right of redemption is yours to buy it.”&#160;’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>“So Hanamel my uncle’s son came to me in the court of the guard according to Yahweh’s word, and said to me, ‘Please buy my field that is in Anathoth, which is in the land of Benjamin; for the right of inheritance is yours, and the redemption is yours. Buy it for yourself.’ 
-</p><p>“Then I knew that this was Yahweh’s word. 
-<span class="v">9&#160;</span>I bought the field that was in Anathoth of Hanamel my uncle’s son, and weighed him the money, even seventeen shekels<span class="f">+ \fr 32:9 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of silver. 
-<span class="v">10&#160;</span>I signed the deed, sealed it, called witnesses, and weighed the money in the balances to him. 
-<span class="v">11&#160;</span>So I took the deed of the purchase, both that which was sealed, containing the terms and conditions, and that which was open; 
-<span class="v">12&#160;</span>and I delivered the deed of the purchase to Baruch the son of Neriah, the son of Mahseiah, in the presence of Hanamel my uncle’s son, and in the presence of the witnesses who signed the deed of the purchase, before all the Jews who sat in the court of the guard. 
-</p><p>
-<span class="v">13&#160;</span>“I commanded Baruch before them, saying, 
-<span class="v">14&#160;</span>Yahweh of Armies, the Elohim of Israel, says: ‘Take these deeds, this deed of the purchase which is sealed, and this deed which is open, and put them in an earthen vessel, that they may last many days.’ 
-<span class="v">15&#160;</span>For Yahweh of Armies, the Elohim of Israel says: ‘Houses and fields and vineyards will yet again be bought in this land.’ 
-</p><p>
-<span class="v">16&#160;</span>Now after I had delivered the deed of the purchase to Baruch the son of Neriah, I prayed to Yahweh, saying, 
-</p><div class="b"> &#160; </div>
-<p class="mi">
-<span class="v">17&#160;</span>“Ah Lord Yahweh! Behold, you have made the heavens and the earth by your great power and by your outstretched arm. There is nothing too hard for you. 
-<span class="v">18&#160;</span>You show loving kindness to thousands, and repay the iniquity of the fathers into the bosom of their children after them. The great, the mighty Elohim, Yahweh of Armies is your name: 
-<span class="v">19&#160;</span>great in counsel, and mighty in work; whose eyes are open to all the ways of the children of men, to give everyone according to his ways, and according to the fruit of his doings; 
-<span class="v">20&#160;</span>who performed signs and wonders in the land of Egypt, even to this day, both in Israel and among other men; and made yourself a name, as it is today; 
-<span class="v">21&#160;</span>and brought your people Israel out of the land of Egypt with signs, with wonders, with a strong hand, with an outstretched arm, and with great terror; 
-<span class="v">22&#160;</span>and gave them this land, which you swore to their fathers to give them, a land flowing with milk and honey. 
-<span class="v">23&#160;</span>They came in and possessed it, but they didn’t obey your voice and didn’t walk in your law. They have done nothing of all that you commanded them to do. Therefore you have caused all this evil to come upon them. 
-</p><p class="pi1">
-<span class="v">24&#160;</span>“Behold, siege ramps have been built against the city to take it. The city is given into the hand of the Chaldeans who fight against it, because of the sword, of the famine, and of the pestilence. What you have spoken has happened. Behold, you see it. 
-<span class="v">25&#160;</span>You have said to me, Lord Yahweh, ‘Buy the field for money, and call witnesses;’ whereas the city is given into the hand of the Chaldeans.” 
-</p><p>
-<span class="v">26&#160;</span>Then Yahweh’s word came to Jeremiah, saying, 
-<span class="v">27&#160;</span>“Behold, I am Yahweh, the Elohim of all flesh. Is there anything too hard for me? 
-<span class="v">28&#160;</span>Therefore Yahweh says: Behold, I will give this city into the hand of the Chaldeans, and into the hand of Nebuchadnezzar king of Babylon, and he will take it. 
-<span class="v">29&#160;</span>The Chaldeans, who fight against this city, will come and set this city on fire, and burn it with the houses on whose roofs they have offered incense to Baal, and poured out drink offerings to other elohims, to provoke me to anger. 
-</p><p>
-<span class="v">30&#160;</span>“For the children of Israel and the children of Judah have done only that which was evil in my sight from their youth; for the children of Israel have only provoked me to anger with the work of their hands, says Yahweh. 
-<span class="v">31&#160;</span>For this city has been to me a provocation of my anger and of my wrath from the day that they built it even to this day, so that I should remove it from before my face, 
-<span class="v">32&#160;</span>because of all the evil of the children of Israel and of the children of Judah, which they have done to provoke me to anger—they, their kings, their princes, their priests, their prophets, the men of Judah, and the inhabitants of Jerusalem. 
-<span class="v">33&#160;</span>They have turned their backs to me, and not their faces. Although I taught them, rising up early and teaching them, yet they have not listened to receive instruction. 
-<span class="v">34&#160;</span>But they set their abominations in the house which is called by my name, to defile it. 
-<span class="v">35&#160;</span>They built the high places of Baal, which are in the valley of the son of Hinnom, to cause their sons and their daughters to pass through fire to Molech, which I didn’t command them. It didn’t even come into my mind, that they should do this abomination, to cause Judah to sin.” 
-</p><p>
-<span class="v">36&#160;</span>Now therefore Yahweh, the Elohim of Israel, says concerning this city, about which you say, “It is given into the hand of the king of Babylon by the sword, by the famine, and by the pestilence:” 
-<span class="v">37&#160;</span>“Behold, I will gather them out of all the countries where I have driven them in my anger, and in my wrath, and in great indignation; and I will bring them again to this place. I will cause them to dwell safely. 
-<span class="v">38&#160;</span>Then they will be my people, and I will be their Elohim. 
-<span class="v">39&#160;</span>I will give them one heart and one way, that they may fear me forever, for their good and the good of their children after them. 
-<span class="v">40&#160;</span>I will make an everlasting covenant with them, that I will not turn away from following them, to do them good. I will put my fear in their hearts, that they may not depart from me. 
-<span class="v">41&#160;</span>Yes, I will rejoice over them to do them good, and I will plant them in this land assuredly with my whole heart and with my whole soul.” 
-</p><p>
-<span class="v">42&#160;</span>For Yahweh says: “Just as I have brought all this great evil on this people, so I will bring on them all the good that I have promised them. 
-<span class="v">43&#160;</span>Fields will be bought in this land, about which you say, ‘It is desolate, without man or animal. It is given into the hand of the Chaldeans.’ 
-<span class="v">44&#160;</span>Men will buy fields for money, sign the deeds, seal them, and call witnesses, in the land of Benjamin, and in the places around Jerusalem, in the cities of Judah, in the cities of the hill country, in the cities of the lowland, and in the cities of the South; for I will cause their captivity to be reversed,” says Yahweh. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p class="nb">
-<span class="v">1&#160;</span>Moreover Yahweh’s word came to Jeremiah the second time, while he was still locked up in the court of the guard, saying, 
-<span class="v">2&#160;</span>“Yahweh who does it, Yahweh who forms it to establish it—Yahweh is his name, says: 
-<span class="v">3&#160;</span>‘Call to me, and I will answer you, and will show you great and difficult things, which you don’t know.’ 
-<span class="v">4&#160;</span>For Yahweh, the Elohim of Israel, says concerning the houses of this city and concerning the houses of the kings of Judah, which are broken down to make a defense against the mounds and against the sword: 
-<span class="v">5&#160;</span>‘While men come to fight with the Chaldeans, and to fill them with the dead bodies of men, whom I have killed in my anger and in my wrath, and for all whose wickedness I have hidden my face from this city, 
-<span class="v">6&#160;</span>behold, I will bring it health and healing, and I will cure them; and I will reveal to them abundance of peace and truth. 
-<span class="v">7&#160;</span>I will restore the fortunes of Judah and Israel, and will build them as at the first. 
-<span class="v">8&#160;</span>I will cleanse them from all their iniquity by which they have sinned against me. I will pardon all their iniquities by which they have sinned against me and by which they have transgressed against me. 
-<span class="v">9&#160;</span>This city will be to me for a name of joy, for praise, and for glory, before all the nations of the earth, which will hear all the good that I do to them, and will fear and tremble for all the good and for all the peace that I provide to it.’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>Yahweh says: “Yet again there will be heard in this place, about which you say, ‘It is waste, without man and without animal, even in the cities of Judah, and in the streets of Jerusalem, that are desolate, without man and without inhabitant and without animal,’ 
-<span class="v">11&#160;</span>the voice of joy and the voice of gladness, the voice of the bridegroom and the voice of the bride, the voice of those who say, ‘Give thanks to Yahweh of Armies, for Yahweh is good, for his loving kindness endures forever;’ who bring thanksgiving into Yahweh’s house. For I will cause the captivity of the land to be reversed as at the first,” says Yahweh. 
-</p><p>
-<span class="v">12&#160;</span>Yahweh of Armies says: “Yet again there will be in this place, which is waste, without man and without animal, and in all its cities, a habitation of shepherds causing their flocks to lie down. 
-<span class="v">13&#160;</span>In the cities of the hill country, in the cities of the lowland, in the cities of the South, in the land of Benjamin, in the places around Jerusalem, and in the cities of Judah, the flocks will again pass under the hands of him who counts them,” says Yahweh. 
-</p><p>
-<span class="v">14&#160;</span>“Behold, the days come,” says Yahweh, “that I will perform that good word which I have spoken concerning the house of Israel and concerning the house of Judah. 
-</p><p class="q1">
-<span class="v">15&#160;</span>“In those days and at that time, 
-</p><p class="q2">I will cause a Branch of righteousness to grow up to David. 
-</p><p class="q2">He will execute justice and righteousness in the land. 
-</p><p class="q1">
-<span class="v">16&#160;</span>In those days Judah will be saved, 
-</p><p class="q2">and Jerusalem will dwell safely. 
-</p><p class="q1">This is the name by which she will be called: 
-</p><p class="q2">Yahweh our righteousness.” 
-</p><p>
-<span class="v">17&#160;</span>For Yahweh says: “David will never lack a man to sit on the throne of the house of Israel. 
-<span class="v">18&#160;</span>The Levitical priests won’t lack a man before me to offer burnt offerings, to burn meal offerings, and to do sacrifice continually.” 
-</p><p>
-<span class="v">19&#160;</span>Yahweh’s word came to Jeremiah, saying, 
-<span class="v">20&#160;</span>“Yahweh says: ‘If you can break my covenant of the day and my covenant of the night, so that there will not be day and night in their time, 
-<span class="v">21&#160;</span>then my covenant could also be broken with David my servant, that he won’t have a son to reign on his throne; and with the Levitical priests, my ministers. 
-<span class="v">22&#160;</span>As the army of the sky can’t be counted, and the sand of the sea can’t be measured, so I will multiply the offspring of David my servant and the Levites who minister to me.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh’s word came to Jeremiah, saying, 
-<span class="v">24&#160;</span>“Don’t consider what this people has spoken, saying, ‘Has Yahweh cast off the two families which he chose?’ Thus they despise my people, that they should be no more a nation before them.” 
-<span class="v">25&#160;</span>Yahweh says: “If my covenant of day and night fails, if I have not appointed the ordinances of heaven and earth, 
-<span class="v">26&#160;</span>then I will also cast away the offspring of Jacob, and of David my servant, so that I will not take of his offspring to be rulers over the offspring of Abraham, Isaac, and Jacob; for I will cause their captivity to be reversed and will have mercy on them.” 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>The word which came to Jeremiah from Yahweh, when Nebuchadnezzar king of Babylon, with all his army, all the kingdoms of the earth that were under his dominion, and all the peoples, were fighting against Jerusalem and against all its cities, saying: 
-<span class="v">2&#160;</span>“Yahweh, the Elohim of Israel, says, ‘Go, and speak to Zedekiah king of Judah, and tell him, Yahweh says, “Behold, I will give this city into the hand of the king of Babylon and he will burn it with fire. 
-<span class="v">3&#160;</span>You won’t escape out of his hand, but will surely be taken and delivered into his hand. Your eyes will see the eyes of the king of Babylon, and he will speak with you mouth to mouth. You will go to Babylon.”&#160;’ 
-</p><p>
-<span class="v">4&#160;</span>“Yet hear Yahweh’s word, O Zedekiah king of Judah. Yahweh says concerning you, ‘You won’t die by the sword. 
-<span class="v">5&#160;</span>You will die in peace; and with the burnings of your fathers, the former kings who were before you, so they will make a burning for you. They will lament you, saying, “Ah Lord!” for I have spoken the word,’ says Yahweh.” 
-</p><p>
-<span class="v">6&#160;</span>Then Jeremiah the prophet spoke all these words to Zedekiah king of Judah in Jerusalem, 
-<span class="v">7&#160;</span>when the king of Babylon’s army was fighting against Jerusalem and against all the cities of Judah that were left, against Lachish and against Azekah; for these alone remained of the cities of Judah as fortified cities. 
-</p><p>
-<span class="v">8&#160;</span>The word came to Jeremiah from Yahweh, after King Zedekiah had made a covenant with all the people who were at Jerusalem, to proclaim liberty to them, 
-<span class="v">9&#160;</span>that every man should let his male servant, and every man his female servant, who is a Hebrew or a Hebrewess, go free, that no one should make bondservants of them, of a Jew his brother. 
-<span class="v">10&#160;</span>All the princes and all the people obeyed who had entered into the covenant, that everyone should let his male servant and everyone his female servant go free, that no one should make bondservants of them any more. They obeyed and let them go, 
-<span class="v">11&#160;</span>but afterwards they turned, and caused the servants and the handmaids whom they had let go free to return, and brought them into subjection for servants and for handmaids. 
-</p><p>
-<span class="v">12&#160;</span>Therefore Yahweh’s word came to Jeremiah from Yahweh, saying, 
-<span class="v">13&#160;</span>“Yahweh, the Elohim of Israel, says: ‘I made a covenant with your fathers in the day that I brought them out of the land of Egypt, out of the house of bondage, saying: 
-<span class="v">14&#160;</span>At the end of seven years, every man of you shall release his brother who is a Hebrew, who has been sold to you, and has served you six years. You shall let him go free from you. But your fathers didn’t listen to me, and didn’t incline their ear. 
-<span class="v">15&#160;</span>You had now turned, and had done that which is right in my eyes, in every man proclaiming liberty to his neighbor. You had made a covenant before me in the house which is called by my name; 
-<span class="v">16&#160;</span>but you turned and profaned my name, and every man caused his servant and every man his handmaid, whom you had let go free at their pleasure, to return. You brought them into subjection, to be to you for servants and for handmaids.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>Therefore Yahweh says: “You have not listened to me, to proclaim liberty, every man to his brother, and every man to his neighbor. Behold, I proclaim to you a liberty,” says Yahweh, “to the sword, to the pestilence, and to the famine. I will make you be tossed back and forth among all the kingdoms of the earth. 
-<span class="v">18&#160;</span>I will give the men who have transgressed my covenant, who have not performed the words of the covenant which they made before me when they cut the calf in two and passed between its parts: 
-<span class="v">19&#160;</span>the princes of Judah, the princes of Jerusalem, the eunuchs, the priests, and all the people of the land, who passed between the parts of the calf. 
-<span class="v">20&#160;</span>I will even give them into the hand of their enemies and into the hand of those who seek their life. Their dead bodies will be food for the birds of the sky and for the animals of the earth. 
-</p><p>
-<span class="v">21&#160;</span>“I will give Zedekiah king of Judah and his princes into the hands of their enemies, into the hands of those who seek their life and into the hands of the king of Babylon’s army, who has gone away from you. 
-<span class="v">22&#160;</span>Behold, I will command,” says Yahweh, “and cause them to return to this city. They will fight against it, take it, and burn it with fire. I will make the cities of Judah a desolation, without inhabitant.” 
-</p><h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>The word which came to Jeremiah from Yahweh in the days of Jehoiakim the son of Josiah, king of Judah, saying, 
-<span class="v">2&#160;</span>“Go to the house of the Rechabites, and speak to them, and bring them into Yahweh’s house, into one of the rooms, and give them wine to drink.” 
-</p><p>
-<span class="v">3&#160;</span>Then I took Jaazaniah the son of Jeremiah, the son of Habazziniah, with his brothers, all his sons, and the whole house of the Rechabites; 
-<span class="v">4&#160;</span>and I brought them into Yahweh’s house, into the room of the sons of Hanan the son of Igdaliah, the man of Elohim, which was by the room of the princes, which was above the room of Maaseiah the son of Shallum, the keeper of the threshold. 
-<span class="v">5&#160;</span>I set before the sons of the house of the Rechabites bowls full of wine, and cups; and I said to them, “Drink wine!” 
-</p><p>
-<span class="v">6&#160;</span>But they said, “We will drink no wine; for Jonadab the son of Rechab, our father, commanded us, saying, ‘You shall drink no wine, neither you nor your children, forever. 
-<span class="v">7&#160;</span>You shall not build a house, sow seed, plant a vineyard, or have any; but all your days you shall dwell in tents, that you may live many days in the land in which you live as nomads.’ 
-<span class="v">8&#160;</span>We have obeyed the voice of Jonadab the son of Rechab, our father, in all that he commanded us, to drink no wine all our days, we, our women, our sons, or our daughters; 
-<span class="v">9&#160;</span>and not to build houses for ourselves to dwell in. We have no vineyard, field, or seed; 
-<span class="v">10&#160;</span>but we have lived in tents, and have obeyed, and done according to all that Jonadab our father commanded us. 
-<span class="v">11&#160;</span>But when Nebuchadnezzar king of Babylon came up into the land, we said, ‘Come! Let’s go to Jerusalem for fear of the army of the Chaldeans, and for fear of the army of the Syrians; so we will dwell at Jerusalem.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Then Yahweh’s word came to Jeremiah, saying, 
-<span class="v">13&#160;</span>“Yahweh of Armies, the Elohim of Israel, says: ‘Go and tell the men of Judah and the inhabitants of Jerusalem, “Will you not receive instruction to listen to my words?” says Yahweh. 
-<span class="v">14&#160;</span>“The words of Jonadab the son of Rechab that he commanded his sons, not to drink wine, are performed; and to this day they drink none, for they obey their father’s commandment; but I have spoken to you, rising up early and speaking, and you have not listened to me. 
-<span class="v">15&#160;</span>I have sent also to you all my servants the prophets, rising up early and sending them, saying, ‘Every one of you must return now from his evil way, amend your doings, and don’t go after other elohims to serve them. Then you will dwell in the land which I have given to you and to your fathers;’ but you have not inclined your ear, nor listened to me. 
-<span class="v">16&#160;</span>The sons of Jonadab the son of Rechab have performed the commandment of their father which he commanded them, but this people has not listened to me.”&#160;’ 
-</p><p>
-<span class="v">17&#160;</span>“Therefore Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Behold, I will bring on Judah and on all the inhabitants of Jerusalem all the evil that I have pronounced against them, because I have spoken to them, but they have not heard; and I have called to them, but they have not answered.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Jeremiah said to the house of the Rechabites, “Yahweh of Armies, the Elohim of Israel, says: ‘Because you have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according to all that he commanded you,’ 
-<span class="v">19&#160;</span>therefore Yahweh of Armies, the Elohim of Israel, says: ‘Jonadab the son of Rechab will not lack a man to stand before me forever.’&#160;” 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>In the fourth year of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
-<span class="v">2&#160;</span>“Take a scroll of a book, and write in it all the words that I have spoken to you against Israel, against Judah, and against all the nations, from the day I spoke to you, from the days of Josiah even to this day. 
-<span class="v">3&#160;</span>It may be that the house of Judah will hear all the evil which I intend to do to them, that they may each return from his evil way; that I may forgive their iniquity and their sin.” 
-</p><p>
-<span class="v">4&#160;</span>Then Jeremiah called Baruch the son of Neriah; and Baruch wrote from the mouth of Jeremiah all Yahweh’s words, which he had spoken to him, on a scroll of a book. 
-<span class="v">5&#160;</span>Jeremiah commanded Baruch, saying, “I am restricted. I can’t go into Yahweh’s house. 
-<span class="v">6&#160;</span>Therefore you go, and read from the scroll which you have written from my mouth, Yahweh’s words, in the ears of the people in Yahweh’s house on the fast day. Also you shall read them in the ears of all Judah who come out of their cities. 
-<span class="v">7&#160;</span>It may be they will present their supplication before Yahweh, and will each return from his evil way; for Yahweh has pronounced great anger and wrath against this people.” 
-</p><p>
-<span class="v">8&#160;</span>Baruch the son of Neriah did according to all that Jeremiah the prophet commanded him, reading in the book Yahweh’s words in Yahweh’s house. 
-<span class="v">9&#160;</span>Now in the fifth year of Jehoiakim the son of Josiah, king of Judah, in the ninth month, all the people in Jerusalem and all the people who came from the cities of Judah to Jerusalem, proclaimed a fast before Yahweh. 
-<span class="v">10&#160;</span>Then Baruch read the words of Jeremiah from the book in Yahweh’s house, in the room of Gemariah the son of Shaphan the scribe, in the upper court, at the entry of the new gate of Yahweh’s house, in the ears of all the people. 
-</p><p>
-<span class="v">11&#160;</span>When Micaiah the son of Gemariah, the son of Shaphan, had heard out of the book all Yahweh’s words, 
-<span class="v">12&#160;</span>he went down into the king’s house, into the scribe’s room; and behold, all the princes were sitting there, Elishama the scribe, Delaiah the son of Shemaiah, Elnathan the son of Achbor, Gemariah the son of Shaphan, Zedekiah the son of Hananiah, and all the princes. 
-<span class="v">13&#160;</span>Then Micaiah declared to them all the words that he had heard, when Baruch read the book in the ears of the people. 
-<span class="v">14&#160;</span>Therefore all the princes sent Jehudi the son of Nethaniah, the son of Shelemiah, the son of Cushi, to Baruch, saying, “Take in your hand the scroll in which you have read in the ears of the people, and come.” 
-</p><p>So Baruch the son of Neriah took the scroll in his hand, and came to them. 
-<span class="v">15&#160;</span>They said to him, “Sit down now, and read it in our hearing.” 
-</p><p>So Baruch read it in their hearing. 
-</p><p>
-<span class="v">16&#160;</span>Now when they had heard all the words, they turned in fear one toward another, and said to Baruch, “We will surely tell the king of all these words.” 
-<span class="v">17&#160;</span>They asked Baruch, saying, “Tell us now, how did you write all these words at his mouth?” 
-</p><p>
-<span class="v">18&#160;</span>Then Baruch answered them, “He dictated all these words to me with his mouth, and I wrote them with ink in the book.” 
-</p><p>
-<span class="v">19&#160;</span>Then the princes said to Baruch, “You and Jeremiah go hide. Don’t let anyone know where you are.” 
-</p><p>
-<span class="v">20&#160;</span>They went in to the king into the court, but they had laid up the scroll in the room of Elishama the scribe. Then they told all the words in the hearing of the king. 
-<span class="v">21&#160;</span>So the king sent Jehudi to get the scroll, and he took it out of the room of Elishama the scribe. Jehudi read it in the hearing of the king, and in the hearing of all the princes who stood beside the king. 
-<span class="v">22&#160;</span>Now the king was sitting in the winter house in the ninth month, and there was a fire in the brazier burning before him. 
-<span class="v">23&#160;</span>When Jehudi had read three or four columns, the king cut it with the penknife, and cast it into the fire that was in the brazier, until all the scroll was consumed in the fire that was in the brazier. 
-<span class="v">24&#160;</span>The king and his servants who heard all these words were not afraid, and didn’t tear their garments. 
-<span class="v">25&#160;</span>Moreover Elnathan and Delaiah and Gemariah had made intercession to the king that he would not burn the scroll; but he would not listen to them. 
-<span class="v">26&#160;</span>The king commanded Jerahmeel the king’s son, and Seraiah the son of Azriel, and Shelemiah the son of Abdeel, to arrest Baruch the scribe and Jeremiah the prophet; but Yahweh hid them. 
-</p><p>
-<span class="v">27&#160;</span>Then Yahweh’s word came to Jeremiah, after the king had burned the scroll, and the words which Baruch wrote at the mouth of Jeremiah, saying, 
-<span class="v">28&#160;</span>“Take again another scroll, and write in it all the former words that were in the first scroll, which Jehoiakim the king of Judah has burned. 
-<span class="v">29&#160;</span>Concerning Jehoiakim king of Judah you shall say, ‘Yahweh says: “You have burned this scroll, saying, ‘Why have you written therein, saying, “The king of Babylon will certainly come and destroy this land, and will cause to cease from there man and animal”?’&#160;” 
-<span class="v">30&#160;</span>Therefore Yahweh says concerning Jehoiakim king of Judah: “He will have no one to sit on David’s throne. His dead body will be cast out in the day to the heat, and in the night to the frost. 
-<span class="v">31&#160;</span>I will punish him, his offspring, and his servants for their iniquity. I will bring on them, on the inhabitants of Jerusalem, and on the men of Judah, all the evil that I have pronounced against them, but they didn’t listen.”&#160;’&#160;” 
-</p><p>
-<span class="v">32&#160;</span>Then Jeremiah took another scroll, and gave it to Baruch the scribe, the son of Neriah, who wrote therein from the mouth of Jeremiah all the words of the book which Jehoiakim king of Judah had burned in the fire; and many similar words were added to them. 
-</p><h2 class="chapterlabel" id="37">37</h2>
-<p>
-<span class="v">1&#160;</span>Zedekiah the son of Josiah reigned as king instead of Coniah the son of Jehoiakim, whom Nebuchadnezzar king of Babylon made king in the land of Judah. 
-<span class="v">2&#160;</span>But neither he, nor his servants, nor the people of the land, listened to Yahweh’s words, which he spoke by the prophet Jeremiah. 
-</p><p>
-<span class="v">3&#160;</span>Zedekiah the king sent Jehucal the son of Shelemiah and Zephaniah the son of Maaseiah, the priest, to the prophet Jeremiah, saying, “Pray now to Yahweh our Elohim for us.” 
-</p><p>
-<span class="v">4&#160;</span>Now Jeremiah came in and went out among the people, for they had not put him into prison. 
-<span class="v">5&#160;</span>Pharaoh’s army had come out of Egypt; and when the Chaldeans who were besieging Jerusalem heard news of them, they withdrew from Jerusalem. 
-</p><p>
-<span class="v">6&#160;</span>Then Yahweh’s word came to the prophet Jeremiah, saying, 
-<span class="v">7&#160;</span>“Yahweh, the Elohim of Israel, says, ‘You shall tell the king of Judah, who sent you to me to inquire of me: “Behold, Pharaoh’s army, which has come out to help you, will return to Egypt into their own land. 
-<span class="v">8&#160;</span>The Chaldeans will come again, and fight against this city. They will take it and burn it with fire.”&#160;’ 
-</p><p>
-<span class="v">9&#160;</span>“Yahweh says, ‘Don’t deceive yourselves, saying, “The Chaldeans will surely depart from us;” for they will not depart. 
-<span class="v">10&#160;</span>For though you had struck the whole army of the Chaldeans who fight against you, and only wounded men remained among them, they would each rise up in his tent and burn this city with fire.’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>When the army of the Chaldeans had withdrawn from Jerusalem for fear of Pharaoh’s army, 
-<span class="v">12&#160;</span>then Jeremiah went out of Jerusalem to go into the land of Benjamin, to receive his portion there, in the middle of the people. 
-<span class="v">13&#160;</span>When he was in Benjamin’s gate, a captain of the guard was there, whose name was Irijah, the son of Shelemiah, the son of Hananiah; and he seized Jeremiah the prophet, saying, “You are defecting to the Chaldeans!” 
-</p><p>
-<span class="v">14&#160;</span>Then Jeremiah said, “That is false! I am not defecting to the Chaldeans.” 
-</p><p>But he didn’t listen to him; so Irijah seized Jeremiah, and brought him to the princes. 
-<span class="v">15&#160;</span>The princes were angry with Jeremiah, and struck him, and put him in prison in the house of Jonathan the scribe; for they had made that the prison. 
-</p><p>
-<span class="v">16&#160;</span>When Jeremiah had come into the dungeon house and into the cells, and Jeremiah had remained there many days, 
-<span class="v">17&#160;</span>then Zedekiah the king sent and had him brought out. The king asked him secretly in his house, “Is there any word from Yahweh?” 
-</p><p>Jeremiah said, “There is.” He also said, “You will be delivered into the hand of the king of Babylon.” 
-</p><p>
-<span class="v">18&#160;</span>Moreover Jeremiah said to King Zedekiah, “How have I sinned against you, against your servants, or against this people, that you have put me in prison? 
-<span class="v">19&#160;</span>Now where are your prophets who prophesied to you, saying, ‘The king of Babylon will not come against you, nor against this land’? 
-<span class="v">20&#160;</span>Now please hear, my lord the king: please let my supplication be presented before you, that you not cause me to return to the house of Jonathan the scribe, lest I die there.” 
-</p><p>
-<span class="v">21&#160;</span>Then Zedekiah the king commanded, and they committed Jeremiah into the court of the guard. They gave him daily a loaf of bread out of the bakers’ street, until all the bread in the city was gone. Thus Jeremiah remained in the court of the guard. 
-</p><h2 class="chapterlabel" id="38">38</h2>
-<p>
-<span class="v">1&#160;</span>Shephatiah the son of Mattan, Gedaliah the son of Pashhur, Jucal the son of Shelemiah, and Pashhur the son of Malchijah heard the words that Jeremiah spoke to all the people, saying, 
-<span class="v">2&#160;</span>“Yahweh says, ‘He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out to the Chaldeans will live. He will escape with his life and he will live.’ 
-<span class="v">3&#160;</span>Yahweh says, ‘This city will surely be given into the hand of the army of the king of Babylon, and he will take it.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>Then the princes said to the king, “Please let this man be put to death, because he weakens the hands of the men of war who remain in this city, and the hands of all the people, in speaking such words to them; for this man doesn’t seek the welfare of this people, but harm.” 
-</p><p>
-<span class="v">5&#160;</span>Zedekiah the king said, “Behold, he is in your hand; for the king can’t do anything to oppose you.” 
-</p><p>
-<span class="v">6&#160;</span>Then they took Jeremiah and threw him into the dungeon of Malchijah the king’s son, that was in the court of the guard. They let down Jeremiah with cords. In the dungeon there was no water, but mire; and Jeremiah sank in the mire. 
-</p><p>
-<span class="v">7&#160;</span>Now when Ebedmelech the Ethiopian, a eunuch, who was in the king’s house, heard that they had put Jeremiah in the dungeon (the king was then sitting in Benjamin’s gate), 
-<span class="v">8&#160;</span>Ebedmelech went out of the king’s house, and spoke to the king, saying, 
-<span class="v">9&#160;</span>“My lord the king, these men have done evil in all that they have done to Jeremiah the prophet, whom they have cast into the dungeon. He is likely to die in the place where he is, because of the famine; for there is no more bread in the city.” 
-</p><p>
-<span class="v">10&#160;</span>Then the king commanded Ebedmelech the Ethiopian, saying, “Take from here thirty men with you, and take up Jeremiah the prophet out of the dungeon, before he dies.” 
-</p><p>
-<span class="v">11&#160;</span>So Ebedmelech took the men with him, and went into the house of the king under the treasury, and took from there rags and worn-out garments, and let them down by cords into the dungeon to Jeremiah. 
-<span class="v">12&#160;</span>Ebedmelech the Ethiopian said to Jeremiah, “Now put these rags and worn-out garments under your armpits under the cords.” 
-</p><p>Jeremiah did so. 
-<span class="v">13&#160;</span>So they lifted Jeremiah up with the cords, and took him up out of the dungeon; and Jeremiah remained in the court of the guard. 
-</p><p>
-<span class="v">14&#160;</span>Then Zedekiah the king sent and took Jeremiah the prophet to himself into the third entry that is in Yahweh’s house. Then the king said to Jeremiah, “I will ask you something. Hide nothing from me.” 
-</p><p>
-<span class="v">15&#160;</span>Then Jeremiah said to Zedekiah, “If I declare it to you, will you not surely put me to death? If I give you counsel, you will not listen to me.” 
-</p><p>
-<span class="v">16&#160;</span>So Zedekiah the king swore secretly to Jeremiah, saying, “As Yahweh lives, who made our souls, I will not put you to death, neither will I give you into the hand of these men who seek your life.” 
-</p><p>
-<span class="v">17&#160;</span>Then Jeremiah said to Zedekiah, “Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘If you will go out to the king of Babylon’s princes, then your soul will live, and this city will not be burned with fire. You will live, along with your house. 
-<span class="v">18&#160;</span>But if you will not go out to the king of Babylon’s princes, then this city will be given into the hand of the Chaldeans, and they will burn it with fire, and you won’t escape out of their hand.’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>Zedekiah the king said to Jeremiah, “I am afraid of the Jews who have defected to the Chaldeans, lest they deliver me into their hand, and they mock me.” 
-</p><p>
-<span class="v">20&#160;</span>But Jeremiah said, “They won’t deliver you. Obey, I beg you, Yahweh’s voice, in that which I speak to you; so it will be well with you, and your soul will live. 
-<span class="v">21&#160;</span>But if you refuse to go out, this is the word that Yahweh has shown me: 
-<span class="v">22&#160;</span>‘Behold, all the women who are left in the king of Judah’s house will be brought out to the king of Babylon’s princes, and those women will say, 
-</p><p class="q1">“Your familiar friends have turned on you, 
-</p><p class="q2">and have prevailed over you. 
-</p><p class="q1">Your feet are sunk in the mire, 
-</p><p class="q2">they have turned away from you.” 
-</p><p>
-<span class="v">23&#160;</span>They will bring out all your women and your children to the Chaldeans. You won’t escape out of their hand, but will be taken by the hand of the king of Babylon. You will cause this city to be burned with fire.’&#160;” 
-</p><p>
-<span class="v">24&#160;</span>Then Zedekiah said to Jeremiah, “Let no man know of these words, and you won’t die. 
-<span class="v">25&#160;</span>But if the princes hear that I have talked with you, and they come to you, and tell you, ‘Declare to us now what you have said to the king; don’t hide it from us, and we will not put you to death; also tell us what the king said to you;’ 
-<span class="v">26&#160;</span>then you shall tell them, ‘I presented my supplication before the king, that he would not cause me to return to Jonathan’s house, to die there.’&#160;” 
-</p><p>
-<span class="v">27&#160;</span>Then all the princes came to Jeremiah, and asked him; and he told them according to all these words that the king had commanded. So they stopped speaking with him, for the matter was not perceived. 
-</p><p>
-<span class="v">28&#160;</span>So Jeremiah stayed in the court of the guard until the day that Jerusalem was taken. 
-</p><h2 class="chapterlabel" id="39">39</h2>
-<p>
-<span class="v">1&#160;</span>In the ninth year of Zedekiah king of Judah, in the tenth month, Nebuchadnezzar king of Babylon and all his army came against Jerusalem, and besieged it. 
-<span class="v">2&#160;</span>In the eleventh year of Zedekiah, in the fourth month, the ninth day of the month, a breach was made in the city. 
-<span class="v">3&#160;</span>All the princes of the king of Babylon came in, and sat in the middle gate: Nergal Sharezer, Samgarnebo, Sarsechim the Rabsaris, Nergal Sharezer the Rabmag, with all the rest of the princes of the king of Babylon. 
-<span class="v">4&#160;</span>When Zedekiah the king of Judah and all the men of war saw them, then they fled and went out of the city by night, by the way of the king’s garden, through the gate between the two walls; and he went out toward the Arabah. 
-</p><p>
-<span class="v">5&#160;</span>But the army of the Chaldeans pursued them, and overtook Zedekiah in the plains of Jericho. When they had taken him, they brought him up to Nebuchadnezzar king of Babylon to Riblah in the land of Hamath; and he pronounced judgment on him. 
-<span class="v">6&#160;</span>Then the king of Babylon killed Zedekiah’s sons in Riblah before his eyes. The king of Babylon also killed all the nobles of Judah. 
-<span class="v">7&#160;</span>Moreover he put out Zedekiah’s eyes and bound him in fetters, to carry him to Babylon. 
-</p><p>
-<span class="v">8&#160;</span>The Chaldeans burned the king’s house and the people’s houses with fire and broke down the walls of Jerusalem. 
-<span class="v">9&#160;</span>Then Nebuzaradan the captain of the guard carried away captive into Babylon the rest of the people who remained in the city, the deserters also who fell away to him, and the rest of the people who remained. 
-<span class="v">10&#160;</span>But Nebuzaradan the captain of the guard left of the poor of the people, who had nothing, in the land of Judah, and gave them vineyards and fields at the same time. 
-</p><p>
-<span class="v">11&#160;</span>Now Nebuchadnezzar king of Babylon commanded Nebuzaradan the captain of the guard concerning Jeremiah, saying, 
-<span class="v">12&#160;</span>“Take him and take care of him. Do him no harm; but do to him even as he tells you.” 
-</p><p>
-<span class="v">13&#160;</span>So Nebuzaradan the captain of the guard, Nebushazban, Rabsaris, and Nergal Sharezer, Rabmag, and all the chief officers of the king of Babylon 
-<span class="v">14&#160;</span>sent and took Jeremiah out of the court of the guard, and committed him to Gedaliah the son of Ahikam, the son of Shaphan, that he should bring him home. So he lived among the people. 
-</p><p>
-<span class="v">15&#160;</span>Now Yahweh’s word came to Jeremiah while he was shut up in the court of the guard, saying, 
-<span class="v">16&#160;</span>“Go, and speak to Ebedmelech the Ethiopian, saying, ‘Yahweh of Armies, the Elohim of Israel, says: “Behold, I will bring my words on this city for evil, and not for good; and they will be accomplished before you in that day. 
-<span class="v">17&#160;</span>But I will deliver you in that day,” says Yahweh; “and you will not be given into the hand of the men of whom you are afraid. 
-<span class="v">18&#160;</span>For I will surely save you. You won’t fall by the sword, but you will escape with your life, because you have put your trust in me,” says Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="40">40</h2>
-<p>
-<span class="v">1&#160;</span>The word which came to Jeremiah from Yahweh, after Nebuzaradan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all the captives of Jerusalem and Judah who were carried away captive to Babylon. 
-<span class="v">2&#160;</span>The captain of the guard took Jeremiah and said to him, “Yahweh your Elohim pronounced this evil on this place; 
-<span class="v">3&#160;</span>and Yahweh has brought it, and done according as he spoke. Because you have sinned against Yahweh, and have not obeyed his voice, therefore this thing has come on you. 
-<span class="v">4&#160;</span>Now, behold, I release you today from the chains which are on your hand. If it seems good to you to come with me into Babylon, come, and I will take care of you; but if it seems bad to you to come with me into Babylon, don’t. Behold, all the land is before you. Where it seems good and right to you to go, go there.” 
-<span class="v">5&#160;</span>Now while he had not yet gone back, “Go back then,” he said, “to Gedaliah the son of Ahikam, the son of Shaphan, whom the king of Babylon has made governor over the cities of Judah, and dwell with him among the people; or go wherever it seems right to you to go.” 
-</p><p>So the captain of the guard gave him food and a present, and let him go. 
-<span class="v">6&#160;</span>Then Jeremiah went to Gedaliah the son of Ahikam to Mizpah, and lived with him among the people who were left in the land. 
-</p><p>
-<span class="v">7&#160;</span>Now when all the captains of the forces who were in the fields, even they and their men, heard that the king of Babylon had made Gedaliah the son of Ahikam governor in the land, and had committed to him men, women, children, and of the poorest of the land, of those who were not carried away captive to Babylon, 
-<span class="v">8&#160;</span>then Ishmael the son of Nethaniah, and Johanan and Jonathan the sons of Kareah, and Seraiah the son of Tanhumeth, and the sons of Ephai the Netophathite, and Jezaniah the son of the Maacathite, they and their men came to Gedaliah to Mizpah. 
-<span class="v">9&#160;</span>Gedaliah the son of Ahikam the son of Shaphan swore to them and to their men, saying, “Don’t be afraid to serve the Chaldeans. Dwell in the land, and serve the king of Babylon, and it will be well with you. 
-<span class="v">10&#160;</span>As for me, behold, I will dwell at Mizpah, to stand before the Chaldeans who will come to us; but you, gather wine and summer fruits and oil, and put them in your vessels, and dwell in your cities that you have taken.” 
-</p><p>
-<span class="v">11&#160;</span>Likewise when all the Jews who were in Moab, and among the children of Ammon, and in Edom, and who were in all the countries, heard that the king of Babylon had left a remnant of Judah, and that he had set over them Gedaliah the son of Ahikam, the son of Shaphan, 
-<span class="v">12&#160;</span>then all the Jews returned out of all places where they were driven, and came to the land of Judah, to Gedaliah, to Mizpah, and gathered very much wine and summer fruits. 
-</p><p>
-<span class="v">13&#160;</span>Moreover Johanan the son of Kareah, and all the captains of the forces who were in the fields, came to Gedaliah to Mizpah, 
-<span class="v">14&#160;</span>and said to him, “Do you know that Baalis the king of the children of Ammon has sent Ishmael the son of Nethaniah to take your life?” 
-</p><p>But Gedaliah the son of Ahikam didn’t believe them. 
-</p><p>
-<span class="v">15&#160;</span>Then Johanan the son of Kareah spoke to Gedaliah in Mizpah secretly, saying, “Please let me go, and I will kill Ishmael the son of Nethaniah, and no man will know it. Why should he take your life, that all the Jews who are gathered to you should be scattered, and the remnant of Judah perish?” 
-</p><p>
-<span class="v">16&#160;</span>But Gedaliah the son of Ahikam said to Johanan the son of Kareah, “You shall not do this thing, for you speak falsely of Ishmael.” 
-</p><h2 class="chapterlabel" id="41">41</h2>
-<p>
-<span class="v">1&#160;</span>Now in the seventh month, Ishmael the son of Nethaniah, the son of Elishama, of the royal offspring and one of the chief officers of the king, and ten men with him, came to Gedaliah the son of Ahikam to Mizpah; and there they ate bread together in Mizpah. 
-<span class="v">2&#160;</span>Then Ishmael the son of Nethaniah arose, and the ten men who were with him, and struck Gedaliah the son of Ahikam the son of Shaphan with the sword and killed him, whom the king of Babylon had made governor over the land. 
-<span class="v">3&#160;</span>Ishmael also killed all the Jews who were with Gedaliah at Mizpah, and the Chaldean men of war who were found there. 
-</p><p>
-<span class="v">4&#160;</span>The second day after he had killed Gedaliah, and no man knew it, 
-<span class="v">5&#160;</span>men came from Shechem, from Shiloh, and from Samaria, even eighty men, having their beards shaved and their clothes torn, and having cut themselves, with meal offerings and frankincense in their hand, to bring them to Yahweh’s house. 
-<span class="v">6&#160;</span>Ishmael the son of Nethaniah went out from Mizpah to meet them, weeping all along as he went, and as he met them, he said to them, “Come to Gedaliah the son of Ahikam.” 
-<span class="v">7&#160;</span>It was so, when they came into the middle of the city, that Ishmael the son of Nethaniah killed them, and cast them into the middle of the pit, he, and the men who were with him. 
-<span class="v">8&#160;</span>But ten men were found among those who said to Ishmael, “Don’t kill us; for we have stores hidden in the field, of wheat, and of barley, and of oil, and of honey.” 
-</p><p>So he stopped, and didn’t kill them among their brothers. 
-<span class="v">9&#160;</span>Now the pit in which Ishmael cast all the dead bodies of the men whom he had killed, by the side of Gedaliah (this was that which Asa the king had made for fear of Baasha king of Israel), Ishmael the son of Nethaniah filled it with those who were killed. 
-</p><p>
-<span class="v">10&#160;</span>Then Ishmael carried away captive all of the people who were left in Mizpah, even the king’s daughters, and all the people who remained in Mizpah, whom Nebuzaradan the captain of the guard had committed to Gedaliah the son of Ahikam. Ishmael the son of Nethaniah carried them away captive, and departed to go over to the children of Ammon. 
-</p><p>
-<span class="v">11&#160;</span>But when Johanan the son of Kareah, and all the captains of the forces who were with him, heard of all the evil that Ishmael the son of Nethaniah had done, 
-<span class="v">12&#160;</span>then they took all the men, and went to fight with Ishmael the son of Nethaniah, and found him by the great waters that are in Gibeon. 
-<span class="v">13&#160;</span>Now when all the people who were with Ishmael saw Johanan the son of Kareah, and all the captains of the forces who were with him, then they were glad. 
-<span class="v">14&#160;</span>So all the people who Ishmael had carried away captive from Mizpah turned about and came back, and went to Johanan the son of Kareah. 
-<span class="v">15&#160;</span>But Ishmael the son of Nethaniah escaped from Johanan with eight men, and went to the children of Ammon. 
-</p><p>
-<span class="v">16&#160;</span>Then Johanan the son of Kareah and all the captains of the forces who were with him took all the remnant of the people whom he had recovered from Ishmael the son of Nethaniah, from Mizpah, after he had killed Gedaliah the son of Ahikam—the men of war, with the women, the children, and the eunuchs, whom he had brought back from Gibeon. 
-<span class="v">17&#160;</span>They departed and lived in Geruth Chimham, which is by Bethlehem, to go to enter into Egypt 
-<span class="v">18&#160;</span>because of the Chaldeans; for they were afraid of them, because Ishmael the son of Nethaniah had killed Gedaliah the son of Ahikam, whom the king of Babylon made governor over the land. 
-</p><h2 class="chapterlabel" id="42">42</h2>
-<p>
-<span class="v">1&#160;</span>Then all the captains of the forces, and Johanan the son of Kareah, and Jezaniah the son of Hoshaiah, and all the people from the least even to the greatest, came near, 
-<span class="v">2&#160;</span>and said to Jeremiah the prophet, “Please let our supplication be presented before you, and pray for us to Yahweh your Elohim, even for all this remnant, for we are left but a few of many, as your eyes see us, 
-<span class="v">3&#160;</span>that Yahweh your Elohim may show us the way in which we should walk, and the things that we should do.” 
-</p><p>
-<span class="v">4&#160;</span>Then Jeremiah the prophet said to them, “I have heard you. Behold, I will pray to Yahweh your Elohim according to your words; and it will happen that whatever thing Yahweh answers you, I will declare it to you. I will keep nothing back from you.” 
-</p><p>
-<span class="v">5&#160;</span>Then they said to Jeremiah, “May Yahweh be a true and faithful witness among us, if we don’t do according to all the word with which Yahweh your Elohim sends you to tell us. 
-<span class="v">6&#160;</span>Whether it is good, or whether it is bad, we will obey the voice of Yahweh our Elohim, to whom we send you; that it may be well with us, when we obey the voice of Yahweh our Elohim.” 
-</p><p>
-<span class="v">7&#160;</span>After ten days, Yahweh’s word came to Jeremiah. 
-<span class="v">8&#160;</span>Then he called Johanan the son of Kareah, and all the captains of the forces who were with him, and all the people from the least even to the greatest, 
-<span class="v">9&#160;</span>and said to them, “Yahweh, the Elohim of Israel, to whom you sent me to present your supplication before him, says: 
-<span class="v">10&#160;</span>‘If you will still live in this land, then I will build you, and not pull you down, and I will plant you, and not pluck you up; for I grieve over the distress that I have brought on you. 
-<span class="v">11&#160;</span>Don’t be afraid of the king of Babylon, of whom you are afraid. Don’t be afraid of him,’ says Yahweh, ‘for I am with you to save you, and to deliver you from his hand. 
-<span class="v">12&#160;</span>I will grant you mercy, that he may have mercy on you, and cause you to return to your own land. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘But if you say, “We will not dwell in this land,” so that you don’t obey Yahweh your Elohim’s voice, 
-<span class="v">14&#160;</span>saying, “No, but we will go into the land of Egypt, where we will see no war, nor hear the sound of the trumpet, nor have hunger of bread; and there we will dwell;”&#160;’ 
-<span class="v">15&#160;</span>now therefore hear Yahweh’s word, O remnant of Judah! Yahweh of Armies, the Elohim of Israel, says, ‘If you indeed set your faces to enter into Egypt, and go to live there, 
-<span class="v">16&#160;</span>then it will happen that the sword, which you fear, will overtake you there in the land of Egypt; and the famine, about which you are afraid, will follow close behind you there in Egypt; and you will die there. 
-<span class="v">17&#160;</span>So will it be with all the men who set their faces to go into Egypt to live there. They will die by the sword, by the famine, and by the pestilence. None of them will remain or escape from the evil that I will bring on them.’ 
-<span class="v">18&#160;</span>For Yahweh of Armies, the Elohim of Israel, says: ‘As my anger and my wrath has been poured out on the inhabitants of Jerusalem, so my wrath will be poured out on you, when you enter into Egypt; and you will be an object of horror, an astonishment, a curse, and a reproach; and you will see this place no more.’ 
-</p><p>
-<span class="v">19&#160;</span>“Yahweh has spoken concerning you, remnant of Judah, ‘Don’t go into Egypt!’ Know certainly that I have testified to you today. 
-<span class="v">20&#160;</span>For you have dealt deceitfully against your own souls; for you sent me to Yahweh your Elohim, saying, ‘Pray for us to Yahweh our Elohim; and according to all that Yahweh our Elohim says, so declare to us, and we will do it.’ 
-<span class="v">21&#160;</span>I have declared it to you today; but you have not obeyed Yahweh your Elohim’s voice in anything for which he has sent me to you. 
-<span class="v">22&#160;</span>Now therefore know certainly that you will die by the sword, by the famine, and by the pestilence in the place where you desire to go to live.” 
-</p><h2 class="chapterlabel" id="43">43</h2>
-<p>
-<span class="v">1&#160;</span>When Jeremiah had finished speaking to all the people all the words of Yahweh their Elohim, with which Yahweh their Elohim had sent him to them, even all these words, 
-<span class="v">2&#160;</span>then Azariah the son of Hoshaiah, Johanan the son of Kareah, and all the proud men spoke, saying to Jeremiah, “You speak falsely. Yahweh our Elohim has not sent you to say, ‘You shall not go into Egypt to live there;’ 
-<span class="v">3&#160;</span>but Baruch the son of Neriah has turned you against us, to deliver us into the hand of the Chaldeans, that they may put us to death or carry us away captive to Babylon.” 
-</p><p>
-<span class="v">4&#160;</span>So Johanan the son of Kareah, and all the captains of the forces, and all the people, didn’t obey Yahweh’s voice, to dwell in the land of Judah. 
-<span class="v">5&#160;</span>But Johanan the son of Kareah and all the captains of the forces took all the remnant of Judah, who had returned from all the nations where they had been driven, to live in the land of Judah—<span class="v">6&#160;</span>the men, the women, the children, the king’s daughters, and every person who Nebuzaradan the captain of the guard had left with Gedaliah the son of Ahikam, the son of Shaphan; and Jeremiah the prophet, and Baruch the son of Neriah. 
-<span class="v">7&#160;</span>They came into the land of Egypt, for they didn’t obey Yahweh’s voice; and they came to Tahpanhes. 
-</p><p>
-<span class="v">8&#160;</span>Then Yahweh’s word came to Jeremiah in Tahpanhes, saying, 
-<span class="v">9&#160;</span>“Take great stones in your hand and hide them in mortar in the brick work which is at the entry of Pharaoh’s house in Tahpanhes, in the sight of the men of Judah. 
-<span class="v">10&#160;</span>Tell them, Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will send and take Nebuchadnezzar the king of Babylon, my servant, and will set his throne on these stones that I have hidden; and he will spread his royal pavilion over them. 
-<span class="v">11&#160;</span>He will come, and will strike the land of Egypt; such as are for death will be put to death, and such as are for captivity to captivity, and such as are for the sword to the sword. 
-<span class="v">12&#160;</span>I will kindle a fire in the houses of the elohims of Egypt. He will burn them, and carry them away captive. He will array himself with the land of Egypt, as a shepherd puts on his garment; and he will go out from there in peace. 
-<span class="v">13&#160;</span>He will also break the pillars of Beth Shemesh that is in the land of Egypt; and he will burn the houses of the elohims of Egypt with fire.’&#160;” 
-</p><h2 class="chapterlabel" id="44">44</h2>
-<p>
-<span class="v">1&#160;</span>The word that came to Jeremiah concerning all the Jews who lived in the land of Egypt, who lived at Migdol, and at Tahpanhes, and at Memphis, and in the country of Pathros, saying, 
-<span class="v">2&#160;</span>“Yahweh of Armies, the Elohim of Israel, says: ‘You have seen all the evil that I have brought on Jerusalem, and on all the cities of Judah. Behold, today they are a desolation, and no man dwells in them, 
-<span class="v">3&#160;</span>because of their wickedness which they have committed to provoke me to anger, in that they went to burn incense, to serve other elohims that they didn’t know, neither they, nor you, nor your fathers. 
-<span class="v">4&#160;</span>However I sent to you all my servants the prophets, rising up early and sending them, saying, “Oh, don’t do this abominable thing that I hate.” 
-<span class="v">5&#160;</span>But they didn’t listen and didn’t incline their ear. They didn’t turn from their wickedness, to stop burning incense to other elohims. 
-<span class="v">6&#160;</span>Therefore my wrath and my anger was poured out, and was kindled in the cities of Judah and in the streets of Jerusalem; and they are wasted and desolate, as it is today.’ 
-</p><p>
-<span class="v">7&#160;</span>“Therefore now Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Why do you commit great evil against your own souls, to cut off from yourselves man and woman, infant and nursing child out of the middle of Judah, to leave yourselves no one remaining, 
-<span class="v">8&#160;</span>in that you provoke me to anger with the works of your hands, burning incense to other elohims in the land of Egypt where you have gone to live, that you may be cut off, and that you may be a curse and a reproach among all the nations of the earth? 
-<span class="v">9&#160;</span>Have you forgotten the wickedness of your fathers, the wickedness of the kings of Judah, the wickedness of their women, your own wickedness, and the wickedness of your women which they committed in the land of Judah and in the streets of Jerusalem? 
-<span class="v">10&#160;</span>They are not humbled even to this day, neither have they feared, nor walked in my law, nor in my statutes, that I set before you and before your fathers.’ 
-</p><p>
-<span class="v">11&#160;</span>“Therefore Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will set my face against you for evil, even to cut off all Judah. 
-<span class="v">12&#160;</span>I will take the remnant of Judah that have set their faces to go into the land of Egypt to live there, and they will all be consumed. They will fall in the land of Egypt. They will be consumed by the sword and by the famine. They will die, from the least even to the greatest, by the sword and by the famine. They will be an object of horror, an astonishment, a curse, and a reproach. 
-<span class="v">13&#160;</span>For I will punish those who dwell in the land of Egypt, as I have punished Jerusalem, by the sword, by the famine, and by the pestilence; 
-<span class="v">14&#160;</span>so that none of the remnant of Judah, who have gone into the land of Egypt to live there, will escape or be left to return into the land of Judah, to which they have a desire to return to dwell there; for no one will return except those who will escape.’&#160;” 
-</p><p>
-<span class="v">15&#160;</span>Then all the men who knew that their women burned incense to other elohims, and all the women who stood by, a great assembly, even all the people who lived in the land of Egypt, in Pathros, answered Jeremiah, saying, 
-<span class="v">16&#160;</span>“As for the word that you have spoken to us in Yahweh’s name, we will not listen to you. 
-<span class="v">17&#160;</span>But we will certainly perform every word that has gone out of our mouth, to burn incense to the queen of the sky and to pour out drink offerings to her, as we have done, we and our fathers, our kings and our princes, in the cities of Judah and in the streets of Jerusalem; for then we had plenty of food, and were well, and saw no evil. 
-<span class="v">18&#160;</span>But since we stopped burning incense to the queen of the sky, and pouring out drink offerings to her, we have lacked all things, and have been consumed by the sword and by the famine.” 
-</p><p>
-<span class="v">19&#160;</span>The women said, “When we burned incense to the queen of the sky and poured out drink offerings to her, did we make her cakes to worship her, and pour out drink offerings to her, without our men?” 
-</p><p>
-<span class="v">20&#160;</span>Then Jeremiah said to all the people—to the men and to the women, even to all the people who had given him an answer, saying, 
-<span class="v">21&#160;</span>“The incense that you burned in the cities of Judah, and in the streets of Jerusalem, you and your fathers, your kings and your princes, and the people of the land, didn’t Yahweh remember them, and didn’t it come into his mind? 
-<span class="v">22&#160;</span>Thus Yahweh could no longer bear it, because of the evil of your doings and because of the abominations which you have committed. Therefore your land has become a desolation, an astonishment, and a curse, without inhabitant, as it is today. 
-<span class="v">23&#160;</span>Because you have burned incense and because you have sinned against Yahweh, and have not obeyed Yahweh’s voice, nor walked in his law, nor in his statutes, nor in his testimonies; therefore this evil has happened to you, as it is today.” 
-</p><p>
-<span class="v">24&#160;</span>Moreover Jeremiah said to all the people, including all the women, “Hear Yahweh’s word, all Judah who are in the land of Egypt! 
-<span class="v">25&#160;</span>Yahweh of Armies, the Elohim of Israel, says, ‘You and your women have both spoken with your mouths, and with your hands have fulfilled it, saying, “We will surely perform our vows that we have vowed, to burn incense to the queen of the sky, and to pour out drink offerings to her.” 
-</p><p>“&#160;‘Establish then your vows, and perform your vows.’ 
-</p><p>
-<span class="v">26&#160;</span>“Therefore hear Yahweh’s word, all Judah who dwell in the land of Egypt: ‘Behold, I have sworn by my great name,’ says Yahweh, ‘that my name will no more be named in the mouth of any man of Judah in all the land of Egypt, saying, “As the Lord Yahweh lives.” 
-<span class="v">27&#160;</span>Behold, I watch over them for evil, and not for good; and all the men of Judah who are in the land of Egypt will be consumed by the sword and by the famine, until they are all gone. 
-<span class="v">28&#160;</span>Those who escape the sword will return out of the land of Egypt into the land of Judah few in number. All the remnant of Judah, who have gone into the land of Egypt to live there, will know whose word will stand, mine or theirs. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘This will be the sign to you,’ says Yahweh, ‘that I will punish you in this place, that you may know that my words will surely stand against you for evil.’ 
-<span class="v">30&#160;</span>Yahweh says, ‘Behold, I will give Pharaoh Hophra king of Egypt into the hand of his enemies and into the hand of those who seek his life, just as I gave Zedekiah king of Judah into the hand of Nebuchadnezzar king of Babylon, who was his enemy and sought his life.’&#160;” 
-</p><h2 class="chapterlabel" id="45">45</h2>
-<p>
-<span class="v">1&#160;</span>The message that Jeremiah the prophet spoke to Baruch the son of Neriah, when he wrote these words in a book at the mouth of Jeremiah, in the fourth year of Jehoiakim the son of Josiah, king of Judah, saying, 
-<span class="v">2&#160;</span>“Yahweh, the Elohim of Israel, says to you, Baruch: 
-<span class="v">3&#160;</span>‘You said, “Woe is me now! For Yahweh has added sorrow to my pain! I am weary with my groaning, and I find no rest.”&#160;’ 
-</p><p>
-<span class="v">4&#160;</span>“You shall tell him, Yahweh says: ‘Behold, that which I have built, I will break down, and that which I have planted I will pluck up; and this in the whole land. 
-<span class="v">5&#160;</span>Do you seek great things for yourself? Don’t seek them; for, behold, I will bring evil on all flesh,’ says Yahweh, ‘but I will let you escape with your life wherever you go.’&#160;” 
-</p><h2 class="chapterlabel" id="46">46</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word which came to Jeremiah the prophet concerning the nations. 
-</p><p>
-<span class="v">2&#160;</span>Of Egypt: concerning the army of Pharaoh Necoh king of Egypt, which was by the river Euphrates in Carchemish, which Nebuchadnezzar king of Babylon struck in the fourth year of Jehoiakim the son of Josiah, king of Judah. 
-</p><p class="q1">
-<span class="v">3&#160;</span>“Prepare the buckler and shield, 
-</p><p class="q2">and draw near to battle! 
-</p><p class="q1">
-<span class="v">4&#160;</span>Harness the horses, and get up, you horsemen, 
-</p><p class="q2">and stand up with your helmets. 
-</p><p class="q1">Polish the spears, 
-</p><p class="q2">put on the coats of mail. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why have I seen it? 
-</p><p class="q2">They are dismayed and are turned backward. 
-</p><p class="q1">Their mighty ones are beaten down, 
-</p><p class="q2">have fled in haste, 
-</p><p class="q2">and don’t look back. 
-</p><p class="q1">Terror is on every side,” 
-</p><p class="q2">says Yahweh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>“Don’t let the swift flee away, 
-</p><p class="q2">nor the mighty man escape. 
-</p><p class="q1">In the north by the river Euphrates 
-</p><p class="q2">they have stumbled and fallen. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Who is this who rises up like the Nile, 
-</p><p class="q2">like rivers whose waters surge? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Egypt rises up like the Nile, 
-</p><p class="q2">like rivers whose waters surge. 
-</p><p class="q1">He says, ‘I will rise up. I will cover the earth. 
-</p><p class="q2">I will destroy cities and its inhabitants.’ 
-</p><p class="q1">
-<span class="v">9&#160;</span>Go up, you horses! 
-</p><p class="q2">Rage, you chariots! 
-</p><p class="q1">Let the mighty men go out: 
-</p><p class="q2">Cush and Put, who handle the shield; 
-</p><p class="q2">and the Ludim, who handle and bend the bow. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For that day is of the Lord, Yahweh of Armies, 
-</p><p class="q2">a day of vengeance, 
-</p><p class="q2">that he may avenge himself of his adversaries. 
-</p><p class="q1">The sword will devour and be satiated, 
-</p><p class="q2">and will drink its fill of their blood; 
-</p><p class="q2">for the Lord, Yahweh of Armies, has a sacrifice in the north country by the river Euphrates. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Go up into Gilead, and take balm, virgin daughter of Egypt. 
-</p><p class="q2">You use many medicines in vain. 
-</p><p class="q2">There is no healing for you. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The nations have heard of your shame, 
-</p><p class="q2">and the earth is full of your cry; 
-</p><p class="q2">for the mighty man has stumbled against the mighty, 
-</p><p class="q2">they both fall together.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">13&#160;</span>The word that Yahweh spoke to Jeremiah the prophet, how that Nebuchadnezzar king of Babylon should come and strike the land of Egypt: 
-</p><p class="q1">
-<span class="v">14&#160;</span>“Declare in Egypt, 
-</p><p class="q2">publish in Migdol, 
-</p><p class="q2">and publish in Memphis and in Tahpanhes; 
-</p><p class="q1">say, ‘Stand up, and prepare, 
-</p><p class="q2">for the sword has devoured around you.’ 
-</p><p class="q1">
-<span class="v">15&#160;</span>Why are your strong ones swept away? 
-</p><p class="q2">They didn’t stand, because Yahweh pushed them. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He made many to stumble. 
-</p><p class="q2">Yes, they fell on one another. 
-</p><p class="q1">They said, ‘Arise! Let’s go again to our own people, 
-</p><p class="q2">and to the land of our birth, 
-</p><p class="q2">from the oppressing sword.’ 
-</p><p class="q1">
-<span class="v">17&#160;</span>They cried there, ‘Pharaoh king of Egypt is but a noise; 
-</p><p class="q2">he has let the appointed time pass by.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“As I live,” says the King, 
-</p><p class="q2">whose name is Yahweh of Armies, 
-</p><p class="q1">“surely like Tabor among the mountains, 
-</p><p class="q2">and like Carmel by the sea, 
-</p><p class="q2">so he will come. 
-</p><p class="q1">
-<span class="v">19&#160;</span>You daughter who dwells in Egypt, 
-</p><p class="q2">furnish yourself to go into captivity; 
-</p><p class="q1">for Memphis will become a desolation, 
-</p><p class="q2">and will be burned up, 
-</p><p class="q2">without inhabitant. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Egypt is a very beautiful heifer; 
-</p><p class="q2">but destruction out of the north has come. 
-</p><p class="q2">It has come. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Also her hired men in the middle of her are like calves of the stall, 
-</p><p class="q2">for they also are turned back. 
-</p><p class="q2">They have fled away together. 
-</p><p class="q1">They didn’t stand, 
-</p><p class="q2">for the day of their calamity has come on them, 
-</p><p class="q2">the time of their visitation. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Its sound will go like the serpent, 
-</p><p class="q2">for they will march with an army, 
-</p><p class="q2">and come against her with axes, as wood cutters. 
-</p><p class="q1">
-<span class="v">23&#160;</span>They will cut down her forest,” says Yahweh, 
-</p><p class="q2">“though it can’t be searched; 
-</p><p class="q1">because they are more than the locusts, 
-</p><p class="q2">and are innumerable. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The daughter of Egypt will be disappointed; 
-</p><p class="q2">she will be delivered into the hand of the people of the north.” 
-</p><p>
-<span class="v">25&#160;</span>Yahweh of Armies, the Elohim of Israel, says: “Behold, I will punish Amon of No, and Pharaoh, and Egypt, with her elohims and her kings, even Pharaoh, and those who trust in him. 
-<span class="v">26&#160;</span>I will deliver them into the hand of those who seek their lives, and into the hand of Nebuchadnezzar king of Babylon, and into the hand of his servants. Afterwards it will be inhabited, as in the days of old,” says Yahweh. 
-</p><p class="q1">
-<span class="v">27&#160;</span>“But don’t you be afraid, Jacob my servant. 
-</p><p class="q2">Don’t be dismayed, Israel; 
-</p><p class="q1">for, behold, I will save you from afar, 
-</p><p class="q2">and your offspring from the land of their captivity. 
-</p><p class="q1">Jacob will return, 
-</p><p class="q2">and will be quiet and at ease. 
-</p><p class="q2">No one will make him afraid. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Don’t be afraid, O Jacob my servant,” says Yahweh, 
-</p><p class="q2">“for I am with you; 
-</p><p class="q2">for I will make a full end of all the nations where I have driven you, 
-</p><p class="q1">but I will not make a full end of you, 
-</p><p class="q2">but I will correct you in measure, 
-</p><p class="q2">and will in no way leave you unpunished.” 
-</p><h2 class="chapterlabel" id="47">47</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word that came to Jeremiah the prophet concerning the Philistines, before Pharaoh struck Gaza. 
-</p><p>
-<span class="v">2&#160;</span>Yahweh says: 
-</p><p class="q1">“Behold, waters rise up out of the north, 
-</p><p class="q2">and will become an overflowing stream, 
-</p><p class="q1">and will overflow the land and all that is therein, 
-</p><p class="q2">the city and those who dwell therein. 
-</p><p class="q1">The men will cry, 
-</p><p class="q2">and all the inhabitants of the land will wail. 
-</p><p class="q1">
-<span class="v">3&#160;</span>At the noise of the stamping of the hoofs of his strong ones, 
-</p><p class="q2">at the rushing of his chariots, 
-</p><p class="q2">at the rumbling of his wheels, 
-</p><p class="q1">the fathers don’t look back for their children 
-</p><p class="q2">because their hands are so feeble, 
-</p><p class="q1">
-<span class="v">4&#160;</span>because of the day that comes to destroy all the Philistines, 
-</p><p class="q2">to cut off from Tyre and Sidon every helper who remains; 
-</p><p class="q1">for Yahweh will destroy the Philistines, 
-</p><p class="q2">the remnant of the isle of Caphtor. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Baldness has come on Gaza; 
-</p><p class="q2">Ashkelon is brought to nothing. 
-</p><p class="q1">You remnant of their valley, 
-</p><p class="q2">how long will you cut yourself? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“&#160;‘You sword of Yahweh, how long will it be before you are quiet? 
-</p><p class="q2">Put yourself back into your scabbard; 
-</p><p class="q2">rest, and be still.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“How can you be quiet, 
-</p><p class="q2">since Yahweh has given you a command? 
-</p><p class="q1">Against Ashkelon, and against the seashore, 
-</p><p class="q2">there he has appointed it.” 
-</p><h2 class="chapterlabel" id="48">48</h2>
-<p>
-<span class="v">1&#160;</span>Of Moab. Yahweh of Armies, the Elohim of Israel, says: 
-</p><p class="q1">“Woe to Nebo! 
-</p><p class="q2">For it is laid waste. 
-</p><p class="q1">Kiriathaim is disappointed. 
-</p><p class="q2">It is taken. 
-</p><p class="q1">Misgab<span class="f">+ \fr 48:1 \ft or, The stronghold</span> is put to shame 
-</p><p class="q2">and broken down. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The praise of Moab is no more. 
-</p><p class="q2">In Heshbon they have devised evil against her: 
-</p><p class="q2">‘Come! Let’s cut her off from being a nation.’ 
-</p><p class="q1">You also, Madmen, will be brought to silence. 
-</p><p class="q2">The sword will pursue you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The sound of a cry from Horonaim, 
-</p><p class="q2">desolation and great destruction! 
-</p><p class="q1">
-<span class="v">4&#160;</span>Moab is destroyed. 
-</p><p class="q2">Her little ones have caused a cry to be heard. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For they will go up by the ascent of Luhith with continual weeping. 
-</p><p class="q2">For at the descent of Horonaim they have heard the distress of the cry of destruction. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Flee! Save your lives! 
-</p><p class="q2">Be like the juniper bush in the wilderness. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For, because you have trusted in your works and in your treasures, 
-</p><p class="q2">you also will be taken. 
-</p><p class="q1">Chemosh will go out into captivity, 
-</p><p class="q2">his priests and his princes together. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The destroyer will come on every city, 
-</p><p class="q2">and no city will escape; 
-</p><p class="q1">the valley also will perish, 
-</p><p class="q2">and the plain will be destroyed, as Yahweh has spoken. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Give wings to Moab, 
-</p><p class="q2">that she may fly and get herself away: 
-</p><p class="q1">and her cities will become a desolation, 
-</p><p class="q2">without anyone to dwell in them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Cursed is he who does the work of Yahweh negligently; 
-</p><p class="q2">and cursed is he who keeps back his sword from blood. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Moab has been at ease from his youth, 
-</p><p class="q2">and he has settled on his dregs, 
-</p><p class="q1">and has not been emptied from vessel to vessel, 
-</p><p class="q2">neither has he gone into captivity; 
-</p><p class="q1">therefore his taste remains in him, 
-</p><p class="q2">and his scent is not changed. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Therefore behold, the days come,” says Yahweh, 
-</p><p class="q2">“that I will send to him those who pour off, 
-</p><p class="q1">and they will pour him off; 
-</p><p class="q2">and they will empty his vessels, 
-</p><p class="q2">and break their containers in pieces. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Moab will be ashamed of Chemosh, 
-</p><p class="q2">as the house of Israel was ashamed of Bethel, their confidence. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“How do you say, ‘We are mighty men, 
-</p><p class="q2">and valiant men for the war’? 
-</p><p class="q1">
-<span class="v">15&#160;</span>Moab is laid waste, 
-</p><p class="q2">and they have gone up into his cities, 
-</p><p class="q2">and his chosen young men have gone down to the slaughter,” 
-</p><p class="q2">says the King, whose name is Yahweh of Armies. 
-</p><p class="q1">
-<span class="v">16&#160;</span>“The calamity of Moab is near to come, 
-</p><p class="q2">and his affliction hurries fast. 
-</p><p class="q1">
-<span class="v">17&#160;</span>All you who are around him, bemoan him; 
-</p><p class="q2">and all you who know his name, say, 
-</p><p class="q1">‘How the strong staff is broken, 
-</p><p class="q2">the beautiful rod!’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“You daughter who dwells in Dibon, 
-</p><p class="q2">come down from your glory, 
-</p><p class="q2">and sit in thirst; 
-</p><p class="q1">for the destroyer of Moab has come up against you. 
-</p><p class="q2">He has destroyed your strongholds. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Inhabitant of Aroer, stand by the way and watch. 
-</p><p class="q2">Ask him who flees, and her who escapes; 
-</p><p class="q2">say, ‘What has been done?’ 
-</p><p class="q1">
-<span class="v">20&#160;</span>Moab is disappointed; 
-</p><p class="q2">for it is broken down. 
-</p><p class="q1">Wail and cry! 
-</p><p class="q2">Tell it by the Arnon, that Moab is laid waste. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Judgment has come on the plain country—</p><p class="q2">on Holon, on Jahzah, on Mephaath, 
-</p><p class="q2">
-<span class="v">22&#160;</span>on Dibon, on Nebo, on Beth Diblathaim, 
-</p><p class="q2">
-<span class="v">23&#160;</span>on Kiriathaim, on Beth Gamul, on Beth Meon, 
-</p><p class="q2">
-<span class="v">24&#160;</span>on Kerioth, on Bozrah, 
-</p><p class="q2">and on all the cities of the land of Moab, far or near. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The horn of Moab is cut off, 
-</p><p class="q2">and his arm is broken,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">26&#160;</span>“Make him drunk, 
-</p><p class="q2">for he magnified himself against Yahweh. 
-</p><p class="q1">Moab will wallow in his vomit, 
-</p><p class="q2">and he also will be in derision. 
-</p><p class="q1">
-<span class="v">27&#160;</span>For wasn’t Israel a derision to you? 
-</p><p class="q2">Was he found among thieves? 
-</p><p class="q1">For as often as you speak of him, 
-</p><p class="q2">you shake your head. 
-</p><p class="q1">
-<span class="v">28&#160;</span>You inhabitants of Moab, leave the cities, and dwell in the rock. 
-</p><p class="q2">Be like the dove that makes her nest over the mouth of the abyss. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">29&#160;</span>“We have heard of the pride of Moab. 
-</p><p class="q2">He is very proud in his loftiness, his pride, 
-</p><p class="q2">his arrogance, and the arrogance of his heart. 
-</p><p class="q1">
-<span class="v">30&#160;</span>I know his wrath,” says Yahweh, “that it is nothing; 
-</p><p class="q2">his boastings have done nothing. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Therefore I will wail for Moab. 
-</p><p class="q2">Yes, I will cry out for all Moab. 
-</p><p class="q2">They will mourn for the men of Kir Heres. 
-</p><p class="q1">
-<span class="v">32&#160;</span>With more than the weeping of Jazer 
-</p><p class="q2">I will weep for you, vine of Sibmah. 
-</p><p class="q1">Your branches passed over the sea. 
-</p><p class="q2">They reached even to the sea of Jazer. 
-</p><p class="q1">The destroyer has fallen on your summer fruits 
-</p><p class="q2">and on your vintage. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Gladness and joy is taken away from the fruitful field 
-</p><p class="q2">and from the land of Moab. 
-</p><p class="q1">I have caused wine to cease from the wine presses. 
-</p><p class="q2">No one will tread with shouting. 
-</p><p class="q2">The shouting will be no shouting. 
-</p><p class="q1">
-<span class="v">34&#160;</span>From the cry of Heshbon even to Elealeh, 
-</p><p class="q2">even to Jahaz they have uttered their voice, 
-</p><p class="q2">from Zoar even to Horonaim, to Eglath Shelishiyah; 
-</p><p class="q2">for the waters of Nimrim will also become desolate. 
-</p><p class="q1">
-<span class="v">35&#160;</span>Moreover I will cause to cease in Moab,” says Yahweh, 
-</p><p class="q2">“him who offers in the high place, 
-</p><p class="q2">and him who burns incense to his elohims. 
-</p><p class="q1">
-<span class="v">36&#160;</span>Therefore my heart sounds for Moab like flutes, 
-</p><p class="q2">and my heart sounds like flutes for the men of Kir Heres. 
-</p><p class="q2">Therefore the abundance that he has gotten has perished. 
-</p><p class="q1">
-<span class="v">37&#160;</span>For every head is bald, 
-</p><p class="q2">and every beard clipped. 
-</p><p class="q1">There are cuttings on all the hands, 
-</p><p class="q2">and sackcloth on the waist. 
-</p><p class="q1">
-<span class="v">38&#160;</span>On all the housetops of Moab, 
-</p><p class="q2">and in its streets, there is lamentation everywhere; 
-</p><p class="q2">for I have broken Moab like a vessel in which no one delights,” says Yahweh. 
-</p><p class="q1">
-<span class="v">39&#160;</span>“How it is broken down! 
-</p><p class="q2">How they wail! 
-</p><p class="q1">How Moab has turned the back with shame! 
-</p><p class="q2">So will Moab become a derision 
-</p><p class="q2">and a terror to all who are around him.” 
-</p><p class="q1">
-<span class="v">40&#160;</span>For Yahweh says: “Behold, he will fly as an eagle, 
-</p><p class="q2">and will spread out his wings against Moab. 
-</p><p class="q1">
-<span class="v">41&#160;</span>Kerioth is taken, 
-</p><p class="q2">and the strongholds are seized. 
-</p><p class="q1">The heart of the mighty men of Moab at that day 
-</p><p class="q2">will be as the heart of a woman in her pangs. 
-</p><p class="q1">
-<span class="v">42&#160;</span>Moab will be destroyed from being a people, 
-</p><p class="q2">because he has magnified himself against Yahweh. 
-</p><p class="q1">
-<span class="v">43&#160;</span>Terror, the pit, and the snare are on you, 
-</p><p class="q2">inhabitant of Moab,” says Yahweh. 
-</p><p class="q1">
-<span class="v">44&#160;</span>“He who flees from the terror will fall into the pit; 
-</p><p class="q2">and he who gets up out of the pit will be taken in the snare, 
-</p><p class="q1">for I will bring on him, even on Moab, 
-</p><p class="q2">the year of their visitation,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">45&#160;</span>“Those who fled stand without strength under the shadow of Heshbon; 
-</p><p class="q2">for a fire has gone out of Heshbon, 
-</p><p class="q2">and a flame from the middle of Sihon, 
-</p><p class="q1">and has devoured the corner of Moab, 
-</p><p class="q2">and the crown of the head of the tumultuous ones. 
-</p><p class="q1">
-<span class="v">46&#160;</span>Woe to you, O Moab! 
-</p><p class="q2">The people of Chemosh are undone; 
-</p><p class="q1">for your sons are taken away captive, 
-</p><p class="q2">and your daughters into captivity. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">47&#160;</span>“Yet I will reverse the captivity of Moab in the latter days,” 
-</p><p class="q2">says Yahweh. 
-</p><p>Thus far is the judgment of Moab. 
-</p><h2 class="chapterlabel" id="49">49</h2>
-<p>
-<span class="v">1&#160;</span>Of the children of Ammon. Yahweh says: 
-</p><p class="q1">“Has Israel no sons? 
-</p><p class="q2">Has he no heir? 
-</p><p class="q1">Why then does Malcam possess Gad, 
-</p><p class="q2">and his people dwell in its cities? 
-</p><p class="q1">
-<span class="v">2&#160;</span>Therefore behold, the days come,” 
-</p><p class="q2">says Yahweh, 
-</p><p class="q1">“that I will cause an alarm of war to be heard against Rabbah of the children of Ammon, 
-</p><p class="q2">and it will become a desolate heap, 
-</p><p class="q2">and her daughters will be burned with fire; 
-</p><p class="q1">then Israel will possess those who possessed him,” 
-</p><p class="q2">says Yahweh. 
-</p><p class="q1">
-<span class="v">3&#160;</span>“Wail, Heshbon, for Ai is laid waste! 
-</p><p class="q2">Cry, you daughters of Rabbah! 
-</p><p class="q1">Clothe yourself in sackcloth. 
-</p><p class="q2">Lament, and run back and forth among the fences; 
-</p><p class="q1">for Malcam will go into captivity, 
-</p><p class="q2">his priests and his princes together. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Why do you boast in the valleys, 
-</p><p class="q2">your flowing valley, backsliding daughter? 
-</p><p class="q1">You trusted in her treasures, 
-</p><p class="q2">saying, ‘Who will come to me?’ 
-</p><p class="q1">
-<span class="v">5&#160;</span>Behold, I will bring a terror on you,” 
-</p><p class="q2">says the Lord, Yahweh of Armies, 
-</p><p class="q1">“from all who are around you. 
-</p><p class="q2">All of you will be driven completely out, 
-</p><p class="q2">and there will be no one to gather together the fugitives. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“But afterward I will reverse the captivity of the children of Ammon,” 
-</p><p class="q2">says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">7&#160;</span>Of Edom, Yahweh of Armies says: 
-</p><p class="q1">“Is wisdom no more in Teman? 
-</p><p class="q2">Has counsel perished from the prudent? 
-</p><p class="q2">Has their wisdom vanished? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Flee! Turn back! 
-</p><p class="q2">Dwell in the depths, inhabitants of Dedan; 
-</p><p class="q2">for I will bring the calamity of Esau on him when I visit him. 
-</p><p class="q1">
-<span class="v">9&#160;</span>If grape gatherers came to you, 
-</p><p class="q2">would they not leave some gleaning grapes? 
-</p><p class="q1">If thieves came by night, 
-</p><p class="q2">wouldn’t they steal until they had enough? 
-</p><p class="q1">
-<span class="v">10&#160;</span>But I have made Esau bare, 
-</p><p class="q2">I have uncovered his secret places, 
-</p><p class="q2">and he will not be able to hide himself. 
-</p><p class="q1">His offspring is destroyed, 
-</p><p class="q2">with his brothers and his neighbors; 
-</p><p class="q2">and he is no more. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Leave your fatherless children. 
-</p><p class="q2">I will preserve them alive. 
-</p><p class="q2">Let your widows trust in me.” 
-</p><p>
-<span class="v">12&#160;</span>For Yahweh says: “Behold, they to whom it didn’t pertain to drink of the cup will certainly drink; and are you he who will altogether go unpunished? You won’t go unpunished, but you will surely drink. 
-<span class="v">13&#160;</span>For I have sworn by myself,” says Yahweh, “that Bozrah will become an astonishment, a reproach, a waste, and a curse. All its cities will be perpetual wastes.” 
-</p><p class="q1">
-<span class="v">14&#160;</span>I have heard news from Yahweh, 
-</p><p class="q2">and an ambassador is sent among the nations, 
-</p><p class="q1">saying, “Gather yourselves together! 
-</p><p class="q2">Come against her! 
-</p><p class="q2">Rise up to the battle!” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“For, behold, I have made you small among the nations, 
-</p><p class="q2">and despised among men. 
-</p><p class="q1">
-<span class="v">16&#160;</span>As for your terror, 
-</p><p class="q2">the pride of your heart has deceived you, 
-</p><p class="q1">O you who dwell in the clefts of the rock, 
-</p><p class="q2">who hold the height of the hill, 
-</p><p class="q1">though you should make your nest as high as the eagle, 
-</p><p class="q2">I will bring you down from there,” says Yahweh. 
-</p><p class="q1">
-<span class="v">17&#160;</span>“Edom will become an astonishment. 
-</p><p class="q2">Everyone who passes by it will be astonished, 
-</p><p class="q2">and will hiss at all its plagues. 
-</p><p class="q1">
-<span class="v">18&#160;</span>As in the overthrow of Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
-</p><p class="q2">“no man will dwell there, 
-</p><p class="q2">neither will any son of man live therein. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“Behold, he will come up like a lion from the pride of the Jordan against the strong habitation; 
-</p><p class="q2">for I will suddenly make them run away from it, 
-</p><p class="q1">and whoever is chosen, 
-</p><p class="q2">I will appoint him over it. 
-</p><p class="q1">For who is like me? 
-</p><p class="q2">Who will appoint me a time? 
-</p><p class="q2">Who is the shepherd who will stand before me?” 
-</p><p class="q1">
-<span class="v">20&#160;</span>Therefore hear the counsel of Yahweh, that he has taken against Edom, 
-</p><p class="q2">and his purposes that he has purposed against the inhabitants of Teman: 
-</p><p class="q1">Surely they will drag them away, 
-</p><p class="q2">the little ones of the flock. 
-</p><p class="q2">Surely he will make their habitation desolate over them. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The earth trembles at the noise of their fall; 
-</p><p class="q2">there is a cry, the noise which is heard in the Red Sea. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Behold, he will come up and fly as the eagle, 
-</p><p class="q2">and spread out his wings against Bozrah. 
-</p><p class="q2">The heart of the mighty men of Edom at that day will be as the heart of a woman in her pangs. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">23&#160;</span>Of Damascus: 
-</p><p class="q1">“Hamath and Arpad are confounded, 
-</p><p class="q2">for they have heard evil news. 
-</p><p class="q2">They have melted away. 
-</p><p class="q1">There is sorrow on the sea. 
-</p><p class="q2">It can’t be quiet. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Damascus has grown feeble, 
-</p><p class="q2">she turns herself to flee, 
-</p><p class="q2">and trembling has seized her. 
-</p><p class="q1">Anguish and sorrows have taken hold of her, 
-</p><p class="q2">as of a woman in travail. 
-</p><p class="q1">
-<span class="v">25&#160;</span>How is the city of praise not forsaken, 
-</p><p class="q2">the city of my joy? 
-</p><p class="q1">
-<span class="v">26&#160;</span>Therefore her young men will fall in her streets, 
-</p><p class="q2">and all the men of war will be brought to silence in that day,” 
-</p><p class="q2">says Yahweh of Armies. 
-</p><p class="q1">
-<span class="v">27&#160;</span>“I will kindle a fire in the wall of Damascus, 
-</p><p class="q2">and it will devour the palaces of Ben Hadad.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>Of Kedar, and of the kingdoms of Hazor, which Nebuchadnezzar king of Babylon struck, Yahweh says: 
-</p><p class="q1">“Arise, go up to Kedar, 
-</p><p class="q2">and destroy the children of the east. 
-</p><p class="q1">
-<span class="v">29&#160;</span>They will take their tents and their flocks. 
-</p><p class="q2">they will carry away for themselves their curtains, 
-</p><p class="q2">all their vessels, and their camels; 
-</p><p class="q2">and they will cry to them, ‘Terror on every side!’ 
-</p><p class="q1">
-<span class="v">30&#160;</span>Flee! 
-</p><p class="q2">Wander far off! 
-</p><p class="q1">Dwell in the depths, you inhabitants of Hazor,” says Yahweh; 
-</p><p class="q2">“for Nebuchadnezzar king of Babylon has taken counsel against you, 
-</p><p class="q2">and has conceived a purpose against you. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Arise! Go up to a nation that is at ease, 
-</p><p class="q2">that dwells without care,” says Yahweh; 
-</p><p class="q2">“that has neither gates nor bars, 
-</p><p class="q2">that dwells alone. 
-</p><p class="q1">
-<span class="v">32&#160;</span>Their camels will be a booty, 
-</p><p class="q2">and the multitude of their livestock a plunder. 
-</p><p class="q1">I will scatter to all winds those who have the corners of their beards cut off; 
-</p><p class="q2">and I will bring their calamity from every side of them,” 
-</p><p class="q2">says Yahweh. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Hazor will be a dwelling place of jackals, 
-</p><p class="q2">a desolation forever. 
-</p><p class="q1">No man will dwell there, 
-</p><p class="q2">neither will any son of man live therein.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">34&#160;</span>Yahweh’s word that came to Jeremiah the prophet concerning Elam, in the beginning of the reign of Zedekiah king of Judah, saying, 
-<span class="v">35&#160;</span>“Yahweh of Armies says: 
-</p><p class="q1">‘Behold, I will break the bow of Elam, 
-</p><p class="q2">the chief of their might. 
-</p><p class="q1">
-<span class="v">36&#160;</span>I will bring on Elam the four winds from the four quarters of the sky, 
-</p><p class="q2">and will scatter them toward all those winds. 
-</p><p class="q2">There will be no nation where the outcasts of Elam will not come. 
-</p><p class="q1">
-<span class="v">37&#160;</span>I will cause Elam to be dismayed before their enemies, 
-</p><p class="q2">and before those who seek their life. 
-</p><p class="q1">I will bring evil on them, even my fierce anger,’ says Yahweh; 
-</p><p class="q2">‘and I will send the sword after them, 
-</p><p class="q2">until I have consumed them. 
-</p><p class="q1">
-<span class="v">38&#160;</span>I will set my throne in Elam, 
-</p><p class="q2">and will destroy from there king and princes,’ says Yahweh. 
-</p><p class="q1">
-<span class="v">39&#160;</span>‘But it will happen in the latter days 
-</p><p class="q2">that I will reverse the captivity of Elam,’ says Yahweh.” 
-</p><h2 class="chapterlabel" id="50">50</h2>
-<p>
-<span class="v">1&#160;</span>The word that Yahweh spoke concerning Babylon, concerning the land of the Chaldeans, by Jeremiah the prophet. 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Declare among the nations and publish, 
-</p><p class="q2">and set up a standard; 
-</p><p class="q2">publish, and don’t conceal; 
-</p><p class="q1">say, ‘Babylon has been taken, 
-</p><p class="q2">Bel is disappointed, 
-</p><p class="q2">Merodach is dismayed! 
-</p><p class="q1">Her images are disappointed. 
-</p><p class="q2">Her idols are dismayed.’ 
-</p><p class="q1">
-<span class="v">3&#160;</span>For a nation comes up out of the north against her, 
-</p><p class="q2">which will make her land desolate, 
-</p><p class="q2">and no one will dwell in it. 
-</p><p class="q1">They have fled. 
-</p><p class="q2">They are gone, 
-</p><p class="q2">both man and animal. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“In those days, and in that time,” says Yahweh, 
-</p><p class="q2">“the children of Israel will come, 
-</p><p class="q2">they and the children of Judah together; 
-</p><p class="q1">they will go on their way weeping, 
-</p><p class="q2">and will seek Yahweh their Elohim. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They will inquire concerning Zion with their faces turned toward it, 
-</p><p class="q2">saying, ‘Come, and join yourselves to Yahweh in an everlasting covenant 
-</p><p class="q2">that will not be forgotten.’ 
-</p><p class="q1">
-<span class="v">6&#160;</span>My people have been lost sheep. 
-</p><p class="q2">Their shepherds have caused them to go astray. 
-</p><p class="q1">They have turned them away on the mountains. 
-</p><p class="q2">They have gone from mountain to hill. 
-</p><p class="q2">They have forgotten their resting place. 
-</p><p class="q1">
-<span class="v">7&#160;</span>All who found them have devoured them. 
-</p><p class="q2">Their adversaries said, ‘We are not guilty, 
-</p><p class="q1">because they have sinned against Yahweh, 
-</p><p class="q2">the habitation of righteousness, 
-</p><p class="q2">even Yahweh, the hope of their fathers.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Flee out of the middle of Babylon! 
-</p><p class="q2">Go out of the land of the Chaldeans, 
-</p><p class="q2">and be as the male goats before the flocks. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For, behold, I will stir up 
-</p><p class="q2">and cause to come up against Babylon a company of great nations from the north country; 
-</p><p class="q2">and they will set themselves in array against her. 
-</p><p class="q1">She will be taken from there. 
-</p><p class="q2">Their arrows will be as of an expert mighty man. 
-</p><p class="q2">None of them will return in vain. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Chaldea will be a prey. 
-</p><p class="q2">All who prey on her will be satisfied,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Because you are glad, 
-</p><p class="q2">because you rejoice, 
-</p><p class="q1">O you who plunder my heritage, 
-</p><p class="q2">because you are wanton as a heifer that treads out the grain, 
-</p><p class="q2">and neigh as strong horses, 
-</p><p class="q1">
-<span class="v">12&#160;</span>your mother will be utterly disappointed. 
-</p><p class="q2">She who bore you will be confounded. 
-</p><p class="q1">Behold, she will be the least of the nations, 
-</p><p class="q2">a wilderness, a dry land, and a desert. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Because of Yahweh’s wrath she won’t be inhabited, 
-</p><p class="q2">but she will be wholly desolate. 
-</p><p class="q1">Everyone who goes by Babylon will be astonished, 
-</p><p class="q2">and hiss at all her plagues. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Set yourselves in array against Babylon all around, 
-</p><p class="q2">all you who bend the bow; 
-</p><p class="q2">shoot at her. 
-</p><p class="q1">Spare no arrows, 
-</p><p class="q2">for she has sinned against Yahweh. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Shout against her all around. 
-</p><p class="q2">She has submitted herself. 
-</p><p class="q2">Her bulwarks have fallen. 
-</p><p class="q1">Her walls have been thrown down, 
-</p><p class="q2">for it is the vengeance of Yahweh. 
-</p><p class="q1">Take vengeance on her. 
-</p><p class="q2">As she has done, do to her. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Cut off the sower from Babylon, 
-</p><p class="q2">and him who handles the sickle in the time of harvest. 
-</p><p class="q1">For fear of the oppressing sword, 
-</p><p class="q2">they will each return to their own people, 
-</p><p class="q2">and they will each flee to their own land. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“Israel is a hunted sheep. 
-</p><p class="q2">The lions have driven him away. 
-</p><p class="q1">First, the king of Assyria devoured him, 
-</p><p class="q2">and now at last Nebuchadnezzar king of Babylon has broken his bones.” 
-</p><p>
-<span class="v">18&#160;</span>Therefore Yahweh of Armies, the Elohim of Israel, says: 
-</p><p class="q1">“Behold, I will punish the king of Babylon and his land, 
-</p><p class="q2">as I have punished the king of Assyria. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I will bring Israel again to his pasture, 
-</p><p class="q2">and he will feed on Carmel and Bashan. 
-</p><p class="q2">His soul will be satisfied on the hills of Ephraim and in Gilead. 
-</p><p class="q1">
-<span class="v">20&#160;</span>In those days, and in that time,” says Yahweh, 
-</p><p class="q2">“the iniquity of Israel will be sought for, 
-</p><p class="q2">and there will be none, 
-</p><p class="q1">also the sins of Judah, 
-</p><p class="q2">and they won’t be found; 
-</p><p class="q2">for I will pardon them whom I leave as a remnant. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Go up against the land of Merathaim, 
-</p><p class="q2">even against it, and against the inhabitants of Pekod. 
-</p><p class="q1">Kill and utterly destroy after them,” says Yahweh, 
-</p><p class="q2">“and do according to all that I have commanded you. 
-</p><p class="q1">
-<span class="v">22&#160;</span>A sound of battle is in the land, 
-</p><p class="q2">and of great destruction. 
-</p><p class="q1">
-<span class="v">23&#160;</span>How the hammer of the whole earth is cut apart and broken! 
-</p><p class="q2">How Babylon has become a desolation among the nations! 
-</p><p class="q1">
-<span class="v">24&#160;</span>I have laid a snare for you, 
-</p><p class="q2">and you are also taken, Babylon, 
-</p><p class="q2">and you weren’t aware. 
-</p><p class="q1">You are found, 
-</p><p class="q2">and also caught, 
-</p><p class="q2">because you have fought against Yahweh. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Yahweh has opened his armory, 
-</p><p class="q2">and has brought out the weapons of his indignation; 
-</p><p class="q2">for the Lord, Yahweh of Armies, has a work to do in the land of the Chaldeans. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Come against her from the farthest border. 
-</p><p class="q2">Open her storehouses. 
-</p><p class="q2">Cast her up as heaps. 
-</p><p class="q1">Destroy her utterly. 
-</p><p class="q2">Let nothing of her be left. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Kill all her bulls. 
-</p><p class="q2">Let them go down to the slaughter. 
-</p><p class="q1">Woe to them! For their day has come, 
-</p><p class="q2">the time of their visitation. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Listen to those who flee and escape out of the land of Babylon, 
-</p><p class="q2">to declare in Zion the vengeance of Yahweh our Elohim, 
-</p><p class="q2">the vengeance of his temple. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">29&#160;</span>“Call together the archers against Babylon, 
-</p><p class="q2">all those who bend the bow. 
-</p><p class="q1">Encamp against her all around. 
-</p><p class="q2">Let none of it escape. 
-</p><p class="q1">Pay her back according to her work. 
-</p><p class="q2">According to all that she has done, do to her; 
-</p><p class="q1">for she has been proud against Yahweh, 
-</p><p class="q2">against the Set-Apart One of Israel. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Therefore her young men will fall in her streets. 
-</p><p class="q2">All her men of war will be brought to silence in that day,” says Yahweh. 
-</p><p class="q1">
-<span class="v">31&#160;</span>“Behold, I am against you, you proud one,” says the Lord, Yahweh of Armies; 
-</p><p class="q2">“for your day has come, 
-</p><p class="q2">the time that I will visit you. 
-</p><p class="q1">
-<span class="v">32&#160;</span>The proud one will stumble and fall, 
-</p><p class="q2">and no one will raise him up. 
-</p><p class="q1">I will kindle a fire in his cities, 
-</p><p class="q2">and it will devour all who are around him.” 
-</p><p class="q1">
-<span class="v">33&#160;</span>Yahweh of Armies says: “The children of Israel and the children of Judah are oppressed together. 
-</p><p class="q2">All who took them captive hold them fast. 
-</p><p class="q2">They refuse to let them go. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Their Redeemer is strong. 
-</p><p class="q2">Yahweh of Armies is his name. 
-</p><p class="q1">He will thoroughly plead their cause, 
-</p><p class="q2">that he may give rest to the earth, 
-</p><p class="q2">and disquiet the inhabitants of Babylon. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">35&#160;</span>“A sword is on the Chaldeans,” says Yahweh, 
-</p><p class="q2">“and on the inhabitants of Babylon, 
-</p><p class="q2">on her princes, 
-</p><p class="q2">and on her wise men. 
-</p><p class="q1">
-<span class="v">36&#160;</span>A sword is on the boasters, 
-</p><p class="q2">and they will become fools. 
-</p><p class="q1">A sword is on her mighty men, 
-</p><p class="q2">and they will be dismayed. 
-</p><p class="q1">
-<span class="v">37&#160;</span>A sword is on their horses, 
-</p><p class="q2">on their chariots, 
-</p><p class="q2">and on all the mixed people who are in the middle of her; 
-</p><p class="q2">and they will become as women. 
-</p><p class="q1">A sword is on her treasures, 
-</p><p class="q2">and they will be robbed. 
-</p><p class="q1">
-<span class="v">38&#160;</span>A drought is on her waters, 
-</p><p class="q2">and they will be dried up; 
-</p><p class="q1">for it is a land of engraved images, 
-</p><p class="q2">and they are mad over idols. 
-</p><p class="q1">
-<span class="v">39&#160;</span>Therefore the wild animals of the desert 
-</p><p class="q2">with the wolves will dwell there. 
-</p><p class="q1">The ostriches will dwell therein. 
-</p><p class="q2">It will be inhabited no more forever, 
-</p><p class="q2">neither will it be lived in from generation to generation. 
-</p><p class="q1">
-<span class="v">40&#160;</span>As when Elohim overthrew Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
-</p><p class="q2">“so no man will dwell there, 
-</p><p class="q2">neither will any son of man live therein. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">41&#160;</span>“Behold, a people comes from the north. 
-</p><p class="q2">A great nation and many kings will be stirred up from the uttermost parts of the earth. 
-</p><p class="q1">
-<span class="v">42&#160;</span>They take up bow and spear. 
-</p><p class="q2">They are cruel, and have no mercy. 
-</p><p class="q2">Their voice roars like the sea. 
-</p><p class="q1">They ride on horses, 
-</p><p class="q2">everyone set in array, 
-</p><p class="q2">as a man to the battle, 
-</p><p class="q2">against you, daughter of Babylon. 
-</p><p class="q1">
-<span class="v">43&#160;</span>The king of Babylon has heard the news of them, 
-</p><p class="q2">and his hands become feeble. 
-</p><p class="q1">Anguish has taken hold of him, 
-</p><p class="q2">pains as of a woman in labor. 
-</p><p class="q1">
-<span class="v">44&#160;</span>Behold, the enemy will come up like a lion 
-</p><p class="q2">from the thickets of the Jordan against the strong habitation; 
-</p><p class="q2">for I will suddenly make them run away from it. 
-</p><p class="q1">Whoever is chosen, 
-</p><p class="q2">I will appoint him over it, 
-</p><p class="q2">for who is like me? 
-</p><p class="q1">Who will appoint me a time? 
-</p><p class="q2">Who is the shepherd who can stand before me?” 
-</p><p class="q1">
-<span class="v">45&#160;</span>Therefore hear the counsel of Yahweh 
-</p><p class="q2">that he has taken against Babylon; 
-</p><p class="q1">and his purposes 
-</p><p class="q2">that he has purposed against the land of the Chaldeans: 
-</p><p class="q1">Surely they will drag them away, 
-</p><p class="q2">even the little ones of the flock. 
-</p><p class="q2">Surely he will make their habitation desolate over them. 
-</p><p class="q1">
-<span class="v">46&#160;</span>The earth trembles at the noise of the taking of Babylon. 
-</p><p class="q2">The cry is heard among the nations. 
-</p><h2 class="chapterlabel" id="51">51</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh says: 
-</p><p class="q1">“Behold, I will raise up against Babylon, 
-</p><p class="q2">and against those who dwell in Lebkamai, a destroying wind. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will send to Babylon strangers, who will winnow her. 
-</p><p class="q2">They will empty her land; 
-</p><p class="q2">for in the day of trouble they will be against her all around. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Against him who bends, let the archer bend his bow, 
-</p><p class="q2">also against him who lifts himself up in his coat of mail. 
-</p><p class="q1">Don’t spare her young men! 
-</p><p class="q2">Utterly destroy all her army! 
-</p><p class="q1">
-<span class="v">4&#160;</span>They will fall down slain in the land of the Chaldeans, 
-</p><p class="q2">and thrust through in her streets. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For Israel is not forsaken, nor Judah, by his Elohim, 
-</p><p class="q2">by Yahweh of Armies; 
-</p><p class="q2">though their land is full of guilt against the Set-Apart One of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“Flee out of the middle of Babylon! 
-</p><p class="q2">Everyone save his own life! 
-</p><p class="q1">Don’t be cut off in her iniquity, 
-</p><p class="q2">for it is the time of Yahweh’s vengeance. 
-</p><p class="q2">He will render to her a recompense. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Babylon has been a golden cup in Yahweh’s hand, 
-</p><p class="q2">who made all the earth drunk. 
-</p><p class="q1">The nations have drunk of her wine; 
-</p><p class="q2">therefore the nations have gone mad. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Babylon has suddenly fallen and been destroyed! 
-</p><p class="q2">Wail for her! 
-</p><p class="q1">Take balm for her pain. 
-</p><p class="q2">Perhaps she may be healed. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“We would have healed Babylon, 
-</p><p class="q2">but she is not healed. 
-</p><p class="q1">Forsake her, 
-</p><p class="q2">and let’s each go into his own country; 
-</p><p class="q1">for her judgment reaches to heaven, 
-</p><p class="q2">and is lifted up even to the skies. 
-</p><p class="q1">
-<span class="v">10&#160;</span>‘Yahweh has produced our righteousness. 
-</p><p class="q2">Come, and let’s declare in Zion the work of Yahweh our Elohim.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Make the arrows sharp! 
-</p><p class="q2">Hold the shields firmly! 
-</p><p class="q1">Yahweh has stirred up the spirit of the kings of the Medes, 
-</p><p class="q2">because his purpose is against Babylon, to destroy it; 
-</p><p class="q1">for it is the vengeance of Yahweh, 
-</p><p class="q2">the vengeance of his temple. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Set up a standard against the walls of Babylon! 
-</p><p class="q2">Make the watch strong! 
-</p><p class="q1">Set the watchmen, 
-</p><p class="q2">and prepare the ambushes; 
-</p><p class="q1">for Yahweh has both purposed and done 
-</p><p class="q2">that which he spoke concerning the inhabitants of Babylon. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You who dwell on many waters, abundant in treasures, 
-</p><p class="q2">your end has come, the measure of your covetousness. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yahweh of Armies has sworn by himself, saying, 
-</p><p class="q2">‘Surely I will fill you with men, 
-</p><p class="q2">as with locusts, 
-</p><p class="q2">and they will lift up a shout against you.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“He has made the earth by his power. 
-</p><p class="q2">He has established the world by his wisdom. 
-</p><p class="q2">By his understanding he has stretched out the heavens. 
-</p><p class="q1">
-<span class="v">16&#160;</span>When he utters his voice, 
-</p><p class="q2">there is a roar of waters in the heavens, 
-</p><p class="q2">and he causes the vapors to ascend from the ends of the earth. 
-</p><p class="q1">He makes lightning for the rain, 
-</p><p class="q2">and brings the wind out of his treasuries. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“Every man has become stupid and without knowledge. 
-</p><p class="q2">Every goldsmith is disappointed by his image, 
-</p><p class="q1">for his molten images are falsehood, 
-</p><p class="q2">and there is no breath in them. 
-</p><p class="q1">
-<span class="v">18&#160;</span>They are vanity, 
-</p><p class="q2">a work of delusion. 
-</p><p class="q2">In the time of their visitation, they will perish. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The portion of Jacob is not like these, 
-</p><p class="q2">for he formed all things, 
-</p><p class="q2">including the tribe of his inheritance. 
-</p><p class="q2">Yahweh of Armies is his name. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“You are my battle ax and weapons of war. 
-</p><p class="q2">With you I will break the nations into pieces. 
-</p><p class="q2">With you I will destroy kingdoms. 
-</p><p class="q1">
-<span class="v">21&#160;</span>With you I will break in pieces 
-</p><p class="q2">the horse and his rider. 
-</p><p class="q1">
-<span class="v">22&#160;</span>With you I will break in pieces 
-</p><p class="q2">the chariot and him who rides therein. 
-</p><p class="q1">With you I will break in pieces 
-</p><p class="q2">man and woman. 
-</p><p class="q1">With you I will break in pieces 
-</p><p class="q2">the old man and the youth. 
-</p><p class="q1">With you I will break in pieces 
-</p><p class="q2">the young man and the virgin. 
-</p><p class="q1">
-<span class="v">23&#160;</span>With you I will break in pieces 
-</p><p class="q2">the shepherd and his flock. 
-</p><p class="q1">With you I will break in pieces 
-</p><p class="q2">the farmer and his yoke. 
-</p><p class="q1">With you I will break in pieces 
-</p><p class="q2">governors and deputies. 
-</p><p>
-<span class="v">24&#160;</span>“I will render to Babylon and to all the inhabitants of Chaldea all their evil that they have done in Zion in your sight,” says Yahweh. 
-</p><p class="q1">
-<span class="v">25&#160;</span>“Behold, I am against you, destroying mountain,” says Yahweh, 
-</p><p class="q2">“which destroys all the earth. 
-</p><p class="q1">I will stretch out my hand on you, 
-</p><p class="q2">roll you down from the rocks, 
-</p><p class="q2">and will make you a burned mountain. 
-</p><p class="q1">
-<span class="v">26&#160;</span>They won’t take a cornerstone from you, 
-</p><p class="q2">nor a stone for foundations; 
-</p><p class="q2">but you will be desolate forever,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">27&#160;</span>“Set up a standard in the land! 
-</p><p class="q2">Blow the trumpet among the nations! 
-</p><p class="q1">Prepare the nations against her! 
-</p><p class="q2">Call together against her the kingdoms of Ararat, Minni, and Ashkenaz! 
-</p><p class="q1">Appoint a marshal against her! 
-</p><p class="q2">Cause the horses to come up as the swarming locusts! 
-</p><p class="q1">
-<span class="v">28&#160;</span>Prepare against her the nations, 
-</p><p class="q2">the kings of the Medes, its governors, and all its deputies, and all the land of their dominion! 
-</p><p class="q1">
-<span class="v">29&#160;</span>The land trembles and is in pain; 
-</p><p class="q2">for the purposes of Yahweh against Babylon stand, 
-</p><p class="q2">to make the land of Babylon a desolation, without inhabitant. 
-</p><p class="q1">
-<span class="v">30&#160;</span>The mighty men of Babylon have stopped fighting, 
-</p><p class="q2">they remain in their strongholds. 
-</p><p class="q1">Their might has failed. 
-</p><p class="q2">They have become as women. 
-</p><p class="q1">Her dwelling places are set on fire. 
-</p><p class="q2">Her bars are broken. 
-</p><p class="q1">
-<span class="v">31&#160;</span>One runner will run to meet another, 
-</p><p class="q2">and one messenger to meet another, 
-</p><p class="q2">to show the king of Babylon that his city is taken on every quarter. 
-</p><p class="q1">
-<span class="v">32&#160;</span>So the passages are seized. 
-</p><p class="q2">They have burned the reeds with fire. 
-</p><p class="q2">The men of war are frightened.” 
-</p><p>
-<span class="v">33&#160;</span>For Yahweh of Armies, the Elohim of Israel says: 
-</p><p class="q1">“The daughter of Babylon is like a threshing floor at the time when it is trodden. 
-</p><p class="q2">Yet a little while, and the time of harvest comes for her.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">34&#160;</span>“Nebuchadnezzar the king of Babylon has devoured me. 
-</p><p class="q2">He has crushed me. 
-</p><p class="q2">He has made me an empty vessel. 
-</p><p class="q1">He has, like a monster, swallowed me up. 
-</p><p class="q2">He has filled his mouth with my delicacies. 
-</p><p class="q2">He has cast me out. 
-</p><p class="q1">
-<span class="v">35&#160;</span>May the violence done to me and to my flesh be on Babylon!” 
-</p><p class="q2">the inhabitant of Zion will say; and, 
-</p><p class="q1">“May my blood be on the inhabitants of Chaldea!” 
-</p><p class="q2">will Jerusalem say. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">36&#160;</span>Therefore Yahweh says: 
-</p><p class="q1">“Behold, I will plead your cause, 
-</p><p class="q2">and take vengeance for you. 
-</p><p class="q1">I will dry up her sea, 
-</p><p class="q2">and make her fountain dry. 
-</p><p class="q1">
-<span class="v">37&#160;</span>Babylon will become heaps, 
-</p><p class="q2">a dwelling place for jackals, 
-</p><p class="q2">an astonishment, and a hissing, 
-</p><p class="q2">without inhabitant. 
-</p><p class="q1">
-<span class="v">38&#160;</span>They will roar together like young lions. 
-</p><p class="q2">They will growl as lions’ cubs. 
-</p><p class="q1">
-<span class="v">39&#160;</span>When they are inflamed, I will make their feast, 
-</p><p class="q2">and I will make them drunk, 
-</p><p class="q1">that they may rejoice, 
-</p><p class="q2">and sleep a perpetual sleep, 
-</p><p class="q2">and not wake up,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">40&#160;</span>“I will bring them down like lambs to the slaughter, 
-</p><p class="q2">like rams with male goats. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">41&#160;</span>“How Sheshach is taken! 
-</p><p class="q2">How the praise of the whole earth is seized! 
-</p><p class="q2">How Babylon has become a desolation among the nations! 
-</p><p class="q1">
-<span class="v">42&#160;</span>The sea has come up on Babylon. 
-</p><p class="q2">She is covered with the multitude of its waves. 
-</p><p class="q1">
-<span class="v">43&#160;</span>Her cities have become a desolation, 
-</p><p class="q2">a dry land, and a desert, 
-</p><p class="q2">a land in which no man dwells. 
-</p><p class="q2">No son of man passes by it. 
-</p><p class="q1">
-<span class="v">44&#160;</span>I will execute judgment on Bel in Babylon, 
-</p><p class="q2">and I will bring out of his mouth that which he has swallowed up. 
-</p><p class="q1">The nations will not flow any more to him. 
-</p><p class="q2">Yes, the wall of Babylon will fall. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">45&#160;</span>“My people, go away from the middle of her, 
-</p><p class="q2">and each of you save yourselves from Yahweh’s fierce anger. 
-</p><p class="q1">
-<span class="v">46&#160;</span>Don’t let your heart faint. 
-</p><p class="q2">Don’t fear for the news that will be heard in the land. 
-</p><p class="q1">For news will come one year, 
-</p><p class="q2">and after that in another year news will come, 
-</p><p class="q2">and violence in the land, 
-</p><p class="q2">ruler against ruler. 
-</p><p class="q1">
-<span class="v">47&#160;</span>Therefore behold, the days come that I will execute judgment on the engraved images of Babylon; 
-</p><p class="q2">and her whole land will be confounded. 
-</p><p class="q2">All her slain will fall in the middle of her. 
-</p><p class="q1">
-<span class="v">48&#160;</span>Then the heavens and the earth, 
-</p><p class="q2">and all that is therein, 
-</p><p class="q1">will sing for joy over Babylon; 
-</p><p class="q2">for the destroyers will come to her from the north,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">49&#160;</span>“As Babylon has caused the slain of Israel to fall, 
-</p><p class="q2">so the slain of all the land will fall at Babylon. 
-</p><p class="q1">
-<span class="v">50&#160;</span>You who have escaped the sword, go! 
-</p><p class="q2">Don’t stand still! 
-</p><p class="q1">Remember Yahweh from afar, 
-</p><p class="q2">and let Jerusalem come into your mind.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">51&#160;</span>“We are confounded 
-</p><p class="q2">because we have heard reproach. 
-</p><p class="q1">Confusion has covered our faces, 
-</p><p class="q2">for strangers have come into the sanctuaries of Yahweh’s house.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">52&#160;</span>“Therefore behold, the days come,” says Yahweh, 
-</p><p class="q2">“that I will execute judgment on her engraved images; 
-</p><p class="q2">and through all her land the wounded will groan. 
-</p><p class="q1">
-<span class="v">53&#160;</span>Though Babylon should mount up to the sky, 
-</p><p class="q2">and though she should fortify the height of her strength, 
-</p><p class="q2">yet destroyers will come to her from me,” says Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">54&#160;</span>“The sound of a cry comes from Babylon, 
-</p><p class="q2">and of great destruction from the land of the Chaldeans! 
-</p><p class="q1">
-<span class="v">55&#160;</span>For Yahweh lays Babylon waste, 
-</p><p class="q2">and destroys out of her the great voice! 
-</p><p class="q1">Their waves roar like many waters. 
-</p><p class="q2">The noise of their voice is uttered. 
-</p><p class="q1">
-<span class="v">56&#160;</span>For the destroyer has come on her, 
-</p><p class="q2">even on Babylon. 
-</p><p class="q1">Her mighty men are taken. 
-</p><p class="q2">Their bows are broken in pieces, 
-</p><p class="q1">for Yahweh is an Elohim of retribution. 
-</p><p class="q2">He will surely repay. 
-</p><p class="q1">
-<span class="v">57&#160;</span>I will make her princes, her wise men, 
-</p><p class="q2">her governors, her deputies, and her mighty men drunk. 
-</p><p class="q1">They will sleep a perpetual sleep, 
-</p><p class="q2">and not wake up,” 
-</p><p class="q2">says the King, whose name is Yahweh of Armies. 
-</p><p>
-<span class="v">58&#160;</span>Yahweh of Armies says: 
-</p><p class="q1">“The wide walls of Babylon will be utterly overthrown. 
-</p><p class="q2">Her high gates will be burned with fire. 
-</p><p class="q1">The peoples will labor for vanity, 
-</p><p class="q2">and the nations for the fire; 
-</p><p class="q2">and they will be weary.” 
-</p><p>
-<span class="v">59&#160;</span>The word which Jeremiah the prophet commanded Seraiah the son of Neriah, the son of Mahseiah, when he went with Zedekiah the king of Judah to Babylon in the fourth year of his reign. Now Seraiah was chief quartermaster. 
-<span class="v">60&#160;</span>Jeremiah wrote in a book all the evil that should come on Babylon, even all these words that are written concerning Babylon. 
-<span class="v">61&#160;</span>Jeremiah said to Seraiah, “When you come to Babylon, then see that you read all these words, 
-<span class="v">62&#160;</span>and say, ‘Yahweh, you have spoken concerning this place, to cut it off, that no one will dwell in it, neither man nor animal, but that it will be desolate forever.’ 
-<span class="v">63&#160;</span>It will be, when you have finished reading this book, that you shall bind a stone to it, and cast it into the middle of the Euphrates. 
-<span class="v">64&#160;</span>Then you shall say, ‘Thus will Babylon sink, and will not rise again because of the evil that I will bring on her; and they will be weary.’&#160;” 
-</p><p>Thus far are the words of Jeremiah. 
-</p><h2 class="chapterlabel" id="52">52</h2>
-<p>
-<span class="v">1&#160;</span>Zedekiah was twenty-one years old when he began to reign. He reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
-<span class="v">2&#160;</span>He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
-<span class="v">3&#160;</span>For through Yahweh’s anger this happened in Jerusalem and Judah, until he had cast them out from his presence. 
-</p><p>Zedekiah rebelled against the king of Babylon. 
-<span class="v">4&#160;</span>In the ninth year of his reign, in the tenth month, in the tenth day of the month, Nebuchadnezzar king of Babylon came, he and all his army, against Jerusalem, and encamped against it; and they built forts against it round about. 
-<span class="v">5&#160;</span>So the city was besieged to the eleventh year of King Zedekiah. 
-</p><p>
-<span class="v">6&#160;</span>In the fourth month, in the ninth day of the month, the famine was severe in the city, so that there was no bread for the people of the land. 
-<span class="v">7&#160;</span>Then a breach was made in the city, and all the men of war fled, and went out of the city by night by the way of the gate between the two walls, which was by the king’s garden. Now the Chaldeans were against the city all around. The men of war went toward the Arabah, 
-<span class="v">8&#160;</span>but the army of the Chaldeans pursued the king, and overtook Zedekiah in the plains of Jericho; and all his army was scattered from him. 
-<span class="v">9&#160;</span>Then they took the king, and carried him up to the king of Babylon to Riblah in the land of Hamath; and he pronounced judgment on him. 
-<span class="v">10&#160;</span>The king of Babylon killed the sons of Zedekiah before his eyes. He also killed all the princes of Judah in Riblah. 
-<span class="v">11&#160;</span>He put out the eyes of Zedekiah; and the king of Babylon bound him in fetters, and carried him to Babylon, and put him in prison until the day of his death. 
-</p><p>
-<span class="v">12&#160;</span>Now in the fifth month, in the tenth day of the month, which was the nineteenth year of King Nebuchadnezzar, king of Babylon, Nebuzaradan the captain of the guard, who stood before the king of Babylon, came into Jerusalem. 
-<span class="v">13&#160;</span>He burned Yahweh’s house, and the king’s house; and all the houses of Jerusalem, even every great house, he burned with fire. 
-<span class="v">14&#160;</span>All the army of the Chaldeans, who were with the captain of the guard, broke down all the walls of Jerusalem all around. 
-<span class="v">15&#160;</span>Then Nebuzaradan the captain of the guard carried away captive of the poorest of the people, and the rest of the people who were left in the city, and those who fell away, who defected to the king of Babylon, and the rest of the multitude. 
-<span class="v">16&#160;</span>But Nebuzaradan the captain of the guard left of the poorest of the land to be vineyard keepers and farmers. 
-</p><p>
-<span class="v">17&#160;</span>The Chaldeans broke the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house in pieces, and carried all of their bronze to Babylon. 
-<span class="v">18&#160;</span>They also took away the pots, the shovels, the snuffers, the basins, the spoons, and all the vessels of bronze with which they ministered. 
-<span class="v">19&#160;</span>The captain of the guard took away the cups, the fire pans, the basins, the pots, the lamp stands, the spoons, and the bowls; that which was of gold, as gold, and that which was of silver, as silver. 
-</p><p>
-<span class="v">20&#160;</span>They took the two pillars, the one sea, and the twelve bronze bulls that were under the bases, which King Solomon had made for Yahweh’s house. The bronze of all these vessels was without weight. 
-<span class="v">21&#160;</span>As for the pillars, the height of the one pillar was eighteen cubits;<span class="f">+ \fr 52:21 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and a line of twelve cubits encircled it; and its thickness was four fingers. It was hollow. 
-<span class="v">22&#160;</span>A capital of bronze was on it; and the height of the one capital was five cubits,<span class="f">+ \fr 52:22 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> with network and pomegranates on the capital all around, all of bronze. The second pillar also had the same, with pomegranates. 
-<span class="v">23&#160;</span>There were ninety-six pomegranates on the sides; all the pomegranates were one hundred on the network all around. 
-</p><p>
-<span class="v">24&#160;</span>The captain of the guard took Seraiah the chief priest, and Zephaniah the second priest, and the three keepers of the threshold, 
-<span class="v">25&#160;</span>and out of the city he took an officer who was set over the men of war; and seven men of those who saw the king’s face, who were found in the city; and the scribe of the captain of the army, who mustered the people of the land; and sixty men of the people of the land, who were found in the middle of the city. 
-<span class="v">26&#160;</span>Nebuzaradan the captain of the guard took them, and brought them to the king of Babylon to Riblah. 
-<span class="v">27&#160;</span>The king of Babylon struck them, and put them to death at Riblah in the land of Hamath. 
-</p><p>So Judah was carried away captive out of his land. 
-<span class="v">28&#160;</span>This is the number of the people whom Nebuchadnezzar carried away captive: 
-</p><p class="m">in the seventh year, three thousand twenty-three Jews; 
-</p><p class="m">
-<span class="v">29&#160;</span>in the eighteenth year of Nebuchadnezzar, he carried away captive from Jerusalem eight hundred thirty-two persons; 
-</p><p class="m">
-<span class="v">30&#160;</span>in the twenty-third year of Nebuchadnezzar, Nebuzaradan the captain of the guard carried away captive of the Jews seven hundred forty-five people. 
-</p><p class="m">All the people numbered four thousand six hundred. 
-</p><p>
-<span class="v">31&#160;</span>In the thirty-seventh year of the captivity of Jehoiachin king of Judah, in the twelfth month, in the twenty-fifth day of the month, Evilmerodach king of Babylon, in the first year of his reign, lifted up the head of Jehoiachin king of Judah, and released him from prison. 
-<span class="v">32&#160;</span>He spoke kindly to him, and set his throne above the throne of the kings who were with him in Babylon, 
-<span class="v">33&#160;</span>and changed his prison garments. Jehoiachin ate bread before him continually all the days of his life. 
-<span class="v">34&#160;</span>For his allowance, there was a continual allowance given him by the king of Babylon, every day a portion until the day of his death, all the days of his life. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+<a href="#41">41</a>
+<a href="#42">42</a>
+<a href="#43">43</a>
+<a href="#44">44</a>
+<a href="#45">45</a>
+<a href="#46">46</a>
+<a href="#47">47</a>
+<a href="#48">48</a>
+<a href="#49">49</a>
+<a href="#50">50</a>
+<a href="#51">51</a>
+<a href="#52">52</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The words of Jeremiah the son of Hilkiah, one of the priests who were in Anathoth in the land of Benjamin. 
+<sup>2&#160;</sup>Yahweh’s word came to him in the days of Josiah the son of Amon, king of Judah, in the thirteenth year of his reign. 
+<sup>3&#160;</sup>It came also in the days of Jehoiakim the son of Josiah, king of Judah, to the end of the eleventh year of Zedekiah, the son of Josiah, king of Judah, to the carrying away of Jerusalem captive in the fifth month. 
+<sup>4&#160;</sup>Now Yahweh’s word came to me, saying, 
+</div><div class="q1">
+<sup>5&#160;</sup>“Before I formed you in the womb, I knew you. 
+</div><div class="q2">Before you were born, I sanctified you. 
+</div><div class="q2">I have appointed you a prophet to the nations.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then I said, “Ah, Lord I don’t know how to speak; for I am a child.” 
+</div><div class="p">
+<sup>7&#160;</sup>But Yahweh said to me, “Don’t say, ‘I am a child;’ for you must go to whomever I send you, and you must say whatever I command you. 
+<sup>8&#160;</sup>Don’t be afraid because of them, for I am with you to rescue you,” says Yahweh. 
+</div><div class="p">
+<sup>9&#160;</sup>Then Yahweh stretched out his hand and touched my mouth. Then Yahweh said to me, “Behold, I have put my words in your mouth. 
+<sup>10&#160;</sup>Behold, I have today set you over the nations and over the kingdoms, to uproot and to tear down, to destroy and to overthrow, to build and to plant.” 
+</div><div class="p">
+<sup>11&#160;</sup>Moreover Yahweh’s word came to me, saying, “Jeremiah, what do you see?” 
+</div><div class="p">I said, “I see a branch of an almond tree.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then Yahweh said to me, “You have seen well; for I watch over my word to perform it.” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh’s word came to me the second time, saying, “What do you see?” 
+</div><div class="p">I said, “I see a boiling cauldron; and it is tipping away from the north.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Yahweh said to me, “Out of the north, evil will break out on all the inhabitants of the land. 
+<sup>15&#160;</sup>For behold, I will call all the families of the kingdoms of the north,” says Yahweh. 
+</div><div class="q1">“They will come, and they will each set his throne at the entrance of the gates of Jerusalem, 
+</div><div class="q2">and against all its walls all around, and against all the cities of Judah. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will utter my judgments against them concerning all their wickedness, 
+</div><div class="q2">in that they have forsaken me, 
+</div><div class="q2">and have burned incense to other elohims, 
+</div><div class="q2">and worshiped the works of their own hands. 
+</div><div class="p">
+<sup>17&#160;</sup>“You therefore put your belt on your waist, arise, and say to them all that I command you. Don’t be dismayed at them, lest I dismay you before them. 
+<sup>18&#160;</sup>For behold, I have made you today a fortified city, an iron pillar, and bronze walls against the whole land—against the kings of Judah, against its princes, against its priests, and against the people of the land. 
+<sup>19&#160;</sup>They will fight against you, but they will not prevail against you; for I am with you”, says Yahweh, “to rescue you.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“Go and proclaim in the ears of Jerusalem, saying, ‘Yahweh says, 
+</div><div class="q1">“I remember for you the kindness of your youth, 
+</div><div class="q2">your love as a bride, 
+</div><div class="q1">how you went after me in the wilderness, 
+</div><div class="q2">in a land that was not sown. 
+</div><div class="q1">
+<sup>3&#160;</sup>Israel was set-apartness to Yahweh, 
+</div><div class="q2">the first fruits of his increase. 
+</div><div class="q1">All who devour him will be held guilty. 
+</div><div class="q2">Evil will come on them,”&#160;’ says Yahweh.” 
+</div><div class="p">
+<sup>4&#160;</sup>Hear Yahweh’s word, O house of Jacob, and all the families of the house of Israel! 
+<sup>5&#160;</sup>Yahweh says, 
+</div><div class="q1">“What unrighteousness have your fathers found in me, 
+</div><div class="q2">that they have gone far from me, 
+</div><div class="q1">and have walked after worthless vanity, 
+</div><div class="q2">and have become worthless? 
+</div><div class="q1">
+<sup>6&#160;</sup>They didn’t say, ‘Where is Yahweh who brought us up out of the land of Egypt, 
+</div><div class="q2">who led us through the wilderness, 
+</div><div class="q2">through a land of deserts and of pits, 
+</div><div class="q2">through a land of drought and of the shadow of death, 
+</div><div class="q2">through a land that no one passed through, 
+</div><div class="q2">and where no man lived?’ 
+</div><div class="q1">
+<sup>7&#160;</sup>I brought you into a plentiful land 
+</div><div class="q2">to eat its fruit and its goodness; 
+</div><div class="q1">but when you entered, you defiled my land, 
+</div><div class="q2">and made my heritage an abomination. 
+</div><div class="q1">
+<sup>8&#160;</sup>The priests didn’t say, ‘Where is Yahweh?’ 
+</div><div class="q2">and those who handle the law didn’t know me. 
+</div><div class="q1">The rulers also transgressed against me, 
+</div><div class="q2">and the prophets prophesied by Baal 
+</div><div class="q2">and followed things that do not profit. 
+</div><div class="q1">
+<sup>9&#160;</sup>“Therefore I will yet contend with you,” says Yahweh, 
+</div><div class="q2">“and I will contend with your children’s children. 
+</div><div class="q1">
+<sup>10&#160;</sup>For pass over to the islands of Kittim, and see. 
+</div><div class="q2">Send to Kedar, and consider diligently, 
+</div><div class="q2">and see if there has been such a thing. 
+</div><div class="q1">
+<sup>11&#160;</sup>Has a nation changed its elohims, 
+</div><div class="q2">which really are no elohims? 
+</div><div class="q2">But my people have changed their glory for that which doesn’t profit. 
+</div><div class="q1">
+<sup>12&#160;</sup>“Be astonished, you heavens, at this 
+</div><div class="q2">and be horribly afraid. 
+</div><div class="q2">Be very desolate,” says Yahweh. 
+</div><div class="q1">
+<sup>13&#160;</sup>“For my people have committed two evils: 
+</div><div class="q2">they have forsaken me, the spring of living waters, 
+</div><div class="q2">and cut out cisterns for themselves: broken cisterns that can’t hold water. 
+</div><div class="q1">
+<sup>14&#160;</sup>Is Israel a slave? 
+</div><div class="q2">Is he born into slavery? 
+</div><div class="q2">Why has he become a captive? 
+</div><div class="q1">
+<sup>15&#160;</sup>The young lions have roared at him and raised their voices. 
+</div><div class="q2">They have made his land waste. 
+</div><div class="q2">His cities are burned up, without inhabitant. 
+</div><div class="q2">
+<sup>16&#160;</sup>The children also of Memphis and Tahpanhes have broken the crown of your head. 
+</div><div class="q1">
+<sup>17&#160;</sup>“Haven’t you brought this on yourself, 
+</div><div class="q2">in that you have forsaken Yahweh your Elohim, when he led you by the way? 
+</div><div class="q1">
+<sup>18&#160;</sup>Now what do you gain by going to Egypt, to drink the waters of the Shihor? 
+</div><div class="q2">Or why do you go on the way to Assyria, to drink the waters of the River? 
+</div><div class="q1">
+<sup>19&#160;</sup>“Your own wickedness will correct you, 
+</div><div class="q2">and your backsliding will rebuke you. 
+</div><div class="q1">Know therefore and see that it is an evil and bitter thing, 
+</div><div class="q2">that you have forsaken Yahweh your Elohim, 
+</div><div class="q2">and that my fear is not in you,” says the Lord, Yahweh of Armies. 
+</div><div class="q1">
+<sup>20&#160;</sup>“For long ago I broke off your yoke, 
+</div><div class="q2">and burst your bonds. 
+</div><div class="q1">You said, ‘I will not serve;’ 
+</div><div class="q2">for on every high hill and under every green tree you bowed yourself, 
+</div><div class="q2">playing the prostitute. 
+</div><div class="q1">
+<sup>21&#160;</sup>Yet I had planted you a noble vine, 
+</div><div class="q2">a pure and faithful seed. 
+</div><div class="q2">How then have you turned into the degenerate branches of a foreign vine to me? 
+</div><div class="q1">
+<sup>22&#160;</sup>For though you wash yourself with lye, 
+</div><div class="q2">and use much soap, 
+</div><div class="q2">yet your iniquity is marked before me,” says the Lord Yahweh. 
+</div><div class="q1">
+<sup>23&#160;</sup>“How can you say, ‘I am not defiled. 
+</div><div class="q2">I have not gone after the Baals’? 
+</div><div class="q1">See your way in the valley. 
+</div><div class="q2">Know what you have done. 
+</div><div class="q1">You are a swift dromedary traversing her ways, 
+<sup>24&#160;</sup>a wild donkey used to the wilderness, that sniffs the wind in her craving. 
+</div><div class="q2">When she is in heat, who can turn her away? 
+</div><div class="q2">All those who seek her will not weary themselves. In her month, they will find her. 
+</div><div class="q1">
+<sup>25&#160;</sup>“Keep your feet from being bare, 
+</div><div class="q2">and your throat from thirst. 
+</div><div class="q1">But you said, ‘It is in vain. 
+</div><div class="q2">No, for I have loved strangers, 
+</div><div class="q2">and I will go after them.’ 
+</div><div class="q1">
+<sup>26&#160;</sup>As the thief is ashamed when he is found, 
+</div><div class="q2">so the house of Israel is ashamed—</div><div class="q2">they, their kings, their princes, their priests, and their prophets, 
+</div><div class="q1">
+<sup>27&#160;</sup>who tell wood, ‘You are my father,’ 
+</div><div class="q2">and a stone, ‘You have given birth to me,’ 
+</div><div class="q1">for they have turned their back to me, 
+</div><div class="q2">and not their face, 
+</div><div class="q2">but in the time of their trouble they will say, ‘Arise, and save us!’ 
+</div><div class="q1">
+<sup>28&#160;</sup>“But where are your elohims that you have made for yourselves? 
+</div><div class="q2">Let them arise, if they can save you in the time of your trouble, 
+</div><div class="q2">for you have as many elohims as you have towns, O Judah. 
+</div><div class="q1">
+<sup>29&#160;</sup>“Why will you contend with me? 
+</div><div class="q2">You all have transgressed against me,” says Yahweh. 
+</div><div class="q1">
+<sup>30&#160;</sup>“I have struck your children in vain. 
+</div><div class="q2">They received no correction. 
+</div><div class="q1">Your own sword has devoured your prophets, 
+</div><div class="q2">like a destroying lion. 
+</div><div class="q1">
+<sup>31&#160;</sup>Generation, consider Yahweh’s word. 
+</div><div class="q2">Have I been a wilderness to Israel? 
+</div><div class="q2">Or a land of thick darkness? 
+</div><div class="q1">Why do my people say, ‘We have broken loose. 
+</div><div class="q2">We will come to you no more’? 
+</div><div class="q1">
+<sup>32&#160;</sup>“Can a virgin forget her ornaments, 
+</div><div class="q2">or a bride her attire? 
+</div><div class="q2">Yet my people have forgotten me for days without number. 
+</div><div class="q1">
+<sup>33&#160;</sup>How well you prepare your way to seek love! 
+</div><div class="q2">Therefore you have even taught the wicked women your ways. 
+</div><div class="q1">
+<sup>34&#160;</sup>Also the blood of the souls of the innocent poor is found in your skirts. 
+</div><div class="q2">You didn’t find them breaking in, 
+</div><div class="q2">but it is because of all these things. 
+</div><div class="q1">
+<sup>35&#160;</sup>“Yet you said, ‘I am innocent. 
+</div><div class="q2">Surely his anger has turned away from me.’ 
+</div><div class="q1">“Behold, I will judge you, 
+</div><div class="q2">because you say, ‘I have not sinned.’ 
+</div><div class="q1">
+<sup>36&#160;</sup>Why do you go about so much to change your ways? 
+</div><div class="q2">You will be ashamed of Egypt also, 
+</div><div class="q2">as you were ashamed of Assyria. 
+</div><div class="q1">
+<sup>37&#160;</sup>You will also leave that place with your hands on your head; 
+</div><div class="q2">for Yahweh has rejected those in whom you trust, 
+</div><div class="q2">and you won’t prosper with them. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>“They say, ‘If a man puts away his woman, and she goes from him, and becomes another man’s, should he return to her again?’ Wouldn’t that land be greatly polluted? But you have played the prostitute with many lovers; yet return again to me,” says Yahweh. 
+</div><div class="p">
+<sup>2&#160;</sup>“Lift up your eyes to the bare heights, and see! Where have you not been lain with? You have sat waiting for them by the road, as an Arabian in the wilderness. You have polluted the land with your prostitution and with your wickedness. 
+<sup>3&#160;</sup>Therefore the showers have been withheld and there has been no latter rain; yet you have had a prostitute’s forehead and you refused to be ashamed. 
+<sup>4&#160;</sup>Will you not from this time cry to me, ‘My Father, you are the guide of my youth!’? 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘Will he retain his anger forever? Will he keep it to the end?’ Behold, you have spoken and have done evil things, and have had your way.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moreover, Yahweh said to me in the days of Josiah the king, “Have you seen that which backsliding Israel has done? She has gone up on every high mountain and under every green tree, and has played the prostitute there. 
+<sup>7&#160;</sup>I said after she had done all these things, ‘She will return to me;’ but she didn’t return, and her treacherous sister Judah saw it. 
+<sup>8&#160;</sup>I saw when, for this very cause, that backsliding Israel had committed adultery, I had put her away and given her a certificate of divorce, yet treacherous Judah, her sister, had no fear, but she also went and played the prostitute. 
+<sup>9&#160;</sup>Because she took her prostitution lightly, the land was polluted, and she committed adultery with stones and with wood. 
+<sup>10&#160;</sup>Yet for all this her treacherous sister, Judah, has not returned to me with her whole heart, but only in pretense,” says Yahweh. 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said to me, “Backsliding Israel has shown herself more righteous than treacherous Judah. 
+<sup>12&#160;</sup>Go, and proclaim these words toward the north, and say, ‘Return, you backsliding Israel,’ says Yahweh; ‘I will not look in anger on you, for I am merciful,’ says Yahweh. ‘I will not keep anger forever. 
+<sup>13&#160;</sup>Only acknowledge your iniquity, that you have transgressed against Yahweh your Elohim, and have scattered your ways to the strangers under every green tree, and you have not obeyed my voice,’&#160;” says Yahweh. 
+<sup>14&#160;</sup>“Return, backsliding children,” says Yahweh, “for I am an owner to you. I will take one of you from a city, and two from a family, and I will bring you to Zion. 
+<sup>15&#160;</sup>I will give you shepherds according to my heart, who will feed you with knowledge and understanding. 
+<sup>16&#160;</sup>It will come to pass, when you are multiplied and increased in the land in those days,” says Yahweh, “they will no longer say, ‘the ark of Yahweh’s covenant!’ It will not come to mind. They won’t remember it. They won’t miss it, nor will another be made. 
+<sup>17&#160;</sup>At that time they will call Jerusalem ‘Yahweh’s Throne;’ and all the nations will be gathered to it, to Yahweh’s name, to Jerusalem. They will no longer walk after the stubbornness of their evil heart. 
+<sup>18&#160;</sup>In those days the house of Judah will walk with the house of Israel, and they will come together out of the land of the north to the land that I gave for an inheritance to your fathers. 
+</div><div class="p">
+<sup>19&#160;</sup>“But I said, ‘How I desire to put you among the children, and give you a pleasant land, a goodly heritage of the armies of the nations!’ and I said, ‘You shall call me “My Father”, and shall not turn away from following me.’ 
+</div><div class="p">
+<sup>20&#160;</sup>“Surely as a woman treacherously departs from her friend, so you have dealt treacherously with me, house of Israel,” says Yahweh. 
+<sup>21&#160;</sup>A voice is heard on the bare heights, the weeping and the petitions of the children of Israel; because they have perverted their way, they have forgotten Yahweh their Elohim. 
+<sup>22&#160;</sup>Return, you backsliding children, and I will heal your backsliding. 
+</div><div class="p">“Behold, we have come to you; for you are Yahweh our Elohim. 
+<sup>23&#160;</sup>Truly help from the hills, the tumult on the mountains, is in vain. Truly the salvation of Israel is in Yahweh our Elohim. 
+<sup>24&#160;</sup>But the shameful thing has devoured the labor of our fathers from our youth, their flocks and their herds, their sons and their daughters. 
+<sup>25&#160;</sup>Let us lie down in our shame, and let our confusion cover us; for we have sinned against Yahweh our Elohim, we and our fathers, from our youth even to this day. We have not obeyed Yahweh our Elohim’s voice.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>“If you will return, Israel,” says Yahweh, “if you will return to me, and if you will put away your abominations out of my sight; then you will not be removed; 
+<sup>2&#160;</sup>and you will swear, ‘As Yahweh lives,’ in truth, in justice, and in righteousness. The nations will bless themselves in him, and they will glory in him.” 
+</div><div class="p">
+<sup>3&#160;</sup>For Yahweh says to the men of Judah and to Jerusalem, “Break up your fallow ground, and don’t sow among thorns. 
+<sup>4&#160;</sup>Circumcise yourselves to Yahweh, and take away the foreskins of your heart, you men of Judah and inhabitants of Jerusalem; lest my wrath go out like fire, and burn so that no one can quench it, because of the evil of your doings. 
+<sup>5&#160;</sup>Declare in Judah, and publish in Jerusalem; and say, ‘Blow the trumpet in the land!’ Cry aloud and say, ‘Assemble yourselves! Let’s go into the fortified cities!’ 
+<sup>6&#160;</sup>Set up a standard toward Zion. Flee for safety! Don’t wait; for I will bring evil from the north, and a great destruction.” 
+</div><div class="p">
+<sup>7&#160;</sup>A lion has gone up from his thicket, and a destroyer of nations. He is on his way. He has gone out from his place, to make your land desolate, that your cities be laid waste, without inhabitant. 
+<sup>8&#160;</sup>For this, clothe yourself with sackcloth, lament and wail; for the fierce anger of Yahweh hasn’t turned back from us. 
+<sup>9&#160;</sup>“It will happen at that day,” says Yahweh, “that the heart of the king will perish, along with the heart of the princes. The priests will be astonished, and the prophets will wonder.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then I said, “Ah, Lord Yahweh! Surely you have greatly deceived this people and Jerusalem, saying, ‘You will have peace;’ whereas the sword reaches to the heart.” 
+</div><div class="p">
+<sup>11&#160;</sup>At that time it will be said to this people and to Jerusalem, “A hot wind blows from the bare heights in the wilderness toward the daughter of my people, not to winnow, nor to cleanse. 
+<sup>12&#160;</sup>A full wind from these will come for me. Now I will also utter judgments against them.” 
+</div><div class="p">
+<sup>13&#160;</sup>Behold, he will come up as clouds, and his chariots will be as the whirlwind. His horses are swifter than eagles. Woe to us! For we are ruined. 
+<sup>14&#160;</sup>Jerusalem, wash your heart from wickedness, that you may be saved. How long will your evil thoughts lodge within you? 
+<sup>15&#160;</sup>For a voice declares from Dan, and publishes evil from the hills of Ephraim: 
+<sup>16&#160;</sup>“Tell the nations, behold, publish against Jerusalem, ‘Watchers come from a far country, and raise their voice against the cities of Judah. 
+<sup>17&#160;</sup>As keepers of a field, they are against her all around, because she has been rebellious against me,’&#160;” says Yahweh. 
+<sup>18&#160;</sup>“Your way and your doings have brought these things to you. This is your wickedness, for it is bitter, for it reaches to your heart.” 
+</div><div class="p">
+<sup>19&#160;</sup>My anguish, my anguish! I am pained at my very heart! My heart trembles within me. I can’t hold my peace, because you have heard, O my soul, the sound of the trumpet, the alarm of war. 
+<sup>20&#160;</sup>Destruction on destruction is decreed, for the whole land is laid waste. Suddenly my tents are destroyed, and my curtains gone in a moment. 
+<sup>21&#160;</sup>How long will I see the standard and hear the sound of the trumpet? 
+</div><div class="p">
+<sup>22&#160;</sup>“For my people are foolish. They don’t know me. They are foolish children, and they have no understanding. They are skillful in doing evil, but they don’t know how to do good.” 
+<sup>23&#160;</sup>I saw the earth and, behold, it was waste and void, and the heavens, and they had no light. 
+<sup>24&#160;</sup>I saw the mountains, and behold, they trembled, and all the hills moved back and forth. 
+<sup>25&#160;</sup>I saw, and behold, there was no man, and all the birds of the sky had fled. 
+<sup>26&#160;</sup>I saw, and behold, the fruitful field was a wilderness, and all its cities were broken down at the presence of Yahweh, before his fierce anger. 
+<sup>27&#160;</sup>For Yahweh says, “The whole land will be a desolation; yet I will not make a full end. 
+<sup>28&#160;</sup>For this the earth will mourn, and the heavens above be black, because I have spoken it. I have planned it, and I have not repented, neither will I turn back from it.” 
+</div><div class="p">
+<sup>29&#160;</sup>Every city flees for the noise of the horsemen and archers. They go into the thickets and climb up on the rocks. Every city is forsaken, and not a man dwells therein. 
+<sup>30&#160;</sup>You, when you are made desolate, what will you do? Though you clothe yourself with scarlet, though you deck yourself with ornaments of gold, though you enlarge your eyes with makeup, you make yourself beautiful in vain. Your lovers despise you. They seek your life. 
+<sup>31&#160;</sup>For I have heard a voice as of a woman in travail, the anguish as of her who gives birth to her first child, the voice of the daughter of Zion, who gasps for breath, who spreads her hands, saying, “Woe is me now! For my soul faints before the murderers.” 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>“Run back and forth through the streets of Jerusalem, and see now, and know, and seek in its wide places, if you can find a man, if there is anyone who does justly, who seeks truth, then I will pardon her. 
+<sup>2&#160;</sup>Though they say, ‘As Yahweh lives,’ surely they swear falsely.” 
+</div><div class="p">
+<sup>3&#160;</sup>O Yahweh, don’t your eyes look on truth? You have stricken them, but they were not grieved. You have consumed them, but they have refused to receive correction. They have made their faces harder than a rock. They have refused to return. 
+</div><div class="p">
+<sup>4&#160;</sup>Then I said, “Surely these are poor. They are foolish; for they don’t know Yahweh’s way, nor the law of their Elohim. 
+<sup>5&#160;</sup>I will go to the great men and will speak to them, for they know the way of Yahweh, and the law of their Elohim.” But these with one accord have broken the yoke, and burst the bonds. 
+<sup>6&#160;</sup>Therefore a lion out of the forest will kill them. A wolf of the evenings will destroy them. A leopard will watch against their cities. Everyone who goes out there will be torn in pieces, because their transgressions are many and their backsliding has increased. 
+</div><div class="p">
+<sup>7&#160;</sup>“How can I pardon you? Your children have forsaken me, and sworn by what are no elohims. When I had fed them to the full, they committed adultery, and assembled themselves in troops at the prostitutes’ houses. 
+<sup>8&#160;</sup>They were as fed horses roaming at large. Everyone neighed after his neighbor’s woman. 
+<sup>9&#160;</sup>Shouldn’t I punish them for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
+</div><div class="p">
+<sup>10&#160;</sup>“Go up on her walls, and destroy, but don’t make a full end. Take away her branches, for they are not Yahweh’s. 
+<sup>11&#160;</sup>For the house of Israel and the house of Judah have dealt very treacherously against me,” says Yahweh. 
+</div><div class="p">
+<sup>12&#160;</sup>They have denied Yahweh, and said, “It is not he. Evil won’t come on us. We won’t see sword or famine. 
+<sup>13&#160;</sup>The prophets will become wind, and the word is not in them. Thus it will be done to them.” 
+</div><div class="p">
+<sup>14&#160;</sup>Therefore Yahweh, the Elohim of Armies says, “Because you speak this word, behold, I will make my words in your mouth fire, and this people wood, and it will devour them. 
+<sup>15&#160;</sup>Behold, I will bring a nation on you from far away, house of Israel,” says Yahweh. “It is a mighty nation. It is an ancient nation, a nation whose language you don’t know and don’t understand what they say. 
+<sup>16&#160;</sup>Their quiver is an open tomb. They are all mighty men. 
+<sup>17&#160;</sup>They will eat up your harvest and your bread, which your sons and your daughters should eat. They will eat up your flocks and your herds. They will eat up your vines and your fig trees. They will beat down your fortified cities in which you trust with the sword. 
+</div><div class="p">
+<sup>18&#160;</sup>“But even in those days,” says Yahweh, “I will not make a full end of you. 
+<sup>19&#160;</sup>It will happen when you say, ‘Why has Yahweh our Elohim done all these things to us?’ Then you shall say to them, ‘Just as you have forsaken me and served foreign elohims in your land, so you will serve strangers in a land that is not yours.’ 
+</div><div class="p">
+<sup>20&#160;</sup>“Declare this in the house of Jacob, and publish it in Judah, saying, 
+<sup>21&#160;</sup>‘Hear this now, foolish people without understanding, who have eyes, and don’t see, who have ears, and don’t hear: 
+<sup>22&#160;</sup>Don’t you fear me?’ says Yahweh; ‘Won’t you tremble at my presence, who have placed the sand for the bound of the sea by a perpetual decree, that it can’t pass it? Though its waves toss themselves, yet they can’t prevail. Though they roar, they still can’t pass over it.’ 
+</div><div class="p">
+<sup>23&#160;</sup>“But this people has a revolting and a rebellious heart. They have revolted and gone. 
+<sup>24&#160;</sup>They don’t say in their heart, ‘Let’s now fear Yahweh our Elohim, who gives rain, both the former and the latter, in its season, who preserves to us the appointed weeks of the harvest.’ 
+</div><div class="p">
+<sup>25&#160;</sup>“Your iniquities have turned away these things, and your sins have withheld good from you. 
+<sup>26&#160;</sup>For wicked men are found among my people. They watch, as fowlers lie in wait. They set a trap. They catch men. 
+<sup>27&#160;</sup>As a cage is full of birds, so are their houses full of deceit. Therefore they have become great, and grew rich. 
+<sup>28&#160;</sup>They have grown fat. They shine; yes, they excel in deeds of wickedness. They don’t plead the cause, the cause of the fatherless, that they may prosper; and they don’t defend the rights of the needy. 
+</div><div class="p">
+<sup>29&#160;</sup>“Shouldn’t I punish for these things?” says Yahweh. “Shouldn’t my soul be avenged on such a nation as this? 
+</div><div class="p">
+<sup>30&#160;</sup>“An astonishing and horrible thing has happened in the land. 
+<sup>31&#160;</sup>The prophets prophesy falsely, and the priests rule by their own authority; and my people love to have it so. What will you do in the end of it? 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>“Flee for safety, you children of Benjamin, out of the middle of Jerusalem! Blow the trumpet in Tekoa and raise up a signal on Beth Haccherem, for evil looks out from the north with a great destruction. 
+<sup>2&#160;</sup>I will cut off the beautiful and delicate one, the daughter of Zion. 
+<sup>3&#160;</sup>Shepherds with their flocks will come to her. They will pitch their tents against her all around. They will feed everyone in his place.” 
+</div><div class="p">
+<sup>4&#160;</sup>“Prepare war against her! Arise! Let’s go up at noon. Woe to us! For the day declines, for the shadows of the evening are stretched out. 
+<sup>5&#160;</sup>Arise! Let’s go up by night, and let’s destroy her palaces.” 
+<sup>6&#160;</sup>For Yahweh of Armies said, “Cut down trees, and cast up a mound against Jerusalem. This is the city to be visited. She is filled with oppression within herself. 
+<sup>7&#160;</sup>As a well produces its waters, so she produces her wickedness. Violence and destruction is heard in her. Sickness and wounds are continually before me. 
+<sup>8&#160;</sup>Be instructed, Jerusalem, lest my soul be alienated from you, lest I make you a desolation, an uninhabited land.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh of Armies says, “They will thoroughly glean the remnant of Israel like a vine. Turn again your hand as a grape gatherer into the baskets.” 
+</div><div class="p">
+<sup>10&#160;</sup>To whom should I speak and testify, that they may hear? Behold, their ear is uncircumcised, and they can’t listen. Behold, Yahweh’s word has become a reproach to them. They have no delight in it. 
+<sup>11&#160;</sup>Therefore I am full of Yahweh’s wrath. I am weary with holding it in. 
+</div><div class="q1">“Pour it out on the children in the street, 
+</div><div class="q2">and on the assembly of young men together; 
+</div><div class="q1">for even the man with the woman will be taken, 
+</div><div class="q2">the aged with him who is full of days. 
+</div><div class="q1">
+<sup>12&#160;</sup>Their houses will be turned to others, 
+</div><div class="q2">their fields and their women together; 
+</div><div class="q1">for I will stretch out my hand on the inhabitants of the land, says Yahweh.” 
+</div><div class="q1">
+<sup>13&#160;</sup>“For from their least even to their greatest, everyone is given to covetousness. 
+</div><div class="q2">From the prophet even to the priest, everyone deals falsely. 
+</div><div class="q1">
+<sup>14&#160;</sup>They have healed also the hurt of my people superficially, 
+</div><div class="q2">saying, ‘Peace, peace!’ when there is no peace. 
+</div><div class="q1">
+<sup>15&#160;</sup>Were they ashamed when they had committed abomination? 
+</div><div class="q2">No, they were not at all ashamed, neither could they blush. 
+</div><div class="q1">Therefore they will fall among those who fall. 
+</div><div class="q2">When I visit them, they will be cast down,” says Yahweh. 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh says, “Stand in the ways and see, and ask for the old paths, ‘Where is the good way?’ and walk in it, and you will find rest for your souls. But they said, ‘We will not walk in it.’ 
+<sup>17&#160;</sup>I set watchmen over you, saying, ‘Listen to the sound of the trumpet!’ But they said, ‘We will not listen!’ 
+<sup>18&#160;</sup>Therefore hear, you nations, and know, congregation, what is among them. 
+<sup>19&#160;</sup>Hear, earth! Behold, I will bring evil on this people, even the fruit of their thoughts, because they have not listened to my words; and as for my law, they have rejected it. 
+<sup>20&#160;</sup>To what purpose does frankincense from Sheba come to me, and the sweet cane from a far country? Your burnt offerings are not acceptable, and your sacrifices are not pleasing to me.” 
+</div><div class="p">
+<sup>21&#160;</sup>Therefore Yahweh says, “Behold, I will lay stumbling blocks before this people. The fathers and the sons together will stumble against them. The neighbor and his friend will perish.” 
+<sup>22&#160;</sup>Yahweh says, “Behold, a people comes from the north country. A great nation will be stirred up from the uttermost parts of the earth. 
+<sup>23&#160;</sup>They take hold of bow and spear. They are cruel, and have no mercy. Their voice roars like the sea, and they ride on horses, everyone set in array, as a man to the battle, against you, daughter of Zion.” 
+</div><div class="p">
+<sup>24&#160;</sup>We have heard its report. Our hands become feeble. Anguish has taken hold of us, and pains as of a woman in labor. 
+<sup>25&#160;</sup>Don’t go out into the field or walk by the way; for the sword of the enemy and terror are on every side. 
+<sup>26&#160;</sup>Daughter of my people, clothe yourself with sackcloth, and wallow in ashes! Mourn, as for an only son, most bitter lamentation, for the destroyer will suddenly come on us. 
+</div><div class="p">
+<sup>27&#160;</sup>“I have made you a tester of metals and a fortress among my people, that you may know and try their way. 
+<sup>28&#160;</sup>They are all grievous rebels, going around to slander. They are bronze and iron. All of them deal corruptly. 
+<sup>29&#160;</sup>The bellows blow fiercely. The lead is consumed in the fire. In vain they go on refining, for the wicked are not plucked away. 
+<sup>30&#160;</sup>Men will call them rejected silver, because Yahweh has rejected them.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>The word that came to Jeremiah from Yahweh, saying, 
+<sup>2&#160;</sup>“Stand in the gate of Yahweh’s house, and proclaim this word there, and say, ‘Hear Yahweh’s word, all you of Judah, who enter in at these gates to worship Yahweh.’&#160;” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh of Armies, the Elohim of Israel says, “Amend your ways and your doings, and I will cause you to dwell in this place. 
+<sup>4&#160;</sup>Don’t trust in lying words, saying, ‘Yahweh’s temple, Yahweh’s temple, Yahweh’s temple, are these.’ 
+<sup>5&#160;</sup>For if you thoroughly amend your ways and your doings, if you thoroughly execute justice between a man and his neighbor; 
+<sup>6&#160;</sup>if you don’t oppress the foreigner, the fatherless, and the widow, and don’t shed innocent blood in this place, and don’t walk after other elohims to your own hurt, 
+<sup>7&#160;</sup>then I will cause you to dwell in this place, in the land that I gave to your fathers, from of old even forever more. 
+<sup>8&#160;</sup>Behold, you trust in lying words that can’t profit. 
+<sup>9&#160;</sup>Will you steal, murder, commit adultery, swear falsely, burn incense to Baal, and walk after other elohims that you have not known, 
+<sup>10&#160;</sup>then come and stand before me in this house, which is called by my name, and say, ‘We are delivered,’ that you may do all these abominations? 
+<sup>11&#160;</sup>Has this house, which is called by my name, become a den of robbers in your eyes? Behold, I myself have seen it,” says Yahweh. 
+</div><div class="p">
+<sup>12&#160;</sup>“But go now to my place which was in Shiloh, where I caused my name to dwell at the first, and see what I did to it for the wickedness of my people Israel. 
+<sup>13&#160;</sup>Now, because you have done all these works,” says Yahweh, “and I spoke to you, rising up early and speaking, but you didn’t hear; and I called you, but you didn’t answer; 
+<sup>14&#160;</sup>therefore I will do to the house which is called by my name, in which you trust, and to the place which I gave to you and to your fathers, as I did to Shiloh. 
+<sup>15&#160;</sup>I will cast you out of my sight, as I have cast out all your brothers, even the whole offspring of Ephraim. 
+</div><div class="p">
+<sup>16&#160;</sup>“Therefore don’t pray for this people. Don’t lift up a cry or prayer for them or make intercession to me; for I will not hear you. 
+<sup>17&#160;</sup>Don’t you see what they do in the cities of Judah and in the streets of Jerusalem? 
+<sup>18&#160;</sup>The children gather wood, and the fathers kindle the fire, and the women knead the dough, to make cakes to the queen of the sky, and to pour out drink offerings to other elohims, that they may provoke me to anger. 
+<sup>19&#160;</sup>Do they provoke me to anger?” says Yahweh. “Don’t they provoke themselves, to the confusion of their own faces?” 
+</div><div class="p">
+<sup>20&#160;</sup>Therefore the Lord Yahweh says: “Behold, my anger and my wrath will be poured out on this place, on man, on animal, on the trees of the field, and on the fruit of the ground; and it will burn and will not be quenched.” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahweh of Armies, the Elohim of Israel says: “Add your burnt offerings to your sacrifices and eat meat. 
+<sup>22&#160;</sup>For I didn’t speak to your fathers or command them in the day that I brought them out of the land of Egypt concerning burnt offerings or sacrifices; 
+<sup>23&#160;</sup>but this thing I commanded them, saying, ‘Listen to my voice, and I will be your Elohim, and you shall be my people. Walk in all the way that I command you, that it may be well with you.’ 
+<sup>24&#160;</sup>But they didn’t listen or turn their ear, but walked in their own counsels and in the stubbornness of their evil heart, and went backward, and not forward. 
+<sup>25&#160;</sup>Since the day that your fathers came out of the land of Egypt to this day, I have sent to you all my servants the prophets, daily rising up early and sending them. 
+<sup>26&#160;</sup>Yet they didn’t listen to me or incline their ear, but made their neck stiff. They did worse than their fathers. 
+</div><div class="p">
+<sup>27&#160;</sup>“You shall speak all these words to them, but they will not listen to you. You shall also call to them, but they will not answer you. 
+<sup>28&#160;</sup>You shall tell them, ‘This is the nation that has not listened to Yahweh their Elohim’s voice, nor received instruction. Truth has perished, and is cut off from their mouth.’ 
+<sup>29&#160;</sup>Cut off your hair, and throw it away, and take up a lamentation on the bare heights; for Yahweh has rejected and forsaken the generation of his wrath. 
+</div><div class="p">
+<sup>30&#160;</sup>“For the children of Judah have done that which is evil in my sight,” says Yahweh. “They have set their abominations in the house which is called by my name, to defile it. 
+<sup>31&#160;</sup>They have built the high places of Topheth, which is in the valley of the son of Hinnom, to burn their sons and their daughters in the fire, which I didn’t command, nor did it come into my mind. 
+<sup>32&#160;</sup>Therefore behold, the days come”, says Yahweh, “that it will no more be called ‘Topheth’ or ‘The valley of the son of Hinnom’, but ‘The valley of Slaughter’; for they will bury in Topheth until there is no place to bury. 
+<sup>33&#160;</sup>The dead bodies of this people will be food for the birds of the sky, and for the animals of the earth. No one will frighten them away. 
+<sup>34&#160;</sup>Then I will cause to cease from the cities of Judah and from the streets of Jerusalem the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride; for the land will become a waste.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>“At that time,” says Yahweh, “they will bring the bones of the kings of Judah, the bones of his princes, the bones of the priests, the bones of the prophets, and the bones of the inhabitants of Jerusalem, out of their graves. 
+<sup>2&#160;</sup>They will spread them before the sun, the moon, and all the army of the sky, which they have loved, which they have served, after which they have walked, which they have sought, and which they have worshiped. They will not be gathered or be buried. They will be like dung on the surface of the earth. 
+<sup>3&#160;</sup>Death will be chosen rather than life by all the residue that remain of this evil family, that remain in all the places where I have driven them,” says Yahweh of Armies. 
+<sup>4&#160;</sup>“Moreover you shall tell them, ‘Yahweh says: 
+</div><div class="q1">“&#160;‘Do men fall, and not rise up again? 
+</div><div class="q2">Does one turn away, and not return? 
+</div><div class="q1">
+<sup>5&#160;</sup>Why then have the people of Jerusalem fallen back by a perpetual backsliding? 
+</div><div class="q2">They cling to deceit. 
+</div><div class="q2">They refuse to return. 
+</div><div class="q1">
+<sup>6&#160;</sup>I listened and heard, but they didn’t say what is right. 
+</div><div class="q2">No one repents of his wickedness, saying, “What have I done?” 
+</div><div class="q1">Everyone turns to his course, 
+</div><div class="q2">as a horse that rushes headlong in the battle. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yes, the stork in the sky knows her appointed times. 
+</div><div class="q2">The turtledove, the swallow, and the crane observe the time of their coming; 
+</div><div class="q2">but my people don’t know Yahweh’s law. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“&#160;‘How do you say, “We are wise, and Yahweh’s law is with us”? 
+</div><div class="q2">But, behold, the false pen of the scribes has made that a lie. 
+</div><div class="q1">
+<sup>9&#160;</sup>The wise men are disappointed. 
+</div><div class="q2">They are dismayed and trapped. 
+</div><div class="q1">Behold, they have rejected Yahweh’s word. 
+</div><div class="q2">What kind of wisdom is in them? 
+</div><div class="q1">
+<sup>10&#160;</sup>Therefore I will give their women to others 
+</div><div class="q2">and their fields to those who will possess them. 
+</div><div class="q1">For everyone from the least even to the greatest is given to covetousness; 
+</div><div class="q2">from the prophet even to the priest everyone deals falsely. 
+</div><div class="q1">
+<sup>11&#160;</sup>They have healed the hurt of the daughter of my people slightly, saying, 
+</div><div class="q2">“Peace, peace,” when there is no peace. 
+</div><div class="q1">
+<sup>12&#160;</sup>Were they ashamed when they had committed abomination? 
+</div><div class="q2">No, they were not at all ashamed. 
+</div><div class="q2">They couldn’t blush. 
+</div><div class="q1">Therefore they will fall among those who fall. 
+</div><div class="q2">In the time of their visitation they will be cast down, says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“&#160;‘I will utterly consume them, says Yahweh. 
+</div><div class="q2">No grapes will be on the vine, 
+</div><div class="q2">no figs on the fig tree, 
+</div><div class="q2">and the leaf will fade. 
+</div><div class="q1">The things that I have given them 
+</div><div class="q2">will pass away from them.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“Why do we sit still? 
+</div><div class="q2">Assemble yourselves! 
+</div><div class="q2">Let’s enter into the fortified cities, 
+</div><div class="q2">and let’s be silent there; 
+</div><div class="q1">for Yahweh our Elohim has put us to silence, 
+</div><div class="q2">and given us poisoned water to drink, 
+</div><div class="q2">because we have sinned against Yahweh. 
+</div><div class="q1">
+<sup>15&#160;</sup>We looked for peace, but no good came; 
+</div><div class="q2">and for a time of healing, and behold, dismay! 
+</div><div class="q1">
+<sup>16&#160;</sup>The snorting of his horses is heard from Dan. 
+</div><div class="q2">The whole land trembles at the sound of the neighing of his strong ones; 
+</div><div class="q1">for they have come, and have devoured the land and all that is in it, 
+</div><div class="q2">the city and those who dwell therein.” 
+</div><div class="q1">
+<sup>17&#160;</sup>“For, behold, I will send serpents, 
+</div><div class="q2">adders among you, 
+</div><div class="q2">which will not be charmed; 
+</div><div class="q2">and they will bite you,” says Yahweh. 
+</div><div class="q1">
+<sup>18&#160;</sup>Oh that I could comfort myself against sorrow! 
+</div><div class="q2">My heart is faint within me. 
+</div><div class="q1">
+<sup>19&#160;</sup>Behold, the voice of the cry of the daughter of my people from a land that is very far off: 
+</div><div class="q2">“Isn’t Yahweh in Zion? 
+</div><div class="q2">Isn’t her King in her?” 
+</div><div class="b"> &#160; </div>
+<div class="q1">“Why have they provoked me to anger with their engraved images, 
+</div><div class="q2">and with foreign idols?” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“The harvest is past. 
+</div><div class="q2">The summer has ended, 
+</div><div class="q2">and we are not saved.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>For the hurt of the daughter of my people, I am hurt. 
+</div><div class="q2">I mourn. 
+</div><div class="q2">Dismay has taken hold of me. 
+</div><div class="q1">
+<sup>22&#160;</sup>Is there no balm in Gilead? 
+</div><div class="q2">Is there no physician there? 
+</div><div class="q1">Why then isn’t the health of the daughter of my people recovered? 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="q1">
+<sup>1&#160;</sup>Oh that my head were waters, 
+</div><div class="q2">and my eyes a spring of tears, 
+</div><div class="q1">that I might weep day and night 
+</div><div class="q2">for the slain of the daughter of my people! 
+</div><div class="q1">
+<sup>2&#160;</sup>Oh that I had in the wilderness 
+</div><div class="q2">a lodging place of wayfaring men, 
+</div><div class="q1">that I might leave my people 
+</div><div class="q2">and go from them! 
+</div><div class="q1">For they are all adulterers, 
+</div><div class="q2">an assembly of treacherous men. 
+</div><div class="q1">
+<sup>3&#160;</sup>“They bend their tongue, 
+</div><div class="q2">as their bow, for falsehood. 
+</div><div class="q1">They have grown strong in the land, 
+</div><div class="q2">but not for truth; 
+</div><div class="q1">for they proceed from evil to evil, 
+</div><div class="q2">and they don’t know me,” says Yahweh. 
+</div><div class="q1">
+<sup>4&#160;</sup>“Everyone beware of his neighbor, 
+</div><div class="q2">and don’t trust in any brother; 
+</div><div class="q1">for every brother will utterly supplant, 
+</div><div class="q2">and every neighbor will go around like a slanderer. 
+</div><div class="q1">
+<sup>5&#160;</sup>Friends deceive each other, 
+</div><div class="q2">and will not speak the truth. 
+</div><div class="q1">They have taught their tongue to speak lies. 
+</div><div class="q2">They weary themselves committing iniquity. 
+</div><div class="q1">
+<sup>6&#160;</sup>Your habitation is in the middle of deceit. 
+</div><div class="q2">Through deceit, they refuse to know me,” says Yahweh. 
+</div><div class="p">
+<sup>7&#160;</sup>Therefore Yahweh of Armies says, 
+</div><div class="q1">“Behold, I will melt them and test them; 
+</div><div class="q2">for how should I deal with the daughter of my people? 
+</div><div class="q1">
+<sup>8&#160;</sup>Their tongue is a deadly arrow. 
+</div><div class="q2">It speaks deceit. 
+</div><div class="q1">One speaks peaceably to his neighbor with his mouth, 
+</div><div class="q2">but in his heart, he waits to ambush him. 
+</div><div class="q1">
+<sup>9&#160;</sup>Shouldn’t I punish them for these things?” says Yahweh. 
+</div><div class="q2">“Shouldn’t my soul be avenged on a nation such as this? 
+</div><div class="q1">
+<sup>10&#160;</sup>I will weep and wail for the mountains, 
+</div><div class="q2">and lament for the pastures of the wilderness, 
+</div><div class="q1">because they are burned up, so that no one passes through; 
+</div><div class="q2">Men can’t hear the voice of the livestock. 
+</div><div class="q1">Both the birds of the sky and the animals have fled. 
+</div><div class="q2">They are gone. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“I will make Jerusalem heaps, 
+</div><div class="q2">a dwelling place of jackals. 
+</div><div class="q1">I will make the cities of Judah a desolation, 
+</div><div class="q2">without inhabitant.” 
+</div><div class="p">
+<sup>12&#160;</sup>Who is wise enough to understand this? Who is he to whom the mouth of Yahweh has spoken, that he may declare it? Why has the land perished and burned up like a wilderness, so that no one passes through? 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh says, “Because they have forsaken my law which I set before them, and have not obeyed my voice or walked in my ways, 
+<sup>14&#160;</sup>but have walked after the stubbornness of their own heart and after the Baals, which their fathers taught them.” 
+<sup>15&#160;</sup>Therefore Yahweh of Armies, the Elohim of Israel, says, “Behold, I will feed them, even this people, with wormwood and give them poisoned water to drink. 
+<sup>16&#160;</sup>I will scatter them also among the nations, whom neither they nor their fathers have known. I will send the sword after them, until I have consumed them.” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh of Armies says, 
+</div><div class="q1">“Consider, and call for the mourning women, that they may come. 
+</div><div class="q2">Send for the skillful women, that they may come. 
+</div><div class="q1">
+<sup>18&#160;</sup>Let them make haste 
+</div><div class="q2">and take up a wailing for us, 
+</div><div class="q1">that our eyes may run down with tears 
+</div><div class="q2">and our eyelids gush out with waters. 
+</div><div class="q1">
+<sup>19&#160;</sup>For a voice of wailing is heard out of Zion, 
+</div><div class="q2">‘How we are ruined! 
+</div><div class="q1">We are greatly confounded 
+</div><div class="q2">because we have forsaken the land, 
+</div><div class="q2">because they have cast down our dwellings.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>Yet hear Yahweh’s word, you women. 
+</div><div class="q2">Let your ear receive the word of his mouth. 
+</div><div class="q1">Teach your daughters wailing. 
+</div><div class="q2">Everyone teach her neighbor a lamentation. 
+</div><div class="q1">
+<sup>21&#160;</sup>For death has come up into our windows. 
+</div><div class="q2">It has entered into our palaces 
+</div><div class="q1">to cut off the children from outside, 
+</div><div class="q2">and the young men from the streets. 
+</div><div class="p">
+<sup>22&#160;</sup>Speak, “Yahweh says, 
+</div><div class="q1">“&#160;‘The dead bodies of men will fall as dung on the open field, 
+</div><div class="q2">and as the handful after the harvester. 
+</div><div class="q2">No one will gather them.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh says, 
+</div><div class="q1">“Don’t let the wise man glory in his wisdom. 
+</div><div class="q2">Don’t let the mighty man glory in his might. 
+</div><div class="q2">Don’t let the rich man glory in his riches. 
+</div><div class="q1">
+<sup>24&#160;</sup>But let him who glories glory in this, 
+</div><div class="q2">that he has understanding, and knows me, 
+</div><div class="q1">that I am Yahweh who exercises loving kindness, justice, and righteousness in the earth, 
+</div><div class="q2">for I delight in these things,” says Yahweh. 
+</div><div class="p">
+<sup>25&#160;</sup>“Behold, the days come,” says Yahweh, “that I will punish all those who are circumcised only in their flesh: 
+<sup>26&#160;</sup>Egypt, Judah, Edom, the children of Ammon, Moab, and all who have the corners of their hair cut off, who dwell in the wilderness, for all the nations are uncircumcised, and all the house of Israel are uncircumcised in heart.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Hear the word which Yahweh speaks to you, house of Israel! 
+<sup>2&#160;</sup>Yahweh says, 
+</div><div class="q1">“Don’t learn the way of the nations, 
+</div><div class="q2">and don’t be dismayed at the signs of the sky; 
+</div><div class="q2">for the nations are dismayed at them. 
+</div><div class="q1">
+<sup>3&#160;</sup>For the customs of the peoples are vanity; 
+</div><div class="q2">for one cuts a tree out of the forest, 
+</div><div class="q2">the work of the hands of the workman with the ax. 
+</div><div class="q1">
+<sup>4&#160;</sup>They deck it with silver and with gold. 
+</div><div class="q2">They fasten it with nails and with hammers, 
+</div><div class="q2">so that it can’t move. 
+</div><div class="q1">
+<sup>5&#160;</sup>They are like a palm tree, of turned work, 
+</div><div class="q2">and don’t speak. 
+</div><div class="q1">They must be carried, 
+</div><div class="q2">because they can’t move. 
+</div><div class="q1">Don’t be afraid of them; 
+</div><div class="q2">for they can’t do evil, 
+</div><div class="q2">neither is it in them to do good.” 
+</div><div class="q1">
+<sup>6&#160;</sup>There is no one like you, Yahweh. 
+</div><div class="q2">You are great, 
+</div><div class="q2">and your name is great in might. 
+</div><div class="q1">
+<sup>7&#160;</sup>Who shouldn’t fear you, 
+</div><div class="q2">King of the nations? 
+</div><div class="q2">For it belongs to you. 
+</div><div class="q1">Because among all the wise men of the nations, 
+</div><div class="q2">and in all their royal estate, 
+</div><div class="q2">there is no one like you. 
+</div><div class="q1">
+<sup>8&#160;</sup>But they are together brutish and foolish, 
+</div><div class="q2">instructed by idols! 
+</div><div class="q2">It is just wood. 
+</div><div class="q1">
+<sup>9&#160;</sup>There is silver beaten into plates, which is brought from Tarshish, 
+</div><div class="q2">and gold from Uphaz, 
+</div><div class="q2">the work of the engraver and of the hands of the goldsmith. 
+</div><div class="q1">Their clothing is blue and purple. 
+</div><div class="q2">They are all the work of skillful men. 
+</div><div class="q1">
+<sup>10&#160;</sup>But Yahweh is the true Elohim. 
+</div><div class="q2">He is the living Elohim, 
+</div><div class="q2">and an everlasting King. 
+</div><div class="q1">At his wrath, the earth trembles. 
+</div><div class="q2">The nations aren’t able to withstand his indignation. 
+</div><div class="p">
+<sup>11&#160;</sup>“You shall say this to them: ‘The elohims that have not made the heavens and the earth will perish from the earth, and from under the heavens.’&#160;” 
+</div><div class="q1">
+<sup>12&#160;</sup>Elohim has made the earth by his power. 
+</div><div class="q2">He has established the world by his wisdom, 
+</div><div class="q2">and by his understanding has he stretched out the heavens. 
+</div><div class="q1">
+<sup>13&#160;</sup>When he utters his voice, 
+</div><div class="q2">the waters in the heavens roar, 
+</div><div class="q2">and he causes the vapors to ascend from the ends of the earth. 
+</div><div class="q1">He makes lightnings for the rain, 
+</div><div class="q2">and brings the wind out of his treasuries. 
+</div><div class="q1">
+<sup>14&#160;</sup>Every man has become brutish and without knowledge. 
+</div><div class="q2">Every goldsmith is disappointed by his engraved image; 
+</div><div class="q1">for his molten image is falsehood, 
+</div><div class="q2">and there is no breath in them. 
+</div><div class="q1">
+<sup>15&#160;</sup>They are vanity, a work of delusion. 
+</div><div class="q2">In the time of their visitation they will perish. 
+</div><div class="q1">
+<sup>16&#160;</sup>The portion of Jacob is not like these; 
+</div><div class="q2">for he is the maker of all things; 
+</div><div class="q1">and Israel is the tribe of his inheritance. 
+</div><div class="q2">Yahweh of Armies is his name. 
+</div><div class="q1">
+<sup>17&#160;</sup>Gather up your wares out of the land, 
+</div><div class="q2">you who live under siege. 
+</div><div class="q1">
+<sup>18&#160;</sup>For Yahweh says, 
+</div><div class="q2">“Behold, I will sling out the inhabitants of the land at this time, 
+</div><div class="q2">and will distress them, that they may feel it.” 
+</div><div class="q1">
+<sup>19&#160;</sup>Woe is me because of my injury! 
+</div><div class="q2">My wound is serious; 
+</div><div class="q1">but I said, 
+</div><div class="q2">“Truly this is my grief, and I must bear it.” 
+</div><div class="q1">
+<sup>20&#160;</sup>My tent has been destroyed, 
+</div><div class="q2">and all my cords are broken. 
+</div><div class="q1">My children have gone away from me, and they are no more. 
+</div><div class="q2">There is no one to spread my tent any more, 
+</div><div class="q2">to set up my curtains. 
+</div><div class="q1">
+<sup>21&#160;</sup>For the shepherds have become brutish, 
+</div><div class="q2">and have not inquired of Yahweh. 
+</div><div class="q1">Therefore they have not prospered, 
+</div><div class="q2">and all their flocks have scattered. 
+</div><div class="q1">
+<sup>22&#160;</sup>The voice of news, behold, it comes, 
+</div><div class="q2">and a great commotion out of the north country, 
+</div><div class="q1">to make the cities of Judah a desolation, 
+</div><div class="q2">a dwelling place of jackals. 
+</div><div class="q1">
+<sup>23&#160;</sup>Yahweh, I know that the way of man is not in himself. 
+</div><div class="q2">It is not in man who walks to direct his steps. 
+</div><div class="q1">
+<sup>24&#160;</sup>Yahweh, correct me, but gently; 
+</div><div class="q2">not in your anger, 
+</div><div class="q2">lest you reduce me to nothing. 
+</div><div class="q1">
+<sup>25&#160;</sup>Pour out your wrath on the nations that don’t know you, 
+</div><div class="q2">and on the families that don’t call on your name; 
+</div><div class="q1">for they have devoured Jacob. 
+</div><div class="q2">Yes, they have devoured him, consumed him, 
+</div><div class="q2">and have laid waste his habitation. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>The word that came to Jeremiah from Yahweh, saying, 
+<sup>2&#160;</sup>“Hear the words of this covenant, and speak to the men of Judah, and to the inhabitants of Jerusalem; 
+<sup>3&#160;</sup>and say to them, Yahweh, the Elohim of Israel says: ‘Cursed is the man who doesn’t hear the words of this covenant, 
+<sup>4&#160;</sup>which I commanded your fathers in the day that I brought them out of the land of Egypt, out of the iron furnace,’ saying, ‘Obey my voice and do them, according to all which I command you; so you shall be my people, and I will be your Elohim; 
+<sup>5&#160;</sup>that I may establish the oath which I swore to your fathers, to give them a land flowing with milk and honey,’ as it is today.” 
+</div><div class="p">Then I answered, and said, “Amen, Yahweh.” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh said to me, “Proclaim all these words in the cities of Judah, and in the streets of Jerusalem, saying, ‘Hear the words of this covenant, and do them. 
+<sup>7&#160;</sup>For I earnestly protested to your fathers in the day that I brought them up out of the land of Egypt, even to this day, rising early and protesting, saying, “Obey my voice.” 
+<sup>8&#160;</sup>Yet they didn’t obey, nor turn their ear, but everyone walked in the stubbornness of their evil heart. Therefore I brought on them all the words of this covenant, which I commanded them to do, but they didn’t do them.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh said to me, “A conspiracy is found among the men of Judah, and among the inhabitants of Jerusalem. 
+<sup>10&#160;</sup>They have turned back to the iniquities of their forefathers, who refused to hear my words. They have gone after other elohims to serve them. The house of Israel and the house of Judah have broken my covenant which I made with their fathers. 
+<sup>11&#160;</sup>Therefore Yahweh says, ‘Behold, I will bring evil on them which they will not be able to escape; and they will cry to me, but I will not listen to them. 
+<sup>12&#160;</sup>Then the cities of Judah and the inhabitants of Jerusalem will go and cry to the elohims to which they offer incense, but they will not save them at all in the time of their trouble. 
+<sup>13&#160;</sup>For according to the number of your cities are your elohims, Judah; and according to the number of the streets of Jerusalem you have set up altars to the shameful thing, even altars to burn incense to Baal.’ 
+</div><div class="p">
+<sup>14&#160;</sup>“Therefore don’t pray for this people. Don’t lift up cry or prayer for them; for I will not hear them in the time that they cry to me because of their trouble. 
+</div><div class="q1">
+<sup>15&#160;</sup>What has my beloved to do in my house, 
+</div><div class="q2">since she has behaved lewdly with many, 
+</div><div class="q2">and the set-apart flesh has passed from you? 
+</div><div class="q1">When you do evil, 
+</div><div class="q2">then you rejoice.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Yahweh called your name, “A green olive tree, 
+</div><div class="q2">beautiful with goodly fruit.” 
+</div><div class="q1">With the noise of a great roar he has kindled fire on it, 
+</div><div class="q2">and its branches are broken. 
+</div><div class="m">
+<sup>17&#160;</sup>For Yahweh of Armies, who planted you, has pronounced evil against you, because of the evil of the house of Israel and of the house of Judah, which they have done to themselves in provoking me to anger by offering incense to Baal. 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh gave me knowledge of it, and I knew it. Then you showed me their doings. 
+<sup>19&#160;</sup>But I was like a gentle lamb that is led to the slaughter. I didn’t know that they had devised plans against me, saying, 
+</div><div class="q1">“Let’s destroy the tree with its fruit, 
+</div><div class="q2">and let’s cut him off from the land of the living, 
+</div><div class="q2">that his name may be no more remembered.” 
+</div><div class="q1">
+<sup>20&#160;</sup>But, Yahweh of Armies, who judges righteously, 
+</div><div class="q2">who tests the heart and the mind, 
+</div><div class="q1">I will see your vengeance on them; 
+</div><div class="q2">for to you I have revealed my cause. 
+</div><div class="p">
+<sup>21&#160;</sup>“Therefore Yahweh says concerning the men of Anathoth, who seek your life, saying, ‘You shall not prophesy in Yahweh’s name, that you not die by our hand’—<sup>22&#160;</sup>therefore Yahweh of Armies says, ‘Behold, I will punish them. The young men will die by the sword. Their sons and their daughters will die by famine. 
+<sup>23&#160;</sup>There will be no remnant to them, for I will bring evil on the men of Anathoth, even the year of their visitation.’&#160;” 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="q1">
+<sup>1&#160;</sup>You are righteous, Yahweh, 
+</div><div class="q2">when I contend with you; 
+</div><div class="q1">yet I would like to plead a case with you. 
+</div><div class="q2">Why does the way of the wicked prosper? 
+</div><div class="q2">Why are they all at ease who deal very treacherously? 
+</div><div class="q1">
+<sup>2&#160;</sup>You have planted them. Yes, they have taken root. 
+</div><div class="q2">They grow. Yes, they produce fruit. 
+</div><div class="q1">You are near in their mouth, 
+</div><div class="q2">and far from their heart. 
+</div><div class="q1">
+<sup>3&#160;</sup>But you, Yahweh, know me. 
+</div><div class="q2">You see me, and test my heart toward you. 
+</div><div class="q1">Pull them out like sheep for the slaughter, 
+</div><div class="q2">and prepare them for the day of slaughter. 
+</div><div class="q1">
+<sup>4&#160;</sup>How long will the land mourn, 
+</div><div class="q2">and the herbs of the whole country wither? 
+</div><div class="q1">Because of the wickedness of those who dwell therein, 
+</div><div class="q2">the animals and birds are consumed; 
+</div><div class="q1">because they said, 
+</div><div class="q2">“He won’t see our latter end.” 
+</div><div class="q1">
+<sup>5&#160;</sup>“If you have run with the footmen, 
+</div><div class="q2">and they have wearied you, 
+</div><div class="q2">then how can you contend with horses? 
+</div><div class="q1">Though in a land of peace you are secure, 
+</div><div class="q2">yet how will you do in the pride of the Jordan? 
+</div><div class="q1">
+<sup>6&#160;</sup>For even your brothers, and the house of your father, 
+</div><div class="q2">even they have dealt treacherously with you! 
+</div><div class="q2">Even they have cried aloud after you! 
+</div><div class="q1">Don’t believe them, 
+</div><div class="q2">though they speak beautiful words to you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“I have forsaken my house. 
+</div><div class="q2">I have cast off my heritage. 
+</div><div class="q2">I have given the dearly beloved of my soul into the hand of her enemies. 
+</div><div class="q1">
+<sup>8&#160;</sup>My heritage has become to me as a lion in the forest. 
+</div><div class="q2">She has uttered her voice against me. 
+</div><div class="q2">Therefore I have hated her. 
+</div><div class="q1">
+<sup>9&#160;</sup>Is my heritage to me as a speckled bird of prey? 
+</div><div class="q2">Are the birds of prey against her all around? 
+</div><div class="q1">Go, assemble all the animals of the field. 
+</div><div class="q2">Bring them to devour. 
+</div><div class="q1">
+<sup>10&#160;</sup>Many shepherds have destroyed my vineyard. 
+</div><div class="q2">They have trodden my portion under foot. 
+</div><div class="q2">They have made my pleasant portion a desolate wilderness. 
+</div><div class="q1">
+<sup>11&#160;</sup>They have made it a desolation. 
+</div><div class="q2">It mourns to me, being desolate. 
+</div><div class="q1">The whole land is made desolate, 
+</div><div class="q2">because no one cares. 
+</div><div class="q1">
+<sup>12&#160;</sup>Destroyers have come on all the bare heights in the wilderness; 
+</div><div class="q2">for the sword of Yahweh devours from the one end of the land even to the other end of the land. 
+</div><div class="q2">No flesh has peace. 
+</div><div class="q1">
+<sup>13&#160;</sup>They have sown wheat, 
+</div><div class="q2">and have reaped thorns. 
+</div><div class="q1">They have exhausted themselves, 
+</div><div class="q2">and profit nothing. 
+</div><div class="q1">You will be ashamed of your fruits, 
+</div><div class="q2">because of Yahweh’s fierce anger.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>14&#160;</sup>Yahweh says, “Concerning all my evil neighbors, who touch the inheritance which I have caused my people Israel to inherit: Behold, I will pluck them up from off their land, and will pluck up the house of Judah from among them. 
+<sup>15&#160;</sup>It will happen that after I have plucked them up, I will return and have compassion on them. I will bring them again, every man to his heritage, and every man to his land. 
+<sup>16&#160;</sup>It will happen, if they will diligently learn the ways of my people, to swear by my name, ‘As Yahweh lives;’ even as they taught my people to swear by Baal, then they will be built up in the middle of my people. 
+<sup>17&#160;</sup>But if they will not hear, then I will pluck up that nation, plucking up and destroying it,” says Yahweh. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to me, “Go, and buy yourself a linen belt, and put it on your waist, and don’t put it in water.” 
+</div><div class="p">
+<sup>2&#160;</sup>So I bought a belt according to Yahweh’s word, and put it on my waist. 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh’s word came to me the second time, saying, 
+<sup>4&#160;</sup>“Take the belt that you have bought, which is on your waist, and arise, go to the Euphrates, and hide it there in a cleft of the rock.” 
+</div><div class="p">
+<sup>5&#160;</sup>So I went and hid it by the Euphrates, as Yahweh commanded me. 
+</div><div class="p">
+<sup>6&#160;</sup>After many days, Yahweh said to me, “Arise, go to the Euphrates, and take the belt from there, which I commanded you to hide there.” 
+</div><div class="p">
+<sup>7&#160;</sup>Then I went to the Euphrates, and dug, and took the belt from the place where I had hidden it; and behold, the belt was ruined. It was profitable for nothing. 
+</div><div class="p">
+<sup>8&#160;</sup>Then Yahweh’s word came to me, saying, 
+<sup>9&#160;</sup>“Yahweh says, ‘In this way I will ruin the pride of Judah, and the great pride of Jerusalem. 
+<sup>10&#160;</sup>This evil people, who refuse to hear my words, who walk in the stubbornness of their heart, and have gone after other elohims to serve them and to worship them, will even be as this belt, which is profitable for nothing. 
+<sup>11&#160;</sup>For as the belt clings to the waist of a man, so I have caused the whole house of Israel and the whole house of Judah to cling to me,’ says Yahweh; ‘that they may be to me for a people, for a name, for praise, and for glory; but they would not hear.’ 
+</div><div class="p">
+<sup>12&#160;</sup>“Therefore you shall speak to them this word: ‘Yahweh, the Elohim of Israel says, “Every container should be filled with wine.”&#160;’ They will tell you, ‘Do we not certainly know that every container should be filled with wine?’ 
+<sup>13&#160;</sup>Then tell them, ‘Yahweh says, “Behold, I will fill all the inhabitants of this land, even the kings who sit on David’s throne, the priests, the prophets, and all the inhabitants of Jerusalem, with drunkenness. 
+<sup>14&#160;</sup>I will dash them one against another, even the fathers and the sons together,” says Yahweh: “I will not pity, spare, or have compassion, that I should not destroy them.”&#160;’&#160;” 
+</div><div class="q1">
+<sup>15&#160;</sup>Hear, and give ear. 
+</div><div class="q2">Don’t be proud, 
+</div><div class="q2">for Yahweh has spoken. 
+</div><div class="q1">
+<sup>16&#160;</sup>Give glory to Yahweh your Elohim, 
+</div><div class="q2">before he causes darkness, 
+</div><div class="q2">and before your feet stumble on the dark mountains, 
+</div><div class="q1">and while you look for light, 
+</div><div class="q2">he turns it into the shadow of death, 
+</div><div class="q2">and makes it deep darkness. 
+</div><div class="q1">
+<sup>17&#160;</sup>But if you will not hear it, 
+</div><div class="q2">my soul will weep in secret for your pride. 
+</div><div class="q1">My eye will weep bitterly, 
+</div><div class="q2">and run down with tears, 
+</div><div class="q2">because Yahweh’s flock has been taken captive. 
+</div><div class="q1">
+<sup>18&#160;</sup>Say to the king and to the queen mother, 
+</div><div class="q2">“Humble yourselves. 
+</div><div class="q1">Sit down, for your crowns have come down, 
+</div><div class="q2">even the crown of your glory. 
+</div><div class="q1">
+<sup>19&#160;</sup>The cities of the South are shut up, 
+</div><div class="q2">and there is no one to open them. 
+</div><div class="q1">Judah is carried away captive: all of them. 
+</div><div class="q2">They are wholly carried away captive. 
+</div><div class="q1">
+<sup>20&#160;</sup>Lift up your eyes, 
+</div><div class="q2">and see those who come from the north. 
+</div><div class="q1">Where is the flock that was given to you, 
+</div><div class="q2">your beautiful flock? 
+</div><div class="q1">
+<sup>21&#160;</sup>What will you say when he sets over you as head those whom you have yourself taught to be friends to you? 
+</div><div class="q2">Won’t sorrows take hold of you, as of a woman in travail? 
+</div><div class="q1">
+<sup>22&#160;</sup>If you say in your heart, 
+</div><div class="q2">“Why have these things come on me?” 
+</div><div class="q1">Your skirts are uncovered because of the greatness of your iniquity, 
+</div><div class="q2">and your heels suffer violence. 
+</div><div class="q1">
+<sup>23&#160;</sup>Can the Ethiopian change his skin, 
+</div><div class="q2">or the leopard his spots? 
+</div><div class="q1">Then may you also do good, 
+</div><div class="q2">who are accustomed to do evil. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>“Therefore I will scatter them 
+</div><div class="q2">as the stubble that passes away 
+</div><div class="q2">by the wind of the wilderness. 
+</div><div class="q1">
+<sup>25&#160;</sup>This is your lot, 
+</div><div class="q2">the portion measured to you from me,” says Yahweh, 
+</div><div class="q1">“because you have forgotten me, 
+</div><div class="q2">and trusted in falsehood.” 
+</div><div class="q1">
+<sup>26&#160;</sup>Therefore I will also uncover your skirts on your face, 
+</div><div class="q2">and your shame will appear. 
+</div><div class="q1">
+<sup>27&#160;</sup>I have seen your abominations, even your adulteries 
+</div><div class="q2">and your neighing, the lewdness of your prostitution, 
+</div><div class="q2">on the hills in the field. 
+</div><div class="q1">Woe to you, Jerusalem! 
+</div><div class="q2">You will not be made clean. 
+</div><div class="q2">How long will it yet be?” 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>This is Yahweh’s word that came to Jeremiah concerning the drought: 
+</div><div class="q1">
+<sup>2&#160;</sup>“Judah mourns, 
+</div><div class="q2">and its gates languish. 
+</div><div class="q1">They sit in black on the ground. 
+</div><div class="q2">The cry of Jerusalem goes up. 
+</div><div class="q1">
+<sup>3&#160;</sup>Their nobles send their little ones to the waters. 
+</div><div class="q2">They come to the cisterns, 
+</div><div class="q2">and find no water. 
+</div><div class="q1">They return with their vessels empty. 
+</div><div class="q2">They are disappointed and confounded, 
+</div><div class="q2">and cover their heads. 
+</div><div class="q1">
+<sup>4&#160;</sup>Because of the ground which is cracked, 
+</div><div class="q2">because no rain has been in the land, 
+</div><div class="q1">the plowmen are disappointed. 
+</div><div class="q2">They cover their heads. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yes, the doe in the field also calves and forsakes her young, 
+</div><div class="q2">because there is no grass. 
+</div><div class="q1">
+<sup>6&#160;</sup>The wild donkeys stand on the bare heights. 
+</div><div class="q2">They pant for air like jackals. 
+</div><div class="q1">Their eyes fail, 
+</div><div class="q2">because there is no vegetation. 
+</div><div class="q1">
+<sup>7&#160;</sup>Though our iniquities testify against us, 
+</div><div class="q2">work for your name’s sake, Yahweh; 
+</div><div class="q1">for our rebellions are many. 
+</div><div class="q2">We have sinned against you. 
+</div><div class="q1">
+<sup>8&#160;</sup>You hope of Israel, 
+</div><div class="q2">its Savior in the time of trouble, 
+</div><div class="q1">why should you be as a foreigner in the land, 
+</div><div class="q2">and as a wayfaring man who turns aside to stay for a night? 
+</div><div class="q1">
+<sup>9&#160;</sup>Why should you be like a scared man, 
+</div><div class="q2">as a mighty man who can’t save? 
+</div><div class="q1">Yet you, Yahweh, are in the middle of us, 
+</div><div class="q2">and we are called by your name. 
+</div><div class="q2">Don’t leave us. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh says to this people: 
+</div><div class="q1">“Even so they have loved to wander. 
+</div><div class="q2">They have not restrained their feet. 
+</div><div class="q1">Therefore Yahweh does not accept them. 
+</div><div class="q2">Now he will remember their iniquity, 
+</div><div class="q2">and punish them for their sins.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said to me, “Don’t pray for this people for their good. 
+<sup>12&#160;</sup>When they fast, I will not hear their cry; and when they offer burnt offering and meal offering, I will not accept them; but I will consume them by the sword, by famine, and by pestilence.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then I said, “Ah, Lord Yahweh! Behold, the prophets tell them, ‘You will not see the sword, neither will you have famine; but I will give you assured peace in this place.’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Yahweh said to me, “The prophets prophesy lies in my name. I didn’t send them. I didn’t command them. I didn’t speak to them. They prophesy to you a lying vision, divination, and a thing of nothing, and the deceit of their own heart. 
+<sup>15&#160;</sup>Therefore Yahweh says concerning the prophets who prophesy in my name, but I didn’t send them, yet they say, ‘Sword and famine will not be in this land.’ Those prophets will be consumed by sword and famine. 
+<sup>16&#160;</sup>The people to whom they prophesy will be cast out in the streets of Jerusalem because of the famine and the sword. They will have no one to bury them—them, their women, their sons, or their daughters, for I will pour their wickedness on them. 
+</div><div class="p">
+<sup>17&#160;</sup>“You shall say this word to them: 
+</div><div class="q1">“&#160;‘Let my eyes run down with tears night and day, 
+</div><div class="q2">and let them not cease; 
+</div><div class="q1">for the virgin daughter of my people is broken with a great breach, 
+</div><div class="q2">with a very grievous wound. 
+</div><div class="q1">
+<sup>18&#160;</sup>If I go out into the field, 
+</div><div class="q2">then behold, the slain with the sword! 
+</div><div class="q1">If I enter into the city, 
+</div><div class="q2">then behold, those who are sick with famine! 
+</div><div class="q1">For both the prophet and the priest go about in the land, 
+</div><div class="q2">and have no knowledge.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Have you utterly rejected Judah? 
+</div><div class="q2">Has your soul loathed Zion? 
+</div><div class="q1">Why have you struck us, and there is no healing for us? 
+</div><div class="q2">We looked for peace, but no good came; 
+</div><div class="q2">and for a time of healing, and behold, dismay! 
+</div><div class="q1">
+<sup>20&#160;</sup>We acknowledge, Yahweh, our wickedness, 
+</div><div class="q2">and the iniquity of our fathers; 
+</div><div class="q2">for we have sinned against you. 
+</div><div class="q1">
+<sup>21&#160;</sup>Do not abhor us, for your name’s sake. 
+</div><div class="q2">Do not disgrace the throne of your glory. 
+</div><div class="q2">Remember, and don’t break your covenant with us. 
+</div><div class="q1">
+<sup>22&#160;</sup>Are there any among the vanities of the nations that can cause rain? 
+</div><div class="q2">Or can the sky give showers? 
+</div><div class="q2">Aren’t you he, Yahweh our Elohim? 
+</div><div class="q1">Therefore we will wait for you; 
+</div><div class="q2">for you have made all these things. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Yahweh said to me, “Though Moses and Samuel stood before me, yet my mind would not turn toward this people. Cast them out of my sight, and let them go out! 
+<sup>2&#160;</sup>It will happen when they ask you, ‘Where shall we go out?’ then you shall tell them, ‘Yahweh says: 
+</div><div class="q1">“Such as are for death, to death; 
+</div><div class="q1">such as are for the sword, to the sword; 
+</div><div class="q1">such as are for the famine, to the famine; 
+</div><div class="q1">and such as are for captivity, to captivity.”&#160;’ 
+</div><div class="p">
+<sup>3&#160;</sup>“I will appoint over them four kinds,” says Yahweh: “the sword to kill, the dogs to tear, the birds of the sky, and the animals of the earth, to devour and to destroy. 
+<sup>4&#160;</sup>I will cause them to be tossed back and forth among all the kingdoms of the earth, because of Manasseh, the son of Hezekiah, king of Judah, for that which he did in Jerusalem. 
+</div><div class="q1">
+<sup>5&#160;</sup>For who will have pity on you, Jerusalem? 
+</div><div class="q2">Who will mourn you? 
+</div><div class="q2">Who will come to ask of your welfare? 
+</div><div class="q1">
+<sup>6&#160;</sup>You have rejected me,” says Yahweh. 
+</div><div class="q2">“You have gone backward. 
+</div><div class="q1">Therefore I have stretched out my hand against you 
+</div><div class="q2">and destroyed you. 
+</div><div class="q2">I am weary of showing compassion. 
+</div><div class="q1">
+<sup>7&#160;</sup>I have winnowed them with a fan in the gates of the land. 
+</div><div class="q2">I have bereaved them of children. 
+</div><div class="q1">I have destroyed my people. 
+</div><div class="q2">They didn’t return from their ways. 
+</div><div class="q1">
+<sup>8&#160;</sup>Their widows are increased more than the sand of the seas. 
+</div><div class="q2">I have brought on them against the mother of the young men a destroyer at noonday. 
+</div><div class="q2">I have caused anguish and terrors to fall on her suddenly. 
+</div><div class="q1">
+<sup>9&#160;</sup>She who has borne seven languishes. 
+</div><div class="q2">She has given up the spirit. 
+</div><div class="q1">Her sun has gone down while it was yet day. 
+</div><div class="q2">She has been disappointed and confounded. 
+</div><div class="q2">I will deliver their residue to the sword before their enemies,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Woe is me, my mother, that you have borne me, a man of strife, 
+</div><div class="q2">and a man of contention to the whole earth! 
+</div><div class="q1">I have not lent, neither have men lent to me; 
+</div><div class="q2">yet every one of them curses me. 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said, 
+</div><div class="q1">“Most certainly I will strengthen you for good. 
+</div><div class="q2">Most certainly I will cause the enemy to make supplication to you in the time of evil 
+</div><div class="q2">and in the time of affliction. 
+</div><div class="q1">
+<sup>12&#160;</sup>Can one break iron, 
+</div><div class="q2">even iron from the north, and bronze? 
+</div><div class="q1">
+<sup>13&#160;</sup>I will give your substance and your treasures for a plunder without price, 
+</div><div class="q2">and that for all your sins, 
+</div><div class="q2">even in all your borders. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will make them to pass with your enemies into a land which you don’t know; 
+</div><div class="q2">for a fire is kindled in my anger, 
+</div><div class="q2">which will burn on you.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>Yahweh, you know. 
+</div><div class="q2">Remember me, visit me, 
+</div><div class="q2">and avenge me of my persecutors. 
+</div><div class="q1">You are patient, so don’t take me away. 
+</div><div class="q2">Know that for your sake I have suffered reproach. 
+</div><div class="q1">
+<sup>16&#160;</sup>Your words were found, 
+</div><div class="q2">and I ate them. 
+</div><div class="q1">Your words were to me a joy and the rejoicing of my heart, 
+</div><div class="q2">for I am called by your name, Yahweh, Elohim of Armies. 
+</div><div class="q1">
+<sup>17&#160;</sup>I didn’t sit in the assembly of those who make merry and rejoice. 
+</div><div class="q2">I sat alone because of your hand, 
+</div><div class="q2">for you have filled me with indignation. 
+</div><div class="q1">
+<sup>18&#160;</sup>Why is my pain perpetual, 
+</div><div class="q2">and my wound incurable, 
+</div><div class="q2">which refuses to be healed? 
+</div><div class="q1">Will you indeed be to me as a deceitful brook, 
+</div><div class="q2">like waters that fail? 
+</div><div class="p">
+<sup>19&#160;</sup>Therefore Yahweh says, 
+</div><div class="q1">“If you return, then I will bring you again, 
+</div><div class="q2">that you may stand before me; 
+</div><div class="q1">and if you take out the precious from the vile, 
+</div><div class="q2">you will be as my mouth. 
+</div><div class="q1">They will return to you, 
+</div><div class="q2">but you will not return to them. 
+</div><div class="q1">
+<sup>20&#160;</sup>I will make you to this people a fortified bronze wall. 
+</div><div class="q2">They will fight against you, 
+</div><div class="q2">but they will not prevail against you; 
+</div><div class="q1">for I am with you to save you 
+</div><div class="q2">and to deliver you,” says Yahweh. 
+</div><div class="q1">
+<sup>21&#160;</sup>“I will deliver you out of the hand of the wicked, 
+</div><div class="q2">and I will redeem you out of the hand of the terrible.” 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Yahweh’s word came to me, saying, 
+<sup>2&#160;</sup>“You shall not take a woman, neither shall you have sons or daughters, in this place.” 
+<sup>3&#160;</sup>For Yahweh says concerning the sons and concerning the daughters who are born in this place, and concerning their mothers who bore them, and concerning their fathers who became their father in this land: 
+<sup>4&#160;</sup>“They will die grievous deaths. They will not be lamented, neither will they be buried. They will be as dung on the surface of the ground. They will be consumed by the sword and by famine. Their dead bodies will be food for the birds of the sky and for the animals of the earth.” 
+</div><div class="p">
+<sup>5&#160;</sup>For Yahweh says, “Don’t enter into the house of mourning. Don’t go to lament. Don’t bemoan them, for I have taken away my peace from this people,” says Yahweh, “even loving kindness and tender mercies. 
+<sup>6&#160;</sup>Both great and small will die in this land. They will not be buried. Men won’t lament for them, cut themselves, or make themselves bald for them. 
+<sup>7&#160;</sup>Men won’t break bread for them in mourning, to comfort them for the dead. Men won’t give them the cup of consolation to drink for their father or for their mother. 
+</div><div class="p">
+<sup>8&#160;</sup>“You shall not go into the house of feasting to sit with them, to eat and to drink.” 
+<sup>9&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: “Behold, I will cause to cease out of this place, before your eyes and in your days, the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride. 
+<sup>10&#160;</sup>It will happen, when you tell this people all these words, and they ask you, ‘Why has Yahweh pronounced all this great evil against us?’ or ‘What is our iniquity?’ or ‘What is our sin that we have committed against Yahweh our Elohim?’ 
+<sup>11&#160;</sup>then you shall tell them, ‘Because your fathers have forsaken me,’ says Yahweh, ‘and have walked after other elohims, have served them, have worshiped them, have forsaken me, and have not kept my law. 
+<sup>12&#160;</sup>You have done evil more than your fathers, for behold, you each walk after the stubbornness of his evil heart, so that you don’t listen to me. 
+<sup>13&#160;</sup>Therefore I will cast you out of this land into the land that you have not known, neither you nor your fathers. There you will serve other elohims day and night, for I will show you no favor.’ 
+</div><div class="p">
+<sup>14&#160;</sup>“Therefore behold, the days come,” says Yahweh, “that it will no more be said, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
+<sup>15&#160;</sup>but, ‘As Yahweh lives, who brought up the children of Israel from the land of the north, and from all the countries where he had driven them.’ I will bring them again into their land that I gave to their fathers. 
+</div><div class="p">
+<sup>16&#160;</sup>“Behold, I will send for many fishermen,” says Yahweh, “and they will fish them up. Afterward I will send for many hunters, and they will hunt them from every mountain, from every hill, and out of the clefts of the rocks. 
+<sup>17&#160;</sup>For my eyes are on all their ways. They are not hidden from my face. Their iniquity isn’t concealed from my eyes. 
+<sup>18&#160;</sup>First I will recompense their iniquity and their sin double, because they have polluted my land with the carcasses of their detestable things, and have filled my inheritance with their abominations.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Yahweh, my strength, my stronghold, 
+</div><div class="q2">and my refuge in the day of affliction, 
+</div><div class="q1">the nations will come to you from the ends of the earth, 
+</div><div class="q2">and will say, 
+</div><div class="q1">“Our fathers have inherited nothing but lies, 
+</div><div class="q2">vanity and things in which there is no profit. 
+</div><div class="q1">
+<sup>20&#160;</sup>Should a man make to himself elohims 
+</div><div class="q2">which yet are no elohims?” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Therefore behold, I will cause them to know, 
+</div><div class="q2">this once I will cause them to know my hand and my might. 
+</div><div class="q2">Then they will know that my name is Yahweh.” 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="q1">
+<sup>1&#160;</sup>“The sin of Judah is written with a pen of iron, 
+</div><div class="q2">and with the point of a diamond. 
+</div><div class="q1">It is engraved on the tablet of their heart, 
+</div><div class="q2">and on the horns of your altars. 
+</div><div class="q1">
+<sup>2&#160;</sup>Even their children remember their altars 
+</div><div class="q2">and their Asherah poles by the green trees on the high hills. 
+</div><div class="q1">
+<sup>3&#160;</sup>My mountain in the field, 
+</div><div class="q2">I will give your substance and all your treasures for a plunder, 
+</div><div class="q2">and your high places, because of sin, throughout all your borders. 
+</div><div class="q1">
+<sup>4&#160;</sup>You, even of yourself, will discontinue from your heritage that I gave you. 
+</div><div class="q2">I will cause you to serve your enemies in the land which you don’t know, 
+</div><div class="q2">for you have kindled a fire in my anger which will burn forever.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh says: 
+</div><div class="q1">“Cursed is the man who trusts in man, 
+</div><div class="q2">relies on strength of flesh, 
+</div><div class="q2">and whose heart departs from Yahweh. 
+</div><div class="q1">
+<sup>6&#160;</sup>For he will be like a bush in the desert, 
+</div><div class="q2">and will not see when good comes, 
+</div><div class="q1">but will inhabit the parched places in the wilderness, 
+</div><div class="q2">an uninhabited salt land. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Blessed is the man who trusts in Yahweh, 
+</div><div class="q2">and whose confidence is in Yahweh. 
+</div><div class="q1">
+<sup>8&#160;</sup>For he will be as a tree planted by the waters, 
+</div><div class="q2">who spreads out its roots by the river, 
+</div><div class="q1">and will not fear when heat comes, 
+</div><div class="q2">but its leaf will be green, 
+</div><div class="q1">and will not be concerned in the year of drought. 
+</div><div class="q2">It won’t cease from yielding fruit. 
+</div><div class="q1">
+<sup>9&#160;</sup>The heart is deceitful above all things 
+</div><div class="q2">and it is exceedingly corrupt. 
+</div><div class="q2">Who can know it? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“I, Yahweh, search the mind. 
+</div><div class="q2">I try the heart, 
+</div><div class="q1">even to give every man according to his ways, 
+</div><div class="q2">according to the fruit of his doings.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>As the partridge that sits on eggs which she has not laid, 
+</div><div class="q2">so is he who gets riches, and not by right. 
+</div><div class="q1">In the middle of his days, they will leave him. 
+</div><div class="q2">At his end, he will be a fool. 
+</div><div class="q1">
+<sup>12&#160;</sup>A glorious throne, set on high from the beginning, 
+</div><div class="q2">is the place of our sanctuary. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yahweh, the hope of Israel, 
+</div><div class="q2">all who forsake you will be disappointed. 
+</div><div class="q1">Those who depart from me will be written in the earth, 
+</div><div class="q2">because they have forsaken Yahweh, 
+</div><div class="q2">the spring of living waters. 
+</div><div class="q1">
+<sup>14&#160;</sup>Heal me, O Yahweh, and I will be healed. 
+</div><div class="q2">Save me, and I will be saved; 
+</div><div class="q2">for you are my praise. 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, they ask me, 
+</div><div class="q2">“Where is Yahweh’s word? 
+</div><div class="q2">Let it be fulfilled now.” 
+</div><div class="q1">
+<sup>16&#160;</sup>As for me, I have not hurried from being a shepherd after you. 
+</div><div class="q2">I haven’t desired the woeful day. You know. 
+</div><div class="q2">That which came out of my lips was before your face. 
+</div><div class="q1">
+<sup>17&#160;</sup>Don’t be a terror to me. 
+</div><div class="q2">You are my refuge in the day of evil. 
+</div><div class="q1">
+<sup>18&#160;</sup>Let them be disappointed who persecute me, 
+</div><div class="q2">but don’t let me be disappointed. 
+</div><div class="q1">Let them be dismayed, 
+</div><div class="q2">but don’t let me be dismayed. 
+</div><div class="q1">Bring on them the day of evil, 
+</div><div class="q2">and destroy them with double destruction. 
+</div><div class="p">
+<sup>19&#160;</sup>Yahweh said this to me: “Go and stand in the gate of the children of the people, through which the kings of Judah come in and by which they go out, and in all the gates of Jerusalem. 
+<sup>20&#160;</sup>Tell them, ‘Hear Yahweh’s word, you kings of Judah, all Judah, and all the inhabitants of Jerusalem, that enter in by these gates: 
+<sup>21&#160;</sup>Yahweh says, “Be careful, and bear no burden on the Sabbath day, nor bring it in by the gates of Jerusalem. 
+<sup>22&#160;</sup>Don’t carry a burden out of your houses on the Sabbath day. Don’t do any work, but make the Sabbath day set-apart, as I commanded your fathers. 
+<sup>23&#160;</sup>But they didn’t listen. They didn’t turn their ear, but made their neck stiff, that they might not hear, and might not receive instruction. 
+<sup>24&#160;</sup>It will happen, if you diligently listen to me,” says Yahweh, “to bring in no burden through the gates of this city on the Sabbath day, but to make the Sabbath day set-apart, to do no work therein; 
+<sup>25&#160;</sup>then there will enter in by the gates of this city kings and princes sitting on David’s throne, riding in chariots and on horses, they and their princes, the men of Judah and the inhabitants of Jerusalem; and this city will remain forever. 
+<sup>26&#160;</sup>They will come from the cities of Judah, and from the places around Jerusalem, from the land of Benjamin, from the lowland, from the hill country, and from the South, bringing burnt offerings, sacrifices, meal offerings, and frankincense, and bringing sacrifices of thanksgiving to Yahweh’s house. 
+<sup>27&#160;</sup>But if you will not listen to me to make the Sabbath day set-apart, and not to bear a burden and enter in at the gates of Jerusalem on the Sabbath day, then I will kindle a fire in its gates, and it will devour the palaces of Jerusalem. It will not be quenched.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, saying, 
+<sup>2&#160;</sup>“Arise, and go down to the potter’s house, and there I will cause you to hear my words.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then I went down to the potter’s house, and behold, he was making something on the wheels. 
+<sup>4&#160;</sup>When the vessel that he made of the clay was marred in the hand of the potter, he made it again another vessel, as seemed good to the potter to make it. 
+</div><div class="p">
+<sup>5&#160;</sup>Then Yahweh’s word came to me, saying, 
+<sup>6&#160;</sup>“House of Israel, can’t I do with you as this potter?” says Yahweh. “Behold, as the clay in the potter’s hand, so are you in my hand, house of Israel. 
+<sup>7&#160;</sup>At the instant I speak concerning a nation, and concerning a kingdom, to pluck up and to break down and to destroy it, 
+<sup>8&#160;</sup>if that nation, concerning which I have spoken, turns from their evil, I will repent of the evil that I thought to do to them. 
+<sup>9&#160;</sup>At the instant I speak concerning a nation, and concerning a kingdom, to build and to plant it, 
+<sup>10&#160;</sup>if they do that which is evil in my sight, that they not obey my voice, then I will repent of the good with which I said I would benefit them. 
+</div><div class="p">
+<sup>11&#160;</sup>“Now therefore, speak to the men of Judah, and to the inhabitants of Jerusalem, saying, ‘Yahweh says: “Behold, I frame evil against you, and devise a plan against you. Everyone return from his evil way now, and amend your ways and your doings.”&#160;’ 
+<sup>12&#160;</sup>But they say, ‘It is in vain; for we will walk after our own plans, and we will each follow the stubbornness of his evil heart.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>Therefore Yahweh says: 
+</div><div class="q1">“Ask now among the nations, 
+</div><div class="q2">‘Who has heard such things?’ 
+</div><div class="q2">The virgin of Israel has done a very horrible thing. 
+</div><div class="q1">
+<sup>14&#160;</sup>Will the snow of Lebanon fail from the rock of the field? 
+</div><div class="q2">Will the cold waters that flow down from afar be dried up? 
+</div><div class="q1">
+<sup>15&#160;</sup>For my people have forgotten me. 
+</div><div class="q2">They have burned incense to false elohims. 
+</div><div class="q1">They have been made to stumble in their ways 
+</div><div class="q2">in the ancient paths, 
+</div><div class="q2">to walk in byways, in a way not built up, 
+</div><div class="q1">
+<sup>16&#160;</sup>to make their land an astonishment, 
+</div><div class="q2">and a perpetual hissing. 
+</div><div class="q1">Everyone who passes by it will be astonished, 
+</div><div class="q2">and shake his head. 
+</div><div class="q1">
+<sup>17&#160;</sup>I will scatter them as with an east wind before the enemy. 
+</div><div class="q2">I will show them the back, and not the face, 
+</div><div class="q2">in the day of their calamity. 
+</div><div class="p">
+<sup>18&#160;</sup>Then they said, “Come! Let’s devise plans against Jeremiah; for the law won’t perish from the priest, nor counsel from the wise, nor the word from the prophet. Come, and let’s strike him with the tongue, and let’s not give heed to any of his words.” 
+</div><div class="q1">
+<sup>19&#160;</sup>Give heed to me, Yahweh, 
+</div><div class="q2">and listen to the voice of those who contend with me. 
+</div><div class="q1">
+<sup>20&#160;</sup>Should evil be recompensed for good? 
+</div><div class="q2">For they have dug a pit for my soul. 
+</div><div class="q1">Remember how I stood before you to speak good for them, 
+</div><div class="q2">to turn away your wrath from them. 
+</div><div class="q1">
+<sup>21&#160;</sup>Therefore deliver up their children to the famine, 
+</div><div class="q2">and give them over to the power of the sword. 
+</div><div class="q1">Let their women become childless and widows. 
+</div><div class="q2">Let their men be killed 
+</div><div class="q2">and their young men struck by the sword in battle. 
+</div><div class="q1">
+<sup>22&#160;</sup>Let a cry be heard from their houses 
+</div><div class="q2">when you bring a troop suddenly on them; 
+</div><div class="q1">for they have dug a pit to take me 
+</div><div class="q2">and hidden snares for my feet. 
+</div><div class="q1">
+<sup>23&#160;</sup>Yet, Yahweh, you know all their counsel against me to kill me. 
+</div><div class="q2">Don’t forgive their iniquity. 
+</div><div class="q2">Don’t blot out their sin from your sight, 
+</div><div class="q1">Let them be overthrown before you. 
+</div><div class="q2">Deal with them in the time of your anger. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Thus said Yahweh, “Go, and buy a potter’s earthen container, and take some of the elders of the people and of the elders of the priests; 
+<sup>2&#160;</sup>and go out to the valley of the son of Hinnom, which is by the entry of the gate Harsith, and proclaim there the words that I will tell you. 
+<sup>3&#160;</sup>Say, ‘Hear Yahweh’s word, kings of Judah and inhabitants of Jerusalem: Yahweh of Armies, the Elohim of Israel says, “Behold, I will bring evil on this place, which whoever hears, his ears will tingle. 
+<sup>4&#160;</sup>Because they have forsaken me, and have defiled this place, and have burned incense in it to other elohims that they didn’t know—they, their fathers, and the kings of Judah—and have filled this place with the blood of innocents, 
+<sup>5&#160;</sup>and have built the high places of Baal to burn their children in the fire for burnt offerings to Baal, which I didn’t command, nor speak, which didn’t even enter into my mind. 
+<sup>6&#160;</sup>Therefore, behold, the days come,” says Yahweh, “that this place will no more be called ‘Topheth’, nor ‘The Valley of the son of Hinnom’, but ‘The valley of Slaughter’. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘&#160;“I will make the counsel of Judah and Jerusalem void in this place. I will cause them to fall by the sword before their enemies, and by the hand of those who seek their life. I will give their dead bodies to be food for the birds of the sky and for the animals of the earth. 
+<sup>8&#160;</sup>I will make this city an astonishment and a hissing. Everyone who passes by it will be astonished and hiss because of all its plagues. 
+<sup>9&#160;</sup>I will cause them to eat the flesh of their sons and the flesh of their daughters. They will each eat the flesh of his friend in the siege and in the distress with which their enemies, and those who seek their life, will distress them.”&#160;’ 
+</div><div class="p">
+<sup>10&#160;</sup>“Then you shall break the container in the sight of the men who go with you, 
+<sup>11&#160;</sup>and shall tell them, ‘Yahweh of Armies says: “Even so I will break this people and this city as one breaks a potter’s vessel, that can’t be made whole again. They will bury in Topheth until there is no place to bury. 
+<sup>12&#160;</sup>This is what I will do to this place,” says Yahweh, “and to its inhabitants, even making this city as Topheth. 
+<sup>13&#160;</sup>The houses of Jerusalem and the houses of the kings of Judah, which are defiled, will be as the place of Topheth, even all the houses on whose roofs they have burned incense to all the army of the sky and have poured out drink offerings to other elohims.”&#160;’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Jeremiah came from Topheth, where Yahweh had sent him to prophesy, and he stood in the court of Yahweh’s house, and said to all the people: 
+<sup>15&#160;</sup>“Yahweh of Armies, the Elohim of Israel says, ‘Behold, I will bring on this city and on all its towns all the evil that I have pronounced against it, because they have made their neck stiff, that they may not hear my words.’&#160;” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Pashhur, the son of Immer the priest, who was chief officer in Yahweh’s house, heard Jeremiah prophesying these things. 
+<sup>2&#160;</sup>Then Pashhur struck Jeremiah the prophet and put him in the stocks that were in the upper gate of Benjamin, which was in Yahweh’s house. 
+<sup>3&#160;</sup>On the next day, Pashhur released Jeremiah out of the stocks. Then Jeremiah said to him, “Yahweh has not called your name Pashhur, but Magormissabib. 
+<sup>4&#160;</sup>For Yahweh says, ‘Behold, I will make you a terror to yourself and to all your friends. They will fall by the sword of their enemies, and your eyes will see it. I will give all Judah into the hand of the king of Babylon, and he will carry them captive to Babylon, and will kill them with the sword. 
+<sup>5&#160;</sup>Moreover I will give all the riches of this city, and all its gains, and all its precious things, yes, I will give all the treasures of the kings of Judah into the hand of their enemies. They will make them captives, take them, and carry them to Babylon. 
+<sup>6&#160;</sup>You, Pashhur, and all who dwell in your house will go into captivity. You will come to Babylon, and there you will die, and there you will be buried, you, and all your friends, to whom you have prophesied falsely.’&#160;” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Yahweh, you have persuaded me, and I was persuaded. 
+</div><div class="q2">You are stronger than I, and have prevailed. 
+</div><div class="q1">I have become a laughingstock all day. 
+</div><div class="q2">Everyone mocks me. 
+</div><div class="q1">
+<sup>8&#160;</sup>For as often as I speak, I cry out; 
+</div><div class="q2">I cry, “Violence and destruction!” 
+</div><div class="q1">because Yahweh’s word has been made a reproach to me, 
+</div><div class="q2">and a derision, all day. 
+</div><div class="q1">
+<sup>9&#160;</sup>If I say that I will not make mention of him, 
+</div><div class="q2">or speak any more in his name, 
+</div><div class="q1">then there is in my heart as it were a burning fire shut up in my bones. 
+</div><div class="q2">I am weary with holding it in. 
+</div><div class="q2">I can’t. 
+</div><div class="q1">
+<sup>10&#160;</sup>For I have heard the defaming of many: 
+</div><div class="q2">“Terror on every side! 
+</div><div class="q2">Denounce, and we will denounce him!” 
+</div><div class="q1">say all my familiar friends, 
+</div><div class="q2">those who watch for my fall. 
+</div><div class="q1">“Perhaps he will be persuaded, 
+</div><div class="q2">and we will prevail against him, 
+</div><div class="q2">and we will take our revenge on him.” 
+</div><div class="q1">
+<sup>11&#160;</sup>But Yahweh is with me as an awesome mighty one. 
+</div><div class="q2">Therefore my persecutors will stumble, 
+</div><div class="q2">and they won’t prevail. 
+</div><div class="q1">They will be utterly disappointed 
+</div><div class="q2">because they have not dealt wisely, 
+</div><div class="q2">even with an everlasting dishonor which will never be forgotten. 
+</div><div class="q1">
+<sup>12&#160;</sup>But Yahweh of Armies, who tests the righteous, 
+</div><div class="q2">who sees the heart and the mind, 
+</div><div class="q1">let me see your vengeance on them, 
+</div><div class="q2">for I have revealed my cause to you. 
+</div><div class="q1">
+<sup>13&#160;</sup>Sing to Yahweh! 
+</div><div class="q2">Praise Yahweh, 
+</div><div class="q2">for he has delivered the soul of the needy from the hand of evildoers. 
+</div><div class="q1">
+<sup>14&#160;</sup>Cursed is the day in which I was born. 
+</div><div class="q2">Don’t let the day in which my mother bore me be blessed. 
+</div><div class="q1">
+<sup>15&#160;</sup>Cursed is the man who brought news to my father, saying, 
+</div><div class="q2">“A boy is born to you,” making him very glad. 
+</div><div class="q1">
+<sup>16&#160;</sup>Let that man be as the cities which Yahweh overthrew, 
+</div><div class="q2">and didn’t repent. 
+</div><div class="q1">Let him hear a cry in the morning, 
+</div><div class="q2">and shouting at noontime, 
+</div><div class="q1">
+<sup>17&#160;</sup>because he didn’t kill me from the womb. 
+</div><div class="q2">So my mother would have been my grave, 
+</div><div class="q2">and her womb always great. 
+</div><div class="q1">
+<sup>18&#160;</sup>Why did I come out of the womb to see labor and sorrow, 
+</div><div class="q2">that my days should be consumed with shame? 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, when King Zedekiah sent to him Pashhur the son of Malchijah, and Zephaniah the son of Maaseiah, the priest, saying, 
+<sup>2&#160;</sup>“Please inquire of Yahweh for us; for Nebuchadnezzar king of Babylon makes war against us. Perhaps Yahweh will deal with us according to all his wondrous works, that he may withdraw from us.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then Jeremiah said to them, “Tell Zedekiah: 
+<sup>4&#160;</sup>‘Yahweh, the Elohim of Israel says, “Behold, I will turn back the weapons of war that are in your hands, with which you fight against the king of Babylon, and against the Chaldeans who besiege you outside the walls; and I will gather them into the middle of this city. 
+<sup>5&#160;</sup>I myself will fight against you with an outstretched hand and with a strong arm, even in anger, in wrath, and in great indignation. 
+<sup>6&#160;</sup>I will strike the inhabitants of this city, both man and animal. They will die of a great pestilence. 
+<sup>7&#160;</sup>Afterward,” says Yahweh, “I will deliver Zedekiah king of Judah, his servants, and the people, even those who are left in this city from the pestilence, from the sword, and from the famine, into the hand of Nebuchadnezzar king of Babylon, and into the hand of their enemies, and into the hand of those who seek their life. He will strike them with the edge of the sword. He will not spare them, have pity, or have mercy.”&#160;’ 
+</div><div class="p">
+<sup>8&#160;</sup>“You shall say to this people, ‘Yahweh says: “Behold, I set before you the way of life and the way of death. 
+<sup>9&#160;</sup>He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out and passes over to the Chaldeans who besiege you, he will live, and he will escape with his life. 
+<sup>10&#160;</sup>For I have set my face on this city for evil, and not for good,” says Yahweh. “It will be given into the hand of the king of Babylon, and he will burn it with fire.”&#160;’ 
+</div><div class="p">
+<sup>11&#160;</sup>“Concerning the house of the king of Judah, hear Yahweh’s word: 
+<sup>12&#160;</sup>House of David, Yahweh says, 
+</div><div class="q1">‘Execute justice in the morning, 
+</div><div class="q2">and deliver him who is robbed out of the hand of the oppressor, 
+</div><div class="q1">lest my wrath go out like fire, 
+</div><div class="q2">and burn so that no one can quench it, 
+</div><div class="q2">because of the evil of your doings. 
+</div><div class="q1">
+<sup>13&#160;</sup>Behold, I am against you, O inhabitant of the valley, 
+</div><div class="q2">and of the rock of the plain,’ says Yahweh. 
+</div><div class="q1">‘You that say, “Who would come down against us?” 
+</div><div class="q2">or, “Who would enter into our homes?” 
+</div><div class="q1">
+<sup>14&#160;</sup>I will punish you according to the fruit of your doings,’ says Yahweh; 
+</div><div class="q2">‘and I will kindle a fire in her forest, 
+</div><div class="q2">and it will devour all that is around her.’&#160;” 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said, “Go down to the house of the king of Judah, and speak this word there: 
+<sup>2&#160;</sup>‘Hear Yahweh’s word, king of Judah, who sits on David’s throne—you, your servants, and your people who enter in by these gates. 
+<sup>3&#160;</sup>Yahweh says: “Execute justice and righteousness, and deliver him who is robbed out of the hand of the oppressor. Do no wrong. Do no violence to the foreigner, the fatherless, or the widow. Don’t shed innocent blood in this place. 
+<sup>4&#160;</sup>For if you do this thing indeed, then kings sitting on David’s throne will enter in by the gates of this house, riding in chariots and on horses—they, their servants, and their people. 
+<sup>5&#160;</sup>But if you will not hear these words, I swear by myself,” says Yahweh, “that this house will become a desolation.”&#160;’&#160;” 
+</div><div class="p">
+<sup>6&#160;</sup>For Yahweh says concerning the house of the king of Judah: 
+</div><div class="q1">“You are Gilead to me, 
+</div><div class="q2">the head of Lebanon. 
+</div><div class="q1">Yet surely I will make you a wilderness, 
+</div><div class="q2">cities which are not inhabited. 
+</div><div class="q1">
+<sup>7&#160;</sup>I will prepare destroyers against you, 
+</div><div class="q2">everyone with his weapons, 
+</div><div class="q1">and they will cut down your choice cedars, 
+</div><div class="q2">and cast them into the fire. 
+</div><div class="p">
+<sup>8&#160;</sup>“Many nations will pass by this city, and they will each ask his neighbor, ‘Why has Yahweh done this to this great city?’ 
+<sup>9&#160;</sup>Then they will answer, ‘Because they abandoned the covenant of Yahweh their Elohim, worshiped other elohims, and served them.’&#160;” 
+</div><div class="q1">
+<sup>10&#160;</sup>Don’t weep for the dead. 
+</div><div class="q2">Don’t bemoan him; 
+</div><div class="q1">but weep bitterly for him who goes away, 
+</div><div class="q2">for he will return no more, 
+</div><div class="q2">and not see his native country. 
+</div><div class="m">
+<sup>11&#160;</sup>For Yahweh says touching Shallum the son of Josiah, king of Judah, who reigned instead of Josiah his father, and who went out of this place: “He won’t return there any more. 
+<sup>12&#160;</sup>But he will die in the place where they have led him captive. He will see this land no more.” 
+</div><div class="q1">
+<sup>13&#160;</sup>“Woe to him who builds his house by unrighteousness, 
+</div><div class="q2">and his rooms by injustice; 
+</div><div class="q1">who uses his neighbor’s service without wages, 
+</div><div class="q2">and doesn’t give him his hire; 
+</div><div class="q1">
+<sup>14&#160;</sup>who says, ‘I will build myself a wide house and spacious rooms,’ 
+</div><div class="q2">and cuts out windows for himself, 
+</div><div class="q1">with a cedar ceiling, 
+</div><div class="q2">and painted with red. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“Should you reign because you strive to excel in cedar? 
+</div><div class="q2">Didn’t your father eat and drink, 
+</div><div class="q2">and do justice and righteousness? 
+</div><div class="q2">Then it was well with him. 
+</div><div class="q1">
+<sup>16&#160;</sup>He judged the cause of the poor and needy; 
+</div><div class="q2">so then it was well. 
+</div><div class="q1">Wasn’t this to know me?” 
+</div><div class="q2">says Yahweh. 
+</div><div class="q1">
+<sup>17&#160;</sup>But your eyes and your heart are only for your covetousness, 
+</div><div class="q2">for shedding innocent blood, 
+</div><div class="q2">for oppression, and for doing violence.” 
+</div><div class="m">
+<sup>18&#160;</sup>Therefore Yahweh says concerning Jehoiakim the son of Josiah, king of Judah: 
+</div><div class="q1">“They won’t lament for him, 
+</div><div class="q2">saying, ‘Ah my brother!’ or, ‘Ah sister!’ 
+</div><div class="q1">They won’t lament for him, 
+</div><div class="q2">saying ‘Ah lord!’ or, ‘Ah his glory!’ 
+</div><div class="q1">
+<sup>19&#160;</sup>He will be buried with the burial of a donkey, 
+</div><div class="q2">drawn and cast out beyond the gates of Jerusalem.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Go up to Lebanon, and cry out. 
+</div><div class="q2">Lift up your voice in Bashan, 
+</div><div class="q1">and cry from Abarim; 
+</div><div class="q2">for all your lovers have been destroyed. 
+</div><div class="q1">
+<sup>21&#160;</sup>I spoke to you in your prosperity, 
+</div><div class="q2">but you said, ‘I will not listen.’ 
+</div><div class="q1">This has been your way from your youth, 
+</div><div class="q2">that you didn’t obey my voice. 
+</div><div class="q1">
+<sup>22&#160;</sup>The wind will feed all your shepherds, 
+</div><div class="q2">and your lovers will go into captivity. 
+</div><div class="q1">Surely then you will be ashamed 
+</div><div class="q2">and confounded for all your wickedness. 
+</div><div class="q1">
+<sup>23&#160;</sup>Inhabitant of Lebanon, 
+</div><div class="q2">who makes your nest in the cedars, 
+</div><div class="q1">how greatly to be pitied you will be when pangs come on you, 
+</div><div class="q2">the pain as of a woman in travail! 
+</div><div class="p">
+<sup>24&#160;</sup>“As I live,” says Yahweh, “though Coniah the son of Jehoiakim king of Judah were the signet on my right hand, I would still pluck you from there. 
+<sup>25&#160;</sup>I would give you into the hand of those who seek your life, and into the hand of them of whom you are afraid, even into the hand of Nebuchadnezzar king of Babylon, and into the hand of the Chaldeans. 
+<sup>26&#160;</sup>I will cast you out with your mother who bore you into another country, where you were not born; and there you will die. 
+<sup>27&#160;</sup>But to the land to which their soul longs to return, there they will not return.” 
+</div><div class="q1">
+<sup>28&#160;</sup>Is this man Coniah a despised broken vessel? 
+</div><div class="q2">Is he a vessel in which no one delights? 
+</div><div class="q1">Why are they cast out, he and his offspring, 
+</div><div class="q2">and cast into a land which they don’t know? 
+</div><div class="q1">
+<sup>29&#160;</sup>O earth, earth, earth, 
+</div><div class="q2">hear Yahweh’s word! 
+</div><div class="q1">
+<sup>30&#160;</sup>Yahweh says, 
+</div><div class="q2">“Record this man as childless, 
+</div><div class="q2">a man who will not prosper in his days; 
+</div><div class="q1">for no more will a man of his offspring prosper, 
+</div><div class="q2">sitting on David’s throne 
+</div><div class="q2">and ruling in Judah.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>“Woe to the shepherds who destroy and scatter the sheep of my pasture!” says Yahweh. 
+<sup>2&#160;</sup>Therefore Yahweh, the Elohim of Israel, says against the shepherds who feed my people: “You have scattered my flock, driven them away, and have not visited them. Behold, I will visit on you the evil of your doings,” says Yahweh. 
+<sup>3&#160;</sup>“I will gather the remnant of my flock out of all the countries where I have driven them, and will bring them again to their folds; and they will be fruitful and multiply. 
+<sup>4&#160;</sup>I will set up shepherds over them who will feed them. They will no longer be afraid or dismayed, neither will any be lacking,” says Yahweh. 
+</div><div class="q1">
+<sup>5&#160;</sup>“Behold, the days come,” says Yahweh, 
+</div><div class="q2">“that I will raise to David a righteous Branch; 
+</div><div class="q1">and he will reign as king and deal wisely, 
+</div><div class="q2">and will execute justice and righteousness in the land. 
+</div><div class="q1">
+<sup>6&#160;</sup>In his days Judah will be saved, 
+</div><div class="q2">and Israel will dwell safely. 
+</div><div class="q1">This is his name by which he will be called: 
+</div><div class="q2">Yahweh our righteousness. 
+</div><div class="m">
+<sup>7&#160;</sup>“Therefore, behold, the days come,” says Yahweh, “that they will no more say, ‘As Yahweh lives, who brought up the children of Israel out of the land of Egypt;’ 
+<sup>8&#160;</sup>but, ‘As Yahweh lives, who brought up and who led the offspring of the house of Israel out of the north country, and from all the countries where I had driven them.’ Then they will dwell in their own land.” 
+</div><div class="p">
+<sup>9&#160;</sup>Concerning the prophets: 
+</div><div class="q1">My heart within me is broken. 
+</div><div class="q2">All my bones shake. 
+</div><div class="q1">I am like a drunken man, 
+</div><div class="q2">and like a man whom wine has overcome, 
+</div><div class="q1">because of Yahweh, 
+</div><div class="q2">and because of his set-apart words. 
+</div><div class="q1">
+<sup>10&#160;</sup>“For the land is full of adulterers; 
+</div><div class="q2">for because of the curse the land mourns. 
+</div><div class="q1">The pastures of the wilderness have dried up. 
+</div><div class="q2">Their course is evil, 
+</div><div class="q2">and their might is not right; 
+</div><div class="q1">
+<sup>11&#160;</sup>for both prophet and priest are profane. 
+</div><div class="q2">Yes, in my house I have found their wickedness,” says Yahweh. 
+</div><div class="q1">
+<sup>12&#160;</sup>Therefore their way will be to them as slippery places in the darkness. 
+</div><div class="q2">They will be driven on, 
+</div><div class="q2">and fall therein; 
+</div><div class="q1">for I will bring evil on them, 
+</div><div class="q2">even the year of their visitation,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“I have seen folly in the prophets of Samaria. 
+</div><div class="q2">They prophesied by Baal, 
+</div><div class="q2">and caused my people Israel to err. 
+</div><div class="q1">
+<sup>14&#160;</sup>In the prophets of Jerusalem I have also seen a horrible thing: 
+</div><div class="q2">they commit adultery and walk in lies. 
+</div><div class="q1">They strengthen the hands of evildoers, 
+</div><div class="q2">so that no one returns from his wickedness. 
+</div><div class="q1">They have all become to me as Sodom, 
+</div><div class="q2">and its inhabitants as Gomorrah.” 
+</div><div class="p">
+<sup>15&#160;</sup>Therefore Yahweh of Armies says concerning the prophets: 
+</div><div class="q1">“Behold, I will feed them with wormwood, 
+</div><div class="q2">and make them drink poisoned water; 
+</div><div class="q2">for from the prophets of Jerusalem unelohimliness has gone out into all the land.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh of Armies says, 
+</div><div class="q1">“Don’t listen to the words of the prophets who prophesy to you. 
+</div><div class="q2">They teach you vanity. 
+</div><div class="q2">They speak a vision of their own heart, 
+</div><div class="q2">and not out of the mouth of Yahweh. 
+</div><div class="q1">
+<sup>17&#160;</sup>They say continually to those who despise me, 
+</div><div class="q2">‘Yahweh has said, “You will have peace;”&#160;’ 
+</div><div class="q1">and to everyone who walks in the stubbornness of his own heart they say, 
+</div><div class="q2">‘No evil will come on you.’ 
+</div><div class="q1">
+<sup>18&#160;</sup>For who has stood in the council of Yahweh, 
+</div><div class="q2">that he should perceive and hear his word? 
+</div><div class="q2">Who has listened to my word, and heard it? 
+</div><div class="q1">
+<sup>19&#160;</sup>Behold, Yahweh’s storm, his wrath, has gone out. 
+</div><div class="q2">Yes, a whirling storm! 
+</div><div class="q2">It will burst on the head of the wicked. 
+</div><div class="q1">
+<sup>20&#160;</sup>Yahweh’s anger will not return until he has executed 
+</div><div class="q2">and performed the intents of his heart. 
+</div><div class="q2">In the latter days, you will understand it perfectly. 
+</div><div class="q1">
+<sup>21&#160;</sup>I didn’t send these prophets, yet they ran. 
+</div><div class="q2">I didn’t speak to them, yet they prophesied. 
+</div><div class="q1">
+<sup>22&#160;</sup>But if they had stood in my council, 
+</div><div class="q2">then they would have caused my people to hear my words, 
+</div><div class="q1">and would have turned them from their evil way, 
+</div><div class="q2">and from the evil of their doings. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>“Am I an Elohim at hand,” says Yahweh, 
+</div><div class="q2">“and not an Elohim afar off? 
+</div><div class="q1">
+<sup>24&#160;</sup>Can anyone hide himself in secret places 
+</div><div class="q2">so that I can’t see him?” says Yahweh. 
+</div><div class="q2">“Don’t I fill heaven and earth?” says Yahweh. 
+</div><div class="p">
+<sup>25&#160;</sup>“I have heard what the prophets have said, who prophesy lies in my name, saying, ‘I had a dream! I had a dream!’ 
+<sup>26&#160;</sup>How long will this be in the heart of the prophets who prophesy lies, even the prophets of the deceit of their own heart? 
+<sup>27&#160;</sup>They intend to cause my people to forget my name by their dreams which they each tell his neighbor, as their fathers forgot my name because of Baal. 
+<sup>28&#160;</sup>The prophet who has a dream, let him tell a dream; and he who has my word, let him speak my word faithfully. What is the straw to the wheat?” says Yahweh. 
+<sup>29&#160;</sup>“Isn’t my word like fire?” says Yahweh; “and like a hammer that breaks the rock in pieces? 
+</div><div class="p">
+<sup>30&#160;</sup>“Therefore behold, I am against the prophets,” says Yahweh, “who each steal my words from his neighbor. 
+<sup>31&#160;</sup>Behold, I am against the prophets,” says Yahweh, “who use their tongues, and say, ‘He says.’ 
+<sup>32&#160;</sup>Behold, I am against those who prophesy lying dreams,” says Yahweh, “who tell them, and cause my people to err by their lies, and by their vain boasting; yet I didn’t send them or command them. They don’t profit this people at all,” says Yahweh. 
+</div><div class="p">
+<sup>33&#160;</sup>“When this people, or the prophet, or a priest, asks you, saying, ‘What is the message from Yahweh?’ Then you shall tell them, ‘&#160;“What message? I will cast you off,” says Yahweh.’ 
+<sup>34&#160;</sup>As for the prophet, the priest, and the people, who say, ‘The message from Yahweh,’ I will even punish that man and his household. 
+<sup>35&#160;</sup>You will say everyone to his neighbor, and everyone to his brother, ‘What has Yahweh answered?’ and, ‘What has Yahweh said?’ 
+<sup>36&#160;</sup>You will mention the message from Yahweh no more, for every man’s own word has become his message; for you have perverted the words of the living Elohim, of Yahweh of Armies, our Elohim. 
+<sup>37&#160;</sup>You will say to the prophet, ‘What has Yahweh answered you?’ and, ‘What has Yahweh spoken?’ 
+<sup>38&#160;</sup>Although you say, ‘The message from Yahweh,’ therefore Yahweh says: ‘Because you say this word, “The message from Yahweh,” and I have sent to you, telling you not to say, “The message from Yahweh,” 
+<sup>39&#160;</sup>therefore behold, I will utterly forget you, and I will cast you off with the city that I gave to you and to your fathers, away from my presence. 
+<sup>40&#160;</sup>I will bring an everlasting reproach on you, and a perpetual shame, which will not be forgotten.’&#160;” 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh showed me, and behold, two baskets of figs were set before Yahweh’s temple, after Nebuchadnezzar king of Babylon had carried away captive Jeconiah the son of Jehoiakim, king of Judah, and the princes of Judah, with the craftsmen and smiths, from Jerusalem, and had brought them to Babylon. 
+<sup>2&#160;</sup>One basket had very good figs, like the figs that are first-ripe; and the other basket had very bad figs, which could not be eaten, they were so bad. 
+</div><div class="p">
+<sup>3&#160;</sup>Then Yahweh asked me, “What do you see, Jeremiah?” 
+</div><div class="p">I said, “Figs. The good figs are very good, and the bad are very bad, so bad that they can’t be eaten.” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>5&#160;</sup>“Yahweh, the Elohim of Israel says: ‘Like these good figs, so I will regard the captives of Judah, whom I have sent out of this place into the land of the Chaldeans, as good. 
+<sup>6&#160;</sup>For I will set my eyes on them for good, and I will bring them again to this land. I will build them, and not pull them down. I will plant them, and not pluck them up. 
+<sup>7&#160;</sup>I will give them a heart to know me, that I am Yahweh. They will be my people, and I will be their Elohim; for they will return to me with their whole heart. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘As the bad figs, which can’t be eaten, they are so bad,’ surely Yahweh says, ‘So I will give up Zedekiah the king of Judah, and his princes, and the remnant of Jerusalem who remain in this land, and those who dwell in the land of Egypt. 
+<sup>9&#160;</sup>I will even give them up to be tossed back and forth among all the kingdoms of the earth for evil, to be a reproach and a proverb, a taunt and a curse, in all places where I will drive them. 
+<sup>10&#160;</sup>I will send the sword, the famine, and the pestilence among them, until they are consumed from off the land that I gave to them and to their fathers.’&#160;” 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>The word that came to Jeremiah concerning all the people of Judah, in the fourth year of Jehoiakim the son of Josiah, king of Judah (this was the first year of Nebuchadnezzar king of Babylon), 
+<sup>2&#160;</sup>which Jeremiah the prophet spoke to all the people of Judah, and to all the inhabitants of Jerusalem: 
+<sup>3&#160;</sup>From the thirteenth year of Josiah the son of Amon, king of Judah, even to this day, these twenty-three years, Yahweh’s word has come to me, and I have spoken to you, rising up early and speaking; but you have not listened. 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh has sent to you all his servants the prophets, rising up early and sending them (but you have not listened or inclined your ear to hear), 
+<sup>5&#160;</sup>saying, “Return now everyone from his evil way, and from the evil of your doings, and dwell in the land that Yahweh has given to you and to your fathers, from of old and even forever more. 
+<sup>6&#160;</sup>Don’t go after other elohims to serve them or worship them, and don’t provoke me to anger with the work of your hands; then I will do you no harm.” 
+</div><div class="p">
+<sup>7&#160;</sup>“Yet you have not listened to me,” says Yahweh, “that you may provoke me to anger with the work of your hands to your own hurt.” 
+</div><div class="p">
+<sup>8&#160;</sup>Therefore Yahweh of Armies says: “Because you have not heard my words, 
+<sup>9&#160;</sup>behold, I will send and take all the families of the north,” says Yahweh, “and I will send to Nebuchadnezzar the king of Babylon, my servant, and will bring them against this land, and against its inhabitants, and against all these nations around. I will utterly destroy them, and make them an astonishment, and a hissing, and perpetual desolations. 
+<sup>10&#160;</sup>Moreover I will take from them the voice of mirth and the voice of gladness, the voice of the bridegroom and the voice of the bride, the sound of the millstones, and the light of the lamp. 
+<sup>11&#160;</sup>This whole land will be a desolation, and an astonishment; and these nations will serve the king of Babylon seventy years. 
+</div><div class="p">
+<sup>12&#160;</sup>“It will happen, when seventy years are accomplished, that I will punish the king of Babylon and that nation,” says Yahweh, “for their iniquity. I will make the land of the Chaldeans desolate forever. 
+<sup>13&#160;</sup>I will bring on that land all my words which I have pronounced against it, even all that is written in this book, which Jeremiah has prophesied against all the nations. 
+<sup>14&#160;</sup>For many nations and great kings will make bondservants of them, even of them. I will recompense them according to their deeds, and according to the work of their hands.” 
+</div><div class="p">
+<sup>15&#160;</sup>For Yahweh, the Elohim of Israel, says to me: “Take this cup of the wine of wrath from my hand, and cause all the nations to whom I send you to drink it. 
+<sup>16&#160;</sup>They will drink, and reel back and forth, and be insane, because of the sword that I will send among them.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then I took the cup at Yahweh’s hand, and made all the nations to drink, to whom Yahweh had sent me: 
+<sup>18&#160;</sup>Jerusalem, and the cities of Judah, with its kings and its princes, to make them a desolation, an astonishment, a hissing, and a curse, as it is today; 
+<sup>19&#160;</sup>Pharaoh king of Egypt, with his servants, his princes, and all his people; 
+<sup>20&#160;</sup>and all the mixed people, and all the kings of the land of Uz, all the kings of the Philistines, Ashkelon, Gaza, Ekron, and the remnant of Ashdod; 
+<sup>21&#160;</sup>Edom, Moab, and the children of Ammon; 
+<sup>22&#160;</sup>and all the kings of Tyre, all the kings of Sidon, and the kings of the isle which is beyond the sea; 
+<sup>23&#160;</sup>Dedan, Tema, Buz, and all who have the corners of their beard cut off; 
+<sup>24&#160;</sup>and all the kings of Arabia, all the kings of the mixed people who dwell in the wilderness; 
+<sup>25&#160;</sup>and all the kings of Zimri, all the kings of Elam, and all the kings of the Medes; 
+<sup>26&#160;</sup>and all the kings of the north, far and near, one with another; and all the kingdoms of the world, which are on the surface of the earth. The king of Sheshach will drink after them. 
+</div><div class="p">
+<sup>27&#160;</sup>“You shall tell them, ‘Yahweh of Armies, the Elohim of Israel says: “Drink, and be drunk, vomit, fall, and rise no more, because of the sword which I will send among you.”&#160;’ 
+<sup>28&#160;</sup>It shall be, if they refuse to take the cup at your hand to drink, then you shall tell them, ‘Yahweh of Armies says: “You shall surely drink. 
+<sup>29&#160;</sup>For, behold, I begin to work evil at the city which is called by my name; and should you be utterly unpunished? You will not be unpunished; for I will call for a sword on all the inhabitants of the earth, says Yahweh of Armies.”&#160;’ 
+</div><div class="p">
+<sup>30&#160;</sup>“Therefore prophesy against them all these words, and tell them, 
+</div><div class="q1">“&#160;‘Yahweh will roar from on high, 
+</div><div class="q2">and utter his voice from his set-apart habitation. 
+</div><div class="q2">He will mightily roar against his fold. 
+</div><div class="q1">He will give a shout, as those who tread grapes, 
+</div><div class="q2">against all the inhabitants of the earth. 
+</div><div class="q1">
+<sup>31&#160;</sup>A noise will come even to the end of the earth; 
+</div><div class="q2">for Yahweh has a controversy with the nations. 
+</div><div class="q1">He will enter into judgment with all flesh. 
+</div><div class="q2">As for the wicked, he will give them to the sword,”&#160;’ says Yahweh.” 
+</div><div class="p">
+<sup>32&#160;</sup>Yahweh of Armies says, 
+</div><div class="q1">“Behold, evil will go out from nation to nation, 
+</div><div class="q2">and a great storm will be raised up from the uttermost parts of the earth.” 
+</div><div class="m">
+<sup>33&#160;</sup>The slain of Yahweh will be at that day from one end of the earth even to the other end of the earth. They won’t be lamented. They won’t be gathered or buried. They will be dung on the surface of the ground. 
+</div><div class="q1">
+<sup>34&#160;</sup>Wail, you shepherds, and cry. 
+</div><div class="q2">Wallow in dust, you leader of the flock; 
+</div><div class="q1">for the days of your slaughter and of your dispersions have fully come, 
+</div><div class="q2">and you will fall like fine pottery. 
+</div><div class="q1">
+<sup>35&#160;</sup>The shepherds will have no way to flee. 
+</div><div class="q2">The leader of the flock will have no escape. 
+</div><div class="q1">
+<sup>36&#160;</sup>A voice of the cry of the shepherds, 
+</div><div class="q2">and the wailing of the leader of the flock, 
+</div><div class="q2">for Yahweh destroys their pasture. 
+</div><div class="q1">
+<sup>37&#160;</sup>The peaceful folds are brought to silence 
+</div><div class="q2">because of the fierce anger of Yahweh. 
+</div><div class="q1">
+<sup>38&#160;</sup>He has left his covert, as the lion; 
+</div><div class="q2">for their land has become an astonishment because of the fierceness of the oppression, 
+</div><div class="q2">and because of his fierce anger. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came from Yahweh: 
+<sup>2&#160;</sup>“Yahweh says: ‘Stand in the court of Yahweh’s house, and speak to all the cities of Judah which come to worship in Yahweh’s house, all the words that I command you to speak to them. Don’t omit a word. 
+<sup>3&#160;</sup>It may be they will listen, and every man turn from his evil way, that I may relent from the evil which I intend to do to them because of the evil of their doings.’&#160;” 
+<sup>4&#160;</sup>You shall tell them, “Yahweh says: ‘If you will not listen to me, to walk in my law which I have set before you, 
+<sup>5&#160;</sup>to listen to the words of my servants the prophets whom I send to you, even rising up early and sending them—but you have not listened—<sup>6&#160;</sup>then I will make this house like Shiloh, and will make this city a curse to all the nations of the earth.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>The priests and the prophets and all the people heard Jeremiah speaking these words in Yahweh’s house. 
+<sup>8&#160;</sup>When Jeremiah had finished speaking all that Yahweh had commanded him to speak to all the people, the priests and the prophets and all the people seized him, saying, “You shall surely die! 
+<sup>9&#160;</sup>Why have you prophesied in Yahweh’s name, saying, ‘This house will be like Shiloh, and this city will be desolate, without inhabitant’?” All the people were crowded around Jeremiah in Yahweh’s house. 
+</div><div class="p">
+<sup>10&#160;</sup>When the princes of Judah heard these things, they came up from the king’s house to Yahweh’s house; and they sat in the entry of the new gate of Yahweh’s house. 
+<sup>11&#160;</sup>Then the priests and the prophets spoke to the princes and to all the people, saying, “This man is worthy of death, for he has prophesied against this city, as you have heard with your ears.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then Jeremiah spoke to all the princes and to all the people, saying, “Yahweh sent me to prophesy against this house and against this city all the words that you have heard. 
+<sup>13&#160;</sup>Now therefore amend your ways and your doings, and obey Yahweh your Elohim’s voice; then Yahweh will relent from the evil that he has pronounced against you. 
+<sup>14&#160;</sup>But as for me, behold, I am in your hand. Do with me what is good and right in your eyes. 
+<sup>15&#160;</sup>Only know for certain that if you put me to death, you will bring innocent blood on yourselves, on this city, and on its inhabitants; for in truth Yahweh has sent me to you to speak all these words in your ears.” 
+</div><div class="p">
+<sup>16&#160;</sup>Then the princes and all the people said to the priests and to the prophets: “This man is not worthy of death; for he has spoken to us in the name of Yahweh our Elohim.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then certain of the elders of the land rose up, and spoke to all the assembly of the people, saying, 
+<sup>18&#160;</sup>“Micah the Morashtite prophesied in the days of Hezekiah king of Judah; and he spoke to all the people of Judah, saying, ‘Yahweh of Armies says: 
+</div><div class="q1">“&#160;‘Zion will be plowed as a field, 
+</div><div class="q2">and Jerusalem will become heaps, 
+</div><div class="q2">and the mountain of the house as the high places of a forest.’ 
+</div><div class="m">
+<sup>19&#160;</sup>Did Hezekiah king of Judah and all Judah put him to death? Didn’t he fear Yahweh, and entreat the favor of Yahweh, and Yahweh relented of the disaster which he had pronounced against them? We would commit great evil against our own souls that way!” 
+</div><div class="p">
+<sup>20&#160;</sup>There was also a man who prophesied in Yahweh’s name, Uriah the son of Shemaiah of Kiriath Jearim; and he prophesied against this city and against this land according to all the words of Jeremiah. 
+<sup>21&#160;</sup>When Jehoiakim the king, with all his mighty men and all the princes heard his words, the king sought to put him to death; but when Uriah heard it, he was afraid, and fled, and went into Egypt. 
+<sup>22&#160;</sup>Then Jehoiakim the king sent Elnathan the son of Achbor and certain men with him into Egypt. 
+<sup>23&#160;</sup>They fetched Uriah out of Egypt and brought him to Jehoiakim the king, who killed him with the sword and cast his dead body into the graves of the common people. 
+</div><div class="p">
+<sup>24&#160;</sup>But the hand of Ahikam the son of Shaphan was with Jeremiah, so that they didn’t give him into the hand of the people to put him to death. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>In the beginning of the reign of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
+<sup>2&#160;</sup>Yahweh says to me: “Make bonds and bars, and put them on your neck. 
+<sup>3&#160;</sup>Then send them to the king of Edom, to the king of Moab, to the king of the children of Ammon, to the king of Tyre, and to the king of Sidon, by the hand of the messengers who come to Jerusalem to Zedekiah king of Judah. 
+<sup>4&#160;</sup>Give them a command to their masters, saying, ‘Yahweh of Armies, the Elohim of Israel says, “You shall tell your masters: 
+<sup>5&#160;</sup>‘I have made the earth, the men, and the animals that are on the surface of the earth by my great power and by my outstretched arm. I give it to whom it seems right to me. 
+<sup>6&#160;</sup>Now I have given all these lands into the hand of Nebuchadnezzar the king of Babylon, my servant. I have also given the animals of the field to him to serve him. 
+<sup>7&#160;</sup>All the nations will serve him, his son, and his son’s son, until the time of his own land comes. Then many nations and great kings will make him their bondservant. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘&#160;“&#160;‘It will happen that I will punish the nation and the kingdom which will not serve the same Nebuchadnezzar king of Babylon, and that will not put their neck under the yoke of the king of Babylon,’ says Yahweh, ‘with the sword, with famine, and with pestilence, until I have consumed them by his hand. 
+<sup>9&#160;</sup>But as for you, don’t listen to your prophets, to your diviners, to your dreams, to your soothsayers, or to your sorcerers, who speak to you, saying, “You shall not serve the king of Babylon;” 
+<sup>10&#160;</sup>for they prophesy a lie to you, to remove you far from your land, so that I would drive you out, and you would perish. 
+<sup>11&#160;</sup>But the nation that brings their neck under the yoke of the king of Babylon and serves him, that nation I will let remain in their own land,’ says Yahweh; ‘and they will till it and dwell in it.’&#160;”&#160;’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>I spoke to Zedekiah king of Judah according to all these words, saying, “Bring your necks under the yoke of the king of Babylon, and serve him and his people, and live. 
+<sup>13&#160;</sup>Why will you die, you and your people, by the sword, by the famine, and by the pestilence, as Yahweh has spoken concerning the nation that will not serve the king of Babylon? 
+<sup>14&#160;</sup>Don’t listen to the words of the prophets who speak to you, saying, ‘You shall not serve the king of Babylon;’ for they prophesy a lie to you. 
+<sup>15&#160;</sup>For I have not sent them,” says Yahweh, “but they prophesy falsely in my name; that I may drive you out, and that you may perish, you, and the prophets who prophesy to you.” 
+</div><div class="p">
+<sup>16&#160;</sup>Also I spoke to the priests and to all this people, saying, Yahweh says, “Don’t listen to the words of your prophets who prophesy to you, saying, ‘Behold, the vessels of Yahweh’s house will now shortly be brought again from Babylon;’ for they prophesy a lie to you. 
+<sup>17&#160;</sup>Don’t listen to them. Serve the king of Babylon, and live. Why should this city become a desolation? 
+<sup>18&#160;</sup>But if they are prophets, and if Yahweh’s word is with them, let them now make intercession to Yahweh of Armies, that the vessels which are left in Yahweh’s house, in the house of the king of Judah, and at Jerusalem, don’t go to Babylon. 
+<sup>19&#160;</sup>For Yahweh of Armies says concerning the pillars, concerning the sea, concerning the bases, and concerning the rest of the vessels that are left in this city, 
+<sup>20&#160;</sup>which Nebuchadnezzar king of Babylon didn’t take when he carried away captive Jeconiah the son of Jehoiakim, king of Judah, from Jerusalem to Babylon, and all the nobles of Judah and Jerusalem—<sup>21&#160;</sup>yes, Yahweh of Armies, the Elohim of Israel, says concerning the vessels that are left in Yahweh’s house, and in the house of the king of Judah, and at Jerusalem: 
+<sup>22&#160;</sup>‘They will be carried to Babylon, and there they will be, until the day that I visit them,’ says Yahweh; ‘then I will bring them up, and restore them to this place.’&#160;” 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>That same year, in the beginning of the reign of Zedekiah king of Judah, in the fourth year, in the fifth month, Hananiah the son of Azzur, the prophet, who was of Gibeon, spoke to me in Yahweh’s house, in the presence of the priests and of all the people, saying, 
+<sup>2&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says, ‘I have broken the yoke of the king of Babylon. 
+<sup>3&#160;</sup>Within two full years I will bring again into this place all the vessels of Yahweh’s house that Nebuchadnezzar king of Babylon took away from this place and carried to Babylon. 
+<sup>4&#160;</sup>I will bring again to this place Jeconiah the son of Jehoiakim, king of Judah, with all the captives of Judah, who went to Babylon,’ says Yahweh; ‘for I will break the yoke of the king of Babylon.’&#160;” 
+</div><div class="p">
+<sup>5&#160;</sup>Then the prophet Jeremiah said to the prophet Hananiah in the presence of the priests, and in the presence of all the people who stood in Yahweh’s house, 
+<sup>6&#160;</sup>even the prophet Jeremiah said, “Amen! May Yahweh do so. May Yahweh perform your words which you have prophesied, to bring again the vessels of Yahweh’s house, and all those who are captives, from Babylon to this place. 
+<sup>7&#160;</sup>Nevertheless listen now to this word that I speak in your ears, and in the ears of all the people: 
+<sup>8&#160;</sup>The prophets who have been before me and before you of old prophesied against many countries, and against great kingdoms, of war, of evil, and of pestilence. 
+<sup>9&#160;</sup>As for the prophet who prophesies of peace, when the word of the prophet happens, then the prophet will be known, that Yahweh has truly sent him.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Hananiah the prophet took the bar from off the prophet Jeremiah’s neck, and broke it. 
+<sup>11&#160;</sup>Hananiah spoke in the presence of all the people, saying, “Yahweh says: ‘Even so I will break the yoke of Nebuchadnezzar king of Babylon from off the neck of all the nations within two full years.’&#160;” Then the prophet Jeremiah went his way. 
+</div><div class="p">
+<sup>12&#160;</sup>Then Yahweh’s word came to Jeremiah, after Hananiah the prophet had broken the bar from off the neck of the prophet Jeremiah, saying, 
+<sup>13&#160;</sup>“Go, and tell Hananiah, saying, ‘Yahweh says, “You have broken the bars of wood, but you have made in their place bars of iron.” 
+<sup>14&#160;</sup>For Yahweh of Armies, the Elohim of Israel says, “I have put a yoke of iron on the neck of all these nations, that they may serve Nebuchadnezzar king of Babylon; and they will serve him. I have also given him the animals of the field.”&#160;’&#160;” 
+</div><div class="p">
+<sup>15&#160;</sup>Then the prophet Jeremiah said to Hananiah the prophet, “Listen, Hananiah! Yahweh has not sent you, but you make this people trust in a lie. 
+<sup>16&#160;</sup>Therefore Yahweh says, ‘Behold, I will send you away from off the surface of the earth. This year you will die, because you have spoken rebellion against Yahweh.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>So Hananiah the prophet died the same year in the seventh month. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the words of the letter that Jeremiah the prophet sent from Jerusalem to the residue of the elders of the captivity, and to the priests, to the prophets, and to all the people whom Nebuchadnezzar had carried away captive from Jerusalem to Babylon, 
+<sup>2&#160;</sup>(after Jeconiah the king, the queen mother, the eunuchs, the princes of Judah and Jerusalem, the craftsmen, and the smiths had departed from Jerusalem), 
+<sup>3&#160;</sup>by the hand of Elasah the son of Shaphan and Gemariah the son of Hilkiah, (whom Zedekiah king of Judah sent to Babylon to Nebuchadnezzar king of Babylon). It said: 
+</div><div class="pi1">
+<sup>4&#160;</sup>Yahweh of Armies, the Elohim of Israel, says to all the captives whom I have caused to be carried away captive from Jerusalem to Babylon: 
+<sup>5&#160;</sup>“Build houses and dwell in them. Plant gardens and eat their fruit. 
+<sup>6&#160;</sup>Take women and father sons and daughters. Take women for your sons, and give your daughters to men, that they may bear sons and daughters. Multiply there, and don’t be diminished. 
+<sup>7&#160;</sup>Seek the peace of the city where I have caused you to be carried away captive, and pray to Yahweh for it; for in its peace you will have peace.” 
+<sup>8&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: “Don’t let your prophets who are among you and your diviners deceive you. Don’t listen to your dreams which you cause to be dreamed. 
+<sup>9&#160;</sup>For they prophesy falsely to you in my name. I have not sent them,” says Yahweh. 
+<sup>10&#160;</sup>For Yahweh says, “After seventy years are accomplished for Babylon, I will visit you and perform my good word toward you, in causing you to return to this place. 
+<sup>11&#160;</sup>For I know the thoughts that I think toward you,” says Yahweh, “thoughts of peace, and not of evil, to give you hope and a future. 
+<sup>12&#160;</sup>You shall call on me, and you shall go and pray to me, and I will listen to you. 
+<sup>13&#160;</sup>You shall seek me and find me, when you search for me with all your heart. 
+<sup>14&#160;</sup>I will be found by you,” says Yahweh, “and I will turn again your captivity, and I will gather you from all the nations, and from all the places where I have driven you, says Yahweh. I will bring you again to the place from where I caused you to be carried away captive.” 
+</div><div class="pi1">
+<sup>15&#160;</sup>Because you have said, “Yahweh has raised us up prophets in Babylon,” 
+<sup>16&#160;</sup>Yahweh says concerning the king who sits on David’s throne, and concerning all the people who dwell in this city, your brothers who haven’t gone with you into captivity, 
+<sup>17&#160;</sup>Yahweh of Armies says: “Behold, I will send on them the sword, the famine, and the pestilence, and will make them like rotten figs that can’t be eaten, they are so bad. 
+<sup>18&#160;</sup>I will pursue after them with the sword, with the famine, and with the pestilence, and will deliver them to be tossed back and forth among all the kingdoms of the earth, to be an object of horror, an astonishment, a hissing, and a reproach among all the nations where I have driven them, 
+<sup>19&#160;</sup>because they have not listened to my words,” says Yahweh, “with which I sent to them my servants the prophets, rising up early and sending them; but you would not hear,” says Yahweh. 
+</div><div class="pi1">
+<sup>20&#160;</sup>Hear therefore Yahweh’s word, all you captives whom I have sent away from Jerusalem to Babylon. 
+<sup>21&#160;</sup>Yahweh of Armies, the Elohim of Israel, says concerning Ahab the son of Kolaiah, and concerning Zedekiah the son of Maaseiah, who prophesy a lie to you in my name: “Behold, I will deliver them into the hand of Nebuchadnezzar king of Babylon; and he will kill them before your eyes. 
+<sup>22&#160;</sup>A curse will be taken up about them by all the captives of Judah who are in Babylon, saying, ‘Yahweh make you like Zedekiah and like Ahab, whom the king of Babylon roasted in the fire;’ 
+<sup>23&#160;</sup>because they have done foolish things in Israel, and have committed adultery with their neighbors’ women, and have spoken words in my name falsely, which I didn’t command them. I am he who knows, and am witness,” says Yahweh. 
+</div><div class="p">
+<sup>24&#160;</sup>Concerning Shemaiah the Nehelamite you shall speak, saying, 
+<sup>25&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says, ‘Because you have sent letters in your own name to all the people who are at Jerusalem, and to Zephaniah the son of Maaseiah, the priest, and to all the priests, saying, 
+<sup>26&#160;</sup>“Yahweh has made you priest in the place of Jehoiada the priest, that there may be officers in Yahweh’s house, for every man who is crazy and makes himself a prophet, that you should put him in the stocks and in shackles. 
+<sup>27&#160;</sup>Now therefore, why have you not rebuked Jeremiah of Anathoth, who makes himself a prophet to you, 
+<sup>28&#160;</sup>because he has sent to us in Babylon, saying, The captivity is long. Build houses, and dwell in them. Plant gardens, and eat their fruit?”&#160;’&#160;” 
+</div><div class="p">
+<sup>29&#160;</sup>Zephaniah the priest read this letter in the hearing of Jeremiah the prophet. 
+<sup>30&#160;</sup>Then Yahweh’s word came to Jeremiah, saying, 
+<sup>31&#160;</sup>“Send to all of the captives, saying, ‘Yahweh says concerning Shemaiah the Nehelamite: “Because Shemaiah has prophesied to you, and I didn’t send him, and he has caused you to trust in a lie,” 
+<sup>32&#160;</sup>therefore Yahweh says, “Behold, I will punish Shemaiah the Nehelamite and his offspring. He will not have a man to dwell among this people. He won’t see the good that I will do to my people,” says Yahweh, “because he has spoken rebellion against Yahweh.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>The word that came to Jeremiah from Yahweh, saying, 
+<sup>2&#160;</sup>“Yahweh, the Elohim of Israel, says, ‘Write all the words that I have spoken to you in a book. 
+<sup>3&#160;</sup>For, behold, the days come,’ says Yahweh, ‘that I will reverse the captivity of my people Israel and Judah,’ says Yahweh. ‘I will cause them to return to the land that I gave to their fathers, and they will possess it.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>These are the words that Yahweh spoke concerning Israel and concerning Judah. 
+<sup>5&#160;</sup>For Yahweh says: 
+</div><div class="q1">“We have heard a voice of trembling; 
+</div><div class="q2">a voice of fear, and not of peace. 
+</div><div class="q1">
+<sup>6&#160;</sup>Ask now, and see whether a man travails with child. 
+</div><div class="q2">Why do I see every man with his hands on his waist, as a woman in travail, 
+</div><div class="q2">and all faces are turned pale? 
+</div><div class="q1">
+<sup>7&#160;</sup>Alas, for that day is great, so that none is like it! 
+</div><div class="q2">It is even the time of Jacob’s trouble; 
+</div><div class="q2">but he will be saved out of it. 
+</div><div class="q1">
+<sup>8&#160;</sup>It will come to pass in that day, says Yahweh of Armies, that I will break his yoke from off your neck, 
+</div><div class="q2">and will burst your bonds. 
+</div><div class="q2">Strangers will no more make them their bondservants; 
+</div><div class="q1">
+<sup>9&#160;</sup>but they will serve Yahweh their Elohim, 
+</div><div class="q2">and David their king, 
+</div><div class="q2">whom I will raise up to them. 
+</div><div class="q1">
+<sup>10&#160;</sup>Therefore don’t be afraid, O Jacob my servant, says Yahweh. 
+</div><div class="q2">Don’t be dismayed, Israel. 
+</div><div class="q1">For, behold, I will save you from afar, 
+</div><div class="q2">and save your offspring from the land of their captivity. 
+</div><div class="q1">Jacob will return, 
+</div><div class="q2">and will be quiet and at ease. 
+</div><div class="q2">No one will make him afraid. 
+</div><div class="q1">
+<sup>11&#160;</sup>For I am with you, says Yahweh, to save you; 
+</div><div class="q2">for I will make a full end of all the nations where I have scattered you, 
+</div><div class="q2">but I will not make a full end of you; 
+</div><div class="q1">but I will correct you in measure, 
+</div><div class="q2">and will in no way leave you unpunished.” 
+</div><div class="p">
+<sup>12&#160;</sup>For Yahweh says, 
+</div><div class="q1">“Your hurt is incurable. 
+</div><div class="q2">Your wound is grievous. 
+</div><div class="q1">
+<sup>13&#160;</sup>There is no one to plead your cause, 
+</div><div class="q2">that you may be bound up. 
+</div><div class="q2">You have no healing medicines. 
+</div><div class="q1">
+<sup>14&#160;</sup>All your lovers have forgotten you. 
+</div><div class="q2">They don’t seek you. 
+</div><div class="q1">For I have wounded you with the wound of an enemy, 
+</div><div class="q2">with the chastisement of a cruel one, 
+</div><div class="q1">for the greatness of your iniquity, 
+</div><div class="q2">because your sins were increased. 
+</div><div class="q1">
+<sup>15&#160;</sup>Why do you cry over your injury? 
+</div><div class="q2">Your pain is incurable. 
+</div><div class="q1">For the greatness of your iniquity, 
+</div><div class="q2">because your sins have increased, 
+</div><div class="q2">I have done these things to you. 
+</div><div class="q1">
+<sup>16&#160;</sup>Therefore all those who devour you will be devoured. 
+</div><div class="q2">All your adversaries, everyone of them, will go into captivity. 
+</div><div class="q1">Those who plunder you will be plunder. 
+</div><div class="q2">I will make all who prey on you become prey. 
+</div><div class="q1">
+<sup>17&#160;</sup>For I will restore health to you, 
+</div><div class="q2">and I will heal you of your wounds,” says Yahweh, 
+</div><div class="q1">“because they have called you an outcast, 
+</div><div class="q2">saying, ‘It is Zion, whom no man seeks after.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh says: 
+</div><div class="q1">“Behold, I will reverse the captivity of Jacob’s tents, 
+</div><div class="q2">and have compassion on his dwelling places. 
+</div><div class="q1">The city will be built on its own hill, 
+</div><div class="q2">and the palace will be inhabited in its own place. 
+</div><div class="q1">
+<sup>19&#160;</sup>Thanksgiving will proceed out of them 
+</div><div class="q2">with the voice of those who make merry. 
+</div><div class="q1">I will multiply them, 
+</div><div class="q2">and they will not be few; 
+</div><div class="q1">I will also glorify them, 
+</div><div class="q2">and they will not be small. 
+</div><div class="q1">
+<sup>20&#160;</sup>Their children also will be as before, 
+</div><div class="q2">and their congregation will be established before me. 
+</div><div class="q2">I will punish all who oppress them. 
+</div><div class="q1">
+<sup>21&#160;</sup>Their prince will be one of them, 
+</div><div class="q2">and their ruler will proceed from among them. 
+</div><div class="q1">I will cause him to draw near, 
+</div><div class="q2">and he will approach me; 
+</div><div class="q2">for who is he who has had boldness to approach me?” says Yahweh. 
+</div><div class="q1">
+<sup>22&#160;</sup>“You shall be my people, 
+</div><div class="q2">and I will be your Elohim. 
+</div><div class="q1">
+<sup>23&#160;</sup>Behold, Yahweh’s storm, his wrath, has gone out, 
+</div><div class="q2">a sweeping storm; 
+</div><div class="q2">it will burst on the head of the wicked. 
+</div><div class="q1">
+<sup>24&#160;</sup>The fierce anger of Yahweh will not return until he has accomplished, 
+</div><div class="q2">and until he has performed the intentions of his heart. 
+</div><div class="q2">In the latter days you will understand it.” 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>“At that time,” says Yahweh, “I will be the Elohim of all the families of Israel, and they will be my people.” 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh says, “The people who survive the sword found favor in the wilderness; even Israel, when I went to cause him to rest.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh appeared of old to me, saying, 
+</div><div class="q1">“Yes, I have loved you with an everlasting love. 
+</div><div class="q2">Therefore I have drawn you with loving kindness. 
+</div><div class="q1">
+<sup>4&#160;</sup>I will build you again, 
+</div><div class="q2">and you will be built, O virgin of Israel. 
+</div><div class="q1">You will again be adorned with your tambourines, 
+</div><div class="q2">and will go out in the dances of those who make merry. 
+</div><div class="q1">
+<sup>5&#160;</sup>Again you will plant vineyards on the mountains of Samaria. 
+</div><div class="q2">The planters will plant, 
+</div><div class="q2">and will enjoy its fruit. 
+</div><div class="q1">
+<sup>6&#160;</sup>For there will be a day that the watchmen on the hills of Ephraim cry, 
+</div><div class="q2">‘Arise! Let’s go up to Zion to Yahweh our Elohim.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>For Yahweh says, 
+</div><div class="q1">“Sing with gladness for Jacob, 
+</div><div class="q2">and shout for the chief of the nations. 
+</div><div class="q1">Publish, praise, and say, 
+</div><div class="q2">‘Yahweh, save your people, 
+</div><div class="q2">the remnant of Israel!’ 
+</div><div class="q1">
+<sup>8&#160;</sup>Behold, I will bring them from the north country, 
+</div><div class="q2">and gather them from the uttermost parts of the earth, 
+</div><div class="q1">along with the blind and the lame, 
+</div><div class="q2">the woman with child and her who travails with child together. 
+</div><div class="q2">They will return as a great company. 
+</div><div class="q1">
+<sup>9&#160;</sup>They will come with weeping. 
+</div><div class="q2">I will lead them with petitions. 
+</div><div class="q1">I will cause them to walk by rivers of waters, 
+</div><div class="q2">in a straight way in which they won’t stumble; 
+</div><div class="q1">for I am a father to Israel. 
+</div><div class="q2">Ephraim is my firstborn. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Hear Yahweh’s word, you nations, 
+</div><div class="q2">and declare it in the distant islands. Say, 
+</div><div class="q1">‘He who scattered Israel will gather him, 
+</div><div class="q2">and keep him, as a shepherd does his flock.’ 
+</div><div class="q1">
+<sup>11&#160;</sup>For Yahweh has ransomed Jacob, 
+</div><div class="q2">and redeemed him from the hand of him who was stronger than he. 
+</div><div class="q1">
+<sup>12&#160;</sup>They will come and sing in the height of Zion, 
+</div><div class="q2">and will flow to the goodness of Yahweh, 
+</div><div class="q1">to the grain, to the new wine, to the oil, 
+</div><div class="q2">and to the young of the flock and of the herd. 
+</div><div class="q1">Their soul will be as a watered garden. 
+</div><div class="q2">They will not sorrow any more at all. 
+</div><div class="q1">
+<sup>13&#160;</sup>Then the virgin will rejoice in the dance, 
+</div><div class="q2">the young men and the old together; 
+</div><div class="q1">for I will turn their mourning into joy, 
+</div><div class="q2">and will comfort them, and make them rejoice from their sorrow. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will satiate the soul of the priests with fatness, 
+</div><div class="q2">and my people will be satisfied with my goodness,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>15&#160;</sup>Yahweh says: 
+</div><div class="q1">“A voice is heard in Ramah, 
+</div><div class="q2">lamentation and bitter weeping, 
+</div><div class="q1">Rachel weeping for her children. 
+</div><div class="q2">She refuses to be comforted for her children, 
+</div><div class="q2">because they are no more.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh says: 
+</div><div class="q1">“Refrain your voice from weeping, 
+</div><div class="q2">and your eyes from tears, 
+</div><div class="q2">for your work will be rewarded,” says Yahweh. 
+</div><div class="q2">“They will come again from the land of the enemy. 
+</div><div class="q1">
+<sup>17&#160;</sup>There is hope for your latter end,” says Yahweh. 
+</div><div class="q2">“Your children will come again to their own territory. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“I have surely heard Ephraim grieving thus, 
+</div><div class="q2">‘You have chastised me, 
+</div><div class="q2">and I was chastised, as an untrained calf. 
+</div><div class="q1">Turn me, and I will be turned, 
+</div><div class="q2">for you are Yahweh my Elohim. 
+</div><div class="q1">
+<sup>19&#160;</sup>Surely after that I was turned. 
+</div><div class="q2">I repented. 
+</div><div class="q1">After that I was instructed. 
+</div><div class="q2">I struck my thigh. 
+</div><div class="q1">I was ashamed, yes, even confounded, 
+</div><div class="q2">because I bore the reproach of my youth.’ 
+</div><div class="q1">
+<sup>20&#160;</sup>Is Ephraim my dear son? 
+</div><div class="q2">Is he a darling child? 
+</div><div class="q1">For as often as I speak against him, 
+</div><div class="q2">I still earnestly remember him. 
+</div><div class="q1">Therefore my heart yearns for him. 
+</div><div class="q2">I will surely have mercy on him,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Set up road signs. 
+</div><div class="q2">Make guideposts. 
+</div><div class="q1">Set your heart toward the highway, 
+</div><div class="q2">even the way by which you went. 
+</div><div class="q1">Turn again, virgin of Israel. 
+</div><div class="q2">Turn again to these your cities. 
+</div><div class="q1">
+<sup>22&#160;</sup>How long will you go here and there, 
+</div><div class="q2">you backsliding daughter? 
+</div><div class="q1">For Yahweh has created a new thing in the earth: 
+</div><div class="q2">a woman will encompass a man.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>23&#160;</sup>Yahweh of Armies, the Elohim of Israel, says: “Yet again they will use this speech in the land of Judah and in its cities, when I reverse their captivity: ‘Yahweh bless you, habitation of righteousness, mountain of set-apartness.’ 
+<sup>24&#160;</sup>Judah and all its cities will dwell therein together, the farmers, and those who go about with flocks. 
+<sup>25&#160;</sup>For I have satiated the weary soul, and I have replenished every sorrowful soul.” 
+</div><div class="p">
+<sup>26&#160;</sup>On this I awakened, and saw; and my sleep was sweet to me. 
+</div><div class="p">
+<sup>27&#160;</sup>“Behold, the days come,” says Yahweh, “that I will sow the house of Israel and the house of Judah with the seed of man and with the seed of animal. 
+<sup>28&#160;</sup>It will happen that, like as I have watched over them to pluck up and to break down and to overthrow and to destroy and to afflict, so I will watch over them to build and to plant,” says Yahweh. 
+<sup>29&#160;</sup>“In those days they will say no more, 
+</div><div class="q1">“&#160;‘The fathers have eaten sour grapes, 
+</div><div class="q2">and the children’s teeth are set on edge.’ 
+</div><div class="m">
+<sup>30&#160;</sup>But everyone will die for his own iniquity. Every man who eats the sour grapes, his teeth will be set on edge. 
+</div><div class="p">
+<sup>31&#160;</sup>“Behold, the days come,” says Yahweh, “that I will make a new covenant with the house of Israel, and with the house of Judah, 
+<sup>32&#160;</sup>not according to the covenant that I made with their fathers in the day that I took them by the hand to bring them out of the land of Egypt, which covenant of mine they broke, although I was an owner to them,” says Yahweh. 
+<sup>33&#160;</sup>“But this is the covenant that I will make with the house of Israel after those days,” says Yahweh: 
+</div><div class="q1">“I will put my law in their inward parts, 
+</div><div class="q2">and I will write it in their heart. 
+</div><div class="q1">I will be their Elohim, 
+</div><div class="q2">and they shall be my people. 
+</div><div class="q1">
+<sup>34&#160;</sup>They will no longer each teach his neighbor, 
+</div><div class="q2">and every man teach his brother, saying, ‘Know Yahweh;’ 
+</div><div class="q1">for they will all know me, 
+</div><div class="q2">from their least to their greatest,” says Yahweh, 
+</div><div class="q1">“for I will forgive their iniquity, 
+</div><div class="q2">and I will remember their sin no more.” 
+</div><div class="q1">
+<sup>35&#160;</sup>Yahweh, who gives the sun for a light by day, 
+</div><div class="q2">and the ordinances of the moon and of the stars for a light by night, 
+</div><div class="q1">who stirs up the sea, so that its waves roar—</div><div class="q2">Yahweh of Armies is his name, says: 
+</div><div class="q1">
+<sup>36&#160;</sup>“If these ordinances depart from before me,” says Yahweh, 
+</div><div class="q2">“then the offspring of Israel also will cease from being a nation before me forever.” 
+</div><div class="q1">
+<sup>37&#160;</sup>Yahweh says: “If heaven above can be measured, 
+</div><div class="q2">and the foundations of the earth searched out beneath, 
+</div><div class="q2">then I will also cast off all the offspring of Israel for all that they have done,” says Yahweh. 
+</div><div class="p">
+<sup>38&#160;</sup>“Behold, the days come,” says Yahweh, “that the city will be built to Yahweh from the tower of Hananel to the gate of the corner. 
+<sup>39&#160;</sup>The measuring line will go out further straight onward to the hill Gareb, and will turn toward Goah. 
+<sup>40&#160;</sup>The whole valley of the dead bodies and of the ashes, and all the fields to the brook Kidron, to the corner of the horse gate toward the east, will be set-apart to Yahweh. It will not be plucked up or thrown down any more forever.” 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>This is the word that came to Jeremiah from Yahweh in the tenth year of Zedekiah king of Judah, which was the eighteenth year of Nebuchadnezzar. 
+<sup>2&#160;</sup>Now at that time the king of Babylon’s army was besieging Jerusalem. Jeremiah the prophet was shut up in the court of the guard, which was in the king of Judah’s house. 
+</div><div class="p">
+<sup>3&#160;</sup>For Zedekiah king of Judah had shut him up, saying, “Why do you prophesy, and say, ‘Yahweh says, “Behold, I will give this city into the hand of the king of Babylon, and he will take it; 
+<sup>4&#160;</sup>and Zedekiah king of Judah won’t escape out of the hand of the Chaldeans, but will surely be delivered into the hand of the king of Babylon, and will speak with him mouth to mouth, and his eyes will see his eyes; 
+<sup>5&#160;</sup>and he will bring Zedekiah to Babylon, and he will be there until I visit him,” says Yahweh, “though you fight with the Chaldeans, you will not prosper”&#160;’?” 
+</div><div class="p">
+<sup>6&#160;</sup>Jeremiah said, “Yahweh’s word came to me, saying, 
+<sup>7&#160;</sup>‘Behold, Hanamel the son of Shallum your uncle will come to you, saying, “Buy my field that is in Anathoth; for the right of redemption is yours to buy it.”&#160;’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>“So Hanamel my uncle’s son came to me in the court of the guard according to Yahweh’s word, and said to me, ‘Please buy my field that is in Anathoth, which is in the land of Benjamin; for the right of inheritance is yours, and the redemption is yours. Buy it for yourself.’ 
+</div><div class="p">“Then I knew that this was Yahweh’s word. 
+<sup>9&#160;</sup>I bought the field that was in Anathoth of Hanamel my uncle’s son, and weighed him the money, even seventeen shekels of silver. 
+<sup>10&#160;</sup>I signed the deed, sealed it, called witnesses, and weighed the money in the balances to him. 
+<sup>11&#160;</sup>So I took the deed of the purchase, both that which was sealed, containing the terms and conditions, and that which was open; 
+<sup>12&#160;</sup>and I delivered the deed of the purchase to Baruch the son of Neriah, the son of Mahseiah, in the presence of Hanamel my uncle’s son, and in the presence of the witnesses who signed the deed of the purchase, before all the Jews who sat in the court of the guard. 
+</div><div class="p">
+<sup>13&#160;</sup>“I commanded Baruch before them, saying, 
+<sup>14&#160;</sup>Yahweh of Armies, the Elohim of Israel, says: ‘Take these deeds, this deed of the purchase which is sealed, and this deed which is open, and put them in an earthen vessel, that they may last many days.’ 
+<sup>15&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: ‘Houses and fields and vineyards will yet again be bought in this land.’ 
+</div><div class="p">
+<sup>16&#160;</sup>Now after I had delivered the deed of the purchase to Baruch the son of Neriah, I prayed to Yahweh, saying, 
+</div><div class="b"> &#160; </div>
+<div class="mi">
+<sup>17&#160;</sup>“Ah Lord Yahweh! Behold, you have made the heavens and the earth by your great power and by your outstretched arm. There is nothing too hard for you. 
+<sup>18&#160;</sup>You show loving kindness to thousands, and repay the iniquity of the fathers into the bosom of their children after them. The great, the mighty Elohim, Yahweh of Armies is your name: 
+<sup>19&#160;</sup>great in counsel, and mighty in work; whose eyes are open to all the ways of the children of men, to give everyone according to his ways, and according to the fruit of his doings; 
+<sup>20&#160;</sup>who performed signs and wonders in the land of Egypt, even to this day, both in Israel and among other men; and made yourself a name, as it is today; 
+<sup>21&#160;</sup>and brought your people Israel out of the land of Egypt with signs, with wonders, with a strong hand, with an outstretched arm, and with great terror; 
+<sup>22&#160;</sup>and gave them this land, which you swore to their fathers to give them, a land flowing with milk and honey. 
+<sup>23&#160;</sup>They came in and possessed it, but they didn’t obey your voice and didn’t walk in your law. They have done nothing of all that you commanded them to do. Therefore you have caused all this evil to come upon them. 
+</div><div class="pi1">
+<sup>24&#160;</sup>“Behold, siege ramps have been built against the city to take it. The city is given into the hand of the Chaldeans who fight against it, because of the sword, of the famine, and of the pestilence. What you have spoken has happened. Behold, you see it. 
+<sup>25&#160;</sup>You have said to me, Lord Yahweh, ‘Buy the field for money, and call witnesses;’ whereas the city is given into the hand of the Chaldeans.” 
+</div><div class="p">
+<sup>26&#160;</sup>Then Yahweh’s word came to Jeremiah, saying, 
+<sup>27&#160;</sup>“Behold, I am Yahweh, the Elohim of all flesh. Is there anything too hard for me? 
+<sup>28&#160;</sup>Therefore Yahweh says: Behold, I will give this city into the hand of the Chaldeans, and into the hand of Nebuchadnezzar king of Babylon, and he will take it. 
+<sup>29&#160;</sup>The Chaldeans, who fight against this city, will come and set this city on fire, and burn it with the houses on whose roofs they have offered incense to Baal, and poured out drink offerings to other elohims, to provoke me to anger. 
+</div><div class="p">
+<sup>30&#160;</sup>“For the children of Israel and the children of Judah have done only that which was evil in my sight from their youth; for the children of Israel have only provoked me to anger with the work of their hands, says Yahweh. 
+<sup>31&#160;</sup>For this city has been to me a provocation of my anger and of my wrath from the day that they built it even to this day, so that I should remove it from before my face, 
+<sup>32&#160;</sup>because of all the evil of the children of Israel and of the children of Judah, which they have done to provoke me to anger—they, their kings, their princes, their priests, their prophets, the men of Judah, and the inhabitants of Jerusalem. 
+<sup>33&#160;</sup>They have turned their backs to me, and not their faces. Although I taught them, rising up early and teaching them, yet they have not listened to receive instruction. 
+<sup>34&#160;</sup>But they set their abominations in the house which is called by my name, to defile it. 
+<sup>35&#160;</sup>They built the high places of Baal, which are in the valley of the son of Hinnom, to cause their sons and their daughters to pass through fire to Molech, which I didn’t command them. It didn’t even come into my mind, that they should do this abomination, to cause Judah to sin.” 
+</div><div class="p">
+<sup>36&#160;</sup>Now therefore Yahweh, the Elohim of Israel, says concerning this city, about which you say, “It is given into the hand of the king of Babylon by the sword, by the famine, and by the pestilence:” 
+<sup>37&#160;</sup>“Behold, I will gather them out of all the countries where I have driven them in my anger, and in my wrath, and in great indignation; and I will bring them again to this place. I will cause them to dwell safely. 
+<sup>38&#160;</sup>Then they will be my people, and I will be their Elohim. 
+<sup>39&#160;</sup>I will give them one heart and one way, that they may fear me forever, for their good and the good of their children after them. 
+<sup>40&#160;</sup>I will make an everlasting covenant with them, that I will not turn away from following them, to do them good. I will put my fear in their hearts, that they may not depart from me. 
+<sup>41&#160;</sup>Yes, I will rejoice over them to do them good, and I will plant them in this land assuredly with my whole heart and with my whole soul.” 
+</div><div class="p">
+<sup>42&#160;</sup>For Yahweh says: “Just as I have brought all this great evil on this people, so I will bring on them all the good that I have promised them. 
+<sup>43&#160;</sup>Fields will be bought in this land, about which you say, ‘It is desolate, without man or animal. It is given into the hand of the Chaldeans.’ 
+<sup>44&#160;</sup>Men will buy fields for money, sign the deeds, seal them, and call witnesses, in the land of Benjamin, and in the places around Jerusalem, in the cities of Judah, in the cities of the hill country, in the cities of the lowland, and in the cities of the South; for I will cause their captivity to be reversed,” says Yahweh. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="nb">
+<sup>1&#160;</sup>Moreover Yahweh’s word came to Jeremiah the second time, while he was still locked up in the court of the guard, saying, 
+<sup>2&#160;</sup>“Yahweh who does it, Yahweh who forms it to establish it—Yahweh is his name, says: 
+<sup>3&#160;</sup>‘Call to me, and I will answer you, and will show you great and difficult things, which you don’t know.’ 
+<sup>4&#160;</sup>For Yahweh, the Elohim of Israel, says concerning the houses of this city and concerning the houses of the kings of Judah, which are broken down to make a defense against the mounds and against the sword: 
+<sup>5&#160;</sup>‘While men come to fight with the Chaldeans, and to fill them with the dead bodies of men, whom I have killed in my anger and in my wrath, and for all whose wickedness I have hidden my face from this city, 
+<sup>6&#160;</sup>behold, I will bring it health and healing, and I will cure them; and I will reveal to them abundance of peace and truth. 
+<sup>7&#160;</sup>I will restore the fortunes of Judah and Israel, and will build them as at the first. 
+<sup>8&#160;</sup>I will cleanse them from all their iniquity by which they have sinned against me. I will pardon all their iniquities by which they have sinned against me and by which they have transgressed against me. 
+<sup>9&#160;</sup>This city will be to me for a name of joy, for praise, and for glory, before all the nations of the earth, which will hear all the good that I do to them, and will fear and tremble for all the good and for all the peace that I provide to it.’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh says: “Yet again there will be heard in this place, about which you say, ‘It is waste, without man and without animal, even in the cities of Judah, and in the streets of Jerusalem, that are desolate, without man and without inhabitant and without animal,’ 
+<sup>11&#160;</sup>the voice of joy and the voice of gladness, the voice of the bridegroom and the voice of the bride, the voice of those who say, ‘Give thanks to Yahweh of Armies, for Yahweh is good, for his loving kindness endures forever;’ who bring thanksgiving into Yahweh’s house. For I will cause the captivity of the land to be reversed as at the first,” says Yahweh. 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh of Armies says: “Yet again there will be in this place, which is waste, without man and without animal, and in all its cities, a habitation of shepherds causing their flocks to lie down. 
+<sup>13&#160;</sup>In the cities of the hill country, in the cities of the lowland, in the cities of the South, in the land of Benjamin, in the places around Jerusalem, and in the cities of Judah, the flocks will again pass under the hands of him who counts them,” says Yahweh. 
+</div><div class="p">
+<sup>14&#160;</sup>“Behold, the days come,” says Yahweh, “that I will perform that good word which I have spoken concerning the house of Israel and concerning the house of Judah. 
+</div><div class="q1">
+<sup>15&#160;</sup>“In those days and at that time, 
+</div><div class="q2">I will cause a Branch of righteousness to grow up to David. 
+</div><div class="q2">He will execute justice and righteousness in the land. 
+</div><div class="q1">
+<sup>16&#160;</sup>In those days Judah will be saved, 
+</div><div class="q2">and Jerusalem will dwell safely. 
+</div><div class="q1">This is the name by which she will be called: 
+</div><div class="q2">Yahweh our righteousness.” 
+</div><div class="p">
+<sup>17&#160;</sup>For Yahweh says: “David will never lack a man to sit on the throne of the house of Israel. 
+<sup>18&#160;</sup>The Levitical priests won’t lack a man before me to offer burnt offerings, to burn meal offerings, and to do sacrifice continually.” 
+</div><div class="p">
+<sup>19&#160;</sup>Yahweh’s word came to Jeremiah, saying, 
+<sup>20&#160;</sup>“Yahweh says: ‘If you can break my covenant of the day and my covenant of the night, so that there will not be day and night in their time, 
+<sup>21&#160;</sup>then my covenant could also be broken with David my servant, that he won’t have a son to reign on his throne; and with the Levitical priests, my ministers. 
+<sup>22&#160;</sup>As the army of the sky can’t be counted, and the sand of the sea can’t be measured, so I will multiply the offspring of David my servant and the Levites who minister to me.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh’s word came to Jeremiah, saying, 
+<sup>24&#160;</sup>“Don’t consider what this people has spoken, saying, ‘Has Yahweh cast off the two families which he chose?’ Thus they despise my people, that they should be no more a nation before them.” 
+<sup>25&#160;</sup>Yahweh says: “If my covenant of day and night fails, if I have not appointed the ordinances of heaven and earth, 
+<sup>26&#160;</sup>then I will also cast away the offspring of Jacob, and of David my servant, so that I will not take of his offspring to be rulers over the offspring of Abraham, Isaac, and Jacob; for I will cause their captivity to be reversed and will have mercy on them.” 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, when Nebuchadnezzar king of Babylon, with all his army, all the kingdoms of the earth that were under his dominion, and all the peoples, were fighting against Jerusalem and against all its cities, saying: 
+<sup>2&#160;</sup>“Yahweh, the Elohim of Israel, says, ‘Go, and speak to Zedekiah king of Judah, and tell him, Yahweh says, “Behold, I will give this city into the hand of the king of Babylon and he will burn it with fire. 
+<sup>3&#160;</sup>You won’t escape out of his hand, but will surely be taken and delivered into his hand. Your eyes will see the eyes of the king of Babylon, and he will speak with you mouth to mouth. You will go to Babylon.”&#160;’ 
+</div><div class="p">
+<sup>4&#160;</sup>“Yet hear Yahweh’s word, O Zedekiah king of Judah. Yahweh says concerning you, ‘You won’t die by the sword. 
+<sup>5&#160;</sup>You will die in peace; and with the burnings of your fathers, the former kings who were before you, so they will make a burning for you. They will lament you, saying, “Ah Lord!” for I have spoken the word,’ says Yahweh.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then Jeremiah the prophet spoke all these words to Zedekiah king of Judah in Jerusalem, 
+<sup>7&#160;</sup>when the king of Babylon’s army was fighting against Jerusalem and against all the cities of Judah that were left, against Lachish and against Azekah; for these alone remained of the cities of Judah as fortified cities. 
+</div><div class="p">
+<sup>8&#160;</sup>The word came to Jeremiah from Yahweh, after King Zedekiah had made a covenant with all the people who were at Jerusalem, to proclaim liberty to them, 
+<sup>9&#160;</sup>that every man should let his male servant, and every man his female servant, who is a Hebrew or a Hebrewess, go free, that no one should make bondservants of them, of a Jew his brother. 
+<sup>10&#160;</sup>All the princes and all the people obeyed who had entered into the covenant, that everyone should let his male servant and everyone his female servant go free, that no one should make bondservants of them any more. They obeyed and let them go, 
+<sup>11&#160;</sup>but afterwards they turned, and caused the servants and the handmaids whom they had let go free to return, and brought them into subjection for servants and for handmaids. 
+</div><div class="p">
+<sup>12&#160;</sup>Therefore Yahweh’s word came to Jeremiah from Yahweh, saying, 
+<sup>13&#160;</sup>“Yahweh, the Elohim of Israel, says: ‘I made a covenant with your fathers in the day that I brought them out of the land of Egypt, out of the house of bondage, saying: 
+<sup>14&#160;</sup>At the end of seven years, every man of you shall release his brother who is a Hebrew, who has been sold to you, and has served you six years. You shall let him go free from you. But your fathers didn’t listen to me, and didn’t incline their ear. 
+<sup>15&#160;</sup>You had now turned, and had done that which is right in my eyes, in every man proclaiming liberty to his neighbor. You had made a covenant before me in the house which is called by my name; 
+<sup>16&#160;</sup>but you turned and profaned my name, and every man caused his servant and every man his handmaid, whom you had let go free at their pleasure, to return. You brought them into subjection, to be to you for servants and for handmaids.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>Therefore Yahweh says: “You have not listened to me, to proclaim liberty, every man to his brother, and every man to his neighbor. Behold, I proclaim to you a liberty,” says Yahweh, “to the sword, to the pestilence, and to the famine. I will make you be tossed back and forth among all the kingdoms of the earth. 
+<sup>18&#160;</sup>I will give the men who have transgressed my covenant, who have not performed the words of the covenant which they made before me when they cut the calf in two and passed between its parts: 
+<sup>19&#160;</sup>the princes of Judah, the princes of Jerusalem, the eunuchs, the priests, and all the people of the land, who passed between the parts of the calf. 
+<sup>20&#160;</sup>I will even give them into the hand of their enemies and into the hand of those who seek their life. Their dead bodies will be food for the birds of the sky and for the animals of the earth. 
+</div><div class="p">
+<sup>21&#160;</sup>“I will give Zedekiah king of Judah and his princes into the hands of their enemies, into the hands of those who seek their life and into the hands of the king of Babylon’s army, who has gone away from you. 
+<sup>22&#160;</sup>Behold, I will command,” says Yahweh, “and cause them to return to this city. They will fight against it, take it, and burn it with fire. I will make the cities of Judah a desolation, without inhabitant.” 
+</div><h2 class="chapterlabel" id="35">35</h2>
+<div class="p">
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh in the days of Jehoiakim the son of Josiah, king of Judah, saying, 
+<sup>2&#160;</sup>“Go to the house of the Rechabites, and speak to them, and bring them into Yahweh’s house, into one of the rooms, and give them wine to drink.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then I took Jaazaniah the son of Jeremiah, the son of Habazziniah, with his brothers, all his sons, and the whole house of the Rechabites; 
+<sup>4&#160;</sup>and I brought them into Yahweh’s house, into the room of the sons of Hanan the son of Igdaliah, the man of Elohim, which was by the room of the princes, which was above the room of Maaseiah the son of Shallum, the keeper of the threshold. 
+<sup>5&#160;</sup>I set before the sons of the house of the Rechabites bowls full of wine, and cups; and I said to them, “Drink wine!” 
+</div><div class="p">
+<sup>6&#160;</sup>But they said, “We will drink no wine; for Jonadab the son of Rechab, our father, commanded us, saying, ‘You shall drink no wine, neither you nor your children, forever. 
+<sup>7&#160;</sup>You shall not build a house, sow seed, plant a vineyard, or have any; but all your days you shall dwell in tents, that you may live many days in the land in which you live as nomads.’ 
+<sup>8&#160;</sup>We have obeyed the voice of Jonadab the son of Rechab, our father, in all that he commanded us, to drink no wine all our days, we, our women, our sons, or our daughters; 
+<sup>9&#160;</sup>and not to build houses for ourselves to dwell in. We have no vineyard, field, or seed; 
+<sup>10&#160;</sup>but we have lived in tents, and have obeyed, and done according to all that Jonadab our father commanded us. 
+<sup>11&#160;</sup>But when Nebuchadnezzar king of Babylon came up into the land, we said, ‘Come! Let’s go to Jerusalem for fear of the army of the Chaldeans, and for fear of the army of the Syrians; so we will dwell at Jerusalem.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Then Yahweh’s word came to Jeremiah, saying, 
+<sup>13&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says: ‘Go and tell the men of Judah and the inhabitants of Jerusalem, “Will you not receive instruction to listen to my words?” says Yahweh. 
+<sup>14&#160;</sup>“The words of Jonadab the son of Rechab that he commanded his sons, not to drink wine, are performed; and to this day they drink none, for they obey their father’s commandment; but I have spoken to you, rising up early and speaking, and you have not listened to me. 
+<sup>15&#160;</sup>I have sent also to you all my servants the prophets, rising up early and sending them, saying, ‘Every one of you must return now from his evil way, amend your doings, and don’t go after other elohims to serve them. Then you will dwell in the land which I have given to you and to your fathers;’ but you have not inclined your ear, nor listened to me. 
+<sup>16&#160;</sup>The sons of Jonadab the son of Rechab have performed the commandment of their father which he commanded them, but this people has not listened to me.”&#160;’ 
+</div><div class="p">
+<sup>17&#160;</sup>“Therefore Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Behold, I will bring on Judah and on all the inhabitants of Jerusalem all the evil that I have pronounced against them, because I have spoken to them, but they have not heard; and I have called to them, but they have not answered.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Jeremiah said to the house of the Rechabites, “Yahweh of Armies, the Elohim of Israel, says: ‘Because you have obeyed the commandment of Jonadab your father, and kept all his precepts, and done according to all that he commanded you,’ 
+<sup>19&#160;</sup>therefore Yahweh of Armies, the Elohim of Israel, says: ‘Jonadab the son of Rechab will not lack a man to stand before me forever.’&#160;” 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>In the fourth year of Jehoiakim the son of Josiah, king of Judah, this word came to Jeremiah from Yahweh, saying, 
+<sup>2&#160;</sup>“Take a scroll of a book, and write in it all the words that I have spoken to you against Israel, against Judah, and against all the nations, from the day I spoke to you, from the days of Josiah even to this day. 
+<sup>3&#160;</sup>It may be that the house of Judah will hear all the evil which I intend to do to them, that they may each return from his evil way; that I may forgive their iniquity and their sin.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then Jeremiah called Baruch the son of Neriah; and Baruch wrote from the mouth of Jeremiah all Yahweh’s words, which he had spoken to him, on a scroll of a book. 
+<sup>5&#160;</sup>Jeremiah commanded Baruch, saying, “I am restricted. I can’t go into Yahweh’s house. 
+<sup>6&#160;</sup>Therefore you go, and read from the scroll which you have written from my mouth, Yahweh’s words, in the ears of the people in Yahweh’s house on the fast day. Also you shall read them in the ears of all Judah who come out of their cities. 
+<sup>7&#160;</sup>It may be they will present their supplication before Yahweh, and will each return from his evil way; for Yahweh has pronounced great anger and wrath against this people.” 
+</div><div class="p">
+<sup>8&#160;</sup>Baruch the son of Neriah did according to all that Jeremiah the prophet commanded him, reading in the book Yahweh’s words in Yahweh’s house. 
+<sup>9&#160;</sup>Now in the fifth year of Jehoiakim the son of Josiah, king of Judah, in the ninth month, all the people in Jerusalem and all the people who came from the cities of Judah to Jerusalem, proclaimed a fast before Yahweh. 
+<sup>10&#160;</sup>Then Baruch read the words of Jeremiah from the book in Yahweh’s house, in the room of Gemariah the son of Shaphan the scribe, in the upper court, at the entry of the new gate of Yahweh’s house, in the ears of all the people. 
+</div><div class="p">
+<sup>11&#160;</sup>When Micaiah the son of Gemariah, the son of Shaphan, had heard out of the book all Yahweh’s words, 
+<sup>12&#160;</sup>he went down into the king’s house, into the scribe’s room; and behold, all the princes were sitting there, Elishama the scribe, Delaiah the son of Shemaiah, Elnathan the son of Achbor, Gemariah the son of Shaphan, Zedekiah the son of Hananiah, and all the princes. 
+<sup>13&#160;</sup>Then Micaiah declared to them all the words that he had heard, when Baruch read the book in the ears of the people. 
+<sup>14&#160;</sup>Therefore all the princes sent Jehudi the son of Nethaniah, the son of Shelemiah, the son of Cushi, to Baruch, saying, “Take in your hand the scroll in which you have read in the ears of the people, and come.” 
+</div><div class="p">So Baruch the son of Neriah took the scroll in his hand, and came to them. 
+<sup>15&#160;</sup>They said to him, “Sit down now, and read it in our hearing.” 
+</div><div class="p">So Baruch read it in their hearing. 
+</div><div class="p">
+<sup>16&#160;</sup>Now when they had heard all the words, they turned in fear one toward another, and said to Baruch, “We will surely tell the king of all these words.” 
+<sup>17&#160;</sup>They asked Baruch, saying, “Tell us now, how did you write all these words at his mouth?” 
+</div><div class="p">
+<sup>18&#160;</sup>Then Baruch answered them, “He dictated all these words to me with his mouth, and I wrote them with ink in the book.” 
+</div><div class="p">
+<sup>19&#160;</sup>Then the princes said to Baruch, “You and Jeremiah go hide. Don’t let anyone know where you are.” 
+</div><div class="p">
+<sup>20&#160;</sup>They went in to the king into the court, but they had laid up the scroll in the room of Elishama the scribe. Then they told all the words in the hearing of the king. 
+<sup>21&#160;</sup>So the king sent Jehudi to get the scroll, and he took it out of the room of Elishama the scribe. Jehudi read it in the hearing of the king, and in the hearing of all the princes who stood beside the king. 
+<sup>22&#160;</sup>Now the king was sitting in the winter house in the ninth month, and there was a fire in the brazier burning before him. 
+<sup>23&#160;</sup>When Jehudi had read three or four columns, the king cut it with the penknife, and cast it into the fire that was in the brazier, until all the scroll was consumed in the fire that was in the brazier. 
+<sup>24&#160;</sup>The king and his servants who heard all these words were not afraid, and didn’t tear their garments. 
+<sup>25&#160;</sup>Moreover Elnathan and Delaiah and Gemariah had made intercession to the king that he would not burn the scroll; but he would not listen to them. 
+<sup>26&#160;</sup>The king commanded Jerahmeel the king’s son, and Seraiah the son of Azriel, and Shelemiah the son of Abdeel, to arrest Baruch the scribe and Jeremiah the prophet; but Yahweh hid them. 
+</div><div class="p">
+<sup>27&#160;</sup>Then Yahweh’s word came to Jeremiah, after the king had burned the scroll, and the words which Baruch wrote at the mouth of Jeremiah, saying, 
+<sup>28&#160;</sup>“Take again another scroll, and write in it all the former words that were in the first scroll, which Jehoiakim the king of Judah has burned. 
+<sup>29&#160;</sup>Concerning Jehoiakim king of Judah you shall say, ‘Yahweh says: “You have burned this scroll, saying, ‘Why have you written therein, saying, “The king of Babylon will certainly come and destroy this land, and will cause to cease from there man and animal”?’&#160;” 
+<sup>30&#160;</sup>Therefore Yahweh says concerning Jehoiakim king of Judah: “He will have no one to sit on David’s throne. His dead body will be cast out in the day to the heat, and in the night to the frost. 
+<sup>31&#160;</sup>I will punish him, his offspring, and his servants for their iniquity. I will bring on them, on the inhabitants of Jerusalem, and on the men of Judah, all the evil that I have pronounced against them, but they didn’t listen.”&#160;’&#160;” 
+</div><div class="p">
+<sup>32&#160;</sup>Then Jeremiah took another scroll, and gave it to Baruch the scribe, the son of Neriah, who wrote therein from the mouth of Jeremiah all the words of the book which Jehoiakim king of Judah had burned in the fire; and many similar words were added to them. 
+</div><h2 class="chapterlabel" id="37">37</h2>
+<div class="p">
+<sup>1&#160;</sup>Zedekiah the son of Josiah reigned as king instead of Coniah the son of Jehoiakim, whom Nebuchadnezzar king of Babylon made king in the land of Judah. 
+<sup>2&#160;</sup>But neither he, nor his servants, nor the people of the land, listened to Yahweh’s words, which he spoke by the prophet Jeremiah. 
+</div><div class="p">
+<sup>3&#160;</sup>Zedekiah the king sent Jehucal the son of Shelemiah and Zephaniah the son of Maaseiah, the priest, to the prophet Jeremiah, saying, “Pray now to Yahweh our Elohim for us.” 
+</div><div class="p">
+<sup>4&#160;</sup>Now Jeremiah came in and went out among the people, for they had not put him into prison. 
+<sup>5&#160;</sup>Pharaoh’s army had come out of Egypt; and when the Chaldeans who were besieging Jerusalem heard news of them, they withdrew from Jerusalem. 
+</div><div class="p">
+<sup>6&#160;</sup>Then Yahweh’s word came to the prophet Jeremiah, saying, 
+<sup>7&#160;</sup>“Yahweh, the Elohim of Israel, says, ‘You shall tell the king of Judah, who sent you to me to inquire of me: “Behold, Pharaoh’s army, which has come out to help you, will return to Egypt into their own land. 
+<sup>8&#160;</sup>The Chaldeans will come again, and fight against this city. They will take it and burn it with fire.”&#160;’ 
+</div><div class="p">
+<sup>9&#160;</sup>“Yahweh says, ‘Don’t deceive yourselves, saying, “The Chaldeans will surely depart from us;” for they will not depart. 
+<sup>10&#160;</sup>For though you had struck the whole army of the Chaldeans who fight against you, and only wounded men remained among them, they would each rise up in his tent and burn this city with fire.’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>When the army of the Chaldeans had withdrawn from Jerusalem for fear of Pharaoh’s army, 
+<sup>12&#160;</sup>then Jeremiah went out of Jerusalem to go into the land of Benjamin, to receive his portion there, in the middle of the people. 
+<sup>13&#160;</sup>When he was in Benjamin’s gate, a captain of the guard was there, whose name was Irijah, the son of Shelemiah, the son of Hananiah; and he seized Jeremiah the prophet, saying, “You are defecting to the Chaldeans!” 
+</div><div class="p">
+<sup>14&#160;</sup>Then Jeremiah said, “That is false! I am not defecting to the Chaldeans.” 
+</div><div class="p">But he didn’t listen to him; so Irijah seized Jeremiah, and brought him to the princes. 
+<sup>15&#160;</sup>The princes were angry with Jeremiah, and struck him, and put him in prison in the house of Jonathan the scribe; for they had made that the prison. 
+</div><div class="p">
+<sup>16&#160;</sup>When Jeremiah had come into the dungeon house and into the cells, and Jeremiah had remained there many days, 
+<sup>17&#160;</sup>then Zedekiah the king sent and had him brought out. The king asked him secretly in his house, “Is there any word from Yahweh?” 
+</div><div class="p">Jeremiah said, “There is.” He also said, “You will be delivered into the hand of the king of Babylon.” 
+</div><div class="p">
+<sup>18&#160;</sup>Moreover Jeremiah said to King Zedekiah, “How have I sinned against you, against your servants, or against this people, that you have put me in prison? 
+<sup>19&#160;</sup>Now where are your prophets who prophesied to you, saying, ‘The king of Babylon will not come against you, nor against this land’? 
+<sup>20&#160;</sup>Now please hear, my lord the king: please let my supplication be presented before you, that you not cause me to return to the house of Jonathan the scribe, lest I die there.” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Zedekiah the king commanded, and they committed Jeremiah into the court of the guard. They gave him daily a loaf of bread out of the bakers’ street, until all the bread in the city was gone. Thus Jeremiah remained in the court of the guard. 
+</div><h2 class="chapterlabel" id="38">38</h2>
+<div class="p">
+<sup>1&#160;</sup>Shephatiah the son of Mattan, Gedaliah the son of Pashhur, Jucal the son of Shelemiah, and Pashhur the son of Malchijah heard the words that Jeremiah spoke to all the people, saying, 
+<sup>2&#160;</sup>“Yahweh says, ‘He who remains in this city will die by the sword, by the famine, and by the pestilence, but he who goes out to the Chaldeans will live. He will escape with his life and he will live.’ 
+<sup>3&#160;</sup>Yahweh says, ‘This city will surely be given into the hand of the army of the king of Babylon, and he will take it.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the princes said to the king, “Please let this man be put to death, because he weakens the hands of the men of war who remain in this city, and the hands of all the people, in speaking such words to them; for this man doesn’t seek the welfare of this people, but harm.” 
+</div><div class="p">
+<sup>5&#160;</sup>Zedekiah the king said, “Behold, he is in your hand; for the king can’t do anything to oppose you.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then they took Jeremiah and threw him into the dungeon of Malchijah the king’s son, that was in the court of the guard. They let down Jeremiah with cords. In the dungeon there was no water, but mire; and Jeremiah sank in the mire. 
+</div><div class="p">
+<sup>7&#160;</sup>Now when Ebedmelech the Ethiopian, a eunuch, who was in the king’s house, heard that they had put Jeremiah in the dungeon (the king was then sitting in Benjamin’s gate), 
+<sup>8&#160;</sup>Ebedmelech went out of the king’s house, and spoke to the king, saying, 
+<sup>9&#160;</sup>“My lord the king, these men have done evil in all that they have done to Jeremiah the prophet, whom they have cast into the dungeon. He is likely to die in the place where he is, because of the famine; for there is no more bread in the city.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then the king commanded Ebedmelech the Ethiopian, saying, “Take from here thirty men with you, and take up Jeremiah the prophet out of the dungeon, before he dies.” 
+</div><div class="p">
+<sup>11&#160;</sup>So Ebedmelech took the men with him, and went into the house of the king under the treasury, and took from there rags and worn-out garments, and let them down by cords into the dungeon to Jeremiah. 
+<sup>12&#160;</sup>Ebedmelech the Ethiopian said to Jeremiah, “Now put these rags and worn-out garments under your armpits under the cords.” 
+</div><div class="p">Jeremiah did so. 
+<sup>13&#160;</sup>So they lifted Jeremiah up with the cords, and took him up out of the dungeon; and Jeremiah remained in the court of the guard. 
+</div><div class="p">
+<sup>14&#160;</sup>Then Zedekiah the king sent and took Jeremiah the prophet to himself into the third entry that is in Yahweh’s house. Then the king said to Jeremiah, “I will ask you something. Hide nothing from me.” 
+</div><div class="p">
+<sup>15&#160;</sup>Then Jeremiah said to Zedekiah, “If I declare it to you, will you not surely put me to death? If I give you counsel, you will not listen to me.” 
+</div><div class="p">
+<sup>16&#160;</sup>So Zedekiah the king swore secretly to Jeremiah, saying, “As Yahweh lives, who made our souls, I will not put you to death, neither will I give you into the hand of these men who seek your life.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Jeremiah said to Zedekiah, “Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘If you will go out to the king of Babylon’s princes, then your soul will live, and this city will not be burned with fire. You will live, along with your house. 
+<sup>18&#160;</sup>But if you will not go out to the king of Babylon’s princes, then this city will be given into the hand of the Chaldeans, and they will burn it with fire, and you won’t escape out of their hand.’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>Zedekiah the king said to Jeremiah, “I am afraid of the Jews who have defected to the Chaldeans, lest they deliver me into their hand, and they mock me.” 
+</div><div class="p">
+<sup>20&#160;</sup>But Jeremiah said, “They won’t deliver you. Obey, I beg you, Yahweh’s voice, in that which I speak to you; so it will be well with you, and your soul will live. 
+<sup>21&#160;</sup>But if you refuse to go out, this is the word that Yahweh has shown me: 
+<sup>22&#160;</sup>‘Behold, all the women who are left in the king of Judah’s house will be brought out to the king of Babylon’s princes, and those women will say, 
+</div><div class="q1">“Your familiar friends have turned on you, 
+</div><div class="q2">and have prevailed over you. 
+</div><div class="q1">Your feet are sunk in the mire, 
+</div><div class="q2">they have turned away from you.” 
+</div><div class="p">
+<sup>23&#160;</sup>They will bring out all your women and your children to the Chaldeans. You won’t escape out of their hand, but will be taken by the hand of the king of Babylon. You will cause this city to be burned with fire.’&#160;” 
+</div><div class="p">
+<sup>24&#160;</sup>Then Zedekiah said to Jeremiah, “Let no man know of these words, and you won’t die. 
+<sup>25&#160;</sup>But if the princes hear that I have talked with you, and they come to you, and tell you, ‘Declare to us now what you have said to the king; don’t hide it from us, and we will not put you to death; also tell us what the king said to you;’ 
+<sup>26&#160;</sup>then you shall tell them, ‘I presented my supplication before the king, that he would not cause me to return to Jonathan’s house, to die there.’&#160;” 
+</div><div class="p">
+<sup>27&#160;</sup>Then all the princes came to Jeremiah, and asked him; and he told them according to all these words that the king had commanded. So they stopped speaking with him, for the matter was not perceived. 
+</div><div class="p">
+<sup>28&#160;</sup>So Jeremiah stayed in the court of the guard until the day that Jerusalem was taken. 
+</div><h2 class="chapterlabel" id="39">39</h2>
+<div class="p">
+<sup>1&#160;</sup>In the ninth year of Zedekiah king of Judah, in the tenth month, Nebuchadnezzar king of Babylon and all his army came against Jerusalem, and besieged it. 
+<sup>2&#160;</sup>In the eleventh year of Zedekiah, in the fourth month, the ninth day of the month, a breach was made in the city. 
+<sup>3&#160;</sup>All the princes of the king of Babylon came in, and sat in the middle gate: Nergal Sharezer, Samgarnebo, Sarsechim the Rabsaris, Nergal Sharezer the Rabmag, with all the rest of the princes of the king of Babylon. 
+<sup>4&#160;</sup>When Zedekiah the king of Judah and all the men of war saw them, then they fled and went out of the city by night, by the way of the king’s garden, through the gate between the two walls; and he went out toward the Arabah. 
+</div><div class="p">
+<sup>5&#160;</sup>But the army of the Chaldeans pursued them, and overtook Zedekiah in the plains of Jericho. When they had taken him, they brought him up to Nebuchadnezzar king of Babylon to Riblah in the land of Hamath; and he pronounced judgment on him. 
+<sup>6&#160;</sup>Then the king of Babylon killed Zedekiah’s sons in Riblah before his eyes. The king of Babylon also killed all the nobles of Judah. 
+<sup>7&#160;</sup>Moreover he put out Zedekiah’s eyes and bound him in fetters, to carry him to Babylon. 
+</div><div class="p">
+<sup>8&#160;</sup>The Chaldeans burned the king’s house and the people’s houses with fire and broke down the walls of Jerusalem. 
+<sup>9&#160;</sup>Then Nebuzaradan the captain of the guard carried away captive into Babylon the rest of the people who remained in the city, the deserters also who fell away to him, and the rest of the people who remained. 
+<sup>10&#160;</sup>But Nebuzaradan the captain of the guard left of the poor of the people, who had nothing, in the land of Judah, and gave them vineyards and fields at the same time. 
+</div><div class="p">
+<sup>11&#160;</sup>Now Nebuchadnezzar king of Babylon commanded Nebuzaradan the captain of the guard concerning Jeremiah, saying, 
+<sup>12&#160;</sup>“Take him and take care of him. Do him no harm; but do to him even as he tells you.” 
+</div><div class="p">
+<sup>13&#160;</sup>So Nebuzaradan the captain of the guard, Nebushazban, Rabsaris, and Nergal Sharezer, Rabmag, and all the chief officers of the king of Babylon 
+<sup>14&#160;</sup>sent and took Jeremiah out of the court of the guard, and committed him to Gedaliah the son of Ahikam, the son of Shaphan, that he should bring him home. So he lived among the people. 
+</div><div class="p">
+<sup>15&#160;</sup>Now Yahweh’s word came to Jeremiah while he was shut up in the court of the guard, saying, 
+<sup>16&#160;</sup>“Go, and speak to Ebedmelech the Ethiopian, saying, ‘Yahweh of Armies, the Elohim of Israel, says: “Behold, I will bring my words on this city for evil, and not for good; and they will be accomplished before you in that day. 
+<sup>17&#160;</sup>But I will deliver you in that day,” says Yahweh; “and you will not be given into the hand of the men of whom you are afraid. 
+<sup>18&#160;</sup>For I will surely save you. You won’t fall by the sword, but you will escape with your life, because you have put your trust in me,” says Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="40">40</h2>
+<div class="p">
+<sup>1&#160;</sup>The word which came to Jeremiah from Yahweh, after Nebuzaradan the captain of the guard had let him go from Ramah, when he had taken him being bound in chains among all the captives of Jerusalem and Judah who were carried away captive to Babylon. 
+<sup>2&#160;</sup>The captain of the guard took Jeremiah and said to him, “Yahweh your Elohim pronounced this evil on this place; 
+<sup>3&#160;</sup>and Yahweh has brought it, and done according as he spoke. Because you have sinned against Yahweh, and have not obeyed his voice, therefore this thing has come on you. 
+<sup>4&#160;</sup>Now, behold, I release you today from the chains which are on your hand. If it seems good to you to come with me into Babylon, come, and I will take care of you; but if it seems bad to you to come with me into Babylon, don’t. Behold, all the land is before you. Where it seems good and right to you to go, go there.” 
+<sup>5&#160;</sup>Now while he had not yet gone back, “Go back then,” he said, “to Gedaliah the son of Ahikam, the son of Shaphan, whom the king of Babylon has made governor over the cities of Judah, and dwell with him among the people; or go wherever it seems right to you to go.” 
+</div><div class="p">So the captain of the guard gave him food and a present, and let him go. 
+<sup>6&#160;</sup>Then Jeremiah went to Gedaliah the son of Ahikam to Mizpah, and lived with him among the people who were left in the land. 
+</div><div class="p">
+<sup>7&#160;</sup>Now when all the captains of the forces who were in the fields, even they and their men, heard that the king of Babylon had made Gedaliah the son of Ahikam governor in the land, and had committed to him men, women, children, and of the poorest of the land, of those who were not carried away captive to Babylon, 
+<sup>8&#160;</sup>then Ishmael the son of Nethaniah, and Johanan and Jonathan the sons of Kareah, and Seraiah the son of Tanhumeth, and the sons of Ephai the Netophathite, and Jezaniah the son of the Maacathite, they and their men came to Gedaliah to Mizpah. 
+<sup>9&#160;</sup>Gedaliah the son of Ahikam the son of Shaphan swore to them and to their men, saying, “Don’t be afraid to serve the Chaldeans. Dwell in the land, and serve the king of Babylon, and it will be well with you. 
+<sup>10&#160;</sup>As for me, behold, I will dwell at Mizpah, to stand before the Chaldeans who will come to us; but you, gather wine and summer fruits and oil, and put them in your vessels, and dwell in your cities that you have taken.” 
+</div><div class="p">
+<sup>11&#160;</sup>Likewise when all the Jews who were in Moab, and among the children of Ammon, and in Edom, and who were in all the countries, heard that the king of Babylon had left a remnant of Judah, and that he had set over them Gedaliah the son of Ahikam, the son of Shaphan, 
+<sup>12&#160;</sup>then all the Jews returned out of all places where they were driven, and came to the land of Judah, to Gedaliah, to Mizpah, and gathered very much wine and summer fruits. 
+</div><div class="p">
+<sup>13&#160;</sup>Moreover Johanan the son of Kareah, and all the captains of the forces who were in the fields, came to Gedaliah to Mizpah, 
+<sup>14&#160;</sup>and said to him, “Do you know that Baalis the king of the children of Ammon has sent Ishmael the son of Nethaniah to take your life?” 
+</div><div class="p">But Gedaliah the son of Ahikam didn’t believe them. 
+</div><div class="p">
+<sup>15&#160;</sup>Then Johanan the son of Kareah spoke to Gedaliah in Mizpah secretly, saying, “Please let me go, and I will kill Ishmael the son of Nethaniah, and no man will know it. Why should he take your life, that all the Jews who are gathered to you should be scattered, and the remnant of Judah perish?” 
+</div><div class="p">
+<sup>16&#160;</sup>But Gedaliah the son of Ahikam said to Johanan the son of Kareah, “You shall not do this thing, for you speak falsely of Ishmael.” 
+</div><h2 class="chapterlabel" id="41">41</h2>
+<div class="p">
+<sup>1&#160;</sup>Now in the seventh month, Ishmael the son of Nethaniah, the son of Elishama, of the royal offspring and one of the chief officers of the king, and ten men with him, came to Gedaliah the son of Ahikam to Mizpah; and there they ate bread together in Mizpah. 
+<sup>2&#160;</sup>Then Ishmael the son of Nethaniah arose, and the ten men who were with him, and struck Gedaliah the son of Ahikam the son of Shaphan with the sword and killed him, whom the king of Babylon had made governor over the land. 
+<sup>3&#160;</sup>Ishmael also killed all the Jews who were with Gedaliah at Mizpah, and the Chaldean men of war who were found there. 
+</div><div class="p">
+<sup>4&#160;</sup>The second day after he had killed Gedaliah, and no man knew it, 
+<sup>5&#160;</sup>men came from Shechem, from Shiloh, and from Samaria, even eighty men, having their beards shaved and their clothes torn, and having cut themselves, with meal offerings and frankincense in their hand, to bring them to Yahweh’s house. 
+<sup>6&#160;</sup>Ishmael the son of Nethaniah went out from Mizpah to meet them, weeping all along as he went, and as he met them, he said to them, “Come to Gedaliah the son of Ahikam.” 
+<sup>7&#160;</sup>It was so, when they came into the middle of the city, that Ishmael the son of Nethaniah killed them, and cast them into the middle of the pit, he, and the men who were with him. 
+<sup>8&#160;</sup>But ten men were found among those who said to Ishmael, “Don’t kill us; for we have stores hidden in the field, of wheat, and of barley, and of oil, and of honey.” 
+</div><div class="p">So he stopped, and didn’t kill them among their brothers. 
+<sup>9&#160;</sup>Now the pit in which Ishmael cast all the dead bodies of the men whom he had killed, by the side of Gedaliah (this was that which Asa the king had made for fear of Baasha king of Israel), Ishmael the son of Nethaniah filled it with those who were killed. 
+</div><div class="p">
+<sup>10&#160;</sup>Then Ishmael carried away captive all of the people who were left in Mizpah, even the king’s daughters, and all the people who remained in Mizpah, whom Nebuzaradan the captain of the guard had committed to Gedaliah the son of Ahikam. Ishmael the son of Nethaniah carried them away captive, and departed to go over to the children of Ammon. 
+</div><div class="p">
+<sup>11&#160;</sup>But when Johanan the son of Kareah, and all the captains of the forces who were with him, heard of all the evil that Ishmael the son of Nethaniah had done, 
+<sup>12&#160;</sup>then they took all the men, and went to fight with Ishmael the son of Nethaniah, and found him by the great waters that are in Gibeon. 
+<sup>13&#160;</sup>Now when all the people who were with Ishmael saw Johanan the son of Kareah, and all the captains of the forces who were with him, then they were glad. 
+<sup>14&#160;</sup>So all the people who Ishmael had carried away captive from Mizpah turned about and came back, and went to Johanan the son of Kareah. 
+<sup>15&#160;</sup>But Ishmael the son of Nethaniah escaped from Johanan with eight men, and went to the children of Ammon. 
+</div><div class="p">
+<sup>16&#160;</sup>Then Johanan the son of Kareah and all the captains of the forces who were with him took all the remnant of the people whom he had recovered from Ishmael the son of Nethaniah, from Mizpah, after he had killed Gedaliah the son of Ahikam—the men of war, with the women, the children, and the eunuchs, whom he had brought back from Gibeon. 
+<sup>17&#160;</sup>They departed and lived in Geruth Chimham, which is by Bethlehem, to go to enter into Egypt 
+<sup>18&#160;</sup>because of the Chaldeans; for they were afraid of them, because Ishmael the son of Nethaniah had killed Gedaliah the son of Ahikam, whom the king of Babylon made governor over the land. 
+</div><h2 class="chapterlabel" id="42">42</h2>
+<div class="p">
+<sup>1&#160;</sup>Then all the captains of the forces, and Johanan the son of Kareah, and Jezaniah the son of Hoshaiah, and all the people from the least even to the greatest, came near, 
+<sup>2&#160;</sup>and said to Jeremiah the prophet, “Please let our supplication be presented before you, and pray for us to Yahweh your Elohim, even for all this remnant, for we are left but a few of many, as your eyes see us, 
+<sup>3&#160;</sup>that Yahweh your Elohim may show us the way in which we should walk, and the things that we should do.” 
+</div><div class="p">
+<sup>4&#160;</sup>Then Jeremiah the prophet said to them, “I have heard you. Behold, I will pray to Yahweh your Elohim according to your words; and it will happen that whatever thing Yahweh answers you, I will declare it to you. I will keep nothing back from you.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then they said to Jeremiah, “May Yahweh be a true and faithful witness among us, if we don’t do according to all the word with which Yahweh your Elohim sends you to tell us. 
+<sup>6&#160;</sup>Whether it is good, or whether it is bad, we will obey the voice of Yahweh our Elohim, to whom we send you; that it may be well with us, when we obey the voice of Yahweh our Elohim.” 
+</div><div class="p">
+<sup>7&#160;</sup>After ten days, Yahweh’s word came to Jeremiah. 
+<sup>8&#160;</sup>Then he called Johanan the son of Kareah, and all the captains of the forces who were with him, and all the people from the least even to the greatest, 
+<sup>9&#160;</sup>and said to them, “Yahweh, the Elohim of Israel, to whom you sent me to present your supplication before him, says: 
+<sup>10&#160;</sup>‘If you will still live in this land, then I will build you, and not pull you down, and I will plant you, and not pluck you up; for I grieve over the distress that I have brought on you. 
+<sup>11&#160;</sup>Don’t be afraid of the king of Babylon, of whom you are afraid. Don’t be afraid of him,’ says Yahweh, ‘for I am with you to save you, and to deliver you from his hand. 
+<sup>12&#160;</sup>I will grant you mercy, that he may have mercy on you, and cause you to return to your own land. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘But if you say, “We will not dwell in this land,” so that you don’t obey Yahweh your Elohim’s voice, 
+<sup>14&#160;</sup>saying, “No, but we will go into the land of Egypt, where we will see no war, nor hear the sound of the trumpet, nor have hunger of bread; and there we will dwell;”&#160;’ 
+<sup>15&#160;</sup>now therefore hear Yahweh’s word, O remnant of Judah! Yahweh of Armies, the Elohim of Israel, says, ‘If you indeed set your faces to enter into Egypt, and go to live there, 
+<sup>16&#160;</sup>then it will happen that the sword, which you fear, will overtake you there in the land of Egypt; and the famine, about which you are afraid, will follow close behind you there in Egypt; and you will die there. 
+<sup>17&#160;</sup>So will it be with all the men who set their faces to go into Egypt to live there. They will die by the sword, by the famine, and by the pestilence. None of them will remain or escape from the evil that I will bring on them.’ 
+<sup>18&#160;</sup>For Yahweh of Armies, the Elohim of Israel, says: ‘As my anger and my wrath has been poured out on the inhabitants of Jerusalem, so my wrath will be poured out on you, when you enter into Egypt; and you will be an object of horror, an astonishment, a curse, and a reproach; and you will see this place no more.’ 
+</div><div class="p">
+<sup>19&#160;</sup>“Yahweh has spoken concerning you, remnant of Judah, ‘Don’t go into Egypt!’ Know certainly that I have testified to you today. 
+<sup>20&#160;</sup>For you have dealt deceitfully against your own souls; for you sent me to Yahweh your Elohim, saying, ‘Pray for us to Yahweh our Elohim; and according to all that Yahweh our Elohim says, so declare to us, and we will do it.’ 
+<sup>21&#160;</sup>I have declared it to you today; but you have not obeyed Yahweh your Elohim’s voice in anything for which he has sent me to you. 
+<sup>22&#160;</sup>Now therefore know certainly that you will die by the sword, by the famine, and by the pestilence in the place where you desire to go to live.” 
+</div><h2 class="chapterlabel" id="43">43</h2>
+<div class="p">
+<sup>1&#160;</sup>When Jeremiah had finished speaking to all the people all the words of Yahweh their Elohim, with which Yahweh their Elohim had sent him to them, even all these words, 
+<sup>2&#160;</sup>then Azariah the son of Hoshaiah, Johanan the son of Kareah, and all the proud men spoke, saying to Jeremiah, “You speak falsely. Yahweh our Elohim has not sent you to say, ‘You shall not go into Egypt to live there;’ 
+<sup>3&#160;</sup>but Baruch the son of Neriah has turned you against us, to deliver us into the hand of the Chaldeans, that they may put us to death or carry us away captive to Babylon.” 
+</div><div class="p">
+<sup>4&#160;</sup>So Johanan the son of Kareah, and all the captains of the forces, and all the people, didn’t obey Yahweh’s voice, to dwell in the land of Judah. 
+<sup>5&#160;</sup>But Johanan the son of Kareah and all the captains of the forces took all the remnant of Judah, who had returned from all the nations where they had been driven, to live in the land of Judah—<sup>6&#160;</sup>the men, the women, the children, the king’s daughters, and every person who Nebuzaradan the captain of the guard had left with Gedaliah the son of Ahikam, the son of Shaphan; and Jeremiah the prophet, and Baruch the son of Neriah. 
+<sup>7&#160;</sup>They came into the land of Egypt, for they didn’t obey Yahweh’s voice; and they came to Tahpanhes. 
+</div><div class="p">
+<sup>8&#160;</sup>Then Yahweh’s word came to Jeremiah in Tahpanhes, saying, 
+<sup>9&#160;</sup>“Take great stones in your hand and hide them in mortar in the brick work which is at the entry of Pharaoh’s house in Tahpanhes, in the sight of the men of Judah. 
+<sup>10&#160;</sup>Tell them, Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will send and take Nebuchadnezzar the king of Babylon, my servant, and will set his throne on these stones that I have hidden; and he will spread his royal pavilion over them. 
+<sup>11&#160;</sup>He will come, and will strike the land of Egypt; such as are for death will be put to death, and such as are for captivity to captivity, and such as are for the sword to the sword. 
+<sup>12&#160;</sup>I will kindle a fire in the houses of the elohims of Egypt. He will burn them, and carry them away captive. He will array himself with the land of Egypt, as a shepherd puts on his garment; and he will go out from there in peace. 
+<sup>13&#160;</sup>He will also break the pillars of Beth Shemesh that is in the land of Egypt; and he will burn the houses of the elohims of Egypt with fire.’&#160;” 
+</div><h2 class="chapterlabel" id="44">44</h2>
+<div class="p">
+<sup>1&#160;</sup>The word that came to Jeremiah concerning all the Jews who lived in the land of Egypt, who lived at Migdol, and at Tahpanhes, and at Memphis, and in the country of Pathros, saying, 
+<sup>2&#160;</sup>“Yahweh of Armies, the Elohim of Israel, says: ‘You have seen all the evil that I have brought on Jerusalem, and on all the cities of Judah. Behold, today they are a desolation, and no man dwells in them, 
+<sup>3&#160;</sup>because of their wickedness which they have committed to provoke me to anger, in that they went to burn incense, to serve other elohims that they didn’t know, neither they, nor you, nor your fathers. 
+<sup>4&#160;</sup>However I sent to you all my servants the prophets, rising up early and sending them, saying, “Oh, don’t do this abominable thing that I hate.” 
+<sup>5&#160;</sup>But they didn’t listen and didn’t incline their ear. They didn’t turn from their wickedness, to stop burning incense to other elohims. 
+<sup>6&#160;</sup>Therefore my wrath and my anger was poured out, and was kindled in the cities of Judah and in the streets of Jerusalem; and they are wasted and desolate, as it is today.’ 
+</div><div class="p">
+<sup>7&#160;</sup>“Therefore now Yahweh, the Elohim of Armies, the Elohim of Israel, says: ‘Why do you commit great evil against your own souls, to cut off from yourselves man and woman, infant and nursing child out of the middle of Judah, to leave yourselves no one remaining, 
+<sup>8&#160;</sup>in that you provoke me to anger with the works of your hands, burning incense to other elohims in the land of Egypt where you have gone to live, that you may be cut off, and that you may be a curse and a reproach among all the nations of the earth? 
+<sup>9&#160;</sup>Have you forgotten the wickedness of your fathers, the wickedness of the kings of Judah, the wickedness of their women, your own wickedness, and the wickedness of your women which they committed in the land of Judah and in the streets of Jerusalem? 
+<sup>10&#160;</sup>They are not humbled even to this day, neither have they feared, nor walked in my law, nor in my statutes, that I set before you and before your fathers.’ 
+</div><div class="p">
+<sup>11&#160;</sup>“Therefore Yahweh of Armies, the Elohim of Israel, says: ‘Behold, I will set my face against you for evil, even to cut off all Judah. 
+<sup>12&#160;</sup>I will take the remnant of Judah that have set their faces to go into the land of Egypt to live there, and they will all be consumed. They will fall in the land of Egypt. They will be consumed by the sword and by the famine. They will die, from the least even to the greatest, by the sword and by the famine. They will be an object of horror, an astonishment, a curse, and a reproach. 
+<sup>13&#160;</sup>For I will punish those who dwell in the land of Egypt, as I have punished Jerusalem, by the sword, by the famine, and by the pestilence; 
+<sup>14&#160;</sup>so that none of the remnant of Judah, who have gone into the land of Egypt to live there, will escape or be left to return into the land of Judah, to which they have a desire to return to dwell there; for no one will return except those who will escape.’&#160;” 
+</div><div class="p">
+<sup>15&#160;</sup>Then all the men who knew that their women burned incense to other elohims, and all the women who stood by, a great assembly, even all the people who lived in the land of Egypt, in Pathros, answered Jeremiah, saying, 
+<sup>16&#160;</sup>“As for the word that you have spoken to us in Yahweh’s name, we will not listen to you. 
+<sup>17&#160;</sup>But we will certainly perform every word that has gone out of our mouth, to burn incense to the queen of the sky and to pour out drink offerings to her, as we have done, we and our fathers, our kings and our princes, in the cities of Judah and in the streets of Jerusalem; for then we had plenty of food, and were well, and saw no evil. 
+<sup>18&#160;</sup>But since we stopped burning incense to the queen of the sky, and pouring out drink offerings to her, we have lacked all things, and have been consumed by the sword and by the famine.” 
+</div><div class="p">
+<sup>19&#160;</sup>The women said, “When we burned incense to the queen of the sky and poured out drink offerings to her, did we make her cakes to worship her, and pour out drink offerings to her, without our men?” 
+</div><div class="p">
+<sup>20&#160;</sup>Then Jeremiah said to all the people—to the men and to the women, even to all the people who had given him an answer, saying, 
+<sup>21&#160;</sup>“The incense that you burned in the cities of Judah, and in the streets of Jerusalem, you and your fathers, your kings and your princes, and the people of the land, didn’t Yahweh remember them, and didn’t it come into his mind? 
+<sup>22&#160;</sup>Thus Yahweh could no longer bear it, because of the evil of your doings and because of the abominations which you have committed. Therefore your land has become a desolation, an astonishment, and a curse, without inhabitant, as it is today. 
+<sup>23&#160;</sup>Because you have burned incense and because you have sinned against Yahweh, and have not obeyed Yahweh’s voice, nor walked in his law, nor in his statutes, nor in his testimonies; therefore this evil has happened to you, as it is today.” 
+</div><div class="p">
+<sup>24&#160;</sup>Moreover Jeremiah said to all the people, including all the women, “Hear Yahweh’s word, all Judah who are in the land of Egypt! 
+<sup>25&#160;</sup>Yahweh of Armies, the Elohim of Israel, says, ‘You and your women have both spoken with your mouths, and with your hands have fulfilled it, saying, “We will surely perform our vows that we have vowed, to burn incense to the queen of the sky, and to pour out drink offerings to her.” 
+</div><div class="p">“&#160;‘Establish then your vows, and perform your vows.’ 
+</div><div class="p">
+<sup>26&#160;</sup>“Therefore hear Yahweh’s word, all Judah who dwell in the land of Egypt: ‘Behold, I have sworn by my great name,’ says Yahweh, ‘that my name will no more be named in the mouth of any man of Judah in all the land of Egypt, saying, “As the Lord Yahweh lives.” 
+<sup>27&#160;</sup>Behold, I watch over them for evil, and not for good; and all the men of Judah who are in the land of Egypt will be consumed by the sword and by the famine, until they are all gone. 
+<sup>28&#160;</sup>Those who escape the sword will return out of the land of Egypt into the land of Judah few in number. All the remnant of Judah, who have gone into the land of Egypt to live there, will know whose word will stand, mine or theirs. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘This will be the sign to you,’ says Yahweh, ‘that I will punish you in this place, that you may know that my words will surely stand against you for evil.’ 
+<sup>30&#160;</sup>Yahweh says, ‘Behold, I will give Pharaoh Hophra king of Egypt into the hand of his enemies and into the hand of those who seek his life, just as I gave Zedekiah king of Judah into the hand of Nebuchadnezzar king of Babylon, who was his enemy and sought his life.’&#160;” 
+</div><h2 class="chapterlabel" id="45">45</h2>
+<div class="p">
+<sup>1&#160;</sup>The message that Jeremiah the prophet spoke to Baruch the son of Neriah, when he wrote these words in a book at the mouth of Jeremiah, in the fourth year of Jehoiakim the son of Josiah, king of Judah, saying, 
+<sup>2&#160;</sup>“Yahweh, the Elohim of Israel, says to you, Baruch: 
+<sup>3&#160;</sup>‘You said, “Woe is me now! For Yahweh has added sorrow to my pain! I am weary with my groaning, and I find no rest.”&#160;’ 
+</div><div class="p">
+<sup>4&#160;</sup>“You shall tell him, Yahweh says: ‘Behold, that which I have built, I will break down, and that which I have planted I will pluck up; and this in the whole land. 
+<sup>5&#160;</sup>Do you seek great things for yourself? Don’t seek them; for, behold, I will bring evil on all flesh,’ says Yahweh, ‘but I will let you escape with your life wherever you go.’&#160;” 
+</div><h2 class="chapterlabel" id="46">46</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word which came to Jeremiah the prophet concerning the nations. 
+</div><div class="p">
+<sup>2&#160;</sup>Of Egypt: concerning the army of Pharaoh Necoh king of Egypt, which was by the river Euphrates in Carchemish, which Nebuchadnezzar king of Babylon struck in the fourth year of Jehoiakim the son of Josiah, king of Judah. 
+</div><div class="q1">
+<sup>3&#160;</sup>“Prepare the buckler and shield, 
+</div><div class="q2">and draw near to battle! 
+</div><div class="q1">
+<sup>4&#160;</sup>Harness the horses, and get up, you horsemen, 
+</div><div class="q2">and stand up with your helmets. 
+</div><div class="q1">Polish the spears, 
+</div><div class="q2">put on the coats of mail. 
+</div><div class="q1">
+<sup>5&#160;</sup>Why have I seen it? 
+</div><div class="q2">They are dismayed and are turned backward. 
+</div><div class="q1">Their mighty ones are beaten down, 
+</div><div class="q2">have fled in haste, 
+</div><div class="q2">and don’t look back. 
+</div><div class="q1">Terror is on every side,” 
+</div><div class="q2">says Yahweh. 
+</div><div class="q1">
+<sup>6&#160;</sup>“Don’t let the swift flee away, 
+</div><div class="q2">nor the mighty man escape. 
+</div><div class="q1">In the north by the river Euphrates 
+</div><div class="q2">they have stumbled and fallen. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Who is this who rises up like the Nile, 
+</div><div class="q2">like rivers whose waters surge? 
+</div><div class="q1">
+<sup>8&#160;</sup>Egypt rises up like the Nile, 
+</div><div class="q2">like rivers whose waters surge. 
+</div><div class="q1">He says, ‘I will rise up. I will cover the earth. 
+</div><div class="q2">I will destroy cities and its inhabitants.’ 
+</div><div class="q1">
+<sup>9&#160;</sup>Go up, you horses! 
+</div><div class="q2">Rage, you chariots! 
+</div><div class="q1">Let the mighty men go out: 
+</div><div class="q2">Cush and Put, who handle the shield; 
+</div><div class="q2">and the Ludim, who handle and bend the bow. 
+</div><div class="q1">
+<sup>10&#160;</sup>For that day is of the Lord, Yahweh of Armies, 
+</div><div class="q2">a day of vengeance, 
+</div><div class="q2">that he may avenge himself of his adversaries. 
+</div><div class="q1">The sword will devour and be satiated, 
+</div><div class="q2">and will drink its fill of their blood; 
+</div><div class="q2">for the Lord, Yahweh of Armies, has a sacrifice in the north country by the river Euphrates. 
+</div><div class="q1">
+<sup>11&#160;</sup>Go up into Gilead, and take balm, virgin daughter of Egypt. 
+</div><div class="q2">You use many medicines in vain. 
+</div><div class="q2">There is no healing for you. 
+</div><div class="q1">
+<sup>12&#160;</sup>The nations have heard of your shame, 
+</div><div class="q2">and the earth is full of your cry; 
+</div><div class="q2">for the mighty man has stumbled against the mighty, 
+</div><div class="q2">they both fall together.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>13&#160;</sup>The word that Yahweh spoke to Jeremiah the prophet, how that Nebuchadnezzar king of Babylon should come and strike the land of Egypt: 
+</div><div class="q1">
+<sup>14&#160;</sup>“Declare in Egypt, 
+</div><div class="q2">publish in Migdol, 
+</div><div class="q2">and publish in Memphis and in Tahpanhes; 
+</div><div class="q1">say, ‘Stand up, and prepare, 
+</div><div class="q2">for the sword has devoured around you.’ 
+</div><div class="q1">
+<sup>15&#160;</sup>Why are your strong ones swept away? 
+</div><div class="q2">They didn’t stand, because Yahweh pushed them. 
+</div><div class="q1">
+<sup>16&#160;</sup>He made many to stumble. 
+</div><div class="q2">Yes, they fell on one another. 
+</div><div class="q1">They said, ‘Arise! Let’s go again to our own people, 
+</div><div class="q2">and to the land of our birth, 
+</div><div class="q2">from the oppressing sword.’ 
+</div><div class="q1">
+<sup>17&#160;</sup>They cried there, ‘Pharaoh king of Egypt is but a noise; 
+</div><div class="q2">he has let the appointed time pass by.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“As I live,” says the King, 
+</div><div class="q2">whose name is Yahweh of Armies, 
+</div><div class="q1">“surely like Tabor among the mountains, 
+</div><div class="q2">and like Carmel by the sea, 
+</div><div class="q2">so he will come. 
+</div><div class="q1">
+<sup>19&#160;</sup>You daughter who dwells in Egypt, 
+</div><div class="q2">furnish yourself to go into captivity; 
+</div><div class="q1">for Memphis will become a desolation, 
+</div><div class="q2">and will be burned up, 
+</div><div class="q2">without inhabitant. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Egypt is a very beautiful heifer; 
+</div><div class="q2">but destruction out of the north has come. 
+</div><div class="q2">It has come. 
+</div><div class="q1">
+<sup>21&#160;</sup>Also her hired men in the middle of her are like calves of the stall, 
+</div><div class="q2">for they also are turned back. 
+</div><div class="q2">They have fled away together. 
+</div><div class="q1">They didn’t stand, 
+</div><div class="q2">for the day of their calamity has come on them, 
+</div><div class="q2">the time of their visitation. 
+</div><div class="q1">
+<sup>22&#160;</sup>Its sound will go like the serpent, 
+</div><div class="q2">for they will march with an army, 
+</div><div class="q2">and come against her with axes, as wood cutters. 
+</div><div class="q1">
+<sup>23&#160;</sup>They will cut down her forest,” says Yahweh, 
+</div><div class="q2">“though it can’t be searched; 
+</div><div class="q1">because they are more than the locusts, 
+</div><div class="q2">and are innumerable. 
+</div><div class="q1">
+<sup>24&#160;</sup>The daughter of Egypt will be disappointed; 
+</div><div class="q2">she will be delivered into the hand of the people of the north.” 
+</div><div class="p">
+<sup>25&#160;</sup>Yahweh of Armies, the Elohim of Israel, says: “Behold, I will punish Amon of No, and Pharaoh, and Egypt, with her elohims and her kings, even Pharaoh, and those who trust in him. 
+<sup>26&#160;</sup>I will deliver them into the hand of those who seek their lives, and into the hand of Nebuchadnezzar king of Babylon, and into the hand of his servants. Afterwards it will be inhabited, as in the days of old,” says Yahweh. 
+</div><div class="q1">
+<sup>27&#160;</sup>“But don’t you be afraid, Jacob my servant. 
+</div><div class="q2">Don’t be dismayed, Israel; 
+</div><div class="q1">for, behold, I will save you from afar, 
+</div><div class="q2">and your offspring from the land of their captivity. 
+</div><div class="q1">Jacob will return, 
+</div><div class="q2">and will be quiet and at ease. 
+</div><div class="q2">No one will make him afraid. 
+</div><div class="q1">
+<sup>28&#160;</sup>Don’t be afraid, O Jacob my servant,” says Yahweh, 
+</div><div class="q2">“for I am with you; 
+</div><div class="q2">for I will make a full end of all the nations where I have driven you, 
+</div><div class="q1">but I will not make a full end of you, 
+</div><div class="q2">but I will correct you in measure, 
+</div><div class="q2">and will in no way leave you unpunished.” 
+</div><h2 class="chapterlabel" id="47">47</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word that came to Jeremiah the prophet concerning the Philistines, before Pharaoh struck Gaza. 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh says: 
+</div><div class="q1">“Behold, waters rise up out of the north, 
+</div><div class="q2">and will become an overflowing stream, 
+</div><div class="q1">and will overflow the land and all that is therein, 
+</div><div class="q2">the city and those who dwell therein. 
+</div><div class="q1">The men will cry, 
+</div><div class="q2">and all the inhabitants of the land will wail. 
+</div><div class="q1">
+<sup>3&#160;</sup>At the noise of the stamping of the hoofs of his strong ones, 
+</div><div class="q2">at the rushing of his chariots, 
+</div><div class="q2">at the rumbling of his wheels, 
+</div><div class="q1">the fathers don’t look back for their children 
+</div><div class="q2">because their hands are so feeble, 
+</div><div class="q1">
+<sup>4&#160;</sup>because of the day that comes to destroy all the Philistines, 
+</div><div class="q2">to cut off from Tyre and Sidon every helper who remains; 
+</div><div class="q1">for Yahweh will destroy the Philistines, 
+</div><div class="q2">the remnant of the isle of Caphtor. 
+</div><div class="q1">
+<sup>5&#160;</sup>Baldness has come on Gaza; 
+</div><div class="q2">Ashkelon is brought to nothing. 
+</div><div class="q1">You remnant of their valley, 
+</div><div class="q2">how long will you cut yourself? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“&#160;‘You sword of Yahweh, how long will it be before you are quiet? 
+</div><div class="q2">Put yourself back into your scabbard; 
+</div><div class="q2">rest, and be still.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“How can you be quiet, 
+</div><div class="q2">since Yahweh has given you a command? 
+</div><div class="q1">Against Ashkelon, and against the seashore, 
+</div><div class="q2">there he has appointed it.” 
+</div><h2 class="chapterlabel" id="48">48</h2>
+<div class="p">
+<sup>1&#160;</sup>Of Moab. Yahweh of Armies, the Elohim of Israel, says: 
+</div><div class="q1">“Woe to Nebo! 
+</div><div class="q2">For it is laid waste. 
+</div><div class="q1">Kiriathaim is disappointed. 
+</div><div class="q2">It is taken. 
+</div><div class="q1">Misgab is put to shame 
+</div><div class="q2">and broken down. 
+</div><div class="q1">
+<sup>2&#160;</sup>The praise of Moab is no more. 
+</div><div class="q2">In Heshbon they have devised evil against her: 
+</div><div class="q2">‘Come! Let’s cut her off from being a nation.’ 
+</div><div class="q1">You also, Madmen, will be brought to silence. 
+</div><div class="q2">The sword will pursue you. 
+</div><div class="q1">
+<sup>3&#160;</sup>The sound of a cry from Horonaim, 
+</div><div class="q2">desolation and great destruction! 
+</div><div class="q1">
+<sup>4&#160;</sup>Moab is destroyed. 
+</div><div class="q2">Her little ones have caused a cry to be heard. 
+</div><div class="q1">
+<sup>5&#160;</sup>For they will go up by the ascent of Luhith with continual weeping. 
+</div><div class="q2">For at the descent of Horonaim they have heard the distress of the cry of destruction. 
+</div><div class="q1">
+<sup>6&#160;</sup>Flee! Save your lives! 
+</div><div class="q2">Be like the juniper bush in the wilderness. 
+</div><div class="q1">
+<sup>7&#160;</sup>For, because you have trusted in your works and in your treasures, 
+</div><div class="q2">you also will be taken. 
+</div><div class="q1">Chemosh will go out into captivity, 
+</div><div class="q2">his priests and his princes together. 
+</div><div class="q1">
+<sup>8&#160;</sup>The destroyer will come on every city, 
+</div><div class="q2">and no city will escape; 
+</div><div class="q1">the valley also will perish, 
+</div><div class="q2">and the plain will be destroyed, as Yahweh has spoken. 
+</div><div class="q1">
+<sup>9&#160;</sup>Give wings to Moab, 
+</div><div class="q2">that she may fly and get herself away: 
+</div><div class="q1">and her cities will become a desolation, 
+</div><div class="q2">without anyone to dwell in them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Cursed is he who does the work of Yahweh negligently; 
+</div><div class="q2">and cursed is he who keeps back his sword from blood. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Moab has been at ease from his youth, 
+</div><div class="q2">and he has settled on his dregs, 
+</div><div class="q1">and has not been emptied from vessel to vessel, 
+</div><div class="q2">neither has he gone into captivity; 
+</div><div class="q1">therefore his taste remains in him, 
+</div><div class="q2">and his scent is not changed. 
+</div><div class="q1">
+<sup>12&#160;</sup>Therefore behold, the days come,” says Yahweh, 
+</div><div class="q2">“that I will send to him those who pour off, 
+</div><div class="q1">and they will pour him off; 
+</div><div class="q2">and they will empty his vessels, 
+</div><div class="q2">and break their containers in pieces. 
+</div><div class="q1">
+<sup>13&#160;</sup>Moab will be ashamed of Chemosh, 
+</div><div class="q2">as the house of Israel was ashamed of Bethel, their confidence. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“How do you say, ‘We are mighty men, 
+</div><div class="q2">and valiant men for the war’? 
+</div><div class="q1">
+<sup>15&#160;</sup>Moab is laid waste, 
+</div><div class="q2">and they have gone up into his cities, 
+</div><div class="q2">and his chosen young men have gone down to the slaughter,” 
+</div><div class="q2">says the King, whose name is Yahweh of Armies. 
+</div><div class="q1">
+<sup>16&#160;</sup>“The calamity of Moab is near to come, 
+</div><div class="q2">and his affliction hurries fast. 
+</div><div class="q1">
+<sup>17&#160;</sup>All you who are around him, bemoan him; 
+</div><div class="q2">and all you who know his name, say, 
+</div><div class="q1">‘How the strong staff is broken, 
+</div><div class="q2">the beautiful rod!’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“You daughter who dwells in Dibon, 
+</div><div class="q2">come down from your glory, 
+</div><div class="q2">and sit in thirst; 
+</div><div class="q1">for the destroyer of Moab has come up against you. 
+</div><div class="q2">He has destroyed your strongholds. 
+</div><div class="q1">
+<sup>19&#160;</sup>Inhabitant of Aroer, stand by the way and watch. 
+</div><div class="q2">Ask him who flees, and her who escapes; 
+</div><div class="q2">say, ‘What has been done?’ 
+</div><div class="q1">
+<sup>20&#160;</sup>Moab is disappointed; 
+</div><div class="q2">for it is broken down. 
+</div><div class="q1">Wail and cry! 
+</div><div class="q2">Tell it by the Arnon, that Moab is laid waste. 
+</div><div class="q1">
+<sup>21&#160;</sup>Judgment has come on the plain country—</div><div class="q2">on Holon, on Jahzah, on Mephaath, 
+</div><div class="q2">
+<sup>22&#160;</sup>on Dibon, on Nebo, on Beth Diblathaim, 
+</div><div class="q2">
+<sup>23&#160;</sup>on Kiriathaim, on Beth Gamul, on Beth Meon, 
+</div><div class="q2">
+<sup>24&#160;</sup>on Kerioth, on Bozrah, 
+</div><div class="q2">and on all the cities of the land of Moab, far or near. 
+</div><div class="q1">
+<sup>25&#160;</sup>The horn of Moab is cut off, 
+</div><div class="q2">and his arm is broken,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>26&#160;</sup>“Make him drunk, 
+</div><div class="q2">for he magnified himself against Yahweh. 
+</div><div class="q1">Moab will wallow in his vomit, 
+</div><div class="q2">and he also will be in derision. 
+</div><div class="q1">
+<sup>27&#160;</sup>For wasn’t Israel a derision to you? 
+</div><div class="q2">Was he found among thieves? 
+</div><div class="q1">For as often as you speak of him, 
+</div><div class="q2">you shake your head. 
+</div><div class="q1">
+<sup>28&#160;</sup>You inhabitants of Moab, leave the cities, and dwell in the rock. 
+</div><div class="q2">Be like the dove that makes her nest over the mouth of the abyss. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>29&#160;</sup>“We have heard of the pride of Moab. 
+</div><div class="q2">He is very proud in his loftiness, his pride, 
+</div><div class="q2">his arrogance, and the arrogance of his heart. 
+</div><div class="q1">
+<sup>30&#160;</sup>I know his wrath,” says Yahweh, “that it is nothing; 
+</div><div class="q2">his boastings have done nothing. 
+</div><div class="q1">
+<sup>31&#160;</sup>Therefore I will wail for Moab. 
+</div><div class="q2">Yes, I will cry out for all Moab. 
+</div><div class="q2">They will mourn for the men of Kir Heres. 
+</div><div class="q1">
+<sup>32&#160;</sup>With more than the weeping of Jazer 
+</div><div class="q2">I will weep for you, vine of Sibmah. 
+</div><div class="q1">Your branches passed over the sea. 
+</div><div class="q2">They reached even to the sea of Jazer. 
+</div><div class="q1">The destroyer has fallen on your summer fruits 
+</div><div class="q2">and on your vintage. 
+</div><div class="q1">
+<sup>33&#160;</sup>Gladness and joy is taken away from the fruitful field 
+</div><div class="q2">and from the land of Moab. 
+</div><div class="q1">I have caused wine to cease from the wine presses. 
+</div><div class="q2">No one will tread with shouting. 
+</div><div class="q2">The shouting will be no shouting. 
+</div><div class="q1">
+<sup>34&#160;</sup>From the cry of Heshbon even to Elealeh, 
+</div><div class="q2">even to Jahaz they have uttered their voice, 
+</div><div class="q2">from Zoar even to Horonaim, to Eglath Shelishiyah; 
+</div><div class="q2">for the waters of Nimrim will also become desolate. 
+</div><div class="q1">
+<sup>35&#160;</sup>Moreover I will cause to cease in Moab,” says Yahweh, 
+</div><div class="q2">“him who offers in the high place, 
+</div><div class="q2">and him who burns incense to his elohims. 
+</div><div class="q1">
+<sup>36&#160;</sup>Therefore my heart sounds for Moab like flutes, 
+</div><div class="q2">and my heart sounds like flutes for the men of Kir Heres. 
+</div><div class="q2">Therefore the abundance that he has gotten has perished. 
+</div><div class="q1">
+<sup>37&#160;</sup>For every head is bald, 
+</div><div class="q2">and every beard clipped. 
+</div><div class="q1">There are cuttings on all the hands, 
+</div><div class="q2">and sackcloth on the waist. 
+</div><div class="q1">
+<sup>38&#160;</sup>On all the housetops of Moab, 
+</div><div class="q2">and in its streets, there is lamentation everywhere; 
+</div><div class="q2">for I have broken Moab like a vessel in which no one delights,” says Yahweh. 
+</div><div class="q1">
+<sup>39&#160;</sup>“How it is broken down! 
+</div><div class="q2">How they wail! 
+</div><div class="q1">How Moab has turned the back with shame! 
+</div><div class="q2">So will Moab become a derision 
+</div><div class="q2">and a terror to all who are around him.” 
+</div><div class="q1">
+<sup>40&#160;</sup>For Yahweh says: “Behold, he will fly as an eagle, 
+</div><div class="q2">and will spread out his wings against Moab. 
+</div><div class="q1">
+<sup>41&#160;</sup>Kerioth is taken, 
+</div><div class="q2">and the strongholds are seized. 
+</div><div class="q1">The heart of the mighty men of Moab at that day 
+</div><div class="q2">will be as the heart of a woman in her pangs. 
+</div><div class="q1">
+<sup>42&#160;</sup>Moab will be destroyed from being a people, 
+</div><div class="q2">because he has magnified himself against Yahweh. 
+</div><div class="q1">
+<sup>43&#160;</sup>Terror, the pit, and the snare are on you, 
+</div><div class="q2">inhabitant of Moab,” says Yahweh. 
+</div><div class="q1">
+<sup>44&#160;</sup>“He who flees from the terror will fall into the pit; 
+</div><div class="q2">and he who gets up out of the pit will be taken in the snare, 
+</div><div class="q1">for I will bring on him, even on Moab, 
+</div><div class="q2">the year of their visitation,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>45&#160;</sup>“Those who fled stand without strength under the shadow of Heshbon; 
+</div><div class="q2">for a fire has gone out of Heshbon, 
+</div><div class="q2">and a flame from the middle of Sihon, 
+</div><div class="q1">and has devoured the corner of Moab, 
+</div><div class="q2">and the crown of the head of the tumultuous ones. 
+</div><div class="q1">
+<sup>46&#160;</sup>Woe to you, O Moab! 
+</div><div class="q2">The people of Chemosh are undone; 
+</div><div class="q1">for your sons are taken away captive, 
+</div><div class="q2">and your daughters into captivity. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>47&#160;</sup>“Yet I will reverse the captivity of Moab in the latter days,” 
+</div><div class="q2">says Yahweh. 
+</div><div class="p">Thus far is the judgment of Moab. 
+</div><h2 class="chapterlabel" id="49">49</h2>
+<div class="p">
+<sup>1&#160;</sup>Of the children of Ammon. Yahweh says: 
+</div><div class="q1">“Has Israel no sons? 
+</div><div class="q2">Has he no heir? 
+</div><div class="q1">Why then does Malcam possess Gad, 
+</div><div class="q2">and his people dwell in its cities? 
+</div><div class="q1">
+<sup>2&#160;</sup>Therefore behold, the days come,” 
+</div><div class="q2">says Yahweh, 
+</div><div class="q1">“that I will cause an alarm of war to be heard against Rabbah of the children of Ammon, 
+</div><div class="q2">and it will become a desolate heap, 
+</div><div class="q2">and her daughters will be burned with fire; 
+</div><div class="q1">then Israel will possess those who possessed him,” 
+</div><div class="q2">says Yahweh. 
+</div><div class="q1">
+<sup>3&#160;</sup>“Wail, Heshbon, for Ai is laid waste! 
+</div><div class="q2">Cry, you daughters of Rabbah! 
+</div><div class="q1">Clothe yourself in sackcloth. 
+</div><div class="q2">Lament, and run back and forth among the fences; 
+</div><div class="q1">for Malcam will go into captivity, 
+</div><div class="q2">his priests and his princes together. 
+</div><div class="q1">
+<sup>4&#160;</sup>Why do you boast in the valleys, 
+</div><div class="q2">your flowing valley, backsliding daughter? 
+</div><div class="q1">You trusted in her treasures, 
+</div><div class="q2">saying, ‘Who will come to me?’ 
+</div><div class="q1">
+<sup>5&#160;</sup>Behold, I will bring a terror on you,” 
+</div><div class="q2">says the Lord, Yahweh of Armies, 
+</div><div class="q1">“from all who are around you. 
+</div><div class="q2">All of you will be driven completely out, 
+</div><div class="q2">and there will be no one to gather together the fugitives. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“But afterward I will reverse the captivity of the children of Ammon,” 
+</div><div class="q2">says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>7&#160;</sup>Of Edom, Yahweh of Armies says: 
+</div><div class="q1">“Is wisdom no more in Teman? 
+</div><div class="q2">Has counsel perished from the prudent? 
+</div><div class="q2">Has their wisdom vanished? 
+</div><div class="q1">
+<sup>8&#160;</sup>Flee! Turn back! 
+</div><div class="q2">Dwell in the depths, inhabitants of Dedan; 
+</div><div class="q2">for I will bring the calamity of Esau on him when I visit him. 
+</div><div class="q1">
+<sup>9&#160;</sup>If grape gatherers came to you, 
+</div><div class="q2">would they not leave some gleaning grapes? 
+</div><div class="q1">If thieves came by night, 
+</div><div class="q2">wouldn’t they steal until they had enough? 
+</div><div class="q1">
+<sup>10&#160;</sup>But I have made Esau bare, 
+</div><div class="q2">I have uncovered his secret places, 
+</div><div class="q2">and he will not be able to hide himself. 
+</div><div class="q1">His offspring is destroyed, 
+</div><div class="q2">with his brothers and his neighbors; 
+</div><div class="q2">and he is no more. 
+</div><div class="q1">
+<sup>11&#160;</sup>Leave your fatherless children. 
+</div><div class="q2">I will preserve them alive. 
+</div><div class="q2">Let your widows trust in me.” 
+</div><div class="p">
+<sup>12&#160;</sup>For Yahweh says: “Behold, they to whom it didn’t pertain to drink of the cup will certainly drink; and are you he who will altogether go unpunished? You won’t go unpunished, but you will surely drink. 
+<sup>13&#160;</sup>For I have sworn by myself,” says Yahweh, “that Bozrah will become an astonishment, a reproach, a waste, and a curse. All its cities will be perpetual wastes.” 
+</div><div class="q1">
+<sup>14&#160;</sup>I have heard news from Yahweh, 
+</div><div class="q2">and an ambassador is sent among the nations, 
+</div><div class="q1">saying, “Gather yourselves together! 
+</div><div class="q2">Come against her! 
+</div><div class="q2">Rise up to the battle!” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“For, behold, I have made you small among the nations, 
+</div><div class="q2">and despised among men. 
+</div><div class="q1">
+<sup>16&#160;</sup>As for your terror, 
+</div><div class="q2">the pride of your heart has deceived you, 
+</div><div class="q1">O you who dwell in the clefts of the rock, 
+</div><div class="q2">who hold the height of the hill, 
+</div><div class="q1">though you should make your nest as high as the eagle, 
+</div><div class="q2">I will bring you down from there,” says Yahweh. 
+</div><div class="q1">
+<sup>17&#160;</sup>“Edom will become an astonishment. 
+</div><div class="q2">Everyone who passes by it will be astonished, 
+</div><div class="q2">and will hiss at all its plagues. 
+</div><div class="q1">
+<sup>18&#160;</sup>As in the overthrow of Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
+</div><div class="q2">“no man will dwell there, 
+</div><div class="q2">neither will any son of man live therein. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“Behold, he will come up like a lion from the pride of the Jordan against the strong habitation; 
+</div><div class="q2">for I will suddenly make them run away from it, 
+</div><div class="q1">and whoever is chosen, 
+</div><div class="q2">I will appoint him over it. 
+</div><div class="q1">For who is like me? 
+</div><div class="q2">Who will appoint me a time? 
+</div><div class="q2">Who is the shepherd who will stand before me?” 
+</div><div class="q1">
+<sup>20&#160;</sup>Therefore hear the counsel of Yahweh, that he has taken against Edom, 
+</div><div class="q2">and his purposes that he has purposed against the inhabitants of Teman: 
+</div><div class="q1">Surely they will drag them away, 
+</div><div class="q2">the little ones of the flock. 
+</div><div class="q2">Surely he will make their habitation desolate over them. 
+</div><div class="q1">
+<sup>21&#160;</sup>The earth trembles at the noise of their fall; 
+</div><div class="q2">there is a cry, the noise which is heard in the Red Sea. 
+</div><div class="q1">
+<sup>22&#160;</sup>Behold, he will come up and fly as the eagle, 
+</div><div class="q2">and spread out his wings against Bozrah. 
+</div><div class="q2">The heart of the mighty men of Edom at that day will be as the heart of a woman in her pangs. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>23&#160;</sup>Of Damascus: 
+</div><div class="q1">“Hamath and Arpad are confounded, 
+</div><div class="q2">for they have heard evil news. 
+</div><div class="q2">They have melted away. 
+</div><div class="q1">There is sorrow on the sea. 
+</div><div class="q2">It can’t be quiet. 
+</div><div class="q1">
+<sup>24&#160;</sup>Damascus has grown feeble, 
+</div><div class="q2">she turns herself to flee, 
+</div><div class="q2">and trembling has seized her. 
+</div><div class="q1">Anguish and sorrows have taken hold of her, 
+</div><div class="q2">as of a woman in travail. 
+</div><div class="q1">
+<sup>25&#160;</sup>How is the city of praise not forsaken, 
+</div><div class="q2">the city of my joy? 
+</div><div class="q1">
+<sup>26&#160;</sup>Therefore her young men will fall in her streets, 
+</div><div class="q2">and all the men of war will be brought to silence in that day,” 
+</div><div class="q2">says Yahweh of Armies. 
+</div><div class="q1">
+<sup>27&#160;</sup>“I will kindle a fire in the wall of Damascus, 
+</div><div class="q2">and it will devour the palaces of Ben Hadad.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>Of Kedar, and of the kingdoms of Hazor, which Nebuchadnezzar king of Babylon struck, Yahweh says: 
+</div><div class="q1">“Arise, go up to Kedar, 
+</div><div class="q2">and destroy the children of the east. 
+</div><div class="q1">
+<sup>29&#160;</sup>They will take their tents and their flocks. 
+</div><div class="q2">they will carry away for themselves their curtains, 
+</div><div class="q2">all their vessels, and their camels; 
+</div><div class="q2">and they will cry to them, ‘Terror on every side!’ 
+</div><div class="q1">
+<sup>30&#160;</sup>Flee! 
+</div><div class="q2">Wander far off! 
+</div><div class="q1">Dwell in the depths, you inhabitants of Hazor,” says Yahweh; 
+</div><div class="q2">“for Nebuchadnezzar king of Babylon has taken counsel against you, 
+</div><div class="q2">and has conceived a purpose against you. 
+</div><div class="q1">
+<sup>31&#160;</sup>Arise! Go up to a nation that is at ease, 
+</div><div class="q2">that dwells without care,” says Yahweh; 
+</div><div class="q2">“that has neither gates nor bars, 
+</div><div class="q2">that dwells alone. 
+</div><div class="q1">
+<sup>32&#160;</sup>Their camels will be a booty, 
+</div><div class="q2">and the multitude of their livestock a plunder. 
+</div><div class="q1">I will scatter to all winds those who have the corners of their beards cut off; 
+</div><div class="q2">and I will bring their calamity from every side of them,” 
+</div><div class="q2">says Yahweh. 
+</div><div class="q1">
+<sup>33&#160;</sup>Hazor will be a dwelling place of jackals, 
+</div><div class="q2">a desolation forever. 
+</div><div class="q1">No man will dwell there, 
+</div><div class="q2">neither will any son of man live therein.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>34&#160;</sup>Yahweh’s word that came to Jeremiah the prophet concerning Elam, in the beginning of the reign of Zedekiah king of Judah, saying, 
+<sup>35&#160;</sup>“Yahweh of Armies says: 
+</div><div class="q1">‘Behold, I will break the bow of Elam, 
+</div><div class="q2">the chief of their might. 
+</div><div class="q1">
+<sup>36&#160;</sup>I will bring on Elam the four winds from the four quarters of the sky, 
+</div><div class="q2">and will scatter them toward all those winds. 
+</div><div class="q2">There will be no nation where the outcasts of Elam will not come. 
+</div><div class="q1">
+<sup>37&#160;</sup>I will cause Elam to be dismayed before their enemies, 
+</div><div class="q2">and before those who seek their life. 
+</div><div class="q1">I will bring evil on them, even my fierce anger,’ says Yahweh; 
+</div><div class="q2">‘and I will send the sword after them, 
+</div><div class="q2">until I have consumed them. 
+</div><div class="q1">
+<sup>38&#160;</sup>I will set my throne in Elam, 
+</div><div class="q2">and will destroy from there king and princes,’ says Yahweh. 
+</div><div class="q1">
+<sup>39&#160;</sup>‘But it will happen in the latter days 
+</div><div class="q2">that I will reverse the captivity of Elam,’ says Yahweh.” 
+</div><h2 class="chapterlabel" id="50">50</h2>
+<div class="p">
+<sup>1&#160;</sup>The word that Yahweh spoke concerning Babylon, concerning the land of the Chaldeans, by Jeremiah the prophet. 
+</div><div class="q1">
+<sup>2&#160;</sup>“Declare among the nations and publish, 
+</div><div class="q2">and set up a standard; 
+</div><div class="q2">publish, and don’t conceal; 
+</div><div class="q1">say, ‘Babylon has been taken, 
+</div><div class="q2">Bel is disappointed, 
+</div><div class="q2">Merodach is dismayed! 
+</div><div class="q1">Her images are disappointed. 
+</div><div class="q2">Her idols are dismayed.’ 
+</div><div class="q1">
+<sup>3&#160;</sup>For a nation comes up out of the north against her, 
+</div><div class="q2">which will make her land desolate, 
+</div><div class="q2">and no one will dwell in it. 
+</div><div class="q1">They have fled. 
+</div><div class="q2">They are gone, 
+</div><div class="q2">both man and animal. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“In those days, and in that time,” says Yahweh, 
+</div><div class="q2">“the children of Israel will come, 
+</div><div class="q2">they and the children of Judah together; 
+</div><div class="q1">they will go on their way weeping, 
+</div><div class="q2">and will seek Yahweh their Elohim. 
+</div><div class="q1">
+<sup>5&#160;</sup>They will inquire concerning Zion with their faces turned toward it, 
+</div><div class="q2">saying, ‘Come, and join yourselves to Yahweh in an everlasting covenant 
+</div><div class="q2">that will not be forgotten.’ 
+</div><div class="q1">
+<sup>6&#160;</sup>My people have been lost sheep. 
+</div><div class="q2">Their shepherds have caused them to go astray. 
+</div><div class="q1">They have turned them away on the mountains. 
+</div><div class="q2">They have gone from mountain to hill. 
+</div><div class="q2">They have forgotten their resting place. 
+</div><div class="q1">
+<sup>7&#160;</sup>All who found them have devoured them. 
+</div><div class="q2">Their adversaries said, ‘We are not guilty, 
+</div><div class="q1">because they have sinned against Yahweh, 
+</div><div class="q2">the habitation of righteousness, 
+</div><div class="q2">even Yahweh, the hope of their fathers.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Flee out of the middle of Babylon! 
+</div><div class="q2">Go out of the land of the Chaldeans, 
+</div><div class="q2">and be as the male goats before the flocks. 
+</div><div class="q1">
+<sup>9&#160;</sup>For, behold, I will stir up 
+</div><div class="q2">and cause to come up against Babylon a company of great nations from the north country; 
+</div><div class="q2">and they will set themselves in array against her. 
+</div><div class="q1">She will be taken from there. 
+</div><div class="q2">Their arrows will be as of an expert mighty man. 
+</div><div class="q2">None of them will return in vain. 
+</div><div class="q1">
+<sup>10&#160;</sup>Chaldea will be a prey. 
+</div><div class="q2">All who prey on her will be satisfied,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Because you are glad, 
+</div><div class="q2">because you rejoice, 
+</div><div class="q1">O you who plunder my heritage, 
+</div><div class="q2">because you are wanton as a heifer that treads out the grain, 
+</div><div class="q2">and neigh as strong horses, 
+</div><div class="q1">
+<sup>12&#160;</sup>your mother will be utterly disappointed. 
+</div><div class="q2">She who bore you will be confounded. 
+</div><div class="q1">Behold, she will be the least of the nations, 
+</div><div class="q2">a wilderness, a dry land, and a desert. 
+</div><div class="q1">
+<sup>13&#160;</sup>Because of Yahweh’s wrath she won’t be inhabited, 
+</div><div class="q2">but she will be wholly desolate. 
+</div><div class="q1">Everyone who goes by Babylon will be astonished, 
+</div><div class="q2">and hiss at all her plagues. 
+</div><div class="q1">
+<sup>14&#160;</sup>Set yourselves in array against Babylon all around, 
+</div><div class="q2">all you who bend the bow; 
+</div><div class="q2">shoot at her. 
+</div><div class="q1">Spare no arrows, 
+</div><div class="q2">for she has sinned against Yahweh. 
+</div><div class="q1">
+<sup>15&#160;</sup>Shout against her all around. 
+</div><div class="q2">She has submitted herself. 
+</div><div class="q2">Her bulwarks have fallen. 
+</div><div class="q1">Her walls have been thrown down, 
+</div><div class="q2">for it is the vengeance of Yahweh. 
+</div><div class="q1">Take vengeance on her. 
+</div><div class="q2">As she has done, do to her. 
+</div><div class="q1">
+<sup>16&#160;</sup>Cut off the sower from Babylon, 
+</div><div class="q2">and him who handles the sickle in the time of harvest. 
+</div><div class="q1">For fear of the oppressing sword, 
+</div><div class="q2">they will each return to their own people, 
+</div><div class="q2">and they will each flee to their own land. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“Israel is a hunted sheep. 
+</div><div class="q2">The lions have driven him away. 
+</div><div class="q1">First, the king of Assyria devoured him, 
+</div><div class="q2">and now at last Nebuchadnezzar king of Babylon has broken his bones.” 
+</div><div class="p">
+<sup>18&#160;</sup>Therefore Yahweh of Armies, the Elohim of Israel, says: 
+</div><div class="q1">“Behold, I will punish the king of Babylon and his land, 
+</div><div class="q2">as I have punished the king of Assyria. 
+</div><div class="q1">
+<sup>19&#160;</sup>I will bring Israel again to his pasture, 
+</div><div class="q2">and he will feed on Carmel and Bashan. 
+</div><div class="q2">His soul will be satisfied on the hills of Ephraim and in Gilead. 
+</div><div class="q1">
+<sup>20&#160;</sup>In those days, and in that time,” says Yahweh, 
+</div><div class="q2">“the iniquity of Israel will be sought for, 
+</div><div class="q2">and there will be none, 
+</div><div class="q1">also the sins of Judah, 
+</div><div class="q2">and they won’t be found; 
+</div><div class="q2">for I will pardon them whom I leave as a remnant. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Go up against the land of Merathaim, 
+</div><div class="q2">even against it, and against the inhabitants of Pekod. 
+</div><div class="q1">Kill and utterly destroy after them,” says Yahweh, 
+</div><div class="q2">“and do according to all that I have commanded you. 
+</div><div class="q1">
+<sup>22&#160;</sup>A sound of battle is in the land, 
+</div><div class="q2">and of great destruction. 
+</div><div class="q1">
+<sup>23&#160;</sup>How the hammer of the whole earth is cut apart and broken! 
+</div><div class="q2">How Babylon has become a desolation among the nations! 
+</div><div class="q1">
+<sup>24&#160;</sup>I have laid a snare for you, 
+</div><div class="q2">and you are also taken, Babylon, 
+</div><div class="q2">and you weren’t aware. 
+</div><div class="q1">You are found, 
+</div><div class="q2">and also caught, 
+</div><div class="q2">because you have fought against Yahweh. 
+</div><div class="q1">
+<sup>25&#160;</sup>Yahweh has opened his armory, 
+</div><div class="q2">and has brought out the weapons of his indignation; 
+</div><div class="q2">for the Lord, Yahweh of Armies, has a work to do in the land of the Chaldeans. 
+</div><div class="q1">
+<sup>26&#160;</sup>Come against her from the farthest border. 
+</div><div class="q2">Open her storehouses. 
+</div><div class="q2">Cast her up as heaps. 
+</div><div class="q1">Destroy her utterly. 
+</div><div class="q2">Let nothing of her be left. 
+</div><div class="q1">
+<sup>27&#160;</sup>Kill all her bulls. 
+</div><div class="q2">Let them go down to the slaughter. 
+</div><div class="q1">Woe to them! For their day has come, 
+</div><div class="q2">the time of their visitation. 
+</div><div class="q1">
+<sup>28&#160;</sup>Listen to those who flee and escape out of the land of Babylon, 
+</div><div class="q2">to declare in Zion the vengeance of Yahweh our Elohim, 
+</div><div class="q2">the vengeance of his temple. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>29&#160;</sup>“Call together the archers against Babylon, 
+</div><div class="q2">all those who bend the bow. 
+</div><div class="q1">Encamp against her all around. 
+</div><div class="q2">Let none of it escape. 
+</div><div class="q1">Pay her back according to her work. 
+</div><div class="q2">According to all that she has done, do to her; 
+</div><div class="q1">for she has been proud against Yahweh, 
+</div><div class="q2">against the Set-Apart One of Israel. 
+</div><div class="q1">
+<sup>30&#160;</sup>Therefore her young men will fall in her streets. 
+</div><div class="q2">All her men of war will be brought to silence in that day,” says Yahweh. 
+</div><div class="q1">
+<sup>31&#160;</sup>“Behold, I am against you, you proud one,” says the Lord, Yahweh of Armies; 
+</div><div class="q2">“for your day has come, 
+</div><div class="q2">the time that I will visit you. 
+</div><div class="q1">
+<sup>32&#160;</sup>The proud one will stumble and fall, 
+</div><div class="q2">and no one will raise him up. 
+</div><div class="q1">I will kindle a fire in his cities, 
+</div><div class="q2">and it will devour all who are around him.” 
+</div><div class="q1">
+<sup>33&#160;</sup>Yahweh of Armies says: “The children of Israel and the children of Judah are oppressed together. 
+</div><div class="q2">All who took them captive hold them fast. 
+</div><div class="q2">They refuse to let them go. 
+</div><div class="q1">
+<sup>34&#160;</sup>Their Redeemer is strong. 
+</div><div class="q2">Yahweh of Armies is his name. 
+</div><div class="q1">He will thoroughly plead their cause, 
+</div><div class="q2">that he may give rest to the earth, 
+</div><div class="q2">and disquiet the inhabitants of Babylon. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>35&#160;</sup>“A sword is on the Chaldeans,” says Yahweh, 
+</div><div class="q2">“and on the inhabitants of Babylon, 
+</div><div class="q2">on her princes, 
+</div><div class="q2">and on her wise men. 
+</div><div class="q1">
+<sup>36&#160;</sup>A sword is on the boasters, 
+</div><div class="q2">and they will become fools. 
+</div><div class="q1">A sword is on her mighty men, 
+</div><div class="q2">and they will be dismayed. 
+</div><div class="q1">
+<sup>37&#160;</sup>A sword is on their horses, 
+</div><div class="q2">on their chariots, 
+</div><div class="q2">and on all the mixed people who are in the middle of her; 
+</div><div class="q2">and they will become as women. 
+</div><div class="q1">A sword is on her treasures, 
+</div><div class="q2">and they will be robbed. 
+</div><div class="q1">
+<sup>38&#160;</sup>A drought is on her waters, 
+</div><div class="q2">and they will be dried up; 
+</div><div class="q1">for it is a land of engraved images, 
+</div><div class="q2">and they are mad over idols. 
+</div><div class="q1">
+<sup>39&#160;</sup>Therefore the wild animals of the desert 
+</div><div class="q2">with the wolves will dwell there. 
+</div><div class="q1">The ostriches will dwell therein. 
+</div><div class="q2">It will be inhabited no more forever, 
+</div><div class="q2">neither will it be lived in from generation to generation. 
+</div><div class="q1">
+<sup>40&#160;</sup>As when Elohim overthrew Sodom and Gomorrah and its neighbor cities,” says Yahweh, 
+</div><div class="q2">“so no man will dwell there, 
+</div><div class="q2">neither will any son of man live therein. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>41&#160;</sup>“Behold, a people comes from the north. 
+</div><div class="q2">A great nation and many kings will be stirred up from the uttermost parts of the earth. 
+</div><div class="q1">
+<sup>42&#160;</sup>They take up bow and spear. 
+</div><div class="q2">They are cruel, and have no mercy. 
+</div><div class="q2">Their voice roars like the sea. 
+</div><div class="q1">They ride on horses, 
+</div><div class="q2">everyone set in array, 
+</div><div class="q2">as a man to the battle, 
+</div><div class="q2">against you, daughter of Babylon. 
+</div><div class="q1">
+<sup>43&#160;</sup>The king of Babylon has heard the news of them, 
+</div><div class="q2">and his hands become feeble. 
+</div><div class="q1">Anguish has taken hold of him, 
+</div><div class="q2">pains as of a woman in labor. 
+</div><div class="q1">
+<sup>44&#160;</sup>Behold, the enemy will come up like a lion 
+</div><div class="q2">from the thickets of the Jordan against the strong habitation; 
+</div><div class="q2">for I will suddenly make them run away from it. 
+</div><div class="q1">Whoever is chosen, 
+</div><div class="q2">I will appoint him over it, 
+</div><div class="q2">for who is like me? 
+</div><div class="q1">Who will appoint me a time? 
+</div><div class="q2">Who is the shepherd who can stand before me?” 
+</div><div class="q1">
+<sup>45&#160;</sup>Therefore hear the counsel of Yahweh 
+</div><div class="q2">that he has taken against Babylon; 
+</div><div class="q1">and his purposes 
+</div><div class="q2">that he has purposed against the land of the Chaldeans: 
+</div><div class="q1">Surely they will drag them away, 
+</div><div class="q2">even the little ones of the flock. 
+</div><div class="q2">Surely he will make their habitation desolate over them. 
+</div><div class="q1">
+<sup>46&#160;</sup>The earth trembles at the noise of the taking of Babylon. 
+</div><div class="q2">The cry is heard among the nations. 
+</div><h2 class="chapterlabel" id="51">51</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh says: 
+</div><div class="q1">“Behold, I will raise up against Babylon, 
+</div><div class="q2">and against those who dwell in Lebkamai, a destroying wind. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will send to Babylon strangers, who will winnow her. 
+</div><div class="q2">They will empty her land; 
+</div><div class="q2">for in the day of trouble they will be against her all around. 
+</div><div class="q1">
+<sup>3&#160;</sup>Against him who bends, let the archer bend his bow, 
+</div><div class="q2">also against him who lifts himself up in his coat of mail. 
+</div><div class="q1">Don’t spare her young men! 
+</div><div class="q2">Utterly destroy all her army! 
+</div><div class="q1">
+<sup>4&#160;</sup>They will fall down slain in the land of the Chaldeans, 
+</div><div class="q2">and thrust through in her streets. 
+</div><div class="q1">
+<sup>5&#160;</sup>For Israel is not forsaken, nor Judah, by his Elohim, 
+</div><div class="q2">by Yahweh of Armies; 
+</div><div class="q2">though their land is full of guilt against the Set-Apart One of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“Flee out of the middle of Babylon! 
+</div><div class="q2">Everyone save his own life! 
+</div><div class="q1">Don’t be cut off in her iniquity, 
+</div><div class="q2">for it is the time of Yahweh’s vengeance. 
+</div><div class="q2">He will render to her a recompense. 
+</div><div class="q1">
+<sup>7&#160;</sup>Babylon has been a golden cup in Yahweh’s hand, 
+</div><div class="q2">who made all the earth drunk. 
+</div><div class="q1">The nations have drunk of her wine; 
+</div><div class="q2">therefore the nations have gone mad. 
+</div><div class="q1">
+<sup>8&#160;</sup>Babylon has suddenly fallen and been destroyed! 
+</div><div class="q2">Wail for her! 
+</div><div class="q1">Take balm for her pain. 
+</div><div class="q2">Perhaps she may be healed. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“We would have healed Babylon, 
+</div><div class="q2">but she is not healed. 
+</div><div class="q1">Forsake her, 
+</div><div class="q2">and let’s each go into his own country; 
+</div><div class="q1">for her judgment reaches to heaven, 
+</div><div class="q2">and is lifted up even to the skies. 
+</div><div class="q1">
+<sup>10&#160;</sup>‘Yahweh has produced our righteousness. 
+</div><div class="q2">Come, and let’s declare in Zion the work of Yahweh our Elohim.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Make the arrows sharp! 
+</div><div class="q2">Hold the shields firmly! 
+</div><div class="q1">Yahweh has stirred up the spirit of the kings of the Medes, 
+</div><div class="q2">because his purpose is against Babylon, to destroy it; 
+</div><div class="q1">for it is the vengeance of Yahweh, 
+</div><div class="q2">the vengeance of his temple. 
+</div><div class="q1">
+<sup>12&#160;</sup>Set up a standard against the walls of Babylon! 
+</div><div class="q2">Make the watch strong! 
+</div><div class="q1">Set the watchmen, 
+</div><div class="q2">and prepare the ambushes; 
+</div><div class="q1">for Yahweh has both purposed and done 
+</div><div class="q2">that which he spoke concerning the inhabitants of Babylon. 
+</div><div class="q1">
+<sup>13&#160;</sup>You who dwell on many waters, abundant in treasures, 
+</div><div class="q2">your end has come, the measure of your covetousness. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yahweh of Armies has sworn by himself, saying, 
+</div><div class="q2">‘Surely I will fill you with men, 
+</div><div class="q2">as with locusts, 
+</div><div class="q2">and they will lift up a shout against you.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“He has made the earth by his power. 
+</div><div class="q2">He has established the world by his wisdom. 
+</div><div class="q2">By his understanding he has stretched out the heavens. 
+</div><div class="q1">
+<sup>16&#160;</sup>When he utters his voice, 
+</div><div class="q2">there is a roar of waters in the heavens, 
+</div><div class="q2">and he causes the vapors to ascend from the ends of the earth. 
+</div><div class="q1">He makes lightning for the rain, 
+</div><div class="q2">and brings the wind out of his treasuries. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“Every man has become stupid and without knowledge. 
+</div><div class="q2">Every goldsmith is disappointed by his image, 
+</div><div class="q1">for his molten images are falsehood, 
+</div><div class="q2">and there is no breath in them. 
+</div><div class="q1">
+<sup>18&#160;</sup>They are vanity, 
+</div><div class="q2">a work of delusion. 
+</div><div class="q2">In the time of their visitation, they will perish. 
+</div><div class="q1">
+<sup>19&#160;</sup>The portion of Jacob is not like these, 
+</div><div class="q2">for he formed all things, 
+</div><div class="q2">including the tribe of his inheritance. 
+</div><div class="q2">Yahweh of Armies is his name. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“You are my battle ax and weapons of war. 
+</div><div class="q2">With you I will break the nations into pieces. 
+</div><div class="q2">With you I will destroy kingdoms. 
+</div><div class="q1">
+<sup>21&#160;</sup>With you I will break in pieces 
+</div><div class="q2">the horse and his rider. 
+</div><div class="q1">
+<sup>22&#160;</sup>With you I will break in pieces 
+</div><div class="q2">the chariot and him who rides therein. 
+</div><div class="q1">With you I will break in pieces 
+</div><div class="q2">man and woman. 
+</div><div class="q1">With you I will break in pieces 
+</div><div class="q2">the old man and the youth. 
+</div><div class="q1">With you I will break in pieces 
+</div><div class="q2">the young man and the virgin. 
+</div><div class="q1">
+<sup>23&#160;</sup>With you I will break in pieces 
+</div><div class="q2">the shepherd and his flock. 
+</div><div class="q1">With you I will break in pieces 
+</div><div class="q2">the farmer and his yoke. 
+</div><div class="q1">With you I will break in pieces 
+</div><div class="q2">governors and deputies. 
+</div><div class="p">
+<sup>24&#160;</sup>“I will render to Babylon and to all the inhabitants of Chaldea all their evil that they have done in Zion in your sight,” says Yahweh. 
+</div><div class="q1">
+<sup>25&#160;</sup>“Behold, I am against you, destroying mountain,” says Yahweh, 
+</div><div class="q2">“which destroys all the earth. 
+</div><div class="q1">I will stretch out my hand on you, 
+</div><div class="q2">roll you down from the rocks, 
+</div><div class="q2">and will make you a burned mountain. 
+</div><div class="q1">
+<sup>26&#160;</sup>They won’t take a cornerstone from you, 
+</div><div class="q2">nor a stone for foundations; 
+</div><div class="q2">but you will be desolate forever,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>27&#160;</sup>“Set up a standard in the land! 
+</div><div class="q2">Blow the trumpet among the nations! 
+</div><div class="q1">Prepare the nations against her! 
+</div><div class="q2">Call together against her the kingdoms of Ararat, Minni, and Ashkenaz! 
+</div><div class="q1">Appoint a marshal against her! 
+</div><div class="q2">Cause the horses to come up as the swarming locusts! 
+</div><div class="q1">
+<sup>28&#160;</sup>Prepare against her the nations, 
+</div><div class="q2">the kings of the Medes, its governors, and all its deputies, and all the land of their dominion! 
+</div><div class="q1">
+<sup>29&#160;</sup>The land trembles and is in pain; 
+</div><div class="q2">for the purposes of Yahweh against Babylon stand, 
+</div><div class="q2">to make the land of Babylon a desolation, without inhabitant. 
+</div><div class="q1">
+<sup>30&#160;</sup>The mighty men of Babylon have stopped fighting, 
+</div><div class="q2">they remain in their strongholds. 
+</div><div class="q1">Their might has failed. 
+</div><div class="q2">They have become as women. 
+</div><div class="q1">Her dwelling places are set on fire. 
+</div><div class="q2">Her bars are broken. 
+</div><div class="q1">
+<sup>31&#160;</sup>One runner will run to meet another, 
+</div><div class="q2">and one messenger to meet another, 
+</div><div class="q2">to show the king of Babylon that his city is taken on every quarter. 
+</div><div class="q1">
+<sup>32&#160;</sup>So the passages are seized. 
+</div><div class="q2">They have burned the reeds with fire. 
+</div><div class="q2">The men of war are frightened.” 
+</div><div class="p">
+<sup>33&#160;</sup>For Yahweh of Armies, the Elohim of Israel says: 
+</div><div class="q1">“The daughter of Babylon is like a threshing floor at the time when it is trodden. 
+</div><div class="q2">Yet a little while, and the time of harvest comes for her.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>34&#160;</sup>“Nebuchadnezzar the king of Babylon has devoured me. 
+</div><div class="q2">He has crushed me. 
+</div><div class="q2">He has made me an empty vessel. 
+</div><div class="q1">He has, like a monster, swallowed me up. 
+</div><div class="q2">He has filled his mouth with my delicacies. 
+</div><div class="q2">He has cast me out. 
+</div><div class="q1">
+<sup>35&#160;</sup>May the violence done to me and to my flesh be on Babylon!” 
+</div><div class="q2">the inhabitant of Zion will say; and, 
+</div><div class="q1">“May my blood be on the inhabitants of Chaldea!” 
+</div><div class="q2">will Jerusalem say. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>36&#160;</sup>Therefore Yahweh says: 
+</div><div class="q1">“Behold, I will plead your cause, 
+</div><div class="q2">and take vengeance for you. 
+</div><div class="q1">I will dry up her sea, 
+</div><div class="q2">and make her fountain dry. 
+</div><div class="q1">
+<sup>37&#160;</sup>Babylon will become heaps, 
+</div><div class="q2">a dwelling place for jackals, 
+</div><div class="q2">an astonishment, and a hissing, 
+</div><div class="q2">without inhabitant. 
+</div><div class="q1">
+<sup>38&#160;</sup>They will roar together like young lions. 
+</div><div class="q2">They will growl as lions’ cubs. 
+</div><div class="q1">
+<sup>39&#160;</sup>When they are inflamed, I will make their feast, 
+</div><div class="q2">and I will make them drunk, 
+</div><div class="q1">that they may rejoice, 
+</div><div class="q2">and sleep a perpetual sleep, 
+</div><div class="q2">and not wake up,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>40&#160;</sup>“I will bring them down like lambs to the slaughter, 
+</div><div class="q2">like rams with male goats. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>41&#160;</sup>“How Sheshach is taken! 
+</div><div class="q2">How the praise of the whole earth is seized! 
+</div><div class="q2">How Babylon has become a desolation among the nations! 
+</div><div class="q1">
+<sup>42&#160;</sup>The sea has come up on Babylon. 
+</div><div class="q2">She is covered with the multitude of its waves. 
+</div><div class="q1">
+<sup>43&#160;</sup>Her cities have become a desolation, 
+</div><div class="q2">a dry land, and a desert, 
+</div><div class="q2">a land in which no man dwells. 
+</div><div class="q2">No son of man passes by it. 
+</div><div class="q1">
+<sup>44&#160;</sup>I will execute judgment on Bel in Babylon, 
+</div><div class="q2">and I will bring out of his mouth that which he has swallowed up. 
+</div><div class="q1">The nations will not flow any more to him. 
+</div><div class="q2">Yes, the wall of Babylon will fall. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>45&#160;</sup>“My people, go away from the middle of her, 
+</div><div class="q2">and each of you save yourselves from Yahweh’s fierce anger. 
+</div><div class="q1">
+<sup>46&#160;</sup>Don’t let your heart faint. 
+</div><div class="q2">Don’t fear for the news that will be heard in the land. 
+</div><div class="q1">For news will come one year, 
+</div><div class="q2">and after that in another year news will come, 
+</div><div class="q2">and violence in the land, 
+</div><div class="q2">ruler against ruler. 
+</div><div class="q1">
+<sup>47&#160;</sup>Therefore behold, the days come that I will execute judgment on the engraved images of Babylon; 
+</div><div class="q2">and her whole land will be confounded. 
+</div><div class="q2">All her slain will fall in the middle of her. 
+</div><div class="q1">
+<sup>48&#160;</sup>Then the heavens and the earth, 
+</div><div class="q2">and all that is therein, 
+</div><div class="q1">will sing for joy over Babylon; 
+</div><div class="q2">for the destroyers will come to her from the north,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>49&#160;</sup>“As Babylon has caused the slain of Israel to fall, 
+</div><div class="q2">so the slain of all the land will fall at Babylon. 
+</div><div class="q1">
+<sup>50&#160;</sup>You who have escaped the sword, go! 
+</div><div class="q2">Don’t stand still! 
+</div><div class="q1">Remember Yahweh from afar, 
+</div><div class="q2">and let Jerusalem come into your mind.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>51&#160;</sup>“We are confounded 
+</div><div class="q2">because we have heard reproach. 
+</div><div class="q1">Confusion has covered our faces, 
+</div><div class="q2">for strangers have come into the sanctuaries of Yahweh’s house.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>52&#160;</sup>“Therefore behold, the days come,” says Yahweh, 
+</div><div class="q2">“that I will execute judgment on her engraved images; 
+</div><div class="q2">and through all her land the wounded will groan. 
+</div><div class="q1">
+<sup>53&#160;</sup>Though Babylon should mount up to the sky, 
+</div><div class="q2">and though she should fortify the height of her strength, 
+</div><div class="q2">yet destroyers will come to her from me,” says Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>54&#160;</sup>“The sound of a cry comes from Babylon, 
+</div><div class="q2">and of great destruction from the land of the Chaldeans! 
+</div><div class="q1">
+<sup>55&#160;</sup>For Yahweh lays Babylon waste, 
+</div><div class="q2">and destroys out of her the great voice! 
+</div><div class="q1">Their waves roar like many waters. 
+</div><div class="q2">The noise of their voice is uttered. 
+</div><div class="q1">
+<sup>56&#160;</sup>For the destroyer has come on her, 
+</div><div class="q2">even on Babylon. 
+</div><div class="q1">Her mighty men are taken. 
+</div><div class="q2">Their bows are broken in pieces, 
+</div><div class="q1">for Yahweh is an Elohim of retribution. 
+</div><div class="q2">He will surely repay. 
+</div><div class="q1">
+<sup>57&#160;</sup>I will make her princes, her wise men, 
+</div><div class="q2">her governors, her deputies, and her mighty men drunk. 
+</div><div class="q1">They will sleep a perpetual sleep, 
+</div><div class="q2">and not wake up,” 
+</div><div class="q2">says the King, whose name is Yahweh of Armies. 
+</div><div class="p">
+<sup>58&#160;</sup>Yahweh of Armies says: 
+</div><div class="q1">“The wide walls of Babylon will be utterly overthrown. 
+</div><div class="q2">Her high gates will be burned with fire. 
+</div><div class="q1">The peoples will labor for vanity, 
+</div><div class="q2">and the nations for the fire; 
+</div><div class="q2">and they will be weary.” 
+</div><div class="p">
+<sup>59&#160;</sup>The word which Jeremiah the prophet commanded Seraiah the son of Neriah, the son of Mahseiah, when he went with Zedekiah the king of Judah to Babylon in the fourth year of his reign. Now Seraiah was chief quartermaster. 
+<sup>60&#160;</sup>Jeremiah wrote in a book all the evil that should come on Babylon, even all these words that are written concerning Babylon. 
+<sup>61&#160;</sup>Jeremiah said to Seraiah, “When you come to Babylon, then see that you read all these words, 
+<sup>62&#160;</sup>and say, ‘Yahweh, you have spoken concerning this place, to cut it off, that no one will dwell in it, neither man nor animal, but that it will be desolate forever.’ 
+<sup>63&#160;</sup>It will be, when you have finished reading this book, that you shall bind a stone to it, and cast it into the middle of the Euphrates. 
+<sup>64&#160;</sup>Then you shall say, ‘Thus will Babylon sink, and will not rise again because of the evil that I will bring on her; and they will be weary.’&#160;” 
+</div><div class="p">Thus far are the words of Jeremiah. 
+</div><h2 class="chapterlabel" id="52">52</h2>
+<div class="p">
+<sup>1&#160;</sup>Zedekiah was twenty-one years old when he began to reign. He reigned eleven years in Jerusalem. His mother’s name was Hamutal the daughter of Jeremiah of Libnah. 
+<sup>2&#160;</sup>He did that which was evil in Yahweh’s sight, according to all that Jehoiakim had done. 
+<sup>3&#160;</sup>For through Yahweh’s anger this happened in Jerusalem and Judah, until he had cast them out from his presence. 
+</div><div class="p">Zedekiah rebelled against the king of Babylon. 
+<sup>4&#160;</sup>In the ninth year of his reign, in the tenth month, in the tenth day of the month, Nebuchadnezzar king of Babylon came, he and all his army, against Jerusalem, and encamped against it; and they built forts against it round about. 
+<sup>5&#160;</sup>So the city was besieged to the eleventh year of King Zedekiah. 
+</div><div class="p">
+<sup>6&#160;</sup>In the fourth month, in the ninth day of the month, the famine was severe in the city, so that there was no bread for the people of the land. 
+<sup>7&#160;</sup>Then a breach was made in the city, and all the men of war fled, and went out of the city by night by the way of the gate between the two walls, which was by the king’s garden. Now the Chaldeans were against the city all around. The men of war went toward the Arabah, 
+<sup>8&#160;</sup>but the army of the Chaldeans pursued the king, and overtook Zedekiah in the plains of Jericho; and all his army was scattered from him. 
+<sup>9&#160;</sup>Then they took the king, and carried him up to the king of Babylon to Riblah in the land of Hamath; and he pronounced judgment on him. 
+<sup>10&#160;</sup>The king of Babylon killed the sons of Zedekiah before his eyes. He also killed all the princes of Judah in Riblah. 
+<sup>11&#160;</sup>He put out the eyes of Zedekiah; and the king of Babylon bound him in fetters, and carried him to Babylon, and put him in prison until the day of his death. 
+</div><div class="p">
+<sup>12&#160;</sup>Now in the fifth month, in the tenth day of the month, which was the nineteenth year of King Nebuchadnezzar, king of Babylon, Nebuzaradan the captain of the guard, who stood before the king of Babylon, came into Jerusalem. 
+<sup>13&#160;</sup>He burned Yahweh’s house, and the king’s house; and all the houses of Jerusalem, even every great house, he burned with fire. 
+<sup>14&#160;</sup>All the army of the Chaldeans, who were with the captain of the guard, broke down all the walls of Jerusalem all around. 
+<sup>15&#160;</sup>Then Nebuzaradan the captain of the guard carried away captive of the poorest of the people, and the rest of the people who were left in the city, and those who fell away, who defected to the king of Babylon, and the rest of the multitude. 
+<sup>16&#160;</sup>But Nebuzaradan the captain of the guard left of the poorest of the land to be vineyard keepers and farmers. 
+</div><div class="p">
+<sup>17&#160;</sup>The Chaldeans broke the pillars of bronze that were in Yahweh’s house and the bases and the bronze sea that were in Yahweh’s house in pieces, and carried all of their bronze to Babylon. 
+<sup>18&#160;</sup>They also took away the pots, the shovels, the snuffers, the basins, the spoons, and all the vessels of bronze with which they ministered. 
+<sup>19&#160;</sup>The captain of the guard took away the cups, the fire pans, the basins, the pots, the lamp stands, the spoons, and the bowls; that which was of gold, as gold, and that which was of silver, as silver. 
+</div><div class="p">
+<sup>20&#160;</sup>They took the two pillars, the one sea, and the twelve bronze bulls that were under the bases, which King Solomon had made for Yahweh’s house. The bronze of all these vessels was without weight. 
+<sup>21&#160;</sup>As for the pillars, the height of the one pillar was eighteen cubits; and a line of twelve cubits encircled it; and its thickness was four fingers. It was hollow. 
+<sup>22&#160;</sup>A capital of bronze was on it; and the height of the one capital was five cubits, with network and pomegranates on the capital all around, all of bronze. The second pillar also had the same, with pomegranates. 
+<sup>23&#160;</sup>There were ninety-six pomegranates on the sides; all the pomegranates were one hundred on the network all around. 
+</div><div class="p">
+<sup>24&#160;</sup>The captain of the guard took Seraiah the chief priest, and Zephaniah the second priest, and the three keepers of the threshold, 
+<sup>25&#160;</sup>and out of the city he took an officer who was set over the men of war; and seven men of those who saw the king’s face, who were found in the city; and the scribe of the captain of the army, who mustered the people of the land; and sixty men of the people of the land, who were found in the middle of the city. 
+<sup>26&#160;</sup>Nebuzaradan the captain of the guard took them, and brought them to the king of Babylon to Riblah. 
+<sup>27&#160;</sup>The king of Babylon struck them, and put them to death at Riblah in the land of Hamath. 
+</div><div class="p">So Judah was carried away captive out of his land. 
+<sup>28&#160;</sup>This is the number of the people whom Nebuchadnezzar carried away captive: 
+</div><div class="m">in the seventh year, three thousand twenty-three Jews; 
+</div><div class="m">
+<sup>29&#160;</sup>in the eighteenth year of Nebuchadnezzar, he carried away captive from Jerusalem eight hundred thirty-two persons; 
+</div><div class="m">
+<sup>30&#160;</sup>in the twenty-third year of Nebuchadnezzar, Nebuzaradan the captain of the guard carried away captive of the Jews seven hundred forty-five people. 
+</div><div class="m">All the people numbered four thousand six hundred. 
+</div><div class="p">
+<sup>31&#160;</sup>In the thirty-seventh year of the captivity of Jehoiachin king of Judah, in the twelfth month, in the twenty-fifth day of the month, Evilmerodach king of Babylon, in the first year of his reign, lifted up the head of Jehoiachin king of Judah, and released him from prison. 
+<sup>32&#160;</sup>He spoke kindly to him, and set his throne above the throne of the kings who were with him in Babylon, 
+<sup>33&#160;</sup>and changed his prison garments. Jehoiachin ate bread before him continually all the days of his life. 
+<sup>34&#160;</sup>For his allowance, there was a continual allowance given him by the king of Babylon, every day a portion until the day of his death, all the days of his life. </div></div><script src="../main.js"></script></body></html>

--- a/book/job.html
+++ b/book/job.html
@@ -3,6 +3,47 @@
 <head>
 <title>Job</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,3400 +53,3443 @@
 <div class="main">
 <!-- JOB World English Scripture (WES) -->
 <h1 class="booklabel">Job</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>There was a man in the land of Uz, whose name was Job. That man was blameless and upright, and one who feared Elohim,<span class="f">+ \fr 1:1 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> and turned away from evil. 
-<span class="v">2&#160;</span>There were born to him seven sons and three daughters. 
-<span class="v">3&#160;</span>His possessions also were seven thousand sheep, three thousand camels, five hundred yoke of oxen, five hundred female donkeys, and a very great household; so that this man was the greatest of all the children of the east. 
-<span class="v">4&#160;</span>His sons went and held a feast in the house of each one on his birthday; and they sent and called for their three sisters to eat and to drink with them. 
-<span class="v">5&#160;</span>It was so, when the days of their feasting had run their course, that Job sent and sanctified them, and rose up early in the morning, and offered burnt offerings according to the number of them all. For Job said, “It may be that my sons have sinned, and renounced Elohim in their hearts.” Job did so continually. 
-</p><p>
-<span class="v">6&#160;</span>Now on the day when Elohim’s sons came to present themselves before Yahweh,<span class="f">+ \fr 1:6 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> Satan also came among them. 
-<span class="v">7&#160;</span>Yahweh said to Satan, “Where have you come from?” 
-</p><p>Then Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
-</p><p>
-<span class="v">8&#160;</span>Yahweh said to Satan, “Have you considered my servant, Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil.” 
-</p><p>
-<span class="v">9&#160;</span>Then Satan answered Yahweh, and said, “Does Job fear Elohim for nothing? 
-<span class="v">10&#160;</span>Haven’t you made a hedge around him, and around his house, and around all that he has, on every side? You have blessed the work of his hands, and his substance is increased in the land. 
-<span class="v">11&#160;</span>But stretch out your hand now, and touch all that he has, and he will renounce you to your face.” 
-</p><p>
-<span class="v">12&#160;</span>Yahweh said to Satan, “Behold,<span class="f">+ \fr 1:12 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> all that he has is in your power. Only on himself don’t stretch out your hand.” 
-</p><p>So Satan went out from the presence of Yahweh. 
-<span class="v">13&#160;</span>It fell on a day when his sons and his daughters were eating and drinking wine in their oldest brother’s house, 
-<span class="v">14&#160;</span>that a messenger came to Job, and said, “The oxen were plowing, and the donkeys feeding beside them, 
-<span class="v">15&#160;</span>and the Sabeans attacked, and took them away. Yes, they have killed the servants with the edge of the sword, and I alone have escaped to tell you.” 
-</p><p>
-<span class="v">16&#160;</span>While he was still speaking, another also came and said, “The fire of Elohim has fallen from the sky, and has burned up the sheep and the servants, and consumed them, and I alone have escaped to tell you.” 
-</p><p>
-<span class="v">17&#160;</span>While he was still speaking, another also came and said, “The Chaldeans made three bands, and swept down on the camels, and have taken them away, yes, and killed the servants with the edge of the sword; and I alone have escaped to tell you.” 
-</p><p>
-<span class="v">18&#160;</span>While he was still speaking, there came also another, and said, “Your sons and your daughters were eating and drinking wine in their oldest brother’s house, 
-<span class="v">19&#160;</span>and behold, there came a great wind from the wilderness, and struck the four corners of the house, and it fell on the young men, and they are dead. I alone have escaped to tell you.” 
-</p><p>
-<span class="v">20&#160;</span>Then Job arose, and tore his robe, and shaved his head, and fell down on the ground, and worshiped. 
-<span class="v">21&#160;</span>He said, “Naked I came out of my mother’s womb, and naked will I return there. Yahweh gave, and Yahweh has taken away. Blessed be Yahweh’s name.” 
-<span class="v">22&#160;</span>In all this, Job didn’t sin, nor charge Elohim with wrongdoing. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Again, on the day when Elohim’s sons came to present themselves before Yahweh, Satan came also among them to present himself before Yahweh. 
-<span class="v">2&#160;</span>Yahweh said to Satan, “Where have you come from?” 
-</p><p>Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
-</p><p>
-<span class="v">3&#160;</span>Yahweh said to Satan, “Have you considered my servant Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil. He still maintains his integrity, although you incited me against him, to ruin him without cause.” 
-</p><p>
-<span class="v">4&#160;</span>Satan answered Yahweh, and said, “Skin for skin. Yes, all that a man has he will give for his life. 
-<span class="v">5&#160;</span>But stretch out your hand now, and touch his bone and his flesh, and he will renounce you to your face.” 
-</p><p>
-<span class="v">6&#160;</span>Yahweh said to Satan, “Behold, he is in your hand. Only spare his life.” 
-</p><p>
-<span class="v">7&#160;</span>So Satan went out from the presence of Yahweh, and struck Job with painful sores from the sole of his foot to his head. 
-<span class="v">8&#160;</span>He took for himself a potsherd to scrape himself with, and he sat among the ashes. 
-<span class="v">9&#160;</span>Then his woman said to him, “Do you still maintain your integrity? Renounce Elohim, and die.” 
-</p><p>
-<span class="v">10&#160;</span>But he said to her, “You speak as one of the foolish women would speak. What? Shall we receive good at the hand of Elohim, and shall we not receive evil?” 
-</p><p>In all this Job didn’t sin with his lips. 
-<span class="v">11&#160;</span>Now when Job’s three friends heard of all this evil that had come on him, they each came from his own place: Eliphaz the Temanite, Bildad the Shuhite, and Zophar the Naamathite; and they made an appointment together to come to sympathize with him and to comfort him. 
-<span class="v">12&#160;</span>When they lifted up their eyes from a distance, and didn’t recognize him, they raised their voices, and wept; and they each tore his robe, and sprinkled dust on their heads toward the sky. 
-<span class="v">13&#160;</span>So they sat down with him on the ground seven days and seven nights, and no one spoke a word to him, for they saw that his grief was very great. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>After this Job opened his mouth, and cursed the day of his birth. 
-<span class="v">2&#160;</span>Job answered: 
-</p><p class="q1">
-<span class="v">3&#160;</span>“Let the day perish in which I was born, 
-</p><p class="q2">the night which said, ‘There is a boy conceived.’ 
-</p><p class="q1">
-<span class="v">4&#160;</span>Let that day be darkness. 
-</p><p class="q2">Don’t let Elohim from above seek for it, 
-</p><p class="q2">neither let the light shine on it. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let darkness and the shadow of death claim it for their own. 
-</p><p class="q2">Let a cloud dwell on it. 
-</p><p class="q2">Let all that makes the day black terrify it. 
-</p><p class="q1">
-<span class="v">6&#160;</span>As for that night, let thick darkness seize on it. 
-</p><p class="q2">Let it not rejoice among the days of the year. 
-</p><p class="q2">Let it not come into the number of the months. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Behold, let that night be barren. 
-</p><p class="q2">Let no joyful voice come therein. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let them curse it who curse the day, 
-</p><p class="q2">who are ready to rouse up leviathan. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Let the stars of its twilight be dark. 
-</p><p class="q2">Let it look for light, but have none, 
-</p><p class="q2">neither let it see the eyelids of the morning, 
-</p><p class="q1">
-<span class="v">10&#160;</span>because it didn’t shut up the doors of my mother’s womb, 
-</p><p class="q2">nor did it hide trouble from my eyes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Why didn’t I die from the womb? 
-</p><p class="q2">Why didn’t I give up the spirit when my mother bore me? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Why did the knees receive me? 
-</p><p class="q2">Or why the breast, that I should nurse? 
-</p><p class="q1">
-<span class="v">13&#160;</span>For now I should have lain down and been quiet. 
-</p><p class="q2">I should have slept, then I would have been at rest, 
-</p><p class="q1">
-<span class="v">14&#160;</span>with kings and counselors of the earth, 
-</p><p class="q2">who built up waste places for themselves; 
-</p><p class="q1">
-<span class="v">15&#160;</span>or with princes who had gold, 
-</p><p class="q2">who filled their houses with silver; 
-</p><p class="q1">
-<span class="v">16&#160;</span>or as a hidden untimely birth I had not been, 
-</p><p class="q2">as infants who never saw light. 
-</p><p class="q1">
-<span class="v">17&#160;</span>There the wicked cease from troubling. 
-</p><p class="q2">There the weary are at rest. 
-</p><p class="q1">
-<span class="v">18&#160;</span>There the prisoners are at ease together. 
-</p><p class="q2">They don’t hear the voice of the taskmaster. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The small and the great are there. 
-</p><p class="q2">The servant is free from his master. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Why is light given to him who is in misery, 
-</p><p class="q2">life to the bitter in soul, 
-</p><p class="q1">
-<span class="v">21&#160;</span>who long for death, but it doesn’t come; 
-</p><p class="q2">and dig for it more than for hidden treasures, 
-</p><p class="q1">
-<span class="v">22&#160;</span>who rejoice exceedingly, 
-</p><p class="q2">and are glad, when they can find the grave? 
-</p><p class="q1">
-<span class="v">23&#160;</span>Why is light given to a man whose way is hidden, 
-</p><p class="q2">whom Elohim has hedged in? 
-</p><p class="q1">
-<span class="v">24&#160;</span>For my sighing comes before I eat. 
-</p><p class="q2">My groanings are poured out like water. 
-</p><p class="q1">
-<span class="v">25&#160;</span>For the thing which I fear comes on me, 
-</p><p class="q2">that which I am afraid of comes to me. 
-</p><p class="q1">
-<span class="v">26&#160;</span>I am not at ease, neither am I quiet, neither do I have rest; 
-</p><p class="q2">but trouble comes.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Then Eliphaz the Temanite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“If someone ventures to talk with you, will you be grieved? 
-</p><p class="q2">But who can withhold himself from speaking? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Behold, you have instructed many, 
-</p><p class="q2">you have strengthened the weak hands. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Your words have supported him who was falling, 
-</p><p class="q2">you have made the feeble knees firm. 
-</p><p class="q1">
-<span class="v">5&#160;</span>But now it has come to you, and you faint. 
-</p><p class="q2">It touches you, and you are troubled. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Isn’t your piety your confidence? 
-</p><p class="q2">Isn’t the integrity of your ways your hope? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Remember, now, whoever perished, being innocent? 
-</p><p class="q2">Or where were the upright cut off? 
-</p><p class="q1">
-<span class="v">8&#160;</span>According to what I have seen, those who plow iniquity 
-</p><p class="q2">and sow trouble, reap the same. 
-</p><p class="q1">
-<span class="v">9&#160;</span>By the breath of Elohim they perish. 
-</p><p class="q2">By the blast of his anger are they consumed. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The roaring of the lion, 
-</p><p class="q2">and the voice of the fierce lion, 
-</p><p class="q2">the teeth of the young lions, are broken. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The old lion perishes for lack of prey. 
-</p><p class="q2">The cubs of the lioness are scattered abroad. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Now a thing was secretly brought to me. 
-</p><p class="q2">My ear received a whisper of it. 
-</p><p class="q1">
-<span class="v">13&#160;</span>In thoughts from the visions of the night, 
-</p><p class="q2">when deep sleep falls on men, 
-</p><p class="q1">
-<span class="v">14&#160;</span>fear came on me, and trembling, 
-</p><p class="q2">which made all my bones shake. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Then a spirit passed before my face. 
-</p><p class="q2">The hair of my flesh stood up. 
-</p><p class="q1">
-<span class="v">16&#160;</span>It stood still, but I couldn’t discern its appearance. 
-</p><p class="q2">A form was before my eyes. 
-</p><p class="q2">Silence, then I heard a voice, saying, 
-</p><p class="q1">
-<span class="v">17&#160;</span>‘Shall mortal man be more just than Elohim? 
-</p><p class="q2">Shall a man be more pure than his Maker? 
-</p><p class="q1">
-<span class="v">18&#160;</span>Behold, he puts no trust in his servants. 
-</p><p class="q2">He charges his angels with error. 
-</p><p class="q1">
-<span class="v">19&#160;</span>How much more those who dwell in houses of clay, 
-</p><p class="q2">whose foundation is in the dust, 
-</p><p class="q2">who are crushed before the moth! 
-</p><p class="q1">
-<span class="v">20&#160;</span>Between morning and evening they are destroyed. 
-</p><p class="q2">They perish forever without any regarding it. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Isn’t their tent cord plucked up within them? 
-</p><p class="q2">They die, and that without wisdom.’ 
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+<a href="#41">41</a>
+<a href="#42">42</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>There was a man in the land of Uz, whose name was Job. That man was blameless and upright, and one who feared Elohim, and turned away from evil. 
+<sup>2&#160;</sup>There were born to him seven sons and three daughters. 
+<sup>3&#160;</sup>His possessions also were seven thousand sheep, three thousand camels, five hundred yoke of oxen, five hundred female donkeys, and a very great household; so that this man was the greatest of all the children of the east. 
+<sup>4&#160;</sup>His sons went and held a feast in the house of each one on his birthday; and they sent and called for their three sisters to eat and to drink with them. 
+<sup>5&#160;</sup>It was so, when the days of their feasting had run their course, that Job sent and sanctified them, and rose up early in the morning, and offered burnt offerings according to the number of them all. For Job said, “It may be that my sons have sinned, and renounced Elohim in their hearts.” Job did so continually. 
+</div><div class="p">
+<sup>6&#160;</sup>Now on the day when Elohim’s sons came to present themselves before Yahweh, Satan also came among them. 
+<sup>7&#160;</sup>Yahweh said to Satan, “Where have you come from?” 
+</div><div class="p">Then Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh said to Satan, “Have you considered my servant, Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil.” 
+</div><div class="p">
+<sup>9&#160;</sup>Then Satan answered Yahweh, and said, “Does Job fear Elohim for nothing? 
+<sup>10&#160;</sup>Haven’t you made a hedge around him, and around his house, and around all that he has, on every side? You have blessed the work of his hands, and his substance is increased in the land. 
+<sup>11&#160;</sup>But stretch out your hand now, and touch all that he has, and he will renounce you to your face.” 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh said to Satan, “Behold, all that he has is in your power. Only on himself don’t stretch out your hand.” 
+</div><div class="p">So Satan went out from the presence of Yahweh. 
+<sup>13&#160;</sup>It fell on a day when his sons and his daughters were eating and drinking wine in their oldest brother’s house, 
+<sup>14&#160;</sup>that a messenger came to Job, and said, “The oxen were plowing, and the donkeys feeding beside them, 
+<sup>15&#160;</sup>and the Sabeans attacked, and took them away. Yes, they have killed the servants with the edge of the sword, and I alone have escaped to tell you.” 
+</div><div class="p">
+<sup>16&#160;</sup>While he was still speaking, another also came and said, “The fire of Elohim has fallen from the sky, and has burned up the sheep and the servants, and consumed them, and I alone have escaped to tell you.” 
+</div><div class="p">
+<sup>17&#160;</sup>While he was still speaking, another also came and said, “The Chaldeans made three bands, and swept down on the camels, and have taken them away, yes, and killed the servants with the edge of the sword; and I alone have escaped to tell you.” 
+</div><div class="p">
+<sup>18&#160;</sup>While he was still speaking, there came also another, and said, “Your sons and your daughters were eating and drinking wine in their oldest brother’s house, 
+<sup>19&#160;</sup>and behold, there came a great wind from the wilderness, and struck the four corners of the house, and it fell on the young men, and they are dead. I alone have escaped to tell you.” 
+</div><div class="p">
+<sup>20&#160;</sup>Then Job arose, and tore his robe, and shaved his head, and fell down on the ground, and worshiped. 
+<sup>21&#160;</sup>He said, “Naked I came out of my mother’s womb, and naked will I return there. Yahweh gave, and Yahweh has taken away. Blessed be Yahweh’s name.” 
+<sup>22&#160;</sup>In all this, Job didn’t sin, nor charge Elohim with wrongdoing. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Again, on the day when Elohim’s sons came to present themselves before Yahweh, Satan came also among them to present himself before Yahweh. 
+<sup>2&#160;</sup>Yahweh said to Satan, “Where have you come from?” 
+</div><div class="p">Satan answered Yahweh, and said, “From going back and forth in the earth, and from walking up and down in it.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh said to Satan, “Have you considered my servant Job? For there is no one like him in the earth, a blameless and an upright man, one who fears Elohim, and turns away from evil. He still maintains his integrity, although you incited me against him, to ruin him without cause.” 
+</div><div class="p">
+<sup>4&#160;</sup>Satan answered Yahweh, and said, “Skin for skin. Yes, all that a man has he will give for his life. 
+<sup>5&#160;</sup>But stretch out your hand now, and touch his bone and his flesh, and he will renounce you to your face.” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh said to Satan, “Behold, he is in your hand. Only spare his life.” 
+</div><div class="p">
+<sup>7&#160;</sup>So Satan went out from the presence of Yahweh, and struck Job with painful sores from the sole of his foot to his head. 
+<sup>8&#160;</sup>He took for himself a potsherd to scrape himself with, and he sat among the ashes. 
+<sup>9&#160;</sup>Then his woman said to him, “Do you still maintain your integrity? Renounce Elohim, and die.” 
+</div><div class="p">
+<sup>10&#160;</sup>But he said to her, “You speak as one of the foolish women would speak. What? Shall we receive good at the hand of Elohim, and shall we not receive evil?” 
+</div><div class="p">In all this Job didn’t sin with his lips. 
+<sup>11&#160;</sup>Now when Job’s three friends heard of all this evil that had come on him, they each came from his own place: Eliphaz the Temanite, Bildad the Shuhite, and Zophar the Naamathite; and they made an appointment together to come to sympathize with him and to comfort him. 
+<sup>12&#160;</sup>When they lifted up their eyes from a distance, and didn’t recognize him, they raised their voices, and wept; and they each tore his robe, and sprinkled dust on their heads toward the sky. 
+<sup>13&#160;</sup>So they sat down with him on the ground seven days and seven nights, and no one spoke a word to him, for they saw that his grief was very great. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>After this Job opened his mouth, and cursed the day of his birth. 
+<sup>2&#160;</sup>Job answered: 
+</div><div class="q1">
+<sup>3&#160;</sup>“Let the day perish in which I was born, 
+</div><div class="q2">the night which said, ‘There is a boy conceived.’ 
+</div><div class="q1">
+<sup>4&#160;</sup>Let that day be darkness. 
+</div><div class="q2">Don’t let Elohim from above seek for it, 
+</div><div class="q2">neither let the light shine on it. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let darkness and the shadow of death claim it for their own. 
+</div><div class="q2">Let a cloud dwell on it. 
+</div><div class="q2">Let all that makes the day black terrify it. 
+</div><div class="q1">
+<sup>6&#160;</sup>As for that night, let thick darkness seize on it. 
+</div><div class="q2">Let it not rejoice among the days of the year. 
+</div><div class="q2">Let it not come into the number of the months. 
+</div><div class="q1">
+<sup>7&#160;</sup>Behold, let that night be barren. 
+</div><div class="q2">Let no joyful voice come therein. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let them curse it who curse the day, 
+</div><div class="q2">who are ready to rouse up leviathan. 
+</div><div class="q1">
+<sup>9&#160;</sup>Let the stars of its twilight be dark. 
+</div><div class="q2">Let it look for light, but have none, 
+</div><div class="q2">neither let it see the eyelids of the morning, 
+</div><div class="q1">
+<sup>10&#160;</sup>because it didn’t shut up the doors of my mother’s womb, 
+</div><div class="q2">nor did it hide trouble from my eyes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Why didn’t I die from the womb? 
+</div><div class="q2">Why didn’t I give up the spirit when my mother bore me? 
+</div><div class="q1">
+<sup>12&#160;</sup>Why did the knees receive me? 
+</div><div class="q2">Or why the breast, that I should nurse? 
+</div><div class="q1">
+<sup>13&#160;</sup>For now I should have lain down and been quiet. 
+</div><div class="q2">I should have slept, then I would have been at rest, 
+</div><div class="q1">
+<sup>14&#160;</sup>with kings and counselors of the earth, 
+</div><div class="q2">who built up waste places for themselves; 
+</div><div class="q1">
+<sup>15&#160;</sup>or with princes who had gold, 
+</div><div class="q2">who filled their houses with silver; 
+</div><div class="q1">
+<sup>16&#160;</sup>or as a hidden untimely birth I had not been, 
+</div><div class="q2">as infants who never saw light. 
+</div><div class="q1">
+<sup>17&#160;</sup>There the wicked cease from troubling. 
+</div><div class="q2">There the weary are at rest. 
+</div><div class="q1">
+<sup>18&#160;</sup>There the prisoners are at ease together. 
+</div><div class="q2">They don’t hear the voice of the taskmaster. 
+</div><div class="q1">
+<sup>19&#160;</sup>The small and the great are there. 
+</div><div class="q2">The servant is free from his master. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Why is light given to him who is in misery, 
+</div><div class="q2">life to the bitter in soul, 
+</div><div class="q1">
+<sup>21&#160;</sup>who long for death, but it doesn’t come; 
+</div><div class="q2">and dig for it more than for hidden treasures, 
+</div><div class="q1">
+<sup>22&#160;</sup>who rejoice exceedingly, 
+</div><div class="q2">and are glad, when they can find the grave? 
+</div><div class="q1">
+<sup>23&#160;</sup>Why is light given to a man whose way is hidden, 
+</div><div class="q2">whom Elohim has hedged in? 
+</div><div class="q1">
+<sup>24&#160;</sup>For my sighing comes before I eat. 
+</div><div class="q2">My groanings are poured out like water. 
+</div><div class="q1">
+<sup>25&#160;</sup>For the thing which I fear comes on me, 
+</div><div class="q2">that which I am afraid of comes to me. 
+</div><div class="q1">
+<sup>26&#160;</sup>I am not at ease, neither am I quiet, neither do I have rest; 
+</div><div class="q2">but trouble comes.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Eliphaz the Temanite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“If someone ventures to talk with you, will you be grieved? 
+</div><div class="q2">But who can withhold himself from speaking? 
+</div><div class="q1">
+<sup>3&#160;</sup>Behold, you have instructed many, 
+</div><div class="q2">you have strengthened the weak hands. 
+</div><div class="q1">
+<sup>4&#160;</sup>Your words have supported him who was falling, 
+</div><div class="q2">you have made the feeble knees firm. 
+</div><div class="q1">
+<sup>5&#160;</sup>But now it has come to you, and you faint. 
+</div><div class="q2">It touches you, and you are troubled. 
+</div><div class="q1">
+<sup>6&#160;</sup>Isn’t your piety your confidence? 
+</div><div class="q2">Isn’t the integrity of your ways your hope? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Remember, now, whoever perished, being innocent? 
+</div><div class="q2">Or where were the upright cut off? 
+</div><div class="q1">
+<sup>8&#160;</sup>According to what I have seen, those who plow iniquity 
+</div><div class="q2">and sow trouble, reap the same. 
+</div><div class="q1">
+<sup>9&#160;</sup>By the breath of Elohim they perish. 
+</div><div class="q2">By the blast of his anger are they consumed. 
+</div><div class="q1">
+<sup>10&#160;</sup>The roaring of the lion, 
+</div><div class="q2">and the voice of the fierce lion, 
+</div><div class="q2">the teeth of the young lions, are broken. 
+</div><div class="q1">
+<sup>11&#160;</sup>The old lion perishes for lack of prey. 
+</div><div class="q2">The cubs of the lioness are scattered abroad. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Now a thing was secretly brought to me. 
+</div><div class="q2">My ear received a whisper of it. 
+</div><div class="q1">
+<sup>13&#160;</sup>In thoughts from the visions of the night, 
+</div><div class="q2">when deep sleep falls on men, 
+</div><div class="q1">
+<sup>14&#160;</sup>fear came on me, and trembling, 
+</div><div class="q2">which made all my bones shake. 
+</div><div class="q1">
+<sup>15&#160;</sup>Then a spirit passed before my face. 
+</div><div class="q2">The hair of my flesh stood up. 
+</div><div class="q1">
+<sup>16&#160;</sup>It stood still, but I couldn’t discern its appearance. 
+</div><div class="q2">A form was before my eyes. 
+</div><div class="q2">Silence, then I heard a voice, saying, 
+</div><div class="q1">
+<sup>17&#160;</sup>‘Shall mortal man be more just than Elohim? 
+</div><div class="q2">Shall a man be more pure than his Maker? 
+</div><div class="q1">
+<sup>18&#160;</sup>Behold, he puts no trust in his servants. 
+</div><div class="q2">He charges his angels with error. 
+</div><div class="q1">
+<sup>19&#160;</sup>How much more those who dwell in houses of clay, 
+</div><div class="q2">whose foundation is in the dust, 
+</div><div class="q2">who are crushed before the moth! 
+</div><div class="q1">
+<sup>20&#160;</sup>Between morning and evening they are destroyed. 
+</div><div class="q2">They perish forever without any regarding it. 
+</div><div class="q1">
+<sup>21&#160;</sup>Isn’t their tent cord plucked up within them? 
+</div><div class="q2">They die, and that without wisdom.’ 
 <h2 class="chapterlabel" id="5">5</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Call now; is there any who will answer you? 
-</p><p class="q2">To which of the set-apart ones will you turn? 
-</p><p class="q1">
-<span class="v">2&#160;</span>For resentment kills the foolish man, 
-</p><p class="q2">and jealousy kills the simple. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I have seen the foolish taking root, 
-</p><p class="q2">but suddenly I cursed his habitation. 
-</p><p class="q1">
-<span class="v">4&#160;</span>His children are far from safety. 
-</p><p class="q2">They are crushed in the gate. 
-</p><p class="q2">Neither is there any to deliver them, 
-</p><p class="q1">
-<span class="v">5&#160;</span>whose harvest the hungry eat up, 
-</p><p class="q2">and take it even out of the thorns. 
-</p><p class="q2">The snare gapes for their substance. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For affliction doesn’t come out of the dust, 
-</p><p class="q2">neither does trouble spring out of the ground; 
-</p><p class="q1">
-<span class="v">7&#160;</span>but man is born to trouble, 
-</p><p class="q2">as the sparks fly upward. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“But as for me, I would seek Elohim. 
-</p><p class="q2">I would commit my cause to Elohim, 
-</p><p class="q1">
-<span class="v">9&#160;</span>who does great things that can’t be fathomed, 
-</p><p class="q2">marvelous things without number; 
-</p><p class="q1">
-<span class="v">10&#160;</span>who gives rain on the earth, 
-</p><p class="q2">and sends waters on the fields; 
-</p><p class="q1">
-<span class="v">11&#160;</span>so that he sets up on high those who are low, 
-</p><p class="q2">those who mourn are exalted to safety. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He frustrates the plans of the crafty, 
-</p><p class="q2">so that their hands can’t perform their enterprise. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He takes the wise in their own craftiness; 
-</p><p class="q2">the counsel of the cunning is carried headlong. 
-</p><p class="q1">
-<span class="v">14&#160;</span>They meet with darkness in the day time, 
-</p><p class="q2">and grope at noonday as in the night. 
-</p><p class="q1">
-<span class="v">15&#160;</span>But he saves from the sword of their mouth, 
-</p><p class="q2">even the needy from the hand of the mighty. 
-</p><p class="q1">
-<span class="v">16&#160;</span>So the poor has hope, 
-</p><p class="q2">and injustice shuts her mouth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“Behold, happy is the man whom Elohim corrects. 
-</p><p class="q2">Therefore do not despise the chastening of the Almighty. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For he wounds and binds up. 
-</p><p class="q2">He injures and his hands make whole. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He will deliver you in six troubles; 
-</p><p class="q2">yes, in seven no evil will touch you. 
-</p><p class="q1">
-<span class="v">20&#160;</span>In famine he will redeem you from death; 
-</p><p class="q2">in war, from the power of the sword. 
-</p><p class="q1">
-<span class="v">21&#160;</span>You will be hidden from the scourge of the tongue, 
-</p><p class="q2">neither will you be afraid of destruction when it comes. 
-</p><p class="q1">
-<span class="v">22&#160;</span>You will laugh at destruction and famine, 
-</p><p class="q2">neither will you be afraid of the animals of the earth. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For you will be allied with the stones of the field. 
-</p><p class="q2">The animals of the field will be at peace with you. 
-</p><p class="q1">
-<span class="v">24&#160;</span>You will know that your tent is in peace. 
-</p><p class="q2">You will visit your fold, and will miss nothing. 
-</p><p class="q1">
-<span class="v">25&#160;</span>You will know also that your offspring<span class="f">+ \fr 5:25 \ft or, seed</span> will be great, 
-</p><p class="q2">your offspring as the grass of the earth. 
-</p><p class="q1">
-<span class="v">26&#160;</span>You will come to your grave in a full age, 
-</p><p class="q2">like a shock of grain comes in its season. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Behold, we have researched it. It is so. 
-</p><p class="q2">Hear it, and know it for your good.” 
-</p><div class="b"> &#160; </div>
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Call now; is there any who will answer you? 
+</div><div class="q2">To which of the set-apart ones will you turn? 
+</div><div class="q1">
+<sup>2&#160;</sup>For resentment kills the foolish man, 
+</div><div class="q2">and jealousy kills the simple. 
+</div><div class="q1">
+<sup>3&#160;</sup>I have seen the foolish taking root, 
+</div><div class="q2">but suddenly I cursed his habitation. 
+</div><div class="q1">
+<sup>4&#160;</sup>His children are far from safety. 
+</div><div class="q2">They are crushed in the gate. 
+</div><div class="q2">Neither is there any to deliver them, 
+</div><div class="q1">
+<sup>5&#160;</sup>whose harvest the hungry eat up, 
+</div><div class="q2">and take it even out of the thorns. 
+</div><div class="q2">The snare gapes for their substance. 
+</div><div class="q1">
+<sup>6&#160;</sup>For affliction doesn’t come out of the dust, 
+</div><div class="q2">neither does trouble spring out of the ground; 
+</div><div class="q1">
+<sup>7&#160;</sup>but man is born to trouble, 
+</div><div class="q2">as the sparks fly upward. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“But as for me, I would seek Elohim. 
+</div><div class="q2">I would commit my cause to Elohim, 
+</div><div class="q1">
+<sup>9&#160;</sup>who does great things that can’t be fathomed, 
+</div><div class="q2">marvelous things without number; 
+</div><div class="q1">
+<sup>10&#160;</sup>who gives rain on the earth, 
+</div><div class="q2">and sends waters on the fields; 
+</div><div class="q1">
+<sup>11&#160;</sup>so that he sets up on high those who are low, 
+</div><div class="q2">those who mourn are exalted to safety. 
+</div><div class="q1">
+<sup>12&#160;</sup>He frustrates the plans of the crafty, 
+</div><div class="q2">so that their hands can’t perform their enterprise. 
+</div><div class="q1">
+<sup>13&#160;</sup>He takes the wise in their own craftiness; 
+</div><div class="q2">the counsel of the cunning is carried headlong. 
+</div><div class="q1">
+<sup>14&#160;</sup>They meet with darkness in the day time, 
+</div><div class="q2">and grope at noonday as in the night. 
+</div><div class="q1">
+<sup>15&#160;</sup>But he saves from the sword of their mouth, 
+</div><div class="q2">even the needy from the hand of the mighty. 
+</div><div class="q1">
+<sup>16&#160;</sup>So the poor has hope, 
+</div><div class="q2">and injustice shuts her mouth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“Behold, happy is the man whom Elohim corrects. 
+</div><div class="q2">Therefore do not despise the chastening of the Almighty. 
+</div><div class="q1">
+<sup>18&#160;</sup>For he wounds and binds up. 
+</div><div class="q2">He injures and his hands make whole. 
+</div><div class="q1">
+<sup>19&#160;</sup>He will deliver you in six troubles; 
+</div><div class="q2">yes, in seven no evil will touch you. 
+</div><div class="q1">
+<sup>20&#160;</sup>In famine he will redeem you from death; 
+</div><div class="q2">in war, from the power of the sword. 
+</div><div class="q1">
+<sup>21&#160;</sup>You will be hidden from the scourge of the tongue, 
+</div><div class="q2">neither will you be afraid of destruction when it comes. 
+</div><div class="q1">
+<sup>22&#160;</sup>You will laugh at destruction and famine, 
+</div><div class="q2">neither will you be afraid of the animals of the earth. 
+</div><div class="q1">
+<sup>23&#160;</sup>For you will be allied with the stones of the field. 
+</div><div class="q2">The animals of the field will be at peace with you. 
+</div><div class="q1">
+<sup>24&#160;</sup>You will know that your tent is in peace. 
+</div><div class="q2">You will visit your fold, and will miss nothing. 
+</div><div class="q1">
+<sup>25&#160;</sup>You will know also that your offspring will be great, 
+</div><div class="q2">your offspring as the grass of the earth. 
+</div><div class="q1">
+<sup>26&#160;</sup>You will come to your grave in a full age, 
+</div><div class="q2">like a shock of grain comes in its season. 
+</div><div class="q1">
+<sup>27&#160;</sup>Behold, we have researched it. It is so. 
+</div><div class="q2">Hear it, and know it for your good.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Oh that my anguish were weighed, 
-</p><p class="q2">and all my calamity laid in the balances! 
-</p><p class="q1">
-<span class="v">3&#160;</span>For now it would be heavier than the sand of the seas, 
-</p><p class="q2">therefore my words have been rash. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For the arrows of the Almighty are within me. 
-</p><p class="q2">My spirit drinks up their poison. 
-</p><p class="q1">The terrors of Elohim set themselves in array against me. 
-</p><p class="q2">
-<span class="v">5&#160;</span>Does the wild donkey bray when he has grass? 
-</p><p class="q1">Or does the ox low over his fodder? 
-</p><p class="q2">
-<span class="v">6&#160;</span>Can that which has no flavor be eaten without salt? 
-</p><p class="q1">Or is there any taste in the white of an egg? 
-</p><p class="q2">
-<span class="v">7&#160;</span>My soul refuses to touch them. 
-</p><p class="q1">They are as loathsome food to me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Oh that I might have my request, 
-</p><p class="q2">that Elohim would grant the thing that I long for, 
-</p><p class="q1">
-<span class="v">9&#160;</span>even that it would please Elohim to crush me; 
-</p><p class="q2">that he would let loose his hand, and cut me off! 
-</p><p class="q1">
-<span class="v">10&#160;</span>Let it still be my consolation, 
-</p><p class="q2">yes, let me exult in pain that doesn’t spare, 
-</p><p class="q2">that I have not denied the words of the Set-Apart One. 
-</p><p class="q1">
-<span class="v">11&#160;</span>What is my strength, that I should wait? 
-</p><p class="q2">What is my end, that I should be patient? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Is my strength the strength of stones? 
-</p><p class="q2">Or is my flesh of bronze? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Isn’t it that I have no help in me, 
-</p><p class="q2">that wisdom is driven away from me? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“To him who is ready to faint, kindness should be shown from his friend; 
-</p><p class="q2">even to him who forsakes the fear of the Almighty. 
-</p><p class="q1">
-<span class="v">15&#160;</span>My brothers have dealt deceitfully as a brook, 
-</p><p class="q2">as the channel of brooks that pass away; 
-</p><p class="q1">
-<span class="v">16&#160;</span>which are black by reason of the ice, 
-</p><p class="q2">in which the snow hides itself. 
-</p><p class="q1">
-<span class="v">17&#160;</span>In the dry season, they vanish. 
-</p><p class="q2">When it is hot, they are consumed out of their place. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The caravans that travel beside them turn away. 
-</p><p class="q2">They go up into the waste, and perish. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The caravans of Tema looked. 
-</p><p class="q2">The companies of Sheba waited for them. 
-</p><p class="q1">
-<span class="v">20&#160;</span>They were distressed because they were confident. 
-</p><p class="q2">They came there, and were confounded. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For now you are nothing. 
-</p><p class="q2">You see a terror, and are afraid. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Did I ever say, ‘Give to me’? 
-</p><p class="q2">or, ‘Offer a present for me from your substance’? 
-</p><p class="q1">
-<span class="v">23&#160;</span>or, ‘Deliver me from the adversary’s hand’? 
-</p><p class="q2">or, ‘Redeem me from the hand of the oppressors’? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>“Teach me, and I will hold my peace. 
-</p><p class="q2">Cause me to understand my error. 
-</p><p class="q1">
-<span class="v">25&#160;</span>How forcible are words of uprightness! 
-</p><p class="q2">But your reproof, what does it reprove? 
-</p><p class="q1">
-<span class="v">26&#160;</span>Do you intend to reprove words, 
-</p><p class="q2">since the speeches of one who is desperate are as wind? 
-</p><p class="q1">
-<span class="v">27&#160;</span>Yes, you would even cast lots for the fatherless, 
-</p><p class="q2">and make merchandise of your friend. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Now therefore be pleased to look at me, 
-</p><p class="q2">for surely I will not lie to your face. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Please return. 
-</p><p class="q2">Let there be no injustice. 
-</p><p class="q2">Yes, return again. 
-</p><p class="q2">My cause is righteous. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Is there injustice on my tongue? 
-</p><p class="q2">Can’t my taste discern mischievous things? 
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Oh that my anguish were weighed, 
+</div><div class="q2">and all my calamity laid in the balances! 
+</div><div class="q1">
+<sup>3&#160;</sup>For now it would be heavier than the sand of the seas, 
+</div><div class="q2">therefore my words have been rash. 
+</div><div class="q1">
+<sup>4&#160;</sup>For the arrows of the Almighty are within me. 
+</div><div class="q2">My spirit drinks up their poison. 
+</div><div class="q1">The terrors of Elohim set themselves in array against me. 
+</div><div class="q2">
+<sup>5&#160;</sup>Does the wild donkey bray when he has grass? 
+</div><div class="q1">Or does the ox low over his fodder? 
+</div><div class="q2">
+<sup>6&#160;</sup>Can that which has no flavor be eaten without salt? 
+</div><div class="q1">Or is there any taste in the white of an egg? 
+</div><div class="q2">
+<sup>7&#160;</sup>My soul refuses to touch them. 
+</div><div class="q1">They are as loathsome food to me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Oh that I might have my request, 
+</div><div class="q2">that Elohim would grant the thing that I long for, 
+</div><div class="q1">
+<sup>9&#160;</sup>even that it would please Elohim to crush me; 
+</div><div class="q2">that he would let loose his hand, and cut me off! 
+</div><div class="q1">
+<sup>10&#160;</sup>Let it still be my consolation, 
+</div><div class="q2">yes, let me exult in pain that doesn’t spare, 
+</div><div class="q2">that I have not denied the words of the Set-Apart One. 
+</div><div class="q1">
+<sup>11&#160;</sup>What is my strength, that I should wait? 
+</div><div class="q2">What is my end, that I should be patient? 
+</div><div class="q1">
+<sup>12&#160;</sup>Is my strength the strength of stones? 
+</div><div class="q2">Or is my flesh of bronze? 
+</div><div class="q1">
+<sup>13&#160;</sup>Isn’t it that I have no help in me, 
+</div><div class="q2">that wisdom is driven away from me? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“To him who is ready to faint, kindness should be shown from his friend; 
+</div><div class="q2">even to him who forsakes the fear of the Almighty. 
+</div><div class="q1">
+<sup>15&#160;</sup>My brothers have dealt deceitfully as a brook, 
+</div><div class="q2">as the channel of brooks that pass away; 
+</div><div class="q1">
+<sup>16&#160;</sup>which are black by reason of the ice, 
+</div><div class="q2">in which the snow hides itself. 
+</div><div class="q1">
+<sup>17&#160;</sup>In the dry season, they vanish. 
+</div><div class="q2">When it is hot, they are consumed out of their place. 
+</div><div class="q1">
+<sup>18&#160;</sup>The caravans that travel beside them turn away. 
+</div><div class="q2">They go up into the waste, and perish. 
+</div><div class="q1">
+<sup>19&#160;</sup>The caravans of Tema looked. 
+</div><div class="q2">The companies of Sheba waited for them. 
+</div><div class="q1">
+<sup>20&#160;</sup>They were distressed because they were confident. 
+</div><div class="q2">They came there, and were confounded. 
+</div><div class="q1">
+<sup>21&#160;</sup>For now you are nothing. 
+</div><div class="q2">You see a terror, and are afraid. 
+</div><div class="q1">
+<sup>22&#160;</sup>Did I ever say, ‘Give to me’? 
+</div><div class="q2">or, ‘Offer a present for me from your substance’? 
+</div><div class="q1">
+<sup>23&#160;</sup>or, ‘Deliver me from the adversary’s hand’? 
+</div><div class="q2">or, ‘Redeem me from the hand of the oppressors’? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>“Teach me, and I will hold my peace. 
+</div><div class="q2">Cause me to understand my error. 
+</div><div class="q1">
+<sup>25&#160;</sup>How forcible are words of uprightness! 
+</div><div class="q2">But your reproof, what does it reprove? 
+</div><div class="q1">
+<sup>26&#160;</sup>Do you intend to reprove words, 
+</div><div class="q2">since the speeches of one who is desperate are as wind? 
+</div><div class="q1">
+<sup>27&#160;</sup>Yes, you would even cast lots for the fatherless, 
+</div><div class="q2">and make merchandise of your friend. 
+</div><div class="q1">
+<sup>28&#160;</sup>Now therefore be pleased to look at me, 
+</div><div class="q2">for surely I will not lie to your face. 
+</div><div class="q1">
+<sup>29&#160;</sup>Please return. 
+</div><div class="q2">Let there be no injustice. 
+</div><div class="q2">Yes, return again. 
+</div><div class="q2">My cause is righteous. 
+</div><div class="q1">
+<sup>30&#160;</sup>Is there injustice on my tongue? 
+</div><div class="q2">Can’t my taste discern mischievous things? 
 <h2 class="chapterlabel" id="7">7</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Isn’t a man forced to labor on earth? 
-</p><p class="q2">Aren’t his days like the days of a hired hand? 
-</p><p class="q1">
-<span class="v">2&#160;</span>As a servant who earnestly desires the shadow, 
-</p><p class="q2">as a hireling who looks for his wages, 
-</p><p class="q1">
-<span class="v">3&#160;</span>so I am made to possess months of misery, 
-</p><p class="q2">wearisome nights are appointed to me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>When I lie down, I say, 
-</p><p class="q2">‘When will I arise, and the night be gone?’ 
-</p><p class="q2">I toss and turn until the dawning of the day. 
-</p><p class="q1">
-<span class="v">5&#160;</span>My flesh is clothed with worms and clods of dust. 
-</p><p class="q2">My skin closes up, and breaks out afresh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>My days are swifter than a weaver’s shuttle, 
-</p><p class="q2">and are spent without hope. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Oh remember that my life is a breath. 
-</p><p class="q2">My eye will no more see good. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The eye of him who sees me will see me no more. 
-</p><p class="q2">Your eyes will be on me, but I will not be. 
-</p><p class="q1">
-<span class="v">9&#160;</span>As the cloud is consumed and vanishes away, 
-</p><p class="q2">so he who goes down to Sheol<span class="f">+ \fr 7:9 \ft Sheol is the place of the dead.</span> will come up no more. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He will return no more to his house, 
-</p><p class="q2">neither will his place know him any more. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Therefore I will not keep silent. 
-</p><p class="q2">I will speak in the anguish of my spirit. 
-</p><p class="q2">I will complain in the bitterness of my soul. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Am I a sea, or a sea monster, 
-</p><p class="q2">that you put a guard over me? 
-</p><p class="q1">
-<span class="v">13&#160;</span>When I say, ‘My bed will comfort me. 
-</p><p class="q2">My couch will ease my complaint,’ 
-</p><p class="q1">
-<span class="v">14&#160;</span>then you scare me with dreams 
-</p><p class="q2">and terrify me through visions, 
-</p><p class="q1">
-<span class="v">15&#160;</span>so that my soul chooses strangling, 
-</p><p class="q2">death rather than my bones. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I loathe my life. 
-</p><p class="q2">I don’t want to live forever. 
-</p><p class="q2">Leave me alone, for my days are but a breath. 
-</p><p class="q1">
-<span class="v">17&#160;</span>What is man, that you should magnify him, 
-</p><p class="q2">that you should set your mind on him, 
-</p><p class="q1">
-<span class="v">18&#160;</span>that you should visit him every morning, 
-</p><p class="q2">and test him every moment? 
-</p><p class="q1">
-<span class="v">19&#160;</span>How long will you not look away from me, 
-</p><p class="q2">nor leave me alone until I swallow down my spittle? 
-</p><p class="q1">
-<span class="v">20&#160;</span>If I have sinned, what do I do to you, you watcher of men? 
-</p><p class="q2">Why have you set me as a mark for you, 
-</p><p class="q2">so that I am a burden to myself? 
-</p><p class="q1">
-<span class="v">21&#160;</span>Why do you not pardon my disobedience, and take away my iniquity? 
-</p><p class="q2">For now will I lie down in the dust. 
-</p><p class="q2">You will seek me diligently, but I will not be.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Then Bildad the Shuhite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“How long will you speak these things? 
-</p><p class="q2">Shall the words of your mouth be a mighty wind? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Does Elohim pervert justice? 
-</p><p class="q2">Or does the Almighty pervert righteousness? 
-</p><p class="q1">
-<span class="v">4&#160;</span>If your children have sinned against him, 
-</p><p class="q2">he has delivered them into the hand of their disobedience. 
-</p><p class="q1">
-<span class="v">5&#160;</span>If you want to seek Elohim diligently, 
-</p><p class="q2">make your supplication to the Almighty. 
-</p><p class="q1">
-<span class="v">6&#160;</span>If you were pure and upright, 
-</p><p class="q2">surely now he would awaken for you, 
-</p><p class="q1">and make the habitation of your righteousness prosperous. 
-</p><p class="q2">
-<span class="v">7&#160;</span>Though your beginning was small, 
-</p><p class="q1">yet your latter end would greatly increase. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Please inquire of past generations. 
-</p><p class="q2">Find out about the learning of their fathers. 
-</p><p class="q1">
-<span class="v">9&#160;</span>(For we are but of yesterday, and know nothing, 
-</p><p class="q2">because our days on earth are a shadow.) 
-</p><p class="q1">
-<span class="v">10&#160;</span>Shall they not teach you, tell you, 
-</p><p class="q2">and utter words out of their heart? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Can the papyrus grow up without mire? 
-</p><p class="q2">Can the rushes grow without water? 
-</p><p class="q1">
-<span class="v">12&#160;</span>While it is yet in its greenness, not cut down, 
-</p><p class="q2">it withers before any other reed. 
-</p><p class="q1">
-<span class="v">13&#160;</span>So are the paths of all who forget Elohim. 
-</p><p class="q2">The hope of the elohimless man will perish, 
-</p><p class="q1">
-<span class="v">14&#160;</span>whose confidence will break apart, 
-</p><p class="q2">whose trust is a spider’s web. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He will lean on his house, but it will not stand. 
-</p><p class="q2">He will cling to it, but it will not endure. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He is green before the sun. 
-</p><p class="q2">His shoots go out along his garden. 
-</p><p class="q1">
-<span class="v">17&#160;</span>His roots are wrapped around the rock pile. 
-</p><p class="q2">He sees the place of stones. 
-</p><p class="q1">
-<span class="v">18&#160;</span>If he is destroyed from his place, 
-</p><p class="q2">then it will deny him, saying, ‘I have not seen you.’ 
-</p><p class="q1">
-<span class="v">19&#160;</span>Behold, this is the joy of his way. 
-</p><p class="q2">Out of the earth, others will spring. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Behold, Elohim will not cast away a blameless man, 
-</p><p class="q2">neither will he uphold the evildoers. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He will still fill your mouth with laughter, 
-</p><p class="q2">your lips with shouting. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Those who hate you will be clothed with shame. 
-</p><p class="q2">The tent of the wicked will be no more.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Truly I know that it is so, 
-</p><p class="q2">but how can man be just with Elohim? 
-</p><p class="q1">
-<span class="v">3&#160;</span>If he is pleased to contend with him, 
-</p><p class="q2">he can’t answer him one time in a thousand. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Elohim is wise in heart, and mighty in strength. 
-</p><p class="q2">Who has hardened himself against him and prospered? 
-</p><p class="q1">
-<span class="v">5&#160;</span>He removes the mountains, and they don’t know it, 
-</p><p class="q2">when he overturns them in his anger. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He shakes the earth out of its place. 
-</p><p class="q2">Its pillars tremble. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He commands the sun and it doesn’t rise, 
-</p><p class="q2">and seals up the stars. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He alone stretches out the heavens, 
-</p><p class="q2">and treads on the waves of the sea. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He makes the Bear, Orion, and the Pleiades, 
-</p><p class="q2">and the rooms of the south. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He does great things past finding out; 
-</p><p class="q2">yes, marvelous things without number. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Behold, he goes by me, and I don’t see him. 
-</p><p class="q2">He passes on also, but I don’t perceive him. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Behold, he snatches away. 
-</p><p class="q2">Who can hinder him? 
-</p><p class="q2">Who will ask him, ‘What are you doing?’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“Elohim will not withdraw his anger. 
-</p><p class="q2">The helpers of Rahab stoop under him. 
-</p><p class="q1">
-<span class="v">14&#160;</span>How much less will I answer him, 
-</p><p class="q2">and choose my words to argue with him? 
-</p><p class="q1">
-<span class="v">15&#160;</span>Though I were righteous, yet I wouldn’t answer him. 
-</p><p class="q2">I would make supplication to my judge. 
-</p><p class="q1">
-<span class="v">16&#160;</span>If I had called, and he had answered me, 
-</p><p class="q2">yet I wouldn’t believe that he listened to my voice. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For he breaks me with a storm, 
-</p><p class="q2">and multiplies my wounds without cause. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He will not allow me to catch my breath, 
-</p><p class="q2">but fills me with bitterness. 
-</p><p class="q1">
-<span class="v">19&#160;</span>If it is a matter of strength, behold, he is mighty! 
-</p><p class="q2">If of justice, ‘Who,’ says he, ‘will summon me?’ 
-</p><p class="q1">
-<span class="v">20&#160;</span>Though I am righteous, my own mouth will condemn me. 
-</p><p class="q2">Though I am blameless, it will prove me perverse. 
-</p><p class="q1">
-<span class="v">21&#160;</span>I am blameless. 
-</p><p class="q2">I don’t respect myself. 
-</p><p class="q2">I despise my life. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“It is all the same. 
-</p><p class="q2">Therefore I say he destroys the blameless and the wicked. 
-</p><p class="q1">
-<span class="v">23&#160;</span>If the scourge kills suddenly, 
-</p><p class="q2">he will mock at the trial of the innocent. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The earth is given into the hand of the wicked. 
-</p><p class="q2">He covers the faces of its judges. 
-</p><p class="q2">If not he, then who is it? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>“Now my days are swifter than a runner. 
-</p><p class="q2">They flee away. They see no good. 
-</p><p class="q1">
-<span class="v">26&#160;</span>They have passed away as the swift ships, 
-</p><p class="q2">as the eagle that swoops on the prey. 
-</p><p class="q1">
-<span class="v">27&#160;</span>If I say, ‘I will forget my complaint, 
-</p><p class="q2">I will put off my sad face, and cheer up,’ 
-</p><p class="q1">
-<span class="v">28&#160;</span>I am afraid of all my sorrows. 
-</p><p class="q2">I know that you will not hold me innocent. 
-</p><p class="q1">
-<span class="v">29&#160;</span>I will be condemned. 
-</p><p class="q2">Why then do I labor in vain? 
-</p><p class="q1">
-<span class="v">30&#160;</span>If I wash myself with snow, 
-</p><p class="q2">and cleanse my hands with lye, 
-</p><p class="q1">
-<span class="v">31&#160;</span>yet you will plunge me in the ditch. 
-</p><p class="q2">My own clothes will abhor me. 
-</p><p class="q1">
-<span class="v">32&#160;</span>For he is not a man, as I am, that I should answer him, 
-</p><p class="q2">that we should come together in judgment. 
-</p><p class="q1">
-<span class="v">33&#160;</span>There is no umpire between us, 
-</p><p class="q2">that might lay his hand on us both. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Let him take his rod away from me. 
-</p><p class="q2">Let his terror not make me afraid; 
-</p><p class="q1">
-<span class="v">35&#160;</span>then I would speak, and not fear him, 
-</p><p class="q2">for I am not so in myself. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Isn’t a man forced to labor on earth? 
+</div><div class="q2">Aren’t his days like the days of a hired hand? 
+</div><div class="q1">
+<sup>2&#160;</sup>As a servant who earnestly desires the shadow, 
+</div><div class="q2">as a hireling who looks for his wages, 
+</div><div class="q1">
+<sup>3&#160;</sup>so I am made to possess months of misery, 
+</div><div class="q2">wearisome nights are appointed to me. 
+</div><div class="q1">
+<sup>4&#160;</sup>When I lie down, I say, 
+</div><div class="q2">‘When will I arise, and the night be gone?’ 
+</div><div class="q2">I toss and turn until the dawning of the day. 
+</div><div class="q1">
+<sup>5&#160;</sup>My flesh is clothed with worms and clods of dust. 
+</div><div class="q2">My skin closes up, and breaks out afresh. 
+</div><div class="q1">
+<sup>6&#160;</sup>My days are swifter than a weaver’s shuttle, 
+</div><div class="q2">and are spent without hope. 
+</div><div class="q1">
+<sup>7&#160;</sup>Oh remember that my life is a breath. 
+</div><div class="q2">My eye will no more see good. 
+</div><div class="q1">
+<sup>8&#160;</sup>The eye of him who sees me will see me no more. 
+</div><div class="q2">Your eyes will be on me, but I will not be. 
+</div><div class="q1">
+<sup>9&#160;</sup>As the cloud is consumed and vanishes away, 
+</div><div class="q2">so he who goes down to Sheol will come up no more. 
+</div><div class="q1">
+<sup>10&#160;</sup>He will return no more to his house, 
+</div><div class="q2">neither will his place know him any more. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Therefore I will not keep silent. 
+</div><div class="q2">I will speak in the anguish of my spirit. 
+</div><div class="q2">I will complain in the bitterness of my soul. 
+</div><div class="q1">
+<sup>12&#160;</sup>Am I a sea, or a sea monster, 
+</div><div class="q2">that you put a guard over me? 
+</div><div class="q1">
+<sup>13&#160;</sup>When I say, ‘My bed will comfort me. 
+</div><div class="q2">My couch will ease my complaint,’ 
+</div><div class="q1">
+<sup>14&#160;</sup>then you scare me with dreams 
+</div><div class="q2">and terrify me through visions, 
+</div><div class="q1">
+<sup>15&#160;</sup>so that my soul chooses strangling, 
+</div><div class="q2">death rather than my bones. 
+</div><div class="q1">
+<sup>16&#160;</sup>I loathe my life. 
+</div><div class="q2">I don’t want to live forever. 
+</div><div class="q2">Leave me alone, for my days are but a breath. 
+</div><div class="q1">
+<sup>17&#160;</sup>What is man, that you should magnify him, 
+</div><div class="q2">that you should set your mind on him, 
+</div><div class="q1">
+<sup>18&#160;</sup>that you should visit him every morning, 
+</div><div class="q2">and test him every moment? 
+</div><div class="q1">
+<sup>19&#160;</sup>How long will you not look away from me, 
+</div><div class="q2">nor leave me alone until I swallow down my spittle? 
+</div><div class="q1">
+<sup>20&#160;</sup>If I have sinned, what do I do to you, you watcher of men? 
+</div><div class="q2">Why have you set me as a mark for you, 
+</div><div class="q2">so that I am a burden to myself? 
+</div><div class="q1">
+<sup>21&#160;</sup>Why do you not pardon my disobedience, and take away my iniquity? 
+</div><div class="q2">For now will I lie down in the dust. 
+</div><div class="q2">You will seek me diligently, but I will not be.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Bildad the Shuhite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“How long will you speak these things? 
+</div><div class="q2">Shall the words of your mouth be a mighty wind? 
+</div><div class="q1">
+<sup>3&#160;</sup>Does Elohim pervert justice? 
+</div><div class="q2">Or does the Almighty pervert righteousness? 
+</div><div class="q1">
+<sup>4&#160;</sup>If your children have sinned against him, 
+</div><div class="q2">he has delivered them into the hand of their disobedience. 
+</div><div class="q1">
+<sup>5&#160;</sup>If you want to seek Elohim diligently, 
+</div><div class="q2">make your supplication to the Almighty. 
+</div><div class="q1">
+<sup>6&#160;</sup>If you were pure and upright, 
+</div><div class="q2">surely now he would awaken for you, 
+</div><div class="q1">and make the habitation of your righteousness prosperous. 
+</div><div class="q2">
+<sup>7&#160;</sup>Though your beginning was small, 
+</div><div class="q1">yet your latter end would greatly increase. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Please inquire of past generations. 
+</div><div class="q2">Find out about the learning of their fathers. 
+</div><div class="q1">
+<sup>9&#160;</sup>(For we are but of yesterday, and know nothing, 
+</div><div class="q2">because our days on earth are a shadow.) 
+</div><div class="q1">
+<sup>10&#160;</sup>Shall they not teach you, tell you, 
+</div><div class="q2">and utter words out of their heart? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Can the papyrus grow up without mire? 
+</div><div class="q2">Can the rushes grow without water? 
+</div><div class="q1">
+<sup>12&#160;</sup>While it is yet in its greenness, not cut down, 
+</div><div class="q2">it withers before any other reed. 
+</div><div class="q1">
+<sup>13&#160;</sup>So are the paths of all who forget Elohim. 
+</div><div class="q2">The hope of the elohimless man will perish, 
+</div><div class="q1">
+<sup>14&#160;</sup>whose confidence will break apart, 
+</div><div class="q2">whose trust is a spider’s web. 
+</div><div class="q1">
+<sup>15&#160;</sup>He will lean on his house, but it will not stand. 
+</div><div class="q2">He will cling to it, but it will not endure. 
+</div><div class="q1">
+<sup>16&#160;</sup>He is green before the sun. 
+</div><div class="q2">His shoots go out along his garden. 
+</div><div class="q1">
+<sup>17&#160;</sup>His roots are wrapped around the rock pile. 
+</div><div class="q2">He sees the place of stones. 
+</div><div class="q1">
+<sup>18&#160;</sup>If he is destroyed from his place, 
+</div><div class="q2">then it will deny him, saying, ‘I have not seen you.’ 
+</div><div class="q1">
+<sup>19&#160;</sup>Behold, this is the joy of his way. 
+</div><div class="q2">Out of the earth, others will spring. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Behold, Elohim will not cast away a blameless man, 
+</div><div class="q2">neither will he uphold the evildoers. 
+</div><div class="q1">
+<sup>21&#160;</sup>He will still fill your mouth with laughter, 
+</div><div class="q2">your lips with shouting. 
+</div><div class="q1">
+<sup>22&#160;</sup>Those who hate you will be clothed with shame. 
+</div><div class="q2">The tent of the wicked will be no more.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Truly I know that it is so, 
+</div><div class="q2">but how can man be just with Elohim? 
+</div><div class="q1">
+<sup>3&#160;</sup>If he is pleased to contend with him, 
+</div><div class="q2">he can’t answer him one time in a thousand. 
+</div><div class="q1">
+<sup>4&#160;</sup>Elohim is wise in heart, and mighty in strength. 
+</div><div class="q2">Who has hardened himself against him and prospered? 
+</div><div class="q1">
+<sup>5&#160;</sup>He removes the mountains, and they don’t know it, 
+</div><div class="q2">when he overturns them in his anger. 
+</div><div class="q1">
+<sup>6&#160;</sup>He shakes the earth out of its place. 
+</div><div class="q2">Its pillars tremble. 
+</div><div class="q1">
+<sup>7&#160;</sup>He commands the sun and it doesn’t rise, 
+</div><div class="q2">and seals up the stars. 
+</div><div class="q1">
+<sup>8&#160;</sup>He alone stretches out the heavens, 
+</div><div class="q2">and treads on the waves of the sea. 
+</div><div class="q1">
+<sup>9&#160;</sup>He makes the Bear, Orion, and the Pleiades, 
+</div><div class="q2">and the rooms of the south. 
+</div><div class="q1">
+<sup>10&#160;</sup>He does great things past finding out; 
+</div><div class="q2">yes, marvelous things without number. 
+</div><div class="q1">
+<sup>11&#160;</sup>Behold, he goes by me, and I don’t see him. 
+</div><div class="q2">He passes on also, but I don’t perceive him. 
+</div><div class="q1">
+<sup>12&#160;</sup>Behold, he snatches away. 
+</div><div class="q2">Who can hinder him? 
+</div><div class="q2">Who will ask him, ‘What are you doing?’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“Elohim will not withdraw his anger. 
+</div><div class="q2">The helpers of Rahab stoop under him. 
+</div><div class="q1">
+<sup>14&#160;</sup>How much less will I answer him, 
+</div><div class="q2">and choose my words to argue with him? 
+</div><div class="q1">
+<sup>15&#160;</sup>Though I were righteous, yet I wouldn’t answer him. 
+</div><div class="q2">I would make supplication to my judge. 
+</div><div class="q1">
+<sup>16&#160;</sup>If I had called, and he had answered me, 
+</div><div class="q2">yet I wouldn’t believe that he listened to my voice. 
+</div><div class="q1">
+<sup>17&#160;</sup>For he breaks me with a storm, 
+</div><div class="q2">and multiplies my wounds without cause. 
+</div><div class="q1">
+<sup>18&#160;</sup>He will not allow me to catch my breath, 
+</div><div class="q2">but fills me with bitterness. 
+</div><div class="q1">
+<sup>19&#160;</sup>If it is a matter of strength, behold, he is mighty! 
+</div><div class="q2">If of justice, ‘Who,’ says he, ‘will summon me?’ 
+</div><div class="q1">
+<sup>20&#160;</sup>Though I am righteous, my own mouth will condemn me. 
+</div><div class="q2">Though I am blameless, it will prove me perverse. 
+</div><div class="q1">
+<sup>21&#160;</sup>I am blameless. 
+</div><div class="q2">I don’t respect myself. 
+</div><div class="q2">I despise my life. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“It is all the same. 
+</div><div class="q2">Therefore I say he destroys the blameless and the wicked. 
+</div><div class="q1">
+<sup>23&#160;</sup>If the scourge kills suddenly, 
+</div><div class="q2">he will mock at the trial of the innocent. 
+</div><div class="q1">
+<sup>24&#160;</sup>The earth is given into the hand of the wicked. 
+</div><div class="q2">He covers the faces of its judges. 
+</div><div class="q2">If not he, then who is it? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>“Now my days are swifter than a runner. 
+</div><div class="q2">They flee away. They see no good. 
+</div><div class="q1">
+<sup>26&#160;</sup>They have passed away as the swift ships, 
+</div><div class="q2">as the eagle that swoops on the prey. 
+</div><div class="q1">
+<sup>27&#160;</sup>If I say, ‘I will forget my complaint, 
+</div><div class="q2">I will put off my sad face, and cheer up,’ 
+</div><div class="q1">
+<sup>28&#160;</sup>I am afraid of all my sorrows. 
+</div><div class="q2">I know that you will not hold me innocent. 
+</div><div class="q1">
+<sup>29&#160;</sup>I will be condemned. 
+</div><div class="q2">Why then do I labor in vain? 
+</div><div class="q1">
+<sup>30&#160;</sup>If I wash myself with snow, 
+</div><div class="q2">and cleanse my hands with lye, 
+</div><div class="q1">
+<sup>31&#160;</sup>yet you will plunge me in the ditch. 
+</div><div class="q2">My own clothes will abhor me. 
+</div><div class="q1">
+<sup>32&#160;</sup>For he is not a man, as I am, that I should answer him, 
+</div><div class="q2">that we should come together in judgment. 
+</div><div class="q1">
+<sup>33&#160;</sup>There is no umpire between us, 
+</div><div class="q2">that might lay his hand on us both. 
+</div><div class="q1">
+<sup>34&#160;</sup>Let him take his rod away from me. 
+</div><div class="q2">Let his terror not make me afraid; 
+</div><div class="q1">
+<sup>35&#160;</sup>then I would speak, and not fear him, 
+</div><div class="q2">for I am not so in myself. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="10">10</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“My soul is weary of my life. 
-</p><p class="q2">I will give free course to my complaint. 
-</p><p class="q2">I will speak in the bitterness of my soul. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will tell Elohim, ‘Do not condemn me. 
-</p><p class="q2">Show me why you contend with me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Is it good to you that you should oppress, 
-</p><p class="q2">that you should despise the work of your hands, 
-</p><p class="q2">and smile on the counsel of the wicked? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Do you have eyes of flesh? 
-</p><p class="q2">Or do you see as man sees? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Are your days as the days of mortals, 
-</p><p class="q2">or your years as man’s years, 
-</p><p class="q1">
-<span class="v">6&#160;</span>that you inquire after my iniquity, 
-</p><p class="q2">and search after my sin? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Although you know that I am not wicked, 
-</p><p class="q2">there is no one who can deliver out of your hand. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“&#160;‘Your hands have framed me and fashioned me altogether, 
-</p><p class="q2">yet you destroy me. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Remember, I beg you, that you have fashioned me as clay. 
-</p><p class="q2">Will you bring me into dust again? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Haven’t you poured me out like milk, 
-</p><p class="q2">and curdled me like cheese? 
-</p><p class="q1">
-<span class="v">11&#160;</span>You have clothed me with skin and flesh, 
-</p><p class="q2">and knit me together with bones and sinews. 
-</p><p class="q1">
-<span class="v">12&#160;</span>You have granted me life and loving kindness. 
-</p><p class="q2">Your visitation has preserved my spirit. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yet you hid these things in your heart. 
-</p><p class="q2">I know that this is with you: 
-</p><p class="q1">
-<span class="v">14&#160;</span>if I sin, then you mark me. 
-</p><p class="q2">You will not acquit me from my iniquity. 
-</p><p class="q1">
-<span class="v">15&#160;</span>If I am wicked, woe to me. 
-</p><p class="q2">If I am righteous, I still will not lift up my head, 
-</p><p class="q2">being filled with disgrace, 
-</p><p class="q2">and conscious of my affliction. 
-</p><p class="q1">
-<span class="v">16&#160;</span>If my head is held high, you hunt me like a lion. 
-</p><p class="q2">Again you show yourself powerful to me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>You renew your witnesses against me, 
-</p><p class="q2">and increase your indignation on me. 
-</p><p class="q2">Changes and warfare are with me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“&#160;‘Why, then, have you brought me out of the womb? 
-</p><p class="q2">I wish I had given up the spirit, and no eye had seen me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I should have been as though I had not been. 
-</p><p class="q2">I should have been carried from the womb to the grave. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Aren’t my days few? 
-</p><p class="q2">Stop! 
-</p><p class="q1">Leave me alone, that I may find a little comfort, 
-</p><p class="q2">
-<span class="v">21&#160;</span>before I go where I will not return from, 
-</p><p class="q2">to the land of darkness and of the shadow of death; 
-</p><p class="q1">
-<span class="v">22&#160;</span>the land dark as midnight, 
-</p><p class="q2">of the shadow of death, 
-</p><p class="q2">without any order, 
-</p><p class="q2">where the light is as midnight.’&#160;” 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Then Zophar, the Naamathite, answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Shouldn’t the multitude of words be answered? 
-</p><p class="q2">Should a man full of talk be justified? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Should your boastings make men hold their peace? 
-</p><p class="q2">When you mock, will no man make you ashamed? 
-</p><p class="q1">
-<span class="v">4&#160;</span>For you say, ‘My doctrine is pure. 
-</p><p class="q2">I am clean in your eyes.’ 
-</p><p class="q1">
-<span class="v">5&#160;</span>But oh that Elohim would speak, 
-</p><p class="q2">and open his lips against you, 
-</p><p class="q1">
-<span class="v">6&#160;</span>that he would show you the secrets of wisdom! 
-</p><p class="q2">For true wisdom has two sides. 
-</p><p class="q2">Know therefore that Elohim exacts of you less than your iniquity deserves. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Can you fathom the mystery of Elohim? 
-</p><p class="q2">Or can you probe the limits of the Almighty? 
-</p><p class="q1">
-<span class="v">8&#160;</span>They are high as heaven. What can you do? 
-</p><p class="q2">They are deeper than Sheol.<span class="f">+ \fr 11:8 \ft Sheol is the place of the dead.</span> What can you know? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Its measure is longer than the earth, 
-</p><p class="q2">and broader than the sea. 
-</p><p class="q1">
-<span class="v">10&#160;</span>If he passes by, or confines, 
-</p><p class="q2">or convenes a court, then who can oppose him? 
-</p><p class="q1">
-<span class="v">11&#160;</span>For he knows false men. 
-</p><p class="q2">He sees iniquity also, even though he doesn’t consider it. 
-</p><p class="q1">
-<span class="v">12&#160;</span>An empty-headed man becomes wise 
-</p><p class="q2">when a man is born as a wild donkey’s colt. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“If you set your heart aright, 
-</p><p class="q2">stretch out your hands toward him. 
-</p><p class="q1">
-<span class="v">14&#160;</span>If iniquity is in your hand, put it far away. 
-</p><p class="q2">Don’t let unrighteousness dwell in your tents. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Surely then you will lift up your face without spot. 
-</p><p class="q2">Yes, you will be steadfast, and will not fear, 
-</p><p class="q2">
-<span class="v">16&#160;</span>for you will forget your misery. 
-</p><p class="q2">You will remember it like waters that have passed away. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Life will be clearer than the noonday. 
-</p><p class="q2">Though there is darkness, it will be as the morning. 
-</p><p class="q1">
-<span class="v">18&#160;</span>You will be secure, because there is hope. 
-</p><p class="q2">Yes, you will search, and will take your rest in safety. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Also you will lie down, and no one will make you afraid. 
-</p><p class="q2">Yes, many will court your favor. 
-</p><p class="q1">
-<span class="v">20&#160;</span>But the eyes of the wicked will fail. 
-</p><p class="q2">They will have no way to flee. 
-</p><p class="q2">Their hope will be the giving up of the spirit.” 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“No doubt, but you are the people, 
-</p><p class="q2">and wisdom will die with you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>But I have understanding as well as you; 
-</p><p class="q2">I am not inferior to you. 
-</p><p class="q2">Yes, who doesn’t know such things as these? 
-</p><p class="q1">
-<span class="v">4&#160;</span>I am like one who is a joke to his neighbor, 
-</p><p class="q2">I, who called on Elohim, and he answered. 
-</p><p class="q2">The just, the blameless man is a joke. 
-</p><p class="q1">
-<span class="v">5&#160;</span>In the thought of him who is at ease there is contempt for misfortune. 
-</p><p class="q2">It is ready for them whose foot slips. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The tents of robbers prosper. 
-</p><p class="q2">Those who provoke Elohim are secure, 
-</p><p class="q2">who carry their elohim in their hands. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“But ask the animals now, and they will teach you; 
-</p><p class="q2">the birds of the sky, and they will tell you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Or speak to the earth, and it will teach you. 
-</p><p class="q2">The fish of the sea will declare to you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Who doesn’t know that in all these, 
-</p><p class="q2">Yahweh’s hand has done this, 
-</p><p class="q1">
-<span class="v">10&#160;</span>in whose hand is the life of every living thing, 
-</p><p class="q2">and the breath of all mankind? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Doesn’t the ear try words, 
-</p><p class="q2">even as the palate tastes its food? 
-</p><p class="q1">
-<span class="v">12&#160;</span>With aged men is wisdom, 
-</p><p class="q2">in length of days understanding. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“With Elohim is wisdom and might. 
-</p><p class="q2">He has counsel and understanding. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Behold, he breaks down, and it can’t be built again. 
-</p><p class="q2">He imprisons a man, and there can be no release. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, he withholds the waters, and they dry up. 
-</p><p class="q2">Again, he sends them out, and they overturn the earth. 
-</p><p class="q1">
-<span class="v">16&#160;</span>With him is strength and wisdom. 
-</p><p class="q2">The deceived and the deceiver are his. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He leads counselors away stripped. 
-</p><p class="q2">He makes judges fools. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He loosens the bond of kings. 
-</p><p class="q2">He binds their waist with a belt. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He leads priests away stripped, 
-</p><p class="q2">and overthrows the mighty. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He removes the speech of those who are trusted, 
-</p><p class="q2">and takes away the understanding of the elders. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He pours contempt on princes, 
-</p><p class="q2">and loosens the belt of the strong. 
-</p><p class="q1">
-<span class="v">22&#160;</span>He uncovers deep things out of darkness, 
-</p><p class="q2">and brings out to light the shadow of death. 
-</p><p class="q1">
-<span class="v">23&#160;</span>He increases the nations, and he destroys them. 
-</p><p class="q2">He enlarges the nations, and he leads them captive. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He takes away understanding from the chiefs of the people of the earth, 
-</p><p class="q2">and causes them to wander in a wilderness where there is no way. 
-</p><p class="q1">
-<span class="v">25&#160;</span>They grope in the dark without light. 
-</p><p class="q2">He makes them stagger like a drunken man. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“My soul is weary of my life. 
+</div><div class="q2">I will give free course to my complaint. 
+</div><div class="q2">I will speak in the bitterness of my soul. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will tell Elohim, ‘Do not condemn me. 
+</div><div class="q2">Show me why you contend with me. 
+</div><div class="q1">
+<sup>3&#160;</sup>Is it good to you that you should oppress, 
+</div><div class="q2">that you should despise the work of your hands, 
+</div><div class="q2">and smile on the counsel of the wicked? 
+</div><div class="q1">
+<sup>4&#160;</sup>Do you have eyes of flesh? 
+</div><div class="q2">Or do you see as man sees? 
+</div><div class="q1">
+<sup>5&#160;</sup>Are your days as the days of mortals, 
+</div><div class="q2">or your years as man’s years, 
+</div><div class="q1">
+<sup>6&#160;</sup>that you inquire after my iniquity, 
+</div><div class="q2">and search after my sin? 
+</div><div class="q1">
+<sup>7&#160;</sup>Although you know that I am not wicked, 
+</div><div class="q2">there is no one who can deliver out of your hand. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“&#160;‘Your hands have framed me and fashioned me altogether, 
+</div><div class="q2">yet you destroy me. 
+</div><div class="q1">
+<sup>9&#160;</sup>Remember, I beg you, that you have fashioned me as clay. 
+</div><div class="q2">Will you bring me into dust again? 
+</div><div class="q1">
+<sup>10&#160;</sup>Haven’t you poured me out like milk, 
+</div><div class="q2">and curdled me like cheese? 
+</div><div class="q1">
+<sup>11&#160;</sup>You have clothed me with skin and flesh, 
+</div><div class="q2">and knit me together with bones and sinews. 
+</div><div class="q1">
+<sup>12&#160;</sup>You have granted me life and loving kindness. 
+</div><div class="q2">Your visitation has preserved my spirit. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yet you hid these things in your heart. 
+</div><div class="q2">I know that this is with you: 
+</div><div class="q1">
+<sup>14&#160;</sup>if I sin, then you mark me. 
+</div><div class="q2">You will not acquit me from my iniquity. 
+</div><div class="q1">
+<sup>15&#160;</sup>If I am wicked, woe to me. 
+</div><div class="q2">If I am righteous, I still will not lift up my head, 
+</div><div class="q2">being filled with disgrace, 
+</div><div class="q2">and conscious of my affliction. 
+</div><div class="q1">
+<sup>16&#160;</sup>If my head is held high, you hunt me like a lion. 
+</div><div class="q2">Again you show yourself powerful to me. 
+</div><div class="q1">
+<sup>17&#160;</sup>You renew your witnesses against me, 
+</div><div class="q2">and increase your indignation on me. 
+</div><div class="q2">Changes and warfare are with me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“&#160;‘Why, then, have you brought me out of the womb? 
+</div><div class="q2">I wish I had given up the spirit, and no eye had seen me. 
+</div><div class="q1">
+<sup>19&#160;</sup>I should have been as though I had not been. 
+</div><div class="q2">I should have been carried from the womb to the grave. 
+</div><div class="q1">
+<sup>20&#160;</sup>Aren’t my days few? 
+</div><div class="q2">Stop! 
+</div><div class="q1">Leave me alone, that I may find a little comfort, 
+</div><div class="q2">
+<sup>21&#160;</sup>before I go where I will not return from, 
+</div><div class="q2">to the land of darkness and of the shadow of death; 
+</div><div class="q1">
+<sup>22&#160;</sup>the land dark as midnight, 
+</div><div class="q2">of the shadow of death, 
+</div><div class="q2">without any order, 
+</div><div class="q2">where the light is as midnight.’&#160;” 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Zophar, the Naamathite, answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Shouldn’t the multitude of words be answered? 
+</div><div class="q2">Should a man full of talk be justified? 
+</div><div class="q1">
+<sup>3&#160;</sup>Should your boastings make men hold their peace? 
+</div><div class="q2">When you mock, will no man make you ashamed? 
+</div><div class="q1">
+<sup>4&#160;</sup>For you say, ‘My doctrine is pure. 
+</div><div class="q2">I am clean in your eyes.’ 
+</div><div class="q1">
+<sup>5&#160;</sup>But oh that Elohim would speak, 
+</div><div class="q2">and open his lips against you, 
+</div><div class="q1">
+<sup>6&#160;</sup>that he would show you the secrets of wisdom! 
+</div><div class="q2">For true wisdom has two sides. 
+</div><div class="q2">Know therefore that Elohim exacts of you less than your iniquity deserves. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Can you fathom the mystery of Elohim? 
+</div><div class="q2">Or can you probe the limits of the Almighty? 
+</div><div class="q1">
+<sup>8&#160;</sup>They are high as heaven. What can you do? 
+</div><div class="q2">They are deeper than Sheol. What can you know? 
+</div><div class="q1">
+<sup>9&#160;</sup>Its measure is longer than the earth, 
+</div><div class="q2">and broader than the sea. 
+</div><div class="q1">
+<sup>10&#160;</sup>If he passes by, or confines, 
+</div><div class="q2">or convenes a court, then who can oppose him? 
+</div><div class="q1">
+<sup>11&#160;</sup>For he knows false men. 
+</div><div class="q2">He sees iniquity also, even though he doesn’t consider it. 
+</div><div class="q1">
+<sup>12&#160;</sup>An empty-headed man becomes wise 
+</div><div class="q2">when a man is born as a wild donkey’s colt. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“If you set your heart aright, 
+</div><div class="q2">stretch out your hands toward him. 
+</div><div class="q1">
+<sup>14&#160;</sup>If iniquity is in your hand, put it far away. 
+</div><div class="q2">Don’t let unrighteousness dwell in your tents. 
+</div><div class="q1">
+<sup>15&#160;</sup>Surely then you will lift up your face without spot. 
+</div><div class="q2">Yes, you will be steadfast, and will not fear, 
+</div><div class="q2">
+<sup>16&#160;</sup>for you will forget your misery. 
+</div><div class="q2">You will remember it like waters that have passed away. 
+</div><div class="q1">
+<sup>17&#160;</sup>Life will be clearer than the noonday. 
+</div><div class="q2">Though there is darkness, it will be as the morning. 
+</div><div class="q1">
+<sup>18&#160;</sup>You will be secure, because there is hope. 
+</div><div class="q2">Yes, you will search, and will take your rest in safety. 
+</div><div class="q1">
+<sup>19&#160;</sup>Also you will lie down, and no one will make you afraid. 
+</div><div class="q2">Yes, many will court your favor. 
+</div><div class="q1">
+<sup>20&#160;</sup>But the eyes of the wicked will fail. 
+</div><div class="q2">They will have no way to flee. 
+</div><div class="q2">Their hope will be the giving up of the spirit.” 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“No doubt, but you are the people, 
+</div><div class="q2">and wisdom will die with you. 
+</div><div class="q1">
+<sup>3&#160;</sup>But I have understanding as well as you; 
+</div><div class="q2">I am not inferior to you. 
+</div><div class="q2">Yes, who doesn’t know such things as these? 
+</div><div class="q1">
+<sup>4&#160;</sup>I am like one who is a joke to his neighbor, 
+</div><div class="q2">I, who called on Elohim, and he answered. 
+</div><div class="q2">The just, the blameless man is a joke. 
+</div><div class="q1">
+<sup>5&#160;</sup>In the thought of him who is at ease there is contempt for misfortune. 
+</div><div class="q2">It is ready for them whose foot slips. 
+</div><div class="q1">
+<sup>6&#160;</sup>The tents of robbers prosper. 
+</div><div class="q2">Those who provoke Elohim are secure, 
+</div><div class="q2">who carry their elohim in their hands. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“But ask the animals now, and they will teach you; 
+</div><div class="q2">the birds of the sky, and they will tell you. 
+</div><div class="q1">
+<sup>8&#160;</sup>Or speak to the earth, and it will teach you. 
+</div><div class="q2">The fish of the sea will declare to you. 
+</div><div class="q1">
+<sup>9&#160;</sup>Who doesn’t know that in all these, 
+</div><div class="q2">Yahweh’s hand has done this, 
+</div><div class="q1">
+<sup>10&#160;</sup>in whose hand is the life of every living thing, 
+</div><div class="q2">and the breath of all mankind? 
+</div><div class="q1">
+<sup>11&#160;</sup>Doesn’t the ear try words, 
+</div><div class="q2">even as the palate tastes its food? 
+</div><div class="q1">
+<sup>12&#160;</sup>With aged men is wisdom, 
+</div><div class="q2">in length of days understanding. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“With Elohim is wisdom and might. 
+</div><div class="q2">He has counsel and understanding. 
+</div><div class="q1">
+<sup>14&#160;</sup>Behold, he breaks down, and it can’t be built again. 
+</div><div class="q2">He imprisons a man, and there can be no release. 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, he withholds the waters, and they dry up. 
+</div><div class="q2">Again, he sends them out, and they overturn the earth. 
+</div><div class="q1">
+<sup>16&#160;</sup>With him is strength and wisdom. 
+</div><div class="q2">The deceived and the deceiver are his. 
+</div><div class="q1">
+<sup>17&#160;</sup>He leads counselors away stripped. 
+</div><div class="q2">He makes judges fools. 
+</div><div class="q1">
+<sup>18&#160;</sup>He loosens the bond of kings. 
+</div><div class="q2">He binds their waist with a belt. 
+</div><div class="q1">
+<sup>19&#160;</sup>He leads priests away stripped, 
+</div><div class="q2">and overthrows the mighty. 
+</div><div class="q1">
+<sup>20&#160;</sup>He removes the speech of those who are trusted, 
+</div><div class="q2">and takes away the understanding of the elders. 
+</div><div class="q1">
+<sup>21&#160;</sup>He pours contempt on princes, 
+</div><div class="q2">and loosens the belt of the strong. 
+</div><div class="q1">
+<sup>22&#160;</sup>He uncovers deep things out of darkness, 
+</div><div class="q2">and brings out to light the shadow of death. 
+</div><div class="q1">
+<sup>23&#160;</sup>He increases the nations, and he destroys them. 
+</div><div class="q2">He enlarges the nations, and he leads them captive. 
+</div><div class="q1">
+<sup>24&#160;</sup>He takes away understanding from the chiefs of the people of the earth, 
+</div><div class="q2">and causes them to wander in a wilderness where there is no way. 
+</div><div class="q1">
+<sup>25&#160;</sup>They grope in the dark without light. 
+</div><div class="q2">He makes them stagger like a drunken man. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="13">13</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Behold, my eye has seen all this. 
-</p><p class="q2">My ear has heard and understood it. 
-</p><p class="q1">
-<span class="v">2&#160;</span>What you know, I know also. 
-</p><p class="q2">I am not inferior to you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Surely I would speak to the Almighty. 
-</p><p class="q2">I desire to reason with Elohim. 
-</p><p class="q1">
-<span class="v">4&#160;</span>But you are forgers of lies. 
-</p><p class="q2">You are all physicians of no value. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Oh that you would be completely silent! 
-</p><p class="q2">Then you would be wise. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Hear now my reasoning. 
-</p><p class="q2">Listen to the pleadings of my lips. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Will you speak unrighteously for Elohim, 
-</p><p class="q2">and talk deceitfully for him? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Will you show partiality to him? 
-</p><p class="q2">Will you contend for Elohim? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Is it good that he should search you out? 
-</p><p class="q2">Or as one deceives a man, will you deceive him? 
-</p><p class="q1">
-<span class="v">10&#160;</span>He will surely reprove you 
-</p><p class="q2">if you secretly show partiality. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Won’t his majesty make you afraid 
-</p><p class="q2">and his dread fall on you? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Your memorable sayings are proverbs of ashes. 
-</p><p class="q2">Your defenses are defenses of clay. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“Be silent! 
-</p><p class="q2">Leave me alone, that I may speak. 
-</p><p class="q2">Let come on me what will. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Why should I take my flesh in my teeth, 
-</p><p class="q2">and put my life in my hand? 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, he will kill me. 
-</p><p class="q2">I have no hope. 
-</p><p class="q2">Nevertheless, I will maintain my ways before him. 
-</p><p class="q1">
-<span class="v">16&#160;</span>This also will be my salvation, 
-</p><p class="q2">that an elohimless man will not come before him. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Listen carefully to my speech. 
-</p><p class="q2">Let my declaration be in your ears. 
-</p><p class="q1">
-<span class="v">18&#160;</span>See now, I have set my cause in order. 
-</p><p class="q2">I know that I am righteous. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Who is he who will contend with me? 
-</p><p class="q2">For then would I hold my peace and give up the spirit. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Only don’t do two things to me, 
-</p><p class="q2">then I will not hide myself from your face: 
-</p><p class="q1">
-<span class="v">21&#160;</span>withdraw your hand far from me, 
-</p><p class="q2">and don’t let your terror make me afraid. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Then call, and I will answer, 
-</p><p class="q2">or let me speak, and you answer me. 
-</p><p class="q1">
-<span class="v">23&#160;</span>How many are my iniquities and sins? 
-</p><p class="q2">Make me know my disobedience and my sin. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Why do you hide your face, 
-</p><p class="q2">and consider me your enemy? 
-</p><p class="q1">
-<span class="v">25&#160;</span>Will you harass a driven leaf? 
-</p><p class="q2">Will you pursue the dry stubble? 
-</p><p class="q1">
-<span class="v">26&#160;</span>For you write bitter things against me, 
-</p><p class="q2">and make me inherit the iniquities of my youth. 
-</p><p class="q1">
-<span class="v">27&#160;</span>You also put my feet in the stocks, 
-</p><p class="q2">and mark all my paths. 
-</p><p class="q2">You set a bound to the soles of my feet, 
-</p><p class="q1">
-<span class="v">28&#160;</span>though I am decaying like a rotten thing, 
-</p><p class="q2">like a garment that is moth-eaten. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Behold, my eye has seen all this. 
+</div><div class="q2">My ear has heard and understood it. 
+</div><div class="q1">
+<sup>2&#160;</sup>What you know, I know also. 
+</div><div class="q2">I am not inferior to you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Surely I would speak to the Almighty. 
+</div><div class="q2">I desire to reason with Elohim. 
+</div><div class="q1">
+<sup>4&#160;</sup>But you are forgers of lies. 
+</div><div class="q2">You are all physicians of no value. 
+</div><div class="q1">
+<sup>5&#160;</sup>Oh that you would be completely silent! 
+</div><div class="q2">Then you would be wise. 
+</div><div class="q1">
+<sup>6&#160;</sup>Hear now my reasoning. 
+</div><div class="q2">Listen to the pleadings of my lips. 
+</div><div class="q1">
+<sup>7&#160;</sup>Will you speak unrighteously for Elohim, 
+</div><div class="q2">and talk deceitfully for him? 
+</div><div class="q1">
+<sup>8&#160;</sup>Will you show partiality to him? 
+</div><div class="q2">Will you contend for Elohim? 
+</div><div class="q1">
+<sup>9&#160;</sup>Is it good that he should search you out? 
+</div><div class="q2">Or as one deceives a man, will you deceive him? 
+</div><div class="q1">
+<sup>10&#160;</sup>He will surely reprove you 
+</div><div class="q2">if you secretly show partiality. 
+</div><div class="q1">
+<sup>11&#160;</sup>Won’t his majesty make you afraid 
+</div><div class="q2">and his dread fall on you? 
+</div><div class="q1">
+<sup>12&#160;</sup>Your memorable sayings are proverbs of ashes. 
+</div><div class="q2">Your defenses are defenses of clay. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“Be silent! 
+</div><div class="q2">Leave me alone, that I may speak. 
+</div><div class="q2">Let come on me what will. 
+</div><div class="q1">
+<sup>14&#160;</sup>Why should I take my flesh in my teeth, 
+</div><div class="q2">and put my life in my hand? 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, he will kill me. 
+</div><div class="q2">I have no hope. 
+</div><div class="q2">Nevertheless, I will maintain my ways before him. 
+</div><div class="q1">
+<sup>16&#160;</sup>This also will be my salvation, 
+</div><div class="q2">that an elohimless man will not come before him. 
+</div><div class="q1">
+<sup>17&#160;</sup>Listen carefully to my speech. 
+</div><div class="q2">Let my declaration be in your ears. 
+</div><div class="q1">
+<sup>18&#160;</sup>See now, I have set my cause in order. 
+</div><div class="q2">I know that I am righteous. 
+</div><div class="q1">
+<sup>19&#160;</sup>Who is he who will contend with me? 
+</div><div class="q2">For then would I hold my peace and give up the spirit. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Only don’t do two things to me, 
+</div><div class="q2">then I will not hide myself from your face: 
+</div><div class="q1">
+<sup>21&#160;</sup>withdraw your hand far from me, 
+</div><div class="q2">and don’t let your terror make me afraid. 
+</div><div class="q1">
+<sup>22&#160;</sup>Then call, and I will answer, 
+</div><div class="q2">or let me speak, and you answer me. 
+</div><div class="q1">
+<sup>23&#160;</sup>How many are my iniquities and sins? 
+</div><div class="q2">Make me know my disobedience and my sin. 
+</div><div class="q1">
+<sup>24&#160;</sup>Why do you hide your face, 
+</div><div class="q2">and consider me your enemy? 
+</div><div class="q1">
+<sup>25&#160;</sup>Will you harass a driven leaf? 
+</div><div class="q2">Will you pursue the dry stubble? 
+</div><div class="q1">
+<sup>26&#160;</sup>For you write bitter things against me, 
+</div><div class="q2">and make me inherit the iniquities of my youth. 
+</div><div class="q1">
+<sup>27&#160;</sup>You also put my feet in the stocks, 
+</div><div class="q2">and mark all my paths. 
+</div><div class="q2">You set a bound to the soles of my feet, 
+</div><div class="q1">
+<sup>28&#160;</sup>though I am decaying like a rotten thing, 
+</div><div class="q2">like a garment that is moth-eaten. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="14">14</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Man, who is born of a woman, 
-</p><p class="q2">is of few days, and full of trouble. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He grows up like a flower, and is cut down. 
-</p><p class="q2">He also flees like a shadow, and doesn’t continue. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Do you open your eyes on such a one, 
-</p><p class="q2">and bring me into judgment with you? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Who can bring a clean thing out of an unclean? 
-</p><p class="q2">Not one. 
-</p><p class="q2">
-<span class="v">5&#160;</span>Seeing his days are determined, 
-</p><p class="q2">the number of his months is with you, 
-</p><p class="q2">and you have appointed his bounds that he can’t pass. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Look away from him, that he may rest, 
-</p><p class="q2">until he accomplishes, as a hireling, his day. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“For there is hope for a tree if it is cut down, 
-</p><p class="q2">that it will sprout again, 
-</p><p class="q2">that the tender branch of it will not cease. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Though its root grows old in the earth, 
-</p><p class="q2">and its stock dies in the ground, 
-</p><p class="q1">
-<span class="v">9&#160;</span>yet through the scent of water it will bud, 
-</p><p class="q2">and sprout boughs like a plant. 
-</p><p class="q1">
-<span class="v">10&#160;</span>But man dies, and is laid low. 
-</p><p class="q2">Yes, man gives up the spirit, and where is he? 
-</p><p class="q1">
-<span class="v">11&#160;</span>As the waters fail from the sea, 
-</p><p class="q2">and the river wastes and dries up, 
-</p><p class="q1">
-<span class="v">12&#160;</span>so man lies down and doesn’t rise. 
-</p><p class="q2">Until the heavens are no more, they will not awake, 
-</p><p class="q2">nor be roused out of their sleep. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“Oh that you would hide me in Sheol,<span class="f">+ \fr 14:13 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">that you would keep me secret until your wrath is past, 
-</p><p class="q2">that you would appoint me a set time and remember me! 
-</p><p class="q1">
-<span class="v">14&#160;</span>If a man dies, will he live again? 
-</p><p class="q2">I would wait all the days of my warfare, 
-</p><p class="q2">until my release should come. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You would call, and I would answer you. 
-</p><p class="q2">You would have a desire for the work of your hands. 
-</p><p class="q1">
-<span class="v">16&#160;</span>But now you count my steps. 
-</p><p class="q2">Don’t you watch over my sin? 
-</p><p class="q1">
-<span class="v">17&#160;</span>My disobedience is sealed up in a bag. 
-</p><p class="q2">You fasten up my iniquity. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“But the mountain falling comes to nothing. 
-</p><p class="q2">The rock is removed out of its place. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The waters wear the stones. 
-</p><p class="q2">The torrents of it wash away the dust of the earth. 
-</p><p class="q2">So you destroy the hope of man. 
-</p><p class="q1">
-<span class="v">20&#160;</span>You forever prevail against him, and he departs. 
-</p><p class="q2">You change his face, and send him away. 
-</p><p class="q1">
-<span class="v">21&#160;</span>His sons come to honor, and he doesn’t know it. 
-</p><p class="q2">They are brought low, but he doesn’t perceive it of them. 
-</p><p class="q1">
-<span class="v">22&#160;</span>But his flesh on him has pain, 
-</p><p class="q2">and his soul within him mourns.” 
-</p><div class="b"> &#160; </div>
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Man, who is born of a woman, 
+</div><div class="q2">is of few days, and full of trouble. 
+</div><div class="q1">
+<sup>2&#160;</sup>He grows up like a flower, and is cut down. 
+</div><div class="q2">He also flees like a shadow, and doesn’t continue. 
+</div><div class="q1">
+<sup>3&#160;</sup>Do you open your eyes on such a one, 
+</div><div class="q2">and bring me into judgment with you? 
+</div><div class="q1">
+<sup>4&#160;</sup>Who can bring a clean thing out of an unclean? 
+</div><div class="q2">Not one. 
+</div><div class="q2">
+<sup>5&#160;</sup>Seeing his days are determined, 
+</div><div class="q2">the number of his months is with you, 
+</div><div class="q2">and you have appointed his bounds that he can’t pass. 
+</div><div class="q1">
+<sup>6&#160;</sup>Look away from him, that he may rest, 
+</div><div class="q2">until he accomplishes, as a hireling, his day. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“For there is hope for a tree if it is cut down, 
+</div><div class="q2">that it will sprout again, 
+</div><div class="q2">that the tender branch of it will not cease. 
+</div><div class="q1">
+<sup>8&#160;</sup>Though its root grows old in the earth, 
+</div><div class="q2">and its stock dies in the ground, 
+</div><div class="q1">
+<sup>9&#160;</sup>yet through the scent of water it will bud, 
+</div><div class="q2">and sprout boughs like a plant. 
+</div><div class="q1">
+<sup>10&#160;</sup>But man dies, and is laid low. 
+</div><div class="q2">Yes, man gives up the spirit, and where is he? 
+</div><div class="q1">
+<sup>11&#160;</sup>As the waters fail from the sea, 
+</div><div class="q2">and the river wastes and dries up, 
+</div><div class="q1">
+<sup>12&#160;</sup>so man lies down and doesn’t rise. 
+</div><div class="q2">Until the heavens are no more, they will not awake, 
+</div><div class="q2">nor be roused out of their sleep. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“Oh that you would hide me in Sheol, 
+</div><div class="q2">that you would keep me secret until your wrath is past, 
+</div><div class="q2">that you would appoint me a set time and remember me! 
+</div><div class="q1">
+<sup>14&#160;</sup>If a man dies, will he live again? 
+</div><div class="q2">I would wait all the days of my warfare, 
+</div><div class="q2">until my release should come. 
+</div><div class="q1">
+<sup>15&#160;</sup>You would call, and I would answer you. 
+</div><div class="q2">You would have a desire for the work of your hands. 
+</div><div class="q1">
+<sup>16&#160;</sup>But now you count my steps. 
+</div><div class="q2">Don’t you watch over my sin? 
+</div><div class="q1">
+<sup>17&#160;</sup>My disobedience is sealed up in a bag. 
+</div><div class="q2">You fasten up my iniquity. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“But the mountain falling comes to nothing. 
+</div><div class="q2">The rock is removed out of its place. 
+</div><div class="q1">
+<sup>19&#160;</sup>The waters wear the stones. 
+</div><div class="q2">The torrents of it wash away the dust of the earth. 
+</div><div class="q2">So you destroy the hope of man. 
+</div><div class="q1">
+<sup>20&#160;</sup>You forever prevail against him, and he departs. 
+</div><div class="q2">You change his face, and send him away. 
+</div><div class="q1">
+<sup>21&#160;</sup>His sons come to honor, and he doesn’t know it. 
+</div><div class="q2">They are brought low, but he doesn’t perceive it of them. 
+</div><div class="q1">
+<sup>22&#160;</sup>But his flesh on him has pain, 
+</div><div class="q2">and his soul within him mourns.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Then Eliphaz the Temanite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Should a wise man answer with vain knowledge, 
-</p><p class="q2">and fill himself with the east wind? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Should he reason with unprofitable talk, 
-</p><p class="q2">or with speeches with which he can do no good? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yes, you do away with fear, 
-</p><p class="q2">and hinder devotion before Elohim. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For your iniquity teaches your mouth, 
-</p><p class="q2">and you choose the language of the crafty. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Your own mouth condemns you, and not I. 
-</p><p class="q2">Yes, your own lips testify against you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Are you the first man who was born? 
-</p><p class="q2">Or were you brought out before the hills? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Have you heard the secret counsel of Elohim? 
-</p><p class="q2">Do you limit wisdom to yourself? 
-</p><p class="q1">
-<span class="v">9&#160;</span>What do you know that we don’t know? 
-</p><p class="q2">What do you understand which is not in us? 
-</p><p class="q1">
-<span class="v">10&#160;</span>With us are both the gray-headed and the very aged men, 
-</p><p class="q2">much older than your father. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Are the consolations of Elohim too small for you, 
-</p><p class="q2">even the word that is gentle toward you? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Why does your heart carry you away? 
-</p><p class="q2">Why do your eyes flash, 
-</p><p class="q1">
-<span class="v">13&#160;</span>that you turn your spirit against Elohim, 
-</p><p class="q2">and let such words go out of your mouth? 
-</p><p class="q1">
-<span class="v">14&#160;</span>What is man, that he should be clean? 
-</p><p class="q2">What is he who is born of a woman, that he should be righteous? 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold, he puts no trust in his set-apart ones. 
-</p><p class="q2">Yes, the heavens are not clean in his sight; 
-</p><p class="q1">
-<span class="v">16&#160;</span>how much less one who is abominable and corrupt, 
-</p><p class="q2">a man who drinks iniquity like water! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“I will show you, listen to me; 
-</p><p class="q2">that which I have seen I will declare 
-</p><p class="q1">
-<span class="v">18&#160;</span>(which wise men have told by their fathers, 
-</p><p class="q2">and have not hidden it; 
-</p><p class="q1">
-<span class="v">19&#160;</span>to whom alone the land was given, 
-</p><p class="q2">and no stranger passed among them): 
-</p><p class="q1">
-<span class="v">20&#160;</span>the wicked man writhes in pain all his days, 
-</p><p class="q2">even the number of years that are laid up for the oppressor. 
-</p><p class="q1">
-<span class="v">21&#160;</span>A sound of terrors is in his ears. 
-</p><p class="q2">In prosperity the destroyer will come on him. 
-</p><p class="q1">
-<span class="v">22&#160;</span>He doesn’t believe that he will return out of darkness. 
-</p><p class="q2">He is waited for by the sword. 
-</p><p class="q1">
-<span class="v">23&#160;</span>He wanders abroad for bread, saying, ‘Where is it?’ 
-</p><p class="q2">He knows that the day of darkness is ready at his hand. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Distress and anguish make him afraid. 
-</p><p class="q2">They prevail against him, as a king ready to the battle. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Because he has stretched out his hand against Elohim, 
-</p><p class="q2">and behaves himself proudly against the Almighty, 
-</p><p class="q1">
-<span class="v">26&#160;</span>he runs at him with a stiff neck, 
-</p><p class="q2">with the thick shields of his bucklers, 
-</p><p class="q1">
-<span class="v">27&#160;</span>because he has covered his face with his fatness, 
-</p><p class="q2">and gathered fat on his thighs. 
-</p><p class="q1">
-<span class="v">28&#160;</span>He has lived in desolate cities, 
-</p><p class="q2">in houses which no one inhabited, 
-</p><p class="q2">which were ready to become heaps. 
-</p><p class="q1">
-<span class="v">29&#160;</span>He will not be rich, neither will his substance continue, 
-</p><p class="q2">neither will their possessions be extended on the earth. 
-</p><p class="q1">
-<span class="v">30&#160;</span>He will not depart out of darkness. 
-</p><p class="q2">The flame will dry up his branches. 
-</p><p class="q2">He will go away by the breath of Elohim’s mouth. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Let him not trust in emptiness, deceiving himself, 
-</p><p class="q2">for emptiness will be his reward. 
-</p><p class="q1">
-<span class="v">32&#160;</span>It will be accomplished before his time. 
-</p><p class="q2">His branch will not be green. 
-</p><p class="q1">
-<span class="v">33&#160;</span>He will shake off his unripe grape as the vine, 
-</p><p class="q2">and will cast off his flower as the olive tree. 
-</p><p class="q1">
-<span class="v">34&#160;</span>For the company of the elohimless will be barren, 
-</p><p class="q2">and fire will consume the tents of bribery. 
-</p><p class="q1">
-<span class="v">35&#160;</span>They conceive mischief and produce iniquity. 
-</p><p class="q2">Their heart prepares deceit.” 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Then Eliphaz the Temanite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Should a wise man answer with vain knowledge, 
+</div><div class="q2">and fill himself with the east wind? 
+</div><div class="q1">
+<sup>3&#160;</sup>Should he reason with unprofitable talk, 
+</div><div class="q2">or with speeches with which he can do no good? 
+</div><div class="q1">
+<sup>4&#160;</sup>Yes, you do away with fear, 
+</div><div class="q2">and hinder devotion before Elohim. 
+</div><div class="q1">
+<sup>5&#160;</sup>For your iniquity teaches your mouth, 
+</div><div class="q2">and you choose the language of the crafty. 
+</div><div class="q1">
+<sup>6&#160;</sup>Your own mouth condemns you, and not I. 
+</div><div class="q2">Yes, your own lips testify against you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Are you the first man who was born? 
+</div><div class="q2">Or were you brought out before the hills? 
+</div><div class="q1">
+<sup>8&#160;</sup>Have you heard the secret counsel of Elohim? 
+</div><div class="q2">Do you limit wisdom to yourself? 
+</div><div class="q1">
+<sup>9&#160;</sup>What do you know that we don’t know? 
+</div><div class="q2">What do you understand which is not in us? 
+</div><div class="q1">
+<sup>10&#160;</sup>With us are both the gray-headed and the very aged men, 
+</div><div class="q2">much older than your father. 
+</div><div class="q1">
+<sup>11&#160;</sup>Are the consolations of Elohim too small for you, 
+</div><div class="q2">even the word that is gentle toward you? 
+</div><div class="q1">
+<sup>12&#160;</sup>Why does your heart carry you away? 
+</div><div class="q2">Why do your eyes flash, 
+</div><div class="q1">
+<sup>13&#160;</sup>that you turn your spirit against Elohim, 
+</div><div class="q2">and let such words go out of your mouth? 
+</div><div class="q1">
+<sup>14&#160;</sup>What is man, that he should be clean? 
+</div><div class="q2">What is he who is born of a woman, that he should be righteous? 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, he puts no trust in his set-apart ones. 
+</div><div class="q2">Yes, the heavens are not clean in his sight; 
+</div><div class="q1">
+<sup>16&#160;</sup>how much less one who is abominable and corrupt, 
+</div><div class="q2">a man who drinks iniquity like water! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“I will show you, listen to me; 
+</div><div class="q2">that which I have seen I will declare 
+</div><div class="q1">
+<sup>18&#160;</sup>(which wise men have told by their fathers, 
+</div><div class="q2">and have not hidden it; 
+</div><div class="q1">
+<sup>19&#160;</sup>to whom alone the land was given, 
+</div><div class="q2">and no stranger passed among them): 
+</div><div class="q1">
+<sup>20&#160;</sup>the wicked man writhes in pain all his days, 
+</div><div class="q2">even the number of years that are laid up for the oppressor. 
+</div><div class="q1">
+<sup>21&#160;</sup>A sound of terrors is in his ears. 
+</div><div class="q2">In prosperity the destroyer will come on him. 
+</div><div class="q1">
+<sup>22&#160;</sup>He doesn’t believe that he will return out of darkness. 
+</div><div class="q2">He is waited for by the sword. 
+</div><div class="q1">
+<sup>23&#160;</sup>He wanders abroad for bread, saying, ‘Where is it?’ 
+</div><div class="q2">He knows that the day of darkness is ready at his hand. 
+</div><div class="q1">
+<sup>24&#160;</sup>Distress and anguish make him afraid. 
+</div><div class="q2">They prevail against him, as a king ready to the battle. 
+</div><div class="q1">
+<sup>25&#160;</sup>Because he has stretched out his hand against Elohim, 
+</div><div class="q2">and behaves himself proudly against the Almighty, 
+</div><div class="q1">
+<sup>26&#160;</sup>he runs at him with a stiff neck, 
+</div><div class="q2">with the thick shields of his bucklers, 
+</div><div class="q1">
+<sup>27&#160;</sup>because he has covered his face with his fatness, 
+</div><div class="q2">and gathered fat on his thighs. 
+</div><div class="q1">
+<sup>28&#160;</sup>He has lived in desolate cities, 
+</div><div class="q2">in houses which no one inhabited, 
+</div><div class="q2">which were ready to become heaps. 
+</div><div class="q1">
+<sup>29&#160;</sup>He will not be rich, neither will his substance continue, 
+</div><div class="q2">neither will their possessions be extended on the earth. 
+</div><div class="q1">
+<sup>30&#160;</sup>He will not depart out of darkness. 
+</div><div class="q2">The flame will dry up his branches. 
+</div><div class="q2">He will go away by the breath of Elohim’s mouth. 
+</div><div class="q1">
+<sup>31&#160;</sup>Let him not trust in emptiness, deceiving himself, 
+</div><div class="q2">for emptiness will be his reward. 
+</div><div class="q1">
+<sup>32&#160;</sup>It will be accomplished before his time. 
+</div><div class="q2">His branch will not be green. 
+</div><div class="q1">
+<sup>33&#160;</sup>He will shake off his unripe grape as the vine, 
+</div><div class="q2">and will cast off his flower as the olive tree. 
+</div><div class="q1">
+<sup>34&#160;</sup>For the company of the elohimless will be barren, 
+</div><div class="q2">and fire will consume the tents of bribery. 
+</div><div class="q1">
+<sup>35&#160;</sup>They conceive mischief and produce iniquity. 
+</div><div class="q2">Their heart prepares deceit.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“I have heard many such things. 
-</p><p class="q2">You are all miserable comforters! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Shall vain words have an end? 
-</p><p class="q2">Or what provokes you that you answer? 
-</p><p class="q1">
-<span class="v">4&#160;</span>I also could speak as you do. 
-</p><p class="q2">If your soul were in my soul’s place, 
-</p><p class="q2">I could join words together against you, 
-</p><p class="q2">and shake my head at you, 
-</p><p class="q1">
-<span class="v">5&#160;</span>but I would strengthen you with my mouth. 
-</p><p class="q2">The solace of my lips would relieve you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“Though I speak, my grief is not subsided. 
-</p><p class="q2">Though I forbear, what am I eased? 
-</p><p class="q1">
-<span class="v">7&#160;</span>But now, Elohim, you have surely worn me out. 
-</p><p class="q2">You have made all my company desolate. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You have shriveled me up. This is a witness against me. 
-</p><p class="q2">My leanness rises up against me. 
-</p><p class="q2">It testifies to my face. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He has torn me in his wrath and persecuted me. 
-</p><p class="q2">He has gnashed on me with his teeth. 
-</p><p class="q2">My adversary sharpens his eyes on me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They have gaped on me with their mouth. 
-</p><p class="q2">They have struck me on the cheek reproachfully. 
-</p><p class="q2">They gather themselves together against me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Elohim delivers me to the unelohimly, 
-</p><p class="q2">and casts me into the hands of the wicked. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I was at ease, and he broke me apart. 
-</p><p class="q2">Yes, he has taken me by the neck, and dashed me to pieces. 
-</p><p class="q2">He has also set me up for his target. 
-</p><p class="q1">
-<span class="v">13&#160;</span>His archers surround me. 
-</p><p class="q2">He splits my kidneys apart, and does not spare. 
-</p><p class="q2">He pours out my bile on the ground. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He breaks me with breach on breach. 
-</p><p class="q2">He runs at me like a giant. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I have sewed sackcloth on my skin, 
-</p><p class="q2">and have thrust my horn in the dust. 
-</p><p class="q1">
-<span class="v">16&#160;</span>My face is red with weeping. 
-</p><p class="q2">Deep darkness is on my eyelids, 
-</p><p class="q1">
-<span class="v">17&#160;</span>although there is no violence in my hands, 
-</p><p class="q2">and my prayer is pure. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“Earth, don’t cover my blood. 
-</p><p class="q2">Let my cry have no place to rest. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Even now, behold, my witness is in heaven. 
-</p><p class="q2">He who vouches for me is on high. 
-</p><p class="q1">
-<span class="v">20&#160;</span>My friends scoff at me. 
-</p><p class="q2">My eyes pour out tears to Elohim, 
-</p><p class="q1">
-<span class="v">21&#160;</span>that he would maintain the right of a man with Elohim, 
-</p><p class="q2">of a son of man with his neighbor! 
-</p><p class="q1">
-<span class="v">22&#160;</span>For when a few years have come, 
-</p><p class="q2">I will go the way of no return. 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“I have heard many such things. 
+</div><div class="q2">You are all miserable comforters! 
+</div><div class="q1">
+<sup>3&#160;</sup>Shall vain words have an end? 
+</div><div class="q2">Or what provokes you that you answer? 
+</div><div class="q1">
+<sup>4&#160;</sup>I also could speak as you do. 
+</div><div class="q2">If your soul were in my soul’s place, 
+</div><div class="q2">I could join words together against you, 
+</div><div class="q2">and shake my head at you, 
+</div><div class="q1">
+<sup>5&#160;</sup>but I would strengthen you with my mouth. 
+</div><div class="q2">The solace of my lips would relieve you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“Though I speak, my grief is not subsided. 
+</div><div class="q2">Though I forbear, what am I eased? 
+</div><div class="q1">
+<sup>7&#160;</sup>But now, Elohim, you have surely worn me out. 
+</div><div class="q2">You have made all my company desolate. 
+</div><div class="q1">
+<sup>8&#160;</sup>You have shriveled me up. This is a witness against me. 
+</div><div class="q2">My leanness rises up against me. 
+</div><div class="q2">It testifies to my face. 
+</div><div class="q1">
+<sup>9&#160;</sup>He has torn me in his wrath and persecuted me. 
+</div><div class="q2">He has gnashed on me with his teeth. 
+</div><div class="q2">My adversary sharpens his eyes on me. 
+</div><div class="q1">
+<sup>10&#160;</sup>They have gaped on me with their mouth. 
+</div><div class="q2">They have struck me on the cheek reproachfully. 
+</div><div class="q2">They gather themselves together against me. 
+</div><div class="q1">
+<sup>11&#160;</sup>Elohim delivers me to the unelohimly, 
+</div><div class="q2">and casts me into the hands of the wicked. 
+</div><div class="q1">
+<sup>12&#160;</sup>I was at ease, and he broke me apart. 
+</div><div class="q2">Yes, he has taken me by the neck, and dashed me to pieces. 
+</div><div class="q2">He has also set me up for his target. 
+</div><div class="q1">
+<sup>13&#160;</sup>His archers surround me. 
+</div><div class="q2">He splits my kidneys apart, and does not spare. 
+</div><div class="q2">He pours out my bile on the ground. 
+</div><div class="q1">
+<sup>14&#160;</sup>He breaks me with breach on breach. 
+</div><div class="q2">He runs at me like a giant. 
+</div><div class="q1">
+<sup>15&#160;</sup>I have sewed sackcloth on my skin, 
+</div><div class="q2">and have thrust my horn in the dust. 
+</div><div class="q1">
+<sup>16&#160;</sup>My face is red with weeping. 
+</div><div class="q2">Deep darkness is on my eyelids, 
+</div><div class="q1">
+<sup>17&#160;</sup>although there is no violence in my hands, 
+</div><div class="q2">and my prayer is pure. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“Earth, don’t cover my blood. 
+</div><div class="q2">Let my cry have no place to rest. 
+</div><div class="q1">
+<sup>19&#160;</sup>Even now, behold, my witness is in heaven. 
+</div><div class="q2">He who vouches for me is on high. 
+</div><div class="q1">
+<sup>20&#160;</sup>My friends scoff at me. 
+</div><div class="q2">My eyes pour out tears to Elohim, 
+</div><div class="q1">
+<sup>21&#160;</sup>that he would maintain the right of a man with Elohim, 
+</div><div class="q2">of a son of man with his neighbor! 
+</div><div class="q1">
+<sup>22&#160;</sup>For when a few years have come, 
+</div><div class="q2">I will go the way of no return. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="17">17</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“My spirit is consumed. 
-</p><p class="q2">My days are extinct 
-</p><p class="q2">and the grave is ready for me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Surely there are mockers with me. 
-</p><p class="q2">My eye dwells on their provocation. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Now give a pledge. Be collateral for me with yourself. 
-</p><p class="q2">Who is there who will strike hands with me? 
-</p><p class="q1">
-<span class="v">4&#160;</span>For you have hidden their heart from understanding, 
-</p><p class="q2">therefore you will not exalt them. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He who denounces his friends for plunder, 
-</p><p class="q2">even the eyes of his children will fail. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“But he has made me a byword of the people. 
-</p><p class="q2">They spit in my face. 
-</p><p class="q1">
-<span class="v">7&#160;</span>My eye also is dim by reason of sorrow. 
-</p><p class="q2">All my members are as a shadow. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Upright men will be astonished at this. 
-</p><p class="q2">The innocent will stir himself up against the elohimless. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yet the righteous will hold to his way. 
-</p><p class="q2">He who has clean hands will grow stronger and stronger. 
-</p><p class="q1">
-<span class="v">10&#160;</span>But as for you all, come back. 
-</p><p class="q2">I will not find a wise man among you. 
-</p><p class="q1">
-<span class="v">11&#160;</span>My days are past. 
-</p><p class="q2">My plans are broken off, 
-</p><p class="q2">as are the thoughts of my heart. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They change the night into day, 
-</p><p class="q2">saying ‘The light is near’ in the presence of darkness. 
-</p><p class="q1">
-<span class="v">13&#160;</span>If I look for Sheol<span class="f">+ \fr 17:13 \ft Sheol is the place of the dead.</span> as my house, 
-</p><p class="q2">if I have spread my couch in the darkness, 
-</p><p class="q1">
-<span class="v">14&#160;</span>if I have said to corruption, ‘You are my father,’ 
-</p><p class="q2">and to the worm, ‘My mother,’ and ‘My sister,’ 
-</p><p class="q1">
-<span class="v">15&#160;</span>where then is my hope? 
-</p><p class="q2">As for my hope, who will see it? 
-</p><p class="q1">
-<span class="v">16&#160;</span>Shall it go down with me to the gates of Sheol,<span class="f">+ \fr 17:16 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">or descend together into the dust?” 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“My spirit is consumed. 
+</div><div class="q2">My days are extinct 
+</div><div class="q2">and the grave is ready for me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Surely there are mockers with me. 
+</div><div class="q2">My eye dwells on their provocation. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Now give a pledge. Be collateral for me with yourself. 
+</div><div class="q2">Who is there who will strike hands with me? 
+</div><div class="q1">
+<sup>4&#160;</sup>For you have hidden their heart from understanding, 
+</div><div class="q2">therefore you will not exalt them. 
+</div><div class="q1">
+<sup>5&#160;</sup>He who denounces his friends for plunder, 
+</div><div class="q2">even the eyes of his children will fail. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“But he has made me a byword of the people. 
+</div><div class="q2">They spit in my face. 
+</div><div class="q1">
+<sup>7&#160;</sup>My eye also is dim by reason of sorrow. 
+</div><div class="q2">All my members are as a shadow. 
+</div><div class="q1">
+<sup>8&#160;</sup>Upright men will be astonished at this. 
+</div><div class="q2">The innocent will stir himself up against the elohimless. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yet the righteous will hold to his way. 
+</div><div class="q2">He who has clean hands will grow stronger and stronger. 
+</div><div class="q1">
+<sup>10&#160;</sup>But as for you all, come back. 
+</div><div class="q2">I will not find a wise man among you. 
+</div><div class="q1">
+<sup>11&#160;</sup>My days are past. 
+</div><div class="q2">My plans are broken off, 
+</div><div class="q2">as are the thoughts of my heart. 
+</div><div class="q1">
+<sup>12&#160;</sup>They change the night into day, 
+</div><div class="q2">saying ‘The light is near’ in the presence of darkness. 
+</div><div class="q1">
+<sup>13&#160;</sup>If I look for Sheol as my house, 
+</div><div class="q2">if I have spread my couch in the darkness, 
+</div><div class="q1">
+<sup>14&#160;</sup>if I have said to corruption, ‘You are my father,’ 
+</div><div class="q2">and to the worm, ‘My mother,’ and ‘My sister,’ 
+</div><div class="q1">
+<sup>15&#160;</sup>where then is my hope? 
+</div><div class="q2">As for my hope, who will see it? 
+</div><div class="q1">
+<sup>16&#160;</sup>Shall it go down with me to the gates of Sheol, 
+</div><div class="q2">or descend together into the dust?” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Then Bildad the Shuhite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“How long will you hunt for words? 
-</p><p class="q2">Consider, and afterwards we will speak. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Why are we counted as animals, 
-</p><p class="q2">which have become unclean in your sight? 
-</p><p class="q1">
-<span class="v">4&#160;</span>You who tear yourself in your anger, 
-</p><p class="q2">will the earth be forsaken for you? 
-</p><p class="q2">Or will the rock be removed out of its place? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Yes, the light of the wicked will be put out. 
-</p><p class="q2">The spark of his fire won’t shine. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The light will be dark in his tent. 
-</p><p class="q2">His lamp above him will be put out. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The steps of his strength will be shortened. 
-</p><p class="q2">His own counsel will cast him down. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For he is cast into a net by his own feet, 
-</p><p class="q2">and he wanders into its mesh. 
-</p><p class="q1">
-<span class="v">9&#160;</span>A snare will take him by the heel. 
-</p><p class="q2">A trap will catch him. 
-</p><p class="q1">
-<span class="v">10&#160;</span>A noose is hidden for him in the ground, 
-</p><p class="q2">a trap for him on the path. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Terrors will make him afraid on every side, 
-</p><p class="q2">and will chase him at his heels. 
-</p><p class="q1">
-<span class="v">12&#160;</span>His strength will be famished. 
-</p><p class="q2">Calamity will be ready at his side. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The members of his body will be devoured. 
-</p><p class="q2">The firstborn of death will devour his members. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He will be rooted out of the security of his tent. 
-</p><p class="q2">He will be brought to the king of terrors. 
-</p><p class="q1">
-<span class="v">15&#160;</span>There will dwell in his tent that which is none of his. 
-</p><p class="q2">Sulfur will be scattered on his habitation. 
-</p><p class="q1">
-<span class="v">16&#160;</span>His roots will be dried up beneath. 
-</p><p class="q2">His branch will be cut off above. 
-</p><p class="q1">
-<span class="v">17&#160;</span>His memory will perish from the earth. 
-</p><p class="q2">He will have no name in the street. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He will be driven from light into darkness, 
-</p><p class="q2">and chased out of the world. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He will have neither son nor grandson among his people, 
-</p><p class="q2">nor any remaining where he lived. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Those who come after will be astonished at his day, 
-</p><p class="q2">as those who went before were frightened. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Surely such are the dwellings of the unrighteous. 
-</p><p class="q2">This is the place of him who doesn’t know Elohim.” 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“How long will you torment me, 
-</p><p class="q2">and crush me with words? 
-</p><p class="q1">
-<span class="v">3&#160;</span>You have reproached me ten times. 
-</p><p class="q2">You aren’t ashamed that you attack me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>If it is true that I have erred, 
-</p><p class="q2">my error remains with myself. 
-</p><p class="q1">
-<span class="v">5&#160;</span>If indeed you will magnify yourselves against me, 
-</p><p class="q2">and plead against me my reproach, 
-</p><p class="q1">
-<span class="v">6&#160;</span>know now that Elohim has subverted me, 
-</p><p class="q2">and has surrounded me with his net. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Behold, I cry out of wrong, but I am not heard. 
-</p><p class="q2">I cry for help, but there is no justice. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He has walled up my way so that I can’t pass, 
-</p><p class="q2">and has set darkness in my paths. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He has stripped me of my glory, 
-</p><p class="q2">and taken the crown from my head. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He has broken me down on every side, and I am gone. 
-</p><p class="q2">He has plucked my hope up like a tree. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He has also kindled his wrath against me. 
-</p><p class="q2">He counts me among his adversaries. 
-</p><p class="q1">
-<span class="v">12&#160;</span>His troops come on together, 
-</p><p class="q2">build a siege ramp against me, 
-</p><p class="q2">and encamp around my tent. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“He has put my brothers far from me. 
-</p><p class="q2">My acquaintances are wholly estranged from me. 
-</p><p class="q1">
-<span class="v">14&#160;</span>My relatives have gone away. 
-</p><p class="q2">My familiar friends have forgotten me. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Those who dwell in my house and my maids consider me a stranger. 
-</p><p class="q2">I am an alien in their sight. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I call to my servant, and he gives me no answer. 
-</p><p class="q2">I beg him with my mouth. 
-</p><p class="q1">
-<span class="v">17&#160;</span>My breath is offensive to my woman. 
-</p><p class="q2">I am loathsome to the children of my own mother. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Even young children despise me. 
-</p><p class="q2">If I arise, they speak against me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>All my familiar friends abhor me. 
-</p><p class="q2">They whom I loved have turned against me. 
-</p><p class="q1">
-<span class="v">20&#160;</span>My bones stick to my skin and to my flesh. 
-</p><p class="q2">I have escaped by the skin of my teeth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Have pity on me. Have pity on me, you my friends, 
-</p><p class="q2">for the hand of Elohim has touched me. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Why do you persecute me as Elohim, 
-</p><p class="q2">and are not satisfied with my flesh? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>“Oh that my words were now written! 
-</p><p class="q2">Oh that they were inscribed in a book! 
-</p><p class="q1">
-<span class="v">24&#160;</span>That with an iron pen and lead 
-</p><p class="q2">they were engraved in the rock forever! 
-</p><p class="q1">
-<span class="v">25&#160;</span>But as for me, I know that my Redeemer lives. 
-</p><p class="q2">In the end, he will stand upon the earth. 
-</p><p class="q1">
-<span class="v">26&#160;</span>After my skin is destroyed, 
-</p><p class="q2">then I will see Elohim in my flesh, 
-</p><p class="q1">
-<span class="v">27&#160;</span>whom I, even I, will see on my side. 
-</p><p class="q2">My eyes will see, and not as a stranger. 
-</p><div class="b"> &#160; </div>
-<p class="q1">“My heart is consumed within me. 
-</p><p class="q1">
-<span class="v">28&#160;</span>If you say, ‘How we will persecute him!’ 
-</p><p class="q2">because the root of the matter is found in me, 
-</p><p class="q1">
-<span class="v">29&#160;</span>be afraid of the sword, 
-</p><p class="q2">for wrath brings the punishments of the sword, 
-</p><p class="q2">that you may know there is a judgment.” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Then Zophar the Naamathite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Therefore my thoughts answer me, 
-</p><p class="q2">even by reason of my haste that is in me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I have heard the reproof which puts me to shame. 
-</p><p class="q2">The spirit of my understanding answers me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Don’t you know this from old time, 
-</p><p class="q2">since man was placed on earth, 
-</p><p class="q1">
-<span class="v">5&#160;</span>that the triumphing of the wicked is short, 
-</p><p class="q2">the joy of the elohimless but for a moment? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Though his height mount up to the heavens, 
-</p><p class="q2">and his head reach to the clouds, 
-</p><p class="q1">
-<span class="v">7&#160;</span>yet he will perish forever like his own dung. 
-</p><p class="q2">Those who have seen him will say, ‘Where is he?’ 
-</p><p class="q1">
-<span class="v">8&#160;</span>He will fly away as a dream, and will not be found. 
-</p><p class="q2">Yes, he will be chased away like a vision of the night. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The eye which saw him will see him no more, 
-</p><p class="q2">neither will his place see him any more. 
-</p><p class="q1">
-<span class="v">10&#160;</span>His children will seek the favor of the poor. 
-</p><p class="q2">His hands will give back his wealth. 
-</p><p class="q1">
-<span class="v">11&#160;</span>His bones are full of his youth, 
-</p><p class="q2">but youth will lie down with him in the dust. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Though wickedness is sweet in his mouth, 
-</p><p class="q2">though he hide it under his tongue, 
-</p><p class="q1">
-<span class="v">13&#160;</span>though he spare it, and will not let it go, 
-</p><p class="q2">but keep it still within his mouth, 
-</p><p class="q1">
-<span class="v">14&#160;</span>yet his food in his bowels is turned. 
-</p><p class="q2">It is cobra venom within him. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He has swallowed down riches, and he will vomit them up again. 
-</p><p class="q2">Elohim will cast them out of his belly. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He will suck cobra venom. 
-</p><p class="q2">The viper’s tongue will kill him. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He will not look at the rivers, 
-</p><p class="q2">the flowing streams of honey and butter. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He will restore that for which he labored, and will not swallow it down. 
-</p><p class="q2">He will not rejoice according to the substance that he has gotten. 
-</p><p class="q1">
-<span class="v">19&#160;</span>For he has oppressed and forsaken the poor. 
-</p><p class="q2">He has violently taken away a house, and he will not build it up. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Because he knew no quietness within him, 
-</p><p class="q2">he will not save anything of that in which he delights. 
-</p><p class="q1">
-<span class="v">21&#160;</span>There was nothing left that he didn’t devour, 
-</p><p class="q2">therefore his prosperity will not endure. 
-</p><p class="q1">
-<span class="v">22&#160;</span>In the fullness of his sufficiency, distress will overtake him. 
-</p><p class="q2">The hand of everyone who is in misery will come on him. 
-</p><p class="q1">
-<span class="v">23&#160;</span>When he is about to fill his belly, Elohim will cast the fierceness of his wrath on him. 
-</p><p class="q2">It will rain on him while he is eating. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He will flee from the iron weapon. 
-</p><p class="q2">The bronze arrow will strike him through. 
-</p><p class="q1">
-<span class="v">25&#160;</span>He draws it out, and it comes out of his body. 
-</p><p class="q2">Yes, the glittering point comes out of his liver. 
-</p><p class="q2">Terrors are on him. 
-</p><p class="q1">
-<span class="v">26&#160;</span>All darkness is laid up for his treasures. 
-</p><p class="q2">An unfanned fire will devour him. 
-</p><p class="q2">It will consume that which is left in his tent. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The heavens will reveal his iniquity. 
-</p><p class="q2">The earth will rise up against him. 
-</p><p class="q1">
-<span class="v">28&#160;</span>The increase of his house will depart. 
-</p><p class="q2">They will rush away in the day of his wrath. 
-</p><p class="q1">
-<span class="v">29&#160;</span>This is the portion of a wicked man from Elohim, 
-</p><p class="q2">the heritage appointed to him by Elohim.” 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Listen diligently to my speech. 
-</p><p class="q2">Let this be your consolation. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Allow me, and I also will speak. 
-</p><p class="q2">After I have spoken, mock on. 
-</p><p class="q1">
-<span class="v">4&#160;</span>As for me, is my complaint to man? 
-</p><p class="q2">Why shouldn’t I be impatient? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Look at me, and be astonished. 
-</p><p class="q2">Lay your hand on your mouth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>When I remember, I am troubled. 
-</p><p class="q2">Horror takes hold of my flesh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Why do the wicked live, 
-</p><p class="q2">become old, yes, and grow mighty in power? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Their child is established with them in their sight, 
-</p><p class="q2">their offspring before their eyes. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Their houses are safe from fear, 
-</p><p class="q2">neither is the rod of Elohim upon them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Their bulls breed without fail. 
-</p><p class="q2">Their cows calve, and don’t miscarry. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They send out their little ones like a flock. 
-</p><p class="q2">Their children dance. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They sing to the tambourine and harp, 
-</p><p class="q2">and rejoice at the sound of the pipe. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They spend their days in prosperity. 
-</p><p class="q2">In an instant they go down to Sheol.<span class="f">+ \fr 21:13 \ft Sheol is the place of the dead. </span> 
-</p><p class="q1">
-<span class="v">14&#160;</span>They tell Elohim, ‘Depart from us, 
-</p><p class="q2">for we don’t want to know about your ways. 
-</p><p class="q1">
-<span class="v">15&#160;</span>What is the Almighty, that we should serve him? 
-</p><p class="q2">What profit should we have, if we pray to him?’ 
-</p><p class="q1">
-<span class="v">16&#160;</span>Behold, their prosperity is not in their hand. 
-</p><p class="q2">The counsel of the wicked is far from me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“How often is it that the lamp of the wicked is put out, 
-</p><p class="q2">that their calamity comes on them, 
-</p><p class="q2">that Elohim distributes sorrows in his anger? 
-</p><p class="q1">
-<span class="v">18&#160;</span>How often is it that they are as stubble before the wind, 
-</p><p class="q2">as chaff that the storm carries away? 
-</p><p class="q1">
-<span class="v">19&#160;</span>You say, ‘Elohim lays up his iniquity for his children.’ 
-</p><p class="q2">Let him recompense it to himself, that he may know it. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Let his own eyes see his destruction. 
-</p><p class="q2">Let him drink of the wrath of the Almighty. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For what does he care for his house after him, 
-</p><p class="q2">when the number of his months is cut off? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“Shall any teach Elohim knowledge, 
-</p><p class="q2">since he judges those who are high? 
-</p><p class="q1">
-<span class="v">23&#160;</span>One dies in his full strength, 
-</p><p class="q2">being wholly at ease and quiet. 
-</p><p class="q1">
-<span class="v">24&#160;</span>His pails are full of milk. 
-</p><p class="q2">The marrow of his bones is moistened. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Another dies in bitterness of soul, 
-</p><p class="q2">and never tastes of good. 
-</p><p class="q1">
-<span class="v">26&#160;</span>They lie down alike in the dust. 
-</p><p class="q2">The worm covers them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">27&#160;</span>“Behold, I know your thoughts, 
-</p><p class="q2">the plans with which you would wrong me. 
-</p><p class="q1">
-<span class="v">28&#160;</span>For you say, ‘Where is the house of the prince? 
-</p><p class="q2">Where is the tent in which the wicked lived?’ 
-</p><p class="q1">
-<span class="v">29&#160;</span>Haven’t you asked wayfaring men? 
-</p><p class="q2">Don’t you know their evidences, 
-</p><p class="q1">
-<span class="v">30&#160;</span>that the evil man is reserved to the day of calamity, 
-</p><p class="q2">that they are led out to the day of wrath? 
-</p><p class="q1">
-<span class="v">31&#160;</span>Who will declare his way to his face? 
-</p><p class="q2">Who will repay him what he has done? 
-</p><p class="q1">
-<span class="v">32&#160;</span>Yet he will be borne to the grave. 
-</p><p class="q2">Men will keep watch over the tomb. 
-</p><p class="q1">
-<span class="v">33&#160;</span>The clods of the valley will be sweet to him. 
-</p><p class="q2">All men will draw after him, 
-</p><p class="q2">as there were innumerable before him. 
-</p><p class="q1">
-<span class="v">34&#160;</span>So how can you comfort me with nonsense, 
-</p><p class="q2">because in your answers there remains only falsehood?” 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Then Eliphaz the Temanite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Can a man be profitable to Elohim? 
-</p><p class="q2">Surely he who is wise is profitable to himself. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Is it any pleasure to the Almighty that you are righteous? 
-</p><p class="q2">Or does it benefit him that you make your ways perfect? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Is it for your piety that he reproves you, 
-</p><p class="q2">that he enters with you into judgment? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Isn’t your wickedness great? 
-</p><p class="q2">Neither is there any end to your iniquities. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For you have taken pledges from your brother for nothing, 
-</p><p class="q2">and stripped the naked of their clothing. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You haven’t given water to the weary to drink, 
-</p><p class="q2">and you have withheld bread from the hungry. 
-</p><p class="q1">
-<span class="v">8&#160;</span>But as for the mighty man, he had the earth. 
-</p><p class="q2">The honorable man, he lived in it. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You have sent widows away empty, 
-</p><p class="q2">and the arms of the fatherless have been broken. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Therefore snares are around you. 
-</p><p class="q2">Sudden fear troubles you, 
-</p><p class="q1">
-<span class="v">11&#160;</span>or darkness, so that you can not see, 
-</p><p class="q2">and floods of waters cover you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Isn’t Elohim in the heights of heaven? 
-</p><p class="q2">See the height of the stars, how high they are! 
-</p><p class="q1">
-<span class="v">13&#160;</span>You say, ‘What does Elohim know? 
-</p><p class="q2">Can he judge through the thick darkness? 
-</p><p class="q1">
-<span class="v">14&#160;</span>Thick clouds are a covering to him, so that he doesn’t see. 
-</p><p class="q2">He walks on the vault of the sky.’ 
-</p><p class="q1">
-<span class="v">15&#160;</span>Will you keep the old way, 
-</p><p class="q2">which wicked men have trodden, 
-</p><p class="q1">
-<span class="v">16&#160;</span>who were snatched away before their time, 
-</p><p class="q2">whose foundation was poured out as a stream, 
-</p><p class="q1">
-<span class="v">17&#160;</span>who said to Elohim, ‘Depart from us!’ 
-</p><p class="q2">and, ‘What can the Almighty do for us?’ 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yet he filled their houses with good things, 
-</p><p class="q2">but the counsel of the wicked is far from me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The righteous see it, and are glad. 
-</p><p class="q2">The innocent ridicule them, 
-</p><p class="q1">
-<span class="v">20&#160;</span>saying, ‘Surely those who rose up against us are cut off. 
-</p><p class="q2">The fire has consumed their remnant.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Acquaint yourself with him now, and be at peace. 
-</p><p class="q2">By it, good will come to you. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Please receive instruction from his mouth, 
-</p><p class="q2">and lay up his words in your heart. 
-</p><p class="q1">
-<span class="v">23&#160;</span>If you return to the Almighty, you will be built up, 
-</p><p class="q2">if you put away unrighteousness far from your tents. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Lay your treasure in the dust, 
-</p><p class="q2">the gold of Ophir among the stones of the brooks. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The Almighty will be your treasure, 
-</p><p class="q2">and precious silver to you. 
-</p><p class="q1">
-<span class="v">26&#160;</span>For then you will delight yourself in the Almighty, 
-</p><p class="q2">and will lift up your face to Elohim. 
-</p><p class="q1">
-<span class="v">27&#160;</span>You will make your prayer to him, and he will hear you. 
-</p><p class="q2">You will pay your vows. 
-</p><p class="q1">
-<span class="v">28&#160;</span>You will also decree a thing, and it will be established to you. 
-</p><p class="q2">Light will shine on your ways. 
-</p><p class="q1">
-<span class="v">29&#160;</span>When they cast down, you will say, ‘be lifted up.’ 
-</p><p class="q2">He will save the humble person. 
-</p><p class="q1">
-<span class="v">30&#160;</span>He will even deliver him who is not innocent. 
-</p><p class="q2">Yes, he will be delivered through the cleanness of your hands.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Even today my complaint is rebellious. 
-</p><p class="q2">His hand is heavy in spite of my groaning. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Oh that I knew where I might find him! 
-</p><p class="q2">That I might come even to his seat! 
-</p><p class="q1">
-<span class="v">4&#160;</span>I would set my cause in order before him, 
-</p><p class="q2">and fill my mouth with arguments. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I would know the words which he would answer me, 
-</p><p class="q2">and understand what he would tell me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Would he contend with me in the greatness of his power? 
-</p><p class="q2">No, but he would listen to me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>There the upright might reason with him, 
-</p><p class="q2">so I should be delivered forever from my judge. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“If I go east, he is not there. 
-</p><p class="q2">If I go west, I can’t find him. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He works to the north, but I can’t see him. 
-</p><p class="q2">He turns south, but I can’t catch a glimpse of him. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>But he knows the way that I take. 
-</p><p class="q2">When he has tried me, I will come out like gold. 
-</p><p class="q1">
-<span class="v">11&#160;</span>My foot has held fast to his steps. 
-</p><p class="q2">I have kept his way, and not turned away. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I haven’t gone back from the commandment of his lips. 
-</p><p class="q2">I have treasured up the words of his mouth more than my necessary food. 
-</p><p class="q1">
-<span class="v">13&#160;</span>But he stands alone, and who can oppose him? 
-</p><p class="q2">What his soul desires, even that he does. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For he performs that which is appointed for me. 
-</p><p class="q2">Many such things are with him. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Therefore I am terrified at his presence. 
-</p><p class="q2">When I consider, I am afraid of him. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For Elohim has made my heart faint. 
-</p><p class="q2">The Almighty has terrified me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Because I was not cut off before the darkness, 
-</p><p class="q2">neither did he cover the thick darkness from my face. 
+<div class="p">
+<sup>1&#160;</sup>Then Bildad the Shuhite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“How long will you hunt for words? 
+</div><div class="q2">Consider, and afterwards we will speak. 
+</div><div class="q1">
+<sup>3&#160;</sup>Why are we counted as animals, 
+</div><div class="q2">which have become unclean in your sight? 
+</div><div class="q1">
+<sup>4&#160;</sup>You who tear yourself in your anger, 
+</div><div class="q2">will the earth be forsaken for you? 
+</div><div class="q2">Or will the rock be removed out of its place? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Yes, the light of the wicked will be put out. 
+</div><div class="q2">The spark of his fire won’t shine. 
+</div><div class="q1">
+<sup>6&#160;</sup>The light will be dark in his tent. 
+</div><div class="q2">His lamp above him will be put out. 
+</div><div class="q1">
+<sup>7&#160;</sup>The steps of his strength will be shortened. 
+</div><div class="q2">His own counsel will cast him down. 
+</div><div class="q1">
+<sup>8&#160;</sup>For he is cast into a net by his own feet, 
+</div><div class="q2">and he wanders into its mesh. 
+</div><div class="q1">
+<sup>9&#160;</sup>A snare will take him by the heel. 
+</div><div class="q2">A trap will catch him. 
+</div><div class="q1">
+<sup>10&#160;</sup>A noose is hidden for him in the ground, 
+</div><div class="q2">a trap for him on the path. 
+</div><div class="q1">
+<sup>11&#160;</sup>Terrors will make him afraid on every side, 
+</div><div class="q2">and will chase him at his heels. 
+</div><div class="q1">
+<sup>12&#160;</sup>His strength will be famished. 
+</div><div class="q2">Calamity will be ready at his side. 
+</div><div class="q1">
+<sup>13&#160;</sup>The members of his body will be devoured. 
+</div><div class="q2">The firstborn of death will devour his members. 
+</div><div class="q1">
+<sup>14&#160;</sup>He will be rooted out of the security of his tent. 
+</div><div class="q2">He will be brought to the king of terrors. 
+</div><div class="q1">
+<sup>15&#160;</sup>There will dwell in his tent that which is none of his. 
+</div><div class="q2">Sulfur will be scattered on his habitation. 
+</div><div class="q1">
+<sup>16&#160;</sup>His roots will be dried up beneath. 
+</div><div class="q2">His branch will be cut off above. 
+</div><div class="q1">
+<sup>17&#160;</sup>His memory will perish from the earth. 
+</div><div class="q2">He will have no name in the street. 
+</div><div class="q1">
+<sup>18&#160;</sup>He will be driven from light into darkness, 
+</div><div class="q2">and chased out of the world. 
+</div><div class="q1">
+<sup>19&#160;</sup>He will have neither son nor grandson among his people, 
+</div><div class="q2">nor any remaining where he lived. 
+</div><div class="q1">
+<sup>20&#160;</sup>Those who come after will be astonished at his day, 
+</div><div class="q2">as those who went before were frightened. 
+</div><div class="q1">
+<sup>21&#160;</sup>Surely such are the dwellings of the unrighteous. 
+</div><div class="q2">This is the place of him who doesn’t know Elohim.” 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“How long will you torment me, 
+</div><div class="q2">and crush me with words? 
+</div><div class="q1">
+<sup>3&#160;</sup>You have reproached me ten times. 
+</div><div class="q2">You aren’t ashamed that you attack me. 
+</div><div class="q1">
+<sup>4&#160;</sup>If it is true that I have erred, 
+</div><div class="q2">my error remains with myself. 
+</div><div class="q1">
+<sup>5&#160;</sup>If indeed you will magnify yourselves against me, 
+</div><div class="q2">and plead against me my reproach, 
+</div><div class="q1">
+<sup>6&#160;</sup>know now that Elohim has subverted me, 
+</div><div class="q2">and has surrounded me with his net. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Behold, I cry out of wrong, but I am not heard. 
+</div><div class="q2">I cry for help, but there is no justice. 
+</div><div class="q1">
+<sup>8&#160;</sup>He has walled up my way so that I can’t pass, 
+</div><div class="q2">and has set darkness in my paths. 
+</div><div class="q1">
+<sup>9&#160;</sup>He has stripped me of my glory, 
+</div><div class="q2">and taken the crown from my head. 
+</div><div class="q1">
+<sup>10&#160;</sup>He has broken me down on every side, and I am gone. 
+</div><div class="q2">He has plucked my hope up like a tree. 
+</div><div class="q1">
+<sup>11&#160;</sup>He has also kindled his wrath against me. 
+</div><div class="q2">He counts me among his adversaries. 
+</div><div class="q1">
+<sup>12&#160;</sup>His troops come on together, 
+</div><div class="q2">build a siege ramp against me, 
+</div><div class="q2">and encamp around my tent. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“He has put my brothers far from me. 
+</div><div class="q2">My acquaintances are wholly estranged from me. 
+</div><div class="q1">
+<sup>14&#160;</sup>My relatives have gone away. 
+</div><div class="q2">My familiar friends have forgotten me. 
+</div><div class="q1">
+<sup>15&#160;</sup>Those who dwell in my house and my maids consider me a stranger. 
+</div><div class="q2">I am an alien in their sight. 
+</div><div class="q1">
+<sup>16&#160;</sup>I call to my servant, and he gives me no answer. 
+</div><div class="q2">I beg him with my mouth. 
+</div><div class="q1">
+<sup>17&#160;</sup>My breath is offensive to my woman. 
+</div><div class="q2">I am loathsome to the children of my own mother. 
+</div><div class="q1">
+<sup>18&#160;</sup>Even young children despise me. 
+</div><div class="q2">If I arise, they speak against me. 
+</div><div class="q1">
+<sup>19&#160;</sup>All my familiar friends abhor me. 
+</div><div class="q2">They whom I loved have turned against me. 
+</div><div class="q1">
+<sup>20&#160;</sup>My bones stick to my skin and to my flesh. 
+</div><div class="q2">I have escaped by the skin of my teeth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Have pity on me. Have pity on me, you my friends, 
+</div><div class="q2">for the hand of Elohim has touched me. 
+</div><div class="q1">
+<sup>22&#160;</sup>Why do you persecute me as Elohim, 
+</div><div class="q2">and are not satisfied with my flesh? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>“Oh that my words were now written! 
+</div><div class="q2">Oh that they were inscribed in a book! 
+</div><div class="q1">
+<sup>24&#160;</sup>That with an iron pen and lead 
+</div><div class="q2">they were engraved in the rock forever! 
+</div><div class="q1">
+<sup>25&#160;</sup>But as for me, I know that my Redeemer lives. 
+</div><div class="q2">In the end, he will stand upon the earth. 
+</div><div class="q1">
+<sup>26&#160;</sup>After my skin is destroyed, 
+</div><div class="q2">then I will see Elohim in my flesh, 
+</div><div class="q1">
+<sup>27&#160;</sup>whom I, even I, will see on my side. 
+</div><div class="q2">My eyes will see, and not as a stranger. 
+</div><div class="b"> &#160; </div>
+<div class="q1">“My heart is consumed within me. 
+</div><div class="q1">
+<sup>28&#160;</sup>If you say, ‘How we will persecute him!’ 
+</div><div class="q2">because the root of the matter is found in me, 
+</div><div class="q1">
+<sup>29&#160;</sup>be afraid of the sword, 
+</div><div class="q2">for wrath brings the punishments of the sword, 
+</div><div class="q2">that you may know there is a judgment.” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Zophar the Naamathite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Therefore my thoughts answer me, 
+</div><div class="q2">even by reason of my haste that is in me. 
+</div><div class="q1">
+<sup>3&#160;</sup>I have heard the reproof which puts me to shame. 
+</div><div class="q2">The spirit of my understanding answers me. 
+</div><div class="q1">
+<sup>4&#160;</sup>Don’t you know this from old time, 
+</div><div class="q2">since man was placed on earth, 
+</div><div class="q1">
+<sup>5&#160;</sup>that the triumphing of the wicked is short, 
+</div><div class="q2">the joy of the elohimless but for a moment? 
+</div><div class="q1">
+<sup>6&#160;</sup>Though his height mount up to the heavens, 
+</div><div class="q2">and his head reach to the clouds, 
+</div><div class="q1">
+<sup>7&#160;</sup>yet he will perish forever like his own dung. 
+</div><div class="q2">Those who have seen him will say, ‘Where is he?’ 
+</div><div class="q1">
+<sup>8&#160;</sup>He will fly away as a dream, and will not be found. 
+</div><div class="q2">Yes, he will be chased away like a vision of the night. 
+</div><div class="q1">
+<sup>9&#160;</sup>The eye which saw him will see him no more, 
+</div><div class="q2">neither will his place see him any more. 
+</div><div class="q1">
+<sup>10&#160;</sup>His children will seek the favor of the poor. 
+</div><div class="q2">His hands will give back his wealth. 
+</div><div class="q1">
+<sup>11&#160;</sup>His bones are full of his youth, 
+</div><div class="q2">but youth will lie down with him in the dust. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Though wickedness is sweet in his mouth, 
+</div><div class="q2">though he hide it under his tongue, 
+</div><div class="q1">
+<sup>13&#160;</sup>though he spare it, and will not let it go, 
+</div><div class="q2">but keep it still within his mouth, 
+</div><div class="q1">
+<sup>14&#160;</sup>yet his food in his bowels is turned. 
+</div><div class="q2">It is cobra venom within him. 
+</div><div class="q1">
+<sup>15&#160;</sup>He has swallowed down riches, and he will vomit them up again. 
+</div><div class="q2">Elohim will cast them out of his belly. 
+</div><div class="q1">
+<sup>16&#160;</sup>He will suck cobra venom. 
+</div><div class="q2">The viper’s tongue will kill him. 
+</div><div class="q1">
+<sup>17&#160;</sup>He will not look at the rivers, 
+</div><div class="q2">the flowing streams of honey and butter. 
+</div><div class="q1">
+<sup>18&#160;</sup>He will restore that for which he labored, and will not swallow it down. 
+</div><div class="q2">He will not rejoice according to the substance that he has gotten. 
+</div><div class="q1">
+<sup>19&#160;</sup>For he has oppressed and forsaken the poor. 
+</div><div class="q2">He has violently taken away a house, and he will not build it up. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Because he knew no quietness within him, 
+</div><div class="q2">he will not save anything of that in which he delights. 
+</div><div class="q1">
+<sup>21&#160;</sup>There was nothing left that he didn’t devour, 
+</div><div class="q2">therefore his prosperity will not endure. 
+</div><div class="q1">
+<sup>22&#160;</sup>In the fullness of his sufficiency, distress will overtake him. 
+</div><div class="q2">The hand of everyone who is in misery will come on him. 
+</div><div class="q1">
+<sup>23&#160;</sup>When he is about to fill his belly, Elohim will cast the fierceness of his wrath on him. 
+</div><div class="q2">It will rain on him while he is eating. 
+</div><div class="q1">
+<sup>24&#160;</sup>He will flee from the iron weapon. 
+</div><div class="q2">The bronze arrow will strike him through. 
+</div><div class="q1">
+<sup>25&#160;</sup>He draws it out, and it comes out of his body. 
+</div><div class="q2">Yes, the glittering point comes out of his liver. 
+</div><div class="q2">Terrors are on him. 
+</div><div class="q1">
+<sup>26&#160;</sup>All darkness is laid up for his treasures. 
+</div><div class="q2">An unfanned fire will devour him. 
+</div><div class="q2">It will consume that which is left in his tent. 
+</div><div class="q1">
+<sup>27&#160;</sup>The heavens will reveal his iniquity. 
+</div><div class="q2">The earth will rise up against him. 
+</div><div class="q1">
+<sup>28&#160;</sup>The increase of his house will depart. 
+</div><div class="q2">They will rush away in the day of his wrath. 
+</div><div class="q1">
+<sup>29&#160;</sup>This is the portion of a wicked man from Elohim, 
+</div><div class="q2">the heritage appointed to him by Elohim.” 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Listen diligently to my speech. 
+</div><div class="q2">Let this be your consolation. 
+</div><div class="q1">
+<sup>3&#160;</sup>Allow me, and I also will speak. 
+</div><div class="q2">After I have spoken, mock on. 
+</div><div class="q1">
+<sup>4&#160;</sup>As for me, is my complaint to man? 
+</div><div class="q2">Why shouldn’t I be impatient? 
+</div><div class="q1">
+<sup>5&#160;</sup>Look at me, and be astonished. 
+</div><div class="q2">Lay your hand on your mouth. 
+</div><div class="q1">
+<sup>6&#160;</sup>When I remember, I am troubled. 
+</div><div class="q2">Horror takes hold of my flesh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Why do the wicked live, 
+</div><div class="q2">become old, yes, and grow mighty in power? 
+</div><div class="q1">
+<sup>8&#160;</sup>Their child is established with them in their sight, 
+</div><div class="q2">their offspring before their eyes. 
+</div><div class="q1">
+<sup>9&#160;</sup>Their houses are safe from fear, 
+</div><div class="q2">neither is the rod of Elohim upon them. 
+</div><div class="q1">
+<sup>10&#160;</sup>Their bulls breed without fail. 
+</div><div class="q2">Their cows calve, and don’t miscarry. 
+</div><div class="q1">
+<sup>11&#160;</sup>They send out their little ones like a flock. 
+</div><div class="q2">Their children dance. 
+</div><div class="q1">
+<sup>12&#160;</sup>They sing to the tambourine and harp, 
+</div><div class="q2">and rejoice at the sound of the pipe. 
+</div><div class="q1">
+<sup>13&#160;</sup>They spend their days in prosperity. 
+</div><div class="q2">In an instant they go down to Sheol. 
+</div><div class="q1">
+<sup>14&#160;</sup>They tell Elohim, ‘Depart from us, 
+</div><div class="q2">for we don’t want to know about your ways. 
+</div><div class="q1">
+<sup>15&#160;</sup>What is the Almighty, that we should serve him? 
+</div><div class="q2">What profit should we have, if we pray to him?’ 
+</div><div class="q1">
+<sup>16&#160;</sup>Behold, their prosperity is not in their hand. 
+</div><div class="q2">The counsel of the wicked is far from me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“How often is it that the lamp of the wicked is put out, 
+</div><div class="q2">that their calamity comes on them, 
+</div><div class="q2">that Elohim distributes sorrows in his anger? 
+</div><div class="q1">
+<sup>18&#160;</sup>How often is it that they are as stubble before the wind, 
+</div><div class="q2">as chaff that the storm carries away? 
+</div><div class="q1">
+<sup>19&#160;</sup>You say, ‘Elohim lays up his iniquity for his children.’ 
+</div><div class="q2">Let him recompense it to himself, that he may know it. 
+</div><div class="q1">
+<sup>20&#160;</sup>Let his own eyes see his destruction. 
+</div><div class="q2">Let him drink of the wrath of the Almighty. 
+</div><div class="q1">
+<sup>21&#160;</sup>For what does he care for his house after him, 
+</div><div class="q2">when the number of his months is cut off? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“Shall any teach Elohim knowledge, 
+</div><div class="q2">since he judges those who are high? 
+</div><div class="q1">
+<sup>23&#160;</sup>One dies in his full strength, 
+</div><div class="q2">being wholly at ease and quiet. 
+</div><div class="q1">
+<sup>24&#160;</sup>His pails are full of milk. 
+</div><div class="q2">The marrow of his bones is moistened. 
+</div><div class="q1">
+<sup>25&#160;</sup>Another dies in bitterness of soul, 
+</div><div class="q2">and never tastes of good. 
+</div><div class="q1">
+<sup>26&#160;</sup>They lie down alike in the dust. 
+</div><div class="q2">The worm covers them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>27&#160;</sup>“Behold, I know your thoughts, 
+</div><div class="q2">the plans with which you would wrong me. 
+</div><div class="q1">
+<sup>28&#160;</sup>For you say, ‘Where is the house of the prince? 
+</div><div class="q2">Where is the tent in which the wicked lived?’ 
+</div><div class="q1">
+<sup>29&#160;</sup>Haven’t you asked wayfaring men? 
+</div><div class="q2">Don’t you know their evidences, 
+</div><div class="q1">
+<sup>30&#160;</sup>that the evil man is reserved to the day of calamity, 
+</div><div class="q2">that they are led out to the day of wrath? 
+</div><div class="q1">
+<sup>31&#160;</sup>Who will declare his way to his face? 
+</div><div class="q2">Who will repay him what he has done? 
+</div><div class="q1">
+<sup>32&#160;</sup>Yet he will be borne to the grave. 
+</div><div class="q2">Men will keep watch over the tomb. 
+</div><div class="q1">
+<sup>33&#160;</sup>The clods of the valley will be sweet to him. 
+</div><div class="q2">All men will draw after him, 
+</div><div class="q2">as there were innumerable before him. 
+</div><div class="q1">
+<sup>34&#160;</sup>So how can you comfort me with nonsense, 
+</div><div class="q2">because in your answers there remains only falsehood?” 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Eliphaz the Temanite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Can a man be profitable to Elohim? 
+</div><div class="q2">Surely he who is wise is profitable to himself. 
+</div><div class="q1">
+<sup>3&#160;</sup>Is it any pleasure to the Almighty that you are righteous? 
+</div><div class="q2">Or does it benefit him that you make your ways perfect? 
+</div><div class="q1">
+<sup>4&#160;</sup>Is it for your piety that he reproves you, 
+</div><div class="q2">that he enters with you into judgment? 
+</div><div class="q1">
+<sup>5&#160;</sup>Isn’t your wickedness great? 
+</div><div class="q2">Neither is there any end to your iniquities. 
+</div><div class="q1">
+<sup>6&#160;</sup>For you have taken pledges from your brother for nothing, 
+</div><div class="q2">and stripped the naked of their clothing. 
+</div><div class="q1">
+<sup>7&#160;</sup>You haven’t given water to the weary to drink, 
+</div><div class="q2">and you have withheld bread from the hungry. 
+</div><div class="q1">
+<sup>8&#160;</sup>But as for the mighty man, he had the earth. 
+</div><div class="q2">The honorable man, he lived in it. 
+</div><div class="q1">
+<sup>9&#160;</sup>You have sent widows away empty, 
+</div><div class="q2">and the arms of the fatherless have been broken. 
+</div><div class="q1">
+<sup>10&#160;</sup>Therefore snares are around you. 
+</div><div class="q2">Sudden fear troubles you, 
+</div><div class="q1">
+<sup>11&#160;</sup>or darkness, so that you can not see, 
+</div><div class="q2">and floods of waters cover you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Isn’t Elohim in the heights of heaven? 
+</div><div class="q2">See the height of the stars, how high they are! 
+</div><div class="q1">
+<sup>13&#160;</sup>You say, ‘What does Elohim know? 
+</div><div class="q2">Can he judge through the thick darkness? 
+</div><div class="q1">
+<sup>14&#160;</sup>Thick clouds are a covering to him, so that he doesn’t see. 
+</div><div class="q2">He walks on the vault of the sky.’ 
+</div><div class="q1">
+<sup>15&#160;</sup>Will you keep the old way, 
+</div><div class="q2">which wicked men have trodden, 
+</div><div class="q1">
+<sup>16&#160;</sup>who were snatched away before their time, 
+</div><div class="q2">whose foundation was poured out as a stream, 
+</div><div class="q1">
+<sup>17&#160;</sup>who said to Elohim, ‘Depart from us!’ 
+</div><div class="q2">and, ‘What can the Almighty do for us?’ 
+</div><div class="q1">
+<sup>18&#160;</sup>Yet he filled their houses with good things, 
+</div><div class="q2">but the counsel of the wicked is far from me. 
+</div><div class="q1">
+<sup>19&#160;</sup>The righteous see it, and are glad. 
+</div><div class="q2">The innocent ridicule them, 
+</div><div class="q1">
+<sup>20&#160;</sup>saying, ‘Surely those who rose up against us are cut off. 
+</div><div class="q2">The fire has consumed their remnant.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Acquaint yourself with him now, and be at peace. 
+</div><div class="q2">By it, good will come to you. 
+</div><div class="q1">
+<sup>22&#160;</sup>Please receive instruction from his mouth, 
+</div><div class="q2">and lay up his words in your heart. 
+</div><div class="q1">
+<sup>23&#160;</sup>If you return to the Almighty, you will be built up, 
+</div><div class="q2">if you put away unrighteousness far from your tents. 
+</div><div class="q1">
+<sup>24&#160;</sup>Lay your treasure in the dust, 
+</div><div class="q2">the gold of Ophir among the stones of the brooks. 
+</div><div class="q1">
+<sup>25&#160;</sup>The Almighty will be your treasure, 
+</div><div class="q2">and precious silver to you. 
+</div><div class="q1">
+<sup>26&#160;</sup>For then you will delight yourself in the Almighty, 
+</div><div class="q2">and will lift up your face to Elohim. 
+</div><div class="q1">
+<sup>27&#160;</sup>You will make your prayer to him, and he will hear you. 
+</div><div class="q2">You will pay your vows. 
+</div><div class="q1">
+<sup>28&#160;</sup>You will also decree a thing, and it will be established to you. 
+</div><div class="q2">Light will shine on your ways. 
+</div><div class="q1">
+<sup>29&#160;</sup>When they cast down, you will say, ‘be lifted up.’ 
+</div><div class="q2">He will save the humble person. 
+</div><div class="q1">
+<sup>30&#160;</sup>He will even deliver him who is not innocent. 
+</div><div class="q2">Yes, he will be delivered through the cleanness of your hands.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Even today my complaint is rebellious. 
+</div><div class="q2">His hand is heavy in spite of my groaning. 
+</div><div class="q1">
+<sup>3&#160;</sup>Oh that I knew where I might find him! 
+</div><div class="q2">That I might come even to his seat! 
+</div><div class="q1">
+<sup>4&#160;</sup>I would set my cause in order before him, 
+</div><div class="q2">and fill my mouth with arguments. 
+</div><div class="q1">
+<sup>5&#160;</sup>I would know the words which he would answer me, 
+</div><div class="q2">and understand what he would tell me. 
+</div><div class="q1">
+<sup>6&#160;</sup>Would he contend with me in the greatness of his power? 
+</div><div class="q2">No, but he would listen to me. 
+</div><div class="q1">
+<sup>7&#160;</sup>There the upright might reason with him, 
+</div><div class="q2">so I should be delivered forever from my judge. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“If I go east, he is not there. 
+</div><div class="q2">If I go west, I can’t find him. 
+</div><div class="q1">
+<sup>9&#160;</sup>He works to the north, but I can’t see him. 
+</div><div class="q2">He turns south, but I can’t catch a glimpse of him. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>But he knows the way that I take. 
+</div><div class="q2">When he has tried me, I will come out like gold. 
+</div><div class="q1">
+<sup>11&#160;</sup>My foot has held fast to his steps. 
+</div><div class="q2">I have kept his way, and not turned away. 
+</div><div class="q1">
+<sup>12&#160;</sup>I haven’t gone back from the commandment of his lips. 
+</div><div class="q2">I have treasured up the words of his mouth more than my necessary food. 
+</div><div class="q1">
+<sup>13&#160;</sup>But he stands alone, and who can oppose him? 
+</div><div class="q2">What his soul desires, even that he does. 
+</div><div class="q1">
+<sup>14&#160;</sup>For he performs that which is appointed for me. 
+</div><div class="q2">Many such things are with him. 
+</div><div class="q1">
+<sup>15&#160;</sup>Therefore I am terrified at his presence. 
+</div><div class="q2">When I consider, I am afraid of him. 
+</div><div class="q1">
+<sup>16&#160;</sup>For Elohim has made my heart faint. 
+</div><div class="q2">The Almighty has terrified me. 
+</div><div class="q1">
+<sup>17&#160;</sup>Because I was not cut off before the darkness, 
+</div><div class="q2">neither did he cover the thick darkness from my face. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="24">24</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Why aren’t times laid up by the Almighty? 
-</p><p class="q2">Why don’t those who know him see his days? 
-</p><p class="q1">
-<span class="v">2&#160;</span>There are people who remove the landmarks. 
-</p><p class="q2">They violently take away flocks, and feed them. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They drive away the donkey of the fatherless, 
-</p><p class="q2">and they take the widow’s ox for a pledge. 
-</p><p class="q1">
-<span class="v">4&#160;</span>They turn the needy out of the way. 
-</p><p class="q2">The poor of the earth all hide themselves. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Behold, as wild donkeys in the desert, 
-</p><p class="q2">they go out to their work, seeking diligently for food. 
-</p><p class="q1">The wilderness yields them bread for their children. 
-</p><p class="q2">
-<span class="v">6&#160;</span>They cut their food in the field. 
-</p><p class="q1">They glean the vineyard of the wicked. 
-</p><p class="q2">
-<span class="v">7&#160;</span>They lie all night naked without clothing, 
-</p><p class="q1">and have no covering in the cold. 
-</p><p class="q2">
-<span class="v">8&#160;</span>They are wet with the showers of the mountains, 
-</p><p class="q1">and embrace the rock for lack of a shelter. 
-</p><p class="q2">
-<span class="v">9&#160;</span>There are those who pluck the fatherless from the breast, 
-</p><p class="q1">and take a pledge of the poor, 
-</p><p class="q2">
-<span class="v">10&#160;</span>so that they go around naked without clothing. 
-</p><p class="q2">Being hungry, they carry the sheaves. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They make oil within the walls of these men. 
-</p><p class="q2">They tread wine presses, and suffer thirst. 
-</p><p class="q1">
-<span class="v">12&#160;</span>From out of the populous city, men groan. 
-</p><p class="q2">The soul of the wounded cries out, 
-</p><p class="q2">yet Elohim doesn’t regard the folly. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“These are of those who rebel against the light. 
-</p><p class="q2">They don’t know its ways, 
-</p><p class="q2">nor stay in its paths. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The murderer rises with the light. 
-</p><p class="q2">He kills the poor and needy. 
-</p><p class="q2">In the night he is like a thief. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The eye also of the adulterer waits for the twilight, 
-</p><p class="q2">saying, ‘No eye will see me.’ 
-</p><p class="q2">He disguises his face. 
-</p><p class="q1">
-<span class="v">16&#160;</span>In the dark they dig through houses. 
-</p><p class="q2">They shut themselves up in the daytime. 
-</p><p class="q2">They don’t know the light. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For the morning is to all of them like thick darkness, 
-</p><p class="q2">for they know the terrors of the thick darkness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“They are foam on the surface of the waters. 
-</p><p class="q2">Their portion is cursed in the earth. 
-</p><p class="q2">They don’t turn into the way of the vineyards. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Drought and heat consume the snow waters, 
-</p><p class="q2">so does Sheol<span class="f">+ \fr 24:19 \ft Sheol is the place of the dead.</span> those who have sinned. 
-</p><p class="q1">
-<span class="v">20&#160;</span>The womb will forget him. 
-</p><p class="q2">The worm will feed sweetly on him. 
-</p><p class="q2">He will be no more remembered. 
-</p><p class="q2">Unrighteousness will be broken as a tree. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He devours the barren who don’t bear. 
-</p><p class="q2">He shows no kindness to the widow. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Yet Elohim preserves the mighty by his power. 
-</p><p class="q2">He rises up who has no assurance of life. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Elohim gives them security, and they rest in it. 
-</p><p class="q2">His eyes are on their ways. 
-</p><p class="q1">
-<span class="v">24&#160;</span>They are exalted; yet a little while, and they are gone. 
-</p><p class="q2">Yes, they are brought low, they are taken out of the way as all others, 
-</p><p class="q2">and are cut off as the tops of the ears of grain. 
-</p><p class="q1">
-<span class="v">25&#160;</span>If it isn’t so now, who will prove me a liar, 
-</p><p class="q2">and make my speech worth nothing?” 
-</p><div class="b"> &#160; </div>
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Why aren’t times laid up by the Almighty? 
+</div><div class="q2">Why don’t those who know him see his days? 
+</div><div class="q1">
+<sup>2&#160;</sup>There are people who remove the landmarks. 
+</div><div class="q2">They violently take away flocks, and feed them. 
+</div><div class="q1">
+<sup>3&#160;</sup>They drive away the donkey of the fatherless, 
+</div><div class="q2">and they take the widow’s ox for a pledge. 
+</div><div class="q1">
+<sup>4&#160;</sup>They turn the needy out of the way. 
+</div><div class="q2">The poor of the earth all hide themselves. 
+</div><div class="q1">
+<sup>5&#160;</sup>Behold, as wild donkeys in the desert, 
+</div><div class="q2">they go out to their work, seeking diligently for food. 
+</div><div class="q1">The wilderness yields them bread for their children. 
+</div><div class="q2">
+<sup>6&#160;</sup>They cut their food in the field. 
+</div><div class="q1">They glean the vineyard of the wicked. 
+</div><div class="q2">
+<sup>7&#160;</sup>They lie all night naked without clothing, 
+</div><div class="q1">and have no covering in the cold. 
+</div><div class="q2">
+<sup>8&#160;</sup>They are wet with the showers of the mountains, 
+</div><div class="q1">and embrace the rock for lack of a shelter. 
+</div><div class="q2">
+<sup>9&#160;</sup>There are those who pluck the fatherless from the breast, 
+</div><div class="q1">and take a pledge of the poor, 
+</div><div class="q2">
+<sup>10&#160;</sup>so that they go around naked without clothing. 
+</div><div class="q2">Being hungry, they carry the sheaves. 
+</div><div class="q1">
+<sup>11&#160;</sup>They make oil within the walls of these men. 
+</div><div class="q2">They tread wine presses, and suffer thirst. 
+</div><div class="q1">
+<sup>12&#160;</sup>From out of the populous city, men groan. 
+</div><div class="q2">The soul of the wounded cries out, 
+</div><div class="q2">yet Elohim doesn’t regard the folly. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“These are of those who rebel against the light. 
+</div><div class="q2">They don’t know its ways, 
+</div><div class="q2">nor stay in its paths. 
+</div><div class="q1">
+<sup>14&#160;</sup>The murderer rises with the light. 
+</div><div class="q2">He kills the poor and needy. 
+</div><div class="q2">In the night he is like a thief. 
+</div><div class="q1">
+<sup>15&#160;</sup>The eye also of the adulterer waits for the twilight, 
+</div><div class="q2">saying, ‘No eye will see me.’ 
+</div><div class="q2">He disguises his face. 
+</div><div class="q1">
+<sup>16&#160;</sup>In the dark they dig through houses. 
+</div><div class="q2">They shut themselves up in the daytime. 
+</div><div class="q2">They don’t know the light. 
+</div><div class="q1">
+<sup>17&#160;</sup>For the morning is to all of them like thick darkness, 
+</div><div class="q2">for they know the terrors of the thick darkness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“They are foam on the surface of the waters. 
+</div><div class="q2">Their portion is cursed in the earth. 
+</div><div class="q2">They don’t turn into the way of the vineyards. 
+</div><div class="q1">
+<sup>19&#160;</sup>Drought and heat consume the snow waters, 
+</div><div class="q2">so does Sheol those who have sinned. 
+</div><div class="q1">
+<sup>20&#160;</sup>The womb will forget him. 
+</div><div class="q2">The worm will feed sweetly on him. 
+</div><div class="q2">He will be no more remembered. 
+</div><div class="q2">Unrighteousness will be broken as a tree. 
+</div><div class="q1">
+<sup>21&#160;</sup>He devours the barren who don’t bear. 
+</div><div class="q2">He shows no kindness to the widow. 
+</div><div class="q1">
+<sup>22&#160;</sup>Yet Elohim preserves the mighty by his power. 
+</div><div class="q2">He rises up who has no assurance of life. 
+</div><div class="q1">
+<sup>23&#160;</sup>Elohim gives them security, and they rest in it. 
+</div><div class="q2">His eyes are on their ways. 
+</div><div class="q1">
+<sup>24&#160;</sup>They are exalted; yet a little while, and they are gone. 
+</div><div class="q2">Yes, they are brought low, they are taken out of the way as all others, 
+</div><div class="q2">and are cut off as the tops of the ears of grain. 
+</div><div class="q1">
+<sup>25&#160;</sup>If it isn’t so now, who will prove me a liar, 
+</div><div class="q2">and make my speech worth nothing?” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Then Bildad the Shuhite answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Dominion and fear are with him. 
-</p><p class="q2">He makes peace in his high places. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Can his armies be counted? 
-</p><p class="q2">On whom does his light not arise? 
-</p><p class="q1">
-<span class="v">4&#160;</span>How then can man be just with Elohim? 
-</p><p class="q2">Or how can he who is born of a woman be clean? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Behold, even the moon has no brightness, 
-</p><p class="q2">and the stars are not pure in his sight; 
-</p><p class="q1">
-<span class="v">6&#160;</span>How much less man, who is a worm, 
-</p><p class="q2">and the son of man, who is a worm!” 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“How have you helped him who is without power! 
-</p><p class="q2">How have you saved the arm that has no strength! 
-</p><p class="q1">
-<span class="v">3&#160;</span>How have you counseled him who has no wisdom, 
-</p><p class="q2">and plentifully declared sound knowledge! 
-</p><p class="q1">
-<span class="v">4&#160;</span>To whom have you uttered words? 
-</p><p class="q2">Whose spirit came out of you? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“The departed spirits tremble, 
-</p><p class="q2">those beneath the waters and all that live in them. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Sheol<span class="f">+ \fr 26:6 \ft Sheol is the place of the dead.</span> is naked before Elohim, 
-</p><p class="q2">and Abaddon<span class="f">+ \fr 26:6 \ft Abaddon means Destroyer.</span> has no covering. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He stretches out the north over empty space, 
-</p><p class="q2">and hangs the earth on nothing. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He binds up the waters in his thick clouds, 
-</p><p class="q2">and the cloud is not burst under them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He encloses the face of his throne, 
-</p><p class="q2">and spreads his cloud on it. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He has described a boundary on the surface of the waters, 
-</p><p class="q2">and to the confines of light and darkness. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The pillars of heaven tremble 
-</p><p class="q2">and are astonished at his rebuke. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He stirs up the sea with his power, 
-</p><p class="q2">and by his understanding he strikes through Rahab. 
-</p><p class="q1">
-<span class="v">13&#160;</span>By his Spirit the heavens are garnished. 
-</p><p class="q2">His hand has pierced the swift serpent. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Behold, these are but the outskirts of his ways. 
-</p><p class="q2">How small a whisper do we hear of him! 
-</p><p class="q2">But the thunder of his power who can understand?” 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Job again took up his parable, and said, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“As Elohim lives, who has taken away my right, 
-</p><p class="q2">the Almighty, who has made my soul bitter 
-</p><p class="q1">
-<span class="v">3&#160;</span>(for the length of my life is still in me, 
-</p><p class="q2">and the spirit of Elohim is in my nostrils); 
-</p><p class="q1">
-<span class="v">4&#160;</span>surely my lips will not speak unrighteousness, 
-</p><p class="q2">neither will my tongue utter deceit. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Far be it from me that I should justify you. 
-</p><p class="q2">Until I die I will not put away my integrity from me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I hold fast to my righteousness, and will not let it go. 
-</p><p class="q2">My heart will not reproach me so long as I live. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Let my enemy be as the wicked. 
-</p><p class="q2">Let him who rises up against me be as the unrighteous. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>For what is the hope of the elohimless, when he is cut off, 
-</p><p class="q2">when Elohim takes away his life? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Will Elohim hear his cry when trouble comes on him? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Will he delight himself in the Almighty, 
-</p><p class="q2">and call on Elohim at all times? 
-</p><p class="q1">
-<span class="v">11&#160;</span>I will teach you about the hand of Elohim. 
-</p><p class="q2">I will not conceal that which is with the Almighty. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Behold, all of you have seen it yourselves; 
-</p><p class="q2">why then have you become altogether vain? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“This is the portion of a wicked man with Elohim, 
-</p><p class="q2">the heritage of oppressors, which they receive from the Almighty. 
-</p><p class="q1">
-<span class="v">14&#160;</span>If his children are multiplied, it is for the sword. 
-</p><p class="q2">His offspring will not be satisfied with bread. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Those who remain of him will be buried in death. 
-</p><p class="q2">His widows will make no lamentation. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Though he heap up silver as the dust, 
-</p><p class="q2">and prepare clothing as the clay; 
-</p><p class="q1">
-<span class="v">17&#160;</span>he may prepare it, but the just will put it on, 
-</p><p class="q2">and the innocent will divide the silver. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He builds his house as the moth, 
-</p><p class="q2">as a booth which the watchman makes. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He lies down rich, but he will not do so again. 
-</p><p class="q2">He opens his eyes, and he is not. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Terrors overtake him like waters. 
-</p><p class="q2">A storm steals him away in the night. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The east wind carries him away, and he departs. 
-</p><p class="q2">It sweeps him out of his place. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For it hurls at him, and does not spare, 
-</p><p class="q2">as he flees away from his hand. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Men will clap their hands at him, 
-</p><p class="q2">and will hiss him out of his place. 
+<div class="p">
+<sup>1&#160;</sup>Then Bildad the Shuhite answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Dominion and fear are with him. 
+</div><div class="q2">He makes peace in his high places. 
+</div><div class="q1">
+<sup>3&#160;</sup>Can his armies be counted? 
+</div><div class="q2">On whom does his light not arise? 
+</div><div class="q1">
+<sup>4&#160;</sup>How then can man be just with Elohim? 
+</div><div class="q2">Or how can he who is born of a woman be clean? 
+</div><div class="q1">
+<sup>5&#160;</sup>Behold, even the moon has no brightness, 
+</div><div class="q2">and the stars are not pure in his sight; 
+</div><div class="q1">
+<sup>6&#160;</sup>How much less man, who is a worm, 
+</div><div class="q2">and the son of man, who is a worm!” 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“How have you helped him who is without power! 
+</div><div class="q2">How have you saved the arm that has no strength! 
+</div><div class="q1">
+<sup>3&#160;</sup>How have you counseled him who has no wisdom, 
+</div><div class="q2">and plentifully declared sound knowledge! 
+</div><div class="q1">
+<sup>4&#160;</sup>To whom have you uttered words? 
+</div><div class="q2">Whose spirit came out of you? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“The departed spirits tremble, 
+</div><div class="q2">those beneath the waters and all that live in them. 
+</div><div class="q1">
+<sup>6&#160;</sup>Sheol is naked before Elohim, 
+</div><div class="q2">and Abaddon has no covering. 
+</div><div class="q1">
+<sup>7&#160;</sup>He stretches out the north over empty space, 
+</div><div class="q2">and hangs the earth on nothing. 
+</div><div class="q1">
+<sup>8&#160;</sup>He binds up the waters in his thick clouds, 
+</div><div class="q2">and the cloud is not burst under them. 
+</div><div class="q1">
+<sup>9&#160;</sup>He encloses the face of his throne, 
+</div><div class="q2">and spreads his cloud on it. 
+</div><div class="q1">
+<sup>10&#160;</sup>He has described a boundary on the surface of the waters, 
+</div><div class="q2">and to the confines of light and darkness. 
+</div><div class="q1">
+<sup>11&#160;</sup>The pillars of heaven tremble 
+</div><div class="q2">and are astonished at his rebuke. 
+</div><div class="q1">
+<sup>12&#160;</sup>He stirs up the sea with his power, 
+</div><div class="q2">and by his understanding he strikes through Rahab. 
+</div><div class="q1">
+<sup>13&#160;</sup>By his Spirit the heavens are garnished. 
+</div><div class="q2">His hand has pierced the swift serpent. 
+</div><div class="q1">
+<sup>14&#160;</sup>Behold, these are but the outskirts of his ways. 
+</div><div class="q2">How small a whisper do we hear of him! 
+</div><div class="q2">But the thunder of his power who can understand?” 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Job again took up his parable, and said, 
+</div><div class="q1">
+<sup>2&#160;</sup>“As Elohim lives, who has taken away my right, 
+</div><div class="q2">the Almighty, who has made my soul bitter 
+</div><div class="q1">
+<sup>3&#160;</sup>(for the length of my life is still in me, 
+</div><div class="q2">and the spirit of Elohim is in my nostrils); 
+</div><div class="q1">
+<sup>4&#160;</sup>surely my lips will not speak unrighteousness, 
+</div><div class="q2">neither will my tongue utter deceit. 
+</div><div class="q1">
+<sup>5&#160;</sup>Far be it from me that I should justify you. 
+</div><div class="q2">Until I die I will not put away my integrity from me. 
+</div><div class="q1">
+<sup>6&#160;</sup>I hold fast to my righteousness, and will not let it go. 
+</div><div class="q2">My heart will not reproach me so long as I live. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Let my enemy be as the wicked. 
+</div><div class="q2">Let him who rises up against me be as the unrighteous. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>For what is the hope of the elohimless, when he is cut off, 
+</div><div class="q2">when Elohim takes away his life? 
+</div><div class="q1">
+<sup>9&#160;</sup>Will Elohim hear his cry when trouble comes on him? 
+</div><div class="q1">
+<sup>10&#160;</sup>Will he delight himself in the Almighty, 
+</div><div class="q2">and call on Elohim at all times? 
+</div><div class="q1">
+<sup>11&#160;</sup>I will teach you about the hand of Elohim. 
+</div><div class="q2">I will not conceal that which is with the Almighty. 
+</div><div class="q1">
+<sup>12&#160;</sup>Behold, all of you have seen it yourselves; 
+</div><div class="q2">why then have you become altogether vain? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“This is the portion of a wicked man with Elohim, 
+</div><div class="q2">the heritage of oppressors, which they receive from the Almighty. 
+</div><div class="q1">
+<sup>14&#160;</sup>If his children are multiplied, it is for the sword. 
+</div><div class="q2">His offspring will not be satisfied with bread. 
+</div><div class="q1">
+<sup>15&#160;</sup>Those who remain of him will be buried in death. 
+</div><div class="q2">His widows will make no lamentation. 
+</div><div class="q1">
+<sup>16&#160;</sup>Though he heap up silver as the dust, 
+</div><div class="q2">and prepare clothing as the clay; 
+</div><div class="q1">
+<sup>17&#160;</sup>he may prepare it, but the just will put it on, 
+</div><div class="q2">and the innocent will divide the silver. 
+</div><div class="q1">
+<sup>18&#160;</sup>He builds his house as the moth, 
+</div><div class="q2">as a booth which the watchman makes. 
+</div><div class="q1">
+<sup>19&#160;</sup>He lies down rich, but he will not do so again. 
+</div><div class="q2">He opens his eyes, and he is not. 
+</div><div class="q1">
+<sup>20&#160;</sup>Terrors overtake him like waters. 
+</div><div class="q2">A storm steals him away in the night. 
+</div><div class="q1">
+<sup>21&#160;</sup>The east wind carries him away, and he departs. 
+</div><div class="q2">It sweeps him out of his place. 
+</div><div class="q1">
+<sup>22&#160;</sup>For it hurls at him, and does not spare, 
+</div><div class="q2">as he flees away from his hand. 
+</div><div class="q1">
+<sup>23&#160;</sup>Men will clap their hands at him, 
+</div><div class="q2">and will hiss him out of his place. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="28">28</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Surely there is a mine for silver, 
-</p><p class="q2">and a place for gold which they refine. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Iron is taken out of the earth, 
-</p><p class="q2">and copper is smelted out of the ore. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Man sets an end to darkness, 
-</p><p class="q2">and searches out, to the furthest bound, 
-</p><p class="q2">the stones of obscurity and of thick darkness. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He breaks open a shaft away from where people live. 
-</p><p class="q2">They are forgotten by the foot. 
-</p><p class="q2">They hang far from men, they swing back and forth. 
-</p><p class="q1">
-<span class="v">5&#160;</span>As for the earth, out of it comes bread. 
-</p><p class="q2">Underneath it is turned up as it were by fire. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Sapphires come from its rocks. 
-</p><p class="q2">It has dust of gold. 
-</p><p class="q1">
-<span class="v">7&#160;</span>That path no bird of prey knows, 
-</p><p class="q2">neither has the falcon’s eye seen it. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The proud animals have not trodden it, 
-</p><p class="q2">nor has the fierce lion passed by there. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He puts his hand on the flinty rock, 
-</p><p class="q2">and he overturns the mountains by the roots. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He cuts out channels among the rocks. 
-</p><p class="q2">His eye sees every precious thing. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He binds the streams that they don’t trickle. 
-</p><p class="q2">The thing that is hidden he brings out to light. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“But where will wisdom be found? 
-</p><p class="q2">Where is the place of understanding? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Man doesn’t know its price, 
-</p><p class="q2">and it isn’t found in the land of the living. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The deep says, ‘It isn’t in me.’ 
-</p><p class="q2">The sea says, ‘It isn’t with me.’ 
-</p><p class="q1">
-<span class="v">15&#160;</span>It can’t be gotten for gold, 
-</p><p class="q2">neither will silver be weighed for its price. 
-</p><p class="q1">
-<span class="v">16&#160;</span>It can’t be valued with the gold of Ophir, 
-</p><p class="q2">with the precious onyx, or the sapphire.<span class="f">+ \fr 28:16 \ft or, lapis lazuli</span> 
-</p><p class="q1">
-<span class="v">17&#160;</span>Gold and glass can’t equal it, 
-</p><p class="q2">neither will it be exchanged for jewels of fine gold. 
-</p><p class="q1">
-<span class="v">18&#160;</span>No mention will be made of coral or of crystal. 
-</p><p class="q2">Yes, the price of wisdom is above rubies. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The topaz of Ethiopia will not equal it. 
-</p><p class="q2">It won’t be valued with pure gold. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Where then does wisdom come from? 
-</p><p class="q2">Where is the place of understanding? 
-</p><p class="q1">
-<span class="v">21&#160;</span>Seeing it is hidden from the eyes of all living, 
-</p><p class="q2">and kept close from the birds of the sky. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Destruction and Death say, 
-</p><p class="q2">‘We have heard a rumor of it with our ears.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>“Elohim understands its way, 
-</p><p class="q2">and he knows its place. 
-</p><p class="q1">
-<span class="v">24&#160;</span>For he looks to the ends of the earth, 
-</p><p class="q2">and sees under the whole sky. 
-</p><p class="q1">
-<span class="v">25&#160;</span>He establishes the force of the wind. 
-</p><p class="q2">Yes, he measures out the waters by measure. 
-</p><p class="q1">
-<span class="v">26&#160;</span>When he made a decree for the rain, 
-</p><p class="q2">and a way for the lightning of the thunder, 
-</p><p class="q1">
-<span class="v">27&#160;</span>then he saw it, and declared it. 
-</p><p class="q2">He established it, yes, and searched it out. 
-</p><p class="q1">
-<span class="v">28&#160;</span>To man he said, 
-</p><p class="q2">‘Behold, the fear of the Lord,<span class="f">+ \fr 28:28 \ft The word translated “Lord” is “Adonai.” </span> that is wisdom. 
-</p><p class="q2">To depart from evil is understanding.’&#160;” 
-</p><div class="b"> &#160; </div>
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Surely there is a mine for silver, 
+</div><div class="q2">and a place for gold which they refine. 
+</div><div class="q1">
+<sup>2&#160;</sup>Iron is taken out of the earth, 
+</div><div class="q2">and copper is smelted out of the ore. 
+</div><div class="q1">
+<sup>3&#160;</sup>Man sets an end to darkness, 
+</div><div class="q2">and searches out, to the furthest bound, 
+</div><div class="q2">the stones of obscurity and of thick darkness. 
+</div><div class="q1">
+<sup>4&#160;</sup>He breaks open a shaft away from where people live. 
+</div><div class="q2">They are forgotten by the foot. 
+</div><div class="q2">They hang far from men, they swing back and forth. 
+</div><div class="q1">
+<sup>5&#160;</sup>As for the earth, out of it comes bread. 
+</div><div class="q2">Underneath it is turned up as it were by fire. 
+</div><div class="q1">
+<sup>6&#160;</sup>Sapphires come from its rocks. 
+</div><div class="q2">It has dust of gold. 
+</div><div class="q1">
+<sup>7&#160;</sup>That path no bird of prey knows, 
+</div><div class="q2">neither has the falcon’s eye seen it. 
+</div><div class="q1">
+<sup>8&#160;</sup>The proud animals have not trodden it, 
+</div><div class="q2">nor has the fierce lion passed by there. 
+</div><div class="q1">
+<sup>9&#160;</sup>He puts his hand on the flinty rock, 
+</div><div class="q2">and he overturns the mountains by the roots. 
+</div><div class="q1">
+<sup>10&#160;</sup>He cuts out channels among the rocks. 
+</div><div class="q2">His eye sees every precious thing. 
+</div><div class="q1">
+<sup>11&#160;</sup>He binds the streams that they don’t trickle. 
+</div><div class="q2">The thing that is hidden he brings out to light. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“But where will wisdom be found? 
+</div><div class="q2">Where is the place of understanding? 
+</div><div class="q1">
+<sup>13&#160;</sup>Man doesn’t know its price, 
+</div><div class="q2">and it isn’t found in the land of the living. 
+</div><div class="q1">
+<sup>14&#160;</sup>The deep says, ‘It isn’t in me.’ 
+</div><div class="q2">The sea says, ‘It isn’t with me.’ 
+</div><div class="q1">
+<sup>15&#160;</sup>It can’t be gotten for gold, 
+</div><div class="q2">neither will silver be weighed for its price. 
+</div><div class="q1">
+<sup>16&#160;</sup>It can’t be valued with the gold of Ophir, 
+</div><div class="q2">with the precious onyx, or the sapphire. 
+</div><div class="q1">
+<sup>17&#160;</sup>Gold and glass can’t equal it, 
+</div><div class="q2">neither will it be exchanged for jewels of fine gold. 
+</div><div class="q1">
+<sup>18&#160;</sup>No mention will be made of coral or of crystal. 
+</div><div class="q2">Yes, the price of wisdom is above rubies. 
+</div><div class="q1">
+<sup>19&#160;</sup>The topaz of Ethiopia will not equal it. 
+</div><div class="q2">It won’t be valued with pure gold. 
+</div><div class="q1">
+<sup>20&#160;</sup>Where then does wisdom come from? 
+</div><div class="q2">Where is the place of understanding? 
+</div><div class="q1">
+<sup>21&#160;</sup>Seeing it is hidden from the eyes of all living, 
+</div><div class="q2">and kept close from the birds of the sky. 
+</div><div class="q1">
+<sup>22&#160;</sup>Destruction and Death say, 
+</div><div class="q2">‘We have heard a rumor of it with our ears.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>“Elohim understands its way, 
+</div><div class="q2">and he knows its place. 
+</div><div class="q1">
+<sup>24&#160;</sup>For he looks to the ends of the earth, 
+</div><div class="q2">and sees under the whole sky. 
+</div><div class="q1">
+<sup>25&#160;</sup>He establishes the force of the wind. 
+</div><div class="q2">Yes, he measures out the waters by measure. 
+</div><div class="q1">
+<sup>26&#160;</sup>When he made a decree for the rain, 
+</div><div class="q2">and a way for the lightning of the thunder, 
+</div><div class="q1">
+<sup>27&#160;</sup>then he saw it, and declared it. 
+</div><div class="q2">He established it, yes, and searched it out. 
+</div><div class="q1">
+<sup>28&#160;</sup>To man he said, 
+</div><div class="q2">‘Behold, the fear of the Lord, that is wisdom. 
+</div><div class="q2">To depart from evil is understanding.’&#160;” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>Job again took up his parable, and said, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Oh that I were as in the months of old, 
-</p><p class="q2">as in the days when Elohim watched over me; 
-</p><p class="q1">
-<span class="v">3&#160;</span>when his lamp shone on my head, 
-</p><p class="q2">and by his light I walked through darkness, 
-</p><p class="q1">
-<span class="v">4&#160;</span>as I was in my prime, 
-</p><p class="q2">when the friendship of Elohim was in my tent, 
-</p><p class="q1">
-<span class="v">5&#160;</span>when the Almighty was yet with me, 
-</p><p class="q2">and my children were around me, 
-</p><p class="q1">
-<span class="v">6&#160;</span>when my steps were washed with butter, 
-</p><p class="q2">and the rock poured out streams of oil for me, 
-</p><p class="q1">
-<span class="v">7&#160;</span>when I went out to the city gate, 
-</p><p class="q2">when I prepared my seat in the street. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The young men saw me and hid themselves. 
-</p><p class="q2">The aged rose up and stood. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The princes refrained from talking, 
-</p><p class="q2">and laid their hand on their mouth. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The voice of the nobles was hushed, 
-</p><p class="q2">and their tongue stuck to the roof of their mouth. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For when the ear heard me, then it blessed me, 
-</p><p class="q2">and when the eye saw me, it commended me, 
-</p><p class="q1">
-<span class="v">12&#160;</span>because I delivered the poor who cried, 
-</p><p class="q2">and the fatherless also, who had no one to help him, 
-</p><p class="q1">
-<span class="v">13&#160;</span>the blessing of him who was ready to perish came on me, 
-</p><p class="q2">and I caused the widow’s heart to sing for joy. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I put on righteousness, and it clothed me. 
-</p><p class="q2">My justice was as a robe and a diadem. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I was eyes to the blind, 
-</p><p class="q2">and feet to the lame. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I was a father to the needy. 
-</p><p class="q2">I researched the cause of him whom I didn’t know. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I broke the jaws of the unrighteous 
-</p><p class="q2">and plucked the prey out of his teeth. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Then I said, ‘I will die in my own house, 
-</p><p class="q2">I will count my days as the sand. 
-</p><p class="q1">
-<span class="v">19&#160;</span>My root is spread out to the waters. 
-</p><p class="q2">The dew lies all night on my branch. 
-</p><p class="q1">
-<span class="v">20&#160;</span>My glory is fresh in me. 
-</p><p class="q2">My bow is renewed in my hand.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“Men listened to me, waited, 
-</p><p class="q2">and kept silence for my counsel. 
-</p><p class="q1">
-<span class="v">22&#160;</span>After my words they didn’t speak again. 
-</p><p class="q2">My speech fell on them. 
-</p><p class="q1">
-<span class="v">23&#160;</span>They waited for me as for the rain. 
-</p><p class="q2">Their mouths drank as with the spring rain. 
-</p><p class="q1">
-<span class="v">24&#160;</span>I smiled on them when they had no confidence. 
-</p><p class="q2">They didn’t reject the light of my face. 
-</p><p class="q1">
-<span class="v">25&#160;</span>I chose out their way, and sat as chief. 
-</p><p class="q2">I lived as a king in the army, 
-</p><p class="q2">as one who comforts the mourners. 
+<div class="p">
+<sup>1&#160;</sup>Job again took up his parable, and said, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Oh that I were as in the months of old, 
+</div><div class="q2">as in the days when Elohim watched over me; 
+</div><div class="q1">
+<sup>3&#160;</sup>when his lamp shone on my head, 
+</div><div class="q2">and by his light I walked through darkness, 
+</div><div class="q1">
+<sup>4&#160;</sup>as I was in my prime, 
+</div><div class="q2">when the friendship of Elohim was in my tent, 
+</div><div class="q1">
+<sup>5&#160;</sup>when the Almighty was yet with me, 
+</div><div class="q2">and my children were around me, 
+</div><div class="q1">
+<sup>6&#160;</sup>when my steps were washed with butter, 
+</div><div class="q2">and the rock poured out streams of oil for me, 
+</div><div class="q1">
+<sup>7&#160;</sup>when I went out to the city gate, 
+</div><div class="q2">when I prepared my seat in the street. 
+</div><div class="q1">
+<sup>8&#160;</sup>The young men saw me and hid themselves. 
+</div><div class="q2">The aged rose up and stood. 
+</div><div class="q1">
+<sup>9&#160;</sup>The princes refrained from talking, 
+</div><div class="q2">and laid their hand on their mouth. 
+</div><div class="q1">
+<sup>10&#160;</sup>The voice of the nobles was hushed, 
+</div><div class="q2">and their tongue stuck to the roof of their mouth. 
+</div><div class="q1">
+<sup>11&#160;</sup>For when the ear heard me, then it blessed me, 
+</div><div class="q2">and when the eye saw me, it commended me, 
+</div><div class="q1">
+<sup>12&#160;</sup>because I delivered the poor who cried, 
+</div><div class="q2">and the fatherless also, who had no one to help him, 
+</div><div class="q1">
+<sup>13&#160;</sup>the blessing of him who was ready to perish came on me, 
+</div><div class="q2">and I caused the widow’s heart to sing for joy. 
+</div><div class="q1">
+<sup>14&#160;</sup>I put on righteousness, and it clothed me. 
+</div><div class="q2">My justice was as a robe and a diadem. 
+</div><div class="q1">
+<sup>15&#160;</sup>I was eyes to the blind, 
+</div><div class="q2">and feet to the lame. 
+</div><div class="q1">
+<sup>16&#160;</sup>I was a father to the needy. 
+</div><div class="q2">I researched the cause of him whom I didn’t know. 
+</div><div class="q1">
+<sup>17&#160;</sup>I broke the jaws of the unrighteous 
+</div><div class="q2">and plucked the prey out of his teeth. 
+</div><div class="q1">
+<sup>18&#160;</sup>Then I said, ‘I will die in my own house, 
+</div><div class="q2">I will count my days as the sand. 
+</div><div class="q1">
+<sup>19&#160;</sup>My root is spread out to the waters. 
+</div><div class="q2">The dew lies all night on my branch. 
+</div><div class="q1">
+<sup>20&#160;</sup>My glory is fresh in me. 
+</div><div class="q2">My bow is renewed in my hand.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“Men listened to me, waited, 
+</div><div class="q2">and kept silence for my counsel. 
+</div><div class="q1">
+<sup>22&#160;</sup>After my words they didn’t speak again. 
+</div><div class="q2">My speech fell on them. 
+</div><div class="q1">
+<sup>23&#160;</sup>They waited for me as for the rain. 
+</div><div class="q2">Their mouths drank as with the spring rain. 
+</div><div class="q1">
+<sup>24&#160;</sup>I smiled on them when they had no confidence. 
+</div><div class="q2">They didn’t reject the light of my face. 
+</div><div class="q1">
+<sup>25&#160;</sup>I chose out their way, and sat as chief. 
+</div><div class="q2">I lived as a king in the army, 
+</div><div class="q2">as one who comforts the mourners. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="30">30</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“But now those who are younger than I have me in derision, 
-</p><p class="q2">whose fathers I considered unworthy to put with my sheep dogs. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Of what use is the strength of their hands to me, 
-</p><p class="q2">men in whom ripe age has perished? 
-</p><p class="q1">
-<span class="v">3&#160;</span>They are gaunt from lack and famine. 
-</p><p class="q2">They gnaw the dry ground, in the gloom of waste and desolation. 
-</p><p class="q1">
-<span class="v">4&#160;</span>They pluck salt herbs by the bushes. 
-</p><p class="q2">The roots of the broom tree are their food. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They are driven out from among men. 
-</p><p class="q2">They cry after them as after a thief, 
-</p><p class="q1">
-<span class="v">6&#160;</span>so that they live in frightful valleys, 
-</p><p class="q2">and in holes of the earth and of the rocks. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They bray among the bushes. 
-</p><p class="q2">They are gathered together under the nettles. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They are children of fools, yes, children of wicked men. 
-</p><p class="q2">They were flogged out of the land. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“Now I have become their song. 
-</p><p class="q2">Yes, I am a byword to them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They abhor me, they stand aloof from me, 
-</p><p class="q2">and don’t hesitate to spit in my face. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For he has untied his cord, and afflicted me; 
-</p><p class="q2">and they have thrown off restraint before me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>On my right hand rise the rabble. 
-</p><p class="q2">They thrust aside my feet. 
-</p><p class="q2">They cast their ways of destruction up against me. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They mar my path. 
-</p><p class="q2">They promote my destruction 
-</p><p class="q2">without anyone’s help. 
-</p><p class="q1">
-<span class="v">14&#160;</span>As through a wide breach they come. 
-</p><p class="q2">They roll themselves in amid the ruin. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Terrors have turned on me. 
-</p><p class="q2">They chase my honor as the wind. 
-</p><p class="q2">My welfare has passed away as a cloud. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>“Now my soul is poured out within me. 
-</p><p class="q2">Days of affliction have taken hold of me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>In the night season my bones are pierced in me, 
-</p><p class="q2">and the pains that gnaw me take no rest. 
-</p><p class="q1">
-<span class="v">18&#160;</span>My garment is disfigured by great force. 
-</p><p class="q2">It binds me about as the collar of my tunic. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He has cast me into the mire. 
-</p><p class="q2">I have become like dust and ashes. 
-</p><p class="q1">
-<span class="v">20&#160;</span>I cry to you, and you do not answer me. 
-</p><p class="q2">I stand up, and you gaze at me. 
-</p><p class="q1">
-<span class="v">21&#160;</span>You have turned to be cruel to me. 
-</p><p class="q2">With the might of your hand you persecute me. 
-</p><p class="q1">
-<span class="v">22&#160;</span>You lift me up to the wind, and drive me with it. 
-</p><p class="q2">You dissolve me in the storm. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For I know that you will bring me to death, 
-</p><p class="q2">to the house appointed for all living. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>“However doesn’t one stretch out a hand in his fall? 
-</p><p class="q2">Or in his calamity therefore cry for help? 
-</p><p class="q1">
-<span class="v">25&#160;</span>Didn’t I weep for him who was in trouble? 
-</p><p class="q2">Wasn’t my soul grieved for the needy? 
-</p><p class="q1">
-<span class="v">26&#160;</span>When I looked for good, then evil came. 
-</p><p class="q2">When I waited for light, darkness came. 
-</p><p class="q1">
-<span class="v">27&#160;</span>My heart is troubled, and doesn’t rest. 
-</p><p class="q2">Days of affliction have come on me. 
-</p><p class="q1">
-<span class="v">28&#160;</span>I go mourning without the sun. 
-</p><p class="q2">I stand up in the assembly, and cry for help. 
-</p><p class="q1">
-<span class="v">29&#160;</span>I am a brother to jackals, 
-</p><p class="q2">and a companion to ostriches. 
-</p><p class="q1">
-<span class="v">30&#160;</span>My skin grows black and peels from me. 
-</p><p class="q2">My bones are burned with heat. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Therefore my harp has turned to mourning, 
-</p><p class="q2">and my pipe into the voice of those who weep. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“But now those who are younger than I have me in derision, 
+</div><div class="q2">whose fathers I considered unworthy to put with my sheep dogs. 
+</div><div class="q1">
+<sup>2&#160;</sup>Of what use is the strength of their hands to me, 
+</div><div class="q2">men in whom ripe age has perished? 
+</div><div class="q1">
+<sup>3&#160;</sup>They are gaunt from lack and famine. 
+</div><div class="q2">They gnaw the dry ground, in the gloom of waste and desolation. 
+</div><div class="q1">
+<sup>4&#160;</sup>They pluck salt herbs by the bushes. 
+</div><div class="q2">The roots of the broom tree are their food. 
+</div><div class="q1">
+<sup>5&#160;</sup>They are driven out from among men. 
+</div><div class="q2">They cry after them as after a thief, 
+</div><div class="q1">
+<sup>6&#160;</sup>so that they live in frightful valleys, 
+</div><div class="q2">and in holes of the earth and of the rocks. 
+</div><div class="q1">
+<sup>7&#160;</sup>They bray among the bushes. 
+</div><div class="q2">They are gathered together under the nettles. 
+</div><div class="q1">
+<sup>8&#160;</sup>They are children of fools, yes, children of wicked men. 
+</div><div class="q2">They were flogged out of the land. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“Now I have become their song. 
+</div><div class="q2">Yes, I am a byword to them. 
+</div><div class="q1">
+<sup>10&#160;</sup>They abhor me, they stand aloof from me, 
+</div><div class="q2">and don’t hesitate to spit in my face. 
+</div><div class="q1">
+<sup>11&#160;</sup>For he has untied his cord, and afflicted me; 
+</div><div class="q2">and they have thrown off restraint before me. 
+</div><div class="q1">
+<sup>12&#160;</sup>On my right hand rise the rabble. 
+</div><div class="q2">They thrust aside my feet. 
+</div><div class="q2">They cast their ways of destruction up against me. 
+</div><div class="q1">
+<sup>13&#160;</sup>They mar my path. 
+</div><div class="q2">They promote my destruction 
+</div><div class="q2">without anyone’s help. 
+</div><div class="q1">
+<sup>14&#160;</sup>As through a wide breach they come. 
+</div><div class="q2">They roll themselves in amid the ruin. 
+</div><div class="q1">
+<sup>15&#160;</sup>Terrors have turned on me. 
+</div><div class="q2">They chase my honor as the wind. 
+</div><div class="q2">My welfare has passed away as a cloud. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>“Now my soul is poured out within me. 
+</div><div class="q2">Days of affliction have taken hold of me. 
+</div><div class="q1">
+<sup>17&#160;</sup>In the night season my bones are pierced in me, 
+</div><div class="q2">and the pains that gnaw me take no rest. 
+</div><div class="q1">
+<sup>18&#160;</sup>My garment is disfigured by great force. 
+</div><div class="q2">It binds me about as the collar of my tunic. 
+</div><div class="q1">
+<sup>19&#160;</sup>He has cast me into the mire. 
+</div><div class="q2">I have become like dust and ashes. 
+</div><div class="q1">
+<sup>20&#160;</sup>I cry to you, and you do not answer me. 
+</div><div class="q2">I stand up, and you gaze at me. 
+</div><div class="q1">
+<sup>21&#160;</sup>You have turned to be cruel to me. 
+</div><div class="q2">With the might of your hand you persecute me. 
+</div><div class="q1">
+<sup>22&#160;</sup>You lift me up to the wind, and drive me with it. 
+</div><div class="q2">You dissolve me in the storm. 
+</div><div class="q1">
+<sup>23&#160;</sup>For I know that you will bring me to death, 
+</div><div class="q2">to the house appointed for all living. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>“However doesn’t one stretch out a hand in his fall? 
+</div><div class="q2">Or in his calamity therefore cry for help? 
+</div><div class="q1">
+<sup>25&#160;</sup>Didn’t I weep for him who was in trouble? 
+</div><div class="q2">Wasn’t my soul grieved for the needy? 
+</div><div class="q1">
+<sup>26&#160;</sup>When I looked for good, then evil came. 
+</div><div class="q2">When I waited for light, darkness came. 
+</div><div class="q1">
+<sup>27&#160;</sup>My heart is troubled, and doesn’t rest. 
+</div><div class="q2">Days of affliction have come on me. 
+</div><div class="q1">
+<sup>28&#160;</sup>I go mourning without the sun. 
+</div><div class="q2">I stand up in the assembly, and cry for help. 
+</div><div class="q1">
+<sup>29&#160;</sup>I am a brother to jackals, 
+</div><div class="q2">and a companion to ostriches. 
+</div><div class="q1">
+<sup>30&#160;</sup>My skin grows black and peels from me. 
+</div><div class="q2">My bones are burned with heat. 
+</div><div class="q1">
+<sup>31&#160;</sup>Therefore my harp has turned to mourning, 
+</div><div class="q2">and my pipe into the voice of those who weep. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="31">31</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“I made a covenant with my eyes; 
-</p><p class="q2">how then should I look lustfully at a young woman? 
-</p><p class="q1">
-<span class="v">2&#160;</span>For what is the portion from Elohim above, 
-</p><p class="q2">and the heritage from the Almighty on high? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Is it not calamity to the unrighteous, 
-</p><p class="q2">and disaster to the workers of iniquity? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Doesn’t he see my ways, 
-</p><p class="q2">and count all my steps? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“If I have walked with falsehood, 
-</p><p class="q2">and my foot has hurried to deceit 
-</p><p class="q1">
-<span class="v">6&#160;</span>(let me be weighed in an even balance, 
-</p><p class="q2">that Elohim may know my integrity); 
-</p><p class="q1">
-<span class="v">7&#160;</span>if my step has turned out of the way, 
-</p><p class="q2">if my heart walked after my eyes, 
-</p><p class="q2">if any defilement has stuck to my hands, 
-</p><p class="q1">
-<span class="v">8&#160;</span>then let me sow, and let another eat. 
-</p><p class="q2">Yes, let the produce of my field be rooted out. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“If my heart has been enticed to a woman, 
-</p><p class="q2">and I have laid wait at my neighbor’s door, 
-</p><p class="q1">
-<span class="v">10&#160;</span>then let my woman grind for another, 
-</p><p class="q2">and let others sleep with her. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For that would be a heinous crime. 
-</p><p class="q2">Yes, it would be an iniquity to be punished by the judges, 
-</p><p class="q1">
-<span class="v">12&#160;</span>for it is a fire that consumes to destruction, 
-</p><p class="q2">and would root out all my increase. 
-</p><p class="q1">
-<span class="v">13&#160;</span>“If I have despised the cause of my male servant 
-</p><p class="q2">or of my female servant, 
-</p><p class="q2">when they contended with me, 
-</p><p class="q1">
-<span class="v">14&#160;</span>what then will I do when Elohim rises up? 
-</p><p class="q2">When he visits, what will I answer him? 
-</p><p class="q1">
-<span class="v">15&#160;</span>Didn’t he who made me in the womb make him? 
-</p><p class="q2">Didn’t one fashion us in the womb? 
-</p><p class="q1">
-<span class="v">16&#160;</span>“If I have withheld the poor from their desire, 
-</p><p class="q2">or have caused the eyes of the widow to fail, 
-</p><p class="q1">
-<span class="v">17&#160;</span>or have eaten my morsel alone, 
-</p><p class="q2">and the fatherless has not eaten of it 
-</p><p class="q1">
-<span class="v">18&#160;</span>(no, from my youth he grew up with me as with a father, 
-</p><p class="q2">I have guided her from my mother’s womb); 
-</p><p class="q1">
-<span class="v">19&#160;</span>if I have seen any perish for want of clothing, 
-</p><p class="q2">or that the needy had no covering; 
-</p><p class="q1">
-<span class="v">20&#160;</span>if his heart hasn’t blessed me, 
-</p><p class="q2">if he hasn’t been warmed with my sheep’s fleece; 
-</p><p class="q1">
-<span class="v">21&#160;</span>if I have lifted up my hand against the fatherless, 
-</p><p class="q2">because I saw my help in the gate; 
-</p><p class="q1">
-<span class="v">22&#160;</span>then let my shoulder fall from the shoulder blade, 
-</p><p class="q2">and my arm be broken from the bone. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For calamity from Elohim is a terror to me. 
-</p><p class="q2">Because of his majesty, I can do nothing. 
-</p><p class="q1">
-<span class="v">24&#160;</span>“If I have made gold my hope, 
-</p><p class="q2">and have said to the fine gold, ‘You are my confidence;’ 
-</p><p class="q1">
-<span class="v">25&#160;</span>If I have rejoiced because my wealth was great, 
-</p><p class="q2">and because my hand had gotten much; 
-</p><p class="q1">
-<span class="v">26&#160;</span>if I have seen the sun when it shined, 
-</p><p class="q2">or the moon moving in splendor, 
-</p><p class="q1">
-<span class="v">27&#160;</span>and my heart has been secretly enticed, 
-</p><p class="q2">and my hand threw a kiss from my mouth; 
-</p><p class="q1">
-<span class="v">28&#160;</span>this also would be an iniquity to be punished by the judges, 
-</p><p class="q2">for I would have denied the Elohim who is above. 
-</p><p class="q1">
-<span class="v">29&#160;</span>“If I have rejoiced at the destruction of him who hated me, 
-</p><p class="q2">or lifted up myself when evil found him 
-</p><p class="q1">
-<span class="v">30&#160;</span>(I have certainly not allowed my mouth to sin 
-</p><p class="q2">by asking his life with a curse); 
-</p><p class="q1">
-<span class="v">31&#160;</span>if the men of my tent have not said, 
-</p><p class="q2">‘Who can find one who has not been filled with his meat?’ 
-</p><p class="q1">
-<span class="v">32&#160;</span>(the foreigner has not camped in the street, 
-</p><p class="q2">but I have opened my doors to the traveler); 
-</p><p class="q1">
-<span class="v">33&#160;</span>if like Adam I have covered my transgressions, 
-</p><p class="q2">by hiding my iniquity in my heart, 
-</p><p class="q1">
-<span class="v">34&#160;</span>because I feared the great multitude, 
-</p><p class="q2">and the contempt of families terrified me, 
-</p><p class="q2">so that I kept silence, and didn’t go out of the door—</p><p class="q1">
-<span class="v">35&#160;</span>oh that I had one to hear me! 
-</p><p class="q2">Behold, here is my signature! Let the Almighty answer me! 
-</p><p class="q2">Let the accuser write my indictment! 
-</p><p class="q1">
-<span class="v">36&#160;</span>Surely I would carry it on my shoulder, 
-</p><p class="q2">and I would bind it to me as a crown. 
-</p><p class="q1">
-<span class="v">37&#160;</span>I would declare to him the number of my steps. 
-</p><p class="q2">I would go near to him like a prince. 
-</p><p class="q1">
-<span class="v">38&#160;</span>If my land cries out against me, 
-</p><p class="q2">and its furrows weep together; 
-</p><p class="q1">
-<span class="v">39&#160;</span>if I have eaten its fruits without money, 
-</p><p class="q2">or have caused its owners to lose their life, 
-</p><p class="q1">
-<span class="v">40&#160;</span>let briers grow instead of wheat, 
-</p><p class="q2">and stinkweed instead of barley.” 
-</p><div class="b"> &#160; </div>
-<p>The words of Job are ended. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>So these three men ceased to answer Job, because he was righteous in his own eyes. 
-<span class="v">2&#160;</span>Then the wrath of Elihu the son of Barachel, the Buzite, of the family of Ram, was kindled against Job. His wrath was kindled because he justified himself rather than Elohim. 
-<span class="v">3&#160;</span>Also his wrath was kindled against his three friends, because they had found no answer, and yet had condemned Job. 
-<span class="v">4&#160;</span>Now Elihu had waited to speak to Job, because they were older than he. 
-<span class="v">5&#160;</span>When Elihu saw that there was no answer in the mouth of these three men, his wrath was kindled. 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">6&#160;</span>Elihu the son of Barachel the Buzite answered, 
-</p><p class="q1">“I am young, and you are very old. 
-</p><p class="q2">Therefore I held back, and didn’t dare show you my opinion. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I said, ‘Days should speak, 
-</p><p class="q2">and multitude of years should teach wisdom.’ 
-</p><p class="q1">
-<span class="v">8&#160;</span>But there is a spirit in man, 
-</p><p class="q2">and the Spirit<span class="f">+ \fr 32:8 \ft or, breath</span> of the Almighty gives them understanding. 
-</p><p class="q1">
-<span class="v">9&#160;</span>It is not the great who are wise, 
-</p><p class="q2">nor the aged who understand justice. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Therefore I said, ‘Listen to me; 
-</p><p class="q2">I also will show my opinion.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>“Behold, I waited for your words, 
-</p><p class="q2">and I listened for your reasoning, 
-</p><p class="q2">while you searched out what to say. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yes, I gave you my full attention, 
-</p><p class="q2">but there was no one who convinced Job, 
-</p><p class="q2">or who answered his words, among you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Beware lest you say, ‘We have found wisdom. 
-</p><p class="q2">Elohim may refute him, not man;’ 
-</p><p class="q1">
-<span class="v">14&#160;</span>for he has not directed his words against me; 
-</p><p class="q2">neither will I answer him with your speeches. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“They are amazed. They answer no more. 
-</p><p class="q2">They don’t have a word to say. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Shall I wait, because they don’t speak, 
-</p><p class="q2">because they stand still, and answer no more? 
-</p><p class="q1">
-<span class="v">17&#160;</span>I also will answer my part, 
-</p><p class="q2">and I also will show my opinion. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For I am full of words. 
-</p><p class="q2">The spirit within me constrains me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Behold, my breast is as wine which has no vent; 
-</p><p class="q2">like new wineskins it is ready to burst. 
-</p><p class="q1">
-<span class="v">20&#160;</span>I will speak, that I may be refreshed. 
-</p><p class="q2">I will open my lips and answer. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Please don’t let me respect any man’s person, 
-</p><p class="q2">neither will I give flattering titles to any man. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For I don’t know how to give flattering titles, 
-</p><p class="q2">or else my Maker would soon take me away. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“I made a covenant with my eyes; 
+</div><div class="q2">how then should I look lustfully at a young woman? 
+</div><div class="q1">
+<sup>2&#160;</sup>For what is the portion from Elohim above, 
+</div><div class="q2">and the heritage from the Almighty on high? 
+</div><div class="q1">
+<sup>3&#160;</sup>Is it not calamity to the unrighteous, 
+</div><div class="q2">and disaster to the workers of iniquity? 
+</div><div class="q1">
+<sup>4&#160;</sup>Doesn’t he see my ways, 
+</div><div class="q2">and count all my steps? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“If I have walked with falsehood, 
+</div><div class="q2">and my foot has hurried to deceit 
+</div><div class="q1">
+<sup>6&#160;</sup>(let me be weighed in an even balance, 
+</div><div class="q2">that Elohim may know my integrity); 
+</div><div class="q1">
+<sup>7&#160;</sup>if my step has turned out of the way, 
+</div><div class="q2">if my heart walked after my eyes, 
+</div><div class="q2">if any defilement has stuck to my hands, 
+</div><div class="q1">
+<sup>8&#160;</sup>then let me sow, and let another eat. 
+</div><div class="q2">Yes, let the produce of my field be rooted out. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“If my heart has been enticed to a woman, 
+</div><div class="q2">and I have laid wait at my neighbor’s door, 
+</div><div class="q1">
+<sup>10&#160;</sup>then let my woman grind for another, 
+</div><div class="q2">and let others sleep with her. 
+</div><div class="q1">
+<sup>11&#160;</sup>For that would be a heinous crime. 
+</div><div class="q2">Yes, it would be an iniquity to be punished by the judges, 
+</div><div class="q1">
+<sup>12&#160;</sup>for it is a fire that consumes to destruction, 
+</div><div class="q2">and would root out all my increase. 
+</div><div class="q1">
+<sup>13&#160;</sup>“If I have despised the cause of my male servant 
+</div><div class="q2">or of my female servant, 
+</div><div class="q2">when they contended with me, 
+</div><div class="q1">
+<sup>14&#160;</sup>what then will I do when Elohim rises up? 
+</div><div class="q2">When he visits, what will I answer him? 
+</div><div class="q1">
+<sup>15&#160;</sup>Didn’t he who made me in the womb make him? 
+</div><div class="q2">Didn’t one fashion us in the womb? 
+</div><div class="q1">
+<sup>16&#160;</sup>“If I have withheld the poor from their desire, 
+</div><div class="q2">or have caused the eyes of the widow to fail, 
+</div><div class="q1">
+<sup>17&#160;</sup>or have eaten my morsel alone, 
+</div><div class="q2">and the fatherless has not eaten of it 
+</div><div class="q1">
+<sup>18&#160;</sup>(no, from my youth he grew up with me as with a father, 
+</div><div class="q2">I have guided her from my mother’s womb); 
+</div><div class="q1">
+<sup>19&#160;</sup>if I have seen any perish for want of clothing, 
+</div><div class="q2">or that the needy had no covering; 
+</div><div class="q1">
+<sup>20&#160;</sup>if his heart hasn’t blessed me, 
+</div><div class="q2">if he hasn’t been warmed with my sheep’s fleece; 
+</div><div class="q1">
+<sup>21&#160;</sup>if I have lifted up my hand against the fatherless, 
+</div><div class="q2">because I saw my help in the gate; 
+</div><div class="q1">
+<sup>22&#160;</sup>then let my shoulder fall from the shoulder blade, 
+</div><div class="q2">and my arm be broken from the bone. 
+</div><div class="q1">
+<sup>23&#160;</sup>For calamity from Elohim is a terror to me. 
+</div><div class="q2">Because of his majesty, I can do nothing. 
+</div><div class="q1">
+<sup>24&#160;</sup>“If I have made gold my hope, 
+</div><div class="q2">and have said to the fine gold, ‘You are my confidence;’ 
+</div><div class="q1">
+<sup>25&#160;</sup>If I have rejoiced because my wealth was great, 
+</div><div class="q2">and because my hand had gotten much; 
+</div><div class="q1">
+<sup>26&#160;</sup>if I have seen the sun when it shined, 
+</div><div class="q2">or the moon moving in splendor, 
+</div><div class="q1">
+<sup>27&#160;</sup>and my heart has been secretly enticed, 
+</div><div class="q2">and my hand threw a kiss from my mouth; 
+</div><div class="q1">
+<sup>28&#160;</sup>this also would be an iniquity to be punished by the judges, 
+</div><div class="q2">for I would have denied the Elohim who is above. 
+</div><div class="q1">
+<sup>29&#160;</sup>“If I have rejoiced at the destruction of him who hated me, 
+</div><div class="q2">or lifted up myself when evil found him 
+</div><div class="q1">
+<sup>30&#160;</sup>(I have certainly not allowed my mouth to sin 
+</div><div class="q2">by asking his life with a curse); 
+</div><div class="q1">
+<sup>31&#160;</sup>if the men of my tent have not said, 
+</div><div class="q2">‘Who can find one who has not been filled with his meat?’ 
+</div><div class="q1">
+<sup>32&#160;</sup>(the foreigner has not camped in the street, 
+</div><div class="q2">but I have opened my doors to the traveler); 
+</div><div class="q1">
+<sup>33&#160;</sup>if like Adam I have covered my transgressions, 
+</div><div class="q2">by hiding my iniquity in my heart, 
+</div><div class="q1">
+<sup>34&#160;</sup>because I feared the great multitude, 
+</div><div class="q2">and the contempt of families terrified me, 
+</div><div class="q2">so that I kept silence, and didn’t go out of the door—</div><div class="q1">
+<sup>35&#160;</sup>oh that I had one to hear me! 
+</div><div class="q2">Behold, here is my signature! Let the Almighty answer me! 
+</div><div class="q2">Let the accuser write my indictment! 
+</div><div class="q1">
+<sup>36&#160;</sup>Surely I would carry it on my shoulder, 
+</div><div class="q2">and I would bind it to me as a crown. 
+</div><div class="q1">
+<sup>37&#160;</sup>I would declare to him the number of my steps. 
+</div><div class="q2">I would go near to him like a prince. 
+</div><div class="q1">
+<sup>38&#160;</sup>If my land cries out against me, 
+</div><div class="q2">and its furrows weep together; 
+</div><div class="q1">
+<sup>39&#160;</sup>if I have eaten its fruits without money, 
+</div><div class="q2">or have caused its owners to lose their life, 
+</div><div class="q1">
+<sup>40&#160;</sup>let briers grow instead of wheat, 
+</div><div class="q2">and stinkweed instead of barley.” 
+</div><div class="b"> &#160; </div>
+<div class="p">The words of Job are ended. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>So these three men ceased to answer Job, because he was righteous in his own eyes. 
+<sup>2&#160;</sup>Then the wrath of Elihu the son of Barachel, the Buzite, of the family of Ram, was kindled against Job. His wrath was kindled because he justified himself rather than Elohim. 
+<sup>3&#160;</sup>Also his wrath was kindled against his three friends, because they had found no answer, and yet had condemned Job. 
+<sup>4&#160;</sup>Now Elihu had waited to speak to Job, because they were older than he. 
+<sup>5&#160;</sup>When Elihu saw that there was no answer in the mouth of these three men, his wrath was kindled. 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>6&#160;</sup>Elihu the son of Barachel the Buzite answered, 
+</div><div class="q1">“I am young, and you are very old. 
+</div><div class="q2">Therefore I held back, and didn’t dare show you my opinion. 
+</div><div class="q1">
+<sup>7&#160;</sup>I said, ‘Days should speak, 
+</div><div class="q2">and multitude of years should teach wisdom.’ 
+</div><div class="q1">
+<sup>8&#160;</sup>But there is a spirit in man, 
+</div><div class="q2">and the Spirit of the Almighty gives them understanding. 
+</div><div class="q1">
+<sup>9&#160;</sup>It is not the great who are wise, 
+</div><div class="q2">nor the aged who understand justice. 
+</div><div class="q1">
+<sup>10&#160;</sup>Therefore I said, ‘Listen to me; 
+</div><div class="q2">I also will show my opinion.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>“Behold, I waited for your words, 
+</div><div class="q2">and I listened for your reasoning, 
+</div><div class="q2">while you searched out what to say. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yes, I gave you my full attention, 
+</div><div class="q2">but there was no one who convinced Job, 
+</div><div class="q2">or who answered his words, among you. 
+</div><div class="q1">
+<sup>13&#160;</sup>Beware lest you say, ‘We have found wisdom. 
+</div><div class="q2">Elohim may refute him, not man;’ 
+</div><div class="q1">
+<sup>14&#160;</sup>for he has not directed his words against me; 
+</div><div class="q2">neither will I answer him with your speeches. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“They are amazed. They answer no more. 
+</div><div class="q2">They don’t have a word to say. 
+</div><div class="q1">
+<sup>16&#160;</sup>Shall I wait, because they don’t speak, 
+</div><div class="q2">because they stand still, and answer no more? 
+</div><div class="q1">
+<sup>17&#160;</sup>I also will answer my part, 
+</div><div class="q2">and I also will show my opinion. 
+</div><div class="q1">
+<sup>18&#160;</sup>For I am full of words. 
+</div><div class="q2">The spirit within me constrains me. 
+</div><div class="q1">
+<sup>19&#160;</sup>Behold, my breast is as wine which has no vent; 
+</div><div class="q2">like new wineskins it is ready to burst. 
+</div><div class="q1">
+<sup>20&#160;</sup>I will speak, that I may be refreshed. 
+</div><div class="q2">I will open my lips and answer. 
+</div><div class="q1">
+<sup>21&#160;</sup>Please don’t let me respect any man’s person, 
+</div><div class="q2">neither will I give flattering titles to any man. 
+</div><div class="q1">
+<sup>22&#160;</sup>For I don’t know how to give flattering titles, 
+</div><div class="q2">or else my Maker would soon take me away. 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="33">33</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“However, Job, please hear my speech, 
-</p><p class="q2">and listen to all my words. 
-</p><p class="q1">
-<span class="v">2&#160;</span>See now, I have opened my mouth. 
-</p><p class="q2">My tongue has spoken in my mouth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>My words will utter the uprightness of my heart. 
-</p><p class="q2">That which my lips know they will speak sincerely. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The Spirit of Elohim has made me, 
-</p><p class="q2">and the breath of the Almighty gives me life. 
-</p><p class="q1">
-<span class="v">5&#160;</span>If you can, answer me. 
-</p><p class="q2">Set your words in order before me, and stand up. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Behold, I am toward Elohim even as you are. 
-</p><p class="q2">I am also formed out of the clay. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Behold, my terror will not make you afraid, 
-</p><p class="q2">neither will my pressure be heavy on you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Surely you have spoken in my hearing, 
-</p><p class="q2">I have heard the voice of your words, saying, 
-</p><p class="q1">
-<span class="v">9&#160;</span>‘I am clean, without disobedience. 
-</p><p class="q2">I am innocent, neither is there iniquity in me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Behold, he finds occasions against me. 
-</p><p class="q2">He counts me for his enemy. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He puts my feet in the stocks. 
-</p><p class="q2">He marks all my paths.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Behold, I will answer you. In this you are not just, 
-</p><p class="q2">for Elohim is greater than man. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Why do you strive against him, 
-</p><p class="q2">because he doesn’t give account of any of his matters? 
-</p><p class="q1">
-<span class="v">14&#160;</span>For Elohim speaks once, 
-</p><p class="q2">yes twice, though man pays no attention. 
-</p><p class="q1">
-<span class="v">15&#160;</span>In a dream, in a vision of the night, 
-</p><p class="q2">when deep sleep falls on men, 
-</p><p class="q2">in slumbering on the bed, 
-</p><p class="q1">
-<span class="v">16&#160;</span>then he opens the ears of men, 
-</p><p class="q2">and seals their instruction, 
-</p><p class="q1">
-<span class="v">17&#160;</span>that he may withdraw man from his purpose, 
-</p><p class="q2">and hide pride from man. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He keeps back his soul from the pit, 
-</p><p class="q2">and his life from perishing by the sword. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“He is chastened also with pain on his bed, 
-</p><p class="q2">with continual strife in his bones, 
-</p><p class="q1">
-<span class="v">20&#160;</span>so that his life abhors bread, 
-</p><p class="q2">and his soul dainty food. 
-</p><p class="q1">
-<span class="v">21&#160;</span>His flesh is so consumed away that it can’t be seen. 
-</p><p class="q2">His bones that were not seen stick out. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Yes, his soul draws near to the pit, 
-</p><p class="q2">and his life to the destroyers. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>“If there is beside him an angel, 
-</p><p class="q2">an interpreter, one among a thousand, 
-</p><p class="q2">to show to man what is right for him, 
-</p><p class="q1">
-<span class="v">24&#160;</span>then Elohim is gracious to him, and says, 
-</p><p class="q2">‘Deliver him from going down to the pit, 
-</p><p class="q2">I have found a ransom.’ 
-</p><p class="q1">
-<span class="v">25&#160;</span>His flesh will be fresher than a child’s. 
-</p><p class="q2">He returns to the days of his youth. 
-</p><p class="q1">
-<span class="v">26&#160;</span>He prays to Elohim, and he is favorable to him, 
-</p><p class="q2">so that he sees his face with joy. 
-</p><p class="q2">He restores to man his righteousness. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He sings before men, and says, 
-</p><p class="q2">‘I have sinned, and perverted that which was right, 
-</p><p class="q2">and it didn’t profit me. 
-</p><p class="q1">
-<span class="v">28&#160;</span>He has redeemed my soul from going into the pit. 
-</p><p class="q2">My life will see the light.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">29&#160;</span>“Behold, Elohim does all these things, 
-</p><p class="q2">twice, yes three times, with a man, 
-</p><p class="q1">
-<span class="v">30&#160;</span>to bring back his soul from the pit, 
-</p><p class="q2">that he may be enlightened with the light of the living. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Mark well, Job, and listen to me. 
-</p><p class="q2">Hold your peace, and I will speak. 
-</p><p class="q1">
-<span class="v">32&#160;</span>If you have anything to say, answer me. 
-</p><p class="q2">Speak, for I desire to justify you. 
-</p><p class="q1">
-<span class="v">33&#160;</span>If not, listen to me. 
-</p><p class="q2">Hold your peace, and I will teach you wisdom.” 
-</p><div class="b"> &#160; </div>
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“However, Job, please hear my speech, 
+</div><div class="q2">and listen to all my words. 
+</div><div class="q1">
+<sup>2&#160;</sup>See now, I have opened my mouth. 
+</div><div class="q2">My tongue has spoken in my mouth. 
+</div><div class="q1">
+<sup>3&#160;</sup>My words will utter the uprightness of my heart. 
+</div><div class="q2">That which my lips know they will speak sincerely. 
+</div><div class="q1">
+<sup>4&#160;</sup>The Spirit of Elohim has made me, 
+</div><div class="q2">and the breath of the Almighty gives me life. 
+</div><div class="q1">
+<sup>5&#160;</sup>If you can, answer me. 
+</div><div class="q2">Set your words in order before me, and stand up. 
+</div><div class="q1">
+<sup>6&#160;</sup>Behold, I am toward Elohim even as you are. 
+</div><div class="q2">I am also formed out of the clay. 
+</div><div class="q1">
+<sup>7&#160;</sup>Behold, my terror will not make you afraid, 
+</div><div class="q2">neither will my pressure be heavy on you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Surely you have spoken in my hearing, 
+</div><div class="q2">I have heard the voice of your words, saying, 
+</div><div class="q1">
+<sup>9&#160;</sup>‘I am clean, without disobedience. 
+</div><div class="q2">I am innocent, neither is there iniquity in me. 
+</div><div class="q1">
+<sup>10&#160;</sup>Behold, he finds occasions against me. 
+</div><div class="q2">He counts me for his enemy. 
+</div><div class="q1">
+<sup>11&#160;</sup>He puts my feet in the stocks. 
+</div><div class="q2">He marks all my paths.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Behold, I will answer you. In this you are not just, 
+</div><div class="q2">for Elohim is greater than man. 
+</div><div class="q1">
+<sup>13&#160;</sup>Why do you strive against him, 
+</div><div class="q2">because he doesn’t give account of any of his matters? 
+</div><div class="q1">
+<sup>14&#160;</sup>For Elohim speaks once, 
+</div><div class="q2">yes twice, though man pays no attention. 
+</div><div class="q1">
+<sup>15&#160;</sup>In a dream, in a vision of the night, 
+</div><div class="q2">when deep sleep falls on men, 
+</div><div class="q2">in slumbering on the bed, 
+</div><div class="q1">
+<sup>16&#160;</sup>then he opens the ears of men, 
+</div><div class="q2">and seals their instruction, 
+</div><div class="q1">
+<sup>17&#160;</sup>that he may withdraw man from his purpose, 
+</div><div class="q2">and hide pride from man. 
+</div><div class="q1">
+<sup>18&#160;</sup>He keeps back his soul from the pit, 
+</div><div class="q2">and his life from perishing by the sword. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“He is chastened also with pain on his bed, 
+</div><div class="q2">with continual strife in his bones, 
+</div><div class="q1">
+<sup>20&#160;</sup>so that his life abhors bread, 
+</div><div class="q2">and his soul dainty food. 
+</div><div class="q1">
+<sup>21&#160;</sup>His flesh is so consumed away that it can’t be seen. 
+</div><div class="q2">His bones that were not seen stick out. 
+</div><div class="q1">
+<sup>22&#160;</sup>Yes, his soul draws near to the pit, 
+</div><div class="q2">and his life to the destroyers. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>“If there is beside him an angel, 
+</div><div class="q2">an interpreter, one among a thousand, 
+</div><div class="q2">to show to man what is right for him, 
+</div><div class="q1">
+<sup>24&#160;</sup>then Elohim is gracious to him, and says, 
+</div><div class="q2">‘Deliver him from going down to the pit, 
+</div><div class="q2">I have found a ransom.’ 
+</div><div class="q1">
+<sup>25&#160;</sup>His flesh will be fresher than a child’s. 
+</div><div class="q2">He returns to the days of his youth. 
+</div><div class="q1">
+<sup>26&#160;</sup>He prays to Elohim, and he is favorable to him, 
+</div><div class="q2">so that he sees his face with joy. 
+</div><div class="q2">He restores to man his righteousness. 
+</div><div class="q1">
+<sup>27&#160;</sup>He sings before men, and says, 
+</div><div class="q2">‘I have sinned, and perverted that which was right, 
+</div><div class="q2">and it didn’t profit me. 
+</div><div class="q1">
+<sup>28&#160;</sup>He has redeemed my soul from going into the pit. 
+</div><div class="q2">My life will see the light.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>29&#160;</sup>“Behold, Elohim does all these things, 
+</div><div class="q2">twice, yes three times, with a man, 
+</div><div class="q1">
+<sup>30&#160;</sup>to bring back his soul from the pit, 
+</div><div class="q2">that he may be enlightened with the light of the living. 
+</div><div class="q1">
+<sup>31&#160;</sup>Mark well, Job, and listen to me. 
+</div><div class="q2">Hold your peace, and I will speak. 
+</div><div class="q1">
+<sup>32&#160;</sup>If you have anything to say, answer me. 
+</div><div class="q2">Speak, for I desire to justify you. 
+</div><div class="q1">
+<sup>33&#160;</sup>If not, listen to me. 
+</div><div class="q2">Hold your peace, and I will teach you wisdom.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Elihu answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Hear my words, you wise men. 
-</p><p class="q2">Give ear to me, you who have knowledge. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For the ear tries words, 
-</p><p class="q2">as the palate tastes food. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Let us choose for us that which is right. 
-</p><p class="q2">Let us know among ourselves what is good. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For Job has said, ‘I am righteous, 
-</p><p class="q2">Elohim has taken away my right. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Notwithstanding my right I am considered a liar. 
-</p><p class="q2">My wound is incurable, though I am without disobedience.’ 
-</p><p class="q1">
-<span class="v">7&#160;</span>What man is like Job, 
-</p><p class="q2">who drinks scorn like water, 
-</p><p class="q1">
-<span class="v">8&#160;</span>who goes in company with the workers of iniquity, 
-</p><p class="q2">and walks with wicked men? 
-</p><p class="q1">
-<span class="v">9&#160;</span>For he has said, ‘It profits a man nothing 
-</p><p class="q2">that he should delight himself with Elohim.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Therefore listen to me, you men of understanding: 
-</p><p class="q2">far be it from Elohim, that he should do wickedness, 
-</p><p class="q2">from the Almighty, that he should commit iniquity. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For the work of a man he will render to him, 
-</p><p class="q2">and cause every man to find according to his ways. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yes surely, Elohim will not do wickedly, 
-</p><p class="q2">neither will the Almighty pervert justice. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Who put him in charge of the earth? 
-</p><p class="q2">Or who has appointed him over the whole world? 
-</p><p class="q1">
-<span class="v">14&#160;</span>If he set his heart on himself, 
-</p><p class="q2">if he gathered to himself his spirit and his breath, 
-</p><p class="q1">
-<span class="v">15&#160;</span>all flesh would perish together, 
-</p><p class="q2">and man would turn again to dust. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>“If now you have understanding, hear this. 
-</p><p class="q2">Listen to the voice of my words. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Should even one who hates justice govern? 
-</p><p class="q2">Will you condemn him who is righteous and mighty, 
-</p><p class="q1">
-<span class="v">18&#160;</span>who says to a king, ‘Vile!’ 
-</p><p class="q2">or to nobles, ‘Wicked!’? 
-</p><p class="q1">
-<span class="v">19&#160;</span>He doesn’t respect the persons of princes, 
-</p><p class="q2">nor respect the rich more than the poor, 
-</p><p class="q2">for they all are the work of his hands. 
-</p><p class="q1">
-<span class="v">20&#160;</span>In a moment they die, even at midnight. 
-</p><p class="q2">The people are shaken and pass away. 
-</p><p class="q2">The mighty are taken away without a hand. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“For his eyes are on the ways of a man. 
-</p><p class="q2">He sees all his goings. 
-</p><p class="q1">
-<span class="v">22&#160;</span>There is no darkness, nor thick gloom, 
-</p><p class="q2">where the workers of iniquity may hide themselves. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For he doesn’t need to consider a man further, 
-</p><p class="q2">that he should go before Elohim in judgment. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He breaks mighty men in pieces in ways past finding out, 
-</p><p class="q2">and sets others in their place. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Therefore he takes knowledge of their works. 
-</p><p class="q2">He overturns them in the night, so that they are destroyed. 
-</p><p class="q1">
-<span class="v">26&#160;</span>He strikes them as wicked men 
-</p><p class="q2">in the open sight of others; 
-</p><p class="q1">
-<span class="v">27&#160;</span>because they turned away from following him, 
-</p><p class="q2">and wouldn’t pay attention to any of his ways, 
-</p><p class="q1">
-<span class="v">28&#160;</span>so that they caused the cry of the poor to come to him. 
-</p><p class="q2">He heard the cry of the afflicted. 
-</p><p class="q1">
-<span class="v">29&#160;</span>When he gives quietness, who then can condemn? 
-</p><p class="q2">When he hides his face, who then can see him? 
-</p><p class="q2">He is over a nation or a man alike, 
-</p><p class="q1">
-<span class="v">30&#160;</span>that the elohimless man may not reign, 
-</p><p class="q2">that there be no one to ensnare the people. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">31&#160;</span>“For has any said to Elohim, 
-</p><p class="q2">‘I am guilty, but I will not offend any more. 
-</p><p class="q1">
-<span class="v">32&#160;</span>Teach me that which I don’t see. 
-</p><p class="q2">If I have done iniquity, I will do it no more’? 
-</p><p class="q1">
-<span class="v">33&#160;</span>Shall his recompense be as you desire, that you refuse it? 
-</p><p class="q2">For you must choose, and not I. 
-</p><p class="q2">Therefore speak what you know. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Men of understanding will tell me, 
-</p><p class="q2">yes, every wise man who hears me: 
-</p><p class="q1">
-<span class="v">35&#160;</span>‘Job speaks without knowledge. 
-</p><p class="q2">His words are without wisdom.’ 
-</p><p class="q1">
-<span class="v">36&#160;</span>I wish that Job were tried to the end, 
-</p><p class="q2">because of his answering like wicked men. 
-</p><p class="q1">
-<span class="v">37&#160;</span>For he adds rebellion to his sin. 
-</p><p class="q2">He claps his hands among us, 
-</p><p class="q2">and multiplies his words against Elohim.” 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Moreover Elihu answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Hear my words, you wise men. 
+</div><div class="q2">Give ear to me, you who have knowledge. 
+</div><div class="q1">
+<sup>3&#160;</sup>For the ear tries words, 
+</div><div class="q2">as the palate tastes food. 
+</div><div class="q1">
+<sup>4&#160;</sup>Let us choose for us that which is right. 
+</div><div class="q2">Let us know among ourselves what is good. 
+</div><div class="q1">
+<sup>5&#160;</sup>For Job has said, ‘I am righteous, 
+</div><div class="q2">Elohim has taken away my right. 
+</div><div class="q1">
+<sup>6&#160;</sup>Notwithstanding my right I am considered a liar. 
+</div><div class="q2">My wound is incurable, though I am without disobedience.’ 
+</div><div class="q1">
+<sup>7&#160;</sup>What man is like Job, 
+</div><div class="q2">who drinks scorn like water, 
+</div><div class="q1">
+<sup>8&#160;</sup>who goes in company with the workers of iniquity, 
+</div><div class="q2">and walks with wicked men? 
+</div><div class="q1">
+<sup>9&#160;</sup>For he has said, ‘It profits a man nothing 
+</div><div class="q2">that he should delight himself with Elohim.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Therefore listen to me, you men of understanding: 
+</div><div class="q2">far be it from Elohim, that he should do wickedness, 
+</div><div class="q2">from the Almighty, that he should commit iniquity. 
+</div><div class="q1">
+<sup>11&#160;</sup>For the work of a man he will render to him, 
+</div><div class="q2">and cause every man to find according to his ways. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yes surely, Elohim will not do wickedly, 
+</div><div class="q2">neither will the Almighty pervert justice. 
+</div><div class="q1">
+<sup>13&#160;</sup>Who put him in charge of the earth? 
+</div><div class="q2">Or who has appointed him over the whole world? 
+</div><div class="q1">
+<sup>14&#160;</sup>If he set his heart on himself, 
+</div><div class="q2">if he gathered to himself his spirit and his breath, 
+</div><div class="q1">
+<sup>15&#160;</sup>all flesh would perish together, 
+</div><div class="q2">and man would turn again to dust. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>“If now you have understanding, hear this. 
+</div><div class="q2">Listen to the voice of my words. 
+</div><div class="q1">
+<sup>17&#160;</sup>Should even one who hates justice govern? 
+</div><div class="q2">Will you condemn him who is righteous and mighty, 
+</div><div class="q1">
+<sup>18&#160;</sup>who says to a king, ‘Vile!’ 
+</div><div class="q2">or to nobles, ‘Wicked!’? 
+</div><div class="q1">
+<sup>19&#160;</sup>He doesn’t respect the persons of princes, 
+</div><div class="q2">nor respect the rich more than the poor, 
+</div><div class="q2">for they all are the work of his hands. 
+</div><div class="q1">
+<sup>20&#160;</sup>In a moment they die, even at midnight. 
+</div><div class="q2">The people are shaken and pass away. 
+</div><div class="q2">The mighty are taken away without a hand. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“For his eyes are on the ways of a man. 
+</div><div class="q2">He sees all his goings. 
+</div><div class="q1">
+<sup>22&#160;</sup>There is no darkness, nor thick gloom, 
+</div><div class="q2">where the workers of iniquity may hide themselves. 
+</div><div class="q1">
+<sup>23&#160;</sup>For he doesn’t need to consider a man further, 
+</div><div class="q2">that he should go before Elohim in judgment. 
+</div><div class="q1">
+<sup>24&#160;</sup>He breaks mighty men in pieces in ways past finding out, 
+</div><div class="q2">and sets others in their place. 
+</div><div class="q1">
+<sup>25&#160;</sup>Therefore he takes knowledge of their works. 
+</div><div class="q2">He overturns them in the night, so that they are destroyed. 
+</div><div class="q1">
+<sup>26&#160;</sup>He strikes them as wicked men 
+</div><div class="q2">in the open sight of others; 
+</div><div class="q1">
+<sup>27&#160;</sup>because they turned away from following him, 
+</div><div class="q2">and wouldn’t pay attention to any of his ways, 
+</div><div class="q1">
+<sup>28&#160;</sup>so that they caused the cry of the poor to come to him. 
+</div><div class="q2">He heard the cry of the afflicted. 
+</div><div class="q1">
+<sup>29&#160;</sup>When he gives quietness, who then can condemn? 
+</div><div class="q2">When he hides his face, who then can see him? 
+</div><div class="q2">He is over a nation or a man alike, 
+</div><div class="q1">
+<sup>30&#160;</sup>that the elohimless man may not reign, 
+</div><div class="q2">that there be no one to ensnare the people. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>31&#160;</sup>“For has any said to Elohim, 
+</div><div class="q2">‘I am guilty, but I will not offend any more. 
+</div><div class="q1">
+<sup>32&#160;</sup>Teach me that which I don’t see. 
+</div><div class="q2">If I have done iniquity, I will do it no more’? 
+</div><div class="q1">
+<sup>33&#160;</sup>Shall his recompense be as you desire, that you refuse it? 
+</div><div class="q2">For you must choose, and not I. 
+</div><div class="q2">Therefore speak what you know. 
+</div><div class="q1">
+<sup>34&#160;</sup>Men of understanding will tell me, 
+</div><div class="q2">yes, every wise man who hears me: 
+</div><div class="q1">
+<sup>35&#160;</sup>‘Job speaks without knowledge. 
+</div><div class="q2">His words are without wisdom.’ 
+</div><div class="q1">
+<sup>36&#160;</sup>I wish that Job were tried to the end, 
+</div><div class="q2">because of his answering like wicked men. 
+</div><div class="q1">
+<sup>37&#160;</sup>For he adds rebellion to his sin. 
+</div><div class="q2">He claps his hands among us, 
+</div><div class="q2">and multiplies his words against Elohim.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Elihu answered, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Do you think this to be your right, 
-</p><p class="q2">or do you say, ‘My righteousness is more than Elohim’s,’ 
-</p><p class="q1">
-<span class="v">3&#160;</span>that you ask, ‘What advantage will it be to you? 
-</p><p class="q2">What profit will I have, more than if I had sinned?’ 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will answer you, 
-</p><p class="q2">and your companions with you. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Look to the skies, and see. 
-</p><p class="q2">See the skies, which are higher than you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>If you have sinned, what effect do you have against him? 
-</p><p class="q2">If your transgressions are multiplied, what do you do to him? 
-</p><p class="q1">
-<span class="v">7&#160;</span>If you are righteous, what do you give him? 
-</p><p class="q2">Or what does he receive from your hand? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Your wickedness may hurt a man as you are, 
-</p><p class="q2">and your righteousness may profit a son of man. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“By reason of the multitude of oppressions they cry out. 
-</p><p class="q2">They cry for help by reason of the arm of the mighty. 
-</p><p class="q1">
-<span class="v">10&#160;</span>But no one says, ‘Where is Elohim my Maker, 
-</p><p class="q2">who gives songs in the night, 
-</p><p class="q1">
-<span class="v">11&#160;</span>who teaches us more than the animals of the earth, 
-</p><p class="q2">and makes us wiser than the birds of the sky?’ 
-</p><p class="q1">
-<span class="v">12&#160;</span>There they cry, but no one answers, 
-</p><p class="q2">because of the pride of evil men. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Surely Elohim will not hear an empty cry, 
-</p><p class="q2">neither will the Almighty regard it. 
-</p><p class="q1">
-<span class="v">14&#160;</span>How much less when you say you don’t see him. 
-</p><p class="q2">The cause is before him, and you wait for him! 
-</p><p class="q1">
-<span class="v">15&#160;</span>But now, because he has not visited in his anger, 
-</p><p class="q2">neither does he greatly regard arrogance, 
-</p><p class="q1">
-<span class="v">16&#160;</span>therefore Job opens his mouth with empty talk, 
-</p><p class="q2">and he multiplies words without knowledge.” 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Moreover Elihu answered, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Do you think this to be your right, 
+</div><div class="q2">or do you say, ‘My righteousness is more than Elohim’s,’ 
+</div><div class="q1">
+<sup>3&#160;</sup>that you ask, ‘What advantage will it be to you? 
+</div><div class="q2">What profit will I have, more than if I had sinned?’ 
+</div><div class="q1">
+<sup>4&#160;</sup>I will answer you, 
+</div><div class="q2">and your companions with you. 
+</div><div class="q1">
+<sup>5&#160;</sup>Look to the skies, and see. 
+</div><div class="q2">See the skies, which are higher than you. 
+</div><div class="q1">
+<sup>6&#160;</sup>If you have sinned, what effect do you have against him? 
+</div><div class="q2">If your transgressions are multiplied, what do you do to him? 
+</div><div class="q1">
+<sup>7&#160;</sup>If you are righteous, what do you give him? 
+</div><div class="q2">Or what does he receive from your hand? 
+</div><div class="q1">
+<sup>8&#160;</sup>Your wickedness may hurt a man as you are, 
+</div><div class="q2">and your righteousness may profit a son of man. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“By reason of the multitude of oppressions they cry out. 
+</div><div class="q2">They cry for help by reason of the arm of the mighty. 
+</div><div class="q1">
+<sup>10&#160;</sup>But no one says, ‘Where is Elohim my Maker, 
+</div><div class="q2">who gives songs in the night, 
+</div><div class="q1">
+<sup>11&#160;</sup>who teaches us more than the animals of the earth, 
+</div><div class="q2">and makes us wiser than the birds of the sky?’ 
+</div><div class="q1">
+<sup>12&#160;</sup>There they cry, but no one answers, 
+</div><div class="q2">because of the pride of evil men. 
+</div><div class="q1">
+<sup>13&#160;</sup>Surely Elohim will not hear an empty cry, 
+</div><div class="q2">neither will the Almighty regard it. 
+</div><div class="q1">
+<sup>14&#160;</sup>How much less when you say you don’t see him. 
+</div><div class="q2">The cause is before him, and you wait for him! 
+</div><div class="q1">
+<sup>15&#160;</sup>But now, because he has not visited in his anger, 
+</div><div class="q2">neither does he greatly regard arrogance, 
+</div><div class="q1">
+<sup>16&#160;</sup>therefore Job opens his mouth with empty talk, 
+</div><div class="q2">and he multiplies words without knowledge.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>Elihu also continued, and said, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Bear with me a little, and I will show you; 
-</p><p class="q2">for I still have something to say on Elohim’s behalf. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I will get my knowledge from afar, 
-</p><p class="q2">and will ascribe righteousness to my Maker. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For truly my words are not false. 
-</p><p class="q2">One who is perfect in knowledge is with you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Behold, Elohim is mighty, and doesn’t despise anyone. 
-</p><p class="q2">He is mighty in strength of understanding. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He doesn’t preserve the life of the wicked, 
-</p><p class="q2">but gives justice to the afflicted. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He doesn’t withdraw his eyes from the righteous, 
-</p><p class="q2">but with kings on the throne, 
-</p><p class="q2">he sets them forever, and they are exalted. 
-</p><p class="q1">
-<span class="v">8&#160;</span>If they are bound in fetters, 
-</p><p class="q2">and are taken in the cords of afflictions, 
-</p><p class="q1">
-<span class="v">9&#160;</span>then he shows them their work, 
-</p><p class="q2">and their transgressions, that they have behaved themselves proudly. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He also opens their ears to instruction, 
-</p><p class="q2">and commands that they return from iniquity. 
-</p><p class="q1">
-<span class="v">11&#160;</span>If they listen and serve him, 
-</p><p class="q2">they will spend their days in prosperity, 
-</p><p class="q2">and their years in pleasures. 
-</p><p class="q1">
-<span class="v">12&#160;</span>But if they don’t listen, they will perish by the sword; 
-</p><p class="q2">they will die without knowledge. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“But those who are elohimless in heart lay up anger. 
-</p><p class="q2">They don’t cry for help when he binds them. 
-</p><p class="q1">
-<span class="v">14&#160;</span>They die in youth. 
-</p><p class="q2">Their life perishes among the unclean. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He delivers the afflicted by their affliction, 
-</p><p class="q2">and opens their ear in oppression. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yes, he would have allured you out of distress, 
-</p><p class="q2">into a wide place, where there is no restriction. 
-</p><p class="q2">That which is set on your table would be full of fatness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“But you are full of the judgment of the wicked. 
-</p><p class="q2">Judgment and justice take hold of you. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Don’t let riches entice you to wrath, 
-</p><p class="q2">neither let the great size of a bribe turn you aside. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Would your wealth sustain you in distress, 
-</p><p class="q2">or all the might of your strength? 
-</p><p class="q1">
-<span class="v">20&#160;</span>Don’t desire the night, 
-</p><p class="q2">when people are cut off in their place. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Take heed, don’t regard iniquity; 
-</p><p class="q2">for you have chosen this rather than affliction. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Behold, Elohim is exalted in his power. 
-</p><p class="q2">Who is a teacher like him? 
-</p><p class="q1">
-<span class="v">23&#160;</span>Who has prescribed his way for him? 
-</p><p class="q2">Or who can say, ‘You have committed unrighteousness’? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>“Remember that you magnify his work, 
-</p><p class="q2">about which men have sung. 
-</p><p class="q1">
-<span class="v">25&#160;</span>All men have looked on it. 
-</p><p class="q2">Man sees it afar off. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Behold, Elohim is great, and we don’t know him. 
-</p><p class="q2">The number of his years is unsearchable. 
-</p><p class="q1">
-<span class="v">27&#160;</span>For he draws up the drops of water, 
-</p><p class="q2">which distill in rain from his vapor, 
-</p><p class="q1">
-<span class="v">28&#160;</span>which the skies pour down 
-</p><p class="q2">and which drop on man abundantly. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Indeed, can anyone understand the spreading of the clouds 
-</p><p class="q2">and the thunderings of his pavilion? 
-</p><p class="q1">
-<span class="v">30&#160;</span>Behold, he spreads his light around him. 
-</p><p class="q2">He covers the bottom of the sea. 
-</p><p class="q1">
-<span class="v">31&#160;</span>For by these he judges the people. 
-</p><p class="q2">He gives food in abundance. 
-</p><p class="q1">
-<span class="v">32&#160;</span>He covers his hands with the lightning, 
-</p><p class="q2">and commands it to strike the mark. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Its noise tells about him, 
-</p><p class="q2">and the livestock also, concerning the storm that comes up. 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Elihu also continued, and said, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Bear with me a little, and I will show you; 
+</div><div class="q2">for I still have something to say on Elohim’s behalf. 
+</div><div class="q1">
+<sup>3&#160;</sup>I will get my knowledge from afar, 
+</div><div class="q2">and will ascribe righteousness to my Maker. 
+</div><div class="q1">
+<sup>4&#160;</sup>For truly my words are not false. 
+</div><div class="q2">One who is perfect in knowledge is with you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Behold, Elohim is mighty, and doesn’t despise anyone. 
+</div><div class="q2">He is mighty in strength of understanding. 
+</div><div class="q1">
+<sup>6&#160;</sup>He doesn’t preserve the life of the wicked, 
+</div><div class="q2">but gives justice to the afflicted. 
+</div><div class="q1">
+<sup>7&#160;</sup>He doesn’t withdraw his eyes from the righteous, 
+</div><div class="q2">but with kings on the throne, 
+</div><div class="q2">he sets them forever, and they are exalted. 
+</div><div class="q1">
+<sup>8&#160;</sup>If they are bound in fetters, 
+</div><div class="q2">and are taken in the cords of afflictions, 
+</div><div class="q1">
+<sup>9&#160;</sup>then he shows them their work, 
+</div><div class="q2">and their transgressions, that they have behaved themselves proudly. 
+</div><div class="q1">
+<sup>10&#160;</sup>He also opens their ears to instruction, 
+</div><div class="q2">and commands that they return from iniquity. 
+</div><div class="q1">
+<sup>11&#160;</sup>If they listen and serve him, 
+</div><div class="q2">they will spend their days in prosperity, 
+</div><div class="q2">and their years in pleasures. 
+</div><div class="q1">
+<sup>12&#160;</sup>But if they don’t listen, they will perish by the sword; 
+</div><div class="q2">they will die without knowledge. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“But those who are elohimless in heart lay up anger. 
+</div><div class="q2">They don’t cry for help when he binds them. 
+</div><div class="q1">
+<sup>14&#160;</sup>They die in youth. 
+</div><div class="q2">Their life perishes among the unclean. 
+</div><div class="q1">
+<sup>15&#160;</sup>He delivers the afflicted by their affliction, 
+</div><div class="q2">and opens their ear in oppression. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yes, he would have allured you out of distress, 
+</div><div class="q2">into a wide place, where there is no restriction. 
+</div><div class="q2">That which is set on your table would be full of fatness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“But you are full of the judgment of the wicked. 
+</div><div class="q2">Judgment and justice take hold of you. 
+</div><div class="q1">
+<sup>18&#160;</sup>Don’t let riches entice you to wrath, 
+</div><div class="q2">neither let the great size of a bribe turn you aside. 
+</div><div class="q1">
+<sup>19&#160;</sup>Would your wealth sustain you in distress, 
+</div><div class="q2">or all the might of your strength? 
+</div><div class="q1">
+<sup>20&#160;</sup>Don’t desire the night, 
+</div><div class="q2">when people are cut off in their place. 
+</div><div class="q1">
+<sup>21&#160;</sup>Take heed, don’t regard iniquity; 
+</div><div class="q2">for you have chosen this rather than affliction. 
+</div><div class="q1">
+<sup>22&#160;</sup>Behold, Elohim is exalted in his power. 
+</div><div class="q2">Who is a teacher like him? 
+</div><div class="q1">
+<sup>23&#160;</sup>Who has prescribed his way for him? 
+</div><div class="q2">Or who can say, ‘You have committed unrighteousness’? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>“Remember that you magnify his work, 
+</div><div class="q2">about which men have sung. 
+</div><div class="q1">
+<sup>25&#160;</sup>All men have looked on it. 
+</div><div class="q2">Man sees it afar off. 
+</div><div class="q1">
+<sup>26&#160;</sup>Behold, Elohim is great, and we don’t know him. 
+</div><div class="q2">The number of his years is unsearchable. 
+</div><div class="q1">
+<sup>27&#160;</sup>For he draws up the drops of water, 
+</div><div class="q2">which distill in rain from his vapor, 
+</div><div class="q1">
+<sup>28&#160;</sup>which the skies pour down 
+</div><div class="q2">and which drop on man abundantly. 
+</div><div class="q1">
+<sup>29&#160;</sup>Indeed, can anyone understand the spreading of the clouds 
+</div><div class="q2">and the thunderings of his pavilion? 
+</div><div class="q1">
+<sup>30&#160;</sup>Behold, he spreads his light around him. 
+</div><div class="q2">He covers the bottom of the sea. 
+</div><div class="q1">
+<sup>31&#160;</sup>For by these he judges the people. 
+</div><div class="q2">He gives food in abundance. 
+</div><div class="q1">
+<sup>32&#160;</sup>He covers his hands with the lightning, 
+</div><div class="q2">and commands it to strike the mark. 
+</div><div class="q1">
+<sup>33&#160;</sup>Its noise tells about him, 
+</div><div class="q2">and the livestock also, concerning the storm that comes up. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="37">37</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Yes, at this my heart trembles, 
-</p><p class="q2">and is moved out of its place. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear, oh, hear the noise of his voice, 
-</p><p class="q2">the sound that goes out of his mouth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He sends it out under the whole sky, 
-</p><p class="q2">and his lightning to the ends of the earth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>After it a voice roars. 
-</p><p class="q2">He thunders with the voice of his majesty. 
-</p><p class="q2">He doesn’t hold back anything when his voice is heard. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Elohim thunders marvelously with his voice. 
-</p><p class="q2">He does great things, which we can’t comprehend. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For he says to the snow, ‘Fall on the earth,’ 
-</p><p class="q2">likewise to the shower of rain, 
-</p><p class="q2">and to the showers of his mighty rain. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He seals up the hand of every man, 
-</p><p class="q2">that all men whom he has made may know it. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Then the animals take cover, 
-</p><p class="q2">and remain in their dens. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Out of its room comes the storm, 
-</p><p class="q2">and cold out of the north. 
-</p><p class="q1">
-<span class="v">10&#160;</span>By the breath of Elohim, ice is given, 
-</p><p class="q2">and the width of the waters is frozen. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yes, he loads the thick cloud with moisture. 
-</p><p class="q2">He spreads abroad the cloud of his lightning. 
-</p><p class="q1">
-<span class="v">12&#160;</span>It is turned around by his guidance, 
-</p><p class="q2">that they may do whatever he commands them 
-</p><p class="q2">on the surface of the habitable world, 
-</p><p class="q1">
-<span class="v">13&#160;</span>whether it is for correction, or for his land, 
-</p><p class="q2">or for loving kindness, that he causes it to come. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“Listen to this, Job. 
-</p><p class="q2">Stand still, and consider the wondrous works of Elohim. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Do you know how Elohim controls them, 
-</p><p class="q2">and causes the lightning of his cloud to shine? 
-</p><p class="q1">
-<span class="v">16&#160;</span>Do you know the workings of the clouds, 
-</p><p class="q2">the wondrous works of him who is perfect in knowledge? 
-</p><p class="q1">
-<span class="v">17&#160;</span>You whose clothing is warm 
-</p><p class="q2">when the earth is still by reason of the south wind? 
-</p><p class="q1">
-<span class="v">18&#160;</span>Can you, with him, spread out the sky, 
-</p><p class="q2">which is strong as a cast metal mirror? 
-</p><p class="q1">
-<span class="v">19&#160;</span>Teach us what we will tell him, 
-</p><p class="q2">for we can’t make our case by reason of darkness. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Will it be told him that I would speak? 
-</p><p class="q2">Or should a man wish that he were swallowed up? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Now men don’t see the light which is bright in the skies, 
-</p><p class="q2">but the wind passes, and clears them. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Out of the north comes golden splendor. 
-</p><p class="q2">With Elohim is awesome majesty. 
-</p><p class="q1">
-<span class="v">23&#160;</span>We can’t reach the Almighty. 
-</p><p class="q2">He is exalted in power. 
-</p><p class="q2">In justice and great righteousness, he will not oppress. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Therefore men revere him. 
-</p><p class="q2">He doesn’t regard any who are wise of heart.” 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Yes, at this my heart trembles, 
+</div><div class="q2">and is moved out of its place. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear, oh, hear the noise of his voice, 
+</div><div class="q2">the sound that goes out of his mouth. 
+</div><div class="q1">
+<sup>3&#160;</sup>He sends it out under the whole sky, 
+</div><div class="q2">and his lightning to the ends of the earth. 
+</div><div class="q1">
+<sup>4&#160;</sup>After it a voice roars. 
+</div><div class="q2">He thunders with the voice of his majesty. 
+</div><div class="q2">He doesn’t hold back anything when his voice is heard. 
+</div><div class="q1">
+<sup>5&#160;</sup>Elohim thunders marvelously with his voice. 
+</div><div class="q2">He does great things, which we can’t comprehend. 
+</div><div class="q1">
+<sup>6&#160;</sup>For he says to the snow, ‘Fall on the earth,’ 
+</div><div class="q2">likewise to the shower of rain, 
+</div><div class="q2">and to the showers of his mighty rain. 
+</div><div class="q1">
+<sup>7&#160;</sup>He seals up the hand of every man, 
+</div><div class="q2">that all men whom he has made may know it. 
+</div><div class="q1">
+<sup>8&#160;</sup>Then the animals take cover, 
+</div><div class="q2">and remain in their dens. 
+</div><div class="q1">
+<sup>9&#160;</sup>Out of its room comes the storm, 
+</div><div class="q2">and cold out of the north. 
+</div><div class="q1">
+<sup>10&#160;</sup>By the breath of Elohim, ice is given, 
+</div><div class="q2">and the width of the waters is frozen. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yes, he loads the thick cloud with moisture. 
+</div><div class="q2">He spreads abroad the cloud of his lightning. 
+</div><div class="q1">
+<sup>12&#160;</sup>It is turned around by his guidance, 
+</div><div class="q2">that they may do whatever he commands them 
+</div><div class="q2">on the surface of the habitable world, 
+</div><div class="q1">
+<sup>13&#160;</sup>whether it is for correction, or for his land, 
+</div><div class="q2">or for loving kindness, that he causes it to come. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“Listen to this, Job. 
+</div><div class="q2">Stand still, and consider the wondrous works of Elohim. 
+</div><div class="q1">
+<sup>15&#160;</sup>Do you know how Elohim controls them, 
+</div><div class="q2">and causes the lightning of his cloud to shine? 
+</div><div class="q1">
+<sup>16&#160;</sup>Do you know the workings of the clouds, 
+</div><div class="q2">the wondrous works of him who is perfect in knowledge? 
+</div><div class="q1">
+<sup>17&#160;</sup>You whose clothing is warm 
+</div><div class="q2">when the earth is still by reason of the south wind? 
+</div><div class="q1">
+<sup>18&#160;</sup>Can you, with him, spread out the sky, 
+</div><div class="q2">which is strong as a cast metal mirror? 
+</div><div class="q1">
+<sup>19&#160;</sup>Teach us what we will tell him, 
+</div><div class="q2">for we can’t make our case by reason of darkness. 
+</div><div class="q1">
+<sup>20&#160;</sup>Will it be told him that I would speak? 
+</div><div class="q2">Or should a man wish that he were swallowed up? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Now men don’t see the light which is bright in the skies, 
+</div><div class="q2">but the wind passes, and clears them. 
+</div><div class="q1">
+<sup>22&#160;</sup>Out of the north comes golden splendor. 
+</div><div class="q2">With Elohim is awesome majesty. 
+</div><div class="q1">
+<sup>23&#160;</sup>We can’t reach the Almighty. 
+</div><div class="q2">He is exalted in power. 
+</div><div class="q2">In justice and great righteousness, he will not oppress. 
+</div><div class="q1">
+<sup>24&#160;</sup>Therefore men revere him. 
+</div><div class="q2">He doesn’t regard any who are wise of heart.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="38">38</h2>
-<p>
-<span class="v">1&#160;</span>Then Yahweh answered Job out of the whirlwind, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Who is this who darkens counsel 
-</p><p class="q2">by words without knowledge? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Brace yourself like a man, 
-</p><p class="q2">for I will question you, then you answer me! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Where were you when I laid the foundations of the earth? 
-</p><p class="q2">Declare, if you have understanding. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Who determined its measures, if you know? 
-</p><p class="q2">Or who stretched the line on it? 
-</p><p class="q1">
-<span class="v">6&#160;</span>What were its foundations fastened on? 
-</p><p class="q2">Or who laid its cornerstone, 
-</p><p class="q1">
-<span class="v">7&#160;</span>when the morning stars sang together, 
-</p><p class="q2">and all the sons of Elohim shouted for joy? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Or who shut up the sea with doors, 
-</p><p class="q2">when it broke out of the womb, 
-</p><p class="q1">
-<span class="v">9&#160;</span>when I made clouds its garment, 
-</p><p class="q2">and wrapped it in thick darkness, 
-</p><p class="q1">
-<span class="v">10&#160;</span>marked out for it my bound, 
-</p><p class="q2">set bars and doors, 
-</p><p class="q1">
-<span class="v">11&#160;</span>and said, ‘You may come here, but no further. 
-</p><p class="q2">Your proud waves shall be stopped here’? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Have you commanded the morning in your days, 
-</p><p class="q2">and caused the dawn to know its place, 
-</p><p class="q1">
-<span class="v">13&#160;</span>that it might take hold of the ends of the earth, 
-</p><p class="q2">and shake the wicked out of it? 
-</p><p class="q1">
-<span class="v">14&#160;</span>It is changed as clay under the seal, 
-</p><p class="q2">and presented as a garment. 
-</p><p class="q1">
-<span class="v">15&#160;</span>From the wicked, their light is withheld. 
-</p><p class="q2">The high arm is broken. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>“Have you entered into the springs of the sea? 
-</p><p class="q2">Or have you walked in the recesses of the deep? 
-</p><p class="q1">
-<span class="v">17&#160;</span>Have the gates of death been revealed to you? 
-</p><p class="q2">Or have you seen the gates of the shadow of death? 
-</p><p class="q1">
-<span class="v">18&#160;</span>Have you comprehended the earth in its width? 
-</p><p class="q2">Declare, if you know it all. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“What is the way to the dwelling of light? 
-</p><p class="q2">As for darkness, where is its place, 
-</p><p class="q1">
-<span class="v">20&#160;</span>that you should take it to its bound, 
-</p><p class="q2">that you should discern the paths to its house? 
-</p><p class="q1">
-<span class="v">21&#160;</span>Surely you know, for you were born then, 
-</p><p class="q2">and the number of your days is great! 
-</p><p class="q1">
-<span class="v">22&#160;</span>Have you entered the storehouses of the snow, 
-</p><p class="q2">or have you seen the storehouses of the hail, 
-</p><p class="q1">
-<span class="v">23&#160;</span>which I have reserved against the time of trouble, 
-</p><p class="q2">against the day of battle and war? 
-</p><p class="q1">
-<span class="v">24&#160;</span>By what way is the lightning distributed, 
-</p><p class="q2">or the east wind scattered on the earth? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>Who has cut a channel for the flood water, 
-</p><p class="q2">or the path for the thunderstorm, 
-</p><p class="q1">
-<span class="v">26&#160;</span>to cause it to rain on a land where there is no man, 
-</p><p class="q2">on the wilderness, in which there is no man, 
-</p><p class="q1">
-<span class="v">27&#160;</span>to satisfy the waste and desolate ground, 
-</p><p class="q2">to cause the tender grass to grow? 
-</p><p class="q1">
-<span class="v">28&#160;</span>Does the rain have a father? 
-</p><p class="q2">Or who fathers the drops of dew? 
-</p><p class="q1">
-<span class="v">29&#160;</span>Whose womb did the ice come out of? 
-</p><p class="q2">Who has given birth to the gray frost of the sky? 
-</p><p class="q1">
-<span class="v">30&#160;</span>The waters become hard like stone, 
-</p><p class="q2">when the surface of the deep is frozen. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">31&#160;</span>“Can you bind the cluster of the Pleiades, 
-</p><p class="q2">or loosen the cords of Orion? 
-</p><p class="q1">
-<span class="v">32&#160;</span>Can you lead the constellations out in their season? 
-</p><p class="q2">Or can you guide the Bear with her cubs? 
-</p><p class="q1">
-<span class="v">33&#160;</span>Do you know the laws of the heavens? 
-</p><p class="q2">Can you establish its dominion over the earth? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">34&#160;</span>“Can you lift up your voice to the clouds, 
-</p><p class="q2">that abundance of waters may cover you? 
-</p><p class="q1">
-<span class="v">35&#160;</span>Can you send out lightnings, that they may go? 
-</p><p class="q2">Do they report to you, ‘Here we are’? 
-</p><p class="q1">
-<span class="v">36&#160;</span>Who has put wisdom in the inward parts? 
-</p><p class="q2">Or who has given understanding to the mind? 
-</p><p class="q1">
-<span class="v">37&#160;</span>Who can count the clouds by wisdom? 
-</p><p class="q2">Or who can pour out the containers of the sky, 
-</p><p class="q1">
-<span class="v">38&#160;</span>when the dust runs into a mass, 
-</p><p class="q2">and the clods of earth stick together? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">39&#160;</span>“Can you hunt the prey for the lioness, 
-</p><p class="q2">or satisfy the appetite of the young lions, 
-</p><p class="q1">
-<span class="v">40&#160;</span>when they crouch in their dens, 
-</p><p class="q2">and lie in wait in the thicket? 
-</p><p class="q1">
-<span class="v">41&#160;</span>Who provides for the raven his prey, 
-</p><p class="q2">when his young ones cry to Elohim, 
-</p><p class="q2">and wander for lack of food? 
-</p><div class="b"> &#160; </div>
+<div class="p">
+<sup>1&#160;</sup>Then Yahweh answered Job out of the whirlwind, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Who is this who darkens counsel 
+</div><div class="q2">by words without knowledge? 
+</div><div class="q1">
+<sup>3&#160;</sup>Brace yourself like a man, 
+</div><div class="q2">for I will question you, then you answer me! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Where were you when I laid the foundations of the earth? 
+</div><div class="q2">Declare, if you have understanding. 
+</div><div class="q1">
+<sup>5&#160;</sup>Who determined its measures, if you know? 
+</div><div class="q2">Or who stretched the line on it? 
+</div><div class="q1">
+<sup>6&#160;</sup>What were its foundations fastened on? 
+</div><div class="q2">Or who laid its cornerstone, 
+</div><div class="q1">
+<sup>7&#160;</sup>when the morning stars sang together, 
+</div><div class="q2">and all the sons of Elohim shouted for joy? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Or who shut up the sea with doors, 
+</div><div class="q2">when it broke out of the womb, 
+</div><div class="q1">
+<sup>9&#160;</sup>when I made clouds its garment, 
+</div><div class="q2">and wrapped it in thick darkness, 
+</div><div class="q1">
+<sup>10&#160;</sup>marked out for it my bound, 
+</div><div class="q2">set bars and doors, 
+</div><div class="q1">
+<sup>11&#160;</sup>and said, ‘You may come here, but no further. 
+</div><div class="q2">Your proud waves shall be stopped here’? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Have you commanded the morning in your days, 
+</div><div class="q2">and caused the dawn to know its place, 
+</div><div class="q1">
+<sup>13&#160;</sup>that it might take hold of the ends of the earth, 
+</div><div class="q2">and shake the wicked out of it? 
+</div><div class="q1">
+<sup>14&#160;</sup>It is changed as clay under the seal, 
+</div><div class="q2">and presented as a garment. 
+</div><div class="q1">
+<sup>15&#160;</sup>From the wicked, their light is withheld. 
+</div><div class="q2">The high arm is broken. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>“Have you entered into the springs of the sea? 
+</div><div class="q2">Or have you walked in the recesses of the deep? 
+</div><div class="q1">
+<sup>17&#160;</sup>Have the gates of death been revealed to you? 
+</div><div class="q2">Or have you seen the gates of the shadow of death? 
+</div><div class="q1">
+<sup>18&#160;</sup>Have you comprehended the earth in its width? 
+</div><div class="q2">Declare, if you know it all. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“What is the way to the dwelling of light? 
+</div><div class="q2">As for darkness, where is its place, 
+</div><div class="q1">
+<sup>20&#160;</sup>that you should take it to its bound, 
+</div><div class="q2">that you should discern the paths to its house? 
+</div><div class="q1">
+<sup>21&#160;</sup>Surely you know, for you were born then, 
+</div><div class="q2">and the number of your days is great! 
+</div><div class="q1">
+<sup>22&#160;</sup>Have you entered the storehouses of the snow, 
+</div><div class="q2">or have you seen the storehouses of the hail, 
+</div><div class="q1">
+<sup>23&#160;</sup>which I have reserved against the time of trouble, 
+</div><div class="q2">against the day of battle and war? 
+</div><div class="q1">
+<sup>24&#160;</sup>By what way is the lightning distributed, 
+</div><div class="q2">or the east wind scattered on the earth? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>Who has cut a channel for the flood water, 
+</div><div class="q2">or the path for the thunderstorm, 
+</div><div class="q1">
+<sup>26&#160;</sup>to cause it to rain on a land where there is no man, 
+</div><div class="q2">on the wilderness, in which there is no man, 
+</div><div class="q1">
+<sup>27&#160;</sup>to satisfy the waste and desolate ground, 
+</div><div class="q2">to cause the tender grass to grow? 
+</div><div class="q1">
+<sup>28&#160;</sup>Does the rain have a father? 
+</div><div class="q2">Or who fathers the drops of dew? 
+</div><div class="q1">
+<sup>29&#160;</sup>Whose womb did the ice come out of? 
+</div><div class="q2">Who has given birth to the gray frost of the sky? 
+</div><div class="q1">
+<sup>30&#160;</sup>The waters become hard like stone, 
+</div><div class="q2">when the surface of the deep is frozen. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>31&#160;</sup>“Can you bind the cluster of the Pleiades, 
+</div><div class="q2">or loosen the cords of Orion? 
+</div><div class="q1">
+<sup>32&#160;</sup>Can you lead the constellations out in their season? 
+</div><div class="q2">Or can you guide the Bear with her cubs? 
+</div><div class="q1">
+<sup>33&#160;</sup>Do you know the laws of the heavens? 
+</div><div class="q2">Can you establish its dominion over the earth? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>34&#160;</sup>“Can you lift up your voice to the clouds, 
+</div><div class="q2">that abundance of waters may cover you? 
+</div><div class="q1">
+<sup>35&#160;</sup>Can you send out lightnings, that they may go? 
+</div><div class="q2">Do they report to you, ‘Here we are’? 
+</div><div class="q1">
+<sup>36&#160;</sup>Who has put wisdom in the inward parts? 
+</div><div class="q2">Or who has given understanding to the mind? 
+</div><div class="q1">
+<sup>37&#160;</sup>Who can count the clouds by wisdom? 
+</div><div class="q2">Or who can pour out the containers of the sky, 
+</div><div class="q1">
+<sup>38&#160;</sup>when the dust runs into a mass, 
+</div><div class="q2">and the clods of earth stick together? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>39&#160;</sup>“Can you hunt the prey for the lioness, 
+</div><div class="q2">or satisfy the appetite of the young lions, 
+</div><div class="q1">
+<sup>40&#160;</sup>when they crouch in their dens, 
+</div><div class="q2">and lie in wait in the thicket? 
+</div><div class="q1">
+<sup>41&#160;</sup>Who provides for the raven his prey, 
+</div><div class="q2">when his young ones cry to Elohim, 
+</div><div class="q2">and wander for lack of food? 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="39">39</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“Do you know the time when the mountain goats give birth? 
-</p><p class="q2">Do you watch when the doe bears fawns? 
-</p><p class="q1">
-<span class="v">2&#160;</span>Can you count the months that they fulfill? 
-</p><p class="q2">Or do you know the time when they give birth? 
-</p><p class="q1">
-<span class="v">3&#160;</span>They bow themselves. They bear their young. 
-</p><p class="q2">They end their labor pains. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Their young ones become strong. 
-</p><p class="q2">They grow up in the open field. 
-</p><p class="q2">They go out, and don’t return again. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Who has set the wild donkey free? 
-</p><p class="q2">Or who has loosened the bonds of the swift donkey, 
-</p><p class="q1">
-<span class="v">6&#160;</span>whose home I have made the wilderness, 
-</p><p class="q2">and the salt land his dwelling place? 
-</p><p class="q1">
-<span class="v">7&#160;</span>He scorns the tumult of the city, 
-</p><p class="q2">neither does he hear the shouting of the driver. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The range of the mountains is his pasture. 
-</p><p class="q2">He searches after every green thing. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>“Will the wild ox be content to serve you? 
-</p><p class="q2">Or will he stay by your feeding trough? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Can you hold the wild ox in the furrow with his harness? 
-</p><p class="q2">Or will he till the valleys after you? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Will you trust him, because his strength is great? 
-</p><p class="q2">Or will you leave to him your labor? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Will you confide in him, that he will bring home your seed, 
-</p><p class="q2">and gather the grain of your threshing floor? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“The wings of the ostrich wave proudly, 
-</p><p class="q2">but are they the feathers and plumage of love? 
-</p><p class="q1">
-<span class="v">14&#160;</span>For she leaves her eggs on the earth, 
-</p><p class="q2">warms them in the dust, 
-</p><p class="q1">
-<span class="v">15&#160;</span>and forgets that the foot may crush them, 
-</p><p class="q2">or that the wild animal may trample them. 
-</p><p class="q1">
-<span class="v">16&#160;</span>She deals harshly with her young ones, as if they were not hers. 
-</p><p class="q2">Though her labor is in vain, she is without fear, 
-</p><p class="q1">
-<span class="v">17&#160;</span>because Elohim has deprived her of wisdom, 
-</p><p class="q2">neither has he imparted to her understanding. 
-</p><p class="q1">
-<span class="v">18&#160;</span>When she lifts up herself on high, 
-</p><p class="q2">she scorns the horse and his rider. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“Have you given the horse might? 
-</p><p class="q2">Have you clothed his neck with a quivering mane? 
-</p><p class="q1">
-<span class="v">20&#160;</span>Have you made him to leap as a locust? 
-</p><p class="q2">The glory of his snorting is awesome. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He paws in the valley, and rejoices in his strength. 
-</p><p class="q2">He goes out to meet the armed men. 
-</p><p class="q1">
-<span class="v">22&#160;</span>He mocks at fear, and is not dismayed, 
-</p><p class="q2">neither does he turn back from the sword. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The quiver rattles against him, 
-</p><p class="q2">the flashing spear and the javelin. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He eats up the ground with fierceness and rage, 
-</p><p class="q2">neither does he stand still at the sound of the trumpet. 
-</p><p class="q1">
-<span class="v">25&#160;</span>As often as the trumpet sounds he snorts, ‘Aha!’ 
-</p><p class="q2">He smells the battle afar off, 
-</p><p class="q2">the thunder of the captains, and the shouting. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">26&#160;</span>“Is it by your wisdom that the hawk soars, 
-</p><p class="q2">and stretches her wings toward the south? 
-</p><p class="q1">
-<span class="v">27&#160;</span>Is it at your command that the eagle mounts up, 
-</p><p class="q2">and makes his nest on high? 
-</p><p class="q1">
-<span class="v">28&#160;</span>On the cliff he dwells and makes his home, 
-</p><p class="q2">on the point of the cliff and the stronghold. 
-</p><p class="q1">
-<span class="v">29&#160;</span>From there he spies out the prey. 
-</p><p class="q2">His eyes see it afar off. 
-</p><p class="q1">
-<span class="v">30&#160;</span>His young ones also suck up blood. 
-</p><p class="q2">Where the slain are, there he is.” 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Do you know the time when the mountain goats give birth? 
+</div><div class="q2">Do you watch when the doe bears fawns? 
+</div><div class="q1">
+<sup>2&#160;</sup>Can you count the months that they fulfill? 
+</div><div class="q2">Or do you know the time when they give birth? 
+</div><div class="q1">
+<sup>3&#160;</sup>They bow themselves. They bear their young. 
+</div><div class="q2">They end their labor pains. 
+</div><div class="q1">
+<sup>4&#160;</sup>Their young ones become strong. 
+</div><div class="q2">They grow up in the open field. 
+</div><div class="q2">They go out, and don’t return again. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Who has set the wild donkey free? 
+</div><div class="q2">Or who has loosened the bonds of the swift donkey, 
+</div><div class="q1">
+<sup>6&#160;</sup>whose home I have made the wilderness, 
+</div><div class="q2">and the salt land his dwelling place? 
+</div><div class="q1">
+<sup>7&#160;</sup>He scorns the tumult of the city, 
+</div><div class="q2">neither does he hear the shouting of the driver. 
+</div><div class="q1">
+<sup>8&#160;</sup>The range of the mountains is his pasture. 
+</div><div class="q2">He searches after every green thing. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>“Will the wild ox be content to serve you? 
+</div><div class="q2">Or will he stay by your feeding trough? 
+</div><div class="q1">
+<sup>10&#160;</sup>Can you hold the wild ox in the furrow with his harness? 
+</div><div class="q2">Or will he till the valleys after you? 
+</div><div class="q1">
+<sup>11&#160;</sup>Will you trust him, because his strength is great? 
+</div><div class="q2">Or will you leave to him your labor? 
+</div><div class="q1">
+<sup>12&#160;</sup>Will you confide in him, that he will bring home your seed, 
+</div><div class="q2">and gather the grain of your threshing floor? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“The wings of the ostrich wave proudly, 
+</div><div class="q2">but are they the feathers and plumage of love? 
+</div><div class="q1">
+<sup>14&#160;</sup>For she leaves her eggs on the earth, 
+</div><div class="q2">warms them in the dust, 
+</div><div class="q1">
+<sup>15&#160;</sup>and forgets that the foot may crush them, 
+</div><div class="q2">or that the wild animal may trample them. 
+</div><div class="q1">
+<sup>16&#160;</sup>She deals harshly with her young ones, as if they were not hers. 
+</div><div class="q2">Though her labor is in vain, she is without fear, 
+</div><div class="q1">
+<sup>17&#160;</sup>because Elohim has deprived her of wisdom, 
+</div><div class="q2">neither has he imparted to her understanding. 
+</div><div class="q1">
+<sup>18&#160;</sup>When she lifts up herself on high, 
+</div><div class="q2">she scorns the horse and his rider. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“Have you given the horse might? 
+</div><div class="q2">Have you clothed his neck with a quivering mane? 
+</div><div class="q1">
+<sup>20&#160;</sup>Have you made him to leap as a locust? 
+</div><div class="q2">The glory of his snorting is awesome. 
+</div><div class="q1">
+<sup>21&#160;</sup>He paws in the valley, and rejoices in his strength. 
+</div><div class="q2">He goes out to meet the armed men. 
+</div><div class="q1">
+<sup>22&#160;</sup>He mocks at fear, and is not dismayed, 
+</div><div class="q2">neither does he turn back from the sword. 
+</div><div class="q1">
+<sup>23&#160;</sup>The quiver rattles against him, 
+</div><div class="q2">the flashing spear and the javelin. 
+</div><div class="q1">
+<sup>24&#160;</sup>He eats up the ground with fierceness and rage, 
+</div><div class="q2">neither does he stand still at the sound of the trumpet. 
+</div><div class="q1">
+<sup>25&#160;</sup>As often as the trumpet sounds he snorts, ‘Aha!’ 
+</div><div class="q2">He smells the battle afar off, 
+</div><div class="q2">the thunder of the captains, and the shouting. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>26&#160;</sup>“Is it by your wisdom that the hawk soars, 
+</div><div class="q2">and stretches her wings toward the south? 
+</div><div class="q1">
+<sup>27&#160;</sup>Is it at your command that the eagle mounts up, 
+</div><div class="q2">and makes his nest on high? 
+</div><div class="q1">
+<sup>28&#160;</sup>On the cliff he dwells and makes his home, 
+</div><div class="q2">on the point of the cliff and the stronghold. 
+</div><div class="q1">
+<sup>29&#160;</sup>From there he spies out the prey. 
+</div><div class="q2">His eyes see it afar off. 
+</div><div class="q1">
+<sup>30&#160;</sup>His young ones also suck up blood. 
+</div><div class="q2">Where the slain are, there he is.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="40">40</h2>
-<p>
-<span class="v">1&#160;</span>Moreover Yahweh answered Job, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Shall he who argues contend with the Almighty? 
-</p><p class="q2">He who argues with Elohim, let him answer it.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">3&#160;</span>Then Job answered Yahweh, 
-</p><p class="q1">
-<span class="v">4&#160;</span>“Behold, I am of small account. What will I answer you? 
-</p><p class="q2">I lay my hand on my mouth. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I have spoken once, and I will not answer; 
-</p><p class="q2">Yes, twice, but I will proceed no further.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">6&#160;</span>Then Yahweh answered Job out of the whirlwind: 
-</p><p class="q1">
-<span class="v">7&#160;</span>“Now brace yourself like a man. 
-</p><p class="q2">I will question you, and you will answer me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Will you even annul my judgment? 
-</p><p class="q2">Will you condemn me, that you may be justified? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Or do you have an arm like Elohim? 
-</p><p class="q2">Can you thunder with a voice like him? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Now deck yourself with excellency and dignity. 
-</p><p class="q2">Array yourself with honor and majesty. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Pour out the fury of your anger. 
-</p><p class="q2">Look at everyone who is proud, and bring him low. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Look at everyone who is proud, and humble him. 
-</p><p class="q2">Crush the wicked in their place. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Hide them in the dust together. 
-</p><p class="q2">Bind their faces in the hidden place. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Then I will also admit to you 
-</p><p class="q2">that your own right hand can save you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“See now behemoth, which I made as well as you. 
-</p><p class="q2">He eats grass as an ox. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Look now, his strength is in his thighs. 
-</p><p class="q2">His force is in the muscles of his belly. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He moves his tail like a cedar. 
-</p><p class="q2">The sinews of his thighs are knit together. 
-</p><p class="q1">
-<span class="v">18&#160;</span>His bones are like tubes of bronze. 
-</p><p class="q2">His limbs are like bars of iron. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>He is the chief of the ways of Elohim. 
-</p><p class="q2">He who made him gives him his sword. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Surely the mountains produce food for him, 
-</p><p class="q2">where all the animals of the field play. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He lies under the lotus trees, 
-</p><p class="q2">in the covert of the reed, and the marsh. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The lotuses cover him with their shade. 
-</p><p class="q2">The willows of the brook surround him. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Behold, if a river overflows, he doesn’t tremble. 
-</p><p class="q2">He is confident, though the Jordan swells even to his mouth. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Shall any take him when he is on the watch, 
-</p><p class="q2">or pierce through his nose with a snare? 
+<div class="p">
+<sup>1&#160;</sup>Moreover Yahweh answered Job, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Shall he who argues contend with the Almighty? 
+</div><div class="q2">He who argues with Elohim, let him answer it.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>3&#160;</sup>Then Job answered Yahweh, 
+</div><div class="q1">
+<sup>4&#160;</sup>“Behold, I am of small account. What will I answer you? 
+</div><div class="q2">I lay my hand on my mouth. 
+</div><div class="q1">
+<sup>5&#160;</sup>I have spoken once, and I will not answer; 
+</div><div class="q2">Yes, twice, but I will proceed no further.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>6&#160;</sup>Then Yahweh answered Job out of the whirlwind: 
+</div><div class="q1">
+<sup>7&#160;</sup>“Now brace yourself like a man. 
+</div><div class="q2">I will question you, and you will answer me. 
+</div><div class="q1">
+<sup>8&#160;</sup>Will you even annul my judgment? 
+</div><div class="q2">Will you condemn me, that you may be justified? 
+</div><div class="q1">
+<sup>9&#160;</sup>Or do you have an arm like Elohim? 
+</div><div class="q2">Can you thunder with a voice like him? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Now deck yourself with excellency and dignity. 
+</div><div class="q2">Array yourself with honor and majesty. 
+</div><div class="q1">
+<sup>11&#160;</sup>Pour out the fury of your anger. 
+</div><div class="q2">Look at everyone who is proud, and bring him low. 
+</div><div class="q1">
+<sup>12&#160;</sup>Look at everyone who is proud, and humble him. 
+</div><div class="q2">Crush the wicked in their place. 
+</div><div class="q1">
+<sup>13&#160;</sup>Hide them in the dust together. 
+</div><div class="q2">Bind their faces in the hidden place. 
+</div><div class="q1">
+<sup>14&#160;</sup>Then I will also admit to you 
+</div><div class="q2">that your own right hand can save you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“See now behemoth, which I made as well as you. 
+</div><div class="q2">He eats grass as an ox. 
+</div><div class="q1">
+<sup>16&#160;</sup>Look now, his strength is in his thighs. 
+</div><div class="q2">His force is in the muscles of his belly. 
+</div><div class="q1">
+<sup>17&#160;</sup>He moves his tail like a cedar. 
+</div><div class="q2">The sinews of his thighs are knit together. 
+</div><div class="q1">
+<sup>18&#160;</sup>His bones are like tubes of bronze. 
+</div><div class="q2">His limbs are like bars of iron. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>He is the chief of the ways of Elohim. 
+</div><div class="q2">He who made him gives him his sword. 
+</div><div class="q1">
+<sup>20&#160;</sup>Surely the mountains produce food for him, 
+</div><div class="q2">where all the animals of the field play. 
+</div><div class="q1">
+<sup>21&#160;</sup>He lies under the lotus trees, 
+</div><div class="q2">in the covert of the reed, and the marsh. 
+</div><div class="q1">
+<sup>22&#160;</sup>The lotuses cover him with their shade. 
+</div><div class="q2">The willows of the brook surround him. 
+</div><div class="q1">
+<sup>23&#160;</sup>Behold, if a river overflows, he doesn’t tremble. 
+</div><div class="q2">He is confident, though the Jordan swells even to his mouth. 
+</div><div class="q1">
+<sup>24&#160;</sup>Shall any take him when he is on the watch, 
+</div><div class="q2">or pierce through his nose with a snare? 
 <div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="41">41</h2>
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">1&#160;</span>“Can you draw out Leviathan<span class="f">+ \fr 41:1 \ft Leviathan is a name for a crocodile or similar creature.</span> with a fish hook, 
-</p><p class="q2">or press down his tongue with a cord? 
-</p><p class="q1">
-<span class="v">2&#160;</span>Can you put a rope into his nose, 
-</p><p class="q2">or pierce his jaw through with a hook? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Will he make many petitions to you, 
-</p><p class="q2">or will he speak soft words to you? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Will he make a covenant with you, 
-</p><p class="q2">that you should take him for a servant forever? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Will you play with him as with a bird? 
-</p><p class="q2">Or will you bind him for your girls? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Will traders barter for him? 
-</p><p class="q2">Will they part him among the merchants? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Can you fill his skin with barbed irons, 
-</p><p class="q2">or his head with fish spears? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Lay your hand on him. 
-</p><p class="q2">Remember the battle, and do so no more. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Behold, the hope of him is in vain. 
-</p><p class="q2">Won’t one be cast down even at the sight of him? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>None is so fierce that he dare stir him up. 
-</p><p class="q2">Who then is he who can stand before me? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Who has first given to me, that I should repay him? 
-</p><p class="q2">Everything under the heavens is mine. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“I will not keep silence concerning his limbs, 
-</p><p class="q2">nor his mighty strength, nor his goodly frame. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Who can strip off his outer garment? 
-</p><p class="q2">Who will come within his jaws? 
-</p><p class="q1">
-<span class="v">14&#160;</span>Who can open the doors of his face? 
-</p><p class="q2">Around his teeth is terror. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Strong scales are his pride, 
-</p><p class="q2">shut up together with a close seal. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>One is so near to another, 
-</p><p class="q2">that no air can come between them. 
-</p><p class="q1">
-<span class="v">17&#160;</span>They are joined to one another. 
-</p><p class="q2">They stick together, so that they can’t be pulled apart. 
-</p><p class="q1">
-<span class="v">18&#160;</span>His sneezing flashes out light. 
-</p><p class="q2">His eyes are like the eyelids of the morning. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Out of his mouth go burning torches. 
-</p><p class="q2">Sparks of fire leap out. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Out of his nostrils a smoke goes, 
-</p><p class="q2">as of a boiling pot over a fire of reeds. 
-</p><p class="q1">
-<span class="v">21&#160;</span>His breath kindles coals. 
-</p><p class="q2">A flame goes out of his mouth. 
-</p><p class="q1">
-<span class="v">22&#160;</span>There is strength in his neck. 
-</p><p class="q2">Terror dances before him. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The flakes of his flesh are joined together. 
-</p><p class="q2">They are firm on him. 
-</p><p class="q2">They can’t be moved. 
-</p><p class="q1">
-<span class="v">24&#160;</span>His heart is as firm as a stone, 
-</p><p class="q2">yes, firm as the lower millstone. 
-</p><p class="q1">
-<span class="v">25&#160;</span>When he raises himself up, the mighty are afraid. 
-</p><p class="q2">They retreat before his thrashing. 
-</p><p class="q1">
-<span class="v">26&#160;</span>If one attacks him with the sword, it can’t prevail; 
-</p><p class="q2">nor the spear, the dart, nor the pointed shaft. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He counts iron as straw, 
-</p><p class="q2">and bronze as rotten wood. 
-</p><p class="q1">
-<span class="v">28&#160;</span>The arrow can’t make him flee. 
-</p><p class="q2">Sling stones are like chaff to him. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Clubs are counted as stubble. 
-</p><p class="q2">He laughs at the rushing of the javelin. 
-</p><p class="q1">
-<span class="v">30&#160;</span>His undersides are like sharp potsherds, 
-</p><p class="q2">leaving a trail in the mud like a threshing sledge. 
-</p><p class="q1">
-<span class="v">31&#160;</span>He makes the deep to boil like a pot. 
-</p><p class="q2">He makes the sea like a pot of ointment. 
-</p><p class="q1">
-<span class="v">32&#160;</span>He makes a path shine after him. 
-</p><p class="q2">One would think the deep had white hair. 
-</p><p class="q1">
-<span class="v">33&#160;</span>On earth there is not his equal, 
-</p><p class="q2">that is made without fear. 
-</p><p class="q1">
-<span class="v">34&#160;</span>He sees everything that is high. 
-</p><p class="q2">He is king over all the sons of pride.” 
-</p><div class="b"> &#160; </div>
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>“Can you draw out Leviathan with a fish hook, 
+</div><div class="q2">or press down his tongue with a cord? 
+</div><div class="q1">
+<sup>2&#160;</sup>Can you put a rope into his nose, 
+</div><div class="q2">or pierce his jaw through with a hook? 
+</div><div class="q1">
+<sup>3&#160;</sup>Will he make many petitions to you, 
+</div><div class="q2">or will he speak soft words to you? 
+</div><div class="q1">
+<sup>4&#160;</sup>Will he make a covenant with you, 
+</div><div class="q2">that you should take him for a servant forever? 
+</div><div class="q1">
+<sup>5&#160;</sup>Will you play with him as with a bird? 
+</div><div class="q2">Or will you bind him for your girls? 
+</div><div class="q1">
+<sup>6&#160;</sup>Will traders barter for him? 
+</div><div class="q2">Will they part him among the merchants? 
+</div><div class="q1">
+<sup>7&#160;</sup>Can you fill his skin with barbed irons, 
+</div><div class="q2">or his head with fish spears? 
+</div><div class="q1">
+<sup>8&#160;</sup>Lay your hand on him. 
+</div><div class="q2">Remember the battle, and do so no more. 
+</div><div class="q1">
+<sup>9&#160;</sup>Behold, the hope of him is in vain. 
+</div><div class="q2">Won’t one be cast down even at the sight of him? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>None is so fierce that he dare stir him up. 
+</div><div class="q2">Who then is he who can stand before me? 
+</div><div class="q1">
+<sup>11&#160;</sup>Who has first given to me, that I should repay him? 
+</div><div class="q2">Everything under the heavens is mine. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“I will not keep silence concerning his limbs, 
+</div><div class="q2">nor his mighty strength, nor his goodly frame. 
+</div><div class="q1">
+<sup>13&#160;</sup>Who can strip off his outer garment? 
+</div><div class="q2">Who will come within his jaws? 
+</div><div class="q1">
+<sup>14&#160;</sup>Who can open the doors of his face? 
+</div><div class="q2">Around his teeth is terror. 
+</div><div class="q1">
+<sup>15&#160;</sup>Strong scales are his pride, 
+</div><div class="q2">shut up together with a close seal. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>One is so near to another, 
+</div><div class="q2">that no air can come between them. 
+</div><div class="q1">
+<sup>17&#160;</sup>They are joined to one another. 
+</div><div class="q2">They stick together, so that they can’t be pulled apart. 
+</div><div class="q1">
+<sup>18&#160;</sup>His sneezing flashes out light. 
+</div><div class="q2">His eyes are like the eyelids of the morning. 
+</div><div class="q1">
+<sup>19&#160;</sup>Out of his mouth go burning torches. 
+</div><div class="q2">Sparks of fire leap out. 
+</div><div class="q1">
+<sup>20&#160;</sup>Out of his nostrils a smoke goes, 
+</div><div class="q2">as of a boiling pot over a fire of reeds. 
+</div><div class="q1">
+<sup>21&#160;</sup>His breath kindles coals. 
+</div><div class="q2">A flame goes out of his mouth. 
+</div><div class="q1">
+<sup>22&#160;</sup>There is strength in his neck. 
+</div><div class="q2">Terror dances before him. 
+</div><div class="q1">
+<sup>23&#160;</sup>The flakes of his flesh are joined together. 
+</div><div class="q2">They are firm on him. 
+</div><div class="q2">They can’t be moved. 
+</div><div class="q1">
+<sup>24&#160;</sup>His heart is as firm as a stone, 
+</div><div class="q2">yes, firm as the lower millstone. 
+</div><div class="q1">
+<sup>25&#160;</sup>When he raises himself up, the mighty are afraid. 
+</div><div class="q2">They retreat before his thrashing. 
+</div><div class="q1">
+<sup>26&#160;</sup>If one attacks him with the sword, it can’t prevail; 
+</div><div class="q2">nor the spear, the dart, nor the pointed shaft. 
+</div><div class="q1">
+<sup>27&#160;</sup>He counts iron as straw, 
+</div><div class="q2">and bronze as rotten wood. 
+</div><div class="q1">
+<sup>28&#160;</sup>The arrow can’t make him flee. 
+</div><div class="q2">Sling stones are like chaff to him. 
+</div><div class="q1">
+<sup>29&#160;</sup>Clubs are counted as stubble. 
+</div><div class="q2">He laughs at the rushing of the javelin. 
+</div><div class="q1">
+<sup>30&#160;</sup>His undersides are like sharp potsherds, 
+</div><div class="q2">leaving a trail in the mud like a threshing sledge. 
+</div><div class="q1">
+<sup>31&#160;</sup>He makes the deep to boil like a pot. 
+</div><div class="q2">He makes the sea like a pot of ointment. 
+</div><div class="q1">
+<sup>32&#160;</sup>He makes a path shine after him. 
+</div><div class="q2">One would think the deep had white hair. 
+</div><div class="q1">
+<sup>33&#160;</sup>On earth there is not his equal, 
+</div><div class="q2">that is made without fear. 
+</div><div class="q1">
+<sup>34&#160;</sup>He sees everything that is high. 
+</div><div class="q2">He is king over all the sons of pride.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="42">42</h2>
-<p>
-<span class="v">1&#160;</span>Then Job answered Yahweh: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“I know that you can do all things, 
-</p><p class="q2">and that no purpose of yours can be restrained. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You asked, ‘Who is this who hides counsel without knowledge?’ 
-</p><p class="q2">therefore I have uttered that which I didn’t understand, 
-</p><p class="q2">things too wonderful for me, which I didn’t know. 
-</p><p class="q1">
-<span class="v">4&#160;</span>You said, ‘Listen, now, and I will speak; 
-</p><p class="q2">I will question you, and you will answer me.’ 
-</p><p class="q1">
-<span class="v">5&#160;</span>I had heard of you by the hearing of the ear, 
-</p><p class="q2">but now my eye sees you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Therefore I abhor myself, 
-</p><p class="q2">and repent in dust and ashes.” 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">7&#160;</span>It was so, that after Yahweh had spoken these words to Job, Yahweh said to Eliphaz the Temanite, “My wrath is kindled against you, and against your two friends; for you have not spoken of me the thing that is right, as my servant Job has. 
-<span class="v">8&#160;</span>Now therefore, take to yourselves seven bulls and seven rams, and go to my servant Job, and offer up for yourselves a burnt offering; and my servant Job shall pray for you, for I will accept him, that I not deal with you according to your folly. For you have not spoken of me the thing that is right, as my servant Job has.” 
-</p><p>
-<span class="v">9&#160;</span>So Eliphaz the Temanite and Bildad the Shuhite and Zophar the Naamathite went and did what Yahweh commanded them, and Yahweh accepted Job. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh restored Job’s prosperity when he prayed for his friends. Yahweh gave Job twice as much as he had before. 
-<span class="v">11&#160;</span>Then all his brothers, all his sisters, and all those who had been of his acquaintance before, came to him and ate bread with him in his house. They comforted him, and consoled him concerning all the evil that Yahweh had brought on him. Everyone also gave him a piece of money,<span class="f">+ \fr 42:11 \ft literally, kesitah, a unit of money, probably silver</span> and everyone a ring of gold. 
-</p><p>
-<span class="v">12&#160;</span>So Yahweh blessed the latter end of Job more than his beginning. He had fourteen thousand sheep, six thousand camels, one thousand yoke of oxen, and a thousand female donkeys. 
-<span class="v">13&#160;</span>He had also seven sons and three daughters. 
-<span class="v">14&#160;</span>He called the name of the first, Jemimah; and the name of the second, Keziah; and the name of the third, Keren Happuch. 
-<span class="v">15&#160;</span>In all the land were no women found so beautiful as the daughters of Job. Their father gave them an inheritance among their brothers. 
-<span class="v">16&#160;</span>After this Job lived one hundred forty years, and saw his sons, and his sons’ sons, to four generations. 
-<span class="v">17&#160;</span>So Job died, being old and full of days. </div><script src="../main.js"></script></body></html>
+<div class="p">
+<sup>1&#160;</sup>Then Job answered Yahweh: 
+</div><div class="q1">
+<sup>2&#160;</sup>“I know that you can do all things, 
+</div><div class="q2">and that no purpose of yours can be restrained. 
+</div><div class="q1">
+<sup>3&#160;</sup>You asked, ‘Who is this who hides counsel without knowledge?’ 
+</div><div class="q2">therefore I have uttered that which I didn’t understand, 
+</div><div class="q2">things too wonderful for me, which I didn’t know. 
+</div><div class="q1">
+<sup>4&#160;</sup>You said, ‘Listen, now, and I will speak; 
+</div><div class="q2">I will question you, and you will answer me.’ 
+</div><div class="q1">
+<sup>5&#160;</sup>I had heard of you by the hearing of the ear, 
+</div><div class="q2">but now my eye sees you. 
+</div><div class="q1">
+<sup>6&#160;</sup>Therefore I abhor myself, 
+</div><div class="q2">and repent in dust and ashes.” 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>7&#160;</sup>It was so, that after Yahweh had spoken these words to Job, Yahweh said to Eliphaz the Temanite, “My wrath is kindled against you, and against your two friends; for you have not spoken of me the thing that is right, as my servant Job has. 
+<sup>8&#160;</sup>Now therefore, take to yourselves seven bulls and seven rams, and go to my servant Job, and offer up for yourselves a burnt offering; and my servant Job shall pray for you, for I will accept him, that I not deal with you according to your folly. For you have not spoken of me the thing that is right, as my servant Job has.” 
+</div><div class="p">
+<sup>9&#160;</sup>So Eliphaz the Temanite and Bildad the Shuhite and Zophar the Naamathite went and did what Yahweh commanded them, and Yahweh accepted Job. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh restored Job’s prosperity when he prayed for his friends. Yahweh gave Job twice as much as he had before. 
+<sup>11&#160;</sup>Then all his brothers, all his sisters, and all those who had been of his acquaintance before, came to him and ate bread with him in his house. They comforted him, and consoled him concerning all the evil that Yahweh had brought on him. Everyone also gave him a piece of money, and everyone a ring of gold. 
+</div><div class="p">
+<sup>12&#160;</sup>So Yahweh blessed the latter end of Job more than his beginning. He had fourteen thousand sheep, six thousand camels, one thousand yoke of oxen, and a thousand female donkeys. 
+<sup>13&#160;</sup>He had also seven sons and three daughters. 
+<sup>14&#160;</sup>He called the name of the first, Jemimah; and the name of the second, Keziah; and the name of the third, Keren Happuch. 
+<sup>15&#160;</sup>In all the land were no women found so beautiful as the daughters of Job. Their father gave them an inheritance among their brothers. 
+<sup>16&#160;</sup>After this Job lived one hundred forty years, and saw his sons, and his sons’ sons, to four generations. 
+<sup>17&#160;</sup>So Job died, being old and full of days. </div></div><script src="../main.js"></script></body></html>

--- a/book/joel.html
+++ b/book/joel.html
@@ -3,6 +3,47 @@
 <head>
 <title>Joel</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,337 +53,341 @@
 <div class="main">
 <!-- JOL World English Scripture (WES) -->
 <h1 class="booklabel">Joel</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word that came to Joel, the son of Pethuel. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear this, you elders, 
-</p><p class="q2">and listen, all you inhabitants of the land! 
-</p><p class="q1">Has this ever happened in your days, 
-</p><p class="q2">or in the days of your fathers? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Tell your children about it, 
-</p><p class="q2">and have your children tell their children, 
-</p><p class="q2">and their children, another generation. 
-</p><p class="q1">
-<span class="v">4&#160;</span>What the swarming locust has left, the great locust has eaten. 
-</p><p class="q2">What the great locust has left, the grasshopper has eaten. 
-</p><p class="q2">What the grasshopper has left, the caterpillar has eaten. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Wake up, you drunkards, and weep! 
-</p><p class="q2">Wail, all you drinkers of wine, because of the sweet wine, 
-</p><p class="q2">for it is cut off from your mouth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For a nation has come up on my land, strong, and without number. 
-</p><p class="q2">His teeth are the teeth of a lion, 
-</p><p class="q2">and he has the fangs of a lioness. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He has laid my vine waste, 
-</p><p class="q2">and stripped my fig tree. 
-</p><p class="q2">He has stripped its bark, and thrown it away. 
-</p><p class="q2">Its branches are made white. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Mourn like a virgin dressed in sackcloth 
-</p><p class="q2">for the owner of her youth! 
-</p><p class="q1">
-<span class="v">9&#160;</span>The meal offering and the drink offering are cut off from Yahweh’s house. 
-</p><p class="q2">The priests, Yahweh’s ministers, mourn. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The field is laid waste. 
-</p><p class="q2">The land mourns, for the grain is destroyed, 
-</p><p class="q2">The new wine has dried up, 
-</p><p class="q2">and the oil languishes. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Be confounded, you farmers! 
-</p><p class="q2">Wail, you vineyard keepers, 
-</p><p class="q2">for the wheat and for the barley; 
-</p><p class="q2">for the harvest of the field has perished. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The vine has dried up, and the fig tree withered—</p><p class="q2">the pomegranate tree, the palm tree also, and the apple tree, 
-</p><p class="q2">even all of the trees of the field are withered; 
-</p><p class="q2">for joy has withered away from the sons of men. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Put on sackcloth and mourn, you priests! 
-</p><p class="q2">Wail, you ministers of the altar. 
-</p><p class="q1">Come, lie all night in sackcloth, you ministers of my Elohim,<span class="f">+ \fr 1:13 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p class="q2">for the meal offering and the drink offering are withheld from your Elohim’s house. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Sanctify a fast. 
-</p><p class="q2">Call a solemn assembly. 
-</p><p class="q2">Gather the elders and all the inhabitants of the land to the house of Yahweh, your Elohim, 
-</p><p class="q2">and cry to Yahweh. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Alas for the day! 
-</p><p class="q2">For the day of Yahweh is at hand, 
-</p><p class="q2">and it will come as destruction from the Almighty. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Isn’t the food cut off before our eyes, 
-</p><p class="q2">joy and gladness from the house of our Elohim? 
-</p><p class="q1">
-<span class="v">17&#160;</span>The seeds rot under their clods. 
-</p><p class="q2">The granaries are laid desolate. 
-</p><p class="q2">The barns are broken down, for the grain has withered. 
-</p><p class="q1">
-<span class="v">18&#160;</span>How the animals groan! 
-</p><p class="q2">The herds of livestock are perplexed, because they have no pasture. 
-</p><p class="q2">Yes, the flocks of sheep are made desolate. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Yahweh, I cry to you, 
-</p><p class="q2">for the fire has devoured the pastures of the wilderness, 
-</p><p class="q2">and the flame has burned all the trees of the field. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Yes, the animals of the field pant to you, 
-</p><p class="q2">for the water brooks have dried up, 
-</p><p class="q2">and the fire has devoured the pastures of the wilderness. 
-</p><div class="b"> &#160; </div>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Yahweh’s word that came to Joel, the son of Pethuel. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear this, you elders, 
+</div><div class="q2">and listen, all you inhabitants of the land! 
+</div><div class="q1">Has this ever happened in your days, 
+</div><div class="q2">or in the days of your fathers? 
+</div><div class="q1">
+<sup>3&#160;</sup>Tell your children about it, 
+</div><div class="q2">and have your children tell their children, 
+</div><div class="q2">and their children, another generation. 
+</div><div class="q1">
+<sup>4&#160;</sup>What the swarming locust has left, the great locust has eaten. 
+</div><div class="q2">What the great locust has left, the grasshopper has eaten. 
+</div><div class="q2">What the grasshopper has left, the caterpillar has eaten. 
+</div><div class="q1">
+<sup>5&#160;</sup>Wake up, you drunkards, and weep! 
+</div><div class="q2">Wail, all you drinkers of wine, because of the sweet wine, 
+</div><div class="q2">for it is cut off from your mouth. 
+</div><div class="q1">
+<sup>6&#160;</sup>For a nation has come up on my land, strong, and without number. 
+</div><div class="q2">His teeth are the teeth of a lion, 
+</div><div class="q2">and he has the fangs of a lioness. 
+</div><div class="q1">
+<sup>7&#160;</sup>He has laid my vine waste, 
+</div><div class="q2">and stripped my fig tree. 
+</div><div class="q2">He has stripped its bark, and thrown it away. 
+</div><div class="q2">Its branches are made white. 
+</div><div class="q1">
+<sup>8&#160;</sup>Mourn like a virgin dressed in sackcloth 
+</div><div class="q2">for the owner of her youth! 
+</div><div class="q1">
+<sup>9&#160;</sup>The meal offering and the drink offering are cut off from Yahweh’s house. 
+</div><div class="q2">The priests, Yahweh’s ministers, mourn. 
+</div><div class="q1">
+<sup>10&#160;</sup>The field is laid waste. 
+</div><div class="q2">The land mourns, for the grain is destroyed, 
+</div><div class="q2">The new wine has dried up, 
+</div><div class="q2">and the oil languishes. 
+</div><div class="q1">
+<sup>11&#160;</sup>Be confounded, you farmers! 
+</div><div class="q2">Wail, you vineyard keepers, 
+</div><div class="q2">for the wheat and for the barley; 
+</div><div class="q2">for the harvest of the field has perished. 
+</div><div class="q1">
+<sup>12&#160;</sup>The vine has dried up, and the fig tree withered—</div><div class="q2">the pomegranate tree, the palm tree also, and the apple tree, 
+</div><div class="q2">even all of the trees of the field are withered; 
+</div><div class="q2">for joy has withered away from the sons of men. 
+</div><div class="q1">
+<sup>13&#160;</sup>Put on sackcloth and mourn, you priests! 
+</div><div class="q2">Wail, you ministers of the altar. 
+</div><div class="q1">Come, lie all night in sackcloth, you ministers of my Elohim, 
+</div><div class="q2">for the meal offering and the drink offering are withheld from your Elohim’s house. 
+</div><div class="q1">
+<sup>14&#160;</sup>Sanctify a fast. 
+</div><div class="q2">Call a solemn assembly. 
+</div><div class="q2">Gather the elders and all the inhabitants of the land to the house of Yahweh, your Elohim, 
+</div><div class="q2">and cry to Yahweh. 
+</div><div class="q1">
+<sup>15&#160;</sup>Alas for the day! 
+</div><div class="q2">For the day of Yahweh is at hand, 
+</div><div class="q2">and it will come as destruction from the Almighty. 
+</div><div class="q1">
+<sup>16&#160;</sup>Isn’t the food cut off before our eyes, 
+</div><div class="q2">joy and gladness from the house of our Elohim? 
+</div><div class="q1">
+<sup>17&#160;</sup>The seeds rot under their clods. 
+</div><div class="q2">The granaries are laid desolate. 
+</div><div class="q2">The barns are broken down, for the grain has withered. 
+</div><div class="q1">
+<sup>18&#160;</sup>How the animals groan! 
+</div><div class="q2">The herds of livestock are perplexed, because they have no pasture. 
+</div><div class="q2">Yes, the flocks of sheep are made desolate. 
+</div><div class="q1">
+<sup>19&#160;</sup>Yahweh, I cry to you, 
+</div><div class="q2">for the fire has devoured the pastures of the wilderness, 
+</div><div class="q2">and the flame has burned all the trees of the field. 
+</div><div class="q1">
+<sup>20&#160;</sup>Yes, the animals of the field pant to you, 
+</div><div class="q2">for the water brooks have dried up, 
+</div><div class="q2">and the fire has devoured the pastures of the wilderness. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="2">2</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Blow the trumpet in Zion, 
-</p><p class="q2">and sound an alarm in my set-apart mountain! 
-</p><p class="q1">Let all the inhabitants of the land tremble, 
-</p><p class="q2">for the day of Yahweh comes, 
-</p><p class="q2">for it is close at hand: 
-</p><p class="q1">
-<span class="v">2&#160;</span>A day of darkness and gloominess, 
-</p><p class="q2">a day of clouds and thick darkness. 
-</p><p class="q1">As the dawn spreading on the mountains, 
-</p><p class="q2">a great and strong people; 
-</p><p class="q2">there has never been the like, 
-</p><p class="q2">neither will there be any more after them, 
-</p><p class="q2">even to the years of many generations. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A fire devours before them, 
-</p><p class="q2">and behind them, a flame burns. 
-</p><p class="q1">The land is as the garden of Eden before them, 
-</p><p class="q2">and behind them, a desolate wilderness. 
-</p><p class="q1">Yes, and no one has escaped them. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Their appearance is as the appearance of horses, 
-</p><p class="q2">and they run as horsemen. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Like the noise of chariots on the tops of the mountains, they leap, 
-</p><p class="q2">like the noise of a flame of fire that devours the stubble, 
-</p><p class="q2">like a strong people set in battle array. 
-</p><p class="q1">
-<span class="v">6&#160;</span>At their presence the peoples are in anguish. 
-</p><p class="q2">All faces have grown pale. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They run like mighty men. 
-</p><p class="q2">They climb the wall like warriors. 
-</p><p class="q2">They each march in his line, and they don’t swerve off course. 
-</p><p class="q1">
-<span class="v">8&#160;</span>One doesn’t jostle another. 
-</p><p class="q2">They each march in their own path. 
-</p><p class="q2">They burst through the defenses 
-</p><p class="q2">and don’t break ranks. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They rush on the city. 
-</p><p class="q2">They run on the wall. 
-</p><p class="q2">They climb up into the houses. 
-</p><p class="q2">They enter in at the windows like thieves. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The earth quakes before them. 
-</p><p class="q2">The heavens tremble. 
-</p><p class="q2">The sun and the moon are darkened, 
-</p><p class="q2">and the stars withdraw their shining. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh thunders his voice before his army, 
-</p><p class="q2">for his forces are very great; 
-</p><p class="q2">for he is strong who obeys his command; 
-</p><p class="q2">for the day of Yahweh is great and very awesome, 
-</p><p class="q2">and who can endure it? 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Yet even now,” says Yahweh, “turn to me with all your heart, 
-</p><p class="q2">and with fasting, and with weeping, and with mourning.” 
-</p><p class="q1">
-<span class="v">13&#160;</span>Tear your heart and not your garments, 
-</p><p class="q2">and turn to Yahweh, your Elohim; 
-</p><p class="q2">for he is gracious and merciful, 
-</p><p class="q2">slow to anger, and abundant in loving kindness, 
-</p><p class="q2">and relents from sending calamity. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Who knows? He may turn and relent, 
-</p><p class="q2">and leave a blessing behind him, 
-</p><p class="q2">even a meal offering and a drink offering to Yahweh, your Elohim. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Blow the trumpet in Zion! 
-</p><p class="q2">Sanctify a fast. 
-</p><p class="q2">Call a solemn assembly. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Gather the people. 
-</p><p class="q2">Sanctify the assembly. 
-</p><p class="q2">Assemble the elders. 
-</p><p class="q2">Gather the children, and those who nurse from breasts. 
-</p><p class="q1">Let the bridegroom go out of his room, 
-</p><p class="q2">and the bride out of her chamber. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let the priests, the ministers of Yahweh, weep between the porch and the altar, 
-</p><p class="q2">and let them say, “Spare your people, Yahweh, 
-</p><p class="q2">and don’t give your heritage to reproach, 
-</p><p class="q2">that the nations should rule over them. 
-</p><p class="q1">Why should they say among the peoples, 
-</p><p class="q2">‘Where is their Elohim?’&#160;” 
-</p><p class="q1">
-<span class="v">18&#160;</span>Then Yahweh was jealous for his land, 
-</p><p class="q2">and had pity on his people. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Yahweh answered his people, 
-</p><p class="q2">“Behold,<span class="f">+ \fr 2:19 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I will send you grain, new wine, and oil, 
-</p><p class="q2">and you will be satisfied with them; 
-</p><p class="q2">and I will no more make you a reproach among the nations. 
-</p><p class="q1">
-<span class="v">20&#160;</span>But I will remove the northern army far away from you, 
-</p><p class="q2">and will drive it into a barren and desolate land, 
-</p><p class="q2">its front into the eastern sea, 
-</p><p class="q2">and its back into the western sea; 
-</p><p class="q2">and its stench will come up, 
-</p><p class="q2">and its bad smell will rise.” 
-</p><p class="q1">Surely he has done great things. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Land, don’t be afraid. 
-</p><p class="q2">Be glad and rejoice, for Yahweh has done great things. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Don’t be afraid, you animals of the field; 
-</p><p class="q2">for the pastures of the wilderness spring up, 
-</p><p class="q2">for the tree bears its fruit. 
-</p><p class="q2">The fig tree and the vine yield their strength. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>“Be glad then, you children of Zion, 
-</p><p class="q2">and rejoice in Yahweh, your Elohim; 
-</p><p class="q2">for he gives you the early rain in just measure, 
-</p><p class="q2">and he causes the rain to come down for you, 
-</p><p class="q2">the early rain and the latter rain, as before. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The threshing floors will be full of wheat, 
-</p><p class="q2">and the vats will overflow with new wine and oil. 
-</p><p class="q1">
-<span class="v">25&#160;</span>I will restore to you the years that the swarming locust has eaten, 
-</p><p class="q2">the great locust, the grasshopper, and the caterpillar, 
-</p><p class="q2">my great army, which I sent among you. 
-</p><p class="q1">
-<span class="v">26&#160;</span>You will have plenty to eat and be satisfied, 
-</p><p class="q2">and will praise the name of Yahweh, your Elohim, 
-</p><p class="q2">who has dealt wondrously with you; 
-</p><p class="q2">and my people will never again be disappointed. 
-</p><p class="q1">
-<span class="v">27&#160;</span>You will know that I am among Israel, 
-</p><p class="q2">and that I am Yahweh, your Elohim, and there is no one else; 
-</p><p class="q2">and my people will never again be disappointed. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>“It will happen afterward, that I will pour out my Spirit on all flesh; 
-</p><p class="q2">and your sons and your daughters will prophesy. 
-</p><p class="q2">Your old men will dream dreams. 
-</p><p class="q2">Your young men will see visions. 
-</p><p class="q1">
-<span class="v">29&#160;</span>And also on the servants and on the handmaids in those days, 
-</p><p class="q2">I will pour out my Spirit. 
-</p><p class="q1">
-<span class="v">30&#160;</span>I will show wonders in the heavens and in the earth: 
-</p><p class="q2">blood, fire, and pillars of smoke. 
-</p><p class="q1">
-<span class="v">31&#160;</span>The sun will be turned into darkness, 
-</p><p class="q2">and the moon into blood, 
-</p><p class="q2">before the great and terrible day of Yahweh comes. 
-</p><p class="q1">
-<span class="v">32&#160;</span>It will happen that whoever will call on Yahweh’s name shall be saved; 
-</p><p class="q2">for in Mount Zion and in Jerusalem there will be those who escape, 
-</p><p class="q2">as Yahweh has said, 
-</p><p class="q2">and among the remnant, those whom Yahweh calls. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Blow the trumpet in Zion, 
+</div><div class="q2">and sound an alarm in my set-apart mountain! 
+</div><div class="q1">Let all the inhabitants of the land tremble, 
+</div><div class="q2">for the day of Yahweh comes, 
+</div><div class="q2">for it is close at hand: 
+</div><div class="q1">
+<sup>2&#160;</sup>A day of darkness and gloominess, 
+</div><div class="q2">a day of clouds and thick darkness. 
+</div><div class="q1">As the dawn spreading on the mountains, 
+</div><div class="q2">a great and strong people; 
+</div><div class="q2">there has never been the like, 
+</div><div class="q2">neither will there be any more after them, 
+</div><div class="q2">even to the years of many generations. 
+</div><div class="q1">
+<sup>3&#160;</sup>A fire devours before them, 
+</div><div class="q2">and behind them, a flame burns. 
+</div><div class="q1">The land is as the garden of Eden before them, 
+</div><div class="q2">and behind them, a desolate wilderness. 
+</div><div class="q1">Yes, and no one has escaped them. 
+</div><div class="q1">
+<sup>4&#160;</sup>Their appearance is as the appearance of horses, 
+</div><div class="q2">and they run as horsemen. 
+</div><div class="q1">
+<sup>5&#160;</sup>Like the noise of chariots on the tops of the mountains, they leap, 
+</div><div class="q2">like the noise of a flame of fire that devours the stubble, 
+</div><div class="q2">like a strong people set in battle array. 
+</div><div class="q1">
+<sup>6&#160;</sup>At their presence the peoples are in anguish. 
+</div><div class="q2">All faces have grown pale. 
+</div><div class="q1">
+<sup>7&#160;</sup>They run like mighty men. 
+</div><div class="q2">They climb the wall like warriors. 
+</div><div class="q2">They each march in his line, and they don’t swerve off course. 
+</div><div class="q1">
+<sup>8&#160;</sup>One doesn’t jostle another. 
+</div><div class="q2">They each march in their own path. 
+</div><div class="q2">They burst through the defenses 
+</div><div class="q2">and don’t break ranks. 
+</div><div class="q1">
+<sup>9&#160;</sup>They rush on the city. 
+</div><div class="q2">They run on the wall. 
+</div><div class="q2">They climb up into the houses. 
+</div><div class="q2">They enter in at the windows like thieves. 
+</div><div class="q1">
+<sup>10&#160;</sup>The earth quakes before them. 
+</div><div class="q2">The heavens tremble. 
+</div><div class="q2">The sun and the moon are darkened, 
+</div><div class="q2">and the stars withdraw their shining. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh thunders his voice before his army, 
+</div><div class="q2">for his forces are very great; 
+</div><div class="q2">for he is strong who obeys his command; 
+</div><div class="q2">for the day of Yahweh is great and very awesome, 
+</div><div class="q2">and who can endure it? 
+</div><div class="q1">
+<sup>12&#160;</sup>“Yet even now,” says Yahweh, “turn to me with all your heart, 
+</div><div class="q2">and with fasting, and with weeping, and with mourning.” 
+</div><div class="q1">
+<sup>13&#160;</sup>Tear your heart and not your garments, 
+</div><div class="q2">and turn to Yahweh, your Elohim; 
+</div><div class="q2">for he is gracious and merciful, 
+</div><div class="q2">slow to anger, and abundant in loving kindness, 
+</div><div class="q2">and relents from sending calamity. 
+</div><div class="q1">
+<sup>14&#160;</sup>Who knows? He may turn and relent, 
+</div><div class="q2">and leave a blessing behind him, 
+</div><div class="q2">even a meal offering and a drink offering to Yahweh, your Elohim. 
+</div><div class="q1">
+<sup>15&#160;</sup>Blow the trumpet in Zion! 
+</div><div class="q2">Sanctify a fast. 
+</div><div class="q2">Call a solemn assembly. 
+</div><div class="q1">
+<sup>16&#160;</sup>Gather the people. 
+</div><div class="q2">Sanctify the assembly. 
+</div><div class="q2">Assemble the elders. 
+</div><div class="q2">Gather the children, and those who nurse from breasts. 
+</div><div class="q1">Let the bridegroom go out of his room, 
+</div><div class="q2">and the bride out of her chamber. 
+</div><div class="q1">
+<sup>17&#160;</sup>Let the priests, the ministers of Yahweh, weep between the porch and the altar, 
+</div><div class="q2">and let them say, “Spare your people, Yahweh, 
+</div><div class="q2">and don’t give your heritage to reproach, 
+</div><div class="q2">that the nations should rule over them. 
+</div><div class="q1">Why should they say among the peoples, 
+</div><div class="q2">‘Where is their Elohim?’&#160;” 
+</div><div class="q1">
+<sup>18&#160;</sup>Then Yahweh was jealous for his land, 
+</div><div class="q2">and had pity on his people. 
+</div><div class="q1">
+<sup>19&#160;</sup>Yahweh answered his people, 
+</div><div class="q2">“Behold, I will send you grain, new wine, and oil, 
+</div><div class="q2">and you will be satisfied with them; 
+</div><div class="q2">and I will no more make you a reproach among the nations. 
+</div><div class="q1">
+<sup>20&#160;</sup>But I will remove the northern army far away from you, 
+</div><div class="q2">and will drive it into a barren and desolate land, 
+</div><div class="q2">its front into the eastern sea, 
+</div><div class="q2">and its back into the western sea; 
+</div><div class="q2">and its stench will come up, 
+</div><div class="q2">and its bad smell will rise.” 
+</div><div class="q1">Surely he has done great things. 
+</div><div class="q1">
+<sup>21&#160;</sup>Land, don’t be afraid. 
+</div><div class="q2">Be glad and rejoice, for Yahweh has done great things. 
+</div><div class="q1">
+<sup>22&#160;</sup>Don’t be afraid, you animals of the field; 
+</div><div class="q2">for the pastures of the wilderness spring up, 
+</div><div class="q2">for the tree bears its fruit. 
+</div><div class="q2">The fig tree and the vine yield their strength. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>“Be glad then, you children of Zion, 
+</div><div class="q2">and rejoice in Yahweh, your Elohim; 
+</div><div class="q2">for he gives you the early rain in just measure, 
+</div><div class="q2">and he causes the rain to come down for you, 
+</div><div class="q2">the early rain and the latter rain, as before. 
+</div><div class="q1">
+<sup>24&#160;</sup>The threshing floors will be full of wheat, 
+</div><div class="q2">and the vats will overflow with new wine and oil. 
+</div><div class="q1">
+<sup>25&#160;</sup>I will restore to you the years that the swarming locust has eaten, 
+</div><div class="q2">the great locust, the grasshopper, and the caterpillar, 
+</div><div class="q2">my great army, which I sent among you. 
+</div><div class="q1">
+<sup>26&#160;</sup>You will have plenty to eat and be satisfied, 
+</div><div class="q2">and will praise the name of Yahweh, your Elohim, 
+</div><div class="q2">who has dealt wondrously with you; 
+</div><div class="q2">and my people will never again be disappointed. 
+</div><div class="q1">
+<sup>27&#160;</sup>You will know that I am among Israel, 
+</div><div class="q2">and that I am Yahweh, your Elohim, and there is no one else; 
+</div><div class="q2">and my people will never again be disappointed. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>“It will happen afterward, that I will pour out my Spirit on all flesh; 
+</div><div class="q2">and your sons and your daughters will prophesy. 
+</div><div class="q2">Your old men will dream dreams. 
+</div><div class="q2">Your young men will see visions. 
+</div><div class="q1">
+<sup>29&#160;</sup>And also on the servants and on the handmaids in those days, 
+</div><div class="q2">I will pour out my Spirit. 
+</div><div class="q1">
+<sup>30&#160;</sup>I will show wonders in the heavens and in the earth: 
+</div><div class="q2">blood, fire, and pillars of smoke. 
+</div><div class="q1">
+<sup>31&#160;</sup>The sun will be turned into darkness, 
+</div><div class="q2">and the moon into blood, 
+</div><div class="q2">before the great and terrible day of Yahweh comes. 
+</div><div class="q1">
+<sup>32&#160;</sup>It will happen that whoever will call on Yahweh’s name shall be saved; 
+</div><div class="q2">for in Mount Zion and in Jerusalem there will be those who escape, 
+</div><div class="q2">as Yahweh has said, 
+</div><div class="q2">and among the remnant, those whom Yahweh calls. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="3">3</h2>
-<p class="q1">
-<span class="v">1&#160;</span>“For, behold, in those days, 
-</p><p class="q2">and in that time, 
-</p><p class="q2">when I restore the fortunes of Judah and Jerusalem, 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will gather all nations, 
-</p><p class="q2">and will bring them down into the valley of Jehoshaphat; 
-</p><p class="q2">and I will execute judgment on them there for my people, 
-</p><p class="q2">and for my heritage, Israel, whom they have scattered among the nations. 
-</p><p class="q2">They have divided my land, 
-</p><p class="q2">
-<span class="v">3&#160;</span>and have cast lots for my people, 
-</p><p class="q2">and have given a boy for a prostitute, 
-</p><p class="q2">and sold a girl for wine, that they may drink. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Yes, and what are you to me, Tyre and Sidon, 
-</p><p class="q2">and all the regions of Philistia? 
-</p><p class="q1">Will you repay me? 
-</p><p class="q2">And if you repay me, 
-</p><p class="q2">I will swiftly and speedily return your repayment on your own head. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Because you have taken my silver and my gold, 
-</p><p class="q2">and have carried my finest treasures into your temples, 
-</p><p class="q2">
-<span class="v">6&#160;</span>and have sold the children of Judah and the children of Jerusalem to the sons of the Greeks, 
-</p><p class="q2">that you may remove them far from their border. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Behold, I will stir them up out of the place where you have sold them, 
-</p><p class="q2">and will return your repayment on your own head; 
-</p><p class="q1">
-<span class="v">8&#160;</span>and I will sell your sons and your daughters into the hands of the children of Judah, 
-</p><p class="q2">and they will sell them to the men of Sheba, 
-</p><p class="q2">to a faraway nation, 
-</p><p class="q2">for Yahweh has spoken it.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Proclaim this among the nations: 
-</p><p class="q2">“Prepare for war! 
-</p><p class="q2">Stir up the mighty men. 
-</p><p class="q1">Let all the warriors draw near. 
-</p><p class="q2">Let them come up. 
-<span class="v">10&#160;</span>Beat your plowshares into swords, 
-</p><p class="q2">and your pruning hooks into spears. 
-</p><p class="q2">Let the weak say, ‘I am strong.’ 
-</p><p class="q1">
-<span class="v">11&#160;</span>Hurry and come, all you surrounding nations, 
-</p><p class="q2">and gather yourselves together.” 
-</p><p class="q1">Cause your mighty ones to come down there, Yahweh. 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Let the nations arouse themselves, 
-</p><p class="q2">and come up to the valley of Jehoshaphat; 
-</p><p class="q2">for there I will sit to judge all the surrounding nations. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Put in the sickle; 
-</p><p class="q2">for the harvest is ripe. 
-</p><p class="q2">Come, tread, for the wine press is full, 
-</p><p class="q2">the vats overflow, for their wickedness is great.” 
-</p><p class="q1">
-<span class="v">14&#160;</span>Multitudes, multitudes in the valley of decision! 
-</p><p class="q2">For the day of Yahweh is near in the valley of decision. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The sun and the moon are darkened, 
-</p><p class="q2">and the stars withdraw their shining. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yahweh will roar from Zion, 
-</p><p class="q2">and thunder from Jerusalem; 
-</p><p class="q2">and the heavens and the earth will shake; 
-</p><p class="q2">but Yahweh will be a refuge to his people, 
-</p><p class="q2">and a stronghold to the children of Israel. 
-</p><p class="q1">
-<span class="v">17&#160;</span>“So you will know that I am Yahweh, your Elohim, 
-</p><p class="q2">dwelling in Zion, my set-apart mountain. 
-</p><p class="q1">Then Jerusalem will be set-apart, 
-</p><p class="q2">and no strangers will pass through her any more. 
-</p><p class="q1">
-<span class="v">18&#160;</span>It will happen in that day, 
-</p><p class="q2">that the mountains will drop down sweet wine, 
-</p><p class="q2">the hills will flow with milk, 
-</p><p class="q2">all the brooks of Judah will flow with waters; 
-</p><p class="q2">and a fountain will flow out from Yahweh’s house, 
-</p><p class="q2">and will water the valley of Shittim. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Egypt will be a desolation 
-</p><p class="q2">and Edom will be a desolate wilderness, 
-</p><p class="q2">for the violence done to the children of Judah, 
-</p><p class="q2">because they have shed innocent blood in their land. 
-</p><p class="q1">
-<span class="v">20&#160;</span>But Judah will be inhabited forever, 
-</p><p class="q2">and Jerusalem from generation to generation. 
-</p><p class="q1">
-<span class="v">21&#160;</span>I will cleanse their blood 
-</p><p class="q2">that I have not cleansed, 
-</p><p class="q2">for Yahweh dwells in Zion.” </div><script src="../main.js"></script></body></html>
+<div class="q1">
+<sup>1&#160;</sup>“For, behold, in those days, 
+</div><div class="q2">and in that time, 
+</div><div class="q2">when I restore the fortunes of Judah and Jerusalem, 
+</div><div class="q1">
+<sup>2&#160;</sup>I will gather all nations, 
+</div><div class="q2">and will bring them down into the valley of Jehoshaphat; 
+</div><div class="q2">and I will execute judgment on them there for my people, 
+</div><div class="q2">and for my heritage, Israel, whom they have scattered among the nations. 
+</div><div class="q2">They have divided my land, 
+</div><div class="q2">
+<sup>3&#160;</sup>and have cast lots for my people, 
+</div><div class="q2">and have given a boy for a prostitute, 
+</div><div class="q2">and sold a girl for wine, that they may drink. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Yes, and what are you to me, Tyre and Sidon, 
+</div><div class="q2">and all the regions of Philistia? 
+</div><div class="q1">Will you repay me? 
+</div><div class="q2">And if you repay me, 
+</div><div class="q2">I will swiftly and speedily return your repayment on your own head. 
+</div><div class="q1">
+<sup>5&#160;</sup>Because you have taken my silver and my gold, 
+</div><div class="q2">and have carried my finest treasures into your temples, 
+</div><div class="q2">
+<sup>6&#160;</sup>and have sold the children of Judah and the children of Jerusalem to the sons of the Greeks, 
+</div><div class="q2">that you may remove them far from their border. 
+</div><div class="q1">
+<sup>7&#160;</sup>Behold, I will stir them up out of the place where you have sold them, 
+</div><div class="q2">and will return your repayment on your own head; 
+</div><div class="q1">
+<sup>8&#160;</sup>and I will sell your sons and your daughters into the hands of the children of Judah, 
+</div><div class="q2">and they will sell them to the men of Sheba, 
+</div><div class="q2">to a faraway nation, 
+</div><div class="q2">for Yahweh has spoken it.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Proclaim this among the nations: 
+</div><div class="q2">“Prepare for war! 
+</div><div class="q2">Stir up the mighty men. 
+</div><div class="q1">Let all the warriors draw near. 
+</div><div class="q2">Let them come up. 
+<sup>10&#160;</sup>Beat your plowshares into swords, 
+</div><div class="q2">and your pruning hooks into spears. 
+</div><div class="q2">Let the weak say, ‘I am strong.’ 
+</div><div class="q1">
+<sup>11&#160;</sup>Hurry and come, all you surrounding nations, 
+</div><div class="q2">and gather yourselves together.” 
+</div><div class="q1">Cause your mighty ones to come down there, Yahweh. 
+</div><div class="q1">
+<sup>12&#160;</sup>“Let the nations arouse themselves, 
+</div><div class="q2">and come up to the valley of Jehoshaphat; 
+</div><div class="q2">for there I will sit to judge all the surrounding nations. 
+</div><div class="q1">
+<sup>13&#160;</sup>Put in the sickle; 
+</div><div class="q2">for the harvest is ripe. 
+</div><div class="q2">Come, tread, for the wine press is full, 
+</div><div class="q2">the vats overflow, for their wickedness is great.” 
+</div><div class="q1">
+<sup>14&#160;</sup>Multitudes, multitudes in the valley of decision! 
+</div><div class="q2">For the day of Yahweh is near in the valley of decision. 
+</div><div class="q1">
+<sup>15&#160;</sup>The sun and the moon are darkened, 
+</div><div class="q2">and the stars withdraw their shining. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yahweh will roar from Zion, 
+</div><div class="q2">and thunder from Jerusalem; 
+</div><div class="q2">and the heavens and the earth will shake; 
+</div><div class="q2">but Yahweh will be a refuge to his people, 
+</div><div class="q2">and a stronghold to the children of Israel. 
+</div><div class="q1">
+<sup>17&#160;</sup>“So you will know that I am Yahweh, your Elohim, 
+</div><div class="q2">dwelling in Zion, my set-apart mountain. 
+</div><div class="q1">Then Jerusalem will be set-apart, 
+</div><div class="q2">and no strangers will pass through her any more. 
+</div><div class="q1">
+<sup>18&#160;</sup>It will happen in that day, 
+</div><div class="q2">that the mountains will drop down sweet wine, 
+</div><div class="q2">the hills will flow with milk, 
+</div><div class="q2">all the brooks of Judah will flow with waters; 
+</div><div class="q2">and a fountain will flow out from Yahweh’s house, 
+</div><div class="q2">and will water the valley of Shittim. 
+</div><div class="q1">
+<sup>19&#160;</sup>Egypt will be a desolation 
+</div><div class="q2">and Edom will be a desolate wilderness, 
+</div><div class="q2">for the violence done to the children of Judah, 
+</div><div class="q2">because they have shed innocent blood in their land. 
+</div><div class="q1">
+<sup>20&#160;</sup>But Judah will be inhabited forever, 
+</div><div class="q2">and Jerusalem from generation to generation. 
+</div><div class="q1">
+<sup>21&#160;</sup>I will cleanse their blood 
+</div><div class="q2">that I have not cleansed, 
+</div><div class="q2">for Yahweh dwells in Zion.” </div></div><script src="../main.js"></script></body></html>

--- a/book/john.html
+++ b/book/john.html
@@ -3,6 +3,47 @@
 <head>
 <title>John</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1284 +53,1306 @@
 <div class="main">
 <!-- JHN World English Scripture (WES) -->
 <h1 class="booklabel">John</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>In the beginning was the Word, and the Word was with Elohim, and an elohim was the Word. 
-<span class="v">2&#160;</span>The same was in the beginning with Elohim. 
-<span class="v">3&#160;</span>All things were made through him. Without him, nothing was made that has been made. 
-<span class="v">4&#160;</span>In him was life, and the life was the light of men. 
-<span class="v">5&#160;</span>The light shines in the darkness, and the darkness hasn’t overcome<span class="f">+ \fr 1:5 \ft The word translated “overcome” (κατέλαβεν) can also be translated “comprehended.” It refers to getting a grip on an enemy to defeat him. </span> it. 
-</p><p>
-<span class="v">6&#160;</span>There came a man sent from Elohim, whose name was John. 
-<span class="v">7&#160;</span>The same came as a witness, that he might testify about the light, that all might believe through him. 
-<span class="v">8&#160;</span>He was not the light, but was sent that he might testify about the light. 
-<span class="v">9&#160;</span>The true light that enlightens everyone was coming into the world. 
-</p><p>
-<span class="v">10&#160;</span>He was in the world, and the world was made through him, and the world didn’t recognize him. 
-<span class="v">11&#160;</span>He came to his own, and those who were his own didn’t receive him. 
-<span class="v">12&#160;</span>But as many as received him, to them he gave the right to become Elohim’s children, to those who believe in his name: 
-<span class="v">13&#160;</span>who were born, not of blood, nor of the will of the flesh, nor of the will of man, but of Elohim. 
-</p><p>
-<span class="v">14&#160;</span>The Word became flesh and lived among us. We saw his glory, such glory as of the only born<span class="f">+ \fr 1:14 \ft The phrase “only born” is from the Greek word “μονογενους”, which is sometimes translated “only begotten” or “one and only”.</span> Son of the Father, full of grace and truth. 
-<span class="v">15&#160;</span>John testified about him. He cried out, saying, “This was he of whom I said, ‘He who comes after me has surpassed me, for he was before me.’&#160;” 
-<span class="v">16&#160;</span>From his fullness we all received grace upon grace. 
-<span class="v">17&#160;</span>For the law was given through Moses. Grace and truth were realized through Yahushua Christ.<span class="f">+ \fr 1:17 \ft “Christ” means “Anointed One”.</span> 
-<span class="v">18&#160;</span>No one has seen Elohim at any time. The only born<span class="f">+ \fr 1:18 \ft The phrase “only born” is from the Greek word “μονογενη”, which is sometimes translated “only begotten” or “one and only”.</span> Son,<span class="f">+ \fr 1:18 \ft NU reads “Elohim”</span> who is in the bosom of the Father, has declared him. 
-</p><p>
-<span class="v">19&#160;</span>This is John’s testimony, when the Jews sent priests and Levites from Jerusalem to ask him, “Who are you?” 
-</p><p>
-<span class="v">20&#160;</span>He declared, and didn’t deny, but he declared, “I am not the Christ.” 
-</p><p>
-<span class="v">21&#160;</span>They asked him, “What then? Are you Elijah?” 
-</p><p>He said, “I am not.” 
-</p><p>“Are you the prophet?” 
-</p><p>He answered, “No.” 
-</p><p>
-<span class="v">22&#160;</span>They said therefore to him, “Who are you? Give us an answer to take back to those who sent us. What do you say about yourself?” 
-</p><p>
-<span class="v">23&#160;</span>He said, “I am the voice of one crying in the wilderness, ‘Make straight the way of the Lord,’<span class="x">+ \xo 1:23 \xt Isaiah 40:3</span> as Isaiah the prophet said.” 
-</p><p>
-<span class="v">24&#160;</span>The ones who had been sent were from the Pharisees. 
-<span class="v">25&#160;</span>They asked him, “Why then do you baptize if you are not the Christ, nor Elijah, nor the prophet?” 
-</p><p>
-<span class="v">26&#160;</span>John answered them, “I baptize in water, but among you stands one whom you don’t know. 
-<span class="v">27&#160;</span>He is the one who comes after me, who is preferred before me, whose sandal strap I’m not worthy to loosen.” 
-<span class="v">28&#160;</span>These things were done in Bethany beyond the Jordan, where John was baptizing. 
-</p><p>
-<span class="v">29&#160;</span>The next day, he saw Yahushua coming to him, and said, “Behold,<span class="f">+ \fr 1:29 \ft “Behold”, from “ἰδοὺ”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> the Lamb of Elohim, who takes away the sin of the world! 
-<span class="v">30&#160;</span>This is he of whom I said, ‘After me comes a man who is preferred before me, for he was before me.’ 
-<span class="v">31&#160;</span>I didn’t know him, but for this reason I came baptizing in water, that he would be revealed to Israel.” 
-<span class="v">32&#160;</span>John testified, saying, “I have seen the Spirit descending like a dove out of heaven, and it remained on him. 
-<span class="v">33&#160;</span>I didn’t recognize him, but he who sent me to baptize in water said to me, ‘On whomever you will see the Spirit descending and remaining on him is he who baptizes in the Set-Apart Spirit.’ 
-<span class="v">34&#160;</span>I have seen and have testified that this is the Son of Elohim.” 
-</p><p>
-<span class="v">35&#160;</span>Again, the next day, John was standing with two of his disciples, 
-<span class="v">36&#160;</span>and he looked at Yahushua as he walked, and said, “Behold, the Lamb of Elohim!” 
-<span class="v">37&#160;</span>The two disciples heard him speak, and they followed Yahushua. 
-<span class="v">38&#160;</span>Yahushua turned and saw them following, and said to them, <span class="wj">“What are you looking for?”</span> 
-</p><p>They said to him, “Rabbi” (which is to say, being interpreted, Teacher), “where are you staying?” 
-</p><p>
-<span class="v">39&#160;</span>He said to them, <span class="wj">“Come and see.”</span> 
-</p><p>They came and saw where he was staying, and they stayed with him that day. It was about the tenth hour.<span class="f">+ \fr 1:39 \ft 4:00 p.m.</span> 
-<span class="v">40&#160;</span>One of the two who heard John and followed him was Andrew, Simon Peter’s brother. 
-<span class="v">41&#160;</span>He first found his own brother, Simon, and said to him, “We have found the Messiah!” (which is, being interpreted, Christ<span class="f">+ \fr 1:41 \ft “Messiah” (Hebrew) and “Christ” (Greek) both mean “Anointed One”.</span>). 
-<span class="v">42&#160;</span>He brought him to Yahushua. Yahushua looked at him and said, <span class="wj">“You are Simon the son of Jonah. You shall be called Cephas”</span> (which is by interpretation, Peter).<span class="f">+ \fr 1:42 \ft “Cephas” (Aramaic) and “Peter” (Greek) both mean “Rock”.</span> 
-</p><p>
-<span class="v">43&#160;</span>On the next day, he was determined to go out into Galilee, and he found Philip. Yahushua said to him, <span class="wj">“Follow me.”</span> 
-<span class="v">44&#160;</span>Now Philip was from Bethsaida, the city of Andrew and Peter. 
-<span class="v">45&#160;</span>Philip found Nathanael, and said to him, “We have found him of whom Moses in the law and also the prophets, wrote: Yahushua of Nazareth, the son of Joseph.” 
-</p><p>
-<span class="v">46&#160;</span>Nathanael said to him, “Can any good thing come out of Nazareth?” 
-</p><p>Philip said to him, “Come and see.” 
-</p><p>
-<span class="v">47&#160;</span>Yahushua saw Nathanael coming to him, and said about him, <span class="wj">“Behold, an Israelite indeed, in whom is no deceit!”</span> 
-</p><p>
-<span class="v">48&#160;</span>Nathanael said to him, “How do you know me?” 
-</p><p>Yahushua answered him, <span class="wj">“Before Philip called you, when you were under the fig tree, I saw you.”</span> 
-</p><p>
-<span class="v">49&#160;</span>Nathanael answered him, “Rabbi, you are the Son of Elohim! You are King of Israel!” 
-</p><p>
-<span class="v">50&#160;</span>Yahushua answered him, <span class="wj">“Because I told you, ‘I saw you underneath the fig tree,’ do you believe? You will see greater things than these!”</span> 
-<span class="v">51&#160;</span>He said to him, <span class="wj">“Most certainly, I tell you all, hereafter you will see heaven opened, and the angels of Elohim ascending and descending on the Son of Man.”</span> 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>The third day, there was a wedding in Cana of Galilee. Yahushua’s mother was there. 
-<span class="v">2&#160;</span>Yahushua also was invited, with his disciples, to the wedding. 
-<span class="v">3&#160;</span>When the wine ran out, Yahushua’s mother said to him, “They have no wine.” 
-</p><p>
-<span class="v">4&#160;</span>Yahushua said to her, <span class="wj">“Woman, what does that have to do with you and me? My hour has not yet come.”</span> 
-</p><p>
-<span class="v">5&#160;</span>His mother said to the servants, “Whatever he says to you, do it.” 
-</p><p>
-<span class="v">6&#160;</span>Now there were six water pots of stone set there after the Jews’ way of purifying, containing two or three metretes<span class="f">+ \fr 2:6 \ft 2 to 3 metretes is about 20 to 30 U. S. Gallons, or 75 to 115 liters.</span> apiece. 
-<span class="v">7&#160;</span>Yahushua said to them, <span class="wj">“Fill the water pots with water.”</span> So they filled them up to the brim. 
-<span class="v">8&#160;</span>He said to them, <span class="wj">“Now draw some out, and take it to the ruler of the feast.”</span> So they took it. 
-<span class="v">9&#160;</span>When the ruler of the feast tasted the water now become wine, and didn’t know where it came from (but the servants who had drawn the water knew), the ruler of the feast called the bridegroom 
-<span class="v">10&#160;</span>and said to him, “Everyone serves the good wine first, and when the guests have drunk freely, then that which is worse. You have kept the good wine until now!” 
-<span class="v">11&#160;</span>This beginning of his signs Yahushua did in Cana of Galilee, and revealed his glory; and his disciples believed in him. 
-</p><p>
-<span class="v">12&#160;</span>After this, he went down to Capernaum, he, and his mother, his brothers, and his disciples; and they stayed there a few days. 
-</p><p>
-<span class="v">13&#160;</span>The Passover of the Jews was at hand, and Yahushua went up to Jerusalem. 
-<span class="v">14&#160;</span>He found in the temple those who sold oxen, sheep, and doves, and the changers of money sitting. 
-<span class="v">15&#160;</span>He made a whip of cords and drove all out of the temple, both the sheep and the oxen; and he poured out the changers’ money and overthrew their tables. 
-<span class="v">16&#160;</span>To those who sold the doves, he said, <span class="wj">“Take these things out of here! Don’t make my Father’s house a marketplace!”</span> 
-<span class="v">17&#160;</span>His disciples remembered that it was written, “Zeal for your house will eat me up.”<span class="x">+ \xo 2:17 \xt Psalm 69:9</span> 
-</p><p>
-<span class="v">18&#160;</span>The Jews therefore answered him, “What sign do you show us, seeing that you do these things?” 
-</p><p>
-<span class="v">19&#160;</span>Yahushua answered them, <span class="wj">“Destroy this temple, and in three days I will raise it up.”</span> 
-</p><p>
-<span class="v">20&#160;</span>The Jews therefore said, “It took forty-six years to build this temple! Will you raise it up in three days?” 
-<span class="v">21&#160;</span>But he spoke of the temple of his body. 
-<span class="v">22&#160;</span>When therefore he was raised from the dead, his disciples remembered that he said this, and they believed the Scripture and the word which Yahushua had said. 
-</p><p>
-<span class="v">23&#160;</span>Now when he was in Jerusalem at the Passover, during the feast, many believed in his name, observing his signs which he did. 
-<span class="v">24&#160;</span>But Yahushua didn’t entrust himself to them, because he knew everyone, 
-<span class="v">25&#160;</span>and because he didn’t need for anyone to testify concerning man; for he himself knew what was in man. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now there was a man of the Pharisees named Nicodemus, a ruler of the Jews. 
-<span class="v">2&#160;</span>He came to Yahushua by night and said to him, “Rabbi, we know that you are a teacher come from Elohim, for no one can do these signs that you do, unless Elohim is with him.” 
-</p><p>
-<span class="v">3&#160;</span>Yahushua answered him, <span class="wj">“Most certainly I tell you, unless one is born anew, </span><span class="f">+ \fr 3:3 \ft The word translated “anew” here and in John 3:7 (ἄνωθεν) also means “again” and “from above”.</span> <span class="wj">he can’t see Elohim’s Kingdom.”</span> 
-</p><p>
-<span class="v">4&#160;</span>Nicodemus said to him, “How can a man be born when he is old? Can he enter a second time into his mother’s womb and be born?” 
-</p><p>
-<span class="v">5&#160;</span>Yahushua answered, <span class="wj">“Most certainly I tell you, unless one is born of water and Spirit, he can’t enter into Elohim’s Kingdom.</span> 
-<span class="v">6&#160;</span><span class="wj">That which is born of the flesh is flesh. That which is born of the Spirit is spirit. </span> 
-<span class="v">7&#160;</span><span class="wj">Don’t marvel that I said to you, ‘You must be born anew.’ </span> 
-<span class="v">8&#160;</span><span class="wj">The wind</span><span class="f">+ \fr 3:8 \ft The same Greek word (πνεῦμα) means wind, breath, and spirit.</span> <span class="wj">blows where it wants to, and you hear its sound, but don’t know where it comes from and where it is going. So is everyone who is born of the Spirit.”</span> 
-</p><p>
-<span class="v">9&#160;</span>Nicodemus answered him, “How can these things be?” 
-</p><p>
-<span class="v">10&#160;</span>Yahushua answered him, <span class="wj">“Are you the teacher of Israel, and don’t understand these things? </span> 
-<span class="v">11&#160;</span><span class="wj">Most certainly I tell you, we speak that which we know and testify of that which we have seen, and you don’t receive our witness. </span> 
-<span class="v">12&#160;</span><span class="wj">If I told you earthly things and you don’t believe, how will you believe if I tell you heavenly things? </span> 
-<span class="v">13&#160;</span><span class="wj">No one has ascended into heaven but he who descended out of heaven, the Son of Man, who is in heaven. </span> 
-<span class="v">14&#160;</span><span class="wj">As Moses lifted up the serpent in the wilderness, even so must the Son of Man be lifted up, </span> 
-<span class="v">15&#160;</span><span class="wj">that whoever believes in him should not perish, but have eternal life. </span> 
-<span class="v">16&#160;</span><span class="wj">For Elohim so loved the world, that he gave his only born</span><span class="f">+ \fr 3:16 \ft The phrase “only born” is from the Greek word “μονογενη”, which is sometimes translated “only begotten” or “one and only”.</span> <span class="wj">Son, that whoever believes in him should not perish, but have eternal life. </span> 
-<span class="v">17&#160;</span><span class="wj">For Elohim didn’t send his Son into the world to judge the world, but that the world should be saved through him. </span> 
-<span class="v">18&#160;</span><span class="wj">He who believes in him is not judged. He who doesn’t believe has been judged already, because he has not believed in the name of the only born Son of Elohim. </span> 
-<span class="v">19&#160;</span><span class="wj">This is the judgment, that the light has come into the world, and men loved the darkness rather than the light, for their works were evil. </span> 
-<span class="v">20&#160;</span><span class="wj">For everyone who does evil hates the light and doesn’t come to the light, lest his works would be exposed. </span> 
-<span class="v">21&#160;</span><span class="wj">But he who does the truth comes to the light, that his works may be revealed, that they have been done in Elohim.”</span> 
-</p><p>
-<span class="v">22&#160;</span>After these things, Yahushua came with his disciples into the land of Judea. He stayed there with them and baptized. 
-<span class="v">23&#160;</span>John also was baptizing in Enon near Salim, because there was much water there. They came and were baptized; 
-<span class="v">24&#160;</span>for John was not yet thrown into prison. 
-<span class="v">25&#160;</span>Therefore a dispute arose on the part of John’s disciples with some Jews about purification. 
-<span class="v">26&#160;</span>They came to John and said to him, “Rabbi, he who was with you beyond the Jordan, to whom you have testified, behold, he baptizes, and everyone is coming to him.” 
-</p><p>
-<span class="v">27&#160;</span>John answered, “A man can receive nothing unless it has been given him from heaven. 
-<span class="v">28&#160;</span>You yourselves testify that I said, ‘I am not the Christ,’ but, ‘I have been sent before him.’ 
-<span class="v">29&#160;</span>He who has the bride is the bridegroom; but the friend of the bridegroom, who stands and hears him, rejoices greatly because of the bridegroom’s voice. Therefore my joy is made full. 
-<span class="v">30&#160;</span>He must increase, but I must decrease. 
-</p><p>
-<span class="v">31&#160;</span>“He who comes from above is above all. He who is from the earth belongs to the earth and speaks of the earth. He who comes from heaven is above all. 
-<span class="v">32&#160;</span>What he has seen and heard, of that he testifies; and no one receives his witness. 
-<span class="v">33&#160;</span>He who has received his witness has set his seal to this, that Elohim is true. 
-<span class="v">34&#160;</span>For he whom Elohim has sent speaks the words of Elohim; for Elohim gives the Spirit without measure. 
-<span class="v">35&#160;</span>The Father loves the Son, and has given all things into his hand. 
-<span class="v">36&#160;</span>One who believes in the Son has eternal life, but one who disobeys<span class="f">+ \fr 3:36 \ft The same word can be translated “disobeys” or “disbelieves” in this context.</span> the Son won’t see life, but the wrath of Elohim remains on him.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Therefore when the Lord knew that the Pharisees had heard that Yahushua was making and baptizing more disciples than John 
-<span class="v">2&#160;</span>(although Yahushua himself didn’t baptize, but his disciples), 
-<span class="v">3&#160;</span>he left Judea and departed into Galilee. 
-<span class="v">4&#160;</span>He needed to pass through Samaria. 
-<span class="v">5&#160;</span>So he came to a city of Samaria called Sychar, near the parcel of ground that Jacob gave to his son Joseph. 
-<span class="v">6&#160;</span>Jacob’s well was there. Yahushua therefore, being tired from his journey, sat down by the well. It was about the sixth hour.<span class="f">+ \fr 4:6 \ft noon</span> 
-</p><p>
-<span class="v">7&#160;</span>A woman of Samaria came to draw water. Yahushua said to her, <span class="wj">“Give me a drink.”</span> 
-<span class="v">8&#160;</span>For his disciples had gone away into the city to buy food. 
-</p><p>
-<span class="v">9&#160;</span>The Samaritan woman therefore said to him, “How is it that you, being a Jew, ask for a drink from me, a Samaritan woman?” (For Jews have no dealings with Samaritans.) 
-</p><p>
-<span class="v">10&#160;</span>Yahushua answered her, <span class="wj">“If you knew the gift of Elohim, and who it is who says to you, ‘Give me a drink,’ you would have asked him, and he would have given you living water.”</span> 
-</p><p>
-<span class="v">11&#160;</span>The woman said to him, “Sir, you have nothing to draw with, and the well is deep. So where do you get that living water? 
-<span class="v">12&#160;</span>Are you greater than our father Jacob, who gave us the well and drank from it himself, as did his children and his livestock?” 
-</p><p>
-<span class="v">13&#160;</span>Yahushua answered her, <span class="wj">“Everyone who drinks of this water will thirst again, </span> 
-<span class="v">14&#160;</span><span class="wj">but whoever drinks of the water that I will give him will never thirst again; but the water that I will give him will become in him a well of water springing up to eternal life.”</span> 
-</p><p>
-<span class="v">15&#160;</span>The woman said to him, “Sir, give me this water, so that I don’t get thirsty, neither come all the way here to draw.” 
-</p><p>
-<span class="v">16&#160;</span>Yahushua said to her, <span class="wj">“Go, call your man, and come here.” </span> 
-</p><p>
-<span class="v">17&#160;</span>The woman answered, “I have no man.” 
-</p><p>Yahushua said to her, <span class="wj">“You said well, ‘I have no man,’ </span> 
-<span class="v">18&#160;</span><span class="wj">for you have had five men; and he whom you now have is not your man. This you have said truly.”</span> 
-</p><p>
-<span class="v">19&#160;</span>The woman said to him, “Sir, I perceive that you are a prophet. 
-<span class="v">20&#160;</span>Our fathers worshiped in this mountain, and you Jews say that in Jerusalem is the place where people ought to worship.” 
-</p><p>
-<span class="v">21&#160;</span>Yahushua said to her, <span class="wj">“Woman, believe me, the hour is coming when neither in this mountain nor in Jerusalem will you worship the Father. </span> 
-<span class="v">22&#160;</span><span class="wj">You worship that which you don’t know. We worship that which we know; for salvation is from the Jews. </span> 
-<span class="v">23&#160;</span><span class="wj">But the hour comes, and now is, when the true worshipers will worship the Father in spirit and truth, for the Father seeks such to be his worshipers. </span> 
-<span class="v">24&#160;</span><span class="wj">Elohim is spirit, and those who worship him must worship in spirit and truth.”</span> 
-</p><p>
-<span class="v">25&#160;</span>The woman said to him, “I know that Messiah is coming, he who is called Christ.<span class="f">+ \fr 4:25 \ft “Messiah” (Hebrew) and “Christ” (Greek) both mean “Anointed One”.</span> When he has come, he will declare to us all things.” 
-</p><p>
-<span class="v">26&#160;</span>Yahushua said to her, <span class="wj">“I am he, the one who speaks to you.”</span> 
-</p><p>
-<span class="v">27&#160;</span>Just then, his disciples came. They marveled that he was speaking with a woman; yet no one said, “What are you looking for?” or, “Why do you speak with her?” 
-<span class="v">28&#160;</span>So the woman left her water pot, went away into the city, and said to the people, 
-<span class="v">29&#160;</span>“Come, see a man who told me everything that I have done. Can this be the Christ?” 
-<span class="v">30&#160;</span>They went out of the city, and were coming to him. 
-</p><p>
-<span class="v">31&#160;</span>In the meanwhile, the disciples urged him, saying, “Rabbi, eat.” 
-</p><p>
-<span class="v">32&#160;</span>But he said to them, <span class="wj">“I have food to eat that you don’t know about.”</span> 
-</p><p>
-<span class="v">33&#160;</span>The disciples therefore said to one another, “Has anyone brought him something to eat?” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua said to them, <span class="wj">“My food is to do the will of him who sent me and to accomplish his work. </span> 
-<span class="v">35&#160;</span><span class="wj">Don’t you say, ‘There are yet four months until the harvest’? Behold, I tell you, lift up your eyes and look at the fields, that they are white for harvest already. </span> 
-<span class="v">36&#160;</span><span class="wj">He who reaps receives wages and gathers fruit to eternal life, that both he who sows and he who reaps may rejoice together. </span> 
-<span class="v">37&#160;</span><span class="wj">For in this the saying is true, ‘One sows, and another reaps.’ </span> 
-<span class="v">38&#160;</span><span class="wj">I sent you to reap that for which you haven’t labored. Others have labored, and you have entered into their labor.”</span> 
-</p><p>
-<span class="v">39&#160;</span>From that city many of the Samaritans believed in him because of the word of the woman, who testified, “He told me everything that I have done.” 
-<span class="v">40&#160;</span>So when the Samaritans came to him, they begged him to stay with them. He stayed there two days. 
-<span class="v">41&#160;</span>Many more believed because of his word. 
-<span class="v">42&#160;</span>They said to the woman, “Now we believe, not because of your speaking; for we have heard for ourselves, and know that this is indeed the Christ, the Savior of the world.” 
-</p><p>
-<span class="v">43&#160;</span>After the two days he went out from there and went into Galilee. 
-<span class="v">44&#160;</span>For Yahushua himself testified that a prophet has no honor in his own country. 
-<span class="v">45&#160;</span>So when he came into Galilee, the Galileans received him, having seen all the things that he did in Jerusalem at the feast, for they also went to the feast. 
-<span class="v">46&#160;</span>Yahushua came therefore again to Cana of Galilee, where he made the water into wine. There was a certain nobleman whose son was sick at Capernaum. 
-<span class="v">47&#160;</span>When he heard that Yahushua had come out of Judea into Galilee, he went to him and begged him that he would come down and heal his son, for he was at the point of death. 
-<span class="v">48&#160;</span>Yahushua therefore said to him, <span class="wj">“Unless you see signs and wonders, you will in no way believe.”</span> 
-</p><p>
-<span class="v">49&#160;</span>The nobleman said to him, “Sir, come down before my child dies.” 
-</p><p>
-<span class="v">50&#160;</span>Yahushua said to him, <span class="wj">“Go your way. Your son lives.”</span> The man believed the word that Yahushua spoke to him, and he went his way. 
-<span class="v">51&#160;</span>As he was going down, his servants met him and reported, saying “Your child lives!” 
-<span class="v">52&#160;</span>So he inquired of them the hour when he began to get better. They said therefore to him, “Yesterday at the seventh hour,<span class="f">+ \fr 4:52 \ft 1:00 p.m.</span> the fever left him.” 
-<span class="v">53&#160;</span>So the father knew that it was at that hour in which Yahushua said to him, <span class="wj">“Your son lives.”</span> He believed, as did his whole house. 
-<span class="v">54&#160;</span>This is again the second sign that Yahushua did, having come out of Judea into Galilee. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>After these things, there was a feast of the Jews, and Yahushua went up to Jerusalem. 
-<span class="v">2&#160;</span>Now in Jerusalem by the sheep gate, there is a pool, which is called in Hebrew, “Bethesda”, having five porches. 
-<span class="v">3&#160;</span>In these lay a great multitude of those who were sick, blind, lame, or paralyzed, waiting for the moving of the water; 
-<span class="v">4&#160;</span>for an angel went down at certain times into the pool and stirred up the water. Whoever stepped in first after the stirring of the water was healed of whatever disease he had.<span class="f">+ \fr 5:4 \ft NU omits from “waiting” in verse 3 to the end of verse 4.</span> 
-<span class="v">5&#160;</span>A certain man was there who had been sick for thirty-eight years. 
-<span class="v">6&#160;</span>When Yahushua saw him lying there, and knew that he had been sick for a long time, he asked him, <span class="wj">“Do you want to be made well?”</span> 
-</p><p>
-<span class="v">7&#160;</span>The sick man answered him, “Sir, I have no one to put me into the pool when the water is stirred up, but while I’m coming, another steps down before me.” 
-</p><p>
-<span class="v">8&#160;</span>Yahushua said to him, <span class="wj">“Arise, take up your mat, and walk.”</span> 
-</p><p>
-<span class="v">9&#160;</span>Immediately, the man was made well, and took up his mat and walked. 
-</p><p>Now that day was a Sabbath. 
-<span class="v">10&#160;</span>So the Jews said to him who was cured, “It is the Sabbath. It is not lawful for you to carry the mat.” 
-</p><p>
-<span class="v">11&#160;</span>He answered them, “He who made me well said to me, <span class="wj">‘Take up your mat and walk.’</span>&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Then they asked him, “Who is the man who said to you, <span class="wj">‘Take up your mat and walk’</span>?” 
-</p><p>
-<span class="v">13&#160;</span>But he who was healed didn’t know who it was, for Yahushua had withdrawn, a crowd being in the place. 
-</p><p>
-<span class="v">14&#160;</span>Afterward Yahushua found him in the temple and said to him, <span class="wj">“Behold, you are made well. Sin no more, so that nothing worse happens to you.” </span> 
-</p><p>
-<span class="v">15&#160;</span>The man went away, and told the Jews that it was Yahushua who had made him well. 
-<span class="v">16&#160;</span>For this cause the Jews persecuted Yahushua and sought to kill him, because he did these things on the Sabbath. 
-<span class="v">17&#160;</span>But Yahushua answered them, <span class="wj">“My Father is still working, so I am working, too.”</span> 
-</p><p>
-<span class="v">18&#160;</span>For this cause therefore the Jews sought all the more to kill him, because he not only broke the Sabbath, but also called Elohim his own Father, making himself equal with Elohim. 
-<span class="v">19&#160;</span>Yahushua therefore answered them, <span class="wj">“Most certainly, I tell you, the Son can do nothing of himself, but what he sees the Father doing. For whatever things he does, these the Son also does likewise. </span> 
-<span class="v">20&#160;</span><span class="wj">For the Father has affection for the Son, and shows him all things that he himself does. He will show him greater works than these, that you may marvel. </span> 
-<span class="v">21&#160;</span><span class="wj">For as the Father raises the dead and gives them life, even so the Son also gives life to whom he desires. </span> 
-<span class="v">22&#160;</span><span class="wj">For the Father judges no one, but he has given all judgment to the Son, </span> 
-<span class="v">23&#160;</span><span class="wj">that all may honor the Son, even as they honor the Father. He who doesn’t honor the Son doesn’t honor the Father who sent him.</span> 
-</p><p>
-<span class="v">24&#160;</span><span class="wj">“Most certainly I tell you, he who hears my word and believes him who sent me has eternal life, and doesn’t come into judgment, but has passed out of death into life. </span> 
-<span class="v">25&#160;</span><span class="wj">Most certainly I tell you, the hour comes, and now is, when the dead will hear the Son of Elohim’s voice; and those who hear will live. </span> 
-<span class="v">26&#160;</span><span class="wj">For as the Father has life in himself, even so he gave to the Son also to have life in himself. </span> 
-<span class="v">27&#160;</span><span class="wj">He also gave him authority to execute judgment, because he is a son of man. </span> 
-<span class="v">28&#160;</span><span class="wj">Don’t marvel at this, for the hour comes in which all who are in the tombs will hear his voice </span> 
-<span class="v">29&#160;</span><span class="wj">and will come out; those who have done good, to the resurrection of life; and those who have done evil, to the resurrection of judgment. </span> 
-<span class="v">30&#160;</span><span class="wj">I can of myself do nothing. As I hear, I judge; and my judgment is righteous, because I don’t seek my own will, but the will of my Father who sent me.</span> 
-</p><p>
-<span class="v">31&#160;</span><span class="wj">“If I testify about myself, my witness is not valid. </span> 
-<span class="v">32&#160;</span><span class="wj">It is another who testifies about me. I know that the testimony which he testifies about me is true. </span> 
-<span class="v">33&#160;</span><span class="wj">You have sent to John, and he has testified to the truth. </span> 
-<span class="v">34&#160;</span><span class="wj">But the testimony which I receive is not from man. However, I say these things that you may be saved. </span> 
-<span class="v">35&#160;</span><span class="wj">He was the burning and shining lamp, and you were willing to rejoice for a while in his light. </span> 
-<span class="v">36&#160;</span><span class="wj">But the testimony which I have is greater than that of John; for the works which the Father gave me to accomplish, the very works that I do, testify about me, that the Father has sent me. </span> 
-<span class="v">37&#160;</span><span class="wj">The Father himself, who sent me, has testified about me. You have neither heard his voice at any time, nor seen his form. </span> 
-<span class="v">38&#160;</span><span class="wj">You don’t have his word living in you, because you don’t believe him whom he sent.</span> 
-</p><p>
-<span class="v">39&#160;</span><span class="wj">“You search the Scriptures, because you think that in them you have eternal life; and these are they which testify about me. </span> 
-<span class="v">40&#160;</span><span class="wj">Yet you will not come to me, that you may have life. </span> 
-<span class="v">41&#160;</span><span class="wj">I don’t receive glory from men. </span> 
-<span class="v">42&#160;</span><span class="wj">But I know you, that you don’t have Elohim’s love in yourselves. </span> 
-<span class="v">43&#160;</span><span class="wj">I have come in my Father’s name, and you don’t receive me. If another comes in his own name, you will receive him. </span> 
-<span class="v">44&#160;</span><span class="wj">How can you believe, who receive glory from one another, and you don’t seek the glory that comes from the only Elohim?</span> 
-</p><p>
-<span class="v">45&#160;</span><span class="wj">“Don’t think that I will accuse you to the Father. There is one who accuses you, even Moses, on whom you have set your hope. </span> 
-<span class="v">46&#160;</span><span class="wj">For if you believed Moses, you would believe me; for he wrote about me. </span> 
-<span class="v">47&#160;</span><span class="wj">But if you don’t believe his writings, how will you believe my words?”</span> 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>After these things, Yahushua went away to the other side of the sea of Galilee, which is also called the Sea of Tiberias. 
-<span class="v">2&#160;</span>A great multitude followed him, because they saw his signs which he did on those who were sick. 
-<span class="v">3&#160;</span>Yahushua went up into the mountain, and he sat there with his disciples. 
-<span class="v">4&#160;</span>Now the Passover, the feast of the Jews, was at hand. 
-<span class="v">5&#160;</span>Yahushua therefore, lifting up his eyes and seeing that a great multitude was coming to him, said to Philip, <span class="wj">“Where are we to buy bread, that these may eat?”</span> 
-<span class="v">6&#160;</span>He said this to test him, for he himself knew what he would do. 
-</p><p>
-<span class="v">7&#160;</span>Philip answered him, “Two hundred denarii<span class="f">+ \fr 6:7 \ft A denarius was a silver coin worth about a day’s wages for an agricultural laborer, so 200 denarii would be between 6 and 7 month’s pay.</span> worth of bread is not sufficient for them, that every one of them may receive a little.” 
-</p><p>
-<span class="v">8&#160;</span>One of his disciples, Andrew, Simon Peter’s brother, said to him, 
-<span class="v">9&#160;</span>“There is a boy here who has five barley loaves and two fish, but what are these among so many?” 
-</p><p>
-<span class="v">10&#160;</span>Yahushua said, <span class="wj">“Have the people sit down.”</span> Now there was much grass in that place. So the men sat down, in number about five thousand. 
-<span class="v">11&#160;</span>Yahushua took the loaves, and having given thanks, he distributed to the disciples, and the disciples to those who were sitting down, likewise also of the fish as much as they desired. 
-<span class="v">12&#160;</span>When they were filled, he said to his disciples, <span class="wj">“Gather up the broken pieces which are left over, that nothing be lost.”</span> 
-<span class="v">13&#160;</span>So they gathered them up, and filled twelve baskets with broken pieces from the five barley loaves, which were left over by those who had eaten. 
-<span class="v">14&#160;</span>When therefore the people saw the sign which Yahushua did, they said, “This is truly the prophet who comes into the world.” 
-<span class="v">15&#160;</span>Yahushua therefore, perceiving that they were about to come and take him by force to make him king, withdrew again to the mountain by himself. 
-</p><p>
-<span class="v">16&#160;</span>When evening came, his disciples went down to the sea. 
-<span class="v">17&#160;</span>They entered into the boat, and were going over the sea to Capernaum. It was now dark, and Yahushua had not come to them. 
-<span class="v">18&#160;</span>The sea was tossed by a great wind blowing. 
-<span class="v">19&#160;</span>When therefore they had rowed about twenty-five or thirty stadia,<span class="f">+ \fr 6:19 \ft 25 to 30 stadia is about 5 to 6 kilometers or about 3 to 4 miles</span> they saw Yahushua walking on the sea<span class="x">+ \xo 6:19 \xt See Job 9:8</span> and drawing near to the boat; and they were afraid. 
-<span class="v">20&#160;</span>But he said to them, <span class="wj">“It is I.</span><span class="f">+ \fr 6:20 \ft or, I AM</span> <span class="wj">Don’t be afraid.”</span> 
-<span class="v">21&#160;</span>They were willing therefore to receive him into the boat. Immediately the boat was at the land where they were going. 
-</p><p>
-<span class="v">22&#160;</span>On the next day, the multitude that stood on the other side of the sea saw that there was no other boat there, except the one in which his disciples had embarked, and that Yahushua hadn’t entered with his disciples into the boat, but his disciples had gone away alone. 
-<span class="v">23&#160;</span>However, boats from Tiberias came near to the place where they ate the bread after the Lord had given thanks. 
-<span class="v">24&#160;</span>When the multitude therefore saw that Yahushua wasn’t there, nor his disciples, they themselves got into the boats and came to Capernaum, seeking Yahushua. 
-<span class="v">25&#160;</span>When they found him on the other side of the sea, they asked him, “Rabbi, when did you come here?” 
-</p><p>
-<span class="v">26&#160;</span>Yahushua answered them, <span class="wj">“Most certainly I tell you, you seek me, not because you saw signs, but because you ate of the loaves and were filled. </span> 
-<span class="v">27&#160;</span><span class="wj">Don’t work for the food which perishes, but for the food which remains to eternal life, which the Son of Man will give to you. For Elohim the Father has sealed him.”</span> 
-</p><p>
-<span class="v">28&#160;</span>They said therefore to him, “What must we do, that we may work the works of Elohim?” 
-</p><p>
-<span class="v">29&#160;</span>Yahushua answered them, <span class="wj">“This is the work of Elohim, that you believe in him whom he has sent.”</span> 
-</p><p>
-<span class="v">30&#160;</span>They said therefore to him, “What then do you do for a sign, that we may see and believe you? What work do you do? 
-<span class="v">31&#160;</span>Our fathers ate the manna in the wilderness. As it is written, ‘He gave them bread out of heaven<span class="f">+ \fr 6:31 \ft Greek and Hebrew use the same word for “heaven”, “the heavens”, “the sky”, and “the air”.</span> to eat.’&#160;”<span class="x">+ \xo 6:31 \xt Exodus 16:4; Nehemiah 9:15; Psalm 78:24-25</span> 
-</p><p>
-<span class="v">32&#160;</span>Yahushua therefore said to them, <span class="wj">“Most certainly, I tell you, it wasn’t Moses who gave you the bread out of heaven, but my Father gives you the true bread out of heaven. </span> 
-<span class="v">33&#160;</span><span class="wj">For the bread of Elohim is that which comes down out of heaven and gives life to the world.”</span> 
-</p><p>
-<span class="v">34&#160;</span>They said therefore to him, “Lord, always give us this bread.” 
-</p><p>
-<span class="v">35&#160;</span>Yahushua said to them, <span class="wj">“I am the bread of life. Whoever comes to me will not be hungry, and whoever believes in me will never be thirsty. </span> 
-<span class="v">36&#160;</span><span class="wj">But I told you that you have seen me, and yet you don’t believe. </span> 
-<span class="v">37&#160;</span><span class="wj">All those whom the Father gives me will come to me. He who comes to me I will in no way throw out. </span> 
-<span class="v">38&#160;</span><span class="wj">For I have come down from heaven, not to do my own will, but the will of him who sent me. </span> 
-<span class="v">39&#160;</span><span class="wj">This is the will of my Father who sent me, that of all he has given to me I should lose nothing, but should raise him up at the last day. </span> 
-<span class="v">40&#160;</span><span class="wj">This is the will of the one who sent me, that everyone who sees the Son and believes in him should have eternal life; and I will raise him up at the last day.”</span> 
-</p><p>
-<span class="v">41&#160;</span>The Jews therefore murmured concerning him, because he said, <span class="wj">“I am the bread which came down out of heaven.”</span> 
-<span class="v">42&#160;</span>They said, “Isn’t this Yahushua, the son of Joseph, whose father and mother we know? How then does he say, <span class="wj">‘I have come down out of heaven’?” </span> 
-</p><p>
-<span class="v">43&#160;</span>Therefore Yahushua answered them, <span class="wj">“Don’t murmur among yourselves. </span> 
-<span class="v">44&#160;</span><span class="wj">No one can come to me unless the Father who sent me draws him; and I will raise him up in the last day. </span> 
-<span class="v">45&#160;</span><span class="wj">It is written in the prophets, ‘They will all be taught by Elohim.’ </span> <span class="x">+ \xo 6:45 \xt Isaiah 54:13</span> <span class="wj">Therefore everyone who hears from the Father and has learned, comes to me. </span> 
-<span class="v">46&#160;</span><span class="wj">Not that anyone has seen the Father, except he who is from Elohim. He has seen the Father. </span> 
-<span class="v">47&#160;</span><span class="wj">Most certainly, I tell you, he who believes in me has eternal life. </span> 
-<span class="v">48&#160;</span><span class="wj">I am the bread of life. </span> 
-<span class="v">49&#160;</span><span class="wj">Your fathers ate the manna in the wilderness and they died. </span> 
-<span class="v">50&#160;</span><span class="wj">This is the bread which comes down out of heaven, that anyone may eat of it and not die. </span> 
-<span class="v">51&#160;</span><span class="wj">I am the living bread which came down out of heaven. If anyone eats of this bread, he will live forever. Yes, the bread which I will give for the life of the world is my flesh.”</span> 
-</p><p>
-<span class="v">52&#160;</span>The Jews therefore contended with one another, saying, “How can this man give us his flesh to eat?” 
-</p><p>
-<span class="v">53&#160;</span>Yahushua therefore said to them, <span class="wj">“Most certainly I tell you, unless you eat the flesh of the Son of Man and drink his blood, you don’t have life in yourselves. </span> 
-<span class="v">54&#160;</span><span class="wj">He who eats my flesh and drinks my blood has eternal life, and I will raise him up at the last day. </span> 
-<span class="v">55&#160;</span><span class="wj">For my flesh is food indeed, and my blood is drink indeed. </span> 
-<span class="v">56&#160;</span><span class="wj">He who eats my flesh and drinks my blood lives in me, and I in him. </span> 
-<span class="v">57&#160;</span><span class="wj">As the living Father sent me, and I live because of the Father, so he who feeds on me will also live because of me. </span> 
-<span class="v">58&#160;</span><span class="wj">This is the bread which came down out of heaven—not as our fathers ate the manna and died. He who eats this bread will live forever.”</span> 
-<span class="v">59&#160;</span>He said these things in the synagogue, as he taught in Capernaum. 
-</p><p>
-<span class="v">60&#160;</span>Therefore many of his disciples, when they heard this, said, “This is a hard saying! Who can listen to it?” 
-</p><p>
-<span class="v">61&#160;</span>But Yahushua knowing in himself that his disciples murmured at this, said to them, <span class="wj">“Does this cause you to stumble? </span> 
-<span class="v">62&#160;</span><span class="wj">Then what if you would see the Son of Man ascending to where he was before? </span> 
-<span class="v">63&#160;</span><span class="wj">It is the spirit who gives life. The flesh profits nothing. The words that I speak to you are spirit, and are life. </span> 
-<span class="v">64&#160;</span><span class="wj">But there are some of you who don’t believe.”</span> For Yahushua knew from the beginning who they were who didn’t believe, and who it was who would betray him. 
-<span class="v">65&#160;</span>He said, <span class="wj">“For this cause I have said to you that no one can come to me, unless it is given to him by my Father.”</span> 
-</p><p>
-<span class="v">66&#160;</span>At this, many of his disciples went back and walked no more with him. 
-<span class="v">67&#160;</span>Yahushua said therefore to the twelve, <span class="wj">“You don’t also want to go away, do you?”</span> 
-</p><p>
-<span class="v">68&#160;</span>Simon Peter answered him, “Lord, to whom would we go? You have the words of eternal life. 
-<span class="v">69&#160;</span>We have come to believe and know that you are the Christ, the Son of the living Elohim.” 
-</p><p>
-<span class="v">70&#160;</span>Yahushua answered them, <span class="wj">“Didn’t I choose you, the twelve, and one of you is a devil?”</span> 
-<span class="v">71&#160;</span>Now he spoke of Judas, the son of Simon Iscariot, for it was he who would betray him, being one of the twelve. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>After these things, Yahushua was walking in Galilee, for he wouldn’t walk in Judea, because the Jews sought to kill him. 
-<span class="v">2&#160;</span>Now the feast of the Jews, the Feast of Booths, was at hand. 
-<span class="v">3&#160;</span>His brothers therefore said to him, “Depart from here and go into Judea, that your disciples also may see your works which you do. 
-<span class="v">4&#160;</span>For no one does anything in secret while he seeks to be known openly. If you do these things, reveal yourself to the world.” 
-<span class="v">5&#160;</span>For even his brothers didn’t believe in him. 
-</p><p>
-<span class="v">6&#160;</span>Yahushua therefore said to them, <span class="wj">“My time has not yet come, but your time is always ready. </span> 
-<span class="v">7&#160;</span><span class="wj">The world can’t hate you, but it hates me, because I testify about it, that its works are evil. </span> 
-<span class="v">8&#160;</span><span class="wj">You go up to the feast. I am not yet going up to this feast, because my time is not yet fulfilled.”</span> 
-</p><p>
-<span class="v">9&#160;</span>Having said these things to them, he stayed in Galilee. 
-<span class="v">10&#160;</span>But when his brothers had gone up to the feast, then he also went up, not publicly, but as it were in secret. 
-<span class="v">11&#160;</span>The Jews therefore sought him at the feast, and said, “Where is he?” 
-<span class="v">12&#160;</span>There was much murmuring among the multitudes concerning him. Some said, “He is a good man.” Others said, “Not so, but he leads the multitude astray.” 
-<span class="v">13&#160;</span>Yet no one spoke openly of him for fear of the Jews. 
-<span class="v">14&#160;</span>But when it was now the middle of the feast, Yahushua went up into the temple and taught. 
-<span class="v">15&#160;</span>The Jews therefore marveled, saying, “How does this man know letters, having never been educated?” 
-</p><p>
-<span class="v">16&#160;</span>Yahushua therefore answered them, <span class="wj">“My teaching is not mine, but his who sent me. </span> 
-<span class="v">17&#160;</span><span class="wj">If anyone desires to do his will, he will know about the teaching, whether it is from Elohim or if I am speaking from myself. </span> 
-<span class="v">18&#160;</span><span class="wj">He who speaks from himself seeks his own glory, but he who seeks the glory of him who sent him is true, and no unrighteousness is in him. </span> 
-<span class="v">19&#160;</span><span class="wj">Didn’t Moses give you the law, and yet none of you keeps the law? Why do you seek to kill me?”</span> 
-</p><p>
-<span class="v">20&#160;</span>The multitude answered, “You have a demon! Who seeks to kill you?” 
-</p><p>
-<span class="v">21&#160;</span>Yahushua answered them, <span class="wj">“I did one work and you all marvel because of it. </span> 
-<span class="v">22&#160;</span><span class="wj">Moses has given you circumcision (not that it is of Moses, but of the fathers), and on the Sabbath you circumcise a boy. </span> 
-<span class="v">23&#160;</span><span class="wj">If a boy receives circumcision on the Sabbath, that the law of Moses may not be broken, are you angry with me because I made a man completely healthy on the Sabbath? </span> 
-<span class="v">24&#160;</span><span class="wj">Don’t judge according to appearance, but judge righteous judgment.” </span> 
-</p><p>
-<span class="v">25&#160;</span>Therefore some of them of Jerusalem said, “Isn’t this he whom they seek to kill? 
-<span class="v">26&#160;</span>Behold, he speaks openly, and they say nothing to him. Can it be that the rulers indeed know that this is truly the Christ? 
-<span class="v">27&#160;</span>However, we know where this man comes from, but when the Christ comes, no one will know where he comes from.” 
-</p><p>
-<span class="v">28&#160;</span>Yahushua therefore cried out in the temple, teaching and saying, <span class="wj">“You both know me, and know where I am from. I have not come of myself, but he who sent me is true, whom you don’t know. </span> 
-<span class="v">29&#160;</span><span class="wj">I know him, because I am from him, and he sent me.”</span> 
-</p><p>
-<span class="v">30&#160;</span>They sought therefore to take him; but no one laid a hand on him, because his hour had not yet come. 
-<span class="v">31&#160;</span>But of the multitude, many believed in him. They said, “When the Christ comes, he won’t do more signs than those which this man has done, will he?” 
-<span class="v">32&#160;</span>The Pharisees heard the multitude murmuring these things concerning him, and the chief priests and the Pharisees sent officers to arrest him. 
-</p><p>
-<span class="v">33&#160;</span>Then Yahushua said, <span class="wj">“I will be with you a little while longer, then I go to him who sent me. </span> 
-<span class="v">34&#160;</span><span class="wj">You will seek me and won’t find me. You can’t come where I am.”</span> 
-</p><p>
-<span class="v">35&#160;</span>The Jews therefore said among themselves, “Where will this man go that we won’t find him? Will he go to the Dispersion among the Greeks and teach the Greeks? 
-<span class="v">36&#160;</span>What is this word that he said, <span class="wj">‘You will seek me, and won’t find me;’</span> and <span class="wj">‘Where I am, you can’t come’</span>?” 
-</p><p>
-<span class="v">37&#160;</span>Now on the last and greatest day of the feast, Yahushua stood and cried out, <span class="wj">“If anyone is thirsty, let him come to me and drink! </span> 
-<span class="v">38&#160;</span><span class="wj">He who believes in me, as the Scripture has said, from within him will flow rivers of living water.”</span> 
-<span class="v">39&#160;</span>But he said this about the Spirit, which those believing in him were to receive. For the Set-Apart Spirit was not yet given, because Yahushua wasn’t yet glorified. 
-</p><p>
-<span class="v">40&#160;</span>Many of the multitude therefore, when they heard these words, said, “This is truly the prophet.” 
-<span class="v">41&#160;</span>Others said, “This is the Christ.” But some said, “What, does the Christ come out of Galilee? 
-<span class="v">42&#160;</span>Hasn’t the Scripture said that the Christ comes of the offspring<span class="f">+ \fr 7:42 \ft or, seed</span> of David, <span class="x">+ \xo 7:42 \xt 2 Samuel 7:12</span> and from Bethlehem,<span class="x">+ \xo 7:42 \xt Micah 5:2</span> the village where David was?” 
-<span class="v">43&#160;</span>So a division arose in the multitude because of him. 
-<span class="v">44&#160;</span>Some of them would have arrested him, but no one laid hands on him. 
-<span class="v">45&#160;</span>The officers therefore came to the chief priests and Pharisees; and they said to them, “Why didn’t you bring him?” 
-</p><p>
-<span class="v">46&#160;</span>The officers answered, “No man ever spoke like this man!” 
-</p><p>
-<span class="v">47&#160;</span>The Pharisees therefore answered them, “You aren’t also led astray, are you? 
-<span class="v">48&#160;</span>Have any of the rulers or any of the Pharisees believed in him? 
-<span class="v">49&#160;</span>But this multitude that doesn’t know the law is cursed.” 
-</p><p>
-<span class="v">50&#160;</span>Nicodemus (he who came to him by night, being one of them) said to them, 
-<span class="v">51&#160;</span>“Does our law judge a man unless it first hears from him personally and knows what he does?” 
-</p><p>
-<span class="v">52&#160;</span>They answered him, “Are you also from Galilee? Search and see that no prophet has arisen out of Galilee.”<span class="x">+ \xo 7:52 \xt See Isaiah 9:1; Matthew 4:13-16</span> 
-</p><p>
-<span class="v">53&#160;</span>Everyone went to his own house, 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p class="nb">
-<span class="v">1&#160;</span>but Yahushua went to the Mount of Olives. 
-</p><p>
-<span class="v">2&#160;</span>Now very early in the morning, he came again into the temple, and all the people came to him. He sat down and taught them. 
-<span class="v">3&#160;</span>The scribes and the Pharisees brought a woman taken in adultery. Having set her in the middle, 
-<span class="v">4&#160;</span>they told him, “Teacher, we found this woman in adultery, in the very act. 
-<span class="v">5&#160;</span>Now in our law, Moses commanded us to stone such women.<span class="x">+ \xo 8:5 \xt Leviticus 20:10; Deuteronomy 22:22</span> What then do you say about her?” 
-<span class="v">6&#160;</span>They said this testing him, that they might have something to accuse him of. 
-</p><p>But Yahushua stooped down and wrote on the ground with his finger. 
-<span class="v">7&#160;</span>But when they continued asking him, he looked up and said to them, <span class="wj">“He who is without sin among you, let him throw the first stone at her.” </span> 
-<span class="v">8&#160;</span>Again he stooped down and wrote on the ground with his finger. 
-</p><p>
-<span class="v">9&#160;</span>They, when they heard it, being convicted by their conscience, went out one by one, beginning from the oldest, even to the last. Yahushua was left alone with the woman where she was, in the middle. 
-<span class="v">10&#160;</span>Yahushua, standing up, saw her and said, <span class="wj">“Woman, where are your accusers? Did no one condemn you?”</span> 
-</p><p>
-<span class="v">11&#160;</span>She said, “No one, Lord.” 
-</p><p>Yahushua said, <span class="wj">“Neither do I condemn you. Go your way. From now on, sin no more.”</span><span class="f">+ \fr 8:11 \ft NU includes John 7:53–John 8:11, but puts brackets around it to indicate that the textual critics had less confidence that this was original.</span> 
-</p><p>
-<span class="v">12&#160;</span>Again, therefore, Yahushua spoke to them, saying, <span class="wj">“I am the light of the world.</span><span class="x">+ \xo 8:12 \xt Isaiah 60:1</span> <span class="wj">He who follows me will not walk in the darkness, but will have the light of life.”</span> 
-</p><p>
-<span class="v">13&#160;</span>The Pharisees therefore said to him, “You testify about yourself. Your testimony is not valid.” 
-</p><p>
-<span class="v">14&#160;</span>Yahushua answered them, <span class="wj">“Even if I testify about myself, my testimony is true, for I know where I came from, and where I am going; but you don’t know where I came from, or where I am going. </span> 
-<span class="v">15&#160;</span><span class="wj">You judge according to the flesh. I judge no one. </span> 
-<span class="v">16&#160;</span><span class="wj">Even if I do judge, my judgment is true, for I am not alone, but I am with the Father who sent me. </span> 
-<span class="v">17&#160;</span><span class="wj">It’s also written in your law that the testimony of two people is valid.</span><span class="x">+ \xo 8:17 \xt Deuteronomy 17:6; 19:15</span> 
-<span class="v">18&#160;</span><span class="wj">I am one who testifies about myself, and the Father who sent me testifies about me.”</span> 
-</p><p>
-<span class="v">19&#160;</span>They said therefore to him, “Where is your Father?” 
-</p><p>Yahushua answered, <span class="wj">“You know neither me nor my Father. If you knew me, you would know my Father also.”</span> 
-<span class="v">20&#160;</span>Yahushua spoke these words in the treasury, as he taught in the temple. Yet no one arrested him, because his hour had not yet come. 
-<span class="v">21&#160;</span>Yahushua said therefore again to them, <span class="wj">“I am going away, and you will seek me, and you will die in your sins. Where I go, you can’t come.” </span> 
-</p><p>
-<span class="v">22&#160;</span>The Jews therefore said, “Will he kill himself, because he says, <span class="wj">‘Where I am going, you can’t come’</span>?” 
-</p><p>
-<span class="v">23&#160;</span>He said to them, <span class="wj">“You are from beneath. I am from above. You are of this world. I am not of this world. </span> 
-<span class="v">24&#160;</span><span class="wj">I said therefore to you that you will die in your sins; for unless you believe that I am</span><span class="f">+ \fr 8:24 \ft or, I AM</span> <span class="wj">he, you will die in your sins.” </span> 
-</p><p>
-<span class="v">25&#160;</span>They said therefore to him, “Who are you?” 
-</p><p>Yahushua said to them, <span class="wj">“Just what I have been saying to you from the beginning. </span> 
-<span class="v">26&#160;</span><span class="wj">I have many things to speak and to judge concerning you. However, he who sent me is true; and the things which I heard from him, these I say to the world.”</span> 
-</p><p>
-<span class="v">27&#160;</span>They didn’t understand that he spoke to them about the Father. 
-<span class="v">28&#160;</span>Yahushua therefore said to them, <span class="wj">“When you have lifted up the Son of Man, then you will know that I am he, and I do nothing of myself, but as my Father taught me, I say these things. </span> 
-<span class="v">29&#160;</span><span class="wj">He who sent me is with me. The Father hasn’t left me alone, for I always do the things that are pleasing to him.”</span> 
-</p><p>
-<span class="v">30&#160;</span>As he spoke these things, many believed in him. 
-<span class="v">31&#160;</span>Yahushua therefore said to those Jews who had believed him, <span class="wj">“If you remain in my word, then you are truly my disciples. </span> 
-<span class="v">32&#160;</span><span class="wj">You will know the truth, and the truth will make you free.” </span><span class="x">+ \xo 8:32 \xt Psalm 119:45</span> 
-</p><p>
-<span class="v">33&#160;</span>They answered him, “We are Abraham’s offspring, and have never been in bondage to anyone. How do you say, <span class="wj">‘You will be made free’</span>?” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua answered them, <span class="wj">“Most certainly I tell you, everyone who commits sin is the bondservant of sin. </span> 
-<span class="v">35&#160;</span><span class="wj">A bondservant doesn’t live in the house forever. A son remains forever. </span> 
-<span class="v">36&#160;</span><span class="wj">If therefore the Son makes you free, you will be free indeed. </span> 
-<span class="v">37&#160;</span><span class="wj">I know that you are Abraham’s offspring, yet you seek to kill me, because my word finds no place in you. </span> 
-<span class="v">38&#160;</span><span class="wj">I say the things which I have seen with my Father; and you also do the things which you have seen with your father.”</span> 
-</p><p>
-<span class="v">39&#160;</span>They answered him, “Our father is Abraham.” 
-</p><p>Yahushua said to them, <span class="wj">“If you were Abraham’s children, you would do the works of Abraham. </span> 
-<span class="v">40&#160;</span><span class="wj">But now you seek to kill me, a man who has told you the truth which I heard from Elohim. Abraham didn’t do this. </span> 
-<span class="v">41&#160;</span><span class="wj">You do the works of your father.”</span> 
-</p><p>They said to him, “We were not born of sexual immorality. We have one Father, Elohim.” 
-</p><p>
-<span class="v">42&#160;</span>Therefore Yahushua said to them, <span class="wj">“If Elohim were your father, you would love me, for I came out and have come from Elohim. For I haven’t come of myself, but he sent me. </span> 
-<span class="v">43&#160;</span><span class="wj">Why don’t you understand my speech? Because you can’t hear my word. </span> 
-<span class="v">44&#160;</span><span class="wj">You are of your father the devil, and you want to do the desires of your father. He was a murderer from the beginning, and doesn’t stand in the truth, because there is no truth in him. When he speaks a lie, he speaks on his own; for he is a liar, and the father of lies. </span> 
-<span class="v">45&#160;</span><span class="wj">But because I tell the truth, you don’t believe me. </span> 
-<span class="v">46&#160;</span><span class="wj">Which of you convicts me of sin? If I tell the truth, why do you not believe me? </span> 
-<span class="v">47&#160;</span><span class="wj">He who is of Elohim hears the words of Elohim. For this cause you don’t hear, because you are not of Elohim.”</span> 
-</p><p>
-<span class="v">48&#160;</span>Then the Jews answered him, “Don’t we say well that you are a Samaritan, and have a demon?” 
-</p><p>
-<span class="v">49&#160;</span>Yahushua answered, <span class="wj">“I don’t have a demon, but I honor my Father and you dishonor me. </span> 
-<span class="v">50&#160;</span><span class="wj">But I don’t seek my own glory. There is one who seeks and judges. </span> 
-<span class="v">51&#160;</span><span class="wj">Most certainly, I tell you, if a person keeps my word, he will never see death.”</span> 
-</p><p>
-<span class="v">52&#160;</span>Then the Jews said to him, “Now we know that you have a demon. Abraham died, as did the prophets; and you say, <span class="wj">‘If a man keeps my word, he will never taste of death.’</span> 
-<span class="v">53&#160;</span>Are you greater than our father Abraham, who died? The prophets died. Who do you make yourself out to be?” 
-</p><p>
-<span class="v">54&#160;</span>Yahushua answered, <span class="wj">“If I glorify myself, my glory is nothing. It is my Father who glorifies me, of whom you say that he is our Elohim. </span> 
-<span class="v">55&#160;</span><span class="wj">You have not known him, but I know him. If I said, ‘I don’t know him,’ I would be like you, a liar. But I know him and keep his word. </span> 
-<span class="v">56&#160;</span><span class="wj">Your father Abraham rejoiced to see my day. He saw it and was glad.”</span> 
-</p><p>
-<span class="v">57&#160;</span>The Jews therefore said to him, “You are not yet fifty years old! Have you seen Abraham?” 
-</p><p>
-<span class="v">58&#160;</span>Yahushua said to them, <span class="wj">“Most certainly, I tell you, before Abraham came into existence, I was.</span><span class="x">+ \xo 8:58 \xt Exodus 3:14</span><span class="wj">”</span> 
-</p><p>
-<span class="v">59&#160;</span>Therefore they took up stones to throw at him, but Yahushua hid himself and went out of the temple, having gone through the middle of them, and so passed by. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>As he passed by, he saw a man blind from birth. 
-<span class="v">2&#160;</span>His disciples asked him, “Rabbi, who sinned, this man or his parents, that he was born blind?” 
-</p><p>
-<span class="v">3&#160;</span>Yahushua answered, <span class="wj">“This man didn’t sin, nor did his parents, but that the works of Elohim might be revealed in him. </span> 
-<span class="v">4&#160;</span><span class="wj">I must work the works of him who sent me while it is day. The night is coming, when no one can work. </span> 
-<span class="v">5&#160;</span><span class="wj">While I am in the world, I am the light of the world.”</span> 
-<span class="v">6&#160;</span>When he had said this, he spat on the ground, made mud with the saliva, anointed the blind man’s eyes with the mud, 
-<span class="v">7&#160;</span>and said to him, <span class="wj">“Go, wash in the pool of Siloam”</span> (which means “Sent”). So he went away, washed, and came back seeing. 
-</p><p>
-<span class="v">8&#160;</span>Therefore the neighbors and those who saw that he was blind before said, “Isn’t this he who sat and begged?” 
-<span class="v">9&#160;</span>Others were saying, “It is he.” Still others were saying, “He looks like him.” 
-</p><p>He said, “I am he.” 
-</p><p>
-<span class="v">10&#160;</span>They therefore were asking him, “How were your eyes opened?” 
-</p><p>
-<span class="v">11&#160;</span>He answered, “A man called Yahushua made mud, anointed my eyes, and said to me, <span class="wj">‘Go to the pool of Siloam and wash.’</span> So I went away and washed, and I received sight.” 
-</p><p>
-<span class="v">12&#160;</span>Then they asked him, “Where is he?” 
-</p><p>He said, “I don’t know.” 
-</p><p>
-<span class="v">13&#160;</span>They brought him who had been blind to the Pharisees. 
-<span class="v">14&#160;</span>It was a Sabbath when Yahushua made the mud and opened his eyes. 
-<span class="v">15&#160;</span>Again therefore the Pharisees also asked him how he received his sight. He said to them, “He put mud on my eyes, I washed, and I see.” 
-</p><p>
-<span class="v">16&#160;</span>Some therefore of the Pharisees said, “This man is not from Elohim, because he doesn’t keep the Sabbath.” 
-</p><p>Others said, “How can a man who is a sinner do such signs?” So there was division among them. 
-</p><p>
-<span class="v">17&#160;</span>Therefore they asked the blind man again, “What do you say about him, because he opened your eyes?” 
-</p><p>He said, “He is a prophet.” 
-</p><p>
-<span class="v">18&#160;</span>The Jews therefore didn’t believe concerning him, that he had been blind and had received his sight, until they called the parents of him who had received his sight, 
-<span class="v">19&#160;</span>and asked them, “Is this your son, whom you say was born blind? How then does he now see?” 
-</p><p>
-<span class="v">20&#160;</span>His parents answered them, “We know that this is our son, and that he was born blind; 
-<span class="v">21&#160;</span>but how he now sees, we don’t know; or who opened his eyes, we don’t know. He is of age. Ask him. He will speak for himself.” 
-<span class="v">22&#160;</span>His parents said these things because they feared the Jews; for the Jews had already agreed that if any man would confess him as Christ, he would be put out of the synagogue. 
-<span class="v">23&#160;</span>Therefore his parents said, “He is of age. Ask him.” 
-</p><p>
-<span class="v">24&#160;</span>So they called the man who was blind a second time, and said to him, “Give glory to Elohim. We know that this man is a sinner.” 
-</p><p>
-<span class="v">25&#160;</span>He therefore answered, “I don’t know if he is a sinner. One thing I do know: that though I was blind, now I see.” 
-</p><p>
-<span class="v">26&#160;</span>They said to him again, “What did he do to you? How did he open your eyes?” 
-</p><p>
-<span class="v">27&#160;</span>He answered them, “I told you already, and you didn’t listen. Why do you want to hear it again? You don’t also want to become his disciples, do you?” 
-</p><p>
-<span class="v">28&#160;</span>They insulted him and said, “You are his disciple, but we are disciples of Moses. 
-<span class="v">29&#160;</span>We know that Elohim has spoken to Moses. But as for this man, we don’t know where he comes from.” 
-</p><p>
-<span class="v">30&#160;</span>The man answered them, “How amazing! You don’t know where he comes from, yet he opened my eyes. 
-<span class="v">31&#160;</span>We know that Elohim doesn’t listen to sinners, but if anyone is a worshiper of Elohim and does his will, he listens to him.<span class="x">+ \xo 9:31 \xt Psalm 66:18; Proverbs 15:29; 28:9</span> 
-<span class="v">32&#160;</span>Since the world began it has never been heard of that anyone opened the eyes of someone born blind. 
-<span class="v">33&#160;</span>If this man were not from Elohim, he could do nothing.” 
-</p><p>
-<span class="v">34&#160;</span>They answered him, “You were altogether born in sins, and do you teach us?” Then they threw him out. 
-</p><p>
-<span class="v">35&#160;</span>Yahushua heard that they had thrown him out, and finding him, he said, <span class="wj">“Do you believe in the Son of Elohim?”</span> 
-</p><p>
-<span class="v">36&#160;</span>He answered, “Who is he, Lord, that I may believe in him?” 
-</p><p>
-<span class="v">37&#160;</span>Yahushua said to him, <span class="wj">“You have both seen him, and it is he who speaks with you.”</span> 
-</p><p>
-<span class="v">38&#160;</span>He said, “Lord, I believe!” and he worshiped him. 
-</p><p>
-<span class="v">39&#160;</span>Yahushua said, <span class="wj">“I came into this world for judgment, that those who don’t see may see; and that those who see may become blind.”</span> 
-</p><p>
-<span class="v">40&#160;</span>Those of the Pharisees who were with him heard these things, and said to him, “Are we also blind?” 
-</p><p>
-<span class="v">41&#160;</span>Yahushua said to them, <span class="wj">“If you were blind, you would have no sin; but now you say, ‘We see.’ Therefore your sin remains.</span> 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“Most certainly, I tell you, one who doesn’t enter by the door into the sheep fold, but climbs up some other way, is a thief and a robber. </span> 
-<span class="v">2&#160;</span><span class="wj">But one who enters in by the door is the shepherd of the sheep. </span> 
-<span class="v">3&#160;</span><span class="wj">The gatekeeper opens the gate for him, and the sheep listen to his voice. He calls his own sheep by name and leads them out. </span> 
-<span class="v">4&#160;</span><span class="wj">Whenever he brings out his own sheep, he goes before them; and the sheep follow him, for they know his voice. </span> 
-<span class="v">5&#160;</span><span class="wj">They will by no means follow a stranger, but will flee from him; for they don’t know the voice of strangers.”</span> 
-<span class="v">6&#160;</span>Yahushua spoke this parable to them, but they didn’t understand what he was telling them. 
-</p><p>
-<span class="v">7&#160;</span>Yahushua therefore said to them again, <span class="wj">“Most certainly, I tell you, I am the sheep’s door. </span> 
-<span class="v">8&#160;</span><span class="wj">All who came before me are thieves and robbers, but the sheep didn’t listen to them. </span> 
-<span class="v">9&#160;</span><span class="wj">I am the door. If anyone enters in by me, he will be saved, and will go in and go out and will find pasture. </span> 
-<span class="v">10&#160;</span><span class="wj">The thief only comes to steal, kill, and destroy. I came that they may have life, and may have it abundantly. </span> 
-</p><p>
-<span class="v">11&#160;</span><span class="wj">“I am the good shepherd.</span><span class="x">+ \xo 10:11 \xt Isaiah 40:11; Ezekiel 34:11-12,15,22</span> <span class="wj">The good shepherd lays down his life for the sheep. </span> 
-<span class="v">12&#160;</span><span class="wj">He who is a hired hand, and not a shepherd, who doesn’t own the sheep, sees the wolf coming, leaves the sheep, and flees. The wolf snatches the sheep and scatters them. </span> 
-<span class="v">13&#160;</span><span class="wj">The hired hand flees because he is a hired hand and doesn’t care for the sheep. </span> 
-<span class="v">14&#160;</span><span class="wj">I am the good shepherd. I know my own, and I’m known by my own; </span> 
-<span class="v">15&#160;</span><span class="wj">even as the Father knows me, and I know the Father. I lay down my life for the sheep. </span> 
-<span class="v">16&#160;</span><span class="wj">I have other sheep which are not of this fold.</span><span class="x">+ \xo 10:16 \xt Isaiah 56:8 </span> <span class="wj">I must bring them also, and they will hear my voice. They will become one flock with one shepherd. </span> 
-<span class="v">17&#160;</span><span class="wj">Therefore the Father loves me, because I lay down my life, </span><span class="x">+ \xo 10:17 \xt Isaiah 53:7-8</span> <span class="wj">that I may take it again. </span> 
-<span class="v">18&#160;</span><span class="wj">No one takes it away from me, but I lay it down by myself. I have power to lay it down, and I have power to take it again. I received this commandment from my Father.”</span> 
-</p><p>
-<span class="v">19&#160;</span>Therefore a division arose again among the Jews because of these words. 
-<span class="v">20&#160;</span>Many of them said, “He has a demon and is insane! Why do you listen to him?” 
-<span class="v">21&#160;</span>Others said, “These are not the sayings of one possessed by a demon. It isn’t possible for a demon to open the eyes of the blind, is it?”<span class="x">+ \xo 10:21 \xt Exodus 4:11</span> 
-</p><p>
-<span class="v">22&#160;</span>It was the Feast of the Dedication<span class="f">+ \fr 10:22 \ft The “Feast of the Dedication” is the Greek name for “Hanukkah”, a celebration of the rededication of the Temple.</span> at Jerusalem. 
-<span class="v">23&#160;</span>It was winter, and Yahushua was walking in the temple, in Solomon’s porch. 
-<span class="v">24&#160;</span>The Jews therefore came around him and said to him, “How long will you hold us in suspense? If you are the Christ, tell us plainly.” 
-</p><p>
-<span class="v">25&#160;</span>Yahushua answered them, <span class="wj">“I told you, and you don’t believe. The works that I do in my Father’s name, these testify about me. </span> 
-<span class="v">26&#160;</span><span class="wj">But you don’t believe, because you are not of my sheep, as I told you. </span> 
-<span class="v">27&#160;</span><span class="wj">My sheep hear my voice, and I know them, and they follow me. </span> 
-<span class="v">28&#160;</span><span class="wj">I give eternal life to them. They will never perish, and no one will snatch them out of my hand. </span> 
-<span class="v">29&#160;</span><span class="wj">My Father who has given them to me is greater than all. No one is able to snatch them out of my Father’s hand. </span> 
-<span class="v">30&#160;</span><span class="wj">I and the Father are one.”</span> 
-</p><p>
-<span class="v">31&#160;</span>Therefore the Jews took up stones again to stone him. 
-<span class="v">32&#160;</span>Yahushua answered them, <span class="wj">“I have shown you many good works from my Father. For which of those works do you stone me?”</span> 
-</p><p>
-<span class="v">33&#160;</span>The Jews answered him, “We don’t stone you for a good work, but for blasphemy, because you, being a man, make yourself Elohim.” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua answered them, <span class="wj">“Isn’t it written in your law, ‘I said, you are elohims’?</span><span class="x">+ \xo 10:34 \xt Psalm 82:6</span> 
-<span class="v">35&#160;</span><span class="wj">If he called them elohims, to whom the word of Elohim came (and the Scripture can’t be broken), </span> 
-<span class="v">36&#160;</span><span class="wj">do you say of him whom the Father sanctified and sent into the world, ‘You blaspheme,’ because I said, ‘I am the Son of Elohim’? </span> 
-<span class="v">37&#160;</span><span class="wj">If I don’t do the works of my Father, don’t believe me. </span> 
-<span class="v">38&#160;</span><span class="wj">But if I do them, though you don’t believe me, believe the works, that you may know and believe that the Father is in me, and I in the Father.” </span> 
-</p><p>
-<span class="v">39&#160;</span>They sought again to seize him, and he went out of their hand. 
-<span class="v">40&#160;</span>He went away again beyond the Jordan into the place where John was baptizing at first, and he stayed there. 
-<span class="v">41&#160;</span>Many came to him. They said, “John indeed did no sign, but everything that John said about this man is true.” 
-<span class="v">42&#160;</span>Many believed in him there. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Now a certain man was sick, Lazarus from Bethany, of the village of Mary and her sister, Martha. 
-<span class="v">2&#160;</span>It was that Mary who had anointed the Lord with ointment and wiped his feet with her hair, whose brother Lazarus was sick. 
-<span class="v">3&#160;</span>The sisters therefore sent to him, saying, “Lord, behold, he for whom you have great affection is sick.” 
-</p><p>
-<span class="v">4&#160;</span>But when Yahushua heard it, he said, <span class="wj">“This sickness is not to death, but for the glory of Elohim, that Elohim’s Son may be glorified by it.”</span> 
-<span class="v">5&#160;</span>Now Yahushua loved Martha, and her sister, and Lazarus. 
-<span class="v">6&#160;</span>When therefore he heard that he was sick, he stayed two days in the place where he was. 
-<span class="v">7&#160;</span>Then after this he said to the disciples, <span class="wj">“Let’s go into Judea again.”</span> 
-</p><p>
-<span class="v">8&#160;</span>The disciples asked him, “Rabbi, the Jews were just trying to stone you. Are you going there again?” 
-</p><p>
-<span class="v">9&#160;</span>Yahushua answered, <span class="wj">“Aren’t there twelve hours of daylight? If a man walks in the day, he doesn’t stumble, because he sees the light of this world. </span> 
-<span class="v">10&#160;</span><span class="wj">But if a man walks in the night, he stumbles, because the light isn’t in him.”</span> 
-<span class="v">11&#160;</span>He said these things, and after that, he said to them, <span class="wj">“Our friend Lazarus has fallen asleep, but I am going so that I may awake him out of sleep.”</span> 
-</p><p>
-<span class="v">12&#160;</span>The disciples therefore said, “Lord, if he has fallen asleep, he will recover.” 
-</p><p>
-<span class="v">13&#160;</span>Now Yahushua had spoken of his death, but they thought that he spoke of taking rest in sleep. 
-<span class="v">14&#160;</span>So Yahushua said to them plainly then, <span class="wj">“Lazarus is dead. </span> 
-<span class="v">15&#160;</span><span class="wj">I am glad for your sakes that I was not there, so that you may believe. Nevertheless, let’s go to him.”</span> 
-</p><p>
-<span class="v">16&#160;</span>Thomas therefore, who is called Didymus,<span class="f">+ \fr 11:16 \ft “Didymus” means “Twin”.</span> said to his fellow disciples, “Let’s also go, that we may die with him.” 
-</p><p>
-<span class="v">17&#160;</span>So when Yahushua came, he found that he had been in the tomb four days already. 
-<span class="v">18&#160;</span>Now Bethany was near Jerusalem, about fifteen stadia<span class="f">+ \fr 11:18 \ft 15 stadia is about 2.8 kilometers or 1.7 miles</span> away. 
-<span class="v">19&#160;</span>Many of the Jews had joined the women around Martha and Mary, to console them concerning their brother. 
-<span class="v">20&#160;</span>Then when Martha heard that Yahushua was coming, she went and met him, but Mary stayed in the house. 
-<span class="v">21&#160;</span>Therefore Martha said to Yahushua, “Lord, if you would have been here, my brother wouldn’t have died. 
-<span class="v">22&#160;</span>Even now I know that whatever you ask of Elohim, Elohim will give you.” 
-</p><p>
-<span class="v">23&#160;</span>Yahushua said to her, <span class="wj">“Your brother will rise again.”</span> 
-</p><p>
-<span class="v">24&#160;</span>Martha said to him, “I know that he will rise again in the resurrection at the last day.” 
-</p><p>
-<span class="v">25&#160;</span>Yahushua said to her, <span class="wj">“I am the resurrection and the life. He who believes in me will still live, even if he dies. </span> 
-<span class="v">26&#160;</span><span class="wj">Whoever lives and believes in me will never die. Do you believe this?”</span> 
-</p><p>
-<span class="v">27&#160;</span>She said to him, “Yes, Lord. I have come to believe that you are the Christ, Elohim’s Son, he who comes into the world.” 
-</p><p>
-<span class="v">28&#160;</span>When she had said this, she went away and called Mary, her sister, secretly, saying, “The Teacher is here and is calling you.” 
-</p><p>
-<span class="v">29&#160;</span>When she heard this, she arose quickly and went to him. 
-<span class="v">30&#160;</span>Now Yahushua had not yet come into the village, but was in the place where Martha met him. 
-<span class="v">31&#160;</span>Then the Jews who were with her in the house and were consoling her, when they saw Mary, that she rose up quickly and went out, followed her, saying, “She is going to the tomb to weep there.” 
-</p><p>
-<span class="v">32&#160;</span>Therefore when Mary came to where Yahushua was and saw him, she fell down at his feet, saying to him, “Lord, if you would have been here, my brother wouldn’t have died.” 
-</p><p>
-<span class="v">33&#160;</span>When Yahushua therefore saw her weeping, and the Jews weeping who came with her, he groaned in the spirit and was troubled, 
-<span class="v">34&#160;</span>and said, <span class="wj">“Where have you laid him?”</span> 
-</p><p>They told him, “Lord, come and see.” 
-</p><p>
-<span class="v">35&#160;</span>Yahushua wept. 
-</p><p>
-<span class="v">36&#160;</span>The Jews therefore said, “See how much affection he had for him!” 
-<span class="v">37&#160;</span>Some of them said, “Couldn’t this man, who opened the eyes of him who was blind, have also kept this man from dying?” 
-</p><p>
-<span class="v">38&#160;</span>Yahushua therefore, again groaning in himself, came to the tomb. Now it was a cave, and a stone lay against it. 
-<span class="v">39&#160;</span>Yahushua said, <span class="wj">“Take away the stone.”</span> 
-</p><p>Martha, the sister of him who was dead, said to him, “Lord, by this time there is a stench, for he has been dead four days.” 
-</p><p>
-<span class="v">40&#160;</span>Yahushua said to her, <span class="wj">“Didn’t I tell you that if you believed, you would see Elohim’s glory?”</span> 
-</p><p>
-<span class="v">41&#160;</span>So they took away the stone from the place where the dead man was lying.<span class="f">+ \fr 11:41 \ft NU omits “from the place where the dead man was lying.”</span> Yahushua lifted up his eyes and said, <span class="wj">“Father, I thank you that you listened to me. </span> 
-<span class="v">42&#160;</span><span class="wj">I know that you always listen to me, but because of the multitude standing around I said this, that they may believe that you sent me.” </span> 
-<span class="v">43&#160;</span>When he had said this, he cried with a loud voice, <span class="wj">“Lazarus, come out!”</span> 
-</p><p>
-<span class="v">44&#160;</span>He who was dead came out, bound hand and foot with wrappings, and his face was wrapped around with a cloth. 
-</p><p>Yahushua said to them, <span class="wj">“Free him, and let him go.”</span> 
-</p><p>
-<span class="v">45&#160;</span>Therefore many of the Jews who came to Mary and saw what Yahushua did believed in him. 
-<span class="v">46&#160;</span>But some of them went away to the Pharisees and told them the things which Yahushua had done. 
-<span class="v">47&#160;</span>The chief priests therefore and the Pharisees gathered a council, and said, “What are we doing? For this man does many signs. 
-<span class="v">48&#160;</span>If we leave him alone like this, everyone will believe in him, and the Romans will come and take away both our place and our nation.” 
-</p><p>
-<span class="v">49&#160;</span>But a certain one of them, Caiaphas, being high priest that year, said to them, “You know nothing at all, 
-<span class="v">50&#160;</span>nor do you consider that it is advantageous for us that one man should die for the people, and that the whole nation not perish.” 
-<span class="v">51&#160;</span>Now he didn’t say this of himself, but being high priest that year, he prophesied that Yahushua would die for the nation, 
-<span class="v">52&#160;</span>and not for the nation only, but that he might also gather together into one the children of Elohim who are scattered abroad. 
-<span class="v">53&#160;</span>So from that day forward they took counsel that they might put him to death. 
-<span class="v">54&#160;</span>Yahushua therefore walked no more openly among the Jews, but departed from there into the country near the wilderness, to a city called Ephraim. He stayed there with his disciples. 
-</p><p>
-<span class="v">55&#160;</span>Now the Passover of the Jews was at hand. Many went up from the country to Jerusalem before the Passover, to purify themselves. 
-<span class="v">56&#160;</span>Then they sought for Yahushua and spoke with one another as they stood in the temple, “What do you think—that he isn’t coming to the feast at all?” 
-<span class="v">57&#160;</span>Now the chief priests and the Pharisees had commanded that if anyone knew where he was, he should report it, that they might seize him. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Then, six days before the Passover, Yahushua came to Bethany, where Lazarus was, who had been dead, whom he raised from the dead. 
-<span class="v">2&#160;</span>So they made him a supper there. Martha served, but Lazarus was one of those who sat at the table with him. 
-<span class="v">3&#160;</span>Therefore Mary took a pound<span class="f">+ \fr 12:3 \ft a Roman pound of 12 ounces, or about 340 grams</span> of ointment of pure nard, very precious, and anointed Yahushua’s feet and wiped his feet with her hair. The house was filled with the fragrance of the ointment. 
-</p><p>
-<span class="v">4&#160;</span>Then Judas Iscariot, Simon’s son, one of his disciples, who would betray him, said, 
-<span class="v">5&#160;</span>“Why wasn’t this ointment sold for three hundred denarii<span class="f">+ \fr 12:5 \ft 300 denarii was about a year’s wages for an agricultural laborer.</span> and given to the poor?” 
-<span class="v">6&#160;</span>Now he said this, not because he cared for the poor, but because he was a thief, and having the money box, used to steal what was put into it. 
-</p><p>
-<span class="v">7&#160;</span>But Yahushua said, <span class="wj">“Leave her alone. She has kept this for the day of my burial. </span> 
-<span class="v">8&#160;</span><span class="wj">For you always have the poor with you, but you don’t always have me.”</span> 
-</p><p>
-<span class="v">9&#160;</span>A large crowd therefore of the Jews learned that he was there; and they came, not for Yahushua’s sake only, but that they might see Lazarus also, whom he had raised from the dead. 
-<span class="v">10&#160;</span>But the chief priests conspired to put Lazarus to death also, 
-<span class="v">11&#160;</span>because on account of him many of the Jews went away and believed in Yahushua. 
-</p><p>
-<span class="v">12&#160;</span>On the next day a great multitude had come to the feast. When they heard that Yahushua was coming to Jerusalem, 
-<span class="v">13&#160;</span>they took the branches of the palm trees and went out to meet him, and cried out, “Hosanna!<span class="f">+ \fr 12:13 \ft “Hosanna” means “save us” or “help us, we pray”.</span> Blessed is he who comes in the name of the Lord,<span class="x">+ \xo 12:13 \xt Psalm 118:25-26 </span> the King of Israel!” 
-</p><p>
-<span class="v">14&#160;</span>Yahushua, having found a young donkey, sat on it. As it is written, 
-<span class="v">15&#160;</span>“Don’t be afraid, daughter of Zion. Behold, your King comes, sitting on a donkey’s colt.”<span class="x">+ \xo 12:15 \xt Zechariah 9:9</span> 
-<span class="v">16&#160;</span>His disciples didn’t understand these things at first, but when Yahushua was glorified, then they remembered that these things were written about him, and that they had done these things to him. 
-<span class="v">17&#160;</span>The multitude therefore that was with him when he called Lazarus out of the tomb and raised him from the dead was testifying about it. 
-<span class="v">18&#160;</span>For this cause also the multitude went and met him, because they heard that he had done this sign. 
-<span class="v">19&#160;</span>The Pharisees therefore said among themselves, “See how you accomplish nothing. Behold, the world has gone after him.” 
-</p><p>
-<span class="v">20&#160;</span>Now there were certain Greeks among those who went up to worship at the feast. 
-<span class="v">21&#160;</span>Therefore, these came to Philip, who was from Bethsaida of Galilee, and asked him, saying, “Sir, we want to see Yahushua.” 
-<span class="v">22&#160;</span>Philip came and told Andrew, and in turn, Andrew came with Philip, and they told Yahushua. 
-</p><p>
-<span class="v">23&#160;</span>Yahushua answered them, <span class="wj">“The time has come for the Son of Man to be glorified. </span> 
-<span class="v">24&#160;</span><span class="wj">Most certainly I tell you, unless a grain of wheat falls into the earth and dies, it remains by itself alone. But if it dies, it bears much fruit. </span> 
-<span class="v">25&#160;</span><span class="wj">He who loves his life will lose it. He who hates his life in this world will keep it to eternal life. </span> 
-<span class="v">26&#160;</span><span class="wj">If anyone serves me, let him follow me. Where I am, there my servant will also be. If anyone serves me, the Father will honor him.</span> 
-</p><p>
-<span class="v">27&#160;</span><span class="wj">“Now my soul is troubled. What shall I say? ‘Father, save me from this time’? But I came to this time for this cause. </span> 
-<span class="v">28&#160;</span><span class="wj">Father, glorify your name!”</span> 
-</p><p>Then a voice came out of the sky, saying, “I have both glorified it and will glorify it again.” 
-</p><p>
-<span class="v">29&#160;</span>Therefore the multitude who stood by and heard it said that it had thundered. Others said, “An angel has spoken to him.” 
-</p><p>
-<span class="v">30&#160;</span>Yahushua answered, <span class="wj">“This voice hasn’t come for my sake, but for your sakes. </span> 
-<span class="v">31&#160;</span><span class="wj">Now is the judgment of this world. Now the prince of this world will be cast out. </span> 
-<span class="v">32&#160;</span><span class="wj">And I, if I am lifted up from the earth, will draw all people to myself.”</span> 
-<span class="v">33&#160;</span>But he said this, signifying by what kind of death he should die. 
-</p><p>
-<span class="v">34&#160;</span>The multitude answered him, “We have heard out of the law that the Christ remains forever.<span class="x">+ \xo 12:34 \xt Isaiah 9:7; Daniel 2:44; See Isaiah 53:8</span> How do you say, <span class="wj">‘The Son of Man must be lifted up’?</span> Who is this Son of Man?” 
-</p><p>
-<span class="v">35&#160;</span>Yahushua therefore said to them, <span class="wj">“Yet a little while the light is with you. Walk while you have the light, that darkness doesn’t overtake you. He who walks in the darkness doesn’t know where he is going. </span> 
-<span class="v">36&#160;</span><span class="wj">While you have the light, believe in the light, that you may become children of light.”</span> Yahushua said these things, and he departed and hid himself from them. 
-<span class="v">37&#160;</span>But though he had done so many signs before them, yet they didn’t believe in him, 
-<span class="v">38&#160;</span>that the word of Isaiah the prophet might be fulfilled, which he spoke: 
-</p><p class="q1">“Lord, who has believed our report? 
-</p><p class="q2">To whom has the arm of the Lord been revealed?”<span class="x">+ \xo 12:38 \xt Isaiah 53:1</span> 
-</p><p>
-<span class="v">39&#160;</span>For this cause they couldn’t believe, for Isaiah said again: 
-</p><p class="q1">
-<span class="v">40&#160;</span>“He has blinded their eyes and he hardened their heart, 
-</p><p class="q2">lest they should see with their eyes, 
-</p><p class="q2">and perceive with their heart, 
-</p><p class="q2">and would turn, 
-</p><p class="q2">and I would heal them.”<span class="x">+ \xo 12:40 \xt Isaiah 6:10</span> 
-</p><p>
-<span class="v">41&#160;</span>Isaiah said these things when he saw his glory, and spoke of him. <span class="x">+ \xo 12:41 \xt Isaiah 6:1</span> 
-<span class="v">42&#160;</span>Nevertheless, even many of the rulers believed in him, but because of the Pharisees they didn’t confess it, so that they wouldn’t be put out of the synagogue, 
-<span class="v">43&#160;</span>for they loved men’s praise more than Elohim’s praise. 
-</p><p>
-<span class="v">44&#160;</span>Yahushua cried out and said, <span class="wj">“Whoever believes in me, believes not in me, but in him who sent me. </span> 
-<span class="v">45&#160;</span><span class="wj">He who sees me sees him who sent me. </span> 
-<span class="v">46&#160;</span><span class="wj">I have come as a light into the world, that whoever believes in me may not remain in the darkness. </span> 
-<span class="v">47&#160;</span><span class="wj">If anyone listens to my sayings and doesn’t believe, I don’t judge him. For I came not to judge the world, but to save the world. </span> 
-<span class="v">48&#160;</span><span class="wj">He who rejects me, and doesn’t receive my sayings, has one who judges him. The word that I spoke will judge him in the last day. </span> 
-<span class="v">49&#160;</span><span class="wj">For I spoke not from myself, but the Father who sent me gave me a commandment, what I should say and what I should speak. </span> 
-<span class="v">50&#160;</span><span class="wj">I know that his commandment is eternal life. The things therefore which I speak, even as the Father has said to me, so I speak.”</span> 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Now before the feast of the Passover, Yahushua, knowing that his time had come that he would depart from this world to the Father, having loved his own who were in the world, he loved them to the end. 
-<span class="v">2&#160;</span>During supper, the devil having already put into the heart of Judas Iscariot, Simon’s son, to betray him, 
-<span class="v">3&#160;</span>Yahushua, knowing that the Father had given all things into his hands, and that he came from Elohim and was going to Elohim, 
-<span class="v">4&#160;</span>arose from supper, and laid aside his outer garments. He took a towel and wrapped a towel around his waist. 
-<span class="v">5&#160;</span>Then he poured water into the basin, and began to wash the disciples’ feet and to wipe them with the towel that was wrapped around him. 
-<span class="v">6&#160;</span>Then he came to Simon Peter. He said to him, “Lord, do you wash my feet?” 
-</p><p>
-<span class="v">7&#160;</span>Yahushua answered him, <span class="wj">“You don’t know what I am doing now, but you will understand later.”</span> 
-</p><p>
-<span class="v">8&#160;</span>Peter said to him, “You will never wash my feet!” 
-</p><p>Yahushua answered him, <span class="wj">“If I don’t wash you, you have no part with me.” </span> 
-</p><p>
-<span class="v">9&#160;</span>Simon Peter said to him, “Lord, not my feet only, but also my hands and my head!” 
-</p><p>
-<span class="v">10&#160;</span>Yahushua said to him, <span class="wj">“Someone who has bathed only needs to have his feet washed, but is completely clean. You are clean, but not all of you.” </span> 
-<span class="v">11&#160;</span>For he knew him who would betray him; therefore he said, <span class="wj">“You are not all clean.”</span> 
-<span class="v">12&#160;</span>So when he had washed their feet, put his outer garment back on, and sat down again, he said to them, <span class="wj">“Do you know what I have done to you? </span> 
-<span class="v">13&#160;</span><span class="wj">You call me, ‘Teacher’ and ‘Lord.’ You say so correctly, for so I am. </span> 
-<span class="v">14&#160;</span><span class="wj">If I then, the Lord and the Teacher, have washed your feet, you also ought to wash one another’s feet. </span> 
-<span class="v">15&#160;</span><span class="wj">For I have given you an example, that you should also do as I have done to you. </span> 
-<span class="v">16&#160;</span><span class="wj">Most certainly I tell you, a servant is not greater than his lord, neither is one who is sent greater than he who sent him. </span> 
-<span class="v">17&#160;</span><span class="wj">If you know these things, blessed are you if you do them. </span> 
-<span class="v">18&#160;</span><span class="wj">I don’t speak concerning all of you. I know whom I have chosen; but that the Scripture may be fulfilled, ‘He who eats bread with me has lifted up his heel against me.’</span><span class="x">+ \xo 13:18 \xt Psalm 41:9</span> 
-<span class="v">19&#160;</span><span class="wj">From now on, I tell you before it happens, that when it happens, you may believe that I am he. </span> 
-<span class="v">20&#160;</span><span class="wj">Most certainly I tell you, he who receives whomever I send, receives me; and he who receives me, receives him who sent me.”</span> 
-</p><p>
-<span class="v">21&#160;</span>When Yahushua had said this, he was troubled in spirit, and testified, <span class="wj">“Most certainly I tell you that one of you will betray me.”</span> 
-</p><p>
-<span class="v">22&#160;</span>The disciples looked at one another, perplexed about whom he spoke. 
-<span class="v">23&#160;</span>One of his disciples, whom Yahushua loved, was at the table, leaning against Yahushua’s breast. 
-<span class="v">24&#160;</span>Simon Peter therefore beckoned to him, and said to him, “Tell us who it is of whom he speaks.” 
-</p><p>
-<span class="v">25&#160;</span>He, leaning back, as he was, on Yahushua’s breast, asked him, “Lord, who is it?” 
-</p><p>
-<span class="v">26&#160;</span>Yahushua therefore answered, <span class="wj">“It is he to whom I will give this piece of bread when I have dipped it.”</span> So when he had dipped the piece of bread, he gave it to Judas, the son of Simon Iscariot. 
-<span class="v">27&#160;</span>After the piece of bread, then Satan entered into him. 
-</p><p>Then Yahushua said to him, <span class="wj">“What you do, do quickly.”</span> 
-</p><p>
-<span class="v">28&#160;</span>Now nobody at the table knew why he said this to him. 
-<span class="v">29&#160;</span>For some thought, because Judas had the money box, that Yahushua said to him, “Buy what things we need for the feast,” or that he should give something to the poor. 
-<span class="v">30&#160;</span>Therefore having received that morsel, he went out immediately. It was night. 
-</p><p>
-<span class="v">31&#160;</span>When he had gone out, Yahushua said, <span class="wj">“Now the Son of Man has been glorified, and Elohim has been glorified in him. </span> 
-<span class="v">32&#160;</span><span class="wj">If Elohim has been glorified in him, Elohim will also glorify him in himself, and he will glorify him immediately. </span> 
-<span class="v">33&#160;</span><span class="wj">Little children, I will be with you a little while longer. You will seek me, and as I said to the Jews, ‘Where I am going, you can’t come,’ so now I tell you. </span> 
-<span class="v">34&#160;</span><span class="wj">A new commandment I give to you, that you love one another. Just as I have loved you, you also love one another. </span> 
-<span class="v">35&#160;</span><span class="wj">By this everyone will know that you are my disciples, if you have love for one another.”</span> 
-</p><p>
-<span class="v">36&#160;</span>Simon Peter said to him, “Lord, where are you going?” 
-</p><p>Yahushua answered, <span class="wj">“Where I am going, you can’t follow now, but you will follow afterwards.”</span> 
-</p><p>
-<span class="v">37&#160;</span>Peter said to him, “Lord, why can’t I follow you now? I will lay down my life for you.” 
-</p><p>
-<span class="v">38&#160;</span>Yahushua answered him, <span class="wj">“Will you lay down your life for me? Most certainly I tell you, the rooster won’t crow until you have denied me three times.</span> 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“Don’t let your heart be troubled. Believe in Elohim. Believe also in me. </span> 
-<span class="v">2&#160;</span><span class="wj">In my Father’s house are many homes. If it weren’t so, I would have told you. I am going to prepare a place for you. </span> 
-<span class="v">3&#160;</span><span class="wj">If I go and prepare a place for you, I will come again and will receive you to myself; that where I am, you may be there also. </span> 
-<span class="v">4&#160;</span><span class="wj">You know where I go, and you know the way.”</span> 
-</p><p>
-<span class="v">5&#160;</span>Thomas said to him, “Lord, we don’t know where you are going. How can we know the way?” 
-</p><p>
-<span class="v">6&#160;</span>Yahushua said to him, <span class="wj">“I am the way, the truth, and the life. No one comes to the Father, except through me. </span> 
-<span class="v">7&#160;</span><span class="wj">If you had known me, you would have known my Father also. From now on, you know him and have seen him.”</span> 
-</p><p>
-<span class="v">8&#160;</span>Philip said to him, “Lord, show us the Father, and that will be enough for us.” 
-</p><p>
-<span class="v">9&#160;</span>Yahushua said to him, <span class="wj">“Have I been with you such a long time, and do you not know me, Philip? He who has seen me has seen the Father. How do you say, ‘Show us the Father’? </span> 
-<span class="v">10&#160;</span><span class="wj">Don’t you believe that I am in the Father, and the Father in me? The words that I tell you, I speak not from myself; but the Father who lives in me does his works. </span> 
-<span class="v">11&#160;</span><span class="wj">Believe me that I am in the Father, and the Father in me; or else believe me for the very works’ sake. </span> 
-<span class="v">12&#160;</span><span class="wj">Most certainly I tell you, he who believes in me, the works that I do, he will do also; and he will do greater works than these, because I am going to my Father. </span> 
-<span class="v">13&#160;</span><span class="wj">Whatever you will ask in my name, I will do it, that the Father may be glorified in the Son. </span> 
-<span class="v">14&#160;</span><span class="wj">If you will ask anything in my name, I will do it. </span> 
-<span class="v">15&#160;</span><span class="wj">If you love me, keep my commandments. </span> 
-<span class="v">16&#160;</span><span class="wj">I will pray to the Father, and he will give you another Counselor, </span><span class="f">+ \fr 14:16 \ft Greek παρακλητον: Counselor, Helper, Intercessor, Advocate, and Comforter.</span> <span class="wj">that he may be with you forever:</span> 
-<span class="v">17&#160;</span><span class="wj">the Spirit of truth, whom the world can’t receive, for it doesn’t see him and doesn’t know him. You know him, for he lives with you and will be in you. </span> 
-<span class="v">18&#160;</span><span class="wj">I will not leave you orphans. I will come to you. </span> 
-<span class="v">19&#160;</span><span class="wj">Yet a little while, and the world will see me no more; but you will see me. Because I live, you will live also. </span> 
-<span class="v">20&#160;</span><span class="wj">In that day you will know that I am in my Father, and you in me, and I in you. </span> 
-<span class="v">21&#160;</span><span class="wj">One who has my commandments and keeps them, that person is one who loves me. One who loves me will be loved by my Father, and I will love him, and will reveal myself to him.”</span> 
-</p><p>
-<span class="v">22&#160;</span>Judas (not Iscariot) said to him, “Lord, what has happened that you are about to reveal yourself to us, and not to the world?” 
-</p><p>
-<span class="v">23&#160;</span>Yahushua answered him, <span class="wj">“If a man loves me, he will keep my word. My Father will love him, and we will come to him and make our home with him. </span> 
-<span class="v">24&#160;</span><span class="wj">He who doesn’t love me doesn’t keep my words. The word which you hear isn’t mine, but the Father’s who sent me. </span> 
-</p><p>
-<span class="v">25&#160;</span><span class="wj">“I have said these things to you while still living with you. </span> 
-<span class="v">26&#160;</span><span class="wj">But the Counselor, the Set-Apart Spirit, whom the Father will send in my name, will teach you all things, and will remind you of all that I said to you. </span> 
-<span class="v">27&#160;</span><span class="wj">Peace I leave with you. My peace I give to you; not as the world gives, I give to you. Don’t let your heart be troubled, neither let it be fearful. </span> 
-<span class="v">28&#160;</span><span class="wj">You heard how I told you, ‘I am going away, and I will come back to you.’ If you loved me, you would have rejoiced because I said ‘I am going to my Father;’ for the Father is greater than I. </span> 
-<span class="v">29&#160;</span><span class="wj">Now I have told you before it happens so that when it happens, you may believe. </span> 
-<span class="v">30&#160;</span><span class="wj">I will no more speak much with you, for the prince of the world comes, and he has nothing in me. </span> 
-<span class="v">31&#160;</span><span class="wj">But that the world may know that I love the Father, and as the Father commanded me, even so I do. Arise, let’s go from here.</span> 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“I am the true vine, and my Father is the farmer. </span> 
-<span class="v">2&#160;</span><span class="wj">Every branch in me that doesn’t bear fruit, he takes away. Every branch that bears fruit, he prunes, that it may bear more fruit. </span> 
-<span class="v">3&#160;</span><span class="wj">You are already pruned clean because of the word which I have spoken to you. </span> 
-<span class="v">4&#160;</span><span class="wj">Remain in me, and I in you. As the branch can’t bear fruit by itself unless it remains in the vine, so neither can you, unless you remain in me. </span> 
-<span class="v">5&#160;</span><span class="wj">I am the vine. You are the branches. He who remains in me and I in him bears much fruit, for apart from me you can do nothing. </span> 
-<span class="v">6&#160;</span><span class="wj">If a man doesn’t remain in me, he is thrown out as a branch and is withered; and they gather them, throw them into the fire, and they are burned. </span> 
-<span class="v">7&#160;</span><span class="wj">If you remain in me, and my words remain in you, you will ask whatever you desire, and it will be done for you.</span> 
-</p><p>
-<span class="v">8&#160;</span><span class="wj">“In this my Father is glorified, that you bear much fruit; and so you will be my disciples. </span> 
-<span class="v">9&#160;</span><span class="wj">Even as the Father has loved me, I also have loved you. Remain in my love. </span> 
-<span class="v">10&#160;</span><span class="wj">If you keep my commandments, you will remain in my love, even as I have kept my Father’s commandments and remain in his love. </span> 
-<span class="v">11&#160;</span><span class="wj">I have spoken these things to you, that my joy may remain in you, and that your joy may be made full.</span> 
-</p><p>
-<span class="v">12&#160;</span><span class="wj">“This is my commandment, that you love one another, even as I have loved you. </span> 
-<span class="v">13&#160;</span><span class="wj">Greater love has no one than this, that someone lay down his life for his friends. </span> 
-<span class="v">14&#160;</span><span class="wj">You are my friends if you do whatever I command you. </span> 
-<span class="v">15&#160;</span><span class="wj">No longer do I call you servants, for the servant doesn’t know what his lord does. But I have called you friends, for everything that I heard from my Father, I have made known to you. </span> 
-<span class="v">16&#160;</span><span class="wj">You didn’t choose me, but I chose you and appointed you, that you should go and bear fruit, and that your fruit should remain; that whatever you will ask of the Father in my name, he may give it to you.</span> 
-</p><p>
-<span class="v">17&#160;</span><span class="wj">“I command these things to you, that you may love one another. </span> 
-<span class="v">18&#160;</span><span class="wj">If the world hates you, you know that it has hated me before it hated you. </span> 
-<span class="v">19&#160;</span><span class="wj">If you were of the world, the world would love its own. But because you are not of the world, since I chose you out of the world, therefore the world hates you. </span> 
-<span class="v">20&#160;</span><span class="wj">Remember the word that I said to you: ‘A servant is not greater than his lord.’</span><span class="x">+ \xo 15:20 \xt John 13:16</span> <span class="wj">If they persecuted me, they will also persecute you. If they kept my word, they will also keep yours. </span> 
-<span class="v">21&#160;</span><span class="wj">But they will do all these things to you for my name’s sake, because they don’t know him who sent me. </span> 
-<span class="v">22&#160;</span><span class="wj">If I had not come and spoken to them, they would not have had sin; but now they have no excuse for their sin. </span> 
-<span class="v">23&#160;</span><span class="wj">He who hates me, hates my Father also. </span> 
-<span class="v">24&#160;</span><span class="wj">If I hadn’t done among them the works which no one else did, they wouldn’t have had sin. But now they have seen and also hated both me and my Father. </span> 
-<span class="v">25&#160;</span><span class="wj">But this happened so that the word may be fulfilled which was written in their law, ‘They hated me without a cause.’</span><span class="x">+ \xo 15:25 \xt Psalm 35:19; 69:4</span> 
-</p><p>
-<span class="v">26&#160;</span><span class="wj">“When the Counselor</span><span class="f">+ \fr 15:26 \ft Greek Parakletos: Counselor, Helper, Advocate, Intercessor, and Comforter.</span> <span class="wj">has come, whom I will send to you from the Father, the Spirit of truth, who proceeds from the Father, he will testify about me. </span> 
-<span class="v">27&#160;</span><span class="wj">You will also testify, because you have been with me from the beginning.</span> 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“I have said these things to you so that you wouldn’t be caused to stumble. </span> 
-<span class="v">2&#160;</span><span class="wj">They will put you out of the synagogues. Yes, the time is coming that whoever kills you will think that he offers service to Elohim. </span> 
-<span class="v">3&#160;</span><span class="wj">They will do these things</span><span class="f">+ \fr 16:3 \ft TR adds “to you”</span> <span class="wj">because they have not known the Father nor me. </span> 
-<span class="v">4&#160;</span><span class="wj">But I have told you these things so that when the time comes, you may remember that I told you about them. I didn’t tell you these things from the beginning, because I was with you. </span> 
-<span class="v">5&#160;</span><span class="wj">But now I am going to him who sent me, and none of you asks me, ‘Where are you going?’ </span> 
-<span class="v">6&#160;</span><span class="wj">But because I have told you these things, sorrow has filled your heart. </span> 
-<span class="v">7&#160;</span><span class="wj">Nevertheless I tell you the truth: It is to your advantage that I go away; for if I don’t go away, the Counselor won’t come to you. But if I go, I will send him to you. </span> 
-<span class="v">8&#160;</span><span class="wj">When he has come, he will convict the world about sin, about righteousness, and about judgment; </span> 
-<span class="v">9&#160;</span><span class="wj">about sin, because they don’t believe in me; </span> 
-<span class="v">10&#160;</span><span class="wj">about righteousness, because I am going to my Father, and you won’t see me any more; </span> 
-<span class="v">11&#160;</span><span class="wj">about judgment, because the prince of this world has been judged. </span> 
-</p><p>
-<span class="v">12&#160;</span><span class="wj">“I still have many things to tell you, but you can’t bear them now. </span> 
-<span class="v">13&#160;</span><span class="wj">However, when he, the Spirit of truth, has come, he will guide you into all truth, for he will not speak from himself; but whatever he hears, he will speak. He will declare to you things that are coming. </span> 
-<span class="v">14&#160;</span><span class="wj">He will glorify me, for he will take from what is mine and will declare it to you. </span> 
-<span class="v">15&#160;</span><span class="wj">All things that the Father has are mine; therefore I said that he takes</span><span class="f">+ \fr 16:15 \ft TR reads “will take” instead of “takes”</span> <span class="wj">of mine and will declare it to you. </span> 
-</p><p>
-<span class="v">16&#160;</span><span class="wj">“A little while, and you will not see me. Again a little while, and you will see me.”</span> 
-</p><p>
-<span class="v">17&#160;</span>Some of his disciples therefore said to one another, “What is this that he says to us, <span class="wj">‘A little while, and you won’t see me, and again a little while, and you will see me;’</span> and, <span class="wj">‘Because I go to the Father’</span>?” 
-<span class="v">18&#160;</span>They said therefore, “What is this that he says, <span class="wj">‘A little while’</span>? We don’t know what he is saying.” 
-</p><p>
-<span class="v">19&#160;</span>Therefore Yahushua perceived that they wanted to ask him, and he said to them, <span class="wj">“Do you inquire among yourselves concerning this, that I said, ‘A little while, and you won’t see me, and again a little while, and you will see me’? </span> 
-<span class="v">20&#160;</span><span class="wj">Most certainly I tell you that you will weep and lament, but the world will rejoice. You will be sorrowful, but your sorrow will be turned into joy. </span> 
-<span class="v">21&#160;</span><span class="wj">A woman, when she gives birth, has sorrow because her time has come. But when she has delivered the child, she doesn’t remember the anguish any more, for the joy that a human being is born into the world. </span> 
-<span class="v">22&#160;</span><span class="wj">Therefore you now have sorrow, but I will see you again, and your heart will rejoice, and no one will take your joy away from you.</span> 
-</p><p>
-<span class="v">23&#160;</span><span class="wj">“In that day you will ask me no questions. Most certainly I tell you, whatever you may ask of the Father in my name, he will give it to you. </span> 
-<span class="v">24&#160;</span><span class="wj">Until now, you have asked nothing in my name. Ask, and you will receive, that your joy may be made full. </span> 
-</p><p>
-<span class="v">25&#160;</span><span class="wj">“I have spoken these things to you in figures of speech. But the time is coming when I will no more speak to you in figures of speech, but will tell you plainly about the Father. </span> 
-<span class="v">26&#160;</span><span class="wj">In that day you will ask in my name; and I don’t say to you that I will pray to the Father for you, </span> 
-<span class="v">27&#160;</span><span class="wj">for the Father himself loves you, because you have loved me, and have believed that I came from Elohim. </span> 
-<span class="v">28&#160;</span><span class="wj">I came from the Father and have come into the world. Again, I leave the world and go to the Father.”</span> 
-</p><p>
-<span class="v">29&#160;</span>His disciples said to him, “Behold, now you are speaking plainly, and using no figures of speech. 
-<span class="v">30&#160;</span>Now we know that you know all things, and don’t need for anyone to question you. By this we believe that you came from Elohim.” 
-</p><p>
-<span class="v">31&#160;</span>Yahushua answered them, <span class="wj">“Do you now believe? </span> 
-<span class="v">32&#160;</span><span class="wj">Behold, the time is coming, yes, and has now come, that you will be scattered, everyone to his own place, and you will leave me alone. Yet I am not alone, because the Father is with me. </span> 
-<span class="v">33&#160;</span><span class="wj">I have told you these things, that in me you may have peace. In the world you have trouble; but cheer up! I have overcome the world.” </span> 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Yahushua said these things, then lifting up his eyes to heaven, he said, <span class="wj">“Father, the time has come. Glorify your Son, that your Son may also glorify you; </span> 
-<span class="v">2&#160;</span><span class="wj">even as you gave him authority over all flesh, so he will give eternal life to all whom you have given him. </span> 
-<span class="v">3&#160;</span><span class="wj">This is eternal life, that they should know you, the only true Elohim, and him whom you sent, Yahushua Christ. </span> 
-<span class="v">4&#160;</span><span class="wj">I glorified you on the earth. I have accomplished the work which you have given me to do. </span> 
-<span class="v">5&#160;</span><span class="wj">Now, Father, glorify me with your own self with the glory which I had with you before the world existed. </span> 
-</p><p>
-<span class="v">6&#160;</span><span class="wj">“I revealed your name to the people whom you have given me out of the world. They were yours, and you have given them to me. They have kept your word. </span> 
-<span class="v">7&#160;</span><span class="wj">Now they have known that all things whatever you have given me are from you, </span> 
-<span class="v">8&#160;</span><span class="wj">for the words which you have given me I have given to them; and they received them, and knew for sure that I came from you. They have believed that you sent me. </span> 
-<span class="v">9&#160;</span><span class="wj">I pray for them. I don’t pray for the world, but for those whom you have given me, for they are yours. </span> 
-<span class="v">10&#160;</span><span class="wj">All things that are mine are yours, and yours are mine, and I am glorified in them. </span> 
-<span class="v">11&#160;</span><span class="wj">I am no more in the world, but these are in the world, and I am coming to you. Set-Apart Father, keep them through your name which you have given me, that they may be one, even as we are. </span> 
-<span class="v">12&#160;</span><span class="wj">While I was with them in the world, I kept them in your name. I have kept those whom you have given me. None of them is lost except the son of destruction, that the Scripture might be fulfilled. </span> 
-<span class="v">13&#160;</span><span class="wj">But now I come to you, and I say these things in the world, that they may have my joy made full in themselves. </span> 
-<span class="v">14&#160;</span><span class="wj">I have given them your word. The world hated them because they are not of the world, even as I am not of the world. </span> 
-<span class="v">15&#160;</span><span class="wj">I pray not that you would take them from the world, but that you would keep them from the evil one. </span> 
-<span class="v">16&#160;</span><span class="wj">They are not of the world, even as I am not of the world. </span> 
-<span class="v">17&#160;</span><span class="wj">Sanctify them in your truth. Your word is truth.</span><span class="x">+ \xo 17:17 \xt Psalm 119:142</span> 
-<span class="v">18&#160;</span><span class="wj">As you sent me into the world, even so I have sent them into the world. </span> 
-<span class="v">19&#160;</span><span class="wj">For their sakes I sanctify myself, that they themselves also may be sanctified in truth. </span> 
-</p><p>
-<span class="v">20&#160;</span><span class="wj">“Not for these only do I pray, but for those also who will believe in me through their word, </span> 
-<span class="v">21&#160;</span><span class="wj">that they may all be one; even as you, Father, are in me, and I in you, that they also may be one in us; that the world may believe that you sent me. </span> 
-<span class="v">22&#160;</span><span class="wj">The glory which you have given me, I have given to them, that they may be one, even as we are one, </span> 
-<span class="v">23&#160;</span><span class="wj">I in them, and you in me, that they may be perfected into one, that the world may know that you sent me and loved them, even as you loved me. </span> 
-<span class="v">24&#160;</span><span class="wj">Father, I desire that they also whom you have given me be with me where I am, that they may see my glory which you have given me, for you loved me before the foundation of the world. </span> 
-<span class="v">25&#160;</span><span class="wj">Righteous Father, the world hasn’t known you, but I knew you; and these knew that you sent me. </span> 
-<span class="v">26&#160;</span><span class="wj">I made known to them your name, and will make it known; that the love with which you loved me may be in them, and I in them.”</span> 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>When Yahushua had spoken these words, he went out with his disciples over the brook Kidron, where there was a garden, into which he and his disciples entered. 
-<span class="v">2&#160;</span>Now Judas, who betrayed him, also knew the place, for Yahushua often met there with his disciples. 
-<span class="v">3&#160;</span>Judas then, having taken a detachment of soldiers and officers from the chief priests and the Pharisees, came there with lanterns, torches, and weapons. 
-<span class="v">4&#160;</span>Yahushua therefore, knowing all the things that were happening to him, went out and said to them, <span class="wj">“Who are you looking for?”</span> 
-</p><p>
-<span class="v">5&#160;</span>They answered him, “Yahushua of Nazareth.” 
-</p><p>Yahushua said to them, <span class="wj">“I am he.”</span> 
-</p><p>Judas also, who betrayed him, was standing with them. 
-<span class="v">6&#160;</span>When therefore he said to them, <span class="wj">“I am he,”</span> they went backward and fell to the ground. 
-</p><p>
-<span class="v">7&#160;</span>Again therefore he asked them, <span class="wj">“Who are you looking for?”</span> 
-</p><p>They said, “Yahushua of Nazareth.” 
-</p><p>
-<span class="v">8&#160;</span>Yahushua answered, <span class="wj">“I told you that I am he. If therefore you seek me, let these go their way,”</span> 
-<span class="v">9&#160;</span>that the word might be fulfilled which he spoke, <span class="wj">“Of those whom you have given me, I have lost none.”</span><span class="x">+ \xo 18:9 \xt John 6:39</span> 
-</p><p>
-<span class="v">10&#160;</span>Simon Peter therefore, having a sword, drew it, struck the high priest’s servant, and cut off his right ear. The servant’s name was Malchus. 
-<span class="v">11&#160;</span>Yahushua therefore said to Peter, <span class="wj">“Put the sword into its sheath. The cup which the Father has given me, shall I not surely drink it?”</span> 
-</p><p>
-<span class="v">12&#160;</span>So the detachment, the commanding officer, and the officers of the Jews seized Yahushua and bound him, 
-<span class="v">13&#160;</span>and led him to Annas first, for he was father-in-law to Caiaphas, who was high priest that year. 
-<span class="v">14&#160;</span>Now it was Caiaphas who advised the Jews that it was expedient that one man should perish for the people. 
-</p><p>
-<span class="v">15&#160;</span>Simon Peter followed Yahushua, as did another disciple. Now that disciple was known to the high priest, and entered in with Yahushua into the court of the high priest; 
-<span class="v">16&#160;</span>but Peter was standing at the door outside. So the other disciple, who was known to the high priest, went out and spoke to her who kept the door, and brought in Peter. 
-<span class="v">17&#160;</span>Then the maid who kept the door said to Peter, “Are you also one of this man’s disciples?” 
-</p><p>He said, “I am not.” 
-</p><p>
-<span class="v">18&#160;</span>Now the servants and the officers were standing there, having made a fire of coals, for it was cold. They were warming themselves. Peter was with them, standing and warming himself. 
-</p><p>
-<span class="v">19&#160;</span>The high priest therefore asked Yahushua about his disciples and about his teaching. 
-</p><p>
-<span class="v">20&#160;</span>Yahushua answered him, <span class="wj">“I spoke openly to the world. I always taught in synagogues and in the temple, where the Jews always meet. I said nothing in secret. </span> 
-<span class="v">21&#160;</span><span class="wj">Why do you ask me? Ask those who have heard me what I said to them. Behold, they know the things which I said.”</span> 
-</p><p>
-<span class="v">22&#160;</span>When he had said this, one of the officers standing by slapped Yahushua with his hand, saying, “Do you answer the high priest like that?” 
-</p><p>
-<span class="v">23&#160;</span>Yahushua answered him, <span class="wj">“If I have spoken evil, testify of the evil; but if well, why do you beat me?”</span> 
-</p><p>
-<span class="v">24&#160;</span>Annas sent him bound to Caiaphas, the high priest. 
-</p><p>
-<span class="v">25&#160;</span>Now Simon Peter was standing and warming himself. They said therefore to him, “You aren’t also one of his disciples, are you?” 
-</p><p>He denied it and said, “I am not.” 
-</p><p>
-<span class="v">26&#160;</span>One of the servants of the high priest, being a relative of him whose ear Peter had cut off, said, “Didn’t I see you in the garden with him?” 
-</p><p>
-<span class="v">27&#160;</span>Peter therefore denied it again, and immediately the rooster crowed. 
-</p><p>
-<span class="v">28&#160;</span>They led Yahushua therefore from Caiaphas into the Praetorium. It was early, and they themselves didn’t enter into the Praetorium, that they might not be defiled, but might eat the Passover. 
-<span class="v">29&#160;</span>Pilate therefore went out to them and said, “What accusation do you bring against this man?” 
-</p><p>
-<span class="v">30&#160;</span>They answered him, “If this man weren’t an evildoer, we wouldn’t have delivered him up to you.” 
-</p><p>
-<span class="v">31&#160;</span>Pilate therefore said to them, “Take him yourselves, and judge him according to your law.” 
-</p><p>Therefore the Jews said to him, “It is illegal for us to put anyone to death,” 
-<span class="v">32&#160;</span>that the word of Yahushua might be fulfilled, which he spoke, signifying by what kind of death he should die. 
-</p><p>
-<span class="v">33&#160;</span>Pilate therefore entered again into the Praetorium, called Yahushua, and said to him, “Are you the King of the Jews?” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua answered him, <span class="wj">“Do you say this by yourself, or did others tell you about me?”</span> 
-</p><p>
-<span class="v">35&#160;</span>Pilate answered, “I’m not a Jew, am I? Your own nation and the chief priests delivered you to me. What have you done?” 
-</p><p>
-<span class="v">36&#160;</span>Yahushua answered, <span class="wj">“My Kingdom is not of this world. If my Kingdom were of this world, then my servants would fight, that I wouldn’t be delivered to the Jews. But now my Kingdom is not from here.”</span> 
-</p><p>
-<span class="v">37&#160;</span>Pilate therefore said to him, “Are you a king then?” 
-</p><p>Yahushua answered, <span class="wj">“You say that I am a king. For this reason I have been born, and for this reason I have come into the world, that I should testify to the truth. Everyone who is of the truth listens to my voice.”</span> 
-</p><p>
-<span class="v">38&#160;</span>Pilate said to him, “What is truth?” 
-</p><p>When he had said this, he went out again to the Jews, and said to them, “I find no basis for a charge against him. 
-<span class="v">39&#160;</span>But you have a custom that I should release someone to you at the Passover. Therefore, do you want me to release to you the King of the Jews?” 
-</p><p>
-<span class="v">40&#160;</span>Then they all shouted again, saying, “Not this man, but Barabbas!” Now Barabbas was a robber. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>So Pilate then took Yahushua and flogged him. 
-<span class="v">2&#160;</span>The soldiers twisted thorns into a crown and put it on his head, and dressed him in a purple garment. 
-<span class="v">3&#160;</span>They kept saying, “Hail, King of the Jews!” and they kept slapping him. 
-</p><p>
-<span class="v">4&#160;</span>Then Pilate went out again, and said to them, “Behold, I bring him out to you, that you may know that I find no basis for a charge against him.” 
-</p><p>
-<span class="v">5&#160;</span>Yahushua therefore came out, wearing the crown of thorns and the purple garment. Pilate said to them, “Behold, the man!” 
-</p><p>
-<span class="v">6&#160;</span>When therefore the chief priests and the officers saw him, they shouted, saying, “Crucify! Crucify!” 
-</p><p>Pilate said to them, “Take him yourselves and crucify him, for I find no basis for a charge against him.” 
-</p><p>
-<span class="v">7&#160;</span>The Jews answered him, “We have a law, and by our law he ought to die, because he made himself the Son of Elohim.” 
-</p><p>
-<span class="v">8&#160;</span>When therefore Pilate heard this saying, he was more afraid. 
-<span class="v">9&#160;</span>He entered into the Praetorium again, and said to Yahushua, “Where are you from?” But Yahushua gave him no answer. 
-<span class="v">10&#160;</span>Pilate therefore said to him, “Aren’t you speaking to me? Don’t you know that I have power to release you and have power to crucify you?” 
-</p><p>
-<span class="v">11&#160;</span>Yahushua answered, <span class="wj">“You would have no power at all against me, unless it were given to you from above. Therefore he who delivered me to you has greater sin.”</span> 
-</p><p>
-<span class="v">12&#160;</span>At this, Pilate was seeking to release him, but the Jews cried out, saying, “If you release this man, you aren’t Caesar’s friend! Everyone who makes himself a king speaks against Caesar!” 
-</p><p>
-<span class="v">13&#160;</span>When Pilate therefore heard these words, he brought Yahushua out and sat down on the judgment seat at a place called “The Pavement”, but in Hebrew, “Gabbatha.” 
-<span class="v">14&#160;</span>Now it was the Preparation Day of the Passover, at about the sixth hour.<span class="f">+ \fr 19:14 \ft “the sixth hour” would have been 6:00 a.m. according to the Roman timekeeping system, or noon for the Jewish timekeeping system in use, then. </span> He said to the Jews, “Behold, your King!” 
-</p><p>
-<span class="v">15&#160;</span>They cried out, “Away with him! Away with him! Crucify him!” 
-</p><p>Pilate said to them, “Shall I crucify your King?” 
-</p><p>The chief priests answered, “We have no king but Caesar!” 
-</p><p>
-<span class="v">16&#160;</span>So then he delivered him to them to be crucified. So they took Yahushua and led him away. 
-<span class="v">17&#160;</span>He went out, bearing his cross, to the place called “The Place of a Skull”, which is called in Hebrew, “Golgotha”, 
-<span class="v">18&#160;</span>where they crucified him, and with him two others, on either side one, and Yahushua in the middle. 
-<span class="v">19&#160;</span>Pilate wrote a title also, and put it on the cross. There was written, “YAHUSHUA OF NAZARETH, THE KING OF THE JEWS.” 
-<span class="v">20&#160;</span>Therefore many of the Jews read this title, for the place where Yahushua was crucified was near the city; and it was written in Hebrew, in Latin, and in Greek. 
-<span class="v">21&#160;</span>The chief priests of the Jews therefore said to Pilate, “Don’t write, ‘The King of the Jews,’ but, ‘he said, “I am King of the Jews.”&#160;’&#160;” 
-</p><p>
-<span class="v">22&#160;</span>Pilate answered, “What I have written, I have written.” 
-</p><p>
-<span class="v">23&#160;</span>Then the soldiers, when they had crucified Yahushua, took his garments and made four parts, to every soldier a part; and also the tunic. Now the tunic was without seam, woven from the top throughout. 
-<span class="v">24&#160;</span>Then they said to one another, “Let’s not tear it, but cast lots for it to decide whose it will be,” that the Scripture might be fulfilled, which says, 
-</p><p class="q1">“They parted my garments among them. 
-</p><p class="q2">They cast lots for my clothing.”<span class="x">+ \xo 19:24 \xt Psalm 22:18</span> 
-</p><p class="m">Therefore the soldiers did these things. 
-</p><p>
-<span class="v">25&#160;</span>But standing by Yahushua’s cross were his mother, his mother’s sister, Mary the woman of Clopas, and Mary Magdalene. 
-<span class="v">26&#160;</span>Therefore when Yahushua saw his mother, and the disciple whom he loved standing there, he said to his mother, <span class="wj">“Woman, behold, your son!” </span> 
-<span class="v">27&#160;</span>Then he said to the disciple, <span class="wj">“Behold, your mother!”</span> From that hour, the disciple took her to his own home. 
-</p><p>
-<span class="v">28&#160;</span>After this, Yahushua, seeing<span class="f">+ \fr 19:28 \ft NU, TR read “knowing” instead of “seeing” </span> that all things were now finished, that the Scripture might be fulfilled, said, <span class="wj">“I am thirsty!”</span> 
-<span class="v">29&#160;</span>Now a vessel full of vinegar was set there; so they put a sponge full of the vinegar on hyssop, and held it at his mouth. 
-<span class="v">30&#160;</span>When Yahushua therefore had received the vinegar, he said, <span class="wj">“It is finished!”</span> Then he bowed his head and gave up his spirit. 
-</p><p>
-<span class="v">31&#160;</span>Therefore the Jews, because it was the Preparation Day, so that the bodies wouldn’t remain on the cross on the Sabbath (for that Sabbath was a special one), asked of Pilate that their legs might be broken and that they might be taken away. 
-<span class="v">32&#160;</span>Therefore the soldiers came and broke the legs of the first and of the other who was crucified with him; 
-<span class="v">33&#160;</span>but when they came to Yahushua and saw that he was already dead, they didn’t break his legs. 
-<span class="v">34&#160;</span>However, one of the soldiers pierced his side with a spear, and immediately blood and water came out. 
-<span class="v">35&#160;</span>He who has seen has testified, and his testimony is true. He knows that he tells the truth, that you may believe. 
-<span class="v">36&#160;</span>For these things happened that the Scripture might be fulfilled, “A bone of him will not be broken.”<span class="x">+ \xo 19:36 \xt Exodus 12:46; Numbers 9:12; Psalm 34:20 </span> 
-<span class="v">37&#160;</span>Again another Scripture says, “They will look on him whom they pierced.”<span class="x">+ \xo 19:37 \xt Zechariah 12:10</span> 
-</p><p>
-<span class="v">38&#160;</span>After these things, Joseph of Arimathaea, being a disciple of Yahushua, but secretly for fear of the Jews, asked of Pilate that he might take away Yahushua’s body. Pilate gave him permission. He came therefore and took away his body. 
-<span class="v">39&#160;</span>Nicodemus, who at first came to Yahushua by night, also came bringing a mixture of myrrh and aloes, about a hundred Roman pounds.<span class="f">+ \fr 19:39 \ft 100 Roman pounds of 12 ounces each, or about 72 pounds, or 33 Kilograms.</span> 
-<span class="v">40&#160;</span>So they took Yahushua’s body, and bound it in linen cloths with the spices, as the custom of the Jews is to bury. 
-<span class="v">41&#160;</span>Now in the place where he was crucified there was a garden. In the garden was a new tomb in which no man had ever yet been laid. 
-<span class="v">42&#160;</span>Then, because of the Jews’ Preparation Day (for the tomb was near at hand), they laid Yahushua there. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Now on the first day of the week, Mary Magdalene went early, while it was still dark, to the tomb, and saw that the stone had been taken away from the tomb. 
-<span class="v">2&#160;</span>Therefore she ran and came to Simon Peter and to the other disciple whom Yahushua loved, and said to them, “They have taken away the Lord out of the tomb, and we don’t know where they have laid him!” 
-</p><p>
-<span class="v">3&#160;</span>Therefore Peter and the other disciple went out, and they went toward the tomb. 
-<span class="v">4&#160;</span>They both ran together. The other disciple outran Peter and came to the tomb first. 
-<span class="v">5&#160;</span>Stooping and looking in, he saw the linen cloths lying there; yet he didn’t enter in. 
-<span class="v">6&#160;</span>Then Simon Peter came, following him, and entered into the tomb. He saw the linen cloths lying, 
-<span class="v">7&#160;</span>and the cloth that had been on his head, not lying with the linen cloths, but rolled up in a place by itself. 
-<span class="v">8&#160;</span>So then the other disciple who came first to the tomb also entered in, and he saw and believed. 
-<span class="v">9&#160;</span>For as yet they didn’t know the Scripture, that he must rise from the dead. 
-<span class="v">10&#160;</span>So the disciples went away again to their own homes. 
-</p><p>
-<span class="v">11&#160;</span>But Mary was standing outside at the tomb weeping. So as she wept, she stooped and looked into the tomb, 
-<span class="v">12&#160;</span>and she saw two angels in white sitting, one at the head and one at the feet, where the body of Yahushua had lain. 
-<span class="v">13&#160;</span>They asked her, “Woman, why are you weeping?” 
-</p><p>She said to them, “Because they have taken away my Lord, and I don’t know where they have laid him.” 
-<span class="v">14&#160;</span>When she had said this, she turned around and saw Yahushua standing, and didn’t know that it was Yahushua. 
-</p><p>
-<span class="v">15&#160;</span>Yahushua said to her, <span class="wj">“Woman, why are you weeping? Who are you looking for?”</span> 
-</p><p>She, supposing him to be the gardener, said to him, “Sir, if you have carried him away, tell me where you have laid him, and I will take him away.” 
-</p><p>
-<span class="v">16&#160;</span>Yahushua said to her, <span class="wj">“Mary.”</span> 
-</p><p>She turned and said to him, “Rabboni!”<span class="f">+ \fr 20:16 \ft Rabboni is a transliteration of the Hebrew word for “great teacher.”</span> which is to say, “Teacher!”<span class="f">+ \fr 20:16 \ft or, Master</span> 
-</p><p>
-<span class="v">17&#160;</span>Yahushua said to her, <span class="wj">“Don’t hold me, for I haven’t yet ascended to my Father; but go to my brothers and tell them, ‘I am ascending to my Father and your Father, to my Elohim and your Elohim.’&#160;”</span> 
-</p><p>
-<span class="v">18&#160;</span>Mary Magdalene came and told the disciples that she had seen the Lord, and that he had said these things to her. 
-<span class="v">19&#160;</span>When therefore it was evening on that day, the first day of the week, and when the doors were locked where the disciples were assembled, for fear of the Jews, Yahushua came and stood in the middle and said to them, <span class="wj">“Peace be to you.”</span> 
-</p><p>
-<span class="v">20&#160;</span>When he had said this, he showed them his hands and his side. The disciples therefore were glad when they saw the Lord. 
-<span class="v">21&#160;</span>Yahushua therefore said to them again, <span class="wj">“Peace be to you. As the Father has sent me, even so I send you.”</span> 
-<span class="v">22&#160;</span>When he had said this, he breathed on them, and said to them, <span class="wj">“Receive the Set-Apart Spirit! </span> 
-<span class="v">23&#160;</span><span class="wj">If you forgive anyone’s sins, they have been forgiven them. If you retain anyone’s sins, they have been retained.”</span> 
-</p><p>
-<span class="v">24&#160;</span>But Thomas, one of the twelve, called Didymus,<span class="f">+ \fr 20:24 \ft or, Twin</span> wasn’t with them when Yahushua came. 
-<span class="v">25&#160;</span>The other disciples therefore said to him, “We have seen the Lord!” 
-</p><p>But he said to them, “Unless I see in his hands the print of the nails, put my finger into the print of the nails, and put my hand into his side, I will not believe.” 
-</p><p>
-<span class="v">26&#160;</span>After eight days, again his disciples were inside and Thomas was with them. Yahushua came, the doors being locked, and stood in the middle, and said, <span class="wj">“Peace be to you.”</span> 
-<span class="v">27&#160;</span>Then he said to Thomas, <span class="wj">“Reach here your finger, and see my hands. Reach here your hand, and put it into my side. Don’t be unbelieving, but believing.”</span> 
-</p><p>
-<span class="v">28&#160;</span>Thomas answered him, “My Lord and my Elohim!” 
-</p><p>
-<span class="v">29&#160;</span>Yahushua said to him, <span class="wj">“Because you have seen me,</span><span class="f">+ \fr 20:29 \ft TR adds “Thomas,”</span> <span class="wj">you have believed. Blessed are those who have not seen and have believed.”</span> 
-</p><p>
-<span class="v">30&#160;</span>Therefore Yahushua did many other signs in the presence of his disciples, which are not written in this book; 
-<span class="v">31&#160;</span>but these are written that you may believe that Yahushua is the Christ, the Son of Elohim, and that believing you may have life in his name. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>After these things, Yahushua revealed himself again to the disciples at the sea of Tiberias. He revealed himself this way. 
-<span class="v">2&#160;</span>Simon Peter, Thomas called Didymus,<span class="f">+ \fr 21:2 \ft or, Twin</span> Nathanael of Cana in Galilee, and the sons of Zebedee, and two others of his disciples were together. 
-<span class="v">3&#160;</span>Simon Peter said to them, “I’m going fishing.” 
-</p><p>They told him, “We are also coming with you.” They immediately went out and entered into the boat. That night, they caught nothing. 
-<span class="v">4&#160;</span>But when day had already come, Yahushua stood on the beach; yet the disciples didn’t know that it was Yahushua. 
-<span class="v">5&#160;</span>Yahushua therefore said to them, <span class="wj">“Children, have you anything to eat?” </span> 
-</p><p>They answered him, “No.” 
-</p><p>
-<span class="v">6&#160;</span>He said to them, <span class="wj">“Cast the net on the right side of the boat, and you will find some.”</span> 
-</p><p>They cast it therefore, and now they weren’t able to draw it in for the multitude of fish. 
-<span class="v">7&#160;</span>That disciple therefore whom Yahushua loved said to Peter, “It’s the Lord!” 
-</p><p>So when Simon Peter heard that it was the Lord, he wrapped his coat around himself (for he was naked), and threw himself into the sea. 
-<span class="v">8&#160;</span>But the other disciples came in the little boat (for they were not far from the land, but about two hundred cubits<span class="f">+ \fr 21:8 \ft 200 cubits is about 100 yards or about 91 meters</span> away), dragging the net full of fish. 
-<span class="v">9&#160;</span>So when they got out on the land, they saw a fire of coals there, with fish and bread laid on it. 
-<span class="v">10&#160;</span>Yahushua said to them, <span class="wj">“Bring some of the fish which you have just caught.”</span> 
-</p><p>
-<span class="v">11&#160;</span>Simon Peter went up, and drew the net to land, full of one hundred fifty-three great fish. Even though there were so many, the net wasn’t torn. 
-</p><p>
-<span class="v">12&#160;</span>Yahushua said to them, <span class="wj">“Come and eat breakfast!”</span> 
-</p><p>None of the disciples dared inquire of him, “Who are you?” knowing that it was the Lord. 
-</p><p>
-<span class="v">13&#160;</span>Then Yahushua came and took the bread, gave it to them, and the fish likewise. 
-<span class="v">14&#160;</span>This is now the third time that Yahushua was revealed to his disciples after he had risen from the dead. 
-<span class="v">15&#160;</span>So when they had eaten their breakfast, Yahushua said to Simon Peter, <span class="wj">“Simon, son of Jonah, do you love me more than these?”</span> 
-</p><p>He said to him, “Yes, Lord; you know that I have affection for you.” 
-</p><p>He said to him, <span class="wj">“Feed my lambs.”</span> 
-<span class="v">16&#160;</span>He said to him again a second time, <span class="wj">“Simon, son of Jonah, do you love me?”</span> 
-</p><p>He said to him, “Yes, Lord; you know that I have affection for you.” 
-</p><p>He said to him, <span class="wj">“Tend my sheep.”</span> 
-<span class="v">17&#160;</span>He said to him the third time, <span class="wj">“Simon, son of Jonah, do you have affection for me?”</span> 
-</p><p>Peter was grieved because he asked him the third time, <span class="wj">“Do you have affection for me?”</span> He said to him, “Lord, you know everything. You know that I have affection for you.” 
-</p><p>Yahushua said to him, <span class="wj">“Feed my sheep. </span> 
-<span class="v">18&#160;</span><span class="wj">Most certainly I tell you, when you were young, you dressed yourself and walked where you wanted to. But when you are old, you will stretch out your hands, and another will dress you and carry you where you don’t want to go.”</span> 
-</p><p>
-<span class="v">19&#160;</span>Now he said this, signifying by what kind of death he would glorify Elohim. When he had said this, he said to him, <span class="wj">“Follow me.”</span> 
-</p><p>
-<span class="v">20&#160;</span>Then Peter, turning around, saw a disciple following. This was the disciple whom Yahushua loved, the one who had also leaned on Yahushua’s breast at the supper and asked, “Lord, who is going to betray you?” 
-<span class="v">21&#160;</span>Peter, seeing him, said to Yahushua, “Lord, what about this man?” 
-</p><p>
-<span class="v">22&#160;</span>Yahushua said to him, <span class="wj">“If I desire that he stay until I come, what is that to you? You follow me.”</span> 
-<span class="v">23&#160;</span>This saying therefore went out among the brothers<span class="f">+ \fr 21:23 \ft The word for “brothers” here may be also correctly translated “brothers and sisters” or “siblings.”</span> that this disciple wouldn’t die. Yet Yahushua didn’t say to him that he wouldn’t die, but, <span class="wj">“If I desire that he stay until I come, what is that to you?”</span> 
-</p><p>
-<span class="v">24&#160;</span>This is the disciple who testifies about these things, and wrote these things. We know that his witness is true. 
-<span class="v">25&#160;</span>There are also many other things which Yahushua did, which if they would all be written, I suppose that even the world itself wouldn’t have room for the books that would be written. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>In the beginning was the Word, and the Word was with Elohim, and an elohim was the Word. 
+<sup>2&#160;</sup>The same was in the beginning with Elohim. 
+<sup>3&#160;</sup>All things were made through him. Without him, nothing was made that has been made. 
+<sup>4&#160;</sup>In him was life, and the life was the light of men. 
+<sup>5&#160;</sup>The light shines in the darkness, and the darkness hasn’t overcome it. 
+</div><div class="p">
+<sup>6&#160;</sup>There came a man sent from Elohim, whose name was John. 
+<sup>7&#160;</sup>The same came as a witness, that he might testify about the light, that all might believe through him. 
+<sup>8&#160;</sup>He was not the light, but was sent that he might testify about the light. 
+<sup>9&#160;</sup>The true light that enlightens everyone was coming into the world. 
+</div><div class="p">
+<sup>10&#160;</sup>He was in the world, and the world was made through him, and the world didn’t recognize him. 
+<sup>11&#160;</sup>He came to his own, and those who were his own didn’t receive him. 
+<sup>12&#160;</sup>But as many as received him, to them he gave the right to become Elohim’s children, to those who believe in his name: 
+<sup>13&#160;</sup>who were born, not of blood, nor of the will of the flesh, nor of the will of man, but of Elohim. 
+</div><div class="p">
+<sup>14&#160;</sup>The Word became flesh and lived among us. We saw his glory, such glory as of the only born Son of the Father, full of grace and truth. 
+<sup>15&#160;</sup>John testified about him. He cried out, saying, “This was he of whom I said, ‘He who comes after me has surpassed me, for he was before me.’&#160;” 
+<sup>16&#160;</sup>From his fullness we all received grace upon grace. 
+<sup>17&#160;</sup>For the law was given through Moses. Grace and truth were realized through Yahushua Christ. 
+<sup>18&#160;</sup>No one has seen Elohim at any time. The only born who is in the bosom of the Father, has declared him. 
+</div><div class="p">
+<sup>19&#160;</sup>This is John’s testimony, when the Jews sent priests and Levites from Jerusalem to ask him, “Who are you?” 
+</div><div class="p">
+<sup>20&#160;</sup>He declared, and didn’t deny, but he declared, “I am not the Christ.” 
+</div><div class="p">
+<sup>21&#160;</sup>They asked him, “What then? Are you Elijah?” 
+</div><div class="p">He said, “I am not.” 
+</div><div class="p">“Are you the prophet?” 
+</div><div class="p">He answered, “No.” 
+</div><div class="p">
+<sup>22&#160;</sup>They said therefore to him, “Who are you? Give us an answer to take back to those who sent us. What do you say about yourself?” 
+</div><div class="p">
+<sup>23&#160;</sup>He said, “I am the voice of one crying in the wilderness, ‘Make straight the way of the Lord,’ as Isaiah the prophet said.” 
+</div><div class="p">
+<sup>24&#160;</sup>The ones who had been sent were from the Pharisees. 
+<sup>25&#160;</sup>They asked him, “Why then do you baptize if you are not the Christ, nor Elijah, nor the prophet?” 
+</div><div class="p">
+<sup>26&#160;</sup>John answered them, “I baptize in water, but among you stands one whom you don’t know. 
+<sup>27&#160;</sup>He is the one who comes after me, who is preferred before me, whose sandal strap I’m not worthy to loosen.” 
+<sup>28&#160;</sup>These things were done in Bethany beyond the Jordan, where John was baptizing. 
+</div><div class="p">
+<sup>29&#160;</sup>The next day, he saw Yahushua coming to him, and said, “Behold, the Lamb of Elohim, who takes away the sin of the world! 
+<sup>30&#160;</sup>This is he of whom I said, ‘After me comes a man who is preferred before me, for he was before me.’ 
+<sup>31&#160;</sup>I didn’t know him, but for this reason I came baptizing in water, that he would be revealed to Israel.” 
+<sup>32&#160;</sup>John testified, saying, “I have seen the Spirit descending like a dove out of heaven, and it remained on him. 
+<sup>33&#160;</sup>I didn’t recognize him, but he who sent me to baptize in water said to me, ‘On whomever you will see the Spirit descending and remaining on him is he who baptizes in the Set-Apart Spirit.’ 
+<sup>34&#160;</sup>I have seen and have testified that this is the Son of Elohim.” 
+</div><div class="p">
+<sup>35&#160;</sup>Again, the next day, John was standing with two of his disciples, 
+<sup>36&#160;</sup>and he looked at Yahushua as he walked, and said, “Behold, the Lamb of Elohim!” 
+<sup>37&#160;</sup>The two disciples heard him speak, and they followed Yahushua. 
+<sup>38&#160;</sup>Yahushua turned and saw them following, and said to them, <span class="wj">“What are you looking for?”</span> 
+</div><div class="p">They said to him, “Rabbi” (which is to say, being interpreted, Teacher), “where are you staying?” 
+</div><div class="p">
+<sup>39&#160;</sup>He said to them, <span class="wj">“Come and see.”</span> 
+</div><div class="p">They came and saw where he was staying, and they stayed with him that day. It was about the tenth hour. 
+<sup>40&#160;</sup>One of the two who heard John and followed him was Andrew, Simon Peter’s brother. 
+<sup>41&#160;</sup>He first found his own brother, Simon, and said to him, “We have found the Messiah!” (which is, being interpreted, Christ). 
+<sup>42&#160;</sup>He brought him to Yahushua. Yahushua looked at him and said, <span class="wj">“You are Simon the son of Jonah. You shall be called Cephas”</span> (which is by interpretation, Peter). 
+</div><div class="p">
+<sup>43&#160;</sup>On the next day, he was determined to go out into Galilee, and he found Philip. Yahushua said to him, <span class="wj">“Follow me.”</span> 
+<sup>44&#160;</sup>Now Philip was from Bethsaida, the city of Andrew and Peter. 
+<sup>45&#160;</sup>Philip found Nathanael, and said to him, “We have found him of whom Moses in the law and also the prophets, wrote: Yahushua of Nazareth, the son of Joseph.” 
+</div><div class="p">
+<sup>46&#160;</sup>Nathanael said to him, “Can any good thing come out of Nazareth?” 
+</div><div class="p">Philip said to him, “Come and see.” 
+</div><div class="p">
+<sup>47&#160;</sup>Yahushua saw Nathanael coming to him, and said about him, <span class="wj">“Behold, an Israelite indeed, in whom is no deceit!”</span> 
+</div><div class="p">
+<sup>48&#160;</sup>Nathanael said to him, “How do you know me?” 
+</div><div class="p">Yahushua answered him, <span class="wj">“Before Philip called you, when you were under the fig tree, I saw you.”</span> 
+</div><div class="p">
+<sup>49&#160;</sup>Nathanael answered him, “Rabbi, you are the Son of Elohim! You are King of Israel!” 
+</div><div class="p">
+<sup>50&#160;</sup>Yahushua answered him, <span class="wj">“Because I told you, ‘I saw you underneath the fig tree,’ do you believe? You will see greater things than these!”</span> 
+<sup>51&#160;</sup>He said to him, <span class="wj">“Most certainly, I tell you all, hereafter you will see heaven opened, and the angels of Elohim ascending and descending on the Son of Man.”</span> 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>The third day, there was a wedding in Cana of Galilee. Yahushua’s mother was there. 
+<sup>2&#160;</sup>Yahushua also was invited, with his disciples, to the wedding. 
+<sup>3&#160;</sup>When the wine ran out, Yahushua’s mother said to him, “They have no wine.” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahushua said to her, <span class="wj">“Woman, what does that have to do with you and me? My hour has not yet come.”</span> 
+</div><div class="p">
+<sup>5&#160;</sup>His mother said to the servants, “Whatever he says to you, do it.” 
+</div><div class="p">
+<sup>6&#160;</sup>Now there were six water pots of stone set there after the Jews’ way of purifying, containing two or three metretes apiece. 
+<sup>7&#160;</sup>Yahushua said to them, <span class="wj">“Fill the water pots with water.”</span> So they filled them up to the brim. 
+<sup>8&#160;</sup>He said to them, <span class="wj">“Now draw some out, and take it to the ruler of the feast.”</span> So they took it. 
+<sup>9&#160;</sup>When the ruler of the feast tasted the water now become wine, and didn’t know where it came from (but the servants who had drawn the water knew), the ruler of the feast called the bridegroom 
+<sup>10&#160;</sup>and said to him, “Everyone serves the good wine first, and when the guests have drunk freely, then that which is worse. You have kept the good wine until now!” 
+<sup>11&#160;</sup>This beginning of his signs Yahushua did in Cana of Galilee, and revealed his glory; and his disciples believed in him. 
+</div><div class="p">
+<sup>12&#160;</sup>After this, he went down to Capernaum, he, and his mother, his brothers, and his disciples; and they stayed there a few days. 
+</div><div class="p">
+<sup>13&#160;</sup>The Passover of the Jews was at hand, and Yahushua went up to Jerusalem. 
+<sup>14&#160;</sup>He found in the temple those who sold oxen, sheep, and doves, and the changers of money sitting. 
+<sup>15&#160;</sup>He made a whip of cords and drove all out of the temple, both the sheep and the oxen; and he poured out the changers’ money and overthrew their tables. 
+<sup>16&#160;</sup>To those who sold the doves, he said, <span class="wj">“Take these things out of here! Don’t make my Father’s house a marketplace!”</span> 
+<sup>17&#160;</sup>His disciples remembered that it was written, “Zeal for your house will eat me up.” 
+</div><div class="p">
+<sup>18&#160;</sup>The Jews therefore answered him, “What sign do you show us, seeing that you do these things?” 
+</div><div class="p">
+<sup>19&#160;</sup>Yahushua answered them, <span class="wj">“Destroy this temple, and in three days I will raise it up.”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>The Jews therefore said, “It took forty-six years to build this temple! Will you raise it up in three days?” 
+<sup>21&#160;</sup>But he spoke of the temple of his body. 
+<sup>22&#160;</sup>When therefore he was raised from the dead, his disciples remembered that he said this, and they believed the Scripture and the word which Yahushua had said. 
+</div><div class="p">
+<sup>23&#160;</sup>Now when he was in Jerusalem at the Passover, during the feast, many believed in his name, observing his signs which he did. 
+<sup>24&#160;</sup>But Yahushua didn’t entrust himself to them, because he knew everyone, 
+<sup>25&#160;</sup>and because he didn’t need for anyone to testify concerning man; for he himself knew what was in man. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now there was a man of the Pharisees named Nicodemus, a ruler of the Jews. 
+<sup>2&#160;</sup>He came to Yahushua by night and said to him, “Rabbi, we know that you are a teacher come from Elohim, for no one can do these signs that you do, unless Elohim is with him.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahushua answered him, <span class="wj">“Most certainly I tell you, unless one is born anew, </span> <span class="wj">he can’t see Elohim’s Kingdom.”</span> 
+</div><div class="p">
+<sup>4&#160;</sup>Nicodemus said to him, “How can a man be born when he is old? Can he enter a second time into his mother’s womb and be born?” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahushua answered, <span class="wj">“Most certainly I tell you, unless one is born of water and Spirit, he can’t enter into Elohim’s Kingdom.</span> 
+<sup>6&#160;</sup><span class="wj">That which is born of the flesh is flesh. That which is born of the Spirit is spirit. </span> 
+<sup>7&#160;</sup><span class="wj">Don’t marvel that I said to you, ‘You must be born anew.’ </span> 
+<sup>8&#160;</sup><span class="wj">The wind</span> <span class="wj">blows where it wants to, and you hear its sound, but don’t know where it comes from and where it is going. So is everyone who is born of the Spirit.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>Nicodemus answered him, “How can these things be?” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahushua answered him, <span class="wj">“Are you the teacher of Israel, and don’t understand these things? </span> 
+<sup>11&#160;</sup><span class="wj">Most certainly I tell you, we speak that which we know and testify of that which we have seen, and you don’t receive our witness. </span> 
+<sup>12&#160;</sup><span class="wj">If I told you earthly things and you don’t believe, how will you believe if I tell you heavenly things? </span> 
+<sup>13&#160;</sup><span class="wj">No one has ascended into heaven but he who descended out of heaven, the Son of Man, who is in heaven. </span> 
+<sup>14&#160;</sup><span class="wj">As Moses lifted up the serpent in the wilderness, even so must the Son of Man be lifted up, </span> 
+<sup>15&#160;</sup><span class="wj">that whoever believes in him should not perish, but have eternal life. </span> 
+<sup>16&#160;</sup><span class="wj">For Elohim so loved the world, that he gave his only born</span> <span class="wj">Son, that whoever believes in him should not perish, but have eternal life. </span> 
+<sup>17&#160;</sup><span class="wj">For Elohim didn’t send his Son into the world to judge the world, but that the world should be saved through him. </span> 
+<sup>18&#160;</sup><span class="wj">He who believes in him is not judged. He who doesn’t believe has been judged already, because he has not believed in the name of the only born Son of Elohim. </span> 
+<sup>19&#160;</sup><span class="wj">This is the judgment, that the light has come into the world, and men loved the darkness rather than the light, for their works were evil. </span> 
+<sup>20&#160;</sup><span class="wj">For everyone who does evil hates the light and doesn’t come to the light, lest his works would be exposed. </span> 
+<sup>21&#160;</sup><span class="wj">But he who does the truth comes to the light, that his works may be revealed, that they have been done in Elohim.”</span> 
+</div><div class="p">
+<sup>22&#160;</sup>After these things, Yahushua came with his disciples into the land of Judea. He stayed there with them and baptized. 
+<sup>23&#160;</sup>John also was baptizing in Enon near Salim, because there was much water there. They came and were baptized; 
+<sup>24&#160;</sup>for John was not yet thrown into prison. 
+<sup>25&#160;</sup>Therefore a dispute arose on the part of John’s disciples with some Jews about purification. 
+<sup>26&#160;</sup>They came to John and said to him, “Rabbi, he who was with you beyond the Jordan, to whom you have testified, behold, he baptizes, and everyone is coming to him.” 
+</div><div class="p">
+<sup>27&#160;</sup>John answered, “A man can receive nothing unless it has been given him from heaven. 
+<sup>28&#160;</sup>You yourselves testify that I said, ‘I am not the Christ,’ but, ‘I have been sent before him.’ 
+<sup>29&#160;</sup>He who has the bride is the bridegroom; but the friend of the bridegroom, who stands and hears him, rejoices greatly because of the bridegroom’s voice. Therefore my joy is made full. 
+<sup>30&#160;</sup>He must increase, but I must decrease. 
+</div><div class="p">
+<sup>31&#160;</sup>“He who comes from above is above all. He who is from the earth belongs to the earth and speaks of the earth. He who comes from heaven is above all. 
+<sup>32&#160;</sup>What he has seen and heard, of that he testifies; and no one receives his witness. 
+<sup>33&#160;</sup>He who has received his witness has set his seal to this, that Elohim is true. 
+<sup>34&#160;</sup>For he whom Elohim has sent speaks the words of Elohim; for Elohim gives the Spirit without measure. 
+<sup>35&#160;</sup>The Father loves the Son, and has given all things into his hand. 
+<sup>36&#160;</sup>One who believes in the Son has eternal life, but one who disobeys the Son won’t see life, but the wrath of Elohim remains on him.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Therefore when the Lord knew that the Pharisees had heard that Yahushua was making and baptizing more disciples than John 
+<sup>2&#160;</sup>(although Yahushua himself didn’t baptize, but his disciples), 
+<sup>3&#160;</sup>he left Judea and departed into Galilee. 
+<sup>4&#160;</sup>He needed to pass through Samaria. 
+<sup>5&#160;</sup>So he came to a city of Samaria called Sychar, near the parcel of ground that Jacob gave to his son Joseph. 
+<sup>6&#160;</sup>Jacob’s well was there. Yahushua therefore, being tired from his journey, sat down by the well. It was about the sixth hour. 
+</div><div class="p">
+<sup>7&#160;</sup>A woman of Samaria came to draw water. Yahushua said to her, <span class="wj">“Give me a drink.”</span> 
+<sup>8&#160;</sup>For his disciples had gone away into the city to buy food. 
+</div><div class="p">
+<sup>9&#160;</sup>The Samaritan woman therefore said to him, “How is it that you, being a Jew, ask for a drink from me, a Samaritan woman?” (For Jews have no dealings with Samaritans.) 
+</div><div class="p">
+<sup>10&#160;</sup>Yahushua answered her, <span class="wj">“If you knew the gift of Elohim, and who it is who says to you, ‘Give me a drink,’ you would have asked him, and he would have given you living water.”</span> 
+</div><div class="p">
+<sup>11&#160;</sup>The woman said to him, “Sir, you have nothing to draw with, and the well is deep. So where do you get that living water? 
+<sup>12&#160;</sup>Are you greater than our father Jacob, who gave us the well and drank from it himself, as did his children and his livestock?” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahushua answered her, <span class="wj">“Everyone who drinks of this water will thirst again, </span> 
+<sup>14&#160;</sup><span class="wj">but whoever drinks of the water that I will give him will never thirst again; but the water that I will give him will become in him a well of water springing up to eternal life.”</span> 
+</div><div class="p">
+<sup>15&#160;</sup>The woman said to him, “Sir, give me this water, so that I don’t get thirsty, neither come all the way here to draw.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahushua said to her, <span class="wj">“Go, call your man, and come here.” </span> 
+</div><div class="p">
+<sup>17&#160;</sup>The woman answered, “I have no man.” 
+</div><div class="p">Yahushua said to her, <span class="wj">“You said well, ‘I have no man,’ </span> 
+<sup>18&#160;</sup><span class="wj">for you have had five men; and he whom you now have is not your man. This you have said truly.”</span> 
+</div><div class="p">
+<sup>19&#160;</sup>The woman said to him, “Sir, I perceive that you are a prophet. 
+<sup>20&#160;</sup>Our fathers worshiped in this mountain, and you Jews say that in Jerusalem is the place where people ought to worship.” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahushua said to her, <span class="wj">“Woman, believe me, the hour is coming when neither in this mountain nor in Jerusalem will you worship the Father. </span> 
+<sup>22&#160;</sup><span class="wj">You worship that which you don’t know. We worship that which we know; for salvation is from the Jews. </span> 
+<sup>23&#160;</sup><span class="wj">But the hour comes, and now is, when the true worshipers will worship the Father in spirit and truth, for the Father seeks such to be his worshipers. </span> 
+<sup>24&#160;</sup><span class="wj">Elohim is spirit, and those who worship him must worship in spirit and truth.”</span> 
+</div><div class="p">
+<sup>25&#160;</sup>The woman said to him, “I know that Messiah is coming, he who is called Christ. When he has come, he will declare to us all things.” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahushua said to her, <span class="wj">“I am he, the one who speaks to you.”</span> 
+</div><div class="p">
+<sup>27&#160;</sup>Just then, his disciples came. They marveled that he was speaking with a woman; yet no one said, “What are you looking for?” or, “Why do you speak with her?” 
+<sup>28&#160;</sup>So the woman left her water pot, went away into the city, and said to the people, 
+<sup>29&#160;</sup>“Come, see a man who told me everything that I have done. Can this be the Christ?” 
+<sup>30&#160;</sup>They went out of the city, and were coming to him. 
+</div><div class="p">
+<sup>31&#160;</sup>In the meanwhile, the disciples urged him, saying, “Rabbi, eat.” 
+</div><div class="p">
+<sup>32&#160;</sup>But he said to them, <span class="wj">“I have food to eat that you don’t know about.”</span> 
+</div><div class="p">
+<sup>33&#160;</sup>The disciples therefore said to one another, “Has anyone brought him something to eat?” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua said to them, <span class="wj">“My food is to do the will of him who sent me and to accomplish his work. </span> 
+<sup>35&#160;</sup><span class="wj">Don’t you say, ‘There are yet four months until the harvest’? Behold, I tell you, lift up your eyes and look at the fields, that they are white for harvest already. </span> 
+<sup>36&#160;</sup><span class="wj">He who reaps receives wages and gathers fruit to eternal life, that both he who sows and he who reaps may rejoice together. </span> 
+<sup>37&#160;</sup><span class="wj">For in this the saying is true, ‘One sows, and another reaps.’ </span> 
+<sup>38&#160;</sup><span class="wj">I sent you to reap that for which you haven’t labored. Others have labored, and you have entered into their labor.”</span> 
+</div><div class="p">
+<sup>39&#160;</sup>From that city many of the Samaritans believed in him because of the word of the woman, who testified, “He told me everything that I have done.” 
+<sup>40&#160;</sup>So when the Samaritans came to him, they begged him to stay with them. He stayed there two days. 
+<sup>41&#160;</sup>Many more believed because of his word. 
+<sup>42&#160;</sup>They said to the woman, “Now we believe, not because of your speaking; for we have heard for ourselves, and know that this is indeed the Christ, the Savior of the world.” 
+</div><div class="p">
+<sup>43&#160;</sup>After the two days he went out from there and went into Galilee. 
+<sup>44&#160;</sup>For Yahushua himself testified that a prophet has no honor in his own country. 
+<sup>45&#160;</sup>So when he came into Galilee, the Galileans received him, having seen all the things that he did in Jerusalem at the feast, for they also went to the feast. 
+<sup>46&#160;</sup>Yahushua came therefore again to Cana of Galilee, where he made the water into wine. There was a certain nobleman whose son was sick at Capernaum. 
+<sup>47&#160;</sup>When he heard that Yahushua had come out of Judea into Galilee, he went to him and begged him that he would come down and heal his son, for he was at the point of death. 
+<sup>48&#160;</sup>Yahushua therefore said to him, <span class="wj">“Unless you see signs and wonders, you will in no way believe.”</span> 
+</div><div class="p">
+<sup>49&#160;</sup>The nobleman said to him, “Sir, come down before my child dies.” 
+</div><div class="p">
+<sup>50&#160;</sup>Yahushua said to him, <span class="wj">“Go your way. Your son lives.”</span> The man believed the word that Yahushua spoke to him, and he went his way. 
+<sup>51&#160;</sup>As he was going down, his servants met him and reported, saying “Your child lives!” 
+<sup>52&#160;</sup>So he inquired of them the hour when he began to get better. They said therefore to him, “Yesterday at the seventh hour, the fever left him.” 
+<sup>53&#160;</sup>So the father knew that it was at that hour in which Yahushua said to him, <span class="wj">“Your son lives.”</span> He believed, as did his whole house. 
+<sup>54&#160;</sup>This is again the second sign that Yahushua did, having come out of Judea into Galilee. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, there was a feast of the Jews, and Yahushua went up to Jerusalem. 
+<sup>2&#160;</sup>Now in Jerusalem by the sheep gate, there is a pool, which is called in Hebrew, “Bethesda”, having five porches. 
+<sup>3&#160;</sup>In these lay a great multitude of those who were sick, blind, lame, or paralyzed, waiting for the moving of the water; 
+<sup>4&#160;</sup>for an angel went down at certain times into the pool and stirred up the water. Whoever stepped in first after the stirring of the water was healed of whatever disease he had. 
+<sup>5&#160;</sup>A certain man was there who had been sick for thirty-eight years. 
+<sup>6&#160;</sup>When Yahushua saw him lying there, and knew that he had been sick for a long time, he asked him, <span class="wj">“Do you want to be made well?”</span> 
+</div><div class="p">
+<sup>7&#160;</sup>The sick man answered him, “Sir, I have no one to put me into the pool when the water is stirred up, but while I’m coming, another steps down before me.” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahushua said to him, <span class="wj">“Arise, take up your mat, and walk.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>Immediately, the man was made well, and took up his mat and walked. 
+</div><div class="p">Now that day was a Sabbath. 
+<sup>10&#160;</sup>So the Jews said to him who was cured, “It is the Sabbath. It is not lawful for you to carry the mat.” 
+</div><div class="p">
+<sup>11&#160;</sup>He answered them, “He who made me well said to me, <span class="wj">‘Take up your mat and walk.’</span>&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Then they asked him, “Who is the man who said to you, <span class="wj">‘Take up your mat and walk’</span>?” 
+</div><div class="p">
+<sup>13&#160;</sup>But he who was healed didn’t know who it was, for Yahushua had withdrawn, a crowd being in the place. 
+</div><div class="p">
+<sup>14&#160;</sup>Afterward Yahushua found him in the temple and said to him, <span class="wj">“Behold, you are made well. Sin no more, so that nothing worse happens to you.” </span> 
+</div><div class="p">
+<sup>15&#160;</sup>The man went away, and told the Jews that it was Yahushua who had made him well. 
+<sup>16&#160;</sup>For this cause the Jews persecuted Yahushua and sought to kill him, because he did these things on the Sabbath. 
+<sup>17&#160;</sup>But Yahushua answered them, <span class="wj">“My Father is still working, so I am working, too.”</span> 
+</div><div class="p">
+<sup>18&#160;</sup>For this cause therefore the Jews sought all the more to kill him, because he not only broke the Sabbath, but also called Elohim his own Father, making himself equal with Elohim. 
+<sup>19&#160;</sup>Yahushua therefore answered them, <span class="wj">“Most certainly, I tell you, the Son can do nothing of himself, but what he sees the Father doing. For whatever things he does, these the Son also does likewise. </span> 
+<sup>20&#160;</sup><span class="wj">For the Father has affection for the Son, and shows him all things that he himself does. He will show him greater works than these, that you may marvel. </span> 
+<sup>21&#160;</sup><span class="wj">For as the Father raises the dead and gives them life, even so the Son also gives life to whom he desires. </span> 
+<sup>22&#160;</sup><span class="wj">For the Father judges no one, but he has given all judgment to the Son, </span> 
+<sup>23&#160;</sup><span class="wj">that all may honor the Son, even as they honor the Father. He who doesn’t honor the Son doesn’t honor the Father who sent him.</span> 
+</div><div class="p">
+<sup>24&#160;</sup><span class="wj">“Most certainly I tell you, he who hears my word and believes him who sent me has eternal life, and doesn’t come into judgment, but has passed out of death into life. </span> 
+<sup>25&#160;</sup><span class="wj">Most certainly I tell you, the hour comes, and now is, when the dead will hear the Son of Elohim’s voice; and those who hear will live. </span> 
+<sup>26&#160;</sup><span class="wj">For as the Father has life in himself, even so he gave to the Son also to have life in himself. </span> 
+<sup>27&#160;</sup><span class="wj">He also gave him authority to execute judgment, because he is a son of man. </span> 
+<sup>28&#160;</sup><span class="wj">Don’t marvel at this, for the hour comes in which all who are in the tombs will hear his voice </span> 
+<sup>29&#160;</sup><span class="wj">and will come out; those who have done good, to the resurrection of life; and those who have done evil, to the resurrection of judgment. </span> 
+<sup>30&#160;</sup><span class="wj">I can of myself do nothing. As I hear, I judge; and my judgment is righteous, because I don’t seek my own will, but the will of my Father who sent me.</span> 
+</div><div class="p">
+<sup>31&#160;</sup><span class="wj">“If I testify about myself, my witness is not valid. </span> 
+<sup>32&#160;</sup><span class="wj">It is another who testifies about me. I know that the testimony which he testifies about me is true. </span> 
+<sup>33&#160;</sup><span class="wj">You have sent to John, and he has testified to the truth. </span> 
+<sup>34&#160;</sup><span class="wj">But the testimony which I receive is not from man. However, I say these things that you may be saved. </span> 
+<sup>35&#160;</sup><span class="wj">He was the burning and shining lamp, and you were willing to rejoice for a while in his light. </span> 
+<sup>36&#160;</sup><span class="wj">But the testimony which I have is greater than that of John; for the works which the Father gave me to accomplish, the very works that I do, testify about me, that the Father has sent me. </span> 
+<sup>37&#160;</sup><span class="wj">The Father himself, who sent me, has testified about me. You have neither heard his voice at any time, nor seen his form. </span> 
+<sup>38&#160;</sup><span class="wj">You don’t have his word living in you, because you don’t believe him whom he sent.</span> 
+</div><div class="p">
+<sup>39&#160;</sup><span class="wj">“You search the Scriptures, because you think that in them you have eternal life; and these are they which testify about me. </span> 
+<sup>40&#160;</sup><span class="wj">Yet you will not come to me, that you may have life. </span> 
+<sup>41&#160;</sup><span class="wj">I don’t receive glory from men. </span> 
+<sup>42&#160;</sup><span class="wj">But I know you, that you don’t have Elohim’s love in yourselves. </span> 
+<sup>43&#160;</sup><span class="wj">I have come in my Father’s name, and you don’t receive me. If another comes in his own name, you will receive him. </span> 
+<sup>44&#160;</sup><span class="wj">How can you believe, who receive glory from one another, and you don’t seek the glory that comes from the only Elohim?</span> 
+</div><div class="p">
+<sup>45&#160;</sup><span class="wj">“Don’t think that I will accuse you to the Father. There is one who accuses you, even Moses, on whom you have set your hope. </span> 
+<sup>46&#160;</sup><span class="wj">For if you believed Moses, you would believe me; for he wrote about me. </span> 
+<sup>47&#160;</sup><span class="wj">But if you don’t believe his writings, how will you believe my words?”</span> 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, Yahushua went away to the other side of the sea of Galilee, which is also called the Sea of Tiberias. 
+<sup>2&#160;</sup>A great multitude followed him, because they saw his signs which he did on those who were sick. 
+<sup>3&#160;</sup>Yahushua went up into the mountain, and he sat there with his disciples. 
+<sup>4&#160;</sup>Now the Passover, the feast of the Jews, was at hand. 
+<sup>5&#160;</sup>Yahushua therefore, lifting up his eyes and seeing that a great multitude was coming to him, said to Philip, <span class="wj">“Where are we to buy bread, that these may eat?”</span> 
+<sup>6&#160;</sup>He said this to test him, for he himself knew what he would do. 
+</div><div class="p">
+<sup>7&#160;</sup>Philip answered him, “Two hundred denarii worth of bread is not sufficient for them, that every one of them may receive a little.” 
+</div><div class="p">
+<sup>8&#160;</sup>One of his disciples, Andrew, Simon Peter’s brother, said to him, 
+<sup>9&#160;</sup>“There is a boy here who has five barley loaves and two fish, but what are these among so many?” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahushua said, <span class="wj">“Have the people sit down.”</span> Now there was much grass in that place. So the men sat down, in number about five thousand. 
+<sup>11&#160;</sup>Yahushua took the loaves, and having given thanks, he distributed to the disciples, and the disciples to those who were sitting down, likewise also of the fish as much as they desired. 
+<sup>12&#160;</sup>When they were filled, he said to his disciples, <span class="wj">“Gather up the broken pieces which are left over, that nothing be lost.”</span> 
+<sup>13&#160;</sup>So they gathered them up, and filled twelve baskets with broken pieces from the five barley loaves, which were left over by those who had eaten. 
+<sup>14&#160;</sup>When therefore the people saw the sign which Yahushua did, they said, “This is truly the prophet who comes into the world.” 
+<sup>15&#160;</sup>Yahushua therefore, perceiving that they were about to come and take him by force to make him king, withdrew again to the mountain by himself. 
+</div><div class="p">
+<sup>16&#160;</sup>When evening came, his disciples went down to the sea. 
+<sup>17&#160;</sup>They entered into the boat, and were going over the sea to Capernaum. It was now dark, and Yahushua had not come to them. 
+<sup>18&#160;</sup>The sea was tossed by a great wind blowing. 
+<sup>19&#160;</sup>When therefore they had rowed about twenty-five or thirty stadia, they saw Yahushua walking on the sea and drawing near to the boat; and they were afraid. 
+<sup>20&#160;</sup>But he said to them, <span class="wj">“It is I.</span> <span class="wj">Don’t be afraid.”</span> 
+<sup>21&#160;</sup>They were willing therefore to receive him into the boat. Immediately the boat was at the land where they were going. 
+</div><div class="p">
+<sup>22&#160;</sup>On the next day, the multitude that stood on the other side of the sea saw that there was no other boat there, except the one in which his disciples had embarked, and that Yahushua hadn’t entered with his disciples into the boat, but his disciples had gone away alone. 
+<sup>23&#160;</sup>However, boats from Tiberias came near to the place where they ate the bread after the Lord had given thanks. 
+<sup>24&#160;</sup>When the multitude therefore saw that Yahushua wasn’t there, nor his disciples, they themselves got into the boats and came to Capernaum, seeking Yahushua. 
+<sup>25&#160;</sup>When they found him on the other side of the sea, they asked him, “Rabbi, when did you come here?” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahushua answered them, <span class="wj">“Most certainly I tell you, you seek me, not because you saw signs, but because you ate of the loaves and were filled. </span> 
+<sup>27&#160;</sup><span class="wj">Don’t work for the food which perishes, but for the food which remains to eternal life, which the Son of Man will give to you. For Elohim the Father has sealed him.”</span> 
+</div><div class="p">
+<sup>28&#160;</sup>They said therefore to him, “What must we do, that we may work the works of Elohim?” 
+</div><div class="p">
+<sup>29&#160;</sup>Yahushua answered them, <span class="wj">“This is the work of Elohim, that you believe in him whom he has sent.”</span> 
+</div><div class="p">
+<sup>30&#160;</sup>They said therefore to him, “What then do you do for a sign, that we may see and believe you? What work do you do? 
+<sup>31&#160;</sup>Our fathers ate the manna in the wilderness. As it is written, ‘He gave them bread out of heaven to eat.’&#160;” 
+</div><div class="p">
+<sup>32&#160;</sup>Yahushua therefore said to them, <span class="wj">“Most certainly, I tell you, it wasn’t Moses who gave you the bread out of heaven, but my Father gives you the true bread out of heaven. </span> 
+<sup>33&#160;</sup><span class="wj">For the bread of Elohim is that which comes down out of heaven and gives life to the world.”</span> 
+</div><div class="p">
+<sup>34&#160;</sup>They said therefore to him, “Lord, always give us this bread.” 
+</div><div class="p">
+<sup>35&#160;</sup>Yahushua said to them, <span class="wj">“I am the bread of life. Whoever comes to me will not be hungry, and whoever believes in me will never be thirsty. </span> 
+<sup>36&#160;</sup><span class="wj">But I told you that you have seen me, and yet you don’t believe. </span> 
+<sup>37&#160;</sup><span class="wj">All those whom the Father gives me will come to me. He who comes to me I will in no way throw out. </span> 
+<sup>38&#160;</sup><span class="wj">For I have come down from heaven, not to do my own will, but the will of him who sent me. </span> 
+<sup>39&#160;</sup><span class="wj">This is the will of my Father who sent me, that of all he has given to me I should lose nothing, but should raise him up at the last day. </span> 
+<sup>40&#160;</sup><span class="wj">This is the will of the one who sent me, that everyone who sees the Son and believes in him should have eternal life; and I will raise him up at the last day.”</span> 
+</div><div class="p">
+<sup>41&#160;</sup>The Jews therefore murmured concerning him, because he said, <span class="wj">“I am the bread which came down out of heaven.”</span> 
+<sup>42&#160;</sup>They said, “Isn’t this Yahushua, the son of Joseph, whose father and mother we know? How then does he say, <span class="wj">‘I have come down out of heaven’?” </span> 
+</div><div class="p">
+<sup>43&#160;</sup>Therefore Yahushua answered them, <span class="wj">“Don’t murmur among yourselves. </span> 
+<sup>44&#160;</sup><span class="wj">No one can come to me unless the Father who sent me draws him; and I will raise him up in the last day. </span> 
+<sup>45&#160;</sup><span class="wj">It is written in the prophets, ‘They will all be taught by Elohim.’ </span> <span class="wj">Therefore everyone who hears from the Father and has learned, comes to me. </span> 
+<sup>46&#160;</sup><span class="wj">Not that anyone has seen the Father, except he who is from Elohim. He has seen the Father. </span> 
+<sup>47&#160;</sup><span class="wj">Most certainly, I tell you, he who believes in me has eternal life. </span> 
+<sup>48&#160;</sup><span class="wj">I am the bread of life. </span> 
+<sup>49&#160;</sup><span class="wj">Your fathers ate the manna in the wilderness and they died. </span> 
+<sup>50&#160;</sup><span class="wj">This is the bread which comes down out of heaven, that anyone may eat of it and not die. </span> 
+<sup>51&#160;</sup><span class="wj">I am the living bread which came down out of heaven. If anyone eats of this bread, he will live forever. Yes, the bread which I will give for the life of the world is my flesh.”</span> 
+</div><div class="p">
+<sup>52&#160;</sup>The Jews therefore contended with one another, saying, “How can this man give us his flesh to eat?” 
+</div><div class="p">
+<sup>53&#160;</sup>Yahushua therefore said to them, <span class="wj">“Most certainly I tell you, unless you eat the flesh of the Son of Man and drink his blood, you don’t have life in yourselves. </span> 
+<sup>54&#160;</sup><span class="wj">He who eats my flesh and drinks my blood has eternal life, and I will raise him up at the last day. </span> 
+<sup>55&#160;</sup><span class="wj">For my flesh is food indeed, and my blood is drink indeed. </span> 
+<sup>56&#160;</sup><span class="wj">He who eats my flesh and drinks my blood lives in me, and I in him. </span> 
+<sup>57&#160;</sup><span class="wj">As the living Father sent me, and I live because of the Father, so he who feeds on me will also live because of me. </span> 
+<sup>58&#160;</sup><span class="wj">This is the bread which came down out of heaven—not as our fathers ate the manna and died. He who eats this bread will live forever.”</span> 
+<sup>59&#160;</sup>He said these things in the synagogue, as he taught in Capernaum. 
+</div><div class="p">
+<sup>60&#160;</sup>Therefore many of his disciples, when they heard this, said, “This is a hard saying! Who can listen to it?” 
+</div><div class="p">
+<sup>61&#160;</sup>But Yahushua knowing in himself that his disciples murmured at this, said to them, <span class="wj">“Does this cause you to stumble? </span> 
+<sup>62&#160;</sup><span class="wj">Then what if you would see the Son of Man ascending to where he was before? </span> 
+<sup>63&#160;</sup><span class="wj">It is the spirit who gives life. The flesh profits nothing. The words that I speak to you are spirit, and are life. </span> 
+<sup>64&#160;</sup><span class="wj">But there are some of you who don’t believe.”</span> For Yahushua knew from the beginning who they were who didn’t believe, and who it was who would betray him. 
+<sup>65&#160;</sup>He said, <span class="wj">“For this cause I have said to you that no one can come to me, unless it is given to him by my Father.”</span> 
+</div><div class="p">
+<sup>66&#160;</sup>At this, many of his disciples went back and walked no more with him. 
+<sup>67&#160;</sup>Yahushua said therefore to the twelve, <span class="wj">“You don’t also want to go away, do you?”</span> 
+</div><div class="p">
+<sup>68&#160;</sup>Simon Peter answered him, “Lord, to whom would we go? You have the words of eternal life. 
+<sup>69&#160;</sup>We have come to believe and know that you are the Christ, the Son of the living Elohim.” 
+</div><div class="p">
+<sup>70&#160;</sup>Yahushua answered them, <span class="wj">“Didn’t I choose you, the twelve, and one of you is a devil?”</span> 
+<sup>71&#160;</sup>Now he spoke of Judas, the son of Simon Iscariot, for it was he who would betray him, being one of the twelve. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, Yahushua was walking in Galilee, for he wouldn’t walk in Judea, because the Jews sought to kill him. 
+<sup>2&#160;</sup>Now the feast of the Jews, the Feast of Booths, was at hand. 
+<sup>3&#160;</sup>His brothers therefore said to him, “Depart from here and go into Judea, that your disciples also may see your works which you do. 
+<sup>4&#160;</sup>For no one does anything in secret while he seeks to be known openly. If you do these things, reveal yourself to the world.” 
+<sup>5&#160;</sup>For even his brothers didn’t believe in him. 
+</div><div class="p">
+<sup>6&#160;</sup>Yahushua therefore said to them, <span class="wj">“My time has not yet come, but your time is always ready. </span> 
+<sup>7&#160;</sup><span class="wj">The world can’t hate you, but it hates me, because I testify about it, that its works are evil. </span> 
+<sup>8&#160;</sup><span class="wj">You go up to the feast. I am not yet going up to this feast, because my time is not yet fulfilled.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>Having said these things to them, he stayed in Galilee. 
+<sup>10&#160;</sup>But when his brothers had gone up to the feast, then he also went up, not publicly, but as it were in secret. 
+<sup>11&#160;</sup>The Jews therefore sought him at the feast, and said, “Where is he?” 
+<sup>12&#160;</sup>There was much murmuring among the multitudes concerning him. Some said, “He is a good man.” Others said, “Not so, but he leads the multitude astray.” 
+<sup>13&#160;</sup>Yet no one spoke openly of him for fear of the Jews. 
+<sup>14&#160;</sup>But when it was now the middle of the feast, Yahushua went up into the temple and taught. 
+<sup>15&#160;</sup>The Jews therefore marveled, saying, “How does this man know letters, having never been educated?” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahushua therefore answered them, <span class="wj">“My teaching is not mine, but his who sent me. </span> 
+<sup>17&#160;</sup><span class="wj">If anyone desires to do his will, he will know about the teaching, whether it is from Elohim or if I am speaking from myself. </span> 
+<sup>18&#160;</sup><span class="wj">He who speaks from himself seeks his own glory, but he who seeks the glory of him who sent him is true, and no unrighteousness is in him. </span> 
+<sup>19&#160;</sup><span class="wj">Didn’t Moses give you the law, and yet none of you keeps the law? Why do you seek to kill me?”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>The multitude answered, “You have a demon! Who seeks to kill you?” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahushua answered them, <span class="wj">“I did one work and you all marvel because of it. </span> 
+<sup>22&#160;</sup><span class="wj">Moses has given you circumcision (not that it is of Moses, but of the fathers), and on the Sabbath you circumcise a boy. </span> 
+<sup>23&#160;</sup><span class="wj">If a boy receives circumcision on the Sabbath, that the law of Moses may not be broken, are you angry with me because I made a man completely healthy on the Sabbath? </span> 
+<sup>24&#160;</sup><span class="wj">Don’t judge according to appearance, but judge righteous judgment.” </span> 
+</div><div class="p">
+<sup>25&#160;</sup>Therefore some of them of Jerusalem said, “Isn’t this he whom they seek to kill? 
+<sup>26&#160;</sup>Behold, he speaks openly, and they say nothing to him. Can it be that the rulers indeed know that this is truly the Christ? 
+<sup>27&#160;</sup>However, we know where this man comes from, but when the Christ comes, no one will know where he comes from.” 
+</div><div class="p">
+<sup>28&#160;</sup>Yahushua therefore cried out in the temple, teaching and saying, <span class="wj">“You both know me, and know where I am from. I have not come of myself, but he who sent me is true, whom you don’t know. </span> 
+<sup>29&#160;</sup><span class="wj">I know him, because I am from him, and he sent me.”</span> 
+</div><div class="p">
+<sup>30&#160;</sup>They sought therefore to take him; but no one laid a hand on him, because his hour had not yet come. 
+<sup>31&#160;</sup>But of the multitude, many believed in him. They said, “When the Christ comes, he won’t do more signs than those which this man has done, will he?” 
+<sup>32&#160;</sup>The Pharisees heard the multitude murmuring these things concerning him, and the chief priests and the Pharisees sent officers to arrest him. 
+</div><div class="p">
+<sup>33&#160;</sup>Then Yahushua said, <span class="wj">“I will be with you a little while longer, then I go to him who sent me. </span> 
+<sup>34&#160;</sup><span class="wj">You will seek me and won’t find me. You can’t come where I am.”</span> 
+</div><div class="p">
+<sup>35&#160;</sup>The Jews therefore said among themselves, “Where will this man go that we won’t find him? Will he go to the Dispersion among the Greeks and teach the Greeks? 
+<sup>36&#160;</sup>What is this word that he said, <span class="wj">‘You will seek me, and won’t find me;’</span> and <span class="wj">‘Where I am, you can’t come’</span>?” 
+</div><div class="p">
+<sup>37&#160;</sup>Now on the last and greatest day of the feast, Yahushua stood and cried out, <span class="wj">“If anyone is thirsty, let him come to me and drink! </span> 
+<sup>38&#160;</sup><span class="wj">He who believes in me, as the Scripture has said, from within him will flow rivers of living water.”</span> 
+<sup>39&#160;</sup>But he said this about the Spirit, which those believing in him were to receive. For the Set-Apart Spirit was not yet given, because Yahushua wasn’t yet glorified. 
+</div><div class="p">
+<sup>40&#160;</sup>Many of the multitude therefore, when they heard these words, said, “This is truly the prophet.” 
+<sup>41&#160;</sup>Others said, “This is the Christ.” But some said, “What, does the Christ come out of Galilee? 
+<sup>42&#160;</sup>Hasn’t the Scripture said that the Christ comes of the offspring of David, the village where David was?” 
+<sup>43&#160;</sup>So a division arose in the multitude because of him. 
+<sup>44&#160;</sup>Some of them would have arrested him, but no one laid hands on him. 
+<sup>45&#160;</sup>The officers therefore came to the chief priests and Pharisees; and they said to them, “Why didn’t you bring him?” 
+</div><div class="p">
+<sup>46&#160;</sup>The officers answered, “No man ever spoke like this man!” 
+</div><div class="p">
+<sup>47&#160;</sup>The Pharisees therefore answered them, “You aren’t also led astray, are you? 
+<sup>48&#160;</sup>Have any of the rulers or any of the Pharisees believed in him? 
+<sup>49&#160;</sup>But this multitude that doesn’t know the law is cursed.” 
+</div><div class="p">
+<sup>50&#160;</sup>Nicodemus (he who came to him by night, being one of them) said to them, 
+<sup>51&#160;</sup>“Does our law judge a man unless it first hears from him personally and knows what he does?” 
+</div><div class="p">
+<sup>52&#160;</sup>They answered him, “Are you also from Galilee? Search and see that no prophet has arisen out of Galilee.” 
+</div><div class="p">
+<sup>53&#160;</sup>Everyone went to his own house, 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="nb">
+<sup>1&#160;</sup>but Yahushua went to the Mount of Olives. 
+</div><div class="p">
+<sup>2&#160;</sup>Now very early in the morning, he came again into the temple, and all the people came to him. He sat down and taught them. 
+<sup>3&#160;</sup>The scribes and the Pharisees brought a woman taken in adultery. Having set her in the middle, 
+<sup>4&#160;</sup>they told him, “Teacher, we found this woman in adultery, in the very act. 
+<sup>5&#160;</sup>Now in our law, Moses commanded us to stone such women. What then do you say about her?” 
+<sup>6&#160;</sup>They said this testing him, that they might have something to accuse him of. 
+</div><div class="p">But Yahushua stooped down and wrote on the ground with his finger. 
+<sup>7&#160;</sup>But when they continued asking him, he looked up and said to them, <span class="wj">“He who is without sin among you, let him throw the first stone at her.” </span> 
+<sup>8&#160;</sup>Again he stooped down and wrote on the ground with his finger. 
+</div><div class="p">
+<sup>9&#160;</sup>They, when they heard it, being convicted by their conscience, went out one by one, beginning from the oldest, even to the last. Yahushua was left alone with the woman where she was, in the middle. 
+<sup>10&#160;</sup>Yahushua, standing up, saw her and said, <span class="wj">“Woman, where are your accusers? Did no one condemn you?”</span> 
+</div><div class="p">
+<sup>11&#160;</sup>She said, “No one, Lord.” 
+</div><div class="p">Yahushua said, <span class="wj">“Neither do I condemn you. Go your way. From now on, sin no more.”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>Again, therefore, Yahushua spoke to them, saying, <span class="wj">“I am the light of the world.</span> <span class="wj">He who follows me will not walk in the darkness, but will have the light of life.”</span> 
+</div><div class="p">
+<sup>13&#160;</sup>The Pharisees therefore said to him, “You testify about yourself. Your testimony is not valid.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahushua answered them, <span class="wj">“Even if I testify about myself, my testimony is true, for I know where I came from, and where I am going; but you don’t know where I came from, or where I am going. </span> 
+<sup>15&#160;</sup><span class="wj">You judge according to the flesh. I judge no one. </span> 
+<sup>16&#160;</sup><span class="wj">Even if I do judge, my judgment is true, for I am not alone, but I am with the Father who sent me. </span> 
+<sup>17&#160;</sup><span class="wj">It’s also written in your law that the testimony of two people is valid.</span> 
+<sup>18&#160;</sup><span class="wj">I am one who testifies about myself, and the Father who sent me testifies about me.”</span> 
+</div><div class="p">
+<sup>19&#160;</sup>They said therefore to him, “Where is your Father?” 
+</div><div class="p">Yahushua answered, <span class="wj">“You know neither me nor my Father. If you knew me, you would know my Father also.”</span> 
+<sup>20&#160;</sup>Yahushua spoke these words in the treasury, as he taught in the temple. Yet no one arrested him, because his hour had not yet come. 
+<sup>21&#160;</sup>Yahushua said therefore again to them, <span class="wj">“I am going away, and you will seek me, and you will die in your sins. Where I go, you can’t come.” </span> 
+</div><div class="p">
+<sup>22&#160;</sup>The Jews therefore said, “Will he kill himself, because he says, <span class="wj">‘Where I am going, you can’t come’</span>?” 
+</div><div class="p">
+<sup>23&#160;</sup>He said to them, <span class="wj">“You are from beneath. I am from above. You are of this world. I am not of this world. </span> 
+<sup>24&#160;</sup><span class="wj">I said therefore to you that you will die in your sins; for unless you believe that I am</span> <span class="wj">he, you will die in your sins.” </span> 
+</div><div class="p">
+<sup>25&#160;</sup>They said therefore to him, “Who are you?” 
+</div><div class="p">Yahushua said to them, <span class="wj">“Just what I have been saying to you from the beginning. </span> 
+<sup>26&#160;</sup><span class="wj">I have many things to speak and to judge concerning you. However, he who sent me is true; and the things which I heard from him, these I say to the world.”</span> 
+</div><div class="p">
+<sup>27&#160;</sup>They didn’t understand that he spoke to them about the Father. 
+<sup>28&#160;</sup>Yahushua therefore said to them, <span class="wj">“When you have lifted up the Son of Man, then you will know that I am he, and I do nothing of myself, but as my Father taught me, I say these things. </span> 
+<sup>29&#160;</sup><span class="wj">He who sent me is with me. The Father hasn’t left me alone, for I always do the things that are pleasing to him.”</span> 
+</div><div class="p">
+<sup>30&#160;</sup>As he spoke these things, many believed in him. 
+<sup>31&#160;</sup>Yahushua therefore said to those Jews who had believed him, <span class="wj">“If you remain in my word, then you are truly my disciples. </span> 
+<sup>32&#160;</sup><span class="wj">You will know the truth, and the truth will make you free.” </span> 
+</div><div class="p">
+<sup>33&#160;</sup>They answered him, “We are Abraham’s offspring, and have never been in bondage to anyone. How do you say, <span class="wj">‘You will be made free’</span>?” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua answered them, <span class="wj">“Most certainly I tell you, everyone who commits sin is the bondservant of sin. </span> 
+<sup>35&#160;</sup><span class="wj">A bondservant doesn’t live in the house forever. A son remains forever. </span> 
+<sup>36&#160;</sup><span class="wj">If therefore the Son makes you free, you will be free indeed. </span> 
+<sup>37&#160;</sup><span class="wj">I know that you are Abraham’s offspring, yet you seek to kill me, because my word finds no place in you. </span> 
+<sup>38&#160;</sup><span class="wj">I say the things which I have seen with my Father; and you also do the things which you have seen with your father.”</span> 
+</div><div class="p">
+<sup>39&#160;</sup>They answered him, “Our father is Abraham.” 
+</div><div class="p">Yahushua said to them, <span class="wj">“If you were Abraham’s children, you would do the works of Abraham. </span> 
+<sup>40&#160;</sup><span class="wj">But now you seek to kill me, a man who has told you the truth which I heard from Elohim. Abraham didn’t do this. </span> 
+<sup>41&#160;</sup><span class="wj">You do the works of your father.”</span> 
+</div><div class="p">They said to him, “We were not born of sexual immorality. We have one Father, Elohim.” 
+</div><div class="p">
+<sup>42&#160;</sup>Therefore Yahushua said to them, <span class="wj">“If Elohim were your father, you would love me, for I came out and have come from Elohim. For I haven’t come of myself, but he sent me. </span> 
+<sup>43&#160;</sup><span class="wj">Why don’t you understand my speech? Because you can’t hear my word. </span> 
+<sup>44&#160;</sup><span class="wj">You are of your father the devil, and you want to do the desires of your father. He was a murderer from the beginning, and doesn’t stand in the truth, because there is no truth in him. When he speaks a lie, he speaks on his own; for he is a liar, and the father of lies. </span> 
+<sup>45&#160;</sup><span class="wj">But because I tell the truth, you don’t believe me. </span> 
+<sup>46&#160;</sup><span class="wj">Which of you convicts me of sin? If I tell the truth, why do you not believe me? </span> 
+<sup>47&#160;</sup><span class="wj">He who is of Elohim hears the words of Elohim. For this cause you don’t hear, because you are not of Elohim.”</span> 
+</div><div class="p">
+<sup>48&#160;</sup>Then the Jews answered him, “Don’t we say well that you are a Samaritan, and have a demon?” 
+</div><div class="p">
+<sup>49&#160;</sup>Yahushua answered, <span class="wj">“I don’t have a demon, but I honor my Father and you dishonor me. </span> 
+<sup>50&#160;</sup><span class="wj">But I don’t seek my own glory. There is one who seeks and judges. </span> 
+<sup>51&#160;</sup><span class="wj">Most certainly, I tell you, if a person keeps my word, he will never see death.”</span> 
+</div><div class="p">
+<sup>52&#160;</sup>Then the Jews said to him, “Now we know that you have a demon. Abraham died, as did the prophets; and you say, <span class="wj">‘If a man keeps my word, he will never taste of death.’</span> 
+<sup>53&#160;</sup>Are you greater than our father Abraham, who died? The prophets died. Who do you make yourself out to be?” 
+</div><div class="p">
+<sup>54&#160;</sup>Yahushua answered, <span class="wj">“If I glorify myself, my glory is nothing. It is my Father who glorifies me, of whom you say that he is our Elohim. </span> 
+<sup>55&#160;</sup><span class="wj">You have not known him, but I know him. If I said, ‘I don’t know him,’ I would be like you, a liar. But I know him and keep his word. </span> 
+<sup>56&#160;</sup><span class="wj">Your father Abraham rejoiced to see my day. He saw it and was glad.”</span> 
+</div><div class="p">
+<sup>57&#160;</sup>The Jews therefore said to him, “You are not yet fifty years old! Have you seen Abraham?” 
+</div><div class="p">
+<sup>58&#160;</sup>Yahushua said to them, <span class="wj">“Most certainly, I tell you, before Abraham came into existence, I was.</span><span class="wj">”</span> 
+</div><div class="p">
+<sup>59&#160;</sup>Therefore they took up stones to throw at him, but Yahushua hid himself and went out of the temple, having gone through the middle of them, and so passed by. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>As he passed by, he saw a man blind from birth. 
+<sup>2&#160;</sup>His disciples asked him, “Rabbi, who sinned, this man or his parents, that he was born blind?” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahushua answered, <span class="wj">“This man didn’t sin, nor did his parents, but that the works of Elohim might be revealed in him. </span> 
+<sup>4&#160;</sup><span class="wj">I must work the works of him who sent me while it is day. The night is coming, when no one can work. </span> 
+<sup>5&#160;</sup><span class="wj">While I am in the world, I am the light of the world.”</span> 
+<sup>6&#160;</sup>When he had said this, he spat on the ground, made mud with the saliva, anointed the blind man’s eyes with the mud, 
+<sup>7&#160;</sup>and said to him, <span class="wj">“Go, wash in the pool of Siloam”</span> (which means “Sent”). So he went away, washed, and came back seeing. 
+</div><div class="p">
+<sup>8&#160;</sup>Therefore the neighbors and those who saw that he was blind before said, “Isn’t this he who sat and begged?” 
+<sup>9&#160;</sup>Others were saying, “It is he.” Still others were saying, “He looks like him.” 
+</div><div class="p">He said, “I am he.” 
+</div><div class="p">
+<sup>10&#160;</sup>They therefore were asking him, “How were your eyes opened?” 
+</div><div class="p">
+<sup>11&#160;</sup>He answered, “A man called Yahushua made mud, anointed my eyes, and said to me, <span class="wj">‘Go to the pool of Siloam and wash.’</span> So I went away and washed, and I received sight.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then they asked him, “Where is he?” 
+</div><div class="p">He said, “I don’t know.” 
+</div><div class="p">
+<sup>13&#160;</sup>They brought him who had been blind to the Pharisees. 
+<sup>14&#160;</sup>It was a Sabbath when Yahushua made the mud and opened his eyes. 
+<sup>15&#160;</sup>Again therefore the Pharisees also asked him how he received his sight. He said to them, “He put mud on my eyes, I washed, and I see.” 
+</div><div class="p">
+<sup>16&#160;</sup>Some therefore of the Pharisees said, “This man is not from Elohim, because he doesn’t keep the Sabbath.” 
+</div><div class="p">Others said, “How can a man who is a sinner do such signs?” So there was division among them. 
+</div><div class="p">
+<sup>17&#160;</sup>Therefore they asked the blind man again, “What do you say about him, because he opened your eyes?” 
+</div><div class="p">He said, “He is a prophet.” 
+</div><div class="p">
+<sup>18&#160;</sup>The Jews therefore didn’t believe concerning him, that he had been blind and had received his sight, until they called the parents of him who had received his sight, 
+<sup>19&#160;</sup>and asked them, “Is this your son, whom you say was born blind? How then does he now see?” 
+</div><div class="p">
+<sup>20&#160;</sup>His parents answered them, “We know that this is our son, and that he was born blind; 
+<sup>21&#160;</sup>but how he now sees, we don’t know; or who opened his eyes, we don’t know. He is of age. Ask him. He will speak for himself.” 
+<sup>22&#160;</sup>His parents said these things because they feared the Jews; for the Jews had already agreed that if any man would confess him as Christ, he would be put out of the synagogue. 
+<sup>23&#160;</sup>Therefore his parents said, “He is of age. Ask him.” 
+</div><div class="p">
+<sup>24&#160;</sup>So they called the man who was blind a second time, and said to him, “Give glory to Elohim. We know that this man is a sinner.” 
+</div><div class="p">
+<sup>25&#160;</sup>He therefore answered, “I don’t know if he is a sinner. One thing I do know: that though I was blind, now I see.” 
+</div><div class="p">
+<sup>26&#160;</sup>They said to him again, “What did he do to you? How did he open your eyes?” 
+</div><div class="p">
+<sup>27&#160;</sup>He answered them, “I told you already, and you didn’t listen. Why do you want to hear it again? You don’t also want to become his disciples, do you?” 
+</div><div class="p">
+<sup>28&#160;</sup>They insulted him and said, “You are his disciple, but we are disciples of Moses. 
+<sup>29&#160;</sup>We know that Elohim has spoken to Moses. But as for this man, we don’t know where he comes from.” 
+</div><div class="p">
+<sup>30&#160;</sup>The man answered them, “How amazing! You don’t know where he comes from, yet he opened my eyes. 
+<sup>31&#160;</sup>We know that Elohim doesn’t listen to sinners, but if anyone is a worshiper of Elohim and does his will, he listens to him. 
+<sup>32&#160;</sup>Since the world began it has never been heard of that anyone opened the eyes of someone born blind. 
+<sup>33&#160;</sup>If this man were not from Elohim, he could do nothing.” 
+</div><div class="p">
+<sup>34&#160;</sup>They answered him, “You were altogether born in sins, and do you teach us?” Then they threw him out. 
+</div><div class="p">
+<sup>35&#160;</sup>Yahushua heard that they had thrown him out, and finding him, he said, <span class="wj">“Do you believe in the Son of Elohim?”</span> 
+</div><div class="p">
+<sup>36&#160;</sup>He answered, “Who is he, Lord, that I may believe in him?” 
+</div><div class="p">
+<sup>37&#160;</sup>Yahushua said to him, <span class="wj">“You have both seen him, and it is he who speaks with you.”</span> 
+</div><div class="p">
+<sup>38&#160;</sup>He said, “Lord, I believe!” and he worshiped him. 
+</div><div class="p">
+<sup>39&#160;</sup>Yahushua said, <span class="wj">“I came into this world for judgment, that those who don’t see may see; and that those who see may become blind.”</span> 
+</div><div class="p">
+<sup>40&#160;</sup>Those of the Pharisees who were with him heard these things, and said to him, “Are we also blind?” 
+</div><div class="p">
+<sup>41&#160;</sup>Yahushua said to them, <span class="wj">“If you were blind, you would have no sin; but now you say, ‘We see.’ Therefore your sin remains.</span> 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“Most certainly, I tell you, one who doesn’t enter by the door into the sheep fold, but climbs up some other way, is a thief and a robber. </span> 
+<sup>2&#160;</sup><span class="wj">But one who enters in by the door is the shepherd of the sheep. </span> 
+<sup>3&#160;</sup><span class="wj">The gatekeeper opens the gate for him, and the sheep listen to his voice. He calls his own sheep by name and leads them out. </span> 
+<sup>4&#160;</sup><span class="wj">Whenever he brings out his own sheep, he goes before them; and the sheep follow him, for they know his voice. </span> 
+<sup>5&#160;</sup><span class="wj">They will by no means follow a stranger, but will flee from him; for they don’t know the voice of strangers.”</span> 
+<sup>6&#160;</sup>Yahushua spoke this parable to them, but they didn’t understand what he was telling them. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahushua therefore said to them again, <span class="wj">“Most certainly, I tell you, I am the sheep’s door. </span> 
+<sup>8&#160;</sup><span class="wj">All who came before me are thieves and robbers, but the sheep didn’t listen to them. </span> 
+<sup>9&#160;</sup><span class="wj">I am the door. If anyone enters in by me, he will be saved, and will go in and go out and will find pasture. </span> 
+<sup>10&#160;</sup><span class="wj">The thief only comes to steal, kill, and destroy. I came that they may have life, and may have it abundantly. </span> 
+</div><div class="p">
+<sup>11&#160;</sup><span class="wj">“I am the good shepherd.</span> <span class="wj">The good shepherd lays down his life for the sheep. </span> 
+<sup>12&#160;</sup><span class="wj">He who is a hired hand, and not a shepherd, who doesn’t own the sheep, sees the wolf coming, leaves the sheep, and flees. The wolf snatches the sheep and scatters them. </span> 
+<sup>13&#160;</sup><span class="wj">The hired hand flees because he is a hired hand and doesn’t care for the sheep. </span> 
+<sup>14&#160;</sup><span class="wj">I am the good shepherd. I know my own, and I’m known by my own; </span> 
+<sup>15&#160;</sup><span class="wj">even as the Father knows me, and I know the Father. I lay down my life for the sheep. </span> 
+<sup>16&#160;</sup><span class="wj">I have other sheep which are not of this fold.</span> <span class="wj">I must bring them also, and they will hear my voice. They will become one flock with one shepherd. </span> 
+<sup>17&#160;</sup><span class="wj">Therefore the Father loves me, because I lay down my life, </span> <span class="wj">that I may take it again. </span> 
+<sup>18&#160;</sup><span class="wj">No one takes it away from me, but I lay it down by myself. I have power to lay it down, and I have power to take it again. I received this commandment from my Father.”</span> 
+</div><div class="p">
+<sup>19&#160;</sup>Therefore a division arose again among the Jews because of these words. 
+<sup>20&#160;</sup>Many of them said, “He has a demon and is insane! Why do you listen to him?” 
+<sup>21&#160;</sup>Others said, “These are not the sayings of one possessed by a demon. It isn’t possible for a demon to open the eyes of the blind, is it?” 
+</div><div class="p">
+<sup>22&#160;</sup>It was the Feast of the Dedication at Jerusalem. 
+<sup>23&#160;</sup>It was winter, and Yahushua was walking in the temple, in Solomon’s porch. 
+<sup>24&#160;</sup>The Jews therefore came around him and said to him, “How long will you hold us in suspense? If you are the Christ, tell us plainly.” 
+</div><div class="p">
+<sup>25&#160;</sup>Yahushua answered them, <span class="wj">“I told you, and you don’t believe. The works that I do in my Father’s name, these testify about me. </span> 
+<sup>26&#160;</sup><span class="wj">But you don’t believe, because you are not of my sheep, as I told you. </span> 
+<sup>27&#160;</sup><span class="wj">My sheep hear my voice, and I know them, and they follow me. </span> 
+<sup>28&#160;</sup><span class="wj">I give eternal life to them. They will never perish, and no one will snatch them out of my hand. </span> 
+<sup>29&#160;</sup><span class="wj">My Father who has given them to me is greater than all. No one is able to snatch them out of my Father’s hand. </span> 
+<sup>30&#160;</sup><span class="wj">I and the Father are one.”</span> 
+</div><div class="p">
+<sup>31&#160;</sup>Therefore the Jews took up stones again to stone him. 
+<sup>32&#160;</sup>Yahushua answered them, <span class="wj">“I have shown you many good works from my Father. For which of those works do you stone me?”</span> 
+</div><div class="p">
+<sup>33&#160;</sup>The Jews answered him, “We don’t stone you for a good work, but for blasphemy, because you, being a man, make yourself Elohim.” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua answered them, <span class="wj">“Isn’t it written in your law, ‘I said, you are elohims’?</span> 
+<sup>35&#160;</sup><span class="wj">If he called them elohims, to whom the word of Elohim came (and the Scripture can’t be broken), </span> 
+<sup>36&#160;</sup><span class="wj">do you say of him whom the Father sanctified and sent into the world, ‘You blaspheme,’ because I said, ‘I am the Son of Elohim’? </span> 
+<sup>37&#160;</sup><span class="wj">If I don’t do the works of my Father, don’t believe me. </span> 
+<sup>38&#160;</sup><span class="wj">But if I do them, though you don’t believe me, believe the works, that you may know and believe that the Father is in me, and I in the Father.” </span> 
+</div><div class="p">
+<sup>39&#160;</sup>They sought again to seize him, and he went out of their hand. 
+<sup>40&#160;</sup>He went away again beyond the Jordan into the place where John was baptizing at first, and he stayed there. 
+<sup>41&#160;</sup>Many came to him. They said, “John indeed did no sign, but everything that John said about this man is true.” 
+<sup>42&#160;</sup>Many believed in him there. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Now a certain man was sick, Lazarus from Bethany, of the village of Mary and her sister, Martha. 
+<sup>2&#160;</sup>It was that Mary who had anointed the Lord with ointment and wiped his feet with her hair, whose brother Lazarus was sick. 
+<sup>3&#160;</sup>The sisters therefore sent to him, saying, “Lord, behold, he for whom you have great affection is sick.” 
+</div><div class="p">
+<sup>4&#160;</sup>But when Yahushua heard it, he said, <span class="wj">“This sickness is not to death, but for the glory of Elohim, that Elohim’s Son may be glorified by it.”</span> 
+<sup>5&#160;</sup>Now Yahushua loved Martha, and her sister, and Lazarus. 
+<sup>6&#160;</sup>When therefore he heard that he was sick, he stayed two days in the place where he was. 
+<sup>7&#160;</sup>Then after this he said to the disciples, <span class="wj">“Let’s go into Judea again.”</span> 
+</div><div class="p">
+<sup>8&#160;</sup>The disciples asked him, “Rabbi, the Jews were just trying to stone you. Are you going there again?” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahushua answered, <span class="wj">“Aren’t there twelve hours of daylight? If a man walks in the day, he doesn’t stumble, because he sees the light of this world. </span> 
+<sup>10&#160;</sup><span class="wj">But if a man walks in the night, he stumbles, because the light isn’t in him.”</span> 
+<sup>11&#160;</sup>He said these things, and after that, he said to them, <span class="wj">“Our friend Lazarus has fallen asleep, but I am going so that I may awake him out of sleep.”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>The disciples therefore said, “Lord, if he has fallen asleep, he will recover.” 
+</div><div class="p">
+<sup>13&#160;</sup>Now Yahushua had spoken of his death, but they thought that he spoke of taking rest in sleep. 
+<sup>14&#160;</sup>So Yahushua said to them plainly then, <span class="wj">“Lazarus is dead. </span> 
+<sup>15&#160;</sup><span class="wj">I am glad for your sakes that I was not there, so that you may believe. Nevertheless, let’s go to him.”</span> 
+</div><div class="p">
+<sup>16&#160;</sup>Thomas therefore, who is called Didymus, said to his fellow disciples, “Let’s also go, that we may die with him.” 
+</div><div class="p">
+<sup>17&#160;</sup>So when Yahushua came, he found that he had been in the tomb four days already. 
+<sup>18&#160;</sup>Now Bethany was near Jerusalem, about fifteen stadia away. 
+<sup>19&#160;</sup>Many of the Jews had joined the women around Martha and Mary, to console them concerning their brother. 
+<sup>20&#160;</sup>Then when Martha heard that Yahushua was coming, she went and met him, but Mary stayed in the house. 
+<sup>21&#160;</sup>Therefore Martha said to Yahushua, “Lord, if you would have been here, my brother wouldn’t have died. 
+<sup>22&#160;</sup>Even now I know that whatever you ask of Elohim, Elohim will give you.” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahushua said to her, <span class="wj">“Your brother will rise again.”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>Martha said to him, “I know that he will rise again in the resurrection at the last day.” 
+</div><div class="p">
+<sup>25&#160;</sup>Yahushua said to her, <span class="wj">“I am the resurrection and the life. He who believes in me will still live, even if he dies. </span> 
+<sup>26&#160;</sup><span class="wj">Whoever lives and believes in me will never die. Do you believe this?”</span> 
+</div><div class="p">
+<sup>27&#160;</sup>She said to him, “Yes, Lord. I have come to believe that you are the Christ, Elohim’s Son, he who comes into the world.” 
+</div><div class="p">
+<sup>28&#160;</sup>When she had said this, she went away and called Mary, her sister, secretly, saying, “The Teacher is here and is calling you.” 
+</div><div class="p">
+<sup>29&#160;</sup>When she heard this, she arose quickly and went to him. 
+<sup>30&#160;</sup>Now Yahushua had not yet come into the village, but was in the place where Martha met him. 
+<sup>31&#160;</sup>Then the Jews who were with her in the house and were consoling her, when they saw Mary, that she rose up quickly and went out, followed her, saying, “She is going to the tomb to weep there.” 
+</div><div class="p">
+<sup>32&#160;</sup>Therefore when Mary came to where Yahushua was and saw him, she fell down at his feet, saying to him, “Lord, if you would have been here, my brother wouldn’t have died.” 
+</div><div class="p">
+<sup>33&#160;</sup>When Yahushua therefore saw her weeping, and the Jews weeping who came with her, he groaned in the spirit and was troubled, 
+<sup>34&#160;</sup>and said, <span class="wj">“Where have you laid him?”</span> 
+</div><div class="p">They told him, “Lord, come and see.” 
+</div><div class="p">
+<sup>35&#160;</sup>Yahushua wept. 
+</div><div class="p">
+<sup>36&#160;</sup>The Jews therefore said, “See how much affection he had for him!” 
+<sup>37&#160;</sup>Some of them said, “Couldn’t this man, who opened the eyes of him who was blind, have also kept this man from dying?” 
+</div><div class="p">
+<sup>38&#160;</sup>Yahushua therefore, again groaning in himself, came to the tomb. Now it was a cave, and a stone lay against it. 
+<sup>39&#160;</sup>Yahushua said, <span class="wj">“Take away the stone.”</span> 
+</div><div class="p">Martha, the sister of him who was dead, said to him, “Lord, by this time there is a stench, for he has been dead four days.” 
+</div><div class="p">
+<sup>40&#160;</sup>Yahushua said to her, <span class="wj">“Didn’t I tell you that if you believed, you would see Elohim’s glory?”</span> 
+</div><div class="p">
+<sup>41&#160;</sup>So they took away the stone from the place where the dead man was lying. Yahushua lifted up his eyes and said, <span class="wj">“Father, I thank you that you listened to me. </span> 
+<sup>42&#160;</sup><span class="wj">I know that you always listen to me, but because of the multitude standing around I said this, that they may believe that you sent me.” </span> 
+<sup>43&#160;</sup>When he had said this, he cried with a loud voice, <span class="wj">“Lazarus, come out!”</span> 
+</div><div class="p">
+<sup>44&#160;</sup>He who was dead came out, bound hand and foot with wrappings, and his face was wrapped around with a cloth. 
+</div><div class="p">Yahushua said to them, <span class="wj">“Free him, and let him go.”</span> 
+</div><div class="p">
+<sup>45&#160;</sup>Therefore many of the Jews who came to Mary and saw what Yahushua did believed in him. 
+<sup>46&#160;</sup>But some of them went away to the Pharisees and told them the things which Yahushua had done. 
+<sup>47&#160;</sup>The chief priests therefore and the Pharisees gathered a council, and said, “What are we doing? For this man does many signs. 
+<sup>48&#160;</sup>If we leave him alone like this, everyone will believe in him, and the Romans will come and take away both our place and our nation.” 
+</div><div class="p">
+<sup>49&#160;</sup>But a certain one of them, Caiaphas, being high priest that year, said to them, “You know nothing at all, 
+<sup>50&#160;</sup>nor do you consider that it is advantageous for us that one man should die for the people, and that the whole nation not perish.” 
+<sup>51&#160;</sup>Now he didn’t say this of himself, but being high priest that year, he prophesied that Yahushua would die for the nation, 
+<sup>52&#160;</sup>and not for the nation only, but that he might also gather together into one the children of Elohim who are scattered abroad. 
+<sup>53&#160;</sup>So from that day forward they took counsel that they might put him to death. 
+<sup>54&#160;</sup>Yahushua therefore walked no more openly among the Jews, but departed from there into the country near the wilderness, to a city called Ephraim. He stayed there with his disciples. 
+</div><div class="p">
+<sup>55&#160;</sup>Now the Passover of the Jews was at hand. Many went up from the country to Jerusalem before the Passover, to purify themselves. 
+<sup>56&#160;</sup>Then they sought for Yahushua and spoke with one another as they stood in the temple, “What do you think—that he isn’t coming to the feast at all?” 
+<sup>57&#160;</sup>Now the chief priests and the Pharisees had commanded that if anyone knew where he was, he should report it, that they might seize him. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Then, six days before the Passover, Yahushua came to Bethany, where Lazarus was, who had been dead, whom he raised from the dead. 
+<sup>2&#160;</sup>So they made him a supper there. Martha served, but Lazarus was one of those who sat at the table with him. 
+<sup>3&#160;</sup>Therefore Mary took a pound of ointment of pure nard, very precious, and anointed Yahushua’s feet and wiped his feet with her hair. The house was filled with the fragrance of the ointment. 
+</div><div class="p">
+<sup>4&#160;</sup>Then Judas Iscariot, Simon’s son, one of his disciples, who would betray him, said, 
+<sup>5&#160;</sup>“Why wasn’t this ointment sold for three hundred denarii and given to the poor?” 
+<sup>6&#160;</sup>Now he said this, not because he cared for the poor, but because he was a thief, and having the money box, used to steal what was put into it. 
+</div><div class="p">
+<sup>7&#160;</sup>But Yahushua said, <span class="wj">“Leave her alone. She has kept this for the day of my burial. </span> 
+<sup>8&#160;</sup><span class="wj">For you always have the poor with you, but you don’t always have me.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>A large crowd therefore of the Jews learned that he was there; and they came, not for Yahushua’s sake only, but that they might see Lazarus also, whom he had raised from the dead. 
+<sup>10&#160;</sup>But the chief priests conspired to put Lazarus to death also, 
+<sup>11&#160;</sup>because on account of him many of the Jews went away and believed in Yahushua. 
+</div><div class="p">
+<sup>12&#160;</sup>On the next day a great multitude had come to the feast. When they heard that Yahushua was coming to Jerusalem, 
+<sup>13&#160;</sup>they took the branches of the palm trees and went out to meet him, and cried out, “Hosanna! Blessed is he who comes in the name of the Lord, the King of Israel!” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahushua, having found a young donkey, sat on it. As it is written, 
+<sup>15&#160;</sup>“Don’t be afraid, daughter of Zion. Behold, your King comes, sitting on a donkey’s colt.” 
+<sup>16&#160;</sup>His disciples didn’t understand these things at first, but when Yahushua was glorified, then they remembered that these things were written about him, and that they had done these things to him. 
+<sup>17&#160;</sup>The multitude therefore that was with him when he called Lazarus out of the tomb and raised him from the dead was testifying about it. 
+<sup>18&#160;</sup>For this cause also the multitude went and met him, because they heard that he had done this sign. 
+<sup>19&#160;</sup>The Pharisees therefore said among themselves, “See how you accomplish nothing. Behold, the world has gone after him.” 
+</div><div class="p">
+<sup>20&#160;</sup>Now there were certain Greeks among those who went up to worship at the feast. 
+<sup>21&#160;</sup>Therefore, these came to Philip, who was from Bethsaida of Galilee, and asked him, saying, “Sir, we want to see Yahushua.” 
+<sup>22&#160;</sup>Philip came and told Andrew, and in turn, Andrew came with Philip, and they told Yahushua. 
+</div><div class="p">
+<sup>23&#160;</sup>Yahushua answered them, <span class="wj">“The time has come for the Son of Man to be glorified. </span> 
+<sup>24&#160;</sup><span class="wj">Most certainly I tell you, unless a grain of wheat falls into the earth and dies, it remains by itself alone. But if it dies, it bears much fruit. </span> 
+<sup>25&#160;</sup><span class="wj">He who loves his life will lose it. He who hates his life in this world will keep it to eternal life. </span> 
+<sup>26&#160;</sup><span class="wj">If anyone serves me, let him follow me. Where I am, there my servant will also be. If anyone serves me, the Father will honor him.</span> 
+</div><div class="p">
+<sup>27&#160;</sup><span class="wj">“Now my soul is troubled. What shall I say? ‘Father, save me from this time’? But I came to this time for this cause. </span> 
+<sup>28&#160;</sup><span class="wj">Father, glorify your name!”</span> 
+</div><div class="p">Then a voice came out of the sky, saying, “I have both glorified it and will glorify it again.” 
+</div><div class="p">
+<sup>29&#160;</sup>Therefore the multitude who stood by and heard it said that it had thundered. Others said, “An angel has spoken to him.” 
+</div><div class="p">
+<sup>30&#160;</sup>Yahushua answered, <span class="wj">“This voice hasn’t come for my sake, but for your sakes. </span> 
+<sup>31&#160;</sup><span class="wj">Now is the judgment of this world. Now the prince of this world will be cast out. </span> 
+<sup>32&#160;</sup><span class="wj">And I, if I am lifted up from the earth, will draw all people to myself.”</span> 
+<sup>33&#160;</sup>But he said this, signifying by what kind of death he should die. 
+</div><div class="p">
+<sup>34&#160;</sup>The multitude answered him, “We have heard out of the law that the Christ remains forever. How do you say, <span class="wj">‘The Son of Man must be lifted up’?</span> Who is this Son of Man?” 
+</div><div class="p">
+<sup>35&#160;</sup>Yahushua therefore said to them, <span class="wj">“Yet a little while the light is with you. Walk while you have the light, that darkness doesn’t overtake you. He who walks in the darkness doesn’t know where he is going. </span> 
+<sup>36&#160;</sup><span class="wj">While you have the light, believe in the light, that you may become children of light.”</span> Yahushua said these things, and he departed and hid himself from them. 
+<sup>37&#160;</sup>But though he had done so many signs before them, yet they didn’t believe in him, 
+<sup>38&#160;</sup>that the word of Isaiah the prophet might be fulfilled, which he spoke: 
+</div><div class="q1">“Lord, who has believed our report? 
+</div><div class="q2">To whom has the arm of the Lord been revealed?” 
+</div><div class="p">
+<sup>39&#160;</sup>For this cause they couldn’t believe, for Isaiah said again: 
+</div><div class="q1">
+<sup>40&#160;</sup>“He has blinded their eyes and he hardened their heart, 
+</div><div class="q2">lest they should see with their eyes, 
+</div><div class="q2">and perceive with their heart, 
+</div><div class="q2">and would turn, 
+</div><div class="q2">and I would heal them.” 
+</div><div class="p">
+<sup>41&#160;</sup>Isaiah said these things when he saw his glory, and spoke of him. 
+<sup>42&#160;</sup>Nevertheless, even many of the rulers believed in him, but because of the Pharisees they didn’t confess it, so that they wouldn’t be put out of the synagogue, 
+<sup>43&#160;</sup>for they loved men’s praise more than Elohim’s praise. 
+</div><div class="p">
+<sup>44&#160;</sup>Yahushua cried out and said, <span class="wj">“Whoever believes in me, believes not in me, but in him who sent me. </span> 
+<sup>45&#160;</sup><span class="wj">He who sees me sees him who sent me. </span> 
+<sup>46&#160;</sup><span class="wj">I have come as a light into the world, that whoever believes in me may not remain in the darkness. </span> 
+<sup>47&#160;</sup><span class="wj">If anyone listens to my sayings and doesn’t believe, I don’t judge him. For I came not to judge the world, but to save the world. </span> 
+<sup>48&#160;</sup><span class="wj">He who rejects me, and doesn’t receive my sayings, has one who judges him. The word that I spoke will judge him in the last day. </span> 
+<sup>49&#160;</sup><span class="wj">For I spoke not from myself, but the Father who sent me gave me a commandment, what I should say and what I should speak. </span> 
+<sup>50&#160;</sup><span class="wj">I know that his commandment is eternal life. The things therefore which I speak, even as the Father has said to me, so I speak.”</span> 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Now before the feast of the Passover, Yahushua, knowing that his time had come that he would depart from this world to the Father, having loved his own who were in the world, he loved them to the end. 
+<sup>2&#160;</sup>During supper, the devil having already put into the heart of Judas Iscariot, Simon’s son, to betray him, 
+<sup>3&#160;</sup>Yahushua, knowing that the Father had given all things into his hands, and that he came from Elohim and was going to Elohim, 
+<sup>4&#160;</sup>arose from supper, and laid aside his outer garments. He took a towel and wrapped a towel around his waist. 
+<sup>5&#160;</sup>Then he poured water into the basin, and began to wash the disciples’ feet and to wipe them with the towel that was wrapped around him. 
+<sup>6&#160;</sup>Then he came to Simon Peter. He said to him, “Lord, do you wash my feet?” 
+</div><div class="p">
+<sup>7&#160;</sup>Yahushua answered him, <span class="wj">“You don’t know what I am doing now, but you will understand later.”</span> 
+</div><div class="p">
+<sup>8&#160;</sup>Peter said to him, “You will never wash my feet!” 
+</div><div class="p">Yahushua answered him, <span class="wj">“If I don’t wash you, you have no part with me.” </span> 
+</div><div class="p">
+<sup>9&#160;</sup>Simon Peter said to him, “Lord, not my feet only, but also my hands and my head!” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahushua said to him, <span class="wj">“Someone who has bathed only needs to have his feet washed, but is completely clean. You are clean, but not all of you.” </span> 
+<sup>11&#160;</sup>For he knew him who would betray him; therefore he said, <span class="wj">“You are not all clean.”</span> 
+<sup>12&#160;</sup>So when he had washed their feet, put his outer garment back on, and sat down again, he said to them, <span class="wj">“Do you know what I have done to you? </span> 
+<sup>13&#160;</sup><span class="wj">You call me, ‘Teacher’ and ‘Lord.’ You say so correctly, for so I am. </span> 
+<sup>14&#160;</sup><span class="wj">If I then, the Lord and the Teacher, have washed your feet, you also ought to wash one another’s feet. </span> 
+<sup>15&#160;</sup><span class="wj">For I have given you an example, that you should also do as I have done to you. </span> 
+<sup>16&#160;</sup><span class="wj">Most certainly I tell you, a servant is not greater than his lord, neither is one who is sent greater than he who sent him. </span> 
+<sup>17&#160;</sup><span class="wj">If you know these things, blessed are you if you do them. </span> 
+<sup>18&#160;</sup><span class="wj">I don’t speak concerning all of you. I know whom I have chosen; but that the Scripture may be fulfilled, ‘He who eats bread with me has lifted up his heel against me.’</span> 
+<sup>19&#160;</sup><span class="wj">From now on, I tell you before it happens, that when it happens, you may believe that I am he. </span> 
+<sup>20&#160;</sup><span class="wj">Most certainly I tell you, he who receives whomever I send, receives me; and he who receives me, receives him who sent me.”</span> 
+</div><div class="p">
+<sup>21&#160;</sup>When Yahushua had said this, he was troubled in spirit, and testified, <span class="wj">“Most certainly I tell you that one of you will betray me.”</span> 
+</div><div class="p">
+<sup>22&#160;</sup>The disciples looked at one another, perplexed about whom he spoke. 
+<sup>23&#160;</sup>One of his disciples, whom Yahushua loved, was at the table, leaning against Yahushua’s breast. 
+<sup>24&#160;</sup>Simon Peter therefore beckoned to him, and said to him, “Tell us who it is of whom he speaks.” 
+</div><div class="p">
+<sup>25&#160;</sup>He, leaning back, as he was, on Yahushua’s breast, asked him, “Lord, who is it?” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahushua therefore answered, <span class="wj">“It is he to whom I will give this piece of bread when I have dipped it.”</span> So when he had dipped the piece of bread, he gave it to Judas, the son of Simon Iscariot. 
+<sup>27&#160;</sup>After the piece of bread, then Satan entered into him. 
+</div><div class="p">Then Yahushua said to him, <span class="wj">“What you do, do quickly.”</span> 
+</div><div class="p">
+<sup>28&#160;</sup>Now nobody at the table knew why he said this to him. 
+<sup>29&#160;</sup>For some thought, because Judas had the money box, that Yahushua said to him, “Buy what things we need for the feast,” or that he should give something to the poor. 
+<sup>30&#160;</sup>Therefore having received that morsel, he went out immediately. It was night. 
+</div><div class="p">
+<sup>31&#160;</sup>When he had gone out, Yahushua said, <span class="wj">“Now the Son of Man has been glorified, and Elohim has been glorified in him. </span> 
+<sup>32&#160;</sup><span class="wj">If Elohim has been glorified in him, Elohim will also glorify him in himself, and he will glorify him immediately. </span> 
+<sup>33&#160;</sup><span class="wj">Little children, I will be with you a little while longer. You will seek me, and as I said to the Jews, ‘Where I am going, you can’t come,’ so now I tell you. </span> 
+<sup>34&#160;</sup><span class="wj">A new commandment I give to you, that you love one another. Just as I have loved you, you also love one another. </span> 
+<sup>35&#160;</sup><span class="wj">By this everyone will know that you are my disciples, if you have love for one another.”</span> 
+</div><div class="p">
+<sup>36&#160;</sup>Simon Peter said to him, “Lord, where are you going?” 
+</div><div class="p">Yahushua answered, <span class="wj">“Where I am going, you can’t follow now, but you will follow afterwards.”</span> 
+</div><div class="p">
+<sup>37&#160;</sup>Peter said to him, “Lord, why can’t I follow you now? I will lay down my life for you.” 
+</div><div class="p">
+<sup>38&#160;</sup>Yahushua answered him, <span class="wj">“Will you lay down your life for me? Most certainly I tell you, the rooster won’t crow until you have denied me three times.</span> 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“Don’t let your heart be troubled. Believe in Elohim. Believe also in me. </span> 
+<sup>2&#160;</sup><span class="wj">In my Father’s house are many homes. If it weren’t so, I would have told you. I am going to prepare a place for you. </span> 
+<sup>3&#160;</sup><span class="wj">If I go and prepare a place for you, I will come again and will receive you to myself; that where I am, you may be there also. </span> 
+<sup>4&#160;</sup><span class="wj">You know where I go, and you know the way.”</span> 
+</div><div class="p">
+<sup>5&#160;</sup>Thomas said to him, “Lord, we don’t know where you are going. How can we know the way?” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahushua said to him, <span class="wj">“I am the way, the truth, and the life. No one comes to the Father, except through me. </span> 
+<sup>7&#160;</sup><span class="wj">If you had known me, you would have known my Father also. From now on, you know him and have seen him.”</span> 
+</div><div class="p">
+<sup>8&#160;</sup>Philip said to him, “Lord, show us the Father, and that will be enough for us.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahushua said to him, <span class="wj">“Have I been with you such a long time, and do you not know me, Philip? He who has seen me has seen the Father. How do you say, ‘Show us the Father’? </span> 
+<sup>10&#160;</sup><span class="wj">Don’t you believe that I am in the Father, and the Father in me? The words that I tell you, I speak not from myself; but the Father who lives in me does his works. </span> 
+<sup>11&#160;</sup><span class="wj">Believe me that I am in the Father, and the Father in me; or else believe me for the very works’ sake. </span> 
+<sup>12&#160;</sup><span class="wj">Most certainly I tell you, he who believes in me, the works that I do, he will do also; and he will do greater works than these, because I am going to my Father. </span> 
+<sup>13&#160;</sup><span class="wj">Whatever you will ask in my name, I will do it, that the Father may be glorified in the Son. </span> 
+<sup>14&#160;</sup><span class="wj">If you will ask anything in my name, I will do it. </span> 
+<sup>15&#160;</sup><span class="wj">If you love me, keep my commandments. </span> 
+<sup>16&#160;</sup><span class="wj">I will pray to the Father, and he will give you another Counselor, </span> <span class="wj">that he may be with you forever:</span> 
+<sup>17&#160;</sup><span class="wj">the Spirit of truth, whom the world can’t receive, for it doesn’t see him and doesn’t know him. You know him, for he lives with you and will be in you. </span> 
+<sup>18&#160;</sup><span class="wj">I will not leave you orphans. I will come to you. </span> 
+<sup>19&#160;</sup><span class="wj">Yet a little while, and the world will see me no more; but you will see me. Because I live, you will live also. </span> 
+<sup>20&#160;</sup><span class="wj">In that day you will know that I am in my Father, and you in me, and I in you. </span> 
+<sup>21&#160;</sup><span class="wj">One who has my commandments and keeps them, that person is one who loves me. One who loves me will be loved by my Father, and I will love him, and will reveal myself to him.”</span> 
+</div><div class="p">
+<sup>22&#160;</sup>Judas (not Iscariot) said to him, “Lord, what has happened that you are about to reveal yourself to us, and not to the world?” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahushua answered him, <span class="wj">“If a man loves me, he will keep my word. My Father will love him, and we will come to him and make our home with him. </span> 
+<sup>24&#160;</sup><span class="wj">He who doesn’t love me doesn’t keep my words. The word which you hear isn’t mine, but the Father’s who sent me. </span> 
+</div><div class="p">
+<sup>25&#160;</sup><span class="wj">“I have said these things to you while still living with you. </span> 
+<sup>26&#160;</sup><span class="wj">But the Counselor, the Set-Apart Spirit, whom the Father will send in my name, will teach you all things, and will remind you of all that I said to you. </span> 
+<sup>27&#160;</sup><span class="wj">Peace I leave with you. My peace I give to you; not as the world gives, I give to you. Don’t let your heart be troubled, neither let it be fearful. </span> 
+<sup>28&#160;</sup><span class="wj">You heard how I told you, ‘I am going away, and I will come back to you.’ If you loved me, you would have rejoiced because I said ‘I am going to my Father;’ for the Father is greater than I. </span> 
+<sup>29&#160;</sup><span class="wj">Now I have told you before it happens so that when it happens, you may believe. </span> 
+<sup>30&#160;</sup><span class="wj">I will no more speak much with you, for the prince of the world comes, and he has nothing in me. </span> 
+<sup>31&#160;</sup><span class="wj">But that the world may know that I love the Father, and as the Father commanded me, even so I do. Arise, let’s go from here.</span> 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“I am the true vine, and my Father is the farmer. </span> 
+<sup>2&#160;</sup><span class="wj">Every branch in me that doesn’t bear fruit, he takes away. Every branch that bears fruit, he prunes, that it may bear more fruit. </span> 
+<sup>3&#160;</sup><span class="wj">You are already pruned clean because of the word which I have spoken to you. </span> 
+<sup>4&#160;</sup><span class="wj">Remain in me, and I in you. As the branch can’t bear fruit by itself unless it remains in the vine, so neither can you, unless you remain in me. </span> 
+<sup>5&#160;</sup><span class="wj">I am the vine. You are the branches. He who remains in me and I in him bears much fruit, for apart from me you can do nothing. </span> 
+<sup>6&#160;</sup><span class="wj">If a man doesn’t remain in me, he is thrown out as a branch and is withered; and they gather them, throw them into the fire, and they are burned. </span> 
+<sup>7&#160;</sup><span class="wj">If you remain in me, and my words remain in you, you will ask whatever you desire, and it will be done for you.</span> 
+</div><div class="p">
+<sup>8&#160;</sup><span class="wj">“In this my Father is glorified, that you bear much fruit; and so you will be my disciples. </span> 
+<sup>9&#160;</sup><span class="wj">Even as the Father has loved me, I also have loved you. Remain in my love. </span> 
+<sup>10&#160;</sup><span class="wj">If you keep my commandments, you will remain in my love, even as I have kept my Father’s commandments and remain in his love. </span> 
+<sup>11&#160;</sup><span class="wj">I have spoken these things to you, that my joy may remain in you, and that your joy may be made full.</span> 
+</div><div class="p">
+<sup>12&#160;</sup><span class="wj">“This is my commandment, that you love one another, even as I have loved you. </span> 
+<sup>13&#160;</sup><span class="wj">Greater love has no one than this, that someone lay down his life for his friends. </span> 
+<sup>14&#160;</sup><span class="wj">You are my friends if you do whatever I command you. </span> 
+<sup>15&#160;</sup><span class="wj">No longer do I call you servants, for the servant doesn’t know what his lord does. But I have called you friends, for everything that I heard from my Father, I have made known to you. </span> 
+<sup>16&#160;</sup><span class="wj">You didn’t choose me, but I chose you and appointed you, that you should go and bear fruit, and that your fruit should remain; that whatever you will ask of the Father in my name, he may give it to you.</span> 
+</div><div class="p">
+<sup>17&#160;</sup><span class="wj">“I command these things to you, that you may love one another. </span> 
+<sup>18&#160;</sup><span class="wj">If the world hates you, you know that it has hated me before it hated you. </span> 
+<sup>19&#160;</sup><span class="wj">If you were of the world, the world would love its own. But because you are not of the world, since I chose you out of the world, therefore the world hates you. </span> 
+<sup>20&#160;</sup><span class="wj">Remember the word that I said to you: ‘A servant is not greater than his lord.’</span> <span class="wj">If they persecuted me, they will also persecute you. If they kept my word, they will also keep yours. </span> 
+<sup>21&#160;</sup><span class="wj">But they will do all these things to you for my name’s sake, because they don’t know him who sent me. </span> 
+<sup>22&#160;</sup><span class="wj">If I had not come and spoken to them, they would not have had sin; but now they have no excuse for their sin. </span> 
+<sup>23&#160;</sup><span class="wj">He who hates me, hates my Father also. </span> 
+<sup>24&#160;</sup><span class="wj">If I hadn’t done among them the works which no one else did, they wouldn’t have had sin. But now they have seen and also hated both me and my Father. </span> 
+<sup>25&#160;</sup><span class="wj">But this happened so that the word may be fulfilled which was written in their law, ‘They hated me without a cause.’</span> 
+</div><div class="p">
+<sup>26&#160;</sup><span class="wj">“When the Counselor</span> <span class="wj">has come, whom I will send to you from the Father, the Spirit of truth, who proceeds from the Father, he will testify about me. </span> 
+<sup>27&#160;</sup><span class="wj">You will also testify, because you have been with me from the beginning.</span> 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“I have said these things to you so that you wouldn’t be caused to stumble. </span> 
+<sup>2&#160;</sup><span class="wj">They will put you out of the synagogues. Yes, the time is coming that whoever kills you will think that he offers service to Elohim. </span> 
+<sup>3&#160;</sup><span class="wj">They will do these things</span> <span class="wj">because they have not known the Father nor me. </span> 
+<sup>4&#160;</sup><span class="wj">But I have told you these things so that when the time comes, you may remember that I told you about them. I didn’t tell you these things from the beginning, because I was with you. </span> 
+<sup>5&#160;</sup><span class="wj">But now I am going to him who sent me, and none of you asks me, ‘Where are you going?’ </span> 
+<sup>6&#160;</sup><span class="wj">But because I have told you these things, sorrow has filled your heart. </span> 
+<sup>7&#160;</sup><span class="wj">Nevertheless I tell you the truth: It is to your advantage that I go away; for if I don’t go away, the Counselor won’t come to you. But if I go, I will send him to you. </span> 
+<sup>8&#160;</sup><span class="wj">When he has come, he will convict the world about sin, about righteousness, and about judgment; </span> 
+<sup>9&#160;</sup><span class="wj">about sin, because they don’t believe in me; </span> 
+<sup>10&#160;</sup><span class="wj">about righteousness, because I am going to my Father, and you won’t see me any more; </span> 
+<sup>11&#160;</sup><span class="wj">about judgment, because the prince of this world has been judged. </span> 
+</div><div class="p">
+<sup>12&#160;</sup><span class="wj">“I still have many things to tell you, but you can’t bear them now. </span> 
+<sup>13&#160;</sup><span class="wj">However, when he, the Spirit of truth, has come, he will guide you into all truth, for he will not speak from himself; but whatever he hears, he will speak. He will declare to you things that are coming. </span> 
+<sup>14&#160;</sup><span class="wj">He will glorify me, for he will take from what is mine and will declare it to you. </span> 
+<sup>15&#160;</sup><span class="wj">All things that the Father has are mine; therefore I said that he takes</span> <span class="wj">of mine and will declare it to you. </span> 
+</div><div class="p">
+<sup>16&#160;</sup><span class="wj">“A little while, and you will not see me. Again a little while, and you will see me.”</span> 
+</div><div class="p">
+<sup>17&#160;</sup>Some of his disciples therefore said to one another, “What is this that he says to us, <span class="wj">‘A little while, and you won’t see me, and again a little while, and you will see me;’</span> and, <span class="wj">‘Because I go to the Father’</span>?” 
+<sup>18&#160;</sup>They said therefore, “What is this that he says, <span class="wj">‘A little while’</span>? We don’t know what he is saying.” 
+</div><div class="p">
+<sup>19&#160;</sup>Therefore Yahushua perceived that they wanted to ask him, and he said to them, <span class="wj">“Do you inquire among yourselves concerning this, that I said, ‘A little while, and you won’t see me, and again a little while, and you will see me’? </span> 
+<sup>20&#160;</sup><span class="wj">Most certainly I tell you that you will weep and lament, but the world will rejoice. You will be sorrowful, but your sorrow will be turned into joy. </span> 
+<sup>21&#160;</sup><span class="wj">A woman, when she gives birth, has sorrow because her time has come. But when she has delivered the child, she doesn’t remember the anguish any more, for the joy that a human being is born into the world. </span> 
+<sup>22&#160;</sup><span class="wj">Therefore you now have sorrow, but I will see you again, and your heart will rejoice, and no one will take your joy away from you.</span> 
+</div><div class="p">
+<sup>23&#160;</sup><span class="wj">“In that day you will ask me no questions. Most certainly I tell you, whatever you may ask of the Father in my name, he will give it to you. </span> 
+<sup>24&#160;</sup><span class="wj">Until now, you have asked nothing in my name. Ask, and you will receive, that your joy may be made full. </span> 
+</div><div class="p">
+<sup>25&#160;</sup><span class="wj">“I have spoken these things to you in figures of speech. But the time is coming when I will no more speak to you in figures of speech, but will tell you plainly about the Father. </span> 
+<sup>26&#160;</sup><span class="wj">In that day you will ask in my name; and I don’t say to you that I will pray to the Father for you, </span> 
+<sup>27&#160;</sup><span class="wj">for the Father himself loves you, because you have loved me, and have believed that I came from Elohim. </span> 
+<sup>28&#160;</sup><span class="wj">I came from the Father and have come into the world. Again, I leave the world and go to the Father.”</span> 
+</div><div class="p">
+<sup>29&#160;</sup>His disciples said to him, “Behold, now you are speaking plainly, and using no figures of speech. 
+<sup>30&#160;</sup>Now we know that you know all things, and don’t need for anyone to question you. By this we believe that you came from Elohim.” 
+</div><div class="p">
+<sup>31&#160;</sup>Yahushua answered them, <span class="wj">“Do you now believe? </span> 
+<sup>32&#160;</sup><span class="wj">Behold, the time is coming, yes, and has now come, that you will be scattered, everyone to his own place, and you will leave me alone. Yet I am not alone, because the Father is with me. </span> 
+<sup>33&#160;</sup><span class="wj">I have told you these things, that in me you may have peace. In the world you have trouble; but cheer up! I have overcome the world.” </span> 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahushua said these things, then lifting up his eyes to heaven, he said, <span class="wj">“Father, the time has come. Glorify your Son, that your Son may also glorify you; </span> 
+<sup>2&#160;</sup><span class="wj">even as you gave him authority over all flesh, so he will give eternal life to all whom you have given him. </span> 
+<sup>3&#160;</sup><span class="wj">This is eternal life, that they should know you, the only true Elohim, and him whom you sent, Yahushua Christ. </span> 
+<sup>4&#160;</sup><span class="wj">I glorified you on the earth. I have accomplished the work which you have given me to do. </span> 
+<sup>5&#160;</sup><span class="wj">Now, Father, glorify me with your own self with the glory which I had with you before the world existed. </span> 
+</div><div class="p">
+<sup>6&#160;</sup><span class="wj">“I revealed your name to the people whom you have given me out of the world. They were yours, and you have given them to me. They have kept your word. </span> 
+<sup>7&#160;</sup><span class="wj">Now they have known that all things whatever you have given me are from you, </span> 
+<sup>8&#160;</sup><span class="wj">for the words which you have given me I have given to them; and they received them, and knew for sure that I came from you. They have believed that you sent me. </span> 
+<sup>9&#160;</sup><span class="wj">I pray for them. I don’t pray for the world, but for those whom you have given me, for they are yours. </span> 
+<sup>10&#160;</sup><span class="wj">All things that are mine are yours, and yours are mine, and I am glorified in them. </span> 
+<sup>11&#160;</sup><span class="wj">I am no more in the world, but these are in the world, and I am coming to you. Set-Apart Father, keep them through your name which you have given me, that they may be one, even as we are. </span> 
+<sup>12&#160;</sup><span class="wj">While I was with them in the world, I kept them in your name. I have kept those whom you have given me. None of them is lost except the son of destruction, that the Scripture might be fulfilled. </span> 
+<sup>13&#160;</sup><span class="wj">But now I come to you, and I say these things in the world, that they may have my joy made full in themselves. </span> 
+<sup>14&#160;</sup><span class="wj">I have given them your word. The world hated them because they are not of the world, even as I am not of the world. </span> 
+<sup>15&#160;</sup><span class="wj">I pray not that you would take them from the world, but that you would keep them from the evil one. </span> 
+<sup>16&#160;</sup><span class="wj">They are not of the world, even as I am not of the world. </span> 
+<sup>17&#160;</sup><span class="wj">Sanctify them in your truth. Your word is truth.</span> 
+<sup>18&#160;</sup><span class="wj">As you sent me into the world, even so I have sent them into the world. </span> 
+<sup>19&#160;</sup><span class="wj">For their sakes I sanctify myself, that they themselves also may be sanctified in truth. </span> 
+</div><div class="p">
+<sup>20&#160;</sup><span class="wj">“Not for these only do I pray, but for those also who will believe in me through their word, </span> 
+<sup>21&#160;</sup><span class="wj">that they may all be one; even as you, Father, are in me, and I in you, that they also may be one in us; that the world may believe that you sent me. </span> 
+<sup>22&#160;</sup><span class="wj">The glory which you have given me, I have given to them, that they may be one, even as we are one, </span> 
+<sup>23&#160;</sup><span class="wj">I in them, and you in me, that they may be perfected into one, that the world may know that you sent me and loved them, even as you loved me. </span> 
+<sup>24&#160;</sup><span class="wj">Father, I desire that they also whom you have given me be with me where I am, that they may see my glory which you have given me, for you loved me before the foundation of the world. </span> 
+<sup>25&#160;</sup><span class="wj">Righteous Father, the world hasn’t known you, but I knew you; and these knew that you sent me. </span> 
+<sup>26&#160;</sup><span class="wj">I made known to them your name, and will make it known; that the love with which you loved me may be in them, and I in them.”</span> 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahushua had spoken these words, he went out with his disciples over the brook Kidron, where there was a garden, into which he and his disciples entered. 
+<sup>2&#160;</sup>Now Judas, who betrayed him, also knew the place, for Yahushua often met there with his disciples. 
+<sup>3&#160;</sup>Judas then, having taken a detachment of soldiers and officers from the chief priests and the Pharisees, came there with lanterns, torches, and weapons. 
+<sup>4&#160;</sup>Yahushua therefore, knowing all the things that were happening to him, went out and said to them, <span class="wj">“Who are you looking for?”</span> 
+</div><div class="p">
+<sup>5&#160;</sup>They answered him, “Yahushua of Nazareth.” 
+</div><div class="p">Yahushua said to them, <span class="wj">“I am he.”</span> 
+</div><div class="p">Judas also, who betrayed him, was standing with them. 
+<sup>6&#160;</sup>When therefore he said to them, <span class="wj">“I am he,”</span> they went backward and fell to the ground. 
+</div><div class="p">
+<sup>7&#160;</sup>Again therefore he asked them, <span class="wj">“Who are you looking for?”</span> 
+</div><div class="p">They said, “Yahushua of Nazareth.” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahushua answered, <span class="wj">“I told you that I am he. If therefore you seek me, let these go their way,”</span> 
+<sup>9&#160;</sup>that the word might be fulfilled which he spoke, <span class="wj">“Of those whom you have given me, I have lost none.”</span> 
+</div><div class="p">
+<sup>10&#160;</sup>Simon Peter therefore, having a sword, drew it, struck the high priest’s servant, and cut off his right ear. The servant’s name was Malchus. 
+<sup>11&#160;</sup>Yahushua therefore said to Peter, <span class="wj">“Put the sword into its sheath. The cup which the Father has given me, shall I not surely drink it?”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>So the detachment, the commanding officer, and the officers of the Jews seized Yahushua and bound him, 
+<sup>13&#160;</sup>and led him to Annas first, for he was father-in-law to Caiaphas, who was high priest that year. 
+<sup>14&#160;</sup>Now it was Caiaphas who advised the Jews that it was expedient that one man should perish for the people. 
+</div><div class="p">
+<sup>15&#160;</sup>Simon Peter followed Yahushua, as did another disciple. Now that disciple was known to the high priest, and entered in with Yahushua into the court of the high priest; 
+<sup>16&#160;</sup>but Peter was standing at the door outside. So the other disciple, who was known to the high priest, went out and spoke to her who kept the door, and brought in Peter. 
+<sup>17&#160;</sup>Then the maid who kept the door said to Peter, “Are you also one of this man’s disciples?” 
+</div><div class="p">He said, “I am not.” 
+</div><div class="p">
+<sup>18&#160;</sup>Now the servants and the officers were standing there, having made a fire of coals, for it was cold. They were warming themselves. Peter was with them, standing and warming himself. 
+</div><div class="p">
+<sup>19&#160;</sup>The high priest therefore asked Yahushua about his disciples and about his teaching. 
+</div><div class="p">
+<sup>20&#160;</sup>Yahushua answered him, <span class="wj">“I spoke openly to the world. I always taught in synagogues and in the temple, where the Jews always meet. I said nothing in secret. </span> 
+<sup>21&#160;</sup><span class="wj">Why do you ask me? Ask those who have heard me what I said to them. Behold, they know the things which I said.”</span> 
+</div><div class="p">
+<sup>22&#160;</sup>When he had said this, one of the officers standing by slapped Yahushua with his hand, saying, “Do you answer the high priest like that?” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahushua answered him, <span class="wj">“If I have spoken evil, testify of the evil; but if well, why do you beat me?”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>Annas sent him bound to Caiaphas, the high priest. 
+</div><div class="p">
+<sup>25&#160;</sup>Now Simon Peter was standing and warming himself. They said therefore to him, “You aren’t also one of his disciples, are you?” 
+</div><div class="p">He denied it and said, “I am not.” 
+</div><div class="p">
+<sup>26&#160;</sup>One of the servants of the high priest, being a relative of him whose ear Peter had cut off, said, “Didn’t I see you in the garden with him?” 
+</div><div class="p">
+<sup>27&#160;</sup>Peter therefore denied it again, and immediately the rooster crowed. 
+</div><div class="p">
+<sup>28&#160;</sup>They led Yahushua therefore from Caiaphas into the Praetorium. It was early, and they themselves didn’t enter into the Praetorium, that they might not be defiled, but might eat the Passover. 
+<sup>29&#160;</sup>Pilate therefore went out to them and said, “What accusation do you bring against this man?” 
+</div><div class="p">
+<sup>30&#160;</sup>They answered him, “If this man weren’t an evildoer, we wouldn’t have delivered him up to you.” 
+</div><div class="p">
+<sup>31&#160;</sup>Pilate therefore said to them, “Take him yourselves, and judge him according to your law.” 
+</div><div class="p">Therefore the Jews said to him, “It is illegal for us to put anyone to death,” 
+<sup>32&#160;</sup>that the word of Yahushua might be fulfilled, which he spoke, signifying by what kind of death he should die. 
+</div><div class="p">
+<sup>33&#160;</sup>Pilate therefore entered again into the Praetorium, called Yahushua, and said to him, “Are you the King of the Jews?” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua answered him, <span class="wj">“Do you say this by yourself, or did others tell you about me?”</span> 
+</div><div class="p">
+<sup>35&#160;</sup>Pilate answered, “I’m not a Jew, am I? Your own nation and the chief priests delivered you to me. What have you done?” 
+</div><div class="p">
+<sup>36&#160;</sup>Yahushua answered, <span class="wj">“My Kingdom is not of this world. If my Kingdom were of this world, then my servants would fight, that I wouldn’t be delivered to the Jews. But now my Kingdom is not from here.”</span> 
+</div><div class="p">
+<sup>37&#160;</sup>Pilate therefore said to him, “Are you a king then?” 
+</div><div class="p">Yahushua answered, <span class="wj">“You say that I am a king. For this reason I have been born, and for this reason I have come into the world, that I should testify to the truth. Everyone who is of the truth listens to my voice.”</span> 
+</div><div class="p">
+<sup>38&#160;</sup>Pilate said to him, “What is truth?” 
+</div><div class="p">When he had said this, he went out again to the Jews, and said to them, “I find no basis for a charge against him. 
+<sup>39&#160;</sup>But you have a custom that I should release someone to you at the Passover. Therefore, do you want me to release to you the King of the Jews?” 
+</div><div class="p">
+<sup>40&#160;</sup>Then they all shouted again, saying, “Not this man, but Barabbas!” Now Barabbas was a robber. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>So Pilate then took Yahushua and flogged him. 
+<sup>2&#160;</sup>The soldiers twisted thorns into a crown and put it on his head, and dressed him in a purple garment. 
+<sup>3&#160;</sup>They kept saying, “Hail, King of the Jews!” and they kept slapping him. 
+</div><div class="p">
+<sup>4&#160;</sup>Then Pilate went out again, and said to them, “Behold, I bring him out to you, that you may know that I find no basis for a charge against him.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahushua therefore came out, wearing the crown of thorns and the purple garment. Pilate said to them, “Behold, the man!” 
+</div><div class="p">
+<sup>6&#160;</sup>When therefore the chief priests and the officers saw him, they shouted, saying, “Crucify! Crucify!” 
+</div><div class="p">Pilate said to them, “Take him yourselves and crucify him, for I find no basis for a charge against him.” 
+</div><div class="p">
+<sup>7&#160;</sup>The Jews answered him, “We have a law, and by our law he ought to die, because he made himself the Son of Elohim.” 
+</div><div class="p">
+<sup>8&#160;</sup>When therefore Pilate heard this saying, he was more afraid. 
+<sup>9&#160;</sup>He entered into the Praetorium again, and said to Yahushua, “Where are you from?” But Yahushua gave him no answer. 
+<sup>10&#160;</sup>Pilate therefore said to him, “Aren’t you speaking to me? Don’t you know that I have power to release you and have power to crucify you?” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahushua answered, <span class="wj">“You would have no power at all against me, unless it were given to you from above. Therefore he who delivered me to you has greater sin.”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>At this, Pilate was seeking to release him, but the Jews cried out, saying, “If you release this man, you aren’t Caesar’s friend! Everyone who makes himself a king speaks against Caesar!” 
+</div><div class="p">
+<sup>13&#160;</sup>When Pilate therefore heard these words, he brought Yahushua out and sat down on the judgment seat at a place called “The Pavement”, but in Hebrew, “Gabbatha.” 
+<sup>14&#160;</sup>Now it was the Preparation Day of the Passover, at about the sixth hour. He said to the Jews, “Behold, your King!” 
+</div><div class="p">
+<sup>15&#160;</sup>They cried out, “Away with him! Away with him! Crucify him!” 
+</div><div class="p">Pilate said to them, “Shall I crucify your King?” 
+</div><div class="p">The chief priests answered, “We have no king but Caesar!” 
+</div><div class="p">
+<sup>16&#160;</sup>So then he delivered him to them to be crucified. So they took Yahushua and led him away. 
+<sup>17&#160;</sup>He went out, bearing his cross, to the place called “The Place of a Skull”, which is called in Hebrew, “Golgotha”, 
+<sup>18&#160;</sup>where they crucified him, and with him two others, on either side one, and Yahushua in the middle. 
+<sup>19&#160;</sup>Pilate wrote a title also, and put it on the cross. There was written, “YAHUSHUA OF NAZARETH, THE KING OF THE JEWS.” 
+<sup>20&#160;</sup>Therefore many of the Jews read this title, for the place where Yahushua was crucified was near the city; and it was written in Hebrew, in Latin, and in Greek. 
+<sup>21&#160;</sup>The chief priests of the Jews therefore said to Pilate, “Don’t write, ‘The King of the Jews,’ but, ‘he said, “I am King of the Jews.”&#160;’&#160;” 
+</div><div class="p">
+<sup>22&#160;</sup>Pilate answered, “What I have written, I have written.” 
+</div><div class="p">
+<sup>23&#160;</sup>Then the soldiers, when they had crucified Yahushua, took his garments and made four parts, to every soldier a part; and also the tunic. Now the tunic was without seam, woven from the top throughout. 
+<sup>24&#160;</sup>Then they said to one another, “Let’s not tear it, but cast lots for it to decide whose it will be,” that the Scripture might be fulfilled, which says, 
+</div><div class="q1">“They parted my garments among them. 
+</div><div class="q2">They cast lots for my clothing.” 
+</div><div class="m">Therefore the soldiers did these things. 
+</div><div class="p">
+<sup>25&#160;</sup>But standing by Yahushua’s cross were his mother, his mother’s sister, Mary the woman of Clopas, and Mary Magdalene. 
+<sup>26&#160;</sup>Therefore when Yahushua saw his mother, and the disciple whom he loved standing there, he said to his mother, <span class="wj">“Woman, behold, your son!” </span> 
+<sup>27&#160;</sup>Then he said to the disciple, <span class="wj">“Behold, your mother!”</span> From that hour, the disciple took her to his own home. 
+</div><div class="p">
+<sup>28&#160;</sup>After this, Yahushua, seeing that all things were now finished, that the Scripture might be fulfilled, said, <span class="wj">“I am thirsty!”</span> 
+<sup>29&#160;</sup>Now a vessel full of vinegar was set there; so they put a sponge full of the vinegar on hyssop, and held it at his mouth. 
+<sup>30&#160;</sup>When Yahushua therefore had received the vinegar, he said, <span class="wj">“It is finished!”</span> Then he bowed his head and gave up his spirit. 
+</div><div class="p">
+<sup>31&#160;</sup>Therefore the Jews, because it was the Preparation Day, so that the bodies wouldn’t remain on the cross on the Sabbath (for that Sabbath was a special one), asked of Pilate that their legs might be broken and that they might be taken away. 
+<sup>32&#160;</sup>Therefore the soldiers came and broke the legs of the first and of the other who was crucified with him; 
+<sup>33&#160;</sup>but when they came to Yahushua and saw that he was already dead, they didn’t break his legs. 
+<sup>34&#160;</sup>However, one of the soldiers pierced his side with a spear, and immediately blood and water came out. 
+<sup>35&#160;</sup>He who has seen has testified, and his testimony is true. He knows that he tells the truth, that you may believe. 
+<sup>36&#160;</sup>For these things happened that the Scripture might be fulfilled, “A bone of him will not be broken.” 
+<sup>37&#160;</sup>Again another Scripture says, “They will look on him whom they pierced.” 
+</div><div class="p">
+<sup>38&#160;</sup>After these things, Joseph of Arimathaea, being a disciple of Yahushua, but secretly for fear of the Jews, asked of Pilate that he might take away Yahushua’s body. Pilate gave him permission. He came therefore and took away his body. 
+<sup>39&#160;</sup>Nicodemus, who at first came to Yahushua by night, also came bringing a mixture of myrrh and aloes, about a hundred Roman pounds. 
+<sup>40&#160;</sup>So they took Yahushua’s body, and bound it in linen cloths with the spices, as the custom of the Jews is to bury. 
+<sup>41&#160;</sup>Now in the place where he was crucified there was a garden. In the garden was a new tomb in which no man had ever yet been laid. 
+<sup>42&#160;</sup>Then, because of the Jews’ Preparation Day (for the tomb was near at hand), they laid Yahushua there. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Now on the first day of the week, Mary Magdalene went early, while it was still dark, to the tomb, and saw that the stone had been taken away from the tomb. 
+<sup>2&#160;</sup>Therefore she ran and came to Simon Peter and to the other disciple whom Yahushua loved, and said to them, “They have taken away the Lord out of the tomb, and we don’t know where they have laid him!” 
+</div><div class="p">
+<sup>3&#160;</sup>Therefore Peter and the other disciple went out, and they went toward the tomb. 
+<sup>4&#160;</sup>They both ran together. The other disciple outran Peter and came to the tomb first. 
+<sup>5&#160;</sup>Stooping and looking in, he saw the linen cloths lying there; yet he didn’t enter in. 
+<sup>6&#160;</sup>Then Simon Peter came, following him, and entered into the tomb. He saw the linen cloths lying, 
+<sup>7&#160;</sup>and the cloth that had been on his head, not lying with the linen cloths, but rolled up in a place by itself. 
+<sup>8&#160;</sup>So then the other disciple who came first to the tomb also entered in, and he saw and believed. 
+<sup>9&#160;</sup>For as yet they didn’t know the Scripture, that he must rise from the dead. 
+<sup>10&#160;</sup>So the disciples went away again to their own homes. 
+</div><div class="p">
+<sup>11&#160;</sup>But Mary was standing outside at the tomb weeping. So as she wept, she stooped and looked into the tomb, 
+<sup>12&#160;</sup>and she saw two angels in white sitting, one at the head and one at the feet, where the body of Yahushua had lain. 
+<sup>13&#160;</sup>They asked her, “Woman, why are you weeping?” 
+</div><div class="p">She said to them, “Because they have taken away my Lord, and I don’t know where they have laid him.” 
+<sup>14&#160;</sup>When she had said this, she turned around and saw Yahushua standing, and didn’t know that it was Yahushua. 
+</div><div class="p">
+<sup>15&#160;</sup>Yahushua said to her, <span class="wj">“Woman, why are you weeping? Who are you looking for?”</span> 
+</div><div class="p">She, supposing him to be the gardener, said to him, “Sir, if you have carried him away, tell me where you have laid him, and I will take him away.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahushua said to her, <span class="wj">“Mary.”</span> 
+</div><div class="p">She turned and said to him, “Rabboni!” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahushua said to her, <span class="wj">“Don’t hold me, for I haven’t yet ascended to my Father; but go to my brothers and tell them, ‘I am ascending to my Father and your Father, to my Elohim and your Elohim.’&#160;”</span> 
+</div><div class="p">
+<sup>18&#160;</sup>Mary Magdalene came and told the disciples that she had seen the Lord, and that he had said these things to her. 
+<sup>19&#160;</sup>When therefore it was evening on that day, the first day of the week, and when the doors were locked where the disciples were assembled, for fear of the Jews, Yahushua came and stood in the middle and said to them, <span class="wj">“Peace be to you.”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>When he had said this, he showed them his hands and his side. The disciples therefore were glad when they saw the Lord. 
+<sup>21&#160;</sup>Yahushua therefore said to them again, <span class="wj">“Peace be to you. As the Father has sent me, even so I send you.”</span> 
+<sup>22&#160;</sup>When he had said this, he breathed on them, and said to them, <span class="wj">“Receive the Set-Apart Spirit! </span> 
+<sup>23&#160;</sup><span class="wj">If you forgive anyone’s sins, they have been forgiven them. If you retain anyone’s sins, they have been retained.”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>But Thomas, one of the twelve, called Didymus, wasn’t with them when Yahushua came. 
+<sup>25&#160;</sup>The other disciples therefore said to him, “We have seen the Lord!” 
+</div><div class="p">But he said to them, “Unless I see in his hands the print of the nails, put my finger into the print of the nails, and put my hand into his side, I will not believe.” 
+</div><div class="p">
+<sup>26&#160;</sup>After eight days, again his disciples were inside and Thomas was with them. Yahushua came, the doors being locked, and stood in the middle, and said, <span class="wj">“Peace be to you.”</span> 
+<sup>27&#160;</sup>Then he said to Thomas, <span class="wj">“Reach here your finger, and see my hands. Reach here your hand, and put it into my side. Don’t be unbelieving, but believing.”</span> 
+</div><div class="p">
+<sup>28&#160;</sup>Thomas answered him, “My Lord and my Elohim!” 
+</div><div class="p">
+<sup>29&#160;</sup>Yahushua said to him, <span class="wj">“Because you have seen me,</span> <span class="wj">you have believed. Blessed are those who have not seen and have believed.”</span> 
+</div><div class="p">
+<sup>30&#160;</sup>Therefore Yahushua did many other signs in the presence of his disciples, which are not written in this book; 
+<sup>31&#160;</sup>but these are written that you may believe that Yahushua is the Christ, the Son of Elohim, and that believing you may have life in his name. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, Yahushua revealed himself again to the disciples at the sea of Tiberias. He revealed himself this way. 
+<sup>2&#160;</sup>Simon Peter, Thomas called Didymus, Nathanael of Cana in Galilee, and the sons of Zebedee, and two others of his disciples were together. 
+<sup>3&#160;</sup>Simon Peter said to them, “I’m going fishing.” 
+</div><div class="p">They told him, “We are also coming with you.” They immediately went out and entered into the boat. That night, they caught nothing. 
+<sup>4&#160;</sup>But when day had already come, Yahushua stood on the beach; yet the disciples didn’t know that it was Yahushua. 
+<sup>5&#160;</sup>Yahushua therefore said to them, <span class="wj">“Children, have you anything to eat?” </span> 
+</div><div class="p">They answered him, “No.” 
+</div><div class="p">
+<sup>6&#160;</sup>He said to them, <span class="wj">“Cast the net on the right side of the boat, and you will find some.”</span> 
+</div><div class="p">They cast it therefore, and now they weren’t able to draw it in for the multitude of fish. 
+<sup>7&#160;</sup>That disciple therefore whom Yahushua loved said to Peter, “It’s the Lord!” 
+</div><div class="p">So when Simon Peter heard that it was the Lord, he wrapped his coat around himself (for he was naked), and threw himself into the sea. 
+<sup>8&#160;</sup>But the other disciples came in the little boat (for they were not far from the land, but about two hundred cubits away), dragging the net full of fish. 
+<sup>9&#160;</sup>So when they got out on the land, they saw a fire of coals there, with fish and bread laid on it. 
+<sup>10&#160;</sup>Yahushua said to them, <span class="wj">“Bring some of the fish which you have just caught.”</span> 
+</div><div class="p">
+<sup>11&#160;</sup>Simon Peter went up, and drew the net to land, full of one hundred fifty-three great fish. Even though there were so many, the net wasn’t torn. 
+</div><div class="p">
+<sup>12&#160;</sup>Yahushua said to them, <span class="wj">“Come and eat breakfast!”</span> 
+</div><div class="p">None of the disciples dared inquire of him, “Who are you?” knowing that it was the Lord. 
+</div><div class="p">
+<sup>13&#160;</sup>Then Yahushua came and took the bread, gave it to them, and the fish likewise. 
+<sup>14&#160;</sup>This is now the third time that Yahushua was revealed to his disciples after he had risen from the dead. 
+<sup>15&#160;</sup>So when they had eaten their breakfast, Yahushua said to Simon Peter, <span class="wj">“Simon, son of Jonah, do you love me more than these?”</span> 
+</div><div class="p">He said to him, “Yes, Lord; you know that I have affection for you.” 
+</div><div class="p">He said to him, <span class="wj">“Feed my lambs.”</span> 
+<sup>16&#160;</sup>He said to him again a second time, <span class="wj">“Simon, son of Jonah, do you love me?”</span> 
+</div><div class="p">He said to him, “Yes, Lord; you know that I have affection for you.” 
+</div><div class="p">He said to him, <span class="wj">“Tend my sheep.”</span> 
+<sup>17&#160;</sup>He said to him the third time, <span class="wj">“Simon, son of Jonah, do you have affection for me?”</span> 
+</div><div class="p">Peter was grieved because he asked him the third time, <span class="wj">“Do you have affection for me?”</span> He said to him, “Lord, you know everything. You know that I have affection for you.” 
+</div><div class="p">Yahushua said to him, <span class="wj">“Feed my sheep. </span> 
+<sup>18&#160;</sup><span class="wj">Most certainly I tell you, when you were young, you dressed yourself and walked where you wanted to. But when you are old, you will stretch out your hands, and another will dress you and carry you where you don’t want to go.”</span> 
+</div><div class="p">
+<sup>19&#160;</sup>Now he said this, signifying by what kind of death he would glorify Elohim. When he had said this, he said to him, <span class="wj">“Follow me.”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>Then Peter, turning around, saw a disciple following. This was the disciple whom Yahushua loved, the one who had also leaned on Yahushua’s breast at the supper and asked, “Lord, who is going to betray you?” 
+<sup>21&#160;</sup>Peter, seeing him, said to Yahushua, “Lord, what about this man?” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahushua said to him, <span class="wj">“If I desire that he stay until I come, what is that to you? You follow me.”</span> 
+<sup>23&#160;</sup>This saying therefore went out among the brothers that this disciple wouldn’t die. Yet Yahushua didn’t say to him that he wouldn’t die, but, <span class="wj">“If I desire that he stay until I come, what is that to you?”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>This is the disciple who testifies about these things, and wrote these things. We know that his witness is true. 
+<sup>25&#160;</sup>There are also many other things which Yahushua did, which if they would all be written, I suppose that even the world itself wouldn’t have room for the books that would be written. </div></div><script src="../main.js"></script></body></html>

--- a/book/jonah.html
+++ b/book/jonah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Jonah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,100 +53,105 @@
 <div class="main">
 <!-- JON World English Scripture (WES) -->
 <h1 class="booklabel">Jonah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word came to Jonah the son of Amittai, saying, 
-<span class="v">2&#160;</span>“Arise, go to Nineveh, that great city, and preach against it, for their wickedness has come up before me.” 
-</p><p>
-<span class="v">3&#160;</span>But Jonah rose up to flee to Tarshish from the presence of Yahweh. He went down to Joppa, and found a ship going to Tarshish; so he paid its fare, and went down into it, to go with them to Tarshish from the presence of Yahweh. 
-</p><p>
-<span class="v">4&#160;</span>But Yahweh sent out a great wind on the sea, and there was a mighty storm on the sea, so that the ship was likely to break up. 
-<span class="v">5&#160;</span>Then the mariners were afraid, and every man cried to his elohim. They threw the cargo that was in the ship into the sea to lighten the ship. But Jonah had gone down into the innermost parts of the ship and he was laying down, and was fast asleep. 
-<span class="v">6&#160;</span>So the ship master came to him, and said to him, “What do you mean, sleeper? Arise, call on your Elohim!<span class="f">+ \fr 1:6 \ft or, elohims</span> Maybe your Elohim<span class="f">+ \fr 1:6 \ft or, elohims </span> will notice us, so that we won’t perish.” 
-</p><p>
-<span class="v">7&#160;</span>They all said to each other, “Come! Let’s cast lots, that we may know who is responsible for this evil that is on us.” So they cast lots, and the lot fell on Jonah. 
-<span class="v">8&#160;</span>Then they asked him, “Tell us, please, for whose cause this evil is on us. What is your occupation? Where do you come from? What is your country? Of what people are you?” 
-</p><p>
-<span class="v">9&#160;</span>He said to them, “I am a Hebrew, and I fear Yahweh, the Elohim<span class="f">+ \fr 1:9 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> of heaven, who has made the sea and the dry land.” 
-</p><p>
-<span class="v">10&#160;</span>Then the men were exceedingly afraid, and said to him, “What have you done?” For the men knew that he was fleeing from the presence of Yahweh, because he had told them. 
-<span class="v">11&#160;</span>Then they said to him, “What shall we do to you, that the sea may be calm to us?” For the sea grew more and more stormy. 
-</p><p>
-<span class="v">12&#160;</span>He said to them, “Take me up, and throw me into the sea. Then the sea will be calm for you; for I know that because of me this great storm is on you.” 
-</p><p>
-<span class="v">13&#160;</span>Nevertheless the men rowed hard to get them back to the land; but they could not, for the sea grew more and more stormy against them. 
-<span class="v">14&#160;</span>Therefore they cried to Yahweh, and said, “We beg you, Yahweh, we beg you, don’t let us die for this man’s life, and don’t lay on us innocent blood; for you, Yahweh, have done as it pleased you.” 
-<span class="v">15&#160;</span>So they took up Jonah and threw him into the sea; and the sea ceased its raging. 
-<span class="v">16&#160;</span>Then the men feared Yahweh exceedingly; and they offered a sacrifice to Yahweh and made vows. 
-</p><p>
-<span class="v">17&#160;</span>Yahweh prepared a huge fish to swallow up Jonah, and Jonah was in the belly of the fish three days and three nights. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Then Jonah prayed to Yahweh, his Elohim, out of the fish’s belly. 
-<span class="v">2&#160;</span>He said, 
-</p><p class="q1">“I called because of my affliction to Yahweh. 
-</p><p class="q2">He answered me. 
-</p><p class="q1">Out of the belly of Sheol<span class="f">+ \fr 2:2 \ft Sheol is the place of the dead.</span> I cried. 
-</p><p class="q2">You heard my voice. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For you threw me into the depths, 
-</p><p class="q2">in the heart of the seas. 
-</p><p class="q1">The flood was all around me. 
-</p><p class="q2">All your waves and your billows passed over me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I said, ‘I have been banished from your sight; 
-</p><p class="q2">yet I will look again toward your set-apart temple.’ 
-</p><p class="q1">
-<span class="v">5&#160;</span>The waters surrounded me, 
-</p><p class="q2">even to the soul. 
-</p><p class="q1">The deep was around me. 
-</p><p class="q2">The weeds were wrapped around my head. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I went down to the bottoms of the mountains. 
-</p><p class="q2">The earth barred me in forever; 
-</p><p class="q2">yet you have brought my life up from the pit, Yahweh my Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“When my soul fainted within me, I remembered Yahweh. 
-</p><p class="q2">My prayer came in to you, into your set-apart temple. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Those who regard vain idols forsake their own mercy. 
-</p><p class="q2">
-<span class="v">9&#160;</span>But I will sacrifice to you with the voice of thanksgiving. 
-</p><p class="q2">I will pay that which I have vowed. 
-</p><p class="q1">Salvation belongs to Yahweh.” 
-</p><p>
-<span class="v">10&#160;</span>Then Yahweh spoke to the fish, and it vomited out Jonah on the dry land. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s word came to Jonah the second time, saying, 
-<span class="v">2&#160;</span>“Arise, go to Nineveh, that great city, and preach to it the message that I give you.” 
-</p><p>
-<span class="v">3&#160;</span>So Jonah arose, and went to Nineveh, according to Yahweh’s word. Now Nineveh was an exceedingly great city, three days’ journey across. 
-<span class="v">4&#160;</span>Jonah began to enter into the city a day’s journey, and he cried out, and said, “In forty days, Nineveh will be overthrown!” 
-</p><p>
-<span class="v">5&#160;</span>The people of Nineveh believed Elohim; and they proclaimed a fast and put on sackcloth, from their greatest even to their least. 
-<span class="v">6&#160;</span>The news reached the king of Nineveh, and he arose from his throne, took off his royal robe, covered himself with sackcloth, and sat in ashes. 
-<span class="v">7&#160;</span>He made a proclamation and published through Nineveh by the decree of the king and his nobles, saying, “Let neither man nor animal, herd nor flock, taste anything; let them not feed, nor drink water; 
-<span class="v">8&#160;</span>but let them be covered with sackcloth, both man and animal, and let them cry mightily to Elohim. Yes, let them turn everyone from his evil way and from the violence that is in his hands. 
-<span class="v">9&#160;</span>Who knows whether Elohim will not turn and relent, and turn away from his fierce anger, so that we might not perish?” 
-</p><p>
-<span class="v">10&#160;</span>Elohim saw their works, that they turned from their evil way. Elohim relented of the disaster which he said he would do to them, and he didn’t do it. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>But it displeased Jonah exceedingly, and he was angry. 
-<span class="v">2&#160;</span>He prayed to Yahweh, and said, “Please, Yahweh, wasn’t this what I said when I was still in my own country? Therefore I hurried to flee to Tarshish, for I knew that you are a gracious Elohim and merciful, slow to anger, and abundant in loving kindness, and you relent of doing harm. 
-<span class="v">3&#160;</span>Therefore now, Yahweh, take, I beg you, my life from me, for it is better for me to die than to live.” 
-</p><p>
-<span class="v">4&#160;</span>Yahweh said, “Is it right for you to be angry?” 
-</p><p>
-<span class="v">5&#160;</span>Then Jonah went out of the city and sat on the east side of the city, and there made himself a booth and sat under it in the shade, until he might see what would become of the city. 
-<span class="v">6&#160;</span>Yahweh Elohim prepared a vine and made it to come up over Jonah, that it might be a shade over his head to deliver him from his discomfort. So Jonah was exceedingly glad because of the vine. 
-<span class="v">7&#160;</span>But Elohim prepared a worm at dawn the next day, and it chewed on the vine so that it withered. 
-<span class="v">8&#160;</span>When the sun arose, Elohim prepared a sultry east wind; and the sun beat on Jonah’s head, so that he was faint and requested for himself that he might die. He said, “It is better for me to die than to live.” 
-</p><p>
-<span class="v">9&#160;</span>Elohim said to Jonah, “Is it right for you to be angry about the vine?” 
-</p><p>He said, “I am right to be angry, even to death.” 
-</p><p>
-<span class="v">10&#160;</span>Yahweh said, “You have been concerned for the vine, for which you have not labored, neither made it grow; which came up in a night and perished in a night. 
-<span class="v">11&#160;</span>Shouldn’t I be concerned for Nineveh, that great city, in which are more than one hundred twenty thousand persons who can’t discern between their right hand and their left hand, and also many animals?” </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now Yahweh’s word came to Jonah the son of Amittai, saying, 
+<sup>2&#160;</sup>“Arise, go to Nineveh, that great city, and preach against it, for their wickedness has come up before me.” 
+</div><div class="p">
+<sup>3&#160;</sup>But Jonah rose up to flee to Tarshish from the presence of Yahweh. He went down to Joppa, and found a ship going to Tarshish; so he paid its fare, and went down into it, to go with them to Tarshish from the presence of Yahweh. 
+</div><div class="p">
+<sup>4&#160;</sup>But Yahweh sent out a great wind on the sea, and there was a mighty storm on the sea, so that the ship was likely to break up. 
+<sup>5&#160;</sup>Then the mariners were afraid, and every man cried to his elohim. They threw the cargo that was in the ship into the sea to lighten the ship. But Jonah had gone down into the innermost parts of the ship and he was laying down, and was fast asleep. 
+<sup>6&#160;</sup>So the ship master came to him, and said to him, “What do you mean, sleeper? Arise, call on your Elohim! will notice us, so that we won’t perish.” 
+</div><div class="p">
+<sup>7&#160;</sup>They all said to each other, “Come! Let’s cast lots, that we may know who is responsible for this evil that is on us.” So they cast lots, and the lot fell on Jonah. 
+<sup>8&#160;</sup>Then they asked him, “Tell us, please, for whose cause this evil is on us. What is your occupation? Where do you come from? What is your country? Of what people are you?” 
+</div><div class="p">
+<sup>9&#160;</sup>He said to them, “I am a Hebrew, and I fear Yahweh, the Elohim of heaven, who has made the sea and the dry land.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then the men were exceedingly afraid, and said to him, “What have you done?” For the men knew that he was fleeing from the presence of Yahweh, because he had told them. 
+<sup>11&#160;</sup>Then they said to him, “What shall we do to you, that the sea may be calm to us?” For the sea grew more and more stormy. 
+</div><div class="p">
+<sup>12&#160;</sup>He said to them, “Take me up, and throw me into the sea. Then the sea will be calm for you; for I know that because of me this great storm is on you.” 
+</div><div class="p">
+<sup>13&#160;</sup>Nevertheless the men rowed hard to get them back to the land; but they could not, for the sea grew more and more stormy against them. 
+<sup>14&#160;</sup>Therefore they cried to Yahweh, and said, “We beg you, Yahweh, we beg you, don’t let us die for this man’s life, and don’t lay on us innocent blood; for you, Yahweh, have done as it pleased you.” 
+<sup>15&#160;</sup>So they took up Jonah and threw him into the sea; and the sea ceased its raging. 
+<sup>16&#160;</sup>Then the men feared Yahweh exceedingly; and they offered a sacrifice to Yahweh and made vows. 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh prepared a huge fish to swallow up Jonah, and Jonah was in the belly of the fish three days and three nights. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Jonah prayed to Yahweh, his Elohim, out of the fish’s belly. 
+<sup>2&#160;</sup>He said, 
+</div><div class="q1">“I called because of my affliction to Yahweh. 
+</div><div class="q2">He answered me. 
+</div><div class="q1">Out of the belly of Sheol I cried. 
+</div><div class="q2">You heard my voice. 
+</div><div class="q1">
+<sup>3&#160;</sup>For you threw me into the depths, 
+</div><div class="q2">in the heart of the seas. 
+</div><div class="q1">The flood was all around me. 
+</div><div class="q2">All your waves and your billows passed over me. 
+</div><div class="q1">
+<sup>4&#160;</sup>I said, ‘I have been banished from your sight; 
+</div><div class="q2">yet I will look again toward your set-apart temple.’ 
+</div><div class="q1">
+<sup>5&#160;</sup>The waters surrounded me, 
+</div><div class="q2">even to the soul. 
+</div><div class="q1">The deep was around me. 
+</div><div class="q2">The weeds were wrapped around my head. 
+</div><div class="q1">
+<sup>6&#160;</sup>I went down to the bottoms of the mountains. 
+</div><div class="q2">The earth barred me in forever; 
+</div><div class="q2">yet you have brought my life up from the pit, Yahweh my Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“When my soul fainted within me, I remembered Yahweh. 
+</div><div class="q2">My prayer came in to you, into your set-apart temple. 
+</div><div class="q1">
+<sup>8&#160;</sup>Those who regard vain idols forsake their own mercy. 
+</div><div class="q2">
+<sup>9&#160;</sup>But I will sacrifice to you with the voice of thanksgiving. 
+</div><div class="q2">I will pay that which I have vowed. 
+</div><div class="q1">Salvation belongs to Yahweh.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Yahweh spoke to the fish, and it vomited out Jonah on the dry land. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s word came to Jonah the second time, saying, 
+<sup>2&#160;</sup>“Arise, go to Nineveh, that great city, and preach to it the message that I give you.” 
+</div><div class="p">
+<sup>3&#160;</sup>So Jonah arose, and went to Nineveh, according to Yahweh’s word. Now Nineveh was an exceedingly great city, three days’ journey across. 
+<sup>4&#160;</sup>Jonah began to enter into the city a day’s journey, and he cried out, and said, “In forty days, Nineveh will be overthrown!” 
+</div><div class="p">
+<sup>5&#160;</sup>The people of Nineveh believed Elohim; and they proclaimed a fast and put on sackcloth, from their greatest even to their least. 
+<sup>6&#160;</sup>The news reached the king of Nineveh, and he arose from his throne, took off his royal robe, covered himself with sackcloth, and sat in ashes. 
+<sup>7&#160;</sup>He made a proclamation and published through Nineveh by the decree of the king and his nobles, saying, “Let neither man nor animal, herd nor flock, taste anything; let them not feed, nor drink water; 
+<sup>8&#160;</sup>but let them be covered with sackcloth, both man and animal, and let them cry mightily to Elohim. Yes, let them turn everyone from his evil way and from the violence that is in his hands. 
+<sup>9&#160;</sup>Who knows whether Elohim will not turn and relent, and turn away from his fierce anger, so that we might not perish?” 
+</div><div class="p">
+<sup>10&#160;</sup>Elohim saw their works, that they turned from their evil way. Elohim relented of the disaster which he said he would do to them, and he didn’t do it. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>But it displeased Jonah exceedingly, and he was angry. 
+<sup>2&#160;</sup>He prayed to Yahweh, and said, “Please, Yahweh, wasn’t this what I said when I was still in my own country? Therefore I hurried to flee to Tarshish, for I knew that you are a gracious Elohim and merciful, slow to anger, and abundant in loving kindness, and you relent of doing harm. 
+<sup>3&#160;</sup>Therefore now, Yahweh, take, I beg you, my life from me, for it is better for me to die than to live.” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh said, “Is it right for you to be angry?” 
+</div><div class="p">
+<sup>5&#160;</sup>Then Jonah went out of the city and sat on the east side of the city, and there made himself a booth and sat under it in the shade, until he might see what would become of the city. 
+<sup>6&#160;</sup>Yahweh Elohim prepared a vine and made it to come up over Jonah, that it might be a shade over his head to deliver him from his discomfort. So Jonah was exceedingly glad because of the vine. 
+<sup>7&#160;</sup>But Elohim prepared a worm at dawn the next day, and it chewed on the vine so that it withered. 
+<sup>8&#160;</sup>When the sun arose, Elohim prepared a sultry east wind; and the sun beat on Jonah’s head, so that he was faint and requested for himself that he might die. He said, “It is better for me to die than to live.” 
+</div><div class="p">
+<sup>9&#160;</sup>Elohim said to Jonah, “Is it right for you to be angry about the vine?” 
+</div><div class="p">He said, “I am right to be angry, even to death.” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh said, “You have been concerned for the vine, for which you have not labored, neither made it grow; which came up in a night and perished in a night. 
+<sup>11&#160;</sup>Shouldn’t I be concerned for Nineveh, that great city, in which are more than one hundred twenty thousand persons who can’t discern between their right hand and their left hand, and also many animals?” </div></div><script src="../main.js"></script></body></html>

--- a/book/joshua.html
+++ b/book/joshua.html
@@ -3,6 +3,47 @@
 <head>
 <title>Joshua</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,883 +53,908 @@
 <div class="main">
 <!-- JOS World English Scripture (WES) -->
 <h1 class="booklabel">Joshua</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Now after the death of Moses the servant of Yahweh,<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> Yahweh spoke to Joshua the son of Nun, Moses’ servant, saying, 
-<span class="v">2&#160;</span>“Moses my servant is dead. Now therefore arise, go across this Jordan, you and all these people, to the land which I am giving to them, even to the children of Israel. 
-<span class="v">3&#160;</span>I have given you every place that the sole of your foot will tread on, as I told Moses. 
-<span class="v">4&#160;</span>From the wilderness and this Lebanon even to the great river, the river Euphrates, all the land of the Hittites, and to the great sea toward the going down of the sun, shall be your border. 
-<span class="v">5&#160;</span>No man will be able to stand before you all the days of your life. As I was with Moses, so I will be with you. I will not fail you nor forsake you. 
-</p><p>
-<span class="v">6&#160;</span>“Be strong and courageous; for you shall cause this people to inherit the land which I swore to their fathers to give them. 
-<span class="v">7&#160;</span>Only be strong and very courageous. Be careful to observe to do according to all the law which Moses my servant commanded you. Don’t turn from it to the right hand or to the left, that you may have good success wherever you go. 
-<span class="v">8&#160;</span>This book of the law shall not depart from your mouth, but you shall meditate on it day and night, that you may observe to do according to all that is written in it; for then you shall make your way prosperous, and then you shall have good success. 
-<span class="v">9&#160;</span>Haven’t I commanded you? Be strong and courageous. Don’t be afraid. Don’t be dismayed, for Yahweh your Elohim<span class="f">+ \fr 1:9 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> is with you wherever you go.” 
-</p><p>
-<span class="v">10&#160;</span>Then Joshua commanded the officers of the people, saying, 
-<span class="v">11&#160;</span>“Pass through the middle of the camp, and command the people, saying, ‘Prepare food; for within three days you are to pass over this Jordan, to go in to possess the land which Yahweh your Elohim gives you to possess.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Joshua spoke to the Reubenites, and to the Gadites, and to the half-tribe of Manasseh, saying, 
-<span class="v">13&#160;</span>“Remember the word which Moses the servant of Yahweh commanded you, saying, ‘Yahweh your Elohim gives you rest, and will give you this land. 
-<span class="v">14&#160;</span>Your women, your little ones, and your livestock shall live in the land which Moses gave you beyond the Jordan; but you shall pass over before your brothers armed, all the mighty men of valor, and shall help them 
-<span class="v">15&#160;</span>until Yahweh has given your brothers rest, as he has given you, and they have also possessed the land which Yahweh your Elohim gives them. Then you shall return to the land of your possession and possess it, which Moses the servant of Yahweh gave you beyond the Jordan toward the sunrise.’&#160;” 
-</p><p>
-<span class="v">16&#160;</span>They answered Joshua, saying, “All that you have commanded us we will do, and wherever you send us we will go. 
-<span class="v">17&#160;</span>Just as we listened to Moses in all things, so will we listen to you. Only may Yahweh your Elohim be with you, as he was with Moses. 
-<span class="v">18&#160;</span>Whoever rebels against your commandment, and doesn’t listen to your words in all that you command him shall himself be put to death. Only be strong and courageous.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Joshua the son of Nun secretly sent two men out of Shittim as spies, saying, “Go, view the land, including Jericho.” They went and came into the house of a prostitute whose name was Rahab, and slept there. 
-</p><p>
-<span class="v">2&#160;</span>The king of Jericho was told, “Behold,<span class="f">+ \fr 2:2 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> men of the children of Israel came in here tonight to spy out the land.” 
-</p><p>
-<span class="v">3&#160;</span>Jericho’s king sent to Rahab, saying, “Bring out the men who have come to you, who have entered into your house; for they have come to spy out all the land.” 
-</p><p>
-<span class="v">4&#160;</span>The woman took the two men and hid them. Then she said, “Yes, the men came to me, but I didn’t know where they came from. 
-<span class="v">5&#160;</span>About the time of the shutting of the gate, when it was dark, the men went out. Where the men went, I don’t know. Pursue them quickly. You may catch up with them.” 
-<span class="v">6&#160;</span>But she had brought them up to the roof, and hidden them under the stalks of flax which she had laid in order on the roof. 
-<span class="v">7&#160;</span>The men pursued them along the way to the fords of the Jordan River. As soon as those who pursued them had gone out, they shut the gate. 
-<span class="v">8&#160;</span>Before they had lain down, she came up to them on the roof. 
-<span class="v">9&#160;</span>She said to the men, “I know that Yahweh has given you the land, and that the fear of you has fallen upon us, and that all the inhabitants of the land melt away before you. 
-<span class="v">10&#160;</span>For we have heard how Yahweh dried up the water of the Red Sea before you, when you came out of Egypt; and what you did to the two kings of the Amorites, who were beyond the Jordan, to Sihon and to Og, whom you utterly destroyed. 
-<span class="v">11&#160;</span>As soon as we had heard it, our hearts melted, and there wasn’t any more spirit in any man, because of you: for Yahweh your Elohim, he is Elohim in heaven above, and on earth beneath. 
-<span class="v">12&#160;</span>Now therefore, please swear to me by Yahweh, since I have dealt kindly with you, that you also will deal kindly with my father’s house, and give me a true sign; 
-<span class="v">13&#160;</span>and that you will save alive my father, my mother, my brothers, and my sisters, and all that they have, and will deliver our lives from death.” 
-</p><p>
-<span class="v">14&#160;</span>The men said to her, “Our life for yours, if you don’t talk about this business of ours; and it shall be, when Yahweh gives us the land, that we will deal kindly and truly with you.” 
-</p><p>
-<span class="v">15&#160;</span>Then she let them down by a cord through the window; for her house was on the side of the wall, and she lived on the wall. 
-<span class="v">16&#160;</span>She said to them, “Go to the mountain, lest the pursuers find you. Hide yourselves there three days, until the pursuers have returned. Afterward, you may go your way.” 
-</p><p>
-<span class="v">17&#160;</span>The men said to her, “We will be guiltless of this your oath which you’ve made us to swear. 
-<span class="v">18&#160;</span>Behold, when we come into the land, tie this line of scarlet thread in the window which you used to let us down. Gather to yourself into the house your father, your mother, your brothers, and all your father’s household. 
-<span class="v">19&#160;</span>It shall be that whoever goes out of the doors of your house into the street, his blood will be on his head, and we will be guiltless. Whoever is with you in the house, his blood shall be on our head, if any hand is on him. 
-<span class="v">20&#160;</span>But if you talk about this business of ours, then we shall be guiltless of your oath which you’ve made us to swear.” 
-</p><p>
-<span class="v">21&#160;</span>She said, “Let it be as you have said.” She sent them away, and they departed. Then she tied the scarlet line in the window. 
-</p><p>
-<span class="v">22&#160;</span>They went and came to the mountain, and stayed there three days, until the pursuers had returned. The pursuers sought them all along the way, but didn’t find them. 
-<span class="v">23&#160;</span>Then the two men returned, descended from the mountain, crossed the river, and came to Joshua the son of Nun. They told him all that had happened to them. 
-<span class="v">24&#160;</span>They said to Joshua, “Truly Yahweh has delivered all the land into our hands. Moreover, all the inhabitants of the land melt away before us.” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Joshua got up early in the morning; and they moved from Shittim and came to the Jordan, he and all the children of Israel. They camped there before they crossed over. 
-<span class="v">2&#160;</span>After three days, the officers went through the middle of the camp; 
-<span class="v">3&#160;</span>and they commanded the people, saying, “When you see the ark of Yahweh your Elohim’s covenant, and the Levitical priests bearing it, then leave your place and follow it. 
-<span class="v">4&#160;</span>Yet there shall be a space between you and it of about two thousand cubits<span class="f">+ \fr 3:4 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters, so 2,000 cubits is about 920 meters.</span> by measure—don’t come closer to it—that you may know the way by which you must go; for you have not passed this way before.” 
-</p><p>
-<span class="v">5&#160;</span>Joshua said to the people, “Sanctify yourselves; for tomorrow Yahweh will do wonders among you.” 
-</p><p>
-<span class="v">6&#160;</span>Joshua spoke to the priests, saying, “Take up the ark of the covenant, and cross over before the people.” They took up the ark of the covenant, and went before the people. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh said to Joshua, “Today I will begin to magnify you in the sight of all Israel, that they may know that as I was with Moses, so I will be with you. 
-<span class="v">8&#160;</span>You shall command the priests who bear the ark of the covenant, saying, ‘When you come to the brink of the waters of the Jordan, you shall stand still in the Jordan.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>Joshua said to the children of Israel, “Come here, and hear the words of Yahweh your Elohim.” 
-<span class="v">10&#160;</span>Joshua said, “By this you shall know that the living Elohim is among you, and that he will without fail drive the Canaanite, the Hittite, the Hivite, the Perizzite, the Girgashite, the Amorite, and the Jebusite out from before you. 
-<span class="v">11&#160;</span>Behold, the ark of the covenant of the Lord<span class="f">+ \fr 3:11 \ft The word translated “Lord” is “Adonai.”</span> of all the earth passes over before you into the Jordan. 
-<span class="v">12&#160;</span>Now therefore take twelve men out of the tribes of Israel, for every tribe a man. 
-<span class="v">13&#160;</span>It shall be that when the soles of the feet of the priests who bear the ark of Yahweh, the Lord of all the earth, rest in the waters of the Jordan, that the waters of the Jordan will be cut off. The waters that come down from above shall stand in one heap.” 
-</p><p>
-<span class="v">14&#160;</span>When the people moved from their tents to pass over the Jordan, the priests who bore the ark of the covenant being before the people, 
-<span class="v">15&#160;</span>and when those who bore the ark had come to the Jordan, and the feet of the priests who bore the ark had dipped in the edge of the water (for the Jordan overflows all its banks all the time of harvest), 
-<span class="v">16&#160;</span>the waters which came down from above stood, and rose up in one heap a great way off, at Adam, the city that is beside Zarethan; and those that went down toward the sea of the Arabah, even the Salt Sea, were wholly cut off. Then the people passed over near Jericho. 
-<span class="v">17&#160;</span>The priests who bore the ark of Yahweh’s covenant stood firm on dry ground in the middle of the Jordan; and all Israel crossed over on dry ground, until all the nation had passed completely over the Jordan. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>When all the nation had completely crossed over the Jordan, Yahweh spoke to Joshua, saying, 
-<span class="v">2&#160;</span>“Take twelve men out of the people, a man out of every tribe, 
-<span class="v">3&#160;</span>and command them, saying, ‘Take from out of the middle of the Jordan, out of the place where the priests’ feet stood firm, twelve stones, carry them over with you, and lay them down in the place where you’ll camp tonight.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>Then Joshua called the twelve men whom he had prepared of the children of Israel, a man out of every tribe. 
-<span class="v">5&#160;</span>Joshua said to them, “Cross before the ark of Yahweh your Elohim into the middle of the Jordan, and each of you pick up a stone and put it on your shoulder, according to the number of the tribes of the children of Israel; 
-<span class="v">6&#160;</span>that this may be a sign among you, that when your children ask in the future, saying, ‘What do you mean by these stones?’ 
-<span class="v">7&#160;</span>then you shall tell them, ‘Because the waters of the Jordan were cut off before the ark of Yahweh’s covenant. When it crossed over the Jordan, the waters of the Jordan were cut off. These stones shall be for a memorial to the children of Israel forever.’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>The children of Israel did as Joshua commanded, and took up twelve stones out of the middle of the Jordan, as Yahweh spoke to Joshua, according to the number of the tribes of the children of Israel. They carried them over with them to the place where they camped, and laid them down there. 
-<span class="v">9&#160;</span>Joshua set up twelve stones in the middle of the Jordan, in the place where the feet of the priests who bore the ark of the covenant stood; and they are there to this day. 
-<span class="v">10&#160;</span>For the priests who bore the ark stood in the middle of the Jordan until everything was finished that Yahweh commanded Joshua to speak to the people, according to all that Moses commanded Joshua; and the people hurried and passed over. 
-<span class="v">11&#160;</span>When all the people had completely crossed over, Yahweh’s ark crossed over with the priests in the presence of the people. 
-</p><p>
-<span class="v">12&#160;</span>The children of Reuben, and the children of Gad, and the half-tribe of Manasseh crossed over armed before the children of Israel, as Moses spoke to them. 
-<span class="v">13&#160;</span>About forty thousand men, ready and armed for war, passed over before Yahweh to battle, to the plains of Jericho. 
-<span class="v">14&#160;</span>On that day, Yahweh magnified Joshua in the sight of all Israel; and they feared him, as they feared Moses, all the days of his life. 
-</p><p>
-<span class="v">15&#160;</span>Yahweh spoke to Joshua, saying, 
-<span class="v">16&#160;</span>“Command the priests who bear the ark of the covenant, that they come up out of the Jordan.” 
-</p><p>
-<span class="v">17&#160;</span>Joshua therefore commanded the priests, saying, “Come up out of the Jordan!” 
-<span class="v">18&#160;</span>When the priests who bore the ark of Yahweh’s covenant had come up out of the middle of the Jordan, and the soles of the priests’ feet had been lifted up to the dry ground, the waters of the Jordan returned to their place, and went over all its banks, as before. 
-<span class="v">19&#160;</span>The people came up out of the Jordan on the tenth day of the first month, and encamped in Gilgal, on the east border of Jericho. 
-</p><p>
-<span class="v">20&#160;</span>Joshua set up those twelve stones, which they took out of the Jordan, in Gilgal. 
-<span class="v">21&#160;</span>He spoke to the children of Israel, saying, “When your children ask their fathers in time to come, saying, ‘What do these stones mean?’ 
-<span class="v">22&#160;</span>Then you shall let your children know, saying, ‘Israel came over this Jordan on dry land. 
-<span class="v">23&#160;</span>For Yahweh your Elohim dried up the waters of the Jordan from before you until you had crossed over, as Yahweh your Elohim did to the Red Sea, which he dried up from before us, until we had crossed over, 
-<span class="v">24&#160;</span>that all the peoples of the earth may know that Yahweh’s hand is mighty, and that you may fear Yahweh your Elohim forever.’&#160;” 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>When all the kings of the Amorites, who were beyond the Jordan westward, and all the kings of the Canaanites, who were by the sea, heard how Yahweh had dried up the waters of the Jordan from before the children of Israel until we had crossed over, their heart melted, and there was no more spirit in them, because of the children of Israel. 
-<span class="v">2&#160;</span>At that time, Yahweh said to Joshua, “Make flint knives, and circumcise again the sons of Israel the second time.” 
-<span class="v">3&#160;</span>Joshua made himself flint knives, and circumcised the sons of Israel at the hill of the foreskins. 
-<span class="v">4&#160;</span>This is the reason Joshua circumcised them: all the people who came out of Egypt, who were males, even all the men of war, died in the wilderness along the way, after they came out of Egypt. 
-<span class="v">5&#160;</span>For all the people who came out were circumcised; but all the people who were born in the wilderness along the way as they came out of Egypt had not been circumcised. 
-<span class="v">6&#160;</span>For the children of Israel walked forty years in the wilderness until all the nation, even the men of war who came out of Egypt, were consumed, because they didn’t listen to Yahweh’s voice. Yahweh swore to them that he wouldn’t let them see the land which Yahweh swore to their fathers that he would give us, a land flowing with milk and honey. 
-<span class="v">7&#160;</span>Their children, whom he raised up in their place, were circumcised by Joshua, for they were uncircumcised, because they had not circumcised them on the way. 
-<span class="v">8&#160;</span>When they were done circumcising the whole nation, they stayed in their places in the camp until they were healed. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh said to Joshua, “Today I have rolled away the reproach of Egypt from you.” Therefore the name of that place was called Gilgal<span class="f">+ \fr 5:9 \ft “Gilgal” sounds like the Hebrew for “roll.”</span> to this day. 
-<span class="v">10&#160;</span>The children of Israel encamped in Gilgal. They kept the Passover on the fourteenth day of the month at evening in the plains of Jericho. 
-<span class="v">11&#160;</span>They ate unleavened cakes and parched grain of the produce of the land on the next day after the Passover, in the same day. 
-<span class="v">12&#160;</span>The manna ceased on the next day, after they had eaten of the produce of the land. The children of Israel didn’t have manna any more, but they ate of the fruit of the land of Canaan that year. 
-</p><p>
-<span class="v">13&#160;</span>When Joshua was by Jericho, he lifted up his eyes and looked, and behold, a man stood in front of him with his sword drawn in his hand. Joshua went to him and said to him, “Are you for us, or for our enemies?” 
-</p><p>
-<span class="v">14&#160;</span>He said, “No; but I have come now as commander of Yahweh’s army.” 
-</p><p>Joshua fell on his face to the earth, and worshiped, and asked him, “What does my lord say to his servant?” 
-</p><p>
-<span class="v">15&#160;</span>The prince of Yahweh’s army said to Joshua, “Take off your sandals, for the place on which you stand is set-apart.” Joshua did so. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Now Jericho was tightly shut up because of the children of Israel. No one went out, and no one came in. 
-<span class="v">2&#160;</span>Yahweh said to Joshua, “Behold, I have given Jericho into your hand, with its king and the mighty men of valor. 
-<span class="v">3&#160;</span>All of your men of war shall march around the city, going around the city once. You shall do this six days. 
-<span class="v">4&#160;</span>Seven priests shall bear seven trumpets of rams’ horns before the ark. On the seventh day, you shall march around the city seven times, and the priests shall blow the trumpets. 
-<span class="v">5&#160;</span>It shall be that when they make a long blast with the ram’s horn, and when you hear the sound of the trumpet, all the people shall shout with a great shout; then the city wall will fall down flat, and the people shall go up, every man straight in front of him.” 
-</p><p>
-<span class="v">6&#160;</span>Joshua the son of Nun called the priests, and said to them, “Take up the ark of the covenant, and let seven priests bear seven trumpets of rams’ horns before Yahweh’s ark.” 
-</p><p>
-<span class="v">7&#160;</span>They said to the people, “Advance! March around the city, and let the armed men pass on before Yahweh’s ark.” 
-</p><p>
-<span class="v">8&#160;</span>It was so, that when Joshua had spoken to the people, the seven priests bearing the seven trumpets of rams’ horns before Yahweh advanced and blew the trumpets, and the ark of Yahweh’s covenant followed them. 
-<span class="v">9&#160;</span>The armed men went before the priests who blew the trumpets, and the ark went after them. The trumpets sounded as they went. 
-</p><p>
-<span class="v">10&#160;</span>Joshua commanded the people, saying, “You shall not shout nor let your voice be heard, neither shall any word proceed out of your mouth until the day I tell you to shout. Then you shall shout.” 
-<span class="v">11&#160;</span>So he caused Yahweh’s ark to go around the city, circling it once. Then they came into the camp, and stayed in the camp. 
-<span class="v">12&#160;</span>Joshua rose early in the morning, and the priests took up Yahweh’s ark. 
-<span class="v">13&#160;</span>The seven priests bearing the seven trumpets of rams’ horns in front of Yahweh’s ark went on continually, and blew the trumpets. The armed men went in front of them. The rear guard came after Yahweh’s ark. The trumpets sounded as they went. 
-<span class="v">14&#160;</span>The second day they marched around the city once, and returned into the camp. They did this six days. 
-</p><p>
-<span class="v">15&#160;</span>On the seventh day, they rose early at the dawning of the day, and marched around the city in the same way seven times. On this day only they marched around the city seven times. 
-<span class="v">16&#160;</span>At the seventh time, when the priests blew the trumpets, Joshua said to the people, “Shout, for Yahweh has given you the city! 
-<span class="v">17&#160;</span>The city shall be devoted, even it and all that is in it, to Yahweh. Only Rahab the prostitute shall live, she and all who are with her in the house, because she hid the messengers that we sent. 
-<span class="v">18&#160;</span>But as for you, only keep yourselves from what is devoted to destruction, lest when you have devoted it, you take of the devoted thing; so you would make the camp of Israel accursed and trouble it. 
-<span class="v">19&#160;</span>But all the silver, gold, and vessels of bronze and iron are set-apart to Yahweh. They shall come into Yahweh’s treasury.” 
-</p><p>
-<span class="v">20&#160;</span>So the people shouted and the priests blew the trumpets. When the people heard the sound of the trumpet, the people shouted with a great shout, and the wall fell down flat, so that the people went up into the city, every man straight in front of him, and they took the city. 
-<span class="v">21&#160;</span>They utterly destroyed all that was in the city, both man and woman, both young and old, and ox, sheep, and donkey, with the edge of the sword. 
-<span class="v">22&#160;</span>Joshua said to the two men who had spied out the land, “Go into the prostitute’s house, and bring the woman and all that she has out from there, as you swore to her.” 
-<span class="v">23&#160;</span>The young men who were spies went in, and brought out Rahab with her father, her mother, her brothers, and all that she had. They also brought out all of her relatives, and they set them outside of the camp of Israel. 
-<span class="v">24&#160;</span>They burned the city with fire, and all that was in it. Only they put the silver, the gold, and the vessels of bronze and of iron into the treasury of Yahweh’s house. 
-<span class="v">25&#160;</span>But Rahab the prostitute, her father’s household, and all that she had, Joshua saved alive. She lives in the middle of Israel to this day, because she hid the messengers whom Joshua sent to spy out Jericho. 
-</p><p>
-<span class="v">26&#160;</span>Joshua commanded them with an oath at that time, saying, “Cursed is the man before Yahweh who rises up and builds this city Jericho. With the loss of his firstborn he will lay its foundation, and with the loss of his youngest son he will set up its gates.” 
-<span class="v">27&#160;</span>So Yahweh was with Joshua; and his fame was in all the land. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>But the children of Israel committed a trespass in the devoted things; for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took some of the devoted things. Therefore Yahweh’s anger burned against the children of Israel. 
-<span class="v">2&#160;</span>Joshua sent men from Jericho to Ai, which is beside Beth Aven, on the east side of Bethel, and spoke to them, saying, “Go up and spy out the land.” 
-</p><p>The men went up and spied out Ai. 
-<span class="v">3&#160;</span>They returned to Joshua, and said to him, “Don’t let all the people go up, but let about two or three thousand men go up and strike Ai. Don’t make all the people to toil there, for there are only a few of them.” 
-<span class="v">4&#160;</span>So about three thousand men of the people went up there, and they fled before the men of Ai. 
-<span class="v">5&#160;</span>The men of Ai struck about thirty-six men of them. They chased them from before the gate even to Shebarim, and struck them at the descent. The hearts of the people melted, and became like water. 
-<span class="v">6&#160;</span>Joshua tore his clothes, and fell to the earth on his face before Yahweh’s ark until the evening, he and the elders of Israel; and they put dust on their heads. 
-<span class="v">7&#160;</span>Joshua said, “Alas, Lord Yahweh, why have you brought this people over the Jordan at all, to deliver us into the hand of the Amorites, to cause us to perish? I wish that we had been content and lived beyond the Jordan! 
-<span class="v">8&#160;</span>Oh, Lord, what shall I say, after Israel has turned their backs before their enemies? 
-<span class="v">9&#160;</span>For the Canaanites and all the inhabitants of the land will hear of it, and will surround us, and cut off our name from the earth. What will you do for your great name?” 
-</p><p>
-<span class="v">10&#160;</span>Yahweh said to Joshua, “Get up! Why have you fallen on your face like that? 
-<span class="v">11&#160;</span>Israel has sinned. Yes, they have even transgressed my covenant which I commanded them. Yes, they have even taken some of the devoted things, and have also stolen, and also deceived. They have even put it among their own stuff. 
-<span class="v">12&#160;</span>Therefore the children of Israel can’t stand before their enemies. They turn their backs before their enemies, because they have become devoted for destruction. I will not be with you any more, unless you destroy the devoted things from among you. 
-<span class="v">13&#160;</span>Get up! Sanctify the people, and say, ‘Sanctify yourselves for tomorrow, for Yahweh, the Elohim of Israel, says, “There is a devoted thing among you, Israel. You cannot stand before your enemies until you take away the devoted thing from among you.” 
-<span class="v">14&#160;</span>In the morning therefore you shall be brought near by your tribes. It shall be that the tribe which Yahweh selects shall come near by families. The family which Yahweh selects shall come near by households. The household which Yahweh selects shall come near man by man. 
-<span class="v">15&#160;</span>It shall be, that he who is taken with the devoted thing shall be burned with fire, he and all that he has, because he has transgressed Yahweh’s covenant, and because he has done a disgraceful thing in Israel.’&#160;” 
-</p><p>
-<span class="v">16&#160;</span>So Joshua rose up early in the morning and brought Israel near by their tribes. The tribe of Judah was selected. 
-<span class="v">17&#160;</span>He brought near the family of Judah, and he selected the family of the Zerahites. He brought near the family of the Zerahites man by man, and Zabdi was selected. 
-<span class="v">18&#160;</span>He brought near his household man by man, and Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, was selected. 
-<span class="v">19&#160;</span>Joshua said to Achan, “My son, please give glory to Yahweh, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
-</p><p>
-<span class="v">20&#160;</span>Achan answered Joshua, and said, “I have truly sinned against Yahweh, the Elohim of Israel, and this is what I have done. 
-<span class="v">21&#160;</span>When I saw among the plunder a beautiful Babylonian robe, two hundred shekels<span class="f">+ \fr 7:21 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of silver, and a wedge of gold weighing fifty shekels, then I coveted them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
-</p><p>
-<span class="v">22&#160;</span>So Joshua sent messengers, and they ran to the tent. Behold, it was hidden in his tent, with the silver under it. 
-<span class="v">23&#160;</span>They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahweh. 
-<span class="v">24&#160;</span>Joshua, and all Israel with him, took Achan the son of Zerah, the silver, the robe, the wedge of gold, his sons, his daughters, his cattle, his donkeys, his sheep, his tent, and all that he had; and they brought them up to the valley of Achor. 
-<span class="v">25&#160;</span>Joshua said, “Why have you troubled us? Yahweh will trouble you today.” All Israel stoned him with stones, and they burned them with fire and stoned them with stones. 
-<span class="v">26&#160;</span>They raised over him a great heap of stones that remains to this day. Yahweh turned from the fierceness of his anger. Therefore the name of that place was called “The valley of Achor” to this day. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Joshua, “Don’t be afraid, and don’t be dismayed. Take all the warriors with you, and arise, go up to Ai. Behold, I have given into your hand the king of Ai, with his people, his city, and his land. 
-<span class="v">2&#160;</span>You shall do to Ai and her king as you did to Jericho and her king, except you shall take its goods and its livestock for yourselves. Set an ambush for the city behind it.” 
-</p><p>
-<span class="v">3&#160;</span>So Joshua arose, with all the warriors, to go up to Ai. Joshua chose thirty thousand men, the mighty men of valor, and sent them out by night. 
-<span class="v">4&#160;</span>He commanded them, saying, “Behold, you shall lie in ambush against the city, behind the city. Don’t go very far from the city, but all of you be ready. 
-<span class="v">5&#160;</span>I and all the people who are with me will approach the city. It shall happen, when they come out against us, as at the first, that we will flee before them. 
-<span class="v">6&#160;</span>They will come out after us until we have drawn them away from the city; for they will say, ‘They flee before us, like the first time.’ So we will flee before them, 
-<span class="v">7&#160;</span>and you shall rise up from the ambush, and take possession of the city; for Yahweh your Elohim will deliver it into your hand. 
-<span class="v">8&#160;</span>It shall be, when you have seized the city, that you shall set the city on fire. You shall do this according to Yahweh’s word. Behold, I have commanded you.” 
-</p><p>
-<span class="v">9&#160;</span>Joshua sent them out; and they went to set up the ambush, and stayed between Bethel and Ai on the west side of Ai; but Joshua stayed among the people that night. 
-<span class="v">10&#160;</span>Joshua rose up early in the morning, mustered the people, and went up, he and the elders of Israel, before the people to Ai. 
-<span class="v">11&#160;</span>All the people, even the men of war who were with him, went up and came near, and came before the city and encamped on the north side of Ai. Now there was a valley between him and Ai. 
-<span class="v">12&#160;</span>He took about five thousand men, and set them in ambush between Bethel and Ai, on the west side of the city. 
-<span class="v">13&#160;</span>So they set the people, even all the army who was on the north of the city, and their ambush on the west of the city; and Joshua went that night into the middle of the valley. 
-<span class="v">14&#160;</span>When the king of Ai saw it, they hurried and rose up early, and the men of the city went out against Israel to battle, he and all his people, at the time appointed, before the Arabah; but he didn’t know that there was an ambush against him behind the city. 
-<span class="v">15&#160;</span>Joshua and all Israel made as if they were beaten before them, and fled by the way of the wilderness. 
-<span class="v">16&#160;</span>All the people who were in the city were called together to pursue after them. They pursued Joshua, and were drawn away from the city. 
-<span class="v">17&#160;</span>There was not a man left in Ai or Bethel who didn’t go out after Israel. They left the city open, and pursued Israel. 
-</p><p>
-<span class="v">18&#160;</span>Yahweh said to Joshua, “Stretch out the javelin that is in your hand toward Ai, for I will give it into your hand.” 
-</p><p>Joshua stretched out the javelin that was in his hand toward the city. 
-<span class="v">19&#160;</span>The ambush arose quickly out of their place, and they ran as soon as he had stretched out his hand and entered into the city and took it. They hurried and set the city on fire. 
-<span class="v">20&#160;</span>When the men of Ai looked behind them, they saw, and behold, the smoke of the city ascended up to heaven, and they had no power to flee this way or that way. The people who fled to the wilderness turned back on the pursuers. 
-<span class="v">21&#160;</span>When Joshua and all Israel saw that the ambush had taken the city, and that the smoke of the city ascended, then they turned back and killed the men of Ai. 
-<span class="v">22&#160;</span>The others came out of the city against them, so they were in the middle of Israel, some on this side, and some on that side. They struck them, so that they let none of them remain or escape. 
-<span class="v">23&#160;</span>They captured the king of Ai alive, and brought him to Joshua. 
-</p><p>
-<span class="v">24&#160;</span>When Israel had finished killing all the inhabitants of Ai in the field, in the wilderness in which they pursued them, and they had all fallen by the edge of the sword until they were consumed, all Israel returned to Ai and struck it with the edge of the sword. 
-<span class="v">25&#160;</span>All that fell that day, both of men and women, were twelve thousand, even all the people of Ai. 
-<span class="v">26&#160;</span>For Joshua didn’t draw back his hand, with which he stretched out the javelin, until he had utterly destroyed all the inhabitants of Ai. 
-<span class="v">27&#160;</span>Israel took for themselves only the livestock and the goods of that city, according to Yahweh’s word which he commanded Joshua. 
-<span class="v">28&#160;</span>So Joshua burned Ai and made it a heap forever, even a desolation, to this day. 
-<span class="v">29&#160;</span>He hanged the king of Ai on a tree until the evening. At sundown, Joshua commanded, and they took his body down from the tree and threw it at the entrance of the gate of the city, and raised a great heap of stones on it that remains to this day. 
-</p><p>
-<span class="v">30&#160;</span>Then Joshua built an altar to Yahweh, the Elohim of Israel, on Mount Ebal, 
-<span class="v">31&#160;</span>as Moses the servant of Yahweh commanded the children of Israel, as it is written in the book of the law of Moses: an altar of uncut stones, on which no one had lifted up any iron. They offered burnt offerings on it to Yahweh and sacrificed peace offerings. 
-<span class="v">32&#160;</span>He wrote there on the stones a copy of Moses’ law, which he wrote in the presence of the children of Israel. 
-<span class="v">33&#160;</span>All Israel, with their elders, officers, and judges, stood on both sides of the ark before the Levitical priests, who carried the ark of Yahweh’s covenant, the foreigner as well as the native; half of them in front of Mount Gerizim, and half of them in front of Mount Ebal, as Moses the servant of Yahweh had commanded at the first, that they should bless the people of Israel. 
-<span class="v">34&#160;</span>Afterward he read all the words of the law, the blessing and the curse, according to all that is written in the book of the law. 
-<span class="v">35&#160;</span>There was not a word of all that Moses commanded which Joshua didn’t read before all the assembly of Israel, with the women, the little ones, and the foreigners who were among them. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>When all the kings who were beyond the Jordan, in the hill country, and in the lowland, and on all the shore of the great sea in front of Lebanon, the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, heard of it 
-<span class="v">2&#160;</span>they gathered themselves together to fight with Joshua and with Israel, with one accord. 
-<span class="v">3&#160;</span>But when the inhabitants of Gibeon heard what Joshua had done to Jericho and to Ai, 
-<span class="v">4&#160;</span>they also resorted to a ruse, and went and made as if they had been ambassadors, and took old sacks on their donkeys, and old, torn-up and bound up wine skins, 
-<span class="v">5&#160;</span>and old and patched sandals on their feet, and wore old garments. All the bread of their food supply was dry and moldy. 
-<span class="v">6&#160;</span>They went to Joshua at the camp at Gilgal, and said to him and to the men of Israel, “We have come from a far country. Now therefore make a covenant with us.” 
-</p><p>
-<span class="v">7&#160;</span>The men of Israel said to the Hivites, “What if you live among us? How could we make a covenant with you?” 
-</p><p>
-<span class="v">8&#160;</span>They said to Joshua, “We are your servants.” 
-</p><p>Joshua said to them, “Who are you? Where do you come from?” 
-</p><p>
-<span class="v">9&#160;</span>They said to him, “Your servants have come from a very far country because of the name of Yahweh your Elohim; for we have heard of his fame, all that he did in Egypt, 
-<span class="v">10&#160;</span>and all that he did to the two kings of the Amorites who were beyond the Jordan, to Sihon king of Heshbon and to Og king of Bashan, who was at Ashtaroth. 
-<span class="v">11&#160;</span>Our elders and all the inhabitants of our country spoke to us, saying, ‘Take supplies in your hand for the journey, and go to meet them. Tell them, “We are your servants. Now make a covenant with us.”&#160;’ 
-<span class="v">12&#160;</span>This our bread we took hot for our supplies out of our houses on the day we went out to go to you; but now, behold, it is dry, and has become moldy. 
-<span class="v">13&#160;</span>These wine skins, which we filled, were new; and behold, they are torn. These our garments and our sandals have become old because of the very long journey.” 
-</p><p>
-<span class="v">14&#160;</span>The men sampled their provisions, and didn’t ask counsel from Yahweh’s mouth. 
-<span class="v">15&#160;</span>Joshua made peace with them, and made a covenant with them, to let them live. The princes of the congregation swore to them. 
-<span class="v">16&#160;</span>At the end of three days after they had made a covenant with them, they heard that they were their neighbors, and that they lived among them. 
-<span class="v">17&#160;</span>The children of Israel traveled and came to their cities on the third day. Now their cities were Gibeon, Chephirah, Beeroth, and Kiriath Jearim. 
-<span class="v">18&#160;</span>The children of Israel didn’t strike them, because the princes of the congregation had sworn to them by Yahweh, the Elohim of Israel. All the congregation murmured against the princes. 
-<span class="v">19&#160;</span>But all the princes said to all the congregation, “We have sworn to them by Yahweh, the Elohim of Israel. Now therefore we may not touch them. 
-<span class="v">20&#160;</span>We will do this to them, and let them live; lest wrath be on us, because of the oath which we swore to them.” 
-<span class="v">21&#160;</span>The princes said to them, “Let them live.” So they became wood cutters and drawers of water for all the congregation, as the princes had spoken to them. 
-</p><p>
-<span class="v">22&#160;</span>Joshua called for them, and he spoke to them, saying, “Why have you deceived us, saying, ‘We are very far from you,’ when you live among us? 
-<span class="v">23&#160;</span>Now therefore you are cursed, and some of you will never fail to be slaves, both wood cutters and drawers of water for the house of my Elohim.” 
-</p><p>
-<span class="v">24&#160;</span>They answered Joshua, and said, “Because your servants were certainly told how Yahweh your Elohim commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you. Therefore we were very afraid for our lives because of you, and have done this thing. 
-<span class="v">25&#160;</span>Now, behold, we are in your hand. Do to us as it seems good and right to you to do.” 
-</p><p>
-<span class="v">26&#160;</span>He did so to them, and delivered them out of the hand of the children of Israel, so that they didn’t kill them. 
-<span class="v">27&#160;</span>That day Joshua made them wood cutters and drawers of water for the congregation and for Yahweh’s altar to this day, in the place which he should choose. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Now when Adoni-Zedek king of Jerusalem heard how Joshua had taken Ai, and had utterly destroyed it; as he had done to Jericho and her king, so he had done to Ai and her king; and how the inhabitants of Gibeon had made peace with Israel, and were among them, 
-<span class="v">2&#160;</span>they were very afraid, because Gibeon was a great city, as one of the royal cities, and because it was greater than Ai, and all its men were mighty. 
-<span class="v">3&#160;</span>Therefore Adoni-Zedek king of Jerusalem sent to Hoham king of Hebron, Piram king of Jarmuth, Japhia king of Lachish, and Debir king of Eglon, saying, 
-<span class="v">4&#160;</span>“Come up to me and help me. Let’s strike Gibeon; for they have made peace with Joshua and with the children of Israel.” 
-<span class="v">5&#160;</span>Therefore the five kings of the Amorites, the king of Jerusalem, the king of Hebron, the king of Jarmuth, the king of Lachish, and the king of Eglon, gathered themselves together and went up, they and all their armies, and encamped against Gibeon, and made war against it. 
-<span class="v">6&#160;</span>The men of Gibeon sent to Joshua at the camp at Gilgal, saying, “Don’t abandon your servants! Come up to us quickly and save us! Help us; for all the kings of the Amorites that dwell in the hill country have gathered together against us.” 
-</p><p>
-<span class="v">7&#160;</span>So Joshua went up from Gilgal, he and the whole army with him, including all the mighty men of valor. 
-<span class="v">8&#160;</span>Yahweh said to Joshua, “Don’t fear them, for I have delivered them into your hands. Not a man of them will stand before you.” 
-</p><p>
-<span class="v">9&#160;</span>Joshua therefore came to them suddenly. He marched from Gilgal all night. 
-<span class="v">10&#160;</span>Yahweh confused them before Israel. He killed them with a great slaughter at Gibeon, and chased them by the way of the ascent of Beth Horon, and struck them to Azekah and to Makkedah. 
-<span class="v">11&#160;</span>As they fled from before Israel, while they were at the descent of Beth Horon, Yahweh hurled down great stones from the sky on them to Azekah, and they died. There were more who died from the hailstones than those whom the children of Israel killed with the sword. 
-</p><p>
-<span class="v">12&#160;</span>Then Joshua spoke to Yahweh in the day when Yahweh delivered up the Amorites before the children of Israel. He said in the sight of Israel, “Sun, stand still on Gibeon! You, moon, stop in the valley of Aijalon!” 
-</p><p>
-<span class="v">13&#160;</span>The sun stood still, and the moon stayed, until the nation had avenged themselves of their enemies. Isn’t this written in the book of Jashar? The sun stayed in the middle of the sky, and didn’t hurry to go down about a whole day. 
-<span class="v">14&#160;</span>There was no day like that before it or after it, that Yahweh listened to the voice of a man; for Yahweh fought for Israel. 
-</p><p>
-<span class="v">15&#160;</span>Joshua returned, and all Israel with him, to the camp to Gilgal. 
-<span class="v">16&#160;</span>These five kings fled, and hid themselves in the cave at Makkedah. 
-<span class="v">17&#160;</span>Joshua was told, saying, “The five kings have been found, hidden in the cave at Makkedah.” 
-</p><p>
-<span class="v">18&#160;</span>Joshua said, “Roll large stones to cover the cave’s entrance, and set men by it to guard them; 
-<span class="v">19&#160;</span>but don’t stay there. Pursue your enemies, and attack them from the rear. Don’t allow them to enter into their cities; for Yahweh your Elohim has delivered them into your hand.” 
-</p><p>
-<span class="v">20&#160;</span>When Joshua and the children of Israel had finished killing them with a very great slaughter until they were consumed, and the remnant which remained of them had entered into the fortified cities, 
-<span class="v">21&#160;</span>all the people returned to the camp to Joshua at Makkedah in peace. None moved his tongue against any of the children of Israel. 
-<span class="v">22&#160;</span>Then Joshua said, “Open the cave entrance, and bring those five kings out of the cave to me.” 
-</p><p>
-<span class="v">23&#160;</span>They did so, and brought those five kings out of the cave to him: the king of Jerusalem, the king of Hebron, the king of Jarmuth, the king of Lachish, and the king of Eglon. 
-<span class="v">24&#160;</span>When they brought those kings out to Joshua, Joshua called for all the men of Israel, and said to the chiefs of the men of war who went with him, “Come near. Put your feet on the necks of these kings.” 
-</p><p>They came near, and put their feet on their necks. 
-</p><p>
-<span class="v">25&#160;</span>Joshua said to them, “Don’t be afraid, nor be dismayed. Be strong and courageous, for Yahweh will do this to all your enemies against whom you fight.” 
-</p><p>
-<span class="v">26&#160;</span>Afterward Joshua struck them, put them to death, and hanged them on five trees. They were hanging on the trees until the evening. 
-<span class="v">27&#160;</span>At the time of the going down of the sun, Joshua commanded, and they took them down off the trees, and threw them into the cave in which they had hidden themselves, and laid great stones on the mouth of the cave, which remain to this very day. 
-</p><p>
-<span class="v">28&#160;</span>Joshua took Makkedah on that day, and struck it with the edge of the sword, with its king. He utterly destroyed it and all the souls who were in it. He left no one remaining. He did to the king of Makkedah as he had done to the king of Jericho. 
-</p><p>
-<span class="v">29&#160;</span>Joshua passed from Makkedah, and all Israel with him, to Libnah, and fought against Libnah. 
-<span class="v">30&#160;</span>Yahweh delivered it also, with its king, into the hand of Israel. He struck it with the edge of the sword, and all the souls who were in it. He left no one remaining in it. He did to its king as he had done to the king of Jericho. 
-</p><p>
-<span class="v">31&#160;</span>Joshua passed from Libnah, and all Israel with him, to Lachish, and encamped against it, and fought against it. 
-<span class="v">32&#160;</span>Yahweh delivered Lachish into the hand of Israel. He took it on the second day, and struck it with the edge of the sword, with all the souls who were in it, according to all that he had done to Libnah. 
-<span class="v">33&#160;</span>Then Horam king of Gezer came up to help Lachish; and Joshua struck him and his people, until he had left him no one remaining. 
-</p><p>
-<span class="v">34&#160;</span>Joshua passed from Lachish, and all Israel with him, to Eglon; and they encamped against it and fought against it. 
-<span class="v">35&#160;</span>They took it on that day, and struck it with the edge of the sword. He utterly destroyed all the souls who were in it that day, according to all that he had done to Lachish. 
-</p><p>
-<span class="v">36&#160;</span>Joshua went up from Eglon, and all Israel with him, to Hebron; and they fought against it. 
-<span class="v">37&#160;</span>They took it, and struck it with the edge of the sword, with its king and all its cities, and all the souls who were in it. He left no one remaining, according to all that he had done to Eglon; but he utterly destroyed it, and all the souls who were in it. 
-</p><p>
-<span class="v">38&#160;</span>Joshua returned, and all Israel with him, to Debir, and fought against it. 
-<span class="v">39&#160;</span>He took it, with its king and all its cities. They struck them with the edge of the sword, and utterly destroyed all the souls who were in it. He left no one remaining. As he had done to Hebron, so he did to Debir, and to its king; as he had done also to Libnah, and to its king. 
-<span class="v">40&#160;</span>So Joshua struck all the land, the hill country, the South, the lowland, the slopes, and all their kings. He left no one remaining, but he utterly destroyed all that breathed, as Yahweh, the Elohim of Israel, commanded. 
-<span class="v">41&#160;</span>Joshua struck them from Kadesh Barnea even to Gaza, and all the country of Goshen, even to Gibeon. 
-<span class="v">42&#160;</span>Joshua took all these kings and their land at one time because Yahweh, the Elohim of Israel, fought for Israel. 
-<span class="v">43&#160;</span>Joshua returned, and all Israel with him, to the camp to Gilgal. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>When Jabin king of Hazor heard of it, he sent to Jobab king of Madon, to the king of Shimron, to the king of Achshaph, 
-<span class="v">2&#160;</span>and to the kings who were on the north, in the hill country, in the Arabah south of Chinneroth, in the lowland, and in the heights of Dor on the west, 
-<span class="v">3&#160;</span>to the Canaanite on the east and on the west, the Amorite, the Hittite, the Perizzite, the Jebusite in the hill country, and the Hivite under Hermon in the land of Mizpah. 
-<span class="v">4&#160;</span>They went out, they and all their armies with them, many people, even as the sand that is on the seashore in multitude, with very many horses and chariots. 
-<span class="v">5&#160;</span>All these kings met together; and they came and encamped together at the waters of Merom, to fight with Israel. 
-</p><p>
-<span class="v">6&#160;</span>Yahweh said to Joshua, “Don’t be afraid because of them; for tomorrow at this time, I will deliver them up all slain before Israel. You shall hamstring their horses and burn their chariots with fire.” 
-</p><p>
-<span class="v">7&#160;</span>So Joshua came suddenly, with all the warriors, against them by the waters of Merom, and attacked them. 
-<span class="v">8&#160;</span>Yahweh delivered them into the hand of Israel, and they struck them, and chased them to great Sidon, and to Misrephoth Maim, and to the valley of Mizpah eastward. They struck them until they left them no one remaining. 
-<span class="v">9&#160;</span>Joshua did to them as Yahweh told him. He hamstrung their horses and burned their chariots with fire. 
-<span class="v">10&#160;</span>Joshua turned back at that time, and took Hazor, and struck its king with the sword; for Hazor used to be the head of all those kingdoms. 
-<span class="v">11&#160;</span>They struck all the souls who were in it with the edge of the sword, utterly destroying them. There was no one left who breathed. He burned Hazor with fire. 
-<span class="v">12&#160;</span>Joshua captured all the cities of those kings, with their kings, and he struck them with the edge of the sword, and utterly destroyed them, as Moses the servant of Yahweh commanded. 
-<span class="v">13&#160;</span>But as for the cities that stood on their mounds, Israel burned none of them, except Hazor only. Joshua burned that. 
-<span class="v">14&#160;</span>The children of Israel took all the plunder of these cities, with the livestock, as plunder for themselves; but every man they struck with the edge of the sword, until they had destroyed them. They didn’t leave any who breathed. 
-</p><p>
-<span class="v">15&#160;</span>As Yahweh commanded Moses his servant, so Moses commanded Joshua. Joshua did so. He left nothing undone of all that Yahweh commanded Moses. 
-<span class="v">16&#160;</span>So Joshua captured all that land, the hill country, all the South, all the land of Goshen, the lowland, the Arabah, the hill country of Israel, and the lowland of the same, 
-<span class="v">17&#160;</span>from Mount Halak, that goes up to Seir, even to Baal Gad in the valley of Lebanon under Mount Hermon. He took all their kings, struck them, and put them to death. 
-<span class="v">18&#160;</span>Joshua made war a long time with all those kings. 
-<span class="v">19&#160;</span>There was not a city that made peace with the children of Israel, except the Hivites, the inhabitants of Gibeon. They took all in battle. 
-<span class="v">20&#160;</span>For it was of Yahweh to harden their hearts, to come against Israel in battle, that he might utterly destroy them, that they might have no favor, but that he might destroy them, as Yahweh commanded Moses. 
-<span class="v">21&#160;</span>Joshua came at that time, and cut off the Anakim from the hill country, from Hebron, from Debir, from Anab, and from all the hill country of Judah, and from all the hill country of Israel. Joshua utterly destroyed them with their cities. 
-<span class="v">22&#160;</span>There were none of the Anakim left in the land of the children of Israel. Only in Gaza, in Gath, and in Ashdod, did some remain. 
-<span class="v">23&#160;</span>So Joshua took the whole land, according to all that Yahweh spoke to Moses; and Joshua gave it for an inheritance to Israel according to their divisions by their tribes. Then the land had rest from war. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the kings of the land, whom the children of Israel struck, and possessed their land beyond the Jordan toward the sunrise, from the valley of the Arnon to Mount Hermon, and all the Arabah eastward: 
-<span class="v">2&#160;</span>Sihon king of the Amorites, who lived in Heshbon, and ruled from Aroer, which is on the edge of the valley of the Arnon, and the middle of the valley, and half Gilead, even to the river Jabbok, the border of the children of Ammon; 
-<span class="v">3&#160;</span>and the Arabah to the sea of Chinneroth, eastward, and to the sea of the Arabah, even the Salt Sea, eastward, the way to Beth Jeshimoth; and on the south, under the slopes of Pisgah: 
-<span class="v">4&#160;</span>and the border of Og king of Bashan, of the remnant of the Rephaim, who lived at Ashtaroth and at Edrei, 
-<span class="v">5&#160;</span>and ruled in Mount Hermon, and in Salecah, and in all Bashan, to the border of the Geshurites and the Maacathites, and half Gilead, the border of Sihon king of Heshbon. 
-<span class="v">6&#160;</span>Moses the servant of Yahweh and the children of Israel struck them. Moses the servant of Yahweh gave it for a possession to the Reubenites, and the Gadites, and the half-tribe of Manasseh. 
-</p><p>
-<span class="v">7&#160;</span>These are the kings of the land whom Joshua and the children of Israel struck beyond the Jordan westward, from Baal Gad in the valley of Lebanon even to Mount Halak, that goes up to Seir. Joshua gave it to the tribes of Israel for a possession according to their divisions; 
-<span class="v">8&#160;</span>in the hill country, and in the lowland, and in the Arabah, and in the slopes, and in the wilderness, and in the South; the Hittite, the Amorite, and the Canaanite, the Perizzite, the Hivite, and the Jebusite: 
-</p><p class="m">
-<span class="v">9&#160;</span>the king of Jericho, one; 
-</p><p class="m">the king of Ai, which is beside Bethel, one; 
-</p><p class="m">
-<span class="v">10&#160;</span>the king of Jerusalem, one; 
-</p><p class="m">the king of Hebron, one; 
-</p><p class="m">
-<span class="v">11&#160;</span>the king of Jarmuth, one; 
-</p><p class="m">the king of Lachish, one; 
-</p><p class="m">
-<span class="v">12&#160;</span>the king of Eglon, one; 
-</p><p class="m">the king of Gezer, one; 
-</p><p class="m">
-<span class="v">13&#160;</span>the king of Debir, one; 
-</p><p class="m">the king of Geder, one; 
-</p><p class="m">
-<span class="v">14&#160;</span>the king of Hormah, one; 
-</p><p class="m">the king of Arad, one; 
-</p><p class="m">
-<span class="v">15&#160;</span>the king of Libnah, one; 
-</p><p class="m">the king of Adullam, one; 
-</p><p class="m">
-<span class="v">16&#160;</span>the king of Makkedah, one; 
-</p><p class="m">the king of Bethel, one; 
-</p><p class="m">
-<span class="v">17&#160;</span>the king of Tappuah, one; 
-</p><p class="m">the king of Hepher, one; 
-</p><p class="m">
-<span class="v">18&#160;</span>the king of Aphek, one; 
-</p><p class="m">the king of Lassharon, one; 
-</p><p class="m">
-<span class="v">19&#160;</span>the king of Madon, one; 
-</p><p class="m">the king of Hazor, one; 
-</p><p class="m">
-<span class="v">20&#160;</span>the king of Shimron Meron, one; 
-</p><p class="m">the king of Achshaph, one; 
-</p><p class="m">
-<span class="v">21&#160;</span>the king of Taanach, one; 
-</p><p class="m">the king of Megiddo, one; 
-</p><p class="m">
-<span class="v">22&#160;</span>the king of Kedesh, one; 
-</p><p class="m">the king of Jokneam in Carmel, one; 
-</p><p class="m">
-<span class="v">23&#160;</span>the king of Dor in the height of Dor, one; 
-</p><p class="m">the king of Goiim in Gilgal, one; 
-</p><p class="m">
-<span class="v">24&#160;</span>the king of Tirzah, one: 
-</p><p class="m">all the kings thirty-one. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Now Joshua was old and well advanced in years. Yahweh said to him, “You are old and advanced in years, and there remains yet very much land to be possessed. 
-</p><p>
-<span class="v">2&#160;</span>“This is the land that still remains: all the regions of the Philistines, and all the Geshurites; 
-<span class="v">3&#160;</span>from the Shihor, which is before Egypt, even to the border of Ekron northward, which is counted as Canaanite; the five lords of the Philistines; the Gazites, and the Ashdodites, the Ashkelonites, the Gittites, and the Ekronites; also the Avvim, 
-<span class="v">4&#160;</span>on the south; all the land of the Canaanites, and Mearah that belongs to the Sidonians, to Aphek, to the border of the Amorites; 
-<span class="v">5&#160;</span>and the land of the Gebalites, and all Lebanon, toward the sunrise, from Baal Gad under Mount Hermon to the entrance of Hamath; 
-<span class="v">6&#160;</span>all the inhabitants of the hill country from Lebanon to Misrephoth Maim, even all the Sidonians. I will drive them out from before the children of Israel. Just allocate it to Israel for an inheritance, as I have commanded you. 
-<span class="v">7&#160;</span>Now therefore divide this land for an inheritance to the nine tribes and the half-tribe of Manasseh.” 
-<span class="v">8&#160;</span>With him the Reubenites and the Gadites received their inheritance, which Moses gave them, beyond the Jordan eastward, even as Moses the servant of Yahweh gave them: 
-<span class="v">9&#160;</span>from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain of Medeba to Dibon; 
-<span class="v">10&#160;</span>and all the cities of Sihon king of the Amorites, who reigned in Heshbon, to the border of the children of Ammon; 
-<span class="v">11&#160;</span>and Gilead, and the border of the Geshurites and Maacathites, and all Mount Hermon, and all Bashan to Salecah; 
-<span class="v">12&#160;</span>all the kingdom of Og in Bashan, who reigned in Ashtaroth and in Edrei (who was left of the remnant of the Rephaim); for Moses attacked these, and drove them out. 
-<span class="v">13&#160;</span>Nevertheless the children of Israel didn’t drive out the Geshurites, nor the Maacathites: but Geshur and Maacath live within Israel to this day. 
-<span class="v">14&#160;</span>Only he gave no inheritance to the tribe of Levi. The offerings of Yahweh, the Elohim of Israel, made by fire are his inheritance, as he spoke to him. 
-<span class="v">15&#160;</span>Moses gave to the tribe of the children of Reuben according to their families. 
-<span class="v">16&#160;</span>Their border was from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain by Medeba; 
-<span class="v">17&#160;</span>Heshbon, and all its cities that are in the plain; Dibon, Bamoth Baal, Beth Baal Meon, 
-<span class="v">18&#160;</span>Jahaz, Kedemoth, Mephaath, 
-<span class="v">19&#160;</span>Kiriathaim, Sibmah, Zereth Shahar in the mount of the valley, 
-<span class="v">20&#160;</span>Beth Peor, the slopes of Pisgah, Beth Jeshimoth, 
-<span class="v">21&#160;</span>all the cities of the plain, and all the kingdom of Sihon king of the Amorites, who reigned in Heshbon, whom Moses struck with the chiefs of Midian, Evi, Rekem, Zur, Hur, and Reba, the princes of Sihon, who lived in the land. 
-<span class="v">22&#160;</span>The children of Israel also killed Balaam the son of Beor, the soothsayer, with the sword, among the rest of their slain. 
-</p><p>
-<span class="v">23&#160;</span>The border of the children of Reuben was the bank of the Jordan. This was the inheritance of the children of Reuben according to their families, the cities and its villages. 
-</p><p>
-<span class="v">24&#160;</span>Moses gave to the tribe of Gad, to the children of Gad, according to their families. 
-<span class="v">25&#160;</span>Their border was Jazer, and all the cities of Gilead, and half the land of the children of Ammon, to Aroer that is near Rabbah; 
-<span class="v">26&#160;</span>and from Heshbon to Ramath Mizpeh, and Betonim; and from Mahanaim to the border of Debir; 
-<span class="v">27&#160;</span>and in the valley, Beth Haram, Beth Nimrah, Succoth, and Zaphon, the rest of the kingdom of Sihon king of Heshbon, the Jordan’s bank, to the uttermost part of the sea of Chinnereth beyond the Jordan eastward. 
-<span class="v">28&#160;</span>This is the inheritance of the children of Gad according to their families, the cities and its villages. 
-</p><p>
-<span class="v">29&#160;</span>Moses gave an inheritance to the half-tribe of Manasseh. It was for the half-tribe of the children of Manasseh according to their families. 
-<span class="v">30&#160;</span>Their border was from Mahanaim, all Bashan, all the kingdom of Og king of Bashan, and all the villages of Jair, which are in Bashan, sixty cities. 
-<span class="v">31&#160;</span>Half Gilead, Ashtaroth, and Edrei, the cities of the kingdom of Og in Bashan, were for the children of Machir the son of Manasseh, even for the half of the children of Machir according to their families. 
-</p><p>
-<span class="v">32&#160;</span>These are the inheritances which Moses distributed in the plains of Moab, beyond the Jordan at Jericho, eastward. 
-<span class="v">33&#160;</span>But Moses gave no inheritance to the tribe of Levi. Yahweh, the Elohim of Israel, is their inheritance, as he spoke to them. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>These are the inheritances which the children of Israel took in the land of Canaan, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed to them, 
-<span class="v">2&#160;</span>by the lot of their inheritance, as Yahweh commanded by Moses, for the nine tribes, and for the half-tribe. 
-<span class="v">3&#160;</span>For Moses had given the inheritance of the two tribes and the half-tribe beyond the Jordan; but to the Levites he gave no inheritance among them. 
-<span class="v">4&#160;</span>For the children of Joseph were two tribes, Manasseh and Ephraim. They gave no portion to the Levites in the land, except cities to dwell in, with their pasture lands for their livestock and for their property. 
-<span class="v">5&#160;</span>The children of Israel did as Yahweh commanded Moses, and they divided the land. 
-</p><p>
-<span class="v">6&#160;</span>Then the children of Judah came near to Joshua in Gilgal. Caleb the son of Jephunneh the Kenizzite said to him, “You know the thing that Yahweh spoke to Moses the man of Elohim concerning me and concerning you in Kadesh Barnea. 
-<span class="v">7&#160;</span>I was forty years old when Moses the servant of Yahweh sent me from Kadesh Barnea to spy out the land. I brought him word again as it was in my heart. 
-<span class="v">8&#160;</span>Nevertheless, my brothers who went up with me made the heart of the people melt; but I wholly followed Yahweh my Elohim. 
-<span class="v">9&#160;</span>Moses swore on that day, saying, ‘Surely the land where you walked shall be an inheritance to you and to your children forever, because you have wholly followed Yahweh my Elohim.’ 
-</p><p>
-<span class="v">10&#160;</span>“Now, behold, Yahweh has kept me alive, as he spoke, these forty-five years, from the time that Yahweh spoke this word to Moses, while Israel walked in the wilderness. Now, behold, I am eighty-five years old, today. 
-<span class="v">11&#160;</span>As yet I am as strong today as I was in the day that Moses sent me. As my strength was then, even so is my strength now for war, to go out and to come in. 
-<span class="v">12&#160;</span>Now therefore give me this hill country, of which Yahweh spoke in that day; for you heard in that day how the Anakim were there, and great and fortified cities. It may be that Yahweh will be with me, and I shall drive them out, as Yahweh said.” 
-</p><p>
-<span class="v">13&#160;</span>Joshua blessed him; and he gave Hebron to Caleb the son of Jephunneh for an inheritance. 
-<span class="v">14&#160;</span>Therefore Hebron became the inheritance of Caleb the son of Jephunneh the Kenizzite to this day, because he followed Yahweh, the Elohim of Israel wholeheartedly. 
-<span class="v">15&#160;</span>Now the name of Hebron before was Kiriath Arba, after the greatest man among the Anakim. Then the land had rest from war. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>The lot for the tribe of the children of Judah according to their families was to the border of Edom, even to the wilderness of Zin southward, at the uttermost part of the south. 
-<span class="v">2&#160;</span>Their south border was from the uttermost part of the Salt Sea, from the bay that looks southward; 
-<span class="v">3&#160;</span>and it went out southward of the ascent of Akrabbim, and passed along to Zin, and went up by the south of Kadesh Barnea, and passed along by Hezron, went up to Addar, and turned toward Karka; 
-<span class="v">4&#160;</span>and it passed along to Azmon, went out at the brook of Egypt; and the border ended at the sea. This shall be your south border. 
-<span class="v">5&#160;</span>The east border was the Salt Sea, even to the end of the Jordan. The border of the north quarter was from the bay of the sea at the end of the Jordan. 
-<span class="v">6&#160;</span>The border went up to Beth Hoglah, and passed along by the north of Beth Arabah; and the border went up to the stone of Bohan the son of Reuben. 
-<span class="v">7&#160;</span>The border went up to Debir from the valley of Achor, and so northward, looking toward Gilgal, that faces the ascent of Adummim, which is on the south side of the river. The border passed along to the waters of En Shemesh, and ended at En Rogel. 
-<span class="v">8&#160;</span>The border went up by the valley of the son of Hinnom to the side of the Jebusite (also called Jerusalem) southward; and the border went up to the top of the mountain that lies before the valley of Hinnom westward, which is at the farthest part of the valley of Rephaim northward. 
-<span class="v">9&#160;</span>The border extended from the top of the mountain to the spring of the waters of Nephtoah, and went out to the cities of Mount Ephron; and the border extended to Baalah (also called Kiriath Jearim); 
-<span class="v">10&#160;</span>and the border turned about from Baalah westward to Mount Seir, and passed along to the side of Mount Jearim (also called Chesalon) on the north, and went down to Beth Shemesh, and passed along by Timnah; 
-<span class="v">11&#160;</span>and the border went out to the side of Ekron northward; and the border extended to Shikkeron, and passed along to Mount Baalah, and went out at Jabneel; and the goings out of the border were at the sea. 
-<span class="v">12&#160;</span>The west border was to the shore of the great sea. This is the border of the children of Judah according to their families. 
-</p><p>
-<span class="v">13&#160;</span>He gave to Caleb the son of Jephunneh a portion among the children of Judah, according to the commandment of Yahweh to Joshua, even Kiriath Arba, named after the father of Anak (also called Hebron). 
-<span class="v">14&#160;</span>Caleb drove out the three sons of Anak: Sheshai, and Ahiman, and Talmai, the children of Anak. 
-<span class="v">15&#160;</span>He went up against the inhabitants of Debir: now the name of Debir before was Kiriath Sepher. 
-<span class="v">16&#160;</span>Caleb said, “He who strikes Kiriath Sepher, and takes it, to him I will give Achsah my daughter as woman.” 
-<span class="v">17&#160;</span>Othniel the son of Kenaz, the brother of Caleb, took it: and he gave him Achsah his daughter as woman. 
-<span class="v">18&#160;</span>When she came, she had him ask her father for a field. She got off her donkey, and Caleb said, “What do you want?” 
-</p><p>
-<span class="v">19&#160;</span>She said, “Give me a blessing. Because you have set me in the land of the South, give me also springs of water.” 
-</p><p>So he gave her the upper springs and the lower springs. 
-</p><p>
-<span class="v">20&#160;</span>This is the inheritance of the tribe of the children of Judah according to their families. 
-<span class="v">21&#160;</span>The farthest cities of the tribe of the children of Judah toward the border of Edom in the South were Kabzeel, Eder, Jagur, 
-<span class="v">22&#160;</span>Kinah, Dimonah, Adadah, 
-<span class="v">23&#160;</span>Kedesh, Hazor, Ithnan, 
-<span class="v">24&#160;</span>Ziph, Telem, Bealoth, 
-<span class="v">25&#160;</span>Hazor Hadattah, Kerioth Hezron (also called Hazor), 
-<span class="v">26&#160;</span>Amam, Shema, Moladah, 
-<span class="v">27&#160;</span>Hazar Gaddah, Heshmon, Beth Pelet, 
-<span class="v">28&#160;</span>Hazar Shual, Beersheba, Biziothiah, 
-<span class="v">29&#160;</span>Baalah, Iim, Ezem, 
-<span class="v">30&#160;</span>Eltolad, Chesil, Hormah, 
-<span class="v">31&#160;</span>Ziklag, Madmannah, Sansannah, 
-<span class="v">32&#160;</span>Lebaoth, Shilhim, Ain, and Rimmon. All the cities are twenty-nine, with their villages. 
-</p><p class="m">
-<span class="v">33&#160;</span>In the lowland, Eshtaol, Zorah, Ashnah, 
-<span class="v">34&#160;</span>Zanoah, En Gannim, Tappuah, Enam, 
-<span class="v">35&#160;</span>Jarmuth, Adullam, Socoh, Azekah, 
-<span class="v">36&#160;</span>Shaaraim, Adithaim and Gederah (or Gederothaim); fourteen cities with their villages. 
-</p><p class="m">
-<span class="v">37&#160;</span>Zenan, Hadashah, Migdal Gad, 
-<span class="v">38&#160;</span>Dilean, Mizpah, Joktheel, 
-<span class="v">39&#160;</span>Lachish, Bozkath, Eglon, 
-<span class="v">40&#160;</span>Cabbon, Lahmam, Chitlish, 
-<span class="v">41&#160;</span>Gederoth, Beth Dagon, Naamah, and Makkedah; sixteen cities with their villages. 
-</p><p class="m">
-<span class="v">42&#160;</span>Libnah, Ether, Ashan, 
-<span class="v">43&#160;</span>Iphtah, Ashnah, Nezib, 
-<span class="v">44&#160;</span>Keilah, Achzib, and Mareshah; nine cities with their villages. 
-</p><p class="m">
-<span class="v">45&#160;</span>Ekron, with its towns and its villages; 
-<span class="v">46&#160;</span>from Ekron even to the sea, all that were by the side of Ashdod, with their villages. 
-<span class="v">47&#160;</span>Ashdod, its towns and its villages; Gaza, its towns and its villages; to the brook of Egypt, and the great sea with its coastline. 
-</p><p class="m">
-<span class="v">48&#160;</span>In the hill country, Shamir, Jattir, Socoh, 
-<span class="v">49&#160;</span>Dannah, Kiriath Sannah (which is Debir), 
-<span class="v">50&#160;</span>Anab, Eshtemoh, Anim, 
-<span class="v">51&#160;</span>Goshen, Holon, and Giloh; eleven cities with their villages. 
-</p><p class="m">
-<span class="v">52&#160;</span>Arab, Dumah, Eshan, 
-<span class="v">53&#160;</span>Janim, Beth Tappuah, Aphekah, 
-<span class="v">54&#160;</span>Humtah, Kiriath Arba (also called Hebron), and Zior; nine cities with their villages. 
-</p><p class="m">
-<span class="v">55&#160;</span>Maon, Carmel, Ziph, Jutah, 
-<span class="v">56&#160;</span>Jezreel, Jokdeam, Zanoah, 
-<span class="v">57&#160;</span>Kain, Gibeah, and Timnah; ten cities with their villages. 
-</p><p class="m">
-<span class="v">58&#160;</span>Halhul, Beth Zur, Gedor, 
-<span class="v">59&#160;</span>Maarath, Beth Anoth, and Eltekon; six cities with their villages. 
-<span class="v">60&#160;</span>Kiriath Baal (also called Kiriath Jearim), and Rabbah; two cities with their villages. 
-</p><p class="m">
-<span class="v">61&#160;</span>In the wilderness, Beth Arabah, Middin, Secacah, 
-<span class="v">62&#160;</span>Nibshan, the City of Salt, and En Gedi; six cities with their villages. 
-</p><p>
-<span class="v">63&#160;</span>As for the Jebusites, the inhabitants of Jerusalem, the children of Judah couldn’t drive them out; but the Jebusites live with the children of Judah at Jerusalem to this day. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>The lot came out for the children of Joseph from the Jordan at Jericho, at the waters of Jericho on the east, even the wilderness, going up from Jericho through the hill country to Bethel. 
-<span class="v">2&#160;</span>It went out from Bethel to Luz, and passed along to the border of the Archites to Ataroth; 
-<span class="v">3&#160;</span>and it went down westward to the border of the Japhletites, to the border of Beth Horon the lower, and on to Gezer; and ended at the sea. 
-</p><p>
-<span class="v">4&#160;</span>The children of Joseph, Manasseh and Ephraim, took their inheritance. 
-<span class="v">5&#160;</span>This was the border of the children of Ephraim according to their families. The border of their inheritance eastward was Ataroth Addar, to Beth Horon the upper. 
-<span class="v">6&#160;</span>The border went out westward at Michmethath on the north. The border turned about eastward to Taanath Shiloh, and passed along it on the east of Janoah. 
-<span class="v">7&#160;</span>It went down from Janoah to Ataroth, to Naarah, reached to Jericho, and went out at the Jordan. 
-<span class="v">8&#160;</span>From Tappuah the border went along westward to the brook of Kanah; and ended at the sea. This is the inheritance of the tribe of the children of Ephraim according to their families; 
-<span class="v">9&#160;</span>together with the cities which were set apart for the children of Ephraim in the middle of the inheritance of the children of Manasseh, all the cities with their villages. 
-<span class="v">10&#160;</span>They didn’t drive out the Canaanites who lived in Gezer; but the Canaanites dwell in the territory of Ephraim to this day, and have become servants to do forced labor. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>This was the lot for the tribe of Manasseh, for he was the firstborn of Joseph. As for Machir the firstborn of Manasseh, the father of Gilead, because he was a man of war, therefore he had Gilead and Bashan. 
-<span class="v">2&#160;</span>So this was for the rest of the children of Manasseh according to their families: for the children of Abiezer, for the children of Helek, for the children of Asriel, for the children of Shechem, for the children of Hepher, and for the children of Shemida. These were the male children of Manasseh the son of Joseph according to their families. 
-<span class="v">3&#160;</span>But Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, had no sons, but daughters. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
-<span class="v">4&#160;</span>They came to Eleazar the priest, and to Joshua the son of Nun, and to the princes, saying, “Yahweh commanded Moses to give us an inheritance among our brothers.” Therefore according to the commandment of Yahweh he gave them an inheritance among the brothers of their father. 
-<span class="v">5&#160;</span>Ten parts fell to Manasseh, in addition to the land of Gilead and Bashan, which is beyond the Jordan; 
-<span class="v">6&#160;</span>because the daughters of Manasseh had an inheritance among his sons. The land of Gilead belonged to the rest of the sons of Manasseh. 
-<span class="v">7&#160;</span>The border of Manasseh was from Asher to Michmethath, which is before Shechem. The border went along to the right hand, to the inhabitants of En Tappuah. 
-<span class="v">8&#160;</span>The land of Tappuah belonged to Manasseh; but Tappuah on the border of Manasseh belonged to the children of Ephraim. 
-<span class="v">9&#160;</span>The border went down to the brook of Kanah, southward of the brook. These cities belonged to Ephraim among the cities of Manasseh. The border of Manasseh was on the north side of the brook, and ended at the sea. 
-<span class="v">10&#160;</span>Southward it was Ephraim’s, and northward it was Manasseh’s, and the sea was his border. They reached to Asher on the north, and to Issachar on the east. 
-<span class="v">11&#160;</span>Manasseh had three heights in Issachar, in Asher Beth Shean and its towns, and Ibleam and its towns, and the inhabitants of Dor and its towns, and the inhabitants of Endor and its towns, and the inhabitants of Taanach and its towns, and the inhabitants of Megiddo and its towns. 
-<span class="v">12&#160;</span>Yet the children of Manasseh couldn’t drive out the inhabitants of those cities; but the Canaanites would dwell in that land. 
-</p><p>
-<span class="v">13&#160;</span>When the children of Israel had grown strong, they put the Canaanites to forced labor, and didn’t utterly drive them out. 
-<span class="v">14&#160;</span>The children of Joseph spoke to Joshua, saying, “Why have you given me just one lot and one part for an inheritance, since we are a numerous people, because Yahweh has blessed us so far?” 
-</p><p>
-<span class="v">15&#160;</span>Joshua said to them, “If you are a numerous people, go up to the forest, and clear land for yourself there in the land of the Perizzites and of the Rephaim, since the hill country of Ephraim is too narrow for you.” 
-</p><p>
-<span class="v">16&#160;</span>The children of Joseph said, “The hill country is not enough for us. All the Canaanites who dwell in the land of the valley have chariots of iron, both those who are in Beth Shean and its towns, and those who are in the valley of Jezreel.” 
-</p><p>
-<span class="v">17&#160;</span>Joshua spoke to the house of Joseph, that is, to Ephraim and to Manasseh, saying, “You are a numerous people, and have great power. You shall not have one lot only; 
-<span class="v">18&#160;</span>but the hill country shall be yours. Although it is a forest, you shall cut it down, and it’s farthest extent shall be yours; for you shall drive out the Canaanites, though they have chariots of iron, and though they are strong.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>The whole congregation of the children of Israel assembled themselves together at Shiloh, and set up the Tent of Meeting there. The land was subdued before them. 
-<span class="v">2&#160;</span>Seven tribes remained among the children of Israel, which had not yet divided their inheritance. 
-<span class="v">3&#160;</span>Joshua said to the children of Israel, “How long will you neglect to go in to possess the land, which Yahweh, the Elohim of your fathers, has given you? 
-<span class="v">4&#160;</span>Appoint for yourselves three men from each tribe. I will send them, and they shall arise, walk through the land, and describe it according to their inheritance; then they shall come to me. 
-<span class="v">5&#160;</span>They shall divide it into seven portions. Judah shall live in his borders on the south, and the house of Joseph shall live in their borders on the north. 
-<span class="v">6&#160;</span>You shall survey the land into seven parts, and bring the description here to me; and I will cast lots for you here before Yahweh our Elohim. 
-<span class="v">7&#160;</span>However, the Levites have no portion among you; for the priesthood of Yahweh is their inheritance. Gad, Reuben, and the half-tribe of Manasseh have received their inheritance east of the Jordan, which Moses the servant of Yahweh gave them.” 
-</p><p>
-<span class="v">8&#160;</span>The men arose and went. Joshua commanded those who went to survey the land, saying, “Go walk through the land, survey it, and come again to me. I will cast lots for you here before Yahweh in Shiloh.” 
-</p><p>
-<span class="v">9&#160;</span>The men went and passed through the land, and surveyed it by cities into seven portions in a book. They came to Joshua to the camp at Shiloh. 
-<span class="v">10&#160;</span>Joshua cast lots for them in Shiloh before Yahweh. There Joshua divided the land to the children of Israel according to their divisions. 
-</p><p>
-<span class="v">11&#160;</span>The lot of the tribe of the children of Benjamin came up according to their families. The border of their lot went out between the children of Judah and the children of Joseph. 
-<span class="v">12&#160;</span>Their border on the north quarter was from the Jordan. The border went up to the side of Jericho on the north, and went up through the hill country westward. It ended at the wilderness of Beth Aven. 
-<span class="v">13&#160;</span>The border passed along from there to Luz, to the side of Luz (also called Bethel), southward. The border went down to Ataroth Addar, by the mountain that lies on the south of Beth Horon the lower. 
-<span class="v">14&#160;</span>The border extended, and turned around on the west quarter southward, from the mountain that lies before Beth Horon southward; and ended at Kiriath Baal (also called Kiriath Jearim), a city of the children of Judah. This was the west quarter. 
-<span class="v">15&#160;</span>The south quarter was from the farthest part of Kiriath Jearim. The border went out westward, and went out to the spring of the waters of Nephtoah. 
-<span class="v">16&#160;</span>The border went down to the farthest part of the mountain that lies before the valley of the son of Hinnom, which is in the valley of Rephaim northward. It went down to the valley of Hinnom, to the side of the Jebusite southward, and went down to En Rogel. 
-<span class="v">17&#160;</span>It extended northward, went out at En Shemesh, and went out to Geliloth, which is opposite the ascent of Adummim. It went down to the stone of Bohan the son of Reuben. 
-<span class="v">18&#160;</span>It passed along to the side opposite the Arabah northward, and went down to the Arabah. 
-<span class="v">19&#160;</span>The border passed along to the side of Beth Hoglah northward; and the border ended at the north bay of the Salt Sea, at the south end of the Jordan. This was the south border. 
-<span class="v">20&#160;</span>The Jordan was its border on the east quarter. This was the inheritance of the children of Benjamin, by the borders around it, according to their families. 
-<span class="v">21&#160;</span>Now the cities of the tribe of the children of Benjamin according to their families were Jericho, Beth Hoglah, Emek Keziz, 
-<span class="v">22&#160;</span>Beth Arabah, Zemaraim, Bethel, 
-<span class="v">23&#160;</span>Avvim, Parah, Ophrah, 
-<span class="v">24&#160;</span>Chephar Ammoni, Ophni, and Geba; twelve cities with their villages. 
-<span class="v">25&#160;</span>Gibeon, Ramah, Beeroth, 
-<span class="v">26&#160;</span>Mizpeh, Chephirah, Mozah, 
-<span class="v">27&#160;</span>Rekem, Irpeel, Taralah, 
-<span class="v">28&#160;</span>Zelah, Eleph, the Jebusite (also called Jerusalem), Gibeath, and Kiriath; fourteen cities with their villages. This is the inheritance of the children of Benjamin according to their families. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>The second lot came out for Simeon, even for the tribe of the children of Simeon according to their families. Their inheritance was in the middle of the inheritance of the children of Judah. 
-<span class="v">2&#160;</span>They had for their inheritance Beersheba (or Sheba), Moladah, 
-<span class="v">3&#160;</span>Hazar Shual, Balah, Ezem, 
-<span class="v">4&#160;</span>Eltolad, Bethul, Hormah, 
-<span class="v">5&#160;</span>Ziklag, Beth Marcaboth, Hazar Susah, 
-<span class="v">6&#160;</span>Beth Lebaoth, and Sharuhen; thirteen cities with their villages; 
-<span class="v">7&#160;</span>Ain, Rimmon, Ether, and Ashan; four cities with their villages; 
-<span class="v">8&#160;</span>and all the villages that were around these cities to Baalath Beer, Ramah of the South. This is the inheritance of the tribe of the children of Simeon according to their families. 
-<span class="v">9&#160;</span>Out of the part of the children of Judah was the inheritance of the children of Simeon; for the portion of the children of Judah was too much for them. Therefore the children of Simeon had inheritance in the middle of their inheritance. 
-</p><p>
-<span class="v">10&#160;</span>The third lot came up for the children of Zebulun according to their families. The border of their inheritance was to Sarid. 
-<span class="v">11&#160;</span>Their border went up westward, even to Maralah, and reached to Dabbesheth. It reached to the brook that is before Jokneam. 
-<span class="v">12&#160;</span>It turned from Sarid eastward toward the sunrise to the border of Chisloth Tabor. It went out to Daberath, and went up to Japhia. 
-<span class="v">13&#160;</span>From there it passed along eastward to Gath Hepher, to Ethkazin; and it went out at Rimmon which stretches to Neah. 
-<span class="v">14&#160;</span>The border turned around it on the north to Hannathon; and it ended at the valley of Iphtah El; 
-<span class="v">15&#160;</span>Kattath, Nahalal, Shimron, Idalah, and Bethlehem: twelve cities with their villages. 
-<span class="v">16&#160;</span>This is the inheritance of the children of Zebulun according to their families, these cities with their villages. 
-</p><p>
-<span class="v">17&#160;</span>The fourth lot came out for Issachar, even for the children of Issachar according to their families. 
-<span class="v">18&#160;</span>Their border was to Jezreel, Chesulloth, Shunem, 
-<span class="v">19&#160;</span>Hapharaim, Shion, Anaharath, 
-<span class="v">20&#160;</span>Rabbith, Kishion, Ebez, 
-<span class="v">21&#160;</span>Remeth, Engannim, En Haddah, and Beth Pazzez. 
-<span class="v">22&#160;</span>The border reached to Tabor, Shahazumah, and Beth Shemesh. Their border ended at the Jordan: sixteen cities with their villages. 
-<span class="v">23&#160;</span>This is the inheritance of the tribe of the children of Issachar according to their families, the cities with their villages. 
-</p><p>
-<span class="v">24&#160;</span>The fifth lot came out for the tribe of the children of Asher according to their families. 
-<span class="v">25&#160;</span>Their border was Helkath, Hali, Beten, Achshaph, 
-<span class="v">26&#160;</span>Allammelech, Amad, Mishal. It reached to Carmel westward, and to Shihorlibnath. 
-<span class="v">27&#160;</span>It turned toward the sunrise to Beth Dagon, and reached to Zebulun, and to the valley of Iphtah El northward to Beth Emek and Neiel. It went out to Cabul on the left hand, 
-<span class="v">28&#160;</span>and Ebron, Rehob, Hammon, and Kanah, even to great Sidon. 
-<span class="v">29&#160;</span>The border turned to Ramah, to the fortified city of Tyre; and the border turned to Hosah. It ended at the sea by the region of Achzib; 
-<span class="v">30&#160;</span>Ummah also, and Aphek, and Rehob: twenty-two cities with their villages. 
-<span class="v">31&#160;</span>This is the inheritance of the tribe of the children of Asher according to their families, these cities with their villages. 
-</p><p>
-<span class="v">32&#160;</span>The sixth lot came out for the children of Naphtali, even for the children of Naphtali according to their families. 
-<span class="v">33&#160;</span>Their border was from Heleph, from the oak in Zaanannim, Adami-nekeb, and Jabneel, to Lakkum. It ended at the Jordan. 
-<span class="v">34&#160;</span>The border turned westward to Aznoth Tabor, and went out from there to Hukkok. It reached to Zebulun on the south, and reached to Asher on the west, and to Judah at the Jordan toward the sunrise. 
-<span class="v">35&#160;</span>The fortified cities were Ziddim, Zer, Hammath, Rakkath, Chinnereth, 
-<span class="v">36&#160;</span>Adamah, Ramah, Hazor, 
-<span class="v">37&#160;</span>Kedesh, Edrei, En Hazor, 
-<span class="v">38&#160;</span>Iron, Migdal El, Horem, Beth Anath, and Beth Shemesh; nineteen cities with their villages. 
-<span class="v">39&#160;</span>This is the inheritance of the tribe of the children of Naphtali according to their families, the cities with their villages. 
-</p><p>
-<span class="v">40&#160;</span>The seventh lot came out for the tribe of the children of Dan according to their families. 
-<span class="v">41&#160;</span>The border of their inheritance was Zorah, Eshtaol, Irshemesh, 
-<span class="v">42&#160;</span>Shaalabbin, Aijalon, Ithlah, 
-<span class="v">43&#160;</span>Elon, Timnah, Ekron, 
-<span class="v">44&#160;</span>Eltekeh, Gibbethon, Baalath, 
-<span class="v">45&#160;</span>Jehud, Bene Berak, Gath Rimmon, 
-<span class="v">46&#160;</span>Me Jarkon, and Rakkon, with the border opposite Joppa. 
-<span class="v">47&#160;</span>The border of the children of Dan went out beyond them; for the children of Dan went up and fought against Leshem, and took it, and struck it with the edge of the sword, and possessed it, and lived therein, and called Leshem, Dan, after the name of Dan their forefather. 
-<span class="v">48&#160;</span>This is the inheritance of the tribe of the children of Dan according to their families, these cities with their villages. 
-</p><p>
-<span class="v">49&#160;</span>So they finished distributing the land for inheritance by its borders. The children of Israel gave an inheritance to Joshua the son of Nun among them. 
-<span class="v">50&#160;</span>According to Yahweh’s commandment, they gave him the city which he asked, even Timnathserah in the hill country of Ephraim; and he built the city, and lived there. 
-<span class="v">51&#160;</span>These are the inheritances, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed for inheritance by lot in Shiloh before Yahweh, at the door of the Tent of Meeting. So they finished dividing the land. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Joshua, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, saying, ‘Assign the cities of refuge, of which I spoke to you by Moses, 
-<span class="v">3&#160;</span>that the man slayer who kills any person accidentally or unintentionally may flee there. They shall be to you for a refuge from the avenger of blood. 
-<span class="v">4&#160;</span>He shall flee to one of those cities, and shall stand at the entrance of the gate of the city, and declare his case in the ears of the elders of that city. They shall take him into the city with them, and give him a place, that he may live among them. 
-<span class="v">5&#160;</span>If the avenger of blood pursues him, then they shall not deliver up the man slayer into his hand; because he struck his neighbor unintentionally, and didn’t hate him before. 
-<span class="v">6&#160;</span>He shall dwell in that city until he stands before the congregation for judgment, until the death of the high priest that shall be in those days. Then the man slayer shall return, and come to his own city, and to his own house, to the city he fled from.’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>They set apart Kedesh in Galilee in the hill country of Naphtali, Shechem in the hill country of Ephraim, and Kiriath Arba (also called Hebron) in the hill country of Judah. 
-<span class="v">8&#160;</span>Beyond the Jordan at Jericho eastward, they assigned Bezer in the wilderness in the plain out of the tribe of Reuben, Ramoth in Gilead out of the tribe of Gad, and Golan in Bashan out of the tribe of Manasseh. 
-<span class="v">9&#160;</span>These were the appointed cities for all the children of Israel, and for the alien who lives among them, that whoever kills any person unintentionally might flee there, and not die by the hand of the avenger of blood, until he stands trial before the congregation. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Then the heads of fathers’ houses of the Levites came near to Eleazar the priest, and to Joshua the son of Nun, and to the heads of fathers’ houses of the tribes of the children of Israel. 
-<span class="v">2&#160;</span>They spoke to them at Shiloh in the land of Canaan, saying, “Yahweh commanded through Moses to give us cities to dwell in, with their pasture lands for our livestock.” 
-</p><p>
-<span class="v">3&#160;</span>The children of Israel gave to the Levites out of their inheritance, according to the commandment of Yahweh, these cities with their pasture lands. 
-<span class="v">4&#160;</span>The lot came out for the families of the Kohathites. The children of Aaron the priest, who were of the Levites, had thirteen cities by lot out of the tribe of Judah, out of the tribe of the Simeonites, and out of the tribe of Benjamin. 
-<span class="v">5&#160;</span>The rest of the children of Kohath had ten cities by lot out of the families of the tribe of Ephraim, out of the tribe of Dan, and out of the half-tribe of Manasseh. 
-<span class="v">6&#160;</span>The children of Gershon had thirteen cities by lot out of the families of the tribe of Issachar, out of the tribe of Asher, out of the tribe of Naphtali, and out of the half-tribe of Manasseh in Bashan. 
-<span class="v">7&#160;</span>The children of Merari according to their families had twelve cities out of the tribe of Reuben, out of the tribe of Gad, and out of the tribe of Zebulun. 
-<span class="v">8&#160;</span>The children of Israel gave these cities with their pasture lands by lot to the Levites, as Yahweh commanded by Moses. 
-<span class="v">9&#160;</span>They gave out of the tribe of the children of Judah, and out of the tribe of the children of Simeon, these cities which are mentioned by name: 
-<span class="v">10&#160;</span>and they were for the children of Aaron, of the families of the Kohathites, who were of the children of Levi; for theirs was the first lot. 
-<span class="v">11&#160;</span>They gave them Kiriath Arba, named after the father of Anak (also called Hebron), in the hill country of Judah, with its pasture lands around it. 
-<span class="v">12&#160;</span>But they gave the fields of the city and its villages to Caleb the son of Jephunneh for his possession. 
-<span class="v">13&#160;</span>To the children of Aaron the priest they gave Hebron with its pasture lands, the city of refuge for the man slayer, Libnah with its pasture lands, 
-<span class="v">14&#160;</span>Jattir with its pasture lands, Eshtemoa with its pasture lands, 
-<span class="v">15&#160;</span>Holon with its pasture lands, Debir with its pasture lands, 
-<span class="v">16&#160;</span>Ain with its pasture lands, Juttah with its pasture lands, and Beth Shemesh with its pasture lands: nine cities out of those two tribes. 
-<span class="v">17&#160;</span>Out of the tribe of Benjamin, Gibeon with its pasture lands, Geba with its pasture lands, 
-<span class="v">18&#160;</span>Anathoth with its pasture lands, and Almon with its pasture lands: four cities. 
-<span class="v">19&#160;</span>All the cities of the children of Aaron, the priests, were thirteen cities with their pasture lands. 
-</p><p>
-<span class="v">20&#160;</span>The families of the children of Kohath, the Levites, even the rest of the children of Kohath, had the cities of their lot out of the tribe of Ephraim. 
-<span class="v">21&#160;</span>They gave them Shechem with its pasture lands in the hill country of Ephraim, the city of refuge for the man slayer, and Gezer with its pasture lands, 
-<span class="v">22&#160;</span>Kibzaim with its pasture lands, and Beth Horon with its pasture lands: four cities. 
-<span class="v">23&#160;</span>Out of the tribe of Dan, Elteke with its pasture lands, Gibbethon with its pasture lands, 
-<span class="v">24&#160;</span>Aijalon with its pasture lands, Gath Rimmon with its pasture lands: four cities. 
-<span class="v">25&#160;</span>Out of the half-tribe of Manasseh, Taanach with its pasture lands, and Gath Rimmon with its pasture lands: two cities. 
-<span class="v">26&#160;</span>All the cities of the families of the rest of the children of Kohath were ten with their pasture lands. 
-</p><p>
-<span class="v">27&#160;</span>They gave to the children of Gershon, of the families of the Levites, out of the half-tribe of Manasseh Golan in Bashan with its pasture lands, the city of refuge for the man slayer, and Be Eshterah with its pasture lands: two cities. 
-<span class="v">28&#160;</span>Out of the tribe of Issachar, Kishion with its pasture lands, Daberath with its pasture lands, 
-<span class="v">29&#160;</span>Jarmuth with its pasture lands, En Gannim with its pasture lands: four cities. 
-<span class="v">30&#160;</span>Out of the tribe of Asher, Mishal with its pasture lands, Abdon with its pasture lands, 
-<span class="v">31&#160;</span>Helkath with its pasture lands, and Rehob with its pasture lands: four cities. 
-<span class="v">32&#160;</span>Out of the tribe of Naphtali, Kedesh in Galilee with its pasture lands, the city of refuge for the man slayer, Hammothdor with its pasture lands, and Kartan with its pasture lands: three cities. 
-<span class="v">33&#160;</span>All the cities of the Gershonites according to their families were thirteen cities with their pasture lands. 
-</p><p>
-<span class="v">34&#160;</span>To the families of the children of Merari, the rest of the Levites, out of the tribe of Zebulun, Jokneam with its pasture lands, Kartah with its pasture lands, 
-<span class="v">35&#160;</span>Dimnah with its pasture lands, and Nahalal with its pasture lands: four cities. 
-<span class="v">36&#160;</span>Out of the tribe of Reuben, Bezer with its pasture lands, Jahaz with its pasture lands, 
-<span class="v">37&#160;</span>Kedemoth with its pasture lands, and Mephaath with its pasture lands: four cities. 
-<span class="v">38&#160;</span>Out of the tribe of Gad, Ramoth in Gilead with its pasture lands, the city of refuge for the man slayer, and Mahanaim with its pasture lands, 
-<span class="v">39&#160;</span>Heshbon with its pasture lands, Jazer with its pasture lands: four cities in all. 
-<span class="v">40&#160;</span>All these were the cities of the children of Merari according to their families, even the rest of the families of the Levites. Their lot was twelve cities. 
-</p><p>
-<span class="v">41&#160;</span>All the cities of the Levites among the possessions of the children of Israel were forty-eight cities with their pasture lands. 
-<span class="v">42&#160;</span>Each of these cities included their pasture lands around them. It was this way with all these cities. 
-</p><p>
-<span class="v">43&#160;</span>So Yahweh gave to Israel all the land which he swore to give to their fathers. They possessed it, and lived in it. 
-<span class="v">44&#160;</span>Yahweh gave them rest all around, according to all that he swore to their fathers. Not a man of all their enemies stood before them. Yahweh delivered all their enemies into their hand. 
-<span class="v">45&#160;</span>Nothing failed of any good thing which Yahweh had spoken to the house of Israel. All came to pass. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Then Joshua called the Reubenites, the Gadites, and the half-tribe of Manasseh, 
-<span class="v">2&#160;</span>and said to them, “You have kept all that Moses the servant of Yahweh commanded you, and have listened to my voice in all that I commanded you. 
-<span class="v">3&#160;</span>You have not left your brothers these many days to this day, but have performed the duty of the commandment of Yahweh your Elohim. 
-<span class="v">4&#160;</span>Now Yahweh your Elohim has given rest to your brothers, as he spoke to them. Therefore now return and go to your tents, to the land of your possession, which Moses the servant of Yahweh gave you beyond the Jordan. 
-<span class="v">5&#160;</span>Only take diligent heed to do the commandment and the law which Moses the servant of Yahweh commanded you, to love Yahweh your Elohim, to walk in all his ways, to keep his commandments, to hold fast to him, and to serve him with all your heart and with all your soul.” 
-</p><p>
-<span class="v">6&#160;</span>So Joshua blessed them, and sent them away; and they went to their tents. 
-<span class="v">7&#160;</span>Now to the one half-tribe of Manasseh Moses had given inheritance in Bashan; but Joshua gave to the other half among their brothers beyond the Jordan westward. Moreover when Joshua sent them away to their tents, he blessed them, 
-<span class="v">8&#160;</span>and spoke to them, saying, “Return with much wealth to your tents, with very much livestock, with silver, with gold, with bronze, with iron, and with very much clothing. Divide the plunder of your enemies with your brothers.” 
-</p><p>
-<span class="v">9&#160;</span>The children of Reuben and the children of Gad and the half-tribe of Manasseh returned, and departed from the children of Israel out of Shiloh, which is in the land of Canaan, to go to the land of Gilead, to the land of their possession, which they owned, according to the commandment of Yahweh by Moses. 
-<span class="v">10&#160;</span>When they came to the region near the Jordan, that is in the land of Canaan, the children of Reuben and the children of Gad and the half-tribe of Manasseh built an altar there by the Jordan, a great altar to look at. 
-<span class="v">11&#160;</span>The children of Israel heard this, “Behold, the children of Reuben and the children of Gad and the half-tribe of Manasseh have built an altar along the border of the land of Canaan, in the region around the Jordan, on the side that belongs to the children of Israel.” 
-<span class="v">12&#160;</span>When the children of Israel heard of it, the whole congregation of the children of Israel gathered themselves together at Shiloh, to go up against them to war. 
-<span class="v">13&#160;</span>The children of Israel sent to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, into the land of Gilead, Phinehas the son of Eleazar the priest. 
-<span class="v">14&#160;</span>With him were ten princes, one prince of a fathers’ house for each of the tribes of Israel; and they were each head of their fathers’ houses among the thousands of Israel. 
-<span class="v">15&#160;</span>They came to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, to the land of Gilead, and they spoke with them, saying, 
-<span class="v">16&#160;</span>“The whole congregation of Yahweh says, ‘What trespass is this that you have committed against the Elohim of Israel, to turn away today from following Yahweh, in that you have built yourselves an altar, to rebel today against Yahweh? 
-<span class="v">17&#160;</span>Is the iniquity of Peor too little for us, from which we have not cleansed ourselves to this day, although there came a plague on the congregation of Yahweh, 
-<span class="v">18&#160;</span>that you must turn away today from following Yahweh? It will be, since you rebel today against Yahweh, that tomorrow he will be angry with the whole congregation of Israel. 
-<span class="v">19&#160;</span>However, if the land of your possession is unclean, then pass over to the land of the possession of Yahweh, in which Yahweh’s tabernacle dwells, and take possession among us; but don’t rebel against Yahweh, nor rebel against us, in building an altar other than Yahweh our Elohim’s altar. 
-<span class="v">20&#160;</span>Didn’t Achan the son of Zerah commit a trespass in the devoted thing, and wrath fell on all the congregation of Israel? That man didn’t perish alone in his iniquity.’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>Then the children of Reuben and the children of Gad and the half-tribe of Manasseh answered, and spoke to the heads of the thousands of Israel, 
-<span class="v">22&#160;</span>“The Mighty One, Elohim, Yahweh, the Mighty One, Elohim, Yahweh, he knows; and Israel shall know: if it was in rebellion, or if in trespass against Yahweh (don’t save us today), 
-<span class="v">23&#160;</span>that we have built us an altar to turn away from following Yahweh; or if to offer burnt offering or meal offering, or if to offer sacrifices of peace offerings, let Yahweh himself require it. 
-</p><p>
-<span class="v">24&#160;</span>“If we have not out of concern done this, and for a reason, saying, ‘In time to come your children might speak to our children, saying, “What have you to do with Yahweh, the Elohim of Israel? 
-<span class="v">25&#160;</span>For Yahweh has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in Yahweh.”&#160;’ So your children might make our children cease from fearing Yahweh. 
-</p><p>
-<span class="v">26&#160;</span>“Therefore we said, ‘Let’s now prepare to build ourselves an altar, not for burnt offering, nor for sacrifice; 
-<span class="v">27&#160;</span>but it will be a witness between us and you, and between our generations after us, that we may perform the service of Yahweh before him with our burnt offerings, with our sacrifices, and with our peace offerings;’ that your children may not tell our children in time to come, ‘You have no portion in Yahweh.’ 
-</p><p>
-<span class="v">28&#160;</span>“Therefore we said, ‘It shall be, when they tell us or our generations this in time to come, that we shall say, “Behold the pattern of Yahweh’s altar, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.”&#160;’ 
-</p><p>
-<span class="v">29&#160;</span>“Far be it from us that we should rebel against Yahweh, and turn away today from following Yahweh, to build an altar for burnt offering, for meal offering, or for sacrifice, besides Yahweh our Elohim’s altar that is before his tabernacle!” 
-</p><p>
-<span class="v">30&#160;</span>When Phinehas the priest, and the princes of the congregation, even the heads of the thousands of Israel that were with him, heard the words that the children of Reuben and the children of Gad and the children of Manasseh spoke, it pleased them well. 
-<span class="v">31&#160;</span>Phinehas the son of Eleazar the priest said to the children of Reuben, to the children of Gad, and to the children of Manasseh, “Today we know that Yahweh is among us, because you have not committed this trespass against Yahweh. Now you have delivered the children of Israel out of Yahweh’s hand.” 
-<span class="v">32&#160;</span>Phinehas the son of Eleazar the priest, and the princes, returned from the children of Reuben, and from the children of Gad, out of the land of Gilead, to the land of Canaan, to the children of Israel, and brought them word again. 
-<span class="v">33&#160;</span>The thing pleased the children of Israel; and the children of Israel blessed Elohim, and spoke no more of going up against them to war, to destroy the land in which the children of Reuben and the children of Gad lived. 
-<span class="v">34&#160;</span>The children of Reuben and the children of Gad named the altar “A Witness Between Us that Yahweh is Elohim.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>After many days, when Yahweh had given rest to Israel from their enemies all around, and Joshua was old and well advanced in years, 
-<span class="v">2&#160;</span>Joshua called for all Israel, for their elders and for their heads, and for their judges and for their officers, and said to them, “I am old and well advanced in years. 
-<span class="v">3&#160;</span>You have seen all that Yahweh your Elohim has done to all these nations because of you; for it is Yahweh your Elohim who has fought for you. 
-<span class="v">4&#160;</span>Behold, I have allotted to you these nations that remain, to be an inheritance for your tribes, from the Jordan, with all the nations that I have cut off, even to the great sea toward the going down of the sun. 
-<span class="v">5&#160;</span>Yahweh your Elohim will thrust them out from before you, and drive them from out of your sight. You shall possess their land, as Yahweh your Elohim spoke to you. 
-</p><p>
-<span class="v">6&#160;</span>“Therefore be very courageous to keep and to do all that is written in the book of the law of Moses, that you not turn away from it to the right hand or to the left; 
-<span class="v">7&#160;</span>that you not come among these nations, these that remain among you; neither make mention of the name of their elohims, nor cause to swear by them, neither serve them, nor bow down yourselves to them; 
-<span class="v">8&#160;</span>but hold fast to Yahweh your Elohim, as you have done to this day. 
-</p><p>
-<span class="v">9&#160;</span>“For Yahweh has driven great and strong nations out from before you. But as for you, no man has stood before you to this day. 
-<span class="v">10&#160;</span>One man of you shall chase a thousand; for it is Yahweh your Elohim who fights for you, as he spoke to you. 
-<span class="v">11&#160;</span>Take good heed therefore to yourselves, that you love Yahweh your Elohim. 
-</p><p>
-<span class="v">12&#160;</span>“But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and make marriages with them, and go in to them, and they to you; 
-<span class="v">13&#160;</span>know for a certainty that Yahweh your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahweh your Elohim has given you. 
-</p><p>
-<span class="v">14&#160;</span>“Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahweh your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 
-<span class="v">15&#160;</span>It shall happen that as all the good things have come on you of which Yahweh your Elohim spoke to you, so Yahweh will bring on you all the evil things, until he has destroyed you from off this good land which Yahweh your Elohim has given you, 
-<span class="v">16&#160;</span>when you disobey the covenant of Yahweh your Elohim, which he commanded you, and go and serve other elohims, and bow down yourselves to them. Then Yahweh’s anger will be kindled against you, and you will perish quickly from off the good land which he has given to you.” 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Joshua gathered all the tribes of Israel to Shechem, and called for the elders of Israel, for their heads, for their judges, and for their officers; and they presented themselves before Elohim. 
-<span class="v">2&#160;</span>Joshua said to all the people, “Yahweh, the Elohim of Israel, says, ‘Your fathers lived of old time beyond the River, even Terah, the father of Abraham, and the father of Nahor. They served other elohims. 
-<span class="v">3&#160;</span>I took your father Abraham from beyond the River, and led him throughout all the land of Canaan, and multiplied his offspring,<span class="f">+ \fr 24:3 \ft or, seed</span> and gave him Isaac. 
-<span class="v">4&#160;</span>I gave to Isaac Jacob and Esau: and I gave to Esau Mount Seir, to possess it. Jacob and his children went down into Egypt. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘I sent Moses and Aaron, and I plagued Egypt, according to that which I did among them: and afterward I brought you out. 
-<span class="v">6&#160;</span>I brought your fathers out of Egypt: and you came to the sea. The Egyptians pursued your fathers with chariots and with horsemen to the Red Sea. 
-<span class="v">7&#160;</span>When they cried out to Yahweh, he put darkness between you and the Egyptians, and brought the sea on them, and covered them; and your eyes saw what I did in Egypt. You lived in the wilderness many days. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘I brought you into the land of the Amorites, that lived beyond the Jordan. They fought with you, and I gave them into your hand. You possessed their land, and I destroyed them from before you. 
-<span class="v">9&#160;</span>Then Balak the son of Zippor, king of Moab, arose and fought against Israel. He sent and called Balaam the son of Beor to curse you, 
-<span class="v">10&#160;</span>but I would not listen to Balaam; therefore he blessed you still. So I delivered you out of his hand. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘You went over the Jordan, and came to Jericho. The owners of Jericho fought against you, the Amorite, the Perizzite, the Canaanite, the Hittite, the Girgashite, the Hivite, and the Jebusite; and I delivered them into your hand. 
-<span class="v">12&#160;</span>I sent the hornet before you, which drove them out from before you, even the two kings of the Amorites; not with your sword, nor with your bow. 
-<span class="v">13&#160;</span>I gave you a land on which you had not labored, and cities which you didn’t build, and you live in them. You eat of vineyards and olive groves which you didn’t plant.’ 
-</p><p>
-<span class="v">14&#160;</span>“Now therefore fear Yahweh, and serve him in sincerity and in truth. Put away the elohims which your fathers served beyond the River, in Egypt; and serve Yahweh. 
-<span class="v">15&#160;</span>If it seems evil to you to serve Yahweh, choose today whom you will serve; whether the elohims which your fathers served that were beyond the River, or the elohims of the Amorites, in whose land you dwell; but as for me and my house, we will serve Yahweh.” 
-</p><p>
-<span class="v">16&#160;</span>The people answered, “Far be it from us that we should forsake Yahweh, to serve other elohims; 
-<span class="v">17&#160;</span>for it is Yahweh our Elohim who brought us and our fathers up out of the land of Egypt, from the house of bondage, and who did those great signs in our sight, and preserved us in all the way in which we went, and among all the peoples through the middle of whom we passed. 
-<span class="v">18&#160;</span>Yahweh drove out from before us all the peoples, even the Amorites who lived in the land. Therefore we also will serve Yahweh; for he is our Elohim.” 
-</p><p>
-<span class="v">19&#160;</span>Joshua said to the people, “You can’t serve Yahweh, for he is a set-apart Elohim. He is a jealous Elohim. He will not forgive your disobedience nor your sins. 
-<span class="v">20&#160;</span>If you forsake Yahweh, and serve foreign elohims, then he will turn and do you evil, and consume you, after he has done you good.” 
-</p><p>
-<span class="v">21&#160;</span>The people said to Joshua, “No, but we will serve Yahweh.” 
-<span class="v">22&#160;</span>Joshua said to the people, “You are witnesses against yourselves that you have chosen Yahweh yourselves, to serve him.” 
-</p><p>They said, “We are witnesses.” 
-</p><p>
-<span class="v">23&#160;</span>“Now therefore put away the foreign elohims which are among you, and incline your heart to Yahweh, the Elohim of Israel.” 
-</p><p>
-<span class="v">24&#160;</span>The people said to Joshua, “We will serve Yahweh our Elohim, and we will listen to his voice.” 
-</p><p>
-<span class="v">25&#160;</span>So Joshua made a covenant with the people that day, and made for them a statute and an ordinance in Shechem. 
-<span class="v">26&#160;</span>Joshua wrote these words in the book of the law of Elohim; and he took a great stone, and set it up there under the oak that was by the sanctuary of Yahweh. 
-<span class="v">27&#160;</span>Joshua said to all the people, “Behold, this stone shall be a witness against us, for it has heard all Yahweh’s words which he spoke to us. It shall be therefore a witness against you, lest you deny your Elohim.” 
-<span class="v">28&#160;</span>So Joshua sent the people away, each to his own inheritance. 
-</p><p>
-<span class="v">29&#160;</span>After these things, Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
-<span class="v">30&#160;</span>They buried him in the border of his inheritance in Timnathserah, which is in the hill country of Ephraim, on the north of the mountain of Gaash. 
-<span class="v">31&#160;</span>Israel served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, and had known all the work of Yahweh, that he had worked for Israel. 
-<span class="v">32&#160;</span>They buried the bones of Joseph, which the children of Israel brought up out of Egypt, in Shechem, in the parcel of ground which Jacob bought from the sons of Hamor the father of Shechem for a hundred pieces of silver.<span class="f">+ \fr 24:32 \ft Hebrew: kesitahs. A kesitah was a kind of silver coin.</span> They became the inheritance of the children of Joseph. 
-<span class="v">33&#160;</span>Eleazar the son of Aaron died. They buried him in the hill of Phinehas his son, which was given him in the hill country of Ephraim. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Now after the death of Moses the servant of Yahweh, Yahweh spoke to Joshua the son of Nun, Moses’ servant, saying, 
+<sup>2&#160;</sup>“Moses my servant is dead. Now therefore arise, go across this Jordan, you and all these people, to the land which I am giving to them, even to the children of Israel. 
+<sup>3&#160;</sup>I have given you every place that the sole of your foot will tread on, as I told Moses. 
+<sup>4&#160;</sup>From the wilderness and this Lebanon even to the great river, the river Euphrates, all the land of the Hittites, and to the great sea toward the going down of the sun, shall be your border. 
+<sup>5&#160;</sup>No man will be able to stand before you all the days of your life. As I was with Moses, so I will be with you. I will not fail you nor forsake you. 
+</div><div class="p">
+<sup>6&#160;</sup>“Be strong and courageous; for you shall cause this people to inherit the land which I swore to their fathers to give them. 
+<sup>7&#160;</sup>Only be strong and very courageous. Be careful to observe to do according to all the law which Moses my servant commanded you. Don’t turn from it to the right hand or to the left, that you may have good success wherever you go. 
+<sup>8&#160;</sup>This book of the law shall not depart from your mouth, but you shall meditate on it day and night, that you may observe to do according to all that is written in it; for then you shall make your way prosperous, and then you shall have good success. 
+<sup>9&#160;</sup>Haven’t I commanded you? Be strong and courageous. Don’t be afraid. Don’t be dismayed, for Yahweh your Elohim is with you wherever you go.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Joshua commanded the officers of the people, saying, 
+<sup>11&#160;</sup>“Pass through the middle of the camp, and command the people, saying, ‘Prepare food; for within three days you are to pass over this Jordan, to go in to possess the land which Yahweh your Elohim gives you to possess.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Joshua spoke to the Reubenites, and to the Gadites, and to the half-tribe of Manasseh, saying, 
+<sup>13&#160;</sup>“Remember the word which Moses the servant of Yahweh commanded you, saying, ‘Yahweh your Elohim gives you rest, and will give you this land. 
+<sup>14&#160;</sup>Your women, your little ones, and your livestock shall live in the land which Moses gave you beyond the Jordan; but you shall pass over before your brothers armed, all the mighty men of valor, and shall help them 
+<sup>15&#160;</sup>until Yahweh has given your brothers rest, as he has given you, and they have also possessed the land which Yahweh your Elohim gives them. Then you shall return to the land of your possession and possess it, which Moses the servant of Yahweh gave you beyond the Jordan toward the sunrise.’&#160;” 
+</div><div class="p">
+<sup>16&#160;</sup>They answered Joshua, saying, “All that you have commanded us we will do, and wherever you send us we will go. 
+<sup>17&#160;</sup>Just as we listened to Moses in all things, so will we listen to you. Only may Yahweh your Elohim be with you, as he was with Moses. 
+<sup>18&#160;</sup>Whoever rebels against your commandment, and doesn’t listen to your words in all that you command him shall himself be put to death. Only be strong and courageous.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Joshua the son of Nun secretly sent two men out of Shittim as spies, saying, “Go, view the land, including Jericho.” They went and came into the house of a prostitute whose name was Rahab, and slept there. 
+</div><div class="p">
+<sup>2&#160;</sup>The king of Jericho was told, “Behold, men of the children of Israel came in here tonight to spy out the land.” 
+</div><div class="p">
+<sup>3&#160;</sup>Jericho’s king sent to Rahab, saying, “Bring out the men who have come to you, who have entered into your house; for they have come to spy out all the land.” 
+</div><div class="p">
+<sup>4&#160;</sup>The woman took the two men and hid them. Then she said, “Yes, the men came to me, but I didn’t know where they came from. 
+<sup>5&#160;</sup>About the time of the shutting of the gate, when it was dark, the men went out. Where the men went, I don’t know. Pursue them quickly. You may catch up with them.” 
+<sup>6&#160;</sup>But she had brought them up to the roof, and hidden them under the stalks of flax which she had laid in order on the roof. 
+<sup>7&#160;</sup>The men pursued them along the way to the fords of the Jordan River. As soon as those who pursued them had gone out, they shut the gate. 
+<sup>8&#160;</sup>Before they had lain down, she came up to them on the roof. 
+<sup>9&#160;</sup>She said to the men, “I know that Yahweh has given you the land, and that the fear of you has fallen upon us, and that all the inhabitants of the land melt away before you. 
+<sup>10&#160;</sup>For we have heard how Yahweh dried up the water of the Red Sea before you, when you came out of Egypt; and what you did to the two kings of the Amorites, who were beyond the Jordan, to Sihon and to Og, whom you utterly destroyed. 
+<sup>11&#160;</sup>As soon as we had heard it, our hearts melted, and there wasn’t any more spirit in any man, because of you: for Yahweh your Elohim, he is Elohim in heaven above, and on earth beneath. 
+<sup>12&#160;</sup>Now therefore, please swear to me by Yahweh, since I have dealt kindly with you, that you also will deal kindly with my father’s house, and give me a true sign; 
+<sup>13&#160;</sup>and that you will save alive my father, my mother, my brothers, and my sisters, and all that they have, and will deliver our lives from death.” 
+</div><div class="p">
+<sup>14&#160;</sup>The men said to her, “Our life for yours, if you don’t talk about this business of ours; and it shall be, when Yahweh gives us the land, that we will deal kindly and truly with you.” 
+</div><div class="p">
+<sup>15&#160;</sup>Then she let them down by a cord through the window; for her house was on the side of the wall, and she lived on the wall. 
+<sup>16&#160;</sup>She said to them, “Go to the mountain, lest the pursuers find you. Hide yourselves there three days, until the pursuers have returned. Afterward, you may go your way.” 
+</div><div class="p">
+<sup>17&#160;</sup>The men said to her, “We will be guiltless of this your oath which you’ve made us to swear. 
+<sup>18&#160;</sup>Behold, when we come into the land, tie this line of scarlet thread in the window which you used to let us down. Gather to yourself into the house your father, your mother, your brothers, and all your father’s household. 
+<sup>19&#160;</sup>It shall be that whoever goes out of the doors of your house into the street, his blood will be on his head, and we will be guiltless. Whoever is with you in the house, his blood shall be on our head, if any hand is on him. 
+<sup>20&#160;</sup>But if you talk about this business of ours, then we shall be guiltless of your oath which you’ve made us to swear.” 
+</div><div class="p">
+<sup>21&#160;</sup>She said, “Let it be as you have said.” She sent them away, and they departed. Then she tied the scarlet line in the window. 
+</div><div class="p">
+<sup>22&#160;</sup>They went and came to the mountain, and stayed there three days, until the pursuers had returned. The pursuers sought them all along the way, but didn’t find them. 
+<sup>23&#160;</sup>Then the two men returned, descended from the mountain, crossed the river, and came to Joshua the son of Nun. They told him all that had happened to them. 
+<sup>24&#160;</sup>They said to Joshua, “Truly Yahweh has delivered all the land into our hands. Moreover, all the inhabitants of the land melt away before us.” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Joshua got up early in the morning; and they moved from Shittim and came to the Jordan, he and all the children of Israel. They camped there before they crossed over. 
+<sup>2&#160;</sup>After three days, the officers went through the middle of the camp; 
+<sup>3&#160;</sup>and they commanded the people, saying, “When you see the ark of Yahweh your Elohim’s covenant, and the Levitical priests bearing it, then leave your place and follow it. 
+<sup>4&#160;</sup>Yet there shall be a space between you and it of about two thousand cubits by measure—don’t come closer to it—that you may know the way by which you must go; for you have not passed this way before.” 
+</div><div class="p">
+<sup>5&#160;</sup>Joshua said to the people, “Sanctify yourselves; for tomorrow Yahweh will do wonders among you.” 
+</div><div class="p">
+<sup>6&#160;</sup>Joshua spoke to the priests, saying, “Take up the ark of the covenant, and cross over before the people.” They took up the ark of the covenant, and went before the people. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh said to Joshua, “Today I will begin to magnify you in the sight of all Israel, that they may know that as I was with Moses, so I will be with you. 
+<sup>8&#160;</sup>You shall command the priests who bear the ark of the covenant, saying, ‘When you come to the brink of the waters of the Jordan, you shall stand still in the Jordan.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>Joshua said to the children of Israel, “Come here, and hear the words of Yahweh your Elohim.” 
+<sup>10&#160;</sup>Joshua said, “By this you shall know that the living Elohim is among you, and that he will without fail drive the Canaanite, the Hittite, the Hivite, the Perizzite, the Girgashite, the Amorite, and the Jebusite out from before you. 
+<sup>11&#160;</sup>Behold, the ark of the covenant of the Lord of all the earth passes over before you into the Jordan. 
+<sup>12&#160;</sup>Now therefore take twelve men out of the tribes of Israel, for every tribe a man. 
+<sup>13&#160;</sup>It shall be that when the soles of the feet of the priests who bear the ark of Yahweh, the Lord of all the earth, rest in the waters of the Jordan, that the waters of the Jordan will be cut off. The waters that come down from above shall stand in one heap.” 
+</div><div class="p">
+<sup>14&#160;</sup>When the people moved from their tents to pass over the Jordan, the priests who bore the ark of the covenant being before the people, 
+<sup>15&#160;</sup>and when those who bore the ark had come to the Jordan, and the feet of the priests who bore the ark had dipped in the edge of the water (for the Jordan overflows all its banks all the time of harvest), 
+<sup>16&#160;</sup>the waters which came down from above stood, and rose up in one heap a great way off, at Adam, the city that is beside Zarethan; and those that went down toward the sea of the Arabah, even the Salt Sea, were wholly cut off. Then the people passed over near Jericho. 
+<sup>17&#160;</sup>The priests who bore the ark of Yahweh’s covenant stood firm on dry ground in the middle of the Jordan; and all Israel crossed over on dry ground, until all the nation had passed completely over the Jordan. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>When all the nation had completely crossed over the Jordan, Yahweh spoke to Joshua, saying, 
+<sup>2&#160;</sup>“Take twelve men out of the people, a man out of every tribe, 
+<sup>3&#160;</sup>and command them, saying, ‘Take from out of the middle of the Jordan, out of the place where the priests’ feet stood firm, twelve stones, carry them over with you, and lay them down in the place where you’ll camp tonight.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>Then Joshua called the twelve men whom he had prepared of the children of Israel, a man out of every tribe. 
+<sup>5&#160;</sup>Joshua said to them, “Cross before the ark of Yahweh your Elohim into the middle of the Jordan, and each of you pick up a stone and put it on your shoulder, according to the number of the tribes of the children of Israel; 
+<sup>6&#160;</sup>that this may be a sign among you, that when your children ask in the future, saying, ‘What do you mean by these stones?’ 
+<sup>7&#160;</sup>then you shall tell them, ‘Because the waters of the Jordan were cut off before the ark of Yahweh’s covenant. When it crossed over the Jordan, the waters of the Jordan were cut off. These stones shall be for a memorial to the children of Israel forever.’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>The children of Israel did as Joshua commanded, and took up twelve stones out of the middle of the Jordan, as Yahweh spoke to Joshua, according to the number of the tribes of the children of Israel. They carried them over with them to the place where they camped, and laid them down there. 
+<sup>9&#160;</sup>Joshua set up twelve stones in the middle of the Jordan, in the place where the feet of the priests who bore the ark of the covenant stood; and they are there to this day. 
+<sup>10&#160;</sup>For the priests who bore the ark stood in the middle of the Jordan until everything was finished that Yahweh commanded Joshua to speak to the people, according to all that Moses commanded Joshua; and the people hurried and passed over. 
+<sup>11&#160;</sup>When all the people had completely crossed over, Yahweh’s ark crossed over with the priests in the presence of the people. 
+</div><div class="p">
+<sup>12&#160;</sup>The children of Reuben, and the children of Gad, and the half-tribe of Manasseh crossed over armed before the children of Israel, as Moses spoke to them. 
+<sup>13&#160;</sup>About forty thousand men, ready and armed for war, passed over before Yahweh to battle, to the plains of Jericho. 
+<sup>14&#160;</sup>On that day, Yahweh magnified Joshua in the sight of all Israel; and they feared him, as they feared Moses, all the days of his life. 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh spoke to Joshua, saying, 
+<sup>16&#160;</sup>“Command the priests who bear the ark of the covenant, that they come up out of the Jordan.” 
+</div><div class="p">
+<sup>17&#160;</sup>Joshua therefore commanded the priests, saying, “Come up out of the Jordan!” 
+<sup>18&#160;</sup>When the priests who bore the ark of Yahweh’s covenant had come up out of the middle of the Jordan, and the soles of the priests’ feet had been lifted up to the dry ground, the waters of the Jordan returned to their place, and went over all its banks, as before. 
+<sup>19&#160;</sup>The people came up out of the Jordan on the tenth day of the first month, and encamped in Gilgal, on the east border of Jericho. 
+</div><div class="p">
+<sup>20&#160;</sup>Joshua set up those twelve stones, which they took out of the Jordan, in Gilgal. 
+<sup>21&#160;</sup>He spoke to the children of Israel, saying, “When your children ask their fathers in time to come, saying, ‘What do these stones mean?’ 
+<sup>22&#160;</sup>Then you shall let your children know, saying, ‘Israel came over this Jordan on dry land. 
+<sup>23&#160;</sup>For Yahweh your Elohim dried up the waters of the Jordan from before you until you had crossed over, as Yahweh your Elohim did to the Red Sea, which he dried up from before us, until we had crossed over, 
+<sup>24&#160;</sup>that all the peoples of the earth may know that Yahweh’s hand is mighty, and that you may fear Yahweh your Elohim forever.’&#160;” 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>When all the kings of the Amorites, who were beyond the Jordan westward, and all the kings of the Canaanites, who were by the sea, heard how Yahweh had dried up the waters of the Jordan from before the children of Israel until we had crossed over, their heart melted, and there was no more spirit in them, because of the children of Israel. 
+<sup>2&#160;</sup>At that time, Yahweh said to Joshua, “Make flint knives, and circumcise again the sons of Israel the second time.” 
+<sup>3&#160;</sup>Joshua made himself flint knives, and circumcised the sons of Israel at the hill of the foreskins. 
+<sup>4&#160;</sup>This is the reason Joshua circumcised them: all the people who came out of Egypt, who were males, even all the men of war, died in the wilderness along the way, after they came out of Egypt. 
+<sup>5&#160;</sup>For all the people who came out were circumcised; but all the people who were born in the wilderness along the way as they came out of Egypt had not been circumcised. 
+<sup>6&#160;</sup>For the children of Israel walked forty years in the wilderness until all the nation, even the men of war who came out of Egypt, were consumed, because they didn’t listen to Yahweh’s voice. Yahweh swore to them that he wouldn’t let them see the land which Yahweh swore to their fathers that he would give us, a land flowing with milk and honey. 
+<sup>7&#160;</sup>Their children, whom he raised up in their place, were circumcised by Joshua, for they were uncircumcised, because they had not circumcised them on the way. 
+<sup>8&#160;</sup>When they were done circumcising the whole nation, they stayed in their places in the camp until they were healed. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh said to Joshua, “Today I have rolled away the reproach of Egypt from you.” Therefore the name of that place was called Gilgal to this day. 
+<sup>10&#160;</sup>The children of Israel encamped in Gilgal. They kept the Passover on the fourteenth day of the month at evening in the plains of Jericho. 
+<sup>11&#160;</sup>They ate unleavened cakes and parched grain of the produce of the land on the next day after the Passover, in the same day. 
+<sup>12&#160;</sup>The manna ceased on the next day, after they had eaten of the produce of the land. The children of Israel didn’t have manna any more, but they ate of the fruit of the land of Canaan that year. 
+</div><div class="p">
+<sup>13&#160;</sup>When Joshua was by Jericho, he lifted up his eyes and looked, and behold, a man stood in front of him with his sword drawn in his hand. Joshua went to him and said to him, “Are you for us, or for our enemies?” 
+</div><div class="p">
+<sup>14&#160;</sup>He said, “No; but I have come now as commander of Yahweh’s army.” 
+</div><div class="p">Joshua fell on his face to the earth, and worshiped, and asked him, “What does my lord say to his servant?” 
+</div><div class="p">
+<sup>15&#160;</sup>The prince of Yahweh’s army said to Joshua, “Take off your sandals, for the place on which you stand is set-apart.” Joshua did so. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Jericho was tightly shut up because of the children of Israel. No one went out, and no one came in. 
+<sup>2&#160;</sup>Yahweh said to Joshua, “Behold, I have given Jericho into your hand, with its king and the mighty men of valor. 
+<sup>3&#160;</sup>All of your men of war shall march around the city, going around the city once. You shall do this six days. 
+<sup>4&#160;</sup>Seven priests shall bear seven trumpets of rams’ horns before the ark. On the seventh day, you shall march around the city seven times, and the priests shall blow the trumpets. 
+<sup>5&#160;</sup>It shall be that when they make a long blast with the ram’s horn, and when you hear the sound of the trumpet, all the people shall shout with a great shout; then the city wall will fall down flat, and the people shall go up, every man straight in front of him.” 
+</div><div class="p">
+<sup>6&#160;</sup>Joshua the son of Nun called the priests, and said to them, “Take up the ark of the covenant, and let seven priests bear seven trumpets of rams’ horns before Yahweh’s ark.” 
+</div><div class="p">
+<sup>7&#160;</sup>They said to the people, “Advance! March around the city, and let the armed men pass on before Yahweh’s ark.” 
+</div><div class="p">
+<sup>8&#160;</sup>It was so, that when Joshua had spoken to the people, the seven priests bearing the seven trumpets of rams’ horns before Yahweh advanced and blew the trumpets, and the ark of Yahweh’s covenant followed them. 
+<sup>9&#160;</sup>The armed men went before the priests who blew the trumpets, and the ark went after them. The trumpets sounded as they went. 
+</div><div class="p">
+<sup>10&#160;</sup>Joshua commanded the people, saying, “You shall not shout nor let your voice be heard, neither shall any word proceed out of your mouth until the day I tell you to shout. Then you shall shout.” 
+<sup>11&#160;</sup>So he caused Yahweh’s ark to go around the city, circling it once. Then they came into the camp, and stayed in the camp. 
+<sup>12&#160;</sup>Joshua rose early in the morning, and the priests took up Yahweh’s ark. 
+<sup>13&#160;</sup>The seven priests bearing the seven trumpets of rams’ horns in front of Yahweh’s ark went on continually, and blew the trumpets. The armed men went in front of them. The rear guard came after Yahweh’s ark. The trumpets sounded as they went. 
+<sup>14&#160;</sup>The second day they marched around the city once, and returned into the camp. They did this six days. 
+</div><div class="p">
+<sup>15&#160;</sup>On the seventh day, they rose early at the dawning of the day, and marched around the city in the same way seven times. On this day only they marched around the city seven times. 
+<sup>16&#160;</sup>At the seventh time, when the priests blew the trumpets, Joshua said to the people, “Shout, for Yahweh has given you the city! 
+<sup>17&#160;</sup>The city shall be devoted, even it and all that is in it, to Yahweh. Only Rahab the prostitute shall live, she and all who are with her in the house, because she hid the messengers that we sent. 
+<sup>18&#160;</sup>But as for you, only keep yourselves from what is devoted to destruction, lest when you have devoted it, you take of the devoted thing; so you would make the camp of Israel accursed and trouble it. 
+<sup>19&#160;</sup>But all the silver, gold, and vessels of bronze and iron are set-apart to Yahweh. They shall come into Yahweh’s treasury.” 
+</div><div class="p">
+<sup>20&#160;</sup>So the people shouted and the priests blew the trumpets. When the people heard the sound of the trumpet, the people shouted with a great shout, and the wall fell down flat, so that the people went up into the city, every man straight in front of him, and they took the city. 
+<sup>21&#160;</sup>They utterly destroyed all that was in the city, both man and woman, both young and old, and ox, sheep, and donkey, with the edge of the sword. 
+<sup>22&#160;</sup>Joshua said to the two men who had spied out the land, “Go into the prostitute’s house, and bring the woman and all that she has out from there, as you swore to her.” 
+<sup>23&#160;</sup>The young men who were spies went in, and brought out Rahab with her father, her mother, her brothers, and all that she had. They also brought out all of her relatives, and they set them outside of the camp of Israel. 
+<sup>24&#160;</sup>They burned the city with fire, and all that was in it. Only they put the silver, the gold, and the vessels of bronze and of iron into the treasury of Yahweh’s house. 
+<sup>25&#160;</sup>But Rahab the prostitute, her father’s household, and all that she had, Joshua saved alive. She lives in the middle of Israel to this day, because she hid the messengers whom Joshua sent to spy out Jericho. 
+</div><div class="p">
+<sup>26&#160;</sup>Joshua commanded them with an oath at that time, saying, “Cursed is the man before Yahweh who rises up and builds this city Jericho. With the loss of his firstborn he will lay its foundation, and with the loss of his youngest son he will set up its gates.” 
+<sup>27&#160;</sup>So Yahweh was with Joshua; and his fame was in all the land. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>But the children of Israel committed a trespass in the devoted things; for Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, took some of the devoted things. Therefore Yahweh’s anger burned against the children of Israel. 
+<sup>2&#160;</sup>Joshua sent men from Jericho to Ai, which is beside Beth Aven, on the east side of Bethel, and spoke to them, saying, “Go up and spy out the land.” 
+</div><div class="p">The men went up and spied out Ai. 
+<sup>3&#160;</sup>They returned to Joshua, and said to him, “Don’t let all the people go up, but let about two or three thousand men go up and strike Ai. Don’t make all the people to toil there, for there are only a few of them.” 
+<sup>4&#160;</sup>So about three thousand men of the people went up there, and they fled before the men of Ai. 
+<sup>5&#160;</sup>The men of Ai struck about thirty-six men of them. They chased them from before the gate even to Shebarim, and struck them at the descent. The hearts of the people melted, and became like water. 
+<sup>6&#160;</sup>Joshua tore his clothes, and fell to the earth on his face before Yahweh’s ark until the evening, he and the elders of Israel; and they put dust on their heads. 
+<sup>7&#160;</sup>Joshua said, “Alas, Lord Yahweh, why have you brought this people over the Jordan at all, to deliver us into the hand of the Amorites, to cause us to perish? I wish that we had been content and lived beyond the Jordan! 
+<sup>8&#160;</sup>Oh, Lord, what shall I say, after Israel has turned their backs before their enemies? 
+<sup>9&#160;</sup>For the Canaanites and all the inhabitants of the land will hear of it, and will surround us, and cut off our name from the earth. What will you do for your great name?” 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh said to Joshua, “Get up! Why have you fallen on your face like that? 
+<sup>11&#160;</sup>Israel has sinned. Yes, they have even transgressed my covenant which I commanded them. Yes, they have even taken some of the devoted things, and have also stolen, and also deceived. They have even put it among their own stuff. 
+<sup>12&#160;</sup>Therefore the children of Israel can’t stand before their enemies. They turn their backs before their enemies, because they have become devoted for destruction. I will not be with you any more, unless you destroy the devoted things from among you. 
+<sup>13&#160;</sup>Get up! Sanctify the people, and say, ‘Sanctify yourselves for tomorrow, for Yahweh, the Elohim of Israel, says, “There is a devoted thing among you, Israel. You cannot stand before your enemies until you take away the devoted thing from among you.” 
+<sup>14&#160;</sup>In the morning therefore you shall be brought near by your tribes. It shall be that the tribe which Yahweh selects shall come near by families. The family which Yahweh selects shall come near by households. The household which Yahweh selects shall come near man by man. 
+<sup>15&#160;</sup>It shall be, that he who is taken with the devoted thing shall be burned with fire, he and all that he has, because he has transgressed Yahweh’s covenant, and because he has done a disgraceful thing in Israel.’&#160;” 
+</div><div class="p">
+<sup>16&#160;</sup>So Joshua rose up early in the morning and brought Israel near by their tribes. The tribe of Judah was selected. 
+<sup>17&#160;</sup>He brought near the family of Judah, and he selected the family of the Zerahites. He brought near the family of the Zerahites man by man, and Zabdi was selected. 
+<sup>18&#160;</sup>He brought near his household man by man, and Achan, the son of Carmi, the son of Zabdi, the son of Zerah, of the tribe of Judah, was selected. 
+<sup>19&#160;</sup>Joshua said to Achan, “My son, please give glory to Yahweh, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
+</div><div class="p">
+<sup>20&#160;</sup>Achan answered Joshua, and said, “I have truly sinned against Yahweh, the Elohim of Israel, and this is what I have done. 
+<sup>21&#160;</sup>When I saw among the plunder a beautiful Babylonian robe, two hundred shekels of silver, and a wedge of gold weighing fifty shekels, then I coveted them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
+</div><div class="p">
+<sup>22&#160;</sup>So Joshua sent messengers, and they ran to the tent. Behold, it was hidden in his tent, with the silver under it. 
+<sup>23&#160;</sup>They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahweh. 
+<sup>24&#160;</sup>Joshua, and all Israel with him, took Achan the son of Zerah, the silver, the robe, the wedge of gold, his sons, his daughters, his cattle, his donkeys, his sheep, his tent, and all that he had; and they brought them up to the valley of Achor. 
+<sup>25&#160;</sup>Joshua said, “Why have you troubled us? Yahweh will trouble you today.” All Israel stoned him with stones, and they burned them with fire and stoned them with stones. 
+<sup>26&#160;</sup>They raised over him a great heap of stones that remains to this day. Yahweh turned from the fierceness of his anger. Therefore the name of that place was called “The valley of Achor” to this day. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Joshua, “Don’t be afraid, and don’t be dismayed. Take all the warriors with you, and arise, go up to Ai. Behold, I have given into your hand the king of Ai, with his people, his city, and his land. 
+<sup>2&#160;</sup>You shall do to Ai and her king as you did to Jericho and her king, except you shall take its goods and its livestock for yourselves. Set an ambush for the city behind it.” 
+</div><div class="p">
+<sup>3&#160;</sup>So Joshua arose, with all the warriors, to go up to Ai. Joshua chose thirty thousand men, the mighty men of valor, and sent them out by night. 
+<sup>4&#160;</sup>He commanded them, saying, “Behold, you shall lie in ambush against the city, behind the city. Don’t go very far from the city, but all of you be ready. 
+<sup>5&#160;</sup>I and all the people who are with me will approach the city. It shall happen, when they come out against us, as at the first, that we will flee before them. 
+<sup>6&#160;</sup>They will come out after us until we have drawn them away from the city; for they will say, ‘They flee before us, like the first time.’ So we will flee before them, 
+<sup>7&#160;</sup>and you shall rise up from the ambush, and take possession of the city; for Yahweh your Elohim will deliver it into your hand. 
+<sup>8&#160;</sup>It shall be, when you have seized the city, that you shall set the city on fire. You shall do this according to Yahweh’s word. Behold, I have commanded you.” 
+</div><div class="p">
+<sup>9&#160;</sup>Joshua sent them out; and they went to set up the ambush, and stayed between Bethel and Ai on the west side of Ai; but Joshua stayed among the people that night. 
+<sup>10&#160;</sup>Joshua rose up early in the morning, mustered the people, and went up, he and the elders of Israel, before the people to Ai. 
+<sup>11&#160;</sup>All the people, even the men of war who were with him, went up and came near, and came before the city and encamped on the north side of Ai. Now there was a valley between him and Ai. 
+<sup>12&#160;</sup>He took about five thousand men, and set them in ambush between Bethel and Ai, on the west side of the city. 
+<sup>13&#160;</sup>So they set the people, even all the army who was on the north of the city, and their ambush on the west of the city; and Joshua went that night into the middle of the valley. 
+<sup>14&#160;</sup>When the king of Ai saw it, they hurried and rose up early, and the men of the city went out against Israel to battle, he and all his people, at the time appointed, before the Arabah; but he didn’t know that there was an ambush against him behind the city. 
+<sup>15&#160;</sup>Joshua and all Israel made as if they were beaten before them, and fled by the way of the wilderness. 
+<sup>16&#160;</sup>All the people who were in the city were called together to pursue after them. They pursued Joshua, and were drawn away from the city. 
+<sup>17&#160;</sup>There was not a man left in Ai or Bethel who didn’t go out after Israel. They left the city open, and pursued Israel. 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh said to Joshua, “Stretch out the javelin that is in your hand toward Ai, for I will give it into your hand.” 
+</div><div class="p">Joshua stretched out the javelin that was in his hand toward the city. 
+<sup>19&#160;</sup>The ambush arose quickly out of their place, and they ran as soon as he had stretched out his hand and entered into the city and took it. They hurried and set the city on fire. 
+<sup>20&#160;</sup>When the men of Ai looked behind them, they saw, and behold, the smoke of the city ascended up to heaven, and they had no power to flee this way or that way. The people who fled to the wilderness turned back on the pursuers. 
+<sup>21&#160;</sup>When Joshua and all Israel saw that the ambush had taken the city, and that the smoke of the city ascended, then they turned back and killed the men of Ai. 
+<sup>22&#160;</sup>The others came out of the city against them, so they were in the middle of Israel, some on this side, and some on that side. They struck them, so that they let none of them remain or escape. 
+<sup>23&#160;</sup>They captured the king of Ai alive, and brought him to Joshua. 
+</div><div class="p">
+<sup>24&#160;</sup>When Israel had finished killing all the inhabitants of Ai in the field, in the wilderness in which they pursued them, and they had all fallen by the edge of the sword until they were consumed, all Israel returned to Ai and struck it with the edge of the sword. 
+<sup>25&#160;</sup>All that fell that day, both of men and women, were twelve thousand, even all the people of Ai. 
+<sup>26&#160;</sup>For Joshua didn’t draw back his hand, with which he stretched out the javelin, until he had utterly destroyed all the inhabitants of Ai. 
+<sup>27&#160;</sup>Israel took for themselves only the livestock and the goods of that city, according to Yahweh’s word which he commanded Joshua. 
+<sup>28&#160;</sup>So Joshua burned Ai and made it a heap forever, even a desolation, to this day. 
+<sup>29&#160;</sup>He hanged the king of Ai on a tree until the evening. At sundown, Joshua commanded, and they took his body down from the tree and threw it at the entrance of the gate of the city, and raised a great heap of stones on it that remains to this day. 
+</div><div class="p">
+<sup>30&#160;</sup>Then Joshua built an altar to Yahweh, the Elohim of Israel, on Mount Ebal, 
+<sup>31&#160;</sup>as Moses the servant of Yahweh commanded the children of Israel, as it is written in the book of the law of Moses: an altar of uncut stones, on which no one had lifted up any iron. They offered burnt offerings on it to Yahweh and sacrificed peace offerings. 
+<sup>32&#160;</sup>He wrote there on the stones a copy of Moses’ law, which he wrote in the presence of the children of Israel. 
+<sup>33&#160;</sup>All Israel, with their elders, officers, and judges, stood on both sides of the ark before the Levitical priests, who carried the ark of Yahweh’s covenant, the foreigner as well as the native; half of them in front of Mount Gerizim, and half of them in front of Mount Ebal, as Moses the servant of Yahweh had commanded at the first, that they should bless the people of Israel. 
+<sup>34&#160;</sup>Afterward he read all the words of the law, the blessing and the curse, according to all that is written in the book of the law. 
+<sup>35&#160;</sup>There was not a word of all that Moses commanded which Joshua didn’t read before all the assembly of Israel, with the women, the little ones, and the foreigners who were among them. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>When all the kings who were beyond the Jordan, in the hill country, and in the lowland, and on all the shore of the great sea in front of Lebanon, the Hittite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite, heard of it 
+<sup>2&#160;</sup>they gathered themselves together to fight with Joshua and with Israel, with one accord. 
+<sup>3&#160;</sup>But when the inhabitants of Gibeon heard what Joshua had done to Jericho and to Ai, 
+<sup>4&#160;</sup>they also resorted to a ruse, and went and made as if they had been ambassadors, and took old sacks on their donkeys, and old, torn-up and bound up wine skins, 
+<sup>5&#160;</sup>and old and patched sandals on their feet, and wore old garments. All the bread of their food supply was dry and moldy. 
+<sup>6&#160;</sup>They went to Joshua at the camp at Gilgal, and said to him and to the men of Israel, “We have come from a far country. Now therefore make a covenant with us.” 
+</div><div class="p">
+<sup>7&#160;</sup>The men of Israel said to the Hivites, “What if you live among us? How could we make a covenant with you?” 
+</div><div class="p">
+<sup>8&#160;</sup>They said to Joshua, “We are your servants.” 
+</div><div class="p">Joshua said to them, “Who are you? Where do you come from?” 
+</div><div class="p">
+<sup>9&#160;</sup>They said to him, “Your servants have come from a very far country because of the name of Yahweh your Elohim; for we have heard of his fame, all that he did in Egypt, 
+<sup>10&#160;</sup>and all that he did to the two kings of the Amorites who were beyond the Jordan, to Sihon king of Heshbon and to Og king of Bashan, who was at Ashtaroth. 
+<sup>11&#160;</sup>Our elders and all the inhabitants of our country spoke to us, saying, ‘Take supplies in your hand for the journey, and go to meet them. Tell them, “We are your servants. Now make a covenant with us.”&#160;’ 
+<sup>12&#160;</sup>This our bread we took hot for our supplies out of our houses on the day we went out to go to you; but now, behold, it is dry, and has become moldy. 
+<sup>13&#160;</sup>These wine skins, which we filled, were new; and behold, they are torn. These our garments and our sandals have become old because of the very long journey.” 
+</div><div class="p">
+<sup>14&#160;</sup>The men sampled their provisions, and didn’t ask counsel from Yahweh’s mouth. 
+<sup>15&#160;</sup>Joshua made peace with them, and made a covenant with them, to let them live. The princes of the congregation swore to them. 
+<sup>16&#160;</sup>At the end of three days after they had made a covenant with them, they heard that they were their neighbors, and that they lived among them. 
+<sup>17&#160;</sup>The children of Israel traveled and came to their cities on the third day. Now their cities were Gibeon, Chephirah, Beeroth, and Kiriath Jearim. 
+<sup>18&#160;</sup>The children of Israel didn’t strike them, because the princes of the congregation had sworn to them by Yahweh, the Elohim of Israel. All the congregation murmured against the princes. 
+<sup>19&#160;</sup>But all the princes said to all the congregation, “We have sworn to them by Yahweh, the Elohim of Israel. Now therefore we may not touch them. 
+<sup>20&#160;</sup>We will do this to them, and let them live; lest wrath be on us, because of the oath which we swore to them.” 
+<sup>21&#160;</sup>The princes said to them, “Let them live.” So they became wood cutters and drawers of water for all the congregation, as the princes had spoken to them. 
+</div><div class="p">
+<sup>22&#160;</sup>Joshua called for them, and he spoke to them, saying, “Why have you deceived us, saying, ‘We are very far from you,’ when you live among us? 
+<sup>23&#160;</sup>Now therefore you are cursed, and some of you will never fail to be slaves, both wood cutters and drawers of water for the house of my Elohim.” 
+</div><div class="p">
+<sup>24&#160;</sup>They answered Joshua, and said, “Because your servants were certainly told how Yahweh your Elohim commanded his servant Moses to give you all the land, and to destroy all the inhabitants of the land from before you. Therefore we were very afraid for our lives because of you, and have done this thing. 
+<sup>25&#160;</sup>Now, behold, we are in your hand. Do to us as it seems good and right to you to do.” 
+</div><div class="p">
+<sup>26&#160;</sup>He did so to them, and delivered them out of the hand of the children of Israel, so that they didn’t kill them. 
+<sup>27&#160;</sup>That day Joshua made them wood cutters and drawers of water for the congregation and for Yahweh’s altar to this day, in the place which he should choose. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when Adoni-Zedek king of Jerusalem heard how Joshua had taken Ai, and had utterly destroyed it; as he had done to Jericho and her king, so he had done to Ai and her king; and how the inhabitants of Gibeon had made peace with Israel, and were among them, 
+<sup>2&#160;</sup>they were very afraid, because Gibeon was a great city, as one of the royal cities, and because it was greater than Ai, and all its men were mighty. 
+<sup>3&#160;</sup>Therefore Adoni-Zedek king of Jerusalem sent to Hoham king of Hebron, Piram king of Jarmuth, Japhia king of Lachish, and Debir king of Eglon, saying, 
+<sup>4&#160;</sup>“Come up to me and help me. Let’s strike Gibeon; for they have made peace with Joshua and with the children of Israel.” 
+<sup>5&#160;</sup>Therefore the five kings of the Amorites, the king of Jerusalem, the king of Hebron, the king of Jarmuth, the king of Lachish, and the king of Eglon, gathered themselves together and went up, they and all their armies, and encamped against Gibeon, and made war against it. 
+<sup>6&#160;</sup>The men of Gibeon sent to Joshua at the camp at Gilgal, saying, “Don’t abandon your servants! Come up to us quickly and save us! Help us; for all the kings of the Amorites that dwell in the hill country have gathered together against us.” 
+</div><div class="p">
+<sup>7&#160;</sup>So Joshua went up from Gilgal, he and the whole army with him, including all the mighty men of valor. 
+<sup>8&#160;</sup>Yahweh said to Joshua, “Don’t fear them, for I have delivered them into your hands. Not a man of them will stand before you.” 
+</div><div class="p">
+<sup>9&#160;</sup>Joshua therefore came to them suddenly. He marched from Gilgal all night. 
+<sup>10&#160;</sup>Yahweh confused them before Israel. He killed them with a great slaughter at Gibeon, and chased them by the way of the ascent of Beth Horon, and struck them to Azekah and to Makkedah. 
+<sup>11&#160;</sup>As they fled from before Israel, while they were at the descent of Beth Horon, Yahweh hurled down great stones from the sky on them to Azekah, and they died. There were more who died from the hailstones than those whom the children of Israel killed with the sword. 
+</div><div class="p">
+<sup>12&#160;</sup>Then Joshua spoke to Yahweh in the day when Yahweh delivered up the Amorites before the children of Israel. He said in the sight of Israel, “Sun, stand still on Gibeon! You, moon, stop in the valley of Aijalon!” 
+</div><div class="p">
+<sup>13&#160;</sup>The sun stood still, and the moon stayed, until the nation had avenged themselves of their enemies. Isn’t this written in the book of Jashar? The sun stayed in the middle of the sky, and didn’t hurry to go down about a whole day. 
+<sup>14&#160;</sup>There was no day like that before it or after it, that Yahweh listened to the voice of a man; for Yahweh fought for Israel. 
+</div><div class="p">
+<sup>15&#160;</sup>Joshua returned, and all Israel with him, to the camp to Gilgal. 
+<sup>16&#160;</sup>These five kings fled, and hid themselves in the cave at Makkedah. 
+<sup>17&#160;</sup>Joshua was told, saying, “The five kings have been found, hidden in the cave at Makkedah.” 
+</div><div class="p">
+<sup>18&#160;</sup>Joshua said, “Roll large stones to cover the cave’s entrance, and set men by it to guard them; 
+<sup>19&#160;</sup>but don’t stay there. Pursue your enemies, and attack them from the rear. Don’t allow them to enter into their cities; for Yahweh your Elohim has delivered them into your hand.” 
+</div><div class="p">
+<sup>20&#160;</sup>When Joshua and the children of Israel had finished killing them with a very great slaughter until they were consumed, and the remnant which remained of them had entered into the fortified cities, 
+<sup>21&#160;</sup>all the people returned to the camp to Joshua at Makkedah in peace. None moved his tongue against any of the children of Israel. 
+<sup>22&#160;</sup>Then Joshua said, “Open the cave entrance, and bring those five kings out of the cave to me.” 
+</div><div class="p">
+<sup>23&#160;</sup>They did so, and brought those five kings out of the cave to him: the king of Jerusalem, the king of Hebron, the king of Jarmuth, the king of Lachish, and the king of Eglon. 
+<sup>24&#160;</sup>When they brought those kings out to Joshua, Joshua called for all the men of Israel, and said to the chiefs of the men of war who went with him, “Come near. Put your feet on the necks of these kings.” 
+</div><div class="p">They came near, and put their feet on their necks. 
+</div><div class="p">
+<sup>25&#160;</sup>Joshua said to them, “Don’t be afraid, nor be dismayed. Be strong and courageous, for Yahweh will do this to all your enemies against whom you fight.” 
+</div><div class="p">
+<sup>26&#160;</sup>Afterward Joshua struck them, put them to death, and hanged them on five trees. They were hanging on the trees until the evening. 
+<sup>27&#160;</sup>At the time of the going down of the sun, Joshua commanded, and they took them down off the trees, and threw them into the cave in which they had hidden themselves, and laid great stones on the mouth of the cave, which remain to this very day. 
+</div><div class="p">
+<sup>28&#160;</sup>Joshua took Makkedah on that day, and struck it with the edge of the sword, with its king. He utterly destroyed it and all the souls who were in it. He left no one remaining. He did to the king of Makkedah as he had done to the king of Jericho. 
+</div><div class="p">
+<sup>29&#160;</sup>Joshua passed from Makkedah, and all Israel with him, to Libnah, and fought against Libnah. 
+<sup>30&#160;</sup>Yahweh delivered it also, with its king, into the hand of Israel. He struck it with the edge of the sword, and all the souls who were in it. He left no one remaining in it. He did to its king as he had done to the king of Jericho. 
+</div><div class="p">
+<sup>31&#160;</sup>Joshua passed from Libnah, and all Israel with him, to Lachish, and encamped against it, and fought against it. 
+<sup>32&#160;</sup>Yahweh delivered Lachish into the hand of Israel. He took it on the second day, and struck it with the edge of the sword, with all the souls who were in it, according to all that he had done to Libnah. 
+<sup>33&#160;</sup>Then Horam king of Gezer came up to help Lachish; and Joshua struck him and his people, until he had left him no one remaining. 
+</div><div class="p">
+<sup>34&#160;</sup>Joshua passed from Lachish, and all Israel with him, to Eglon; and they encamped against it and fought against it. 
+<sup>35&#160;</sup>They took it on that day, and struck it with the edge of the sword. He utterly destroyed all the souls who were in it that day, according to all that he had done to Lachish. 
+</div><div class="p">
+<sup>36&#160;</sup>Joshua went up from Eglon, and all Israel with him, to Hebron; and they fought against it. 
+<sup>37&#160;</sup>They took it, and struck it with the edge of the sword, with its king and all its cities, and all the souls who were in it. He left no one remaining, according to all that he had done to Eglon; but he utterly destroyed it, and all the souls who were in it. 
+</div><div class="p">
+<sup>38&#160;</sup>Joshua returned, and all Israel with him, to Debir, and fought against it. 
+<sup>39&#160;</sup>He took it, with its king and all its cities. They struck them with the edge of the sword, and utterly destroyed all the souls who were in it. He left no one remaining. As he had done to Hebron, so he did to Debir, and to its king; as he had done also to Libnah, and to its king. 
+<sup>40&#160;</sup>So Joshua struck all the land, the hill country, the South, the lowland, the slopes, and all their kings. He left no one remaining, but he utterly destroyed all that breathed, as Yahweh, the Elohim of Israel, commanded. 
+<sup>41&#160;</sup>Joshua struck them from Kadesh Barnea even to Gaza, and all the country of Goshen, even to Gibeon. 
+<sup>42&#160;</sup>Joshua took all these kings and their land at one time because Yahweh, the Elohim of Israel, fought for Israel. 
+<sup>43&#160;</sup>Joshua returned, and all Israel with him, to the camp to Gilgal. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>When Jabin king of Hazor heard of it, he sent to Jobab king of Madon, to the king of Shimron, to the king of Achshaph, 
+<sup>2&#160;</sup>and to the kings who were on the north, in the hill country, in the Arabah south of Chinneroth, in the lowland, and in the heights of Dor on the west, 
+<sup>3&#160;</sup>to the Canaanite on the east and on the west, the Amorite, the Hittite, the Perizzite, the Jebusite in the hill country, and the Hivite under Hermon in the land of Mizpah. 
+<sup>4&#160;</sup>They went out, they and all their armies with them, many people, even as the sand that is on the seashore in multitude, with very many horses and chariots. 
+<sup>5&#160;</sup>All these kings met together; and they came and encamped together at the waters of Merom, to fight with Israel. 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh said to Joshua, “Don’t be afraid because of them; for tomorrow at this time, I will deliver them up all slain before Israel. You shall hamstring their horses and burn their chariots with fire.” 
+</div><div class="p">
+<sup>7&#160;</sup>So Joshua came suddenly, with all the warriors, against them by the waters of Merom, and attacked them. 
+<sup>8&#160;</sup>Yahweh delivered them into the hand of Israel, and they struck them, and chased them to great Sidon, and to Misrephoth Maim, and to the valley of Mizpah eastward. They struck them until they left them no one remaining. 
+<sup>9&#160;</sup>Joshua did to them as Yahweh told him. He hamstrung their horses and burned their chariots with fire. 
+<sup>10&#160;</sup>Joshua turned back at that time, and took Hazor, and struck its king with the sword; for Hazor used to be the head of all those kingdoms. 
+<sup>11&#160;</sup>They struck all the souls who were in it with the edge of the sword, utterly destroying them. There was no one left who breathed. He burned Hazor with fire. 
+<sup>12&#160;</sup>Joshua captured all the cities of those kings, with their kings, and he struck them with the edge of the sword, and utterly destroyed them, as Moses the servant of Yahweh commanded. 
+<sup>13&#160;</sup>But as for the cities that stood on their mounds, Israel burned none of them, except Hazor only. Joshua burned that. 
+<sup>14&#160;</sup>The children of Israel took all the plunder of these cities, with the livestock, as plunder for themselves; but every man they struck with the edge of the sword, until they had destroyed them. They didn’t leave any who breathed. 
+</div><div class="p">
+<sup>15&#160;</sup>As Yahweh commanded Moses his servant, so Moses commanded Joshua. Joshua did so. He left nothing undone of all that Yahweh commanded Moses. 
+<sup>16&#160;</sup>So Joshua captured all that land, the hill country, all the South, all the land of Goshen, the lowland, the Arabah, the hill country of Israel, and the lowland of the same, 
+<sup>17&#160;</sup>from Mount Halak, that goes up to Seir, even to Baal Gad in the valley of Lebanon under Mount Hermon. He took all their kings, struck them, and put them to death. 
+<sup>18&#160;</sup>Joshua made war a long time with all those kings. 
+<sup>19&#160;</sup>There was not a city that made peace with the children of Israel, except the Hivites, the inhabitants of Gibeon. They took all in battle. 
+<sup>20&#160;</sup>For it was of Yahweh to harden their hearts, to come against Israel in battle, that he might utterly destroy them, that they might have no favor, but that he might destroy them, as Yahweh commanded Moses. 
+<sup>21&#160;</sup>Joshua came at that time, and cut off the Anakim from the hill country, from Hebron, from Debir, from Anab, and from all the hill country of Judah, and from all the hill country of Israel. Joshua utterly destroyed them with their cities. 
+<sup>22&#160;</sup>There were none of the Anakim left in the land of the children of Israel. Only in Gaza, in Gath, and in Ashdod, did some remain. 
+<sup>23&#160;</sup>So Joshua took the whole land, according to all that Yahweh spoke to Moses; and Joshua gave it for an inheritance to Israel according to their divisions by their tribes. Then the land had rest from war. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the kings of the land, whom the children of Israel struck, and possessed their land beyond the Jordan toward the sunrise, from the valley of the Arnon to Mount Hermon, and all the Arabah eastward: 
+<sup>2&#160;</sup>Sihon king of the Amorites, who lived in Heshbon, and ruled from Aroer, which is on the edge of the valley of the Arnon, and the middle of the valley, and half Gilead, even to the river Jabbok, the border of the children of Ammon; 
+<sup>3&#160;</sup>and the Arabah to the sea of Chinneroth, eastward, and to the sea of the Arabah, even the Salt Sea, eastward, the way to Beth Jeshimoth; and on the south, under the slopes of Pisgah: 
+<sup>4&#160;</sup>and the border of Og king of Bashan, of the remnant of the Rephaim, who lived at Ashtaroth and at Edrei, 
+<sup>5&#160;</sup>and ruled in Mount Hermon, and in Salecah, and in all Bashan, to the border of the Geshurites and the Maacathites, and half Gilead, the border of Sihon king of Heshbon. 
+<sup>6&#160;</sup>Moses the servant of Yahweh and the children of Israel struck them. Moses the servant of Yahweh gave it for a possession to the Reubenites, and the Gadites, and the half-tribe of Manasseh. 
+</div><div class="p">
+<sup>7&#160;</sup>These are the kings of the land whom Joshua and the children of Israel struck beyond the Jordan westward, from Baal Gad in the valley of Lebanon even to Mount Halak, that goes up to Seir. Joshua gave it to the tribes of Israel for a possession according to their divisions; 
+<sup>8&#160;</sup>in the hill country, and in the lowland, and in the Arabah, and in the slopes, and in the wilderness, and in the South; the Hittite, the Amorite, and the Canaanite, the Perizzite, the Hivite, and the Jebusite: 
+</div><div class="m">
+<sup>9&#160;</sup>the king of Jericho, one; 
+</div><div class="m">the king of Ai, which is beside Bethel, one; 
+</div><div class="m">
+<sup>10&#160;</sup>the king of Jerusalem, one; 
+</div><div class="m">the king of Hebron, one; 
+</div><div class="m">
+<sup>11&#160;</sup>the king of Jarmuth, one; 
+</div><div class="m">the king of Lachish, one; 
+</div><div class="m">
+<sup>12&#160;</sup>the king of Eglon, one; 
+</div><div class="m">the king of Gezer, one; 
+</div><div class="m">
+<sup>13&#160;</sup>the king of Debir, one; 
+</div><div class="m">the king of Geder, one; 
+</div><div class="m">
+<sup>14&#160;</sup>the king of Hormah, one; 
+</div><div class="m">the king of Arad, one; 
+</div><div class="m">
+<sup>15&#160;</sup>the king of Libnah, one; 
+</div><div class="m">the king of Adullam, one; 
+</div><div class="m">
+<sup>16&#160;</sup>the king of Makkedah, one; 
+</div><div class="m">the king of Bethel, one; 
+</div><div class="m">
+<sup>17&#160;</sup>the king of Tappuah, one; 
+</div><div class="m">the king of Hepher, one; 
+</div><div class="m">
+<sup>18&#160;</sup>the king of Aphek, one; 
+</div><div class="m">the king of Lassharon, one; 
+</div><div class="m">
+<sup>19&#160;</sup>the king of Madon, one; 
+</div><div class="m">the king of Hazor, one; 
+</div><div class="m">
+<sup>20&#160;</sup>the king of Shimron Meron, one; 
+</div><div class="m">the king of Achshaph, one; 
+</div><div class="m">
+<sup>21&#160;</sup>the king of Taanach, one; 
+</div><div class="m">the king of Megiddo, one; 
+</div><div class="m">
+<sup>22&#160;</sup>the king of Kedesh, one; 
+</div><div class="m">the king of Jokneam in Carmel, one; 
+</div><div class="m">
+<sup>23&#160;</sup>the king of Dor in the height of Dor, one; 
+</div><div class="m">the king of Goiim in Gilgal, one; 
+</div><div class="m">
+<sup>24&#160;</sup>the king of Tirzah, one: 
+</div><div class="m">all the kings thirty-one. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Joshua was old and well advanced in years. Yahweh said to him, “You are old and advanced in years, and there remains yet very much land to be possessed. 
+</div><div class="p">
+<sup>2&#160;</sup>“This is the land that still remains: all the regions of the Philistines, and all the Geshurites; 
+<sup>3&#160;</sup>from the Shihor, which is before Egypt, even to the border of Ekron northward, which is counted as Canaanite; the five lords of the Philistines; the Gazites, and the Ashdodites, the Ashkelonites, the Gittites, and the Ekronites; also the Avvim, 
+<sup>4&#160;</sup>on the south; all the land of the Canaanites, and Mearah that belongs to the Sidonians, to Aphek, to the border of the Amorites; 
+<sup>5&#160;</sup>and the land of the Gebalites, and all Lebanon, toward the sunrise, from Baal Gad under Mount Hermon to the entrance of Hamath; 
+<sup>6&#160;</sup>all the inhabitants of the hill country from Lebanon to Misrephoth Maim, even all the Sidonians. I will drive them out from before the children of Israel. Just allocate it to Israel for an inheritance, as I have commanded you. 
+<sup>7&#160;</sup>Now therefore divide this land for an inheritance to the nine tribes and the half-tribe of Manasseh.” 
+<sup>8&#160;</sup>With him the Reubenites and the Gadites received their inheritance, which Moses gave them, beyond the Jordan eastward, even as Moses the servant of Yahweh gave them: 
+<sup>9&#160;</sup>from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain of Medeba to Dibon; 
+<sup>10&#160;</sup>and all the cities of Sihon king of the Amorites, who reigned in Heshbon, to the border of the children of Ammon; 
+<sup>11&#160;</sup>and Gilead, and the border of the Geshurites and Maacathites, and all Mount Hermon, and all Bashan to Salecah; 
+<sup>12&#160;</sup>all the kingdom of Og in Bashan, who reigned in Ashtaroth and in Edrei (who was left of the remnant of the Rephaim); for Moses attacked these, and drove them out. 
+<sup>13&#160;</sup>Nevertheless the children of Israel didn’t drive out the Geshurites, nor the Maacathites: but Geshur and Maacath live within Israel to this day. 
+<sup>14&#160;</sup>Only he gave no inheritance to the tribe of Levi. The offerings of Yahweh, the Elohim of Israel, made by fire are his inheritance, as he spoke to him. 
+<sup>15&#160;</sup>Moses gave to the tribe of the children of Reuben according to their families. 
+<sup>16&#160;</sup>Their border was from Aroer, that is on the edge of the valley of the Arnon, and the city that is in the middle of the valley, and all the plain by Medeba; 
+<sup>17&#160;</sup>Heshbon, and all its cities that are in the plain; Dibon, Bamoth Baal, Beth Baal Meon, 
+<sup>18&#160;</sup>Jahaz, Kedemoth, Mephaath, 
+<sup>19&#160;</sup>Kiriathaim, Sibmah, Zereth Shahar in the mount of the valley, 
+<sup>20&#160;</sup>Beth Peor, the slopes of Pisgah, Beth Jeshimoth, 
+<sup>21&#160;</sup>all the cities of the plain, and all the kingdom of Sihon king of the Amorites, who reigned in Heshbon, whom Moses struck with the chiefs of Midian, Evi, Rekem, Zur, Hur, and Reba, the princes of Sihon, who lived in the land. 
+<sup>22&#160;</sup>The children of Israel also killed Balaam the son of Beor, the soothsayer, with the sword, among the rest of their slain. 
+</div><div class="p">
+<sup>23&#160;</sup>The border of the children of Reuben was the bank of the Jordan. This was the inheritance of the children of Reuben according to their families, the cities and its villages. 
+</div><div class="p">
+<sup>24&#160;</sup>Moses gave to the tribe of Gad, to the children of Gad, according to their families. 
+<sup>25&#160;</sup>Their border was Jazer, and all the cities of Gilead, and half the land of the children of Ammon, to Aroer that is near Rabbah; 
+<sup>26&#160;</sup>and from Heshbon to Ramath Mizpeh, and Betonim; and from Mahanaim to the border of Debir; 
+<sup>27&#160;</sup>and in the valley, Beth Haram, Beth Nimrah, Succoth, and Zaphon, the rest of the kingdom of Sihon king of Heshbon, the Jordan’s bank, to the uttermost part of the sea of Chinnereth beyond the Jordan eastward. 
+<sup>28&#160;</sup>This is the inheritance of the children of Gad according to their families, the cities and its villages. 
+</div><div class="p">
+<sup>29&#160;</sup>Moses gave an inheritance to the half-tribe of Manasseh. It was for the half-tribe of the children of Manasseh according to their families. 
+<sup>30&#160;</sup>Their border was from Mahanaim, all Bashan, all the kingdom of Og king of Bashan, and all the villages of Jair, which are in Bashan, sixty cities. 
+<sup>31&#160;</sup>Half Gilead, Ashtaroth, and Edrei, the cities of the kingdom of Og in Bashan, were for the children of Machir the son of Manasseh, even for the half of the children of Machir according to their families. 
+</div><div class="p">
+<sup>32&#160;</sup>These are the inheritances which Moses distributed in the plains of Moab, beyond the Jordan at Jericho, eastward. 
+<sup>33&#160;</sup>But Moses gave no inheritance to the tribe of Levi. Yahweh, the Elohim of Israel, is their inheritance, as he spoke to them. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>These are the inheritances which the children of Israel took in the land of Canaan, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed to them, 
+<sup>2&#160;</sup>by the lot of their inheritance, as Yahweh commanded by Moses, for the nine tribes, and for the half-tribe. 
+<sup>3&#160;</sup>For Moses had given the inheritance of the two tribes and the half-tribe beyond the Jordan; but to the Levites he gave no inheritance among them. 
+<sup>4&#160;</sup>For the children of Joseph were two tribes, Manasseh and Ephraim. They gave no portion to the Levites in the land, except cities to dwell in, with their pasture lands for their livestock and for their property. 
+<sup>5&#160;</sup>The children of Israel did as Yahweh commanded Moses, and they divided the land. 
+</div><div class="p">
+<sup>6&#160;</sup>Then the children of Judah came near to Joshua in Gilgal. Caleb the son of Jephunneh the Kenizzite said to him, “You know the thing that Yahweh spoke to Moses the man of Elohim concerning me and concerning you in Kadesh Barnea. 
+<sup>7&#160;</sup>I was forty years old when Moses the servant of Yahweh sent me from Kadesh Barnea to spy out the land. I brought him word again as it was in my heart. 
+<sup>8&#160;</sup>Nevertheless, my brothers who went up with me made the heart of the people melt; but I wholly followed Yahweh my Elohim. 
+<sup>9&#160;</sup>Moses swore on that day, saying, ‘Surely the land where you walked shall be an inheritance to you and to your children forever, because you have wholly followed Yahweh my Elohim.’ 
+</div><div class="p">
+<sup>10&#160;</sup>“Now, behold, Yahweh has kept me alive, as he spoke, these forty-five years, from the time that Yahweh spoke this word to Moses, while Israel walked in the wilderness. Now, behold, I am eighty-five years old, today. 
+<sup>11&#160;</sup>As yet I am as strong today as I was in the day that Moses sent me. As my strength was then, even so is my strength now for war, to go out and to come in. 
+<sup>12&#160;</sup>Now therefore give me this hill country, of which Yahweh spoke in that day; for you heard in that day how the Anakim were there, and great and fortified cities. It may be that Yahweh will be with me, and I shall drive them out, as Yahweh said.” 
+</div><div class="p">
+<sup>13&#160;</sup>Joshua blessed him; and he gave Hebron to Caleb the son of Jephunneh for an inheritance. 
+<sup>14&#160;</sup>Therefore Hebron became the inheritance of Caleb the son of Jephunneh the Kenizzite to this day, because he followed Yahweh, the Elohim of Israel wholeheartedly. 
+<sup>15&#160;</sup>Now the name of Hebron before was Kiriath Arba, after the greatest man among the Anakim. Then the land had rest from war. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>The lot for the tribe of the children of Judah according to their families was to the border of Edom, even to the wilderness of Zin southward, at the uttermost part of the south. 
+<sup>2&#160;</sup>Their south border was from the uttermost part of the Salt Sea, from the bay that looks southward; 
+<sup>3&#160;</sup>and it went out southward of the ascent of Akrabbim, and passed along to Zin, and went up by the south of Kadesh Barnea, and passed along by Hezron, went up to Addar, and turned toward Karka; 
+<sup>4&#160;</sup>and it passed along to Azmon, went out at the brook of Egypt; and the border ended at the sea. This shall be your south border. 
+<sup>5&#160;</sup>The east border was the Salt Sea, even to the end of the Jordan. The border of the north quarter was from the bay of the sea at the end of the Jordan. 
+<sup>6&#160;</sup>The border went up to Beth Hoglah, and passed along by the north of Beth Arabah; and the border went up to the stone of Bohan the son of Reuben. 
+<sup>7&#160;</sup>The border went up to Debir from the valley of Achor, and so northward, looking toward Gilgal, that faces the ascent of Adummim, which is on the south side of the river. The border passed along to the waters of En Shemesh, and ended at En Rogel. 
+<sup>8&#160;</sup>The border went up by the valley of the son of Hinnom to the side of the Jebusite (also called Jerusalem) southward; and the border went up to the top of the mountain that lies before the valley of Hinnom westward, which is at the farthest part of the valley of Rephaim northward. 
+<sup>9&#160;</sup>The border extended from the top of the mountain to the spring of the waters of Nephtoah, and went out to the cities of Mount Ephron; and the border extended to Baalah (also called Kiriath Jearim); 
+<sup>10&#160;</sup>and the border turned about from Baalah westward to Mount Seir, and passed along to the side of Mount Jearim (also called Chesalon) on the north, and went down to Beth Shemesh, and passed along by Timnah; 
+<sup>11&#160;</sup>and the border went out to the side of Ekron northward; and the border extended to Shikkeron, and passed along to Mount Baalah, and went out at Jabneel; and the goings out of the border were at the sea. 
+<sup>12&#160;</sup>The west border was to the shore of the great sea. This is the border of the children of Judah according to their families. 
+</div><div class="p">
+<sup>13&#160;</sup>He gave to Caleb the son of Jephunneh a portion among the children of Judah, according to the commandment of Yahweh to Joshua, even Kiriath Arba, named after the father of Anak (also called Hebron). 
+<sup>14&#160;</sup>Caleb drove out the three sons of Anak: Sheshai, and Ahiman, and Talmai, the children of Anak. 
+<sup>15&#160;</sup>He went up against the inhabitants of Debir: now the name of Debir before was Kiriath Sepher. 
+<sup>16&#160;</sup>Caleb said, “He who strikes Kiriath Sepher, and takes it, to him I will give Achsah my daughter as woman.” 
+<sup>17&#160;</sup>Othniel the son of Kenaz, the brother of Caleb, took it: and he gave him Achsah his daughter as woman. 
+<sup>18&#160;</sup>When she came, she had him ask her father for a field. She got off her donkey, and Caleb said, “What do you want?” 
+</div><div class="p">
+<sup>19&#160;</sup>She said, “Give me a blessing. Because you have set me in the land of the South, give me also springs of water.” 
+</div><div class="p">So he gave her the upper springs and the lower springs. 
+</div><div class="p">
+<sup>20&#160;</sup>This is the inheritance of the tribe of the children of Judah according to their families. 
+<sup>21&#160;</sup>The farthest cities of the tribe of the children of Judah toward the border of Edom in the South were Kabzeel, Eder, Jagur, 
+<sup>22&#160;</sup>Kinah, Dimonah, Adadah, 
+<sup>23&#160;</sup>Kedesh, Hazor, Ithnan, 
+<sup>24&#160;</sup>Ziph, Telem, Bealoth, 
+<sup>25&#160;</sup>Hazor Hadattah, Kerioth Hezron (also called Hazor), 
+<sup>26&#160;</sup>Amam, Shema, Moladah, 
+<sup>27&#160;</sup>Hazar Gaddah, Heshmon, Beth Pelet, 
+<sup>28&#160;</sup>Hazar Shual, Beersheba, Biziothiah, 
+<sup>29&#160;</sup>Baalah, Iim, Ezem, 
+<sup>30&#160;</sup>Eltolad, Chesil, Hormah, 
+<sup>31&#160;</sup>Ziklag, Madmannah, Sansannah, 
+<sup>32&#160;</sup>Lebaoth, Shilhim, Ain, and Rimmon. All the cities are twenty-nine, with their villages. 
+</div><div class="m">
+<sup>33&#160;</sup>In the lowland, Eshtaol, Zorah, Ashnah, 
+<sup>34&#160;</sup>Zanoah, En Gannim, Tappuah, Enam, 
+<sup>35&#160;</sup>Jarmuth, Adullam, Socoh, Azekah, 
+<sup>36&#160;</sup>Shaaraim, Adithaim and Gederah (or Gederothaim); fourteen cities with their villages. 
+</div><div class="m">
+<sup>37&#160;</sup>Zenan, Hadashah, Migdal Gad, 
+<sup>38&#160;</sup>Dilean, Mizpah, Joktheel, 
+<sup>39&#160;</sup>Lachish, Bozkath, Eglon, 
+<sup>40&#160;</sup>Cabbon, Lahmam, Chitlish, 
+<sup>41&#160;</sup>Gederoth, Beth Dagon, Naamah, and Makkedah; sixteen cities with their villages. 
+</div><div class="m">
+<sup>42&#160;</sup>Libnah, Ether, Ashan, 
+<sup>43&#160;</sup>Iphtah, Ashnah, Nezib, 
+<sup>44&#160;</sup>Keilah, Achzib, and Mareshah; nine cities with their villages. 
+</div><div class="m">
+<sup>45&#160;</sup>Ekron, with its towns and its villages; 
+<sup>46&#160;</sup>from Ekron even to the sea, all that were by the side of Ashdod, with their villages. 
+<sup>47&#160;</sup>Ashdod, its towns and its villages; Gaza, its towns and its villages; to the brook of Egypt, and the great sea with its coastline. 
+</div><div class="m">
+<sup>48&#160;</sup>In the hill country, Shamir, Jattir, Socoh, 
+<sup>49&#160;</sup>Dannah, Kiriath Sannah (which is Debir), 
+<sup>50&#160;</sup>Anab, Eshtemoh, Anim, 
+<sup>51&#160;</sup>Goshen, Holon, and Giloh; eleven cities with their villages. 
+</div><div class="m">
+<sup>52&#160;</sup>Arab, Dumah, Eshan, 
+<sup>53&#160;</sup>Janim, Beth Tappuah, Aphekah, 
+<sup>54&#160;</sup>Humtah, Kiriath Arba (also called Hebron), and Zior; nine cities with their villages. 
+</div><div class="m">
+<sup>55&#160;</sup>Maon, Carmel, Ziph, Jutah, 
+<sup>56&#160;</sup>Jezreel, Jokdeam, Zanoah, 
+<sup>57&#160;</sup>Kain, Gibeah, and Timnah; ten cities with their villages. 
+</div><div class="m">
+<sup>58&#160;</sup>Halhul, Beth Zur, Gedor, 
+<sup>59&#160;</sup>Maarath, Beth Anoth, and Eltekon; six cities with their villages. 
+<sup>60&#160;</sup>Kiriath Baal (also called Kiriath Jearim), and Rabbah; two cities with their villages. 
+</div><div class="m">
+<sup>61&#160;</sup>In the wilderness, Beth Arabah, Middin, Secacah, 
+<sup>62&#160;</sup>Nibshan, the City of Salt, and En Gedi; six cities with their villages. 
+</div><div class="p">
+<sup>63&#160;</sup>As for the Jebusites, the inhabitants of Jerusalem, the children of Judah couldn’t drive them out; but the Jebusites live with the children of Judah at Jerusalem to this day. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>The lot came out for the children of Joseph from the Jordan at Jericho, at the waters of Jericho on the east, even the wilderness, going up from Jericho through the hill country to Bethel. 
+<sup>2&#160;</sup>It went out from Bethel to Luz, and passed along to the border of the Archites to Ataroth; 
+<sup>3&#160;</sup>and it went down westward to the border of the Japhletites, to the border of Beth Horon the lower, and on to Gezer; and ended at the sea. 
+</div><div class="p">
+<sup>4&#160;</sup>The children of Joseph, Manasseh and Ephraim, took their inheritance. 
+<sup>5&#160;</sup>This was the border of the children of Ephraim according to their families. The border of their inheritance eastward was Ataroth Addar, to Beth Horon the upper. 
+<sup>6&#160;</sup>The border went out westward at Michmethath on the north. The border turned about eastward to Taanath Shiloh, and passed along it on the east of Janoah. 
+<sup>7&#160;</sup>It went down from Janoah to Ataroth, to Naarah, reached to Jericho, and went out at the Jordan. 
+<sup>8&#160;</sup>From Tappuah the border went along westward to the brook of Kanah; and ended at the sea. This is the inheritance of the tribe of the children of Ephraim according to their families; 
+<sup>9&#160;</sup>together with the cities which were set apart for the children of Ephraim in the middle of the inheritance of the children of Manasseh, all the cities with their villages. 
+<sup>10&#160;</sup>They didn’t drive out the Canaanites who lived in Gezer; but the Canaanites dwell in the territory of Ephraim to this day, and have become servants to do forced labor. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>This was the lot for the tribe of Manasseh, for he was the firstborn of Joseph. As for Machir the firstborn of Manasseh, the father of Gilead, because he was a man of war, therefore he had Gilead and Bashan. 
+<sup>2&#160;</sup>So this was for the rest of the children of Manasseh according to their families: for the children of Abiezer, for the children of Helek, for the children of Asriel, for the children of Shechem, for the children of Hepher, and for the children of Shemida. These were the male children of Manasseh the son of Joseph according to their families. 
+<sup>3&#160;</sup>But Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, had no sons, but daughters. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
+<sup>4&#160;</sup>They came to Eleazar the priest, and to Joshua the son of Nun, and to the princes, saying, “Yahweh commanded Moses to give us an inheritance among our brothers.” Therefore according to the commandment of Yahweh he gave them an inheritance among the brothers of their father. 
+<sup>5&#160;</sup>Ten parts fell to Manasseh, in addition to the land of Gilead and Bashan, which is beyond the Jordan; 
+<sup>6&#160;</sup>because the daughters of Manasseh had an inheritance among his sons. The land of Gilead belonged to the rest of the sons of Manasseh. 
+<sup>7&#160;</sup>The border of Manasseh was from Asher to Michmethath, which is before Shechem. The border went along to the right hand, to the inhabitants of En Tappuah. 
+<sup>8&#160;</sup>The land of Tappuah belonged to Manasseh; but Tappuah on the border of Manasseh belonged to the children of Ephraim. 
+<sup>9&#160;</sup>The border went down to the brook of Kanah, southward of the brook. These cities belonged to Ephraim among the cities of Manasseh. The border of Manasseh was on the north side of the brook, and ended at the sea. 
+<sup>10&#160;</sup>Southward it was Ephraim’s, and northward it was Manasseh’s, and the sea was his border. They reached to Asher on the north, and to Issachar on the east. 
+<sup>11&#160;</sup>Manasseh had three heights in Issachar, in Asher Beth Shean and its towns, and Ibleam and its towns, and the inhabitants of Dor and its towns, and the inhabitants of Endor and its towns, and the inhabitants of Taanach and its towns, and the inhabitants of Megiddo and its towns. 
+<sup>12&#160;</sup>Yet the children of Manasseh couldn’t drive out the inhabitants of those cities; but the Canaanites would dwell in that land. 
+</div><div class="p">
+<sup>13&#160;</sup>When the children of Israel had grown strong, they put the Canaanites to forced labor, and didn’t utterly drive them out. 
+<sup>14&#160;</sup>The children of Joseph spoke to Joshua, saying, “Why have you given me just one lot and one part for an inheritance, since we are a numerous people, because Yahweh has blessed us so far?” 
+</div><div class="p">
+<sup>15&#160;</sup>Joshua said to them, “If you are a numerous people, go up to the forest, and clear land for yourself there in the land of the Perizzites and of the Rephaim, since the hill country of Ephraim is too narrow for you.” 
+</div><div class="p">
+<sup>16&#160;</sup>The children of Joseph said, “The hill country is not enough for us. All the Canaanites who dwell in the land of the valley have chariots of iron, both those who are in Beth Shean and its towns, and those who are in the valley of Jezreel.” 
+</div><div class="p">
+<sup>17&#160;</sup>Joshua spoke to the house of Joseph, that is, to Ephraim and to Manasseh, saying, “You are a numerous people, and have great power. You shall not have one lot only; 
+<sup>18&#160;</sup>but the hill country shall be yours. Although it is a forest, you shall cut it down, and it’s farthest extent shall be yours; for you shall drive out the Canaanites, though they have chariots of iron, and though they are strong.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>The whole congregation of the children of Israel assembled themselves together at Shiloh, and set up the Tent of Meeting there. The land was subdued before them. 
+<sup>2&#160;</sup>Seven tribes remained among the children of Israel, which had not yet divided their inheritance. 
+<sup>3&#160;</sup>Joshua said to the children of Israel, “How long will you neglect to go in to possess the land, which Yahweh, the Elohim of your fathers, has given you? 
+<sup>4&#160;</sup>Appoint for yourselves three men from each tribe. I will send them, and they shall arise, walk through the land, and describe it according to their inheritance; then they shall come to me. 
+<sup>5&#160;</sup>They shall divide it into seven portions. Judah shall live in his borders on the south, and the house of Joseph shall live in their borders on the north. 
+<sup>6&#160;</sup>You shall survey the land into seven parts, and bring the description here to me; and I will cast lots for you here before Yahweh our Elohim. 
+<sup>7&#160;</sup>However, the Levites have no portion among you; for the priesthood of Yahweh is their inheritance. Gad, Reuben, and the half-tribe of Manasseh have received their inheritance east of the Jordan, which Moses the servant of Yahweh gave them.” 
+</div><div class="p">
+<sup>8&#160;</sup>The men arose and went. Joshua commanded those who went to survey the land, saying, “Go walk through the land, survey it, and come again to me. I will cast lots for you here before Yahweh in Shiloh.” 
+</div><div class="p">
+<sup>9&#160;</sup>The men went and passed through the land, and surveyed it by cities into seven portions in a book. They came to Joshua to the camp at Shiloh. 
+<sup>10&#160;</sup>Joshua cast lots for them in Shiloh before Yahweh. There Joshua divided the land to the children of Israel according to their divisions. 
+</div><div class="p">
+<sup>11&#160;</sup>The lot of the tribe of the children of Benjamin came up according to their families. The border of their lot went out between the children of Judah and the children of Joseph. 
+<sup>12&#160;</sup>Their border on the north quarter was from the Jordan. The border went up to the side of Jericho on the north, and went up through the hill country westward. It ended at the wilderness of Beth Aven. 
+<sup>13&#160;</sup>The border passed along from there to Luz, to the side of Luz (also called Bethel), southward. The border went down to Ataroth Addar, by the mountain that lies on the south of Beth Horon the lower. 
+<sup>14&#160;</sup>The border extended, and turned around on the west quarter southward, from the mountain that lies before Beth Horon southward; and ended at Kiriath Baal (also called Kiriath Jearim), a city of the children of Judah. This was the west quarter. 
+<sup>15&#160;</sup>The south quarter was from the farthest part of Kiriath Jearim. The border went out westward, and went out to the spring of the waters of Nephtoah. 
+<sup>16&#160;</sup>The border went down to the farthest part of the mountain that lies before the valley of the son of Hinnom, which is in the valley of Rephaim northward. It went down to the valley of Hinnom, to the side of the Jebusite southward, and went down to En Rogel. 
+<sup>17&#160;</sup>It extended northward, went out at En Shemesh, and went out to Geliloth, which is opposite the ascent of Adummim. It went down to the stone of Bohan the son of Reuben. 
+<sup>18&#160;</sup>It passed along to the side opposite the Arabah northward, and went down to the Arabah. 
+<sup>19&#160;</sup>The border passed along to the side of Beth Hoglah northward; and the border ended at the north bay of the Salt Sea, at the south end of the Jordan. This was the south border. 
+<sup>20&#160;</sup>The Jordan was its border on the east quarter. This was the inheritance of the children of Benjamin, by the borders around it, according to their families. 
+<sup>21&#160;</sup>Now the cities of the tribe of the children of Benjamin according to their families were Jericho, Beth Hoglah, Emek Keziz, 
+<sup>22&#160;</sup>Beth Arabah, Zemaraim, Bethel, 
+<sup>23&#160;</sup>Avvim, Parah, Ophrah, 
+<sup>24&#160;</sup>Chephar Ammoni, Ophni, and Geba; twelve cities with their villages. 
+<sup>25&#160;</sup>Gibeon, Ramah, Beeroth, 
+<sup>26&#160;</sup>Mizpeh, Chephirah, Mozah, 
+<sup>27&#160;</sup>Rekem, Irpeel, Taralah, 
+<sup>28&#160;</sup>Zelah, Eleph, the Jebusite (also called Jerusalem), Gibeath, and Kiriath; fourteen cities with their villages. This is the inheritance of the children of Benjamin according to their families. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>The second lot came out for Simeon, even for the tribe of the children of Simeon according to their families. Their inheritance was in the middle of the inheritance of the children of Judah. 
+<sup>2&#160;</sup>They had for their inheritance Beersheba (or Sheba), Moladah, 
+<sup>3&#160;</sup>Hazar Shual, Balah, Ezem, 
+<sup>4&#160;</sup>Eltolad, Bethul, Hormah, 
+<sup>5&#160;</sup>Ziklag, Beth Marcaboth, Hazar Susah, 
+<sup>6&#160;</sup>Beth Lebaoth, and Sharuhen; thirteen cities with their villages; 
+<sup>7&#160;</sup>Ain, Rimmon, Ether, and Ashan; four cities with their villages; 
+<sup>8&#160;</sup>and all the villages that were around these cities to Baalath Beer, Ramah of the South. This is the inheritance of the tribe of the children of Simeon according to their families. 
+<sup>9&#160;</sup>Out of the part of the children of Judah was the inheritance of the children of Simeon; for the portion of the children of Judah was too much for them. Therefore the children of Simeon had inheritance in the middle of their inheritance. 
+</div><div class="p">
+<sup>10&#160;</sup>The third lot came up for the children of Zebulun according to their families. The border of their inheritance was to Sarid. 
+<sup>11&#160;</sup>Their border went up westward, even to Maralah, and reached to Dabbesheth. It reached to the brook that is before Jokneam. 
+<sup>12&#160;</sup>It turned from Sarid eastward toward the sunrise to the border of Chisloth Tabor. It went out to Daberath, and went up to Japhia. 
+<sup>13&#160;</sup>From there it passed along eastward to Gath Hepher, to Ethkazin; and it went out at Rimmon which stretches to Neah. 
+<sup>14&#160;</sup>The border turned around it on the north to Hannathon; and it ended at the valley of Iphtah El; 
+<sup>15&#160;</sup>Kattath, Nahalal, Shimron, Idalah, and Bethlehem: twelve cities with their villages. 
+<sup>16&#160;</sup>This is the inheritance of the children of Zebulun according to their families, these cities with their villages. 
+</div><div class="p">
+<sup>17&#160;</sup>The fourth lot came out for Issachar, even for the children of Issachar according to their families. 
+<sup>18&#160;</sup>Their border was to Jezreel, Chesulloth, Shunem, 
+<sup>19&#160;</sup>Hapharaim, Shion, Anaharath, 
+<sup>20&#160;</sup>Rabbith, Kishion, Ebez, 
+<sup>21&#160;</sup>Remeth, Engannim, En Haddah, and Beth Pazzez. 
+<sup>22&#160;</sup>The border reached to Tabor, Shahazumah, and Beth Shemesh. Their border ended at the Jordan: sixteen cities with their villages. 
+<sup>23&#160;</sup>This is the inheritance of the tribe of the children of Issachar according to their families, the cities with their villages. 
+</div><div class="p">
+<sup>24&#160;</sup>The fifth lot came out for the tribe of the children of Asher according to their families. 
+<sup>25&#160;</sup>Their border was Helkath, Hali, Beten, Achshaph, 
+<sup>26&#160;</sup>Allammelech, Amad, Mishal. It reached to Carmel westward, and to Shihorlibnath. 
+<sup>27&#160;</sup>It turned toward the sunrise to Beth Dagon, and reached to Zebulun, and to the valley of Iphtah El northward to Beth Emek and Neiel. It went out to Cabul on the left hand, 
+<sup>28&#160;</sup>and Ebron, Rehob, Hammon, and Kanah, even to great Sidon. 
+<sup>29&#160;</sup>The border turned to Ramah, to the fortified city of Tyre; and the border turned to Hosah. It ended at the sea by the region of Achzib; 
+<sup>30&#160;</sup>Ummah also, and Aphek, and Rehob: twenty-two cities with their villages. 
+<sup>31&#160;</sup>This is the inheritance of the tribe of the children of Asher according to their families, these cities with their villages. 
+</div><div class="p">
+<sup>32&#160;</sup>The sixth lot came out for the children of Naphtali, even for the children of Naphtali according to their families. 
+<sup>33&#160;</sup>Their border was from Heleph, from the oak in Zaanannim, Adami-nekeb, and Jabneel, to Lakkum. It ended at the Jordan. 
+<sup>34&#160;</sup>The border turned westward to Aznoth Tabor, and went out from there to Hukkok. It reached to Zebulun on the south, and reached to Asher on the west, and to Judah at the Jordan toward the sunrise. 
+<sup>35&#160;</sup>The fortified cities were Ziddim, Zer, Hammath, Rakkath, Chinnereth, 
+<sup>36&#160;</sup>Adamah, Ramah, Hazor, 
+<sup>37&#160;</sup>Kedesh, Edrei, En Hazor, 
+<sup>38&#160;</sup>Iron, Migdal El, Horem, Beth Anath, and Beth Shemesh; nineteen cities with their villages. 
+<sup>39&#160;</sup>This is the inheritance of the tribe of the children of Naphtali according to their families, the cities with their villages. 
+</div><div class="p">
+<sup>40&#160;</sup>The seventh lot came out for the tribe of the children of Dan according to their families. 
+<sup>41&#160;</sup>The border of their inheritance was Zorah, Eshtaol, Irshemesh, 
+<sup>42&#160;</sup>Shaalabbin, Aijalon, Ithlah, 
+<sup>43&#160;</sup>Elon, Timnah, Ekron, 
+<sup>44&#160;</sup>Eltekeh, Gibbethon, Baalath, 
+<sup>45&#160;</sup>Jehud, Bene Berak, Gath Rimmon, 
+<sup>46&#160;</sup>Me Jarkon, and Rakkon, with the border opposite Joppa. 
+<sup>47&#160;</sup>The border of the children of Dan went out beyond them; for the children of Dan went up and fought against Leshem, and took it, and struck it with the edge of the sword, and possessed it, and lived therein, and called Leshem, Dan, after the name of Dan their forefather. 
+<sup>48&#160;</sup>This is the inheritance of the tribe of the children of Dan according to their families, these cities with their villages. 
+</div><div class="p">
+<sup>49&#160;</sup>So they finished distributing the land for inheritance by its borders. The children of Israel gave an inheritance to Joshua the son of Nun among them. 
+<sup>50&#160;</sup>According to Yahweh’s commandment, they gave him the city which he asked, even Timnathserah in the hill country of Ephraim; and he built the city, and lived there. 
+<sup>51&#160;</sup>These are the inheritances, which Eleazar the priest, Joshua the son of Nun, and the heads of the fathers’ houses of the tribes of the children of Israel, distributed for inheritance by lot in Shiloh before Yahweh, at the door of the Tent of Meeting. So they finished dividing the land. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Joshua, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘Assign the cities of refuge, of which I spoke to you by Moses, 
+<sup>3&#160;</sup>that the man slayer who kills any person accidentally or unintentionally may flee there. They shall be to you for a refuge from the avenger of blood. 
+<sup>4&#160;</sup>He shall flee to one of those cities, and shall stand at the entrance of the gate of the city, and declare his case in the ears of the elders of that city. They shall take him into the city with them, and give him a place, that he may live among them. 
+<sup>5&#160;</sup>If the avenger of blood pursues him, then they shall not deliver up the man slayer into his hand; because he struck his neighbor unintentionally, and didn’t hate him before. 
+<sup>6&#160;</sup>He shall dwell in that city until he stands before the congregation for judgment, until the death of the high priest that shall be in those days. Then the man slayer shall return, and come to his own city, and to his own house, to the city he fled from.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>They set apart Kedesh in Galilee in the hill country of Naphtali, Shechem in the hill country of Ephraim, and Kiriath Arba (also called Hebron) in the hill country of Judah. 
+<sup>8&#160;</sup>Beyond the Jordan at Jericho eastward, they assigned Bezer in the wilderness in the plain out of the tribe of Reuben, Ramoth in Gilead out of the tribe of Gad, and Golan in Bashan out of the tribe of Manasseh. 
+<sup>9&#160;</sup>These were the appointed cities for all the children of Israel, and for the alien who lives among them, that whoever kills any person unintentionally might flee there, and not die by the hand of the avenger of blood, until he stands trial before the congregation. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Then the heads of fathers’ houses of the Levites came near to Eleazar the priest, and to Joshua the son of Nun, and to the heads of fathers’ houses of the tribes of the children of Israel. 
+<sup>2&#160;</sup>They spoke to them at Shiloh in the land of Canaan, saying, “Yahweh commanded through Moses to give us cities to dwell in, with their pasture lands for our livestock.” 
+</div><div class="p">
+<sup>3&#160;</sup>The children of Israel gave to the Levites out of their inheritance, according to the commandment of Yahweh, these cities with their pasture lands. 
+<sup>4&#160;</sup>The lot came out for the families of the Kohathites. The children of Aaron the priest, who were of the Levites, had thirteen cities by lot out of the tribe of Judah, out of the tribe of the Simeonites, and out of the tribe of Benjamin. 
+<sup>5&#160;</sup>The rest of the children of Kohath had ten cities by lot out of the families of the tribe of Ephraim, out of the tribe of Dan, and out of the half-tribe of Manasseh. 
+<sup>6&#160;</sup>The children of Gershon had thirteen cities by lot out of the families of the tribe of Issachar, out of the tribe of Asher, out of the tribe of Naphtali, and out of the half-tribe of Manasseh in Bashan. 
+<sup>7&#160;</sup>The children of Merari according to their families had twelve cities out of the tribe of Reuben, out of the tribe of Gad, and out of the tribe of Zebulun. 
+<sup>8&#160;</sup>The children of Israel gave these cities with their pasture lands by lot to the Levites, as Yahweh commanded by Moses. 
+<sup>9&#160;</sup>They gave out of the tribe of the children of Judah, and out of the tribe of the children of Simeon, these cities which are mentioned by name: 
+<sup>10&#160;</sup>and they were for the children of Aaron, of the families of the Kohathites, who were of the children of Levi; for theirs was the first lot. 
+<sup>11&#160;</sup>They gave them Kiriath Arba, named after the father of Anak (also called Hebron), in the hill country of Judah, with its pasture lands around it. 
+<sup>12&#160;</sup>But they gave the fields of the city and its villages to Caleb the son of Jephunneh for his possession. 
+<sup>13&#160;</sup>To the children of Aaron the priest they gave Hebron with its pasture lands, the city of refuge for the man slayer, Libnah with its pasture lands, 
+<sup>14&#160;</sup>Jattir with its pasture lands, Eshtemoa with its pasture lands, 
+<sup>15&#160;</sup>Holon with its pasture lands, Debir with its pasture lands, 
+<sup>16&#160;</sup>Ain with its pasture lands, Juttah with its pasture lands, and Beth Shemesh with its pasture lands: nine cities out of those two tribes. 
+<sup>17&#160;</sup>Out of the tribe of Benjamin, Gibeon with its pasture lands, Geba with its pasture lands, 
+<sup>18&#160;</sup>Anathoth with its pasture lands, and Almon with its pasture lands: four cities. 
+<sup>19&#160;</sup>All the cities of the children of Aaron, the priests, were thirteen cities with their pasture lands. 
+</div><div class="p">
+<sup>20&#160;</sup>The families of the children of Kohath, the Levites, even the rest of the children of Kohath, had the cities of their lot out of the tribe of Ephraim. 
+<sup>21&#160;</sup>They gave them Shechem with its pasture lands in the hill country of Ephraim, the city of refuge for the man slayer, and Gezer with its pasture lands, 
+<sup>22&#160;</sup>Kibzaim with its pasture lands, and Beth Horon with its pasture lands: four cities. 
+<sup>23&#160;</sup>Out of the tribe of Dan, Elteke with its pasture lands, Gibbethon with its pasture lands, 
+<sup>24&#160;</sup>Aijalon with its pasture lands, Gath Rimmon with its pasture lands: four cities. 
+<sup>25&#160;</sup>Out of the half-tribe of Manasseh, Taanach with its pasture lands, and Gath Rimmon with its pasture lands: two cities. 
+<sup>26&#160;</sup>All the cities of the families of the rest of the children of Kohath were ten with their pasture lands. 
+</div><div class="p">
+<sup>27&#160;</sup>They gave to the children of Gershon, of the families of the Levites, out of the half-tribe of Manasseh Golan in Bashan with its pasture lands, the city of refuge for the man slayer, and Be Eshterah with its pasture lands: two cities. 
+<sup>28&#160;</sup>Out of the tribe of Issachar, Kishion with its pasture lands, Daberath with its pasture lands, 
+<sup>29&#160;</sup>Jarmuth with its pasture lands, En Gannim with its pasture lands: four cities. 
+<sup>30&#160;</sup>Out of the tribe of Asher, Mishal with its pasture lands, Abdon with its pasture lands, 
+<sup>31&#160;</sup>Helkath with its pasture lands, and Rehob with its pasture lands: four cities. 
+<sup>32&#160;</sup>Out of the tribe of Naphtali, Kedesh in Galilee with its pasture lands, the city of refuge for the man slayer, Hammothdor with its pasture lands, and Kartan with its pasture lands: three cities. 
+<sup>33&#160;</sup>All the cities of the Gershonites according to their families were thirteen cities with their pasture lands. 
+</div><div class="p">
+<sup>34&#160;</sup>To the families of the children of Merari, the rest of the Levites, out of the tribe of Zebulun, Jokneam with its pasture lands, Kartah with its pasture lands, 
+<sup>35&#160;</sup>Dimnah with its pasture lands, and Nahalal with its pasture lands: four cities. 
+<sup>36&#160;</sup>Out of the tribe of Reuben, Bezer with its pasture lands, Jahaz with its pasture lands, 
+<sup>37&#160;</sup>Kedemoth with its pasture lands, and Mephaath with its pasture lands: four cities. 
+<sup>38&#160;</sup>Out of the tribe of Gad, Ramoth in Gilead with its pasture lands, the city of refuge for the man slayer, and Mahanaim with its pasture lands, 
+<sup>39&#160;</sup>Heshbon with its pasture lands, Jazer with its pasture lands: four cities in all. 
+<sup>40&#160;</sup>All these were the cities of the children of Merari according to their families, even the rest of the families of the Levites. Their lot was twelve cities. 
+</div><div class="p">
+<sup>41&#160;</sup>All the cities of the Levites among the possessions of the children of Israel were forty-eight cities with their pasture lands. 
+<sup>42&#160;</sup>Each of these cities included their pasture lands around them. It was this way with all these cities. 
+</div><div class="p">
+<sup>43&#160;</sup>So Yahweh gave to Israel all the land which he swore to give to their fathers. They possessed it, and lived in it. 
+<sup>44&#160;</sup>Yahweh gave them rest all around, according to all that he swore to their fathers. Not a man of all their enemies stood before them. Yahweh delivered all their enemies into their hand. 
+<sup>45&#160;</sup>Nothing failed of any good thing which Yahweh had spoken to the house of Israel. All came to pass. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Joshua called the Reubenites, the Gadites, and the half-tribe of Manasseh, 
+<sup>2&#160;</sup>and said to them, “You have kept all that Moses the servant of Yahweh commanded you, and have listened to my voice in all that I commanded you. 
+<sup>3&#160;</sup>You have not left your brothers these many days to this day, but have performed the duty of the commandment of Yahweh your Elohim. 
+<sup>4&#160;</sup>Now Yahweh your Elohim has given rest to your brothers, as he spoke to them. Therefore now return and go to your tents, to the land of your possession, which Moses the servant of Yahweh gave you beyond the Jordan. 
+<sup>5&#160;</sup>Only take diligent heed to do the commandment and the law which Moses the servant of Yahweh commanded you, to love Yahweh your Elohim, to walk in all his ways, to keep his commandments, to hold fast to him, and to serve him with all your heart and with all your soul.” 
+</div><div class="p">
+<sup>6&#160;</sup>So Joshua blessed them, and sent them away; and they went to their tents. 
+<sup>7&#160;</sup>Now to the one half-tribe of Manasseh Moses had given inheritance in Bashan; but Joshua gave to the other half among their brothers beyond the Jordan westward. Moreover when Joshua sent them away to their tents, he blessed them, 
+<sup>8&#160;</sup>and spoke to them, saying, “Return with much wealth to your tents, with very much livestock, with silver, with gold, with bronze, with iron, and with very much clothing. Divide the plunder of your enemies with your brothers.” 
+</div><div class="p">
+<sup>9&#160;</sup>The children of Reuben and the children of Gad and the half-tribe of Manasseh returned, and departed from the children of Israel out of Shiloh, which is in the land of Canaan, to go to the land of Gilead, to the land of their possession, which they owned, according to the commandment of Yahweh by Moses. 
+<sup>10&#160;</sup>When they came to the region near the Jordan, that is in the land of Canaan, the children of Reuben and the children of Gad and the half-tribe of Manasseh built an altar there by the Jordan, a great altar to look at. 
+<sup>11&#160;</sup>The children of Israel heard this, “Behold, the children of Reuben and the children of Gad and the half-tribe of Manasseh have built an altar along the border of the land of Canaan, in the region around the Jordan, on the side that belongs to the children of Israel.” 
+<sup>12&#160;</sup>When the children of Israel heard of it, the whole congregation of the children of Israel gathered themselves together at Shiloh, to go up against them to war. 
+<sup>13&#160;</sup>The children of Israel sent to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, into the land of Gilead, Phinehas the son of Eleazar the priest. 
+<sup>14&#160;</sup>With him were ten princes, one prince of a fathers’ house for each of the tribes of Israel; and they were each head of their fathers’ houses among the thousands of Israel. 
+<sup>15&#160;</sup>They came to the children of Reuben, and to the children of Gad, and to the half-tribe of Manasseh, to the land of Gilead, and they spoke with them, saying, 
+<sup>16&#160;</sup>“The whole congregation of Yahweh says, ‘What trespass is this that you have committed against the Elohim of Israel, to turn away today from following Yahweh, in that you have built yourselves an altar, to rebel today against Yahweh? 
+<sup>17&#160;</sup>Is the iniquity of Peor too little for us, from which we have not cleansed ourselves to this day, although there came a plague on the congregation of Yahweh, 
+<sup>18&#160;</sup>that you must turn away today from following Yahweh? It will be, since you rebel today against Yahweh, that tomorrow he will be angry with the whole congregation of Israel. 
+<sup>19&#160;</sup>However, if the land of your possession is unclean, then pass over to the land of the possession of Yahweh, in which Yahweh’s tabernacle dwells, and take possession among us; but don’t rebel against Yahweh, nor rebel against us, in building an altar other than Yahweh our Elohim’s altar. 
+<sup>20&#160;</sup>Didn’t Achan the son of Zerah commit a trespass in the devoted thing, and wrath fell on all the congregation of Israel? That man didn’t perish alone in his iniquity.’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>Then the children of Reuben and the children of Gad and the half-tribe of Manasseh answered, and spoke to the heads of the thousands of Israel, 
+<sup>22&#160;</sup>“The Mighty One, Elohim, Yahweh, the Mighty One, Elohim, Yahweh, he knows; and Israel shall know: if it was in rebellion, or if in trespass against Yahweh (don’t save us today), 
+<sup>23&#160;</sup>that we have built us an altar to turn away from following Yahweh; or if to offer burnt offering or meal offering, or if to offer sacrifices of peace offerings, let Yahweh himself require it. 
+</div><div class="p">
+<sup>24&#160;</sup>“If we have not out of concern done this, and for a reason, saying, ‘In time to come your children might speak to our children, saying, “What have you to do with Yahweh, the Elohim of Israel? 
+<sup>25&#160;</sup>For Yahweh has made the Jordan a border between us and you, you children of Reuben and children of Gad. You have no portion in Yahweh.”&#160;’ So your children might make our children cease from fearing Yahweh. 
+</div><div class="p">
+<sup>26&#160;</sup>“Therefore we said, ‘Let’s now prepare to build ourselves an altar, not for burnt offering, nor for sacrifice; 
+<sup>27&#160;</sup>but it will be a witness between us and you, and between our generations after us, that we may perform the service of Yahweh before him with our burnt offerings, with our sacrifices, and with our peace offerings;’ that your children may not tell our children in time to come, ‘You have no portion in Yahweh.’ 
+</div><div class="p">
+<sup>28&#160;</sup>“Therefore we said, ‘It shall be, when they tell us or our generations this in time to come, that we shall say, “Behold the pattern of Yahweh’s altar, which our fathers made, not for burnt offering, nor for sacrifice; but it is a witness between us and you.”&#160;’ 
+</div><div class="p">
+<sup>29&#160;</sup>“Far be it from us that we should rebel against Yahweh, and turn away today from following Yahweh, to build an altar for burnt offering, for meal offering, or for sacrifice, besides Yahweh our Elohim’s altar that is before his tabernacle!” 
+</div><div class="p">
+<sup>30&#160;</sup>When Phinehas the priest, and the princes of the congregation, even the heads of the thousands of Israel that were with him, heard the words that the children of Reuben and the children of Gad and the children of Manasseh spoke, it pleased them well. 
+<sup>31&#160;</sup>Phinehas the son of Eleazar the priest said to the children of Reuben, to the children of Gad, and to the children of Manasseh, “Today we know that Yahweh is among us, because you have not committed this trespass against Yahweh. Now you have delivered the children of Israel out of Yahweh’s hand.” 
+<sup>32&#160;</sup>Phinehas the son of Eleazar the priest, and the princes, returned from the children of Reuben, and from the children of Gad, out of the land of Gilead, to the land of Canaan, to the children of Israel, and brought them word again. 
+<sup>33&#160;</sup>The thing pleased the children of Israel; and the children of Israel blessed Elohim, and spoke no more of going up against them to war, to destroy the land in which the children of Reuben and the children of Gad lived. 
+<sup>34&#160;</sup>The children of Reuben and the children of Gad named the altar “A Witness Between Us that Yahweh is Elohim.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>After many days, when Yahweh had given rest to Israel from their enemies all around, and Joshua was old and well advanced in years, 
+<sup>2&#160;</sup>Joshua called for all Israel, for their elders and for their heads, and for their judges and for their officers, and said to them, “I am old and well advanced in years. 
+<sup>3&#160;</sup>You have seen all that Yahweh your Elohim has done to all these nations because of you; for it is Yahweh your Elohim who has fought for you. 
+<sup>4&#160;</sup>Behold, I have allotted to you these nations that remain, to be an inheritance for your tribes, from the Jordan, with all the nations that I have cut off, even to the great sea toward the going down of the sun. 
+<sup>5&#160;</sup>Yahweh your Elohim will thrust them out from before you, and drive them from out of your sight. You shall possess their land, as Yahweh your Elohim spoke to you. 
+</div><div class="p">
+<sup>6&#160;</sup>“Therefore be very courageous to keep and to do all that is written in the book of the law of Moses, that you not turn away from it to the right hand or to the left; 
+<sup>7&#160;</sup>that you not come among these nations, these that remain among you; neither make mention of the name of their elohims, nor cause to swear by them, neither serve them, nor bow down yourselves to them; 
+<sup>8&#160;</sup>but hold fast to Yahweh your Elohim, as you have done to this day. 
+</div><div class="p">
+<sup>9&#160;</sup>“For Yahweh has driven great and strong nations out from before you. But as for you, no man has stood before you to this day. 
+<sup>10&#160;</sup>One man of you shall chase a thousand; for it is Yahweh your Elohim who fights for you, as he spoke to you. 
+<sup>11&#160;</sup>Take good heed therefore to yourselves, that you love Yahweh your Elohim. 
+</div><div class="p">
+<sup>12&#160;</sup>“But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and make marriages with them, and go in to them, and they to you; 
+<sup>13&#160;</sup>know for a certainty that Yahweh your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahweh your Elohim has given you. 
+</div><div class="p">
+<sup>14&#160;</sup>“Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahweh your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 
+<sup>15&#160;</sup>It shall happen that as all the good things have come on you of which Yahweh your Elohim spoke to you, so Yahweh will bring on you all the evil things, until he has destroyed you from off this good land which Yahweh your Elohim has given you, 
+<sup>16&#160;</sup>when you disobey the covenant of Yahweh your Elohim, which he commanded you, and go and serve other elohims, and bow down yourselves to them. Then Yahweh’s anger will be kindled against you, and you will perish quickly from off the good land which he has given to you.” 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Joshua gathered all the tribes of Israel to Shechem, and called for the elders of Israel, for their heads, for their judges, and for their officers; and they presented themselves before Elohim. 
+<sup>2&#160;</sup>Joshua said to all the people, “Yahweh, the Elohim of Israel, says, ‘Your fathers lived of old time beyond the River, even Terah, the father of Abraham, and the father of Nahor. They served other elohims. 
+<sup>3&#160;</sup>I took your father Abraham from beyond the River, and led him throughout all the land of Canaan, and multiplied his offspring, and gave him Isaac. 
+<sup>4&#160;</sup>I gave to Isaac Jacob and Esau: and I gave to Esau Mount Seir, to possess it. Jacob and his children went down into Egypt. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘I sent Moses and Aaron, and I plagued Egypt, according to that which I did among them: and afterward I brought you out. 
+<sup>6&#160;</sup>I brought your fathers out of Egypt: and you came to the sea. The Egyptians pursued your fathers with chariots and with horsemen to the Red Sea. 
+<sup>7&#160;</sup>When they cried out to Yahweh, he put darkness between you and the Egyptians, and brought the sea on them, and covered them; and your eyes saw what I did in Egypt. You lived in the wilderness many days. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘I brought you into the land of the Amorites, that lived beyond the Jordan. They fought with you, and I gave them into your hand. You possessed their land, and I destroyed them from before you. 
+<sup>9&#160;</sup>Then Balak the son of Zippor, king of Moab, arose and fought against Israel. He sent and called Balaam the son of Beor to curse you, 
+<sup>10&#160;</sup>but I would not listen to Balaam; therefore he blessed you still. So I delivered you out of his hand. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘You went over the Jordan, and came to Jericho. The owners of Jericho fought against you, the Amorite, the Perizzite, the Canaanite, the Hittite, the Girgashite, the Hivite, and the Jebusite; and I delivered them into your hand. 
+<sup>12&#160;</sup>I sent the hornet before you, which drove them out from before you, even the two kings of the Amorites; not with your sword, nor with your bow. 
+<sup>13&#160;</sup>I gave you a land on which you had not labored, and cities which you didn’t build, and you live in them. You eat of vineyards and olive groves which you didn’t plant.’ 
+</div><div class="p">
+<sup>14&#160;</sup>“Now therefore fear Yahweh, and serve him in sincerity and in truth. Put away the elohims which your fathers served beyond the River, in Egypt; and serve Yahweh. 
+<sup>15&#160;</sup>If it seems evil to you to serve Yahweh, choose today whom you will serve; whether the elohims which your fathers served that were beyond the River, or the elohims of the Amorites, in whose land you dwell; but as for me and my house, we will serve Yahweh.” 
+</div><div class="p">
+<sup>16&#160;</sup>The people answered, “Far be it from us that we should forsake Yahweh, to serve other elohims; 
+<sup>17&#160;</sup>for it is Yahweh our Elohim who brought us and our fathers up out of the land of Egypt, from the house of bondage, and who did those great signs in our sight, and preserved us in all the way in which we went, and among all the peoples through the middle of whom we passed. 
+<sup>18&#160;</sup>Yahweh drove out from before us all the peoples, even the Amorites who lived in the land. Therefore we also will serve Yahweh; for he is our Elohim.” 
+</div><div class="p">
+<sup>19&#160;</sup>Joshua said to the people, “You can’t serve Yahweh, for he is a set-apart Elohim. He is a jealous Elohim. He will not forgive your disobedience nor your sins. 
+<sup>20&#160;</sup>If you forsake Yahweh, and serve foreign elohims, then he will turn and do you evil, and consume you, after he has done you good.” 
+</div><div class="p">
+<sup>21&#160;</sup>The people said to Joshua, “No, but we will serve Yahweh.” 
+<sup>22&#160;</sup>Joshua said to the people, “You are witnesses against yourselves that you have chosen Yahweh yourselves, to serve him.” 
+</div><div class="p">They said, “We are witnesses.” 
+</div><div class="p">
+<sup>23&#160;</sup>“Now therefore put away the foreign elohims which are among you, and incline your heart to Yahweh, the Elohim of Israel.” 
+</div><div class="p">
+<sup>24&#160;</sup>The people said to Joshua, “We will serve Yahweh our Elohim, and we will listen to his voice.” 
+</div><div class="p">
+<sup>25&#160;</sup>So Joshua made a covenant with the people that day, and made for them a statute and an ordinance in Shechem. 
+<sup>26&#160;</sup>Joshua wrote these words in the book of the law of Elohim; and he took a great stone, and set it up there under the oak that was by the sanctuary of Yahweh. 
+<sup>27&#160;</sup>Joshua said to all the people, “Behold, this stone shall be a witness against us, for it has heard all Yahweh’s words which he spoke to us. It shall be therefore a witness against you, lest you deny your Elohim.” 
+<sup>28&#160;</sup>So Joshua sent the people away, each to his own inheritance. 
+</div><div class="p">
+<sup>29&#160;</sup>After these things, Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
+<sup>30&#160;</sup>They buried him in the border of his inheritance in Timnathserah, which is in the hill country of Ephraim, on the north of the mountain of Gaash. 
+<sup>31&#160;</sup>Israel served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, and had known all the work of Yahweh, that he had worked for Israel. 
+<sup>32&#160;</sup>They buried the bones of Joseph, which the children of Israel brought up out of Egypt, in Shechem, in the parcel of ground which Jacob bought from the sons of Hamor the father of Shechem for a hundred pieces of silver. They became the inheritance of the children of Joseph. 
+<sup>33&#160;</sup>Eleazar the son of Aaron died. They buried him in the hill of Phinehas his son, which was given him in the hill country of Ephraim. </div></div><script src="../main.js"></script></body></html>

--- a/book/jude.html
+++ b/book/jude.html
@@ -3,6 +3,47 @@
 <head>
 <title>Jude</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,35 +53,37 @@
 <div class="main">
 <!-- JUD World English Scripture (WES) -->
 <h1 class="booklabel">Jude</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Jude,<span class="f">+ \fr 1:1 \ft or, Judah</span> a servant of Yahushua Christ,<span class="f">+ \fr 1:1 \ft “Christ” means “Anointed One”.</span> and brother of James, to those who are called, sanctified by Elohim the Father, and kept for Yahushua Christ: 
-<span class="v">2&#160;</span>May mercy, peace, and love be multiplied to you. 
-</p><p>
-<span class="v">3&#160;</span>Beloved, while I was very eager to write to you about our common salvation, I was constrained to write to you exhorting you to contend earnestly for the faith which was once for all delivered to the saints. 
-<span class="v">4&#160;</span>For there are certain men who crept in secretly, even those who were long ago written about for this condemnation: unelohimly men, turning the grace of our Elohim into indecency, and denying our only Master, Elohim, and Lord, Yahushua Christ. 
-</p><p>
-<span class="v">5&#160;</span>Now I desire to remind you, though you already know this, that the Lord, having saved a people out of the land of Egypt, afterward destroyed those who didn’t believe. 
-<span class="v">6&#160;</span>Angels who didn’t keep their first domain, but deserted their own dwelling place, he has kept in everlasting bonds under darkness for the judgment of the great day. 
-<span class="v">7&#160;</span>Even as Sodom and Gomorrah and the cities around them, having in the same way as these given themselves over to sexual immorality and gone after strange flesh, are shown as an example, suffering the punishment of eternal fire. 
-<span class="v">8&#160;</span>Yet in the same way, these also in their dreaming defile the flesh, despise authority, and slander celestial beings. 
-<span class="v">9&#160;</span>But Michael, the archangel, when contending with the devil and arguing about the body of Moses, dared not bring against him an abusive condemnation, but said, “May the Lord rebuke you!” 
-<span class="v">10&#160;</span>But these speak evil of whatever things they don’t know. They are destroyed in these things that they understand naturally, like the creatures without reason. 
-<span class="v">11&#160;</span>Woe to them! For they went in the way of Cain, and ran riotously in the error of Balaam for hire, and perished in Korah’s rebellion. 
-<span class="v">12&#160;</span>These are hidden rocky reefs in your love feasts when they feast with you, shepherds who without fear feed themselves; clouds without water, carried along by winds; autumn trees without fruit, twice dead, plucked up by the roots; 
-<span class="v">13&#160;</span>wild waves of the sea, foaming out their own shame; wandering stars, for whom the blackness of darkness has been reserved forever. 
-<span class="v">14&#160;</span>About these also Enoch, the seventh from Adam, prophesied, saying, “Behold,<span class="f">+ \fr 1:14 \ft “Behold”, from “ἰδοὺ”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> the Lord came with ten thousands of his set-apart ones, 
-<span class="v">15&#160;</span>to execute judgment on all, and to convict all the unelohimly of all their works of unelohimliness which they have done in an unelohimly way, and of all the hard things which unelohimly sinners have spoken against him.” 
-<span class="v">16&#160;</span>These are murmurers and complainers, walking after their lusts—and their mouth speaks proud things—showing respect of persons to gain advantage. 
-</p><p>
-<span class="v">17&#160;</span>But you, beloved, remember the words which have been spoken before by the apostles of our Lord Yahushua Christ. 
-<span class="v">18&#160;</span>They said to you, “In the last time there will be mockers, walking after their own unelohimly lusts.” 
-<span class="v">19&#160;</span>These are those who cause divisions and are sensual, not having the Spirit. 
-</p><p>
-<span class="v">20&#160;</span>But you, beloved, keep building up yourselves on your most set-apart faith, praying in the Set-Apart Spirit. 
-<span class="v">21&#160;</span>Keep yourselves in Elohim’s love, looking for the mercy of our Lord Yahushua Christ to eternal life. 
-<span class="v">22&#160;</span>On some have compassion, making a distinction, 
-<span class="v">23&#160;</span>and some save, snatching them out of the fire with fear, hating even the clothing stained by the flesh. 
-</p><p>
-<span class="v">24&#160;</span>Now to him who is able to keep them<span class="f">+ \fr 1:24 \ft TR and NU read “you”</span> from stumbling, and to present you faultless before the presence of his glory in great joy, 
-<span class="v">25&#160;</span>to Elohim our Savior, who alone is wise, be glory and majesty, dominion and power, both now and forever. Amen. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Jude, and brother of James, to those who are called, sanctified by Elohim the Father, and kept for Yahushua Christ: 
+<sup>2&#160;</sup>May mercy, peace, and love be multiplied to you. 
+</div><div class="p">
+<sup>3&#160;</sup>Beloved, while I was very eager to write to you about our common salvation, I was constrained to write to you exhorting you to contend earnestly for the faith which was once for all delivered to the saints. 
+<sup>4&#160;</sup>For there are certain men who crept in secretly, even those who were long ago written about for this condemnation: unelohimly men, turning the grace of our Elohim into indecency, and denying our only Master, Elohim, and Lord, Yahushua Christ. 
+</div><div class="p">
+<sup>5&#160;</sup>Now I desire to remind you, though you already know this, that the Lord, having saved a people out of the land of Egypt, afterward destroyed those who didn’t believe. 
+<sup>6&#160;</sup>Angels who didn’t keep their first domain, but deserted their own dwelling place, he has kept in everlasting bonds under darkness for the judgment of the great day. 
+<sup>7&#160;</sup>Even as Sodom and Gomorrah and the cities around them, having in the same way as these given themselves over to sexual immorality and gone after strange flesh, are shown as an example, suffering the punishment of eternal fire. 
+<sup>8&#160;</sup>Yet in the same way, these also in their dreaming defile the flesh, despise authority, and slander celestial beings. 
+<sup>9&#160;</sup>But Michael, the archangel, when contending with the devil and arguing about the body of Moses, dared not bring against him an abusive condemnation, but said, “May the Lord rebuke you!” 
+<sup>10&#160;</sup>But these speak evil of whatever things they don’t know. They are destroyed in these things that they understand naturally, like the creatures without reason. 
+<sup>11&#160;</sup>Woe to them! For they went in the way of Cain, and ran riotously in the error of Balaam for hire, and perished in Korah’s rebellion. 
+<sup>12&#160;</sup>These are hidden rocky reefs in your love feasts when they feast with you, shepherds who without fear feed themselves; clouds without water, carried along by winds; autumn trees without fruit, twice dead, plucked up by the roots; 
+<sup>13&#160;</sup>wild waves of the sea, foaming out their own shame; wandering stars, for whom the blackness of darkness has been reserved forever. 
+<sup>14&#160;</sup>About these also Enoch, the seventh from Adam, prophesied, saying, “Behold, the Lord came with ten thousands of his set-apart ones, 
+<sup>15&#160;</sup>to execute judgment on all, and to convict all the unelohimly of all their works of unelohimliness which they have done in an unelohimly way, and of all the hard things which unelohimly sinners have spoken against him.” 
+<sup>16&#160;</sup>These are murmurers and complainers, walking after their lusts—and their mouth speaks proud things—showing respect of persons to gain advantage. 
+</div><div class="p">
+<sup>17&#160;</sup>But you, beloved, remember the words which have been spoken before by the apostles of our Lord Yahushua Christ. 
+<sup>18&#160;</sup>They said to you, “In the last time there will be mockers, walking after their own unelohimly lusts.” 
+<sup>19&#160;</sup>These are those who cause divisions and are sensual, not having the Spirit. 
+</div><div class="p">
+<sup>20&#160;</sup>But you, beloved, keep building up yourselves on your most set-apart faith, praying in the Set-Apart Spirit. 
+<sup>21&#160;</sup>Keep yourselves in Elohim’s love, looking for the mercy of our Lord Yahushua Christ to eternal life. 
+<sup>22&#160;</sup>On some have compassion, making a distinction, 
+<sup>23&#160;</sup>and some save, snatching them out of the fire with fear, hating even the clothing stained by the flesh. 
+</div><div class="p">
+<sup>24&#160;</sup>Now to him who is able to keep them from stumbling, and to present you faultless before the presence of his glory in great joy, 
+<sup>25&#160;</sup>to Elohim our Savior, who alone is wise, be glory and majesty, dominion and power, both now and forever. Amen. </div></div><script src="../main.js"></script></body></html>

--- a/book/judges.html
+++ b/book/judges.html
@@ -3,6 +3,47 @@
 <head>
 <title>Judges</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1004 +53,1026 @@
 <div class="main">
 <!-- JDG World English Scripture (WES) -->
 <h1 class="booklabel">Judges</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>After the death of Joshua, the children of Israel asked of Yahweh,<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> saying, “Who should go up for us first against the Canaanites, to fight against them?” 
-</p><p>
-<span class="v">2&#160;</span>Yahweh said, “Judah shall go up. Behold,<span class="f">+ \fr 1:2 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I have delivered the land into his hand.” 
-</p><p>
-<span class="v">3&#160;</span>Judah said to Simeon his brother, “Come up with me into my lot, that we may fight against the Canaanites; and I likewise will go with you into your lot.” So Simeon went with him. 
-<span class="v">4&#160;</span>Judah went up, and Yahweh delivered the Canaanites and the Perizzites into their hand. They struck ten thousand men in Bezek. 
-<span class="v">5&#160;</span>They found Adoni-Bezek in Bezek, and they fought against him. They struck the Canaanites and the Perizzites. 
-<span class="v">6&#160;</span>But Adoni-Bezek fled. They pursued him, caught him, and cut off his thumbs and his big toes. 
-<span class="v">7&#160;</span>Adoni-Bezek said, “Seventy kings, having their thumbs and their big toes cut off, scavenged under my table. As I have done, so Elohim<span class="f">+ \fr 1:7 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> has done to me.” They brought him to Jerusalem, and he died there. 
-<span class="v">8&#160;</span>The children of Judah fought against Jerusalem, took it, struck it with the edge of the sword, and set the city on fire. 
-</p><p>
-<span class="v">9&#160;</span>After that, the children of Judah went down to fight against the Canaanites who lived in the hill country, and in the South, and in the lowland. 
-<span class="v">10&#160;</span>Judah went against the Canaanites who lived in Hebron. (The name of Hebron before that was Kiriath Arba.) They struck Sheshai, Ahiman, and Talmai. 
-</p><p>
-<span class="v">11&#160;</span>From there he went against the inhabitants of Debir. (The name of Debir before that was Kiriath Sepher.) 
-<span class="v">12&#160;</span>Caleb said, “I will give Achsah my daughter as woman to the man who strikes Kiriath Sepher, and takes it.” 
-<span class="v">13&#160;</span>Othniel the son of Kenaz, Caleb’s younger brother, took it, so he gave him Achsah his daughter as his woman. 
-</p><p>
-<span class="v">14&#160;</span>When she came, she got him to ask her father for a field. She got off her donkey; and Caleb said to her, “What would you like?” 
-</p><p>
-<span class="v">15&#160;</span>She said to him, “Give me a blessing; because you have set me in the land of the South, give me also springs of water.” Then Caleb gave her the upper springs and the lower springs. 
-<span class="v">16&#160;</span>The children of the Kenite, Moses’ brother-in-law, went up out of the city of palm trees with the children of Judah into the wilderness of Judah, which is in the south of Arad; and they went and lived with the people. 
-<span class="v">17&#160;</span>Judah went with Simeon his brother, and they struck the Canaanites who inhabited Zephath, and utterly destroyed it. The name of the city was called Hormah. 
-<span class="v">18&#160;</span>Also Judah took Gaza with its border, and Ashkelon with its border, and Ekron with its border. 
-<span class="v">19&#160;</span>Yahweh was with Judah, and drove out the inhabitants of the hill country; for he could not drive out the inhabitants of the valley, because they had chariots of iron. 
-<span class="v">20&#160;</span>They gave Hebron to Caleb, as Moses had said, and he drove the three sons of Anak out of there. 
-<span class="v">21&#160;</span>The children of Benjamin didn’t drive out the Jebusites who inhabited Jerusalem, but the Jebusites dwell with the children of Benjamin in Jerusalem to this day. 
-</p><p>
-<span class="v">22&#160;</span>The house of Joseph also went up against Bethel, and Yahweh was with them. 
-<span class="v">23&#160;</span>The house of Joseph sent to spy out Bethel. (The name of the city before that was Luz.) 
-<span class="v">24&#160;</span>The watchers saw a man come out of the city, and they said to him, “Please show us the entrance into the city, and we will deal kindly with you.” 
-<span class="v">25&#160;</span>He showed them the entrance into the city, and they struck the city with the edge of the sword; but they let the man and all his family go. 
-<span class="v">26&#160;</span>The man went into the land of the Hittites, built a city, and called its name Luz, which is its name to this day. 
-</p><p>
-<span class="v">27&#160;</span>Manasseh didn’t drive out the inhabitants of Beth Shean and its towns, nor Taanach and its towns, nor the inhabitants of Dor and its towns, nor the inhabitants of Ibleam and its towns, nor the inhabitants of Megiddo and its towns; but the Canaanites would dwell in that land. 
-<span class="v">28&#160;</span>When Israel had grown strong, they put the Canaanites to forced labor, and didn’t utterly drive them out. 
-<span class="v">29&#160;</span>Ephraim didn’t drive out the Canaanites who lived in Gezer, but the Canaanites lived in Gezer among them. 
-<span class="v">30&#160;</span>Zebulun didn’t drive out the inhabitants of Kitron, nor the inhabitants of Nahalol; but the Canaanites lived among them, and became subject to forced labor. 
-<span class="v">31&#160;</span>Asher didn’t drive out the inhabitants of Acco, nor the inhabitants of Sidon, nor of Ahlab, nor of Achzib, nor of Helbah, nor of Aphik, nor of Rehob; 
-<span class="v">32&#160;</span>but the Asherites lived among the Canaanites, the inhabitants of the land, for they didn’t drive them out. 
-<span class="v">33&#160;</span>Naphtali didn’t drive out the inhabitants of Beth Shemesh, nor the inhabitants of Beth Anath; but he lived among the Canaanites, the inhabitants of the land. Nevertheless the inhabitants of Beth Shemesh and of Beth Anath became subject to forced labor. 
-<span class="v">34&#160;</span>The Amorites forced the children of Dan into the hill country, for they would not allow them to come down to the valley; 
-<span class="v">35&#160;</span>but the Amorites would dwell in Mount Heres, in Aijalon, and in Shaalbim. Yet the hand of the house of Joseph prevailed, so that they became subject to forced labor. 
-<span class="v">36&#160;</span>The border of the Amorites was from the ascent of Akrabbim, from the rock, and upward. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh’s angel came up from Gilgal to Bochim. He said, “I brought you out of Egypt, and have brought you to the land which I swore to give your fathers. I said, ‘I will never break my covenant with you. 
-<span class="v">2&#160;</span>You shall make no covenant with the inhabitants of this land. You shall break down their altars.’ But you have not listened to my voice. Why have you done this? 
-<span class="v">3&#160;</span>Therefore I also said, ‘I will not drive them out from before you; but they shall be in your sides, and their elohims will be a snare to you.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>When Yahweh’s angel spoke these words to all the children of Israel, the people lifted up their voice and wept. 
-<span class="v">5&#160;</span>They called the name of that place Bochim,<span class="f">+ \fr 2:5 \ft “Bochim” means “weepers”.</span> and they sacrificed there to Yahweh. 
-<span class="v">6&#160;</span>Now when Joshua had sent the people away, the children of Israel each went to his inheritance to possess the land. 
-<span class="v">7&#160;</span>The people served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, who had seen all the great work of Yahweh that he had worked for Israel. 
-<span class="v">8&#160;</span>Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
-<span class="v">9&#160;</span>They buried him in the border of his inheritance in Timnath Heres, in the hill country of Ephraim, on the north of the mountain of Gaash. 
-<span class="v">10&#160;</span>After all that generation were gathered to their fathers, another generation arose after them who didn’t know Yahweh, nor the work which he had done for Israel. 
-<span class="v">11&#160;</span>The children of Israel did that which was evil in Yahweh’s sight, and served the Baals. 
-<span class="v">12&#160;</span>They abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and followed other elohims, of the elohims of the peoples who were around them, and bowed themselves down to them; and they provoked Yahweh to anger. 
-<span class="v">13&#160;</span>They abandoned Yahweh, and served Baal and the Ashtaroth. 
-<span class="v">14&#160;</span>Yahweh’s anger burned against Israel, and he delivered them into the hands of raiders who plundered them. He sold them into the hands of their enemies all around, so that they could no longer stand before their enemies. 
-<span class="v">15&#160;</span>Wherever they went out, Yahweh’s hand was against them for evil, as Yahweh had spoken, and as Yahweh had sworn to them; and they were very distressed. 
-<span class="v">16&#160;</span>Yahweh raised up judges, who saved them out of the hand of those who plundered them. 
-<span class="v">17&#160;</span>Yet they didn’t listen to their judges; for they prostituted themselves to other elohims, and bowed themselves down to them. They quickly turned away from the way in which their fathers walked, obeying Yahweh’s commandments. They didn’t do so. 
-<span class="v">18&#160;</span>When Yahweh raised up judges for them, then Yahweh was with the judge, and saved them out of the hand of their enemies all the days of the judge; for it grieved Yahweh because of their groaning by reason of those who oppressed them and troubled them. 
-<span class="v">19&#160;</span>But when the judge was dead, they turned back, and dealt more corruptly than their fathers in following other elohims to serve them and to bow down to them. They didn’t cease what they were doing, or give up their stubborn ways. 
-<span class="v">20&#160;</span>Yahweh’s anger burned against Israel; and he said, “Because this nation transgressed my covenant which I commanded their fathers, and has not listened to my voice, 
-<span class="v">21&#160;</span>I also will no longer drive out any of the nations that Joshua left when he died from before them; 
-<span class="v">22&#160;</span>that by them I may test Israel, to see if they will keep Yahweh’s way to walk therein, as their fathers kept it, or not.” 
-<span class="v">23&#160;</span>So Yahweh left those nations, without driving them out hastily. He didn’t deliver them into Joshua’s hand. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the nations which Yahweh left, to test Israel by them, even as many as had not known all the wars of Canaan; 
-<span class="v">2&#160;</span>only that the generations of the children of Israel might know, to teach them war, at least those who knew nothing of it before: 
-<span class="v">3&#160;</span>the five lords of the Philistines, all the Canaanites, the Sidonians, and the Hivites who lived on Mount Lebanon, from Mount Baal Hermon to the entrance of Hamath. 
-<span class="v">4&#160;</span>They were left to test Israel by them, to know whether they would listen to Yahweh’s commandments, which he commanded their fathers by Moses. 
-<span class="v">5&#160;</span>The children of Israel lived among the Canaanites, the Hittites, the Amorites, the Perizzites, the Hivites, and the Jebusites. 
-<span class="v">6&#160;</span>They took their daughters to be their women, and gave their own daughters to their sons and served their elohims. 
-<span class="v">7&#160;</span>The children of Israel did that which was evil in Yahweh’s sight, and forgot Yahweh their Elohim, and served the Baals and the Asheroth. 
-<span class="v">8&#160;</span>Therefore Yahweh’s anger burned against Israel, and he sold them into the hand of Cushan Rishathaim king of Mesopotamia; and the children of Israel served Cushan Rishathaim eight years. 
-<span class="v">9&#160;</span>When the children of Israel cried to Yahweh, Yahweh raised up a savior to the children of Israel, who saved them, even Othniel the son of Kenaz, Caleb’s younger brother. 
-<span class="v">10&#160;</span>Yahweh’s Spirit came on him, and he judged Israel; and he went out to war, and Yahweh delivered Cushan Rishathaim king of Mesopotamia into his hand. His hand prevailed against Cushan Rishathaim. 
-<span class="v">11&#160;</span>The land had rest forty years, then Othniel the son of Kenaz died. 
-</p><p>
-<span class="v">12&#160;</span>The children of Israel again did that which was evil in Yahweh’s sight, and Yahweh strengthened Eglon the king of Moab against Israel, because they had done that which was evil in Yahweh’s sight. 
-<span class="v">13&#160;</span>He gathered the children of Ammon and Amalek to himself; and he went and struck Israel, and they possessed the city of palm trees. 
-<span class="v">14&#160;</span>The children of Israel served Eglon the king of Moab eighteen years. 
-<span class="v">15&#160;</span>But when the children of Israel cried to Yahweh, Yahweh raised up a savior for them: Ehud the son of Gera, the Benjamite, a left-handed man. The children of Israel sent tribute by him to Eglon the king of Moab. 
-<span class="v">16&#160;</span>Ehud made himself a sword which had two edges, a cubit<span class="f">+ \fr 3:16 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> in length; and he wore it under his clothing on his right thigh. 
-<span class="v">17&#160;</span>He offered the tribute to Eglon king of Moab. Now Eglon was a very fat man. 
-<span class="v">18&#160;</span>When Ehud had finished offering the tribute, he sent away the people who carried the tribute. 
-<span class="v">19&#160;</span>But he himself turned back from the stone idols that were by Gilgal, and said, “I have a secret message for you, O king.” 
-</p><p>The king said, “Keep silence!” All who stood by him left him. 
-</p><p>
-<span class="v">20&#160;</span>Ehud came to him; and he was sitting by himself alone in the cool upper room. Ehud said, “I have a message from Elohim to you.” He arose out of his seat. 
-<span class="v">21&#160;</span>Ehud put out his left hand, and took the sword from his right thigh, and thrust it into his body. 
-<span class="v">22&#160;</span>The handle also went in after the blade; and the fat closed on the blade, for he didn’t draw the sword out of his body; and it came out behind. 
-<span class="v">23&#160;</span>Then Ehud went out onto the porch, and shut the doors of the upper room on him, and locked them. 
-</p><p>
-<span class="v">24&#160;</span>After he had gone, his servants came and saw that the doors of the upper room were locked. They said, “Surely he is covering his feet<span class="f">+ \fr 3:24 \ft or, “relieving himself”.</span> in the upper room.” 
-<span class="v">25&#160;</span>They waited until they were ashamed; and behold, he didn’t open the doors of the upper room. Therefore they took the key and opened them, and behold, their lord had fallen down dead on the floor. 
-</p><p>
-<span class="v">26&#160;</span>Ehud escaped while they waited, passed beyond the stone idols, and escaped to Seirah. 
-<span class="v">27&#160;</span>When he had come, he blew a trumpet in the hill country of Ephraim; and the children of Israel went down with him from the hill country, and he led them. 
-</p><p>
-<span class="v">28&#160;</span>He said to them, “Follow me; for Yahweh has delivered your enemies the Moabites into your hand.” They followed him, and took the fords of the Jordan against the Moabites, and didn’t allow any man to pass over. 
-<span class="v">29&#160;</span>They struck at that time about ten thousand men of Moab, every strong man and every man of valor. No man escaped. 
-<span class="v">30&#160;</span>So Moab was subdued that day under the hand of Israel. Then the land had rest eighty years. 
-</p><p>
-<span class="v">31&#160;</span>After him was Shamgar the son of Anath, who struck six hundred men of the Philistines with an ox goad. He also saved Israel. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>The children of Israel again did that which was evil in Yahweh’s sight, when Ehud was dead. 
-<span class="v">2&#160;</span>Yahweh sold them into the hand of Jabin king of Canaan, who reigned in Hazor; the captain of whose army was Sisera, who lived in Harosheth of the Gentiles. 
-<span class="v">3&#160;</span>The children of Israel cried to Yahweh, for he had nine hundred chariots of iron; and he mightily oppressed the children of Israel for twenty years. 
-<span class="v">4&#160;</span>Now Deborah, a prophetess, the woman of Lappidoth, judged Israel at that time. 
-<span class="v">5&#160;</span>She lived under Deborah’s palm tree between Ramah and Bethel in the hill country of Ephraim; and the children of Israel came up to her for judgment. 
-<span class="v">6&#160;</span>She sent and called Barak the son of Abinoam out of Kedesh Naphtali, and said to him, “Hasn’t Yahweh, the Elohim of Israel, commanded, ‘Go and lead the way to Mount Tabor, and take with you ten thousand men of the children of Naphtali and of the children of Zebulun? 
-<span class="v">7&#160;</span>I will draw to you, to the river Kishon, Sisera, the captain of Jabin’s army, with his chariots and his multitude; and I will deliver him into your hand.’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>Barak said to her, “If you will go with me, then I will go; but if you will not go with me, I will not go.” 
-</p><p>
-<span class="v">9&#160;</span>She said, “I will surely go with you. Nevertheless, the journey that you take won’t be for your honor; for Yahweh will sell Sisera into a woman’s hand.” Deborah arose, and went with Barak to Kedesh. 
-</p><p>
-<span class="v">10&#160;</span>Barak called Zebulun and Naphtali together to Kedesh. Ten thousand men followed him; and Deborah went up with him. 
-<span class="v">11&#160;</span>Now Heber the Kenite had separated himself from the Kenites, even from the children of Hobab, Moses’ brother-in-law, and had pitched his tent as far as the oak in Zaanannim, which is by Kedesh. 
-<span class="v">12&#160;</span>They told Sisera that Barak the son of Abinoam had gone up to Mount Tabor. 
-<span class="v">13&#160;</span>Sisera gathered together all his chariots, even nine hundred chariots of iron, and all the people who were with him, from Harosheth of the Gentiles, to the river Kishon. 
-</p><p>
-<span class="v">14&#160;</span>Deborah said to Barak, “Go; for this is the day in which Yahweh has delivered Sisera into your hand. Hasn’t Yahweh gone out before you?” So Barak went down from Mount Tabor, and ten thousand men after him. 
-<span class="v">15&#160;</span>Yahweh confused Sisera, all his chariots, and all his army, with the edge of the sword before Barak. Sisera abandoned his chariot and fled away on his feet. 
-<span class="v">16&#160;</span>But Barak pursued the chariots and the army to Harosheth of the Gentiles; and all the army of Sisera fell by the edge of the sword. There was not a man left. 
-</p><p>
-<span class="v">17&#160;</span>However Sisera fled away on his feet to the tent of Jael the woman of Heber the Kenite; for there was peace between Jabin the king of Hazor and the house of Heber the Kenite. 
-<span class="v">18&#160;</span>Jael went out to meet Sisera, and said to him, “Turn in, my lord, turn in to me; don’t be afraid.” He came in to her into the tent, and she covered him with a rug. 
-</p><p>
-<span class="v">19&#160;</span>He said to her, “Please give me a little water to drink; for I am thirsty.” 
-</p><p>She opened a container of milk, and gave him a drink, and covered him. 
-</p><p>
-<span class="v">20&#160;</span>He said to her, “Stand in the door of the tent, and if any man comes and inquires of you, and says, ‘Is there any man here?’ you shall say, ‘No.’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>Then Jael, Heber’s woman, took a tent peg, and took a hammer in her hand, and went softly to him, and struck the pin into his temples, and it pierced through into the ground, for he was in a deep sleep; so he fainted and died. 
-<span class="v">22&#160;</span>Behold, as Barak pursued Sisera, Jael came out to meet him, and said to him, “Come, and I will show you the man whom you seek.” He came to her; and behold, Sisera lay dead, and the tent peg was in his temples. 
-<span class="v">23&#160;</span>So Elohim subdued Jabin the king of Canaan before the children of Israel on that day. 
-<span class="v">24&#160;</span>The hand of the children of Israel prevailed more and more against Jabin the king of Canaan, until they had destroyed Jabin king of Canaan. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Then Deborah and Barak the son of Abinoam sang on that day, saying, 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Because the leaders took the lead in Israel, 
-</p><p class="q2">because the people offered themselves willingly, 
-</p><p class="q1">be blessed, Yahweh! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Hear, you kings! 
-</p><p class="q2">Give ear, you princes! 
-</p><p class="q1">I, even I, will sing to Yahweh. 
-</p><p class="q2">I will sing praise to Yahweh, the Elohim of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>“Yahweh, when you went out of Seir, 
-</p><p class="q2">when you marched out of the field of Edom, 
-</p><p class="q1">the earth trembled, the sky also dropped. 
-</p><p class="q2">Yes, the clouds dropped water. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The mountains quaked at Yahweh’s presence, 
-</p><p class="q2">even Sinai at the presence of Yahweh, the Elohim of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“In the days of Shamgar the son of Anath, 
-</p><p class="q2">in the days of Jael, the highways were unoccupied. 
-</p><p class="q2">The travelers walked through byways. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The rulers ceased in Israel. 
-</p><p class="q2">They ceased until I, Deborah, arose; 
-</p><p class="q2">Until I arose a mother in Israel. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They chose new elohims. 
-</p><p class="q2">Then war was in the gates. 
-</p><p class="q2">Was there a shield or spear seen among forty thousand in Israel? 
-</p><p class="q1">
-<span class="v">9&#160;</span>My heart is toward the governors of Israel, 
-</p><p class="q2">who offered themselves willingly among the people. 
-</p><p class="q2">Bless Yahweh! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Speak, you who ride on white donkeys, 
-</p><p class="q2">you who sit on rich carpets, 
-</p><p class="q2">and you who walk by the way. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Far from the noise of archers, in the places of drawing water, 
-</p><p class="q2">there they will rehearse Yahweh’s righteous acts, 
-</p><p class="q2">the righteous acts of his rule in Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">“Then Yahweh’s people went down to the gates. 
-</p><p class="q2">
-<span class="v">12&#160;</span>‘Awake, awake, Deborah! 
-</p><p class="q2">Awake, awake, utter a song! 
-</p><p class="q2">Arise, Barak, and lead away your captives, you son of Abinoam.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“Then a remnant of the nobles and the people came down. 
-</p><p class="q2">Yahweh came down for me against the mighty. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Those whose root is in Amalek came out of Ephraim, 
-</p><p class="q2">after you, Benjamin, among your peoples. 
-</p><p class="q1">Governors come down out of Machir. 
-</p><p class="q2">Those who handle the marshal’s staff came out of Zebulun. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The princes of Issachar were with Deborah. 
-</p><p class="q2">As was Issachar, so was Barak. 
-</p><p class="q2">They rushed into the valley at his feet. 
-</p><p class="q1">By the watercourses of Reuben, 
-</p><p class="q2">there were great resolves of heart. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Why did you sit among the sheepfolds? 
-</p><p class="q2">To hear the whistling for the flocks? 
-</p><p class="q1">At the watercourses of Reuben, 
-</p><p class="q2">there were great searchings of heart. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Gilead lived beyond the Jordan. 
-</p><p class="q2">Why did Dan remain in ships? 
-</p><p class="q2">Asher sat still at the haven of the sea, 
-</p><p class="q2">and lived by his creeks. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Zebulun was a people that jeopardized their lives to the death; 
-</p><p class="q2">Naphtali also, on the high places of the field. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“The kings came and fought, 
-</p><p class="q2">then the kings of Canaan fought at Taanach by the waters of Megiddo. 
-</p><p class="q2">They took no plunder of silver. 
-</p><p class="q1">
-<span class="v">20&#160;</span>From the sky the stars fought. 
-</p><p class="q2">From their courses, they fought against Sisera. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The river Kishon swept them away, 
-</p><p class="q2">that ancient river, the river Kishon. 
-</p><p class="q2">My soul, march on with strength. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Then the horse hoofs stamped because of the prancing, 
-</p><p class="q2">the prancing of their strong ones. 
-</p><p class="q1">
-<span class="v">23&#160;</span>‘Curse Meroz,’ said Yahweh’s angel. 
-</p><p class="q2">‘Curse bitterly its inhabitants, 
-</p><p class="q2">because they didn’t come to help Yahweh, 
-</p><p class="q2">to help Yahweh against the mighty.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>“Jael shall be blessed above women, 
-</p><p class="q2">the woman of Heber the Kenite; 
-</p><p class="q2">blessed shall she be above women in the tent. 
-</p><p class="q1">
-<span class="v">25&#160;</span>He asked for water. 
-</p><p class="q2">She gave him milk. 
-</p><p class="q2">She brought him butter in a lordly dish. 
-</p><p class="q1">
-<span class="v">26&#160;</span>She put her hand to the tent peg, 
-</p><p class="q2">and her right hand to the workmen’s hammer. 
-</p><p class="q1">With the hammer she struck Sisera. 
-</p><p class="q2">She struck through his head. 
-</p><p class="q2">Yes, she pierced and struck through his temples. 
-</p><p class="q1">
-<span class="v">27&#160;</span>At her feet he bowed, he fell, he lay. 
-</p><p class="q2">At her feet he bowed, he fell. 
-</p><p class="q2">Where he bowed, there he fell down dead. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>“Through the window she looked out, and cried: 
-</p><p class="q2">Sisera’s mother looked through the lattice. 
-</p><p class="q1">‘Why is his chariot so long in coming? 
-</p><p class="q2">Why do the wheels of his chariots wait?’ 
-</p><p class="q1">
-<span class="v">29&#160;</span>Her wise ladies answered her, 
-</p><p class="q2">Yes, she returned answer to herself, 
-</p><p class="q1">
-<span class="v">30&#160;</span>‘Have they not found, have they not divided the plunder? 
-</p><p class="q2">A lady, two ladies to every man; 
-</p><p class="q1">to Sisera a plunder of dyed garments, 
-</p><p class="q2">a plunder of dyed garments embroidered, 
-</p><p class="q2">of dyed garments embroidered on both sides, on the necks of the plunder?’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">31&#160;</span>“So let all your enemies perish, Yahweh, 
-</p><p class="q2">but let those who love him be as the sun when it rises in its strength.” 
-</p><div class="b"> &#160; </div>
-<p>Then the land had rest forty years. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>The children of Israel did that which was evil in Yahweh’s sight, so Yahweh delivered them into the hand of Midian seven years. 
-<span class="v">2&#160;</span>The hand of Midian prevailed against Israel; and because of Midian the children of Israel made themselves the dens which are in the mountains, the caves, and the strongholds. 
-<span class="v">3&#160;</span>So it was, when Israel had sown, that the Midianites, the Amalekites, and the children of the east came up against them. 
-<span class="v">4&#160;</span>They encamped against them, and destroyed the increase of the earth, until you come to Gaza. They left no sustenance in Israel, and no sheep, ox, or donkey. 
-<span class="v">5&#160;</span>For they came up with their livestock and their tents. They came in as locusts for multitude. Both they and their camels were without number; and they came into the land to destroy it. 
-<span class="v">6&#160;</span>Israel was brought very low because of Midian; and the children of Israel cried to Yahweh. 
-</p><p>
-<span class="v">7&#160;</span>When the children of Israel cried to Yahweh because of Midian, 
-<span class="v">8&#160;</span>Yahweh sent a prophet to the children of Israel; and he said to them, “Yahweh, the Elohim of Israel, says, ‘I brought you up from Egypt, and brought you out of the house of bondage. 
-<span class="v">9&#160;</span>I delivered you out of the hand of the Egyptians and out of the hand of all who oppressed you, and drove them out from before you, and gave you their land. 
-<span class="v">10&#160;</span>I said to you, “I am Yahweh your Elohim. You shall not fear the elohims of the Amorites, in whose land you dwell.” But you have not listened to my voice.’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh’s angel came and sat under the oak which was in Ophrah, that belonged to Joash the Abiezrite. His son Gideon was beating out wheat in the wine press, to hide it from the Midianites. 
-<span class="v">12&#160;</span>Yahweh’s angel appeared to him, and said to him, “Yahweh is with you, you mighty man of valor!” 
-</p><p>
-<span class="v">13&#160;</span>Gideon said to him, “Oh, my lord, if Yahweh is with us, why then has all this happened to us? Where are all his wondrous works which our fathers told us of, saying, ‘Didn’t Yahweh bring us up from Egypt?’ But now Yahweh has cast us off, and delivered us into the hand of Midian.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh looked at him, and said, “Go in this your might, and save Israel from the hand of Midian. Haven’t I sent you?” 
-</p><p>
-<span class="v">15&#160;</span>He said to him, “O Lord,<span class="f">+ \fr 6:15 \ft The word translated “Lord” is “Adonai.”</span> how shall I save Israel? Behold, my family is the poorest in Manasseh, and I am the least in my father’s house.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh said to him, “Surely I will be with you, and you shall strike the Midianites as one man.” 
-</p><p>
-<span class="v">17&#160;</span>He said to him, “If now I have found favor in your sight, then show me a sign that it is you who talk with me. 
-<span class="v">18&#160;</span>Please don’t go away until I come to you, and bring out my present, and lay it before you.” 
-</p><p>He said, “I will wait until you come back.” 
-</p><p>
-<span class="v">19&#160;</span>Gideon went in and prepared a young goat and unleavened cakes of an ephah<span class="f">+ \fr 6:19 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of meal. He put the meat in a basket and he put the broth in a pot, and brought it out to him under the oak, and presented it. 
-</p><p>
-<span class="v">20&#160;</span>The angel of Elohim said to him, “Take the meat and the unleavened cakes, and lay them on this rock, and pour out the broth.” 
-</p><p>He did so. 
-<span class="v">21&#160;</span>Then Yahweh’s angel stretched out the end of the staff that was in his hand, and touched the meat and the unleavened cakes; and fire went up out of the rock and consumed the meat and the unleavened cakes. Then Yahweh’s angel departed out of his sight. 
-</p><p>
-<span class="v">22&#160;</span>Gideon saw that he was Yahweh’s angel; and Gideon said, “Alas, Lord Yahweh! Because I have seen Yahweh’s angel face to face!” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh said to him, “Peace be to you! Don’t be afraid. You shall not die.” 
-</p><p>
-<span class="v">24&#160;</span>Then Gideon built an altar there to Yahweh, and called it “Yahweh is Peace.”<span class="f">+ \fr 6:24 \ft or, Yahweh Shalom</span> To this day it is still in Ophrah of the Abiezrites. 
-</p><p>
-<span class="v">25&#160;</span>That same night, Yahweh said to him, “Take your father’s bull, even the second bull seven years old, and throw down the altar of Baal that your father has, and cut down the Asherah that is by it. 
-<span class="v">26&#160;</span>Then build an altar to Yahweh your Elohim on the top of this stronghold, in an orderly way, and take the second bull, and offer a burnt offering with the wood of the Asherah which you shall cut down.” 
-</p><p>
-<span class="v">27&#160;</span>Then Gideon took ten men of his servants, and did as Yahweh had spoken to him. Because he feared his father’s household and the men of the city, he could not do it by day, but he did it by night. 
-</p><p>
-<span class="v">28&#160;</span>When the men of the city arose early in the morning, behold, the altar of Baal was broken down, and the Asherah was cut down that was by it, and the second bull was offered on the altar that was built. 
-<span class="v">29&#160;</span>They said to one another, “Who has done this thing?” 
-</p><p>When they inquired and asked, they said, “Gideon the son of Joash has done this thing.” 
-</p><p>
-<span class="v">30&#160;</span>Then the men of the city said to Joash, “Bring out your son, that he may die, because he has broken down the altar of Baal, and because he has cut down the Asherah that was by it.” 
-<span class="v">31&#160;</span>Joash said to all who stood against him, “Will you contend for Baal? Or will you save him? He who will contend for him, let him be put to death by morning! If he is an elohim, let him contend for himself, because someone has broken down his altar!” 
-<span class="v">32&#160;</span>Therefore on that day he named him Jerub-Baal,<span class="f">+ \fr 6:32 \ft “Jerub-Baal” means “Let Baal contend”.</span> saying, “Let Baal contend against him, because he has broken down his altar.” 
-</p><p>
-<span class="v">33&#160;</span>Then all the Midianites and the Amalekites and the children of the east assembled themselves together; and they passed over, and encamped in the valley of Jezreel. 
-<span class="v">34&#160;</span>But Yahweh’s Spirit came on Gideon, and he blew a trumpet; and Abiezer was gathered together to follow him. 
-<span class="v">35&#160;</span>He sent messengers throughout all Manasseh, and they also were gathered together to follow him. He sent messengers to Asher, to Zebulun, and to Naphtali; and they came up to meet them. 
-</p><p>
-<span class="v">36&#160;</span>Gideon said to Elohim, “If you will save Israel by my hand, as you have spoken, 
-<span class="v">37&#160;</span>behold, I will put a fleece of wool on the threshing floor. If there is dew on the fleece only, and it is dry on all the ground, then I’ll know that you will save Israel by my hand, as you have spoken.” 
-</p><p>
-<span class="v">38&#160;</span>It was so; for he rose up early on the next day, and pressed the fleece together, and wrung the dew out of the fleece, a bowl full of water. 
-</p><p>
-<span class="v">39&#160;</span>Gideon said to Elohim, “Don’t let your anger be kindled against me, and I will speak but this once. Please let me make a trial just this once with the fleece. Let it now be dry only on the fleece, and on all the ground let there be dew.” 
-</p><p>
-<span class="v">40&#160;</span>Elohim did so that night; for it was dry on the fleece only, and there was dew on all the ground. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Then Jerubbaal, who is Gideon, and all the people who were with him, rose up early and encamped beside the spring of Harod. Midian’s camp was on the north side of them, by the hill of Moreh, in the valley. 
-<span class="v">2&#160;</span>Yahweh said to Gideon, “The people who are with you are too many for me to give the Midianites into their hand, lest Israel brag against me, saying, ‘My own hand has saved me.’ 
-<span class="v">3&#160;</span>Now therefore proclaim in the ears of the people, saying, ‘Whoever is fearful and trembling, let him return and depart from Mount Gilead.’&#160;” So twenty-two thousand of the people returned, and ten thousand remained. 
-</p><p>
-<span class="v">4&#160;</span>Yahweh said to Gideon, “There are still too many people. Bring them down to the water, and I will test them for you there. It shall be, that those whom I tell you, ‘This shall go with you,’ shall go with you; and whoever I tell you, ‘This shall not go with you,’ shall not go.” 
-<span class="v">5&#160;</span>So he brought down the people to the water; and Yahweh said to Gideon, “Everyone who laps of the water with his tongue, like a dog laps, you shall set him by himself; likewise everyone who bows down on his knees to drink.” 
-<span class="v">6&#160;</span>The number of those who lapped, putting their hand to their mouth, was three hundred men; but all the rest of the people bowed down on their knees to drink water. 
-<span class="v">7&#160;</span>Yahweh said to Gideon, “I will save you by the three hundred men who lapped, and deliver the Midianites into your hand. Let all the other people go, each to his own place.” 
-</p><p>
-<span class="v">8&#160;</span>So the people took food in their hand, and their trumpets; and he sent all the rest of the men of Israel to their own tents, but retained the three hundred men; and the camp of Midian was beneath him in the valley. 
-<span class="v">9&#160;</span>That same night, Yahweh said to him, “Arise, go down into the camp, for I have delivered it into your hand. 
-<span class="v">10&#160;</span>But if you are afraid to go down, go with Purah your servant down to the camp. 
-<span class="v">11&#160;</span>You will hear what they say; and afterward your hands will be strengthened to go down into the camp.” Then went he down with Purah his servant to the outermost part of the armed men who were in the camp. 
-</p><p>
-<span class="v">12&#160;</span>The Midianites and the Amalekites and all the children of the east lay along in the valley like locusts for multitude; and their camels were without number, as the sand which is on the seashore for multitude. 
-</p><p>
-<span class="v">13&#160;</span>When Gideon had come, behold, there was a man telling a dream to his fellow. He said, “Behold, I dreamed a dream; and behold, a cake of barley bread tumbled into the camp of Midian, came to the tent, and struck it so that it fell, and turned it upside down, so that the tent lay flat.” 
-</p><p>
-<span class="v">14&#160;</span>His fellow answered, “This is nothing other than the sword of Gideon the son of Joash, a man of Israel. Elohim has delivered Midian into his hand, with all the army.” 
-</p><p>
-<span class="v">15&#160;</span>It was so, when Gideon heard the telling of the dream and its interpretation, that he worshiped. Then he returned into the camp of Israel and said, “Arise, for Yahweh has delivered the army of Midian into your hand!” 
-</p><p>
-<span class="v">16&#160;</span>He divided the three hundred men into three companies, and he put into the hands of all of them trumpets and empty pitchers, with torches within the pitchers. 
-</p><p>
-<span class="v">17&#160;</span>He said to them, “Watch me, and do likewise. Behold, when I come to the outermost part of the camp, it shall be that, as I do, so you shall do. 
-<span class="v">18&#160;</span>When I blow the trumpet, I and all who are with me, then blow the trumpets also on every side of all the camp, and shout, ‘For Yahweh and for Gideon!’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>So Gideon and the hundred men who were with him came to the outermost part of the camp in the beginning of the middle watch, when they had but newly set the watch. Then they blew the trumpets and broke in pieces the pitchers that were in their hands. 
-<span class="v">20&#160;</span>The three companies blew the trumpets, broke the pitchers, and held the torches in their left hands and the trumpets in their right hands with which to blow; and they shouted, “The sword of Yahweh and of Gideon!” 
-<span class="v">21&#160;</span>They each stood in his place around the camp, and all the army ran; and they shouted, and put them to flight. 
-<span class="v">22&#160;</span>They blew the three hundred trumpets, and Yahweh set every man’s sword against his fellow and against all the army; and the army fled as far as Beth Shittah toward Zererah, as far as the border of Abel Meholah, by Tabbath. 
-<span class="v">23&#160;</span>The men of Israel were gathered together out of Naphtali, out of Asher, and out of all Manasseh, and pursued Midian. 
-<span class="v">24&#160;</span>Gideon sent messengers throughout all the hill country of Ephraim, saying, “Come down against Midian and take the waters before them as far as Beth Barah, even the Jordan!” So all the men of Ephraim were gathered together and took the waters as far as Beth Barah, even the Jordan. 
-<span class="v">25&#160;</span>They took the two princes of Midian, Oreb and Zeeb. They killed Oreb at Oreb’s rock, and Zeeb they killed at Zeeb’s wine press, as they pursued Midian. Then they brought the heads of Oreb and Zeeb to Gideon beyond the Jordan. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>The men of Ephraim said to him, “Why have you treated us this way, that you didn’t call us when you went to fight with Midian?” They rebuked him sharply. 
-<span class="v">2&#160;</span>He said to them, “What have I now done in comparison with you? Isn’t the gleaning of the grapes of Ephraim better than the vintage of Abiezer? 
-<span class="v">3&#160;</span>Elohim has delivered into your hand the princes of Midian, Oreb and Zeeb! What was I able to do in comparison with you?” Then their anger was abated toward him when he had said that. 
-</p><p>
-<span class="v">4&#160;</span>Gideon came to the Jordan and passed over, he and the three hundred men who were with him, faint, yet pursuing. 
-<span class="v">5&#160;</span>He said to the men of Succoth, “Please give loaves of bread to the people who follow me; for they are faint, and I am pursuing after Zebah and Zalmunna, the kings of Midian.” 
-</p><p>
-<span class="v">6&#160;</span>The princes of Succoth said, “Are the hands of Zebah and Zalmunna now in your hand, that we should give bread to your army?” 
-</p><p>
-<span class="v">7&#160;</span>Gideon said, “Therefore when Yahweh has delivered Zebah and Zalmunna into my hand, then I will tear your flesh with the thorns of the wilderness and with briers.” 
-</p><p>
-<span class="v">8&#160;</span>He went up there to Penuel, and spoke to them in the same way; and the men of Penuel answered him as the men of Succoth had answered. 
-<span class="v">9&#160;</span>He spoke also to the men of Penuel, saying, “When I come again in peace, I will break down this tower.” 
-</p><p>
-<span class="v">10&#160;</span>Now Zebah and Zalmunna were in Karkor, and their armies with them, about fifteen thousand men, all who were left of all the army of the children of the east; for there fell one hundred twenty thousand men who drew sword. 
-<span class="v">11&#160;</span>Gideon went up by the way of those who lived in tents on the east of Nobah and Jogbehah, and struck the army; for the army felt secure. 
-<span class="v">12&#160;</span>Zebah and Zalmunna fled and he pursued them. He took the two kings of Midian, Zebah and Zalmunna, and confused all the army. 
-<span class="v">13&#160;</span>Gideon the son of Joash returned from the battle from the ascent of Heres. 
-<span class="v">14&#160;</span>He caught a young man of the men of Succoth, and inquired of him; and he described for him the princes of Succoth, and its elders, seventy-seven men. 
-<span class="v">15&#160;</span>He came to the men of Succoth, and said, “See Zebah and Zalmunna, concerning whom you taunted me, saying, ‘Are the hands of Zebah and Zalmunna now in your hand, that we should give bread to your men who are weary?’&#160;” 
-<span class="v">16&#160;</span>He took the elders of the city, and thorns of the wilderness and briers, and with them he taught the men of Succoth. 
-<span class="v">17&#160;</span>He broke down the tower of Penuel, and killed the men of the city. 
-</p><p>
-<span class="v">18&#160;</span>Then he said to Zebah and Zalmunna, “What kind of men were they whom you killed at Tabor?” 
-</p><p>They answered, “They were like you. They all resembled the children of a king.” 
-</p><p>
-<span class="v">19&#160;</span>He said, “They were my brothers, the sons of my mother. As Yahweh lives, if you had saved them alive, I would not kill you.” 
-</p><p>
-<span class="v">20&#160;</span>He said to Jether his firstborn, “Get up and kill them!” But the youth didn’t draw his sword; for he was afraid, because he was yet a youth. 
-</p><p>
-<span class="v">21&#160;</span>Then Zebah and Zalmunna said, “You rise and fall on us; for as the man is, so is his strength.” Gideon arose, and killed Zebah and Zalmunna, and took the crescents that were on their camels’ necks. 
-</p><p>
-<span class="v">22&#160;</span>Then the men of Israel said to Gideon, “Rule over us, both you, your son, and your son’s son also; for you have saved us out of the hand of Midian.” 
-</p><p>
-<span class="v">23&#160;</span>Gideon said to them, “I will not rule over you, neither shall my son rule over you. Yahweh shall rule over you.” 
-<span class="v">24&#160;</span>Gideon said to them, “I do have a request: that you would each give me the earrings of his plunder.” (For they had golden earrings, because they were Ishmaelites.) 
-</p><p>
-<span class="v">25&#160;</span>They answered, “We will willingly give them.” They spread a garment, and every man threw the earrings of his plunder into it. 
-<span class="v">26&#160;</span>The weight of the golden earrings that he requested was one thousand and seven hundred shekels<span class="f">+ \fr 8:26 \ft A shekel is about 10 grams or about 0.32 Troy ounces, so 1700 shekels is about 17 kilograms or 37.4 pounds.</span> of gold, in addition to the crescents, and the pendants, and the purple clothing that was on the kings of Midian, and in addition to the chains that were about their camels’ necks. 
-<span class="v">27&#160;</span>Gideon made an ephod out of it, and put it in Ophrah, his city. Then all Israel played the prostitute with it there; and it became a snare to Gideon and to his house. 
-<span class="v">28&#160;</span>So Midian was subdued before the children of Israel, and they lifted up their heads no more. The land had rest forty years in the days of Gideon. 
-</p><p>
-<span class="v">29&#160;</span>Jerubbaal the son of Joash went and lived in his own house. 
-<span class="v">30&#160;</span>Gideon had seventy sons conceived from his body, for he had many women. 
-<span class="v">31&#160;</span>His concubine who was in Shechem also bore him a son, and he named him Abimelech. 
-<span class="v">32&#160;</span>Gideon the son of Joash died in a good old age, and was buried in the tomb of Joash his father, in Ophrah of the Abiezrites. 
-</p><p>
-<span class="v">33&#160;</span>As soon as Gideon was dead, the children of Israel turned again and played the prostitute following the Baals, and made Baal Berith their elohim. 
-<span class="v">34&#160;</span>The children of Israel didn’t remember Yahweh their Elohim, who had delivered them out of the hand of all their enemies on every side; 
-<span class="v">35&#160;</span>neither did they show kindness to the house of Jerubbaal, that is, Gideon, according to all the goodness which he had shown to Israel. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Abimelech the son of Jerubbaal went to Shechem to his mother’s brothers, and spoke with them and with all the family of the house of his mother’s father, saying, 
-<span class="v">2&#160;</span>“Please speak in the ears of all the owners of Shechem, ‘Is it better for you that all the sons of Jerubbaal, who are seventy persons, rule over you, or that one rule over you?’ Remember also that I am your bone and your flesh.” 
-</p><p>
-<span class="v">3&#160;</span>His mother’s brothers spoke of him in the ears of all the owners of Shechem all these words. Their hearts inclined to follow Abimelech; for they said, “He is our brother.” 
-<span class="v">4&#160;</span>They gave him seventy pieces of silver out of the house of Baal Berith, with which Abimelech hired vain and reckless fellows who followed him. 
-<span class="v">5&#160;</span>He went to his father’s house at Ophrah, and killed his brothers the sons of Jerubbaal, being seventy persons, on one stone; but Jotham the youngest son of Jerubbaal was left, for he hid himself. 
-<span class="v">6&#160;</span>All the owners of Shechem assembled themselves together with all the house of Millo, and went and made Abimelech king by the oak of the pillar that was in Shechem. 
-<span class="v">7&#160;</span>When they told it to Jotham, he went and stood on the top of Mount Gerizim and lifted up his voice, cried out, and said to them, “Listen to me, you men of Shechem, that Elohim may listen to you. 
-<span class="v">8&#160;</span>The trees set out to anoint a king over themselves. They said to the olive tree, ‘Reign over us.’ 
-</p><p>
-<span class="v">9&#160;</span>“But the olive tree said to them, ‘Should I stop producing my oil, with which they honor Elohim and man by me, and go to wave back and forth over the trees?’ 
-</p><p>
-<span class="v">10&#160;</span>“The trees said to the fig tree, ‘Come and reign over us.’ 
-</p><p>
-<span class="v">11&#160;</span>“But the fig tree said to them, ‘Should I leave my sweetness, and my good fruit, and go to wave back and forth over the trees?’ 
-</p><p>
-<span class="v">12&#160;</span>“The trees said to the vine, ‘Come and reign over us.’ 
-</p><p>
-<span class="v">13&#160;</span>“The vine said to them, ‘Should I leave my new wine, which cheers Elohim and man, and go to wave back and forth over the trees?’ 
-</p><p>
-<span class="v">14&#160;</span>“Then all the trees said to the bramble, ‘Come and reign over us.’ 
-</p><p>
-<span class="v">15&#160;</span>“The bramble said to the trees, ‘If in truth you anoint me king over you, then come and take refuge in my shade; and if not, let fire come out of the bramble, and devour the cedars of Lebanon.’ 
-</p><p>
-<span class="v">16&#160;</span>“Now therefore, if you have dealt truly and righteously, in that you have made Abimelech king, and if you have dealt well with Jerubbaal and his house, and have done to him according to the deserving of his hands 
-<span class="v">17&#160;</span>(for my father fought for you, risked his life, and delivered you out of the hand of Midian; 
-<span class="v">18&#160;</span>and you have risen up against my father’s house today and have slain his sons, seventy persons, on one stone, and have made Abimelech, the son of his female servant, king over the owners of Shechem, because he is your brother); 
-<span class="v">19&#160;</span>if you then have dealt truly and righteously with Jerubbaal and with his house today, then rejoice in Abimelech, and let him also rejoice in you; 
-<span class="v">20&#160;</span>but if not, let fire come out from Abimelech and devour the owners of Shechem and the house of Millo; and let fire come out from the owners of Shechem and from the house of Millo and devour Abimelech.” 
-</p><p>
-<span class="v">21&#160;</span>Jotham ran away and fled, and went to Beer<span class="f">+ \fr 9:21 \ft “Beer” is Hebrew for “well”, i.e., a village named for its well.</span> and lived there, for fear of Abimelech his brother. 
-</p><p>
-<span class="v">22&#160;</span>Abimelech was prince over Israel three years. 
-<span class="v">23&#160;</span>Then Elohim sent an evil spirit between Abimelech and the owners of Shechem; and the owners of Shechem dealt treacherously with Abimelech, 
-<span class="v">24&#160;</span>that the violence done to the seventy sons of Jerubbaal might come, and that their blood might be laid on Abimelech their brother who killed them, and on the owners of Shechem who strengthened his hands to kill his brothers. 
-<span class="v">25&#160;</span>The owners of Shechem set an ambush for him on the tops of the mountains, and they robbed all who came along that way by them; and Abimelech was told about it. 
-</p><p>
-<span class="v">26&#160;</span>Gaal the son of Ebed came with his brothers and went over to Shechem; and the owners of Shechem put their trust in him. 
-<span class="v">27&#160;</span>They went out into the field, harvested their vineyards, trod the grapes, celebrated, and went into the house of their elohim and ate and drank, and cursed Abimelech. 
-<span class="v">28&#160;</span>Gaal the son of Ebed said, “Who is Abimelech, and who is Shechem, that we should serve him? Isn’t he the son of Jerubbaal? Isn’t Zebul his officer? Serve the men of Hamor the father of Shechem, but why should we serve him? 
-<span class="v">29&#160;</span>I wish that this people were under my hand! Then I would remove Abimelech.” He said to Abimelech, “Increase your army and come out!” 
-</p><p>
-<span class="v">30&#160;</span>When Zebul the ruler of the city heard the words of Gaal the son of Ebed, his anger burned. 
-<span class="v">31&#160;</span>He sent messengers to Abimelech craftily, saying, “Behold, Gaal the son of Ebed and his brothers have come to Shechem; and behold, they incite the city against you. 
-<span class="v">32&#160;</span>Now therefore, go up by night, you and the people who are with you, and lie in wait in the field. 
-<span class="v">33&#160;</span>It shall be that in the morning, as soon as the sun is up, you shall rise early and rush on the city. Behold, when he and the people who are with him come out against you, then may you do to them as you shall find occasion.” 
-</p><p>
-<span class="v">34&#160;</span>Abimelech rose up, and all the people who were with him, by night, and they laid wait against Shechem in four companies. 
-<span class="v">35&#160;</span>Gaal the son of Ebed went out, and stood in the entrance of the gate of the city. Abimelech rose up, and the people who were with him, from the ambush. 
-</p><p>
-<span class="v">36&#160;</span>When Gaal saw the people, he said to Zebul, “Behold, people are coming down from the tops of the mountains.” 
-</p><p>Zebul said to him, “You see the shadows of the mountains as if they were men.” 
-</p><p>
-<span class="v">37&#160;</span>Gaal spoke again and said, “Behold, people are coming down by the middle of the land, and one company comes by the way of the oak of Meonenim.” 
-</p><p>
-<span class="v">38&#160;</span>Then Zebul said to him, “Now where is your mouth, that you said, ‘Who is Abimelech, that we should serve him?’ Isn’t this the people that you have despised? Please go out now and fight with them.” 
-</p><p>
-<span class="v">39&#160;</span>Gaal went out before the owners of Shechem, and fought with Abimelech. 
-<span class="v">40&#160;</span>Abimelech chased him, and he fled before him, and many fell wounded, even to the entrance of the gate. 
-<span class="v">41&#160;</span>Abimelech lived at Arumah; and Zebul drove out Gaal and his brothers, that they should not dwell in Shechem. 
-<span class="v">42&#160;</span>On the next day, the people went out into the field; and they told Abimelech. 
-<span class="v">43&#160;</span>He took the people and divided them into three companies, and laid wait in the field; and he looked, and behold, the people came out of the city. So, he rose up against them and struck them. 
-<span class="v">44&#160;</span>Abimelech and the companies that were with him rushed forward and stood in the entrance of the gate of the city; and the two companies rushed on all who were in the field and struck them. 
-<span class="v">45&#160;</span>Abimelech fought against the city all that day; and he took the city and killed the people in it. He beat down the city and sowed it with salt. 
-</p><p>
-<span class="v">46&#160;</span>When all the owners of the tower of Shechem heard of it, they entered into the stronghold of the house of Elberith. 
-<span class="v">47&#160;</span>Abimelech was told that all the owners of the tower of Shechem were gathered together. 
-<span class="v">48&#160;</span>Abimelech went up to Mount Zalmon, he and all the people who were with him; and Abimelech took an ax in his hand, and cut down a bough from the trees, and took it up, and laid it on his shoulder. Then he said to the people who were with him, “What you have seen me do, make haste, and do as I have done!” 
-<span class="v">49&#160;</span>All the people likewise each cut down his bough, followed Abimelech, and put them at the base of the stronghold, and set the stronghold on fire over them, so that all the people of the tower of Shechem died also, about a thousand men and women. 
-<span class="v">50&#160;</span>Then Abimelech went to Thebez and encamped against Thebez, and took it. 
-<span class="v">51&#160;</span>But there was a strong tower within the city, and all the men and women and all the owners of the city fled there, and shut themselves in, and went up to the roof of the tower. 
-<span class="v">52&#160;</span>Abimelech came to the tower and fought against it, and came near to the door of the tower to burn it with fire. 
-<span class="v">53&#160;</span>A certain woman cast an upper millstone on Abimelech’s head, and broke his skull. 
-</p><p>
-<span class="v">54&#160;</span>Then he called hastily to the young man, his armor bearer, and said to him, “Draw your sword and kill me, that men not say of me, ‘A woman killed him.’ His young man thrust him through, and he died.” 
-</p><p>
-<span class="v">55&#160;</span>When the men of Israel saw that Abimelech was dead, they each departed to his place. 
-<span class="v">56&#160;</span>Thus Elohim repaid the wickedness of Abimelech, which he did to his father in killing his seventy brothers; 
-<span class="v">57&#160;</span>and Elohim repaid all the wickedness of the men of Shechem on their heads; and the curse of Jotham the son of Jerubbaal came on them. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>After Abimelech, Tola the son of Puah, the son of Dodo, a man of Issachar, arose to save Israel. He lived in Shamir in the hill country of Ephraim. 
-<span class="v">2&#160;</span>He judged Israel twenty-three years, and died, and was buried in Shamir. 
-</p><p>
-<span class="v">3&#160;</span>After him Jair, the Gileadite, arose. He judged Israel twenty-two years. 
-<span class="v">4&#160;</span>He had thirty sons who rode on thirty donkey colts. They had thirty cities, which are called Havvoth Jair to this day, which are in the land of Gilead. 
-<span class="v">5&#160;</span>Jair died, and was buried in Kamon. 
-</p><p>
-<span class="v">6&#160;</span>The children of Israel again did that which was evil in Yahweh’s sight, and served the Baals, the Ashtaroth, the elohims of Syria, the elohims of Sidon, the elohims of Moab, the elohims of the children of Ammon, and the elohims of the Philistines. They abandoned Yahweh, and didn’t serve him. 
-<span class="v">7&#160;</span>Yahweh’s anger burned against Israel, and he sold them into the hand of the Philistines and into the hand of the children of Ammon. 
-<span class="v">8&#160;</span>They troubled and oppressed the children of Israel that year. For eighteen years they oppressed all the children of Israel that were beyond the Jordan in the land of the Amorites, which is in Gilead. 
-<span class="v">9&#160;</span>The children of Ammon passed over the Jordan to fight also against Judah, and against Benjamin, and against the house of Ephraim, so that Israel was very distressed. 
-<span class="v">10&#160;</span>The children of Israel cried to Yahweh, saying, “We have sinned against you, even because we have forsaken our Elohim, and have served the Baals.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said to the children of Israel, “Didn’t I save you from the Egyptians, and from the Amorites, from the children of Ammon, and from the Philistines? 
-<span class="v">12&#160;</span>The Sidonians also, and the Amalekites, and the Maonites, oppressed you; and you cried to me, and I saved you out of their hand. 
-<span class="v">13&#160;</span>Yet you have forsaken me and served other elohims. Therefore I will save you no more. 
-<span class="v">14&#160;</span>Go and cry to the elohims which you have chosen. Let them save you in the time of your distress!” 
-</p><p>
-<span class="v">15&#160;</span>The children of Israel said to Yahweh, “We have sinned! Do to us whatever seems good to you; only deliver us, please, today.” 
-<span class="v">16&#160;</span>They put away the foreign elohims from among them and served Yahweh; and his soul was grieved for the misery of Israel. 
-</p><p>
-<span class="v">17&#160;</span>Then the children of Ammon were gathered together and encamped in Gilead. The children of Israel assembled themselves together and encamped in Mizpah. 
-<span class="v">18&#160;</span>The people, the princes of Gilead, said to one another, “Who is the man who will begin to fight against the children of Ammon? He shall be head over all the inhabitants of Gilead.” 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Now Jephthah the Gileadite was a mighty man of valor. He was the son of a prostitute. Gilead brought forth Jephthah. 
-<span class="v">2&#160;</span>Gilead’s woman bore him sons. When his woman’s sons grew up, they drove Jephthah out and said to him, “You will not inherit in our father’s house, for you are the son of another woman.” 
-<span class="v">3&#160;</span>Then Jephthah fled from his brothers and lived in the land of Tob. Outlaws joined up with Jephthah, and they went out with him. 
-</p><p>
-<span class="v">4&#160;</span>After a while, the children of Ammon made war against Israel. 
-<span class="v">5&#160;</span>When the children of Ammon made war against Israel, the elders of Gilead went to get Jephthah out of the land of Tob. 
-<span class="v">6&#160;</span>They said to Jephthah, “Come and be our chief, that we may fight with the children of Ammon.” 
-</p><p>
-<span class="v">7&#160;</span>Jephthah said to the elders of Gilead, “Didn’t you hate me, and drive me out of my father’s house? Why have you come to me now when you are in distress?” 
-</p><p>
-<span class="v">8&#160;</span>The elders of Gilead said to Jephthah, “Therefore we have turned again to you now, that you may go with us and fight with the children of Ammon. You will be our head over all the inhabitants of Gilead.” 
-</p><p>
-<span class="v">9&#160;</span>Jephthah said to the elders of Gilead, “If you bring me home again to fight with the children of Ammon, and Yahweh delivers them before me, will I be your head?” 
-</p><p>
-<span class="v">10&#160;</span>The elders of Gilead said to Jephthah, “Yahweh will be witness between us. Surely we will do what you say.” 
-</p><p>
-<span class="v">11&#160;</span>Then Jephthah went with the elders of Gilead, and the people made him head and chief over them. Jephthah spoke all his words before Yahweh in Mizpah. 
-</p><p>
-<span class="v">12&#160;</span>Jephthah sent messengers to the king of the children of Ammon, saying, “What do you have to do with me, that you have come to me to fight against my land?” 
-</p><p>
-<span class="v">13&#160;</span>The king of the children of Ammon answered the messengers of Jephthah, “Because Israel took away my land when he came up out of Egypt, from the Arnon even to the Jabbok, and to the Jordan. Now therefore restore that territory again peaceably.” 
-</p><p>
-<span class="v">14&#160;</span>Jephthah sent messengers again to the king of the children of Ammon; 
-<span class="v">15&#160;</span>and he said to him, “Jephthah says: Israel didn’t take away the land of Moab, nor the land of the children of Ammon; 
-<span class="v">16&#160;</span>but when they came up from Egypt, and Israel went through the wilderness to the Red Sea, and came to Kadesh, 
-<span class="v">17&#160;</span>then Israel sent messengers to the king of Edom, saying, ‘Please let me pass through your land;’ but the king of Edom didn’t listen. In the same way, he sent to the king of Moab, but he refused; so Israel stayed in Kadesh. 
-<span class="v">18&#160;</span>Then they went through the wilderness, and went around the land of Edom, and the land of Moab, and came by the east side of the land of Moab, and they encamped on the other side of the Arnon; but they didn’t come within the border of Moab, for the Arnon was the border of Moab. 
-<span class="v">19&#160;</span>Israel sent messengers to Sihon king of the Amorites, the king of Heshbon; and Israel said to him, ‘Please let us pass through your land to my place.’ 
-<span class="v">20&#160;</span>But Sihon didn’t trust Israel to pass through his border; but Sihon gathered all his people together, and encamped in Jahaz, and fought against Israel. 
-<span class="v">21&#160;</span>Yahweh, the Elohim of Israel, delivered Sihon and all his people into the hand of Israel, and they struck them. So Israel possessed all the land of the Amorites, the inhabitants of that country. 
-<span class="v">22&#160;</span>They possessed all the border of the Amorites, from the Arnon even to the Jabbok, and from the wilderness even to the Jordan. 
-<span class="v">23&#160;</span>So now Yahweh, the Elohim of Israel, has dispossessed the Amorites from before his people Israel, and should you possess them? 
-<span class="v">24&#160;</span>Won’t you possess that which Chemosh your elohim gives you to possess? So whoever Yahweh our Elohim has dispossessed from before us, them will we possess. 
-<span class="v">25&#160;</span>Now are you anything better than Balak the son of Zippor, king of Moab? Did he ever strive against Israel, or did he ever fight against them? 
-<span class="v">26&#160;</span>Israel lived in Heshbon and its towns, and in Aroer and its towns, and in all the cities that are along the side of the Arnon for three hundred years! Why didn’t you recover them within that time? 
-<span class="v">27&#160;</span>Therefore I have not sinned against you, but you do me wrong to war against me. May Yahweh the Judge be judge today between the children of Israel and the children of Ammon.” 
-</p><p>
-<span class="v">28&#160;</span>However, the king of the children of Ammon didn’t listen to the words of Jephthah which he sent him. 
-<span class="v">29&#160;</span>Then Yahweh’s Spirit came on Jephthah, and he passed over Gilead and Manasseh, and passed over Mizpah of Gilead, and from Mizpah of Gilead he passed over to the children of Ammon. 
-</p><p>
-<span class="v">30&#160;</span>Jephthah vowed a vow to Yahweh, and said, “If you will indeed deliver the children of Ammon into my hand, 
-<span class="v">31&#160;</span>then it shall be, that whatever comes out of the doors of my house to meet me when I return in peace from the children of Ammon, it shall be Yahweh’s, and I will offer it up for a burnt offering.” 
-</p><p>
-<span class="v">32&#160;</span>So Jephthah passed over to the children of Ammon to fight against them; and Yahweh delivered them into his hand. 
-<span class="v">33&#160;</span>He struck them from Aroer until you come to Minnith, even twenty cities, and to Abelcheramim, with a very great slaughter. So the children of Ammon were subdued before the children of Israel. 
-</p><p>
-<span class="v">34&#160;</span>Jephthah came to Mizpah to his house; and behold, his daughter came out to meet him with tambourines and with dances. She was his only child. Besides her he had neither son nor daughter. 
-<span class="v">35&#160;</span>When he saw her, he tore his clothes, and said, “Alas, my daughter! You have brought me very low, and you are one of those who trouble me; for I have opened my mouth to Yahweh, and I can’t go back.” 
-</p><p>
-<span class="v">36&#160;</span>She said to him, “My father, you have opened your mouth to Yahweh; do to me according to that which has proceeded out of your mouth, because Yahweh has taken vengeance for you on your enemies, even on the children of Ammon.” 
-<span class="v">37&#160;</span>Then she said to her father, “Let this thing be done for me. Leave me alone two months, that I may depart and go down on the mountains, and bewail my virginity, I and my companions.” 
-</p><p>
-<span class="v">38&#160;</span>He said, “Go.” He sent her away for two months; and she departed, she and her companions, and mourned her virginity on the mountains. 
-<span class="v">39&#160;</span>At the end of two months, she returned to her father, who did with her according to his vow which he had vowed. She was a virgin. It became a custom in Israel 
-<span class="v">40&#160;</span>that the daughters of Israel went yearly to celebrate the daughter of Jephthah the Gileadite four days in a year. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>The men of Ephraim were gathered together, and passed northward; and they said to Jephthah, “Why did you pass over to fight against the children of Ammon, and didn’t call us to go with you? We will burn your house around you with fire!” 
-</p><p>
-<span class="v">2&#160;</span>Jephthah said to them, “I and my people were at great strife with the children of Ammon; and when I called you, you didn’t save me out of their hand. 
-<span class="v">3&#160;</span>When I saw that you didn’t save me, I put my life in my hand, and passed over against the children of Ammon, and Yahweh delivered them into my hand. Why then have you come up to me today, to fight against me?” 
-</p><p>
-<span class="v">4&#160;</span>Then Jephthah gathered together all the men of Gilead, and fought with Ephraim. The men of Gilead struck Ephraim, because they said, “You are fugitives of Ephraim, you Gileadites, in the middle of Ephraim, and in the middle of Manasseh.” 
-<span class="v">5&#160;</span>The Gileadites took the fords of the Jordan against the Ephraimites. Whenever a fugitive of Ephraim said, “Let me go over,” the men of Gilead said to him, “Are you an Ephraimite?” If he said, “No;” 
-<span class="v">6&#160;</span>then they said to him, “Now say ‘Shibboleth;’&#160;” and he said “Sibboleth”; for he couldn’t manage to pronounce it correctly, then they seized him and killed him at the fords of the Jordan. At that time, forty-two thousand of Ephraim fell. 
-</p><p>
-<span class="v">7&#160;</span>Jephthah judged Israel six years. Then Jephthah the Gileadite died, and was buried in the cities of Gilead. 
-</p><p>
-<span class="v">8&#160;</span>After him Ibzan of Bethlehem judged Israel. 
-<span class="v">9&#160;</span>He had thirty sons. He sent his thirty daughters outside his clan, and he brought in thirty daughters from outside his clan for his sons. He judged Israel seven years. 
-<span class="v">10&#160;</span>Ibzan died, and was buried at Bethlehem. 
-</p><p>
-<span class="v">11&#160;</span>After him, Elon the Zebulunite judged Israel; and he judged Israel ten years. 
-<span class="v">12&#160;</span>Elon the Zebulunite died, and was buried in Aijalon in the land of Zebulun. 
-</p><p>
-<span class="v">13&#160;</span>After him, Abdon the son of Hillel the Pirathonite judged Israel. 
-<span class="v">14&#160;</span>He had forty sons and thirty sons’ sons who rode on seventy donkey colts. He judged Israel eight years. 
-<span class="v">15&#160;</span>Abdon the son of Hillel the Pirathonite died, and was buried in Pirathon in the land of Ephraim, in the hill country of the Amalekites. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>The children of Israel again did that which was evil in Yahweh’s sight; and Yahweh delivered them into the hand of the Philistines forty years. 
-</p><p>
-<span class="v">2&#160;</span>There was a certain man of Zorah, of the family of the Danites, whose name was Manoah; and his woman was barren, and childless. 
-<span class="v">3&#160;</span>Yahweh’s angel appeared to the woman, and said to her, “See now, you are barren and childless; but you shall conceive and bear a son. 
-<span class="v">4&#160;</span>Now therefore please beware and drink no wine nor strong drink, and don’t eat any unclean thing; 
-<span class="v">5&#160;</span>for, behold, you shall conceive and give birth to a son. No razor shall come on his head, for the child shall be a Nazirite to Elohim from the womb. He shall begin to save Israel out of the hand of the Philistines.” 
-</p><p>
-<span class="v">6&#160;</span>Then the woman came and told her man, saying, “A man of Elohim came to me, and his face was like the face of the angel of Elohim, very awesome. I didn’t ask him where he was from, neither did he tell me his name; 
-<span class="v">7&#160;</span>but he said to me, ‘Behold, you shall conceive and bear a son; and now drink no wine nor strong drink. Don’t eat any unclean thing, for the child shall be a Nazirite to Elohim from the womb to the day of his death.’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>Then Manoah entreated Yahweh, and said, “Oh, Lord, please let the man of Elohim whom you sent come again to us, and teach us what we should do to the child who shall be born.” 
-</p><p>
-<span class="v">9&#160;</span>Elohim listened to the voice of Manoah, and the angel of Elohim came again to the woman as she sat in the field; but Manoah, her man, wasn’t with her. 
-<span class="v">10&#160;</span>The woman hurried and ran, and told her man, saying to him, “Behold, the man who came to me that day has appeared to me.” 
-</p><p>
-<span class="v">11&#160;</span>Manoah arose and followed his woman, and came to the man, and said to him, “Are you the man who spoke to my woman?” 
-</p><p>He said, “I am.” 
-</p><p>
-<span class="v">12&#160;</span>Manoah said, “Now let your words happen. What shall the child’s way of life and mission be?” 
-</p><p>
-<span class="v">13&#160;</span>Yahweh’s angel said to Manoah, “Of all that I said to the woman let her beware. 
-<span class="v">14&#160;</span>She may not eat of anything that comes of the vine, neither let her drink wine or strong drink, nor eat any unclean thing. Let her observe all that I commanded her.” 
-</p><p>
-<span class="v">15&#160;</span>Manoah said to Yahweh’s angel, “Please stay with us, that we may make a young goat ready for you.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh’s angel said to Manoah, “Though you detain me, I won’t eat your bread. If you will prepare a burnt offering, you must offer it to Yahweh.” For Manoah didn’t know that he was Yahweh’s angel. 
-</p><p>
-<span class="v">17&#160;</span>Manoah said to Yahweh’s angel, “What is your name, that when your words happen, we may honor you?” 
-</p><p>
-<span class="v">18&#160;</span>Yahweh’s angel said to him, “Why do you ask about my name, since it is incomprehensible<span class="f">+ \fr 13:18 \ft or, wonderful</span>?” 
-</p><p>
-<span class="v">19&#160;</span>So Manoah took the young goat with the meal offering, and offered it on the rock to Yahweh. Then the angel did an amazing thing as Manoah and his woman watched. 
-<span class="v">20&#160;</span>For when the flame went up toward the sky from off the altar, Yahweh’s angel ascended in the flame of the altar. Manoah and his woman watched; and they fell on their faces to the ground. 
-<span class="v">21&#160;</span>But Yahweh’s angel didn’t appear to Manoah or to his woman any more. Then Manoah knew that he was Yahweh’s angel. 
-<span class="v">22&#160;</span>Manoah said to his woman, “We shall surely die, because we have seen Elohim.” 
-</p><p>
-<span class="v">23&#160;</span>But his woman said to him, “If Yahweh were pleased to kill us, he wouldn’t have received a burnt offering and a meal offering at our hand, and he wouldn’t have shown us all these things, nor would he have told us such things as these at this time.” 
-<span class="v">24&#160;</span>The woman bore a son and named him Samson. The child grew, and Yahweh blessed him. 
-<span class="v">25&#160;</span>Yahweh’s Spirit began to move him in Mahaneh Dan, between Zorah and Eshtaol. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Samson went down to Timnah, and saw a woman in Timnah of the daughters of the Philistines. 
-<span class="v">2&#160;</span>He came up, and told his father and his mother, saying, “I have seen a woman in Timnah of the daughters of the Philistines. Now therefore get her for me as my woman.” 
-</p><p>
-<span class="v">3&#160;</span>Then his father and his mother said to him, “Isn’t there a woman among your brothers’ daughters, or among all my people, that you go to take a woman of the uncircumcised Philistines?” 
-</p><p>Samson said to his father, “Get her for me, for she pleases me well.” 
-</p><p>
-<span class="v">4&#160;</span>But his father and his mother didn’t know that it was of Yahweh; for he sought an occasion against the Philistines. Now at that time the Philistines ruled over Israel. 
-</p><p>
-<span class="v">5&#160;</span>Then Samson went down to Timnah with his father and his mother, and came to the vineyards of Timnah; and behold, a young lion roared at him. 
-<span class="v">6&#160;</span>Yahweh’s Spirit came mightily on him, and he tore him as he would have torn a young goat with his bare hands, but he didn’t tell his father or his mother what he had done. 
-<span class="v">7&#160;</span>He went down and talked with the woman, and she pleased Samson well. 
-<span class="v">8&#160;</span>After a while he returned to take her, and he went over to see the carcass of the lion; and behold, there was a swarm of bees in the body of the lion, and honey. 
-<span class="v">9&#160;</span>He took it into his hands, and went on, eating as he went. He came to his father and mother and gave to them, and they ate, but he didn’t tell them that he had taken the honey out of the lion’s body. 
-<span class="v">10&#160;</span>His father went down to the woman; and Samson made a feast there, for the young men used to do so. 
-<span class="v">11&#160;</span>When they saw him, they brought thirty companions to be with him. 
-</p><p>
-<span class="v">12&#160;</span>Samson said to them, “Let me tell you a riddle now. If you can tell me the answer within the seven days of the feast, and find it out, then I will give you thirty linen garments and thirty changes of clothing; 
-<span class="v">13&#160;</span>but if you can’t tell me the answer, then you shall give me thirty linen garments and thirty changes of clothing.” 
-</p><p>They said to him, “Tell us your riddle, that we may hear it.” 
-</p><p>
-<span class="v">14&#160;</span>He said to them, 
-</p><p class="q1">“Out of the eater came out food. 
-</p><p class="q2">Out of the strong came out sweetness.” 
-</p><p>They couldn’t in three days declare the riddle. 
-<span class="v">15&#160;</span>On the seventh day, they said to Samson’s woman, “Entice your man, that he may declare to us the riddle, lest we burn you and your father’s house with fire. Have you called us to impoverish us? Isn’t that so?” 
-</p><p>
-<span class="v">16&#160;</span>Samson’s woman wept before him, and said, “You just hate me, and don’t love me. You’ve told a riddle to the children of my people, and haven’t told it to me.” 
-</p><p>He said to her, “Behold, I haven’t told my father or my mother, so why should I tell you?” 
-</p><p>
-<span class="v">17&#160;</span>She wept before him the seven days, while their feast lasted; and on the seventh day, he told her, because she pressed him severely; and she told the riddle to the children of her people. 
-<span class="v">18&#160;</span>The men of the city said to him on the seventh day before the sun went down, “What is sweeter than honey? What is stronger than a lion?” 
-</p><p>He said to them, 
-</p><p class="q1">“If you hadn’t plowed with my heifer, 
-</p><p class="q2">you wouldn’t have found out my riddle.” 
-</p><p>
-<span class="v">19&#160;</span>Yahweh’s Spirit came mightily on him, and he went down to Ashkelon and struck thirty men of them. He took their plunder, then gave the changes of clothing to those who declared the riddle. His anger burned, and he went up to his father’s house. 
-<span class="v">20&#160;</span>But Samson’s woman was given to his companion, who had been his friend. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>But after a while, in the time of wheat harvest, Samson visited his woman with a young goat. He said, “I will go in to my woman’s room.” 
-</p><p>But her father wouldn’t allow him to go in. 
-<span class="v">2&#160;</span>Her father said, “I most certainly thought that you utterly hated her; therefore I gave her to your companion. Isn’t her younger sister more beautiful than she? Please, take her instead.” 
-</p><p>
-<span class="v">3&#160;</span>Samson said to them, “This time I will be blameless in the case of the Philistines when I harm them.” 
-<span class="v">4&#160;</span>Samson went and caught three hundred foxes, and took torches, and turned tail to tail, and put a torch in the middle between every two tails. 
-<span class="v">5&#160;</span>When he had set the torches on fire, he let them go into the standing grain of the Philistines, and burned up both the shocks and the standing grain, and also the olive groves. 
-</p><p>
-<span class="v">6&#160;</span>Then the Philistines said, “Who has done this?” 
-</p><p>They said, “Samson, the son-in-law of the Timnite, because he has taken his woman and given her to his companion.” The Philistines came up, and burned her and her father with fire. 
-</p><p>
-<span class="v">7&#160;</span>Samson said to them, “If you behave like this, surely I will take revenge on you, and after that I will cease.” 
-<span class="v">8&#160;</span>He struck them hip and thigh with a great slaughter; and he went down and lived in the cave in Etam’s rock. 
-<span class="v">9&#160;</span>Then the Philistines went up, encamped in Judah, and spread themselves in Lehi. 
-</p><p>
-<span class="v">10&#160;</span>The men of Judah said, “Why have you come up against us?” 
-</p><p>They said, “We have come up to bind Samson, to do to him as he has done to us.” 
-</p><p>
-<span class="v">11&#160;</span>Then three thousand men of Judah went down to the cave in Etam’s rock, and said to Samson, “Don’t you know that the Philistines are rulers over us? What then is this that you have done to us?” 
-</p><p>He said to them, “As they did to me, so I have done to them.” 
-</p><p>
-<span class="v">12&#160;</span>They said to him, “We have come down to bind you, that we may deliver you into the hand of the Philistines.” 
-</p><p>Samson said to them, “Swear to me that you will not attack me yourselves.” 
-</p><p>
-<span class="v">13&#160;</span>They spoke to him, saying, “No, but we will bind you securely and deliver you into their hands; but surely we will not kill you.” They bound him with two new ropes, and brought him up from the rock. 
-</p><p>
-<span class="v">14&#160;</span>When he came to Lehi, the Philistines shouted as they met him. Then Yahweh’s Spirit came mightily on him, and the ropes that were on his arms became as flax that was burned with fire; and his bands dropped from off his hands. 
-<span class="v">15&#160;</span>He found a fresh jawbone of a donkey, put out his hand, took it, and struck a thousand men with it. 
-<span class="v">16&#160;</span>Samson said, “With the jawbone of a donkey, heaps on heaps; with the jawbone of a donkey I have struck a thousand men.” 
-<span class="v">17&#160;</span>When he had finished speaking, he threw the jawbone out of his hand; and that place was called Ramath Lehi.<span class="f">+ \fr 15:17 \ft “Ramath” means “hill” and “Lehi” means “jawbone”.</span> 
-</p><p>
-<span class="v">18&#160;</span>He was very thirsty, and called on Yahweh and said, “You have given this great deliverance by the hand of your servant; and now shall I die of thirst, and fall into the hands of the uncircumcised?” 
-</p><p>
-<span class="v">19&#160;</span>But Elohim split the hollow place that is in Lehi, and water came out of it. When he had drunk, his spirit came again, and he revived. Therefore its name was called En Hakkore, which is in Lehi, to this day. 
-<span class="v">20&#160;</span>He judged Israel twenty years in the days of the Philistines. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Samson went to Gaza, and saw there a prostitute, and went in to her. 
-<span class="v">2&#160;</span>The Gazites were told, “Samson is here!” They surrounded him and laid wait for him all night in the gate of the city, and were quiet all the night, saying, “Wait until morning light; then we will kill him.” 
-<span class="v">3&#160;</span>Samson lay until midnight, then arose at midnight and took hold of the doors of the gate of the city, with the two posts, and plucked them up, bar and all, and put them on his shoulders and carried them up to the top of the mountain that is before Hebron. 
-</p><p>
-<span class="v">4&#160;</span>It came to pass afterward that he loved a woman in the valley of Sorek, whose name was Delilah. 
-<span class="v">5&#160;</span>The lords of the Philistines came up to her and said to her, “Entice him, and see in which his great strength lies, and by what means we may prevail against him, that we may bind him to afflict him; and we will each give you eleven hundred pieces of silver.” 
-</p><p>
-<span class="v">6&#160;</span>Delilah said to Samson, “Please tell me where your great strength lies, and what you might be bound to afflict you.” 
-</p><p>
-<span class="v">7&#160;</span>Samson said to her, “If they bind me with seven green cords that were never dried, then shall I become weak, and be as another man.” 
-</p><p>
-<span class="v">8&#160;</span>Then the lords of the Philistines brought up to her seven green cords which had not been dried, and she bound him with them. 
-<span class="v">9&#160;</span>Now she had an ambush waiting in the inner room. She said to him, “The Philistines are on you, Samson!” He broke the cords as a flax thread is broken when it touches the fire. So his strength was not known. 
-</p><p>
-<span class="v">10&#160;</span>Delilah said to Samson, “Behold, you have mocked me, and told me lies. Now please tell me how you might be bound.” 
-</p><p>
-<span class="v">11&#160;</span>He said to her, “If they only bind me with new ropes with which no work has been done, then shall I become weak, and be as another man.” 
-</p><p>
-<span class="v">12&#160;</span>So Delilah took new ropes and bound him with them, then said to him, “The Philistines are on you, Samson!” The ambush was waiting in the inner room. He broke them off his arms like a thread. 
-</p><p>
-<span class="v">13&#160;</span>Delilah said to Samson, “Until now, you have mocked me and told me lies. Tell me with what you might be bound.” 
-</p><p>He said to her, “If you weave the seven locks of my head with the fabric on the loom.” 
-</p><p>
-<span class="v">14&#160;</span>She fastened it with the pin, and said to him, “The Philistines are on you, Samson!” He awakened out of his sleep, and plucked away the pin of the beam and the fabric. 
-</p><p>
-<span class="v">15&#160;</span>She said to him, “How can you say, ‘I love you,’ when your heart is not with me? You have mocked me these three times, and have not told me where your great strength lies.” 
-</p><p>
-<span class="v">16&#160;</span>When she pressed him daily with her words and urged him, his soul was troubled to death. 
-<span class="v">17&#160;</span>He told her all his heart and said to her, “No razor has ever come on my head; for I have been a Nazirite to Elohim from my mother’s womb. If I am shaved, then my strength will go from me and I will become weak, and be like any other man.” 
-</p><p>
-<span class="v">18&#160;</span>When Delilah saw that he had told her all his heart, she sent and called for the lords of the Philistines, saying, “Come up this once, for he has told me all his heart.” Then the lords of the Philistines came up to her and brought the money in their hand. 
-<span class="v">19&#160;</span>She made him sleep on her knees; and she called for a man and shaved off the seven locks of his head; and she began to afflict him, and his strength went from him. 
-<span class="v">20&#160;</span>She said, “The Philistines are upon you, Samson!” 
-</p><p>He awoke out of his sleep, and said, “I will go out as at other times, and shake myself free.” But he didn’t know that Yahweh had departed from him. 
-<span class="v">21&#160;</span>The Philistines laid hold on him and put out his eyes; and they brought him down to Gaza and bound him with fetters of bronze; and he ground at the mill in the prison. 
-<span class="v">22&#160;</span>However, the hair of his head began to grow again after he was shaved. 
-</p><p>
-<span class="v">23&#160;</span>The lords of the Philistines gathered together to offer a great sacrifice to Dagon their elohim, and to rejoice; for they said, “Our elohim has delivered Samson our enemy into our hand.” 
-<span class="v">24&#160;</span>When the people saw him, they praised their elohim; for they said, “Our elohim has delivered our enemy and the destroyer of our country, who has slain many of us, into our hand.” 
-</p><p>
-<span class="v">25&#160;</span>When their hearts were merry, they said, “Call for Samson, that he may entertain us.” They called for Samson out of the prison; and he performed before them. They set him between the pillars; 
-<span class="v">26&#160;</span>and Samson said to the boy who held him by the hand, “Allow me to feel the pillars on which the house rests, that I may lean on them.” 
-<span class="v">27&#160;</span>Now the house was full of men and women; and all the lords of the Philistines were there; and there were on the roof about three thousand men and women, who saw while Samson performed. 
-<span class="v">28&#160;</span>Samson called to Yahweh, and said, “Lord Yahweh, remember me, please, and strengthen me, please, only this once, Elohim, that I may be at once avenged of the Philistines for my two eyes.” 
-<span class="v">29&#160;</span>Samson took hold of the two middle pillars on which the house rested and leaned on them, the one with his right hand and the other with his left. 
-<span class="v">30&#160;</span>Samson said, “Let me die with the Philistines!” He bowed himself with all his might; and the house fell on the lords, and on all the people who were in it. So the dead that he killed at his death were more than those who he killed in his life. 
-</p><p>
-<span class="v">31&#160;</span>Then his brothers and all the house of his father came down and took him, and brought him up and buried him between Zorah and Eshtaol in the burial site of Manoah his father. He judged Israel twenty years. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>There was a man of the hill country of Ephraim, whose name was Micah. 
-<span class="v">2&#160;</span>He said to his mother, “The eleven hundred pieces of silver that were taken from you, about which you uttered a curse, and also spoke it in my ears—behold, the silver is with me. I took it.” 
-</p><p>His mother said, “May Yahweh bless my son!” 
-</p><p>
-<span class="v">3&#160;</span>He restored the eleven hundred pieces of silver to his mother, then his mother said, “I most certainly dedicate the silver to Yahweh from my hand for my son, to make a carved image and a molten image. Now therefore I will restore it to you.” 
-</p><p>
-<span class="v">4&#160;</span>When he restored the money to his mother, his mother took two hundred pieces of silver, and gave them to a silversmith, who made a carved image and a molten image out of it. It was in the house of Micah. 
-</p><p>
-<span class="v">5&#160;</span>The man Micah had a house of elohims, and he made an ephod, and teraphim,<span class="f">+ \fr 17:5 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> and consecrated one of his sons, who became his priest. 
-<span class="v">6&#160;</span>In those days there was no king in Israel. Everyone did that which was right in his own eyes. 
-<span class="v">7&#160;</span>There was a young man out of Bethlehem Judah, of the family of Judah, who was a Levite; and he lived there. 
-<span class="v">8&#160;</span>The man departed out of the city, out of Bethlehem Judah, to live where he could find a place, and he came to the hill country of Ephraim, to the house of Micah, as he traveled. 
-<span class="v">9&#160;</span>Micah said to him, “Where did you come from?” 
-</p><p>He said to him, “I am a Levite of Bethlehem Judah, and I am looking for a place to live.” 
-</p><p>
-<span class="v">10&#160;</span>Micah said to him, “Dwell with me, and be to me a father and a priest, and I will give you ten pieces of silver per year, a suit of clothing, and your food.” So the Levite went in. 
-<span class="v">11&#160;</span>The Levite was content to dwell with the man; and the young man was to him as one of his sons. 
-<span class="v">12&#160;</span>Micah consecrated the Levite, and the young man became his priest, and was in the house of Micah. 
-<span class="v">13&#160;</span>Then Micah said, “Now I know that Yahweh will do good to me, since I have a Levite as my priest.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>In those days there was no king in Israel. In those days the tribe of the Danites sought an inheritance to dwell in; for to that day, their inheritance had not fallen to them among the tribes of Israel. 
-<span class="v">2&#160;</span>The children of Dan sent five men of their family from their whole number, men of valor, from Zorah and from Eshtaol, to spy out the land and to search it. They said to them, “Go, explore the land!” 
-</p><p>They came to the hill country of Ephraim, to the house of Micah, and lodged there. 
-<span class="v">3&#160;</span>When they were by the house of Micah, they knew the voice of the young man the Levite; so they went over there and said to him, “Who brought you here? What do you do in this place? What do you have here?” 
-</p><p>
-<span class="v">4&#160;</span>He said to them, “Thus and thus has Micah dealt with me, and he has hired me, and I have become his priest.” 
-</p><p>
-<span class="v">5&#160;</span>They said to him, “Please ask counsel of Elohim, that we may know whether our way which we go shall be prosperous.” 
-</p><p>
-<span class="v">6&#160;</span>The priest said to them, “Go in peace. Your way in which you go is before Yahweh.” 
-</p><p>
-<span class="v">7&#160;</span>Then the five men departed and came to Laish and saw the people who were there, how they lived in safety, in the way of the Sidonians, quiet and secure; for there was no one in the land possessing authority, that might put them to shame in anything, and they were far from the Sidonians, and had no dealings with anyone else. 
-<span class="v">8&#160;</span>They came to their brothers at Zorah and Eshtaol; and their brothers asked them, “What do you say?” 
-</p><p>
-<span class="v">9&#160;</span>They said, “Arise, and let’s go up against them; for we have seen the land, and behold, it is very good. Do you stand still? Don’t be slothful to go and to enter in to possess the land. 
-<span class="v">10&#160;</span>When you go, you will come to an unsuspecting people, and the land is large; for Elohim has given it into your hand, a place where there is no lack of anything that is in the earth.” 
-</p><p>
-<span class="v">11&#160;</span>The family of the Danites set out from Zorah and Eshtaol with six hundred men armed with weapons of war. 
-<span class="v">12&#160;</span>They went up and encamped in Kiriath Jearim in Judah. Therefore they call that place Mahaneh Dan to this day. Behold, it is behind Kiriath Jearim. 
-<span class="v">13&#160;</span>They passed from there to the hill country of Ephraim, and came to the house of Micah. 
-</p><p>
-<span class="v">14&#160;</span>Then the five men who went to spy out the country of Laish answered and said to their brothers, “Do you know that there is in these houses an ephod, and teraphim,<span class="f">+ \fr 18:14 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> and a carved image, and a molten image? Now therefore consider what you have to do.” 
-<span class="v">15&#160;</span>They went over there and came to the house of the young Levite man, even to the house of Micah, and asked him how he was doing. 
-<span class="v">16&#160;</span>The six hundred men armed with their weapons of war, who were of the children of Dan, stood by the entrance of the gate. 
-<span class="v">17&#160;</span>The five men who went to spy out the land went up, and came in there, and took the engraved image, the ephod, the teraphim, and the molten image; and the priest stood by the entrance of the gate with the six hundred men armed with weapons of war. 
-</p><p>
-<span class="v">18&#160;</span>When these went into Micah’s house, and took the engraved image, the ephod, the teraphim, and the molten image, the priest said to them, “What are you doing?” 
-</p><p>
-<span class="v">19&#160;</span>They said to him, “Hold your peace, put your hand on your mouth, and go with us. Be a father and a priest to us. Is it better for you to be priest to the house of one man, or to be priest to a tribe and a family in Israel?” 
-</p><p>
-<span class="v">20&#160;</span>The priest’s heart was glad, and he took the ephod, the teraphim, and the engraved image, and went with the people. 
-<span class="v">21&#160;</span>So they turned and departed, and put the little ones, the livestock, and the goods before them. 
-<span class="v">22&#160;</span>When they were a good way from the house of Micah, the men who were in the houses near Micah’s house gathered together and overtook the children of Dan. 
-<span class="v">23&#160;</span>As they called to the children of Dan, they turned their faces, and said to Micah, “What ails you, that you come with such a company?” 
-</p><p>
-<span class="v">24&#160;</span>He said, “You have taken away my elohims which I made, and the priest, and have gone away! What more do I have? How can you ask me, ‘What ails you?’&#160;” 
-</p><p>
-<span class="v">25&#160;</span>The children of Dan said to him, “Don’t let your voice be heard among us, lest angry fellows fall on you, and you lose your life, with the lives of your household.” 
-</p><p>
-<span class="v">26&#160;</span>The children of Dan went their way; and when Micah saw that they were too strong for him, he turned and went back to his house. 
-<span class="v">27&#160;</span>They took that which Micah had made, and the priest whom he had, and came to Laish, to a people quiet and unsuspecting, and struck them with the edge of the sword; then they burned the city with fire. 
-<span class="v">28&#160;</span>There was no deliverer, because it was far from Sidon, and they had no dealings with anyone else; and it was in the valley that lies by Beth Rehob. They built the city and lived in it. 
-<span class="v">29&#160;</span>They called the name of the city Dan, after the name of Dan their father, who was born to Israel; however the name of the city used to be Laish. 
-<span class="v">30&#160;</span>The children of Dan set up for themselves the engraved image; and Jonathan, the son of Gershom, the son of Moses, and his sons were priests to the tribe of the Danites until the day of the captivity of the land. 
-<span class="v">31&#160;</span>So they set up for themselves Micah’s engraved image which he made, and it remained all the time that Elohim’s house was in Shiloh. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>In those days, when there was no king in Israel, there was a certain Levite living on the farther side of the hill country of Ephraim, who took for himself a concubine out of Bethlehem Judah. 
-<span class="v">2&#160;</span>His concubine played the prostitute against him, and went away from him to her father’s house to Bethlehem Judah, and was there for four months. 
-<span class="v">3&#160;</span>Her man arose and went after her to speak kindly to her, to bring her again, having his servant with him and a couple of donkeys. She brought him into her father’s house; and when the father of the young lady saw him, he rejoiced to meet him. 
-<span class="v">4&#160;</span>His father-in-law, the young lady’s father, kept him there; and he stayed with him three days. So they ate and drank, and stayed there. 
-</p><p>
-<span class="v">5&#160;</span>On the fourth day, they got up early in the morning, and he rose up to depart. The young lady’s father said to his son-in-law, “Strengthen your heart with a morsel of bread, and afterward you shall go your way.” 
-<span class="v">6&#160;</span>So they sat down, ate, and drank, both of them together. Then the young lady’s father said to the man, “Please be pleased to stay all night, and let your heart be merry.” 
-<span class="v">7&#160;</span>The man rose up to depart; but his father-in-law urged him, and he stayed there again. 
-<span class="v">8&#160;</span>He arose early in the morning on the fifth day to depart; and the young lady’s father said, “Please strengthen your heart and stay until the day declines;” and they both ate. 
-</p><p>
-<span class="v">9&#160;</span>When the man rose up to depart, he, and his concubine, and his servant, his father-in-law, the young lady’s father, said to him, “Behold, now the day draws toward evening, please stay all night. Behold, the day is ending. Stay here, that your heart may be merry; and tomorrow go on your way early, that you may go home.” 
-<span class="v">10&#160;</span>But the man wouldn’t stay that night, but he rose up and went near Jebus (also called Jerusalem). With him were a couple of saddled donkeys. His concubine also was with him. 
-</p><p>
-<span class="v">11&#160;</span>When they were by Jebus, the day was far spent; and the servant said to his master, “Please come and let’s enter into this city of the Jebusites, and stay in it.” 
-</p><p>
-<span class="v">12&#160;</span>His master said to him, “We won’t enter into the city of a foreigner that is not of the children of Israel; but we will pass over to Gibeah.” 
-<span class="v">13&#160;</span>He said to his servant, “Come and let’s draw near to one of these places; and we will lodge in Gibeah, or in Ramah.” 
-<span class="v">14&#160;</span>So they passed on and went their way; and the sun went down on them near Gibeah, which belongs to Benjamin. 
-<span class="v">15&#160;</span>They went over there, to go in to stay in Gibeah. He went in, and sat down in the street of the city; for there was no one who took them into his house to stay. 
-</p><p>
-<span class="v">16&#160;</span>Behold, an old man came from his work out of the field at evening. Now the man was from the hill country of Ephraim, and he lived in Gibeah; but the men of the place were Benjamites. 
-<span class="v">17&#160;</span>He lifted up his eyes, and saw the wayfaring man in the street of the city; and the old man said, “Where are you going? Where did you come from?” 
-</p><p>
-<span class="v">18&#160;</span>He said to him, “We are passing from Bethlehem Judah to the farther side of the hill country of Ephraim. I am from there, and I went to Bethlehem Judah. I am going to Yahweh’s house; and there is no one who has taken me into his house. 
-<span class="v">19&#160;</span>Yet there is both straw and feed for our donkeys; and there is bread and wine also for me, and for your servant, and for the young man who is with your servants. There is no lack of anything.” 
-</p><p>
-<span class="v">20&#160;</span>The old man said, “Peace be to you! Just let me supply all your needs, but don’t sleep in the street.” 
-<span class="v">21&#160;</span>So he brought him into his house, and gave the donkeys fodder. Then they washed their feet, and ate and drank. 
-<span class="v">22&#160;</span>As they were making their hearts merry, behold, the men of the city, certain wicked fellows, surrounded the house, beating at the door; and they spoke to the owner of the house, the old man, saying, “Bring out the man who came into your house, that we can have sex with him!” 
-</p><p>
-<span class="v">23&#160;</span>The man, the owner of the house, went out to them, and said to them, “No, my brothers, please don’t act so wickedly; since this man has come into my house, don’t do this folly. 
-<span class="v">24&#160;</span>Behold, here is my virgin daughter and his concubine. I will bring them out now. Humble them, and do with them what seems good to you; but to this man don’t do any such folly.” 
-</p><p>
-<span class="v">25&#160;</span>But the men wouldn’t listen to him; so the man grabbed his concubine, and brought her out to them; and they had sex with her, and abused her all night until the morning. When the day began to dawn, they let her go. 
-<span class="v">26&#160;</span>Then the woman came in the dawning of the day, and fell down at the door of the man’s house where her lord was, until it was light. 
-<span class="v">27&#160;</span>Her lord rose up in the morning and opened the doors of the house, and went out to go his way; and behold, the woman his concubine had fallen down at the door of the house, with her hands on the threshold. 
-</p><p>
-<span class="v">28&#160;</span>He said to her, “Get up, and let’s get going!” but no one answered. Then he took her up on the donkey; and the man rose up, and went to his place. 
-</p><p>
-<span class="v">29&#160;</span>When he had come into his house, he took a knife and cut up his concubine, and divided her, limb by limb, into twelve pieces, and sent her throughout all the borders of Israel. 
-<span class="v">30&#160;</span>It was so, that all who saw it said, “Such a deed has not been done or seen from the day that the children of Israel came up out of the land of Egypt to this day! Consider it, take counsel, and speak.” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Then all the children of Israel went out, and the congregation was assembled as one man, from Dan even to Beersheba, with the land of Gilead, to Yahweh at Mizpah. 
-<span class="v">2&#160;</span>The chiefs of all the people, even of all the tribes of Israel, presented themselves in the assembly of the people of Elohim, four hundred thousand footmen who drew sword. 
-<span class="v">3&#160;</span>(Now the children of Benjamin heard that the children of Israel had gone up to Mizpah.) The children of Israel said, “Tell us, how did this wickedness happen?” 
-</p><p>
-<span class="v">4&#160;</span>The Levite, the man of the woman who was murdered, answered, “I came into Gibeah that belongs to Benjamin, I and my concubine, to spend the night. 
-<span class="v">5&#160;</span>The men of Gibeah rose against me, and surrounded the house by night. They intended to kill me and they raped my concubine, and she is dead. 
-<span class="v">6&#160;</span>I took my concubine and cut her in pieces, and sent her throughout all the country of the inheritance of Israel; for they have committed lewdness and folly in Israel. 
-<span class="v">7&#160;</span>Behold, you children of Israel, all of you, give here your advice and counsel.” 
-</p><p>
-<span class="v">8&#160;</span>All the people arose as one man, saying, “None of us will go to his tent, neither will any of us turn to his house. 
-<span class="v">9&#160;</span>But now this is the thing which we will do to Gibeah: we will go up against it by lot; 
-<span class="v">10&#160;</span>and we will take ten men of one hundred throughout all the tribes of Israel, and one hundred of one thousand, and a thousand out of ten thousand to get food for the people, that they may do, when they come to Gibeah of Benjamin, according to all the folly that the owners of Gibeah have done in Israel.” 
-<span class="v">11&#160;</span>So all the men of Israel were gathered against the city, knit together as one man. 
-</p><p>
-<span class="v">12&#160;</span>The tribes of Israel sent men through all the tribe of Benjamin, saying, “What wickedness is this that has happened among you? 
-<span class="v">13&#160;</span>Now therefore deliver up the men, the wicked fellows who are in Gibeah, that we may put them to death and put away evil from Israel.” 
-</p><p>But Benjamin would not listen to the voice of their brothers, the children of Israel. 
-<span class="v">14&#160;</span>The children of Benjamin gathered themselves together out of the cities to Gibeah, to go out to battle against the children of Israel. 
-<span class="v">15&#160;</span>The children of Benjamin were counted on that day out of the cities twenty-six thousand men who drew the sword, in addition to the inhabitants of Gibeah, who were counted seven hundred chosen men. 
-<span class="v">16&#160;</span>Among all these soldiers there were seven hundred chosen men who were left-handed. Every one of them could sling a stone at a hair and not miss. 
-<span class="v">17&#160;</span>The men of Israel, besides Benjamin, were counted four hundred thousand men who drew sword. All these were men of war. 
-</p><p>
-<span class="v">18&#160;</span>The children of Israel arose, went up to Bethel, and asked counsel of Elohim. They asked, “Who shall go up for us first to battle against the children of Benjamin?” 
-</p><p>Yahweh said, “Judah first.” 
-</p><p>
-<span class="v">19&#160;</span>The children of Israel rose up in the morning and encamped against Gibeah. 
-<span class="v">20&#160;</span>The men of Israel went out to battle against Benjamin; and the men of Israel set the battle in array against them at Gibeah. 
-<span class="v">21&#160;</span>The children of Benjamin came out of Gibeah, and on that day destroyed twenty-two thousand of the Israelite men down to the ground. 
-<span class="v">22&#160;</span>The people, the men of Israel, encouraged themselves, and set the battle again in array in the place where they set themselves in array the first day. 
-<span class="v">23&#160;</span>The children of Israel went up and wept before Yahweh until evening; and they asked of Yahweh, saying, “Shall I again draw near to battle against the children of Benjamin my brother?” 
-</p><p>Yahweh said, “Go up against him.” 
-</p><p>
-<span class="v">24&#160;</span>The children of Israel came near against the children of Benjamin the second day. 
-<span class="v">25&#160;</span>Benjamin went out against them out of Gibeah the second day, and destroyed down to the ground of the children of Israel again eighteen thousand men. All these drew the sword. 
-</p><p>
-<span class="v">26&#160;</span>Then all the children of Israel and all the people went up, and came to Bethel, and wept, and sat there before Yahweh, and fasted that day until evening; then they offered burnt offerings and peace offerings before Yahweh. 
-<span class="v">27&#160;</span>The children of Israel asked Yahweh (for the ark of the covenant of Elohim was there in those days, 
-<span class="v">28&#160;</span>and Phinehas, the son of Eleazar, the son of Aaron, stood before it in those days), saying, “Shall I yet again go out to battle against the children of Benjamin my brother, or shall I cease?” 
-</p><p>Yahweh said, “Go up; for tomorrow I will deliver him into your hand.” 
-</p><p>
-<span class="v">29&#160;</span>Israel set ambushes all around Gibeah. 
-<span class="v">30&#160;</span>The children of Israel went up against the children of Benjamin on the third day, and set themselves in array against Gibeah, as at other times. 
-<span class="v">31&#160;</span>The children of Benjamin went out against the people, and were drawn away from the city; and they began to strike and kill of the people as at other times, in the highways, of which one goes up to Bethel and the other to Gibeah, in the field, about thirty men of Israel. 
-</p><p>
-<span class="v">32&#160;</span>The children of Benjamin said, “They are struck down before us, as at the first.” But the children of Israel said, “Let’s flee, and draw them away from the city to the highways.” 
-</p><p>
-<span class="v">33&#160;</span>All the men of Israel rose up out of their place and set themselves in array at Baal Tamar. Then the ambushers of Israel broke out of their place, even out of Maareh Geba. 
-<span class="v">34&#160;</span>Ten thousand chosen men out of all Israel came over against Gibeah, and the battle was severe; but they didn’t know that disaster was close to them. 
-<span class="v">35&#160;</span>Yahweh struck Benjamin before Israel; and the children of Israel destroyed of Benjamin that day twenty-five thousand one hundred men. All these drew the sword. 
-<span class="v">36&#160;</span>So the children of Benjamin saw that they were struck, for the men of Israel yielded to Benjamin because they trusted the ambushers whom they had set against Gibeah. 
-<span class="v">37&#160;</span>The ambushers hurried, and rushed on Gibeah; then the ambushers spread out, and struck all the city with the edge of the sword. 
-<span class="v">38&#160;</span>Now the appointed sign between the men of Israel and the ambushers was that they should make a great cloud of smoke rise up out of the city. 
-<span class="v">39&#160;</span>The men of Israel turned in the battle, and Benjamin began to strike and kill of the men of Israel about thirty persons; for they said, “Surely they are struck down before us, as in the first battle.” 
-<span class="v">40&#160;</span>But when the cloud began to arise up out of the city in a pillar of smoke, the Benjamites looked behind them; and behold, the whole city went up in smoke to the sky. 
-<span class="v">41&#160;</span>The men of Israel turned, and the men of Benjamin were dismayed; for they saw that disaster had come on them. 
-<span class="v">42&#160;</span>Therefore they turned their backs before the men of Israel to the way of the wilderness, but the battle followed hard after them; and those who came out of the cities destroyed them in the middle of it. 
-<span class="v">43&#160;</span>They surrounded the Benjamites, chased them, and trod them down at their resting place, as far as near Gibeah toward the sunrise. 
-<span class="v">44&#160;</span>Eighteen thousand men of Benjamin fell; all these were men of valor. 
-<span class="v">45&#160;</span>They turned and fled toward the wilderness to the rock of Rimmon. They gleaned five thousand men of them in the highways, and followed hard after them to Gidom, and struck two thousand men of them. 
-<span class="v">46&#160;</span>So that all who fell that day of Benjamin were twenty-five thousand men who drew the sword. All these were men of valor. 
-<span class="v">47&#160;</span>But six hundred men turned and fled toward the wilderness to the rock of Rimmon, and stayed in the rock of Rimmon four months. 
-<span class="v">48&#160;</span>The men of Israel turned again on the children of Benjamin, and struck them with the edge of the sword—including the entire city, the livestock, and all that they found. Moreover they set all the cities which they found on fire. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Now the men of Israel had sworn in Mizpah, saying, “None of us will give his daughter to Benjamin as a woman.” 
-<span class="v">2&#160;</span>The people came to Bethel and sat there until evening before Elohim, and lifted up their voices, and wept severely. 
-<span class="v">3&#160;</span>They said, “Yahweh, the Elohim of Israel, why has this happened in Israel, that there should be one tribe lacking in Israel today?” 
-</p><p>
-<span class="v">4&#160;</span>On the next day, the people rose early and built an altar there, and offered burnt offerings and peace offerings. 
-<span class="v">5&#160;</span>The children of Israel said, “Who is there among all the tribes of Israel who didn’t come up in the assembly to Yahweh?” For they had made a great oath concerning him who didn’t come up to Yahweh to Mizpah, saying, “He shall surely be put to death.” 
-<span class="v">6&#160;</span>The children of Israel grieved for Benjamin their brother, and said, “There is one tribe cut off from Israel today. 
-<span class="v">7&#160;</span>How shall we provide women for those who remain, since we have sworn by Yahweh that we will not give them of our daughters to women?” 
-<span class="v">8&#160;</span>They said, “What one is there of the tribes of Israel who didn’t come up to Yahweh to Mizpah?” Behold, no one came from Jabesh Gilead to the camp to the assembly. 
-<span class="v">9&#160;</span>For when the people were counted, behold, there were none of the inhabitants of Jabesh Gilead there. 
-<span class="v">10&#160;</span>The congregation sent twelve thousand of the most valiant men there, and commanded them, saying, “Go and strike the inhabitants of Jabesh Gilead with the edge of the sword, with the women and the little ones. 
-<span class="v">11&#160;</span>This is the thing that you shall do: you shall utterly destroy every male, and every woman who has lain with a man.” 
-<span class="v">12&#160;</span>They found among the inhabitants of Jabesh Gilead four hundred young virgins who had not known man by lying with him; and they brought them to the camp to Shiloh, which is in the land of Canaan. 
-</p><p>
-<span class="v">13&#160;</span>The whole congregation sent and spoke to the children of Benjamin who were in the rock of Rimmon, and proclaimed peace to them. 
-<span class="v">14&#160;</span>Benjamin returned at that time; and they gave them the women whom they had saved alive of the women of Jabesh Gilead. There still weren’t enough for them. 
-<span class="v">15&#160;</span>The people grieved for Benjamin, because Yahweh had made a breach in the tribes of Israel. 
-<span class="v">16&#160;</span>Then the elders of the congregation said, “How shall we provide women for those who remain, since the women are destroyed out of Benjamin?” 
-<span class="v">17&#160;</span>They said, “There must be an inheritance for those who are escaped of Benjamin, that a tribe not be blotted out from Israel. 
-<span class="v">18&#160;</span>However, we may not give them women of our daughters, for the children of Israel had sworn, saying, ‘Cursed is he who gives a woman to Benjamin.’&#160;” 
-<span class="v">19&#160;</span>They said, “Behold, there is a feast of Yahweh from year to year in Shiloh, which is on the north of Bethel, on the east side of the highway that goes up from Bethel to Shechem, and on the south of Lebonah.” 
-<span class="v">20&#160;</span>They commanded the children of Benjamin, saying, “Go and lie in wait in the vineyards, 
-<span class="v">21&#160;</span>and see, and behold, if the daughters of Shiloh come out to dance in the dances, then come out of the vineyards, and each man catch his woman of the daughters of Shiloh, and go to the land of Benjamin. 
-<span class="v">22&#160;</span>It shall be, when their fathers or their brothers come to complain to us, that we will say to them, ‘Grant them graciously to us, because we didn’t take for each man his woman in battle, neither did you give them to them; otherwise you would now be guilty.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>The children of Benjamin did so, and took women for themselves according to their number, of those who danced, whom they carried off. They went and returned to their inheritance, built the cities, and lived in them. 
-<span class="v">24&#160;</span>The children of Israel departed from there at that time, every man to his tribe and to his family, and they each went out from there to his own inheritance. 
-<span class="v">25&#160;</span>In those days there was no king in Israel. Everyone did that which was right in his own eyes. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>After the death of Joshua, the children of Israel asked of Yahweh, saying, “Who should go up for us first against the Canaanites, to fight against them?” 
+</div><div class="p">
+<sup>2&#160;</sup>Yahweh said, “Judah shall go up. Behold, I have delivered the land into his hand.” 
+</div><div class="p">
+<sup>3&#160;</sup>Judah said to Simeon his brother, “Come up with me into my lot, that we may fight against the Canaanites; and I likewise will go with you into your lot.” So Simeon went with him. 
+<sup>4&#160;</sup>Judah went up, and Yahweh delivered the Canaanites and the Perizzites into their hand. They struck ten thousand men in Bezek. 
+<sup>5&#160;</sup>They found Adoni-Bezek in Bezek, and they fought against him. They struck the Canaanites and the Perizzites. 
+<sup>6&#160;</sup>But Adoni-Bezek fled. They pursued him, caught him, and cut off his thumbs and his big toes. 
+<sup>7&#160;</sup>Adoni-Bezek said, “Seventy kings, having their thumbs and their big toes cut off, scavenged under my table. As I have done, so Elohim has done to me.” They brought him to Jerusalem, and he died there. 
+<sup>8&#160;</sup>The children of Judah fought against Jerusalem, took it, struck it with the edge of the sword, and set the city on fire. 
+</div><div class="p">
+<sup>9&#160;</sup>After that, the children of Judah went down to fight against the Canaanites who lived in the hill country, and in the South, and in the lowland. 
+<sup>10&#160;</sup>Judah went against the Canaanites who lived in Hebron. (The name of Hebron before that was Kiriath Arba.) They struck Sheshai, Ahiman, and Talmai. 
+</div><div class="p">
+<sup>11&#160;</sup>From there he went against the inhabitants of Debir. (The name of Debir before that was Kiriath Sepher.) 
+<sup>12&#160;</sup>Caleb said, “I will give Achsah my daughter as woman to the man who strikes Kiriath Sepher, and takes it.” 
+<sup>13&#160;</sup>Othniel the son of Kenaz, Caleb’s younger brother, took it, so he gave him Achsah his daughter as his woman. 
+</div><div class="p">
+<sup>14&#160;</sup>When she came, she got him to ask her father for a field. She got off her donkey; and Caleb said to her, “What would you like?” 
+</div><div class="p">
+<sup>15&#160;</sup>She said to him, “Give me a blessing; because you have set me in the land of the South, give me also springs of water.” Then Caleb gave her the upper springs and the lower springs. 
+<sup>16&#160;</sup>The children of the Kenite, Moses’ brother-in-law, went up out of the city of palm trees with the children of Judah into the wilderness of Judah, which is in the south of Arad; and they went and lived with the people. 
+<sup>17&#160;</sup>Judah went with Simeon his brother, and they struck the Canaanites who inhabited Zephath, and utterly destroyed it. The name of the city was called Hormah. 
+<sup>18&#160;</sup>Also Judah took Gaza with its border, and Ashkelon with its border, and Ekron with its border. 
+<sup>19&#160;</sup>Yahweh was with Judah, and drove out the inhabitants of the hill country; for he could not drive out the inhabitants of the valley, because they had chariots of iron. 
+<sup>20&#160;</sup>They gave Hebron to Caleb, as Moses had said, and he drove the three sons of Anak out of there. 
+<sup>21&#160;</sup>The children of Benjamin didn’t drive out the Jebusites who inhabited Jerusalem, but the Jebusites dwell with the children of Benjamin in Jerusalem to this day. 
+</div><div class="p">
+<sup>22&#160;</sup>The house of Joseph also went up against Bethel, and Yahweh was with them. 
+<sup>23&#160;</sup>The house of Joseph sent to spy out Bethel. (The name of the city before that was Luz.) 
+<sup>24&#160;</sup>The watchers saw a man come out of the city, and they said to him, “Please show us the entrance into the city, and we will deal kindly with you.” 
+<sup>25&#160;</sup>He showed them the entrance into the city, and they struck the city with the edge of the sword; but they let the man and all his family go. 
+<sup>26&#160;</sup>The man went into the land of the Hittites, built a city, and called its name Luz, which is its name to this day. 
+</div><div class="p">
+<sup>27&#160;</sup>Manasseh didn’t drive out the inhabitants of Beth Shean and its towns, nor Taanach and its towns, nor the inhabitants of Dor and its towns, nor the inhabitants of Ibleam and its towns, nor the inhabitants of Megiddo and its towns; but the Canaanites would dwell in that land. 
+<sup>28&#160;</sup>When Israel had grown strong, they put the Canaanites to forced labor, and didn’t utterly drive them out. 
+<sup>29&#160;</sup>Ephraim didn’t drive out the Canaanites who lived in Gezer, but the Canaanites lived in Gezer among them. 
+<sup>30&#160;</sup>Zebulun didn’t drive out the inhabitants of Kitron, nor the inhabitants of Nahalol; but the Canaanites lived among them, and became subject to forced labor. 
+<sup>31&#160;</sup>Asher didn’t drive out the inhabitants of Acco, nor the inhabitants of Sidon, nor of Ahlab, nor of Achzib, nor of Helbah, nor of Aphik, nor of Rehob; 
+<sup>32&#160;</sup>but the Asherites lived among the Canaanites, the inhabitants of the land, for they didn’t drive them out. 
+<sup>33&#160;</sup>Naphtali didn’t drive out the inhabitants of Beth Shemesh, nor the inhabitants of Beth Anath; but he lived among the Canaanites, the inhabitants of the land. Nevertheless the inhabitants of Beth Shemesh and of Beth Anath became subject to forced labor. 
+<sup>34&#160;</sup>The Amorites forced the children of Dan into the hill country, for they would not allow them to come down to the valley; 
+<sup>35&#160;</sup>but the Amorites would dwell in Mount Heres, in Aijalon, and in Shaalbim. Yet the hand of the house of Joseph prevailed, so that they became subject to forced labor. 
+<sup>36&#160;</sup>The border of the Amorites was from the ascent of Akrabbim, from the rock, and upward. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh’s angel came up from Gilgal to Bochim. He said, “I brought you out of Egypt, and have brought you to the land which I swore to give your fathers. I said, ‘I will never break my covenant with you. 
+<sup>2&#160;</sup>You shall make no covenant with the inhabitants of this land. You shall break down their altars.’ But you have not listened to my voice. Why have you done this? 
+<sup>3&#160;</sup>Therefore I also said, ‘I will not drive them out from before you; but they shall be in your sides, and their elohims will be a snare to you.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>When Yahweh’s angel spoke these words to all the children of Israel, the people lifted up their voice and wept. 
+<sup>5&#160;</sup>They called the name of that place Bochim, and they sacrificed there to Yahweh. 
+<sup>6&#160;</sup>Now when Joshua had sent the people away, the children of Israel each went to his inheritance to possess the land. 
+<sup>7&#160;</sup>The people served Yahweh all the days of Joshua, and all the days of the elders who outlived Joshua, who had seen all the great work of Yahweh that he had worked for Israel. 
+<sup>8&#160;</sup>Joshua the son of Nun, the servant of Yahweh, died, being one hundred ten years old. 
+<sup>9&#160;</sup>They buried him in the border of his inheritance in Timnath Heres, in the hill country of Ephraim, on the north of the mountain of Gaash. 
+<sup>10&#160;</sup>After all that generation were gathered to their fathers, another generation arose after them who didn’t know Yahweh, nor the work which he had done for Israel. 
+<sup>11&#160;</sup>The children of Israel did that which was evil in Yahweh’s sight, and served the Baals. 
+<sup>12&#160;</sup>They abandoned Yahweh, the Elohim of their fathers, who brought them out of the land of Egypt, and followed other elohims, of the elohims of the peoples who were around them, and bowed themselves down to them; and they provoked Yahweh to anger. 
+<sup>13&#160;</sup>They abandoned Yahweh, and served Baal and the Ashtaroth. 
+<sup>14&#160;</sup>Yahweh’s anger burned against Israel, and he delivered them into the hands of raiders who plundered them. He sold them into the hands of their enemies all around, so that they could no longer stand before their enemies. 
+<sup>15&#160;</sup>Wherever they went out, Yahweh’s hand was against them for evil, as Yahweh had spoken, and as Yahweh had sworn to them; and they were very distressed. 
+<sup>16&#160;</sup>Yahweh raised up judges, who saved them out of the hand of those who plundered them. 
+<sup>17&#160;</sup>Yet they didn’t listen to their judges; for they prostituted themselves to other elohims, and bowed themselves down to them. They quickly turned away from the way in which their fathers walked, obeying Yahweh’s commandments. They didn’t do so. 
+<sup>18&#160;</sup>When Yahweh raised up judges for them, then Yahweh was with the judge, and saved them out of the hand of their enemies all the days of the judge; for it grieved Yahweh because of their groaning by reason of those who oppressed them and troubled them. 
+<sup>19&#160;</sup>But when the judge was dead, they turned back, and dealt more corruptly than their fathers in following other elohims to serve them and to bow down to them. They didn’t cease what they were doing, or give up their stubborn ways. 
+<sup>20&#160;</sup>Yahweh’s anger burned against Israel; and he said, “Because this nation transgressed my covenant which I commanded their fathers, and has not listened to my voice, 
+<sup>21&#160;</sup>I also will no longer drive out any of the nations that Joshua left when he died from before them; 
+<sup>22&#160;</sup>that by them I may test Israel, to see if they will keep Yahweh’s way to walk therein, as their fathers kept it, or not.” 
+<sup>23&#160;</sup>So Yahweh left those nations, without driving them out hastily. He didn’t deliver them into Joshua’s hand. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the nations which Yahweh left, to test Israel by them, even as many as had not known all the wars of Canaan; 
+<sup>2&#160;</sup>only that the generations of the children of Israel might know, to teach them war, at least those who knew nothing of it before: 
+<sup>3&#160;</sup>the five lords of the Philistines, all the Canaanites, the Sidonians, and the Hivites who lived on Mount Lebanon, from Mount Baal Hermon to the entrance of Hamath. 
+<sup>4&#160;</sup>They were left to test Israel by them, to know whether they would listen to Yahweh’s commandments, which he commanded their fathers by Moses. 
+<sup>5&#160;</sup>The children of Israel lived among the Canaanites, the Hittites, the Amorites, the Perizzites, the Hivites, and the Jebusites. 
+<sup>6&#160;</sup>They took their daughters to be their women, and gave their own daughters to their sons and served their elohims. 
+<sup>7&#160;</sup>The children of Israel did that which was evil in Yahweh’s sight, and forgot Yahweh their Elohim, and served the Baals and the Asheroth. 
+<sup>8&#160;</sup>Therefore Yahweh’s anger burned against Israel, and he sold them into the hand of Cushan Rishathaim king of Mesopotamia; and the children of Israel served Cushan Rishathaim eight years. 
+<sup>9&#160;</sup>When the children of Israel cried to Yahweh, Yahweh raised up a savior to the children of Israel, who saved them, even Othniel the son of Kenaz, Caleb’s younger brother. 
+<sup>10&#160;</sup>Yahweh’s Spirit came on him, and he judged Israel; and he went out to war, and Yahweh delivered Cushan Rishathaim king of Mesopotamia into his hand. His hand prevailed against Cushan Rishathaim. 
+<sup>11&#160;</sup>The land had rest forty years, then Othniel the son of Kenaz died. 
+</div><div class="p">
+<sup>12&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight, and Yahweh strengthened Eglon the king of Moab against Israel, because they had done that which was evil in Yahweh’s sight. 
+<sup>13&#160;</sup>He gathered the children of Ammon and Amalek to himself; and he went and struck Israel, and they possessed the city of palm trees. 
+<sup>14&#160;</sup>The children of Israel served Eglon the king of Moab eighteen years. 
+<sup>15&#160;</sup>But when the children of Israel cried to Yahweh, Yahweh raised up a savior for them: Ehud the son of Gera, the Benjamite, a left-handed man. The children of Israel sent tribute by him to Eglon the king of Moab. 
+<sup>16&#160;</sup>Ehud made himself a sword which had two edges, a cubit in length; and he wore it under his clothing on his right thigh. 
+<sup>17&#160;</sup>He offered the tribute to Eglon king of Moab. Now Eglon was a very fat man. 
+<sup>18&#160;</sup>When Ehud had finished offering the tribute, he sent away the people who carried the tribute. 
+<sup>19&#160;</sup>But he himself turned back from the stone idols that were by Gilgal, and said, “I have a secret message for you, O king.” 
+</div><div class="p">The king said, “Keep silence!” All who stood by him left him. 
+</div><div class="p">
+<sup>20&#160;</sup>Ehud came to him; and he was sitting by himself alone in the cool upper room. Ehud said, “I have a message from Elohim to you.” He arose out of his seat. 
+<sup>21&#160;</sup>Ehud put out his left hand, and took the sword from his right thigh, and thrust it into his body. 
+<sup>22&#160;</sup>The handle also went in after the blade; and the fat closed on the blade, for he didn’t draw the sword out of his body; and it came out behind. 
+<sup>23&#160;</sup>Then Ehud went out onto the porch, and shut the doors of the upper room on him, and locked them. 
+</div><div class="p">
+<sup>24&#160;</sup>After he had gone, his servants came and saw that the doors of the upper room were locked. They said, “Surely he is covering his feet in the upper room.” 
+<sup>25&#160;</sup>They waited until they were ashamed; and behold, he didn’t open the doors of the upper room. Therefore they took the key and opened them, and behold, their lord had fallen down dead on the floor. 
+</div><div class="p">
+<sup>26&#160;</sup>Ehud escaped while they waited, passed beyond the stone idols, and escaped to Seirah. 
+<sup>27&#160;</sup>When he had come, he blew a trumpet in the hill country of Ephraim; and the children of Israel went down with him from the hill country, and he led them. 
+</div><div class="p">
+<sup>28&#160;</sup>He said to them, “Follow me; for Yahweh has delivered your enemies the Moabites into your hand.” They followed him, and took the fords of the Jordan against the Moabites, and didn’t allow any man to pass over. 
+<sup>29&#160;</sup>They struck at that time about ten thousand men of Moab, every strong man and every man of valor. No man escaped. 
+<sup>30&#160;</sup>So Moab was subdued that day under the hand of Israel. Then the land had rest eighty years. 
+</div><div class="p">
+<sup>31&#160;</sup>After him was Shamgar the son of Anath, who struck six hundred men of the Philistines with an ox goad. He also saved Israel. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight, when Ehud was dead. 
+<sup>2&#160;</sup>Yahweh sold them into the hand of Jabin king of Canaan, who reigned in Hazor; the captain of whose army was Sisera, who lived in Harosheth of the Gentiles. 
+<sup>3&#160;</sup>The children of Israel cried to Yahweh, for he had nine hundred chariots of iron; and he mightily oppressed the children of Israel for twenty years. 
+<sup>4&#160;</sup>Now Deborah, a prophetess, the woman of Lappidoth, judged Israel at that time. 
+<sup>5&#160;</sup>She lived under Deborah’s palm tree between Ramah and Bethel in the hill country of Ephraim; and the children of Israel came up to her for judgment. 
+<sup>6&#160;</sup>She sent and called Barak the son of Abinoam out of Kedesh Naphtali, and said to him, “Hasn’t Yahweh, the Elohim of Israel, commanded, ‘Go and lead the way to Mount Tabor, and take with you ten thousand men of the children of Naphtali and of the children of Zebulun? 
+<sup>7&#160;</sup>I will draw to you, to the river Kishon, Sisera, the captain of Jabin’s army, with his chariots and his multitude; and I will deliver him into your hand.’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>Barak said to her, “If you will go with me, then I will go; but if you will not go with me, I will not go.” 
+</div><div class="p">
+<sup>9&#160;</sup>She said, “I will surely go with you. Nevertheless, the journey that you take won’t be for your honor; for Yahweh will sell Sisera into a woman’s hand.” Deborah arose, and went with Barak to Kedesh. 
+</div><div class="p">
+<sup>10&#160;</sup>Barak called Zebulun and Naphtali together to Kedesh. Ten thousand men followed him; and Deborah went up with him. 
+<sup>11&#160;</sup>Now Heber the Kenite had separated himself from the Kenites, even from the children of Hobab, Moses’ brother-in-law, and had pitched his tent as far as the oak in Zaanannim, which is by Kedesh. 
+<sup>12&#160;</sup>They told Sisera that Barak the son of Abinoam had gone up to Mount Tabor. 
+<sup>13&#160;</sup>Sisera gathered together all his chariots, even nine hundred chariots of iron, and all the people who were with him, from Harosheth of the Gentiles, to the river Kishon. 
+</div><div class="p">
+<sup>14&#160;</sup>Deborah said to Barak, “Go; for this is the day in which Yahweh has delivered Sisera into your hand. Hasn’t Yahweh gone out before you?” So Barak went down from Mount Tabor, and ten thousand men after him. 
+<sup>15&#160;</sup>Yahweh confused Sisera, all his chariots, and all his army, with the edge of the sword before Barak. Sisera abandoned his chariot and fled away on his feet. 
+<sup>16&#160;</sup>But Barak pursued the chariots and the army to Harosheth of the Gentiles; and all the army of Sisera fell by the edge of the sword. There was not a man left. 
+</div><div class="p">
+<sup>17&#160;</sup>However Sisera fled away on his feet to the tent of Jael the woman of Heber the Kenite; for there was peace between Jabin the king of Hazor and the house of Heber the Kenite. 
+<sup>18&#160;</sup>Jael went out to meet Sisera, and said to him, “Turn in, my lord, turn in to me; don’t be afraid.” He came in to her into the tent, and she covered him with a rug. 
+</div><div class="p">
+<sup>19&#160;</sup>He said to her, “Please give me a little water to drink; for I am thirsty.” 
+</div><div class="p">She opened a container of milk, and gave him a drink, and covered him. 
+</div><div class="p">
+<sup>20&#160;</sup>He said to her, “Stand in the door of the tent, and if any man comes and inquires of you, and says, ‘Is there any man here?’ you shall say, ‘No.’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>Then Jael, Heber’s woman, took a tent peg, and took a hammer in her hand, and went softly to him, and struck the pin into his temples, and it pierced through into the ground, for he was in a deep sleep; so he fainted and died. 
+<sup>22&#160;</sup>Behold, as Barak pursued Sisera, Jael came out to meet him, and said to him, “Come, and I will show you the man whom you seek.” He came to her; and behold, Sisera lay dead, and the tent peg was in his temples. 
+<sup>23&#160;</sup>So Elohim subdued Jabin the king of Canaan before the children of Israel on that day. 
+<sup>24&#160;</sup>The hand of the children of Israel prevailed more and more against Jabin the king of Canaan, until they had destroyed Jabin king of Canaan. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Deborah and Barak the son of Abinoam sang on that day, saying, 
+</div><div class="q1">
+<sup>2&#160;</sup>“Because the leaders took the lead in Israel, 
+</div><div class="q2">because the people offered themselves willingly, 
+</div><div class="q1">be blessed, Yahweh! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Hear, you kings! 
+</div><div class="q2">Give ear, you princes! 
+</div><div class="q1">I, even I, will sing to Yahweh. 
+</div><div class="q2">I will sing praise to Yahweh, the Elohim of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>“Yahweh, when you went out of Seir, 
+</div><div class="q2">when you marched out of the field of Edom, 
+</div><div class="q1">the earth trembled, the sky also dropped. 
+</div><div class="q2">Yes, the clouds dropped water. 
+</div><div class="q1">
+<sup>5&#160;</sup>The mountains quaked at Yahweh’s presence, 
+</div><div class="q2">even Sinai at the presence of Yahweh, the Elohim of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“In the days of Shamgar the son of Anath, 
+</div><div class="q2">in the days of Jael, the highways were unoccupied. 
+</div><div class="q2">The travelers walked through byways. 
+</div><div class="q1">
+<sup>7&#160;</sup>The rulers ceased in Israel. 
+</div><div class="q2">They ceased until I, Deborah, arose; 
+</div><div class="q2">Until I arose a mother in Israel. 
+</div><div class="q1">
+<sup>8&#160;</sup>They chose new elohims. 
+</div><div class="q2">Then war was in the gates. 
+</div><div class="q2">Was there a shield or spear seen among forty thousand in Israel? 
+</div><div class="q1">
+<sup>9&#160;</sup>My heart is toward the governors of Israel, 
+</div><div class="q2">who offered themselves willingly among the people. 
+</div><div class="q2">Bless Yahweh! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Speak, you who ride on white donkeys, 
+</div><div class="q2">you who sit on rich carpets, 
+</div><div class="q2">and you who walk by the way. 
+</div><div class="q1">
+<sup>11&#160;</sup>Far from the noise of archers, in the places of drawing water, 
+</div><div class="q2">there they will rehearse Yahweh’s righteous acts, 
+</div><div class="q2">the righteous acts of his rule in Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">“Then Yahweh’s people went down to the gates. 
+</div><div class="q2">
+<sup>12&#160;</sup>‘Awake, awake, Deborah! 
+</div><div class="q2">Awake, awake, utter a song! 
+</div><div class="q2">Arise, Barak, and lead away your captives, you son of Abinoam.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“Then a remnant of the nobles and the people came down. 
+</div><div class="q2">Yahweh came down for me against the mighty. 
+</div><div class="q1">
+<sup>14&#160;</sup>Those whose root is in Amalek came out of Ephraim, 
+</div><div class="q2">after you, Benjamin, among your peoples. 
+</div><div class="q1">Governors come down out of Machir. 
+</div><div class="q2">Those who handle the marshal’s staff came out of Zebulun. 
+</div><div class="q1">
+<sup>15&#160;</sup>The princes of Issachar were with Deborah. 
+</div><div class="q2">As was Issachar, so was Barak. 
+</div><div class="q2">They rushed into the valley at his feet. 
+</div><div class="q1">By the watercourses of Reuben, 
+</div><div class="q2">there were great resolves of heart. 
+</div><div class="q1">
+<sup>16&#160;</sup>Why did you sit among the sheepfolds? 
+</div><div class="q2">To hear the whistling for the flocks? 
+</div><div class="q1">At the watercourses of Reuben, 
+</div><div class="q2">there were great searchings of heart. 
+</div><div class="q1">
+<sup>17&#160;</sup>Gilead lived beyond the Jordan. 
+</div><div class="q2">Why did Dan remain in ships? 
+</div><div class="q2">Asher sat still at the haven of the sea, 
+</div><div class="q2">and lived by his creeks. 
+</div><div class="q1">
+<sup>18&#160;</sup>Zebulun was a people that jeopardized their lives to the death; 
+</div><div class="q2">Naphtali also, on the high places of the field. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“The kings came and fought, 
+</div><div class="q2">then the kings of Canaan fought at Taanach by the waters of Megiddo. 
+</div><div class="q2">They took no plunder of silver. 
+</div><div class="q1">
+<sup>20&#160;</sup>From the sky the stars fought. 
+</div><div class="q2">From their courses, they fought against Sisera. 
+</div><div class="q1">
+<sup>21&#160;</sup>The river Kishon swept them away, 
+</div><div class="q2">that ancient river, the river Kishon. 
+</div><div class="q2">My soul, march on with strength. 
+</div><div class="q1">
+<sup>22&#160;</sup>Then the horse hoofs stamped because of the prancing, 
+</div><div class="q2">the prancing of their strong ones. 
+</div><div class="q1">
+<sup>23&#160;</sup>‘Curse Meroz,’ said Yahweh’s angel. 
+</div><div class="q2">‘Curse bitterly its inhabitants, 
+</div><div class="q2">because they didn’t come to help Yahweh, 
+</div><div class="q2">to help Yahweh against the mighty.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>“Jael shall be blessed above women, 
+</div><div class="q2">the woman of Heber the Kenite; 
+</div><div class="q2">blessed shall she be above women in the tent. 
+</div><div class="q1">
+<sup>25&#160;</sup>He asked for water. 
+</div><div class="q2">She gave him milk. 
+</div><div class="q2">She brought him butter in a lordly dish. 
+</div><div class="q1">
+<sup>26&#160;</sup>She put her hand to the tent peg, 
+</div><div class="q2">and her right hand to the workmen’s hammer. 
+</div><div class="q1">With the hammer she struck Sisera. 
+</div><div class="q2">She struck through his head. 
+</div><div class="q2">Yes, she pierced and struck through his temples. 
+</div><div class="q1">
+<sup>27&#160;</sup>At her feet he bowed, he fell, he lay. 
+</div><div class="q2">At her feet he bowed, he fell. 
+</div><div class="q2">Where he bowed, there he fell down dead. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>“Through the window she looked out, and cried: 
+</div><div class="q2">Sisera’s mother looked through the lattice. 
+</div><div class="q1">‘Why is his chariot so long in coming? 
+</div><div class="q2">Why do the wheels of his chariots wait?’ 
+</div><div class="q1">
+<sup>29&#160;</sup>Her wise ladies answered her, 
+</div><div class="q2">Yes, she returned answer to herself, 
+</div><div class="q1">
+<sup>30&#160;</sup>‘Have they not found, have they not divided the plunder? 
+</div><div class="q2">A lady, two ladies to every man; 
+</div><div class="q1">to Sisera a plunder of dyed garments, 
+</div><div class="q2">a plunder of dyed garments embroidered, 
+</div><div class="q2">of dyed garments embroidered on both sides, on the necks of the plunder?’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>31&#160;</sup>“So let all your enemies perish, Yahweh, 
+</div><div class="q2">but let those who love him be as the sun when it rises in its strength.” 
+</div><div class="b"> &#160; </div>
+<div class="p">Then the land had rest forty years. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>The children of Israel did that which was evil in Yahweh’s sight, so Yahweh delivered them into the hand of Midian seven years. 
+<sup>2&#160;</sup>The hand of Midian prevailed against Israel; and because of Midian the children of Israel made themselves the dens which are in the mountains, the caves, and the strongholds. 
+<sup>3&#160;</sup>So it was, when Israel had sown, that the Midianites, the Amalekites, and the children of the east came up against them. 
+<sup>4&#160;</sup>They encamped against them, and destroyed the increase of the earth, until you come to Gaza. They left no sustenance in Israel, and no sheep, ox, or donkey. 
+<sup>5&#160;</sup>For they came up with their livestock and their tents. They came in as locusts for multitude. Both they and their camels were without number; and they came into the land to destroy it. 
+<sup>6&#160;</sup>Israel was brought very low because of Midian; and the children of Israel cried to Yahweh. 
+</div><div class="p">
+<sup>7&#160;</sup>When the children of Israel cried to Yahweh because of Midian, 
+<sup>8&#160;</sup>Yahweh sent a prophet to the children of Israel; and he said to them, “Yahweh, the Elohim of Israel, says, ‘I brought you up from Egypt, and brought you out of the house of bondage. 
+<sup>9&#160;</sup>I delivered you out of the hand of the Egyptians and out of the hand of all who oppressed you, and drove them out from before you, and gave you their land. 
+<sup>10&#160;</sup>I said to you, “I am Yahweh your Elohim. You shall not fear the elohims of the Amorites, in whose land you dwell.” But you have not listened to my voice.’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh’s angel came and sat under the oak which was in Ophrah, that belonged to Joash the Abiezrite. His son Gideon was beating out wheat in the wine press, to hide it from the Midianites. 
+<sup>12&#160;</sup>Yahweh’s angel appeared to him, and said to him, “Yahweh is with you, you mighty man of valor!” 
+</div><div class="p">
+<sup>13&#160;</sup>Gideon said to him, “Oh, my lord, if Yahweh is with us, why then has all this happened to us? Where are all his wondrous works which our fathers told us of, saying, ‘Didn’t Yahweh bring us up from Egypt?’ But now Yahweh has cast us off, and delivered us into the hand of Midian.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh looked at him, and said, “Go in this your might, and save Israel from the hand of Midian. Haven’t I sent you?” 
+</div><div class="p">
+<sup>15&#160;</sup>He said to him, “O Lord, how shall I save Israel? Behold, my family is the poorest in Manasseh, and I am the least in my father’s house.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh said to him, “Surely I will be with you, and you shall strike the Midianites as one man.” 
+</div><div class="p">
+<sup>17&#160;</sup>He said to him, “If now I have found favor in your sight, then show me a sign that it is you who talk with me. 
+<sup>18&#160;</sup>Please don’t go away until I come to you, and bring out my present, and lay it before you.” 
+</div><div class="p">He said, “I will wait until you come back.” 
+</div><div class="p">
+<sup>19&#160;</sup>Gideon went in and prepared a young goat and unleavened cakes of an ephah of meal. He put the meat in a basket and he put the broth in a pot, and brought it out to him under the oak, and presented it. 
+</div><div class="p">
+<sup>20&#160;</sup>The angel of Elohim said to him, “Take the meat and the unleavened cakes, and lay them on this rock, and pour out the broth.” 
+</div><div class="p">He did so. 
+<sup>21&#160;</sup>Then Yahweh’s angel stretched out the end of the staff that was in his hand, and touched the meat and the unleavened cakes; and fire went up out of the rock and consumed the meat and the unleavened cakes. Then Yahweh’s angel departed out of his sight. 
+</div><div class="p">
+<sup>22&#160;</sup>Gideon saw that he was Yahweh’s angel; and Gideon said, “Alas, Lord Yahweh! Because I have seen Yahweh’s angel face to face!” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh said to him, “Peace be to you! Don’t be afraid. You shall not die.” 
+</div><div class="p">
+<sup>24&#160;</sup>Then Gideon built an altar there to Yahweh, and called it “Yahweh is Peace.” To this day it is still in Ophrah of the Abiezrites. 
+</div><div class="p">
+<sup>25&#160;</sup>That same night, Yahweh said to him, “Take your father’s bull, even the second bull seven years old, and throw down the altar of Baal that your father has, and cut down the Asherah that is by it. 
+<sup>26&#160;</sup>Then build an altar to Yahweh your Elohim on the top of this stronghold, in an orderly way, and take the second bull, and offer a burnt offering with the wood of the Asherah which you shall cut down.” 
+</div><div class="p">
+<sup>27&#160;</sup>Then Gideon took ten men of his servants, and did as Yahweh had spoken to him. Because he feared his father’s household and the men of the city, he could not do it by day, but he did it by night. 
+</div><div class="p">
+<sup>28&#160;</sup>When the men of the city arose early in the morning, behold, the altar of Baal was broken down, and the Asherah was cut down that was by it, and the second bull was offered on the altar that was built. 
+<sup>29&#160;</sup>They said to one another, “Who has done this thing?” 
+</div><div class="p">When they inquired and asked, they said, “Gideon the son of Joash has done this thing.” 
+</div><div class="p">
+<sup>30&#160;</sup>Then the men of the city said to Joash, “Bring out your son, that he may die, because he has broken down the altar of Baal, and because he has cut down the Asherah that was by it.” 
+<sup>31&#160;</sup>Joash said to all who stood against him, “Will you contend for Baal? Or will you save him? He who will contend for him, let him be put to death by morning! If he is an elohim, let him contend for himself, because someone has broken down his altar!” 
+<sup>32&#160;</sup>Therefore on that day he named him Jerub-Baal, saying, “Let Baal contend against him, because he has broken down his altar.” 
+</div><div class="p">
+<sup>33&#160;</sup>Then all the Midianites and the Amalekites and the children of the east assembled themselves together; and they passed over, and encamped in the valley of Jezreel. 
+<sup>34&#160;</sup>But Yahweh’s Spirit came on Gideon, and he blew a trumpet; and Abiezer was gathered together to follow him. 
+<sup>35&#160;</sup>He sent messengers throughout all Manasseh, and they also were gathered together to follow him. He sent messengers to Asher, to Zebulun, and to Naphtali; and they came up to meet them. 
+</div><div class="p">
+<sup>36&#160;</sup>Gideon said to Elohim, “If you will save Israel by my hand, as you have spoken, 
+<sup>37&#160;</sup>behold, I will put a fleece of wool on the threshing floor. If there is dew on the fleece only, and it is dry on all the ground, then I’ll know that you will save Israel by my hand, as you have spoken.” 
+</div><div class="p">
+<sup>38&#160;</sup>It was so; for he rose up early on the next day, and pressed the fleece together, and wrung the dew out of the fleece, a bowl full of water. 
+</div><div class="p">
+<sup>39&#160;</sup>Gideon said to Elohim, “Don’t let your anger be kindled against me, and I will speak but this once. Please let me make a trial just this once with the fleece. Let it now be dry only on the fleece, and on all the ground let there be dew.” 
+</div><div class="p">
+<sup>40&#160;</sup>Elohim did so that night; for it was dry on the fleece only, and there was dew on all the ground. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Jerubbaal, who is Gideon, and all the people who were with him, rose up early and encamped beside the spring of Harod. Midian’s camp was on the north side of them, by the hill of Moreh, in the valley. 
+<sup>2&#160;</sup>Yahweh said to Gideon, “The people who are with you are too many for me to give the Midianites into their hand, lest Israel brag against me, saying, ‘My own hand has saved me.’ 
+<sup>3&#160;</sup>Now therefore proclaim in the ears of the people, saying, ‘Whoever is fearful and trembling, let him return and depart from Mount Gilead.’&#160;” So twenty-two thousand of the people returned, and ten thousand remained. 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh said to Gideon, “There are still too many people. Bring them down to the water, and I will test them for you there. It shall be, that those whom I tell you, ‘This shall go with you,’ shall go with you; and whoever I tell you, ‘This shall not go with you,’ shall not go.” 
+<sup>5&#160;</sup>So he brought down the people to the water; and Yahweh said to Gideon, “Everyone who laps of the water with his tongue, like a dog laps, you shall set him by himself; likewise everyone who bows down on his knees to drink.” 
+<sup>6&#160;</sup>The number of those who lapped, putting their hand to their mouth, was three hundred men; but all the rest of the people bowed down on their knees to drink water. 
+<sup>7&#160;</sup>Yahweh said to Gideon, “I will save you by the three hundred men who lapped, and deliver the Midianites into your hand. Let all the other people go, each to his own place.” 
+</div><div class="p">
+<sup>8&#160;</sup>So the people took food in their hand, and their trumpets; and he sent all the rest of the men of Israel to their own tents, but retained the three hundred men; and the camp of Midian was beneath him in the valley. 
+<sup>9&#160;</sup>That same night, Yahweh said to him, “Arise, go down into the camp, for I have delivered it into your hand. 
+<sup>10&#160;</sup>But if you are afraid to go down, go with Purah your servant down to the camp. 
+<sup>11&#160;</sup>You will hear what they say; and afterward your hands will be strengthened to go down into the camp.” Then went he down with Purah his servant to the outermost part of the armed men who were in the camp. 
+</div><div class="p">
+<sup>12&#160;</sup>The Midianites and the Amalekites and all the children of the east lay along in the valley like locusts for multitude; and their camels were without number, as the sand which is on the seashore for multitude. 
+</div><div class="p">
+<sup>13&#160;</sup>When Gideon had come, behold, there was a man telling a dream to his fellow. He said, “Behold, I dreamed a dream; and behold, a cake of barley bread tumbled into the camp of Midian, came to the tent, and struck it so that it fell, and turned it upside down, so that the tent lay flat.” 
+</div><div class="p">
+<sup>14&#160;</sup>His fellow answered, “This is nothing other than the sword of Gideon the son of Joash, a man of Israel. Elohim has delivered Midian into his hand, with all the army.” 
+</div><div class="p">
+<sup>15&#160;</sup>It was so, when Gideon heard the telling of the dream and its interpretation, that he worshiped. Then he returned into the camp of Israel and said, “Arise, for Yahweh has delivered the army of Midian into your hand!” 
+</div><div class="p">
+<sup>16&#160;</sup>He divided the three hundred men into three companies, and he put into the hands of all of them trumpets and empty pitchers, with torches within the pitchers. 
+</div><div class="p">
+<sup>17&#160;</sup>He said to them, “Watch me, and do likewise. Behold, when I come to the outermost part of the camp, it shall be that, as I do, so you shall do. 
+<sup>18&#160;</sup>When I blow the trumpet, I and all who are with me, then blow the trumpets also on every side of all the camp, and shout, ‘For Yahweh and for Gideon!’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>So Gideon and the hundred men who were with him came to the outermost part of the camp in the beginning of the middle watch, when they had but newly set the watch. Then they blew the trumpets and broke in pieces the pitchers that were in their hands. 
+<sup>20&#160;</sup>The three companies blew the trumpets, broke the pitchers, and held the torches in their left hands and the trumpets in their right hands with which to blow; and they shouted, “The sword of Yahweh and of Gideon!” 
+<sup>21&#160;</sup>They each stood in his place around the camp, and all the army ran; and they shouted, and put them to flight. 
+<sup>22&#160;</sup>They blew the three hundred trumpets, and Yahweh set every man’s sword against his fellow and against all the army; and the army fled as far as Beth Shittah toward Zererah, as far as the border of Abel Meholah, by Tabbath. 
+<sup>23&#160;</sup>The men of Israel were gathered together out of Naphtali, out of Asher, and out of all Manasseh, and pursued Midian. 
+<sup>24&#160;</sup>Gideon sent messengers throughout all the hill country of Ephraim, saying, “Come down against Midian and take the waters before them as far as Beth Barah, even the Jordan!” So all the men of Ephraim were gathered together and took the waters as far as Beth Barah, even the Jordan. 
+<sup>25&#160;</sup>They took the two princes of Midian, Oreb and Zeeb. They killed Oreb at Oreb’s rock, and Zeeb they killed at Zeeb’s wine press, as they pursued Midian. Then they brought the heads of Oreb and Zeeb to Gideon beyond the Jordan. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>The men of Ephraim said to him, “Why have you treated us this way, that you didn’t call us when you went to fight with Midian?” They rebuked him sharply. 
+<sup>2&#160;</sup>He said to them, “What have I now done in comparison with you? Isn’t the gleaning of the grapes of Ephraim better than the vintage of Abiezer? 
+<sup>3&#160;</sup>Elohim has delivered into your hand the princes of Midian, Oreb and Zeeb! What was I able to do in comparison with you?” Then their anger was abated toward him when he had said that. 
+</div><div class="p">
+<sup>4&#160;</sup>Gideon came to the Jordan and passed over, he and the three hundred men who were with him, faint, yet pursuing. 
+<sup>5&#160;</sup>He said to the men of Succoth, “Please give loaves of bread to the people who follow me; for they are faint, and I am pursuing after Zebah and Zalmunna, the kings of Midian.” 
+</div><div class="p">
+<sup>6&#160;</sup>The princes of Succoth said, “Are the hands of Zebah and Zalmunna now in your hand, that we should give bread to your army?” 
+</div><div class="p">
+<sup>7&#160;</sup>Gideon said, “Therefore when Yahweh has delivered Zebah and Zalmunna into my hand, then I will tear your flesh with the thorns of the wilderness and with briers.” 
+</div><div class="p">
+<sup>8&#160;</sup>He went up there to Penuel, and spoke to them in the same way; and the men of Penuel answered him as the men of Succoth had answered. 
+<sup>9&#160;</sup>He spoke also to the men of Penuel, saying, “When I come again in peace, I will break down this tower.” 
+</div><div class="p">
+<sup>10&#160;</sup>Now Zebah and Zalmunna were in Karkor, and their armies with them, about fifteen thousand men, all who were left of all the army of the children of the east; for there fell one hundred twenty thousand men who drew sword. 
+<sup>11&#160;</sup>Gideon went up by the way of those who lived in tents on the east of Nobah and Jogbehah, and struck the army; for the army felt secure. 
+<sup>12&#160;</sup>Zebah and Zalmunna fled and he pursued them. He took the two kings of Midian, Zebah and Zalmunna, and confused all the army. 
+<sup>13&#160;</sup>Gideon the son of Joash returned from the battle from the ascent of Heres. 
+<sup>14&#160;</sup>He caught a young man of the men of Succoth, and inquired of him; and he described for him the princes of Succoth, and its elders, seventy-seven men. 
+<sup>15&#160;</sup>He came to the men of Succoth, and said, “See Zebah and Zalmunna, concerning whom you taunted me, saying, ‘Are the hands of Zebah and Zalmunna now in your hand, that we should give bread to your men who are weary?’&#160;” 
+<sup>16&#160;</sup>He took the elders of the city, and thorns of the wilderness and briers, and with them he taught the men of Succoth. 
+<sup>17&#160;</sup>He broke down the tower of Penuel, and killed the men of the city. 
+</div><div class="p">
+<sup>18&#160;</sup>Then he said to Zebah and Zalmunna, “What kind of men were they whom you killed at Tabor?” 
+</div><div class="p">They answered, “They were like you. They all resembled the children of a king.” 
+</div><div class="p">
+<sup>19&#160;</sup>He said, “They were my brothers, the sons of my mother. As Yahweh lives, if you had saved them alive, I would not kill you.” 
+</div><div class="p">
+<sup>20&#160;</sup>He said to Jether his firstborn, “Get up and kill them!” But the youth didn’t draw his sword; for he was afraid, because he was yet a youth. 
+</div><div class="p">
+<sup>21&#160;</sup>Then Zebah and Zalmunna said, “You rise and fall on us; for as the man is, so is his strength.” Gideon arose, and killed Zebah and Zalmunna, and took the crescents that were on their camels’ necks. 
+</div><div class="p">
+<sup>22&#160;</sup>Then the men of Israel said to Gideon, “Rule over us, both you, your son, and your son’s son also; for you have saved us out of the hand of Midian.” 
+</div><div class="p">
+<sup>23&#160;</sup>Gideon said to them, “I will not rule over you, neither shall my son rule over you. Yahweh shall rule over you.” 
+<sup>24&#160;</sup>Gideon said to them, “I do have a request: that you would each give me the earrings of his plunder.” (For they had golden earrings, because they were Ishmaelites.) 
+</div><div class="p">
+<sup>25&#160;</sup>They answered, “We will willingly give them.” They spread a garment, and every man threw the earrings of his plunder into it. 
+<sup>26&#160;</sup>The weight of the golden earrings that he requested was one thousand and seven hundred shekels of gold, in addition to the crescents, and the pendants, and the purple clothing that was on the kings of Midian, and in addition to the chains that were about their camels’ necks. 
+<sup>27&#160;</sup>Gideon made an ephod out of it, and put it in Ophrah, his city. Then all Israel played the prostitute with it there; and it became a snare to Gideon and to his house. 
+<sup>28&#160;</sup>So Midian was subdued before the children of Israel, and they lifted up their heads no more. The land had rest forty years in the days of Gideon. 
+</div><div class="p">
+<sup>29&#160;</sup>Jerubbaal the son of Joash went and lived in his own house. 
+<sup>30&#160;</sup>Gideon had seventy sons conceived from his body, for he had many women. 
+<sup>31&#160;</sup>His concubine who was in Shechem also bore him a son, and he named him Abimelech. 
+<sup>32&#160;</sup>Gideon the son of Joash died in a good old age, and was buried in the tomb of Joash his father, in Ophrah of the Abiezrites. 
+</div><div class="p">
+<sup>33&#160;</sup>As soon as Gideon was dead, the children of Israel turned again and played the prostitute following the Baals, and made Baal Berith their elohim. 
+<sup>34&#160;</sup>The children of Israel didn’t remember Yahweh their Elohim, who had delivered them out of the hand of all their enemies on every side; 
+<sup>35&#160;</sup>neither did they show kindness to the house of Jerubbaal, that is, Gideon, according to all the goodness which he had shown to Israel. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Abimelech the son of Jerubbaal went to Shechem to his mother’s brothers, and spoke with them and with all the family of the house of his mother’s father, saying, 
+<sup>2&#160;</sup>“Please speak in the ears of all the owners of Shechem, ‘Is it better for you that all the sons of Jerubbaal, who are seventy persons, rule over you, or that one rule over you?’ Remember also that I am your bone and your flesh.” 
+</div><div class="p">
+<sup>3&#160;</sup>His mother’s brothers spoke of him in the ears of all the owners of Shechem all these words. Their hearts inclined to follow Abimelech; for they said, “He is our brother.” 
+<sup>4&#160;</sup>They gave him seventy pieces of silver out of the house of Baal Berith, with which Abimelech hired vain and reckless fellows who followed him. 
+<sup>5&#160;</sup>He went to his father’s house at Ophrah, and killed his brothers the sons of Jerubbaal, being seventy persons, on one stone; but Jotham the youngest son of Jerubbaal was left, for he hid himself. 
+<sup>6&#160;</sup>All the owners of Shechem assembled themselves together with all the house of Millo, and went and made Abimelech king by the oak of the pillar that was in Shechem. 
+<sup>7&#160;</sup>When they told it to Jotham, he went and stood on the top of Mount Gerizim and lifted up his voice, cried out, and said to them, “Listen to me, you men of Shechem, that Elohim may listen to you. 
+<sup>8&#160;</sup>The trees set out to anoint a king over themselves. They said to the olive tree, ‘Reign over us.’ 
+</div><div class="p">
+<sup>9&#160;</sup>“But the olive tree said to them, ‘Should I stop producing my oil, with which they honor Elohim and man by me, and go to wave back and forth over the trees?’ 
+</div><div class="p">
+<sup>10&#160;</sup>“The trees said to the fig tree, ‘Come and reign over us.’ 
+</div><div class="p">
+<sup>11&#160;</sup>“But the fig tree said to them, ‘Should I leave my sweetness, and my good fruit, and go to wave back and forth over the trees?’ 
+</div><div class="p">
+<sup>12&#160;</sup>“The trees said to the vine, ‘Come and reign over us.’ 
+</div><div class="p">
+<sup>13&#160;</sup>“The vine said to them, ‘Should I leave my new wine, which cheers Elohim and man, and go to wave back and forth over the trees?’ 
+</div><div class="p">
+<sup>14&#160;</sup>“Then all the trees said to the bramble, ‘Come and reign over us.’ 
+</div><div class="p">
+<sup>15&#160;</sup>“The bramble said to the trees, ‘If in truth you anoint me king over you, then come and take refuge in my shade; and if not, let fire come out of the bramble, and devour the cedars of Lebanon.’ 
+</div><div class="p">
+<sup>16&#160;</sup>“Now therefore, if you have dealt truly and righteously, in that you have made Abimelech king, and if you have dealt well with Jerubbaal and his house, and have done to him according to the deserving of his hands 
+<sup>17&#160;</sup>(for my father fought for you, risked his life, and delivered you out of the hand of Midian; 
+<sup>18&#160;</sup>and you have risen up against my father’s house today and have slain his sons, seventy persons, on one stone, and have made Abimelech, the son of his female servant, king over the owners of Shechem, because he is your brother); 
+<sup>19&#160;</sup>if you then have dealt truly and righteously with Jerubbaal and with his house today, then rejoice in Abimelech, and let him also rejoice in you; 
+<sup>20&#160;</sup>but if not, let fire come out from Abimelech and devour the owners of Shechem and the house of Millo; and let fire come out from the owners of Shechem and from the house of Millo and devour Abimelech.” 
+</div><div class="p">
+<sup>21&#160;</sup>Jotham ran away and fled, and went to Beer and lived there, for fear of Abimelech his brother. 
+</div><div class="p">
+<sup>22&#160;</sup>Abimelech was prince over Israel three years. 
+<sup>23&#160;</sup>Then Elohim sent an evil spirit between Abimelech and the owners of Shechem; and the owners of Shechem dealt treacherously with Abimelech, 
+<sup>24&#160;</sup>that the violence done to the seventy sons of Jerubbaal might come, and that their blood might be laid on Abimelech their brother who killed them, and on the owners of Shechem who strengthened his hands to kill his brothers. 
+<sup>25&#160;</sup>The owners of Shechem set an ambush for him on the tops of the mountains, and they robbed all who came along that way by them; and Abimelech was told about it. 
+</div><div class="p">
+<sup>26&#160;</sup>Gaal the son of Ebed came with his brothers and went over to Shechem; and the owners of Shechem put their trust in him. 
+<sup>27&#160;</sup>They went out into the field, harvested their vineyards, trod the grapes, celebrated, and went into the house of their elohim and ate and drank, and cursed Abimelech. 
+<sup>28&#160;</sup>Gaal the son of Ebed said, “Who is Abimelech, and who is Shechem, that we should serve him? Isn’t he the son of Jerubbaal? Isn’t Zebul his officer? Serve the men of Hamor the father of Shechem, but why should we serve him? 
+<sup>29&#160;</sup>I wish that this people were under my hand! Then I would remove Abimelech.” He said to Abimelech, “Increase your army and come out!” 
+</div><div class="p">
+<sup>30&#160;</sup>When Zebul the ruler of the city heard the words of Gaal the son of Ebed, his anger burned. 
+<sup>31&#160;</sup>He sent messengers to Abimelech craftily, saying, “Behold, Gaal the son of Ebed and his brothers have come to Shechem; and behold, they incite the city against you. 
+<sup>32&#160;</sup>Now therefore, go up by night, you and the people who are with you, and lie in wait in the field. 
+<sup>33&#160;</sup>It shall be that in the morning, as soon as the sun is up, you shall rise early and rush on the city. Behold, when he and the people who are with him come out against you, then may you do to them as you shall find occasion.” 
+</div><div class="p">
+<sup>34&#160;</sup>Abimelech rose up, and all the people who were with him, by night, and they laid wait against Shechem in four companies. 
+<sup>35&#160;</sup>Gaal the son of Ebed went out, and stood in the entrance of the gate of the city. Abimelech rose up, and the people who were with him, from the ambush. 
+</div><div class="p">
+<sup>36&#160;</sup>When Gaal saw the people, he said to Zebul, “Behold, people are coming down from the tops of the mountains.” 
+</div><div class="p">Zebul said to him, “You see the shadows of the mountains as if they were men.” 
+</div><div class="p">
+<sup>37&#160;</sup>Gaal spoke again and said, “Behold, people are coming down by the middle of the land, and one company comes by the way of the oak of Meonenim.” 
+</div><div class="p">
+<sup>38&#160;</sup>Then Zebul said to him, “Now where is your mouth, that you said, ‘Who is Abimelech, that we should serve him?’ Isn’t this the people that you have despised? Please go out now and fight with them.” 
+</div><div class="p">
+<sup>39&#160;</sup>Gaal went out before the owners of Shechem, and fought with Abimelech. 
+<sup>40&#160;</sup>Abimelech chased him, and he fled before him, and many fell wounded, even to the entrance of the gate. 
+<sup>41&#160;</sup>Abimelech lived at Arumah; and Zebul drove out Gaal and his brothers, that they should not dwell in Shechem. 
+<sup>42&#160;</sup>On the next day, the people went out into the field; and they told Abimelech. 
+<sup>43&#160;</sup>He took the people and divided them into three companies, and laid wait in the field; and he looked, and behold, the people came out of the city. So, he rose up against them and struck them. 
+<sup>44&#160;</sup>Abimelech and the companies that were with him rushed forward and stood in the entrance of the gate of the city; and the two companies rushed on all who were in the field and struck them. 
+<sup>45&#160;</sup>Abimelech fought against the city all that day; and he took the city and killed the people in it. He beat down the city and sowed it with salt. 
+</div><div class="p">
+<sup>46&#160;</sup>When all the owners of the tower of Shechem heard of it, they entered into the stronghold of the house of Elberith. 
+<sup>47&#160;</sup>Abimelech was told that all the owners of the tower of Shechem were gathered together. 
+<sup>48&#160;</sup>Abimelech went up to Mount Zalmon, he and all the people who were with him; and Abimelech took an ax in his hand, and cut down a bough from the trees, and took it up, and laid it on his shoulder. Then he said to the people who were with him, “What you have seen me do, make haste, and do as I have done!” 
+<sup>49&#160;</sup>All the people likewise each cut down his bough, followed Abimelech, and put them at the base of the stronghold, and set the stronghold on fire over them, so that all the people of the tower of Shechem died also, about a thousand men and women. 
+<sup>50&#160;</sup>Then Abimelech went to Thebez and encamped against Thebez, and took it. 
+<sup>51&#160;</sup>But there was a strong tower within the city, and all the men and women and all the owners of the city fled there, and shut themselves in, and went up to the roof of the tower. 
+<sup>52&#160;</sup>Abimelech came to the tower and fought against it, and came near to the door of the tower to burn it with fire. 
+<sup>53&#160;</sup>A certain woman cast an upper millstone on Abimelech’s head, and broke his skull. 
+</div><div class="p">
+<sup>54&#160;</sup>Then he called hastily to the young man, his armor bearer, and said to him, “Draw your sword and kill me, that men not say of me, ‘A woman killed him.’ His young man thrust him through, and he died.” 
+</div><div class="p">
+<sup>55&#160;</sup>When the men of Israel saw that Abimelech was dead, they each departed to his place. 
+<sup>56&#160;</sup>Thus Elohim repaid the wickedness of Abimelech, which he did to his father in killing his seventy brothers; 
+<sup>57&#160;</sup>and Elohim repaid all the wickedness of the men of Shechem on their heads; and the curse of Jotham the son of Jerubbaal came on them. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>After Abimelech, Tola the son of Puah, the son of Dodo, a man of Issachar, arose to save Israel. He lived in Shamir in the hill country of Ephraim. 
+<sup>2&#160;</sup>He judged Israel twenty-three years, and died, and was buried in Shamir. 
+</div><div class="p">
+<sup>3&#160;</sup>After him Jair, the Gileadite, arose. He judged Israel twenty-two years. 
+<sup>4&#160;</sup>He had thirty sons who rode on thirty donkey colts. They had thirty cities, which are called Havvoth Jair to this day, which are in the land of Gilead. 
+<sup>5&#160;</sup>Jair died, and was buried in Kamon. 
+</div><div class="p">
+<sup>6&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight, and served the Baals, the Ashtaroth, the elohims of Syria, the elohims of Sidon, the elohims of Moab, the elohims of the children of Ammon, and the elohims of the Philistines. They abandoned Yahweh, and didn’t serve him. 
+<sup>7&#160;</sup>Yahweh’s anger burned against Israel, and he sold them into the hand of the Philistines and into the hand of the children of Ammon. 
+<sup>8&#160;</sup>They troubled and oppressed the children of Israel that year. For eighteen years they oppressed all the children of Israel that were beyond the Jordan in the land of the Amorites, which is in Gilead. 
+<sup>9&#160;</sup>The children of Ammon passed over the Jordan to fight also against Judah, and against Benjamin, and against the house of Ephraim, so that Israel was very distressed. 
+<sup>10&#160;</sup>The children of Israel cried to Yahweh, saying, “We have sinned against you, even because we have forsaken our Elohim, and have served the Baals.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said to the children of Israel, “Didn’t I save you from the Egyptians, and from the Amorites, from the children of Ammon, and from the Philistines? 
+<sup>12&#160;</sup>The Sidonians also, and the Amalekites, and the Maonites, oppressed you; and you cried to me, and I saved you out of their hand. 
+<sup>13&#160;</sup>Yet you have forsaken me and served other elohims. Therefore I will save you no more. 
+<sup>14&#160;</sup>Go and cry to the elohims which you have chosen. Let them save you in the time of your distress!” 
+</div><div class="p">
+<sup>15&#160;</sup>The children of Israel said to Yahweh, “We have sinned! Do to us whatever seems good to you; only deliver us, please, today.” 
+<sup>16&#160;</sup>They put away the foreign elohims from among them and served Yahweh; and his soul was grieved for the misery of Israel. 
+</div><div class="p">
+<sup>17&#160;</sup>Then the children of Ammon were gathered together and encamped in Gilead. The children of Israel assembled themselves together and encamped in Mizpah. 
+<sup>18&#160;</sup>The people, the princes of Gilead, said to one another, “Who is the man who will begin to fight against the children of Ammon? He shall be head over all the inhabitants of Gilead.” 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Jephthah the Gileadite was a mighty man of valor. He was the son of a prostitute. Gilead brought forth Jephthah. 
+<sup>2&#160;</sup>Gilead’s woman bore him sons. When his woman’s sons grew up, they drove Jephthah out and said to him, “You will not inherit in our father’s house, for you are the son of another woman.” 
+<sup>3&#160;</sup>Then Jephthah fled from his brothers and lived in the land of Tob. Outlaws joined up with Jephthah, and they went out with him. 
+</div><div class="p">
+<sup>4&#160;</sup>After a while, the children of Ammon made war against Israel. 
+<sup>5&#160;</sup>When the children of Ammon made war against Israel, the elders of Gilead went to get Jephthah out of the land of Tob. 
+<sup>6&#160;</sup>They said to Jephthah, “Come and be our chief, that we may fight with the children of Ammon.” 
+</div><div class="p">
+<sup>7&#160;</sup>Jephthah said to the elders of Gilead, “Didn’t you hate me, and drive me out of my father’s house? Why have you come to me now when you are in distress?” 
+</div><div class="p">
+<sup>8&#160;</sup>The elders of Gilead said to Jephthah, “Therefore we have turned again to you now, that you may go with us and fight with the children of Ammon. You will be our head over all the inhabitants of Gilead.” 
+</div><div class="p">
+<sup>9&#160;</sup>Jephthah said to the elders of Gilead, “If you bring me home again to fight with the children of Ammon, and Yahweh delivers them before me, will I be your head?” 
+</div><div class="p">
+<sup>10&#160;</sup>The elders of Gilead said to Jephthah, “Yahweh will be witness between us. Surely we will do what you say.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then Jephthah went with the elders of Gilead, and the people made him head and chief over them. Jephthah spoke all his words before Yahweh in Mizpah. 
+</div><div class="p">
+<sup>12&#160;</sup>Jephthah sent messengers to the king of the children of Ammon, saying, “What do you have to do with me, that you have come to me to fight against my land?” 
+</div><div class="p">
+<sup>13&#160;</sup>The king of the children of Ammon answered the messengers of Jephthah, “Because Israel took away my land when he came up out of Egypt, from the Arnon even to the Jabbok, and to the Jordan. Now therefore restore that territory again peaceably.” 
+</div><div class="p">
+<sup>14&#160;</sup>Jephthah sent messengers again to the king of the children of Ammon; 
+<sup>15&#160;</sup>and he said to him, “Jephthah says: Israel didn’t take away the land of Moab, nor the land of the children of Ammon; 
+<sup>16&#160;</sup>but when they came up from Egypt, and Israel went through the wilderness to the Red Sea, and came to Kadesh, 
+<sup>17&#160;</sup>then Israel sent messengers to the king of Edom, saying, ‘Please let me pass through your land;’ but the king of Edom didn’t listen. In the same way, he sent to the king of Moab, but he refused; so Israel stayed in Kadesh. 
+<sup>18&#160;</sup>Then they went through the wilderness, and went around the land of Edom, and the land of Moab, and came by the east side of the land of Moab, and they encamped on the other side of the Arnon; but they didn’t come within the border of Moab, for the Arnon was the border of Moab. 
+<sup>19&#160;</sup>Israel sent messengers to Sihon king of the Amorites, the king of Heshbon; and Israel said to him, ‘Please let us pass through your land to my place.’ 
+<sup>20&#160;</sup>But Sihon didn’t trust Israel to pass through his border; but Sihon gathered all his people together, and encamped in Jahaz, and fought against Israel. 
+<sup>21&#160;</sup>Yahweh, the Elohim of Israel, delivered Sihon and all his people into the hand of Israel, and they struck them. So Israel possessed all the land of the Amorites, the inhabitants of that country. 
+<sup>22&#160;</sup>They possessed all the border of the Amorites, from the Arnon even to the Jabbok, and from the wilderness even to the Jordan. 
+<sup>23&#160;</sup>So now Yahweh, the Elohim of Israel, has dispossessed the Amorites from before his people Israel, and should you possess them? 
+<sup>24&#160;</sup>Won’t you possess that which Chemosh your elohim gives you to possess? So whoever Yahweh our Elohim has dispossessed from before us, them will we possess. 
+<sup>25&#160;</sup>Now are you anything better than Balak the son of Zippor, king of Moab? Did he ever strive against Israel, or did he ever fight against them? 
+<sup>26&#160;</sup>Israel lived in Heshbon and its towns, and in Aroer and its towns, and in all the cities that are along the side of the Arnon for three hundred years! Why didn’t you recover them within that time? 
+<sup>27&#160;</sup>Therefore I have not sinned against you, but you do me wrong to war against me. May Yahweh the Judge be judge today between the children of Israel and the children of Ammon.” 
+</div><div class="p">
+<sup>28&#160;</sup>However, the king of the children of Ammon didn’t listen to the words of Jephthah which he sent him. 
+<sup>29&#160;</sup>Then Yahweh’s Spirit came on Jephthah, and he passed over Gilead and Manasseh, and passed over Mizpah of Gilead, and from Mizpah of Gilead he passed over to the children of Ammon. 
+</div><div class="p">
+<sup>30&#160;</sup>Jephthah vowed a vow to Yahweh, and said, “If you will indeed deliver the children of Ammon into my hand, 
+<sup>31&#160;</sup>then it shall be, that whatever comes out of the doors of my house to meet me when I return in peace from the children of Ammon, it shall be Yahweh’s, and I will offer it up for a burnt offering.” 
+</div><div class="p">
+<sup>32&#160;</sup>So Jephthah passed over to the children of Ammon to fight against them; and Yahweh delivered them into his hand. 
+<sup>33&#160;</sup>He struck them from Aroer until you come to Minnith, even twenty cities, and to Abelcheramim, with a very great slaughter. So the children of Ammon were subdued before the children of Israel. 
+</div><div class="p">
+<sup>34&#160;</sup>Jephthah came to Mizpah to his house; and behold, his daughter came out to meet him with tambourines and with dances. She was his only child. Besides her he had neither son nor daughter. 
+<sup>35&#160;</sup>When he saw her, he tore his clothes, and said, “Alas, my daughter! You have brought me very low, and you are one of those who trouble me; for I have opened my mouth to Yahweh, and I can’t go back.” 
+</div><div class="p">
+<sup>36&#160;</sup>She said to him, “My father, you have opened your mouth to Yahweh; do to me according to that which has proceeded out of your mouth, because Yahweh has taken vengeance for you on your enemies, even on the children of Ammon.” 
+<sup>37&#160;</sup>Then she said to her father, “Let this thing be done for me. Leave me alone two months, that I may depart and go down on the mountains, and bewail my virginity, I and my companions.” 
+</div><div class="p">
+<sup>38&#160;</sup>He said, “Go.” He sent her away for two months; and she departed, she and her companions, and mourned her virginity on the mountains. 
+<sup>39&#160;</sup>At the end of two months, she returned to her father, who did with her according to his vow which he had vowed. She was a virgin. It became a custom in Israel 
+<sup>40&#160;</sup>that the daughters of Israel went yearly to celebrate the daughter of Jephthah the Gileadite four days in a year. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>The men of Ephraim were gathered together, and passed northward; and they said to Jephthah, “Why did you pass over to fight against the children of Ammon, and didn’t call us to go with you? We will burn your house around you with fire!” 
+</div><div class="p">
+<sup>2&#160;</sup>Jephthah said to them, “I and my people were at great strife with the children of Ammon; and when I called you, you didn’t save me out of their hand. 
+<sup>3&#160;</sup>When I saw that you didn’t save me, I put my life in my hand, and passed over against the children of Ammon, and Yahweh delivered them into my hand. Why then have you come up to me today, to fight against me?” 
+</div><div class="p">
+<sup>4&#160;</sup>Then Jephthah gathered together all the men of Gilead, and fought with Ephraim. The men of Gilead struck Ephraim, because they said, “You are fugitives of Ephraim, you Gileadites, in the middle of Ephraim, and in the middle of Manasseh.” 
+<sup>5&#160;</sup>The Gileadites took the fords of the Jordan against the Ephraimites. Whenever a fugitive of Ephraim said, “Let me go over,” the men of Gilead said to him, “Are you an Ephraimite?” If he said, “No;” 
+<sup>6&#160;</sup>then they said to him, “Now say ‘Shibboleth;’&#160;” and he said “Sibboleth”; for he couldn’t manage to pronounce it correctly, then they seized him and killed him at the fords of the Jordan. At that time, forty-two thousand of Ephraim fell. 
+</div><div class="p">
+<sup>7&#160;</sup>Jephthah judged Israel six years. Then Jephthah the Gileadite died, and was buried in the cities of Gilead. 
+</div><div class="p">
+<sup>8&#160;</sup>After him Ibzan of Bethlehem judged Israel. 
+<sup>9&#160;</sup>He had thirty sons. He sent his thirty daughters outside his clan, and he brought in thirty daughters from outside his clan for his sons. He judged Israel seven years. 
+<sup>10&#160;</sup>Ibzan died, and was buried at Bethlehem. 
+</div><div class="p">
+<sup>11&#160;</sup>After him, Elon the Zebulunite judged Israel; and he judged Israel ten years. 
+<sup>12&#160;</sup>Elon the Zebulunite died, and was buried in Aijalon in the land of Zebulun. 
+</div><div class="p">
+<sup>13&#160;</sup>After him, Abdon the son of Hillel the Pirathonite judged Israel. 
+<sup>14&#160;</sup>He had forty sons and thirty sons’ sons who rode on seventy donkey colts. He judged Israel eight years. 
+<sup>15&#160;</sup>Abdon the son of Hillel the Pirathonite died, and was buried in Pirathon in the land of Ephraim, in the hill country of the Amalekites. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>The children of Israel again did that which was evil in Yahweh’s sight; and Yahweh delivered them into the hand of the Philistines forty years. 
+</div><div class="p">
+<sup>2&#160;</sup>There was a certain man of Zorah, of the family of the Danites, whose name was Manoah; and his woman was barren, and childless. 
+<sup>3&#160;</sup>Yahweh’s angel appeared to the woman, and said to her, “See now, you are barren and childless; but you shall conceive and bear a son. 
+<sup>4&#160;</sup>Now therefore please beware and drink no wine nor strong drink, and don’t eat any unclean thing; 
+<sup>5&#160;</sup>for, behold, you shall conceive and give birth to a son. No razor shall come on his head, for the child shall be a Nazirite to Elohim from the womb. He shall begin to save Israel out of the hand of the Philistines.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then the woman came and told her man, saying, “A man of Elohim came to me, and his face was like the face of the angel of Elohim, very awesome. I didn’t ask him where he was from, neither did he tell me his name; 
+<sup>7&#160;</sup>but he said to me, ‘Behold, you shall conceive and bear a son; and now drink no wine nor strong drink. Don’t eat any unclean thing, for the child shall be a Nazirite to Elohim from the womb to the day of his death.’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Manoah entreated Yahweh, and said, “Oh, Lord, please let the man of Elohim whom you sent come again to us, and teach us what we should do to the child who shall be born.” 
+</div><div class="p">
+<sup>9&#160;</sup>Elohim listened to the voice of Manoah, and the angel of Elohim came again to the woman as she sat in the field; but Manoah, her man, wasn’t with her. 
+<sup>10&#160;</sup>The woman hurried and ran, and told her man, saying to him, “Behold, the man who came to me that day has appeared to me.” 
+</div><div class="p">
+<sup>11&#160;</sup>Manoah arose and followed his woman, and came to the man, and said to him, “Are you the man who spoke to my woman?” 
+</div><div class="p">He said, “I am.” 
+</div><div class="p">
+<sup>12&#160;</sup>Manoah said, “Now let your words happen. What shall the child’s way of life and mission be?” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh’s angel said to Manoah, “Of all that I said to the woman let her beware. 
+<sup>14&#160;</sup>She may not eat of anything that comes of the vine, neither let her drink wine or strong drink, nor eat any unclean thing. Let her observe all that I commanded her.” 
+</div><div class="p">
+<sup>15&#160;</sup>Manoah said to Yahweh’s angel, “Please stay with us, that we may make a young goat ready for you.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh’s angel said to Manoah, “Though you detain me, I won’t eat your bread. If you will prepare a burnt offering, you must offer it to Yahweh.” For Manoah didn’t know that he was Yahweh’s angel. 
+</div><div class="p">
+<sup>17&#160;</sup>Manoah said to Yahweh’s angel, “What is your name, that when your words happen, we may honor you?” 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh’s angel said to him, “Why do you ask about my name, since it is incomprehensible?” 
+</div><div class="p">
+<sup>19&#160;</sup>So Manoah took the young goat with the meal offering, and offered it on the rock to Yahweh. Then the angel did an amazing thing as Manoah and his woman watched. 
+<sup>20&#160;</sup>For when the flame went up toward the sky from off the altar, Yahweh’s angel ascended in the flame of the altar. Manoah and his woman watched; and they fell on their faces to the ground. 
+<sup>21&#160;</sup>But Yahweh’s angel didn’t appear to Manoah or to his woman any more. Then Manoah knew that he was Yahweh’s angel. 
+<sup>22&#160;</sup>Manoah said to his woman, “We shall surely die, because we have seen Elohim.” 
+</div><div class="p">
+<sup>23&#160;</sup>But his woman said to him, “If Yahweh were pleased to kill us, he wouldn’t have received a burnt offering and a meal offering at our hand, and he wouldn’t have shown us all these things, nor would he have told us such things as these at this time.” 
+<sup>24&#160;</sup>The woman bore a son and named him Samson. The child grew, and Yahweh blessed him. 
+<sup>25&#160;</sup>Yahweh’s Spirit began to move him in Mahaneh Dan, between Zorah and Eshtaol. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Samson went down to Timnah, and saw a woman in Timnah of the daughters of the Philistines. 
+<sup>2&#160;</sup>He came up, and told his father and his mother, saying, “I have seen a woman in Timnah of the daughters of the Philistines. Now therefore get her for me as my woman.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then his father and his mother said to him, “Isn’t there a woman among your brothers’ daughters, or among all my people, that you go to take a woman of the uncircumcised Philistines?” 
+</div><div class="p">Samson said to his father, “Get her for me, for she pleases me well.” 
+</div><div class="p">
+<sup>4&#160;</sup>But his father and his mother didn’t know that it was of Yahweh; for he sought an occasion against the Philistines. Now at that time the Philistines ruled over Israel. 
+</div><div class="p">
+<sup>5&#160;</sup>Then Samson went down to Timnah with his father and his mother, and came to the vineyards of Timnah; and behold, a young lion roared at him. 
+<sup>6&#160;</sup>Yahweh’s Spirit came mightily on him, and he tore him as he would have torn a young goat with his bare hands, but he didn’t tell his father or his mother what he had done. 
+<sup>7&#160;</sup>He went down and talked with the woman, and she pleased Samson well. 
+<sup>8&#160;</sup>After a while he returned to take her, and he went over to see the carcass of the lion; and behold, there was a swarm of bees in the body of the lion, and honey. 
+<sup>9&#160;</sup>He took it into his hands, and went on, eating as he went. He came to his father and mother and gave to them, and they ate, but he didn’t tell them that he had taken the honey out of the lion’s body. 
+<sup>10&#160;</sup>His father went down to the woman; and Samson made a feast there, for the young men used to do so. 
+<sup>11&#160;</sup>When they saw him, they brought thirty companions to be with him. 
+</div><div class="p">
+<sup>12&#160;</sup>Samson said to them, “Let me tell you a riddle now. If you can tell me the answer within the seven days of the feast, and find it out, then I will give you thirty linen garments and thirty changes of clothing; 
+<sup>13&#160;</sup>but if you can’t tell me the answer, then you shall give me thirty linen garments and thirty changes of clothing.” 
+</div><div class="p">They said to him, “Tell us your riddle, that we may hear it.” 
+</div><div class="p">
+<sup>14&#160;</sup>He said to them, 
+</div><div class="q1">“Out of the eater came out food. 
+</div><div class="q2">Out of the strong came out sweetness.” 
+</div><div class="p">They couldn’t in three days declare the riddle. 
+<sup>15&#160;</sup>On the seventh day, they said to Samson’s woman, “Entice your man, that he may declare to us the riddle, lest we burn you and your father’s house with fire. Have you called us to impoverish us? Isn’t that so?” 
+</div><div class="p">
+<sup>16&#160;</sup>Samson’s woman wept before him, and said, “You just hate me, and don’t love me. You’ve told a riddle to the children of my people, and haven’t told it to me.” 
+</div><div class="p">He said to her, “Behold, I haven’t told my father or my mother, so why should I tell you?” 
+</div><div class="p">
+<sup>17&#160;</sup>She wept before him the seven days, while their feast lasted; and on the seventh day, he told her, because she pressed him severely; and she told the riddle to the children of her people. 
+<sup>18&#160;</sup>The men of the city said to him on the seventh day before the sun went down, “What is sweeter than honey? What is stronger than a lion?” 
+</div><div class="p">He said to them, 
+</div><div class="q1">“If you hadn’t plowed with my heifer, 
+</div><div class="q2">you wouldn’t have found out my riddle.” 
+</div><div class="p">
+<sup>19&#160;</sup>Yahweh’s Spirit came mightily on him, and he went down to Ashkelon and struck thirty men of them. He took their plunder, then gave the changes of clothing to those who declared the riddle. His anger burned, and he went up to his father’s house. 
+<sup>20&#160;</sup>But Samson’s woman was given to his companion, who had been his friend. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>But after a while, in the time of wheat harvest, Samson visited his woman with a young goat. He said, “I will go in to my woman’s room.” 
+</div><div class="p">But her father wouldn’t allow him to go in. 
+<sup>2&#160;</sup>Her father said, “I most certainly thought that you utterly hated her; therefore I gave her to your companion. Isn’t her younger sister more beautiful than she? Please, take her instead.” 
+</div><div class="p">
+<sup>3&#160;</sup>Samson said to them, “This time I will be blameless in the case of the Philistines when I harm them.” 
+<sup>4&#160;</sup>Samson went and caught three hundred foxes, and took torches, and turned tail to tail, and put a torch in the middle between every two tails. 
+<sup>5&#160;</sup>When he had set the torches on fire, he let them go into the standing grain of the Philistines, and burned up both the shocks and the standing grain, and also the olive groves. 
+</div><div class="p">
+<sup>6&#160;</sup>Then the Philistines said, “Who has done this?” 
+</div><div class="p">They said, “Samson, the son-in-law of the Timnite, because he has taken his woman and given her to his companion.” The Philistines came up, and burned her and her father with fire. 
+</div><div class="p">
+<sup>7&#160;</sup>Samson said to them, “If you behave like this, surely I will take revenge on you, and after that I will cease.” 
+<sup>8&#160;</sup>He struck them hip and thigh with a great slaughter; and he went down and lived in the cave in Etam’s rock. 
+<sup>9&#160;</sup>Then the Philistines went up, encamped in Judah, and spread themselves in Lehi. 
+</div><div class="p">
+<sup>10&#160;</sup>The men of Judah said, “Why have you come up against us?” 
+</div><div class="p">They said, “We have come up to bind Samson, to do to him as he has done to us.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then three thousand men of Judah went down to the cave in Etam’s rock, and said to Samson, “Don’t you know that the Philistines are rulers over us? What then is this that you have done to us?” 
+</div><div class="p">He said to them, “As they did to me, so I have done to them.” 
+</div><div class="p">
+<sup>12&#160;</sup>They said to him, “We have come down to bind you, that we may deliver you into the hand of the Philistines.” 
+</div><div class="p">Samson said to them, “Swear to me that you will not attack me yourselves.” 
+</div><div class="p">
+<sup>13&#160;</sup>They spoke to him, saying, “No, but we will bind you securely and deliver you into their hands; but surely we will not kill you.” They bound him with two new ropes, and brought him up from the rock. 
+</div><div class="p">
+<sup>14&#160;</sup>When he came to Lehi, the Philistines shouted as they met him. Then Yahweh’s Spirit came mightily on him, and the ropes that were on his arms became as flax that was burned with fire; and his bands dropped from off his hands. 
+<sup>15&#160;</sup>He found a fresh jawbone of a donkey, put out his hand, took it, and struck a thousand men with it. 
+<sup>16&#160;</sup>Samson said, “With the jawbone of a donkey, heaps on heaps; with the jawbone of a donkey I have struck a thousand men.” 
+<sup>17&#160;</sup>When he had finished speaking, he threw the jawbone out of his hand; and that place was called Ramath Lehi. 
+</div><div class="p">
+<sup>18&#160;</sup>He was very thirsty, and called on Yahweh and said, “You have given this great deliverance by the hand of your servant; and now shall I die of thirst, and fall into the hands of the uncircumcised?” 
+</div><div class="p">
+<sup>19&#160;</sup>But Elohim split the hollow place that is in Lehi, and water came out of it. When he had drunk, his spirit came again, and he revived. Therefore its name was called En Hakkore, which is in Lehi, to this day. 
+<sup>20&#160;</sup>He judged Israel twenty years in the days of the Philistines. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Samson went to Gaza, and saw there a prostitute, and went in to her. 
+<sup>2&#160;</sup>The Gazites were told, “Samson is here!” They surrounded him and laid wait for him all night in the gate of the city, and were quiet all the night, saying, “Wait until morning light; then we will kill him.” 
+<sup>3&#160;</sup>Samson lay until midnight, then arose at midnight and took hold of the doors of the gate of the city, with the two posts, and plucked them up, bar and all, and put them on his shoulders and carried them up to the top of the mountain that is before Hebron. 
+</div><div class="p">
+<sup>4&#160;</sup>It came to pass afterward that he loved a woman in the valley of Sorek, whose name was Delilah. 
+<sup>5&#160;</sup>The lords of the Philistines came up to her and said to her, “Entice him, and see in which his great strength lies, and by what means we may prevail against him, that we may bind him to afflict him; and we will each give you eleven hundred pieces of silver.” 
+</div><div class="p">
+<sup>6&#160;</sup>Delilah said to Samson, “Please tell me where your great strength lies, and what you might be bound to afflict you.” 
+</div><div class="p">
+<sup>7&#160;</sup>Samson said to her, “If they bind me with seven green cords that were never dried, then shall I become weak, and be as another man.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then the lords of the Philistines brought up to her seven green cords which had not been dried, and she bound him with them. 
+<sup>9&#160;</sup>Now she had an ambush waiting in the inner room. She said to him, “The Philistines are on you, Samson!” He broke the cords as a flax thread is broken when it touches the fire. So his strength was not known. 
+</div><div class="p">
+<sup>10&#160;</sup>Delilah said to Samson, “Behold, you have mocked me, and told me lies. Now please tell me how you might be bound.” 
+</div><div class="p">
+<sup>11&#160;</sup>He said to her, “If they only bind me with new ropes with which no work has been done, then shall I become weak, and be as another man.” 
+</div><div class="p">
+<sup>12&#160;</sup>So Delilah took new ropes and bound him with them, then said to him, “The Philistines are on you, Samson!” The ambush was waiting in the inner room. He broke them off his arms like a thread. 
+</div><div class="p">
+<sup>13&#160;</sup>Delilah said to Samson, “Until now, you have mocked me and told me lies. Tell me with what you might be bound.” 
+</div><div class="p">He said to her, “If you weave the seven locks of my head with the fabric on the loom.” 
+</div><div class="p">
+<sup>14&#160;</sup>She fastened it with the pin, and said to him, “The Philistines are on you, Samson!” He awakened out of his sleep, and plucked away the pin of the beam and the fabric. 
+</div><div class="p">
+<sup>15&#160;</sup>She said to him, “How can you say, ‘I love you,’ when your heart is not with me? You have mocked me these three times, and have not told me where your great strength lies.” 
+</div><div class="p">
+<sup>16&#160;</sup>When she pressed him daily with her words and urged him, his soul was troubled to death. 
+<sup>17&#160;</sup>He told her all his heart and said to her, “No razor has ever come on my head; for I have been a Nazirite to Elohim from my mother’s womb. If I am shaved, then my strength will go from me and I will become weak, and be like any other man.” 
+</div><div class="p">
+<sup>18&#160;</sup>When Delilah saw that he had told her all his heart, she sent and called for the lords of the Philistines, saying, “Come up this once, for he has told me all his heart.” Then the lords of the Philistines came up to her and brought the money in their hand. 
+<sup>19&#160;</sup>She made him sleep on her knees; and she called for a man and shaved off the seven locks of his head; and she began to afflict him, and his strength went from him. 
+<sup>20&#160;</sup>She said, “The Philistines are upon you, Samson!” 
+</div><div class="p">He awoke out of his sleep, and said, “I will go out as at other times, and shake myself free.” But he didn’t know that Yahweh had departed from him. 
+<sup>21&#160;</sup>The Philistines laid hold on him and put out his eyes; and they brought him down to Gaza and bound him with fetters of bronze; and he ground at the mill in the prison. 
+<sup>22&#160;</sup>However, the hair of his head began to grow again after he was shaved. 
+</div><div class="p">
+<sup>23&#160;</sup>The lords of the Philistines gathered together to offer a great sacrifice to Dagon their elohim, and to rejoice; for they said, “Our elohim has delivered Samson our enemy into our hand.” 
+<sup>24&#160;</sup>When the people saw him, they praised their elohim; for they said, “Our elohim has delivered our enemy and the destroyer of our country, who has slain many of us, into our hand.” 
+</div><div class="p">
+<sup>25&#160;</sup>When their hearts were merry, they said, “Call for Samson, that he may entertain us.” They called for Samson out of the prison; and he performed before them. They set him between the pillars; 
+<sup>26&#160;</sup>and Samson said to the boy who held him by the hand, “Allow me to feel the pillars on which the house rests, that I may lean on them.” 
+<sup>27&#160;</sup>Now the house was full of men and women; and all the lords of the Philistines were there; and there were on the roof about three thousand men and women, who saw while Samson performed. 
+<sup>28&#160;</sup>Samson called to Yahweh, and said, “Lord Yahweh, remember me, please, and strengthen me, please, only this once, Elohim, that I may be at once avenged of the Philistines for my two eyes.” 
+<sup>29&#160;</sup>Samson took hold of the two middle pillars on which the house rested and leaned on them, the one with his right hand and the other with his left. 
+<sup>30&#160;</sup>Samson said, “Let me die with the Philistines!” He bowed himself with all his might; and the house fell on the lords, and on all the people who were in it. So the dead that he killed at his death were more than those who he killed in his life. 
+</div><div class="p">
+<sup>31&#160;</sup>Then his brothers and all the house of his father came down and took him, and brought him up and buried him between Zorah and Eshtaol in the burial site of Manoah his father. He judged Israel twenty years. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>There was a man of the hill country of Ephraim, whose name was Micah. 
+<sup>2&#160;</sup>He said to his mother, “The eleven hundred pieces of silver that were taken from you, about which you uttered a curse, and also spoke it in my ears—behold, the silver is with me. I took it.” 
+</div><div class="p">His mother said, “May Yahweh bless my son!” 
+</div><div class="p">
+<sup>3&#160;</sup>He restored the eleven hundred pieces of silver to his mother, then his mother said, “I most certainly dedicate the silver to Yahweh from my hand for my son, to make a carved image and a molten image. Now therefore I will restore it to you.” 
+</div><div class="p">
+<sup>4&#160;</sup>When he restored the money to his mother, his mother took two hundred pieces of silver, and gave them to a silversmith, who made a carved image and a molten image out of it. It was in the house of Micah. 
+</div><div class="p">
+<sup>5&#160;</sup>The man Micah had a house of elohims, and he made an ephod, and teraphim, and consecrated one of his sons, who became his priest. 
+<sup>6&#160;</sup>In those days there was no king in Israel. Everyone did that which was right in his own eyes. 
+<sup>7&#160;</sup>There was a young man out of Bethlehem Judah, of the family of Judah, who was a Levite; and he lived there. 
+<sup>8&#160;</sup>The man departed out of the city, out of Bethlehem Judah, to live where he could find a place, and he came to the hill country of Ephraim, to the house of Micah, as he traveled. 
+<sup>9&#160;</sup>Micah said to him, “Where did you come from?” 
+</div><div class="p">He said to him, “I am a Levite of Bethlehem Judah, and I am looking for a place to live.” 
+</div><div class="p">
+<sup>10&#160;</sup>Micah said to him, “Dwell with me, and be to me a father and a priest, and I will give you ten pieces of silver per year, a suit of clothing, and your food.” So the Levite went in. 
+<sup>11&#160;</sup>The Levite was content to dwell with the man; and the young man was to him as one of his sons. 
+<sup>12&#160;</sup>Micah consecrated the Levite, and the young man became his priest, and was in the house of Micah. 
+<sup>13&#160;</sup>Then Micah said, “Now I know that Yahweh will do good to me, since I have a Levite as my priest.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>In those days there was no king in Israel. In those days the tribe of the Danites sought an inheritance to dwell in; for to that day, their inheritance had not fallen to them among the tribes of Israel. 
+<sup>2&#160;</sup>The children of Dan sent five men of their family from their whole number, men of valor, from Zorah and from Eshtaol, to spy out the land and to search it. They said to them, “Go, explore the land!” 
+</div><div class="p">They came to the hill country of Ephraim, to the house of Micah, and lodged there. 
+<sup>3&#160;</sup>When they were by the house of Micah, they knew the voice of the young man the Levite; so they went over there and said to him, “Who brought you here? What do you do in this place? What do you have here?” 
+</div><div class="p">
+<sup>4&#160;</sup>He said to them, “Thus and thus has Micah dealt with me, and he has hired me, and I have become his priest.” 
+</div><div class="p">
+<sup>5&#160;</sup>They said to him, “Please ask counsel of Elohim, that we may know whether our way which we go shall be prosperous.” 
+</div><div class="p">
+<sup>6&#160;</sup>The priest said to them, “Go in peace. Your way in which you go is before Yahweh.” 
+</div><div class="p">
+<sup>7&#160;</sup>Then the five men departed and came to Laish and saw the people who were there, how they lived in safety, in the way of the Sidonians, quiet and secure; for there was no one in the land possessing authority, that might put them to shame in anything, and they were far from the Sidonians, and had no dealings with anyone else. 
+<sup>8&#160;</sup>They came to their brothers at Zorah and Eshtaol; and their brothers asked them, “What do you say?” 
+</div><div class="p">
+<sup>9&#160;</sup>They said, “Arise, and let’s go up against them; for we have seen the land, and behold, it is very good. Do you stand still? Don’t be slothful to go and to enter in to possess the land. 
+<sup>10&#160;</sup>When you go, you will come to an unsuspecting people, and the land is large; for Elohim has given it into your hand, a place where there is no lack of anything that is in the earth.” 
+</div><div class="p">
+<sup>11&#160;</sup>The family of the Danites set out from Zorah and Eshtaol with six hundred men armed with weapons of war. 
+<sup>12&#160;</sup>They went up and encamped in Kiriath Jearim in Judah. Therefore they call that place Mahaneh Dan to this day. Behold, it is behind Kiriath Jearim. 
+<sup>13&#160;</sup>They passed from there to the hill country of Ephraim, and came to the house of Micah. 
+</div><div class="p">
+<sup>14&#160;</sup>Then the five men who went to spy out the country of Laish answered and said to their brothers, “Do you know that there is in these houses an ephod, and teraphim, and a carved image, and a molten image? Now therefore consider what you have to do.” 
+<sup>15&#160;</sup>They went over there and came to the house of the young Levite man, even to the house of Micah, and asked him how he was doing. 
+<sup>16&#160;</sup>The six hundred men armed with their weapons of war, who were of the children of Dan, stood by the entrance of the gate. 
+<sup>17&#160;</sup>The five men who went to spy out the land went up, and came in there, and took the engraved image, the ephod, the teraphim, and the molten image; and the priest stood by the entrance of the gate with the six hundred men armed with weapons of war. 
+</div><div class="p">
+<sup>18&#160;</sup>When these went into Micah’s house, and took the engraved image, the ephod, the teraphim, and the molten image, the priest said to them, “What are you doing?” 
+</div><div class="p">
+<sup>19&#160;</sup>They said to him, “Hold your peace, put your hand on your mouth, and go with us. Be a father and a priest to us. Is it better for you to be priest to the house of one man, or to be priest to a tribe and a family in Israel?” 
+</div><div class="p">
+<sup>20&#160;</sup>The priest’s heart was glad, and he took the ephod, the teraphim, and the engraved image, and went with the people. 
+<sup>21&#160;</sup>So they turned and departed, and put the little ones, the livestock, and the goods before them. 
+<sup>22&#160;</sup>When they were a good way from the house of Micah, the men who were in the houses near Micah’s house gathered together and overtook the children of Dan. 
+<sup>23&#160;</sup>As they called to the children of Dan, they turned their faces, and said to Micah, “What ails you, that you come with such a company?” 
+</div><div class="p">
+<sup>24&#160;</sup>He said, “You have taken away my elohims which I made, and the priest, and have gone away! What more do I have? How can you ask me, ‘What ails you?’&#160;” 
+</div><div class="p">
+<sup>25&#160;</sup>The children of Dan said to him, “Don’t let your voice be heard among us, lest angry fellows fall on you, and you lose your life, with the lives of your household.” 
+</div><div class="p">
+<sup>26&#160;</sup>The children of Dan went their way; and when Micah saw that they were too strong for him, he turned and went back to his house. 
+<sup>27&#160;</sup>They took that which Micah had made, and the priest whom he had, and came to Laish, to a people quiet and unsuspecting, and struck them with the edge of the sword; then they burned the city with fire. 
+<sup>28&#160;</sup>There was no deliverer, because it was far from Sidon, and they had no dealings with anyone else; and it was in the valley that lies by Beth Rehob. They built the city and lived in it. 
+<sup>29&#160;</sup>They called the name of the city Dan, after the name of Dan their father, who was born to Israel; however the name of the city used to be Laish. 
+<sup>30&#160;</sup>The children of Dan set up for themselves the engraved image; and Jonathan, the son of Gershom, the son of Moses, and his sons were priests to the tribe of the Danites until the day of the captivity of the land. 
+<sup>31&#160;</sup>So they set up for themselves Micah’s engraved image which he made, and it remained all the time that Elohim’s house was in Shiloh. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>In those days, when there was no king in Israel, there was a certain Levite living on the farther side of the hill country of Ephraim, who took for himself a concubine out of Bethlehem Judah. 
+<sup>2&#160;</sup>His concubine played the prostitute against him, and went away from him to her father’s house to Bethlehem Judah, and was there for four months. 
+<sup>3&#160;</sup>Her man arose and went after her to speak kindly to her, to bring her again, having his servant with him and a couple of donkeys. She brought him into her father’s house; and when the father of the young lady saw him, he rejoiced to meet him. 
+<sup>4&#160;</sup>His father-in-law, the young lady’s father, kept him there; and he stayed with him three days. So they ate and drank, and stayed there. 
+</div><div class="p">
+<sup>5&#160;</sup>On the fourth day, they got up early in the morning, and he rose up to depart. The young lady’s father said to his son-in-law, “Strengthen your heart with a morsel of bread, and afterward you shall go your way.” 
+<sup>6&#160;</sup>So they sat down, ate, and drank, both of them together. Then the young lady’s father said to the man, “Please be pleased to stay all night, and let your heart be merry.” 
+<sup>7&#160;</sup>The man rose up to depart; but his father-in-law urged him, and he stayed there again. 
+<sup>8&#160;</sup>He arose early in the morning on the fifth day to depart; and the young lady’s father said, “Please strengthen your heart and stay until the day declines;” and they both ate. 
+</div><div class="p">
+<sup>9&#160;</sup>When the man rose up to depart, he, and his concubine, and his servant, his father-in-law, the young lady’s father, said to him, “Behold, now the day draws toward evening, please stay all night. Behold, the day is ending. Stay here, that your heart may be merry; and tomorrow go on your way early, that you may go home.” 
+<sup>10&#160;</sup>But the man wouldn’t stay that night, but he rose up and went near Jebus (also called Jerusalem). With him were a couple of saddled donkeys. His concubine also was with him. 
+</div><div class="p">
+<sup>11&#160;</sup>When they were by Jebus, the day was far spent; and the servant said to his master, “Please come and let’s enter into this city of the Jebusites, and stay in it.” 
+</div><div class="p">
+<sup>12&#160;</sup>His master said to him, “We won’t enter into the city of a foreigner that is not of the children of Israel; but we will pass over to Gibeah.” 
+<sup>13&#160;</sup>He said to his servant, “Come and let’s draw near to one of these places; and we will lodge in Gibeah, or in Ramah.” 
+<sup>14&#160;</sup>So they passed on and went their way; and the sun went down on them near Gibeah, which belongs to Benjamin. 
+<sup>15&#160;</sup>They went over there, to go in to stay in Gibeah. He went in, and sat down in the street of the city; for there was no one who took them into his house to stay. 
+</div><div class="p">
+<sup>16&#160;</sup>Behold, an old man came from his work out of the field at evening. Now the man was from the hill country of Ephraim, and he lived in Gibeah; but the men of the place were Benjamites. 
+<sup>17&#160;</sup>He lifted up his eyes, and saw the wayfaring man in the street of the city; and the old man said, “Where are you going? Where did you come from?” 
+</div><div class="p">
+<sup>18&#160;</sup>He said to him, “We are passing from Bethlehem Judah to the farther side of the hill country of Ephraim. I am from there, and I went to Bethlehem Judah. I am going to Yahweh’s house; and there is no one who has taken me into his house. 
+<sup>19&#160;</sup>Yet there is both straw and feed for our donkeys; and there is bread and wine also for me, and for your servant, and for the young man who is with your servants. There is no lack of anything.” 
+</div><div class="p">
+<sup>20&#160;</sup>The old man said, “Peace be to you! Just let me supply all your needs, but don’t sleep in the street.” 
+<sup>21&#160;</sup>So he brought him into his house, and gave the donkeys fodder. Then they washed their feet, and ate and drank. 
+<sup>22&#160;</sup>As they were making their hearts merry, behold, the men of the city, certain wicked fellows, surrounded the house, beating at the door; and they spoke to the owner of the house, the old man, saying, “Bring out the man who came into your house, that we can have sex with him!” 
+</div><div class="p">
+<sup>23&#160;</sup>The man, the owner of the house, went out to them, and said to them, “No, my brothers, please don’t act so wickedly; since this man has come into my house, don’t do this folly. 
+<sup>24&#160;</sup>Behold, here is my virgin daughter and his concubine. I will bring them out now. Humble them, and do with them what seems good to you; but to this man don’t do any such folly.” 
+</div><div class="p">
+<sup>25&#160;</sup>But the men wouldn’t listen to him; so the man grabbed his concubine, and brought her out to them; and they had sex with her, and abused her all night until the morning. When the day began to dawn, they let her go. 
+<sup>26&#160;</sup>Then the woman came in the dawning of the day, and fell down at the door of the man’s house where her lord was, until it was light. 
+<sup>27&#160;</sup>Her lord rose up in the morning and opened the doors of the house, and went out to go his way; and behold, the woman his concubine had fallen down at the door of the house, with her hands on the threshold. 
+</div><div class="p">
+<sup>28&#160;</sup>He said to her, “Get up, and let’s get going!” but no one answered. Then he took her up on the donkey; and the man rose up, and went to his place. 
+</div><div class="p">
+<sup>29&#160;</sup>When he had come into his house, he took a knife and cut up his concubine, and divided her, limb by limb, into twelve pieces, and sent her throughout all the borders of Israel. 
+<sup>30&#160;</sup>It was so, that all who saw it said, “Such a deed has not been done or seen from the day that the children of Israel came up out of the land of Egypt to this day! Consider it, take counsel, and speak.” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Then all the children of Israel went out, and the congregation was assembled as one man, from Dan even to Beersheba, with the land of Gilead, to Yahweh at Mizpah. 
+<sup>2&#160;</sup>The chiefs of all the people, even of all the tribes of Israel, presented themselves in the assembly of the people of Elohim, four hundred thousand footmen who drew sword. 
+<sup>3&#160;</sup>(Now the children of Benjamin heard that the children of Israel had gone up to Mizpah.) The children of Israel said, “Tell us, how did this wickedness happen?” 
+</div><div class="p">
+<sup>4&#160;</sup>The Levite, the man of the woman who was murdered, answered, “I came into Gibeah that belongs to Benjamin, I and my concubine, to spend the night. 
+<sup>5&#160;</sup>The men of Gibeah rose against me, and surrounded the house by night. They intended to kill me and they raped my concubine, and she is dead. 
+<sup>6&#160;</sup>I took my concubine and cut her in pieces, and sent her throughout all the country of the inheritance of Israel; for they have committed lewdness and folly in Israel. 
+<sup>7&#160;</sup>Behold, you children of Israel, all of you, give here your advice and counsel.” 
+</div><div class="p">
+<sup>8&#160;</sup>All the people arose as one man, saying, “None of us will go to his tent, neither will any of us turn to his house. 
+<sup>9&#160;</sup>But now this is the thing which we will do to Gibeah: we will go up against it by lot; 
+<sup>10&#160;</sup>and we will take ten men of one hundred throughout all the tribes of Israel, and one hundred of one thousand, and a thousand out of ten thousand to get food for the people, that they may do, when they come to Gibeah of Benjamin, according to all the folly that the owners of Gibeah have done in Israel.” 
+<sup>11&#160;</sup>So all the men of Israel were gathered against the city, knit together as one man. 
+</div><div class="p">
+<sup>12&#160;</sup>The tribes of Israel sent men through all the tribe of Benjamin, saying, “What wickedness is this that has happened among you? 
+<sup>13&#160;</sup>Now therefore deliver up the men, the wicked fellows who are in Gibeah, that we may put them to death and put away evil from Israel.” 
+</div><div class="p">But Benjamin would not listen to the voice of their brothers, the children of Israel. 
+<sup>14&#160;</sup>The children of Benjamin gathered themselves together out of the cities to Gibeah, to go out to battle against the children of Israel. 
+<sup>15&#160;</sup>The children of Benjamin were counted on that day out of the cities twenty-six thousand men who drew the sword, in addition to the inhabitants of Gibeah, who were counted seven hundred chosen men. 
+<sup>16&#160;</sup>Among all these soldiers there were seven hundred chosen men who were left-handed. Every one of them could sling a stone at a hair and not miss. 
+<sup>17&#160;</sup>The men of Israel, besides Benjamin, were counted four hundred thousand men who drew sword. All these were men of war. 
+</div><div class="p">
+<sup>18&#160;</sup>The children of Israel arose, went up to Bethel, and asked counsel of Elohim. They asked, “Who shall go up for us first to battle against the children of Benjamin?” 
+</div><div class="p">Yahweh said, “Judah first.” 
+</div><div class="p">
+<sup>19&#160;</sup>The children of Israel rose up in the morning and encamped against Gibeah. 
+<sup>20&#160;</sup>The men of Israel went out to battle against Benjamin; and the men of Israel set the battle in array against them at Gibeah. 
+<sup>21&#160;</sup>The children of Benjamin came out of Gibeah, and on that day destroyed twenty-two thousand of the Israelite men down to the ground. 
+<sup>22&#160;</sup>The people, the men of Israel, encouraged themselves, and set the battle again in array in the place where they set themselves in array the first day. 
+<sup>23&#160;</sup>The children of Israel went up and wept before Yahweh until evening; and they asked of Yahweh, saying, “Shall I again draw near to battle against the children of Benjamin my brother?” 
+</div><div class="p">Yahweh said, “Go up against him.” 
+</div><div class="p">
+<sup>24&#160;</sup>The children of Israel came near against the children of Benjamin the second day. 
+<sup>25&#160;</sup>Benjamin went out against them out of Gibeah the second day, and destroyed down to the ground of the children of Israel again eighteen thousand men. All these drew the sword. 
+</div><div class="p">
+<sup>26&#160;</sup>Then all the children of Israel and all the people went up, and came to Bethel, and wept, and sat there before Yahweh, and fasted that day until evening; then they offered burnt offerings and peace offerings before Yahweh. 
+<sup>27&#160;</sup>The children of Israel asked Yahweh (for the ark of the covenant of Elohim was there in those days, 
+<sup>28&#160;</sup>and Phinehas, the son of Eleazar, the son of Aaron, stood before it in those days), saying, “Shall I yet again go out to battle against the children of Benjamin my brother, or shall I cease?” 
+</div><div class="p">Yahweh said, “Go up; for tomorrow I will deliver him into your hand.” 
+</div><div class="p">
+<sup>29&#160;</sup>Israel set ambushes all around Gibeah. 
+<sup>30&#160;</sup>The children of Israel went up against the children of Benjamin on the third day, and set themselves in array against Gibeah, as at other times. 
+<sup>31&#160;</sup>The children of Benjamin went out against the people, and were drawn away from the city; and they began to strike and kill of the people as at other times, in the highways, of which one goes up to Bethel and the other to Gibeah, in the field, about thirty men of Israel. 
+</div><div class="p">
+<sup>32&#160;</sup>The children of Benjamin said, “They are struck down before us, as at the first.” But the children of Israel said, “Let’s flee, and draw them away from the city to the highways.” 
+</div><div class="p">
+<sup>33&#160;</sup>All the men of Israel rose up out of their place and set themselves in array at Baal Tamar. Then the ambushers of Israel broke out of their place, even out of Maareh Geba. 
+<sup>34&#160;</sup>Ten thousand chosen men out of all Israel came over against Gibeah, and the battle was severe; but they didn’t know that disaster was close to them. 
+<sup>35&#160;</sup>Yahweh struck Benjamin before Israel; and the children of Israel destroyed of Benjamin that day twenty-five thousand one hundred men. All these drew the sword. 
+<sup>36&#160;</sup>So the children of Benjamin saw that they were struck, for the men of Israel yielded to Benjamin because they trusted the ambushers whom they had set against Gibeah. 
+<sup>37&#160;</sup>The ambushers hurried, and rushed on Gibeah; then the ambushers spread out, and struck all the city with the edge of the sword. 
+<sup>38&#160;</sup>Now the appointed sign between the men of Israel and the ambushers was that they should make a great cloud of smoke rise up out of the city. 
+<sup>39&#160;</sup>The men of Israel turned in the battle, and Benjamin began to strike and kill of the men of Israel about thirty persons; for they said, “Surely they are struck down before us, as in the first battle.” 
+<sup>40&#160;</sup>But when the cloud began to arise up out of the city in a pillar of smoke, the Benjamites looked behind them; and behold, the whole city went up in smoke to the sky. 
+<sup>41&#160;</sup>The men of Israel turned, and the men of Benjamin were dismayed; for they saw that disaster had come on them. 
+<sup>42&#160;</sup>Therefore they turned their backs before the men of Israel to the way of the wilderness, but the battle followed hard after them; and those who came out of the cities destroyed them in the middle of it. 
+<sup>43&#160;</sup>They surrounded the Benjamites, chased them, and trod them down at their resting place, as far as near Gibeah toward the sunrise. 
+<sup>44&#160;</sup>Eighteen thousand men of Benjamin fell; all these were men of valor. 
+<sup>45&#160;</sup>They turned and fled toward the wilderness to the rock of Rimmon. They gleaned five thousand men of them in the highways, and followed hard after them to Gidom, and struck two thousand men of them. 
+<sup>46&#160;</sup>So that all who fell that day of Benjamin were twenty-five thousand men who drew the sword. All these were men of valor. 
+<sup>47&#160;</sup>But six hundred men turned and fled toward the wilderness to the rock of Rimmon, and stayed in the rock of Rimmon four months. 
+<sup>48&#160;</sup>The men of Israel turned again on the children of Benjamin, and struck them with the edge of the sword—including the entire city, the livestock, and all that they found. Moreover they set all the cities which they found on fire. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the men of Israel had sworn in Mizpah, saying, “None of us will give his daughter to Benjamin as a woman.” 
+<sup>2&#160;</sup>The people came to Bethel and sat there until evening before Elohim, and lifted up their voices, and wept severely. 
+<sup>3&#160;</sup>They said, “Yahweh, the Elohim of Israel, why has this happened in Israel, that there should be one tribe lacking in Israel today?” 
+</div><div class="p">
+<sup>4&#160;</sup>On the next day, the people rose early and built an altar there, and offered burnt offerings and peace offerings. 
+<sup>5&#160;</sup>The children of Israel said, “Who is there among all the tribes of Israel who didn’t come up in the assembly to Yahweh?” For they had made a great oath concerning him who didn’t come up to Yahweh to Mizpah, saying, “He shall surely be put to death.” 
+<sup>6&#160;</sup>The children of Israel grieved for Benjamin their brother, and said, “There is one tribe cut off from Israel today. 
+<sup>7&#160;</sup>How shall we provide women for those who remain, since we have sworn by Yahweh that we will not give them of our daughters to women?” 
+<sup>8&#160;</sup>They said, “What one is there of the tribes of Israel who didn’t come up to Yahweh to Mizpah?” Behold, no one came from Jabesh Gilead to the camp to the assembly. 
+<sup>9&#160;</sup>For when the people were counted, behold, there were none of the inhabitants of Jabesh Gilead there. 
+<sup>10&#160;</sup>The congregation sent twelve thousand of the most valiant men there, and commanded them, saying, “Go and strike the inhabitants of Jabesh Gilead with the edge of the sword, with the women and the little ones. 
+<sup>11&#160;</sup>This is the thing that you shall do: you shall utterly destroy every male, and every woman who has lain with a man.” 
+<sup>12&#160;</sup>They found among the inhabitants of Jabesh Gilead four hundred young virgins who had not known man by lying with him; and they brought them to the camp to Shiloh, which is in the land of Canaan. 
+</div><div class="p">
+<sup>13&#160;</sup>The whole congregation sent and spoke to the children of Benjamin who were in the rock of Rimmon, and proclaimed peace to them. 
+<sup>14&#160;</sup>Benjamin returned at that time; and they gave them the women whom they had saved alive of the women of Jabesh Gilead. There still weren’t enough for them. 
+<sup>15&#160;</sup>The people grieved for Benjamin, because Yahweh had made a breach in the tribes of Israel. 
+<sup>16&#160;</sup>Then the elders of the congregation said, “How shall we provide women for those who remain, since the women are destroyed out of Benjamin?” 
+<sup>17&#160;</sup>They said, “There must be an inheritance for those who are escaped of Benjamin, that a tribe not be blotted out from Israel. 
+<sup>18&#160;</sup>However, we may not give them women of our daughters, for the children of Israel had sworn, saying, ‘Cursed is he who gives a woman to Benjamin.’&#160;” 
+<sup>19&#160;</sup>They said, “Behold, there is a feast of Yahweh from year to year in Shiloh, which is on the north of Bethel, on the east side of the highway that goes up from Bethel to Shechem, and on the south of Lebonah.” 
+<sup>20&#160;</sup>They commanded the children of Benjamin, saying, “Go and lie in wait in the vineyards, 
+<sup>21&#160;</sup>and see, and behold, if the daughters of Shiloh come out to dance in the dances, then come out of the vineyards, and each man catch his woman of the daughters of Shiloh, and go to the land of Benjamin. 
+<sup>22&#160;</sup>It shall be, when their fathers or their brothers come to complain to us, that we will say to them, ‘Grant them graciously to us, because we didn’t take for each man his woman in battle, neither did you give them to them; otherwise you would now be guilty.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>The children of Benjamin did so, and took women for themselves according to their number, of those who danced, whom they carried off. They went and returned to their inheritance, built the cities, and lived in them. 
+<sup>24&#160;</sup>The children of Israel departed from there at that time, every man to his tribe and to his family, and they each went out from there to his own inheritance. 
+<sup>25&#160;</sup>In those days there was no king in Israel. Everyone did that which was right in his own eyes. </div></div><script src="../main.js"></script></body></html>

--- a/book/lamentations.html
+++ b/book/lamentations.html
@@ -3,6 +3,47 @@
 <head>
 <title>Lamentations</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,708 +53,714 @@
 <div class="main">
 <!-- LAM World English Scripture (WES) -->
 <h1 class="booklabel">Lamentations</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>How the city sits solitary, 
-</p><p class="q2">that was full of people! 
-</p><p class="q1">She has become as a widow, 
-</p><p class="q2">who was great among the nations! 
-</p><p class="q1">She who was a princess among the provinces 
-</p><p class="q2">has become a slave! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">2&#160;</span>She weeps bitterly in the night. 
-</p><p class="q2">Her tears are on her cheeks. 
-</p><p class="q1">Among all her lovers 
-</p><p class="q2">she has no one to comfort her. 
-</p><p class="q1">All her friends have dealt treacherously with her. 
-</p><p class="q2">They have become her enemies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>Judah has gone into captivity because of affliction 
-</p><p class="q2">and because of great servitude. 
-</p><p class="q1">She dwells among the nations. 
-</p><p class="q2">She finds no rest. 
-</p><p class="q2">All her persecutors overtook her in her distress. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>The roads to Zion mourn, 
-</p><p class="q2">because no one comes to the solemn assembly. 
-</p><p class="q1">All her gates are desolate. 
-</p><p class="q2">Her priests sigh. 
-</p><p class="q1">Her virgins are afflicted, 
-</p><p class="q2">and she herself is in bitterness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Her adversaries have become the head. 
-</p><p class="q2">Her enemies prosper; 
-</p><p class="q1">for Yahweh<span class="f">+ \fr 1:5 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> has afflicted her for the multitude of her transgressions. 
-</p><p class="q2">Her young children have gone into captivity before the adversary. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>All majesty has departed from the daughter of Zion. 
-</p><p class="q2">Her princes have become like deer that find no pasture. 
-</p><p class="q2">They have gone without strength before the pursuer. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Jerusalem remembers in the days of her affliction and of her miseries 
-</p><p class="q2">all her pleasant things that were from the days of old; 
-</p><p class="q1">when her people fell into the hand of the adversary, 
-</p><p class="q2">and no one helped her. 
-</p><p class="q1">The adversaries saw her. 
-</p><p class="q2">They mocked at her desolations. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Jerusalem has grievously sinned. 
-</p><p class="q2">Therefore she has become unclean. 
-</p><p class="q1">All who honored her despise her, 
-</p><p class="q2">because they have seen her nakedness. 
-</p><p class="q2">Yes, she sighs and turns backward. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Her filthiness was in her skirts. 
-</p><p class="q2">She didn’t remember her latter end. 
-</p><p class="q1">Therefore she has come down astoundingly. 
-</p><p class="q2">She has no comforter. 
-</p><p class="q1">“See, Yahweh, my affliction; 
-</p><p class="q2">for the enemy has magnified himself.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>The adversary has spread out his hand on all her pleasant things; 
-</p><p class="q2">for she has seen that the nations have entered into her sanctuary, 
-</p><p class="q2">concerning whom you commanded that they should not enter into your assembly. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>All her people sigh. 
-</p><p class="q2">They seek bread. 
-</p><p class="q2">They have given their pleasant things for food to refresh their soul. 
-</p><p class="q1">“Look, Yahweh, and see, 
-</p><p class="q2">for I have become despised.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“Is it nothing to you, all you who pass by? 
-</p><p class="q2">Look, and see if there is any sorrow like my sorrow, 
-</p><p class="q2">which is brought on me, 
-</p><p class="q2">with which Yahweh has afflicted me in the day of his fierce anger. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>“From on high has he sent fire into my bones, 
-</p><p class="q2">and it prevails against them. 
-</p><p class="q1">He has spread a net for my feet. 
-</p><p class="q2">He has turned me back. 
-</p><p class="q2">He has made me desolate and I faint all day long. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>“The yoke of my transgressions is bound by his hand. 
-</p><p class="q2">They are knit together. 
-</p><p class="q2">They have come up on my neck. 
-</p><p class="q2">He made my strength fail. 
-</p><p class="q1">The Lord<span class="f">+ \fr 1:14 \ft The word translated “Lord” is “Adonai.”</span> has delivered me into their hands, 
-</p><p class="q2">against whom I am not able to stand. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“The Lord has set at nothing all my mighty men within me. 
-</p><p class="q2">He has called a solemn assembly against me to crush my young men. 
-</p><p class="q2">The Lord has trodden the virgin daughter of Judah as in a wine press. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>“For these things I weep. 
-</p><p class="q2">My eye, my eye runs down with water, 
-</p><p class="q2">because the comforter who should refresh my soul is far from me. 
-</p><p class="q1">My children are desolate, 
-</p><p class="q2">because the enemy has prevailed.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Zion spreads out her hands. 
-</p><p class="q2">There is no one to comfort her. 
-</p><p class="q1">Yahweh has commanded concerning Jacob, 
-</p><p class="q2">that those who are around him should be his adversaries. 
-</p><p class="q2">Jerusalem is among them as an unclean thing. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“Yahweh is righteous, 
-</p><p class="q2">for I have rebelled against his commandment. 
-</p><p class="q1">Please hear all you peoples, 
-</p><p class="q2">and see my sorrow. 
-</p><p class="q2">My virgins and my young men have gone into captivity. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“I called for my lovers, 
-</p><p class="q2">but they deceived me. 
-</p><p class="q1">My priests and my elders gave up the spirit in the city, 
-</p><p class="q2">while they sought food for themselves to refresh their souls. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Look, Yahweh; for I am in distress. 
-</p><p class="q2">My heart is troubled. 
-</p><p class="q1">My heart turns over within me, 
-</p><p class="q2">for I have grievously rebelled. 
-</p><p class="q1">Abroad, the sword bereaves. 
-</p><p class="q2">At home, it is like death. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“They have heard that I sigh. 
-</p><p class="q2">There is no one to comfort me. 
-</p><p class="q1">All my enemies have heard of my trouble. 
-</p><p class="q2">They are glad that you have done it. 
-</p><p class="q1">You will bring the day that you have proclaimed, 
-</p><p class="q2">and they will be like me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“Let all their wickedness come before you. 
-</p><p class="q2">Do to them as you have done to me for all my transgressions. 
-</p><p class="q1">For my sighs are many, 
-</p><p class="q2">and my heart is faint. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>How has the Lord covered the daughter of Zion with a cloud in his anger! 
-</p><p class="q2">He has cast the beauty of Israel down from heaven to the earth, 
-</p><p class="q2">and hasn’t remembered his footstool in the day of his anger. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">2&#160;</span>The Lord has swallowed up all the dwellings of Jacob 
-</p><p class="q2">without pity. 
-</p><p class="q1">He has thrown down in his wrath the strongholds of the daughter of Judah. 
-</p><p class="q2">He has brought them down to the ground. 
-</p><p class="q2">He has profaned the kingdom and its princes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>He has cut off all the horn of Israel in fierce anger. 
-</p><p class="q2">He has drawn back his right hand from before the enemy. 
-</p><p class="q1">He has burned up Jacob like a flaming fire, 
-</p><p class="q2">which devours all around. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>He has bent his bow like an enemy. 
-</p><p class="q2">He has stood with his right hand as an adversary. 
-</p><p class="q1">He has killed all that were pleasant to the eye. 
-</p><p class="q2">In the tent of the daughter of Zion, he has poured out his wrath like fire. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>The Lord has become as an enemy. 
-</p><p class="q2">He has swallowed up Israel. 
-</p><p class="q1">He has swallowed up all her palaces. 
-</p><p class="q2">He has destroyed his strongholds. 
-</p><p class="q2">He has multiplied mourning and lamentation in the daughter of Judah. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>He has violently taken away his tabernacle, 
-</p><p class="q2">as if it were a garden. 
-</p><p class="q1">He has destroyed his place of assembly. 
-</p><p class="q2">Yahweh has caused solemn assembly and Sabbath to be forgotten in Zion. 
-</p><p class="q2">In the indignation of his anger, he has despised the king and the priest. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>The Lord has cast off his altar. 
-</p><p class="q2">He has abhorred his sanctuary. 
-</p><p class="q1">He has given the walls of her palaces into the hand of the enemy. 
-</p><p class="q2">They have made a noise in Yahweh’s house, 
-</p><p class="q2">as in the day of a solemn assembly. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Yahweh has purposed to destroy the wall of the daughter of Zion. 
-</p><p class="q2">He has stretched out the line. 
-</p><p class="q2">He has not withdrawn his hand from destroying; 
-</p><p class="q1">He has made the rampart and wall lament. 
-</p><p class="q2">They languish together. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Her gates have sunk into the ground. 
-</p><p class="q2">He has destroyed and broken her bars. 
-</p><p class="q1">Her king and her princes are among the nations where the law is not. 
-</p><p class="q2">Yes, her prophets find no vision from Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>The elders of the daughter of Zion sit on the ground. 
-</p><p class="q2">They keep silence. 
-</p><p class="q1">They have cast up dust on their heads. 
-</p><p class="q2">They have clothed themselves with sackcloth. 
-</p><p class="q2">The virgins of Jerusalem hang down their heads to the ground. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>My eyes fail with tears. 
-</p><p class="q2">My heart is troubled. 
-</p><p class="q1">My bile is poured on the earth, 
-</p><p class="q2">because of the destruction of the daughter of my people, 
-</p><p class="q2">because the young children and the infants swoon in the streets of the city. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>They ask their mothers, 
-</p><p class="q2">“Where is grain and wine?” 
-</p><p class="q2">when they swoon as the wounded in the streets of the city, 
-</p><p class="q2">when their soul is poured out into their mothers’ bosom. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>What shall I testify to you? 
-</p><p class="q2">What shall I liken to you, daughter of Jerusalem? 
-</p><p class="q1">What shall I compare to you, 
-</p><p class="q2">that I may comfort you, virgin daughter of Zion? 
-</p><p class="q1">For your breach is as big as the sea. 
-</p><p class="q2">Who can heal you? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>Your prophets have seen false and foolish visions for you. 
-</p><p class="q2">They have not uncovered your iniquity, 
-</p><p class="q2">to reverse your captivity, 
-</p><p class="q2">but have seen for you false revelations and causes of banishment. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>All that pass by clap their hands at you. 
-</p><p class="q2">They hiss and wag their head at the daughter of Jerusalem, saying, 
-</p><p class="q1">“Is this the city that men called ‘The perfection of beauty, 
-</p><p class="q2">the joy of the whole earth’?” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>All your enemies have opened their mouth wide against you. 
-</p><p class="q2">They hiss and gnash their teeth. 
-</p><p class="q2">They say, “We have swallowed her up. 
-</p><p class="q1">Certainly this is the day that we looked for. 
-</p><p class="q2">We have found it. 
-</p><p class="q2">We have seen it.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Yahweh has done that which he planned. 
-</p><p class="q2">He has fulfilled his word that he commanded in the days of old. 
-</p><p class="q1">He has thrown down, 
-</p><p class="q2">and has not pitied. 
-</p><p class="q1">He has caused the enemy to rejoice over you. 
-</p><p class="q2">He has exalted the horn of your adversaries. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>Their heart cried to the Lord. 
-</p><p class="q2">O wall of the daughter of Zion, 
-</p><p class="q2">let tears run down like a river day and night. 
-</p><p class="q1">Give yourself no relief. 
-</p><p class="q2">Don’t let your eyes rest. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Arise, cry out in the night, 
-</p><p class="q2">at the beginning of the watches! 
-</p><p class="q1">Pour out your heart like water before the face of the Lord. 
-</p><p class="q2">Lift up your hands toward him for the life of your young children, 
-</p><p class="q2">who faint for hunger at the head of every street. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“Look, Yahweh, and see to whom you have done thus! 
-</p><p class="q2">Should the women eat their offspring, 
-</p><p class="q2">the children that they held and bounced on their knees? 
-</p><p class="q2">Should the priest and the prophet be killed in the sanctuary of the Lord? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“The youth and the old man lie on the ground in the streets. 
-</p><p class="q2">My virgins and my young men have fallen by the sword. 
-</p><p class="q1">You have killed them in the day of your anger. 
-</p><p class="q2">You have slaughtered, and not pitied. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“You have called, as in the day of a solemn assembly, my terrors on every side. 
-</p><p class="q2">There was no one that escaped or remained in the day of Yahweh’s anger. 
-</p><p class="q2">My enemy has consumed those whom I have cared for and brought up. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p class="q1">
-<span class="v">1&#160;</span>I am the man who has seen affliction 
-</p><p class="q2">by the rod of his wrath. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He has led me and caused me to walk in darkness, 
-</p><p class="q2">and not in light. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Surely he turns his hand against me 
-</p><p class="q2">again and again all day long. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>He has made my flesh and my skin old. 
-</p><p class="q2">He has broken my bones. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He has built against me, 
-</p><p class="q2">and surrounded me with bitterness and hardship. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He has made me dwell in dark places, 
-</p><p class="q2">as those who have been long dead. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>He has walled me about, so that I can’t go out. 
-</p><p class="q2">He has made my chain heavy. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yes, when I cry, and call for help, 
-</p><p class="q2">he shuts out my prayer. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He has walled up my ways with cut stone. 
-</p><p class="q2">He has made my paths crooked. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>He is to me as a bear lying in wait, 
-</p><p class="q2">as a lion in hiding. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He has turned away my path, 
-</p><p class="q2">and pulled me in pieces. 
-</p><p class="q2">He has made me desolate. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He has bent his bow, 
-</p><p class="q2">and set me as a mark for the arrow. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>He has caused the shafts of his quiver to enter into my kidneys. 
-</p><p class="q2">
-<span class="v">14&#160;</span>I have become a derision to all my people, 
-</p><p class="q2">and their song all day long. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He has filled me with bitterness. 
-</p><p class="q2">He has stuffed me with wormwood. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>He has also broken my teeth with gravel. 
-</p><p class="q2">He has covered me with ashes. 
-</p><p class="q1">
-<span class="v">17&#160;</span>You have removed my soul far away from peace. 
-</p><p class="q2">I forgot prosperity. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I said, “My strength has perished, 
-</p><p class="q2">along with my expectation from Yahweh.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Remember my affliction and my misery, 
-</p><p class="q2">the wormwood and the bitterness. 
-</p><p class="q1">
-<span class="v">20&#160;</span>My soul still remembers them, 
-</p><p class="q2">and is bowed down within me. 
-</p><p class="q1">
-<span class="v">21&#160;</span>This I recall to my mind; 
-</p><p class="q2">therefore I have hope. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>It is because of Yahweh’s loving kindnesses that we are not consumed, 
-</p><p class="q2">because his mercies don’t fail. 
-</p><p class="q1">
-<span class="v">23&#160;</span>They are new every morning. 
-</p><p class="q2">Great is your faithfulness. 
-</p><p class="q1">
-<span class="v">24&#160;</span>“Yahweh is my portion,” says my soul. 
-</p><p class="q2">“Therefore I will hope in him.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>Yahweh is good to those who wait for him, 
-</p><p class="q2">to the soul who seeks him. 
-</p><p class="q1">
-<span class="v">26&#160;</span>It is good that a man should hope 
-</p><p class="q2">and quietly wait for the salvation of Yahweh. 
-</p><p class="q2">
-<span class="v">27&#160;</span>It is good for a man that he bear the yoke in his youth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>Let him sit alone and keep silence, 
-</p><p class="q2">because he has laid it on him. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Let him put his mouth in the dust, 
-</p><p class="q2">if it is so that there may be hope. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Let him give his cheek to him who strikes him. 
-</p><p class="q2">Let him be filled full of reproach. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">31&#160;</span>For the Lord will not cast off forever. 
-</p><p class="q2">
-<span class="v">32&#160;</span>For though he causes grief, 
-</p><p class="q2">yet he will have compassion according to the multitude of his loving kindnesses. 
-</p><p class="q1">
-<span class="v">33&#160;</span>For he does not afflict willingly, 
-</p><p class="q2">nor grieve the children of men. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">34&#160;</span>To crush under foot all the prisoners of the earth, 
-</p><p class="q2">
-<span class="v">35&#160;</span>to turn away the right of a man before the face of the Most High, 
-</p><p class="q2">
-<span class="v">36&#160;</span>to subvert a man in his cause, the Lord doesn’t approve. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">37&#160;</span>Who is he who says, and it comes to pass, 
-</p><p class="q2">when the Lord doesn’t command it? 
-</p><p class="q1">
-<span class="v">38&#160;</span>Doesn’t evil and good come out of the mouth of the Most High? 
-</p><p class="q2">
-<span class="v">39&#160;</span>Why should a living man complain, 
-</p><p class="q2">a man for the punishment of his sins? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">40&#160;</span>Let us search and try our ways, 
-</p><p class="q2">and turn again to Yahweh. 
-</p><p class="q1">
-<span class="v">41&#160;</span>Let’s lift up our heart with our hands to Elohim<span class="f">+ \fr 3:41 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> in the heavens. 
-</p><p class="q2">
-<span class="v">42&#160;</span>“We have transgressed and have rebelled. 
-</p><p class="q2">You have not pardoned. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">43&#160;</span>“You have covered us with anger and pursued us. 
-</p><p class="q2">You have killed. 
-</p><p class="q2">You have not pitied. 
-</p><p class="q1">
-<span class="v">44&#160;</span>You have covered yourself with a cloud, 
-</p><p class="q2">so that no prayer can pass through. 
-</p><p class="q1">
-<span class="v">45&#160;</span>You have made us an off-scouring and refuse 
-</p><p class="q2">in the middle of the peoples. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">46&#160;</span>“All our enemies have opened their mouth wide against us. 
-</p><p class="q2">
-<span class="v">47&#160;</span>Terror and the pit have come on us, 
-</p><p class="q2">devastation and destruction.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">48&#160;</span>My eye runs down with streams of water, 
-</p><p class="q2">for the destruction of the daughter of my people. 
-</p><p class="q1">
-<span class="v">49&#160;</span>My eye pours down 
-</p><p class="q2">and doesn’t cease, 
-</p><p class="q2">without any intermission, 
-</p><p class="q1">
-<span class="v">50&#160;</span>until Yahweh looks down, 
-</p><p class="q2">and sees from heaven. 
-</p><p class="q1">
-<span class="v">51&#160;</span>My eye affects my soul, 
-</p><p class="q2">because of all the daughters of my city. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">52&#160;</span>They have chased me relentlessly like a bird, 
-</p><p class="q2">those who are my enemies without cause. 
-</p><p class="q1">
-<span class="v">53&#160;</span>They have cut off my life in the dungeon, 
-</p><p class="q2">and have cast a stone on me. 
-</p><p class="q1">
-<span class="v">54&#160;</span>Waters flowed over my head. 
-</p><p class="q2">I said, “I am cut off.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">55&#160;</span>I called on your name, Yahweh, 
-</p><p class="q2">out of the lowest dungeon. 
-</p><p class="q1">
-<span class="v">56&#160;</span>You heard my voice: 
-</p><p class="q2">“Don’t hide your ear from my sighing, 
-</p><p class="q2">and my cry.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">57&#160;</span>You came near in the day that I called on you. 
-</p><p class="q2">You said, “Don’t be afraid.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">58&#160;</span>Lord, you have pleaded the causes of my soul. 
-</p><p class="q2">You have redeemed my life. 
-</p><p class="q1">
-<span class="v">59&#160;</span>Yahweh, you have seen my wrong. 
-</p><p class="q2">Judge my cause. 
-</p><p class="q1">
-<span class="v">60&#160;</span>You have seen all their vengeance 
-</p><p class="q2">and all their plans against me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">61&#160;</span>You have heard their reproach, Yahweh, 
-</p><p class="q2">and all their plans against me, 
-</p><p class="q1">
-<span class="v">62&#160;</span>the lips of those that rose up against me, 
-</p><p class="q2">and their plots against me all day long. 
-</p><p class="q1">
-<span class="v">63&#160;</span>You see their sitting down and their rising up. 
-</p><p class="q2">I am their song. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">64&#160;</span>You will pay them back, Yahweh, 
-</p><p class="q2">according to the work of their hands. 
-</p><p class="q1">
-<span class="v">65&#160;</span>You will give them hardness of heart, 
-</p><p class="q2">your curse to them. 
-</p><p class="q1">
-<span class="v">66&#160;</span>You will pursue them in anger, 
-</p><p class="q2">and destroy them from under the heavens of Yahweh. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p class="q1">
-<span class="v">1&#160;</span>How the gold has become dim! 
-</p><p class="q2">The most pure gold has changed! 
-</p><p class="q1">The stones of the sanctuary are poured out 
-</p><p class="q2">at the head of every street. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">2&#160;</span>The precious sons of Zion, 
-</p><p class="q2">comparable to fine gold, 
-</p><p class="q1">how they are esteemed as earthen pitchers, 
-</p><p class="q2">the work of the hands of the potter! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>Even the jackals offer their breast. 
-</p><p class="q2">They nurse their young ones. 
-</p><p class="q1">But the daughter of my people has become cruel, 
-</p><p class="q2">like the ostriches in the wilderness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>The tongue of the nursing child clings to the roof of his mouth for thirst. 
-</p><p class="q2">The young children ask for bread, 
-</p><p class="q2">and no one breaks it for them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Those who ate delicacies are desolate in the streets. 
-</p><p class="q2">Those who were brought up in purple embrace dunghills. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>For the iniquity of the daughter of my people is greater than the sin of Sodom, 
-</p><p class="q2">which was overthrown as in a moment. 
-</p><p class="q2">No hands were laid on her. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Her nobles were purer than snow. 
-</p><p class="q2">They were whiter than milk. 
-</p><p class="q1">They were more ruddy in body than rubies. 
-</p><p class="q2">Their polishing was like sapphire. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Their appearance is blacker than a coal. 
-</p><p class="q2">They are not known in the streets. 
-</p><p class="q1">Their skin clings to their bones. 
-</p><p class="q2">It is withered. 
-</p><p class="q2">It has become like wood. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Those who are killed with the sword are better than those who are killed with hunger; 
-</p><p class="q2">for these pine away, stricken through, 
-</p><p class="q2">for lack of the fruits of the field. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>The hands of the pitiful women have boiled their own children. 
-</p><p class="q2">They were their food in the destruction of the daughter of my people. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Yahweh has accomplished his wrath. 
-</p><p class="q2">He has poured out his fierce anger. 
-</p><p class="q1">He has kindled a fire in Zion, 
-</p><p class="q2">which has devoured its foundations. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>The kings of the earth didn’t believe, 
-</p><p class="q2">neither did all the inhabitants of the world, 
-</p><p class="q2">that the adversary and the enemy would enter into the gates of Jerusalem. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>It is because of the sins of her prophets 
-</p><p class="q2">and the iniquities of her priests, 
-</p><p class="q2">that have shed the blood of the just in the middle of her. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>They wander as blind men in the streets. 
-</p><p class="q2">They are polluted with blood, 
-</p><p class="q2">So that men can’t touch their garments. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“Go away!” they cried to them. 
-</p><p class="q2">“Unclean! Go away! Go away! Don’t touch! 
-</p><p class="q1">When they fled away and wandered, men said among the nations, 
-</p><p class="q2">“They can’t live here any more.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Yahweh’s anger has scattered them. 
-</p><p class="q2">He will not pay attention to them any more. 
-</p><p class="q1">They didn’t respect the persons of the priests. 
-</p><p class="q2">They didn’t favor the elders. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Our eyes still fail, 
-</p><p class="q2">looking in vain for our help. 
-</p><p class="q2">In our watching we have watched for a nation that could not save. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>They hunt our steps, 
-</p><p class="q2">so that we can’t go in our streets. 
-</p><p class="q1">Our end is near. 
-</p><p class="q2">Our days are fulfilled, 
-</p><p class="q2">for our end has come. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Our pursuers were swifter than the eagles of the sky. 
-</p><p class="q2">They chased us on the mountains. 
-</p><p class="q2">They set an ambush for us in the wilderness. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>The breath of our nostrils, 
-</p><p class="q2">the anointed of Yahweh, 
-</p><p class="q2">was taken in their pits; 
-</p><p class="q1">of whom we said, 
-</p><p class="q2">under his shadow we will live among the nations. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>Rejoice and be glad, daughter of Edom, 
-</p><p class="q2">who dwells in the land of Uz. 
-</p><p class="q1">The cup will pass through to you also. 
-</p><p class="q2">You will be drunken, 
-</p><p class="q2">and will make yourself naked. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>The punishment of your iniquity is accomplished, daughter of Zion. 
-</p><p class="q2">He will no more carry you away into captivity. 
-</p><p class="q1">He will visit your iniquity, daughter of Edom. 
-</p><p class="q2">He will uncover your sins. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Remember, Yahweh, what has come on us. 
-</p><p class="q2">Look, and see our reproach. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Our inheritance has been turned over to strangers, 
-</p><p class="q2">our houses to aliens. 
-</p><p class="q1">
-<span class="v">3&#160;</span>We are orphans and fatherless. 
-</p><p class="q2">Our mothers are as widows. 
-</p><p class="q1">
-<span class="v">4&#160;</span>We must pay for water to drink. 
-</p><p class="q2">Our wood is sold to us. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Our pursuers are on our necks. 
-</p><p class="q2">We are weary, and have no rest. 
-</p><p class="q1">
-<span class="v">6&#160;</span>We have given our hands to the Egyptians, 
-</p><p class="q2">and to the Assyrians, to be satisfied with bread. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Our fathers sinned, and are no more. 
-</p><p class="q2">We have borne their iniquities. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Servants rule over us. 
-</p><p class="q2">There is no one to deliver us out of their hand. 
-</p><p class="q1">
-<span class="v">9&#160;</span>We get our bread at the peril of our lives, 
-</p><p class="q2">because of the sword in the wilderness. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Our skin is black like an oven, 
-</p><p class="q2">because of the burning heat of famine. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They ravished the women in Zion, 
-</p><p class="q2">the virgins in the cities of Judah. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Princes were hanged up by their hands. 
-</p><p class="q2">The faces of elders were not honored. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The young men carry millstones. 
-</p><p class="q2">The children stumbled under loads of wood. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The elders have ceased from the gate, 
-</p><p class="q2">and the young men from their music. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The joy of our heart has ceased. 
-</p><p class="q2">Our dance is turned into mourning. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The crown has fallen from our head. 
-</p><p class="q2">Woe to us, for we have sinned! 
-</p><p class="q1">
-<span class="v">17&#160;</span>For this our heart is faint. 
-</p><p class="q2">For these things our eyes are dim: 
-</p><p class="q1">
-<span class="v">18&#160;</span>for the mountain of Zion, which is desolate. 
-</p><p class="q2">The foxes walk on it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>You, Yahweh, remain forever. 
-</p><p class="q2">Your throne is from generation to generation. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Why do you forget us forever, 
-</p><p class="q2">and forsake us for so long a time? 
-</p><p class="q1">
-<span class="v">21&#160;</span>Turn us to yourself, Yahweh, and we will be turned. 
-</p><p class="q2">Renew our days as of old. 
-</p><p class="q1">
-<span class="v">22&#160;</span>But you have utterly rejected us. 
-</p><p class="q2">You are very angry against us. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>How the city sits solitary, 
+</div><div class="q2">that was full of people! 
+</div><div class="q1">She has become as a widow, 
+</div><div class="q2">who was great among the nations! 
+</div><div class="q1">She who was a princess among the provinces 
+</div><div class="q2">has become a slave! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>2&#160;</sup>She weeps bitterly in the night. 
+</div><div class="q2">Her tears are on her cheeks. 
+</div><div class="q1">Among all her lovers 
+</div><div class="q2">she has no one to comfort her. 
+</div><div class="q1">All her friends have dealt treacherously with her. 
+</div><div class="q2">They have become her enemies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>Judah has gone into captivity because of affliction 
+</div><div class="q2">and because of great servitude. 
+</div><div class="q1">She dwells among the nations. 
+</div><div class="q2">She finds no rest. 
+</div><div class="q2">All her persecutors overtook her in her distress. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>The roads to Zion mourn, 
+</div><div class="q2">because no one comes to the solemn assembly. 
+</div><div class="q1">All her gates are desolate. 
+</div><div class="q2">Her priests sigh. 
+</div><div class="q1">Her virgins are afflicted, 
+</div><div class="q2">and she herself is in bitterness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Her adversaries have become the head. 
+</div><div class="q2">Her enemies prosper; 
+</div><div class="q1">for Yahweh has afflicted her for the multitude of her transgressions. 
+</div><div class="q2">Her young children have gone into captivity before the adversary. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>All majesty has departed from the daughter of Zion. 
+</div><div class="q2">Her princes have become like deer that find no pasture. 
+</div><div class="q2">They have gone without strength before the pursuer. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Jerusalem remembers in the days of her affliction and of her miseries 
+</div><div class="q2">all her pleasant things that were from the days of old; 
+</div><div class="q1">when her people fell into the hand of the adversary, 
+</div><div class="q2">and no one helped her. 
+</div><div class="q1">The adversaries saw her. 
+</div><div class="q2">They mocked at her desolations. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Jerusalem has grievously sinned. 
+</div><div class="q2">Therefore she has become unclean. 
+</div><div class="q1">All who honored her despise her, 
+</div><div class="q2">because they have seen her nakedness. 
+</div><div class="q2">Yes, she sighs and turns backward. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Her filthiness was in her skirts. 
+</div><div class="q2">She didn’t remember her latter end. 
+</div><div class="q1">Therefore she has come down astoundingly. 
+</div><div class="q2">She has no comforter. 
+</div><div class="q1">“See, Yahweh, my affliction; 
+</div><div class="q2">for the enemy has magnified himself.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>The adversary has spread out his hand on all her pleasant things; 
+</div><div class="q2">for she has seen that the nations have entered into her sanctuary, 
+</div><div class="q2">concerning whom you commanded that they should not enter into your assembly. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>All her people sigh. 
+</div><div class="q2">They seek bread. 
+</div><div class="q2">They have given their pleasant things for food to refresh their soul. 
+</div><div class="q1">“Look, Yahweh, and see, 
+</div><div class="q2">for I have become despised.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“Is it nothing to you, all you who pass by? 
+</div><div class="q2">Look, and see if there is any sorrow like my sorrow, 
+</div><div class="q2">which is brought on me, 
+</div><div class="q2">with which Yahweh has afflicted me in the day of his fierce anger. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>“From on high has he sent fire into my bones, 
+</div><div class="q2">and it prevails against them. 
+</div><div class="q1">He has spread a net for my feet. 
+</div><div class="q2">He has turned me back. 
+</div><div class="q2">He has made me desolate and I faint all day long. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>“The yoke of my transgressions is bound by his hand. 
+</div><div class="q2">They are knit together. 
+</div><div class="q2">They have come up on my neck. 
+</div><div class="q2">He made my strength fail. 
+</div><div class="q1">The Lord has delivered me into their hands, 
+</div><div class="q2">against whom I am not able to stand. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“The Lord has set at nothing all my mighty men within me. 
+</div><div class="q2">He has called a solemn assembly against me to crush my young men. 
+</div><div class="q2">The Lord has trodden the virgin daughter of Judah as in a wine press. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>“For these things I weep. 
+</div><div class="q2">My eye, my eye runs down with water, 
+</div><div class="q2">because the comforter who should refresh my soul is far from me. 
+</div><div class="q1">My children are desolate, 
+</div><div class="q2">because the enemy has prevailed.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Zion spreads out her hands. 
+</div><div class="q2">There is no one to comfort her. 
+</div><div class="q1">Yahweh has commanded concerning Jacob, 
+</div><div class="q2">that those who are around him should be his adversaries. 
+</div><div class="q2">Jerusalem is among them as an unclean thing. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“Yahweh is righteous, 
+</div><div class="q2">for I have rebelled against his commandment. 
+</div><div class="q1">Please hear all you peoples, 
+</div><div class="q2">and see my sorrow. 
+</div><div class="q2">My virgins and my young men have gone into captivity. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“I called for my lovers, 
+</div><div class="q2">but they deceived me. 
+</div><div class="q1">My priests and my elders gave up the spirit in the city, 
+</div><div class="q2">while they sought food for themselves to refresh their souls. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Look, Yahweh; for I am in distress. 
+</div><div class="q2">My heart is troubled. 
+</div><div class="q1">My heart turns over within me, 
+</div><div class="q2">for I have grievously rebelled. 
+</div><div class="q1">Abroad, the sword bereaves. 
+</div><div class="q2">At home, it is like death. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“They have heard that I sigh. 
+</div><div class="q2">There is no one to comfort me. 
+</div><div class="q1">All my enemies have heard of my trouble. 
+</div><div class="q2">They are glad that you have done it. 
+</div><div class="q1">You will bring the day that you have proclaimed, 
+</div><div class="q2">and they will be like me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“Let all their wickedness come before you. 
+</div><div class="q2">Do to them as you have done to me for all my transgressions. 
+</div><div class="q1">For my sighs are many, 
+</div><div class="q2">and my heart is faint. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>How has the Lord covered the daughter of Zion with a cloud in his anger! 
+</div><div class="q2">He has cast the beauty of Israel down from heaven to the earth, 
+</div><div class="q2">and hasn’t remembered his footstool in the day of his anger. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>2&#160;</sup>The Lord has swallowed up all the dwellings of Jacob 
+</div><div class="q2">without pity. 
+</div><div class="q1">He has thrown down in his wrath the strongholds of the daughter of Judah. 
+</div><div class="q2">He has brought them down to the ground. 
+</div><div class="q2">He has profaned the kingdom and its princes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>He has cut off all the horn of Israel in fierce anger. 
+</div><div class="q2">He has drawn back his right hand from before the enemy. 
+</div><div class="q1">He has burned up Jacob like a flaming fire, 
+</div><div class="q2">which devours all around. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>He has bent his bow like an enemy. 
+</div><div class="q2">He has stood with his right hand as an adversary. 
+</div><div class="q1">He has killed all that were pleasant to the eye. 
+</div><div class="q2">In the tent of the daughter of Zion, he has poured out his wrath like fire. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>The Lord has become as an enemy. 
+</div><div class="q2">He has swallowed up Israel. 
+</div><div class="q1">He has swallowed up all her palaces. 
+</div><div class="q2">He has destroyed his strongholds. 
+</div><div class="q2">He has multiplied mourning and lamentation in the daughter of Judah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>He has violently taken away his tabernacle, 
+</div><div class="q2">as if it were a garden. 
+</div><div class="q1">He has destroyed his place of assembly. 
+</div><div class="q2">Yahweh has caused solemn assembly and Sabbath to be forgotten in Zion. 
+</div><div class="q2">In the indignation of his anger, he has despised the king and the priest. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>The Lord has cast off his altar. 
+</div><div class="q2">He has abhorred his sanctuary. 
+</div><div class="q1">He has given the walls of her palaces into the hand of the enemy. 
+</div><div class="q2">They have made a noise in Yahweh’s house, 
+</div><div class="q2">as in the day of a solemn assembly. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Yahweh has purposed to destroy the wall of the daughter of Zion. 
+</div><div class="q2">He has stretched out the line. 
+</div><div class="q2">He has not withdrawn his hand from destroying; 
+</div><div class="q1">He has made the rampart and wall lament. 
+</div><div class="q2">They languish together. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Her gates have sunk into the ground. 
+</div><div class="q2">He has destroyed and broken her bars. 
+</div><div class="q1">Her king and her princes are among the nations where the law is not. 
+</div><div class="q2">Yes, her prophets find no vision from Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>The elders of the daughter of Zion sit on the ground. 
+</div><div class="q2">They keep silence. 
+</div><div class="q1">They have cast up dust on their heads. 
+</div><div class="q2">They have clothed themselves with sackcloth. 
+</div><div class="q2">The virgins of Jerusalem hang down their heads to the ground. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>My eyes fail with tears. 
+</div><div class="q2">My heart is troubled. 
+</div><div class="q1">My bile is poured on the earth, 
+</div><div class="q2">because of the destruction of the daughter of my people, 
+</div><div class="q2">because the young children and the infants swoon in the streets of the city. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>They ask their mothers, 
+</div><div class="q2">“Where is grain and wine?” 
+</div><div class="q2">when they swoon as the wounded in the streets of the city, 
+</div><div class="q2">when their soul is poured out into their mothers’ bosom. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>What shall I testify to you? 
+</div><div class="q2">What shall I liken to you, daughter of Jerusalem? 
+</div><div class="q1">What shall I compare to you, 
+</div><div class="q2">that I may comfort you, virgin daughter of Zion? 
+</div><div class="q1">For your breach is as big as the sea. 
+</div><div class="q2">Who can heal you? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>Your prophets have seen false and foolish visions for you. 
+</div><div class="q2">They have not uncovered your iniquity, 
+</div><div class="q2">to reverse your captivity, 
+</div><div class="q2">but have seen for you false revelations and causes of banishment. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>All that pass by clap their hands at you. 
+</div><div class="q2">They hiss and wag their head at the daughter of Jerusalem, saying, 
+</div><div class="q1">“Is this the city that men called ‘The perfection of beauty, 
+</div><div class="q2">the joy of the whole earth’?” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>All your enemies have opened their mouth wide against you. 
+</div><div class="q2">They hiss and gnash their teeth. 
+</div><div class="q2">They say, “We have swallowed her up. 
+</div><div class="q1">Certainly this is the day that we looked for. 
+</div><div class="q2">We have found it. 
+</div><div class="q2">We have seen it.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Yahweh has done that which he planned. 
+</div><div class="q2">He has fulfilled his word that he commanded in the days of old. 
+</div><div class="q1">He has thrown down, 
+</div><div class="q2">and has not pitied. 
+</div><div class="q1">He has caused the enemy to rejoice over you. 
+</div><div class="q2">He has exalted the horn of your adversaries. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>Their heart cried to the Lord. 
+</div><div class="q2">O wall of the daughter of Zion, 
+</div><div class="q2">let tears run down like a river day and night. 
+</div><div class="q1">Give yourself no relief. 
+</div><div class="q2">Don’t let your eyes rest. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Arise, cry out in the night, 
+</div><div class="q2">at the beginning of the watches! 
+</div><div class="q1">Pour out your heart like water before the face of the Lord. 
+</div><div class="q2">Lift up your hands toward him for the life of your young children, 
+</div><div class="q2">who faint for hunger at the head of every street. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“Look, Yahweh, and see to whom you have done thus! 
+</div><div class="q2">Should the women eat their offspring, 
+</div><div class="q2">the children that they held and bounced on their knees? 
+</div><div class="q2">Should the priest and the prophet be killed in the sanctuary of the Lord? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“The youth and the old man lie on the ground in the streets. 
+</div><div class="q2">My virgins and my young men have fallen by the sword. 
+</div><div class="q1">You have killed them in the day of your anger. 
+</div><div class="q2">You have slaughtered, and not pitied. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“You have called, as in the day of a solemn assembly, my terrors on every side. 
+</div><div class="q2">There was no one that escaped or remained in the day of Yahweh’s anger. 
+</div><div class="q2">My enemy has consumed those whom I have cared for and brought up. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="q1">
+<sup>1&#160;</sup>I am the man who has seen affliction 
+</div><div class="q2">by the rod of his wrath. 
+</div><div class="q1">
+<sup>2&#160;</sup>He has led me and caused me to walk in darkness, 
+</div><div class="q2">and not in light. 
+</div><div class="q1">
+<sup>3&#160;</sup>Surely he turns his hand against me 
+</div><div class="q2">again and again all day long. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>He has made my flesh and my skin old. 
+</div><div class="q2">He has broken my bones. 
+</div><div class="q1">
+<sup>5&#160;</sup>He has built against me, 
+</div><div class="q2">and surrounded me with bitterness and hardship. 
+</div><div class="q1">
+<sup>6&#160;</sup>He has made me dwell in dark places, 
+</div><div class="q2">as those who have been long dead. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>He has walled me about, so that I can’t go out. 
+</div><div class="q2">He has made my chain heavy. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yes, when I cry, and call for help, 
+</div><div class="q2">he shuts out my prayer. 
+</div><div class="q1">
+<sup>9&#160;</sup>He has walled up my ways with cut stone. 
+</div><div class="q2">He has made my paths crooked. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>He is to me as a bear lying in wait, 
+</div><div class="q2">as a lion in hiding. 
+</div><div class="q1">
+<sup>11&#160;</sup>He has turned away my path, 
+</div><div class="q2">and pulled me in pieces. 
+</div><div class="q2">He has made me desolate. 
+</div><div class="q1">
+<sup>12&#160;</sup>He has bent his bow, 
+</div><div class="q2">and set me as a mark for the arrow. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>He has caused the shafts of his quiver to enter into my kidneys. 
+</div><div class="q2">
+<sup>14&#160;</sup>I have become a derision to all my people, 
+</div><div class="q2">and their song all day long. 
+</div><div class="q1">
+<sup>15&#160;</sup>He has filled me with bitterness. 
+</div><div class="q2">He has stuffed me with wormwood. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>He has also broken my teeth with gravel. 
+</div><div class="q2">He has covered me with ashes. 
+</div><div class="q1">
+<sup>17&#160;</sup>You have removed my soul far away from peace. 
+</div><div class="q2">I forgot prosperity. 
+</div><div class="q1">
+<sup>18&#160;</sup>I said, “My strength has perished, 
+</div><div class="q2">along with my expectation from Yahweh.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Remember my affliction and my misery, 
+</div><div class="q2">the wormwood and the bitterness. 
+</div><div class="q1">
+<sup>20&#160;</sup>My soul still remembers them, 
+</div><div class="q2">and is bowed down within me. 
+</div><div class="q1">
+<sup>21&#160;</sup>This I recall to my mind; 
+</div><div class="q2">therefore I have hope. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>It is because of Yahweh’s loving kindnesses that we are not consumed, 
+</div><div class="q2">because his mercies don’t fail. 
+</div><div class="q1">
+<sup>23&#160;</sup>They are new every morning. 
+</div><div class="q2">Great is your faithfulness. 
+</div><div class="q1">
+<sup>24&#160;</sup>“Yahweh is my portion,” says my soul. 
+</div><div class="q2">“Therefore I will hope in him.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>Yahweh is good to those who wait for him, 
+</div><div class="q2">to the soul who seeks him. 
+</div><div class="q1">
+<sup>26&#160;</sup>It is good that a man should hope 
+</div><div class="q2">and quietly wait for the salvation of Yahweh. 
+</div><div class="q2">
+<sup>27&#160;</sup>It is good for a man that he bear the yoke in his youth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>Let him sit alone and keep silence, 
+</div><div class="q2">because he has laid it on him. 
+</div><div class="q1">
+<sup>29&#160;</sup>Let him put his mouth in the dust, 
+</div><div class="q2">if it is so that there may be hope. 
+</div><div class="q1">
+<sup>30&#160;</sup>Let him give his cheek to him who strikes him. 
+</div><div class="q2">Let him be filled full of reproach. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>31&#160;</sup>For the Lord will not cast off forever. 
+</div><div class="q2">
+<sup>32&#160;</sup>For though he causes grief, 
+</div><div class="q2">yet he will have compassion according to the multitude of his loving kindnesses. 
+</div><div class="q1">
+<sup>33&#160;</sup>For he does not afflict willingly, 
+</div><div class="q2">nor grieve the children of men. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>34&#160;</sup>To crush under foot all the prisoners of the earth, 
+</div><div class="q2">
+<sup>35&#160;</sup>to turn away the right of a man before the face of the Most High, 
+</div><div class="q2">
+<sup>36&#160;</sup>to subvert a man in his cause, the Lord doesn’t approve. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>37&#160;</sup>Who is he who says, and it comes to pass, 
+</div><div class="q2">when the Lord doesn’t command it? 
+</div><div class="q1">
+<sup>38&#160;</sup>Doesn’t evil and good come out of the mouth of the Most High? 
+</div><div class="q2">
+<sup>39&#160;</sup>Why should a living man complain, 
+</div><div class="q2">a man for the punishment of his sins? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>40&#160;</sup>Let us search and try our ways, 
+</div><div class="q2">and turn again to Yahweh. 
+</div><div class="q1">
+<sup>41&#160;</sup>Let’s lift up our heart with our hands to Elohim in the heavens. 
+</div><div class="q2">
+<sup>42&#160;</sup>“We have transgressed and have rebelled. 
+</div><div class="q2">You have not pardoned. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>43&#160;</sup>“You have covered us with anger and pursued us. 
+</div><div class="q2">You have killed. 
+</div><div class="q2">You have not pitied. 
+</div><div class="q1">
+<sup>44&#160;</sup>You have covered yourself with a cloud, 
+</div><div class="q2">so that no prayer can pass through. 
+</div><div class="q1">
+<sup>45&#160;</sup>You have made us an off-scouring and refuse 
+</div><div class="q2">in the middle of the peoples. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>46&#160;</sup>“All our enemies have opened their mouth wide against us. 
+</div><div class="q2">
+<sup>47&#160;</sup>Terror and the pit have come on us, 
+</div><div class="q2">devastation and destruction.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>48&#160;</sup>My eye runs down with streams of water, 
+</div><div class="q2">for the destruction of the daughter of my people. 
+</div><div class="q1">
+<sup>49&#160;</sup>My eye pours down 
+</div><div class="q2">and doesn’t cease, 
+</div><div class="q2">without any intermission, 
+</div><div class="q1">
+<sup>50&#160;</sup>until Yahweh looks down, 
+</div><div class="q2">and sees from heaven. 
+</div><div class="q1">
+<sup>51&#160;</sup>My eye affects my soul, 
+</div><div class="q2">because of all the daughters of my city. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>52&#160;</sup>They have chased me relentlessly like a bird, 
+</div><div class="q2">those who are my enemies without cause. 
+</div><div class="q1">
+<sup>53&#160;</sup>They have cut off my life in the dungeon, 
+</div><div class="q2">and have cast a stone on me. 
+</div><div class="q1">
+<sup>54&#160;</sup>Waters flowed over my head. 
+</div><div class="q2">I said, “I am cut off.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>55&#160;</sup>I called on your name, Yahweh, 
+</div><div class="q2">out of the lowest dungeon. 
+</div><div class="q1">
+<sup>56&#160;</sup>You heard my voice: 
+</div><div class="q2">“Don’t hide your ear from my sighing, 
+</div><div class="q2">and my cry.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>57&#160;</sup>You came near in the day that I called on you. 
+</div><div class="q2">You said, “Don’t be afraid.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>58&#160;</sup>Lord, you have pleaded the causes of my soul. 
+</div><div class="q2">You have redeemed my life. 
+</div><div class="q1">
+<sup>59&#160;</sup>Yahweh, you have seen my wrong. 
+</div><div class="q2">Judge my cause. 
+</div><div class="q1">
+<sup>60&#160;</sup>You have seen all their vengeance 
+</div><div class="q2">and all their plans against me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>61&#160;</sup>You have heard their reproach, Yahweh, 
+</div><div class="q2">and all their plans against me, 
+</div><div class="q1">
+<sup>62&#160;</sup>the lips of those that rose up against me, 
+</div><div class="q2">and their plots against me all day long. 
+</div><div class="q1">
+<sup>63&#160;</sup>You see their sitting down and their rising up. 
+</div><div class="q2">I am their song. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>64&#160;</sup>You will pay them back, Yahweh, 
+</div><div class="q2">according to the work of their hands. 
+</div><div class="q1">
+<sup>65&#160;</sup>You will give them hardness of heart, 
+</div><div class="q2">your curse to them. 
+</div><div class="q1">
+<sup>66&#160;</sup>You will pursue them in anger, 
+</div><div class="q2">and destroy them from under the heavens of Yahweh. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="q1">
+<sup>1&#160;</sup>How the gold has become dim! 
+</div><div class="q2">The most pure gold has changed! 
+</div><div class="q1">The stones of the sanctuary are poured out 
+</div><div class="q2">at the head of every street. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>2&#160;</sup>The precious sons of Zion, 
+</div><div class="q2">comparable to fine gold, 
+</div><div class="q1">how they are esteemed as earthen pitchers, 
+</div><div class="q2">the work of the hands of the potter! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>Even the jackals offer their breast. 
+</div><div class="q2">They nurse their young ones. 
+</div><div class="q1">But the daughter of my people has become cruel, 
+</div><div class="q2">like the ostriches in the wilderness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>The tongue of the nursing child clings to the roof of his mouth for thirst. 
+</div><div class="q2">The young children ask for bread, 
+</div><div class="q2">and no one breaks it for them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Those who ate delicacies are desolate in the streets. 
+</div><div class="q2">Those who were brought up in purple embrace dunghills. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>For the iniquity of the daughter of my people is greater than the sin of Sodom, 
+</div><div class="q2">which was overthrown as in a moment. 
+</div><div class="q2">No hands were laid on her. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Her nobles were purer than snow. 
+</div><div class="q2">They were whiter than milk. 
+</div><div class="q1">They were more ruddy in body than rubies. 
+</div><div class="q2">Their polishing was like sapphire. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Their appearance is blacker than a coal. 
+</div><div class="q2">They are not known in the streets. 
+</div><div class="q1">Their skin clings to their bones. 
+</div><div class="q2">It is withered. 
+</div><div class="q2">It has become like wood. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Those who are killed with the sword are better than those who are killed with hunger; 
+</div><div class="q2">for these pine away, stricken through, 
+</div><div class="q2">for lack of the fruits of the field. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>The hands of the pitiful women have boiled their own children. 
+</div><div class="q2">They were their food in the destruction of the daughter of my people. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Yahweh has accomplished his wrath. 
+</div><div class="q2">He has poured out his fierce anger. 
+</div><div class="q1">He has kindled a fire in Zion, 
+</div><div class="q2">which has devoured its foundations. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>The kings of the earth didn’t believe, 
+</div><div class="q2">neither did all the inhabitants of the world, 
+</div><div class="q2">that the adversary and the enemy would enter into the gates of Jerusalem. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>It is because of the sins of her prophets 
+</div><div class="q2">and the iniquities of her priests, 
+</div><div class="q2">that have shed the blood of the just in the middle of her. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>They wander as blind men in the streets. 
+</div><div class="q2">They are polluted with blood, 
+</div><div class="q2">So that men can’t touch their garments. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“Go away!” they cried to them. 
+</div><div class="q2">“Unclean! Go away! Go away! Don’t touch! 
+</div><div class="q1">When they fled away and wandered, men said among the nations, 
+</div><div class="q2">“They can’t live here any more.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Yahweh’s anger has scattered them. 
+</div><div class="q2">He will not pay attention to them any more. 
+</div><div class="q1">They didn’t respect the persons of the priests. 
+</div><div class="q2">They didn’t favor the elders. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Our eyes still fail, 
+</div><div class="q2">looking in vain for our help. 
+</div><div class="q2">In our watching we have watched for a nation that could not save. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>They hunt our steps, 
+</div><div class="q2">so that we can’t go in our streets. 
+</div><div class="q1">Our end is near. 
+</div><div class="q2">Our days are fulfilled, 
+</div><div class="q2">for our end has come. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Our pursuers were swifter than the eagles of the sky. 
+</div><div class="q2">They chased us on the mountains. 
+</div><div class="q2">They set an ambush for us in the wilderness. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>The breath of our nostrils, 
+</div><div class="q2">the anointed of Yahweh, 
+</div><div class="q2">was taken in their pits; 
+</div><div class="q1">of whom we said, 
+</div><div class="q2">under his shadow we will live among the nations. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>Rejoice and be glad, daughter of Edom, 
+</div><div class="q2">who dwells in the land of Uz. 
+</div><div class="q1">The cup will pass through to you also. 
+</div><div class="q2">You will be drunken, 
+</div><div class="q2">and will make yourself naked. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>The punishment of your iniquity is accomplished, daughter of Zion. 
+</div><div class="q2">He will no more carry you away into captivity. 
+</div><div class="q1">He will visit your iniquity, daughter of Edom. 
+</div><div class="q2">He will uncover your sins. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="q1">
+<sup>1&#160;</sup>Remember, Yahweh, what has come on us. 
+</div><div class="q2">Look, and see our reproach. 
+</div><div class="q1">
+<sup>2&#160;</sup>Our inheritance has been turned over to strangers, 
+</div><div class="q2">our houses to aliens. 
+</div><div class="q1">
+<sup>3&#160;</sup>We are orphans and fatherless. 
+</div><div class="q2">Our mothers are as widows. 
+</div><div class="q1">
+<sup>4&#160;</sup>We must pay for water to drink. 
+</div><div class="q2">Our wood is sold to us. 
+</div><div class="q1">
+<sup>5&#160;</sup>Our pursuers are on our necks. 
+</div><div class="q2">We are weary, and have no rest. 
+</div><div class="q1">
+<sup>6&#160;</sup>We have given our hands to the Egyptians, 
+</div><div class="q2">and to the Assyrians, to be satisfied with bread. 
+</div><div class="q1">
+<sup>7&#160;</sup>Our fathers sinned, and are no more. 
+</div><div class="q2">We have borne their iniquities. 
+</div><div class="q1">
+<sup>8&#160;</sup>Servants rule over us. 
+</div><div class="q2">There is no one to deliver us out of their hand. 
+</div><div class="q1">
+<sup>9&#160;</sup>We get our bread at the peril of our lives, 
+</div><div class="q2">because of the sword in the wilderness. 
+</div><div class="q1">
+<sup>10&#160;</sup>Our skin is black like an oven, 
+</div><div class="q2">because of the burning heat of famine. 
+</div><div class="q1">
+<sup>11&#160;</sup>They ravished the women in Zion, 
+</div><div class="q2">the virgins in the cities of Judah. 
+</div><div class="q1">
+<sup>12&#160;</sup>Princes were hanged up by their hands. 
+</div><div class="q2">The faces of elders were not honored. 
+</div><div class="q1">
+<sup>13&#160;</sup>The young men carry millstones. 
+</div><div class="q2">The children stumbled under loads of wood. 
+</div><div class="q1">
+<sup>14&#160;</sup>The elders have ceased from the gate, 
+</div><div class="q2">and the young men from their music. 
+</div><div class="q1">
+<sup>15&#160;</sup>The joy of our heart has ceased. 
+</div><div class="q2">Our dance is turned into mourning. 
+</div><div class="q1">
+<sup>16&#160;</sup>The crown has fallen from our head. 
+</div><div class="q2">Woe to us, for we have sinned! 
+</div><div class="q1">
+<sup>17&#160;</sup>For this our heart is faint. 
+</div><div class="q2">For these things our eyes are dim: 
+</div><div class="q1">
+<sup>18&#160;</sup>for the mountain of Zion, which is desolate. 
+</div><div class="q2">The foxes walk on it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>You, Yahweh, remain forever. 
+</div><div class="q2">Your throne is from generation to generation. 
+</div><div class="q1">
+<sup>20&#160;</sup>Why do you forget us forever, 
+</div><div class="q2">and forsake us for so long a time? 
+</div><div class="q1">
+<sup>21&#160;</sup>Turn us to yourself, Yahweh, and we will be turned. 
+</div><div class="q2">Renew our days as of old. 
+</div><div class="q1">
+<sup>22&#160;</sup>But you have utterly rejected us. 
+</div><div class="q2">You are very angry against us. </div></div><script src="../main.js"></script></body></html>

--- a/book/leviticus.html
+++ b/book/leviticus.html
@@ -3,6 +3,47 @@
 <head>
 <title>Leviticus</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1159 +53,1187 @@
 <div class="main">
 <!-- LEV World English Scripture (WES) -->
 <h1 class="booklabel">Leviticus</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Yahweh<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> called to Moses, and spoke to him from the Tent of Meeting, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and tell them, ‘When anyone of you offers an offering to Yahweh, you shall offer your offering of the livestock, from the herd and from the flock. 
-</p><p>
-<span class="v">3&#160;</span>“&#160;‘If his offering is a burnt offering from the herd, he shall offer a male without defect. He shall offer it at the door of the Tent of Meeting, that he may be accepted before Yahweh. 
-<span class="v">4&#160;</span>He shall lay his hand on the head of the burnt offering, and it shall be accepted for him to make atonement for him. 
-<span class="v">5&#160;</span>He shall kill the bull before Yahweh. Aaron’s sons, the priests, shall present the blood and sprinkle the blood around on the altar that is at the door of the Tent of Meeting. 
-<span class="v">6&#160;</span>He shall skin the burnt offering and cut it into pieces. 
-<span class="v">7&#160;</span>The sons of Aaron the priest shall put fire on the altar, and lay wood in order on the fire; 
-<span class="v">8&#160;</span>and Aaron’s sons, the priests, shall lay the pieces, the head, and the fat in order on the wood that is on the fire which is on the altar; 
-<span class="v">9&#160;</span>but he shall wash its innards and its legs with water. The priest shall burn all of it on the altar, for a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘If his offering is from the flock, from the sheep or from the goats, for a burnt offering, he shall offer a male without defect. 
-<span class="v">11&#160;</span>He shall kill it on the north side of the altar before Yahweh. Aaron’s sons, the priests, shall sprinkle its blood around on the altar. 
-<span class="v">12&#160;</span>He shall cut it into its pieces, with its head and its fat. The priest shall lay them in order on the wood that is on the fire which is on the altar, 
-<span class="v">13&#160;</span>but the innards and the legs he shall wash with water. The priest shall offer the whole, and burn it on the altar. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘If his offering to Yahweh is a burnt offering of birds, then he shall offer his offering from turtledoves or of young pigeons. 
-<span class="v">15&#160;</span>The priest shall bring it to the altar, and wring off its head, and burn it on the altar; and its blood shall be drained out on the side of the altar; 
-<span class="v">16&#160;</span>and he shall take away its crop and its feathers, and cast it beside the altar on the east part, in the place of the ashes. 
-<span class="v">17&#160;</span>He shall tear it by its wings, but shall not divide it apart. The priest shall burn it on the altar, on the wood that is on the fire. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘When anyone offers an offering of a meal offering to Yahweh, his offering shall be of fine flour. He shall pour oil on it, and put frankincense on it. 
-<span class="v">2&#160;</span>He shall bring it to Aaron’s sons, the priests. He shall take his handful of its fine flour, and of its oil, with all its frankincense, and the priest shall burn its memorial on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
-<span class="v">3&#160;</span>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘When you offer an offering of a meal offering baked in the oven, it shall be unleavened cakes of fine flour mixed with oil, or unleavened wafers anointed with oil. 
-<span class="v">5&#160;</span>If your offering is a meal offering made on a griddle, it shall be of unleavened fine flour, mixed with oil. 
-<span class="v">6&#160;</span>You shall cut it in pieces, and pour oil on it. It is a meal offering. 
-<span class="v">7&#160;</span>If your offering is a meal offering of the pan, it shall be made of fine flour with oil. 
-<span class="v">8&#160;</span>You shall bring the meal offering that is made of these things to Yahweh. It shall be presented to the priest, and he shall bring it to the altar. 
-<span class="v">9&#160;</span>The priest shall take from the meal offering its memorial, and shall burn it on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
-<span class="v">10&#160;</span>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘No meal offering which you shall offer to Yahweh shall be made with yeast; for you shall burn no yeast, nor any honey, as an offering made by fire to Yahweh. 
-<span class="v">12&#160;</span>As an offering of first fruits you shall offer them to Yahweh, but they shall not rise up as a pleasant aroma on the altar. 
-<span class="v">13&#160;</span>Every offering of your meal offering you shall season with salt. You shall not allow the salt of the covenant of your Elohim<span class="f">+ \fr 2:13 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> to be lacking from your meal offering. With all your offerings you shall offer salt. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘If you offer a meal offering of first fruits to Yahweh, you shall offer for the meal offering of your first fruits fresh heads of grain parched with fire and crushed. 
-<span class="v">15&#160;</span>You shall put oil on it and lay frankincense on it. It is a meal offering. 
-<span class="v">16&#160;</span>The priest shall burn as its memorial part of its crushed grain and part of its oil, along with all its frankincense. It is an offering made by fire to Yahweh. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘If his offering is a sacrifice of peace offerings, if he offers it from the herd, whether male or female, he shall offer it without defect before Yahweh. 
-<span class="v">2&#160;</span>He shall lay his hand on the head of his offering, and kill it at the door of the Tent of Meeting. Aaron’s sons, the priests, shall sprinkle the blood around on the altar. 
-<span class="v">3&#160;</span>He shall offer of the sacrifice of peace offerings an offering made by fire to Yahweh. The fat that covers the innards, and all the fat that is on the innards, 
-<span class="v">4&#160;</span>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-<span class="v">5&#160;</span>Aaron’s sons shall burn it on the altar on the burnt offering, which is on the wood that is on the fire: it is an offering made by fire, of a pleasant aroma to Yahweh. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘If his offering for a sacrifice of peace offerings to Yahweh is from the flock, either male or female, he shall offer it without defect. 
-<span class="v">7&#160;</span>If he offers a lamb for his offering, then he shall offer it before Yahweh; 
-<span class="v">8&#160;</span>and he shall lay his hand on the head of his offering, and kill it before the Tent of Meeting. Aaron’s sons shall sprinkle its blood around on the altar. 
-<span class="v">9&#160;</span>He shall offer from the sacrifice of peace offerings an offering made by fire to Yahweh; its fat, the entire tail fat, he shall take away close to the backbone; and the fat that covers the entrails, and all the fat that is on the entrails, 
-<span class="v">10&#160;</span>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-<span class="v">11&#160;</span>The priest shall burn it on the altar: it is the food of the offering made by fire to Yahweh. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘If his offering is a goat, then he shall offer it before Yahweh. 
-<span class="v">13&#160;</span>He shall lay his hand on its head, and kill it before the Tent of Meeting; and the sons of Aaron shall sprinkle its blood around on the altar. 
-<span class="v">14&#160;</span>He shall offer from it as his offering, an offering made by fire to Yahweh; the fat that covers the innards, and all the fat that is on the innards, 
-<span class="v">15&#160;</span>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
-<span class="v">16&#160;</span>The priest shall burn them on the altar: it is the food of the offering made by fire, for a pleasant aroma; all the fat is Yahweh’s. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘It shall be a perpetual statute throughout your generations in all your dwellings, that you shall eat neither fat nor blood.’&#160;” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, saying, ‘If anyone sins unintentionally, in any of the things which Yahweh has commanded not to be done, and does any one of them, 
-<span class="v">3&#160;</span>if the anointed priest sins so as to bring guilt on the people, then let him offer for his sin which he has sinned a young bull without defect to Yahweh for a sin offering. 
-<span class="v">4&#160;</span>He shall bring the bull to the door of the Tent of Meeting before Yahweh; and he shall lay his hand on the head of the bull, and kill the bull before Yahweh. 
-<span class="v">5&#160;</span>The anointed priest shall take some of the blood of the bull, and bring it to the Tent of Meeting. 
-<span class="v">6&#160;</span>The priest shall dip his finger in the blood, and sprinkle some of the blood seven times before Yahweh, before the veil of the sanctuary. 
-<span class="v">7&#160;</span>The priest shall put some of the blood on the horns of the altar of sweet incense before Yahweh, which is in the Tent of Meeting; and he shall pour out the rest of the blood of the bull at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
-<span class="v">8&#160;</span>He shall take all the fat of the bull of the sin offering from it: the fat that covers the innards, and all the fat that is on the innards, 
-<span class="v">9&#160;</span>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall remove, 
-<span class="v">10&#160;</span>as it is removed from the bull of the sacrifice of peace offerings. The priest shall burn them on the altar of burnt offering. 
-<span class="v">11&#160;</span>He shall carry the bull’s skin, all its meat, with its head, and with its legs, its innards, and its dung<span class="v">12&#160;</span>—all the rest of the bull—outside of the camp to a clean place where the ashes are poured out, and burn it on wood with fire. It shall be burned where the ashes are poured out. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘If the whole congregation of Israel sins, and the thing is hidden from the eyes of the assembly, and they have done any of the things which Yahweh has commanded not to be done, and are guilty; 
-<span class="v">14&#160;</span>when the sin in which they have sinned is known, then the assembly shall offer a young bull for a sin offering, and bring it before the Tent of Meeting. 
-<span class="v">15&#160;</span>The elders of the congregation shall lay their hands on the head of the bull before Yahweh; and the bull shall be killed before Yahweh. 
-<span class="v">16&#160;</span>The anointed priest shall bring some of the blood of the bull to the Tent of Meeting. 
-<span class="v">17&#160;</span>The priest shall dip his finger in the blood and sprinkle it seven times before Yahweh, before the veil. 
-<span class="v">18&#160;</span>He shall put some of the blood on the horns of the altar which is before Yahweh, that is in the Tent of Meeting; and the rest of the blood he shall pour out at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
-<span class="v">19&#160;</span>All its fat he shall take from it, and burn it on the altar. 
-<span class="v">20&#160;</span>He shall do this with the bull; as he did with the bull of the sin offering, so he shall do with this; and the priest shall make atonement for them, and they shall be forgiven. 
-<span class="v">21&#160;</span>He shall carry the bull outside the camp, and burn it as he burned the first bull. It is the sin offering for the assembly. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘When a ruler sins, and unwittingly does any one of all the things which Yahweh his Elohim has commanded not to be done, and is guilty, 
-<span class="v">23&#160;</span>if his sin in which he has sinned is made known to him, he shall bring as his offering a goat, a male without defect. 
-<span class="v">24&#160;</span>He shall lay his hand on the head of the goat, and kill it in the place where they kill the burnt offering before Yahweh. It is a sin offering. 
-<span class="v">25&#160;</span>The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering. He shall pour out the rest of its blood at the base of the altar of burnt offering. 
-<span class="v">26&#160;</span>All its fat he shall burn on the altar, like the fat of the sacrifice of peace offerings; and the priest shall make atonement for him concerning his sin, and he will be forgiven. 
-</p><p>
-<span class="v">27&#160;</span>“&#160;‘If anyone of the common people sins unwittingly, in doing any of the things which Yahweh has commanded not to be done, and is guilty, 
-<span class="v">28&#160;</span>if his sin which he has sinned is made known to him, then he shall bring for his offering a goat, a female without defect, for his sin which he has sinned. 
-<span class="v">29&#160;</span>He shall lay his hand on the head of the sin offering, and kill the sin offering in the place of burnt offering. 
-<span class="v">30&#160;</span>The priest shall take some of its blood with his finger, and put it on the horns of the altar of burnt offering; and the rest of its blood he shall pour out at the base of the altar. 
-<span class="v">31&#160;</span>All its fat he shall take away, like the fat is taken away from the sacrifice of peace offerings; and the priest shall burn it on the altar for a pleasant aroma to Yahweh; and the priest shall make atonement for him, and he will be forgiven. 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘If he brings a lamb as his offering for a sin offering, he shall bring a female without defect. 
-<span class="v">33&#160;</span>He shall lay his hand on the head of the sin offering, and kill it for a sin offering in the place where they kill the burnt offering. 
-<span class="v">34&#160;</span>The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering; and all the rest of its blood he shall pour out at the base of the altar. 
-<span class="v">35&#160;</span>He shall remove all its fat, like the fat of the lamb is removed from the sacrifice of peace offerings. The priest shall burn them on the altar, on the offerings of Yahweh made by fire. The priest shall make atonement for him concerning his sin that he has sinned, and he will be forgiven. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘If anyone sins, in that he hears a public adjuration to testify, he being a witness, whether he has seen or known, if he doesn’t report it, then he shall bear his iniquity. 
-</p><p>
-<span class="v">2&#160;</span>“&#160;‘Or if anyone touches any unclean thing, whether it is the carcass of an unclean animal, or the carcass of unclean livestock, or the carcass of unclean creeping things, and it is hidden from him, and he is unclean, then he shall be guilty. 
-</p><p>
-<span class="v">3&#160;</span>“&#160;‘Or if he touches the uncleanness of man, whatever his uncleanness is with which he is unclean, and it is hidden from him; when he knows of it, then he shall be guilty. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘Or if anyone swears rashly with his lips to do evil or to do good—whatever it is that a man might utter rashly with an oath, and it is hidden from him—when he knows of it, then he will be guilty of one of these. 
-<span class="v">5&#160;</span>It shall be, when he is guilty of one of these, he shall confess that in which he has sinned; 
-<span class="v">6&#160;</span>and he shall bring his trespass offering to Yahweh for his sin which he has sinned: a female from the flock, a lamb or a goat, for a sin offering; and the priest shall make atonement for him concerning his sin. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘If he can’t afford a lamb, then he shall bring his trespass offering for that in which he has sinned, two turtledoves, or two young pigeons, to Yahweh; one for a sin offering, and the other for a burnt offering. 
-<span class="v">8&#160;</span>He shall bring them to the priest, who shall first offer the one which is for the sin offering. He shall wring off its head from its neck, but shall not sever it completely. 
-<span class="v">9&#160;</span>He shall sprinkle some of the blood of the sin offering on the side of the altar; and the rest of the blood shall be drained out at the base of the altar. It is a sin offering. 
-<span class="v">10&#160;</span>He shall offer the second for a burnt offering, according to the ordinance; and the priest shall make atonement for him concerning his sin which he has sinned, and he shall be forgiven. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘But if he can’t afford two turtledoves or two young pigeons, then he shall bring as his offering for that in which he has sinned, one tenth of an ephah<span class="f">+ \fr 5:11 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour for a sin offering. He shall put no oil on it, and he shall not put any frankincense on it, for it is a sin offering. 
-<span class="v">12&#160;</span>He shall bring it to the priest, and the priest shall take his handful of it as the memorial portion, and burn it on the altar, on the offerings of Yahweh made by fire. It is a sin offering. 
-<span class="v">13&#160;</span>The priest shall make atonement for him concerning his sin that he has sinned in any of these things, and he will be forgiven; and the rest shall be the priest’s, as the meal offering.’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">15&#160;</span>“If anyone commits a trespass, and sins unwittingly regarding Yahweh’s set-apart things, then he shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation in silver by shekels, according to the shekel<span class="f">+ \fr 5:15 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of the sanctuary, for a trespass offering. 
-<span class="v">16&#160;</span>He shall make restitution for that which he has done wrong regarding the set-apart thing, and shall add a fifth part to it, and give it to the priest; and the priest shall make atonement for him with the ram of the trespass offering, and he will be forgiven. 
-</p><p>
-<span class="v">17&#160;</span>“If anyone sins, doing any of the things which Yahweh has commanded not to be done, though he didn’t know it, he is still guilty, and shall bear his iniquity. 
-<span class="v">18&#160;</span>He shall bring a ram without defect from of the flock, according to your estimation, for a trespass offering, to the priest; and the priest shall make atonement for him concerning the thing in which he sinned and didn’t know it, and he will be forgiven. 
-<span class="v">19&#160;</span>It is a trespass offering. He is certainly guilty before Yahweh.” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“If anyone sins, and commits a trespass against Yahweh, and deals falsely with his neighbor in a matter of deposit, or of bargain, or of robbery, or has oppressed his neighbor, 
-<span class="v">3&#160;</span>or has found that which was lost, and lied about it, and swearing to a lie—in any of these things that a man sins in his actions—<span class="v">4&#160;</span>then it shall be, if he has sinned, and is guilty, he shall restore that which he took by robbery, or the thing which he has gotten by oppression, or the deposit which was committed to him, or the lost thing which he found, 
-<span class="v">5&#160;</span>or any thing about which he has sworn falsely: he shall restore it in full, and shall add a fifth part more to it. He shall return it to him to whom it belongs in the day of his being found guilty. 
-<span class="v">6&#160;</span>He shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation, for a trespass offering, to the priest. 
-<span class="v">7&#160;</span>The priest shall make atonement for him before Yahweh, and he will be forgiven concerning whatever he does to become guilty.” 
-</p><p>
-<span class="v">8&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">9&#160;</span>“Command Aaron and his sons, saying, ‘This is the law of the burnt offering: the burnt offering shall be on the hearth on the altar all night until the morning; and the fire of the altar shall be kept burning on it. 
-<span class="v">10&#160;</span>The priest shall put on his linen garment, and he shall put on his linen trousers upon his body; and he shall remove the ashes from where the fire has consumed the burnt offering on the altar, and he shall put them beside the altar. 
-<span class="v">11&#160;</span>He shall take off his garments, and put on other garments, and carry the ashes outside the camp to a clean place. 
-<span class="v">12&#160;</span>The fire on the altar shall be kept burning on it, it shall not go out; and the priest shall burn wood on it every morning. He shall lay the burnt offering in order upon it, and shall burn on it the fat of the peace offerings. 
-<span class="v">13&#160;</span>Fire shall be kept burning on the altar continually; it shall not go out. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘This is the law of the meal offering: the sons of Aaron shall offer it before Yahweh, before the altar. 
-<span class="v">15&#160;</span>He shall take from there his handful of the fine flour of the meal offering, and of its oil, and all the frankincense which is on the meal offering, and shall burn it on the altar for a pleasant aroma, as its memorial portion, to Yahweh. 
-<span class="v">16&#160;</span>That which is left of it Aaron and his sons shall eat. It shall be eaten without yeast in a set-apart place. They shall eat it in the court of the Tent of Meeting. 
-<span class="v">17&#160;</span>It shall not be baked with yeast. I have given it as their portion of my offerings made by fire. It is most set-apart, as are the sin offering and the trespass offering. 
-<span class="v">18&#160;</span>Every male among the children of Aaron shall eat of it, as their portion forever throughout your generations, from the offerings of Yahweh made by fire. Whoever touches them shall be set-apart.’&#160;” 
-</p><p>
-<span class="v">19&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">20&#160;</span>“This is the offering of Aaron and of his sons, which they shall offer to Yahweh in the day when he is anointed: one tenth of an ephah<span class="f">+ \fr 6:20 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour for a meal offering perpetually, half of it in the morning, and half of it in the evening. 
-<span class="v">21&#160;</span>It shall be made with oil in a griddle. When it is soaked, you shall bring it in. You shall offer the meal offering in baked pieces for a pleasant aroma to Yahweh. 
-<span class="v">22&#160;</span>The anointed priest that will be in his place from among his sons shall offer it. By a statute forever, it shall be wholly burned to Yahweh. 
-<span class="v">23&#160;</span>Every meal offering of a priest shall be wholly burned. It shall not be eaten.” 
-</p><p>
-<span class="v">24&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">25&#160;</span>“Speak to Aaron and to his sons, saying, ‘This is the law of the sin offering: in the place where the burnt offering is killed, the sin offering shall be killed before Yahweh. It is most set-apart. 
-<span class="v">26&#160;</span>The priest who offers it for sin shall eat it. It shall be eaten in a set-apart place, in the court of the Tent of Meeting. 
-<span class="v">27&#160;</span>Whatever shall touch its flesh shall be set-apart. When there is any of its blood sprinkled on a garment, you shall wash that on which it was sprinkled in a set-apart place. 
-<span class="v">28&#160;</span>But the earthen vessel in which it is boiled shall be broken; and if it is boiled in a bronze vessel, it shall be scoured, and rinsed in water. 
-<span class="v">29&#160;</span>Every male among the priests shall eat of it. It is most set-apart. 
-<span class="v">30&#160;</span>No sin offering, of which any of the blood is brought into the Tent of Meeting to make atonement in the Set-Apart Place, shall be eaten. It shall be burned with fire. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘This is the law of the trespass offering: It is most set-apart. 
-<span class="v">2&#160;</span>In the place where they kill the burnt offering, he shall kill the trespass offering; and its blood he shall sprinkle around on the altar. 
-<span class="v">3&#160;</span>He shall offer all of its fat: the fat tail, and the fat that covers the innards, 
-<span class="v">4&#160;</span>and he shall take away the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys; 
-<span class="v">5&#160;</span>and the priest shall burn them on the altar for an offering made by fire to Yahweh: it is a trespass offering. 
-<span class="v">6&#160;</span>Every male among the priests may eat of it. It shall be eaten in a set-apart place. It is most set-apart. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘As is the sin offering, so is the trespass offering; there is one law for them. The priest who makes atonement with them shall have it. 
-<span class="v">8&#160;</span>The priest who offers any man’s burnt offering shall have for himself the skin of the burnt offering which he has offered. 
-<span class="v">9&#160;</span>Every meal offering that is baked in the oven, and all that is prepared in the pan and on the griddle, shall be the priest’s who offers it. 
-<span class="v">10&#160;</span>Every meal offering, mixed with oil or dry, belongs to all the sons of Aaron, one as well as another. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘This is the law of the sacrifice of peace offerings, which one shall offer to Yahweh: 
-<span class="v">12&#160;</span>If he offers it for a thanksgiving, then he shall offer with the sacrifice of thanksgiving unleavened cakes mixed with oil, and unleavened wafers anointed with oil, and cakes mixed with oil. 
-<span class="v">13&#160;</span>He shall offer his offering with the sacrifice of his peace offerings for thanksgiving with cakes of leavened bread. 
-<span class="v">14&#160;</span>Of it he shall offer one out of each offering for a heave offering to Yahweh. It shall be the priest’s who sprinkles the blood of the peace offerings. 
-<span class="v">15&#160;</span>The flesh of the sacrifice of his peace offerings for thanksgiving shall be eaten on the day of his offering. He shall not leave any of it until the morning. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘But if the sacrifice of his offering is a vow, or a free will offering, it shall be eaten on the day that he offers his sacrifice. On the next day what remains of it shall be eaten, 
-<span class="v">17&#160;</span>but what remains of the meat of the sacrifice on the third day shall be burned with fire. 
-<span class="v">18&#160;</span>If any of the meat of the sacrifice of his peace offerings is eaten on the third day, it will not be accepted, and it shall not be credited to him who offers it. It will be an abomination, and the soul who eats any of it will bear his iniquity. 
-</p><p>
-<span class="v">19&#160;</span>“&#160;‘The meat that touches any unclean thing shall not be eaten. It shall be burned with fire. As for the meat, everyone who is clean may eat it; 
-<span class="v">20&#160;</span>but the soul who eats of the meat of the sacrifice of peace offerings that belongs to Yahweh, having his uncleanness on him, that soul shall be cut off from his people. 
-<span class="v">21&#160;</span>When anyone touches any unclean thing, the uncleanness of man, or an unclean animal, or any unclean abomination, and eats some of the meat of the sacrifice of peace offerings which belong to Yahweh, that soul shall be cut off from his people.’&#160;” 
-</p><p>
-<span class="v">22&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">23&#160;</span>“Speak to the children of Israel, saying, ‘You shall eat no fat, of bull, or sheep, or goat. 
-<span class="v">24&#160;</span>The fat of that which dies of itself, and the fat of that which is torn of animals, may be used for any other service, but you shall in no way eat of it. 
-<span class="v">25&#160;</span>For whoever eats the fat of the animal which men offer as an offering made by fire to Yahweh, even the soul who eats it shall be cut off from his people. 
-<span class="v">26&#160;</span>You shall not eat any blood, whether it is of bird or of animal, in any of your dwellings. 
-<span class="v">27&#160;</span>Whoever it is who eats any blood, that soul shall be cut off from his people.’&#160;” 
-</p><p>
-<span class="v">28&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">29&#160;</span>“Speak to the children of Israel, saying, ‘He who offers the sacrifice of his peace offerings to Yahweh shall bring his offering to Yahweh out of the sacrifice of his peace offerings. 
-<span class="v">30&#160;</span>With his own hands he shall bring the offerings of Yahweh made by fire. He shall bring the fat with the breast, that the breast may be waved for a wave offering before Yahweh. 
-<span class="v">31&#160;</span>The priest shall burn the fat on the altar, but the breast shall be Aaron’s and his sons’. 
-<span class="v">32&#160;</span>The right thigh you shall give to the priest for a heave offering out of the sacrifices of your peace offerings. 
-<span class="v">33&#160;</span>He among the sons of Aaron who offers the blood of the peace offerings, and the fat, shall have the right thigh for a portion. 
-<span class="v">34&#160;</span>For the waved breast and the heaved thigh I have taken from the children of Israel out of the sacrifices of their peace offerings, and have given them to Aaron the priest and to his sons as their portion forever from the children of Israel.’&#160;” 
-</p><p>
-<span class="v">35&#160;</span>This is the consecrated portion of Aaron, and the consecrated portion of his sons, out of the offerings of Yahweh made by fire, in the day when he presented them to minister to Yahweh in the priest’s office; 
-<span class="v">36&#160;</span>which Yahweh commanded to be given them of the children of Israel, in the day that he anointed them. It is their portion forever throughout their generations. 
-<span class="v">37&#160;</span>This is the law of the burnt offering, the meal offering, the sin offering, the trespass offering, the consecration, and the sacrifice of peace offerings 
-<span class="v">38&#160;</span>which Yahweh commanded Moses in Mount Sinai in the day that he commanded the children of Israel to offer their offerings to Yahweh, in the wilderness of Sinai. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Take Aaron and his sons with him, and the garments, and the anointing oil, and the bull of the sin offering, and the two rams, and the basket of unleavened bread; 
-<span class="v">3&#160;</span>and assemble all the congregation at the door of the Tent of Meeting.” 
-</p><p>
-<span class="v">4&#160;</span>Moses did as Yahweh commanded him; and the congregation was assembled at the door of the Tent of Meeting. 
-<span class="v">5&#160;</span>Moses said to the congregation, “This is the thing which Yahweh has commanded to be done.” 
-<span class="v">6&#160;</span>Moses brought Aaron and his sons, and washed them with water. 
-<span class="v">7&#160;</span>He put the tunic on him, tied the sash on him, clothed him with the robe, put the ephod on him, and he tied the skillfully woven band of the ephod on him and fastened it to him with it. 
-<span class="v">8&#160;</span>He placed the breastplate on him. He put the Urim and Thummim in the breastplate. 
-<span class="v">9&#160;</span>He set the turban on his head. He set the golden plate, the set-apart crown, on the front of the turban, as Yahweh commanded Moses. 
-<span class="v">10&#160;</span>Moses took the anointing oil, and anointed the tabernacle and all that was in it, and sanctified them. 
-<span class="v">11&#160;</span>He sprinkled it on the altar seven times, and anointed the altar and all its vessels, and the basin and its base, to sanctify them. 
-<span class="v">12&#160;</span>He poured some of the anointing oil on Aaron’s head, and anointed him, to sanctify him. 
-<span class="v">13&#160;</span>Moses brought Aaron’s sons, and clothed them with tunics, and tied sashes on them, and put headbands on them, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">14&#160;</span>He brought the bull of the sin offering, and Aaron and his sons laid their hands on the head of the bull of the sin offering. 
-<span class="v">15&#160;</span>He killed it; and Moses took the blood, and put it around on the horns of the altar with his finger, and purified the altar, and poured out the blood at the base of the altar, and sanctified it, to make atonement for it. 
-<span class="v">16&#160;</span>He took all the fat that was on the innards, and the cover of the liver, and the two kidneys, and their fat; and Moses burned it on the altar. 
-<span class="v">17&#160;</span>But the bull, and its skin, and its meat, and its dung, he burned with fire outside the camp, as Yahweh commanded Moses. 
-<span class="v">18&#160;</span>He presented the ram of the burnt offering. Aaron and his sons laid their hands on the head of the ram. 
-<span class="v">19&#160;</span>He killed it; and Moses sprinkled the blood around on the altar. 
-<span class="v">20&#160;</span>He cut the ram into its pieces; and Moses burned the head, and the pieces, and the fat. 
-<span class="v">21&#160;</span>He washed the innards and the legs with water; and Moses burned the whole ram on the altar. It was a burnt offering for a pleasant aroma. It was an offering made by fire to Yahweh, as Yahweh commanded Moses. 
-<span class="v">22&#160;</span>He presented the other ram, the ram of consecration. Aaron and his sons laid their hands on the head of the ram. 
-<span class="v">23&#160;</span>He killed it; and Moses took some of its blood, and put it on the tip of Aaron’s right ear, and on the thumb of his right hand, and on the great toe of his right foot. 
-<span class="v">24&#160;</span>He brought Aaron’s sons; and Moses put some of the blood on the tip of their right ear, and on the thumb of their right hand, and on the great toe of their right foot; and Moses sprinkled the blood around on the altar. 
-<span class="v">25&#160;</span>He took the fat, the fat tail, all the fat that was on the innards, the cover of the liver, the two kidneys and their fat, and the right thigh; 
-<span class="v">26&#160;</span>and out of the basket of unleavened bread that was before Yahweh, he took one unleavened cake, one cake of oiled bread, and one wafer, and placed them on the fat and on the right thigh. 
-<span class="v">27&#160;</span>He put all these in Aaron’s hands and in his sons’ hands, and waved them for a wave offering before Yahweh. 
-<span class="v">28&#160;</span>Moses took them from their hands, and burned them on the altar on the burnt offering. They were a consecration offering for a pleasant aroma. It was an offering made by fire to Yahweh. 
-<span class="v">29&#160;</span>Moses took the breast, and waved it for a wave offering before Yahweh. It was Moses’ portion of the ram of consecration, as Yahweh commanded Moses. 
-<span class="v">30&#160;</span>Moses took some of the anointing oil, and some of the blood which was on the altar, and sprinkled it on Aaron, on his garments, and on his sons, and on his sons’ garments with him, and sanctified Aaron, his garments, and his sons, and his sons’ garments with him. 
-</p><p>
-<span class="v">31&#160;</span>Moses said to Aaron and to his sons, “Boil the meat at the door of the Tent of Meeting, and there eat it and the bread that is in the basket of consecration, as I commanded, saying, ‘Aaron and his sons shall eat it.’ 
-<span class="v">32&#160;</span>What remains of the meat and of the bread you shall burn with fire. 
-<span class="v">33&#160;</span>You shall not go out from the door of the Tent of Meeting for seven days, until the days of your consecration are fulfilled: for he shall consecrate you seven days. 
-<span class="v">34&#160;</span>What has been done today, so Yahweh has commanded to do, to make atonement for you. 
-<span class="v">35&#160;</span>You shall stay at the door of the Tent of Meeting day and night seven days, and keep Yahweh’s command, that you don’t die: for so I am commanded.” 
-<span class="v">36&#160;</span>Aaron and his sons did all the things which Yahweh commanded by Moses. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>On the eighth day, Moses called Aaron and his sons, and the elders of Israel; 
-<span class="v">2&#160;</span>and he said to Aaron, “Take a calf from the herd for a sin offering, and a ram for a burnt offering, without defect, and offer them before Yahweh. 
-<span class="v">3&#160;</span>You shall speak to the children of Israel, saying, ‘Take a male goat for a sin offering; and a calf and a lamb, both a year old, without defect, for a burnt offering; 
-<span class="v">4&#160;</span>and a bull and a ram for peace offerings, to sacrifice before Yahweh; and a meal offering mixed with oil: for today Yahweh appears to you.’&#160;” 
-</p><p>
-<span class="v">5&#160;</span>They brought what Moses commanded before the Tent of Meeting. All the congregation came near and stood before Yahweh. 
-<span class="v">6&#160;</span>Moses said, “This is the thing which Yahweh commanded that you should do; and Yahweh’s glory shall appear to you.” 
-<span class="v">7&#160;</span>Moses said to Aaron, “Draw near to the altar, and offer your sin offering, and your burnt offering, and make atonement for yourself, and for the people; and offer the offering of the people, and make atonement for them, as Yahweh commanded.” 
-</p><p>
-<span class="v">8&#160;</span>So Aaron came near to the altar, and killed the calf of the sin offering, which was for himself. 
-<span class="v">9&#160;</span>The sons of Aaron presented the blood to him; and he dipped his finger in the blood, and put it on the horns of the altar, and poured out the blood at the base of the altar; 
-<span class="v">10&#160;</span>but the fat, and the kidneys, and the cover from the liver of the sin offering, he burned upon the altar, as Yahweh commanded Moses. 
-<span class="v">11&#160;</span>The meat and the skin he burned with fire outside the camp. 
-<span class="v">12&#160;</span>He killed the burnt offering; and Aaron’s sons delivered the blood to him, and he sprinkled it around on the altar. 
-<span class="v">13&#160;</span>They delivered the burnt offering to him, piece by piece, and the head. He burned them upon the altar. 
-<span class="v">14&#160;</span>He washed the innards and the legs, and burned them on the burnt offering on the altar. 
-<span class="v">15&#160;</span>He presented the people’s offering, and took the goat of the sin offering which was for the people, and killed it, and offered it for sin, like the first. 
-<span class="v">16&#160;</span>He presented the burnt offering, and offered it according to the ordinance. 
-<span class="v">17&#160;</span>He presented the meal offering, and filled his hand from there, and burned it upon the altar, in addition to the burnt offering of the morning. 
-<span class="v">18&#160;</span>He also killed the bull and the ram, the sacrifice of peace offerings, which was for the people. Aaron’s sons delivered to him the blood, which he sprinkled around on the altar; 
-<span class="v">19&#160;</span>and the fat of the bull and of the ram, the fat tail, and that which covers the innards, and the kidneys, and the cover of the liver; 
-<span class="v">20&#160;</span>and they put the fat upon the breasts, and he burned the fat on the altar. 
-<span class="v">21&#160;</span>Aaron waved the breasts and the right thigh for a wave offering before Yahweh, as Moses commanded. 
-<span class="v">22&#160;</span>Aaron lifted up his hands toward the people, and blessed them; and he came down from offering the sin offering, and the burnt offering, and the peace offerings. 
-</p><p>
-<span class="v">23&#160;</span>Moses and Aaron went into the Tent of Meeting, and came out, and blessed the people; and Yahweh’s glory appeared to all the people. 
-<span class="v">24&#160;</span>Fire came out from before Yahweh, and consumed the burnt offering and the fat upon the altar. When all the people saw it, they shouted, and fell on their faces. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Nadab and Abihu, the sons of Aaron, each took his censer, and put fire in it, and laid incense on it, and offered strange fire before Yahweh, which he had not commanded them. 
-<span class="v">2&#160;</span>Fire came out from before Yahweh, and devoured them, and they died before Yahweh. 
-</p><p>
-<span class="v">3&#160;</span>Then Moses said to Aaron, “This is what Yahweh spoke of, saying, 
-</p><p class="q1">‘I will show myself set-apart to those who come near me, 
-</p><p class="q2">and before all the people I will be glorified.’&#160;” 
-</p><p>Aaron held his peace. 
-<span class="v">4&#160;</span>Moses called Mishael and Elzaphan, the sons of Uzziel the uncle of Aaron, and said to them, “Draw near, carry your brothers from before the sanctuary out of the camp.” 
-<span class="v">5&#160;</span>So they came near, and carried them in their tunics out of the camp, as Moses had said. 
-</p><p>
-<span class="v">6&#160;</span>Moses said to Aaron, and to Eleazar and to Ithamar, his sons, “Don’t let the hair of your heads go loose, and don’t tear your clothes, so that you don’t die, and so that he will not be angry with all the congregation; but let your brothers, the whole house of Israel, bewail the burning which Yahweh has kindled. 
-<span class="v">7&#160;</span>You shall not go out from the door of the Tent of Meeting, lest you die; for the anointing oil of Yahweh is on you.” They did according to the word of Moses. 
-<span class="v">8&#160;</span>Then Yahweh said to Aaron, 
-<span class="v">9&#160;</span>“You and your sons are not to drink wine or strong drink whenever you go into the Tent of Meeting, or you will die. This shall be a statute forever throughout your generations. 
-<span class="v">10&#160;</span>You are to make a distinction between the set-apart and the common, and between the unclean and the clean. 
-<span class="v">11&#160;</span>You are to teach the children of Israel all the statutes which Yahweh has spoken to them by Moses.” 
-</p><p>
-<span class="v">12&#160;</span>Moses spoke to Aaron, and to Eleazar and to Ithamar, his sons who were left, “Take the meal offering that remains of the offerings of Yahweh made by fire, and eat it without yeast beside the altar; for it is most set-apart; 
-<span class="v">13&#160;</span>and you shall eat it in a set-apart place, because it is your portion, and your sons’ portion, of the offerings of Yahweh made by fire; for so I am commanded. 
-<span class="v">14&#160;</span>The waved breast and the heaved thigh you shall eat in a clean place, you, and your sons, and your daughters with you: for they are given as your portion, and your sons’ portion, out of the sacrifices of the peace offerings of the children of Israel. 
-<span class="v">15&#160;</span>They shall bring the heaved thigh and the waved breast with the offerings made by fire of the fat, to wave it for a wave offering before Yahweh. It shall be yours, and your sons’ with you, as a portion forever, as Yahweh has commanded.” 
-</p><p>
-<span class="v">16&#160;</span>Moses diligently inquired about the goat of the sin offering, and, behold,<span class="f">+ \fr 10:16 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> it was burned. He was angry with Eleazar and with Ithamar, the sons of Aaron who were left, saying, 
-<span class="v">17&#160;</span>“Why haven’t you eaten the sin offering in the place of the sanctuary, since it is most set-apart, and he has given it to you to bear the iniquity of the congregation, to make atonement for them before Yahweh? 
-<span class="v">18&#160;</span>Behold, its blood was not brought into the inner part of the sanctuary. You certainly should have eaten it in the sanctuary, as I commanded.” 
-</p><p>
-<span class="v">19&#160;</span>Aaron spoke to Moses, “Behold, today they have offered their sin offering and their burnt offering before Yahweh; and such things as these have happened to me. If I had eaten the sin offering today, would it have been pleasing in Yahweh’s sight?” 
-</p><p>
-<span class="v">20&#160;</span>When Moses heard that, it was pleasing in his sight. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and to Aaron, saying to them, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, saying, ‘These are the living things which you may eat among all the animals that are on the earth. 
-<span class="v">3&#160;</span>Whatever parts the hoof, and is cloven-footed, and chews the cud among the animals, that you may eat. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘Nevertheless these you shall not eat of those that chew the cud, or of those who part the hoof: the camel, because it chews the cud but doesn’t have a parted hoof, is unclean to you. 
-<span class="v">5&#160;</span>The hyrax,<span class="f">+ \fr 11:5 \ft or rock badger, or cony</span> because it chews the cud but doesn’t have a parted hoof, is unclean to you. 
-<span class="v">6&#160;</span>The hare, because it chews the cud but doesn’t have a parted hoof, is unclean to you. 
-<span class="v">7&#160;</span>The pig, because it has a split hoof, and is cloven-footed, but doesn’t chew the cud, is unclean to you. 
-<span class="v">8&#160;</span>You shall not eat their meat. You shall not touch their carcasses. They are unclean to you. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘You may eat of all these that are in the waters: whatever has fins and scales in the waters, in the seas, and in the rivers, that you may eat. 
-<span class="v">10&#160;</span>All that don’t have fins and scales in the seas and rivers, all that move in the waters, and all the living creatures that are in the waters, they are an abomination to you, 
-<span class="v">11&#160;</span>and you shall detest them. You shall not eat of their meat, and you shall detest their carcasses. 
-<span class="v">12&#160;</span>Whatever has no fins nor scales in the waters is an abomination to you. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘You shall detest these among the birds; they shall not be eaten because they are an abomination: the eagle, the vulture, the black vulture, 
-<span class="v">14&#160;</span>the red kite, any kind of black kite, 
-<span class="v">15&#160;</span>any kind of raven, 
-<span class="v">16&#160;</span>the horned owl, the screech owl, the gull, any kind of hawk, 
-<span class="v">17&#160;</span>the little owl, the cormorant, the great owl, 
-<span class="v">18&#160;</span>the white owl, the desert owl, the osprey, 
-<span class="v">19&#160;</span>the stork, any kind of heron, the hoopoe, and the bat. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘All flying insects that walk on all fours are an abomination to you. 
-<span class="v">21&#160;</span>Yet you may eat these: of all winged creeping things that go on all fours, which have long, jointed legs for hopping on the earth. 
-<span class="v">22&#160;</span>Even of these you may eat: any kind of locust, any kind of katydid, any kind of cricket, and any kind of grasshopper. 
-<span class="v">23&#160;</span>But all winged creeping things which have four feet are an abomination to you. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘By these you will become unclean: whoever touches their carcass shall be unclean until the evening. 
-<span class="v">25&#160;</span>Whoever carries any part of their carcass shall wash his clothes, and be unclean until the evening. 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘Every animal which has a split hoof that isn’t completely divided, or doesn’t chew the cud, is unclean to you. Everyone who touches them shall be unclean. 
-<span class="v">27&#160;</span>Whatever goes on its paws, among all animals that go on all fours, they are unclean to you. Whoever touches their carcass shall be unclean until the evening. 
-<span class="v">28&#160;</span>He who carries their carcass shall wash his clothes, and be unclean until the evening. They are unclean to you. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘These are they which are unclean to you among the creeping things that creep on the earth: the weasel, the rat, any kind of great lizard, 
-<span class="v">30&#160;</span>the gecko, and the monitor lizard, the wall lizard, the skink, and the chameleon. 
-<span class="v">31&#160;</span>These are they which are unclean to you among all that creep. Whoever touches them when they are dead shall be unclean until the evening. 
-<span class="v">32&#160;</span>Anything they fall on when they are dead shall be unclean; whether it is any vessel of wood, or clothing, or skin, or sack, whatever vessel it is, with which any work is done, it must be put into water, and it shall be unclean until the evening. Then it will be clean. 
-<span class="v">33&#160;</span>Every earthen vessel into which any of them falls and all that is in it shall be unclean. You shall break it. 
-<span class="v">34&#160;</span>All food which may be eaten which is soaked in water shall be unclean. All drink that may be drunk in every such vessel shall be unclean. 
-<span class="v">35&#160;</span>Everything whereupon part of their carcass falls shall be unclean; whether oven, or range for pots, it shall be broken in pieces. They are unclean, and shall be unclean to you. 
-<span class="v">36&#160;</span>Nevertheless a spring or a cistern in which water is gathered shall be clean, but that which touches their carcass shall be unclean. 
-<span class="v">37&#160;</span>If part of their carcass falls on any sowing seed which is to be sown, it is clean. 
-<span class="v">38&#160;</span>But if water is put on the seed, and part of their carcass falls on it, it is unclean to you. 
-</p><p>
-<span class="v">39&#160;</span>“&#160;‘If any animal of which you may eat dies, he who touches its carcass shall be unclean until the evening. 
-<span class="v">40&#160;</span>He who eats of its carcass shall wash his clothes, and be unclean until the evening. He also who carries its carcass shall wash his clothes, and be unclean until the evening. 
-</p><p>
-<span class="v">41&#160;</span>“&#160;‘Every creeping thing that creeps on the earth is an abomination. It shall not be eaten. 
-<span class="v">42&#160;</span>Whatever goes on its belly, and whatever goes on all fours, or whatever has many feet, even all creeping things that creep on the earth, them you shall not eat; for they are an abomination. 
-<span class="v">43&#160;</span>You shall not make yourselves abominable with any creeping thing that creeps. You shall not make yourselves unclean with them, that you should be defiled by them. 
-<span class="v">44&#160;</span>For I am Yahweh your Elohim. Sanctify yourselves therefore, and be set-apart; for I am set-apart. You shall not defile yourselves with any kind of creeping thing that moves on the earth. 
-<span class="v">45&#160;</span>For I am Yahweh who brought you up out of the land of Egypt, to be your Elohim. You shall therefore be set-apart, for I am set-apart. 
-</p><p>
-<span class="v">46&#160;</span>“&#160;‘This is the law of the animal, and of the bird, and of every living creature that moves in the waters, and of every creature that creeps on the earth, 
-<span class="v">47&#160;</span>to make a distinction between the unclean and the clean, and between the living thing that may be eaten and the living thing that may not be eaten.’&#160;” 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, saying, ‘If a woman conceives, and bears a male child, then she shall be unclean seven days; as in the days of her monthly period she shall be unclean. 
-<span class="v">3&#160;</span>In the eighth day the flesh of his foreskin shall be circumcised. 
-<span class="v">4&#160;</span>She shall continue in the blood of purification thirty-three days. She shall not touch any set-apart thing, nor come into the sanctuary, until the days of her purifying are completed. 
-<span class="v">5&#160;</span>But if she bears a female child, then she shall be unclean two weeks, as in her period; and she shall continue in the blood of purification sixty-six days. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘When the days of her purification are completed for a son or for a daughter, she shall bring to the priest at the door of the Tent of Meeting, a year old lamb for a burnt offering, and a young pigeon or a turtledove, for a sin offering. 
-<span class="v">7&#160;</span>He shall offer it before Yahweh, and make atonement for her; then she shall be cleansed from the fountain of her blood. 
-</p><p>“&#160;‘This is the law for her who bears, whether a male or a female. 
-<span class="v">8&#160;</span>If she cannot afford a lamb, then she shall take two turtledoves or two young pigeons: the one for a burnt offering, and the other for a sin offering. The priest shall make atonement for her, and she shall be clean.’&#160;” 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">2&#160;</span>“When a man shall have a swelling in his body’s skin, or a scab, or a bright spot, and it becomes in the skin of his body the plague of leprosy, then he shall be brought to Aaron the priest or to one of his sons, the priests. 
-<span class="v">3&#160;</span>The priest shall examine the plague in the skin of the body. If the hair in the plague has turned white, and the appearance of the plague is deeper than the body’s skin, it is the plague of leprosy; so the priest shall examine him and pronounce him unclean. 
-<span class="v">4&#160;</span>If the bright spot is white in the skin of his body, and its appearance isn’t deeper than the skin, and its hair hasn’t turned white, then the priest shall isolate the infected person for seven days. 
-<span class="v">5&#160;</span>The priest shall examine him on the seventh day. Behold, if in his eyes the plague is arrested and the plague hasn’t spread in the skin, then the priest shall isolate him for seven more days. 
-<span class="v">6&#160;</span>The priest shall examine him again on the seventh day. Behold, if the plague has faded and the plague hasn’t spread in the skin, then the priest shall pronounce him clean. It is a scab. He shall wash his clothes, and be clean. 
-<span class="v">7&#160;</span>But if the scab spreads on the skin after he has shown himself to the priest for his cleansing, he shall show himself to the priest again. 
-<span class="v">8&#160;</span>The priest shall examine him; and behold, if the scab has spread on the skin, then the priest shall pronounce him unclean. It is leprosy. 
-</p><p>
-<span class="v">9&#160;</span>“When the plague of leprosy is in a man, then he shall be brought to the priest; 
-<span class="v">10&#160;</span>and the priest shall examine him. Behold, if there is a white swelling in the skin, and it has turned the hair white, and there is raw flesh in the swelling, 
-<span class="v">11&#160;</span>it is a chronic leprosy in the skin of his body, and the priest shall pronounce him unclean. He shall not isolate him, for he is already unclean. 
-</p><p>
-<span class="v">12&#160;</span>“If the leprosy breaks out all over the skin, and the leprosy covers all the skin of the infected person from his head even to his feet, as far as it appears to the priest, 
-<span class="v">13&#160;</span>then the priest shall examine him. Behold, if the leprosy has covered all his flesh, he shall pronounce him clean of the plague. It has all turned white: he is clean. 
-<span class="v">14&#160;</span>But whenever raw flesh appears in him, he shall be unclean. 
-<span class="v">15&#160;</span>The priest shall examine the raw flesh, and pronounce him unclean: the raw flesh is unclean. It is leprosy. 
-<span class="v">16&#160;</span>Or if the raw flesh turns again, and is changed to white, then he shall come to the priest. 
-<span class="v">17&#160;</span>The priest shall examine him. Behold, if the plague has turned white, then the priest shall pronounce him clean of the plague. He is clean. 
-</p><p>
-<span class="v">18&#160;</span>“When the body has a boil on its skin, and it has healed, 
-<span class="v">19&#160;</span>and in the place of the boil there is a white swelling, or a bright spot, reddish-white, then it shall be shown to the priest. 
-<span class="v">20&#160;</span>The priest shall examine it. Behold, if its appearance is deeper than the skin, and its hair has turned white, then the priest shall pronounce him unclean. It is the plague of leprosy. It has broken out in the boil. 
-<span class="v">21&#160;</span>But if the priest examines it, and behold, there are no white hairs in it, and it isn’t deeper than the skin, but is dim, then the priest shall isolate him seven days. 
-<span class="v">22&#160;</span>If it spreads in the skin, then the priest shall pronounce him unclean. It is a plague. 
-<span class="v">23&#160;</span>But if the bright spot stays in its place, and hasn’t spread, it is the scar from the boil; and the priest shall pronounce him clean. 
-</p><p>
-<span class="v">24&#160;</span>“Or when the body has a burn from fire on its skin, and the raw flesh of the burn becomes a bright spot, reddish-white, or white, 
-<span class="v">25&#160;</span>then the priest shall examine it; and behold, if the hair in the bright spot has turned white, and its appearance is deeper than the skin, it is leprosy. It has broken out in the burning, and the priest shall pronounce him unclean. It is the plague of leprosy. 
-<span class="v">26&#160;</span>But if the priest examines it, and behold, there is no white hair in the bright spot, and it isn’t deeper than the skin, but has faded, then the priest shall isolate him seven days. 
-<span class="v">27&#160;</span>The priest shall examine him on the seventh day. If it has spread in the skin, then the priest shall pronounce him unclean. It is the plague of leprosy. 
-<span class="v">28&#160;</span>If the bright spot stays in its place, and hasn’t spread in the skin, but is faded, it is the swelling from the burn, and the priest shall pronounce him clean, for it is the scar from the burn. 
-</p><p>
-<span class="v">29&#160;</span>“When a man or woman has a plague on the head or on the beard, 
-<span class="v">30&#160;</span>then the priest shall examine the plague; and behold, if its appearance is deeper than the skin, and the hair in it is yellow and thin, then the priest shall pronounce him unclean. It is an itch. It is leprosy of the head or of the beard. 
-<span class="v">31&#160;</span>If the priest examines the plague of itching, and behold, its appearance isn’t deeper than the skin, and there is no black hair in it, then the priest shall isolate the person infected with itching seven days. 
-<span class="v">32&#160;</span>On the seventh day the priest shall examine the plague; and behold, if the itch hasn’t spread, and there is no yellow hair in it, and the appearance of the itch isn’t deeper than the skin, 
-<span class="v">33&#160;</span>then he shall be shaved, but he shall not shave the itch. Then the priest shall isolate the one who has the itch seven more days. 
-<span class="v">34&#160;</span>On the seventh day, the priest shall examine the itch; and behold, if the itch hasn’t spread in the skin, and its appearance isn’t deeper than the skin, then the priest shall pronounce him clean. He shall wash his clothes and be clean. 
-<span class="v">35&#160;</span>But if the itch spreads in the skin after his cleansing, 
-<span class="v">36&#160;</span>then the priest shall examine him; and behold, if the itch has spread in the skin, the priest shall not look for the yellow hair; he is unclean. 
-<span class="v">37&#160;</span>But if in his eyes the itch is arrested and black hair has grown in it, then the itch is healed. He is clean. The priest shall pronounce him clean. 
-</p><p>
-<span class="v">38&#160;</span>“When a man or a woman has bright spots in the skin of the body, even white bright spots, 
-<span class="v">39&#160;</span>then the priest shall examine them. Behold, if the bright spots on the skin of their body are a dull white, it is a harmless rash. It has broken out in the skin. He is clean. 
-</p><p>
-<span class="v">40&#160;</span>“If a man’s hair has fallen from his head, he is bald. He is clean. 
-<span class="v">41&#160;</span>If his hair has fallen off from the front part of his head, he is forehead bald. He is clean. 
-<span class="v">42&#160;</span>But if a reddish-white plague is in the bald head or the bald forehead, it is leprosy breaking out in his bald head or his bald forehead. 
-<span class="v">43&#160;</span>Then the priest shall examine him. Behold, if the swelling of the plague is reddish-white in his bald head, or in his bald forehead, like the appearance of leprosy in the skin of the body, 
-<span class="v">44&#160;</span>he is a leprous man. He is unclean. The priest shall surely pronounce him unclean. His plague is on his head. 
-</p><p>
-<span class="v">45&#160;</span>“The leper in whom the plague is shall wear torn clothes, and the hair of his head shall hang loose. He shall cover his upper lip, and shall cry, ‘Unclean! Unclean!’ 
-<span class="v">46&#160;</span>All the days in which the plague is in him he shall be unclean. He is unclean. He shall dwell alone. His dwelling shall be outside of the camp. 
-</p><p>
-<span class="v">47&#160;</span>“The garment also that the plague of leprosy is in, whether it is a woolen garment, or a linen garment; 
-<span class="v">48&#160;</span>whether it is in warp or woof;<span class="f">+ \fr 13:48 \ft warp and woof are the vertical and horizontal threads in woven cloth</span> of linen or of wool; whether in a leather, or in anything made of leather; 
-<span class="v">49&#160;</span>if the plague is greenish or reddish in the garment, or in the leather, or in the warp, or in the woof, or in anything made of leather; it is the plague of leprosy, and shall be shown to the priest. 
-<span class="v">50&#160;</span>The priest shall examine the plague, and isolate the plague seven days. 
-<span class="v">51&#160;</span>He shall examine the plague on the seventh day. If the plague has spread in the garment, either in the warp, or in the woof, or in the skin, whatever use the skin is used for, the plague is a destructive mildew. It is unclean. 
-<span class="v">52&#160;</span>He shall burn the garment, whether the warp or the woof, in wool or in linen, or anything of leather, in which the plague is, for it is a destructive mildew. It shall be burned in the fire. 
-</p><p>
-<span class="v">53&#160;</span>“If the priest examines it, and behold, the plague hasn’t spread in the garment, either in the warp, or in the woof, or in anything of skin; 
-<span class="v">54&#160;</span>then the priest shall command that they wash the thing that the plague is in, and he shall isolate it seven more days. 
-<span class="v">55&#160;</span>Then the priest shall examine it, after the plague is washed; and behold, if the plague hasn’t changed its color, and the plague hasn’t spread, it is unclean; you shall burn it in the fire. It is a mildewed spot, whether the bareness is inside or outside. 
-<span class="v">56&#160;</span>If the priest looks, and behold, the plague has faded after it is washed, then he shall tear it out of the garment, or out of the skin, or out of the warp, or out of the woof; 
-<span class="v">57&#160;</span>and if it appears again in the garment, either in the warp, or in the woof, or in anything of skin, it is spreading. You shall burn what the plague is in with fire. 
-<span class="v">58&#160;</span>The garment, either the warp, or the woof, or whatever thing of skin it is, which you shall wash, if the plague has departed from them, then it shall be washed the second time, and it will be clean.” 
-</p><p>
-<span class="v">59&#160;</span>This is the law of the plague of mildew in a garment of wool or linen, either in the warp, or the woof, or in anything of skin, to pronounce it clean, or to pronounce it unclean. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-</p><p>
-<span class="v">2&#160;</span>“This shall be the law of the leper in the day of his cleansing: He shall be brought to the priest, 
-<span class="v">3&#160;</span>and the priest shall go out of the camp. The priest shall examine him. Behold, if the plague of leprosy is healed in the leper, 
-<span class="v">4&#160;</span>then the priest shall command them to take for him who is to be cleansed two living clean birds, cedar wood, scarlet, and hyssop. 
-<span class="v">5&#160;</span>The priest shall command them to kill one of the birds in an earthen vessel over running water. 
-<span class="v">6&#160;</span>As for the living bird, he shall take it, the cedar wood, the scarlet, and the hyssop, and shall dip them and the living bird in the blood of the bird that was killed over the running water. 
-<span class="v">7&#160;</span>He shall sprinkle on him who is to be cleansed from the leprosy seven times, and shall pronounce him clean, and shall let the living bird go into the open field. 
-</p><p>
-<span class="v">8&#160;</span>“He who is to be cleansed shall wash his clothes, and shave off all his hair, and bathe himself in water; and he shall be clean. After that he shall come into the camp, but shall dwell outside his tent seven days. 
-<span class="v">9&#160;</span>It shall be on the seventh day, that he shall shave all his hair off his head and his beard and his eyebrows. He shall shave off all his hair. He shall wash his clothes, and he shall bathe his body in water. Then he shall be clean. 
-</p><p>
-<span class="v">10&#160;</span>“On the eighth day he shall take two male lambs without defect, one ewe lamb a year old without defect, three tenths of an ephah<span class="f">+ \fr 14:10 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour for a meal offering, mixed with oil, and one log<span class="f">+ \fr 14:10 \ft a log is a liquid measure of about 300 ml or 10 ounces</span> of oil. 
-<span class="v">11&#160;</span>The priest who cleanses him shall set the man who is to be cleansed, and those things, before Yahweh, at the door of the Tent of Meeting. 
-</p><p>
-<span class="v">12&#160;</span>“The priest shall take one of the male lambs, and offer him for a trespass offering, with the log of oil, and wave them for a wave offering before Yahweh. 
-<span class="v">13&#160;</span>He shall kill the male lamb in the place where they kill the sin offering and the burnt offering, in the place of the sanctuary; for as the sin offering is the priest’s, so is the trespass offering. It is most set-apart. 
-<span class="v">14&#160;</span>The priest shall take some of the blood of the trespass offering, and the priest shall put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
-<span class="v">15&#160;</span>The priest shall take some of the log of oil, and pour it into the palm of his own left hand. 
-<span class="v">16&#160;</span>The priest shall dip his right finger in the oil that is in his left hand, and shall sprinkle some of the oil with his finger seven times before Yahweh. 
-<span class="v">17&#160;</span>The priest shall put some of the rest of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, upon the blood of the trespass offering. 
-<span class="v">18&#160;</span>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, and the priest shall make atonement for him before Yahweh. 
-</p><p>
-<span class="v">19&#160;</span>“The priest shall offer the sin offering, and make atonement for him who is to be cleansed because of his uncleanness. Afterward he shall kill the burnt offering; 
-<span class="v">20&#160;</span>then the priest shall offer the burnt offering and the meal offering on the altar. The priest shall make atonement for him, and he shall be clean. 
-</p><p>
-<span class="v">21&#160;</span>“If he is poor, and can’t afford so much, then he shall take one male lamb for a trespass offering to be waved, to make atonement for him, and one tenth of an ephah<span class="f">+ \fr 14:21 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour mixed with oil for a meal offering, and a log<span class="f">+ \fr 14:21 \ft a log is a liquid measure of about 300 ml or 10 ounces</span> of oil; 
-<span class="v">22&#160;</span>and two turtledoves, or two young pigeons, such as he is able to afford; and the one shall be a sin offering, and the other a burnt offering. 
-</p><p>
-<span class="v">23&#160;</span>“On the eighth day he shall bring them for his cleansing to the priest, to the door of the Tent of Meeting, before Yahweh. 
-<span class="v">24&#160;</span>The priest shall take the lamb of the trespass offering, and the log of oil, and the priest shall wave them for a wave offering before Yahweh. 
-<span class="v">25&#160;</span>He shall kill the lamb of the trespass offering. The priest shall take some of the blood of the trespass offering and put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
-<span class="v">26&#160;</span>The priest shall pour some of the oil into the palm of his own left hand; 
-<span class="v">27&#160;</span>and the priest shall sprinkle with his right finger some of the oil that is in his left hand seven times before Yahweh. 
-<span class="v">28&#160;</span>Then the priest shall put some of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, on the place of the blood of the trespass offering. 
-<span class="v">29&#160;</span>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, to make atonement for him before Yahweh. 
-<span class="v">30&#160;</span>He shall offer one of the turtledoves, or of the young pigeons, which ever he is able to afford, 
-<span class="v">31&#160;</span>of the kind he is able to afford, the one for a sin offering, and the other for a burnt offering, with the meal offering. The priest shall make atonement for him who is to be cleansed before Yahweh.” 
-</p><p>
-<span class="v">32&#160;</span>This is the law for him in whom is the plague of leprosy, who is not able to afford the sacrifice for his cleansing. 
-</p><p>
-<span class="v">33&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">34&#160;</span>“When you have come into the land of Canaan, which I give to you for a possession, and I put a spreading mildew in a house in the land of your possession, 
-<span class="v">35&#160;</span>then he who owns the house shall come and tell the priest, saying, ‘There seems to me to be some sort of plague in the house.’ 
-<span class="v">36&#160;</span>The priest shall command that they empty the house, before the priest goes in to examine the plague, that all that is in the house not be made unclean. Afterward the priest shall go in to inspect the house. 
-<span class="v">37&#160;</span>He shall examine the plague; and behold, if the plague is in the walls of the house with hollow streaks, greenish or reddish, and it appears to be deeper than the wall, 
-<span class="v">38&#160;</span>then the priest shall go out of the house to the door of the house, and shut up the house seven days. 
-<span class="v">39&#160;</span>The priest shall come again on the seventh day, and look. If the plague has spread in the walls of the house, 
-<span class="v">40&#160;</span>then the priest shall command that they take out the stones in which is the plague, and cast them into an unclean place outside of the city. 
-<span class="v">41&#160;</span>He shall cause the inside of the house to be scraped all over. They shall pour out the mortar that they scraped off outside of the city into an unclean place. 
-<span class="v">42&#160;</span>They shall take other stones, and put them in the place of those stones; and he shall take other mortar, and shall plaster the house. 
-</p><p>
-<span class="v">43&#160;</span>“If the plague comes again, and breaks out in the house after he has taken out the stones, and after he has scraped the house, and after it was plastered, 
-<span class="v">44&#160;</span>then the priest shall come in and look; and behold, if the plague has spread in the house, it is a destructive mildew in the house. It is unclean. 
-<span class="v">45&#160;</span>He shall break down the house, its stones, and its timber, and all the house’s mortar. He shall carry them out of the city into an unclean place. 
-</p><p>
-<span class="v">46&#160;</span>“Moreover he who goes into the house while it is shut up shall be unclean until the evening. 
-<span class="v">47&#160;</span>He who lies down in the house shall wash his clothes; and he who eats in the house shall wash his clothes. 
-</p><p>
-<span class="v">48&#160;</span>“If the priest shall come in, and examine it, and behold, the plague hasn’t spread in the house, after the house was plastered, then the priest shall pronounce the house clean, because the plague is healed. 
-<span class="v">49&#160;</span>To cleanse the house he shall take two birds, cedar wood, scarlet, and hyssop. 
-<span class="v">50&#160;</span>He shall kill one of the birds in an earthen vessel over running water. 
-<span class="v">51&#160;</span>He shall take the cedar wood, the hyssop, the scarlet, and the living bird, and dip them in the blood of the slain bird, and in the running water, and sprinkle the house seven times. 
-<span class="v">52&#160;</span>He shall cleanse the house with the blood of the bird, and with the running water, with the living bird, with the cedar wood, with the hyssop, and with the scarlet; 
-<span class="v">53&#160;</span>but he shall let the living bird go out of the city into the open field. So shall he make atonement for the house; and it shall be clean.” 
-</p><p>
-<span class="v">54&#160;</span>This is the law for any plague of leprosy, and for an itch, 
-<span class="v">55&#160;</span>and for the destructive mildew of a garment, and for a house, 
-<span class="v">56&#160;</span>and for a swelling, and for a scab, and for a bright spot; 
-<span class="v">57&#160;</span>to teach when it is unclean, and when it is clean. 
-</p><p>This is the law of leprosy. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and tell them, ‘When any man has a discharge from his body, because of his discharge he is unclean. 
-<span class="v">3&#160;</span>This shall be his uncleanness in his discharge: whether his body runs with his discharge, or his body has stopped from his discharge, it is his uncleanness. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘Every bed on which he who has the discharge lies shall be unclean; and everything he sits on shall be unclean. 
-<span class="v">5&#160;</span>Whoever touches his bed shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-<span class="v">6&#160;</span>He who sits on anything on which the man who has the discharge sat shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘He who touches the body of him who has the discharge shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘If he who has the discharge spits on him who is clean, then he shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘Whatever saddle he who has the discharge rides on shall be unclean. 
-<span class="v">10&#160;</span>Whoever touches anything that was under him shall be unclean until the evening. He who carries those things shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘Whomever he who has the discharge touches, without having rinsed his hands in water, he shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘The earthen vessel, which he who has the discharge touches, shall be broken; and every vessel of wood shall be rinsed in water. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘When he who has a discharge is cleansed of his discharge, then he shall count to himself seven days for his cleansing, and wash his clothes; and he shall bathe his flesh in running water, and shall be clean. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘On the eighth day he shall take two turtledoves, or two young pigeons, and come before Yahweh to the door of the Tent of Meeting, and give them to the priest. 
-<span class="v">15&#160;</span>The priest shall offer them, the one for a sin offering, and the other for a burnt offering. The priest shall make atonement for him before Yahweh for his discharge. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘If any man has an emission of semen, then he shall bathe all his flesh in water, and be unclean until the evening. 
-<span class="v">17&#160;</span>Every garment and every skin which the semen is on shall be washed with water, and be unclean until the evening. 
-<span class="v">18&#160;</span>If a man lies with a woman and there is an emission of semen, they shall both bathe themselves in water, and be unclean until the evening. 
-</p><p>
-<span class="v">19&#160;</span>“&#160;‘If a woman has a discharge, and her discharge in her flesh is blood, she shall be in her impurity seven days. Whoever touches her shall be unclean until the evening. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘Everything that she lies on in her impurity shall be unclean. Everything also that she sits on shall be unclean. 
-<span class="v">21&#160;</span>Whoever touches her bed shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-<span class="v">22&#160;</span>Whoever touches anything that she sits on shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
-<span class="v">23&#160;</span>If it is on the bed, or on anything she sits on, when he touches it, he shall be unclean until the evening. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘If any man lies with her, and her monthly flow is on him, he shall be unclean seven days; and every bed he lies on shall be unclean. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘If a woman has a discharge of her blood many days not in the time of her period, or if she has a discharge beyond the time of her period, all the days of the discharge of her uncleanness shall be as in the days of her period. She is unclean. 
-<span class="v">26&#160;</span>Every bed she lies on all the days of her discharge shall be to her as the bed of her period. Everything she sits on shall be unclean, as the uncleanness of her period. 
-<span class="v">27&#160;</span>Whoever touches these things shall be unclean, and shall wash his clothes and bathe himself in water, and be unclean until the evening. 
-</p><p>
-<span class="v">28&#160;</span>“&#160;‘But if she is cleansed of her discharge, then she shall count to herself seven days, and after that she shall be clean. 
-<span class="v">29&#160;</span>On the eighth day she shall take two turtledoves, or two young pigeons, and bring them to the priest, to the door of the Tent of Meeting. 
-<span class="v">30&#160;</span>The priest shall offer the one for a sin offering, and the other for a burnt offering; and the priest shall make atonement for her before Yahweh for the uncleanness of her discharge. 
-</p><p>
-<span class="v">31&#160;</span>“&#160;‘Thus you shall separate the children of Israel from their uncleanness, so they will not die in their uncleanness when they defile my tabernacle that is among them.’&#160;” 
-</p><p>
-<span class="v">32&#160;</span>This is the law of him who has a discharge, and of him who has an emission of semen, so that he is unclean by it; 
-<span class="v">33&#160;</span>and of her who has her period, and of a man or woman who has a discharge, and of him who lies with her who is unclean. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses after the death of the two sons of Aaron, when they came near before Yahweh, and died; 
-<span class="v">2&#160;</span>and Yahweh said to Moses, “Tell Aaron your brother not to come at just any time into the Most Set-Apart Place within the veil, before the mercy seat which is on the ark; lest he die; for I will appear in the cloud on the mercy seat. 
-</p><p>
-<span class="v">3&#160;</span>“Aaron shall come into the sanctuary with a young bull for a sin offering, and a ram for a burnt offering. 
-<span class="v">4&#160;</span>He shall put on the set-apart linen tunic. He shall have the linen trousers on his body, and shall put on the linen sash, and he shall be clothed with the linen turban. They are the set-apart garments. He shall bathe his body in water, and put them on. 
-<span class="v">5&#160;</span>He shall take from the congregation of the children of Israel two male goats for a sin offering, and one ram for a burnt offering. 
-</p><p>
-<span class="v">6&#160;</span>“Aaron shall offer the bull of the sin offering, which is for himself, and make atonement for himself and for his house. 
-<span class="v">7&#160;</span>He shall take the two goats, and set them before Yahweh at the door of the Tent of Meeting. 
-<span class="v">8&#160;</span>Aaron shall cast lots for the two goats: one lot for Yahweh, and the other lot for the scapegoat. 
-<span class="v">9&#160;</span>Aaron shall present the goat on which the lot fell for Yahweh, and offer him for a sin offering. 
-<span class="v">10&#160;</span>But the goat on which the lot fell for the scapegoat shall be presented alive before Yahweh, to make atonement for him, to send him away as the scapegoat into the wilderness. 
-</p><p>
-<span class="v">11&#160;</span>“Aaron shall present the bull of the sin offering, which is for himself, and shall make atonement for himself and for his house, and shall kill the bull of the sin offering which is for himself. 
-<span class="v">12&#160;</span>He shall take a censer full of coals of fire from off the altar before Yahweh, and two handfuls of sweet incense beaten small, and bring it within the veil. 
-<span class="v">13&#160;</span>He shall put the incense on the fire before Yahweh, that the cloud of the incense may cover the mercy seat that is on the covenant, so that he will not die. 
-<span class="v">14&#160;</span>He shall take some of the blood of the bull, and sprinkle it with his finger on the mercy seat on the east; and before the mercy seat he shall sprinkle some of the blood with his finger seven times. 
-</p><p>
-<span class="v">15&#160;</span>“Then he shall kill the goat of the sin offering that is for the people, and bring his blood within the veil, and do with his blood as he did with the blood of the bull, and sprinkle it on the mercy seat and before the mercy seat. 
-<span class="v">16&#160;</span>He shall make atonement for the Set-Apart Place, because of the uncleanness of the children of Israel, and because of their transgressions, even all their sins; and so he shall do for the Tent of Meeting that dwells with them in the middle of their uncleanness. 
-<span class="v">17&#160;</span>No one shall be in the Tent of Meeting when he enters to make atonement in the Set-Apart Place, until he comes out, and has made atonement for himself and for his household, and for all the assembly of Israel. 
-</p><p>
-<span class="v">18&#160;</span>“He shall go out to the altar that is before Yahweh and make atonement for it, and shall take some of the bull’s blood, and some of the goat’s blood, and put it around on the horns of the altar. 
-<span class="v">19&#160;</span>He shall sprinkle some of the blood on it with his finger seven times, and cleanse it, and make it set-apart from the uncleanness of the children of Israel. 
-</p><p>
-<span class="v">20&#160;</span>“When he has finished atoning for the Set-Apart Place, the Tent of Meeting, and the altar, he shall present the live goat. 
-<span class="v">21&#160;</span>Aaron shall lay both his hands on the head of the live goat, and confess over him all the iniquities of the children of Israel, and all their transgressions, even all their sins; and he shall put them on the head of the goat, and shall send him away into the wilderness by the hand of a man who is ready. 
-<span class="v">22&#160;</span>The goat shall carry all their iniquities on himself to a solitary land, and he shall release the goat in the wilderness. 
-</p><p>
-<span class="v">23&#160;</span>“Aaron shall come into the Tent of Meeting, and shall take off the linen garments which he put on when he went into the Set-Apart Place, and shall leave them there. 
-<span class="v">24&#160;</span>Then he shall bathe himself in water in a set-apart place, put on his garments, and come out and offer his burnt offering and the burnt offering of the people, and make atonement for himself and for the people. 
-<span class="v">25&#160;</span>The fat of the sin offering he shall burn on the altar. 
-</p><p>
-<span class="v">26&#160;</span>“He who lets the goat go as the scapegoat shall wash his clothes, and bathe his flesh in water, and afterward he shall come into the camp. 
-<span class="v">27&#160;</span>The bull for the sin offering, and the goat for the sin offering, whose blood was brought in to make atonement in the Set-Apart Place, shall be carried outside the camp; and they shall burn their skins, their flesh, and their dung with fire. 
-<span class="v">28&#160;</span>He who burns them shall wash his clothes, and bathe his flesh in water, and afterward he shall come into the camp. 
-</p><p>
-<span class="v">29&#160;</span>“It shall be a statute to you forever: in the seventh month, on the tenth day of the month, you shall afflict your souls, and shall do no kind of work, whether native-born or a stranger who lives as a foreigner among you; 
-<span class="v">30&#160;</span>for on this day shall atonement be made for you, to cleanse you. You shall be clean from all your sins before Yahweh. 
-<span class="v">31&#160;</span>It is a Sabbath of solemn rest to you, and you shall afflict your souls. It is a statute forever. 
-<span class="v">32&#160;</span>The priest, who is anointed and who is consecrated to be priest in his father’s place, shall make the atonement, and shall put on the linen garments, even the set-apart garments. 
-<span class="v">33&#160;</span>Then he shall make atonement for the Set-Apart Sanctuary; and he shall make atonement for the Tent of Meeting and for the altar; and he shall make atonement for the priests and for all the people of the assembly. 
-</p><p>
-<span class="v">34&#160;</span>“This shall be an everlasting statute for you, to make atonement for the children of Israel once in the year because of all their sins.” 
-</p><p>It was done as Yahweh commanded Moses. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘This is the thing which Yahweh has commanded: 
-<span class="v">3&#160;</span>Whatever man there is of the house of Israel who kills a bull, or lamb, or goat in the camp, or who kills it outside the camp, 
-<span class="v">4&#160;</span>and hasn’t brought it to the door of the Tent of Meeting to offer it as an offering to Yahweh before Yahweh’s tabernacle: blood shall be imputed to that man. He has shed blood. That man shall be cut off from among his people. 
-<span class="v">5&#160;</span>This is to the end that the children of Israel may bring their sacrifices, which they sacrifice in the open field, that they may bring them to Yahweh, to the door of the Tent of Meeting, to the priest, and sacrifice them for sacrifices of peace offerings to Yahweh. 
-<span class="v">6&#160;</span>The priest shall sprinkle the blood on Yahweh’s altar at the door of the Tent of Meeting, and burn the fat for a pleasant aroma to Yahweh. 
-<span class="v">7&#160;</span>They shall no more sacrifice their sacrifices to the goat idols, after which they play the prostitute. This shall be a statute forever to them throughout their generations.’ 
-</p><p>
-<span class="v">8&#160;</span>“You shall say to them, ‘Any man there is of the house of Israel, or of the strangers who live as foreigners among them, who offers a burnt offering or sacrifice, 
-<span class="v">9&#160;</span>and doesn’t bring it to the door of the Tent of Meeting to sacrifice it to Yahweh, that man shall be cut off from his people. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘Any man of the house of Israel, or of the strangers who live as foreigners among them, who eats any kind of blood, I will set my face against that soul who eats blood, and will cut him off from among his people. 
-<span class="v">11&#160;</span>For the life of the flesh is in the blood. I have given it to you on the altar to make atonement for your souls; for it is the blood that makes atonement by reason of the life. 
-<span class="v">12&#160;</span>Therefore I have said to the children of Israel, “No person among you may eat blood, nor may any stranger who lives as a foreigner among you eat blood.” 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘Whatever man there is of the children of Israel, or of the strangers who live as foreigners among them, who takes in hunting any animal or bird that may be eaten, he shall pour out its blood, and cover it with dust. 
-<span class="v">14&#160;</span>For as to the life of all flesh, its blood is with its life. Therefore I said to the children of Israel, “You shall not eat the blood of any kind of flesh; for the life of all flesh is its blood. Whoever eats it shall be cut off.” 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘Every person that eats what dies of itself, or that which is torn by animals, whether he is native-born or a foreigner, shall wash his clothes, and bathe himself in water, and be unclean until the evening. Then he shall be clean. 
-<span class="v">16&#160;</span>But if he doesn’t wash them, or bathe his flesh, then he shall bear his iniquity.’&#160;” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and say to them, ‘I am Yahweh your Elohim. 
-<span class="v">3&#160;</span>You shall not do as they do in the land of Egypt, where you lived. You shall not do as they do in the land of Canaan, where I am bringing you. You shall not follow their statutes. 
-<span class="v">4&#160;</span>You shall do my ordinances. You shall keep my statutes and walk in them. I am Yahweh your Elohim. 
-<span class="v">5&#160;</span>You shall therefore keep my statutes and my ordinances, which if a man does, he shall live in them. I am Yahweh. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘None of you shall approach any close relatives, to uncover their nakedness: I am Yahweh. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘You shall not uncover the nakedness of your father, nor the nakedness of your mother: she is your mother. You shall not uncover her nakedness. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘You shall not uncover the nakedness of your father’s woman. It is your father’s nakedness. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘You shall not uncover the nakedness of your sister, the daughter of your father, or the daughter of your mother, whether born at home or born abroad. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘You shall not uncover the nakedness of your son’s daughter, or of your daughter’s daughter, even their nakedness; for theirs is your own nakedness. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘You shall not uncover the nakedness of your father’s woman’s daughter, conceived by your father, since she is your sister. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘You shall not uncover the nakedness of your father’s sister. She is your father’s near kinswoman. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘You shall not uncover the nakedness of your mother’s sister, for she is your mother’s near kinswoman. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘You shall not uncover the nakedness of your father’s brother. You shall not approach his woman. She is your aunt. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘You shall not uncover the nakedness of your daughter-in-law. She is your son’s woman. You shall not uncover her nakedness. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘You shall not uncover the nakedness of your brother’s woman. It is your brother’s nakedness. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘You shall not uncover the nakedness of a woman and her daughter. You shall not take her son’s daughter, or her daughter’s daughter, to uncover her nakedness. They are near kinswomen. It is wickedness. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘You shall not take a woman in addition to her sister, to be a rival, to uncover her nakedness, while her sister is still alive. 
-</p><p>
-<span class="v">19&#160;</span>“&#160;‘You shall not approach a woman to uncover her nakedness, as long as she is impure by her uncleanness. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘You shall not lie carnally with your neighbor’s woman, and defile yourself with her. 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘You shall not give any of your children as a sacrifice to Molech. You shall not profane the name of your Elohim. I am Yahweh. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘You shall not lie with a man as with a woman. That is detestable. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘You shall not lie with any animal to defile yourself with it. No woman may give herself to an animal, to lie down with it: it is a perversion. 
-</p><p>
-<span class="v">24&#160;</span>“&#160;‘Don’t defile yourselves in any of these things; for in all these the nations which I am casting out before you were defiled. 
-<span class="v">25&#160;</span>The land was defiled. Therefore I punished its iniquity, and the land vomited out her inhabitants. 
-<span class="v">26&#160;</span>You therefore shall keep my statutes and my ordinances, and shall not do any of these abominations; neither the native-born, nor the stranger who lives as a foreigner among you 
-<span class="v">27&#160;</span>(for the men of the land that were before you had done all these abominations, and the land became defiled), 
-<span class="v">28&#160;</span>that the land not vomit you out also, when you defile it, as it vomited out the nation that was before you. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘For whoever shall do any of these abominations, even the souls that do them shall be cut off from among their people. 
-<span class="v">30&#160;</span>Therefore you shall keep my requirements, that you do not practice any of these abominable customs which were practiced before you, and that you do not defile yourselves with them. I am Yahweh your Elohim.’&#160;” 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to all the congregation of the children of Israel, and tell them, ‘You shall be set-apart; for I, Yahweh your Elohim, am set-apart. 
-</p><p>
-<span class="v">3&#160;</span>“&#160;‘Each one of you shall respect his mother and his father. You shall keep my Sabbaths. I am Yahweh your Elohim. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘Don’t turn to idols, nor make molten elohims for yourselves. I am Yahweh your Elohim. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘When you offer a sacrifice of peace offerings to Yahweh, you shall offer it so that you may be accepted. 
-<span class="v">6&#160;</span>It shall be eaten the same day you offer it, and on the next day. If anything remains until the third day, it shall be burned with fire. 
-<span class="v">7&#160;</span>If it is eaten at all on the third day, it is an abomination. It will not be accepted; 
-<span class="v">8&#160;</span>but everyone who eats it shall bear his iniquity, because he has profaned the set-apart thing of Yahweh, and that soul shall be cut off from his people. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘When you reap the harvest of your land, you shall not wholly reap the corners of your field, neither shall you gather the gleanings of your harvest. 
-<span class="v">10&#160;</span>You shall not glean your vineyard, neither shall you gather the fallen grapes of your vineyard. You shall leave them for the poor and for the foreigner. I am Yahweh your Elohim. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘You shall not steal. 
-</p><p>“&#160;‘You shall not lie. 
-</p><p>“&#160;‘You shall not deceive one another. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘You shall not swear by my name falsely, and profane the name of your Elohim. I am Yahweh. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘You shall not oppress your neighbor, nor rob him. 
-</p><p>“&#160;‘The wages of a hired servant shall not remain with you all night until the morning. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘You shall not curse the deaf, nor put a stumbling block before the blind; but you shall fear your Elohim. I am Yahweh. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘You shall do no injustice in judgment. You shall not be partial to the poor, nor show favoritism to the great; but you shall judge your neighbor in righteousness. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘You shall not go around as a slanderer among your people. 
-</p><p>“&#160;‘You shall not endanger the life<span class="f">+ \fr 19:16 \ft literally, “blood”</span> of your neighbor. I am Yahweh. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘You shall not hate your brother in your heart. You shall surely rebuke your neighbor, and not bear sin because of him. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘You shall not take vengeance, nor bear any grudge against the children of your people; but you shall love your neighbor as yourself. I am Yahweh. 
-</p><p>
-<span class="v">19&#160;</span>“&#160;‘You shall keep my statutes. 
-</p><p>“&#160;‘You shall not cross-breed different kinds of animals. 
-</p><p>“&#160;‘You shall not sow your field with two kinds of seed; 
-</p><p>“&#160;‘Don’t wear a garment made of two kinds of material. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘If a man lies carnally with a woman who is a slave girl, pledged to be married to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
-<span class="v">21&#160;</span>He shall bring his trespass offering to Yahweh, to the door of the Tent of Meeting, even a ram for a trespass offering. 
-<span class="v">22&#160;</span>The priest shall make atonement for him with the ram of the trespass offering before Yahweh for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘When you come into the land, and have planted all kinds of trees for food, then you shall count their fruit as forbidden.<span class="f">+ \fr 19:23 \ft literally, “uncircumcised”</span> For three years it shall be forbidden to you. It shall not be eaten. 
-<span class="v">24&#160;</span>But in the fourth year all its fruit shall be set-apart, for giving praise to Yahweh. 
-<span class="v">25&#160;</span>In the fifth year you shall eat its fruit, that it may yield its increase to you. I am Yahweh your Elohim. 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘You shall not eat any meat with the blood still in it. You shall not use enchantments, nor practice sorcery. 
-</p><p>
-<span class="v">27&#160;</span>“&#160;‘You shall not cut the hair on the sides of your head or clip off the edge of your beard. 
-</p><p>
-<span class="v">28&#160;</span>“&#160;‘You shall not make any cuttings in your flesh for the dead, nor tattoo any marks on you. I am Yahweh. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘Don’t profane your daughter, to make her a prostitute; lest the land fall to prostitution, and the land become full of wickedness. 
-</p><p>
-<span class="v">30&#160;</span>“&#160;‘You shall keep my Sabbaths, and reverence my sanctuary; I am Yahweh. 
-</p><p>
-<span class="v">31&#160;</span>“&#160;‘Don’t turn to those who are mediums, nor to the wizards. Don’t seek them out, to be defiled by them. I am Yahweh your Elohim. 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘You shall rise up before the gray head and honor the face of the elderly; and you shall fear your Elohim. I am Yahweh. 
-</p><p>
-<span class="v">33&#160;</span>“&#160;‘If a stranger lives as a foreigner with you in your land, you shall not do him wrong. 
-<span class="v">34&#160;</span>The stranger who lives as a foreigner with you shall be to you as the native-born among you, and you shall love him as yourself; for you lived as foreigners in the land of Egypt. I am Yahweh your Elohim. 
-</p><p>
-<span class="v">35&#160;</span>“&#160;‘You shall do no unrighteousness in judgment, in measures of length, of weight, or of quantity. 
-<span class="v">36&#160;</span>You shall have just balances, just weights, a just ephah,<span class="f">+ \fr 19:36 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> and a just hin.<span class="f">+ \fr 19:36 \ft A hin is about 6.5 liters or 1.7 gallons.</span> I am Yahweh your Elohim, who brought you out of the land of Egypt. 
-</p><p>
-<span class="v">37&#160;</span>“&#160;‘You shall observe all my statutes and all my ordinances, and do them. I am Yahweh.’&#160;” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Moreover, you shall tell the children of Israel, ‘Anyone of the children of Israel, or of the strangers who live as foreigners in Israel, who gives any of his offspring<span class="f">+ \fr 20:2 \ft or, seed</span> to Molech shall surely be put to death. The people of the land shall stone that person with stones. 
-<span class="v">3&#160;</span>I also will set my face against that person, and will cut him off from among his people, because he has given of his offspring to Molech, to defile my sanctuary, and to profane my set-apart name. 
-<span class="v">4&#160;</span>If the people of the land all hide their eyes from that person when he gives of his offspring to Molech, and don’t put him to death, 
-<span class="v">5&#160;</span>then I will set my face against that man and against his family, and will cut him off, and all who play the prostitute after him to play the prostitute with Molech, from among their people. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘The person that turns to those who are mediums and wizards, to play the prostitute after them, I will even set my face against that person, and will cut him off from among his people. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘Sanctify yourselves therefore, and be set-apart; for I am Yahweh your Elohim. 
-<span class="v">8&#160;</span>You shall keep my statutes, and do them. I am Yahweh who sanctifies you. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘For everyone who curses his father or his mother shall surely be put to death. He has cursed his father or his mother. His blood shall be upon himself. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘The man who commits adultery with another man’s woman, even he who commits adultery with his neighbor’s woman, the adulterer and the adulteress shall surely be put to death. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘The man who lies with his father’s woman has uncovered his father’s nakedness. Both of them shall surely be put to death. Their blood shall be upon themselves. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘If a man lies with his daughter-in-law, both of them shall surely be put to death. They have committed a perversion. Their blood shall be upon themselves. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘If a man lies with a male, as with a woman, both of them have committed an abomination. They shall surely be put to death. Their blood shall be upon themselves. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘If a man takes a woman and her mother, it is wickedness. They shall be burned with fire, both he and they, that there may be no wickedness among you. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘If a man lies with an animal, he shall surely be put to death; and you shall kill the animal. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘If a woman approaches any animal and lies with it, you shall kill the woman and the animal. They shall surely be put to death. Their blood shall be upon them. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘If a man takes his sister—his father’s daughter, or his mother’s daughter—and sees her nakedness, and she sees his nakedness, it is a shameful thing. They shall be cut off in the sight of the children of their people. He has uncovered his sister’s nakedness. He shall bear his iniquity. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘If a man lies with a woman having her monthly period, and uncovers her nakedness, he has made her fountain naked, and she has uncovered the fountain of her blood. Both of them shall be cut off from among their people. 
-</p><p>
-<span class="v">19&#160;</span>“&#160;‘You shall not uncover the nakedness of your mother’s sister, nor of your father’s sister, for he has made his close relative naked. They shall bear their iniquity. 
-<span class="v">20&#160;</span>If a man lies with his uncle’s woman, he has uncovered his uncle’s nakedness. They shall bear their sin. They shall die childless. 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘If a man takes his brother’s woman, it is an impurity. He has uncovered his brother’s nakedness. They shall be childless. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘You shall therefore keep all my statutes and all my ordinances, and do them, that the land where I am bringing you to dwell may not vomit you out. 
-<span class="v">23&#160;</span>You shall not walk in the customs of the nation which I am casting out before you; for they did all these things, and therefore I abhorred them. 
-<span class="v">24&#160;</span>But I have said to you, “You shall inherit their land, and I will give it to you to possess it, a land flowing with milk and honey.” I am Yahweh your Elohim, who has separated you from the peoples. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘You shall therefore make a distinction between the clean animal and the unclean, and between the unclean fowl and the clean. You shall not make yourselves abominable by animal, or by bird, or by anything with which the ground teems, which I have separated from you as unclean for you. 
-<span class="v">26&#160;</span>You shall be set-apart to me, for I, Yahweh, am set-apart, and have set you apart from the peoples, that you should be mine. 
-</p><p>
-<span class="v">27&#160;</span>“&#160;‘A man or a woman that is a medium or is a wizard shall surely be put to death. They shall be stoned with stones. Their blood shall be upon themselves.’&#160;” 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses, “Speak to the priests, the sons of Aaron, and say to them, ‘A priest shall not defile himself for the dead among his people, 
-<span class="v">2&#160;</span>except for his relatives that are near to him: for his mother, for his father, for his son, for his daughter, for his brother, 
-<span class="v">3&#160;</span>and for his virgin sister who is near to him, who has had no man; for her he may defile himself. 
-<span class="v">4&#160;</span>He shall not defile himself, being an owner among his people, to profane himself. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘They shall not shave their heads or shave off the corners of their beards or make any cuttings in their flesh. 
-<span class="v">6&#160;</span>They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahweh made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘They shall not marry a woman who is a prostitute, or profane. A priest shall not marry a woman divorced from her man; for he is set-apart to his Elohim. 
-<span class="v">8&#160;</span>Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahweh, who sanctify you, am set-apart. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘The daughter of any priest, if she profanes herself by playing the prostitute, she profanes her father. She shall be burned with fire. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘He who is the high priest among his brothers, upon whose head the anointing oil is poured, and who is consecrated to put on the garments, shall not let the hair of his head hang loose, or tear his clothes. 
-<span class="v">11&#160;</span>He must not go in to any dead body, or defile himself for his father or for his mother. 
-<span class="v">12&#160;</span>He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahweh. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘He shall take a woman in her virginity. 
-<span class="v">14&#160;</span>He shall not marry a widow, or one divorced, or a woman who has been defiled, or a prostitute. He shall take a virgin of his own people as a woman. 
-<span class="v">15&#160;</span>He shall not profane his offspring among his people, for I am Yahweh who sanctifies him.’&#160;” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">17&#160;</span>“Say to Aaron, ‘None of your offspring throughout their generations who has a defect may approach to offer the bread of his Elohim. 
-<span class="v">18&#160;</span>For whatever man he is that has a defect, he shall not draw near: a blind man, or a lame, or he who has a flat nose, or any deformity, 
-<span class="v">19&#160;</span>or a man who has an injured foot, or an injured hand, 
-<span class="v">20&#160;</span>or hunchbacked, or a dwarf, or one who has a defect in his eye, or an itching disease, or scabs, or who has damaged testicles. 
-<span class="v">21&#160;</span>No man of the offspring of Aaron the priest who has a defect shall come near to offer the offerings of Yahweh made by fire. Since he has a defect, he shall not come near to offer the bread of his Elohim. 
-<span class="v">22&#160;</span>He shall eat the bread of his Elohim, both of the most set-apart, and of the set-apart. 
-<span class="v">23&#160;</span>He shall not come near to the veil, nor come near to the altar, because he has a defect; that he may not profane my sanctuaries, for I am Yahweh who sanctifies them.’&#160;” 
-</p><p>
-<span class="v">24&#160;</span>So Moses spoke to Aaron, and to his sons, and to all the children of Israel. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Tell Aaron and his sons to separate themselves from the set-apart things of the children of Israel, which they make set-apart to me, and that they not profane my set-apart name. I am Yahweh. 
-</p><p>
-<span class="v">3&#160;</span>“Tell them, ‘If anyone of all your offspring throughout your generations approaches the set-apart things which the children of Israel make set-apart to Yahweh, having his uncleanness on him, that soul shall be cut off from before me. I am Yahweh. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘Whoever of the offspring of Aaron is a leper or has a discharge shall not eat of the set-apart things until he is clean. Whoever touches anything that is unclean by the dead, or a man who has a seminal emission, 
-<span class="v">5&#160;</span>or whoever touches any creeping thing by which he may be made unclean, or a man from whom he may become unclean, whatever uncleanness he has—<span class="v">6&#160;</span>the person that touches any such shall be unclean until the evening, and shall not eat of the set-apart things unless he bathes his body in water. 
-<span class="v">7&#160;</span>When the sun is down, he shall be clean; and afterward he shall eat of the set-apart things, because it is his bread. 
-<span class="v">8&#160;</span>He shall not eat that which dies of itself or is torn by animals, defiling himself by it. I am Yahweh. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘They shall therefore follow my commandment, lest they bear sin for it and die in it, if they profane it. I am Yahweh who sanctifies them. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘No stranger shall eat of the set-apart thing: a foreigner living with the priests, or a hired servant, shall not eat of the set-apart thing. 
-<span class="v">11&#160;</span>But if a priest buys a slave, purchased by his money, he shall eat of it; and those who are born in his house shall eat of his bread. 
-<span class="v">12&#160;</span>If a priest’s daughter is married to an outsider, she shall not eat of the heave offering of the set-apart things. 
-<span class="v">13&#160;</span>But if a priest’s daughter is a widow, or divorced, and has no child, and has returned to her father’s house as in her youth, she may eat of her father’s bread; but no stranger shall eat any of it. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘If a man eats something set-apart unwittingly, then he shall add the fifth part of its value to it, and shall give the set-apart thing to the priest. 
-<span class="v">15&#160;</span>The priests shall not profane the set-apart things of the children of Israel, which they offer to Yahweh, 
-<span class="v">16&#160;</span>and so cause them to bear the iniquity that brings guilt when they eat their set-apart things; for I am Yahweh who sanctifies them.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">18&#160;</span>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘Whoever is of the house of Israel, or of the foreigners in Israel, who offers his offering, whether it is any of their vows or any of their free will offerings, which they offer to Yahweh for a burnt offering: 
-<span class="v">19&#160;</span>that you may be accepted, you shall offer a male without defect, of the bulls, of the sheep, or of the goats. 
-<span class="v">20&#160;</span>But you shall not offer whatever has a defect, for it shall not be acceptable for you. 
-<span class="v">21&#160;</span>Whoever offers a sacrifice of peace offerings to Yahweh to accomplish a vow, or for a free will offering of the herd or of the flock, it shall be perfect to be accepted. It shall have no defect. 
-<span class="v">22&#160;</span>You shall not offer what is blind, is injured, is maimed, has a wart, is festering, or has a running sore to Yahweh, nor make an offering by fire of them on the altar to Yahweh. 
-<span class="v">23&#160;</span>Either a bull or a lamb that has any deformity or lacking in his parts, that you may offer for a free will offering; but for a vow it shall not be accepted. 
-<span class="v">24&#160;</span>You must not offer to Yahweh that which has its testicles bruised, crushed, broken, or cut. You must not do this in your land. 
-<span class="v">25&#160;</span>You must not offer any of these as the bread of your Elohim from the hand of a foreigner, because their corruption is in them. There is a defect in them. They shall not be accepted for you.’&#160;” 
-</p><p>
-<span class="v">26&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">27&#160;</span>“When a bull, a sheep, or a goat is born, it shall remain seven days with its mother. From the eighth day on it shall be accepted for the offering of an offering made by fire to Yahweh. 
-<span class="v">28&#160;</span>Whether it is a cow or ewe, you shall not kill it and its young both in one day. 
-</p><p>
-<span class="v">29&#160;</span>“When you sacrifice a sacrifice of thanksgiving to Yahweh, you shall sacrifice it so that you may be accepted. 
-<span class="v">30&#160;</span>It shall be eaten on the same day; you shall leave none of it until the morning. I am Yahweh. 
-</p><p>
-<span class="v">31&#160;</span>“Therefore you shall keep my commandments, and do them. I am Yahweh. 
-<span class="v">32&#160;</span>You shall not profane my set-apart name, but I will be made set-apart among the children of Israel. I am Yahweh who makes you set-apart, 
-<span class="v">33&#160;</span>who brought you out of the land of Egypt, to be your Elohim. I am Yahweh.” 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and tell them, ‘The set feasts of Yahweh, which you shall proclaim to be set-apart convocations, even these are my set feasts. 
-</p><p>
-<span class="v">3&#160;</span>“&#160;‘Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, a set-apart convocation; you shall do no kind of work. It is a Sabbath to Yahweh in all your dwellings. 
-</p><p>
-<span class="v">4&#160;</span>“&#160;‘These are the set feasts of Yahweh, even set-apart convocations, which you shall proclaim in their appointed season. 
-<span class="v">5&#160;</span>In the first month, on the fourteenth day of the month in the evening, is Yahweh’s Passover. 
-<span class="v">6&#160;</span>On the fifteenth day of the same month is the feast of unleavened bread to Yahweh. Seven days you shall eat unleavened bread. 
-<span class="v">7&#160;</span>In the first day you shall have a set-apart convocation. You shall do no regular work. 
-<span class="v">8&#160;</span>But you shall offer an offering made by fire to Yahweh seven days. In the seventh day is a set-apart convocation. You shall do no regular work.’&#160;” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">10&#160;</span>“Speak to the children of Israel, and tell them, ‘When you have come into the land which I give to you, and shall reap its harvest, then you shall bring the sheaf of the first fruits of your harvest to the priest. 
-<span class="v">11&#160;</span>He shall wave the sheaf before Yahweh, to be accepted for you. On the next day after the Sabbath the priest shall wave it. 
-<span class="v">12&#160;</span>On the day when you wave the sheaf, you shall offer a male lamb without defect a year old for a burnt offering to Yahweh. 
-<span class="v">13&#160;</span>The meal offering with it shall be two tenths of an ephah<span class="f">+ \fr 23:13 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour mixed with oil, an offering made by fire to Yahweh for a pleasant aroma; and the drink offering with it shall be of wine, the fourth part of a hin.<span class="f">+ \fr 23:13 \ft A hin is about 6.5 liters or 1.7 gallons.</span> 
-<span class="v">14&#160;</span>You must not eat bread, or roasted grain, or fresh grain, until this same day, until you have brought the offering of your Elohim. This is a statute forever throughout your generations in all your dwellings. 
-</p><p>
-<span class="v">15&#160;</span>“&#160;‘You shall count from the next day after the Sabbath, from the day that you brought the sheaf of the wave offering: seven Sabbaths shall be completed. 
-<span class="v">16&#160;</span>The next day after the seventh Sabbath you shall count fifty days; and you shall offer a new meal offering to Yahweh. 
-<span class="v">17&#160;</span>You shall bring out of your habitations two loaves of bread for a wave offering made of two tenths of an ephah<span class="f">+ \fr 23:17 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour. They shall be baked with yeast, for first fruits to Yahweh. 
-<span class="v">18&#160;</span>You shall present with the bread seven lambs without defect a year old, one young bull, and two rams. They shall be a burnt offering to Yahweh, with their meal offering and their drink offerings, even an offering made by fire, of a sweet aroma to Yahweh. 
-<span class="v">19&#160;</span>You shall offer one male goat for a sin offering, and two male lambs a year old for a sacrifice of peace offerings. 
-<span class="v">20&#160;</span>The priest shall wave them with the bread of the first fruits for a wave offering before Yahweh, with the two lambs. They shall be set-apart to Yahweh for the priest. 
-<span class="v">21&#160;</span>You shall make proclamation on the same day that there shall be a set-apart convocation to you. You shall do no regular work. This is a statute forever in all your dwellings throughout your generations. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘When you reap the harvest of your land, you must not wholly reap into the corners of your field. You must not gather the gleanings of your harvest. You must leave them for the poor and for the foreigner. I am Yahweh your Elohim.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">24&#160;</span>“Speak to the children of Israel, saying, ‘In the seventh month, on the first day of the month, there shall be a solemn rest for you, a memorial of blowing of trumpets, a set-apart convocation. 
-<span class="v">25&#160;</span>You shall do no regular work. You shall offer an offering made by fire to Yahweh.’&#160;” 
-</p><p>
-<span class="v">26&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">27&#160;</span>“However on the tenth day of this seventh month is the day of atonement. It shall be a set-apart convocation to you. You shall afflict yourselves and you shall offer an offering made by fire to Yahweh. 
-<span class="v">28&#160;</span>You shall do no kind of work in that same day, for it is a day of atonement, to make atonement for you before Yahweh your Elohim. 
-<span class="v">29&#160;</span>For whoever it is who shall not deny himself in that same day shall be cut off from his people. 
-<span class="v">30&#160;</span>Whoever does any kind of work in that same day, I will destroy that person from among his people. 
-<span class="v">31&#160;</span>You shall do no kind of work: it is a statute forever throughout your generations in all your dwellings. 
-<span class="v">32&#160;</span>It shall be a Sabbath of solemn rest for you, and you shall deny yourselves. In the ninth day of the month at evening, from evening to evening, you shall keep your Sabbath.” 
-</p><p>
-<span class="v">33&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">34&#160;</span>“Speak to the children of Israel, and say, ‘On the fifteenth day of this seventh month is the feast of booths<span class="f">+ \fr 23:34 \ft or, feast of tents, or Succoth</span> for seven days to Yahweh. 
-<span class="v">35&#160;</span>On the first day shall be a set-apart convocation. You shall do no regular work. 
-<span class="v">36&#160;</span>Seven days you shall offer an offering made by fire to Yahweh. On the eighth day shall be a set-apart convocation to you. You shall offer an offering made by fire to Yahweh. It is a solemn assembly; you shall do no regular work. 
-</p><p>
-<span class="v">37&#160;</span>“&#160;‘These are the appointed feasts of Yahweh which you shall proclaim to be set-apart convocations, to offer an offering made by fire to Yahweh, a burnt offering, a meal offering, a sacrifice, and drink offerings, each on its own day—<span class="v">38&#160;</span>in addition to the Sabbaths of Yahweh, and in addition to your gifts, and in addition to all your vows, and in addition to all your free will offerings, which you give to Yahweh. 
-</p><p>
-<span class="v">39&#160;</span>“&#160;‘So on the fifteenth day of the seventh month, when you have gathered in the fruits of the land, you shall keep the feast of Yahweh seven days. On the first day shall be a solemn rest, and on the eighth day shall be a solemn rest. 
-<span class="v">40&#160;</span>You shall take on the first day the fruit of majestic trees, branches of palm trees, and boughs of thick trees, and willows of the brook; and you shall rejoice before Yahweh your Elohim seven days. 
-<span class="v">41&#160;</span>You shall keep it as a feast to Yahweh seven days in the year. It is a statute forever throughout your generations. You shall keep it in the seventh month. 
-<span class="v">42&#160;</span>You shall dwell in temporary shelters<span class="f">+ \fr 23:42 \ft or, booths</span> for seven days. All who are native-born in Israel shall dwell in temporary shelters,<span class="f">+ \fr 23:42 \ft or, booths</span> 
-<span class="v">43&#160;</span>that your generations may know that I made the children of Israel to dwell in temporary shelters<span class="f">+ \fr 23:43 \ft or, booths</span> when I brought them out of the land of Egypt. I am Yahweh your Elohim.’&#160;” 
-</p><p>
-<span class="v">44&#160;</span>So Moses declared to the children of Israel the appointed feasts of Yahweh. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
-<span class="v">3&#160;</span>Outside of the veil of the Testimony, in the Tent of Meeting, Aaron shall keep it in order from evening to morning before Yahweh continually. It shall be a statute forever throughout your generations. 
-<span class="v">4&#160;</span>He shall keep in order the lamps on the pure gold lamp stand before Yahweh continually. 
-</p><p>
-<span class="v">5&#160;</span>“You shall take fine flour, and bake twelve cakes of it: two tenths of an ephah<span class="f">+ \fr 24:5 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> shall be in one cake. 
-<span class="v">6&#160;</span>You shall set them in two rows, six on a row, on the pure gold table before Yahweh. 
-<span class="v">7&#160;</span>You shall put pure frankincense on each row, that it may be to the bread for a memorial, even an offering made by fire to Yahweh. 
-<span class="v">8&#160;</span>Every Sabbath day he shall set it in order before Yahweh continually. It is an everlasting covenant on the behalf of the children of Israel. 
-<span class="v">9&#160;</span>It shall be for Aaron and his sons. They shall eat it in a set-apart place; for it is most set-apart to him of the offerings of Yahweh made by fire by a perpetual statute.” 
-</p><p>
-<span class="v">10&#160;</span>The son of an Israelite woman, whose father was an Egyptian, went out among the children of Israel; and the son of the Israelite woman and a man of Israel strove together in the camp. 
-<span class="v">11&#160;</span>The son of the Israelite woman blasphemed the Name, and cursed; and they brought him to Moses. His mother’s name was Shelomith, the daughter of Dibri, of the tribe of Dan. 
-<span class="v">12&#160;</span>They put him in custody until Yahweh’s will should be declared to them. 
-<span class="v">13&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">14&#160;</span>“Bring him who cursed out of the camp; and let all who heard him lay their hands on his head, and let all the congregation stone him. 
-<span class="v">15&#160;</span>You shall speak to the children of Israel, saying, ‘Whoever curses his Elohim shall bear his sin. 
-<span class="v">16&#160;</span>He who blasphemes Yahweh’s name, he shall surely be put to death. All the congregation shall certainly stone him. The foreigner as well as the native-born shall be put to death when he blasphemes the Name. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘He who strikes any man mortally shall surely be put to death. 
-<span class="v">18&#160;</span>He who strikes an animal mortally shall make it good, life for life. 
-<span class="v">19&#160;</span>If anyone injures his neighbor, it shall be done to him as he has done: 
-<span class="v">20&#160;</span>fracture for fracture, eye for eye, tooth for tooth. It shall be done to him as he has injured someone. 
-<span class="v">21&#160;</span>He who kills an animal shall make it good; and he who kills a man shall be put to death. 
-<span class="v">22&#160;</span>You shall have one kind of law for the foreigner as well as the native-born; for I am Yahweh your Elohim.’&#160;” 
-</p><p>
-<span class="v">23&#160;</span>Moses spoke to the children of Israel; and they brought him who had cursed out of the camp, and stoned him with stones. The children of Israel did as Yahweh commanded Moses. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Moses on Mount Sinai, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and tell them, ‘When you come into the land which I give you, then the land shall keep a Sabbath to Yahweh. 
-<span class="v">3&#160;</span>You shall sow your field six years, and you shall prune your vineyard six years, and gather in its fruits; 
-<span class="v">4&#160;</span>but in the seventh year there shall be a Sabbath of solemn rest for the land, a Sabbath to Yahweh. You shall not sow your field or prune your vineyard. 
-<span class="v">5&#160;</span>What grows of itself in your harvest you shall not reap, and you shall not gather the grapes of your undressed vine. It shall be a year of solemn rest for the land. 
-<span class="v">6&#160;</span>The Sabbath of the land shall be for food for you; for yourself, for your servant, for your maid, for your hired servant, and for your stranger, who lives as a foreigner with you. 
-<span class="v">7&#160;</span>For your livestock also, and for the animals that are in your land, shall all its increase be for food. 
-</p><p>
-<span class="v">8&#160;</span>“&#160;‘You shall count off seven Sabbaths of years, seven times seven years; and there shall be to you the days of seven Sabbaths of years, even forty-nine years. 
-<span class="v">9&#160;</span>Then you shall sound the loud trumpet on the tenth day of the seventh month. On the Day of Atonement you shall sound the trumpet throughout all your land. 
-<span class="v">10&#160;</span>You shall make the fiftieth year set-apart, and proclaim liberty throughout the land to all its inhabitants. It shall be a jubilee to you; and each of you shall return to his own property, and each of you shall return to his family. 
-<span class="v">11&#160;</span>That fiftieth year shall be a jubilee to you. In it you shall not sow, neither reap that which grows of itself, nor gather from the undressed vines. 
-<span class="v">12&#160;</span>For it is a jubilee; it shall be set-apart to you. You shall eat of its increase out of the field. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘In this Year of Jubilee each of you shall return to his property. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘If you sell anything to your neighbor, or buy from your neighbor, you shall not wrong one another. 
-<span class="v">15&#160;</span>According to the number of years after the Jubilee you shall buy from your neighbor. According to the number of years of the crops he shall sell to you. 
-<span class="v">16&#160;</span>According to the length of the years you shall increase its price, and according to the shortness of the years you shall diminish its price; for he is selling the number of the crops to you. 
-<span class="v">17&#160;</span>You shall not wrong one another, but you shall fear your Elohim; for I am Yahweh your Elohim. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘Therefore you shall do my statutes, and keep my ordinances and do them; and you shall dwell in the land in safety. 
-<span class="v">19&#160;</span>The land shall yield its fruit, and you shall eat your fill, and dwell therein in safety. 
-<span class="v">20&#160;</span>If you said, “What shall we eat the seventh year? Behold, we shall not sow, nor gather in our increase;” 
-<span class="v">21&#160;</span>then I will command my blessing on you in the sixth year, and it shall bear fruit for the three years. 
-<span class="v">22&#160;</span>You shall sow the eighth year, and eat of the fruits from the old store until the ninth year. Until its fruits come in, you shall eat the old store. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘The land shall not be sold in perpetuity, for the land is mine; for you are strangers and live as foreigners with me. 
-<span class="v">24&#160;</span>In all the land of your possession you shall grant a redemption for the land. 
-</p><p>
-<span class="v">25&#160;</span>“&#160;‘If your brother becomes poor, and sells some of his possessions, then his kinsman who is next to him shall come, and redeem that which his brother has sold. 
-<span class="v">26&#160;</span>If a man has no one to redeem it, and he becomes prosperous and finds sufficient means to redeem it, 
-<span class="v">27&#160;</span>then let him reckon the years since its sale, and restore the surplus to the man to whom he sold it; and he shall return to his property. 
-<span class="v">28&#160;</span>But if he isn’t able to get it back for himself, then what he has sold shall remain in the hand of him who has bought it until the Year of Jubilee. In the Jubilee it shall be released, and he shall return to his property. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘If a man sells a dwelling house in a walled city, then he may redeem it within a whole year after it has been sold. For a full year he shall have the right of redemption. 
-<span class="v">30&#160;</span>If it isn’t redeemed within the space of a full year, then the house that is in the walled city shall be made sure in perpetuity to him who bought it, throughout his generations. It shall not be released in the Jubilee. 
-<span class="v">31&#160;</span>But the houses of the villages which have no wall around them shall be accounted for with the fields of the country: they may be redeemed, and they shall be released in the Jubilee. 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘Nevertheless, in the cities of the Levites, the Levites may redeem the houses in the cities of their possession at any time. 
-<span class="v">33&#160;</span>The Levites may redeem the house that was sold, and the city of his possession, and it shall be released in the Jubilee; for the houses of the cities of the Levites are their possession among the children of Israel. 
-<span class="v">34&#160;</span>But the field of the pasture lands of their cities may not be sold, for it is their perpetual possession. 
-</p><p>
-<span class="v">35&#160;</span>“&#160;‘If your brother has become poor, and his hand can’t support himself among you, then you shall uphold him. He shall live with you like an alien and a temporary resident. 
-<span class="v">36&#160;</span>Take no interest from him or profit; but fear your Elohim, that your brother may live among you. 
-<span class="v">37&#160;</span>You shall not lend him your money at interest, nor give him your food for profit. 
-<span class="v">38&#160;</span>I am Yahweh your Elohim, who brought you out of the land of Egypt, to give you the land of Canaan, and to be your Elohim. 
-</p><p>
-<span class="v">39&#160;</span>“&#160;‘If your brother has grown poor among you, and sells himself to you, you shall not make him to serve as a slave. 
-<span class="v">40&#160;</span>As a hired servant, and as a temporary resident, he shall be with you; he shall serve with you until the Year of Jubilee. 
-<span class="v">41&#160;</span>Then he shall go out from you, he and his children with him, and shall return to his own family, and to the possession of his fathers. 
-<span class="v">42&#160;</span>For they are my servants, whom I brought out of the land of Egypt. They shall not be sold as slaves. 
-<span class="v">43&#160;</span>You shall not rule over him with harshness, but shall fear your Elohim. 
-</p><p>
-<span class="v">44&#160;</span>“&#160;‘As for your male and your female slaves, whom you may have from the nations that are around you, from them you may buy male and female slaves. 
-<span class="v">45&#160;</span>Moreover, of the children of the aliens who live among you, of them you may buy, and of their families who are with you, which they have conceived in your land; and they will be your property. 
-<span class="v">46&#160;</span>You may make them an inheritance for your children after you, to hold for a possession. Of them you may take your slaves forever, but over your brothers the children of Israel you shall not rule, one over another, with harshness. 
-</p><p>
-<span class="v">47&#160;</span>“&#160;‘If an alien or temporary resident with you becomes rich, and your brother beside him has grown poor, and sells himself to the stranger or foreigner living among you, or to a member of the stranger’s family, 
-<span class="v">48&#160;</span>after he is sold he may be redeemed. One of his brothers may redeem him; 
-<span class="v">49&#160;</span>or his uncle, or his uncle’s son, may redeem him, or any who is a close relative to him of his family may redeem him; or if he has grown rich, he may redeem himself. 
-<span class="v">50&#160;</span>He shall reckon with him who bought him from the year that he sold himself to him to the Year of Jubilee. The price of his sale shall be according to the number of years; he shall be with him according to the time of a hired servant. 
-<span class="v">51&#160;</span>If there are yet many years, according to them he shall give back the price of his redemption out of the money that he was bought for. 
-<span class="v">52&#160;</span>If there remain but a few years to the year of jubilee, then he shall reckon with him; according to his years of service he shall give back the price of his redemption. 
-<span class="v">53&#160;</span>As a servant hired year by year shall he be with him. He shall not rule with harshness over him in your sight. 
-<span class="v">54&#160;</span>If he isn’t redeemed by these means, then he shall be released in the Year of Jubilee: he and his children with him. 
-<span class="v">55&#160;</span>For to me the children of Israel are servants; they are my servants whom I brought out of the land of Egypt. I am Yahweh your Elohim. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘You shall make for yourselves no idols, and you shall not raise up a carved image or a pillar, and you shall not place any figured stone in your land, to bow down to it; for I am Yahweh your Elohim. 
-</p><p>
-<span class="v">2&#160;</span>“&#160;‘You shall keep my Sabbaths, and have reverence for my sanctuary. I am Yahweh. 
-</p><p>
-<span class="v">3&#160;</span>“&#160;‘If you walk in my statutes and keep my commandments, and do them, 
-<span class="v">4&#160;</span>then I will give you your rains in their season, and the land shall yield its increase, and the trees of the field shall yield their fruit. 
-<span class="v">5&#160;</span>Your threshing shall continue until the vintage, and the vintage shall continue until the sowing time. You shall eat your bread to the full, and dwell in your land safely. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘I will give peace in the land, and you shall lie down, and no one will make you afraid. I will remove evil animals out of the land, neither shall the sword go through your land. 
-<span class="v">7&#160;</span>You shall chase your enemies, and they shall fall before you by the sword. 
-<span class="v">8&#160;</span>Five of you shall chase a hundred, and a hundred of you shall chase ten thousand; and your enemies shall fall before you by the sword. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘I will have respect for you, make you fruitful, multiply you, and will establish my covenant with you. 
-<span class="v">10&#160;</span>You shall eat old supplies long kept, and you shall move out the old because of the new. 
-<span class="v">11&#160;</span>I will set my tent among you, and my soul won’t abhor you. 
-<span class="v">12&#160;</span>I will walk among you, and will be your Elohim, and you will be my people. 
-<span class="v">13&#160;</span>I am Yahweh your Elohim, who brought you out of the land of Egypt, that you should not be their slaves. I have broken the bars of your yoke, and made you walk upright. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘But if you will not listen to me, and will not do all these commandments, 
-<span class="v">15&#160;</span>and if you shall reject my statutes, and if your soul abhors my ordinances, so that you will not do all my commandments, but break my covenant, 
-<span class="v">16&#160;</span>I also will do this to you: I will appoint terror over you, even consumption and fever, that shall consume the eyes, and make the soul to pine away. You will sow your seed in vain, for your enemies will eat it. 
-<span class="v">17&#160;</span>I will set my face against you, and you will be struck before your enemies. Those who hate you will rule over you; and you will flee when no one pursues you. 
-</p><p>
-<span class="v">18&#160;</span>“&#160;‘If you in spite of these things will not listen to me, then I will chastise you seven times more for your sins. 
-<span class="v">19&#160;</span>I will break the pride of your power, and I will make your sky like iron, and your soil like bronze. 
-<span class="v">20&#160;</span>Your strength will be spent in vain; for your land won’t yield its increase, neither will the trees of the land yield their fruit. 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘If you walk contrary to me, and won’t listen to me, then I will bring seven times more plagues on you according to your sins. 
-<span class="v">22&#160;</span>I will send the wild animals among you, which will rob you of your children, destroy your livestock, and make you few in number. Your roads will become desolate. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘If by these things you won’t be turned back to me, but will walk contrary to me, 
-<span class="v">24&#160;</span>then I will also walk contrary to you; and I will strike you, even I, seven times for your sins. 
-<span class="v">25&#160;</span>I will bring a sword upon you that will execute the vengeance of the covenant. You will be gathered together within your cities, and I will send the pestilence among you. You will be delivered into the hand of the enemy. 
-<span class="v">26&#160;</span>When I break your staff of bread, ten women shall bake your bread in one oven, and they shall deliver your bread again by weight. You shall eat, and not be satisfied. 
-</p><p>
-<span class="v">27&#160;</span>“&#160;‘If you in spite of this won’t listen to me, but walk contrary to me, 
-<span class="v">28&#160;</span>then I will walk contrary to you in wrath. I will also chastise you seven times for your sins. 
-<span class="v">29&#160;</span>You will eat the flesh of your sons, and you will eat the flesh of your daughters. 
-<span class="v">30&#160;</span>I will destroy your high places, and cut down your incense altars, and cast your dead bodies upon the bodies of your idols; and my soul will abhor you. 
-<span class="v">31&#160;</span>I will lay your cities waste, and will bring your sanctuaries to desolation. I will not take delight in the sweet fragrance of your offerings. 
-<span class="v">32&#160;</span>I will bring the land into desolation, and your enemies who dwell in it will be astonished at it. 
-<span class="v">33&#160;</span>I will scatter you among the nations, and I will draw out the sword after you. Your land will be a desolation, and your cities shall be a waste. 
-<span class="v">34&#160;</span>Then the land will enjoy its Sabbaths as long as it lies desolate and you are in your enemies’ land. Even then the land will rest and enjoy its Sabbaths. 
-<span class="v">35&#160;</span>As long as it lies desolate it shall have rest, even the rest which it didn’t have in your Sabbaths when you lived on it. 
-</p><p>
-<span class="v">36&#160;</span>“&#160;‘As for those of you who are left, I will send a faintness into their hearts in the lands of their enemies. The sound of a driven leaf will put them to flight; and they shall flee, as one flees from the sword. They will fall when no one pursues. 
-<span class="v">37&#160;</span>They will stumble over one another, as it were before the sword, when no one pursues. You will have no power to stand before your enemies. 
-<span class="v">38&#160;</span>You will perish among the nations. The land of your enemies will eat you up. 
-<span class="v">39&#160;</span>Those of you who are left will pine away in their iniquity in your enemies’ lands; and also in the iniquities of their fathers they shall pine away with them. 
-</p><p>
-<span class="v">40&#160;</span>“&#160;‘If they confess their iniquity and the iniquity of their fathers, in their trespass which they trespassed against me; and also that because they walked contrary to me, 
-<span class="v">41&#160;</span>I also walked contrary to them, and brought them into the land of their enemies; if then their uncircumcised heart is humbled, and they then accept the punishment of their iniquity, 
-<span class="v">42&#160;</span>then I will remember my covenant with Jacob, my covenant with Isaac, and also my covenant with Abraham; and I will remember the land. 
-<span class="v">43&#160;</span>The land also will be left by them, and will enjoy its Sabbaths while it lies desolate without them; and they will accept the punishment of their iniquity because they rejected my ordinances, and their soul abhorred my statutes. 
-<span class="v">44&#160;</span>Yet for all that, when they are in the land of their enemies, I will not reject them, neither will I abhor them, to destroy them utterly and to break my covenant with them; for I am Yahweh their Elohim. 
-<span class="v">45&#160;</span>But I will for their sake remember the covenant of their ancestors, whom I brought out of the land of Egypt in the sight of the nations, that I might be their Elohim. I am Yahweh.’&#160;” 
-</p><p>
-<span class="v">46&#160;</span>These are the statutes, ordinances, and laws, which Yahweh made between him and the children of Israel in Mount Sinai by Moses. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and say to them, ‘When a man consecrates a person to Yahweh in a vow, according to your valuation, 
-<span class="v">3&#160;</span>your valuation of a male from twenty years old to sixty years old shall be fifty shekels of silver, according to the shekel<span class="f">+ \fr 27:3 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of the sanctuary. 
-<span class="v">4&#160;</span>If she is a female, then your valuation shall be thirty shekels. 
-<span class="v">5&#160;</span>If the person is from five years old to twenty years old, then your valuation shall be for a male twenty shekels, and for a female ten shekels. 
-<span class="v">6&#160;</span>If the person is from a month old to five years old, then your valuation shall be for a male five shekels of silver, and for a female your valuation shall be three shekels of silver. 
-<span class="v">7&#160;</span>If the person is from sixty years old and upward; if he is a male, then your valuation shall be fifteen shekels, and for a female ten shekels. 
-<span class="v">8&#160;</span>But if he is poorer than your valuation, then he shall be set before the priest, and the priest shall assign a value to him. The priest shall assign a value according to his ability to pay. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘If it is an animal of which men offer an offering to Yahweh, all that any man gives of such to Yahweh becomes set-apart. 
-<span class="v">10&#160;</span>He shall not alter it, nor exchange it, a good for a bad, or a bad for a good. If he shall at all exchange animal for animal, then both it and that for which it is exchanged shall be set-apart. 
-<span class="v">11&#160;</span>If it is any unclean animal, of which they do not offer as an offering to Yahweh, then he shall set the animal before the priest; 
-<span class="v">12&#160;</span>and the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall be. 
-<span class="v">13&#160;</span>But if he will indeed redeem it, then he shall add the fifth part of it to its valuation. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘When a man dedicates his house to be set-apart to Yahweh, then the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall stand. 
-<span class="v">15&#160;</span>If he who dedicates it will redeem his house, then he shall add the fifth part of the money of your valuation to it, and it shall be his. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘If a man dedicates to Yahweh part of the field of his possession, then your valuation shall be according to the seed for it. The sowing of a homer<span class="f">+ \fr 27:16 \ft 1 homer is about 220 liters or 6 bushels</span> of barley shall be valued at fifty shekels<span class="f">+ \fr 27:16 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of silver. 
-<span class="v">17&#160;</span>If he dedicates his field from the Year of Jubilee, according to your valuation it shall stand. 
-<span class="v">18&#160;</span>But if he dedicates his field after the Jubilee, then the priest shall reckon to him the money according to the years that remain to the Year of Jubilee; and an abatement shall be made from your valuation. 
-<span class="v">19&#160;</span>If he who dedicated the field will indeed redeem it, then he shall add the fifth part of the money of your valuation to it, and it shall remain his. 
-<span class="v">20&#160;</span>If he will not redeem the field, or if he has sold the field to another man, it shall not be redeemed any more; 
-<span class="v">21&#160;</span>but the field, when it goes out in the Jubilee, shall be set-apart to Yahweh, as a devoted field. It shall be owned by the priests. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘If he dedicates a field to Yahweh which he has bought, which is not of the field of his possession, 
-<span class="v">23&#160;</span>then the priest shall reckon to him the worth of your valuation up to the Year of Jubilee; and he shall give your valuation on that day, as a set-apart thing to Yahweh. 
-<span class="v">24&#160;</span>In the Year of Jubilee the field shall return to him from whom it was bought, even to him to whom the possession of the land belongs. 
-<span class="v">25&#160;</span>All your valuations shall be according to the shekel of the sanctuary: twenty gerahs<span class="f">+ \fr 27:25 \ft A gerah is about 0.5 grams or about 7.7 grains.</span> to the shekel.<span class="f">+ \fr 27:25 \ft A shekel is about 10 grams or about 0.35 ounces.</span> 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘However the firstborn among animals, which belongs to Yahweh as a firstborn, no man may dedicate, whether an ox or a sheep. It is Yahweh’s. 
-<span class="v">27&#160;</span>If it is an unclean animal, then he shall buy it back according to your valuation, and shall add to it the fifth part of it; or if it isn’t redeemed, then it shall be sold according to your valuation. 
-</p><p>
-<span class="v">28&#160;</span>“&#160;‘Notwithstanding, no devoted thing that a man devotes to Yahweh of all that he has, whether of man or animal, or of the field of his possession, shall be sold or redeemed. Everything that is permanently devoted is most set-apart to Yahweh. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘No one devoted to destruction, who shall be devoted from among men, shall be ransomed. He shall surely be put to death. 
-</p><p>
-<span class="v">30&#160;</span>“&#160;‘All the tithe of the land, whether of the seed of the land or of the fruit of the trees, is Yahweh’s. It is set-apart to Yahweh. 
-<span class="v">31&#160;</span>If a man redeems anything of his tithe, he shall add a fifth part to it. 
-<span class="v">32&#160;</span>All the tithe of the herds or the flocks, whatever passes under the rod, the tenth shall be set-apart to Yahweh. 
-<span class="v">33&#160;</span>He shall not examine whether it is good or bad, neither shall he exchange it. If he exchanges it at all, then both it and that for which it is exchanged shall be set-apart. It shall not be redeemed.’&#160;” 
-</p><p>
-<span class="v">34&#160;</span>These are the commandments which Yahweh commanded Moses for the children of Israel on Mount Sinai. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Yahweh called to Moses, and spoke to him from the Tent of Meeting, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When anyone of you offers an offering to Yahweh, you shall offer your offering of the livestock, from the herd and from the flock. 
+</div><div class="p">
+<sup>3&#160;</sup>“&#160;‘If his offering is a burnt offering from the herd, he shall offer a male without defect. He shall offer it at the door of the Tent of Meeting, that he may be accepted before Yahweh. 
+<sup>4&#160;</sup>He shall lay his hand on the head of the burnt offering, and it shall be accepted for him to make atonement for him. 
+<sup>5&#160;</sup>He shall kill the bull before Yahweh. Aaron’s sons, the priests, shall present the blood and sprinkle the blood around on the altar that is at the door of the Tent of Meeting. 
+<sup>6&#160;</sup>He shall skin the burnt offering and cut it into pieces. 
+<sup>7&#160;</sup>The sons of Aaron the priest shall put fire on the altar, and lay wood in order on the fire; 
+<sup>8&#160;</sup>and Aaron’s sons, the priests, shall lay the pieces, the head, and the fat in order on the wood that is on the fire which is on the altar; 
+<sup>9&#160;</sup>but he shall wash its innards and its legs with water. The priest shall burn all of it on the altar, for a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘If his offering is from the flock, from the sheep or from the goats, for a burnt offering, he shall offer a male without defect. 
+<sup>11&#160;</sup>He shall kill it on the north side of the altar before Yahweh. Aaron’s sons, the priests, shall sprinkle its blood around on the altar. 
+<sup>12&#160;</sup>He shall cut it into its pieces, with its head and its fat. The priest shall lay them in order on the wood that is on the fire which is on the altar, 
+<sup>13&#160;</sup>but the innards and the legs he shall wash with water. The priest shall offer the whole, and burn it on the altar. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘If his offering to Yahweh is a burnt offering of birds, then he shall offer his offering from turtledoves or of young pigeons. 
+<sup>15&#160;</sup>The priest shall bring it to the altar, and wring off its head, and burn it on the altar; and its blood shall be drained out on the side of the altar; 
+<sup>16&#160;</sup>and he shall take away its crop and its feathers, and cast it beside the altar on the east part, in the place of the ashes. 
+<sup>17&#160;</sup>He shall tear it by its wings, but shall not divide it apart. The priest shall burn it on the altar, on the wood that is on the fire. It is a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘When anyone offers an offering of a meal offering to Yahweh, his offering shall be of fine flour. He shall pour oil on it, and put frankincense on it. 
+<sup>2&#160;</sup>He shall bring it to Aaron’s sons, the priests. He shall take his handful of its fine flour, and of its oil, with all its frankincense, and the priest shall burn its memorial on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>3&#160;</sup>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘When you offer an offering of a meal offering baked in the oven, it shall be unleavened cakes of fine flour mixed with oil, or unleavened wafers anointed with oil. 
+<sup>5&#160;</sup>If your offering is a meal offering made on a griddle, it shall be of unleavened fine flour, mixed with oil. 
+<sup>6&#160;</sup>You shall cut it in pieces, and pour oil on it. It is a meal offering. 
+<sup>7&#160;</sup>If your offering is a meal offering of the pan, it shall be made of fine flour with oil. 
+<sup>8&#160;</sup>You shall bring the meal offering that is made of these things to Yahweh. It shall be presented to the priest, and he shall bring it to the altar. 
+<sup>9&#160;</sup>The priest shall take from the meal offering its memorial, and shall burn it on the altar, an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>10&#160;</sup>That which is left of the meal offering shall be Aaron’s and his sons’. It is a most set-apart part of the offerings of Yahweh made by fire. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘No meal offering which you shall offer to Yahweh shall be made with yeast; for you shall burn no yeast, nor any honey, as an offering made by fire to Yahweh. 
+<sup>12&#160;</sup>As an offering of first fruits you shall offer them to Yahweh, but they shall not rise up as a pleasant aroma on the altar. 
+<sup>13&#160;</sup>Every offering of your meal offering you shall season with salt. You shall not allow the salt of the covenant of your Elohim to be lacking from your meal offering. With all your offerings you shall offer salt. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘If you offer a meal offering of first fruits to Yahweh, you shall offer for the meal offering of your first fruits fresh heads of grain parched with fire and crushed. 
+<sup>15&#160;</sup>You shall put oil on it and lay frankincense on it. It is a meal offering. 
+<sup>16&#160;</sup>The priest shall burn as its memorial part of its crushed grain and part of its oil, along with all its frankincense. It is an offering made by fire to Yahweh. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘If his offering is a sacrifice of peace offerings, if he offers it from the herd, whether male or female, he shall offer it without defect before Yahweh. 
+<sup>2&#160;</sup>He shall lay his hand on the head of his offering, and kill it at the door of the Tent of Meeting. Aaron’s sons, the priests, shall sprinkle the blood around on the altar. 
+<sup>3&#160;</sup>He shall offer of the sacrifice of peace offerings an offering made by fire to Yahweh. The fat that covers the innards, and all the fat that is on the innards, 
+<sup>4&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
+<sup>5&#160;</sup>Aaron’s sons shall burn it on the altar on the burnt offering, which is on the wood that is on the fire: it is an offering made by fire, of a pleasant aroma to Yahweh. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘If his offering for a sacrifice of peace offerings to Yahweh is from the flock, either male or female, he shall offer it without defect. 
+<sup>7&#160;</sup>If he offers a lamb for his offering, then he shall offer it before Yahweh; 
+<sup>8&#160;</sup>and he shall lay his hand on the head of his offering, and kill it before the Tent of Meeting. Aaron’s sons shall sprinkle its blood around on the altar. 
+<sup>9&#160;</sup>He shall offer from the sacrifice of peace offerings an offering made by fire to Yahweh; its fat, the entire tail fat, he shall take away close to the backbone; and the fat that covers the entrails, and all the fat that is on the entrails, 
+<sup>10&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
+<sup>11&#160;</sup>The priest shall burn it on the altar: it is the food of the offering made by fire to Yahweh. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘If his offering is a goat, then he shall offer it before Yahweh. 
+<sup>13&#160;</sup>He shall lay his hand on its head, and kill it before the Tent of Meeting; and the sons of Aaron shall sprinkle its blood around on the altar. 
+<sup>14&#160;</sup>He shall offer from it as his offering, an offering made by fire to Yahweh; the fat that covers the innards, and all the fat that is on the innards, 
+<sup>15&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall take away. 
+<sup>16&#160;</sup>The priest shall burn them on the altar: it is the food of the offering made by fire, for a pleasant aroma; all the fat is Yahweh’s. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘It shall be a perpetual statute throughout your generations in all your dwellings, that you shall eat neither fat nor blood.’&#160;” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘If anyone sins unintentionally, in any of the things which Yahweh has commanded not to be done, and does any one of them, 
+<sup>3&#160;</sup>if the anointed priest sins so as to bring guilt on the people, then let him offer for his sin which he has sinned a young bull without defect to Yahweh for a sin offering. 
+<sup>4&#160;</sup>He shall bring the bull to the door of the Tent of Meeting before Yahweh; and he shall lay his hand on the head of the bull, and kill the bull before Yahweh. 
+<sup>5&#160;</sup>The anointed priest shall take some of the blood of the bull, and bring it to the Tent of Meeting. 
+<sup>6&#160;</sup>The priest shall dip his finger in the blood, and sprinkle some of the blood seven times before Yahweh, before the veil of the sanctuary. 
+<sup>7&#160;</sup>The priest shall put some of the blood on the horns of the altar of sweet incense before Yahweh, which is in the Tent of Meeting; and he shall pour out the rest of the blood of the bull at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
+<sup>8&#160;</sup>He shall take all the fat of the bull of the sin offering from it: the fat that covers the innards, and all the fat that is on the innards, 
+<sup>9&#160;</sup>and the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys, he shall remove, 
+<sup>10&#160;</sup>as it is removed from the bull of the sacrifice of peace offerings. The priest shall burn them on the altar of burnt offering. 
+<sup>11&#160;</sup>He shall carry the bull’s skin, all its meat, with its head, and with its legs, its innards, and its dung<sup>12&#160;</sup>—all the rest of the bull—outside of the camp to a clean place where the ashes are poured out, and burn it on wood with fire. It shall be burned where the ashes are poured out. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘If the whole congregation of Israel sins, and the thing is hidden from the eyes of the assembly, and they have done any of the things which Yahweh has commanded not to be done, and are guilty; 
+<sup>14&#160;</sup>when the sin in which they have sinned is known, then the assembly shall offer a young bull for a sin offering, and bring it before the Tent of Meeting. 
+<sup>15&#160;</sup>The elders of the congregation shall lay their hands on the head of the bull before Yahweh; and the bull shall be killed before Yahweh. 
+<sup>16&#160;</sup>The anointed priest shall bring some of the blood of the bull to the Tent of Meeting. 
+<sup>17&#160;</sup>The priest shall dip his finger in the blood and sprinkle it seven times before Yahweh, before the veil. 
+<sup>18&#160;</sup>He shall put some of the blood on the horns of the altar which is before Yahweh, that is in the Tent of Meeting; and the rest of the blood he shall pour out at the base of the altar of burnt offering, which is at the door of the Tent of Meeting. 
+<sup>19&#160;</sup>All its fat he shall take from it, and burn it on the altar. 
+<sup>20&#160;</sup>He shall do this with the bull; as he did with the bull of the sin offering, so he shall do with this; and the priest shall make atonement for them, and they shall be forgiven. 
+<sup>21&#160;</sup>He shall carry the bull outside the camp, and burn it as he burned the first bull. It is the sin offering for the assembly. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘When a ruler sins, and unwittingly does any one of all the things which Yahweh his Elohim has commanded not to be done, and is guilty, 
+<sup>23&#160;</sup>if his sin in which he has sinned is made known to him, he shall bring as his offering a goat, a male without defect. 
+<sup>24&#160;</sup>He shall lay his hand on the head of the goat, and kill it in the place where they kill the burnt offering before Yahweh. It is a sin offering. 
+<sup>25&#160;</sup>The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering. He shall pour out the rest of its blood at the base of the altar of burnt offering. 
+<sup>26&#160;</sup>All its fat he shall burn on the altar, like the fat of the sacrifice of peace offerings; and the priest shall make atonement for him concerning his sin, and he will be forgiven. 
+</div><div class="p">
+<sup>27&#160;</sup>“&#160;‘If anyone of the common people sins unwittingly, in doing any of the things which Yahweh has commanded not to be done, and is guilty, 
+<sup>28&#160;</sup>if his sin which he has sinned is made known to him, then he shall bring for his offering a goat, a female without defect, for his sin which he has sinned. 
+<sup>29&#160;</sup>He shall lay his hand on the head of the sin offering, and kill the sin offering in the place of burnt offering. 
+<sup>30&#160;</sup>The priest shall take some of its blood with his finger, and put it on the horns of the altar of burnt offering; and the rest of its blood he shall pour out at the base of the altar. 
+<sup>31&#160;</sup>All its fat he shall take away, like the fat is taken away from the sacrifice of peace offerings; and the priest shall burn it on the altar for a pleasant aroma to Yahweh; and the priest shall make atonement for him, and he will be forgiven. 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘If he brings a lamb as his offering for a sin offering, he shall bring a female without defect. 
+<sup>33&#160;</sup>He shall lay his hand on the head of the sin offering, and kill it for a sin offering in the place where they kill the burnt offering. 
+<sup>34&#160;</sup>The priest shall take some of the blood of the sin offering with his finger, and put it on the horns of the altar of burnt offering; and all the rest of its blood he shall pour out at the base of the altar. 
+<sup>35&#160;</sup>He shall remove all its fat, like the fat of the lamb is removed from the sacrifice of peace offerings. The priest shall burn them on the altar, on the offerings of Yahweh made by fire. The priest shall make atonement for him concerning his sin that he has sinned, and he will be forgiven. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘If anyone sins, in that he hears a public adjuration to testify, he being a witness, whether he has seen or known, if he doesn’t report it, then he shall bear his iniquity. 
+</div><div class="p">
+<sup>2&#160;</sup>“&#160;‘Or if anyone touches any unclean thing, whether it is the carcass of an unclean animal, or the carcass of unclean livestock, or the carcass of unclean creeping things, and it is hidden from him, and he is unclean, then he shall be guilty. 
+</div><div class="p">
+<sup>3&#160;</sup>“&#160;‘Or if he touches the uncleanness of man, whatever his uncleanness is with which he is unclean, and it is hidden from him; when he knows of it, then he shall be guilty. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘Or if anyone swears rashly with his lips to do evil or to do good—whatever it is that a man might utter rashly with an oath, and it is hidden from him—when he knows of it, then he will be guilty of one of these. 
+<sup>5&#160;</sup>It shall be, when he is guilty of one of these, he shall confess that in which he has sinned; 
+<sup>6&#160;</sup>and he shall bring his trespass offering to Yahweh for his sin which he has sinned: a female from the flock, a lamb or a goat, for a sin offering; and the priest shall make atonement for him concerning his sin. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘If he can’t afford a lamb, then he shall bring his trespass offering for that in which he has sinned, two turtledoves, or two young pigeons, to Yahweh; one for a sin offering, and the other for a burnt offering. 
+<sup>8&#160;</sup>He shall bring them to the priest, who shall first offer the one which is for the sin offering. He shall wring off its head from its neck, but shall not sever it completely. 
+<sup>9&#160;</sup>He shall sprinkle some of the blood of the sin offering on the side of the altar; and the rest of the blood shall be drained out at the base of the altar. It is a sin offering. 
+<sup>10&#160;</sup>He shall offer the second for a burnt offering, according to the ordinance; and the priest shall make atonement for him concerning his sin which he has sinned, and he shall be forgiven. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘But if he can’t afford two turtledoves or two young pigeons, then he shall bring as his offering for that in which he has sinned, one tenth of an ephah of fine flour for a sin offering. He shall put no oil on it, and he shall not put any frankincense on it, for it is a sin offering. 
+<sup>12&#160;</sup>He shall bring it to the priest, and the priest shall take his handful of it as the memorial portion, and burn it on the altar, on the offerings of Yahweh made by fire. It is a sin offering. 
+<sup>13&#160;</sup>The priest shall make atonement for him concerning his sin that he has sinned in any of these things, and he will be forgiven; and the rest shall be the priest’s, as the meal offering.’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>15&#160;</sup>“If anyone commits a trespass, and sins unwittingly regarding Yahweh’s set-apart things, then he shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation in silver by shekels, according to the shekel of the sanctuary, for a trespass offering. 
+<sup>16&#160;</sup>He shall make restitution for that which he has done wrong regarding the set-apart thing, and shall add a fifth part to it, and give it to the priest; and the priest shall make atonement for him with the ram of the trespass offering, and he will be forgiven. 
+</div><div class="p">
+<sup>17&#160;</sup>“If anyone sins, doing any of the things which Yahweh has commanded not to be done, though he didn’t know it, he is still guilty, and shall bear his iniquity. 
+<sup>18&#160;</sup>He shall bring a ram without defect from of the flock, according to your estimation, for a trespass offering, to the priest; and the priest shall make atonement for him concerning the thing in which he sinned and didn’t know it, and he will be forgiven. 
+<sup>19&#160;</sup>It is a trespass offering. He is certainly guilty before Yahweh.” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“If anyone sins, and commits a trespass against Yahweh, and deals falsely with his neighbor in a matter of deposit, or of bargain, or of robbery, or has oppressed his neighbor, 
+<sup>3&#160;</sup>or has found that which was lost, and lied about it, and swearing to a lie—in any of these things that a man sins in his actions—<sup>4&#160;</sup>then it shall be, if he has sinned, and is guilty, he shall restore that which he took by robbery, or the thing which he has gotten by oppression, or the deposit which was committed to him, or the lost thing which he found, 
+<sup>5&#160;</sup>or any thing about which he has sworn falsely: he shall restore it in full, and shall add a fifth part more to it. He shall return it to him to whom it belongs in the day of his being found guilty. 
+<sup>6&#160;</sup>He shall bring his trespass offering to Yahweh: a ram without defect from the flock, according to your estimation, for a trespass offering, to the priest. 
+<sup>7&#160;</sup>The priest shall make atonement for him before Yahweh, and he will be forgiven concerning whatever he does to become guilty.” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>9&#160;</sup>“Command Aaron and his sons, saying, ‘This is the law of the burnt offering: the burnt offering shall be on the hearth on the altar all night until the morning; and the fire of the altar shall be kept burning on it. 
+<sup>10&#160;</sup>The priest shall put on his linen garment, and he shall put on his linen trousers upon his body; and he shall remove the ashes from where the fire has consumed the burnt offering on the altar, and he shall put them beside the altar. 
+<sup>11&#160;</sup>He shall take off his garments, and put on other garments, and carry the ashes outside the camp to a clean place. 
+<sup>12&#160;</sup>The fire on the altar shall be kept burning on it, it shall not go out; and the priest shall burn wood on it every morning. He shall lay the burnt offering in order upon it, and shall burn on it the fat of the peace offerings. 
+<sup>13&#160;</sup>Fire shall be kept burning on the altar continually; it shall not go out. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘This is the law of the meal offering: the sons of Aaron shall offer it before Yahweh, before the altar. 
+<sup>15&#160;</sup>He shall take from there his handful of the fine flour of the meal offering, and of its oil, and all the frankincense which is on the meal offering, and shall burn it on the altar for a pleasant aroma, as its memorial portion, to Yahweh. 
+<sup>16&#160;</sup>That which is left of it Aaron and his sons shall eat. It shall be eaten without yeast in a set-apart place. They shall eat it in the court of the Tent of Meeting. 
+<sup>17&#160;</sup>It shall not be baked with yeast. I have given it as their portion of my offerings made by fire. It is most set-apart, as are the sin offering and the trespass offering. 
+<sup>18&#160;</sup>Every male among the children of Aaron shall eat of it, as their portion forever throughout your generations, from the offerings of Yahweh made by fire. Whoever touches them shall be set-apart.’&#160;” 
+</div><div class="p">
+<sup>19&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>20&#160;</sup>“This is the offering of Aaron and of his sons, which they shall offer to Yahweh in the day when he is anointed: one tenth of an ephah of fine flour for a meal offering perpetually, half of it in the morning, and half of it in the evening. 
+<sup>21&#160;</sup>It shall be made with oil in a griddle. When it is soaked, you shall bring it in. You shall offer the meal offering in baked pieces for a pleasant aroma to Yahweh. 
+<sup>22&#160;</sup>The anointed priest that will be in his place from among his sons shall offer it. By a statute forever, it shall be wholly burned to Yahweh. 
+<sup>23&#160;</sup>Every meal offering of a priest shall be wholly burned. It shall not be eaten.” 
+</div><div class="p">
+<sup>24&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>25&#160;</sup>“Speak to Aaron and to his sons, saying, ‘This is the law of the sin offering: in the place where the burnt offering is killed, the sin offering shall be killed before Yahweh. It is most set-apart. 
+<sup>26&#160;</sup>The priest who offers it for sin shall eat it. It shall be eaten in a set-apart place, in the court of the Tent of Meeting. 
+<sup>27&#160;</sup>Whatever shall touch its flesh shall be set-apart. When there is any of its blood sprinkled on a garment, you shall wash that on which it was sprinkled in a set-apart place. 
+<sup>28&#160;</sup>But the earthen vessel in which it is boiled shall be broken; and if it is boiled in a bronze vessel, it shall be scoured, and rinsed in water. 
+<sup>29&#160;</sup>Every male among the priests shall eat of it. It is most set-apart. 
+<sup>30&#160;</sup>No sin offering, of which any of the blood is brought into the Tent of Meeting to make atonement in the Set-Apart Place, shall be eaten. It shall be burned with fire. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘This is the law of the trespass offering: It is most set-apart. 
+<sup>2&#160;</sup>In the place where they kill the burnt offering, he shall kill the trespass offering; and its blood he shall sprinkle around on the altar. 
+<sup>3&#160;</sup>He shall offer all of its fat: the fat tail, and the fat that covers the innards, 
+<sup>4&#160;</sup>and he shall take away the two kidneys, and the fat that is on them, which is by the loins, and the cover on the liver, with the kidneys; 
+<sup>5&#160;</sup>and the priest shall burn them on the altar for an offering made by fire to Yahweh: it is a trespass offering. 
+<sup>6&#160;</sup>Every male among the priests may eat of it. It shall be eaten in a set-apart place. It is most set-apart. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘As is the sin offering, so is the trespass offering; there is one law for them. The priest who makes atonement with them shall have it. 
+<sup>8&#160;</sup>The priest who offers any man’s burnt offering shall have for himself the skin of the burnt offering which he has offered. 
+<sup>9&#160;</sup>Every meal offering that is baked in the oven, and all that is prepared in the pan and on the griddle, shall be the priest’s who offers it. 
+<sup>10&#160;</sup>Every meal offering, mixed with oil or dry, belongs to all the sons of Aaron, one as well as another. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘This is the law of the sacrifice of peace offerings, which one shall offer to Yahweh: 
+<sup>12&#160;</sup>If he offers it for a thanksgiving, then he shall offer with the sacrifice of thanksgiving unleavened cakes mixed with oil, and unleavened wafers anointed with oil, and cakes mixed with oil. 
+<sup>13&#160;</sup>He shall offer his offering with the sacrifice of his peace offerings for thanksgiving with cakes of leavened bread. 
+<sup>14&#160;</sup>Of it he shall offer one out of each offering for a heave offering to Yahweh. It shall be the priest’s who sprinkles the blood of the peace offerings. 
+<sup>15&#160;</sup>The flesh of the sacrifice of his peace offerings for thanksgiving shall be eaten on the day of his offering. He shall not leave any of it until the morning. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘But if the sacrifice of his offering is a vow, or a free will offering, it shall be eaten on the day that he offers his sacrifice. On the next day what remains of it shall be eaten, 
+<sup>17&#160;</sup>but what remains of the meat of the sacrifice on the third day shall be burned with fire. 
+<sup>18&#160;</sup>If any of the meat of the sacrifice of his peace offerings is eaten on the third day, it will not be accepted, and it shall not be credited to him who offers it. It will be an abomination, and the soul who eats any of it will bear his iniquity. 
+</div><div class="p">
+<sup>19&#160;</sup>“&#160;‘The meat that touches any unclean thing shall not be eaten. It shall be burned with fire. As for the meat, everyone who is clean may eat it; 
+<sup>20&#160;</sup>but the soul who eats of the meat of the sacrifice of peace offerings that belongs to Yahweh, having his uncleanness on him, that soul shall be cut off from his people. 
+<sup>21&#160;</sup>When anyone touches any unclean thing, the uncleanness of man, or an unclean animal, or any unclean abomination, and eats some of the meat of the sacrifice of peace offerings which belong to Yahweh, that soul shall be cut off from his people.’&#160;” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>23&#160;</sup>“Speak to the children of Israel, saying, ‘You shall eat no fat, of bull, or sheep, or goat. 
+<sup>24&#160;</sup>The fat of that which dies of itself, and the fat of that which is torn of animals, may be used for any other service, but you shall in no way eat of it. 
+<sup>25&#160;</sup>For whoever eats the fat of the animal which men offer as an offering made by fire to Yahweh, even the soul who eats it shall be cut off from his people. 
+<sup>26&#160;</sup>You shall not eat any blood, whether it is of bird or of animal, in any of your dwellings. 
+<sup>27&#160;</sup>Whoever it is who eats any blood, that soul shall be cut off from his people.’&#160;” 
+</div><div class="p">
+<sup>28&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>29&#160;</sup>“Speak to the children of Israel, saying, ‘He who offers the sacrifice of his peace offerings to Yahweh shall bring his offering to Yahweh out of the sacrifice of his peace offerings. 
+<sup>30&#160;</sup>With his own hands he shall bring the offerings of Yahweh made by fire. He shall bring the fat with the breast, that the breast may be waved for a wave offering before Yahweh. 
+<sup>31&#160;</sup>The priest shall burn the fat on the altar, but the breast shall be Aaron’s and his sons’. 
+<sup>32&#160;</sup>The right thigh you shall give to the priest for a heave offering out of the sacrifices of your peace offerings. 
+<sup>33&#160;</sup>He among the sons of Aaron who offers the blood of the peace offerings, and the fat, shall have the right thigh for a portion. 
+<sup>34&#160;</sup>For the waved breast and the heaved thigh I have taken from the children of Israel out of the sacrifices of their peace offerings, and have given them to Aaron the priest and to his sons as their portion forever from the children of Israel.’&#160;” 
+</div><div class="p">
+<sup>35&#160;</sup>This is the consecrated portion of Aaron, and the consecrated portion of his sons, out of the offerings of Yahweh made by fire, in the day when he presented them to minister to Yahweh in the priest’s office; 
+<sup>36&#160;</sup>which Yahweh commanded to be given them of the children of Israel, in the day that he anointed them. It is their portion forever throughout their generations. 
+<sup>37&#160;</sup>This is the law of the burnt offering, the meal offering, the sin offering, the trespass offering, the consecration, and the sacrifice of peace offerings 
+<sup>38&#160;</sup>which Yahweh commanded Moses in Mount Sinai in the day that he commanded the children of Israel to offer their offerings to Yahweh, in the wilderness of Sinai. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Take Aaron and his sons with him, and the garments, and the anointing oil, and the bull of the sin offering, and the two rams, and the basket of unleavened bread; 
+<sup>3&#160;</sup>and assemble all the congregation at the door of the Tent of Meeting.” 
+</div><div class="p">
+<sup>4&#160;</sup>Moses did as Yahweh commanded him; and the congregation was assembled at the door of the Tent of Meeting. 
+<sup>5&#160;</sup>Moses said to the congregation, “This is the thing which Yahweh has commanded to be done.” 
+<sup>6&#160;</sup>Moses brought Aaron and his sons, and washed them with water. 
+<sup>7&#160;</sup>He put the tunic on him, tied the sash on him, clothed him with the robe, put the ephod on him, and he tied the skillfully woven band of the ephod on him and fastened it to him with it. 
+<sup>8&#160;</sup>He placed the breastplate on him. He put the Urim and Thummim in the breastplate. 
+<sup>9&#160;</sup>He set the turban on his head. He set the golden plate, the set-apart crown, on the front of the turban, as Yahweh commanded Moses. 
+<sup>10&#160;</sup>Moses took the anointing oil, and anointed the tabernacle and all that was in it, and sanctified them. 
+<sup>11&#160;</sup>He sprinkled it on the altar seven times, and anointed the altar and all its vessels, and the basin and its base, to sanctify them. 
+<sup>12&#160;</sup>He poured some of the anointing oil on Aaron’s head, and anointed him, to sanctify him. 
+<sup>13&#160;</sup>Moses brought Aaron’s sons, and clothed them with tunics, and tied sashes on them, and put headbands on them, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>14&#160;</sup>He brought the bull of the sin offering, and Aaron and his sons laid their hands on the head of the bull of the sin offering. 
+<sup>15&#160;</sup>He killed it; and Moses took the blood, and put it around on the horns of the altar with his finger, and purified the altar, and poured out the blood at the base of the altar, and sanctified it, to make atonement for it. 
+<sup>16&#160;</sup>He took all the fat that was on the innards, and the cover of the liver, and the two kidneys, and their fat; and Moses burned it on the altar. 
+<sup>17&#160;</sup>But the bull, and its skin, and its meat, and its dung, he burned with fire outside the camp, as Yahweh commanded Moses. 
+<sup>18&#160;</sup>He presented the ram of the burnt offering. Aaron and his sons laid their hands on the head of the ram. 
+<sup>19&#160;</sup>He killed it; and Moses sprinkled the blood around on the altar. 
+<sup>20&#160;</sup>He cut the ram into its pieces; and Moses burned the head, and the pieces, and the fat. 
+<sup>21&#160;</sup>He washed the innards and the legs with water; and Moses burned the whole ram on the altar. It was a burnt offering for a pleasant aroma. It was an offering made by fire to Yahweh, as Yahweh commanded Moses. 
+<sup>22&#160;</sup>He presented the other ram, the ram of consecration. Aaron and his sons laid their hands on the head of the ram. 
+<sup>23&#160;</sup>He killed it; and Moses took some of its blood, and put it on the tip of Aaron’s right ear, and on the thumb of his right hand, and on the great toe of his right foot. 
+<sup>24&#160;</sup>He brought Aaron’s sons; and Moses put some of the blood on the tip of their right ear, and on the thumb of their right hand, and on the great toe of their right foot; and Moses sprinkled the blood around on the altar. 
+<sup>25&#160;</sup>He took the fat, the fat tail, all the fat that was on the innards, the cover of the liver, the two kidneys and their fat, and the right thigh; 
+<sup>26&#160;</sup>and out of the basket of unleavened bread that was before Yahweh, he took one unleavened cake, one cake of oiled bread, and one wafer, and placed them on the fat and on the right thigh. 
+<sup>27&#160;</sup>He put all these in Aaron’s hands and in his sons’ hands, and waved them for a wave offering before Yahweh. 
+<sup>28&#160;</sup>Moses took them from their hands, and burned them on the altar on the burnt offering. They were a consecration offering for a pleasant aroma. It was an offering made by fire to Yahweh. 
+<sup>29&#160;</sup>Moses took the breast, and waved it for a wave offering before Yahweh. It was Moses’ portion of the ram of consecration, as Yahweh commanded Moses. 
+<sup>30&#160;</sup>Moses took some of the anointing oil, and some of the blood which was on the altar, and sprinkled it on Aaron, on his garments, and on his sons, and on his sons’ garments with him, and sanctified Aaron, his garments, and his sons, and his sons’ garments with him. 
+</div><div class="p">
+<sup>31&#160;</sup>Moses said to Aaron and to his sons, “Boil the meat at the door of the Tent of Meeting, and there eat it and the bread that is in the basket of consecration, as I commanded, saying, ‘Aaron and his sons shall eat it.’ 
+<sup>32&#160;</sup>What remains of the meat and of the bread you shall burn with fire. 
+<sup>33&#160;</sup>You shall not go out from the door of the Tent of Meeting for seven days, until the days of your consecration are fulfilled: for he shall consecrate you seven days. 
+<sup>34&#160;</sup>What has been done today, so Yahweh has commanded to do, to make atonement for you. 
+<sup>35&#160;</sup>You shall stay at the door of the Tent of Meeting day and night seven days, and keep Yahweh’s command, that you don’t die: for so I am commanded.” 
+<sup>36&#160;</sup>Aaron and his sons did all the things which Yahweh commanded by Moses. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>On the eighth day, Moses called Aaron and his sons, and the elders of Israel; 
+<sup>2&#160;</sup>and he said to Aaron, “Take a calf from the herd for a sin offering, and a ram for a burnt offering, without defect, and offer them before Yahweh. 
+<sup>3&#160;</sup>You shall speak to the children of Israel, saying, ‘Take a male goat for a sin offering; and a calf and a lamb, both a year old, without defect, for a burnt offering; 
+<sup>4&#160;</sup>and a bull and a ram for peace offerings, to sacrifice before Yahweh; and a meal offering mixed with oil: for today Yahweh appears to you.’&#160;” 
+</div><div class="p">
+<sup>5&#160;</sup>They brought what Moses commanded before the Tent of Meeting. All the congregation came near and stood before Yahweh. 
+<sup>6&#160;</sup>Moses said, “This is the thing which Yahweh commanded that you should do; and Yahweh’s glory shall appear to you.” 
+<sup>7&#160;</sup>Moses said to Aaron, “Draw near to the altar, and offer your sin offering, and your burnt offering, and make atonement for yourself, and for the people; and offer the offering of the people, and make atonement for them, as Yahweh commanded.” 
+</div><div class="p">
+<sup>8&#160;</sup>So Aaron came near to the altar, and killed the calf of the sin offering, which was for himself. 
+<sup>9&#160;</sup>The sons of Aaron presented the blood to him; and he dipped his finger in the blood, and put it on the horns of the altar, and poured out the blood at the base of the altar; 
+<sup>10&#160;</sup>but the fat, and the kidneys, and the cover from the liver of the sin offering, he burned upon the altar, as Yahweh commanded Moses. 
+<sup>11&#160;</sup>The meat and the skin he burned with fire outside the camp. 
+<sup>12&#160;</sup>He killed the burnt offering; and Aaron’s sons delivered the blood to him, and he sprinkled it around on the altar. 
+<sup>13&#160;</sup>They delivered the burnt offering to him, piece by piece, and the head. He burned them upon the altar. 
+<sup>14&#160;</sup>He washed the innards and the legs, and burned them on the burnt offering on the altar. 
+<sup>15&#160;</sup>He presented the people’s offering, and took the goat of the sin offering which was for the people, and killed it, and offered it for sin, like the first. 
+<sup>16&#160;</sup>He presented the burnt offering, and offered it according to the ordinance. 
+<sup>17&#160;</sup>He presented the meal offering, and filled his hand from there, and burned it upon the altar, in addition to the burnt offering of the morning. 
+<sup>18&#160;</sup>He also killed the bull and the ram, the sacrifice of peace offerings, which was for the people. Aaron’s sons delivered to him the blood, which he sprinkled around on the altar; 
+<sup>19&#160;</sup>and the fat of the bull and of the ram, the fat tail, and that which covers the innards, and the kidneys, and the cover of the liver; 
+<sup>20&#160;</sup>and they put the fat upon the breasts, and he burned the fat on the altar. 
+<sup>21&#160;</sup>Aaron waved the breasts and the right thigh for a wave offering before Yahweh, as Moses commanded. 
+<sup>22&#160;</sup>Aaron lifted up his hands toward the people, and blessed them; and he came down from offering the sin offering, and the burnt offering, and the peace offerings. 
+</div><div class="p">
+<sup>23&#160;</sup>Moses and Aaron went into the Tent of Meeting, and came out, and blessed the people; and Yahweh’s glory appeared to all the people. 
+<sup>24&#160;</sup>Fire came out from before Yahweh, and consumed the burnt offering and the fat upon the altar. When all the people saw it, they shouted, and fell on their faces. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Nadab and Abihu, the sons of Aaron, each took his censer, and put fire in it, and laid incense on it, and offered strange fire before Yahweh, which he had not commanded them. 
+<sup>2&#160;</sup>Fire came out from before Yahweh, and devoured them, and they died before Yahweh. 
+</div><div class="p">
+<sup>3&#160;</sup>Then Moses said to Aaron, “This is what Yahweh spoke of, saying, 
+</div><div class="q1">‘I will show myself set-apart to those who come near me, 
+</div><div class="q2">and before all the people I will be glorified.’&#160;” 
+</div><div class="p">Aaron held his peace. 
+<sup>4&#160;</sup>Moses called Mishael and Elzaphan, the sons of Uzziel the uncle of Aaron, and said to them, “Draw near, carry your brothers from before the sanctuary out of the camp.” 
+<sup>5&#160;</sup>So they came near, and carried them in their tunics out of the camp, as Moses had said. 
+</div><div class="p">
+<sup>6&#160;</sup>Moses said to Aaron, and to Eleazar and to Ithamar, his sons, “Don’t let the hair of your heads go loose, and don’t tear your clothes, so that you don’t die, and so that he will not be angry with all the congregation; but let your brothers, the whole house of Israel, bewail the burning which Yahweh has kindled. 
+<sup>7&#160;</sup>You shall not go out from the door of the Tent of Meeting, lest you die; for the anointing oil of Yahweh is on you.” They did according to the word of Moses. 
+<sup>8&#160;</sup>Then Yahweh said to Aaron, 
+<sup>9&#160;</sup>“You and your sons are not to drink wine or strong drink whenever you go into the Tent of Meeting, or you will die. This shall be a statute forever throughout your generations. 
+<sup>10&#160;</sup>You are to make a distinction between the set-apart and the common, and between the unclean and the clean. 
+<sup>11&#160;</sup>You are to teach the children of Israel all the statutes which Yahweh has spoken to them by Moses.” 
+</div><div class="p">
+<sup>12&#160;</sup>Moses spoke to Aaron, and to Eleazar and to Ithamar, his sons who were left, “Take the meal offering that remains of the offerings of Yahweh made by fire, and eat it without yeast beside the altar; for it is most set-apart; 
+<sup>13&#160;</sup>and you shall eat it in a set-apart place, because it is your portion, and your sons’ portion, of the offerings of Yahweh made by fire; for so I am commanded. 
+<sup>14&#160;</sup>The waved breast and the heaved thigh you shall eat in a clean place, you, and your sons, and your daughters with you: for they are given as your portion, and your sons’ portion, out of the sacrifices of the peace offerings of the children of Israel. 
+<sup>15&#160;</sup>They shall bring the heaved thigh and the waved breast with the offerings made by fire of the fat, to wave it for a wave offering before Yahweh. It shall be yours, and your sons’ with you, as a portion forever, as Yahweh has commanded.” 
+</div><div class="p">
+<sup>16&#160;</sup>Moses diligently inquired about the goat of the sin offering, and, behold, it was burned. He was angry with Eleazar and with Ithamar, the sons of Aaron who were left, saying, 
+<sup>17&#160;</sup>“Why haven’t you eaten the sin offering in the place of the sanctuary, since it is most set-apart, and he has given it to you to bear the iniquity of the congregation, to make atonement for them before Yahweh? 
+<sup>18&#160;</sup>Behold, its blood was not brought into the inner part of the sanctuary. You certainly should have eaten it in the sanctuary, as I commanded.” 
+</div><div class="p">
+<sup>19&#160;</sup>Aaron spoke to Moses, “Behold, today they have offered their sin offering and their burnt offering before Yahweh; and such things as these have happened to me. If I had eaten the sin offering today, would it have been pleasing in Yahweh’s sight?” 
+</div><div class="p">
+<sup>20&#160;</sup>When Moses heard that, it was pleasing in his sight. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying to them, 
+<sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘These are the living things which you may eat among all the animals that are on the earth. 
+<sup>3&#160;</sup>Whatever parts the hoof, and is cloven-footed, and chews the cud among the animals, that you may eat. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘Nevertheless these you shall not eat of those that chew the cud, or of those who part the hoof: the camel, because it chews the cud but doesn’t have a parted hoof, is unclean to you. 
+<sup>5&#160;</sup>The hyrax, because it chews the cud but doesn’t have a parted hoof, is unclean to you. 
+<sup>6&#160;</sup>The hare, because it chews the cud but doesn’t have a parted hoof, is unclean to you. 
+<sup>7&#160;</sup>The pig, because it has a split hoof, and is cloven-footed, but doesn’t chew the cud, is unclean to you. 
+<sup>8&#160;</sup>You shall not eat their meat. You shall not touch their carcasses. They are unclean to you. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘You may eat of all these that are in the waters: whatever has fins and scales in the waters, in the seas, and in the rivers, that you may eat. 
+<sup>10&#160;</sup>All that don’t have fins and scales in the seas and rivers, all that move in the waters, and all the living creatures that are in the waters, they are an abomination to you, 
+<sup>11&#160;</sup>and you shall detest them. You shall not eat of their meat, and you shall detest their carcasses. 
+<sup>12&#160;</sup>Whatever has no fins nor scales in the waters is an abomination to you. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘You shall detest these among the birds; they shall not be eaten because they are an abomination: the eagle, the vulture, the black vulture, 
+<sup>14&#160;</sup>the red kite, any kind of black kite, 
+<sup>15&#160;</sup>any kind of raven, 
+<sup>16&#160;</sup>the horned owl, the screech owl, the gull, any kind of hawk, 
+<sup>17&#160;</sup>the little owl, the cormorant, the great owl, 
+<sup>18&#160;</sup>the white owl, the desert owl, the osprey, 
+<sup>19&#160;</sup>the stork, any kind of heron, the hoopoe, and the bat. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘All flying insects that walk on all fours are an abomination to you. 
+<sup>21&#160;</sup>Yet you may eat these: of all winged creeping things that go on all fours, which have long, jointed legs for hopping on the earth. 
+<sup>22&#160;</sup>Even of these you may eat: any kind of locust, any kind of katydid, any kind of cricket, and any kind of grasshopper. 
+<sup>23&#160;</sup>But all winged creeping things which have four feet are an abomination to you. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘By these you will become unclean: whoever touches their carcass shall be unclean until the evening. 
+<sup>25&#160;</sup>Whoever carries any part of their carcass shall wash his clothes, and be unclean until the evening. 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘Every animal which has a split hoof that isn’t completely divided, or doesn’t chew the cud, is unclean to you. Everyone who touches them shall be unclean. 
+<sup>27&#160;</sup>Whatever goes on its paws, among all animals that go on all fours, they are unclean to you. Whoever touches their carcass shall be unclean until the evening. 
+<sup>28&#160;</sup>He who carries their carcass shall wash his clothes, and be unclean until the evening. They are unclean to you. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘These are they which are unclean to you among the creeping things that creep on the earth: the weasel, the rat, any kind of great lizard, 
+<sup>30&#160;</sup>the gecko, and the monitor lizard, the wall lizard, the skink, and the chameleon. 
+<sup>31&#160;</sup>These are they which are unclean to you among all that creep. Whoever touches them when they are dead shall be unclean until the evening. 
+<sup>32&#160;</sup>Anything they fall on when they are dead shall be unclean; whether it is any vessel of wood, or clothing, or skin, or sack, whatever vessel it is, with which any work is done, it must be put into water, and it shall be unclean until the evening. Then it will be clean. 
+<sup>33&#160;</sup>Every earthen vessel into which any of them falls and all that is in it shall be unclean. You shall break it. 
+<sup>34&#160;</sup>All food which may be eaten which is soaked in water shall be unclean. All drink that may be drunk in every such vessel shall be unclean. 
+<sup>35&#160;</sup>Everything whereupon part of their carcass falls shall be unclean; whether oven, or range for pots, it shall be broken in pieces. They are unclean, and shall be unclean to you. 
+<sup>36&#160;</sup>Nevertheless a spring or a cistern in which water is gathered shall be clean, but that which touches their carcass shall be unclean. 
+<sup>37&#160;</sup>If part of their carcass falls on any sowing seed which is to be sown, it is clean. 
+<sup>38&#160;</sup>But if water is put on the seed, and part of their carcass falls on it, it is unclean to you. 
+</div><div class="p">
+<sup>39&#160;</sup>“&#160;‘If any animal of which you may eat dies, he who touches its carcass shall be unclean until the evening. 
+<sup>40&#160;</sup>He who eats of its carcass shall wash his clothes, and be unclean until the evening. He also who carries its carcass shall wash his clothes, and be unclean until the evening. 
+</div><div class="p">
+<sup>41&#160;</sup>“&#160;‘Every creeping thing that creeps on the earth is an abomination. It shall not be eaten. 
+<sup>42&#160;</sup>Whatever goes on its belly, and whatever goes on all fours, or whatever has many feet, even all creeping things that creep on the earth, them you shall not eat; for they are an abomination. 
+<sup>43&#160;</sup>You shall not make yourselves abominable with any creeping thing that creeps. You shall not make yourselves unclean with them, that you should be defiled by them. 
+<sup>44&#160;</sup>For I am Yahweh your Elohim. Sanctify yourselves therefore, and be set-apart; for I am set-apart. You shall not defile yourselves with any kind of creeping thing that moves on the earth. 
+<sup>45&#160;</sup>For I am Yahweh who brought you up out of the land of Egypt, to be your Elohim. You shall therefore be set-apart, for I am set-apart. 
+</div><div class="p">
+<sup>46&#160;</sup>“&#160;‘This is the law of the animal, and of the bird, and of every living creature that moves in the waters, and of every creature that creeps on the earth, 
+<sup>47&#160;</sup>to make a distinction between the unclean and the clean, and between the living thing that may be eaten and the living thing that may not be eaten.’&#160;” 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, saying, ‘If a woman conceives, and bears a male child, then she shall be unclean seven days; as in the days of her monthly period she shall be unclean. 
+<sup>3&#160;</sup>In the eighth day the flesh of his foreskin shall be circumcised. 
+<sup>4&#160;</sup>She shall continue in the blood of purification thirty-three days. She shall not touch any set-apart thing, nor come into the sanctuary, until the days of her purifying are completed. 
+<sup>5&#160;</sup>But if she bears a female child, then she shall be unclean two weeks, as in her period; and she shall continue in the blood of purification sixty-six days. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘When the days of her purification are completed for a son or for a daughter, she shall bring to the priest at the door of the Tent of Meeting, a year old lamb for a burnt offering, and a young pigeon or a turtledove, for a sin offering. 
+<sup>7&#160;</sup>He shall offer it before Yahweh, and make atonement for her; then she shall be cleansed from the fountain of her blood. 
+</div><div class="p">“&#160;‘This is the law for her who bears, whether a male or a female. 
+<sup>8&#160;</sup>If she cannot afford a lamb, then she shall take two turtledoves or two young pigeons: the one for a burnt offering, and the other for a sin offering. The priest shall make atonement for her, and she shall be clean.’&#160;” 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>2&#160;</sup>“When a man shall have a swelling in his body’s skin, or a scab, or a bright spot, and it becomes in the skin of his body the plague of leprosy, then he shall be brought to Aaron the priest or to one of his sons, the priests. 
+<sup>3&#160;</sup>The priest shall examine the plague in the skin of the body. If the hair in the plague has turned white, and the appearance of the plague is deeper than the body’s skin, it is the plague of leprosy; so the priest shall examine him and pronounce him unclean. 
+<sup>4&#160;</sup>If the bright spot is white in the skin of his body, and its appearance isn’t deeper than the skin, and its hair hasn’t turned white, then the priest shall isolate the infected person for seven days. 
+<sup>5&#160;</sup>The priest shall examine him on the seventh day. Behold, if in his eyes the plague is arrested and the plague hasn’t spread in the skin, then the priest shall isolate him for seven more days. 
+<sup>6&#160;</sup>The priest shall examine him again on the seventh day. Behold, if the plague has faded and the plague hasn’t spread in the skin, then the priest shall pronounce him clean. It is a scab. He shall wash his clothes, and be clean. 
+<sup>7&#160;</sup>But if the scab spreads on the skin after he has shown himself to the priest for his cleansing, he shall show himself to the priest again. 
+<sup>8&#160;</sup>The priest shall examine him; and behold, if the scab has spread on the skin, then the priest shall pronounce him unclean. It is leprosy. 
+</div><div class="p">
+<sup>9&#160;</sup>“When the plague of leprosy is in a man, then he shall be brought to the priest; 
+<sup>10&#160;</sup>and the priest shall examine him. Behold, if there is a white swelling in the skin, and it has turned the hair white, and there is raw flesh in the swelling, 
+<sup>11&#160;</sup>it is a chronic leprosy in the skin of his body, and the priest shall pronounce him unclean. He shall not isolate him, for he is already unclean. 
+</div><div class="p">
+<sup>12&#160;</sup>“If the leprosy breaks out all over the skin, and the leprosy covers all the skin of the infected person from his head even to his feet, as far as it appears to the priest, 
+<sup>13&#160;</sup>then the priest shall examine him. Behold, if the leprosy has covered all his flesh, he shall pronounce him clean of the plague. It has all turned white: he is clean. 
+<sup>14&#160;</sup>But whenever raw flesh appears in him, he shall be unclean. 
+<sup>15&#160;</sup>The priest shall examine the raw flesh, and pronounce him unclean: the raw flesh is unclean. It is leprosy. 
+<sup>16&#160;</sup>Or if the raw flesh turns again, and is changed to white, then he shall come to the priest. 
+<sup>17&#160;</sup>The priest shall examine him. Behold, if the plague has turned white, then the priest shall pronounce him clean of the plague. He is clean. 
+</div><div class="p">
+<sup>18&#160;</sup>“When the body has a boil on its skin, and it has healed, 
+<sup>19&#160;</sup>and in the place of the boil there is a white swelling, or a bright spot, reddish-white, then it shall be shown to the priest. 
+<sup>20&#160;</sup>The priest shall examine it. Behold, if its appearance is deeper than the skin, and its hair has turned white, then the priest shall pronounce him unclean. It is the plague of leprosy. It has broken out in the boil. 
+<sup>21&#160;</sup>But if the priest examines it, and behold, there are no white hairs in it, and it isn’t deeper than the skin, but is dim, then the priest shall isolate him seven days. 
+<sup>22&#160;</sup>If it spreads in the skin, then the priest shall pronounce him unclean. It is a plague. 
+<sup>23&#160;</sup>But if the bright spot stays in its place, and hasn’t spread, it is the scar from the boil; and the priest shall pronounce him clean. 
+</div><div class="p">
+<sup>24&#160;</sup>“Or when the body has a burn from fire on its skin, and the raw flesh of the burn becomes a bright spot, reddish-white, or white, 
+<sup>25&#160;</sup>then the priest shall examine it; and behold, if the hair in the bright spot has turned white, and its appearance is deeper than the skin, it is leprosy. It has broken out in the burning, and the priest shall pronounce him unclean. It is the plague of leprosy. 
+<sup>26&#160;</sup>But if the priest examines it, and behold, there is no white hair in the bright spot, and it isn’t deeper than the skin, but has faded, then the priest shall isolate him seven days. 
+<sup>27&#160;</sup>The priest shall examine him on the seventh day. If it has spread in the skin, then the priest shall pronounce him unclean. It is the plague of leprosy. 
+<sup>28&#160;</sup>If the bright spot stays in its place, and hasn’t spread in the skin, but is faded, it is the swelling from the burn, and the priest shall pronounce him clean, for it is the scar from the burn. 
+</div><div class="p">
+<sup>29&#160;</sup>“When a man or woman has a plague on the head or on the beard, 
+<sup>30&#160;</sup>then the priest shall examine the plague; and behold, if its appearance is deeper than the skin, and the hair in it is yellow and thin, then the priest shall pronounce him unclean. It is an itch. It is leprosy of the head or of the beard. 
+<sup>31&#160;</sup>If the priest examines the plague of itching, and behold, its appearance isn’t deeper than the skin, and there is no black hair in it, then the priest shall isolate the person infected with itching seven days. 
+<sup>32&#160;</sup>On the seventh day the priest shall examine the plague; and behold, if the itch hasn’t spread, and there is no yellow hair in it, and the appearance of the itch isn’t deeper than the skin, 
+<sup>33&#160;</sup>then he shall be shaved, but he shall not shave the itch. Then the priest shall isolate the one who has the itch seven more days. 
+<sup>34&#160;</sup>On the seventh day, the priest shall examine the itch; and behold, if the itch hasn’t spread in the skin, and its appearance isn’t deeper than the skin, then the priest shall pronounce him clean. He shall wash his clothes and be clean. 
+<sup>35&#160;</sup>But if the itch spreads in the skin after his cleansing, 
+<sup>36&#160;</sup>then the priest shall examine him; and behold, if the itch has spread in the skin, the priest shall not look for the yellow hair; he is unclean. 
+<sup>37&#160;</sup>But if in his eyes the itch is arrested and black hair has grown in it, then the itch is healed. He is clean. The priest shall pronounce him clean. 
+</div><div class="p">
+<sup>38&#160;</sup>“When a man or a woman has bright spots in the skin of the body, even white bright spots, 
+<sup>39&#160;</sup>then the priest shall examine them. Behold, if the bright spots on the skin of their body are a dull white, it is a harmless rash. It has broken out in the skin. He is clean. 
+</div><div class="p">
+<sup>40&#160;</sup>“If a man’s hair has fallen from his head, he is bald. He is clean. 
+<sup>41&#160;</sup>If his hair has fallen off from the front part of his head, he is forehead bald. He is clean. 
+<sup>42&#160;</sup>But if a reddish-white plague is in the bald head or the bald forehead, it is leprosy breaking out in his bald head or his bald forehead. 
+<sup>43&#160;</sup>Then the priest shall examine him. Behold, if the swelling of the plague is reddish-white in his bald head, or in his bald forehead, like the appearance of leprosy in the skin of the body, 
+<sup>44&#160;</sup>he is a leprous man. He is unclean. The priest shall surely pronounce him unclean. His plague is on his head. 
+</div><div class="p">
+<sup>45&#160;</sup>“The leper in whom the plague is shall wear torn clothes, and the hair of his head shall hang loose. He shall cover his upper lip, and shall cry, ‘Unclean! Unclean!’ 
+<sup>46&#160;</sup>All the days in which the plague is in him he shall be unclean. He is unclean. He shall dwell alone. His dwelling shall be outside of the camp. 
+</div><div class="p">
+<sup>47&#160;</sup>“The garment also that the plague of leprosy is in, whether it is a woolen garment, or a linen garment; 
+<sup>48&#160;</sup>whether it is in warp or woof; of linen or of wool; whether in a leather, or in anything made of leather; 
+<sup>49&#160;</sup>if the plague is greenish or reddish in the garment, or in the leather, or in the warp, or in the woof, or in anything made of leather; it is the plague of leprosy, and shall be shown to the priest. 
+<sup>50&#160;</sup>The priest shall examine the plague, and isolate the plague seven days. 
+<sup>51&#160;</sup>He shall examine the plague on the seventh day. If the plague has spread in the garment, either in the warp, or in the woof, or in the skin, whatever use the skin is used for, the plague is a destructive mildew. It is unclean. 
+<sup>52&#160;</sup>He shall burn the garment, whether the warp or the woof, in wool or in linen, or anything of leather, in which the plague is, for it is a destructive mildew. It shall be burned in the fire. 
+</div><div class="p">
+<sup>53&#160;</sup>“If the priest examines it, and behold, the plague hasn’t spread in the garment, either in the warp, or in the woof, or in anything of skin; 
+<sup>54&#160;</sup>then the priest shall command that they wash the thing that the plague is in, and he shall isolate it seven more days. 
+<sup>55&#160;</sup>Then the priest shall examine it, after the plague is washed; and behold, if the plague hasn’t changed its color, and the plague hasn’t spread, it is unclean; you shall burn it in the fire. It is a mildewed spot, whether the bareness is inside or outside. 
+<sup>56&#160;</sup>If the priest looks, and behold, the plague has faded after it is washed, then he shall tear it out of the garment, or out of the skin, or out of the warp, or out of the woof; 
+<sup>57&#160;</sup>and if it appears again in the garment, either in the warp, or in the woof, or in anything of skin, it is spreading. You shall burn what the plague is in with fire. 
+<sup>58&#160;</sup>The garment, either the warp, or the woof, or whatever thing of skin it is, which you shall wash, if the plague has departed from them, then it shall be washed the second time, and it will be clean.” 
+</div><div class="p">
+<sup>59&#160;</sup>This is the law of the plague of mildew in a garment of wool or linen, either in the warp, or the woof, or in anything of skin, to pronounce it clean, or to pronounce it unclean. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+</div><div class="p">
+<sup>2&#160;</sup>“This shall be the law of the leper in the day of his cleansing: He shall be brought to the priest, 
+<sup>3&#160;</sup>and the priest shall go out of the camp. The priest shall examine him. Behold, if the plague of leprosy is healed in the leper, 
+<sup>4&#160;</sup>then the priest shall command them to take for him who is to be cleansed two living clean birds, cedar wood, scarlet, and hyssop. 
+<sup>5&#160;</sup>The priest shall command them to kill one of the birds in an earthen vessel over running water. 
+<sup>6&#160;</sup>As for the living bird, he shall take it, the cedar wood, the scarlet, and the hyssop, and shall dip them and the living bird in the blood of the bird that was killed over the running water. 
+<sup>7&#160;</sup>He shall sprinkle on him who is to be cleansed from the leprosy seven times, and shall pronounce him clean, and shall let the living bird go into the open field. 
+</div><div class="p">
+<sup>8&#160;</sup>“He who is to be cleansed shall wash his clothes, and shave off all his hair, and bathe himself in water; and he shall be clean. After that he shall come into the camp, but shall dwell outside his tent seven days. 
+<sup>9&#160;</sup>It shall be on the seventh day, that he shall shave all his hair off his head and his beard and his eyebrows. He shall shave off all his hair. He shall wash his clothes, and he shall bathe his body in water. Then he shall be clean. 
+</div><div class="p">
+<sup>10&#160;</sup>“On the eighth day he shall take two male lambs without defect, one ewe lamb a year old without defect, three tenths of an ephah of oil. 
+<sup>11&#160;</sup>The priest who cleanses him shall set the man who is to be cleansed, and those things, before Yahweh, at the door of the Tent of Meeting. 
+</div><div class="p">
+<sup>12&#160;</sup>“The priest shall take one of the male lambs, and offer him for a trespass offering, with the log of oil, and wave them for a wave offering before Yahweh. 
+<sup>13&#160;</sup>He shall kill the male lamb in the place where they kill the sin offering and the burnt offering, in the place of the sanctuary; for as the sin offering is the priest’s, so is the trespass offering. It is most set-apart. 
+<sup>14&#160;</sup>The priest shall take some of the blood of the trespass offering, and the priest shall put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
+<sup>15&#160;</sup>The priest shall take some of the log of oil, and pour it into the palm of his own left hand. 
+<sup>16&#160;</sup>The priest shall dip his right finger in the oil that is in his left hand, and shall sprinkle some of the oil with his finger seven times before Yahweh. 
+<sup>17&#160;</sup>The priest shall put some of the rest of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, upon the blood of the trespass offering. 
+<sup>18&#160;</sup>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, and the priest shall make atonement for him before Yahweh. 
+</div><div class="p">
+<sup>19&#160;</sup>“The priest shall offer the sin offering, and make atonement for him who is to be cleansed because of his uncleanness. Afterward he shall kill the burnt offering; 
+<sup>20&#160;</sup>then the priest shall offer the burnt offering and the meal offering on the altar. The priest shall make atonement for him, and he shall be clean. 
+</div><div class="p">
+<sup>21&#160;</sup>“If he is poor, and can’t afford so much, then he shall take one male lamb for a trespass offering to be waved, to make atonement for him, and one tenth of an ephah of oil; 
+<sup>22&#160;</sup>and two turtledoves, or two young pigeons, such as he is able to afford; and the one shall be a sin offering, and the other a burnt offering. 
+</div><div class="p">
+<sup>23&#160;</sup>“On the eighth day he shall bring them for his cleansing to the priest, to the door of the Tent of Meeting, before Yahweh. 
+<sup>24&#160;</sup>The priest shall take the lamb of the trespass offering, and the log of oil, and the priest shall wave them for a wave offering before Yahweh. 
+<sup>25&#160;</sup>He shall kill the lamb of the trespass offering. The priest shall take some of the blood of the trespass offering and put it on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot. 
+<sup>26&#160;</sup>The priest shall pour some of the oil into the palm of his own left hand; 
+<sup>27&#160;</sup>and the priest shall sprinkle with his right finger some of the oil that is in his left hand seven times before Yahweh. 
+<sup>28&#160;</sup>Then the priest shall put some of the oil that is in his hand on the tip of the right ear of him who is to be cleansed, and on the thumb of his right hand, and on the big toe of his right foot, on the place of the blood of the trespass offering. 
+<sup>29&#160;</sup>The rest of the oil that is in the priest’s hand he shall put on the head of him who is to be cleansed, to make atonement for him before Yahweh. 
+<sup>30&#160;</sup>He shall offer one of the turtledoves, or of the young pigeons, which ever he is able to afford, 
+<sup>31&#160;</sup>of the kind he is able to afford, the one for a sin offering, and the other for a burnt offering, with the meal offering. The priest shall make atonement for him who is to be cleansed before Yahweh.” 
+</div><div class="p">
+<sup>32&#160;</sup>This is the law for him in whom is the plague of leprosy, who is not able to afford the sacrifice for his cleansing. 
+</div><div class="p">
+<sup>33&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>34&#160;</sup>“When you have come into the land of Canaan, which I give to you for a possession, and I put a spreading mildew in a house in the land of your possession, 
+<sup>35&#160;</sup>then he who owns the house shall come and tell the priest, saying, ‘There seems to me to be some sort of plague in the house.’ 
+<sup>36&#160;</sup>The priest shall command that they empty the house, before the priest goes in to examine the plague, that all that is in the house not be made unclean. Afterward the priest shall go in to inspect the house. 
+<sup>37&#160;</sup>He shall examine the plague; and behold, if the plague is in the walls of the house with hollow streaks, greenish or reddish, and it appears to be deeper than the wall, 
+<sup>38&#160;</sup>then the priest shall go out of the house to the door of the house, and shut up the house seven days. 
+<sup>39&#160;</sup>The priest shall come again on the seventh day, and look. If the plague has spread in the walls of the house, 
+<sup>40&#160;</sup>then the priest shall command that they take out the stones in which is the plague, and cast them into an unclean place outside of the city. 
+<sup>41&#160;</sup>He shall cause the inside of the house to be scraped all over. They shall pour out the mortar that they scraped off outside of the city into an unclean place. 
+<sup>42&#160;</sup>They shall take other stones, and put them in the place of those stones; and he shall take other mortar, and shall plaster the house. 
+</div><div class="p">
+<sup>43&#160;</sup>“If the plague comes again, and breaks out in the house after he has taken out the stones, and after he has scraped the house, and after it was plastered, 
+<sup>44&#160;</sup>then the priest shall come in and look; and behold, if the plague has spread in the house, it is a destructive mildew in the house. It is unclean. 
+<sup>45&#160;</sup>He shall break down the house, its stones, and its timber, and all the house’s mortar. He shall carry them out of the city into an unclean place. 
+</div><div class="p">
+<sup>46&#160;</sup>“Moreover he who goes into the house while it is shut up shall be unclean until the evening. 
+<sup>47&#160;</sup>He who lies down in the house shall wash his clothes; and he who eats in the house shall wash his clothes. 
+</div><div class="p">
+<sup>48&#160;</sup>“If the priest shall come in, and examine it, and behold, the plague hasn’t spread in the house, after the house was plastered, then the priest shall pronounce the house clean, because the plague is healed. 
+<sup>49&#160;</sup>To cleanse the house he shall take two birds, cedar wood, scarlet, and hyssop. 
+<sup>50&#160;</sup>He shall kill one of the birds in an earthen vessel over running water. 
+<sup>51&#160;</sup>He shall take the cedar wood, the hyssop, the scarlet, and the living bird, and dip them in the blood of the slain bird, and in the running water, and sprinkle the house seven times. 
+<sup>52&#160;</sup>He shall cleanse the house with the blood of the bird, and with the running water, with the living bird, with the cedar wood, with the hyssop, and with the scarlet; 
+<sup>53&#160;</sup>but he shall let the living bird go out of the city into the open field. So shall he make atonement for the house; and it shall be clean.” 
+</div><div class="p">
+<sup>54&#160;</sup>This is the law for any plague of leprosy, and for an itch, 
+<sup>55&#160;</sup>and for the destructive mildew of a garment, and for a house, 
+<sup>56&#160;</sup>and for a swelling, and for a scab, and for a bright spot; 
+<sup>57&#160;</sup>to teach when it is unclean, and when it is clean. 
+</div><div class="p">This is the law of leprosy. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When any man has a discharge from his body, because of his discharge he is unclean. 
+<sup>3&#160;</sup>This shall be his uncleanness in his discharge: whether his body runs with his discharge, or his body has stopped from his discharge, it is his uncleanness. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘Every bed on which he who has the discharge lies shall be unclean; and everything he sits on shall be unclean. 
+<sup>5&#160;</sup>Whoever touches his bed shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+<sup>6&#160;</sup>He who sits on anything on which the man who has the discharge sat shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘He who touches the body of him who has the discharge shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘If he who has the discharge spits on him who is clean, then he shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘Whatever saddle he who has the discharge rides on shall be unclean. 
+<sup>10&#160;</sup>Whoever touches anything that was under him shall be unclean until the evening. He who carries those things shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘Whomever he who has the discharge touches, without having rinsed his hands in water, he shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘The earthen vessel, which he who has the discharge touches, shall be broken; and every vessel of wood shall be rinsed in water. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘When he who has a discharge is cleansed of his discharge, then he shall count to himself seven days for his cleansing, and wash his clothes; and he shall bathe his flesh in running water, and shall be clean. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘On the eighth day he shall take two turtledoves, or two young pigeons, and come before Yahweh to the door of the Tent of Meeting, and give them to the priest. 
+<sup>15&#160;</sup>The priest shall offer them, the one for a sin offering, and the other for a burnt offering. The priest shall make atonement for him before Yahweh for his discharge. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘If any man has an emission of semen, then he shall bathe all his flesh in water, and be unclean until the evening. 
+<sup>17&#160;</sup>Every garment and every skin which the semen is on shall be washed with water, and be unclean until the evening. 
+<sup>18&#160;</sup>If a man lies with a woman and there is an emission of semen, they shall both bathe themselves in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>19&#160;</sup>“&#160;‘If a woman has a discharge, and her discharge in her flesh is blood, she shall be in her impurity seven days. Whoever touches her shall be unclean until the evening. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘Everything that she lies on in her impurity shall be unclean. Everything also that she sits on shall be unclean. 
+<sup>21&#160;</sup>Whoever touches her bed shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+<sup>22&#160;</sup>Whoever touches anything that she sits on shall wash his clothes, and bathe himself in water, and be unclean until the evening. 
+<sup>23&#160;</sup>If it is on the bed, or on anything she sits on, when he touches it, he shall be unclean until the evening. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘If any man lies with her, and her monthly flow is on him, he shall be unclean seven days; and every bed he lies on shall be unclean. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘If a woman has a discharge of her blood many days not in the time of her period, or if she has a discharge beyond the time of her period, all the days of the discharge of her uncleanness shall be as in the days of her period. She is unclean. 
+<sup>26&#160;</sup>Every bed she lies on all the days of her discharge shall be to her as the bed of her period. Everything she sits on shall be unclean, as the uncleanness of her period. 
+<sup>27&#160;</sup>Whoever touches these things shall be unclean, and shall wash his clothes and bathe himself in water, and be unclean until the evening. 
+</div><div class="p">
+<sup>28&#160;</sup>“&#160;‘But if she is cleansed of her discharge, then she shall count to herself seven days, and after that she shall be clean. 
+<sup>29&#160;</sup>On the eighth day she shall take two turtledoves, or two young pigeons, and bring them to the priest, to the door of the Tent of Meeting. 
+<sup>30&#160;</sup>The priest shall offer the one for a sin offering, and the other for a burnt offering; and the priest shall make atonement for her before Yahweh for the uncleanness of her discharge. 
+</div><div class="p">
+<sup>31&#160;</sup>“&#160;‘Thus you shall separate the children of Israel from their uncleanness, so they will not die in their uncleanness when they defile my tabernacle that is among them.’&#160;” 
+</div><div class="p">
+<sup>32&#160;</sup>This is the law of him who has a discharge, and of him who has an emission of semen, so that he is unclean by it; 
+<sup>33&#160;</sup>and of her who has her period, and of a man or woman who has a discharge, and of him who lies with her who is unclean. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses after the death of the two sons of Aaron, when they came near before Yahweh, and died; 
+<sup>2&#160;</sup>and Yahweh said to Moses, “Tell Aaron your brother not to come at just any time into the Most Set-Apart Place within the veil, before the mercy seat which is on the ark; lest he die; for I will appear in the cloud on the mercy seat. 
+</div><div class="p">
+<sup>3&#160;</sup>“Aaron shall come into the sanctuary with a young bull for a sin offering, and a ram for a burnt offering. 
+<sup>4&#160;</sup>He shall put on the set-apart linen tunic. He shall have the linen trousers on his body, and shall put on the linen sash, and he shall be clothed with the linen turban. They are the set-apart garments. He shall bathe his body in water, and put them on. 
+<sup>5&#160;</sup>He shall take from the congregation of the children of Israel two male goats for a sin offering, and one ram for a burnt offering. 
+</div><div class="p">
+<sup>6&#160;</sup>“Aaron shall offer the bull of the sin offering, which is for himself, and make atonement for himself and for his house. 
+<sup>7&#160;</sup>He shall take the two goats, and set them before Yahweh at the door of the Tent of Meeting. 
+<sup>8&#160;</sup>Aaron shall cast lots for the two goats: one lot for Yahweh, and the other lot for the scapegoat. 
+<sup>9&#160;</sup>Aaron shall present the goat on which the lot fell for Yahweh, and offer him for a sin offering. 
+<sup>10&#160;</sup>But the goat on which the lot fell for the scapegoat shall be presented alive before Yahweh, to make atonement for him, to send him away as the scapegoat into the wilderness. 
+</div><div class="p">
+<sup>11&#160;</sup>“Aaron shall present the bull of the sin offering, which is for himself, and shall make atonement for himself and for his house, and shall kill the bull of the sin offering which is for himself. 
+<sup>12&#160;</sup>He shall take a censer full of coals of fire from off the altar before Yahweh, and two handfuls of sweet incense beaten small, and bring it within the veil. 
+<sup>13&#160;</sup>He shall put the incense on the fire before Yahweh, that the cloud of the incense may cover the mercy seat that is on the covenant, so that he will not die. 
+<sup>14&#160;</sup>He shall take some of the blood of the bull, and sprinkle it with his finger on the mercy seat on the east; and before the mercy seat he shall sprinkle some of the blood with his finger seven times. 
+</div><div class="p">
+<sup>15&#160;</sup>“Then he shall kill the goat of the sin offering that is for the people, and bring his blood within the veil, and do with his blood as he did with the blood of the bull, and sprinkle it on the mercy seat and before the mercy seat. 
+<sup>16&#160;</sup>He shall make atonement for the Set-Apart Place, because of the uncleanness of the children of Israel, and because of their transgressions, even all their sins; and so he shall do for the Tent of Meeting that dwells with them in the middle of their uncleanness. 
+<sup>17&#160;</sup>No one shall be in the Tent of Meeting when he enters to make atonement in the Set-Apart Place, until he comes out, and has made atonement for himself and for his household, and for all the assembly of Israel. 
+</div><div class="p">
+<sup>18&#160;</sup>“He shall go out to the altar that is before Yahweh and make atonement for it, and shall take some of the bull’s blood, and some of the goat’s blood, and put it around on the horns of the altar. 
+<sup>19&#160;</sup>He shall sprinkle some of the blood on it with his finger seven times, and cleanse it, and make it set-apart from the uncleanness of the children of Israel. 
+</div><div class="p">
+<sup>20&#160;</sup>“When he has finished atoning for the Set-Apart Place, the Tent of Meeting, and the altar, he shall present the live goat. 
+<sup>21&#160;</sup>Aaron shall lay both his hands on the head of the live goat, and confess over him all the iniquities of the children of Israel, and all their transgressions, even all their sins; and he shall put them on the head of the goat, and shall send him away into the wilderness by the hand of a man who is ready. 
+<sup>22&#160;</sup>The goat shall carry all their iniquities on himself to a solitary land, and he shall release the goat in the wilderness. 
+</div><div class="p">
+<sup>23&#160;</sup>“Aaron shall come into the Tent of Meeting, and shall take off the linen garments which he put on when he went into the Set-Apart Place, and shall leave them there. 
+<sup>24&#160;</sup>Then he shall bathe himself in water in a set-apart place, put on his garments, and come out and offer his burnt offering and the burnt offering of the people, and make atonement for himself and for the people. 
+<sup>25&#160;</sup>The fat of the sin offering he shall burn on the altar. 
+</div><div class="p">
+<sup>26&#160;</sup>“He who lets the goat go as the scapegoat shall wash his clothes, and bathe his flesh in water, and afterward he shall come into the camp. 
+<sup>27&#160;</sup>The bull for the sin offering, and the goat for the sin offering, whose blood was brought in to make atonement in the Set-Apart Place, shall be carried outside the camp; and they shall burn their skins, their flesh, and their dung with fire. 
+<sup>28&#160;</sup>He who burns them shall wash his clothes, and bathe his flesh in water, and afterward he shall come into the camp. 
+</div><div class="p">
+<sup>29&#160;</sup>“It shall be a statute to you forever: in the seventh month, on the tenth day of the month, you shall afflict your souls, and shall do no kind of work, whether native-born or a stranger who lives as a foreigner among you; 
+<sup>30&#160;</sup>for on this day shall atonement be made for you, to cleanse you. You shall be clean from all your sins before Yahweh. 
+<sup>31&#160;</sup>It is a Sabbath of solemn rest to you, and you shall afflict your souls. It is a statute forever. 
+<sup>32&#160;</sup>The priest, who is anointed and who is consecrated to be priest in his father’s place, shall make the atonement, and shall put on the linen garments, even the set-apart garments. 
+<sup>33&#160;</sup>Then he shall make atonement for the Set-Apart Sanctuary; and he shall make atonement for the Tent of Meeting and for the altar; and he shall make atonement for the priests and for all the people of the assembly. 
+</div><div class="p">
+<sup>34&#160;</sup>“This shall be an everlasting statute for you, to make atonement for the children of Israel once in the year because of all their sins.” 
+</div><div class="p">It was done as Yahweh commanded Moses. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘This is the thing which Yahweh has commanded: 
+<sup>3&#160;</sup>Whatever man there is of the house of Israel who kills a bull, or lamb, or goat in the camp, or who kills it outside the camp, 
+<sup>4&#160;</sup>and hasn’t brought it to the door of the Tent of Meeting to offer it as an offering to Yahweh before Yahweh’s tabernacle: blood shall be imputed to that man. He has shed blood. That man shall be cut off from among his people. 
+<sup>5&#160;</sup>This is to the end that the children of Israel may bring their sacrifices, which they sacrifice in the open field, that they may bring them to Yahweh, to the door of the Tent of Meeting, to the priest, and sacrifice them for sacrifices of peace offerings to Yahweh. 
+<sup>6&#160;</sup>The priest shall sprinkle the blood on Yahweh’s altar at the door of the Tent of Meeting, and burn the fat for a pleasant aroma to Yahweh. 
+<sup>7&#160;</sup>They shall no more sacrifice their sacrifices to the goat idols, after which they play the prostitute. This shall be a statute forever to them throughout their generations.’ 
+</div><div class="p">
+<sup>8&#160;</sup>“You shall say to them, ‘Any man there is of the house of Israel, or of the strangers who live as foreigners among them, who offers a burnt offering or sacrifice, 
+<sup>9&#160;</sup>and doesn’t bring it to the door of the Tent of Meeting to sacrifice it to Yahweh, that man shall be cut off from his people. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘Any man of the house of Israel, or of the strangers who live as foreigners among them, who eats any kind of blood, I will set my face against that soul who eats blood, and will cut him off from among his people. 
+<sup>11&#160;</sup>For the life of the flesh is in the blood. I have given it to you on the altar to make atonement for your souls; for it is the blood that makes atonement by reason of the life. 
+<sup>12&#160;</sup>Therefore I have said to the children of Israel, “No person among you may eat blood, nor may any stranger who lives as a foreigner among you eat blood.” 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘Whatever man there is of the children of Israel, or of the strangers who live as foreigners among them, who takes in hunting any animal or bird that may be eaten, he shall pour out its blood, and cover it with dust. 
+<sup>14&#160;</sup>For as to the life of all flesh, its blood is with its life. Therefore I said to the children of Israel, “You shall not eat the blood of any kind of flesh; for the life of all flesh is its blood. Whoever eats it shall be cut off.” 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘Every person that eats what dies of itself, or that which is torn by animals, whether he is native-born or a foreigner, shall wash his clothes, and bathe himself in water, and be unclean until the evening. Then he shall be clean. 
+<sup>16&#160;</sup>But if he doesn’t wash them, or bathe his flesh, then he shall bear his iniquity.’&#160;” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and say to them, ‘I am Yahweh your Elohim. 
+<sup>3&#160;</sup>You shall not do as they do in the land of Egypt, where you lived. You shall not do as they do in the land of Canaan, where I am bringing you. You shall not follow their statutes. 
+<sup>4&#160;</sup>You shall do my ordinances. You shall keep my statutes and walk in them. I am Yahweh your Elohim. 
+<sup>5&#160;</sup>You shall therefore keep my statutes and my ordinances, which if a man does, he shall live in them. I am Yahweh. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘None of you shall approach any close relatives, to uncover their nakedness: I am Yahweh. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘You shall not uncover the nakedness of your father, nor the nakedness of your mother: she is your mother. You shall not uncover her nakedness. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘You shall not uncover the nakedness of your father’s woman. It is your father’s nakedness. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘You shall not uncover the nakedness of your sister, the daughter of your father, or the daughter of your mother, whether born at home or born abroad. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘You shall not uncover the nakedness of your son’s daughter, or of your daughter’s daughter, even their nakedness; for theirs is your own nakedness. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘You shall not uncover the nakedness of your father’s woman’s daughter, conceived by your father, since she is your sister. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘You shall not uncover the nakedness of your father’s sister. She is your father’s near kinswoman. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘You shall not uncover the nakedness of your mother’s sister, for she is your mother’s near kinswoman. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘You shall not uncover the nakedness of your father’s brother. You shall not approach his woman. She is your aunt. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘You shall not uncover the nakedness of your daughter-in-law. She is your son’s woman. You shall not uncover her nakedness. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘You shall not uncover the nakedness of your brother’s woman. It is your brother’s nakedness. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘You shall not uncover the nakedness of a woman and her daughter. You shall not take her son’s daughter, or her daughter’s daughter, to uncover her nakedness. They are near kinswomen. It is wickedness. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘You shall not take a woman in addition to her sister, to be a rival, to uncover her nakedness, while her sister is still alive. 
+</div><div class="p">
+<sup>19&#160;</sup>“&#160;‘You shall not approach a woman to uncover her nakedness, as long as she is impure by her uncleanness. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘You shall not lie carnally with your neighbor’s woman, and defile yourself with her. 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘You shall not give any of your children as a sacrifice to Molech. You shall not profane the name of your Elohim. I am Yahweh. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘You shall not lie with a man as with a woman. That is detestable. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘You shall not lie with any animal to defile yourself with it. No woman may give herself to an animal, to lie down with it: it is a perversion. 
+</div><div class="p">
+<sup>24&#160;</sup>“&#160;‘Don’t defile yourselves in any of these things; for in all these the nations which I am casting out before you were defiled. 
+<sup>25&#160;</sup>The land was defiled. Therefore I punished its iniquity, and the land vomited out her inhabitants. 
+<sup>26&#160;</sup>You therefore shall keep my statutes and my ordinances, and shall not do any of these abominations; neither the native-born, nor the stranger who lives as a foreigner among you 
+<sup>27&#160;</sup>(for the men of the land that were before you had done all these abominations, and the land became defiled), 
+<sup>28&#160;</sup>that the land not vomit you out also, when you defile it, as it vomited out the nation that was before you. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘For whoever shall do any of these abominations, even the souls that do them shall be cut off from among their people. 
+<sup>30&#160;</sup>Therefore you shall keep my requirements, that you do not practice any of these abominable customs which were practiced before you, and that you do not defile yourselves with them. I am Yahweh your Elohim.’&#160;” 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to all the congregation of the children of Israel, and tell them, ‘You shall be set-apart; for I, Yahweh your Elohim, am set-apart. 
+</div><div class="p">
+<sup>3&#160;</sup>“&#160;‘Each one of you shall respect his mother and his father. You shall keep my Sabbaths. I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘Don’t turn to idols, nor make molten elohims for yourselves. I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘When you offer a sacrifice of peace offerings to Yahweh, you shall offer it so that you may be accepted. 
+<sup>6&#160;</sup>It shall be eaten the same day you offer it, and on the next day. If anything remains until the third day, it shall be burned with fire. 
+<sup>7&#160;</sup>If it is eaten at all on the third day, it is an abomination. It will not be accepted; 
+<sup>8&#160;</sup>but everyone who eats it shall bear his iniquity, because he has profaned the set-apart thing of Yahweh, and that soul shall be cut off from his people. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘When you reap the harvest of your land, you shall not wholly reap the corners of your field, neither shall you gather the gleanings of your harvest. 
+<sup>10&#160;</sup>You shall not glean your vineyard, neither shall you gather the fallen grapes of your vineyard. You shall leave them for the poor and for the foreigner. I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘You shall not steal. 
+</div><div class="p">“&#160;‘You shall not lie. 
+</div><div class="p">“&#160;‘You shall not deceive one another. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘You shall not swear by my name falsely, and profane the name of your Elohim. I am Yahweh. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘You shall not oppress your neighbor, nor rob him. 
+</div><div class="p">“&#160;‘The wages of a hired servant shall not remain with you all night until the morning. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘You shall not curse the deaf, nor put a stumbling block before the blind; but you shall fear your Elohim. I am Yahweh. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘You shall do no injustice in judgment. You shall not be partial to the poor, nor show favoritism to the great; but you shall judge your neighbor in righteousness. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘You shall not go around as a slanderer among your people. 
+</div><div class="p">“&#160;‘You shall not endanger the life of your neighbor. I am Yahweh. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘You shall not hate your brother in your heart. You shall surely rebuke your neighbor, and not bear sin because of him. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘You shall not take vengeance, nor bear any grudge against the children of your people; but you shall love your neighbor as yourself. I am Yahweh. 
+</div><div class="p">
+<sup>19&#160;</sup>“&#160;‘You shall keep my statutes. 
+</div><div class="p">“&#160;‘You shall not cross-breed different kinds of animals. 
+</div><div class="p">“&#160;‘You shall not sow your field with two kinds of seed; 
+</div><div class="p">“&#160;‘Don’t wear a garment made of two kinds of material. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘If a man lies carnally with a woman who is a slave girl, pledged to be married to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
+<sup>21&#160;</sup>He shall bring his trespass offering to Yahweh, to the door of the Tent of Meeting, even a ram for a trespass offering. 
+<sup>22&#160;</sup>The priest shall make atonement for him with the ram of the trespass offering before Yahweh for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘When you come into the land, and have planted all kinds of trees for food, then you shall count their fruit as forbidden. For three years it shall be forbidden to you. It shall not be eaten. 
+<sup>24&#160;</sup>But in the fourth year all its fruit shall be set-apart, for giving praise to Yahweh. 
+<sup>25&#160;</sup>In the fifth year you shall eat its fruit, that it may yield its increase to you. I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘You shall not eat any meat with the blood still in it. You shall not use enchantments, nor practice sorcery. 
+</div><div class="p">
+<sup>27&#160;</sup>“&#160;‘You shall not cut the hair on the sides of your head or clip off the edge of your beard. 
+</div><div class="p">
+<sup>28&#160;</sup>“&#160;‘You shall not make any cuttings in your flesh for the dead, nor tattoo any marks on you. I am Yahweh. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘Don’t profane your daughter, to make her a prostitute; lest the land fall to prostitution, and the land become full of wickedness. 
+</div><div class="p">
+<sup>30&#160;</sup>“&#160;‘You shall keep my Sabbaths, and reverence my sanctuary; I am Yahweh. 
+</div><div class="p">
+<sup>31&#160;</sup>“&#160;‘Don’t turn to those who are mediums, nor to the wizards. Don’t seek them out, to be defiled by them. I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘You shall rise up before the gray head and honor the face of the elderly; and you shall fear your Elohim. I am Yahweh. 
+</div><div class="p">
+<sup>33&#160;</sup>“&#160;‘If a stranger lives as a foreigner with you in your land, you shall not do him wrong. 
+<sup>34&#160;</sup>The stranger who lives as a foreigner with you shall be to you as the native-born among you, and you shall love him as yourself; for you lived as foreigners in the land of Egypt. I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>35&#160;</sup>“&#160;‘You shall do no unrighteousness in judgment, in measures of length, of weight, or of quantity. 
+<sup>36&#160;</sup>You shall have just balances, just weights, a just ephah, I am Yahweh your Elohim, who brought you out of the land of Egypt. 
+</div><div class="p">
+<sup>37&#160;</sup>“&#160;‘You shall observe all my statutes and all my ordinances, and do them. I am Yahweh.’&#160;” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Moreover, you shall tell the children of Israel, ‘Anyone of the children of Israel, or of the strangers who live as foreigners in Israel, who gives any of his offspring to Molech shall surely be put to death. The people of the land shall stone that person with stones. 
+<sup>3&#160;</sup>I also will set my face against that person, and will cut him off from among his people, because he has given of his offspring to Molech, to defile my sanctuary, and to profane my set-apart name. 
+<sup>4&#160;</sup>If the people of the land all hide their eyes from that person when he gives of his offspring to Molech, and don’t put him to death, 
+<sup>5&#160;</sup>then I will set my face against that man and against his family, and will cut him off, and all who play the prostitute after him to play the prostitute with Molech, from among their people. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘The person that turns to those who are mediums and wizards, to play the prostitute after them, I will even set my face against that person, and will cut him off from among his people. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘Sanctify yourselves therefore, and be set-apart; for I am Yahweh your Elohim. 
+<sup>8&#160;</sup>You shall keep my statutes, and do them. I am Yahweh who sanctifies you. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘For everyone who curses his father or his mother shall surely be put to death. He has cursed his father or his mother. His blood shall be upon himself. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘The man who commits adultery with another man’s woman, even he who commits adultery with his neighbor’s woman, the adulterer and the adulteress shall surely be put to death. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘The man who lies with his father’s woman has uncovered his father’s nakedness. Both of them shall surely be put to death. Their blood shall be upon themselves. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘If a man lies with his daughter-in-law, both of them shall surely be put to death. They have committed a perversion. Their blood shall be upon themselves. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘If a man lies with a male, as with a woman, both of them have committed an abomination. They shall surely be put to death. Their blood shall be upon themselves. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘If a man takes a woman and her mother, it is wickedness. They shall be burned with fire, both he and they, that there may be no wickedness among you. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘If a man lies with an animal, he shall surely be put to death; and you shall kill the animal. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘If a woman approaches any animal and lies with it, you shall kill the woman and the animal. They shall surely be put to death. Their blood shall be upon them. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘If a man takes his sister—his father’s daughter, or his mother’s daughter—and sees her nakedness, and she sees his nakedness, it is a shameful thing. They shall be cut off in the sight of the children of their people. He has uncovered his sister’s nakedness. He shall bear his iniquity. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘If a man lies with a woman having her monthly period, and uncovers her nakedness, he has made her fountain naked, and she has uncovered the fountain of her blood. Both of them shall be cut off from among their people. 
+</div><div class="p">
+<sup>19&#160;</sup>“&#160;‘You shall not uncover the nakedness of your mother’s sister, nor of your father’s sister, for he has made his close relative naked. They shall bear their iniquity. 
+<sup>20&#160;</sup>If a man lies with his uncle’s woman, he has uncovered his uncle’s nakedness. They shall bear their sin. They shall die childless. 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘If a man takes his brother’s woman, it is an impurity. He has uncovered his brother’s nakedness. They shall be childless. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘You shall therefore keep all my statutes and all my ordinances, and do them, that the land where I am bringing you to dwell may not vomit you out. 
+<sup>23&#160;</sup>You shall not walk in the customs of the nation which I am casting out before you; for they did all these things, and therefore I abhorred them. 
+<sup>24&#160;</sup>But I have said to you, “You shall inherit their land, and I will give it to you to possess it, a land flowing with milk and honey.” I am Yahweh your Elohim, who has separated you from the peoples. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘You shall therefore make a distinction between the clean animal and the unclean, and between the unclean fowl and the clean. You shall not make yourselves abominable by animal, or by bird, or by anything with which the ground teems, which I have separated from you as unclean for you. 
+<sup>26&#160;</sup>You shall be set-apart to me, for I, Yahweh, am set-apart, and have set you apart from the peoples, that you should be mine. 
+</div><div class="p">
+<sup>27&#160;</sup>“&#160;‘A man or a woman that is a medium or is a wizard shall surely be put to death. They shall be stoned with stones. Their blood shall be upon themselves.’&#160;” 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses, “Speak to the priests, the sons of Aaron, and say to them, ‘A priest shall not defile himself for the dead among his people, 
+<sup>2&#160;</sup>except for his relatives that are near to him: for his mother, for his father, for his son, for his daughter, for his brother, 
+<sup>3&#160;</sup>and for his virgin sister who is near to him, who has had no man; for her he may defile himself. 
+<sup>4&#160;</sup>He shall not defile himself, being an owner among his people, to profane himself. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘They shall not shave their heads or shave off the corners of their beards or make any cuttings in their flesh. 
+<sup>6&#160;</sup>They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahweh made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘They shall not marry a woman who is a prostitute, or profane. A priest shall not marry a woman divorced from her man; for he is set-apart to his Elohim. 
+<sup>8&#160;</sup>Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahweh, who sanctify you, am set-apart. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘The daughter of any priest, if she profanes herself by playing the prostitute, she profanes her father. She shall be burned with fire. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘He who is the high priest among his brothers, upon whose head the anointing oil is poured, and who is consecrated to put on the garments, shall not let the hair of his head hang loose, or tear his clothes. 
+<sup>11&#160;</sup>He must not go in to any dead body, or defile himself for his father or for his mother. 
+<sup>12&#160;</sup>He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahweh. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘He shall take a woman in her virginity. 
+<sup>14&#160;</sup>He shall not marry a widow, or one divorced, or a woman who has been defiled, or a prostitute. He shall take a virgin of his own people as a woman. 
+<sup>15&#160;</sup>He shall not profane his offspring among his people, for I am Yahweh who sanctifies him.’&#160;” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>17&#160;</sup>“Say to Aaron, ‘None of your offspring throughout their generations who has a defect may approach to offer the bread of his Elohim. 
+<sup>18&#160;</sup>For whatever man he is that has a defect, he shall not draw near: a blind man, or a lame, or he who has a flat nose, or any deformity, 
+<sup>19&#160;</sup>or a man who has an injured foot, or an injured hand, 
+<sup>20&#160;</sup>or hunchbacked, or a dwarf, or one who has a defect in his eye, or an itching disease, or scabs, or who has damaged testicles. 
+<sup>21&#160;</sup>No man of the offspring of Aaron the priest who has a defect shall come near to offer the offerings of Yahweh made by fire. Since he has a defect, he shall not come near to offer the bread of his Elohim. 
+<sup>22&#160;</sup>He shall eat the bread of his Elohim, both of the most set-apart, and of the set-apart. 
+<sup>23&#160;</sup>He shall not come near to the veil, nor come near to the altar, because he has a defect; that he may not profane my sanctuaries, for I am Yahweh who sanctifies them.’&#160;” 
+</div><div class="p">
+<sup>24&#160;</sup>So Moses spoke to Aaron, and to his sons, and to all the children of Israel. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Tell Aaron and his sons to separate themselves from the set-apart things of the children of Israel, which they make set-apart to me, and that they not profane my set-apart name. I am Yahweh. 
+</div><div class="p">
+<sup>3&#160;</sup>“Tell them, ‘If anyone of all your offspring throughout your generations approaches the set-apart things which the children of Israel make set-apart to Yahweh, having his uncleanness on him, that soul shall be cut off from before me. I am Yahweh. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘Whoever of the offspring of Aaron is a leper or has a discharge shall not eat of the set-apart things until he is clean. Whoever touches anything that is unclean by the dead, or a man who has a seminal emission, 
+<sup>5&#160;</sup>or whoever touches any creeping thing by which he may be made unclean, or a man from whom he may become unclean, whatever uncleanness he has—<sup>6&#160;</sup>the person that touches any such shall be unclean until the evening, and shall not eat of the set-apart things unless he bathes his body in water. 
+<sup>7&#160;</sup>When the sun is down, he shall be clean; and afterward he shall eat of the set-apart things, because it is his bread. 
+<sup>8&#160;</sup>He shall not eat that which dies of itself or is torn by animals, defiling himself by it. I am Yahweh. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘They shall therefore follow my commandment, lest they bear sin for it and die in it, if they profane it. I am Yahweh who sanctifies them. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘No stranger shall eat of the set-apart thing: a foreigner living with the priests, or a hired servant, shall not eat of the set-apart thing. 
+<sup>11&#160;</sup>But if a priest buys a slave, purchased by his money, he shall eat of it; and those who are born in his house shall eat of his bread. 
+<sup>12&#160;</sup>If a priest’s daughter is married to an outsider, she shall not eat of the heave offering of the set-apart things. 
+<sup>13&#160;</sup>But if a priest’s daughter is a widow, or divorced, and has no child, and has returned to her father’s house as in her youth, she may eat of her father’s bread; but no stranger shall eat any of it. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘If a man eats something set-apart unwittingly, then he shall add the fifth part of its value to it, and shall give the set-apart thing to the priest. 
+<sup>15&#160;</sup>The priests shall not profane the set-apart things of the children of Israel, which they offer to Yahweh, 
+<sup>16&#160;</sup>and so cause them to bear the iniquity that brings guilt when they eat their set-apart things; for I am Yahweh who sanctifies them.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>18&#160;</sup>“Speak to Aaron, and to his sons, and to all the children of Israel, and say to them, ‘Whoever is of the house of Israel, or of the foreigners in Israel, who offers his offering, whether it is any of their vows or any of their free will offerings, which they offer to Yahweh for a burnt offering: 
+<sup>19&#160;</sup>that you may be accepted, you shall offer a male without defect, of the bulls, of the sheep, or of the goats. 
+<sup>20&#160;</sup>But you shall not offer whatever has a defect, for it shall not be acceptable for you. 
+<sup>21&#160;</sup>Whoever offers a sacrifice of peace offerings to Yahweh to accomplish a vow, or for a free will offering of the herd or of the flock, it shall be perfect to be accepted. It shall have no defect. 
+<sup>22&#160;</sup>You shall not offer what is blind, is injured, is maimed, has a wart, is festering, or has a running sore to Yahweh, nor make an offering by fire of them on the altar to Yahweh. 
+<sup>23&#160;</sup>Either a bull or a lamb that has any deformity or lacking in his parts, that you may offer for a free will offering; but for a vow it shall not be accepted. 
+<sup>24&#160;</sup>You must not offer to Yahweh that which has its testicles bruised, crushed, broken, or cut. You must not do this in your land. 
+<sup>25&#160;</sup>You must not offer any of these as the bread of your Elohim from the hand of a foreigner, because their corruption is in them. There is a defect in them. They shall not be accepted for you.’&#160;” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>27&#160;</sup>“When a bull, a sheep, or a goat is born, it shall remain seven days with its mother. From the eighth day on it shall be accepted for the offering of an offering made by fire to Yahweh. 
+<sup>28&#160;</sup>Whether it is a cow or ewe, you shall not kill it and its young both in one day. 
+</div><div class="p">
+<sup>29&#160;</sup>“When you sacrifice a sacrifice of thanksgiving to Yahweh, you shall sacrifice it so that you may be accepted. 
+<sup>30&#160;</sup>It shall be eaten on the same day; you shall leave none of it until the morning. I am Yahweh. 
+</div><div class="p">
+<sup>31&#160;</sup>“Therefore you shall keep my commandments, and do them. I am Yahweh. 
+<sup>32&#160;</sup>You shall not profane my set-apart name, but I will be made set-apart among the children of Israel. I am Yahweh who makes you set-apart, 
+<sup>33&#160;</sup>who brought you out of the land of Egypt, to be your Elohim. I am Yahweh.” 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘The set feasts of Yahweh, which you shall proclaim to be set-apart convocations, even these are my set feasts. 
+</div><div class="p">
+<sup>3&#160;</sup>“&#160;‘Six days shall work be done, but on the seventh day is a Sabbath of solemn rest, a set-apart convocation; you shall do no kind of work. It is a Sabbath to Yahweh in all your dwellings. 
+</div><div class="p">
+<sup>4&#160;</sup>“&#160;‘These are the set feasts of Yahweh, even set-apart convocations, which you shall proclaim in their appointed season. 
+<sup>5&#160;</sup>In the first month, on the fourteenth day of the month in the evening, is Yahweh’s Passover. 
+<sup>6&#160;</sup>On the fifteenth day of the same month is the feast of unleavened bread to Yahweh. Seven days you shall eat unleavened bread. 
+<sup>7&#160;</sup>In the first day you shall have a set-apart convocation. You shall do no regular work. 
+<sup>8&#160;</sup>But you shall offer an offering made by fire to Yahweh seven days. In the seventh day is a set-apart convocation. You shall do no regular work.’&#160;” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>10&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you have come into the land which I give to you, and shall reap its harvest, then you shall bring the sheaf of the first fruits of your harvest to the priest. 
+<sup>11&#160;</sup>He shall wave the sheaf before Yahweh, to be accepted for you. On the next day after the Sabbath the priest shall wave it. 
+<sup>12&#160;</sup>On the day when you wave the sheaf, you shall offer a male lamb without defect a year old for a burnt offering to Yahweh. 
+<sup>13&#160;</sup>The meal offering with it shall be two tenths of an ephah 
+<sup>14&#160;</sup>You must not eat bread, or roasted grain, or fresh grain, until this same day, until you have brought the offering of your Elohim. This is a statute forever throughout your generations in all your dwellings. 
+</div><div class="p">
+<sup>15&#160;</sup>“&#160;‘You shall count from the next day after the Sabbath, from the day that you brought the sheaf of the wave offering: seven Sabbaths shall be completed. 
+<sup>16&#160;</sup>The next day after the seventh Sabbath you shall count fifty days; and you shall offer a new meal offering to Yahweh. 
+<sup>17&#160;</sup>You shall bring out of your habitations two loaves of bread for a wave offering made of two tenths of an ephah of fine flour. They shall be baked with yeast, for first fruits to Yahweh. 
+<sup>18&#160;</sup>You shall present with the bread seven lambs without defect a year old, one young bull, and two rams. They shall be a burnt offering to Yahweh, with their meal offering and their drink offerings, even an offering made by fire, of a sweet aroma to Yahweh. 
+<sup>19&#160;</sup>You shall offer one male goat for a sin offering, and two male lambs a year old for a sacrifice of peace offerings. 
+<sup>20&#160;</sup>The priest shall wave them with the bread of the first fruits for a wave offering before Yahweh, with the two lambs. They shall be set-apart to Yahweh for the priest. 
+<sup>21&#160;</sup>You shall make proclamation on the same day that there shall be a set-apart convocation to you. You shall do no regular work. This is a statute forever in all your dwellings throughout your generations. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘When you reap the harvest of your land, you must not wholly reap into the corners of your field. You must not gather the gleanings of your harvest. You must leave them for the poor and for the foreigner. I am Yahweh your Elohim.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>24&#160;</sup>“Speak to the children of Israel, saying, ‘In the seventh month, on the first day of the month, there shall be a solemn rest for you, a memorial of blowing of trumpets, a set-apart convocation. 
+<sup>25&#160;</sup>You shall do no regular work. You shall offer an offering made by fire to Yahweh.’&#160;” 
+</div><div class="p">
+<sup>26&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>27&#160;</sup>“However on the tenth day of this seventh month is the day of atonement. It shall be a set-apart convocation to you. You shall afflict yourselves and you shall offer an offering made by fire to Yahweh. 
+<sup>28&#160;</sup>You shall do no kind of work in that same day, for it is a day of atonement, to make atonement for you before Yahweh your Elohim. 
+<sup>29&#160;</sup>For whoever it is who shall not deny himself in that same day shall be cut off from his people. 
+<sup>30&#160;</sup>Whoever does any kind of work in that same day, I will destroy that person from among his people. 
+<sup>31&#160;</sup>You shall do no kind of work: it is a statute forever throughout your generations in all your dwellings. 
+<sup>32&#160;</sup>It shall be a Sabbath of solemn rest for you, and you shall deny yourselves. In the ninth day of the month at evening, from evening to evening, you shall keep your Sabbath.” 
+</div><div class="p">
+<sup>33&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>34&#160;</sup>“Speak to the children of Israel, and say, ‘On the fifteenth day of this seventh month is the feast of booths for seven days to Yahweh. 
+<sup>35&#160;</sup>On the first day shall be a set-apart convocation. You shall do no regular work. 
+<sup>36&#160;</sup>Seven days you shall offer an offering made by fire to Yahweh. On the eighth day shall be a set-apart convocation to you. You shall offer an offering made by fire to Yahweh. It is a solemn assembly; you shall do no regular work. 
+</div><div class="p">
+<sup>37&#160;</sup>“&#160;‘These are the appointed feasts of Yahweh which you shall proclaim to be set-apart convocations, to offer an offering made by fire to Yahweh, a burnt offering, a meal offering, a sacrifice, and drink offerings, each on its own day—<sup>38&#160;</sup>in addition to the Sabbaths of Yahweh, and in addition to your gifts, and in addition to all your vows, and in addition to all your free will offerings, which you give to Yahweh. 
+</div><div class="p">
+<sup>39&#160;</sup>“&#160;‘So on the fifteenth day of the seventh month, when you have gathered in the fruits of the land, you shall keep the feast of Yahweh seven days. On the first day shall be a solemn rest, and on the eighth day shall be a solemn rest. 
+<sup>40&#160;</sup>You shall take on the first day the fruit of majestic trees, branches of palm trees, and boughs of thick trees, and willows of the brook; and you shall rejoice before Yahweh your Elohim seven days. 
+<sup>41&#160;</sup>You shall keep it as a feast to Yahweh seven days in the year. It is a statute forever throughout your generations. You shall keep it in the seventh month. 
+<sup>42&#160;</sup>You shall dwell in temporary shelters 
+<sup>43&#160;</sup>that your generations may know that I made the children of Israel to dwell in temporary shelters when I brought them out of the land of Egypt. I am Yahweh your Elohim.’&#160;” 
+</div><div class="p">
+<sup>44&#160;</sup>So Moses declared to the children of Israel the appointed feasts of Yahweh. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Command the children of Israel, that they bring to you pure olive oil beaten for the light, to cause a lamp to burn continually. 
+<sup>3&#160;</sup>Outside of the veil of the Testimony, in the Tent of Meeting, Aaron shall keep it in order from evening to morning before Yahweh continually. It shall be a statute forever throughout your generations. 
+<sup>4&#160;</sup>He shall keep in order the lamps on the pure gold lamp stand before Yahweh continually. 
+</div><div class="p">
+<sup>5&#160;</sup>“You shall take fine flour, and bake twelve cakes of it: two tenths of an ephah shall be in one cake. 
+<sup>6&#160;</sup>You shall set them in two rows, six on a row, on the pure gold table before Yahweh. 
+<sup>7&#160;</sup>You shall put pure frankincense on each row, that it may be to the bread for a memorial, even an offering made by fire to Yahweh. 
+<sup>8&#160;</sup>Every Sabbath day he shall set it in order before Yahweh continually. It is an everlasting covenant on the behalf of the children of Israel. 
+<sup>9&#160;</sup>It shall be for Aaron and his sons. They shall eat it in a set-apart place; for it is most set-apart to him of the offerings of Yahweh made by fire by a perpetual statute.” 
+</div><div class="p">
+<sup>10&#160;</sup>The son of an Israelite woman, whose father was an Egyptian, went out among the children of Israel; and the son of the Israelite woman and a man of Israel strove together in the camp. 
+<sup>11&#160;</sup>The son of the Israelite woman blasphemed the Name, and cursed; and they brought him to Moses. His mother’s name was Shelomith, the daughter of Dibri, of the tribe of Dan. 
+<sup>12&#160;</sup>They put him in custody until Yahweh’s will should be declared to them. 
+<sup>13&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>14&#160;</sup>“Bring him who cursed out of the camp; and let all who heard him lay their hands on his head, and let all the congregation stone him. 
+<sup>15&#160;</sup>You shall speak to the children of Israel, saying, ‘Whoever curses his Elohim shall bear his sin. 
+<sup>16&#160;</sup>He who blasphemes Yahweh’s name, he shall surely be put to death. All the congregation shall certainly stone him. The foreigner as well as the native-born shall be put to death when he blasphemes the Name. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘He who strikes any man mortally shall surely be put to death. 
+<sup>18&#160;</sup>He who strikes an animal mortally shall make it good, life for life. 
+<sup>19&#160;</sup>If anyone injures his neighbor, it shall be done to him as he has done: 
+<sup>20&#160;</sup>fracture for fracture, eye for eye, tooth for tooth. It shall be done to him as he has injured someone. 
+<sup>21&#160;</sup>He who kills an animal shall make it good; and he who kills a man shall be put to death. 
+<sup>22&#160;</sup>You shall have one kind of law for the foreigner as well as the native-born; for I am Yahweh your Elohim.’&#160;” 
+</div><div class="p">
+<sup>23&#160;</sup>Moses spoke to the children of Israel; and they brought him who had cursed out of the camp, and stoned him with stones. The children of Israel did as Yahweh commanded Moses. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Moses on Mount Sinai, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you come into the land which I give you, then the land shall keep a Sabbath to Yahweh. 
+<sup>3&#160;</sup>You shall sow your field six years, and you shall prune your vineyard six years, and gather in its fruits; 
+<sup>4&#160;</sup>but in the seventh year there shall be a Sabbath of solemn rest for the land, a Sabbath to Yahweh. You shall not sow your field or prune your vineyard. 
+<sup>5&#160;</sup>What grows of itself in your harvest you shall not reap, and you shall not gather the grapes of your undressed vine. It shall be a year of solemn rest for the land. 
+<sup>6&#160;</sup>The Sabbath of the land shall be for food for you; for yourself, for your servant, for your maid, for your hired servant, and for your stranger, who lives as a foreigner with you. 
+<sup>7&#160;</sup>For your livestock also, and for the animals that are in your land, shall all its increase be for food. 
+</div><div class="p">
+<sup>8&#160;</sup>“&#160;‘You shall count off seven Sabbaths of years, seven times seven years; and there shall be to you the days of seven Sabbaths of years, even forty-nine years. 
+<sup>9&#160;</sup>Then you shall sound the loud trumpet on the tenth day of the seventh month. On the Day of Atonement you shall sound the trumpet throughout all your land. 
+<sup>10&#160;</sup>You shall make the fiftieth year set-apart, and proclaim liberty throughout the land to all its inhabitants. It shall be a jubilee to you; and each of you shall return to his own property, and each of you shall return to his family. 
+<sup>11&#160;</sup>That fiftieth year shall be a jubilee to you. In it you shall not sow, neither reap that which grows of itself, nor gather from the undressed vines. 
+<sup>12&#160;</sup>For it is a jubilee; it shall be set-apart to you. You shall eat of its increase out of the field. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘In this Year of Jubilee each of you shall return to his property. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘If you sell anything to your neighbor, or buy from your neighbor, you shall not wrong one another. 
+<sup>15&#160;</sup>According to the number of years after the Jubilee you shall buy from your neighbor. According to the number of years of the crops he shall sell to you. 
+<sup>16&#160;</sup>According to the length of the years you shall increase its price, and according to the shortness of the years you shall diminish its price; for he is selling the number of the crops to you. 
+<sup>17&#160;</sup>You shall not wrong one another, but you shall fear your Elohim; for I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘Therefore you shall do my statutes, and keep my ordinances and do them; and you shall dwell in the land in safety. 
+<sup>19&#160;</sup>The land shall yield its fruit, and you shall eat your fill, and dwell therein in safety. 
+<sup>20&#160;</sup>If you said, “What shall we eat the seventh year? Behold, we shall not sow, nor gather in our increase;” 
+<sup>21&#160;</sup>then I will command my blessing on you in the sixth year, and it shall bear fruit for the three years. 
+<sup>22&#160;</sup>You shall sow the eighth year, and eat of the fruits from the old store until the ninth year. Until its fruits come in, you shall eat the old store. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘The land shall not be sold in perpetuity, for the land is mine; for you are strangers and live as foreigners with me. 
+<sup>24&#160;</sup>In all the land of your possession you shall grant a redemption for the land. 
+</div><div class="p">
+<sup>25&#160;</sup>“&#160;‘If your brother becomes poor, and sells some of his possessions, then his kinsman who is next to him shall come, and redeem that which his brother has sold. 
+<sup>26&#160;</sup>If a man has no one to redeem it, and he becomes prosperous and finds sufficient means to redeem it, 
+<sup>27&#160;</sup>then let him reckon the years since its sale, and restore the surplus to the man to whom he sold it; and he shall return to his property. 
+<sup>28&#160;</sup>But if he isn’t able to get it back for himself, then what he has sold shall remain in the hand of him who has bought it until the Year of Jubilee. In the Jubilee it shall be released, and he shall return to his property. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘If a man sells a dwelling house in a walled city, then he may redeem it within a whole year after it has been sold. For a full year he shall have the right of redemption. 
+<sup>30&#160;</sup>If it isn’t redeemed within the space of a full year, then the house that is in the walled city shall be made sure in perpetuity to him who bought it, throughout his generations. It shall not be released in the Jubilee. 
+<sup>31&#160;</sup>But the houses of the villages which have no wall around them shall be accounted for with the fields of the country: they may be redeemed, and they shall be released in the Jubilee. 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘Nevertheless, in the cities of the Levites, the Levites may redeem the houses in the cities of their possession at any time. 
+<sup>33&#160;</sup>The Levites may redeem the house that was sold, and the city of his possession, and it shall be released in the Jubilee; for the houses of the cities of the Levites are their possession among the children of Israel. 
+<sup>34&#160;</sup>But the field of the pasture lands of their cities may not be sold, for it is their perpetual possession. 
+</div><div class="p">
+<sup>35&#160;</sup>“&#160;‘If your brother has become poor, and his hand can’t support himself among you, then you shall uphold him. He shall live with you like an alien and a temporary resident. 
+<sup>36&#160;</sup>Take no interest from him or profit; but fear your Elohim, that your brother may live among you. 
+<sup>37&#160;</sup>You shall not lend him your money at interest, nor give him your food for profit. 
+<sup>38&#160;</sup>I am Yahweh your Elohim, who brought you out of the land of Egypt, to give you the land of Canaan, and to be your Elohim. 
+</div><div class="p">
+<sup>39&#160;</sup>“&#160;‘If your brother has grown poor among you, and sells himself to you, you shall not make him to serve as a slave. 
+<sup>40&#160;</sup>As a hired servant, and as a temporary resident, he shall be with you; he shall serve with you until the Year of Jubilee. 
+<sup>41&#160;</sup>Then he shall go out from you, he and his children with him, and shall return to his own family, and to the possession of his fathers. 
+<sup>42&#160;</sup>For they are my servants, whom I brought out of the land of Egypt. They shall not be sold as slaves. 
+<sup>43&#160;</sup>You shall not rule over him with harshness, but shall fear your Elohim. 
+</div><div class="p">
+<sup>44&#160;</sup>“&#160;‘As for your male and your female slaves, whom you may have from the nations that are around you, from them you may buy male and female slaves. 
+<sup>45&#160;</sup>Moreover, of the children of the aliens who live among you, of them you may buy, and of their families who are with you, which they have conceived in your land; and they will be your property. 
+<sup>46&#160;</sup>You may make them an inheritance for your children after you, to hold for a possession. Of them you may take your slaves forever, but over your brothers the children of Israel you shall not rule, one over another, with harshness. 
+</div><div class="p">
+<sup>47&#160;</sup>“&#160;‘If an alien or temporary resident with you becomes rich, and your brother beside him has grown poor, and sells himself to the stranger or foreigner living among you, or to a member of the stranger’s family, 
+<sup>48&#160;</sup>after he is sold he may be redeemed. One of his brothers may redeem him; 
+<sup>49&#160;</sup>or his uncle, or his uncle’s son, may redeem him, or any who is a close relative to him of his family may redeem him; or if he has grown rich, he may redeem himself. 
+<sup>50&#160;</sup>He shall reckon with him who bought him from the year that he sold himself to him to the Year of Jubilee. The price of his sale shall be according to the number of years; he shall be with him according to the time of a hired servant. 
+<sup>51&#160;</sup>If there are yet many years, according to them he shall give back the price of his redemption out of the money that he was bought for. 
+<sup>52&#160;</sup>If there remain but a few years to the year of jubilee, then he shall reckon with him; according to his years of service he shall give back the price of his redemption. 
+<sup>53&#160;</sup>As a servant hired year by year shall he be with him. He shall not rule with harshness over him in your sight. 
+<sup>54&#160;</sup>If he isn’t redeemed by these means, then he shall be released in the Year of Jubilee: he and his children with him. 
+<sup>55&#160;</sup>For to me the children of Israel are servants; they are my servants whom I brought out of the land of Egypt. I am Yahweh your Elohim. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘You shall make for yourselves no idols, and you shall not raise up a carved image or a pillar, and you shall not place any figured stone in your land, to bow down to it; for I am Yahweh your Elohim. 
+</div><div class="p">
+<sup>2&#160;</sup>“&#160;‘You shall keep my Sabbaths, and have reverence for my sanctuary. I am Yahweh. 
+</div><div class="p">
+<sup>3&#160;</sup>“&#160;‘If you walk in my statutes and keep my commandments, and do them, 
+<sup>4&#160;</sup>then I will give you your rains in their season, and the land shall yield its increase, and the trees of the field shall yield their fruit. 
+<sup>5&#160;</sup>Your threshing shall continue until the vintage, and the vintage shall continue until the sowing time. You shall eat your bread to the full, and dwell in your land safely. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘I will give peace in the land, and you shall lie down, and no one will make you afraid. I will remove evil animals out of the land, neither shall the sword go through your land. 
+<sup>7&#160;</sup>You shall chase your enemies, and they shall fall before you by the sword. 
+<sup>8&#160;</sup>Five of you shall chase a hundred, and a hundred of you shall chase ten thousand; and your enemies shall fall before you by the sword. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘I will have respect for you, make you fruitful, multiply you, and will establish my covenant with you. 
+<sup>10&#160;</sup>You shall eat old supplies long kept, and you shall move out the old because of the new. 
+<sup>11&#160;</sup>I will set my tent among you, and my soul won’t abhor you. 
+<sup>12&#160;</sup>I will walk among you, and will be your Elohim, and you will be my people. 
+<sup>13&#160;</sup>I am Yahweh your Elohim, who brought you out of the land of Egypt, that you should not be their slaves. I have broken the bars of your yoke, and made you walk upright. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘But if you will not listen to me, and will not do all these commandments, 
+<sup>15&#160;</sup>and if you shall reject my statutes, and if your soul abhors my ordinances, so that you will not do all my commandments, but break my covenant, 
+<sup>16&#160;</sup>I also will do this to you: I will appoint terror over you, even consumption and fever, that shall consume the eyes, and make the soul to pine away. You will sow your seed in vain, for your enemies will eat it. 
+<sup>17&#160;</sup>I will set my face against you, and you will be struck before your enemies. Those who hate you will rule over you; and you will flee when no one pursues you. 
+</div><div class="p">
+<sup>18&#160;</sup>“&#160;‘If you in spite of these things will not listen to me, then I will chastise you seven times more for your sins. 
+<sup>19&#160;</sup>I will break the pride of your power, and I will make your sky like iron, and your soil like bronze. 
+<sup>20&#160;</sup>Your strength will be spent in vain; for your land won’t yield its increase, neither will the trees of the land yield their fruit. 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘If you walk contrary to me, and won’t listen to me, then I will bring seven times more plagues on you according to your sins. 
+<sup>22&#160;</sup>I will send the wild animals among you, which will rob you of your children, destroy your livestock, and make you few in number. Your roads will become desolate. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘If by these things you won’t be turned back to me, but will walk contrary to me, 
+<sup>24&#160;</sup>then I will also walk contrary to you; and I will strike you, even I, seven times for your sins. 
+<sup>25&#160;</sup>I will bring a sword upon you that will execute the vengeance of the covenant. You will be gathered together within your cities, and I will send the pestilence among you. You will be delivered into the hand of the enemy. 
+<sup>26&#160;</sup>When I break your staff of bread, ten women shall bake your bread in one oven, and they shall deliver your bread again by weight. You shall eat, and not be satisfied. 
+</div><div class="p">
+<sup>27&#160;</sup>“&#160;‘If you in spite of this won’t listen to me, but walk contrary to me, 
+<sup>28&#160;</sup>then I will walk contrary to you in wrath. I will also chastise you seven times for your sins. 
+<sup>29&#160;</sup>You will eat the flesh of your sons, and you will eat the flesh of your daughters. 
+<sup>30&#160;</sup>I will destroy your high places, and cut down your incense altars, and cast your dead bodies upon the bodies of your idols; and my soul will abhor you. 
+<sup>31&#160;</sup>I will lay your cities waste, and will bring your sanctuaries to desolation. I will not take delight in the sweet fragrance of your offerings. 
+<sup>32&#160;</sup>I will bring the land into desolation, and your enemies who dwell in it will be astonished at it. 
+<sup>33&#160;</sup>I will scatter you among the nations, and I will draw out the sword after you. Your land will be a desolation, and your cities shall be a waste. 
+<sup>34&#160;</sup>Then the land will enjoy its Sabbaths as long as it lies desolate and you are in your enemies’ land. Even then the land will rest and enjoy its Sabbaths. 
+<sup>35&#160;</sup>As long as it lies desolate it shall have rest, even the rest which it didn’t have in your Sabbaths when you lived on it. 
+</div><div class="p">
+<sup>36&#160;</sup>“&#160;‘As for those of you who are left, I will send a faintness into their hearts in the lands of their enemies. The sound of a driven leaf will put them to flight; and they shall flee, as one flees from the sword. They will fall when no one pursues. 
+<sup>37&#160;</sup>They will stumble over one another, as it were before the sword, when no one pursues. You will have no power to stand before your enemies. 
+<sup>38&#160;</sup>You will perish among the nations. The land of your enemies will eat you up. 
+<sup>39&#160;</sup>Those of you who are left will pine away in their iniquity in your enemies’ lands; and also in the iniquities of their fathers they shall pine away with them. 
+</div><div class="p">
+<sup>40&#160;</sup>“&#160;‘If they confess their iniquity and the iniquity of their fathers, in their trespass which they trespassed against me; and also that because they walked contrary to me, 
+<sup>41&#160;</sup>I also walked contrary to them, and brought them into the land of their enemies; if then their uncircumcised heart is humbled, and they then accept the punishment of their iniquity, 
+<sup>42&#160;</sup>then I will remember my covenant with Jacob, my covenant with Isaac, and also my covenant with Abraham; and I will remember the land. 
+<sup>43&#160;</sup>The land also will be left by them, and will enjoy its Sabbaths while it lies desolate without them; and they will accept the punishment of their iniquity because they rejected my ordinances, and their soul abhorred my statutes. 
+<sup>44&#160;</sup>Yet for all that, when they are in the land of their enemies, I will not reject them, neither will I abhor them, to destroy them utterly and to break my covenant with them; for I am Yahweh their Elohim. 
+<sup>45&#160;</sup>But I will for their sake remember the covenant of their ancestors, whom I brought out of the land of Egypt in the sight of the nations, that I might be their Elohim. I am Yahweh.’&#160;” 
+</div><div class="p">
+<sup>46&#160;</sup>These are the statutes, ordinances, and laws, which Yahweh made between him and the children of Israel in Mount Sinai by Moses. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and say to them, ‘When a man consecrates a person to Yahweh in a vow, according to your valuation, 
+<sup>3&#160;</sup>your valuation of a male from twenty years old to sixty years old shall be fifty shekels of silver, according to the shekel of the sanctuary. 
+<sup>4&#160;</sup>If she is a female, then your valuation shall be thirty shekels. 
+<sup>5&#160;</sup>If the person is from five years old to twenty years old, then your valuation shall be for a male twenty shekels, and for a female ten shekels. 
+<sup>6&#160;</sup>If the person is from a month old to five years old, then your valuation shall be for a male five shekels of silver, and for a female your valuation shall be three shekels of silver. 
+<sup>7&#160;</sup>If the person is from sixty years old and upward; if he is a male, then your valuation shall be fifteen shekels, and for a female ten shekels. 
+<sup>8&#160;</sup>But if he is poorer than your valuation, then he shall be set before the priest, and the priest shall assign a value to him. The priest shall assign a value according to his ability to pay. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘If it is an animal of which men offer an offering to Yahweh, all that any man gives of such to Yahweh becomes set-apart. 
+<sup>10&#160;</sup>He shall not alter it, nor exchange it, a good for a bad, or a bad for a good. If he shall at all exchange animal for animal, then both it and that for which it is exchanged shall be set-apart. 
+<sup>11&#160;</sup>If it is any unclean animal, of which they do not offer as an offering to Yahweh, then he shall set the animal before the priest; 
+<sup>12&#160;</sup>and the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall be. 
+<sup>13&#160;</sup>But if he will indeed redeem it, then he shall add the fifth part of it to its valuation. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘When a man dedicates his house to be set-apart to Yahweh, then the priest shall evaluate it, whether it is good or bad. As the priest evaluates it, so it shall stand. 
+<sup>15&#160;</sup>If he who dedicates it will redeem his house, then he shall add the fifth part of the money of your valuation to it, and it shall be his. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘If a man dedicates to Yahweh part of the field of his possession, then your valuation shall be according to the seed for it. The sowing of a homer of silver. 
+<sup>17&#160;</sup>If he dedicates his field from the Year of Jubilee, according to your valuation it shall stand. 
+<sup>18&#160;</sup>But if he dedicates his field after the Jubilee, then the priest shall reckon to him the money according to the years that remain to the Year of Jubilee; and an abatement shall be made from your valuation. 
+<sup>19&#160;</sup>If he who dedicated the field will indeed redeem it, then he shall add the fifth part of the money of your valuation to it, and it shall remain his. 
+<sup>20&#160;</sup>If he will not redeem the field, or if he has sold the field to another man, it shall not be redeemed any more; 
+<sup>21&#160;</sup>but the field, when it goes out in the Jubilee, shall be set-apart to Yahweh, as a devoted field. It shall be owned by the priests. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘If he dedicates a field to Yahweh which he has bought, which is not of the field of his possession, 
+<sup>23&#160;</sup>then the priest shall reckon to him the worth of your valuation up to the Year of Jubilee; and he shall give your valuation on that day, as a set-apart thing to Yahweh. 
+<sup>24&#160;</sup>In the Year of Jubilee the field shall return to him from whom it was bought, even to him to whom the possession of the land belongs. 
+<sup>25&#160;</sup>All your valuations shall be according to the shekel of the sanctuary: twenty gerahs 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘However the firstborn among animals, which belongs to Yahweh as a firstborn, no man may dedicate, whether an ox or a sheep. It is Yahweh’s. 
+<sup>27&#160;</sup>If it is an unclean animal, then he shall buy it back according to your valuation, and shall add to it the fifth part of it; or if it isn’t redeemed, then it shall be sold according to your valuation. 
+</div><div class="p">
+<sup>28&#160;</sup>“&#160;‘Notwithstanding, no devoted thing that a man devotes to Yahweh of all that he has, whether of man or animal, or of the field of his possession, shall be sold or redeemed. Everything that is permanently devoted is most set-apart to Yahweh. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘No one devoted to destruction, who shall be devoted from among men, shall be ransomed. He shall surely be put to death. 
+</div><div class="p">
+<sup>30&#160;</sup>“&#160;‘All the tithe of the land, whether of the seed of the land or of the fruit of the trees, is Yahweh’s. It is set-apart to Yahweh. 
+<sup>31&#160;</sup>If a man redeems anything of his tithe, he shall add a fifth part to it. 
+<sup>32&#160;</sup>All the tithe of the herds or the flocks, whatever passes under the rod, the tenth shall be set-apart to Yahweh. 
+<sup>33&#160;</sup>He shall not examine whether it is good or bad, neither shall he exchange it. If he exchanges it at all, then both it and that for which it is exchanged shall be set-apart. It shall not be redeemed.’&#160;” 
+</div><div class="p">
+<sup>34&#160;</sup>These are the commandments which Yahweh commanded Moses for the children of Israel on Mount Sinai. </div></div><script src="../main.js"></script></body></html>

--- a/book/malachi.html
+++ b/book/malachi.html
@@ -3,6 +3,47 @@
 <head>
 <title>Malachi</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,83 +53,88 @@
 <div class="main">
 <!-- MAL World English Scripture (WES) -->
 <h1 class="booklabel">Malachi</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>A revelation, Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word to Israel by Malachi. 
-</p><p>
-<span class="v">2&#160;</span>“I have loved you,” says Yahweh. 
-</p><p>Yet you say, “How have you loved us?” 
-</p><p>“Wasn’t Esau Jacob’s brother?” says Yahweh, “Yet I loved Jacob; 
-<span class="v">3&#160;</span>but Esau I hated, and made his mountains a desolation, and gave his heritage to the jackals of the wilderness.” 
-<span class="v">4&#160;</span>Whereas Edom says, “We are beaten down, but we will return and build the waste places,” Yahweh of Armies says, “They shall build, but I will throw down; and men will call them ‘The Wicked Land,’ even the people against whom Yahweh shows wrath forever.” 
-</p><p>
-<span class="v">5&#160;</span>Your eyes will see, and you will say, “Yahweh is great—even beyond the border of Israel!” 
-</p><p>
-<span class="v">6&#160;</span>“A son honors his father, and a servant his master. If I am a father, then where is my honor? And if I am a master, where is the respect due me?” says Yahweh of Armies to you priests who despise my name. “You say, ‘How have we despised your name?’ 
-<span class="v">7&#160;</span>You offer polluted bread on my altar. You say, ‘How have we polluted you?’ In that you say, ‘Yahweh’s table is contemptible.’ 
-<span class="v">8&#160;</span>When you offer the blind for sacrifice, isn’t that evil? And when you offer the lame and sick, isn’t that evil? Present it now to your governor! Will he be pleased with you? Or will he accept your person?” says Yahweh of Armies. 
-</p><p>
-<span class="v">9&#160;</span>“Now, please entreat the favor of Elohim,<span class="f">+ \fr 1:9 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> that he may be gracious to us. With this, will he accept any of you?” says Yahweh of Armies. 
-</p><p>
-<span class="v">10&#160;</span>“Oh that there were one among you who would shut the doors, that you might not kindle fire on my altar in vain! I have no pleasure in you,” says Yahweh of Armies, “neither will I accept an offering at your hand. 
-<span class="v">11&#160;</span>For from the rising of the sun even to its going down, my name is great among the nations, and in every place incense will be offered to my name, and a pure offering; for my name is great among the nations,” says Yahweh of Armies. 
-<span class="v">12&#160;</span>“But you profane it when you say, ‘Yahweh’s table is polluted, and its fruit, even its food, is contemptible.’ 
-<span class="v">13&#160;</span>You say also, ‘Behold,<span class="f">+ \fr 1:13 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> what a weariness it is!’ And you have sniffed at it”, says Yahweh of Armies; “and you have brought that which was taken by violence, the lame, and the sick; thus you bring the offering. Should I accept this at your hand?” says Yahweh. 
-</p><p>
-<span class="v">14&#160;</span>“But the deceiver is cursed who has in his flock a male, and vows and sacrifices to the Lord<span class="f">+ \fr 1:14 \ft The word translated “Lord” is “Adonai.”</span> a defective thing; for I am a great King,” says Yahweh of Armies, “and my name is awesome among the nations.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>“Now, you priests, this commandment is for you. 
-<span class="v">2&#160;</span>If you will not listen, and if you will not take it to heart, to give glory to my name,” says Yahweh of Armies, “then I will send the curse on you, and I will curse your blessings. Indeed, I have cursed them already, because you do not take it to heart. 
-<span class="v">3&#160;</span>Behold, I will rebuke your offspring,<span class="f">+ \fr 2:3 \ft or, seed</span> and will spread dung on your faces, even the dung of your feasts; and you will be taken away with it. 
-<span class="v">4&#160;</span>You will know that I have sent this commandment to you, that my covenant may be with Levi,” says Yahweh of Armies. 
-<span class="v">5&#160;</span>“My covenant was with him of life and peace; and I gave them to him that he might be reverent toward me; and he was reverent toward me, and stood in awe of my name. 
-<span class="v">6&#160;</span>The law of truth was in his mouth, and unrighteousness was not found in his lips. He walked with me in peace and uprightness, and turned many away from iniquity. 
-<span class="v">7&#160;</span>For the priest’s lips should keep knowledge, and they should seek the law at his mouth; for he is the messenger of Yahweh of Armies. 
-<span class="v">8&#160;</span>But you have turned away from the path. You have caused many to stumble in the law. You have corrupted the covenant of Levi,” says Yahweh of Armies. 
-<span class="v">9&#160;</span>“Therefore I have also made you contemptible and wicked before all the people, according to the way you have not kept my ways, but have had respect for persons in the law. 
-<span class="v">10&#160;</span>Don’t we all have one father? Hasn’t one Elohim created us? Why do we deal treacherously every man against his brother, profaning the covenant of our fathers? 
-<span class="v">11&#160;</span>Judah has dealt treacherously, and an abomination is committed in Israel and in Jerusalem; for Judah has profaned the set-apartness of Yahweh which he loves, and has owned the daughter of a foreign elohim. 
-<span class="v">12&#160;</span>Yahweh will cut off the man who does this, him who wakes and him who answers, out of the tents of Jacob and him who offers an offering to Yahweh of Armies. 
-</p><p>
-<span class="v">13&#160;</span>“This again you do: you cover Yahweh’s altar with tears, with weeping, and with sighing, because he doesn’t regard the offering any more, neither receives it with good will at your hand. 
-<span class="v">14&#160;</span>Yet you say, ‘Why?’ Because Yahweh has been witness between you and the woman of your youth, against whom you have dealt treacherously, though she is your companion and the woman of your covenant. 
-<span class="v">15&#160;</span>Did he not make you one, although he had the residue of the Spirit? Why one? He sought elohimly offspring. Therefore take heed to your spirit, and let no one deal treacherously against the woman of his youth. 
-<span class="v">16&#160;</span>One who hates and divorces”, says Yahweh, the Elohim of Israel, “covers his garment with violence!” says Yahweh of Armies. “Therefore pay attention to your spirit, that you don’t be unfaithful. 
-</p><p>
-<span class="v">17&#160;</span>You have wearied Yahweh with your words. Yet you say, ‘How have we wearied him?’ In that you say, ‘Everyone who does evil is good in Yahweh’s sight, and he delights in them;’ or ‘Where is the Elohim of justice?’ 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>“Behold, I send my messenger, and he will prepare the way before me! The Lord, whom you seek, will suddenly come to his temple. Behold, the messenger of the covenant, whom you desire, is coming!” says Yahweh of Armies. 
-<span class="v">2&#160;</span>“But who can endure the day of his coming? And who will stand when he appears? For he is like a refiner’s fire, and like launderers’ soap; 
-<span class="v">3&#160;</span>and he will sit as a refiner and purifier of silver, and he will purify the sons of Levi, and refine them as gold and silver; and they shall offer to Yahweh offerings in righteousness. 
-<span class="v">4&#160;</span>Then the offering of Judah and Jerusalem will be pleasant to Yahweh as in the days of old and as in ancient years. 
-</p><p>
-<span class="v">5&#160;</span>I will come near to you to judgment. I will be a swift witness against the sorcerers, against the adulterers, against the perjurers, and against those who oppress the hireling in his wages, the widow, and the fatherless, and who deprive the foreigner of justice, and don’t fear me,” says Yahweh of Armies. 
-</p><p>
-<span class="v">6&#160;</span>“For I, Yahweh, don’t change; therefore you, sons of Jacob, are not consumed. 
-<span class="v">7&#160;</span>From the days of your fathers you have turned away from my ordinances and have not kept them. Return to me, and I will return to you,” says Yahweh of Armies. “But you say, ‘How shall we return?’ 
-</p><p>
-<span class="v">8&#160;</span>Will a man rob Elohim? Yet you rob me! But you say, ‘How have we robbed you?’ In tithes and offerings. 
-<span class="v">9&#160;</span>You are cursed with the curse; for you rob me, even this whole nation. 
-<span class="v">10&#160;</span>Bring the whole tithe into the storehouse, that there may be food in my house, and test me now in this,” says Yahweh of Armies, “if I will not open you the windows of heaven, and pour you out a blessing, that there will not be enough room for. 
-<span class="v">11&#160;</span>I will rebuke the devourer for your sakes, and he shall not destroy the fruits of your ground; neither shall your vine cast its fruit before its time in the field,” says Yahweh of Armies. 
-<span class="v">12&#160;</span>“All nations shall call you blessed, for you will be a delightful land,” says Yahweh of Armies. 
-</p><p>
-<span class="v">13&#160;</span>“Your words have been harsh against me,” says Yahweh. “Yet you say, ‘What have we spoken against you?’ 
-<span class="v">14&#160;</span>You have said, ‘It is vain to serve Elohim,’ and ‘What profit is it that we have followed his instructions and that we have walked mournfully before Yahweh of Armies? 
-<span class="v">15&#160;</span>Now we call the proud happy; yes, those who work wickedness are built up; yes, they tempt Elohim, and escape.’ 
-</p><p>
-<span class="v">16&#160;</span>Then those who feared Yahweh spoke one with another; and Yahweh listened and heard, and a book of memory was written before him for those who feared Yahweh and who honored his name. 
-<span class="v">17&#160;</span>They shall be mine,” says Yahweh of Armies, “my own possession in the day that I make. I will spare them, as a man spares his own son who serves him. 
-<span class="v">18&#160;</span>Then you shall return and discern between the righteous and the wicked, between him who serves Elohim and him who doesn’t serve him. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>“For behold, the day comes, burning like a furnace, when all the proud and all who work wickedness will be stubble. The day that comes will burn them up,” says Yahweh of Armies, “so that it will leave them neither root nor branch. 
-<span class="v">2&#160;</span>But to you who fear my name shall the sun of righteousness arise with healing in its wings. You will go out and leap like calves of the stall. 
-<span class="v">3&#160;</span>You shall tread down the wicked; for they will be ashes under the soles of your feet in the day that I make,” says Yahweh of Armies. 
-</p><p>
-<span class="v">4&#160;</span>“Remember the law of Moses my servant, which I commanded to him in Horeb for all Israel, even statutes and ordinances. 
-</p><p>
-<span class="v">5&#160;</span>Behold, I will send you Elijah the prophet before the great and terrible day of Yahweh comes. 
-<span class="v">6&#160;</span>He will turn the hearts of the fathers to the children and the hearts of the children to their fathers, lest I come and strike the earth with a curse.” </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>A revelation, Yahweh’s word to Israel by Malachi. 
+</div><div class="p">
+<sup>2&#160;</sup>“I have loved you,” says Yahweh. 
+</div><div class="p">Yet you say, “How have you loved us?” 
+</div><div class="p">“Wasn’t Esau Jacob’s brother?” says Yahweh, “Yet I loved Jacob; 
+<sup>3&#160;</sup>but Esau I hated, and made his mountains a desolation, and gave his heritage to the jackals of the wilderness.” 
+<sup>4&#160;</sup>Whereas Edom says, “We are beaten down, but we will return and build the waste places,” Yahweh of Armies says, “They shall build, but I will throw down; and men will call them ‘The Wicked Land,’ even the people against whom Yahweh shows wrath forever.” 
+</div><div class="p">
+<sup>5&#160;</sup>Your eyes will see, and you will say, “Yahweh is great—even beyond the border of Israel!” 
+</div><div class="p">
+<sup>6&#160;</sup>“A son honors his father, and a servant his master. If I am a father, then where is my honor? And if I am a master, where is the respect due me?” says Yahweh of Armies to you priests who despise my name. “You say, ‘How have we despised your name?’ 
+<sup>7&#160;</sup>You offer polluted bread on my altar. You say, ‘How have we polluted you?’ In that you say, ‘Yahweh’s table is contemptible.’ 
+<sup>8&#160;</sup>When you offer the blind for sacrifice, isn’t that evil? And when you offer the lame and sick, isn’t that evil? Present it now to your governor! Will he be pleased with you? Or will he accept your person?” says Yahweh of Armies. 
+</div><div class="p">
+<sup>9&#160;</sup>“Now, please entreat the favor of Elohim, that he may be gracious to us. With this, will he accept any of you?” says Yahweh of Armies. 
+</div><div class="p">
+<sup>10&#160;</sup>“Oh that there were one among you who would shut the doors, that you might not kindle fire on my altar in vain! I have no pleasure in you,” says Yahweh of Armies, “neither will I accept an offering at your hand. 
+<sup>11&#160;</sup>For from the rising of the sun even to its going down, my name is great among the nations, and in every place incense will be offered to my name, and a pure offering; for my name is great among the nations,” says Yahweh of Armies. 
+<sup>12&#160;</sup>“But you profane it when you say, ‘Yahweh’s table is polluted, and its fruit, even its food, is contemptible.’ 
+<sup>13&#160;</sup>You say also, ‘Behold, what a weariness it is!’ And you have sniffed at it”, says Yahweh of Armies; “and you have brought that which was taken by violence, the lame, and the sick; thus you bring the offering. Should I accept this at your hand?” says Yahweh. 
+</div><div class="p">
+<sup>14&#160;</sup>“But the deceiver is cursed who has in his flock a male, and vows and sacrifices to the Lord a defective thing; for I am a great King,” says Yahweh of Armies, “and my name is awesome among the nations.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>“Now, you priests, this commandment is for you. 
+<sup>2&#160;</sup>If you will not listen, and if you will not take it to heart, to give glory to my name,” says Yahweh of Armies, “then I will send the curse on you, and I will curse your blessings. Indeed, I have cursed them already, because you do not take it to heart. 
+<sup>3&#160;</sup>Behold, I will rebuke your offspring, and will spread dung on your faces, even the dung of your feasts; and you will be taken away with it. 
+<sup>4&#160;</sup>You will know that I have sent this commandment to you, that my covenant may be with Levi,” says Yahweh of Armies. 
+<sup>5&#160;</sup>“My covenant was with him of life and peace; and I gave them to him that he might be reverent toward me; and he was reverent toward me, and stood in awe of my name. 
+<sup>6&#160;</sup>The law of truth was in his mouth, and unrighteousness was not found in his lips. He walked with me in peace and uprightness, and turned many away from iniquity. 
+<sup>7&#160;</sup>For the priest’s lips should keep knowledge, and they should seek the law at his mouth; for he is the messenger of Yahweh of Armies. 
+<sup>8&#160;</sup>But you have turned away from the path. You have caused many to stumble in the law. You have corrupted the covenant of Levi,” says Yahweh of Armies. 
+<sup>9&#160;</sup>“Therefore I have also made you contemptible and wicked before all the people, according to the way you have not kept my ways, but have had respect for persons in the law. 
+<sup>10&#160;</sup>Don’t we all have one father? Hasn’t one Elohim created us? Why do we deal treacherously every man against his brother, profaning the covenant of our fathers? 
+<sup>11&#160;</sup>Judah has dealt treacherously, and an abomination is committed in Israel and in Jerusalem; for Judah has profaned the set-apartness of Yahweh which he loves, and has owned the daughter of a foreign elohim. 
+<sup>12&#160;</sup>Yahweh will cut off the man who does this, him who wakes and him who answers, out of the tents of Jacob and him who offers an offering to Yahweh of Armies. 
+</div><div class="p">
+<sup>13&#160;</sup>“This again you do: you cover Yahweh’s altar with tears, with weeping, and with sighing, because he doesn’t regard the offering any more, neither receives it with good will at your hand. 
+<sup>14&#160;</sup>Yet you say, ‘Why?’ Because Yahweh has been witness between you and the woman of your youth, against whom you have dealt treacherously, though she is your companion and the woman of your covenant. 
+<sup>15&#160;</sup>Did he not make you one, although he had the residue of the Spirit? Why one? He sought elohimly offspring. Therefore take heed to your spirit, and let no one deal treacherously against the woman of his youth. 
+<sup>16&#160;</sup>One who hates and divorces”, says Yahweh, the Elohim of Israel, “covers his garment with violence!” says Yahweh of Armies. “Therefore pay attention to your spirit, that you don’t be unfaithful. 
+</div><div class="p">
+<sup>17&#160;</sup>You have wearied Yahweh with your words. Yet you say, ‘How have we wearied him?’ In that you say, ‘Everyone who does evil is good in Yahweh’s sight, and he delights in them;’ or ‘Where is the Elohim of justice?’ 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>“Behold, I send my messenger, and he will prepare the way before me! The Lord, whom you seek, will suddenly come to his temple. Behold, the messenger of the covenant, whom you desire, is coming!” says Yahweh of Armies. 
+<sup>2&#160;</sup>“But who can endure the day of his coming? And who will stand when he appears? For he is like a refiner’s fire, and like launderers’ soap; 
+<sup>3&#160;</sup>and he will sit as a refiner and purifier of silver, and he will purify the sons of Levi, and refine them as gold and silver; and they shall offer to Yahweh offerings in righteousness. 
+<sup>4&#160;</sup>Then the offering of Judah and Jerusalem will be pleasant to Yahweh as in the days of old and as in ancient years. 
+</div><div class="p">
+<sup>5&#160;</sup>I will come near to you to judgment. I will be a swift witness against the sorcerers, against the adulterers, against the perjurers, and against those who oppress the hireling in his wages, the widow, and the fatherless, and who deprive the foreigner of justice, and don’t fear me,” says Yahweh of Armies. 
+</div><div class="p">
+<sup>6&#160;</sup>“For I, Yahweh, don’t change; therefore you, sons of Jacob, are not consumed. 
+<sup>7&#160;</sup>From the days of your fathers you have turned away from my ordinances and have not kept them. Return to me, and I will return to you,” says Yahweh of Armies. “But you say, ‘How shall we return?’ 
+</div><div class="p">
+<sup>8&#160;</sup>Will a man rob Elohim? Yet you rob me! But you say, ‘How have we robbed you?’ In tithes and offerings. 
+<sup>9&#160;</sup>You are cursed with the curse; for you rob me, even this whole nation. 
+<sup>10&#160;</sup>Bring the whole tithe into the storehouse, that there may be food in my house, and test me now in this,” says Yahweh of Armies, “if I will not open you the windows of heaven, and pour you out a blessing, that there will not be enough room for. 
+<sup>11&#160;</sup>I will rebuke the devourer for your sakes, and he shall not destroy the fruits of your ground; neither shall your vine cast its fruit before its time in the field,” says Yahweh of Armies. 
+<sup>12&#160;</sup>“All nations shall call you blessed, for you will be a delightful land,” says Yahweh of Armies. 
+</div><div class="p">
+<sup>13&#160;</sup>“Your words have been harsh against me,” says Yahweh. “Yet you say, ‘What have we spoken against you?’ 
+<sup>14&#160;</sup>You have said, ‘It is vain to serve Elohim,’ and ‘What profit is it that we have followed his instructions and that we have walked mournfully before Yahweh of Armies? 
+<sup>15&#160;</sup>Now we call the proud happy; yes, those who work wickedness are built up; yes, they tempt Elohim, and escape.’ 
+</div><div class="p">
+<sup>16&#160;</sup>Then those who feared Yahweh spoke one with another; and Yahweh listened and heard, and a book of memory was written before him for those who feared Yahweh and who honored his name. 
+<sup>17&#160;</sup>They shall be mine,” says Yahweh of Armies, “my own possession in the day that I make. I will spare them, as a man spares his own son who serves him. 
+<sup>18&#160;</sup>Then you shall return and discern between the righteous and the wicked, between him who serves Elohim and him who doesn’t serve him. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>“For behold, the day comes, burning like a furnace, when all the proud and all who work wickedness will be stubble. The day that comes will burn them up,” says Yahweh of Armies, “so that it will leave them neither root nor branch. 
+<sup>2&#160;</sup>But to you who fear my name shall the sun of righteousness arise with healing in its wings. You will go out and leap like calves of the stall. 
+<sup>3&#160;</sup>You shall tread down the wicked; for they will be ashes under the soles of your feet in the day that I make,” says Yahweh of Armies. 
+</div><div class="p">
+<sup>4&#160;</sup>“Remember the law of Moses my servant, which I commanded to him in Horeb for all Israel, even statutes and ordinances. 
+</div><div class="p">
+<sup>5&#160;</sup>Behold, I will send you Elijah the prophet before the great and terrible day of Yahweh comes. 
+<sup>6&#160;</sup>He will turn the hearts of the fathers to the children and the hearts of the children to their fathers, lest I come and strike the earth with a curse.” </div></div><script src="../main.js"></script></body></html>

--- a/book/matthew.html
+++ b/book/matthew.html
@@ -3,6 +3,47 @@
 <head>
 <title>Matthew</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1604 +53,1633 @@
 <div class="main">
 <!-- MAT World English Scripture (WES) -->
 <h1 class="booklabel">Matthew</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The book of the genealogy of Yahushua Christ,<span class="f">+ \fr 1:1 \ft Messiah (Hebrew) and Christ (Greek) both mean “Anointed One”</span> the son of David, the son of Abraham. 
-</p><p>
-<span class="v">2&#160;</span>Abraham brought forth Isaac. Isaac brought forth Jacob. Jacob brought forth Judah and his brothers. 
-<span class="v">3&#160;</span>Judah brought forth Perez and Zerah by Tamar. Perez brought forth Hezron. Hezron brought forth Ram. 
-<span class="v">4&#160;</span>Ram brought forth Amminadab. Amminadab brought forth Nahshon. Nahshon brought forth Salmon. 
-<span class="v">5&#160;</span>Salmon brought forth Boaz by Rahab. Boaz brought forth Obed by Ruth. Obed brought forth Jesse. 
-<span class="v">6&#160;</span>Jesse brought forth King David. David the king<span class="f">+ \fr 1:6 \ft NU omits “the king”.</span> brought forth Solomon by her who had been Uriah’s woman. 
-<span class="v">7&#160;</span>Solomon brought forth Rehoboam. Rehoboam brought forth Abijah. Abijah brought forth Asa. 
-<span class="v">8&#160;</span>Asa brought forth Jehoshaphat. Jehoshaphat brought forth Joram. Joram brought forth Uzziah. 
-<span class="v">9&#160;</span>Uzziah brought forth Jotham. Jotham brought forth Ahaz. Ahaz brought forth Hezekiah. 
-<span class="v">10&#160;</span>Hezekiah brought forth Manasseh. Manasseh brought forth Amon. Amon brought forth Josiah. 
-<span class="v">11&#160;</span>Josiah brought forth Jechoniah and his brothers at the time of the exile to Babylon. 
-</p><p>
-<span class="v">12&#160;</span>After the exile to Babylon, Jechoniah brought forth Shealtiel. Shealtiel brought forth Zerubbabel. 
-<span class="v">13&#160;</span>Zerubbabel brought forth Abiud. Abiud brought forth Eliakim. Eliakim brought forth Azor. 
-<span class="v">14&#160;</span>Azor brought forth Zadok. Zadok brought forth Achim. Achim brought forth Eliud. 
-<span class="v">15&#160;</span>Eliud brought forth Eleazar. Eleazar brought forth Matthan. Matthan brought forth Jacob. 
-<span class="v">16&#160;</span>Jacob brought forth Joseph. This Joseph brought forth Yahushua,<span class="f">+ \fr 1:16 \ft “Yahushua” means “Salvation”.</span> who is called Christ. 
-</p><p>
-<span class="v">17&#160;</span>So all the generations from Abraham to David are fourteen generations; from David to the exile to Babylon fourteen generations; and from the carrying away to Babylon to the Christ, fourteen generations. 
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The book of the genealogy of Yahushua Christ, the son of David, the son of Abraham. 
+</div><div class="p">
+<sup>2&#160;</sup>Abraham brought forth Isaac. Isaac brought forth Jacob. Jacob brought forth Judah and his brothers. 
+<sup>3&#160;</sup>Judah brought forth Perez and Zerah by Tamar. Perez brought forth Hezron. Hezron brought forth Ram. 
+<sup>4&#160;</sup>Ram brought forth Amminadab. Amminadab brought forth Nahshon. Nahshon brought forth Salmon. 
+<sup>5&#160;</sup>Salmon brought forth Boaz by Rahab. Boaz brought forth Obed by Ruth. Obed brought forth Jesse. 
+<sup>6&#160;</sup>Jesse brought forth King David. David the king brought forth Solomon by her who had been Uriah’s woman. 
+<sup>7&#160;</sup>Solomon brought forth Rehoboam. Rehoboam brought forth Abijah. Abijah brought forth Asa. 
+<sup>8&#160;</sup>Asa brought forth Jehoshaphat. Jehoshaphat brought forth Joram. Joram brought forth Uzziah. 
+<sup>9&#160;</sup>Uzziah brought forth Jotham. Jotham brought forth Ahaz. Ahaz brought forth Hezekiah. 
+<sup>10&#160;</sup>Hezekiah brought forth Manasseh. Manasseh brought forth Amon. Amon brought forth Josiah. 
+<sup>11&#160;</sup>Josiah brought forth Jechoniah and his brothers at the time of the exile to Babylon. 
+</div><div class="p">
+<sup>12&#160;</sup>After the exile to Babylon, Jechoniah brought forth Shealtiel. Shealtiel brought forth Zerubbabel. 
+<sup>13&#160;</sup>Zerubbabel brought forth Abiud. Abiud brought forth Eliakim. Eliakim brought forth Azor. 
+<sup>14&#160;</sup>Azor brought forth Zadok. Zadok brought forth Achim. Achim brought forth Eliud. 
+<sup>15&#160;</sup>Eliud brought forth Eleazar. Eleazar brought forth Matthan. Matthan brought forth Jacob. 
+<sup>16&#160;</sup>Jacob brought forth Joseph. This Joseph brought forth Yahushua, who is called Christ. 
+</div><div class="p">
+<sup>17&#160;</sup>So all the generations from Abraham to David are fourteen generations; from David to the exile to Babylon fourteen generations; and from the carrying away to Babylon to the Christ, fourteen generations. 
  
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Now when Yahushua was born in Bethlehem of Judea in the days of King Herod, behold, wise men<span class="f">+ \fr 2:1 \ft The word for “wise men” (magoi) can also mean teachers, scientists, physicians, astrologers, seers, interpreters of dreams, or sorcerers.</span> from the east came to Jerusalem, saying, 
-<span class="v">2&#160;</span>“Where is he who is born King of the Jews? For we saw his star in the east, and have come to worship him.” 
-<span class="v">3&#160;</span>When King Herod heard it, he was troubled, and all Jerusalem with him. 
-<span class="v">4&#160;</span>Gathering together all the chief priests and scribes of the people, he asked them where the Christ would be born. 
-<span class="v">5&#160;</span>They said to him, “In Bethlehem of Judea, for this is written through the prophet, 
-</p><p class="q1">
-<span class="v">6&#160;</span>‘You Bethlehem, land of Judah, 
-</p><p class="q2">are in no way least among the princes of Judah; 
-</p><p class="q1">for out of you shall come a governor 
-</p><p class="q2">who shall shepherd my people, Israel.’&#160;”<span class="x">+ \xo 2:6 \xt Micah 5:2</span> 
-</p><p>
-<span class="v">7&#160;</span>Then Herod secretly called the wise men, and learned from them exactly what time the star appeared. 
-<span class="v">8&#160;</span>He sent them to Bethlehem, and said, “Go and search diligently for the young child. When you have found him, bring me word, so that I also may come and worship him.” 
-</p><p>
-<span class="v">9&#160;</span>They, having heard the king, went their way; and behold, the star, which they saw in the east, went before them until it came and stood over where the young child was. 
-<span class="v">10&#160;</span>When they saw the star, they rejoiced with exceedingly great joy. 
-<span class="v">11&#160;</span>They came into the house and saw the young child with Mary, his mother, and they fell down and worshiped him. Opening their treasures, they offered to him gifts: gold, frankincense, and myrrh. 
-<span class="v">12&#160;</span>Being warned in a dream not to return to Herod, they went back to their own country another way. 
-</p><p>
-<span class="v">13&#160;</span>Now when they had departed, behold, an angel of the Lord appeared to Joseph in a dream, saying, “Arise and take the young child and his mother, and flee into Egypt, and stay there until I tell you, for Herod will seek the young child to destroy him.” 
-</p><p>
-<span class="v">14&#160;</span>He arose and took the young child and his mother by night and departed into Egypt, 
-<span class="v">15&#160;</span>and was there until the death of Herod, that it might be fulfilled which was spoken by the Lord through the prophet, saying, “Out of Egypt I called my son.”<span class="x">+ \xo 2:15 \xt Hosea 11:1</span> 
-</p><p>
-<span class="v">16&#160;</span>Then Herod, when he saw that he was mocked by the wise men, was exceedingly angry, and sent out and killed all the male children who were in Bethlehem and in all the surrounding countryside, from two years old and under, according to the exact time which he had learned from the wise men. 
-<span class="v">17&#160;</span>Then that which was spoken by Jeremiah the prophet was fulfilled, saying, 
-</p><p class="q1">
-<span class="v">18&#160;</span>“A voice was heard in Ramah, 
-</p><p class="q2">lamentation, weeping and great mourning, 
-</p><p class="q1">Rachel weeping for her children; 
-</p><p class="q2">she wouldn’t be comforted, 
-</p><p class="q2">because they are no more.”<span class="x">+ \xo 2:18 \xt Jeremiah 31:15</span> 
-</p><p>
-<span class="v">19&#160;</span>But when Herod was dead, behold, an angel of the Lord appeared in a dream to Joseph in Egypt, saying, 
-<span class="v">20&#160;</span>“Arise and take the young child and his mother, and go into the land of Israel, for those who sought the young child’s life are dead.” 
-</p><p>
-<span class="v">21&#160;</span>He arose and took the young child and his mother, and came into the land of Israel. 
-<span class="v">22&#160;</span>But when he heard that Archelaus was reigning over Judea in the place of his father, Herod, he was afraid to go there. Being warned in a dream, he withdrew into the region of Galilee, 
-<span class="v">23&#160;</span>and came and lived in a city called Nazareth; that it might be fulfilled which was spoken through the prophets that he will be called a Nazarene. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>In those days, John the Baptizer came, preaching in the wilderness of Judea, saying, 
-<span class="v">2&#160;</span>“Repent, for the Kingdom of Heaven is at hand!” 
-<span class="v">3&#160;</span>For this is he who was spoken of by Isaiah the prophet, saying, 
-</p><p class="q1">“The voice of one crying in the wilderness, 
-</p><p class="q2">make the way of the Lord ready! 
-</p><p class="q2">Make his paths straight!”<span class="x">+ \xo 3:3 \xt Isaiah 40:3</span> 
-</p><p>
-<span class="v">4&#160;</span>Now John himself wore clothing made of camel’s hair with a leather belt around his waist. His food was locusts and wild honey. 
-<span class="v">5&#160;</span>Then people from Jerusalem, all of Judea, and all the region around the Jordan went out to him. 
-<span class="v">6&#160;</span>They were baptized by him in the Jordan, confessing their sins. 
-</p><p>
-<span class="v">7&#160;</span>But when he saw many of the Pharisees and Sadducees coming for his baptism, he said to them, “You offspring of vipers, who warned you to flee from the wrath to come? 
-<span class="v">8&#160;</span>Therefore produce fruit worthy of repentance! 
-<span class="v">9&#160;</span>Don’t think to yourselves, ‘We have Abraham for our father,’ for I tell you that Elohim is able to raise up children to Abraham from these stones. 
-<span class="v">10&#160;</span>Even now the ax lies at the root of the trees. Therefore every tree that doesn’t produce good fruit is cut down, and cast into the fire. 
-</p><p>
-<span class="v">11&#160;</span>“I indeed baptize you in water for repentance, but he who comes after me is mightier than I, whose sandals I am not worthy to carry. He will baptize you in the Set-Apart Spirit.<span class="f">+ \fr 3:11 \ft TR and NU add “and with fire” </span> 
-<span class="v">12&#160;</span>His winnowing fork is in his hand, and he will thoroughly cleanse his threshing floor. He will gather his wheat into the barn, but the chaff he will burn up with unquenchable fire.” 
-</p><p>
-<span class="v">13&#160;</span>Then Yahushua came from Galilee to the Jordan<span class="f">+ \fr 3:13 \ft i.e., the Jordan River</span> to John, to be baptized by him. 
-<span class="v">14&#160;</span>But John would have hindered him, saying, “I need to be baptized by you, and you come to me?” 
-</p><p>
-<span class="v">15&#160;</span>But Yahushua, answering, said to him, <span class="wj">“Allow it now, for this is the fitting way for us to fulfill all righteousness.”</span> Then he allowed him. 
-</p><p>
-<span class="v">16&#160;</span>Yahushua, when he was baptized, went up directly from the water: and behold, the heavens were opened to him. He saw the Spirit of Elohim descending as a dove, and coming on him. 
-<span class="v">17&#160;</span>Behold, a voice out of the heavens said, “This is my beloved Son, with whom I am well pleased. Today I have become his father.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Then Yahushua was led up by the Spirit into the wilderness to be tempted by the devil. 
-<span class="v">2&#160;</span>When he had fasted forty days and forty nights, he was hungry afterward. 
-<span class="v">3&#160;</span>The tempter came and said to him, “If you are the Son of Elohim, command that these stones become bread.” 
-</p><p>
-<span class="v">4&#160;</span>But he answered, <span class="wj">“It is written, ‘Man shall not live by bread alone, but by every word that proceeds out of Elohim’s mouth.’&#160;”</span><span class="x">+ \xo 4:4 \xt Deuteronomy 8:3</span> 
-</p><p>
-<span class="v">5&#160;</span>Then the devil took him into the set-apart city. He set him on the pinnacle of the temple, 
-<span class="v">6&#160;</span>and said to him, “If you are the Son of Elohim, throw yourself down, for it is written, 
-</p><p class="q1">‘He will command his angels concerning you,’ and, 
-</p><p class="q1">‘On their hands they will bear you up, 
-</p><p class="q2">so that you don’t dash your foot against a stone.’&#160;”<span class="x">+ \xo 4:6 \xt Psalm 91:11-12 </span> 
-</p><p>
-<span class="v">7&#160;</span>Yahushua said to him, <span class="wj">“Again, it is written, ‘You shall not test the Lord, your Elohim.’&#160;”</span><span class="x">+ \xo 4:7 \xt Deuteronomy 6:16</span> 
-</p><p>
-<span class="v">8&#160;</span>Again, the devil took him to an exceedingly high mountain, and showed him all the kingdoms of the world and their glory. 
-<span class="v">9&#160;</span>He said to him, “I will give you all of these things, if you will fall down and worship me.” 
-</p><p>
-<span class="v">10&#160;</span>Then Yahushua said to him, <span class="wj">“Get behind me,</span><span class="f">+ \fr 4:10 \ft TR and NU read “Go away” instead of “Get behind me”</span> <span class="wj">Satan! For it is written, ‘You shall worship the Lord your Elohim, and you shall serve him only.’&#160;”</span> <span class="x">+ \xo 4:10 \xt Deuteronomy 6:13</span> 
-</p><p>
-<span class="v">11&#160;</span>Then the devil left him, and behold, angels came and served him. 
-</p><p>
-<span class="v">12&#160;</span>Now when Yahushua heard that John was delivered up, he withdrew into Galilee. 
-<span class="v">13&#160;</span>Leaving Nazareth, he came and lived in Capernaum, which is by the sea, in the region of Zebulun and Naphtali, 
-<span class="v">14&#160;</span>that it might be fulfilled which was spoken through Isaiah the prophet, saying, 
-</p><p class="q1">
-<span class="v">15&#160;</span>“The land of Zebulun and the land of Naphtali, 
-</p><p class="q2">toward the sea, beyond the Jordan, 
-</p><p class="q2">Galilee of the Gentiles, 
-</p><p class="q1">
-<span class="v">16&#160;</span>the people who sat in darkness saw a great light; 
-</p><p class="q2">to those who sat in the region and shadow of death, 
-</p><p class="q2">to them light has dawned.”<span class="x">+ \xo 4:16 \xt Isaiah 9:1-2</span> 
-</p><p>
-<span class="v">17&#160;</span>From that time, Yahushua began to preach, and to say, <span class="wj">“Repent! For the Kingdom of Heaven is at hand.”</span> 
-</p><p>
-<span class="v">18&#160;</span>Walking by the sea of Galilee, he<span class="f">+ \fr 4:18 \ft TR reads “Yahushua” instead of “he” </span> saw two brothers: Simon, who is called Peter, and Andrew, his brother, casting a net into the sea; for they were fishermen. 
-<span class="v">19&#160;</span>He said to them, <span class="wj">“Come after me, and I will make you fishers for men.”</span> 
-</p><p>
-<span class="v">20&#160;</span>They immediately left their nets and followed him. 
-<span class="v">21&#160;</span>Going on from there, he saw two other brothers, James the son of Zebedee, and John his brother, in the boat with Zebedee their father, mending their nets. He called them. 
-<span class="v">22&#160;</span>They immediately left the boat and their father, and followed him. 
-</p><p>
-<span class="v">23&#160;</span>Yahushua went about in all Galilee, teaching in their synagogues, preaching the Good News of the Kingdom, and healing every disease and every sickness among the people. 
-<span class="v">24&#160;</span>The report about him went out into all Syria. They brought to him all who were sick, afflicted with various diseases and torments, possessed with demons, epileptics, and paralytics; and he healed them. 
-<span class="v">25&#160;</span>Great multitudes from Galilee, Decapolis, Jerusalem, Judea, and from beyond the Jordan followed him. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Seeing the multitudes, he went up onto the mountain. When he had sat down, his disciples came to him. 
-<span class="v">2&#160;</span>He opened his mouth and taught them, saying, 
-</p><p class="q1">
-<span class="v">3&#160;</span><span class="wj">“Blessed are the poor in spirit,</span> 
-</p><p class="q2"><span class="wj">for theirs is the Kingdom of Heaven.</span><span class="x">+ \xo 5:3 \xt Isaiah 57:15; 66:2</span> 
-</p><p class="q1">
-<span class="v">4&#160;</span><span class="wj">Blessed are those who mourn,</span> 
-</p><p class="q2"><span class="wj">for they shall be comforted.</span><span class="x">+ \xo 5:4 \xt Isaiah 61:2; 66:10,13</span> 
-</p><p class="q1">
-<span class="v">5&#160;</span><span class="wj">Blessed are the gentle,</span> 
-</p><p class="q2"><span class="wj">for they shall inherit the earth.</span><span class="f">+ \fr 5:5 \ft or, land.</span><span class="x">+ \xo 5:5 \xt Psalm 37:11</span> 
-</p><p class="q1">
-<span class="v">6&#160;</span><span class="wj">Blessed are those who hunger and thirst for righteousness, </span> 
-</p><p class="q2"><span class="wj">for they shall be filled.</span> 
-</p><p class="q1">
-<span class="v">7&#160;</span><span class="wj">Blessed are the merciful,</span> 
-</p><p class="q2"><span class="wj">for they shall obtain mercy.</span> 
-</p><p class="q1">
-<span class="v">8&#160;</span><span class="wj">Blessed are the pure in heart,</span> 
-</p><p class="q2"><span class="wj">for they shall see Elohim.</span> 
-</p><p class="q1">
-<span class="v">9&#160;</span><span class="wj">Blessed are the peacemakers,</span> 
-</p><p class="q2"><span class="wj">for they shall be called children of Elohim.</span> 
-</p><p class="q1">
-<span class="v">10&#160;</span><span class="wj">Blessed are those who have been persecuted for righteousness’ sake, </span> 
-</p><p class="q2"><span class="wj">for theirs is the Kingdom of Heaven.</span> 
-</p><p>
-<span class="v">11&#160;</span><span class="wj">“Blessed are you when people reproach you, persecute you, and say all kinds of evil against you falsely, for my sake. </span> 
-<span class="v">12&#160;</span><span class="wj">Rejoice, and be exceedingly glad, for great is your reward in heaven. For that is how they persecuted the prophets who were before you. </span> 
-</p><p>
-<span class="v">13&#160;</span><span class="wj">“You are the salt of the earth, but if the salt has lost its flavor, with what will it be salted? It is then good for nothing, but to be cast out and trodden under the feet of men. </span> 
-</p><p>
-<span class="v">14&#160;</span><span class="wj">You are the light of the world. A city located on a hill can’t be hidden. </span> 
-<span class="v">15&#160;</span><span class="wj">Neither do you light a lamp and put it under a measuring basket, but on a stand; and it shines to all who are in the house. </span> 
-<span class="v">16&#160;</span><span class="wj">Even so, let your light shine before men, that they may see your good works and glorify your Father who is in heaven.</span> 
-</p><p>
-<span class="v">17&#160;</span><span class="wj">“Don’t think that I came to destroy the law or the prophets. I didn’t come to destroy, but to fulfill. </span> 
-<span class="v">18&#160;</span><span class="wj">For most certainly, I tell you, until heaven and earth pass away, not even one smallest letter</span><span class="f">+ \fr 5:18 \ft literally, iota</span> <span class="wj">or one tiny pen stroke</span><span class="f">+ \fr 5:18 \ft or, serif</span> <span class="wj">shall in any way pass away from the law, until all things are accomplished. </span> 
-<span class="v">19&#160;</span><span class="wj">Therefore, whoever shall break one of these least commandments and teach others to do so, shall be called least in the Kingdom of Heaven; but whoever shall do and teach them shall be called great in the Kingdom of Heaven. </span> 
-<span class="v">20&#160;</span><span class="wj">For I tell you that unless your righteousness exceeds that of the scribes and Pharisees, there is no way you will enter into the Kingdom of Heaven.</span> 
-</p><p>
-<span class="v">21&#160;</span><span class="wj">“You have heard that it was said to the ancient ones, ‘You shall not murder;’</span><span class="x">+ \xo 5:21 \xt Exodus 20:13</span> <span class="wj">and ‘Whoever murders will be in danger of the judgment.’ </span> 
-<span class="v">22&#160;</span><span class="wj">But I tell you that everyone who is angry with his brother without a cause </span><span class="f">+ \fr 5:22 \ft NU omits “without a cause”.</span> <span class="wj">will be in danger of the judgment. Whoever says to his brother, ‘Raca!’ </span><span class="f">+ \fr 5:22 \ft “Raca” is an Aramaic insult, related to the word for “empty” and conveying the idea of empty-headedness.</span> <span class="wj">will be in danger of the council. Whoever says, ‘You fool!’ will be in danger of the fire of Gehenna.</span><span class="f">+ \fr 5:22 \ft or, Hell</span> 
-</p><p>
-<span class="v">23&#160;</span><span class="wj">“If therefore you are offering your gift at the altar, and there remember that your brother has anything against you, </span> 
-<span class="v">24&#160;</span><span class="wj">leave your gift there before the altar, and go your way. First be reconciled to your brother, and then come and offer your gift. </span> 
-<span class="v">25&#160;</span><span class="wj">Agree with your adversary quickly while you are with him on the way; lest perhaps the prosecutor deliver you to the judge, and the judge deliver you to the officer, and you be cast into prison. </span> 
-<span class="v">26&#160;</span><span class="wj">Most certainly I tell you, you shall by no means get out of there until you have paid the last penny.</span><span class="f">+ \fr 5:26 \ft literally, kodrantes. A kodrantes was a small copper coin worth about 2 lepta (widow’s mites)—not enough to buy very much of anything.</span> 
-</p><p>
-<span class="v">27&#160;</span><span class="wj">“You have heard that it was said, </span><span class="f">+ \fr 5:27 \ft TR adds “to the ancients”.</span> <span class="wj">‘You shall not commit adultery;’</span><span class="x">+ \xo 5:27 \xt Exodus 20:14</span> 
-<span class="v">28&#160;</span><span class="wj">but I tell you that everyone who gazes at a woman to lust after her has committed adultery with her already in his heart. </span> 
-<span class="v">29&#160;</span><span class="wj">If your right eye causes you to stumble, pluck it out and throw it away from you. For it is more profitable for you that one of your members should perish than for your whole body to be cast into Gehenna.</span><span class="f">+ \fr 5:29 \ft or, Hell</span> 
-<span class="v">30&#160;</span><span class="wj">If your right hand causes you to stumble, cut it off, and throw it away from you. For it is more profitable for you that one of your members should perish, than for your whole body to be cast into Gehenna.</span><span class="f">+ \fr 5:30 \ft or, Hell</span> 
-</p><p>
-<span class="v">31&#160;</span><span class="wj">“It was also said, ‘Whoever shall put away his woman, let him give her a writing of divorce,’</span><span class="x">+ \xo 5:31 \xt Deuteronomy 24:1</span> 
-<span class="v">32&#160;</span><span class="wj">but I tell you that whoever puts away his woman, except for the cause of sexual immorality, makes her an adulteress; and whoever marries her when she is put away commits adultery.</span> 
-</p><p>
-<span class="v">33&#160;</span><span class="wj">“Again you have heard that it was said to the ancient ones, ‘You shall not make false vows by my name, but shall perform to the Lord your vows,’</span><span class="x">+ \xo 5:33 \xt Numbers 30:2; Deuteronomy 23:21; Ecclesiastes 5:4</span> 
-<span class="v">34&#160;</span><span class="wj">but I tell you, don’t swear falsely at all: neither by heaven, for it is the throne of Elohim; </span> 
-<span class="v">35&#160;</span><span class="wj">nor by the earth, for it is the footstool of his feet; nor by Jerusalem, for it is the city of the great King. </span> 
-<span class="v">36&#160;</span><span class="wj">Neither shall you swear by your head, for you can’t make one hair white or black. </span> 
-<span class="v">37&#160;</span><span class="wj">But let your ‘Yes’ be ‘Yes’ and your ‘No’ be ‘No.’ Whatever is more than these is of the evil one.</span> 
-</p><p>
-<span class="v">38&#160;</span><span class="wj">“You have heard that it was said, ‘An eye for an eye, and a tooth for a tooth.’</span><span class="x">+ \xo 5:38 \xt Exodus 21:24; Leviticus 24:20; Deuteronomy 19:21</span> 
-<span class="v">39&#160;</span><span class="wj">And I say to you not to pay evil in exchange for evil, but if hit on your right cheek, prepare for a hit to your left! </span> 
-<span class="v">40&#160;</span><span class="wj">If anyone sues you to take away your coat, let him have your cloak also. </span> 
-<span class="v">41&#160;</span><span class="wj">Whoever compels you to go one mile, go with him two. </span> 
-<span class="v">42&#160;</span><span class="wj">Give to him who asks you, and don’t turn away him who desires to borrow from you.</span> 
-</p><p>
-<span class="v">43&#160;</span><span class="wj">“You have heard that it was said, ‘You shall love your neighbor </span><span class="x">+ \xo 5:43 \xt Leviticus 19:18</span> <span class="wj">and hate your enemy.’</span><span class="f">+ \fr 5:43 \ft not in the Bible, but see Qumran Manual of Discipline Ix, 21-26</span> 
-<span class="v">44&#160;</span><span class="wj">But I tell you, love your enemies, bless those who curse you, do good to those who hate you, and pray for those who mistreat you and persecute you, </span> 
-<span class="v">45&#160;</span><span class="wj">that you may be children of your Father who is in heaven. For he makes his sun to rise on the evil and the good, and sends rain on the just and the unjust. </span> 
-<span class="v">46&#160;</span><span class="wj">For if you love those who love you, what reward do you have? Don’t even the tax collectors do the same? </span> 
-<span class="v">47&#160;</span><span class="wj">If you only greet your friends, what more do you do than others? Don’t even the tax collectors</span><span class="f">+ \fr 5:47 \ft NU reads “Gentiles” instead of “tax collectors”.</span> <span class="wj">do the same? </span> 
-<span class="v">48&#160;</span><span class="wj">Therefore you shall be perfect, just as your Father in heaven is perfect.</span> 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“Be careful that you don’t do your charitable giving</span><span class="f">+ \fr 6:1 \ft NU reads “acts of righteousness” instead of “charitable giving”</span> <span class="wj">before men, to be seen by them, or else you have no reward from your Father who is in heaven. </span> 
-<span class="v">2&#160;</span><span class="wj">Therefore, when you do merciful deeds, don’t sound a trumpet before yourself, as the hypocrites do in the synagogues and in the streets, that they may get glory from men. Most certainly I tell you, they have received their reward. </span> 
-<span class="v">3&#160;</span><span class="wj">But when you do merciful deeds, don’t let your left hand know what your right hand does, </span> 
-<span class="v">4&#160;</span><span class="wj">so that your merciful deeds may be in secret, then your Father who sees in secret will reward you openly.</span> 
-</p><p>
-<span class="v">5&#160;</span><span class="wj">“When you pray, you shall not be as the hypocrites, for they love to stand and pray in the synagogues and in the corners of the streets, that they may be seen by men. Most certainly, I tell you, they have received their reward. </span> 
-<span class="v">6&#160;</span><span class="wj">But you, when you pray, enter into your inner room, and having shut your door, pray to your Father who is in secret; and your Father who sees in secret will reward you openly. </span> 
-<span class="v">7&#160;</span><span class="wj">In praying, don’t use vain repetitions as the Gentiles do; for they think that they will be heard for their much speaking. </span> 
-<span class="v">8&#160;</span><span class="wj">Therefore don’t be like them, for your Father knows what things you need before you ask him. </span> 
-<span class="v">9&#160;</span><span class="wj">Pray like this: </span> 
-</p><p class="q1"><span class="wj">“&#160;‘Our Father in heaven, may your name be kept set-apart. </span> 
-</p><p class="q1">
-<span class="v">10&#160;</span><span class="wj">Let your Kingdom come. </span> 
-</p><p class="q2"><span class="wj">Let your will be done on earth as it is in heaven. </span> 
-</p><p class="q1">
-<span class="v">11&#160;</span><span class="wj">Give us today our daily bread. </span> 
-</p><p class="q1">
-<span class="v">12&#160;</span><span class="wj">Forgive us our debts,</span> 
-</p><p class="q2"><span class="wj">as we also forgive our debtors. </span> 
-</p><p class="q1">
-<span class="v">13&#160;</span><span class="wj">Bring us not into temptation,</span> 
-</p><p class="q2"><span class="wj">but deliver us from evil.</span> 
-</p><p>
-<span class="v">14&#160;</span><span class="wj">“For if you forgive men their trespasses, your heavenly Father will also forgive you. </span> 
-<span class="v">15&#160;</span><span class="wj">But if you don’t forgive men their trespasses, neither will your Father forgive your trespasses.</span> 
-</p><p>
-<span class="v">16&#160;</span><span class="wj">“Moreover when you fast, don’t be like the hypocrites, with sad faces. For they disfigure their faces that they may be seen by men to be fasting. Most certainly I tell you, they have received their reward. </span> 
-<span class="v">17&#160;</span><span class="wj">But you, when you fast, anoint your head and wash your face, </span> 
-<span class="v">18&#160;</span><span class="wj">so that you are not seen by men to be fasting, but by your Father who is in secret; and your Father, who sees in secret, will reward you. </span> 
-</p><p>
-<span class="v">19&#160;</span><span class="wj">“Don’t lay up treasures for yourselves on the earth, where moth and rust consume, and where thieves break through and steal; </span> 
-<span class="v">20&#160;</span><span class="wj">but lay up for yourselves treasures in heaven, where neither moth nor rust consume, and where thieves don’t break through and steal; </span> 
-<span class="v">21&#160;</span><span class="wj">for where your treasure is, there your heart will be also. </span> 
-</p><p>
-<span class="v">22&#160;</span><span class="wj">“The lamp of the body is the eye. If therefore your eye is sound, your whole body will be full of light. </span> 
-<span class="v">23&#160;</span><span class="wj">But if your eye is evil, your whole body will be full of darkness. If therefore the light that is in you is darkness, how great is the darkness! </span> 
-</p><p>
-<span class="v">24&#160;</span><span class="wj">“No one can serve two masters, for either he will hate the one and love the other, or else he will be devoted to one and despise the other. You can’t serve both Elohim and Mammon. </span> 
-<span class="v">25&#160;</span><span class="wj">Therefore I tell you, don’t be anxious for your life: what you will eat, or what you will drink; nor yet for your body, what you will wear. Isn’t life more than food, and the body more than clothing? </span> 
-<span class="v">26&#160;</span><span class="wj">See the birds of the sky, that they don’t sow, neither do they reap, nor gather into barns. Your heavenly Father feeds them. Aren’t you of much more value than they?</span> 
-</p><p>
-<span class="v">27&#160;</span><span class="wj">“Which of you by being anxious, can add one moment</span><span class="f">+ \fr 6:27 \ft literally, cubit</span> <span class="wj">to his lifespan? </span> 
-<span class="v">28&#160;</span><span class="wj">Why are you anxious about clothing? Consider the lilies of the field, how they grow. They don’t toil, neither do they spin, </span> 
-<span class="v">29&#160;</span><span class="wj">yet I tell you that even Solomon in all his glory was not dressed like one of these. </span> 
-<span class="v">30&#160;</span><span class="wj">But if Elohim so clothes the grass of the field, which today exists and tomorrow is thrown into the oven, won’t he much more clothe you, you of little faith?</span> 
-</p><p>
-<span class="v">31&#160;</span><span class="wj">“Therefore don’t be anxious, saying, ‘What will we eat?’, ‘What will we drink?’ or, ‘With what will we be clothed?’ </span> 
-<span class="v">32&#160;</span><span class="wj">For the Gentiles seek after all these things; for your heavenly Father knows that you need all these things. </span> 
-<span class="v">33&#160;</span><span class="wj">But seek first Elohim’s Kingdom and his righteousness; and all these things will be given to you as well. </span> 
-<span class="v">34&#160;</span><span class="wj">Therefore don’t be anxious for tomorrow, for tomorrow will be anxious for itself. Each day’s own evil is sufficient.</span> 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“Don’t judge, so that you won’t be judged. </span> 
-<span class="v">2&#160;</span><span class="wj">For with whatever judgment you judge, you will be judged; and with whatever measure you measure, it will be measured to you. </span> 
-<span class="v">3&#160;</span><span class="wj">Why do you see the speck that is in your brother’s eye, but don’t consider the beam that is in your own eye? </span> 
-<span class="v">4&#160;</span><span class="wj">Or how will you tell your brother, ‘Let me remove the speck from your eye,’ and behold, the beam is in your own eye? </span> 
-<span class="v">5&#160;</span><span class="wj">You hypocrite! First remove the beam out of your own eye, and then you can see clearly to remove the speck out of your brother’s eye.</span> 
-</p><p>
-<span class="v">6&#160;</span><span class="wj">“Don’t give that which is set-apart to the dogs, neither throw your pearls before the pigs, lest perhaps they trample them under their feet, and turn and tear you to pieces.</span> 
-</p><p>
-<span class="v">7&#160;</span><span class="wj">“Ask, and it will be given you. Seek, and you will find. Knock, and it will be opened for you. </span> 
-<span class="v">8&#160;</span><span class="wj">For everyone who asks receives. He who seeks finds. To him who knocks it will be opened. </span> 
-<span class="v">9&#160;</span><span class="wj">Or who is there among you who, if his son asks him for bread, will give him a stone? </span> 
-<span class="v">10&#160;</span><span class="wj">Or if he asks for a fish, who will give him a serpent? </span> 
-<span class="v">11&#160;</span><span class="wj">If you then, being evil, know how to give good gifts to your children, how much more will your Father who is in heaven give good things to those who ask him! </span> 
-<span class="v">12&#160;</span><span class="wj">Therefore, whatever you desire for men to do to you, you shall also do to them; for this is the law and the prophets.</span> 
-</p><p>
-<span class="v">13&#160;</span><span class="wj">“Enter in by the narrow gate; for the gate is wide and the way is broad that leads to destruction, and there are many who enter in by it. </span> 
-<span class="v">14&#160;</span><span class="wj">How</span><span class="f">+ \fr 7:14 \ft TR reads “Because” instead of “How”</span> <span class="wj">narrow is the gate and the way is restricted that leads to life! There are few who find it.</span> 
-</p><p>
-<span class="v">15&#160;</span><span class="wj">“Beware of false prophets, who come to you in sheep’s clothing, but inwardly are ravening wolves. </span> 
-<span class="v">16&#160;</span><span class="wj">By their fruits you will know them. Do you gather grapes from thorns or figs from thistles? </span> 
-<span class="v">17&#160;</span><span class="wj">Even so, every good tree produces good fruit, but the corrupt tree produces evil fruit. </span> 
-<span class="v">18&#160;</span><span class="wj">A good tree can’t produce evil fruit, neither can a corrupt tree produce good fruit. </span> 
-<span class="v">19&#160;</span><span class="wj">Every tree that doesn’t grow good fruit is cut down and thrown into the fire. </span> 
-<span class="v">20&#160;</span><span class="wj">Therefore by their fruits you will know them. </span> 
-</p><p>
-<span class="v">21&#160;</span><span class="wj">“Not everyone who says to me, ‘Lord, Lord,’ will enter into the Kingdom of Heaven, but he who does the will of my Father who is in heaven. </span> 
-<span class="v">22&#160;</span><span class="wj">Many will tell me in that day, ‘Lord, Lord, didn’t we prophesy in your name, in your name cast out demons, and in your name do many mighty works?’ </span> 
-<span class="v">23&#160;</span><span class="wj">Then I will tell them, ‘I never knew you. Depart from me, you who work iniquity.’</span> 
-</p><p>
-<span class="v">24&#160;</span><span class="wj">“Everyone therefore who hears these words of mine and does them, I will liken him to a wise man who built his house on a rock. </span> 
-<span class="v">25&#160;</span><span class="wj">The rain came down, the floods came, and the winds blew and beat on that house; and it didn’t fall, for it was founded on the rock. </span> 
-<span class="v">26&#160;</span><span class="wj">Everyone who hears these words of mine and doesn’t do them will be like a foolish man who built his house on the sand. </span> 
-<span class="v">27&#160;</span><span class="wj">The rain came down, the floods came, and the winds blew and beat on that house; and it fell—and its fall was great.”</span> 
-</p><p>
-<span class="v">28&#160;</span>When Yahushua had finished saying these things, the multitudes were astonished at his teaching, 
-<span class="v">29&#160;</span>for he taught them with authority, and not like the scribes. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>When he came down from the mountain, great multitudes followed him. 
-<span class="v">2&#160;</span>Behold, a leper came to him and worshiped him, saying, “Lord, if you want to, you can make me clean.” 
-</p><p>
-<span class="v">3&#160;</span>Yahushua stretched out his hand and touched him, saying, <span class="wj">“I want to. Be made clean.”</span> Immediately his leprosy was cleansed. 
-<span class="v">4&#160;</span>Yahushua said to him, <span class="wj">“See that you tell nobody; but go, show yourself to the priest, and offer the gift that Moses commanded, as a testimony to them.”</span> 
-</p><p>
-<span class="v">5&#160;</span>When he came into Capernaum, a centurion came to him, asking him for help, 
-<span class="v">6&#160;</span>saying, “Lord, my servant lies in the house paralyzed, grievously tormented.” 
-</p><p>
-<span class="v">7&#160;</span>Yahushua said to him, <span class="wj">“I will come and heal him.”</span> 
-</p><p>
-<span class="v">8&#160;</span>The centurion answered, “Lord, I’m not worthy for you to come under my roof. Just say the word, and my servant will be healed. 
-<span class="v">9&#160;</span>For I am also a man under authority, having under myself soldiers. I tell this one, ‘Go,’ and he goes; and tell another, ‘Come,’ and he comes; and tell my servant, ‘Do this,’ and he does it.” 
-</p><p>
-<span class="v">10&#160;</span>When Yahushua heard it, he marveled and said to those who followed, <span class="wj">“Most certainly I tell you, I haven’t found so great a faith, not even in Israel. </span> 
-<span class="v">11&#160;</span><span class="wj">I tell you that many will come from the east and the west, and will sit down with Abraham, Isaac, and Jacob in the Kingdom of Heaven, </span> 
-<span class="v">12&#160;</span><span class="wj">but the children of the Kingdom will be thrown out into the outer darkness. There will be weeping and gnashing of teeth.”</span> 
-<span class="v">13&#160;</span>Yahushua said to the centurion, <span class="wj">“Go your way. Let it be done for you as you have believed.”</span> His servant was healed in that hour. 
-</p><p>
-<span class="v">14&#160;</span>When Yahushua came into Peter’s house, he saw his woman’s mother lying sick with a fever. 
-<span class="v">15&#160;</span>He touched her hand, and the fever left her. So she got up and served him.<span class="f">+ \fr 8:15 \ft TR reads “them” instead of “him”</span> 
-<span class="v">16&#160;</span>When evening came, they brought to him many possessed with demons. He cast out the spirits with a word, and healed all who were sick, 
-<span class="v">17&#160;</span>that it might be fulfilled which was spoken through Isaiah the prophet, saying, “He took our infirmities and bore our diseases.”<span class="x">+ \xo 8:17 \xt Isaiah 53:4 </span> 
-</p><p>
-<span class="v">18&#160;</span>Now when Yahushua saw great multitudes around him, he gave the order to depart to the other side. 
-</p><p>
-<span class="v">19&#160;</span>A scribe came and said to him, “Teacher, I will follow you wherever you go.” 
-</p><p>
-<span class="v">20&#160;</span>Yahushua said to him, <span class="wj">“The foxes have holes and the birds of the sky have nests, but the Son of Man has nowhere to lay his head.”</span> 
-</p><p>
-<span class="v">21&#160;</span>Another of his disciples said to him, “Lord, allow me first to go and bury my father.” 
-</p><p>
-<span class="v">22&#160;</span>But Yahushua said to him, <span class="wj">“Follow me, and leave the dead to bury their own dead.”</span> 
-</p><p>
-<span class="v">23&#160;</span>When he got into a boat, his disciples followed him. 
-<span class="v">24&#160;</span>Behold, a violent storm came up on the sea, so much that the boat was covered with the waves; but he was asleep. 
-<span class="v">25&#160;</span>The disciples came to him and woke him up, saying, “Save us, Lord! We are dying!” 
-</p><p>
-<span class="v">26&#160;</span>He said to them, <span class="wj">“Why are you fearful, O you of little faith?” </span> Then he got up, rebuked the wind and the sea, and there was a great calm. 
-</p><p>
-<span class="v">27&#160;</span>The men marveled, saying, “What kind of man is this, that even the wind and the sea obey him?” 
-</p><p>
-<span class="v">28&#160;</span>When he came to the other side, into the country of the Gergesenes,<span class="f">+ \fr 8:28 \ft NU reads “Gadarenes”</span> two people possessed by demons met him there, coming out of the tombs, exceedingly fierce, so that nobody could pass that way. 
-<span class="v">29&#160;</span>Behold, they cried out, saying, “What do we have to do with you, Yahushua, Son of Elohim? Have you come here to torment us before the time?” 
-<span class="v">30&#160;</span>Now there was a herd of many pigs feeding far away from them. 
-<span class="v">31&#160;</span>The demons begged him, saying, “If you cast us out, permit us to go away into the herd of pigs.” 
-</p><p>
-<span class="v">32&#160;</span>He said to them, <span class="wj">“Go!”</span> 
-</p><p>They came out and went into the herd of pigs; and behold, the whole herd of pigs rushed down the cliff into the sea and died in the water. 
-<span class="v">33&#160;</span>Those who fed them fled and went away into the city and told everything, including what happened to those who were possessed with demons. 
-<span class="v">34&#160;</span>Behold, all the city came out to meet Yahushua. When they saw him, they begged that he would depart from their borders. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>He entered into a boat and crossed over, and came into his own city. 
-<span class="v">2&#160;</span>Behold, they brought to him a man who was paralyzed, lying on a bed. Yahushua, seeing their faith, said to the paralytic, <span class="wj">“Son, cheer up! Your sins are forgiven you.”</span> 
-</p><p>
-<span class="v">3&#160;</span>Behold, some of the scribes said to themselves, “This man blasphemes.” 
-</p><p>
-<span class="v">4&#160;</span>Yahushua, knowing their thoughts, said, <span class="wj">“Why do you think evil in your hearts? </span> 
-<span class="v">5&#160;</span><span class="wj">For which is easier, to say, ‘Your sins are forgiven;’ or to say, ‘Get up, and walk’? </span> 
-<span class="v">6&#160;</span><span class="wj">But that you may know that the Son of Man has authority on earth to forgive sins—”</span> (then he said to the paralytic), <span class="wj">“Get up, and take up your mat, and go to your house.”</span> 
-</p><p>
-<span class="v">7&#160;</span>He arose and departed to his house. 
-<span class="v">8&#160;</span>But when the multitudes saw it, they marveled and glorified Elohim, who had given such authority to men. 
-</p><p>
-<span class="v">9&#160;</span>As Yahushua passed by from there, he saw a man called Matthew sitting at the tax collection office. He said to him, <span class="wj">“Follow me.”</span> He got up and followed him. 
-<span class="v">10&#160;</span>As he sat in the house, behold, many tax collectors and sinners came and sat down with Yahushua and his disciples. 
-<span class="v">11&#160;</span>When the Pharisees saw it, they said to his disciples, “Why does your teacher eat with tax collectors and sinners?” 
-</p><p>
-<span class="v">12&#160;</span>When Yahushua heard it, he said to them, <span class="wj">“Those who are healthy have no need for a physician, but those who are sick do. </span> 
-<span class="v">13&#160;</span><span class="wj">But you go and learn what this means: ‘I desire mercy, and not sacrifice,’</span><span class="x">+ \xo 9:13 \xt Hosea 6:6</span> <span class="wj">for I came not to call the righteous, but sinners to repentance.”</span><span class="f">+ \fr 9:13 \ft NU omits “to repentance”.</span> 
-</p><p>
-<span class="v">14&#160;</span>Then John’s disciples came to him, saying, “Why do we and the Pharisees fast often, but your disciples don’t fast?” 
-</p><p>
-<span class="v">15&#160;</span>Yahushua said to them, <span class="wj">“Can the friends of the bridegroom mourn as long as the bridegroom is with them? But the days will come when the bridegroom will be taken away from them, and then they will fast. </span> 
-<span class="v">16&#160;</span><span class="wj">No one puts a piece of unshrunk cloth on an old garment; for the patch would tear away from the garment, and a worse hole is made. </span> 
-<span class="v">17&#160;</span><span class="wj">Neither do people put new wine into old wine skins, or else the skins would burst, and the wine be spilled, and the skins ruined. No, they put new wine into fresh wine skins, and both are preserved.”</span> 
-</p><p>
-<span class="v">18&#160;</span>While he told these things to them, behold, a ruler came and worshiped him, saying, “My daughter has just died, but come and lay your hand on her, and she will live.” 
-</p><p>
-<span class="v">19&#160;</span>Yahushua got up and followed him, as did his disciples. 
-<span class="v">20&#160;</span>Behold, a woman who had a discharge of blood for twelve years came behind him, and touched the fringe<span class="f">+ \fr 9:20 \ft or, tassel</span> of his garment; 
-<span class="v">21&#160;</span>for she said within herself, “If I just touch his garment, I will be made well.” 
-</p><p>
-<span class="v">22&#160;</span>But Yahushua, turning around and seeing her, said, <span class="wj">“Daughter, cheer up! Your faith has made you well.”</span> And the woman was made well from that hour. 
-</p><p>
-<span class="v">23&#160;</span>When Yahushua came into the ruler’s house and saw the flute players and the crowd in noisy disorder, 
-<span class="v">24&#160;</span>he said to them, <span class="wj">“Make room, because the girl isn’t dead, but sleeping.”</span> 
-</p><p>They were ridiculing him. 
-<span class="v">25&#160;</span>But when the crowd was sent out, he entered in, took her by the hand, and the girl arose. 
-<span class="v">26&#160;</span>The report of this went out into all that land. 
-</p><p>
-<span class="v">27&#160;</span>As Yahushua passed by from there, two blind men followed him, calling out and saying, “Have mercy on us, son of David!” 
-<span class="v">28&#160;</span>When he had come into the house, the blind men came to him. Yahushua said to them, <span class="wj">“Do you believe that I am able to do this?”</span> 
-</p><p>They told him, “Yes, Lord.” 
-</p><p>
-<span class="v">29&#160;</span>Then he touched their eyes, saying, <span class="wj">“According to your faith be it done to you.”</span> 
-<span class="v">30&#160;</span>Then their eyes were opened. Yahushua strictly commanded them, saying, <span class="wj">“See that no one knows about this.”</span> 
-<span class="v">31&#160;</span>But they went out and spread abroad his fame in all that land. 
-</p><p>
-<span class="v">32&#160;</span>As they went out, behold, a mute man who was demon possessed was brought to him. 
-<span class="v">33&#160;</span>When the demon was cast out, the mute man spoke. The multitudes marveled, saying, “Nothing like this has ever been seen in Israel!” 
-</p><p>
-<span class="v">34&#160;</span>But the Pharisees said, “By the prince of the demons, he casts out demons.” 
-</p><p>
-<span class="v">35&#160;</span>Yahushua went about all the cities and the villages, teaching in their synagogues and preaching the Good News of the Kingdom, and healing every disease and every sickness among the people. 
-<span class="v">36&#160;</span>But when he saw the multitudes, he was moved with compassion for them because they were harassed<span class="f">+ \fr 9:36 \ft TR reads “weary” instead of “harassed” </span> and scattered, like sheep without a shepherd. 
-<span class="v">37&#160;</span>Then he said to his disciples, <span class="wj">“The harvest indeed is plentiful, but the laborers are few. </span> 
-<span class="v">38&#160;</span><span class="wj">Pray therefore that the Lord of the harvest will send out laborers into his harvest.”</span> 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>He called to himself his twelve disciples, and gave them authority over unclean spirits, to cast them out, and to heal every disease and every sickness. 
-<span class="v">2&#160;</span>Now the names of the twelve apostles are these. The first, Simon, who is called Peter; Andrew, his brother; James the son of Zebedee; John, his brother; 
-<span class="v">3&#160;</span>Philip; Bartholomew; Thomas; Matthew the tax collector; James the son of Alphaeus; Lebbaeus, who was also called<span class="f">+ \fr 10:3 \ft NU omits “Lebbaeus, who was also called”</span> Thaddaeus; 
-<span class="v">4&#160;</span>Simon the Zealot; and Judas Iscariot, who also betrayed him. 
-</p><p>
-<span class="v">5&#160;</span>Yahushua sent these twelve out and commanded them, saying, <span class="wj">“Don’t go among the Gentiles, and don’t enter into any city of the Samaritans. </span> 
-<span class="v">6&#160;</span><span class="wj">Rather, go to the lost sheep of the house of Israel. </span> 
-<span class="v">7&#160;</span><span class="wj">As you go, preach, saying, ‘The Kingdom of Heaven is at hand!’ </span> 
-<span class="v">8&#160;</span><span class="wj">Heal the sick, cleanse the lepers,</span><span class="f">+ \fr 10:8 \ft TR adds “raise the dead,”</span> <span class="wj">and cast out demons. Freely you received, so freely give. </span> 
-<span class="v">9&#160;</span><span class="wj">Don’t take any gold, silver, or brass in your money belts. </span> 
-<span class="v">10&#160;</span><span class="wj">Take no bag for your journey, neither two coats, nor sandals, nor staff: for the laborer is worthy of his food. </span> 
-<span class="v">11&#160;</span><span class="wj">Into whatever city or village you enter, find out who in it is worthy, and stay there until you go on. </span> 
-<span class="v">12&#160;</span><span class="wj">As you enter into the household, greet it. </span> 
-<span class="v">13&#160;</span><span class="wj">If the household is worthy, let your peace come on it, but if it isn’t worthy, let your peace return to you. </span> 
-<span class="v">14&#160;</span><span class="wj">Whoever doesn’t receive you or hear your words, as you go out of that house or that city, shake the dust off your feet. </span> 
-<span class="v">15&#160;</span><span class="wj">Most certainly I tell you, it will be more tolerable for the land of Sodom and Gomorrah in the day of judgment than for that city.</span> 
-</p><p>
-<span class="v">16&#160;</span><span class="wj">“Behold, I send you out as sheep among wolves. Therefore be wise as serpents and harmless as doves. </span> 
-<span class="v">17&#160;</span><span class="wj">But beware of men, for they will deliver you up to councils, and in their synagogues they will scourge you. </span> 
-<span class="v">18&#160;</span><span class="wj">Yes, and you will be brought before governors and kings for my sake, for a testimony to them and to the nations. </span> 
-<span class="v">19&#160;</span><span class="wj">But when they deliver you up, don’t be anxious how or what you will say, for it will be given you in that hour what you will say. </span> 
-<span class="v">20&#160;</span><span class="wj">For it is not you who speak, but the Spirit of your Father who speaks in you.</span> 
-</p><p>
-<span class="v">21&#160;</span><span class="wj">“Brother will deliver up brother to death, and the father his child. Children will rise up against parents and cause them to be put to death. </span> 
-<span class="v">22&#160;</span><span class="wj">You will be hated by all men for my name’s sake, but he who endures to the end will be saved. </span> 
-<span class="v">23&#160;</span><span class="wj">But when they persecute you in this city, flee into the next, for most certainly I tell you, you will not have gone through the cities of Israel until the Son of Man has come.</span> 
-</p><p>
-<span class="v">24&#160;</span><span class="wj">“A disciple is not above his teacher, nor a servant above his lord. </span> 
-<span class="v">25&#160;</span><span class="wj">It is enough for the disciple that he be like his teacher, and the servant like his lord. If they have called the master of the house Beelzebul,</span><span class="f">+ \fr 10:25 \ft Literally, Lord of the Flies, or the devil</span> <span class="wj">how much more those of his household! </span> 
-<span class="v">26&#160;</span><span class="wj">Therefore don’t be afraid of them, for there is nothing covered that will not be revealed, or hidden that will not be known. </span> 
-<span class="v">27&#160;</span><span class="wj">What I tell you in the darkness, speak in the light; and what you hear whispered in the ear, proclaim on the housetops. </span> 
-<span class="v">28&#160;</span><span class="wj">Don’t be afraid of those who kill the body, but are not able to kill the soul. Rather, fear him who is able to destroy both soul and body in Gehenna.</span><span class="f">+ \fr 10:28 \ft or, Hell.</span> 
-</p><p>
-<span class="v">29&#160;</span><span class="wj">“Aren’t two sparrows sold for an assarion coin?</span><span class="f">+ \fr 10:29 \ft An assarion is a small coin worth one tenth of a drachma or a sixteenth of a denarius. An assarion is approximately the wages of one half hour of agricultural labor.</span> <span class="wj">Not one of them falls to the ground apart from your Father’s will. </span> 
-<span class="v">30&#160;</span><span class="wj">But the very hairs of your head are all numbered. </span> 
-<span class="v">31&#160;</span><span class="wj">Therefore don’t be afraid. You are of more value than many sparrows. </span> 
-<span class="v">32&#160;</span><span class="wj">Everyone therefore who confesses me before men, I will also confess him before my Father who is in heaven. </span> 
-<span class="v">33&#160;</span><span class="wj">But whoever denies me before men, I will also deny him before my Father who is in heaven.</span> 
-</p><p>
-<span class="v">34&#160;</span><span class="wj">“Don’t think that I came to send peace on the earth. I didn’t come to send peace, but a sword. </span> 
-<span class="v">35&#160;</span><span class="wj">For I came to set a man at odds against his father, and a daughter against her mother, and a daughter-in-law against her mother-in-law. </span> 
-<span class="v">36&#160;</span><span class="wj">A man’s foes will be those of his own household.</span><span class="x">+ \xo 10:36 \xt Micah 7:6</span> 
-<span class="v">37&#160;</span><span class="wj">He who loves father or mother more than me is not worthy of me; and he who loves son or daughter more than me isn’t worthy of me. </span> 
-<span class="v">38&#160;</span><span class="wj">He who doesn’t take his cross and follow after me isn’t worthy of me. </span> 
-<span class="v">39&#160;</span><span class="wj">He who seeks his life will lose it; and he who loses his life for my sake will find it. </span> 
-</p><p>
-<span class="v">40&#160;</span><span class="wj">“He who receives you receives me, and he who receives me receives him who sent me. </span> 
-<span class="v">41&#160;</span><span class="wj">He who receives a prophet in the name of a prophet will receive a prophet’s reward. He who receives a righteous man in the name of a righteous man will receive a righteous man’s reward. </span> 
-<span class="v">42&#160;</span><span class="wj">Whoever gives one of these little ones just a cup of cold water to drink in the name of a disciple, most certainly I tell you, he will in no way lose his reward.”</span> 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>When Yahushua had finished directing his twelve disciples, he departed from there to teach and preach in their cities. 
-</p><p>
-<span class="v">2&#160;</span>Now when John heard in the prison the works of Christ, he sent two of his disciples 
-<span class="v">3&#160;</span>and said to him, “Are you he who comes, or should we look for another?” 
-</p><p>
-<span class="v">4&#160;</span>Yahushua answered them, <span class="wj">“Go and tell John the things which you hear and see: </span> 
-<span class="v">5&#160;</span><span class="wj">the blind receive their sight, the lame walk, the lepers are cleansed, the deaf hear,</span><span class="x">+ \xo 11:5 \xt Isaiah 35:5</span> <span class="wj">the dead are raised up, and the poor have good news preached to them.</span><span class="x">+ \xo 11:5 \xt Isaiah 61:1-4</span> 
-<span class="v">6&#160;</span><span class="wj">Blessed is he who finds no occasion for stumbling in me.”</span> 
-</p><p>
-<span class="v">7&#160;</span>As these went their way, Yahushua began to say to the multitudes concerning John, <span class="wj">“What did you go out into the wilderness to see? A reed shaken by the wind? </span> 
-<span class="v">8&#160;</span><span class="wj">But what did you go out to see? A man in soft clothing? Behold, those who wear soft clothing are in kings’ houses. </span> 
-<span class="v">9&#160;</span><span class="wj">But why did you go out? To see a prophet? Yes, I tell you, and much more than a prophet. </span> 
-<span class="v">10&#160;</span><span class="wj">For this is he, of whom it is written, ‘Behold, I send my messenger before your face, who will prepare your way before you.’</span><span class="x">+ \xo 11:10 \xt Malachi 3:1 </span> 
-<span class="v">11&#160;</span><span class="wj">Most certainly I tell you, among those who are born of women there has not arisen anyone greater than John the Baptizer; yet he who is least in the Kingdom of Heaven is greater than he. </span> 
-<span class="v">12&#160;</span><span class="wj">From the days of John the Baptizer until now, the Kingdom of Heaven suffers violence, and the violent take it by force.</span><span class="f">+ \fr 11:12 \ft or, plunder it. </span> 
-<span class="v">13&#160;</span><span class="wj">For all the prophets and the law prophesied until John. </span> 
-<span class="v">14&#160;</span><span class="wj">If you are willing to receive it, this is Elijah, who is to come. </span> 
-<span class="v">15&#160;</span><span class="wj">He who has ears to hear, let him hear.</span> 
-</p><p>
-<span class="v">16&#160;</span><span class="wj">“But to what shall I compare this generation? It is like children sitting in the marketplaces, who call to their companions </span> 
-<span class="v">17&#160;</span><span class="wj">and say, ‘We played the flute for you, and you didn’t dance. We mourned for you, and you didn’t lament.’ </span> 
-<span class="v">18&#160;</span><span class="wj">For John came neither eating nor drinking, and they say, ‘He has a demon.’ </span> 
-<span class="v">19&#160;</span><span class="wj">The Son of Man came eating and drinking, and they say, ‘Behold, a gluttonous man and a drunkard, a friend of tax collectors and sinners!’ But wisdom is justified by her children.”</span><span class="f">+ \fr 11:19 \ft NU reads “actions” instead of “children”</span> 
-</p><p>
-<span class="v">20&#160;</span>Then he began to denounce the cities in which most of his mighty works had been done, because they didn’t repent. 
-<span class="v">21&#160;</span><span class="wj">“Woe to you, Chorazin! Woe to you, Bethsaida! For if the mighty works had been done in Tyre and Sidon which were done in you, they would have repented long ago in sackcloth and ashes. </span> 
-<span class="v">22&#160;</span><span class="wj">But I tell you, it will be more tolerable for Tyre and Sidon on the day of judgment than for you. </span> 
-<span class="v">23&#160;</span><span class="wj">You, Capernaum, who are exalted to heaven, you will go down to Hades. </span><span class="f">+ \fr 11:23 \ft or, Hell</span> <span class="wj">For if the mighty works had been done in Sodom which were done in you, it would have remained until today. </span> 
-<span class="v">24&#160;</span><span class="wj">But I tell you that it will be more tolerable for the land of Sodom on the day of judgment, than for you.”</span> 
-</p><p>
-<span class="v">25&#160;</span>At that time, Yahushua answered, <span class="wj">“I thank you, Father, Lord of heaven and earth, that you hid these things from the wise and understanding, and revealed them to infants. </span> 
-<span class="v">26&#160;</span><span class="wj">Yes, Father, for so it was well-pleasing in your sight. </span> 
-<span class="v">27&#160;</span><span class="wj">All things have been delivered to me by my Father. No one knows the Son, except the Father; neither does anyone know the Father, except the Son and he to whom the Son desires to reveal him.</span> 
-</p><p>
-<span class="v">28&#160;</span><span class="wj">“Come to me, all you who labor and are heavily burdened, and I will give you rest. </span> 
-<span class="v">29&#160;</span><span class="wj">Take my yoke upon you and learn from me, for I am gentle and humble in heart; and you will find rest for your souls. </span> 
-<span class="v">30&#160;</span><span class="wj">For my yoke is easy, and my burden is light.”</span> 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>At that time, Yahushua went on the Sabbath day through the grain fields. His disciples were hungry and began to pluck heads of grain and to eat. 
-<span class="v">2&#160;</span>But the Pharisees, when they saw it, said to him, “Behold, your disciples do what is not lawful to do on the Sabbath.” 
-</p><p>
-<span class="v">3&#160;</span>But he said to them, <span class="wj">“Haven’t you read what David did when he was hungry, and those who were with him: </span> 
-<span class="v">4&#160;</span><span class="wj">how he entered into Elohim’s house and ate the show bread, which was not lawful for him to eat, nor for those who were with him, but only for the priests?</span><span class="x">+ \xo 12:4 \xt 1 Samuel 21:3-6</span> 
-<span class="v">5&#160;</span><span class="wj">Or have you not read in the law that on the Sabbath day the priests in the temple profane the Sabbath and are guiltless? </span> 
-<span class="v">6&#160;</span><span class="wj">But I tell you that one greater than the temple is here. </span> 
-<span class="v">7&#160;</span><span class="wj">But if you had known what this means, ‘I desire mercy, and not sacrifice,’</span><span class="x">+ \xo 12:7 \xt Hosea 6:6</span> <span class="wj">you wouldn’t have condemned the guiltless. </span> 
-<span class="v">8&#160;</span><span class="wj">For the Son of Man is Lord of the Sabbath.”</span> 
-</p><p>
-<span class="v">9&#160;</span>He departed from there and went into their synagogue. 
-<span class="v">10&#160;</span>And behold, there was a man with a withered hand. They asked him, “Is it lawful to heal on the Sabbath day?” so that they might accuse him. 
-</p><p>
-<span class="v">11&#160;</span>He said to them, <span class="wj">“What man is there among you who has one sheep, and if this one falls into a pit on the Sabbath day, won’t he grab on to it and lift it out? </span> 
-<span class="v">12&#160;</span><span class="wj">Of how much more value then is a man than a sheep! Therefore it is lawful to do good on the Sabbath day.”</span> 
-<span class="v">13&#160;</span>Then he told the man, <span class="wj">“Stretch out your hand.”</span> He stretched it out; and it was restored whole, just like the other. 
-<span class="v">14&#160;</span>But the Pharisees went out and conspired against him, how they might destroy him. 
-</p><p>
-<span class="v">15&#160;</span>Yahushua, perceiving that, withdrew from there. Great multitudes followed him; and he healed them all, 
-<span class="v">16&#160;</span>and commanded them that they should not make him known, 
-<span class="v">17&#160;</span>that it might be fulfilled which was spoken through Isaiah the prophet, saying, 
-</p><p class="q1">
-<span class="v">18&#160;</span>“Behold, my servant whom I have chosen, 
-</p><p class="q2">my beloved in whom my soul is well pleased. 
-</p><p class="q1">I will put my Spirit on him. 
-</p><p class="q2">He will proclaim justice to the nations. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He will not strive, nor shout, 
-</p><p class="q2">neither will anyone hear his voice in the streets. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He won’t break a bruised reed. 
-</p><p class="q2">He won’t quench a smoking flax, 
-</p><p class="q1">until he leads justice to victory. 
-</p><p class="q2">
-<span class="v">21&#160;</span>In his name, the nations will hope.”<span class="x">+ \xo 12:21 \xt Isaiah 42:1-4</span> 
-</p><p>
-<span class="v">22&#160;</span>Then one possessed by a demon, blind and mute, was brought to him; and he healed him, so that the blind and mute man both spoke and saw. 
-<span class="v">23&#160;</span>All the multitudes were amazed, and said, “Can this be the son of David?” 
-<span class="v">24&#160;</span>But when the Pharisees heard it, they said, “This man does not cast out demons except by Beelzebul, the prince of the demons.” 
-</p><p>
-<span class="v">25&#160;</span>Knowing their thoughts, Yahushua said to them, <span class="wj">“Every kingdom divided against itself is brought to desolation, and every city or house divided against itself will not stand. </span> 
-<span class="v">26&#160;</span><span class="wj">If Satan casts out Satan, he is divided against himself. How then will his kingdom stand? </span> 
-<span class="v">27&#160;</span><span class="wj">If I by Beelzebul cast out demons, by whom do your children cast them out? Therefore they will be your judges. </span> 
-<span class="v">28&#160;</span><span class="wj">But if I by the Spirit of Elohim cast out demons, then Elohim’s Kingdom has come upon you. </span> 
-<span class="v">29&#160;</span><span class="wj">Or how can one enter into the house of the strong man and plunder his goods, unless he first bind the strong man? Then he will plunder his house.</span> 
-</p><p>
-<span class="v">30&#160;</span><span class="wj">“He who is not with me is against me, and he who doesn’t gather with me, scatters. </span> 
-<span class="v">31&#160;</span><span class="wj">Therefore I tell you, every sin and blasphemy will be forgiven men, but the blasphemy against the Spirit will not be forgiven men. </span> 
-<span class="v">32&#160;</span><span class="wj">Whoever speaks a word against the Son of Man, it will be forgiven him; but whoever speaks against the Set-Apart Spirit, it will not be forgiven him, either in this age, or in that which is to come.</span> 
-</p><p>
-<span class="v">33&#160;</span><span class="wj">“Either make the tree good and its fruit good, or make the tree corrupt and its fruit corrupt; for the tree is known by its fruit. </span> 
-<span class="v">34&#160;</span><span class="wj">You offspring of vipers, how can you, being evil, speak good things? For out of the abundance of the heart, the mouth speaks. </span> 
-<span class="v">35&#160;</span><span class="wj">The good man out of his good treasure</span><span class="f">+ \fr 12:35 \ft TR adds “of the heart”</span> <span class="wj">brings out good things, and the evil man out of his evil treasure brings out evil things. </span> 
-<span class="v">36&#160;</span><span class="wj">I tell you that every idle word that men speak, they will give account of it in the day of judgment. </span> 
-<span class="v">37&#160;</span><span class="wj">For by your words you will be justified, and by your words you will be condemned.”</span> 
-</p><p>
-<span class="v">38&#160;</span>Then certain of the scribes and Pharisees answered, “Teacher, we want to see a sign from you.” 
-</p><p>
-<span class="v">39&#160;</span>But he answered them, <span class="wj">“An evil and adulterous generation seeks after a sign, but no sign will be given to it but the sign of Jonah the prophet. </span> 
-<span class="v">40&#160;</span><span class="wj">For as Jonah was three days and three nights in the belly of the huge fish, so will the Son of Man be three days and three nights in the heart of the earth. </span> 
-<span class="v">41&#160;</span><span class="wj">The men of Nineveh will stand up in the judgment with this generation and will condemn it, for they repented at the preaching of Jonah; and behold, someone greater than Jonah is here. </span> 
-<span class="v">42&#160;</span><span class="wj">The Queen of the South will rise up in the judgment with this generation and will condemn it, for she came from the ends of the earth to hear the wisdom of Solomon; and behold, someone greater than Solomon is here. </span> 
-</p><p>
-<span class="v">43&#160;</span><span class="wj">“When an unclean spirit has gone out of a man, he passes through waterless places seeking rest, and doesn’t find it. </span> 
-<span class="v">44&#160;</span><span class="wj">Then he says, ‘I will return into my house from which I came;’ and when he has come back, he finds it empty, swept, and put in order. </span> 
-<span class="v">45&#160;</span><span class="wj">Then he goes and takes with himself seven other spirits more evil than he is, and they enter in and dwell there. The last state of that man becomes worse than the first. Even so will it be also to this evil generation.”</span> 
-</p><p>
-<span class="v">46&#160;</span>While he was yet speaking to the multitudes, behold, his mother and his brothers stood outside, seeking to speak to him. 
-<span class="v">47&#160;</span>One said to him, “Behold, your mother and your brothers stand outside, seeking to speak to you.” 
-</p><p>
-<span class="v">48&#160;</span>But he answered him who spoke to him, <span class="wj">“Who is my mother? Who are my brothers?”</span> 
-<span class="v">49&#160;</span>He stretched out his hand toward his disciples, and said, <span class="wj">“Behold, my mother and my brothers! </span> 
-<span class="v">50&#160;</span><span class="wj">For whoever does the will of my Father who is in heaven, he is my brother, and sister, and mother.”</span> 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>On that day Yahushua went out of the house and sat by the seaside. 
-<span class="v">2&#160;</span>Great multitudes gathered to him, so that he entered into a boat and sat; and all the multitude stood on the beach. 
-<span class="v">3&#160;</span>He spoke to them many things in parables, saying, <span class="wj">“Behold, a farmer went out to sow. </span> 
-<span class="v">4&#160;</span><span class="wj">As he sowed, some seeds fell by the roadside, and the birds came and devoured them. </span> 
-<span class="v">5&#160;</span><span class="wj">Others fell on rocky ground, where they didn’t have much soil, and immediately they sprang up, because they had no depth of earth. </span> 
-<span class="v">6&#160;</span><span class="wj">When the sun had risen, they were scorched. Because they had no root, they withered away. </span> 
-<span class="v">7&#160;</span><span class="wj">Others fell among thorns. The thorns grew up and choked them. </span> 
-<span class="v">8&#160;</span><span class="wj">Others fell on good soil and yielded fruit: some one hundred times as much, some sixty, and some thirty. </span> 
-<span class="v">9&#160;</span><span class="wj">He who has ears to hear, let him hear.”</span> 
-</p><p>
-<span class="v">10&#160;</span>The disciples came, and said to him, “Why do you speak to them in parables?” 
-</p><p>
-<span class="v">11&#160;</span>He answered them, <span class="wj">“To you it is given to know the mysteries of the Kingdom of Heaven, but it is not given to them. </span> 
-<span class="v">12&#160;</span><span class="wj">For whoever has, to him will be given, and he will have abundance; but whoever doesn’t have, from him will be taken away even that which he has. </span> 
-<span class="v">13&#160;</span><span class="wj">Therefore I speak to them in parables, because seeing they don’t see, and hearing, they don’t hear, neither do they understand. </span> 
-<span class="v">14&#160;</span><span class="wj">In them the prophecy of Isaiah is fulfilled, which says, </span> 
-</p><p class="q1"><span class="wj">‘By hearing you will hear,</span> 
-</p><p class="q2"><span class="wj">and will in no way understand;</span> 
-</p><p class="q1"><span class="wj">Seeing you will see,</span> 
-</p><p class="q2"><span class="wj">and will in no way perceive;</span> 
-</p><p class="q1">
-<span class="v">15&#160;</span><span class="wj">for this people’s heart has grown callous,</span> 
-</p><p class="q2"><span class="wj">their ears are dull of hearing,</span> 
-</p><p class="q2"><span class="wj">and they have closed their eyes;</span> 
-</p><p class="q1"><span class="wj">or else perhaps they might perceive with their eyes,</span> 
-</p><p class="q2"><span class="wj">hear with their ears,</span> 
-</p><p class="q2"><span class="wj">understand with their heart,</span> 
-</p><p class="q1"><span class="wj">and would turn again,</span> 
-</p><p class="q2"><span class="wj">and I would heal them.’</span><span class="x">+ \xo 13:15 \xt Isaiah 6:9-10</span> 
-</p><p>
-<span class="v">16&#160;</span><span class="wj">“But blessed are your eyes, for they see; and your ears, for they hear. </span> 
-<span class="v">17&#160;</span><span class="wj">For most certainly I tell you that many prophets and righteous men desired to see the things which you see, and didn’t see them; and to hear the things which you hear, and didn’t hear them.</span> 
-</p><p>
-<span class="v">18&#160;</span><span class="wj">“Hear, then, the parable of the farmer. </span> 
-<span class="v">19&#160;</span><span class="wj">When anyone hears the word of the Kingdom and doesn’t understand it, the evil one comes and snatches away that which has been sown in his heart. This is what was sown by the roadside. </span> 
-<span class="v">20&#160;</span><span class="wj">What was sown on the rocky places, this is he who hears the word and immediately with joy receives it; </span> 
-<span class="v">21&#160;</span><span class="wj">yet he has no root in himself, but endures for a while. When oppression or persecution arises because of the word, immediately he stumbles. </span> 
-<span class="v">22&#160;</span><span class="wj">What was sown among the thorns, this is he who hears the word, but the cares of this age and the deceitfulness of riches choke the word, and he becomes unfruitful. </span> 
-<span class="v">23&#160;</span><span class="wj">What was sown on the good ground, this is he who hears the word and understands it, who most certainly bears fruit and produces, some one hundred times as much, some sixty, and some thirty.”</span> 
-</p><p>
-<span class="v">24&#160;</span>He set another parable before them, saying, <span class="wj">“The Kingdom of Heaven is like a man who sowed good seed in his field, </span> 
-<span class="v">25&#160;</span><span class="wj">but while people slept, his enemy came and sowed darnel weeds</span><span class="f">+ \fr 13:25 \ft darnel is a weed grass (probably bearded darnel or lolium temulentum) that looks very much like wheat until it is mature, when the difference becomes very apparent.</span> <span class="wj">also among the wheat, and went away. </span> 
-<span class="v">26&#160;</span><span class="wj">But when the blade sprang up and produced grain, then the darnel weeds appeared also. </span> 
-<span class="v">27&#160;</span><span class="wj">The servants of the householder came and said to him, ‘Sir, didn’t you sow good seed in your field? Where did these darnel weeds come from?’</span> 
-</p><p>
-<span class="v">28&#160;</span><span class="wj">“He said to them, ‘An enemy has done this.’</span> 
-</p><p><span class="wj">“The servants asked him, ‘Do you want us to go and gather them up?’ </span> 
-</p><p>
-<span class="v">29&#160;</span><span class="wj">“But he said, ‘No, lest perhaps while you gather up the darnel weeds, you root up the wheat with them. </span> 
-<span class="v">30&#160;</span><span class="wj">Let both grow together until the harvest, and in the harvest time I will tell the reapers, “First, gather up the darnel weeds, and bind them in bundles to burn them; but gather the wheat into my barn.”&#160;’&#160;”</span> 
-</p><p>
-<span class="v">31&#160;</span>He set another parable before them, saying, <span class="wj">“The Kingdom of Heaven is like a grain of mustard seed which a man took, and sowed in his field, </span> 
-<span class="v">32&#160;</span><span class="wj">which indeed is smaller than all seeds. But when it is grown, it is greater than the herbs and becomes a tree, so that the birds of the air come and lodge in its branches.”</span> 
-</p><p>
-<span class="v">33&#160;</span>He spoke another parable to them. <span class="wj">“The Kingdom of Heaven is like yeast which a woman took and hid in three measures</span><span class="f">+ \fr 13:33 \ft literally, three sata. Three sata is about 39 liters or a bit more than a bushel</span> <span class="wj">of meal, until it was all leavened.”</span> 
-</p><p>
-<span class="v">34&#160;</span>Yahushua spoke all these things in parables to the multitudes; and without a parable, he didn’t speak to them, 
-<span class="v">35&#160;</span>that it might be fulfilled which was spoken through the prophet, saying, 
-</p><p class="q1">“I will open my mouth in parables; 
-</p><p class="q2">I will utter things hidden from the foundation of the world.”<span class="x">+ \xo 13:35 \xt Psalm 78:2</span> 
-</p><p>
-<span class="v">36&#160;</span>Then Yahushua sent the multitudes away, and went into the house. His disciples came to him, saying, “Explain to us the parable of the darnel weeds of the field.” 
-</p><p>
-<span class="v">37&#160;</span>He answered them, <span class="wj">“He who sows the good seed is the Son of Man, </span> 
-<span class="v">38&#160;</span><span class="wj">the field is the world, the good seeds are the children of the Kingdom, and the darnel weeds are the children of the evil one. </span> 
-<span class="v">39&#160;</span><span class="wj">The enemy who sowed them is the devil. The harvest is the end of the age, and the reapers are angels. </span> 
-<span class="v">40&#160;</span><span class="wj">As therefore the darnel weeds are gathered up and burned with fire; so will it be at the end of this age. </span> 
-<span class="v">41&#160;</span><span class="wj">The Son of Man will send out his angels, and they will gather out of his Kingdom all things that cause stumbling and those who do iniquity, </span> 
-<span class="v">42&#160;</span><span class="wj">and will cast them into the furnace of fire. There will be weeping and gnashing of teeth. </span> 
-<span class="v">43&#160;</span><span class="wj">Then the righteous will shine like the sun in the Kingdom of their Father. He who has ears to hear, let him hear.</span> 
-</p><p>
-<span class="v">44&#160;</span><span class="wj">“Again, the Kingdom of Heaven is like treasure hidden in the field, which a man found and hid. In his joy, he goes and sells all that he has and buys that field.</span> 
-</p><p>
-<span class="v">45&#160;</span><span class="wj">“Again, the Kingdom of Heaven is like a man who is a merchant seeking fine pearls, </span> 
-<span class="v">46&#160;</span><span class="wj">who having found one pearl of great price, he went and sold all that he had and bought it.</span> 
-</p><p>
-<span class="v">47&#160;</span><span class="wj">“Again, the Kingdom of Heaven is like a dragnet that was cast into the sea and gathered some fish of every kind, </span> 
-<span class="v">48&#160;</span><span class="wj">which, when it was filled, fishermen drew up on the beach. They sat down and gathered the good into containers, but the bad they threw away. </span> 
-<span class="v">49&#160;</span><span class="wj">So it will be in the end of the world.</span><span class="f">+ \fr 13:49 \ft or, end of the age.</span> <span class="wj">The angels will come and separate the wicked from among the righteous, </span> 
-<span class="v">50&#160;</span><span class="wj">and will cast them into the furnace of fire. There will be weeping and gnashing of teeth.”</span> 
-<span class="v">51&#160;</span>Yahushua said to them, <span class="wj">“Have you understood all these things?” </span> 
-</p><p>They answered him, “Yes, Lord.” 
-</p><p>
-<span class="v">52&#160;</span>He said to them, <span class="wj">“Therefore every scribe who has been made a disciple in the Kingdom of Heaven is like a man who is a householder, who brings out of his treasure new and old things.”</span> 
-</p><p>
-<span class="v">53&#160;</span>When Yahushua had finished these parables, he departed from there. 
-<span class="v">54&#160;</span>Coming into his own country, he taught them in their synagogue, so that they were astonished and said, “Where did this man get this wisdom and these mighty works? 
-<span class="v">55&#160;</span>Isn’t this the carpenter’s son? Isn’t his mother called Mary, and his brothers James, Joses, Simon, and Judas?<span class="f">+ \fr 13:55 \ft or, Judah</span> 
-<span class="v">56&#160;</span>Aren’t all of his sisters with us? Where then did this man get all of these things?” 
-<span class="v">57&#160;</span>They were offended by him. 
-</p><p>But Yahushua said to them, <span class="wj">“A prophet is not without honor, except in his own country and in his own house.”</span> 
-<span class="v">58&#160;</span>He didn’t do many mighty works there because of their unbelief. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>At that time, Herod the tetrarch heard the report concerning Yahushua, 
-<span class="v">2&#160;</span>and said to his servants, “This is John the Baptizer. He is risen from the dead. That is why these powers work in him.” 
-<span class="v">3&#160;</span>For Herod had arrested John, bound him, and put him in prison for the sake of Herodias, his brother Philip’s woman. 
-<span class="v">4&#160;</span>For John said to him, “It is not lawful for you to have her.” 
-<span class="v">5&#160;</span>When he would have put him to death, he feared the multitude, because they counted him as a prophet. 
-<span class="v">6&#160;</span>But when Herod’s birthday came, the daughter of Herodias danced among them and pleased Herod. 
-<span class="v">7&#160;</span>Therefore he promised with an oath to give her whatever she should ask. 
-<span class="v">8&#160;</span>She, being prompted by her mother, said, “Give me here on a platter the head of John the Baptizer.” 
-</p><p>
-<span class="v">9&#160;</span>The king was grieved, but for the sake of his oaths and of those who sat at the table with him, he commanded it to be given, 
-<span class="v">10&#160;</span>and he sent and beheaded John in the prison. 
-<span class="v">11&#160;</span>His head was brought on a platter and given to the young lady; and she brought it to her mother. 
-<span class="v">12&#160;</span>His disciples came, took the body, and buried it. Then they went and told Yahushua. 
-<span class="v">13&#160;</span>Now when Yahushua heard this, he withdrew from there in a boat to a deserted place apart. When the multitudes heard it, they followed him on foot from the cities. 
-</p><p>
-<span class="v">14&#160;</span>Yahushua went out, and he saw a great multitude. He had compassion on them and healed their sick. 
-<span class="v">15&#160;</span>When evening had come, his disciples came to him, saying, “This place is deserted, and the hour is already late. Send the multitudes away, that they may go into the villages, and buy themselves food.” 
-</p><p>
-<span class="v">16&#160;</span>But Yahushua said to them, <span class="wj">“They don’t need to go away. You give them something to eat.”</span> 
-</p><p>
-<span class="v">17&#160;</span>They told him, “We only have here five loaves and two fish.” 
-</p><p>
-<span class="v">18&#160;</span>He said, <span class="wj">“Bring them here to me.”</span> 
-<span class="v">19&#160;</span>He commanded the multitudes to sit down on the grass; and he took the five loaves and the two fish, and looking up to heaven, he blessed, broke and gave the loaves to the disciples; and the disciples gave to the multitudes. 
-<span class="v">20&#160;</span>They all ate and were filled. They took up twelve baskets full of that which remained left over from the broken pieces. 
-<span class="v">21&#160;</span>Those who ate were about five thousand men, in addition to women and children. 
-</p><p>
-<span class="v">22&#160;</span>Immediately Yahushua made the disciples get into the boat and go ahead of him to the other side, while he sent the multitudes away. 
-<span class="v">23&#160;</span>After he had sent the multitudes away, he went up into the mountain by himself to pray. When evening had come, he was there alone. 
-<span class="v">24&#160;</span>But the boat was now in the middle of the sea, distressed by the waves, for the wind was contrary. 
-<span class="v">25&#160;</span>In the fourth watch of the night,<span class="f">+ \fr 14:25 \ft The night was equally divided into four watches, so the fourth watch is approximately 3:00 a.m. to sunrise. </span> Yahushua came to them, walking on the sea.<span class="x">+ \xo 14:25 \xt See Job 9:8</span> 
-<span class="v">26&#160;</span>When the disciples saw him walking on the sea, they were troubled, saying, “It’s a ghost!” and they cried out for fear. 
-<span class="v">27&#160;</span>But immediately Yahushua spoke to them, saying, <span class="wj">“Cheer up! It is I! </span><span class="f">+ \fr 14:27 \ft or, I AM!</span> <span class="wj">Don’t be afraid.”</span> 
-</p><p>
-<span class="v">28&#160;</span>Peter answered him and said, “Lord, if it is you, command me to come to you on the waters.” 
-</p><p>
-<span class="v">29&#160;</span>He said, <span class="wj">“Come!”</span> 
-</p><p>Peter stepped down from the boat and walked on the waters to come to Yahushua. 
-<span class="v">30&#160;</span>But when he saw that the wind was strong, he was afraid, and beginning to sink, he cried out, saying, “Lord, save me!” 
-</p><p>
-<span class="v">31&#160;</span>Immediately Yahushua stretched out his hand, took hold of him, and said to him, <span class="wj">“You of little faith, why did you doubt?”</span> 
-<span class="v">32&#160;</span>When they got up into the boat, the wind ceased. 
-<span class="v">33&#160;</span>Those who were in the boat came and worshiped him, saying, “You are truly the Son of Elohim!” 
-</p><p>
-<span class="v">34&#160;</span>When they had crossed over, they came to the land of Gennesaret. 
-<span class="v">35&#160;</span>When the people of that place recognized him, they sent into all that surrounding region and brought to him all who were sick; 
-<span class="v">36&#160;</span>and they begged him that they might just touch the fringe<span class="f">+ \fr 14:36 \ft or, tassel</span> of his garment. As many as touched it were made whole. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Then Pharisees and scribes came to Yahushua from Jerusalem, saying, 
-<span class="v">2&#160;</span>“Why do your disciples disobey the tradition of the elders? For they don’t wash their hands when they eat bread.” 
-</p><p>
-<span class="v">3&#160;</span>He answered them, <span class="wj">“Why do you also disobey the commandment of Elohim because of your tradition? </span> 
-<span class="v">4&#160;</span><span class="wj">For Elohim commanded, ‘Honor your father and your mother,’</span><span class="x">+ \xo 15:4 \xt Exodus 20:12; Deuteronomy 5:16</span> <span class="wj">and, ‘He who speaks evil of father or mother, let him be put to death.’</span><span class="x">+ \xo 15:4 \xt Exodus 21:17; Leviticus 20:9</span> 
-<span class="v">5&#160;</span><span class="wj">But you say, ‘Whoever may tell his father or his mother, “Whatever help you might otherwise have gotten from me is a gift devoted to Elohim,” </span> 
-<span class="v">6&#160;</span><span class="wj">he shall not honor his father or mother.’ You have made the commandment of Elohim void because of your tradition. </span> 
-<span class="v">7&#160;</span><span class="wj">You hypocrites! Well did Isaiah prophesy of you, saying,</span> 
-</p><p class="q1">
-<span class="v">8&#160;</span><span class="wj">‘These people draw near to me with their mouth,</span> 
-</p><p class="q2"><span class="wj">and honor me with their lips;</span> 
-</p><p class="q2"><span class="wj">but their heart is far from me.</span> 
-</p><p class="q1">
-<span class="v">9&#160;</span><span class="wj">And they worship me in vain,</span> 
-</p><p class="q2"><span class="wj">teaching as doctrine rules made by men.’&#160;”</span><span class="x">+ \xo 15:9 \xt Isaiah 29:13 </span> 
-</p><p>
-<span class="v">10&#160;</span>He summoned the multitude, and said to them, <span class="wj">“Hear, and understand. </span> 
-<span class="v">11&#160;</span><span class="wj">That which enters into the mouth doesn’t defile the man; but that which proceeds out of the mouth, this defiles the man.”</span> 
-</p><p>
-<span class="v">12&#160;</span>Then the disciples came and said to him, “Do you know that the Pharisees were offended when they heard this saying?” 
-</p><p>
-<span class="v">13&#160;</span>But he answered, <span class="wj">“Every plant which my heavenly Father didn’t plant will be uprooted. </span> 
-<span class="v">14&#160;</span><span class="wj">Leave them alone. They are blind guides of the blind. If the blind guide the blind, both will fall into a pit.”</span> 
-</p><p>
-<span class="v">15&#160;</span>Peter answered him, “Explain the parable to us.” 
-</p><p>
-<span class="v">16&#160;</span>So Yahushua said, <span class="wj">“Do you also still not understand? </span> 
-<span class="v">17&#160;</span><span class="wj">Don’t you understand that whatever goes into the mouth passes into the belly and then out of the body? </span> 
-<span class="v">18&#160;</span><span class="wj">But the things which proceed out of the mouth come out of the heart, and they defile the man. </span> 
-<span class="v">19&#160;</span><span class="wj">For out of the heart come evil thoughts, murders, adulteries, sexual sins, thefts, false testimony, and blasphemies. </span> 
-<span class="v">20&#160;</span><span class="wj">These are the things which defile the man; but to eat with unwashed hands doesn’t defile the man.”</span> 
-</p><p>
-<span class="v">21&#160;</span>Yahushua went out from there and withdrew into the region of Tyre and Sidon. 
-<span class="v">22&#160;</span>Behold, a Canaanite woman came out from those borders and cried, saying, “Have mercy on me, Lord, you son of David! My daughter is severely possessed by a demon!” 
-</p><p>
-<span class="v">23&#160;</span>But he answered her not a word. 
-</p><p>His disciples came and begged him, saying, “Send her away; for she cries after us.” 
-</p><p>
-<span class="v">24&#160;</span>But he answered, <span class="wj">“I wasn’t sent to anyone but the lost sheep of the house of Israel.”</span> 
-</p><p>
-<span class="v">25&#160;</span>But she came and worshiped him, saying, “Lord, help me.” 
-</p><p>
-<span class="v">26&#160;</span>But he answered, <span class="wj">“It is not appropriate to take the children’s bread and throw it to the dogs.”</span> 
-</p><p>
-<span class="v">27&#160;</span>But she said, “Yes, Lord, but even the dogs eat the crumbs which fall from their masters’ table.” 
-</p><p>
-<span class="v">28&#160;</span>Then Yahushua answered her, <span class="wj">“Woman, great is your faith! Be it done to you even as you desire.”</span> And her daughter was healed from that hour. 
-</p><p>
-<span class="v">29&#160;</span>Yahushua departed from there and came near to the sea of Galilee; and he went up on the mountain and sat there. 
-<span class="v">30&#160;</span>Great multitudes came to him, having with them the lame, blind, mute, maimed, and many others, and they put them down at his feet. He healed them, 
-<span class="v">31&#160;</span>so that the multitude wondered when they saw the mute speaking, the injured healed, the lame walking, and the blind seeing—and they glorified the Elohim of Israel. 
-</p><p>
-<span class="v">32&#160;</span>Yahushua summoned his disciples and said, <span class="wj">“I have compassion on the multitude, because they have continued with me now three days and have nothing to eat. I don’t want to send them away fasting, or they might faint on the way.” </span> 
-</p><p>
-<span class="v">33&#160;</span>The disciples said to him, “Where could we get so many loaves in a deserted place as to satisfy so great a multitude?” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua said to them, <span class="wj">“How many loaves do you have?”</span> 
-</p><p>They said, “Seven, and a few small fish.” 
-</p><p>
-<span class="v">35&#160;</span>He commanded the multitude to sit down on the ground; 
-<span class="v">36&#160;</span>and he took the seven loaves and the fish. He gave thanks and broke them, and gave to the disciples, and the disciples to the multitudes. 
-<span class="v">37&#160;</span>They all ate and were filled. They took up seven baskets full of the broken pieces that were left over. 
-<span class="v">38&#160;</span>Those who ate were four thousand men, in addition to women and children. 
-<span class="v">39&#160;</span>Then he sent away the multitudes, got into the boat, and came into the borders of Magdala. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>The Pharisees and Sadducees came, and testing him, asked him to show them a sign from heaven. 
-<span class="v">2&#160;</span>But he answered them, <span class="wj">“When it is evening, you say, ‘It will be fair weather, for the sky is red.’ </span> 
-<span class="v">3&#160;</span><span class="wj">In the morning, ‘It will be foul weather today, for the sky is red and threatening.’ Hypocrites! You know how to discern the appearance of the sky, but you can’t discern the signs of the times! </span> 
-<span class="v">4&#160;</span><span class="wj">An evil and adulterous generation seeks after a sign, and there will be no sign given to it, except the sign of the prophet Jonah.”</span> 
-</p><p>He left them and departed. 
-<span class="v">5&#160;</span>The disciples came to the other side and had forgotten to take bread. 
-<span class="v">6&#160;</span>Yahushua said to them, <span class="wj">“Take heed and beware of the yeast of the Pharisees and Sadducees.”</span> 
-</p><p>
-<span class="v">7&#160;</span>They reasoned among themselves, saying, “We brought no bread.” 
-</p><p>
-<span class="v">8&#160;</span>Yahushua, perceiving it, said, <span class="wj">“Why do you reason among yourselves, you of little faith, because you have brought no bread? </span> 
-<span class="v">9&#160;</span><span class="wj">Don’t you yet perceive or remember the five loaves for the five thousand, and how many baskets you took up, </span> 
-<span class="v">10&#160;</span><span class="wj">or the seven loaves for the four thousand, and how many baskets you took up? </span> 
-<span class="v">11&#160;</span><span class="wj">How is it that you don’t perceive that I didn’t speak to you concerning bread? But beware of the yeast of the Pharisees and Sadducees.” </span> 
-</p><p>
-<span class="v">12&#160;</span>Then they understood that he didn’t tell them to beware of the yeast of bread, but of the teaching of the Pharisees and Sadducees. 
-</p><p>
-<span class="v">13&#160;</span>Now when Yahushua came into the parts of Caesarea Philippi, he asked his disciples, saying, <span class="wj">“Who do men say that I, the Son of Man, am?”</span> 
-</p><p>
-<span class="v">14&#160;</span>They said, “Some say John the Baptizer, some, Elijah, and others, Jeremiah or one of the prophets.” 
-</p><p>
-<span class="v">15&#160;</span>He said to them, <span class="wj">“But who do you say that I am?”</span> 
-</p><p>
-<span class="v">16&#160;</span>Simon Peter answered, “You are the Christ, the Son of the living Elohim.” 
-</p><p>
-<span class="v">17&#160;</span>Yahushua answered him, <span class="wj">“Blessed are you, Simon Bar Jonah, for flesh and blood has not revealed this to you, but my Father who is in heaven. </span> 
-<span class="v">18&#160;</span><span class="wj">I also tell you that you are Peter,</span><span class="f">+ \fr 16:18 \ft Peter’s name, Petros in Greek, is the word for a specific rock or stone.</span> <span class="wj">and on this rock </span><span class="f">+ \fr 16:18 \ft Greek, petra, a rock mass or bedrock.</span> <span class="wj">I will build my assembly, and the gates of Hades</span><span class="f">+ \fr 16:18 \ft or, Hell</span> <span class="wj">will not prevail against it. </span> 
-<span class="v">19&#160;</span><span class="wj">I will give to you the keys of the Kingdom of Heaven, and whatever you bind on earth will have been bound in heaven; and whatever you release on earth will have been released in heaven.”</span> 
-<span class="v">20&#160;</span>Then he commanded the disciples that they should tell no one that he was Yahushua the Christ. 
-</p><p>
-<span class="v">21&#160;</span>From that time, Yahushua began to show his disciples that he must go to Jerusalem and suffer many things from the elders, chief priests, and scribes, and be killed, and the third day be raised up. 
-</p><p>
-<span class="v">22&#160;</span>Peter took him aside and began to rebuke him, saying, “Far be it from you, Lord! This will never be done to you.” 
-</p><p>
-<span class="v">23&#160;</span>But he turned and said to Peter, <span class="wj">“Get behind me, Satan! You are a stumbling block to me, for you are not setting your mind on the things of Elohim, but on the things of men.”</span> 
-</p><p>
-<span class="v">24&#160;</span>Then Yahushua said to his disciples, <span class="wj">“If anyone desires to come after me, let him deny himself, take up his cross, and follow me. </span> 
-<span class="v">25&#160;</span><span class="wj">For whoever desires to save his life will lose it, and whoever will lose his life for my sake will find it. </span> 
-<span class="v">26&#160;</span><span class="wj">For what will it profit a man if he gains the whole world and forfeits his life? Or what will a man give in exchange for his life? </span> 
-<span class="v">27&#160;</span><span class="wj">For the Son of Man will come in the glory of his Father with his angels, and then he will render to everyone according to his deeds. </span> 
-<span class="v">28&#160;</span><span class="wj">Most certainly I tell you, there are some standing here who will in no way taste of death until they see the Son of Man coming in his Kingdom.” </span> 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>After six days, Yahushua took with him Peter, James, and John his brother, and brought them up into a high mountain by themselves. 
-<span class="v">2&#160;</span>He was changed<span class="f">+ \fr 17:2 \ft or, transfigured</span> before them. His face shone like the sun, and his garments became as white as the light. 
-<span class="v">3&#160;</span>Behold, Moses and Elijah appeared to them talking with him. 
-</p><p>
-<span class="v">4&#160;</span>Peter answered and said to Yahushua, “Lord, it is good for us to be here. If you want, let’s make three tents here: one for you, one for Moses, and one for Elijah.” 
-</p><p>
-<span class="v">5&#160;</span>While he was still speaking, behold, a bright cloud overshadowed them. Behold, a voice came out of the cloud, saying, “This is my beloved Son, in whom I am well pleased. Listen to him.” 
-</p><p>
-<span class="v">6&#160;</span>When the disciples heard it, they fell on their faces, and were very afraid. 
-<span class="v">7&#160;</span>Yahushua came and touched them and said, <span class="wj">“Get up, and don’t be afraid.” </span> 
-<span class="v">8&#160;</span>Lifting up their eyes, they saw no one, except Yahushua alone. 
-</p><p>
-<span class="v">9&#160;</span>As they were coming down from the mountain, Yahushua commanded them, saying, <span class="wj">“Don’t tell anyone what you saw, until the Son of Man has risen from the dead.”</span> 
-</p><p>
-<span class="v">10&#160;</span>His disciples asked him, saying, “Then why do the scribes say that Elijah must come first?” 
-</p><p>
-<span class="v">11&#160;</span>Yahushua answered them, <span class="wj">“Elijah indeed comes first, and will restore all things; </span> 
-<span class="v">12&#160;</span><span class="wj">but I tell you that Elijah has come already, and they didn’t recognize him, but did to him whatever they wanted to. Even so the Son of Man will also suffer by them.”</span> 
-<span class="v">13&#160;</span>Then the disciples understood that he spoke to them of John the Baptizer. 
-</p><p>
-<span class="v">14&#160;</span>When they came to the multitude, a man came to him, kneeling down to him and saying, 
-<span class="v">15&#160;</span>“Lord, have mercy on my son, for he is epileptic and suffers grievously; for he often falls into the fire, and often into the water. 
-<span class="v">16&#160;</span>So I brought him to your disciples, and they could not cure him.” 
-</p><p>
-<span class="v">17&#160;</span>Yahushua answered, <span class="wj">“Faithless and perverse generation! How long will I be with you? How long will I bear with you? Bring him here to me.”</span> 
-<span class="v">18&#160;</span>Yahushua rebuked the demon, and it went out of him, and the boy was cured from that hour. 
-</p><p>
-<span class="v">19&#160;</span>Then the disciples came to Yahushua privately, and said, “Why weren’t we able to cast it out?” 
-</p><p>
-<span class="v">20&#160;</span>He said to them, <span class="wj">“Because of your unbelief. For most certainly I tell you, if you have faith as a grain of mustard seed, you will tell this mountain, ‘Move from here to there,’ and it will move; and nothing will be impossible for you. </span> 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when Yahushua was born in Bethlehem of Judea in the days of King Herod, behold, wise men from the east came to Jerusalem, saying, 
+<sup>2&#160;</sup>“Where is he who is born King of the Jews? For we saw his star in the east, and have come to worship him.” 
+<sup>3&#160;</sup>When King Herod heard it, he was troubled, and all Jerusalem with him. 
+<sup>4&#160;</sup>Gathering together all the chief priests and scribes of the people, he asked them where the Christ would be born. 
+<sup>5&#160;</sup>They said to him, “In Bethlehem of Judea, for this is written through the prophet, 
+</div><div class="q1">
+<sup>6&#160;</sup>‘You Bethlehem, land of Judah, 
+</div><div class="q2">are in no way least among the princes of Judah; 
+</div><div class="q1">for out of you shall come a governor 
+</div><div class="q2">who shall shepherd my people, Israel.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>Then Herod secretly called the wise men, and learned from them exactly what time the star appeared. 
+<sup>8&#160;</sup>He sent them to Bethlehem, and said, “Go and search diligently for the young child. When you have found him, bring me word, so that I also may come and worship him.” 
+</div><div class="p">
+<sup>9&#160;</sup>They, having heard the king, went their way; and behold, the star, which they saw in the east, went before them until it came and stood over where the young child was. 
+<sup>10&#160;</sup>When they saw the star, they rejoiced with exceedingly great joy. 
+<sup>11&#160;</sup>They came into the house and saw the young child with Mary, his mother, and they fell down and worshiped him. Opening their treasures, they offered to him gifts: gold, frankincense, and myrrh. 
+<sup>12&#160;</sup>Being warned in a dream not to return to Herod, they went back to their own country another way. 
+</div><div class="p">
+<sup>13&#160;</sup>Now when they had departed, behold, an angel of the Lord appeared to Joseph in a dream, saying, “Arise and take the young child and his mother, and flee into Egypt, and stay there until I tell you, for Herod will seek the young child to destroy him.” 
+</div><div class="p">
+<sup>14&#160;</sup>He arose and took the young child and his mother by night and departed into Egypt, 
+<sup>15&#160;</sup>and was there until the death of Herod, that it might be fulfilled which was spoken by the Lord through the prophet, saying, “Out of Egypt I called my son.” 
+</div><div class="p">
+<sup>16&#160;</sup>Then Herod, when he saw that he was mocked by the wise men, was exceedingly angry, and sent out and killed all the male children who were in Bethlehem and in all the surrounding countryside, from two years old and under, according to the exact time which he had learned from the wise men. 
+<sup>17&#160;</sup>Then that which was spoken by Jeremiah the prophet was fulfilled, saying, 
+</div><div class="q1">
+<sup>18&#160;</sup>“A voice was heard in Ramah, 
+</div><div class="q2">lamentation, weeping and great mourning, 
+</div><div class="q1">Rachel weeping for her children; 
+</div><div class="q2">she wouldn’t be comforted, 
+</div><div class="q2">because they are no more.” 
+</div><div class="p">
+<sup>19&#160;</sup>But when Herod was dead, behold, an angel of the Lord appeared in a dream to Joseph in Egypt, saying, 
+<sup>20&#160;</sup>“Arise and take the young child and his mother, and go into the land of Israel, for those who sought the young child’s life are dead.” 
+</div><div class="p">
+<sup>21&#160;</sup>He arose and took the young child and his mother, and came into the land of Israel. 
+<sup>22&#160;</sup>But when he heard that Archelaus was reigning over Judea in the place of his father, Herod, he was afraid to go there. Being warned in a dream, he withdrew into the region of Galilee, 
+<sup>23&#160;</sup>and came and lived in a city called Nazareth; that it might be fulfilled which was spoken through the prophets that he will be called a Nazarene. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>In those days, John the Baptizer came, preaching in the wilderness of Judea, saying, 
+<sup>2&#160;</sup>“Repent, for the Kingdom of Heaven is at hand!” 
+<sup>3&#160;</sup>For this is he who was spoken of by Isaiah the prophet, saying, 
+</div><div class="q1">“The voice of one crying in the wilderness, 
+</div><div class="q2">make the way of the Lord ready! 
+</div><div class="q2">Make his paths straight!” 
+</div><div class="p">
+<sup>4&#160;</sup>Now John himself wore clothing made of camel’s hair with a leather belt around his waist. His food was locusts and wild honey. 
+<sup>5&#160;</sup>Then people from Jerusalem, all of Judea, and all the region around the Jordan went out to him. 
+<sup>6&#160;</sup>They were baptized by him in the Jordan, confessing their sins. 
+</div><div class="p">
+<sup>7&#160;</sup>But when he saw many of the Pharisees and Sadducees coming for his baptism, he said to them, “You offspring of vipers, who warned you to flee from the wrath to come? 
+<sup>8&#160;</sup>Therefore produce fruit worthy of repentance! 
+<sup>9&#160;</sup>Don’t think to yourselves, ‘We have Abraham for our father,’ for I tell you that Elohim is able to raise up children to Abraham from these stones. 
+<sup>10&#160;</sup>Even now the ax lies at the root of the trees. Therefore every tree that doesn’t produce good fruit is cut down, and cast into the fire. 
+</div><div class="p">
+<sup>11&#160;</sup>“I indeed baptize you in water for repentance, but he who comes after me is mightier than I, whose sandals I am not worthy to carry. He will baptize you in the Set-Apart Spirit. 
+<sup>12&#160;</sup>His winnowing fork is in his hand, and he will thoroughly cleanse his threshing floor. He will gather his wheat into the barn, but the chaff he will burn up with unquenchable fire.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then Yahushua came from Galilee to the Jordan to John, to be baptized by him. 
+<sup>14&#160;</sup>But John would have hindered him, saying, “I need to be baptized by you, and you come to me?” 
+</div><div class="p">
+<sup>15&#160;</sup>But Yahushua, answering, said to him, <span class="wj">“Allow it now, for this is the fitting way for us to fulfill all righteousness.”</span> Then he allowed him. 
+</div><div class="p">
+<sup>16&#160;</sup>Yahushua, when he was baptized, went up directly from the water: and behold, the heavens were opened to him. He saw the Spirit of Elohim descending as a dove, and coming on him. 
+<sup>17&#160;</sup>Behold, a voice out of the heavens said, “This is my beloved Son, with whom I am well pleased. Today I have become his father.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Yahushua was led up by the Spirit into the wilderness to be tempted by the devil. 
+<sup>2&#160;</sup>When he had fasted forty days and forty nights, he was hungry afterward. 
+<sup>3&#160;</sup>The tempter came and said to him, “If you are the Son of Elohim, command that these stones become bread.” 
+</div><div class="p">
+<sup>4&#160;</sup>But he answered, <span class="wj">“It is written, ‘Man shall not live by bread alone, but by every word that proceeds out of Elohim’s mouth.’&#160;”</span> 
+</div><div class="p">
+<sup>5&#160;</sup>Then the devil took him into the set-apart city. He set him on the pinnacle of the temple, 
+<sup>6&#160;</sup>and said to him, “If you are the Son of Elohim, throw yourself down, for it is written, 
+</div><div class="q1">‘He will command his angels concerning you,’ and, 
+</div><div class="q1">‘On their hands they will bear you up, 
+</div><div class="q2">so that you don’t dash your foot against a stone.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>Yahushua said to him, <span class="wj">“Again, it is written, ‘You shall not test the Lord, your Elohim.’&#160;”</span> 
+</div><div class="p">
+<sup>8&#160;</sup>Again, the devil took him to an exceedingly high mountain, and showed him all the kingdoms of the world and their glory. 
+<sup>9&#160;</sup>He said to him, “I will give you all of these things, if you will fall down and worship me.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then Yahushua said to him, <span class="wj">“Get behind me,</span> <span class="wj">Satan! For it is written, ‘You shall worship the Lord your Elohim, and you shall serve him only.’&#160;”</span> 
+</div><div class="p">
+<sup>11&#160;</sup>Then the devil left him, and behold, angels came and served him. 
+</div><div class="p">
+<sup>12&#160;</sup>Now when Yahushua heard that John was delivered up, he withdrew into Galilee. 
+<sup>13&#160;</sup>Leaving Nazareth, he came and lived in Capernaum, which is by the sea, in the region of Zebulun and Naphtali, 
+<sup>14&#160;</sup>that it might be fulfilled which was spoken through Isaiah the prophet, saying, 
+</div><div class="q1">
+<sup>15&#160;</sup>“The land of Zebulun and the land of Naphtali, 
+</div><div class="q2">toward the sea, beyond the Jordan, 
+</div><div class="q2">Galilee of the Gentiles, 
+</div><div class="q1">
+<sup>16&#160;</sup>the people who sat in darkness saw a great light; 
+</div><div class="q2">to those who sat in the region and shadow of death, 
+</div><div class="q2">to them light has dawned.” 
+</div><div class="p">
+<sup>17&#160;</sup>From that time, Yahushua began to preach, and to say, <span class="wj">“Repent! For the Kingdom of Heaven is at hand.”</span> 
+</div><div class="p">
+<sup>18&#160;</sup>Walking by the sea of Galilee, he saw two brothers: Simon, who is called Peter, and Andrew, his brother, casting a net into the sea; for they were fishermen. 
+<sup>19&#160;</sup>He said to them, <span class="wj">“Come after me, and I will make you fishers for men.”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>They immediately left their nets and followed him. 
+<sup>21&#160;</sup>Going on from there, he saw two other brothers, James the son of Zebedee, and John his brother, in the boat with Zebedee their father, mending their nets. He called them. 
+<sup>22&#160;</sup>They immediately left the boat and their father, and followed him. 
+</div><div class="p">
+<sup>23&#160;</sup>Yahushua went about in all Galilee, teaching in their synagogues, preaching the Good News of the Kingdom, and healing every disease and every sickness among the people. 
+<sup>24&#160;</sup>The report about him went out into all Syria. They brought to him all who were sick, afflicted with various diseases and torments, possessed with demons, epileptics, and paralytics; and he healed them. 
+<sup>25&#160;</sup>Great multitudes from Galilee, Decapolis, Jerusalem, Judea, and from beyond the Jordan followed him. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Seeing the multitudes, he went up onto the mountain. When he had sat down, his disciples came to him. 
+<sup>2&#160;</sup>He opened his mouth and taught them, saying, 
+</div><div class="q1">
+<sup>3&#160;</sup><span class="wj">“Blessed are the poor in spirit,</span> 
+</div><div class="q2"><span class="wj">for theirs is the Kingdom of Heaven.</span> 
+</div><div class="q1">
+<sup>4&#160;</sup><span class="wj">Blessed are those who mourn,</span> 
+</div><div class="q2"><span class="wj">for they shall be comforted.</span> 
+</div><div class="q1">
+<sup>5&#160;</sup><span class="wj">Blessed are the gentle,</span> 
+</div><div class="q2"><span class="wj">for they shall inherit the earth.</span> 
+</div><div class="q1">
+<sup>6&#160;</sup><span class="wj">Blessed are those who hunger and thirst for righteousness, </span> 
+</div><div class="q2"><span class="wj">for they shall be filled.</span> 
+</div><div class="q1">
+<sup>7&#160;</sup><span class="wj">Blessed are the merciful,</span> 
+</div><div class="q2"><span class="wj">for they shall obtain mercy.</span> 
+</div><div class="q1">
+<sup>8&#160;</sup><span class="wj">Blessed are the pure in heart,</span> 
+</div><div class="q2"><span class="wj">for they shall see Elohim.</span> 
+</div><div class="q1">
+<sup>9&#160;</sup><span class="wj">Blessed are the peacemakers,</span> 
+</div><div class="q2"><span class="wj">for they shall be called children of Elohim.</span> 
+</div><div class="q1">
+<sup>10&#160;</sup><span class="wj">Blessed are those who have been persecuted for righteousness’ sake, </span> 
+</div><div class="q2"><span class="wj">for theirs is the Kingdom of Heaven.</span> 
+</div><div class="p">
+<sup>11&#160;</sup><span class="wj">“Blessed are you when people reproach you, persecute you, and say all kinds of evil against you falsely, for my sake. </span> 
+<sup>12&#160;</sup><span class="wj">Rejoice, and be exceedingly glad, for great is your reward in heaven. For that is how they persecuted the prophets who were before you. </span> 
+</div><div class="p">
+<sup>13&#160;</sup><span class="wj">“You are the salt of the earth, but if the salt has lost its flavor, with what will it be salted? It is then good for nothing, but to be cast out and trodden under the feet of men. </span> 
+</div><div class="p">
+<sup>14&#160;</sup><span class="wj">You are the light of the world. A city located on a hill can’t be hidden. </span> 
+<sup>15&#160;</sup><span class="wj">Neither do you light a lamp and put it under a measuring basket, but on a stand; and it shines to all who are in the house. </span> 
+<sup>16&#160;</sup><span class="wj">Even so, let your light shine before men, that they may see your good works and glorify your Father who is in heaven.</span> 
+</div><div class="p">
+<sup>17&#160;</sup><span class="wj">“Don’t think that I came to destroy the law or the prophets. I didn’t come to destroy, but to fulfill. </span> 
+<sup>18&#160;</sup><span class="wj">For most certainly, I tell you, until heaven and earth pass away, not even one smallest letter</span> <span class="wj">shall in any way pass away from the law, until all things are accomplished. </span> 
+<sup>19&#160;</sup><span class="wj">Therefore, whoever shall break one of these least commandments and teach others to do so, shall be called least in the Kingdom of Heaven; but whoever shall do and teach them shall be called great in the Kingdom of Heaven. </span> 
+<sup>20&#160;</sup><span class="wj">For I tell you that unless your righteousness exceeds that of the scribes and Pharisees, there is no way you will enter into the Kingdom of Heaven.</span> 
+</div><div class="p">
+<sup>21&#160;</sup><span class="wj">“You have heard that it was said to the ancient ones, ‘You shall not murder;’</span> <span class="wj">and ‘Whoever murders will be in danger of the judgment.’ </span> 
+<sup>22&#160;</sup><span class="wj">But I tell you that everyone who is angry with his brother without a cause </span> 
+</div><div class="p">
+<sup>23&#160;</sup><span class="wj">“If therefore you are offering your gift at the altar, and there remember that your brother has anything against you, </span> 
+<sup>24&#160;</sup><span class="wj">leave your gift there before the altar, and go your way. First be reconciled to your brother, and then come and offer your gift. </span> 
+<sup>25&#160;</sup><span class="wj">Agree with your adversary quickly while you are with him on the way; lest perhaps the prosecutor deliver you to the judge, and the judge deliver you to the officer, and you be cast into prison. </span> 
+<sup>26&#160;</sup><span class="wj">Most certainly I tell you, you shall by no means get out of there until you have paid the last penny.</span> 
+</div><div class="p">
+<sup>27&#160;</sup><span class="wj">“You have heard that it was said, </span> <span class="wj">‘You shall not commit adultery;’</span> 
+<sup>28&#160;</sup><span class="wj">but I tell you that everyone who gazes at a woman to lust after her has committed adultery with her already in his heart. </span> 
+<sup>29&#160;</sup><span class="wj">If your right eye causes you to stumble, pluck it out and throw it away from you. For it is more profitable for you that one of your members should perish than for your whole body to be cast into Gehenna.</span> 
+<sup>30&#160;</sup><span class="wj">If your right hand causes you to stumble, cut it off, and throw it away from you. For it is more profitable for you that one of your members should perish, than for your whole body to be cast into Gehenna.</span> 
+</div><div class="p">
+<sup>31&#160;</sup><span class="wj">“It was also said, ‘Whoever shall put away his woman, let him give her a writing of divorce,’</span> 
+<sup>32&#160;</sup><span class="wj">but I tell you that whoever puts away his woman, except for the cause of sexual immorality, makes her an adulteress; and whoever marries her when she is put away commits adultery.</span> 
+</div><div class="p">
+<sup>33&#160;</sup><span class="wj">“Again you have heard that it was said to the ancient ones, ‘You shall not make false vows by my name, but shall perform to the Lord your vows,’</span> 
+<sup>34&#160;</sup><span class="wj">but I tell you, don’t swear falsely at all: neither by heaven, for it is the throne of Elohim; </span> 
+<sup>35&#160;</sup><span class="wj">nor by the earth, for it is the footstool of his feet; nor by Jerusalem, for it is the city of the great King. </span> 
+<sup>36&#160;</sup><span class="wj">Neither shall you swear by your head, for you can’t make one hair white or black. </span> 
+<sup>37&#160;</sup><span class="wj">But let your ‘Yes’ be ‘Yes’ and your ‘No’ be ‘No.’ Whatever is more than these is of the evil one.</span> 
+</div><div class="p">
+<sup>38&#160;</sup><span class="wj">“You have heard that it was said, ‘An eye for an eye, and a tooth for a tooth.’</span> 
+<sup>39&#160;</sup><span class="wj">And I say to you not to pay evil in exchange for evil, but if hit on your right cheek, prepare for a hit to your left! </span> 
+<sup>40&#160;</sup><span class="wj">If anyone sues you to take away your coat, let him have your cloak also. </span> 
+<sup>41&#160;</sup><span class="wj">Whoever compels you to go one mile, go with him two. </span> 
+<sup>42&#160;</sup><span class="wj">Give to him who asks you, and don’t turn away him who desires to borrow from you.</span> 
+</div><div class="p">
+<sup>43&#160;</sup><span class="wj">“You have heard that it was said, ‘You shall love your neighbor </span> <span class="wj">and hate your enemy.’</span> 
+<sup>44&#160;</sup><span class="wj">But I tell you, love your enemies, bless those who curse you, do good to those who hate you, and pray for those who mistreat you and persecute you, </span> 
+<sup>45&#160;</sup><span class="wj">that you may be children of your Father who is in heaven. For he makes his sun to rise on the evil and the good, and sends rain on the just and the unjust. </span> 
+<sup>46&#160;</sup><span class="wj">For if you love those who love you, what reward do you have? Don’t even the tax collectors do the same? </span> 
+<sup>47&#160;</sup><span class="wj">If you only greet your friends, what more do you do than others? Don’t even the tax collectors</span> <span class="wj">do the same? </span> 
+<sup>48&#160;</sup><span class="wj">Therefore you shall be perfect, just as your Father in heaven is perfect.</span> 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“Be careful that you don’t do your charitable giving</span> <span class="wj">before men, to be seen by them, or else you have no reward from your Father who is in heaven. </span> 
+<sup>2&#160;</sup><span class="wj">Therefore, when you do merciful deeds, don’t sound a trumpet before yourself, as the hypocrites do in the synagogues and in the streets, that they may get glory from men. Most certainly I tell you, they have received their reward. </span> 
+<sup>3&#160;</sup><span class="wj">But when you do merciful deeds, don’t let your left hand know what your right hand does, </span> 
+<sup>4&#160;</sup><span class="wj">so that your merciful deeds may be in secret, then your Father who sees in secret will reward you openly.</span> 
+</div><div class="p">
+<sup>5&#160;</sup><span class="wj">“When you pray, you shall not be as the hypocrites, for they love to stand and pray in the synagogues and in the corners of the streets, that they may be seen by men. Most certainly, I tell you, they have received their reward. </span> 
+<sup>6&#160;</sup><span class="wj">But you, when you pray, enter into your inner room, and having shut your door, pray to your Father who is in secret; and your Father who sees in secret will reward you openly. </span> 
+<sup>7&#160;</sup><span class="wj">In praying, don’t use vain repetitions as the Gentiles do; for they think that they will be heard for their much speaking. </span> 
+<sup>8&#160;</sup><span class="wj">Therefore don’t be like them, for your Father knows what things you need before you ask him. </span> 
+<sup>9&#160;</sup><span class="wj">Pray like this: </span> 
+</div><div class="q1"><span class="wj">“&#160;‘Our Father in heaven, may your name be kept set-apart. </span> 
+</div><div class="q1">
+<sup>10&#160;</sup><span class="wj">Let your Kingdom come. </span> 
+</div><div class="q2"><span class="wj">Let your will be done on earth as it is in heaven. </span> 
+</div><div class="q1">
+<sup>11&#160;</sup><span class="wj">Give us today our daily bread. </span> 
+</div><div class="q1">
+<sup>12&#160;</sup><span class="wj">Forgive us our debts,</span> 
+</div><div class="q2"><span class="wj">as we also forgive our debtors. </span> 
+</div><div class="q1">
+<sup>13&#160;</sup><span class="wj">Bring us not into temptation,</span> 
+</div><div class="q2"><span class="wj">but deliver us from evil.</span> 
+</div><div class="p">
+<sup>14&#160;</sup><span class="wj">“For if you forgive men their trespasses, your heavenly Father will also forgive you. </span> 
+<sup>15&#160;</sup><span class="wj">But if you don’t forgive men their trespasses, neither will your Father forgive your trespasses.</span> 
+</div><div class="p">
+<sup>16&#160;</sup><span class="wj">“Moreover when you fast, don’t be like the hypocrites, with sad faces. For they disfigure their faces that they may be seen by men to be fasting. Most certainly I tell you, they have received their reward. </span> 
+<sup>17&#160;</sup><span class="wj">But you, when you fast, anoint your head and wash your face, </span> 
+<sup>18&#160;</sup><span class="wj">so that you are not seen by men to be fasting, but by your Father who is in secret; and your Father, who sees in secret, will reward you. </span> 
+</div><div class="p">
+<sup>19&#160;</sup><span class="wj">“Don’t lay up treasures for yourselves on the earth, where moth and rust consume, and where thieves break through and steal; </span> 
+<sup>20&#160;</sup><span class="wj">but lay up for yourselves treasures in heaven, where neither moth nor rust consume, and where thieves don’t break through and steal; </span> 
+<sup>21&#160;</sup><span class="wj">for where your treasure is, there your heart will be also. </span> 
+</div><div class="p">
+<sup>22&#160;</sup><span class="wj">“The lamp of the body is the eye. If therefore your eye is sound, your whole body will be full of light. </span> 
+<sup>23&#160;</sup><span class="wj">But if your eye is evil, your whole body will be full of darkness. If therefore the light that is in you is darkness, how great is the darkness! </span> 
+</div><div class="p">
+<sup>24&#160;</sup><span class="wj">“No one can serve two masters, for either he will hate the one and love the other, or else he will be devoted to one and despise the other. You can’t serve both Elohim and Mammon. </span> 
+<sup>25&#160;</sup><span class="wj">Therefore I tell you, don’t be anxious for your life: what you will eat, or what you will drink; nor yet for your body, what you will wear. Isn’t life more than food, and the body more than clothing? </span> 
+<sup>26&#160;</sup><span class="wj">See the birds of the sky, that they don’t sow, neither do they reap, nor gather into barns. Your heavenly Father feeds them. Aren’t you of much more value than they?</span> 
+</div><div class="p">
+<sup>27&#160;</sup><span class="wj">“Which of you by being anxious, can add one moment</span> <span class="wj">to his lifespan? </span> 
+<sup>28&#160;</sup><span class="wj">Why are you anxious about clothing? Consider the lilies of the field, how they grow. They don’t toil, neither do they spin, </span> 
+<sup>29&#160;</sup><span class="wj">yet I tell you that even Solomon in all his glory was not dressed like one of these. </span> 
+<sup>30&#160;</sup><span class="wj">But if Elohim so clothes the grass of the field, which today exists and tomorrow is thrown into the oven, won’t he much more clothe you, you of little faith?</span> 
+</div><div class="p">
+<sup>31&#160;</sup><span class="wj">“Therefore don’t be anxious, saying, ‘What will we eat?’, ‘What will we drink?’ or, ‘With what will we be clothed?’ </span> 
+<sup>32&#160;</sup><span class="wj">For the Gentiles seek after all these things; for your heavenly Father knows that you need all these things. </span> 
+<sup>33&#160;</sup><span class="wj">But seek first Elohim’s Kingdom and his righteousness; and all these things will be given to you as well. </span> 
+<sup>34&#160;</sup><span class="wj">Therefore don’t be anxious for tomorrow, for tomorrow will be anxious for itself. Each day’s own evil is sufficient.</span> 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“Don’t judge, so that you won’t be judged. </span> 
+<sup>2&#160;</sup><span class="wj">For with whatever judgment you judge, you will be judged; and with whatever measure you measure, it will be measured to you. </span> 
+<sup>3&#160;</sup><span class="wj">Why do you see the speck that is in your brother’s eye, but don’t consider the beam that is in your own eye? </span> 
+<sup>4&#160;</sup><span class="wj">Or how will you tell your brother, ‘Let me remove the speck from your eye,’ and behold, the beam is in your own eye? </span> 
+<sup>5&#160;</sup><span class="wj">You hypocrite! First remove the beam out of your own eye, and then you can see clearly to remove the speck out of your brother’s eye.</span> 
+</div><div class="p">
+<sup>6&#160;</sup><span class="wj">“Don’t give that which is set-apart to the dogs, neither throw your pearls before the pigs, lest perhaps they trample them under their feet, and turn and tear you to pieces.</span> 
+</div><div class="p">
+<sup>7&#160;</sup><span class="wj">“Ask, and it will be given you. Seek, and you will find. Knock, and it will be opened for you. </span> 
+<sup>8&#160;</sup><span class="wj">For everyone who asks receives. He who seeks finds. To him who knocks it will be opened. </span> 
+<sup>9&#160;</sup><span class="wj">Or who is there among you who, if his son asks him for bread, will give him a stone? </span> 
+<sup>10&#160;</sup><span class="wj">Or if he asks for a fish, who will give him a serpent? </span> 
+<sup>11&#160;</sup><span class="wj">If you then, being evil, know how to give good gifts to your children, how much more will your Father who is in heaven give good things to those who ask him! </span> 
+<sup>12&#160;</sup><span class="wj">Therefore, whatever you desire for men to do to you, you shall also do to them; for this is the law and the prophets.</span> 
+</div><div class="p">
+<sup>13&#160;</sup><span class="wj">“Enter in by the narrow gate; for the gate is wide and the way is broad that leads to destruction, and there are many who enter in by it. </span> 
+<sup>14&#160;</sup><span class="wj">How</span> <span class="wj">narrow is the gate and the way is restricted that leads to life! There are few who find it.</span> 
+</div><div class="p">
+<sup>15&#160;</sup><span class="wj">“Beware of false prophets, who come to you in sheep’s clothing, but inwardly are ravening wolves. </span> 
+<sup>16&#160;</sup><span class="wj">By their fruits you will know them. Do you gather grapes from thorns or figs from thistles? </span> 
+<sup>17&#160;</sup><span class="wj">Even so, every good tree produces good fruit, but the corrupt tree produces evil fruit. </span> 
+<sup>18&#160;</sup><span class="wj">A good tree can’t produce evil fruit, neither can a corrupt tree produce good fruit. </span> 
+<sup>19&#160;</sup><span class="wj">Every tree that doesn’t grow good fruit is cut down and thrown into the fire. </span> 
+<sup>20&#160;</sup><span class="wj">Therefore by their fruits you will know them. </span> 
+</div><div class="p">
+<sup>21&#160;</sup><span class="wj">“Not everyone who says to me, ‘Lord, Lord,’ will enter into the Kingdom of Heaven, but he who does the will of my Father who is in heaven. </span> 
+<sup>22&#160;</sup><span class="wj">Many will tell me in that day, ‘Lord, Lord, didn’t we prophesy in your name, in your name cast out demons, and in your name do many mighty works?’ </span> 
+<sup>23&#160;</sup><span class="wj">Then I will tell them, ‘I never knew you. Depart from me, you who work iniquity.’</span> 
+</div><div class="p">
+<sup>24&#160;</sup><span class="wj">“Everyone therefore who hears these words of mine and does them, I will liken him to a wise man who built his house on a rock. </span> 
+<sup>25&#160;</sup><span class="wj">The rain came down, the floods came, and the winds blew and beat on that house; and it didn’t fall, for it was founded on the rock. </span> 
+<sup>26&#160;</sup><span class="wj">Everyone who hears these words of mine and doesn’t do them will be like a foolish man who built his house on the sand. </span> 
+<sup>27&#160;</sup><span class="wj">The rain came down, the floods came, and the winds blew and beat on that house; and it fell—and its fall was great.”</span> 
+</div><div class="p">
+<sup>28&#160;</sup>When Yahushua had finished saying these things, the multitudes were astonished at his teaching, 
+<sup>29&#160;</sup>for he taught them with authority, and not like the scribes. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>When he came down from the mountain, great multitudes followed him. 
+<sup>2&#160;</sup>Behold, a leper came to him and worshiped him, saying, “Lord, if you want to, you can make me clean.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahushua stretched out his hand and touched him, saying, <span class="wj">“I want to. Be made clean.”</span> Immediately his leprosy was cleansed. 
+<sup>4&#160;</sup>Yahushua said to him, <span class="wj">“See that you tell nobody; but go, show yourself to the priest, and offer the gift that Moses commanded, as a testimony to them.”</span> 
+</div><div class="p">
+<sup>5&#160;</sup>When he came into Capernaum, a centurion came to him, asking him for help, 
+<sup>6&#160;</sup>saying, “Lord, my servant lies in the house paralyzed, grievously tormented.” 
+</div><div class="p">
+<sup>7&#160;</sup>Yahushua said to him, <span class="wj">“I will come and heal him.”</span> 
+</div><div class="p">
+<sup>8&#160;</sup>The centurion answered, “Lord, I’m not worthy for you to come under my roof. Just say the word, and my servant will be healed. 
+<sup>9&#160;</sup>For I am also a man under authority, having under myself soldiers. I tell this one, ‘Go,’ and he goes; and tell another, ‘Come,’ and he comes; and tell my servant, ‘Do this,’ and he does it.” 
+</div><div class="p">
+<sup>10&#160;</sup>When Yahushua heard it, he marveled and said to those who followed, <span class="wj">“Most certainly I tell you, I haven’t found so great a faith, not even in Israel. </span> 
+<sup>11&#160;</sup><span class="wj">I tell you that many will come from the east and the west, and will sit down with Abraham, Isaac, and Jacob in the Kingdom of Heaven, </span> 
+<sup>12&#160;</sup><span class="wj">but the children of the Kingdom will be thrown out into the outer darkness. There will be weeping and gnashing of teeth.”</span> 
+<sup>13&#160;</sup>Yahushua said to the centurion, <span class="wj">“Go your way. Let it be done for you as you have believed.”</span> His servant was healed in that hour. 
+</div><div class="p">
+<sup>14&#160;</sup>When Yahushua came into Peter’s house, he saw his woman’s mother lying sick with a fever. 
+<sup>15&#160;</sup>He touched her hand, and the fever left her. So she got up and served him. 
+<sup>16&#160;</sup>When evening came, they brought to him many possessed with demons. He cast out the spirits with a word, and healed all who were sick, 
+<sup>17&#160;</sup>that it might be fulfilled which was spoken through Isaiah the prophet, saying, “He took our infirmities and bore our diseases.” 
+</div><div class="p">
+<sup>18&#160;</sup>Now when Yahushua saw great multitudes around him, he gave the order to depart to the other side. 
+</div><div class="p">
+<sup>19&#160;</sup>A scribe came and said to him, “Teacher, I will follow you wherever you go.” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahushua said to him, <span class="wj">“The foxes have holes and the birds of the sky have nests, but the Son of Man has nowhere to lay his head.”</span> 
+</div><div class="p">
+<sup>21&#160;</sup>Another of his disciples said to him, “Lord, allow me first to go and bury my father.” 
+</div><div class="p">
+<sup>22&#160;</sup>But Yahushua said to him, <span class="wj">“Follow me, and leave the dead to bury their own dead.”</span> 
+</div><div class="p">
+<sup>23&#160;</sup>When he got into a boat, his disciples followed him. 
+<sup>24&#160;</sup>Behold, a violent storm came up on the sea, so much that the boat was covered with the waves; but he was asleep. 
+<sup>25&#160;</sup>The disciples came to him and woke him up, saying, “Save us, Lord! We are dying!” 
+</div><div class="p">
+<sup>26&#160;</sup>He said to them, <span class="wj">“Why are you fearful, O you of little faith?” </span> Then he got up, rebuked the wind and the sea, and there was a great calm. 
+</div><div class="p">
+<sup>27&#160;</sup>The men marveled, saying, “What kind of man is this, that even the wind and the sea obey him?” 
+</div><div class="p">
+<sup>28&#160;</sup>When he came to the other side, into the country of the Gergesenes, two people possessed by demons met him there, coming out of the tombs, exceedingly fierce, so that nobody could pass that way. 
+<sup>29&#160;</sup>Behold, they cried out, saying, “What do we have to do with you, Yahushua, Son of Elohim? Have you come here to torment us before the time?” 
+<sup>30&#160;</sup>Now there was a herd of many pigs feeding far away from them. 
+<sup>31&#160;</sup>The demons begged him, saying, “If you cast us out, permit us to go away into the herd of pigs.” 
+</div><div class="p">
+<sup>32&#160;</sup>He said to them, <span class="wj">“Go!”</span> 
+</div><div class="p">They came out and went into the herd of pigs; and behold, the whole herd of pigs rushed down the cliff into the sea and died in the water. 
+<sup>33&#160;</sup>Those who fed them fled and went away into the city and told everything, including what happened to those who were possessed with demons. 
+<sup>34&#160;</sup>Behold, all the city came out to meet Yahushua. When they saw him, they begged that he would depart from their borders. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>He entered into a boat and crossed over, and came into his own city. 
+<sup>2&#160;</sup>Behold, they brought to him a man who was paralyzed, lying on a bed. Yahushua, seeing their faith, said to the paralytic, <span class="wj">“Son, cheer up! Your sins are forgiven you.”</span> 
+</div><div class="p">
+<sup>3&#160;</sup>Behold, some of the scribes said to themselves, “This man blasphemes.” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahushua, knowing their thoughts, said, <span class="wj">“Why do you think evil in your hearts? </span> 
+<sup>5&#160;</sup><span class="wj">For which is easier, to say, ‘Your sins are forgiven;’ or to say, ‘Get up, and walk’? </span> 
+<sup>6&#160;</sup><span class="wj">But that you may know that the Son of Man has authority on earth to forgive sins—”</span> (then he said to the paralytic), <span class="wj">“Get up, and take up your mat, and go to your house.”</span> 
+</div><div class="p">
+<sup>7&#160;</sup>He arose and departed to his house. 
+<sup>8&#160;</sup>But when the multitudes saw it, they marveled and glorified Elohim, who had given such authority to men. 
+</div><div class="p">
+<sup>9&#160;</sup>As Yahushua passed by from there, he saw a man called Matthew sitting at the tax collection office. He said to him, <span class="wj">“Follow me.”</span> He got up and followed him. 
+<sup>10&#160;</sup>As he sat in the house, behold, many tax collectors and sinners came and sat down with Yahushua and his disciples. 
+<sup>11&#160;</sup>When the Pharisees saw it, they said to his disciples, “Why does your teacher eat with tax collectors and sinners?” 
+</div><div class="p">
+<sup>12&#160;</sup>When Yahushua heard it, he said to them, <span class="wj">“Those who are healthy have no need for a physician, but those who are sick do. </span> 
+<sup>13&#160;</sup><span class="wj">But you go and learn what this means: ‘I desire mercy, and not sacrifice,’</span> <span class="wj">for I came not to call the righteous, but sinners to repentance.”</span> 
+</div><div class="p">
+<sup>14&#160;</sup>Then John’s disciples came to him, saying, “Why do we and the Pharisees fast often, but your disciples don’t fast?” 
+</div><div class="p">
+<sup>15&#160;</sup>Yahushua said to them, <span class="wj">“Can the friends of the bridegroom mourn as long as the bridegroom is with them? But the days will come when the bridegroom will be taken away from them, and then they will fast. </span> 
+<sup>16&#160;</sup><span class="wj">No one puts a piece of unshrunk cloth on an old garment; for the patch would tear away from the garment, and a worse hole is made. </span> 
+<sup>17&#160;</sup><span class="wj">Neither do people put new wine into old wine skins, or else the skins would burst, and the wine be spilled, and the skins ruined. No, they put new wine into fresh wine skins, and both are preserved.”</span> 
+</div><div class="p">
+<sup>18&#160;</sup>While he told these things to them, behold, a ruler came and worshiped him, saying, “My daughter has just died, but come and lay your hand on her, and she will live.” 
+</div><div class="p">
+<sup>19&#160;</sup>Yahushua got up and followed him, as did his disciples. 
+<sup>20&#160;</sup>Behold, a woman who had a discharge of blood for twelve years came behind him, and touched the fringe of his garment; 
+<sup>21&#160;</sup>for she said within herself, “If I just touch his garment, I will be made well.” 
+</div><div class="p">
+<sup>22&#160;</sup>But Yahushua, turning around and seeing her, said, <span class="wj">“Daughter, cheer up! Your faith has made you well.”</span> And the woman was made well from that hour. 
+</div><div class="p">
+<sup>23&#160;</sup>When Yahushua came into the ruler’s house and saw the flute players and the crowd in noisy disorder, 
+<sup>24&#160;</sup>he said to them, <span class="wj">“Make room, because the girl isn’t dead, but sleeping.”</span> 
+</div><div class="p">They were ridiculing him. 
+<sup>25&#160;</sup>But when the crowd was sent out, he entered in, took her by the hand, and the girl arose. 
+<sup>26&#160;</sup>The report of this went out into all that land. 
+</div><div class="p">
+<sup>27&#160;</sup>As Yahushua passed by from there, two blind men followed him, calling out and saying, “Have mercy on us, son of David!” 
+<sup>28&#160;</sup>When he had come into the house, the blind men came to him. Yahushua said to them, <span class="wj">“Do you believe that I am able to do this?”</span> 
+</div><div class="p">They told him, “Yes, Lord.” 
+</div><div class="p">
+<sup>29&#160;</sup>Then he touched their eyes, saying, <span class="wj">“According to your faith be it done to you.”</span> 
+<sup>30&#160;</sup>Then their eyes were opened. Yahushua strictly commanded them, saying, <span class="wj">“See that no one knows about this.”</span> 
+<sup>31&#160;</sup>But they went out and spread abroad his fame in all that land. 
+</div><div class="p">
+<sup>32&#160;</sup>As they went out, behold, a mute man who was demon possessed was brought to him. 
+<sup>33&#160;</sup>When the demon was cast out, the mute man spoke. The multitudes marveled, saying, “Nothing like this has ever been seen in Israel!” 
+</div><div class="p">
+<sup>34&#160;</sup>But the Pharisees said, “By the prince of the demons, he casts out demons.” 
+</div><div class="p">
+<sup>35&#160;</sup>Yahushua went about all the cities and the villages, teaching in their synagogues and preaching the Good News of the Kingdom, and healing every disease and every sickness among the people. 
+<sup>36&#160;</sup>But when he saw the multitudes, he was moved with compassion for them because they were harassed and scattered, like sheep without a shepherd. 
+<sup>37&#160;</sup>Then he said to his disciples, <span class="wj">“The harvest indeed is plentiful, but the laborers are few. </span> 
+<sup>38&#160;</sup><span class="wj">Pray therefore that the Lord of the harvest will send out laborers into his harvest.”</span> 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>He called to himself his twelve disciples, and gave them authority over unclean spirits, to cast them out, and to heal every disease and every sickness. 
+<sup>2&#160;</sup>Now the names of the twelve apostles are these. The first, Simon, who is called Peter; Andrew, his brother; James the son of Zebedee; John, his brother; 
+<sup>3&#160;</sup>Philip; Bartholomew; Thomas; Matthew the tax collector; James the son of Alphaeus; Lebbaeus, who was also called Thaddaeus; 
+<sup>4&#160;</sup>Simon the Zealot; and Judas Iscariot, who also betrayed him. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahushua sent these twelve out and commanded them, saying, <span class="wj">“Don’t go among the Gentiles, and don’t enter into any city of the Samaritans. </span> 
+<sup>6&#160;</sup><span class="wj">Rather, go to the lost sheep of the house of Israel. </span> 
+<sup>7&#160;</sup><span class="wj">As you go, preach, saying, ‘The Kingdom of Heaven is at hand!’ </span> 
+<sup>8&#160;</sup><span class="wj">Heal the sick, cleanse the lepers,</span> <span class="wj">and cast out demons. Freely you received, so freely give. </span> 
+<sup>9&#160;</sup><span class="wj">Don’t take any gold, silver, or brass in your money belts. </span> 
+<sup>10&#160;</sup><span class="wj">Take no bag for your journey, neither two coats, nor sandals, nor staff: for the laborer is worthy of his food. </span> 
+<sup>11&#160;</sup><span class="wj">Into whatever city or village you enter, find out who in it is worthy, and stay there until you go on. </span> 
+<sup>12&#160;</sup><span class="wj">As you enter into the household, greet it. </span> 
+<sup>13&#160;</sup><span class="wj">If the household is worthy, let your peace come on it, but if it isn’t worthy, let your peace return to you. </span> 
+<sup>14&#160;</sup><span class="wj">Whoever doesn’t receive you or hear your words, as you go out of that house or that city, shake the dust off your feet. </span> 
+<sup>15&#160;</sup><span class="wj">Most certainly I tell you, it will be more tolerable for the land of Sodom and Gomorrah in the day of judgment than for that city.</span> 
+</div><div class="p">
+<sup>16&#160;</sup><span class="wj">“Behold, I send you out as sheep among wolves. Therefore be wise as serpents and harmless as doves. </span> 
+<sup>17&#160;</sup><span class="wj">But beware of men, for they will deliver you up to councils, and in their synagogues they will scourge you. </span> 
+<sup>18&#160;</sup><span class="wj">Yes, and you will be brought before governors and kings for my sake, for a testimony to them and to the nations. </span> 
+<sup>19&#160;</sup><span class="wj">But when they deliver you up, don’t be anxious how or what you will say, for it will be given you in that hour what you will say. </span> 
+<sup>20&#160;</sup><span class="wj">For it is not you who speak, but the Spirit of your Father who speaks in you.</span> 
+</div><div class="p">
+<sup>21&#160;</sup><span class="wj">“Brother will deliver up brother to death, and the father his child. Children will rise up against parents and cause them to be put to death. </span> 
+<sup>22&#160;</sup><span class="wj">You will be hated by all men for my name’s sake, but he who endures to the end will be saved. </span> 
+<sup>23&#160;</sup><span class="wj">But when they persecute you in this city, flee into the next, for most certainly I tell you, you will not have gone through the cities of Israel until the Son of Man has come.</span> 
+</div><div class="p">
+<sup>24&#160;</sup><span class="wj">“A disciple is not above his teacher, nor a servant above his lord. </span> 
+<sup>25&#160;</sup><span class="wj">It is enough for the disciple that he be like his teacher, and the servant like his lord. If they have called the master of the house Beelzebul,</span> <span class="wj">how much more those of his household! </span> 
+<sup>26&#160;</sup><span class="wj">Therefore don’t be afraid of them, for there is nothing covered that will not be revealed, or hidden that will not be known. </span> 
+<sup>27&#160;</sup><span class="wj">What I tell you in the darkness, speak in the light; and what you hear whispered in the ear, proclaim on the housetops. </span> 
+<sup>28&#160;</sup><span class="wj">Don’t be afraid of those who kill the body, but are not able to kill the soul. Rather, fear him who is able to destroy both soul and body in Gehenna.</span> 
+</div><div class="p">
+<sup>29&#160;</sup><span class="wj">“Aren’t two sparrows sold for an assarion coin?</span> <span class="wj">Not one of them falls to the ground apart from your Father’s will. </span> 
+<sup>30&#160;</sup><span class="wj">But the very hairs of your head are all numbered. </span> 
+<sup>31&#160;</sup><span class="wj">Therefore don’t be afraid. You are of more value than many sparrows. </span> 
+<sup>32&#160;</sup><span class="wj">Everyone therefore who confesses me before men, I will also confess him before my Father who is in heaven. </span> 
+<sup>33&#160;</sup><span class="wj">But whoever denies me before men, I will also deny him before my Father who is in heaven.</span> 
+</div><div class="p">
+<sup>34&#160;</sup><span class="wj">“Don’t think that I came to send peace on the earth. I didn’t come to send peace, but a sword. </span> 
+<sup>35&#160;</sup><span class="wj">For I came to set a man at odds against his father, and a daughter against her mother, and a daughter-in-law against her mother-in-law. </span> 
+<sup>36&#160;</sup><span class="wj">A man’s foes will be those of his own household.</span> 
+<sup>37&#160;</sup><span class="wj">He who loves father or mother more than me is not worthy of me; and he who loves son or daughter more than me isn’t worthy of me. </span> 
+<sup>38&#160;</sup><span class="wj">He who doesn’t take his cross and follow after me isn’t worthy of me. </span> 
+<sup>39&#160;</sup><span class="wj">He who seeks his life will lose it; and he who loses his life for my sake will find it. </span> 
+</div><div class="p">
+<sup>40&#160;</sup><span class="wj">“He who receives you receives me, and he who receives me receives him who sent me. </span> 
+<sup>41&#160;</sup><span class="wj">He who receives a prophet in the name of a prophet will receive a prophet’s reward. He who receives a righteous man in the name of a righteous man will receive a righteous man’s reward. </span> 
+<sup>42&#160;</sup><span class="wj">Whoever gives one of these little ones just a cup of cold water to drink in the name of a disciple, most certainly I tell you, he will in no way lose his reward.”</span> 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahushua had finished directing his twelve disciples, he departed from there to teach and preach in their cities. 
+</div><div class="p">
+<sup>2&#160;</sup>Now when John heard in the prison the works of Christ, he sent two of his disciples 
+<sup>3&#160;</sup>and said to him, “Are you he who comes, or should we look for another?” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahushua answered them, <span class="wj">“Go and tell John the things which you hear and see: </span> 
+<sup>5&#160;</sup><span class="wj">the blind receive their sight, the lame walk, the lepers are cleansed, the deaf hear,</span> 
+<sup>6&#160;</sup><span class="wj">Blessed is he who finds no occasion for stumbling in me.”</span> 
+</div><div class="p">
+<sup>7&#160;</sup>As these went their way, Yahushua began to say to the multitudes concerning John, <span class="wj">“What did you go out into the wilderness to see? A reed shaken by the wind? </span> 
+<sup>8&#160;</sup><span class="wj">But what did you go out to see? A man in soft clothing? Behold, those who wear soft clothing are in kings’ houses. </span> 
+<sup>9&#160;</sup><span class="wj">But why did you go out? To see a prophet? Yes, I tell you, and much more than a prophet. </span> 
+<sup>10&#160;</sup><span class="wj">For this is he, of whom it is written, ‘Behold, I send my messenger before your face, who will prepare your way before you.’</span> 
+<sup>11&#160;</sup><span class="wj">Most certainly I tell you, among those who are born of women there has not arisen anyone greater than John the Baptizer; yet he who is least in the Kingdom of Heaven is greater than he. </span> 
+<sup>12&#160;</sup><span class="wj">From the days of John the Baptizer until now, the Kingdom of Heaven suffers violence, and the violent take it by force.</span> 
+<sup>13&#160;</sup><span class="wj">For all the prophets and the law prophesied until John. </span> 
+<sup>14&#160;</sup><span class="wj">If you are willing to receive it, this is Elijah, who is to come. </span> 
+<sup>15&#160;</sup><span class="wj">He who has ears to hear, let him hear.</span> 
+</div><div class="p">
+<sup>16&#160;</sup><span class="wj">“But to what shall I compare this generation? It is like children sitting in the marketplaces, who call to their companions </span> 
+<sup>17&#160;</sup><span class="wj">and say, ‘We played the flute for you, and you didn’t dance. We mourned for you, and you didn’t lament.’ </span> 
+<sup>18&#160;</sup><span class="wj">For John came neither eating nor drinking, and they say, ‘He has a demon.’ </span> 
+<sup>19&#160;</sup><span class="wj">The Son of Man came eating and drinking, and they say, ‘Behold, a gluttonous man and a drunkard, a friend of tax collectors and sinners!’ But wisdom is justified by her children.”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>Then he began to denounce the cities in which most of his mighty works had been done, because they didn’t repent. 
+<sup>21&#160;</sup><span class="wj">“Woe to you, Chorazin! Woe to you, Bethsaida! For if the mighty works had been done in Tyre and Sidon which were done in you, they would have repented long ago in sackcloth and ashes. </span> 
+<sup>22&#160;</sup><span class="wj">But I tell you, it will be more tolerable for Tyre and Sidon on the day of judgment than for you. </span> 
+<sup>23&#160;</sup><span class="wj">You, Capernaum, who are exalted to heaven, you will go down to Hades. </span> <span class="wj">For if the mighty works had been done in Sodom which were done in you, it would have remained until today. </span> 
+<sup>24&#160;</sup><span class="wj">But I tell you that it will be more tolerable for the land of Sodom on the day of judgment, than for you.”</span> 
+</div><div class="p">
+<sup>25&#160;</sup>At that time, Yahushua answered, <span class="wj">“I thank you, Father, Lord of heaven and earth, that you hid these things from the wise and understanding, and revealed them to infants. </span> 
+<sup>26&#160;</sup><span class="wj">Yes, Father, for so it was well-pleasing in your sight. </span> 
+<sup>27&#160;</sup><span class="wj">All things have been delivered to me by my Father. No one knows the Son, except the Father; neither does anyone know the Father, except the Son and he to whom the Son desires to reveal him.</span> 
+</div><div class="p">
+<sup>28&#160;</sup><span class="wj">“Come to me, all you who labor and are heavily burdened, and I will give you rest. </span> 
+<sup>29&#160;</sup><span class="wj">Take my yoke upon you and learn from me, for I am gentle and humble in heart; and you will find rest for your souls. </span> 
+<sup>30&#160;</sup><span class="wj">For my yoke is easy, and my burden is light.”</span> 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>At that time, Yahushua went on the Sabbath day through the grain fields. His disciples were hungry and began to pluck heads of grain and to eat. 
+<sup>2&#160;</sup>But the Pharisees, when they saw it, said to him, “Behold, your disciples do what is not lawful to do on the Sabbath.” 
+</div><div class="p">
+<sup>3&#160;</sup>But he said to them, <span class="wj">“Haven’t you read what David did when he was hungry, and those who were with him: </span> 
+<sup>4&#160;</sup><span class="wj">how he entered into Elohim’s house and ate the show bread, which was not lawful for him to eat, nor for those who were with him, but only for the priests?</span> 
+<sup>5&#160;</sup><span class="wj">Or have you not read in the law that on the Sabbath day the priests in the temple profane the Sabbath and are guiltless? </span> 
+<sup>6&#160;</sup><span class="wj">But I tell you that one greater than the temple is here. </span> 
+<sup>7&#160;</sup><span class="wj">But if you had known what this means, ‘I desire mercy, and not sacrifice,’</span> <span class="wj">you wouldn’t have condemned the guiltless. </span> 
+<sup>8&#160;</sup><span class="wj">For the Son of Man is Lord of the Sabbath.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>He departed from there and went into their synagogue. 
+<sup>10&#160;</sup>And behold, there was a man with a withered hand. They asked him, “Is it lawful to heal on the Sabbath day?” so that they might accuse him. 
+</div><div class="p">
+<sup>11&#160;</sup>He said to them, <span class="wj">“What man is there among you who has one sheep, and if this one falls into a pit on the Sabbath day, won’t he grab on to it and lift it out? </span> 
+<sup>12&#160;</sup><span class="wj">Of how much more value then is a man than a sheep! Therefore it is lawful to do good on the Sabbath day.”</span> 
+<sup>13&#160;</sup>Then he told the man, <span class="wj">“Stretch out your hand.”</span> He stretched it out; and it was restored whole, just like the other. 
+<sup>14&#160;</sup>But the Pharisees went out and conspired against him, how they might destroy him. 
+</div><div class="p">
+<sup>15&#160;</sup>Yahushua, perceiving that, withdrew from there. Great multitudes followed him; and he healed them all, 
+<sup>16&#160;</sup>and commanded them that they should not make him known, 
+<sup>17&#160;</sup>that it might be fulfilled which was spoken through Isaiah the prophet, saying, 
+</div><div class="q1">
+<sup>18&#160;</sup>“Behold, my servant whom I have chosen, 
+</div><div class="q2">my beloved in whom my soul is well pleased. 
+</div><div class="q1">I will put my Spirit on him. 
+</div><div class="q2">He will proclaim justice to the nations. 
+</div><div class="q1">
+<sup>19&#160;</sup>He will not strive, nor shout, 
+</div><div class="q2">neither will anyone hear his voice in the streets. 
+</div><div class="q1">
+<sup>20&#160;</sup>He won’t break a bruised reed. 
+</div><div class="q2">He won’t quench a smoking flax, 
+</div><div class="q1">until he leads justice to victory. 
+</div><div class="q2">
+<sup>21&#160;</sup>In his name, the nations will hope.” 
+</div><div class="p">
+<sup>22&#160;</sup>Then one possessed by a demon, blind and mute, was brought to him; and he healed him, so that the blind and mute man both spoke and saw. 
+<sup>23&#160;</sup>All the multitudes were amazed, and said, “Can this be the son of David?” 
+<sup>24&#160;</sup>But when the Pharisees heard it, they said, “This man does not cast out demons except by Beelzebul, the prince of the demons.” 
+</div><div class="p">
+<sup>25&#160;</sup>Knowing their thoughts, Yahushua said to them, <span class="wj">“Every kingdom divided against itself is brought to desolation, and every city or house divided against itself will not stand. </span> 
+<sup>26&#160;</sup><span class="wj">If Satan casts out Satan, he is divided against himself. How then will his kingdom stand? </span> 
+<sup>27&#160;</sup><span class="wj">If I by Beelzebul cast out demons, by whom do your children cast them out? Therefore they will be your judges. </span> 
+<sup>28&#160;</sup><span class="wj">But if I by the Spirit of Elohim cast out demons, then Elohim’s Kingdom has come upon you. </span> 
+<sup>29&#160;</sup><span class="wj">Or how can one enter into the house of the strong man and plunder his goods, unless he first bind the strong man? Then he will plunder his house.</span> 
+</div><div class="p">
+<sup>30&#160;</sup><span class="wj">“He who is not with me is against me, and he who doesn’t gather with me, scatters. </span> 
+<sup>31&#160;</sup><span class="wj">Therefore I tell you, every sin and blasphemy will be forgiven men, but the blasphemy against the Spirit will not be forgiven men. </span> 
+<sup>32&#160;</sup><span class="wj">Whoever speaks a word against the Son of Man, it will be forgiven him; but whoever speaks against the Set-Apart Spirit, it will not be forgiven him, either in this age, or in that which is to come.</span> 
+</div><div class="p">
+<sup>33&#160;</sup><span class="wj">“Either make the tree good and its fruit good, or make the tree corrupt and its fruit corrupt; for the tree is known by its fruit. </span> 
+<sup>34&#160;</sup><span class="wj">You offspring of vipers, how can you, being evil, speak good things? For out of the abundance of the heart, the mouth speaks. </span> 
+<sup>35&#160;</sup><span class="wj">The good man out of his good treasure</span> <span class="wj">brings out good things, and the evil man out of his evil treasure brings out evil things. </span> 
+<sup>36&#160;</sup><span class="wj">I tell you that every idle word that men speak, they will give account of it in the day of judgment. </span> 
+<sup>37&#160;</sup><span class="wj">For by your words you will be justified, and by your words you will be condemned.”</span> 
+</div><div class="p">
+<sup>38&#160;</sup>Then certain of the scribes and Pharisees answered, “Teacher, we want to see a sign from you.” 
+</div><div class="p">
+<sup>39&#160;</sup>But he answered them, <span class="wj">“An evil and adulterous generation seeks after a sign, but no sign will be given to it but the sign of Jonah the prophet. </span> 
+<sup>40&#160;</sup><span class="wj">For as Jonah was three days and three nights in the belly of the huge fish, so will the Son of Man be three days and three nights in the heart of the earth. </span> 
+<sup>41&#160;</sup><span class="wj">The men of Nineveh will stand up in the judgment with this generation and will condemn it, for they repented at the preaching of Jonah; and behold, someone greater than Jonah is here. </span> 
+<sup>42&#160;</sup><span class="wj">The Queen of the South will rise up in the judgment with this generation and will condemn it, for she came from the ends of the earth to hear the wisdom of Solomon; and behold, someone greater than Solomon is here. </span> 
+</div><div class="p">
+<sup>43&#160;</sup><span class="wj">“When an unclean spirit has gone out of a man, he passes through waterless places seeking rest, and doesn’t find it. </span> 
+<sup>44&#160;</sup><span class="wj">Then he says, ‘I will return into my house from which I came;’ and when he has come back, he finds it empty, swept, and put in order. </span> 
+<sup>45&#160;</sup><span class="wj">Then he goes and takes with himself seven other spirits more evil than he is, and they enter in and dwell there. The last state of that man becomes worse than the first. Even so will it be also to this evil generation.”</span> 
+</div><div class="p">
+<sup>46&#160;</sup>While he was yet speaking to the multitudes, behold, his mother and his brothers stood outside, seeking to speak to him. 
+<sup>47&#160;</sup>One said to him, “Behold, your mother and your brothers stand outside, seeking to speak to you.” 
+</div><div class="p">
+<sup>48&#160;</sup>But he answered him who spoke to him, <span class="wj">“Who is my mother? Who are my brothers?”</span> 
+<sup>49&#160;</sup>He stretched out his hand toward his disciples, and said, <span class="wj">“Behold, my mother and my brothers! </span> 
+<sup>50&#160;</sup><span class="wj">For whoever does the will of my Father who is in heaven, he is my brother, and sister, and mother.”</span> 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>On that day Yahushua went out of the house and sat by the seaside. 
+<sup>2&#160;</sup>Great multitudes gathered to him, so that he entered into a boat and sat; and all the multitude stood on the beach. 
+<sup>3&#160;</sup>He spoke to them many things in parables, saying, <span class="wj">“Behold, a farmer went out to sow. </span> 
+<sup>4&#160;</sup><span class="wj">As he sowed, some seeds fell by the roadside, and the birds came and devoured them. </span> 
+<sup>5&#160;</sup><span class="wj">Others fell on rocky ground, where they didn’t have much soil, and immediately they sprang up, because they had no depth of earth. </span> 
+<sup>6&#160;</sup><span class="wj">When the sun had risen, they were scorched. Because they had no root, they withered away. </span> 
+<sup>7&#160;</sup><span class="wj">Others fell among thorns. The thorns grew up and choked them. </span> 
+<sup>8&#160;</sup><span class="wj">Others fell on good soil and yielded fruit: some one hundred times as much, some sixty, and some thirty. </span> 
+<sup>9&#160;</sup><span class="wj">He who has ears to hear, let him hear.”</span> 
+</div><div class="p">
+<sup>10&#160;</sup>The disciples came, and said to him, “Why do you speak to them in parables?” 
+</div><div class="p">
+<sup>11&#160;</sup>He answered them, <span class="wj">“To you it is given to know the mysteries of the Kingdom of Heaven, but it is not given to them. </span> 
+<sup>12&#160;</sup><span class="wj">For whoever has, to him will be given, and he will have abundance; but whoever doesn’t have, from him will be taken away even that which he has. </span> 
+<sup>13&#160;</sup><span class="wj">Therefore I speak to them in parables, because seeing they don’t see, and hearing, they don’t hear, neither do they understand. </span> 
+<sup>14&#160;</sup><span class="wj">In them the prophecy of Isaiah is fulfilled, which says, </span> 
+</div><div class="q1"><span class="wj">‘By hearing you will hear,</span> 
+</div><div class="q2"><span class="wj">and will in no way understand;</span> 
+</div><div class="q1"><span class="wj">Seeing you will see,</span> 
+</div><div class="q2"><span class="wj">and will in no way perceive;</span> 
+</div><div class="q1">
+<sup>15&#160;</sup><span class="wj">for this people’s heart has grown callous,</span> 
+</div><div class="q2"><span class="wj">their ears are dull of hearing,</span> 
+</div><div class="q2"><span class="wj">and they have closed their eyes;</span> 
+</div><div class="q1"><span class="wj">or else perhaps they might perceive with their eyes,</span> 
+</div><div class="q2"><span class="wj">hear with their ears,</span> 
+</div><div class="q2"><span class="wj">understand with their heart,</span> 
+</div><div class="q1"><span class="wj">and would turn again,</span> 
+</div><div class="q2"><span class="wj">and I would heal them.’</span> 
+</div><div class="p">
+<sup>16&#160;</sup><span class="wj">“But blessed are your eyes, for they see; and your ears, for they hear. </span> 
+<sup>17&#160;</sup><span class="wj">For most certainly I tell you that many prophets and righteous men desired to see the things which you see, and didn’t see them; and to hear the things which you hear, and didn’t hear them.</span> 
+</div><div class="p">
+<sup>18&#160;</sup><span class="wj">“Hear, then, the parable of the farmer. </span> 
+<sup>19&#160;</sup><span class="wj">When anyone hears the word of the Kingdom and doesn’t understand it, the evil one comes and snatches away that which has been sown in his heart. This is what was sown by the roadside. </span> 
+<sup>20&#160;</sup><span class="wj">What was sown on the rocky places, this is he who hears the word and immediately with joy receives it; </span> 
+<sup>21&#160;</sup><span class="wj">yet he has no root in himself, but endures for a while. When oppression or persecution arises because of the word, immediately he stumbles. </span> 
+<sup>22&#160;</sup><span class="wj">What was sown among the thorns, this is he who hears the word, but the cares of this age and the deceitfulness of riches choke the word, and he becomes unfruitful. </span> 
+<sup>23&#160;</sup><span class="wj">What was sown on the good ground, this is he who hears the word and understands it, who most certainly bears fruit and produces, some one hundred times as much, some sixty, and some thirty.”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>He set another parable before them, saying, <span class="wj">“The Kingdom of Heaven is like a man who sowed good seed in his field, </span> 
+<sup>25&#160;</sup><span class="wj">but while people slept, his enemy came and sowed darnel weeds</span> <span class="wj">also among the wheat, and went away. </span> 
+<sup>26&#160;</sup><span class="wj">But when the blade sprang up and produced grain, then the darnel weeds appeared also. </span> 
+<sup>27&#160;</sup><span class="wj">The servants of the householder came and said to him, ‘Sir, didn’t you sow good seed in your field? Where did these darnel weeds come from?’</span> 
+</div><div class="p">
+<sup>28&#160;</sup><span class="wj">“He said to them, ‘An enemy has done this.’</span> 
+</div><div class="p"><span class="wj">“The servants asked him, ‘Do you want us to go and gather them up?’ </span> 
+</div><div class="p">
+<sup>29&#160;</sup><span class="wj">“But he said, ‘No, lest perhaps while you gather up the darnel weeds, you root up the wheat with them. </span> 
+<sup>30&#160;</sup><span class="wj">Let both grow together until the harvest, and in the harvest time I will tell the reapers, “First, gather up the darnel weeds, and bind them in bundles to burn them; but gather the wheat into my barn.”&#160;’&#160;”</span> 
+</div><div class="p">
+<sup>31&#160;</sup>He set another parable before them, saying, <span class="wj">“The Kingdom of Heaven is like a grain of mustard seed which a man took, and sowed in his field, </span> 
+<sup>32&#160;</sup><span class="wj">which indeed is smaller than all seeds. But when it is grown, it is greater than the herbs and becomes a tree, so that the birds of the air come and lodge in its branches.”</span> 
+</div><div class="p">
+<sup>33&#160;</sup>He spoke another parable to them. <span class="wj">“The Kingdom of Heaven is like yeast which a woman took and hid in three measures</span> <span class="wj">of meal, until it was all leavened.”</span> 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua spoke all these things in parables to the multitudes; and without a parable, he didn’t speak to them, 
+<sup>35&#160;</sup>that it might be fulfilled which was spoken through the prophet, saying, 
+</div><div class="q1">“I will open my mouth in parables; 
+</div><div class="q2">I will utter things hidden from the foundation of the world.” 
+</div><div class="p">
+<sup>36&#160;</sup>Then Yahushua sent the multitudes away, and went into the house. His disciples came to him, saying, “Explain to us the parable of the darnel weeds of the field.” 
+</div><div class="p">
+<sup>37&#160;</sup>He answered them, <span class="wj">“He who sows the good seed is the Son of Man, </span> 
+<sup>38&#160;</sup><span class="wj">the field is the world, the good seeds are the children of the Kingdom, and the darnel weeds are the children of the evil one. </span> 
+<sup>39&#160;</sup><span class="wj">The enemy who sowed them is the devil. The harvest is the end of the age, and the reapers are angels. </span> 
+<sup>40&#160;</sup><span class="wj">As therefore the darnel weeds are gathered up and burned with fire; so will it be at the end of this age. </span> 
+<sup>41&#160;</sup><span class="wj">The Son of Man will send out his angels, and they will gather out of his Kingdom all things that cause stumbling and those who do iniquity, </span> 
+<sup>42&#160;</sup><span class="wj">and will cast them into the furnace of fire. There will be weeping and gnashing of teeth. </span> 
+<sup>43&#160;</sup><span class="wj">Then the righteous will shine like the sun in the Kingdom of their Father. He who has ears to hear, let him hear.</span> 
+</div><div class="p">
+<sup>44&#160;</sup><span class="wj">“Again, the Kingdom of Heaven is like treasure hidden in the field, which a man found and hid. In his joy, he goes and sells all that he has and buys that field.</span> 
+</div><div class="p">
+<sup>45&#160;</sup><span class="wj">“Again, the Kingdom of Heaven is like a man who is a merchant seeking fine pearls, </span> 
+<sup>46&#160;</sup><span class="wj">who having found one pearl of great price, he went and sold all that he had and bought it.</span> 
+</div><div class="p">
+<sup>47&#160;</sup><span class="wj">“Again, the Kingdom of Heaven is like a dragnet that was cast into the sea and gathered some fish of every kind, </span> 
+<sup>48&#160;</sup><span class="wj">which, when it was filled, fishermen drew up on the beach. They sat down and gathered the good into containers, but the bad they threw away. </span> 
+<sup>49&#160;</sup><span class="wj">So it will be in the end of the world.</span> <span class="wj">The angels will come and separate the wicked from among the righteous, </span> 
+<sup>50&#160;</sup><span class="wj">and will cast them into the furnace of fire. There will be weeping and gnashing of teeth.”</span> 
+<sup>51&#160;</sup>Yahushua said to them, <span class="wj">“Have you understood all these things?” </span> 
+</div><div class="p">They answered him, “Yes, Lord.” 
+</div><div class="p">
+<sup>52&#160;</sup>He said to them, <span class="wj">“Therefore every scribe who has been made a disciple in the Kingdom of Heaven is like a man who is a householder, who brings out of his treasure new and old things.”</span> 
+</div><div class="p">
+<sup>53&#160;</sup>When Yahushua had finished these parables, he departed from there. 
+<sup>54&#160;</sup>Coming into his own country, he taught them in their synagogue, so that they were astonished and said, “Where did this man get this wisdom and these mighty works? 
+<sup>55&#160;</sup>Isn’t this the carpenter’s son? Isn’t his mother called Mary, and his brothers James, Joses, Simon, and Judas? 
+<sup>56&#160;</sup>Aren’t all of his sisters with us? Where then did this man get all of these things?” 
+<sup>57&#160;</sup>They were offended by him. 
+</div><div class="p">But Yahushua said to them, <span class="wj">“A prophet is not without honor, except in his own country and in his own house.”</span> 
+<sup>58&#160;</sup>He didn’t do many mighty works there because of their unbelief. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>At that time, Herod the tetrarch heard the report concerning Yahushua, 
+<sup>2&#160;</sup>and said to his servants, “This is John the Baptizer. He is risen from the dead. That is why these powers work in him.” 
+<sup>3&#160;</sup>For Herod had arrested John, bound him, and put him in prison for the sake of Herodias, his brother Philip’s woman. 
+<sup>4&#160;</sup>For John said to him, “It is not lawful for you to have her.” 
+<sup>5&#160;</sup>When he would have put him to death, he feared the multitude, because they counted him as a prophet. 
+<sup>6&#160;</sup>But when Herod’s birthday came, the daughter of Herodias danced among them and pleased Herod. 
+<sup>7&#160;</sup>Therefore he promised with an oath to give her whatever she should ask. 
+<sup>8&#160;</sup>She, being prompted by her mother, said, “Give me here on a platter the head of John the Baptizer.” 
+</div><div class="p">
+<sup>9&#160;</sup>The king was grieved, but for the sake of his oaths and of those who sat at the table with him, he commanded it to be given, 
+<sup>10&#160;</sup>and he sent and beheaded John in the prison. 
+<sup>11&#160;</sup>His head was brought on a platter and given to the young lady; and she brought it to her mother. 
+<sup>12&#160;</sup>His disciples came, took the body, and buried it. Then they went and told Yahushua. 
+<sup>13&#160;</sup>Now when Yahushua heard this, he withdrew from there in a boat to a deserted place apart. When the multitudes heard it, they followed him on foot from the cities. 
+</div><div class="p">
+<sup>14&#160;</sup>Yahushua went out, and he saw a great multitude. He had compassion on them and healed their sick. 
+<sup>15&#160;</sup>When evening had come, his disciples came to him, saying, “This place is deserted, and the hour is already late. Send the multitudes away, that they may go into the villages, and buy themselves food.” 
+</div><div class="p">
+<sup>16&#160;</sup>But Yahushua said to them, <span class="wj">“They don’t need to go away. You give them something to eat.”</span> 
+</div><div class="p">
+<sup>17&#160;</sup>They told him, “We only have here five loaves and two fish.” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, <span class="wj">“Bring them here to me.”</span> 
+<sup>19&#160;</sup>He commanded the multitudes to sit down on the grass; and he took the five loaves and the two fish, and looking up to heaven, he blessed, broke and gave the loaves to the disciples; and the disciples gave to the multitudes. 
+<sup>20&#160;</sup>They all ate and were filled. They took up twelve baskets full of that which remained left over from the broken pieces. 
+<sup>21&#160;</sup>Those who ate were about five thousand men, in addition to women and children. 
+</div><div class="p">
+<sup>22&#160;</sup>Immediately Yahushua made the disciples get into the boat and go ahead of him to the other side, while he sent the multitudes away. 
+<sup>23&#160;</sup>After he had sent the multitudes away, he went up into the mountain by himself to pray. When evening had come, he was there alone. 
+<sup>24&#160;</sup>But the boat was now in the middle of the sea, distressed by the waves, for the wind was contrary. 
+<sup>25&#160;</sup>In the fourth watch of the night, Yahushua came to them, walking on the sea. 
+<sup>26&#160;</sup>When the disciples saw him walking on the sea, they were troubled, saying, “It’s a ghost!” and they cried out for fear. 
+<sup>27&#160;</sup>But immediately Yahushua spoke to them, saying, <span class="wj">“Cheer up! It is I! </span> <span class="wj">Don’t be afraid.”</span> 
+</div><div class="p">
+<sup>28&#160;</sup>Peter answered him and said, “Lord, if it is you, command me to come to you on the waters.” 
+</div><div class="p">
+<sup>29&#160;</sup>He said, <span class="wj">“Come!”</span> 
+</div><div class="p">Peter stepped down from the boat and walked on the waters to come to Yahushua. 
+<sup>30&#160;</sup>But when he saw that the wind was strong, he was afraid, and beginning to sink, he cried out, saying, “Lord, save me!” 
+</div><div class="p">
+<sup>31&#160;</sup>Immediately Yahushua stretched out his hand, took hold of him, and said to him, <span class="wj">“You of little faith, why did you doubt?”</span> 
+<sup>32&#160;</sup>When they got up into the boat, the wind ceased. 
+<sup>33&#160;</sup>Those who were in the boat came and worshiped him, saying, “You are truly the Son of Elohim!” 
+</div><div class="p">
+<sup>34&#160;</sup>When they had crossed over, they came to the land of Gennesaret. 
+<sup>35&#160;</sup>When the people of that place recognized him, they sent into all that surrounding region and brought to him all who were sick; 
+<sup>36&#160;</sup>and they begged him that they might just touch the fringe of his garment. As many as touched it were made whole. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Pharisees and scribes came to Yahushua from Jerusalem, saying, 
+<sup>2&#160;</sup>“Why do your disciples disobey the tradition of the elders? For they don’t wash their hands when they eat bread.” 
+</div><div class="p">
+<sup>3&#160;</sup>He answered them, <span class="wj">“Why do you also disobey the commandment of Elohim because of your tradition? </span> 
+<sup>4&#160;</sup><span class="wj">For Elohim commanded, ‘Honor your father and your mother,’</span> 
+<sup>5&#160;</sup><span class="wj">But you say, ‘Whoever may tell his father or his mother, “Whatever help you might otherwise have gotten from me is a gift devoted to Elohim,” </span> 
+<sup>6&#160;</sup><span class="wj">he shall not honor his father or mother.’ You have made the commandment of Elohim void because of your tradition. </span> 
+<sup>7&#160;</sup><span class="wj">You hypocrites! Well did Isaiah prophesy of you, saying,</span> 
+</div><div class="q1">
+<sup>8&#160;</sup><span class="wj">‘These people draw near to me with their mouth,</span> 
+</div><div class="q2"><span class="wj">and honor me with their lips;</span> 
+</div><div class="q2"><span class="wj">but their heart is far from me.</span> 
+</div><div class="q1">
+<sup>9&#160;</sup><span class="wj">And they worship me in vain,</span> 
+</div><div class="q2"><span class="wj">teaching as doctrine rules made by men.’&#160;”</span> 
+</div><div class="p">
+<sup>10&#160;</sup>He summoned the multitude, and said to them, <span class="wj">“Hear, and understand. </span> 
+<sup>11&#160;</sup><span class="wj">That which enters into the mouth doesn’t defile the man; but that which proceeds out of the mouth, this defiles the man.”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>Then the disciples came and said to him, “Do you know that the Pharisees were offended when they heard this saying?” 
+</div><div class="p">
+<sup>13&#160;</sup>But he answered, <span class="wj">“Every plant which my heavenly Father didn’t plant will be uprooted. </span> 
+<sup>14&#160;</sup><span class="wj">Leave them alone. They are blind guides of the blind. If the blind guide the blind, both will fall into a pit.”</span> 
+</div><div class="p">
+<sup>15&#160;</sup>Peter answered him, “Explain the parable to us.” 
+</div><div class="p">
+<sup>16&#160;</sup>So Yahushua said, <span class="wj">“Do you also still not understand? </span> 
+<sup>17&#160;</sup><span class="wj">Don’t you understand that whatever goes into the mouth passes into the belly and then out of the body? </span> 
+<sup>18&#160;</sup><span class="wj">But the things which proceed out of the mouth come out of the heart, and they defile the man. </span> 
+<sup>19&#160;</sup><span class="wj">For out of the heart come evil thoughts, murders, adulteries, sexual sins, thefts, false testimony, and blasphemies. </span> 
+<sup>20&#160;</sup><span class="wj">These are the things which defile the man; but to eat with unwashed hands doesn’t defile the man.”</span> 
+</div><div class="p">
+<sup>21&#160;</sup>Yahushua went out from there and withdrew into the region of Tyre and Sidon. 
+<sup>22&#160;</sup>Behold, a Canaanite woman came out from those borders and cried, saying, “Have mercy on me, Lord, you son of David! My daughter is severely possessed by a demon!” 
+</div><div class="p">
+<sup>23&#160;</sup>But he answered her not a word. 
+</div><div class="p">His disciples came and begged him, saying, “Send her away; for she cries after us.” 
+</div><div class="p">
+<sup>24&#160;</sup>But he answered, <span class="wj">“I wasn’t sent to anyone but the lost sheep of the house of Israel.”</span> 
+</div><div class="p">
+<sup>25&#160;</sup>But she came and worshiped him, saying, “Lord, help me.” 
+</div><div class="p">
+<sup>26&#160;</sup>But he answered, <span class="wj">“It is not appropriate to take the children’s bread and throw it to the dogs.”</span> 
+</div><div class="p">
+<sup>27&#160;</sup>But she said, “Yes, Lord, but even the dogs eat the crumbs which fall from their masters’ table.” 
+</div><div class="p">
+<sup>28&#160;</sup>Then Yahushua answered her, <span class="wj">“Woman, great is your faith! Be it done to you even as you desire.”</span> And her daughter was healed from that hour. 
+</div><div class="p">
+<sup>29&#160;</sup>Yahushua departed from there and came near to the sea of Galilee; and he went up on the mountain and sat there. 
+<sup>30&#160;</sup>Great multitudes came to him, having with them the lame, blind, mute, maimed, and many others, and they put them down at his feet. He healed them, 
+<sup>31&#160;</sup>so that the multitude wondered when they saw the mute speaking, the injured healed, the lame walking, and the blind seeing—and they glorified the Elohim of Israel. 
+</div><div class="p">
+<sup>32&#160;</sup>Yahushua summoned his disciples and said, <span class="wj">“I have compassion on the multitude, because they have continued with me now three days and have nothing to eat. I don’t want to send them away fasting, or they might faint on the way.” </span> 
+</div><div class="p">
+<sup>33&#160;</sup>The disciples said to him, “Where could we get so many loaves in a deserted place as to satisfy so great a multitude?” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua said to them, <span class="wj">“How many loaves do you have?”</span> 
+</div><div class="p">They said, “Seven, and a few small fish.” 
+</div><div class="p">
+<sup>35&#160;</sup>He commanded the multitude to sit down on the ground; 
+<sup>36&#160;</sup>and he took the seven loaves and the fish. He gave thanks and broke them, and gave to the disciples, and the disciples to the multitudes. 
+<sup>37&#160;</sup>They all ate and were filled. They took up seven baskets full of the broken pieces that were left over. 
+<sup>38&#160;</sup>Those who ate were four thousand men, in addition to women and children. 
+<sup>39&#160;</sup>Then he sent away the multitudes, got into the boat, and came into the borders of Magdala. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>The Pharisees and Sadducees came, and testing him, asked him to show them a sign from heaven. 
+<sup>2&#160;</sup>But he answered them, <span class="wj">“When it is evening, you say, ‘It will be fair weather, for the sky is red.’ </span> 
+<sup>3&#160;</sup><span class="wj">In the morning, ‘It will be foul weather today, for the sky is red and threatening.’ Hypocrites! You know how to discern the appearance of the sky, but you can’t discern the signs of the times! </span> 
+<sup>4&#160;</sup><span class="wj">An evil and adulterous generation seeks after a sign, and there will be no sign given to it, except the sign of the prophet Jonah.”</span> 
+</div><div class="p">He left them and departed. 
+<sup>5&#160;</sup>The disciples came to the other side and had forgotten to take bread. 
+<sup>6&#160;</sup>Yahushua said to them, <span class="wj">“Take heed and beware of the yeast of the Pharisees and Sadducees.”</span> 
+</div><div class="p">
+<sup>7&#160;</sup>They reasoned among themselves, saying, “We brought no bread.” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahushua, perceiving it, said, <span class="wj">“Why do you reason among yourselves, you of little faith, because you have brought no bread? </span> 
+<sup>9&#160;</sup><span class="wj">Don’t you yet perceive or remember the five loaves for the five thousand, and how many baskets you took up, </span> 
+<sup>10&#160;</sup><span class="wj">or the seven loaves for the four thousand, and how many baskets you took up? </span> 
+<sup>11&#160;</sup><span class="wj">How is it that you don’t perceive that I didn’t speak to you concerning bread? But beware of the yeast of the Pharisees and Sadducees.” </span> 
+</div><div class="p">
+<sup>12&#160;</sup>Then they understood that he didn’t tell them to beware of the yeast of bread, but of the teaching of the Pharisees and Sadducees. 
+</div><div class="p">
+<sup>13&#160;</sup>Now when Yahushua came into the parts of Caesarea Philippi, he asked his disciples, saying, <span class="wj">“Who do men say that I, the Son of Man, am?”</span> 
+</div><div class="p">
+<sup>14&#160;</sup>They said, “Some say John the Baptizer, some, Elijah, and others, Jeremiah or one of the prophets.” 
+</div><div class="p">
+<sup>15&#160;</sup>He said to them, <span class="wj">“But who do you say that I am?”</span> 
+</div><div class="p">
+<sup>16&#160;</sup>Simon Peter answered, “You are the Christ, the Son of the living Elohim.” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahushua answered him, <span class="wj">“Blessed are you, Simon Bar Jonah, for flesh and blood has not revealed this to you, but my Father who is in heaven. </span> 
+<sup>18&#160;</sup><span class="wj">I also tell you that you are Peter,</span> <span class="wj">will not prevail against it. </span> 
+<sup>19&#160;</sup><span class="wj">I will give to you the keys of the Kingdom of Heaven, and whatever you bind on earth will have been bound in heaven; and whatever you release on earth will have been released in heaven.”</span> 
+<sup>20&#160;</sup>Then he commanded the disciples that they should tell no one that he was Yahushua the Christ. 
+</div><div class="p">
+<sup>21&#160;</sup>From that time, Yahushua began to show his disciples that he must go to Jerusalem and suffer many things from the elders, chief priests, and scribes, and be killed, and the third day be raised up. 
+</div><div class="p">
+<sup>22&#160;</sup>Peter took him aside and began to rebuke him, saying, “Far be it from you, Lord! This will never be done to you.” 
+</div><div class="p">
+<sup>23&#160;</sup>But he turned and said to Peter, <span class="wj">“Get behind me, Satan! You are a stumbling block to me, for you are not setting your mind on the things of Elohim, but on the things of men.”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>Then Yahushua said to his disciples, <span class="wj">“If anyone desires to come after me, let him deny himself, take up his cross, and follow me. </span> 
+<sup>25&#160;</sup><span class="wj">For whoever desires to save his life will lose it, and whoever will lose his life for my sake will find it. </span> 
+<sup>26&#160;</sup><span class="wj">For what will it profit a man if he gains the whole world and forfeits his life? Or what will a man give in exchange for his life? </span> 
+<sup>27&#160;</sup><span class="wj">For the Son of Man will come in the glory of his Father with his angels, and then he will render to everyone according to his deeds. </span> 
+<sup>28&#160;</sup><span class="wj">Most certainly I tell you, there are some standing here who will in no way taste of death until they see the Son of Man coming in his Kingdom.” </span> 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>After six days, Yahushua took with him Peter, James, and John his brother, and brought them up into a high mountain by themselves. 
+<sup>2&#160;</sup>He was changed before them. His face shone like the sun, and his garments became as white as the light. 
+<sup>3&#160;</sup>Behold, Moses and Elijah appeared to them talking with him. 
+</div><div class="p">
+<sup>4&#160;</sup>Peter answered and said to Yahushua, “Lord, it is good for us to be here. If you want, let’s make three tents here: one for you, one for Moses, and one for Elijah.” 
+</div><div class="p">
+<sup>5&#160;</sup>While he was still speaking, behold, a bright cloud overshadowed them. Behold, a voice came out of the cloud, saying, “This is my beloved Son, in whom I am well pleased. Listen to him.” 
+</div><div class="p">
+<sup>6&#160;</sup>When the disciples heard it, they fell on their faces, and were very afraid. 
+<sup>7&#160;</sup>Yahushua came and touched them and said, <span class="wj">“Get up, and don’t be afraid.” </span> 
+<sup>8&#160;</sup>Lifting up their eyes, they saw no one, except Yahushua alone. 
+</div><div class="p">
+<sup>9&#160;</sup>As they were coming down from the mountain, Yahushua commanded them, saying, <span class="wj">“Don’t tell anyone what you saw, until the Son of Man has risen from the dead.”</span> 
+</div><div class="p">
+<sup>10&#160;</sup>His disciples asked him, saying, “Then why do the scribes say that Elijah must come first?” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahushua answered them, <span class="wj">“Elijah indeed comes first, and will restore all things; </span> 
+<sup>12&#160;</sup><span class="wj">but I tell you that Elijah has come already, and they didn’t recognize him, but did to him whatever they wanted to. Even so the Son of Man will also suffer by them.”</span> 
+<sup>13&#160;</sup>Then the disciples understood that he spoke to them of John the Baptizer. 
+</div><div class="p">
+<sup>14&#160;</sup>When they came to the multitude, a man came to him, kneeling down to him and saying, 
+<sup>15&#160;</sup>“Lord, have mercy on my son, for he is epileptic and suffers grievously; for he often falls into the fire, and often into the water. 
+<sup>16&#160;</sup>So I brought him to your disciples, and they could not cure him.” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahushua answered, <span class="wj">“Faithless and perverse generation! How long will I be with you? How long will I bear with you? Bring him here to me.”</span> 
+<sup>18&#160;</sup>Yahushua rebuked the demon, and it went out of him, and the boy was cured from that hour. 
+</div><div class="p">
+<sup>19&#160;</sup>Then the disciples came to Yahushua privately, and said, “Why weren’t we able to cast it out?” 
+</div><div class="p">
+<sup>20&#160;</sup>He said to them, <span class="wj">“Because of your unbelief. For most certainly I tell you, if you have faith as a grain of mustard seed, you will tell this mountain, ‘Move from here to there,’ and it will move; and nothing will be impossible for you. </span> 
 
-</p><p>
-<span class="v">22&#160;</span>While they were staying in Galilee, Yahushua said to them, <span class="wj">“The Son of Man is about to be delivered up into the hands of men, </span> 
-<span class="v">23&#160;</span><span class="wj">and they will kill him, and the third day he will be raised up.” </span> 
-</p><p>They were exceedingly sorry. 
-</p><p>
-<span class="v">24&#160;</span>When they had come to Capernaum, those who collected the didrachma coins<span class="f">+ \fr 17:24 \ft A didrachma is a Greek silver coin worth 2 drachmas, about as much as 2 Roman denarii, or about 2 days’ wages. It was commonly used to pay the half-shekel temple tax, because 2 drachmas were worth one half shekel of silver. A shekel is about 10 grams or about 0.35 ounces.</span> came to Peter, and said, “Doesn’t your teacher pay the didrachma?” 
-<span class="v">25&#160;</span>He said, “Yes.” 
-</p><p>When he came into the house, Yahushua anticipated him, saying, <span class="wj">“What do you think, Simon? From whom do the kings of the earth receive toll or tribute? From their children, or from strangers?”</span> 
-</p><p>
-<span class="v">26&#160;</span>Peter said to him, “From strangers.” 
-</p><p>Yahushua said to him, <span class="wj">“Therefore the children are exempt. </span> 
-<span class="v">27&#160;</span><span class="wj">But, lest we cause them to stumble, go to the sea, cast a hook, and take up the first fish that comes up. When you have opened its mouth, you will find a stater coin.</span><span class="f">+ \fr 17:27 \ft A stater is a silver coin equivalent to four Attic or two Alexandrian drachmas, or a Jewish shekel: just exactly enough to cover the half-shekel temple tax for two people. A shekel is about 10 grams or about 0.35 ounces, usually in the form of a silver coin.</span> <span class="wj">Take that, and give it to them for me and you.”</span> 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>In that hour the disciples came to Yahushua, saying, “Who then is greatest in the Kingdom of Heaven?” 
-</p><p>
-<span class="v">2&#160;</span>Yahushua called a little child to himself, and set him in the middle of them 
-<span class="v">3&#160;</span>and said, <span class="wj">“Most certainly I tell you, unless you turn and become as little children, you will in no way enter into the Kingdom of Heaven. </span> 
-<span class="v">4&#160;</span><span class="wj">Whoever therefore humbles himself as this little child is the greatest in the Kingdom of Heaven. </span> 
-<span class="v">5&#160;</span><span class="wj">Whoever receives one such little child in my name receives me, </span> 
-<span class="v">6&#160;</span><span class="wj">but whoever causes one of these little ones who believe in me to stumble, it would be better for him if a huge millstone were hung around his neck and that he were sunk in the depths of the sea. </span> 
-</p><p>
-<span class="v">7&#160;</span><span class="wj">“Woe to the world because of occasions of stumbling! For it must be that the occasions come, but woe to that person through whom the occasion comes! </span> 
-<span class="v">8&#160;</span><span class="wj">If your hand or your foot causes you to stumble, cut it off and cast it from you. It is better for you to enter into life maimed or crippled, rather than having two hands or two feet to be cast into the eternal fire. </span> 
-<span class="v">9&#160;</span><span class="wj">If your eye causes you to stumble, pluck it out and cast it from you. It is better for you to enter into life with one eye, rather than having two eyes to be cast into the Gehenna</span><span class="f">+ \fr 18:9 \ft or, Hell</span> <span class="wj">of fire. </span> 
-<span class="v">10&#160;</span><span class="wj">See that you don’t despise one of these little ones, for I tell you that in heaven their angels always see the face of my Father who is in heaven. </span> 
+</div><div class="p">
+<sup>22&#160;</sup>While they were staying in Galilee, Yahushua said to them, <span class="wj">“The Son of Man is about to be delivered up into the hands of men, </span> 
+<sup>23&#160;</sup><span class="wj">and they will kill him, and the third day he will be raised up.” </span> 
+</div><div class="p">They were exceedingly sorry. 
+</div><div class="p">
+<sup>24&#160;</sup>When they had come to Capernaum, those who collected the didrachma coins came to Peter, and said, “Doesn’t your teacher pay the didrachma?” 
+<sup>25&#160;</sup>He said, “Yes.” 
+</div><div class="p">When he came into the house, Yahushua anticipated him, saying, <span class="wj">“What do you think, Simon? From whom do the kings of the earth receive toll or tribute? From their children, or from strangers?”</span> 
+</div><div class="p">
+<sup>26&#160;</sup>Peter said to him, “From strangers.” 
+</div><div class="p">Yahushua said to him, <span class="wj">“Therefore the children are exempt. </span> 
+<sup>27&#160;</sup><span class="wj">But, lest we cause them to stumble, go to the sea, cast a hook, and take up the first fish that comes up. When you have opened its mouth, you will find a stater coin.</span> <span class="wj">Take that, and give it to them for me and you.”</span> 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>In that hour the disciples came to Yahushua, saying, “Who then is greatest in the Kingdom of Heaven?” 
+</div><div class="p">
+<sup>2&#160;</sup>Yahushua called a little child to himself, and set him in the middle of them 
+<sup>3&#160;</sup>and said, <span class="wj">“Most certainly I tell you, unless you turn and become as little children, you will in no way enter into the Kingdom of Heaven. </span> 
+<sup>4&#160;</sup><span class="wj">Whoever therefore humbles himself as this little child is the greatest in the Kingdom of Heaven. </span> 
+<sup>5&#160;</sup><span class="wj">Whoever receives one such little child in my name receives me, </span> 
+<sup>6&#160;</sup><span class="wj">but whoever causes one of these little ones who believe in me to stumble, it would be better for him if a huge millstone were hung around his neck and that he were sunk in the depths of the sea. </span> 
+</div><div class="p">
+<sup>7&#160;</sup><span class="wj">“Woe to the world because of occasions of stumbling! For it must be that the occasions come, but woe to that person through whom the occasion comes! </span> 
+<sup>8&#160;</sup><span class="wj">If your hand or your foot causes you to stumble, cut it off and cast it from you. It is better for you to enter into life maimed or crippled, rather than having two hands or two feet to be cast into the eternal fire. </span> 
+<sup>9&#160;</sup><span class="wj">If your eye causes you to stumble, pluck it out and cast it from you. It is better for you to enter into life with one eye, rather than having two eyes to be cast into the Gehenna</span> <span class="wj">of fire. </span> 
+<sup>10&#160;</sup><span class="wj">See that you don’t despise one of these little ones, for I tell you that in heaven their angels always see the face of my Father who is in heaven. </span> 
 
-</p><p>
-<span class="v">12&#160;</span><span class="wj">“What do you think? If a man has one hundred sheep, and one of them goes astray, doesn’t he leave the ninety-nine, go to the mountains, and seek that which has gone astray? </span> 
-<span class="v">13&#160;</span><span class="wj">If he finds it, most certainly I tell you, he rejoices over it more than over the ninety-nine which have not gone astray. </span> 
-<span class="v">14&#160;</span><span class="wj">Even so it is not the will of your Father who is in heaven that one of these little ones should perish.</span> 
-</p><p>
-<span class="v">15&#160;</span><span class="wj">“If your brother sins against you, go, show him his fault between you and him alone. If he listens to you, you have gained back your brother. </span> 
-<span class="v">16&#160;</span><span class="wj">But if he doesn’t listen, take one or two more with you, that at the mouth of two or three witnesses every word may be established.</span><span class="x">+ \xo 18:16 \xt Deuteronomy 19:15</span> 
-<span class="v">17&#160;</span><span class="wj">If he refuses to listen to them, tell it to the assembly. If he refuses to hear the assembly also, let him be to you as a Gentile or a tax collector. </span> 
-<span class="v">18&#160;</span><span class="wj">Most certainly I tell you, whatever things you bind on earth will have been bound in heaven, and whatever things you release on earth will have been released in heaven. </span> 
-<span class="v">19&#160;</span><span class="wj">Again, assuredly I tell you, that if two of you will agree on earth concerning anything that they will ask, it will be done for them by my Father who is in heaven. </span> 
-<span class="v">20&#160;</span><span class="wj">For where two or three are gathered together in my name, there I am in the middle of them.”</span> 
-</p><p>
-<span class="v">21&#160;</span>Then Peter came and said to him, “Lord, how often shall my brother sin against me, and I forgive him? Until seven times?” 
-</p><p>
-<span class="v">22&#160;</span>Yahushua said to him, <span class="wj">“I don’t tell you until seven times, but, until seventy times seven. </span> 
-<span class="v">23&#160;</span><span class="wj">Therefore the Kingdom of Heaven is like a certain king who wanted to settle accounts with his servants. </span> 
-<span class="v">24&#160;</span><span class="wj">When he had begun to settle, one was brought to him who owed him ten thousand talents.</span><span class="f">+ \fr 18:24 \ft Ten thousand talents (about 300 metric tons of silver) represents an extremely large sum of money, equivalent to about 60,000,000 denarii, where one denarius was typical of one day’s wages for agricultural labor.</span> 
-<span class="v">25&#160;</span><span class="wj">But because he couldn’t pay, his lord commanded him to be sold, with his woman, his children, and all that he had, and payment to be made. </span> 
-<span class="v">26&#160;</span><span class="wj">The servant therefore fell down and knelt before him, saying, ‘Lord, have patience with me, and I will repay you all!’ </span> 
-<span class="v">27&#160;</span><span class="wj">The lord of that servant, being moved with compassion, released him and forgave him the debt.</span> 
-</p><p>
-<span class="v">28&#160;</span><span class="wj">“But that servant went out and found one of his fellow servants who owed him one hundred denarii,</span><span class="f">+ \fr 18:28 \ft 100 denarii was about one sixtieth of a talent, or about 500 grams (1.1 pounds) of silver.</span> <span class="wj">and he grabbed him and took him by the throat, saying, ‘Pay me what you owe!’</span> 
-</p><p>
-<span class="v">29&#160;</span><span class="wj">“So his fellow servant fell down at his feet and begged him, saying, ‘Have patience with me, and I will repay you!’ </span> 
-<span class="v">30&#160;</span><span class="wj">He would not, but went and cast him into prison until he should pay back that which was due. </span> 
-<span class="v">31&#160;</span><span class="wj">So when his fellow servants saw what was done, they were exceedingly sorry, and came and told their lord all that was done. </span> 
-<span class="v">32&#160;</span><span class="wj">Then his lord called him in and said to him, ‘You wicked servant! I forgave you all that debt because you begged me. </span> 
-<span class="v">33&#160;</span><span class="wj">Shouldn’t you also have had mercy on your fellow servant, even as I had mercy on you?’ </span> 
-<span class="v">34&#160;</span><span class="wj">His lord was angry, and delivered him to the tormentors until he should pay all that was due to him. </span> 
-<span class="v">35&#160;</span><span class="wj">So my heavenly Father will also do to you, if you don’t each forgive your brother from your hearts for his misdeeds.”</span> 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>When Yahushua had finished these words, he departed from Galilee and came into the borders of Judea beyond the Jordan. 
-<span class="v">2&#160;</span>Great multitudes followed him, and he healed them there. 
-</p><p>
-<span class="v">3&#160;</span>Pharisees came to him, testing him and saying, “Is it lawful for a man to divorce his woman for any reason?” 
-</p><p>
-<span class="v">4&#160;</span>He answered, <span class="wj">“Haven’t you read that he who made them from the beginning made them male and female,</span><span class="x">+ \xo 19:4 \xt Genesis 1:27</span> 
-<span class="v">5&#160;</span><span class="wj">and said, ‘For this cause a man shall leave his father and mother, and shall be joined to his woman; and the two shall become one flesh’?</span><span class="x">+ \xo 19:5 \xt Genesis 2:24</span> 
-<span class="v">6&#160;</span><span class="wj">So that they are no more two, but one flesh. What therefore Elohim has joined together, don’t let man tear apart.”</span> 
-</p><p>
-<span class="v">7&#160;</span>They asked him, “Why then did Moses command us to give her a certificate of divorce and divorce her?” 
-</p><p>
-<span class="v">8&#160;</span>He said to them, <span class="wj">“Moses, because of the hardness of your hearts, allowed you to put away your women, but from the beginning it has not been so. </span> 
-<span class="v">9&#160;</span><span class="wj">I tell you that whoever puts away his woman, except for sexual immorality, and marries another, commits adultery; and he who marries her when she is put away commits adultery.”</span> 
-</p><p>
-<span class="v">10&#160;</span>His disciples said to him, “If this is the case of the man with his woman, it is not expedient to marry.” 
-</p><p>
-<span class="v">11&#160;</span>But he said to them, <span class="wj">“Not all men can receive this saying, but those to whom it is given. </span> 
-<span class="v">12&#160;</span><span class="wj">For there are eunuchs who were born that way from their mother’s womb, and there are eunuchs who were made eunuchs by men; and there are eunuchs who made themselves eunuchs for the Kingdom of Heaven’s sake. He who is able to receive it, let him receive it.”</span> 
-</p><p>
-<span class="v">13&#160;</span>Then little children were brought to him that he should lay his hands on them and pray; and the disciples rebuked them. 
-<span class="v">14&#160;</span>But Yahushua said, <span class="wj">“Allow the little children, and don’t forbid them to come to me; for the Kingdom of Heaven belongs to ones like these.”</span> 
-<span class="v">15&#160;</span>He laid his hands on them, and departed from there. 
-</p><p>
-<span class="v">16&#160;</span>Behold, one came to him and said, “Good teacher, what good thing shall I do, that I may have eternal life?” 
-</p><p>
-<span class="v">17&#160;</span>He said to him, <span class="wj">“Why do you call me good?</span><span class="f">+ \fr 19:17 \ft So MT and TR. NU reads “Why do you ask me about what is good?”</span> <span class="wj">No one is good but one, Elohim the Father. But if you want to enter into life, keep the commandments.” </span> 
-</p><p>
-<span class="v">18&#160;</span>He said to him, “Which ones?” 
-</p><p>Yahushua said, <span class="wj">“&#160;‘You shall not murder.’ ‘You shall not commit adultery.’ ‘You shall not steal.’ ‘You shall not offer false testimony.’ </span> 
-<span class="v">19&#160;</span><span class="wj">‘Honor your father and your mother.’</span><span class="x">+ \xo 19:19 \xt Exodus 20:12-16; Deuteronomy 5:16-20</span> <span class="wj">And, ‘You shall love your neighbor as yourself.’&#160;”</span><span class="x">+ \xo 19:19 \xt Leviticus 19:18</span> 
-</p><p>
-<span class="v">20&#160;</span>The young man said to him, “All these things I have observed from my youth. What do I still lack?” 
-</p><p>
-<span class="v">21&#160;</span>Yahushua said to him, <span class="wj">“If you want to be perfect, go, sell what you have, and give to the poor, and you will have treasure in heaven; and come, follow me.”</span> 
-<span class="v">22&#160;</span>But when the young man heard this, he went away sad, for he was one who had great possessions. 
-</p><p>
-<span class="v">23&#160;</span>Yahushua said to his disciples, <span class="wj">“Most certainly I say to you, a rich man will enter into the Kingdom of Heaven with difficulty. </span> 
-<span class="v">24&#160;</span><span class="wj">Again I tell you, it is easier for a camel to go through a needle’s eye than for a rich man to enter into Elohim’s Kingdom.”</span> 
-</p><p>
-<span class="v">25&#160;</span>When the disciples heard it, they were exceedingly astonished, saying, “Who then can be saved?” 
-</p><p>
-<span class="v">26&#160;</span>Looking at them, Yahushua said, <span class="wj">“With men this is impossible, but with Elohim all things are possible.”</span> 
-</p><p>
-<span class="v">27&#160;</span>Then Peter answered, “Behold, we have left everything and followed you. What then will we have?” 
-</p><p>
-<span class="v">28&#160;</span>Yahushua said to them, <span class="wj">“Most certainly I tell you that you who have followed me, in the regeneration when the Son of Man will sit on the throne of his glory, you also will sit on twelve thrones, judging the twelve tribes of Israel. </span> 
-<span class="v">29&#160;</span><span class="wj">Everyone who has left houses, or brothers, or sisters, or father, or mother, or woman, or children, or lands, for my name’s sake, will receive one hundred times, and will inherit eternal life. </span> 
-<span class="v">30&#160;</span><span class="wj">But many will be last who are first, and first who are last. </span> 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“For the Kingdom of Heaven is like a man who was the master of a household, who went out early in the morning to hire laborers for his vineyard. </span> 
-<span class="v">2&#160;</span><span class="wj">When he had agreed with the laborers for a denarius</span><span class="f">+ \fr 20:2 \ft A denarius is a silver Roman coin worth 1/25th of a Roman aureus. This was a common wage for a day of farm labor.</span> <span class="wj">a day, he sent them into his vineyard. </span> 
-<span class="v">3&#160;</span><span class="wj">He went out about the third hour,</span><span class="f">+ \fr 20:3 \ft Time was measured from sunrise to sunset, so the third hour would be about 9:00 a.m.</span> <span class="wj">and saw others standing idle in the marketplace. </span> 
-<span class="v">4&#160;</span><span class="wj">He said to them, ‘You also go into the vineyard, and whatever is right I will give you.’ So they went their way. </span> 
-<span class="v">5&#160;</span><span class="wj">Again he went out about the sixth and the ninth hour,</span><span class="f">+ \fr 20:5 \ft noon and 3:00 p.m.</span> <span class="wj">and did likewise. </span> 
-<span class="v">6&#160;</span><span class="wj">About the eleventh hour</span><span class="f">+ \fr 20:6 \ft 5:00 p.m.</span> <span class="wj">he went out and found others standing idle. He said to them, ‘Why do you stand here all day idle?’ </span> 
-</p><p>
-<span class="v">7&#160;</span><span class="wj">“They said to him, ‘Because no one has hired us.’</span> 
-</p><p><span class="wj">“He said to them, ‘You also go into the vineyard, and you will receive whatever is right.’ </span> 
-</p><p>
-<span class="v">8&#160;</span><span class="wj">“When evening had come, the lord of the vineyard said to his manager, ‘Call the laborers and pay them their wages, beginning from the last to the first.’</span> 
-<span class="v">9&#160;</span><span class="wj">“When those who were hired at about the eleventh hour came, they each received a denarius. </span> 
-<span class="v">10&#160;</span><span class="wj">When the first came, they supposed that they would receive more; and they likewise each received a denarius. </span> 
-<span class="v">11&#160;</span><span class="wj">When they received it, they murmured against the master of the household, </span> 
-<span class="v">12&#160;</span><span class="wj">saying, ‘These last have spent one hour, and you have made them equal to us who have borne the burden of the day and the scorching heat!’ </span> 
-</p><p>
-<span class="v">13&#160;</span><span class="wj">“But he answered one of them, ‘Friend, I am doing you no wrong. Didn’t you agree with me for a denarius? </span> 
-<span class="v">14&#160;</span><span class="wj">Take that which is yours, and go your way. It is my desire to give to this last just as much as to you. </span> 
-<span class="v">15&#160;</span><span class="wj">Isn’t it lawful for me to do what I want to with what I own? Or is your eye evil, because I am good?’ </span> 
-<span class="v">16&#160;</span><span class="wj">So the last will be first, and the first last. For many are called, but few are chosen.”</span> 
-</p><p>
-<span class="v">17&#160;</span>As Yahushua was going up to Jerusalem, he took the twelve disciples aside, and on the way he said to them, 
-<span class="v">18&#160;</span><span class="wj">“Behold, we are going up to Jerusalem, and the Son of Man will be delivered to the chief priests and scribes, and they will condemn him to death, </span> 
-<span class="v">19&#160;</span><span class="wj">and will hand him over to the Gentiles to mock, to scourge, and to crucify; and the third day he will be raised up.”</span> 
-</p><p>
-<span class="v">20&#160;</span>Then the mother of the sons of Zebedee came to him with her sons, kneeling and asking a certain thing of him. 
-<span class="v">21&#160;</span>He said to her, <span class="wj">“What do you want?”</span> 
-</p><p>She said to him, “Command that these, my two sons, may sit, one on your right hand and one on your left hand, in your Kingdom.” 
-</p><p>
-<span class="v">22&#160;</span>But Yahushua answered, <span class="wj">“You don’t know what you are asking. Are you able to drink the cup that I am about to drink, and be baptized with the baptism that I am baptized with?”</span> 
-</p><p>They said to him, “We are able.” 
-</p><p>
-<span class="v">23&#160;</span>He said to them, <span class="wj">“You will indeed drink my cup, and be baptized with the baptism that I am baptized with; but to sit on my right hand and on my left hand is not mine to give, but it is for whom it has been prepared by my Father.”</span> 
-</p><p>
-<span class="v">24&#160;</span>When the ten heard it, they were indignant with the two brothers. 
-</p><p>
-<span class="v">25&#160;</span>But Yahushua summoned them, and said, <span class="wj">“You know that the rulers of the nations lord it over them, and their great ones exercise authority over them. </span> 
-<span class="v">26&#160;</span><span class="wj">It shall not be so among you; but whoever desires to become great among you shall be</span><span class="f">+ \fr 20:26 \ft TR reads “let him be” instead of “shall be” </span> <span class="wj">your servant. </span> 
-<span class="v">27&#160;</span><span class="wj">Whoever desires to be first among you shall be your bondservant, </span> 
-<span class="v">28&#160;</span><span class="wj">even as the Son of Man came not to be served, but to serve, and to give his life as a ransom for many.”</span> 
-</p><p>
-<span class="v">29&#160;</span>As they went out from Jericho, a great multitude followed him. 
-<span class="v">30&#160;</span>Behold, two blind men sitting by the road, when they heard that Yahushua was passing by, cried out, “Lord, have mercy on us, you son of David!” 
-<span class="v">31&#160;</span>The multitude rebuked them, telling them that they should be quiet, but they cried out even more, “Lord, have mercy on us, you son of David!” 
-</p><p>
-<span class="v">32&#160;</span>Yahushua stood still and called them, and asked, <span class="wj">“What do you want me to do for you?”</span> 
-</p><p>
-<span class="v">33&#160;</span>They told him, “Lord, that our eyes may be opened.” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua, being moved with compassion, touched their eyes; and immediately their eyes received their sight, and they followed him. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>When they came near to Jerusalem and came to Bethsphage,<span class="f">+ \fr 21:1 \ft TR & NU read “Bethphage” instead of “Bethsphage”</span> to the Mount of Olives, then Yahushua sent two disciples, 
-<span class="v">2&#160;</span>saying to them, <span class="wj">“Go into the village that is opposite you, and immediately you will find a donkey tied, and a colt with her. Untie them and bring them to me. </span> 
-<span class="v">3&#160;</span><span class="wj">If anyone says anything to you, you shall say, ‘The Lord needs them,’ and immediately he will send them.”</span> 
-</p><p>
-<span class="v">4&#160;</span>All this was done that it might be fulfilled which was spoken through the prophet, saying, 
-</p><p class="q1">
-<span class="v">5&#160;</span>“Tell the daughter of Zion, 
-</p><p class="q2">behold, your King comes to you, 
-</p><p class="q2">humble, and riding on a donkey, 
-</p><p class="q2">on a colt, the foal of a donkey.”<span class="x">+ \xo 21:5 \xt Zechariah 9:9</span> 
-</p><p>
-<span class="v">6&#160;</span>The disciples went and did just as Yahushua commanded them, 
-<span class="v">7&#160;</span>and brought the donkey and the colt and laid their clothes on them; and he sat on them. 
-<span class="v">8&#160;</span>A very great multitude spread their clothes on the road. Others cut branches from the trees and spread them on the road. 
-<span class="v">9&#160;</span>The multitudes who went in front of him, and those who followed, kept shouting, “Hosanna<span class="f">+ \fr 21:9 \ft “Hosanna” means “save us” or “help us, we pray”.</span> to the son of David! Blessed is he who comes in the name of the Lord! Hosanna in the highest!” <span class="x">+ \xo 21:9 \xt Psalm 118:26</span> 
-</p><p>
-<span class="v">10&#160;</span>When he had come into Jerusalem, all the city was stirred up, saying, “Who is this?” 
-</p><p>
-<span class="v">11&#160;</span>The multitudes said, “This is the prophet, Yahushua, from Nazareth of Galilee.” 
-</p><p>
-<span class="v">12&#160;</span>Yahushua entered into the temple of Elohim and drove out all of those who sold and bought in the temple, and overthrew the money changers’ tables and the seats of those who sold the doves. 
-<span class="v">13&#160;</span>He said to them, <span class="wj">“It is written, ‘My house shall be called a house of prayer,’</span><span class="x">+ \xo 21:13 \xt Isaiah 56:7</span> <span class="wj">but you have made it a den of robbers!”</span><span class="x">+ \xo 21:13 \xt Jeremiah 7:11</span> 
-</p><p>
-<span class="v">14&#160;</span>The lame and the blind came to him in the temple, and he healed them. 
-<span class="v">15&#160;</span>But when the chief priests and the scribes saw the wonderful things that he did, and the children who were crying in the temple and saying, “Hosanna to the son of David!” they were indignant, 
-<span class="v">16&#160;</span>and said to him, “Do you hear what these are saying?” 
-</p><p>Yahushua said to them, <span class="wj">“Yes. Did you never read, ‘Out of the mouth of children and nursing babies, you have perfected praise’?”</span><span class="x">+ \xo 21:16 \xt Psalm 8:2</span> 
-</p><p>
-<span class="v">17&#160;</span>He left them and went out of the city to Bethany, and camped there. 
-</p><p>
-<span class="v">18&#160;</span>Now in the morning, as he returned to the city, he was hungry. 
-<span class="v">19&#160;</span>Seeing a fig tree by the road, he came to it and found nothing on it but leaves. He said to it, <span class="wj">“Let there be no fruit from you forever!” </span> 
-</p><p>Immediately the fig tree withered away. 
-</p><p>
-<span class="v">20&#160;</span>When the disciples saw it, they marveled, saying, “How did the fig tree immediately wither away?” 
-</p><p>
-<span class="v">21&#160;</span>Yahushua answered them, <span class="wj">“Most certainly I tell you, if you have faith and don’t doubt, you will not only do what was done to the fig tree, but even if you told this mountain, ‘Be taken up and cast into the sea,’ it would be done. </span> 
-<span class="v">22&#160;</span><span class="wj">All things, whatever you ask in prayer, believing, you will receive.”</span> 
-</p><p>
-<span class="v">23&#160;</span>When he had come into the temple, the chief priests and the elders of the people came to him as he was teaching, and said, “By what authority do you do these things? Who gave you this authority?” 
-</p><p>
-<span class="v">24&#160;</span>Yahushua answered them, <span class="wj">“I also will ask you one question, which if you tell me, I likewise will tell you by what authority I do these things. </span> 
-<span class="v">25&#160;</span><span class="wj">The baptism of John, where was it from? From heaven or from men?” </span> 
-</p><p>They reasoned with themselves, saying, “If we say, ‘From heaven,’ he will ask us, ‘Why then did you not believe him?’ 
-<span class="v">26&#160;</span>But if we say, ‘From men,’ we fear the multitude, for all hold John as a prophet.” 
-<span class="v">27&#160;</span>They answered Yahushua, and said, “We don’t know.” 
-</p><p>He also said to them, <span class="wj">“Neither will I tell you by what authority I do these things. </span> 
-<span class="v">28&#160;</span><span class="wj">But what do you think? A man had two sons, and he came to the first, and said, ‘Son, go work today in my vineyard.’ </span> 
-<span class="v">29&#160;</span><span class="wj">He answered, ‘I will not,’ but afterward he changed his mind, and went. </span> 
-<span class="v">30&#160;</span><span class="wj">He came to the second, and said the same thing. He answered, ‘I’m going, sir,’ but he didn’t go. </span> 
-<span class="v">31&#160;</span><span class="wj">Which of the two did the will of his father?”</span> 
-</p><p>They said to him, “The first.” 
-</p><p>Yahushua said to them, <span class="wj">“Most certainly I tell you that the tax collectors and the prostitutes are entering into Elohim’s Kingdom before you. </span> 
-<span class="v">32&#160;</span><span class="wj">For John came to you in the way of righteousness, and you didn’t believe him; but the tax collectors and the prostitutes believed him. When you saw it, you didn’t even repent afterward, that you might believe him. </span> 
-</p><p>
-<span class="v">33&#160;</span><span class="wj">“Hear another parable. There was a man who was a master of a household who planted a vineyard, set a hedge about it, dug a wine press in it, built a tower, leased it out to farmers, and went into another country. </span> 
-<span class="v">34&#160;</span><span class="wj">When the season for the fruit came near, he sent his servants to the farmers to receive his fruit. </span> 
-<span class="v">35&#160;</span><span class="wj">The farmers took his servants, beat one, killed another, and stoned another. </span> 
-<span class="v">36&#160;</span><span class="wj">Again, he sent other servants more than the first; and they treated them the same way. </span> 
-<span class="v">37&#160;</span><span class="wj">But afterward he sent to them his son, saying, ‘They will respect my son.’ </span> 
-<span class="v">38&#160;</span><span class="wj">But the farmers, when they saw the son, said among themselves, ‘This is the heir. Come, let’s kill him and seize his inheritance.’ </span> 
-<span class="v">39&#160;</span><span class="wj">So they took him and threw him out of the vineyard, then killed him. </span> 
-<span class="v">40&#160;</span><span class="wj">When therefore the lord of the vineyard comes, what will he do to those farmers?”</span> 
-</p><p>
-<span class="v">41&#160;</span>They told him, “He will miserably destroy those miserable men, and will lease out the vineyard to other farmers who will give him the fruit in its season.” 
-</p><p>
-<span class="v">42&#160;</span>Yahushua said to them, <span class="wj">“Did you never read in the Scriptures, </span> 
-</p><p class="q1"><span class="wj">‘The stone which the builders rejected</span> 
-</p><p class="q2"><span class="wj">was made the head of the corner.</span> 
-</p><p class="q1"><span class="wj">This was from the Lord.</span> 
-</p><p class="q2"><span class="wj">It is marvelous in our eyes’?</span><span class="x">+ \xo 21:42 \xt Psalm 118:22-23</span> 
-</p><p>
-<span class="v">43&#160;</span><span class="wj">“Therefore I tell you, Elohim’s Kingdom will be taken away from you and will be given to a nation producing its fruit. </span> 
-<span class="v">44&#160;</span><span class="wj">He who falls on this stone will be broken to pieces, but on whomever it will fall, it will scatter him as dust.”</span> 
-</p><p>
-<span class="v">45&#160;</span>When the chief priests and the Pharisees heard his parables, they perceived that he spoke about them. 
-<span class="v">46&#160;</span>When they sought to seize him, they feared the multitudes, because they considered him to be a prophet. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>Yahushua answered and spoke to them again in parables, saying, 
-<span class="v">2&#160;</span><span class="wj">“The Kingdom of Heaven is like a certain king, who made a wedding feast for his son, </span> 
-<span class="v">3&#160;</span><span class="wj">and sent out his servants to call those who were invited to the wedding feast, but they would not come. </span> 
-<span class="v">4&#160;</span><span class="wj">Again he sent out other servants, saying, ‘Tell those who are invited, “Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the wedding feast!”&#160;’ </span> 
-<span class="v">5&#160;</span><span class="wj">But they made light of it, and went their ways, one to his own farm, another to his merchandise; </span> 
-<span class="v">6&#160;</span><span class="wj">and the rest grabbed his servants, treated them shamefully, and killed them. </span> 
-<span class="v">7&#160;</span><span class="wj">When the king heard that, he was angry, and sent his armies, destroyed those murderers, and burned their city.</span> 
-</p><p>
-<span class="v">8&#160;</span><span class="wj">“Then he said to his servants, ‘The wedding is ready, but those who were invited weren’t worthy. </span> 
-<span class="v">9&#160;</span><span class="wj">Go therefore to the intersections of the highways, and as many as you may find, invite to the wedding feast.’ </span> 
-<span class="v">10&#160;</span><span class="wj">Those servants went out into the highways and gathered together as many as they found, both bad and good. The wedding was filled with guests. </span> 
-</p><p>
-<span class="v">11&#160;</span><span class="wj">“But when the king came in to see the guests, he saw there a man who didn’t have on wedding clothing, </span> 
-<span class="v">12&#160;</span><span class="wj">and he said to him, ‘Friend, how did you come in here not wearing wedding clothing?’ He was speechless. </span> 
-<span class="v">13&#160;</span><span class="wj">Then the king said to the servants, ‘Bind him hand and foot, take him away, and throw him into the outer darkness. That is where the weeping and grinding of teeth will be.’ </span> 
-<span class="v">14&#160;</span><span class="wj">For many are called, but few chosen.”</span> 
-</p><p>
-<span class="v">15&#160;</span>Then the Pharisees went and took counsel how they might entrap him in his talk. 
-<span class="v">16&#160;</span>They sent their disciples to him, along with the Herodians, saying, “Teacher, we know that you are honest, and teach the way of Elohim in truth, no matter whom you teach; for you aren’t partial to anyone. 
-<span class="v">17&#160;</span>Tell us therefore, what do you think? Is it lawful to pay taxes to Caesar, or not?” 
-</p><p>
-<span class="v">18&#160;</span>But Yahushua perceived their wickedness, and said, <span class="wj">“Why do you test me, you hypocrites? </span> 
-<span class="v">19&#160;</span><span class="wj">Show me the tax money.”</span> 
-</p><p>They brought to him a denarius. 
-</p><p>
-<span class="v">20&#160;</span>He asked them, <span class="wj">“Whose is this image and inscription?”</span> 
-</p><p>
-<span class="v">21&#160;</span>They said to him, “Caesar’s.” 
-</p><p>Then he said to them, <span class="wj">“Give therefore to Caesar the things that are Caesar’s, and to Elohim the things that are Elohim’s.”</span> 
-</p><p>
-<span class="v">22&#160;</span>When they heard it, they marveled, and left him and went away. 
-</p><p>
-<span class="v">23&#160;</span>On that day Sadducees (those who say that there is no resurrection) came to him. They asked him, 
-<span class="v">24&#160;</span>saying, “Teacher, Moses said, ‘If a man dies, having no children, his brother shall marry his woman and raise up offspring<span class="f">+ \fr 22:24 \ft or, seed</span> for his brother.’ 
-<span class="v">25&#160;</span>Now there were with us seven brothers. The first married and died, and having no offspring left his woman to his brother. 
-<span class="v">26&#160;</span>In the same way, the second also, and the third, to the seventh. 
-<span class="v">27&#160;</span>After them all, the woman died. 
-<span class="v">28&#160;</span>In the resurrection therefore, whose woman will she be of the seven? For they all had her.” 
-</p><p>
-<span class="v">29&#160;</span>But Yahushua answered them, <span class="wj">“You are mistaken, not knowing the Scriptures, nor the power of Elohim. </span> 
-<span class="v">30&#160;</span><span class="wj">For in the resurrection they neither marry nor are given in marriage, but are like Elohim’s angels in heaven. </span> 
-<span class="v">31&#160;</span><span class="wj">But concerning the resurrection of the dead, haven’t you read that which was spoken to you by Elohim, saying, </span> 
-<span class="v">32&#160;</span><span class="wj">‘I am the Elohim of Abraham, and the Elohim of Isaac, and the Elohim of Jacob’?</span><span class="x">+ \xo 22:32 \xt Exodus 3:6</span> <span class="wj">Elohim is not the Elohim of the dead, but of the living.”</span> 
-</p><p>
-<span class="v">33&#160;</span>When the multitudes heard it, they were astonished at his teaching. 
-</p><p>
-<span class="v">34&#160;</span>But the Pharisees, when they heard that he had silenced the Sadducees, gathered themselves together. 
-<span class="v">35&#160;</span>One of them, a lawyer, asked him a question, testing him. 
-<span class="v">36&#160;</span>“Teacher, which is the greatest commandment in the law?” 
-</p><p>
-<span class="v">37&#160;</span>Yahushua said to him, <span class="wj">“&#160;‘You shall love the Lord your Elohim with all your heart, with all your soul, and with all your mind.’</span><span class="x">+ \xo 22:37 \xt Deuteronomy 6:5 </span> 
-<span class="v">38&#160;</span><span class="wj">This is the first and great commandment. </span> 
-<span class="v">39&#160;</span><span class="wj">A second likewise is this, ‘You shall love your neighbor as yourself.’</span><span class="x">+ \xo 22:39 \xt Leviticus 19:18</span> 
-<span class="v">40&#160;</span><span class="wj">The whole law and the prophets depend on these two commandments.” </span> 
-</p><p>
-<span class="v">41&#160;</span>Now while the Pharisees were gathered together, Yahushua asked them a question, 
-<span class="v">42&#160;</span>saying, <span class="wj">“What do you think of the Christ? Whose son is he?” </span> 
-</p><p>They said to him, “Of David.” 
-</p><p>
-<span class="v">43&#160;</span>He said to them, <span class="wj">“How then does David in the Spirit call him Lord, saying,</span> 
-</p><p class="q1">
-<span class="v">44&#160;</span><span class="wj">‘The Lord said to my Lord,</span> 
-</p><p class="q2"><span class="wj">sit on my right hand,</span> 
-</p><p class="q2"><span class="wj">until I make your enemies a footstool for your feet’?</span><span class="x">+ \xo 22:44 \xt Psalm 110:1</span> 
-</p><p>
-<span class="v">45&#160;</span><span class="wj">“If then David calls him Lord, how is he his son?”</span> 
-</p><p>
-<span class="v">46&#160;</span>No one was able to answer him a word, neither did any man dare ask him any more questions from that day forward. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Then Yahushua spoke to the multitudes and to his disciples, 
-<span class="v">2&#160;</span>saying, <span class="wj">“The scribes and the Pharisees sit on Moses’ seat. </span> 
-<span class="v">3&#160;</span><span class="wj">All things therefore whatever he tells you to observe, observe and do, but don’t do their works; for they say, and don’t do. </span> 
-<span class="v">4&#160;</span><span class="wj">For they bind heavy burdens that are grievous to be borne, and lay them on men’s shoulders; but they themselves will not lift a finger to help them. </span> 
-<span class="v">5&#160;</span><span class="wj">But they do all their works to be seen by men. They make their phylacteries</span><span class="f">+ \fr 23:5 \ft phylacteries (tefillin in Hebrew) are small leather pouches that some Jewish men wear on their forehead and arm in prayer. They are used to carry a small scroll with some Scripture in it. See Deuteronomy 6:8.</span> <span class="wj">broad and enlarge the fringes</span><span class="f">+ \fr 23:5 \ft or, tassels</span> <span class="wj">of their garments, </span> 
-<span class="v">6&#160;</span><span class="wj">and love the place of honor at feasts, the best seats in the synagogues, </span> 
-<span class="v">7&#160;</span><span class="wj">the salutations in the marketplaces, and to be called ‘Rabbi, Rabbi’</span><span class="f">+ \fr 23:7 \ft NU omits the second “Rabbi”. </span> <span class="wj">by men. </span> 
-<span class="v">8&#160;</span><span class="wj">But you are not to be called ‘Rabbi’, for one is your teacher, the Christ, and all of you are brothers. </span> 
-<span class="v">9&#160;</span><span class="wj">Call no man on the earth your father, for one is your Father, he who is in heaven. </span> 
-<span class="v">10&#160;</span><span class="wj">Neither be called masters, for one is your master, the Christ. </span> 
-<span class="v">11&#160;</span><span class="wj">But he who is greatest among you will be your servant. </span> 
-<span class="v">12&#160;</span><span class="wj">Whoever exalts himself will be humbled, and whoever humbles himself will be exalted.</span> 
-</p><p>
-<span class="v">13&#160;</span><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you devour widows’ houses, and as a pretense you make long prayers. Therefore you will receive greater condemnation.</span> 
-</p><p>
-<span class="v">14&#160;</span><span class="wj">“But woe to you, scribes and Pharisees, hypocrites! Because you shut up the Kingdom of Heaven against men; for you don’t enter in yourselves, neither do you allow those who are entering in to enter.</span><span class="f">+ \fr 23:14 \ft Some Greek texts reverse the order of verses 13 and 14, and some omit verse 13, numbering verse 14 as 13. NU omits verse 14.</span> 
-<span class="v">15&#160;</span><span class="wj">Woe to you, scribes and Pharisees, hypocrites! For you travel around by sea and land to make one proselyte; and when he becomes one, you make him twice as much a son of Gehenna</span><span class="f">+ \fr 23:15 \ft or, Hell</span> <span class="wj">as yourselves. </span> 
-</p><p>
-<span class="v">16&#160;</span><span class="wj">“Woe to you, you blind guides, who say, ‘Whoever swears by the temple, it is nothing; but whoever swears by the gold of the temple, he is obligated.’ </span> 
-<span class="v">17&#160;</span><span class="wj">You blind fools! For which is greater, the gold or the temple that sanctifies the gold? </span> 
-<span class="v">18&#160;</span><span class="wj">And, ‘Whoever swears by the altar, it is nothing; but whoever swears by the gift that is on it, he is obligated.’ </span> 
-<span class="v">19&#160;</span><span class="wj">You blind fools! For which is greater, the gift, or the altar that sanctifies the gift? </span> 
-<span class="v">20&#160;</span><span class="wj">He therefore who swears by the altar, swears by it and by everything on it. </span> 
-<span class="v">21&#160;</span><span class="wj">He who swears by the temple, swears by it and by him who has been living</span><span class="f">+ \fr 23:21 \ft NU reads “lives”</span> <span class="wj">in it. </span> 
-<span class="v">22&#160;</span><span class="wj">He who swears by heaven, swears by the throne of Elohim and by him who sits on it.</span> 
-</p><p>
-<span class="v">23&#160;</span><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you tithe mint, dill, and cumin,</span><span class="f">+ \fr 23:23 \ft cumin is an aromatic seed from Cuminum cyminum, resembling caraway in flavor and appearance. It is used as a spice.</span> <span class="wj">and have left undone the weightier matters of the law: justice, mercy, and faith. But you ought to have done these, and not to have left the other undone. </span> 
-<span class="v">24&#160;</span><span class="wj">You blind guides, who strain out a gnat, and swallow a camel! </span> 
-</p><p>
-<span class="v">25&#160;</span><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you clean the outside of the cup and of the platter, but within they are full of extortion and unrighteousness.</span><span class="f">+ \fr 23:25 \ft TR reads “self-indulgence” instead of “unrighteousness”</span> 
-<span class="v">26&#160;</span><span class="wj">You blind Pharisee, first clean the inside of the cup and of the platter, that its outside may become clean also.</span> 
-</p><p>
-<span class="v">27&#160;</span><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you are like whitened tombs, which outwardly appear beautiful, but inwardly are full of dead men’s bones and of all uncleanness. </span> 
-<span class="v">28&#160;</span><span class="wj">Even so you also outwardly appear righteous to men, but inwardly you are full of hypocrisy and iniquity.</span> 
-</p><p>
-<span class="v">29&#160;</span><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you build the tombs of the prophets and decorate the tombs of the righteous, </span> 
-<span class="v">30&#160;</span><span class="wj">and say, ‘If we had lived in the days of our fathers, we wouldn’t have been partakers with them in the blood of the prophets.’ </span> 
-<span class="v">31&#160;</span><span class="wj">Therefore you testify to yourselves that you are children of those who killed the prophets. </span> 
-<span class="v">32&#160;</span><span class="wj">Fill up, then, the measure of your fathers. </span> 
-<span class="v">33&#160;</span><span class="wj">You serpents, you offspring of vipers, how will you escape the judgment of Gehenna?</span><span class="f">+ \fr 23:33 \ft or, Hell</span> 
-<span class="v">34&#160;</span><span class="wj">Therefore, behold, I send to you prophets, wise men, and scribes. Some of them you will kill and crucify; and some of them you will scourge in your synagogues and persecute from city to city, </span> 
-<span class="v">35&#160;</span><span class="wj">that on you may come all the righteous blood shed on the earth, from the blood of righteous Abel to the blood of Zachariah son of Barachiah, whom you killed between the sanctuary and the altar. </span> 
-<span class="v">36&#160;</span><span class="wj">Most certainly I tell you, all these things will come upon this generation.</span> 
-</p><p>
-<span class="v">37&#160;</span><span class="wj">“Jerusalem, Jerusalem, who kills the prophets and stones those who are sent to her! How often I would have gathered your children together, even as a hen gathers her chicks under her wings, and you would not! </span> 
-<span class="v">38&#160;</span><span class="wj">Behold, your house is left to you desolate. </span> 
-<span class="v">39&#160;</span><span class="wj">For I tell you, you will not see me from now on, until you say, ‘Blessed is he who comes in the name of the Lord!’&#160;”</span><span class="x">+ \xo 23:39 \xt Psalm 118:26 </span> 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>Yahushua went out from the temple, and was going on his way. His disciples came to him to show him the buildings of the temple. 
-<span class="v">2&#160;</span>But he answered them, <span class="wj">“You see all of these things, don’t you? Most certainly I tell you, there will not be left here one stone on another, that will not be thrown down.”</span> 
-</p><p>
-<span class="v">3&#160;</span>As he sat on the Mount of Olives, the disciples came to him privately, saying, “Tell us, when will these things be? What is the sign of your coming, and of the end of the age?” 
-</p><p>
-<span class="v">4&#160;</span>Yahushua answered them, <span class="wj">“Be careful that no one leads you astray. </span> 
-<span class="v">5&#160;</span><span class="wj">For many will come in my name, saying, ‘I am the Christ,’ and will lead many astray. </span> 
-<span class="v">6&#160;</span><span class="wj">You will hear of wars and rumors of wars. See that you aren’t troubled, for all this must happen, but the end is not yet. </span> 
-<span class="v">7&#160;</span><span class="wj">For nation will rise against nation, and kingdom against kingdom; and there will be famines, plagues, and earthquakes in various places. </span> 
-<span class="v">8&#160;</span><span class="wj">But all these things are the beginning of birth pains. </span> 
-</p><p>
-<span class="v">9&#160;</span><span class="wj">“Then they will deliver you up to oppression and will kill you. You will be hated by all of the nations for my name’s sake. </span> 
-<span class="v">10&#160;</span><span class="wj">Then many will stumble, and will deliver up one another, and will hate one another. </span> 
-<span class="v">11&#160;</span><span class="wj">Many false prophets will arise and will lead many astray. </span> 
-<span class="v">12&#160;</span><span class="wj">Because iniquity will be multiplied, the love of many will grow cold. </span> 
-<span class="v">13&#160;</span><span class="wj">But he who endures to the end will be saved. </span> 
-<span class="v">14&#160;</span><span class="wj">This Good News of the Kingdom will be preached in the whole world for a testimony to all the nations, and then the end will come.</span> 
-</p><p>
-<span class="v">15&#160;</span><span class="wj">“When, therefore, you see the abomination of desolation,</span><span class="x">+ \xo 24:15 \xt Daniel 9:27; 11:31; 12:11</span> <span class="wj">which was spoken of through Daniel the prophet, standing in the set-apart place (let the reader understand), </span> 
-<span class="v">16&#160;</span><span class="wj">then let those who are in Judea flee to the mountains. </span> 
-<span class="v">17&#160;</span><span class="wj">Let him who is on the housetop not go down to take out the things that are in his house. </span> 
-<span class="v">18&#160;</span><span class="wj">Let him who is in the field not return back to get his clothes. </span> 
-<span class="v">19&#160;</span><span class="wj">But woe to those who are with child and to nursing mothers in those days! </span> 
-<span class="v">20&#160;</span><span class="wj">Pray that your flight will not be in the winter nor on a Sabbath, </span> 
-<span class="v">21&#160;</span><span class="wj">for then there will be great suffering,</span><span class="f">+ \fr 24:21 \ft or, oppression</span> <span class="wj">such as has not been from the beginning of the world until now, no, nor ever will be. </span> 
-<span class="v">22&#160;</span><span class="wj">Unless those days had been shortened, no flesh would have been saved. But for the sake of the chosen ones, those days will be shortened. </span> 
-</p><p>
-<span class="v">23&#160;</span><span class="wj">“Then if any man tells you, ‘Behold, here is the Christ!’ or, ‘There!’ don’t believe it. </span> 
-<span class="v">24&#160;</span><span class="wj">For false christs and false prophets will arise, and they will show great signs and wonders, so as to lead astray, if possible, even the chosen ones.</span> 
-</p><p>
-<span class="v">25&#160;</span><span class="wj">“Behold, I have told you beforehand. </span> 
-</p><p>
-<span class="v">26&#160;</span><span class="wj">“If therefore they tell you, ‘Behold, he is in the wilderness,’ don’t go out; or ‘Behold, he is in the inner rooms,’ don’t believe it. </span> 
-<span class="v">27&#160;</span><span class="wj">For as the lightning flashes from the east, and is seen even to the west, so will the coming of the Son of Man be. </span> 
-<span class="v">28&#160;</span><span class="wj">For wherever the carcass is, that is where the vultures</span><span class="f">+ \fr 24:28 \ft or, eagles</span> <span class="wj">gather together. </span> 
-</p><p>
-<span class="v">29&#160;</span><span class="wj">“But immediately after the suffering</span><span class="f">+ \fr 24:29 \ft or, oppression</span> <span class="wj">of those days, the sun will be darkened, the moon will not give its light, the stars will fall from the sky, and the powers of the heavens will be shaken;</span><span class="x">+ \xo 24:29 \xt Isaiah 13:10; 34:4 </span> 
-<span class="v">30&#160;</span><span class="wj">and then the sign of the Son of Man will appear in the sky. Then all the tribes of the earth will mourn, and they will see the Son of Man coming on the clouds of the sky with power and great glory. </span> 
-<span class="v">31&#160;</span><span class="wj">He will send out his angels with a great sound of a trumpet, and they will gather together his chosen ones from the four winds, from one end of the sky to the other.</span> 
-</p><p>
-<span class="v">32&#160;</span><span class="wj">“Now from the fig tree learn this parable: When its branch has now become tender and produces its leaves, you know that the summer is near. </span> 
-<span class="v">33&#160;</span><span class="wj">Even so you also, when you see all these things, know that he is near, even at the doors. </span> 
-<span class="v">34&#160;</span><span class="wj">Most certainly I tell you, this generation</span><span class="f">+ \fr 24:34 \ft The word for “generation” (genea) can also be translated as “race.”</span> <span class="wj">will not pass away until all these things are accomplished. </span> 
-<span class="v">35&#160;</span><span class="wj">Heaven and earth will pass away, but my words will not pass away. </span> 
-</p><p>
-<span class="v">36&#160;</span><span class="wj">“But no one knows of that day and hour, not even the angels of heaven,</span><span class="f">+ \fr 24:36 \ft NU adds “nor the son”</span> <span class="wj">but my Father only.</span> 
-<span class="v">37&#160;</span><span class="wj">As the days of Noah were, so will the coming of the Son of Man be. </span> 
-<span class="v">38&#160;</span><span class="wj">For as in those days which were before the flood they were eating and drinking, marrying and giving in marriage, until the day that Noah entered into the ship, </span> 
-<span class="v">39&#160;</span><span class="wj">and they didn’t know until the flood came and took them all away, so will the coming of the Son of Man be. </span> 
-<span class="v">40&#160;</span><span class="wj">Then two men will be in the field: one will be taken and one will be left. </span> 
-<span class="v">41&#160;</span><span class="wj">Two women will be grinding at the mill: one will be taken and one will be left. </span> 
-<span class="v">42&#160;</span><span class="wj">Watch therefore, for you don’t know in what hour your Lord comes. </span> 
-<span class="v">43&#160;</span><span class="wj">But know this, that if the master of the house had known in what watch of the night the thief was coming, he would have watched, and would not have allowed his house to be broken into. </span> 
-<span class="v">44&#160;</span><span class="wj">Therefore also be ready, for in an hour that you don’t expect, the Son of Man will come.</span> 
-</p><p>
-<span class="v">45&#160;</span><span class="wj">“Who then is the faithful and wise servant, whom his lord has set over his household, to give them their food in due season? </span> 
-<span class="v">46&#160;</span><span class="wj">Blessed is that servant whom his lord finds doing so when he comes. </span> 
-<span class="v">47&#160;</span><span class="wj">Most certainly I tell you that he will set him over all that he has. </span> 
-<span class="v">48&#160;</span><span class="wj">But if that evil servant should say in his heart, ‘My lord is delaying his coming,’ </span> 
-<span class="v">49&#160;</span><span class="wj">and begins to beat his fellow servants, and eat and drink with the drunkards, </span> 
-<span class="v">50&#160;</span><span class="wj">the lord of that servant will come in a day when he doesn’t expect it and in an hour when he doesn’t know it, </span> 
-<span class="v">51&#160;</span><span class="wj">and will cut him in pieces and appoint his portion with the hypocrites. That is where the weeping and grinding of teeth will be. </span> 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“Then the Kingdom of Heaven will be like ten virgins who took their lamps and went out to meet the bridegroom. </span> 
-<span class="v">2&#160;</span><span class="wj">Five of them were foolish, and five were wise. </span> 
-<span class="v">3&#160;</span><span class="wj">Those who were foolish, when they took their lamps, took no oil with them, </span> 
-<span class="v">4&#160;</span><span class="wj">but the wise took oil in their vessels with their lamps. </span> 
-<span class="v">5&#160;</span><span class="wj">Now while the bridegroom delayed, they all slumbered and slept. </span> 
-<span class="v">6&#160;</span><span class="wj">But at midnight there was a cry, ‘Behold! The bridegroom is coming! Come out to meet him!’ </span> 
-<span class="v">7&#160;</span><span class="wj">Then all those virgins arose, and trimmed their lamps.</span><span class="f">+ \fr 25:7 \ft The end of the wick of an oil lamp needs to be cut off periodically to avoid having it become clogged with carbon deposits. The wick height is also adjusted so that the flame burns evenly and gives good light without producing a lot of smoke.</span> 
-<span class="v">8&#160;</span><span class="wj">The foolish said to the wise, ‘Give us some of your oil, for our lamps are going out.’ </span> 
-<span class="v">9&#160;</span><span class="wj">But the wise answered, saying, ‘What if there isn’t enough for us and you? You go rather to those who sell, and buy for yourselves.’ </span> 
-<span class="v">10&#160;</span><span class="wj">While they went away to buy, the bridegroom came, and those who were ready went in with him to the wedding feast, and the door was shut. </span> 
-<span class="v">11&#160;</span><span class="wj">Afterward the other virgins also came, saying, ‘Lord, Lord, open to us.’ </span> 
-<span class="v">12&#160;</span><span class="wj">But he answered, ‘Most certainly I tell you, I don’t know you.’ </span> 
-<span class="v">13&#160;</span><span class="wj">Watch therefore, for you don’t know the day nor the hour in which the Son of Man is coming.</span> 
-</p><p>
-<span class="v">14&#160;</span><span class="wj">“For it is like a man going into another country, who called his own servants and entrusted his goods to them. </span> 
-<span class="v">15&#160;</span><span class="wj">To one he gave five talents,</span><span class="f">+ \fr 25:15 \ft A talent is about 30 kilograms or 66 pounds (usually used to weigh silver unless otherwise specified)</span> <span class="wj">to another two, to another one, to each according to his own ability. Then he went on his journey. </span> 
-<span class="v">16&#160;</span><span class="wj">Immediately he who received the five talents went and traded with them, and made another five talents. </span> 
-<span class="v">17&#160;</span><span class="wj">In the same way, he also who got the two gained another two. </span> 
-<span class="v">18&#160;</span><span class="wj">But he who received the one talent went away and dug in the earth and hid his lord’s money.</span> 
-</p><p>
-<span class="v">19&#160;</span><span class="wj">“Now after a long time the lord of those servants came, and settled accounts with them. </span> 
-<span class="v">20&#160;</span><span class="wj">He who received the five talents came and brought another five talents, saying, ‘Lord, you delivered to me five talents. Behold, I have gained another five talents in addition to them.’</span> 
-</p><p>
-<span class="v">21&#160;</span><span class="wj">“His lord said to him, ‘Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.’</span> 
-</p><p>
-<span class="v">22&#160;</span><span class="wj">“He also who got the two talents came and said, ‘Lord, you delivered to me two talents. Behold, I have gained another two talents in addition to them.’ </span> 
-</p><p>
-<span class="v">23&#160;</span><span class="wj">“His lord said to him, ‘Well done, good and faithful servant. You have been faithful over a few things. I will set you over many things. Enter into the joy of your lord.’</span> 
-</p><p>
-<span class="v">24&#160;</span><span class="wj">“He also who had received the one talent came and said, ‘Lord, I knew you that you are a hard man, reaping where you didn’t sow, and gathering where you didn’t scatter. </span> 
-<span class="v">25&#160;</span><span class="wj">I was afraid, and went away and hid your talent in the earth. Behold, you have what is yours.’</span> 
-</p><p>
-<span class="v">26&#160;</span><span class="wj">“But his lord answered him, ‘You wicked and slothful servant. You knew that I reap where I didn’t sow, and gather where I didn’t scatter. </span> 
-<span class="v">27&#160;</span><span class="wj">You ought therefore to have deposited my money with the bankers, and at my coming I should have received back my own with interest. </span> 
-<span class="v">28&#160;</span><span class="wj">Take away therefore the talent from him and give it to him who has the ten talents. </span> 
-<span class="v">29&#160;</span><span class="wj">For to everyone who has will be given, and he will have abundance, but from him who doesn’t have, even that which he has will be taken away. </span> 
-<span class="v">30&#160;</span><span class="wj">Throw out the unprofitable servant into the outer darkness, where there will be weeping and gnashing of teeth.’</span> 
-</p><p>
-<span class="v">31&#160;</span><span class="wj">“But when the Son of Man comes in his glory, and all the set-apart angels with him, then he will sit on the throne of his glory. </span> 
-<span class="v">32&#160;</span><span class="wj">Before him all the nations will be gathered, and he will separate them one from another, as a shepherd separates the sheep from the goats. </span> 
-<span class="v">33&#160;</span><span class="wj">He will set the sheep on his right hand, but the goats on the left. </span> 
-<span class="v">34&#160;</span><span class="wj">Then the King will tell those on his right hand, ‘Come, blessed of my Father, inherit the Kingdom prepared for you from the foundation of the world; </span> 
-<span class="v">35&#160;</span><span class="wj">for I was hungry and you gave me food to eat. I was thirsty and you gave me drink. I was a stranger and you took me in. </span> 
-<span class="v">36&#160;</span><span class="wj">I was naked and you clothed me. I was sick and you visited me. I was in prison and you came to me.’</span> 
-</p><p>
-<span class="v">37&#160;</span><span class="wj">“Then the righteous will answer him, saying, ‘Lord, when did we see you hungry and feed you, or thirsty and give you a drink? </span> 
-<span class="v">38&#160;</span><span class="wj">When did we see you as a stranger and take you in, or naked and clothe you? </span> 
-<span class="v">39&#160;</span><span class="wj">When did we see you sick or in prison and come to you?’</span> 
-</p><p>
-<span class="v">40&#160;</span><span class="wj">“The King will answer them, ‘Most certainly I tell you, because you did it to one of the least of these my brothers,</span><span class="f">+ \fr 25:40 \ft The word for “brothers” here may be also correctly translated “brothers and sisters” or “siblings.”</span> <span class="wj">you did it to me.’ </span> 
-<span class="v">41&#160;</span><span class="wj">Then he will say also to those on the left hand, ‘Depart from me, you cursed, into the eternal fire which is prepared for the devil and his angels; </span> 
-<span class="v">42&#160;</span><span class="wj">for I was hungry, and you didn’t give me food to eat; I was thirsty, and you gave me no drink; </span> 
-<span class="v">43&#160;</span><span class="wj">I was a stranger, and you didn’t take me in; naked, and you didn’t clothe me; sick, and in prison, and you didn’t visit me.’</span> 
-</p><p>
-<span class="v">44&#160;</span><span class="wj">“Then they will also answer, saying, ‘Lord, when did we see you hungry, or thirsty, or a stranger, or naked, or sick, or in prison, and didn’t help you?’</span> 
-</p><p>
-<span class="v">45&#160;</span><span class="wj">“Then he will answer them, saying, ‘Most certainly I tell you, because you didn’t do it to one of the least of these, you didn’t do it to me.’ </span> 
-<span class="v">46&#160;</span><span class="wj">These will go away into eternal punishment, but the righteous into eternal life.”</span> 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>When Yahushua had finished all these words, he said to his disciples, 
-<span class="v">2&#160;</span><span class="wj">“You know that after two days the Passover is coming, and the Son of Man will be delivered up to be crucified.”</span> 
-</p><p>
-<span class="v">3&#160;</span>Then the chief priests, the scribes, and the elders of the people were gathered together in the court of the high priest, who was called Caiaphas. 
-<span class="v">4&#160;</span>They took counsel together that they might take Yahushua by deceit and kill him. 
-<span class="v">5&#160;</span>But they said, “Not during the feast, lest a riot occur among the people.” 
-</p><p>
-<span class="v">6&#160;</span>Now when Yahushua was in Bethany, in the house of Simon the leper, 
-<span class="v">7&#160;</span>a woman came to him having an alabaster jar of very expensive ointment, and she poured it on his head as he sat at the table. 
-<span class="v">8&#160;</span>But when his disciples saw this, they were indignant, saying, “Why this waste? 
-<span class="v">9&#160;</span>For this ointment might have been sold for much and given to the poor.” 
-</p><p>
-<span class="v">10&#160;</span>However, knowing this, Yahushua said to them, <span class="wj">“Why do you trouble the woman? She has done a good work for me. </span> 
-<span class="v">11&#160;</span><span class="wj">For you always have the poor with you, but you don’t always have me. </span> 
-<span class="v">12&#160;</span><span class="wj">For in pouring this ointment on my body, she did it to prepare me for burial. </span> 
-<span class="v">13&#160;</span><span class="wj">Most certainly I tell you, wherever this Good News is preached in the whole world, what this woman has done will also be spoken of as a memorial of her.”</span> 
-</p><p>
-<span class="v">14&#160;</span>Then one of the twelve, who was called Judas Iscariot, went to the chief priests 
-<span class="v">15&#160;</span>and said, “What are you willing to give me if I deliver him to you?” So they weighed out for him thirty pieces of silver. 
-<span class="v">16&#160;</span>From that time he sought opportunity to betray him. 
-</p><p>
-<span class="v">17&#160;</span>Now on the first day of unleavened bread, the disciples came to Yahushua, saying to him, “Where do you want us to prepare for you to eat the Passover?” 
-</p><p>
-<span class="v">18&#160;</span>He said, <span class="wj">“Go into the city to a certain person, and tell him, ‘The Teacher says, “My time is at hand. I will keep the Passover at your house with my disciples.”&#160;’&#160;”</span> 
-</p><p>
-<span class="v">19&#160;</span>The disciples did as Yahushua commanded them, and they prepared the Passover. 
-</p><p>
-<span class="v">20&#160;</span>Now when evening had come, he was reclining at the table with the twelve disciples. 
-<span class="v">21&#160;</span>As they were eating, he said, <span class="wj">“Most certainly I tell you that one of you will betray me.”</span> 
-</p><p>
-<span class="v">22&#160;</span>They were exceedingly sorrowful, and each began to ask him, “It isn’t me, is it, Lord?” 
-</p><p>
-<span class="v">23&#160;</span>He answered, <span class="wj">“He who dipped his hand with me in the dish will betray me. </span> 
-<span class="v">24&#160;</span><span class="wj">The Son of Man goes even as it is written of him, but woe to that man through whom the Son of Man is betrayed! It would be better for that man if he had not been born.”</span> 
-</p><p>
-<span class="v">25&#160;</span>Judas, who betrayed him, answered, “It isn’t me, is it, Rabbi?” 
-</p><p>He said to him, <span class="wj">“You said it.”</span> 
-</p><p>
-<span class="v">26&#160;</span>As they were eating, Yahushua took bread, gave thanks for<span class="f">+ \fr 26:26 \ft TR reads “blessed” instead of “gave thanks for”</span> it, and broke it. He gave to the disciples and said, <span class="wj">“Take, eat; this is my body.”</span> 
-<span class="v">27&#160;</span>He took the cup, gave thanks, and gave to them, saying, <span class="wj">“All of you drink it, </span> 
-<span class="v">28&#160;</span><span class="wj">for this is my blood of the new covenant, which is poured out for many for the remission of sins. </span> 
-<span class="v">29&#160;</span><span class="wj">But I tell you that I will not drink of this fruit of the vine from now on, until that day when I drink it anew with you in my Father’s Kingdom.” </span> 
-</p><p>
-<span class="v">30&#160;</span>When they had sung a hymn, they went out to the Mount of Olives. 
-</p><p>
-<span class="v">31&#160;</span>Then Yahushua said to them, <span class="wj">“All of you will be made to stumble because of me tonight, for it is written, ‘I will strike the shepherd, and the sheep of the flock will be scattered.’</span><span class="x">+ \xo 26:31 \xt Zechariah 13:7</span> 
-<span class="v">32&#160;</span><span class="wj">But after I am raised up, I will go before you into Galilee.” </span> 
-</p><p>
-<span class="v">33&#160;</span>But Peter answered him, “Even if all will be made to stumble because of you, I will never be made to stumble.” 
-</p><p>
-<span class="v">34&#160;</span>Yahushua said to him, <span class="wj">“Most certainly I tell you that tonight, before the rooster crows, you will deny me three times.”</span> 
-</p><p>
-<span class="v">35&#160;</span>Peter said to him, “Even if I must die with you, I will not deny you.” All of the disciples also said likewise. 
-</p><p>
-<span class="v">36&#160;</span>Then Yahushua came with them to a place called Gethsemane, and said to his disciples, <span class="wj">“Sit here, while I go there and pray.”</span> 
-<span class="v">37&#160;</span>He took with him Peter and the two sons of Zebedee, and began to be sorrowful and severely troubled. 
-<span class="v">38&#160;</span>Then he said to them, <span class="wj">“My soul is exceedingly sorrowful, even to death. Stay here and watch with me.”</span> 
-</p><p>
-<span class="v">39&#160;</span>He went forward a little, fell on his face, and prayed, saying, <span class="wj">“My Father, if it is possible, let this cup pass away from me; nevertheless, not what I desire, but what you desire.”</span> 
-</p><p>
-<span class="v">40&#160;</span>He came to the disciples and found them sleeping, and said to Peter, <span class="wj">“What, couldn’t you watch with me for one hour? </span> 
-<span class="v">41&#160;</span><span class="wj">Watch and pray, that you don’t enter into temptation. The spirit indeed is willing, but the flesh is weak.”</span> 
-</p><p>
-<span class="v">42&#160;</span>Again, a second time he went away and prayed, saying, <span class="wj">“My Father, if this cup can’t pass away from me unless I drink it, your desire be done.” </span> 
-</p><p>
-<span class="v">43&#160;</span>He came again and found them sleeping, for their eyes were heavy. 
-<span class="v">44&#160;</span>He left them again, went away, and prayed a third time, saying the same words. 
-<span class="v">45&#160;</span>Then he came to his disciples and said to them, <span class="wj">“Are you still sleeping and resting? Behold, the hour is at hand, and the Son of Man is betrayed into the hands of sinners. </span> 
-<span class="v">46&#160;</span><span class="wj">Arise, let’s be going. Behold, he who betrays me is at hand.” </span> 
-</p><p>
-<span class="v">47&#160;</span>While he was still speaking, behold, Judas, one of the twelve, came, and with him a great multitude with swords and clubs, from the chief priests and elders of the people. 
-<span class="v">48&#160;</span>Now he who betrayed him had given them a sign, saying, “Whoever I kiss, he is the one. Seize him.” 
-<span class="v">49&#160;</span>Immediately he came to Yahushua, and said, “Greetings, Rabbi!” and kissed him. 
-</p><p>
-<span class="v">50&#160;</span>Yahushua said to him, <span class="wj">“Friend, why are you here?”</span> 
-</p><p>Then they came and laid hands on Yahushua, and took him. 
-<span class="v">51&#160;</span>Behold, one of those who were with Yahushua stretched out his hand and drew his sword, and struck the servant of the high priest, and cut off his ear. 
-</p><p>
-<span class="v">52&#160;</span>Then Yahushua said to him, <span class="wj">“Put your sword back into its place, for all those who take the sword will die by the sword. </span> 
-<span class="v">53&#160;</span><span class="wj">Or do you think that I couldn’t ask my Father, and he would even now send me more than twelve legions of angels? </span> 
-<span class="v">54&#160;</span><span class="wj">How then would the Scriptures be fulfilled that it must be so?” </span> 
-</p><p>
-<span class="v">55&#160;</span>In that hour Yahushua said to the multitudes, <span class="wj">“Have you come out as against a robber with swords and clubs to seize me? I sat daily in the temple teaching, and you didn’t arrest me. </span> 
-<span class="v">56&#160;</span><span class="wj">But all this has happened that the Scriptures of the prophets might be fulfilled.”</span> 
-</p><p>Then all the disciples left him and fled. 
-</p><p>
-<span class="v">57&#160;</span>Those who had taken Yahushua led him away to Caiaphas the high priest, where the scribes and the elders were gathered together. 
-<span class="v">58&#160;</span>But Peter followed him from a distance to the court of the high priest, and entered in and sat with the officers, to see the end. 
-</p><p>
-<span class="v">59&#160;</span>Now the chief priests, the elders, and the whole council sought false testimony against Yahushua, that they might put him to death, 
-<span class="v">60&#160;</span>and they found none. Even though many false witnesses came forward, they found none. But at last two false witnesses came forward 
-<span class="v">61&#160;</span>and said, “This man said, ‘I am able to destroy the temple of Elohim, and to build it in three days.’&#160;” 
-</p><p>
-<span class="v">62&#160;</span>The high priest stood up and said to him, “Have you no answer? What is this that these testify against you?” 
-<span class="v">63&#160;</span>But Yahushua stayed silent. The high priest answered him, “I adjure you by the living Elohim that you tell us whether you are the Christ, the Son of Elohim.” 
-</p><p>
-<span class="v">64&#160;</span>Yahushua said to him, <span class="wj">“You have said so. Nevertheless, I tell you, after this you will see the Son of Man sitting at the right hand of Yahweh, and coming on the clouds of the sky.”</span> 
-</p><p>
-<span class="v">65&#160;</span>Then the high priest tore his clothing, saying, “He has spoken blasphemy! Why do we need any more witnesses? Behold, now you have heard his blasphemy. 
-<span class="v">66&#160;</span>What do you think?” 
-</p><p>They answered, “He is worthy of death!” 
-<span class="v">67&#160;</span>Then they spat in his face and beat him with their fists, and some slapped him, 
-<span class="v">68&#160;</span>saying, “Prophesy to us, you Christ! Who hit you?” 
-</p><p>
-<span class="v">69&#160;</span>Now Peter was sitting outside in the court, and a maid came to him, saying, “You were also with Yahushua, the Galilean!” 
-</p><p>
-<span class="v">70&#160;</span>But he denied it before them all, saying, “I don’t know what you are talking about.” 
-</p><p>
-<span class="v">71&#160;</span>When he had gone out onto the porch, someone else saw him and said to those who were there, “This man also was with Yahushua of Nazareth.” 
-</p><p>
-<span class="v">72&#160;</span>Again he denied it with an oath, “I don’t know the man.” 
-</p><p>
-<span class="v">73&#160;</span>After a little while those who stood by came and said to Peter, “Surely you are also one of them, for your speech makes you known.” 
-</p><p>
-<span class="v">74&#160;</span>Then he began to curse and to swear, “I don’t know the man!” 
-</p><p>Immediately the rooster crowed. 
-<span class="v">75&#160;</span>Peter remembered the word which Yahushua had said to him, <span class="wj">“Before the rooster crows, you will deny me three times.”</span> Then he went out and wept bitterly. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Now when morning had come, all the chief priests and the elders of the people took counsel against Yahushua to put him to death. 
-<span class="v">2&#160;</span>They bound him, led him away, and delivered him up to Pontius Pilate, the governor. 
-</p><p>
-<span class="v">3&#160;</span>Then Judas, who betrayed him, when he saw that Yahushua was condemned, felt remorse, and brought back the thirty pieces of silver to the chief priests and elders, 
-<span class="v">4&#160;</span>saying, “I have sinned in that I betrayed innocent blood.” 
-</p><p>But they said, “What is that to us? You see to it.” 
-</p><p>
-<span class="v">5&#160;</span>He threw down the pieces of silver in the sanctuary and departed. Then he went away and hanged himself. 
-</p><p>
-<span class="v">6&#160;</span>The chief priests took the pieces of silver and said, “It’s not lawful to put them into the treasury, since it is the price of blood.” 
-<span class="v">7&#160;</span>They took counsel, and bought the potter’s field with them to bury strangers in. 
-<span class="v">8&#160;</span>Therefore that field has been called “The Field of Blood” to this day. 
-<span class="v">9&#160;</span>Then that which was spoken through Jeremiah<span class="f">+ \fr 27:9 \ft some manuscripts omit “Jeremiah”</span> the prophet was fulfilled, saying, 
-</p><p class="q1">“They took the thirty pieces of silver, 
-</p><p class="q2">the price of him upon whom a price had been set, 
-</p><p class="q2">whom some of the children of Israel priced, 
-</p><p class="q1">
-<span class="v">10&#160;</span>and they gave them for the potter’s field, 
-</p><p class="q2">as the Lord commanded me.”<span class="x">+ \xo 27:10 \xt Zechariah 11:12-13; Jeremiah 19:1-13; 32:6-9</span> 
-</p><p>
-<span class="v">11&#160;</span>Now Yahushua stood before the governor; and the governor asked him, saying, “Are you the King of the Jews?” 
-</p><p>Yahushua said to him, <span class="wj">“So you say.”</span> 
-</p><p>
-<span class="v">12&#160;</span>When he was accused by the chief priests and elders, he answered nothing. 
-<span class="v">13&#160;</span>Then Pilate said to him, “Don’t you hear how many things they testify against you?” 
-</p><p>
-<span class="v">14&#160;</span>He gave him no answer, not even one word, so that the governor marveled greatly. 
-</p><p>
-<span class="v">15&#160;</span>Now at the feast the governor was accustomed to release to the multitude one prisoner whom they desired. 
-<span class="v">16&#160;</span>They had then a notable prisoner called Barabbas. 
-<span class="v">17&#160;</span>When therefore they were gathered together, Pilate said to them, “Whom do you want me to release to you? Barabbas, or Yahushua who is called Christ?” 
-<span class="v">18&#160;</span>For he knew that because of envy they had delivered him up. 
-</p><p>
-<span class="v">19&#160;</span>While he was sitting on the judgment seat, his woman sent to him, saying, “Have nothing to do with that righteous man, for I have suffered many things today in a dream because of him.” 
-</p><p>
-<span class="v">20&#160;</span>Now the chief priests and the elders persuaded the multitudes to ask for Barabbas and destroy Yahushua. 
-<span class="v">21&#160;</span>But the governor answered them, “Which of the two do you want me to release to you?” 
-</p><p>They said, “Barabbas!” 
-</p><p>
-<span class="v">22&#160;</span>Pilate said to them, “What then shall I do to Yahushua who is called Christ?” 
-</p><p>They all said to him, “Let him be crucified!” 
-</p><p>
-<span class="v">23&#160;</span>But the governor said, “Why? What evil has he done?” 
-</p><p>But they cried out exceedingly, saying, “Let him be crucified!” 
-</p><p>
-<span class="v">24&#160;</span>So when Pilate saw that nothing was being gained, but rather that a disturbance was starting, he took water and washed his hands before the multitude, saying, “I am innocent of the blood of this righteous person. You see to it.” 
-</p><p>
-<span class="v">25&#160;</span>All the people answered, “May his blood be on us and on our children!” 
-</p><p>
-<span class="v">26&#160;</span>Then he released Barabbas to them, but Yahushua he flogged and delivered to be crucified. 
-</p><p>
-<span class="v">27&#160;</span>Then the governor’s soldiers took Yahushua into the Praetorium, and gathered the whole garrison together against him. 
-<span class="v">28&#160;</span>They stripped him and put a scarlet robe on him. 
-<span class="v">29&#160;</span>They braided a crown of thorns and put it on his head, and a reed in his right hand; and they kneeled down before him and mocked him, saying, “Hail, King of the Jews!” 
-<span class="v">30&#160;</span>They spat on him, and took the reed and struck him on the head. 
-<span class="v">31&#160;</span>When they had mocked him, they took the robe off him, and put his clothes on him, and led him away to crucify him. 
-</p><p>
-<span class="v">32&#160;</span>As they came out, they found a man of Cyrene, Simon by name, and they compelled him to go with them, that he might carry his cross. 
-<span class="v">33&#160;</span>When they came to a place called “Golgotha”, that is to say, “The place of a skull,” 
-<span class="v">34&#160;</span>they gave him sour wine<span class="f">+ \fr 27:34 \ft or, vinegar</span> to drink mixed with gall.<span class="f">+ \fr 27:34 \ft Gall is a bitter-tasting, dark green oil from a wormwood plant that is alcoholic in its effect.</span> When he had tasted it, he would not drink. 
-<span class="v">35&#160;</span>When they had crucified him, they divided his clothing among them, casting lots,<span class="f">+ \fr 27:35 \ft TR adds “that it might be fulfilled which was spoken by the prophet: ‘They divided my garments among them, and for my clothing they cast lots;’&#160;” [see Psalm 22:18 and John 19:24]</span> 
-<span class="v">36&#160;</span>and they sat and watched him there. 
-<span class="v">37&#160;</span>They set up over his head the accusation against him written, “THIS IS YAHUSHUA, THE KING OF THE JEWS.” 
-</p><p>
-<span class="v">38&#160;</span>Then there were two robbers crucified with him, one on his right hand and one on the left. 
-</p><p>
-<span class="v">39&#160;</span>Those who passed by blasphemed him, wagging their heads 
-<span class="v">40&#160;</span>and saying, “You who destroy the temple and build it in three days, save yourself! If you are the Son of Elohim, come down from the cross!” 
-</p><p>
-<span class="v">41&#160;</span>Likewise the chief priests also mocking with the scribes, the Pharisees,<span class="f">+ \fr 27:41 \ft TR omits “the Pharisees”</span> and the elders, said, 
-<span class="v">42&#160;</span>“He saved others, but he can’t save himself. If he is the King of Israel, let him come down from the cross now, and we will believe in him. 
-<span class="v">43&#160;</span>He trusts in Elohim. Let Elohim deliver him now, if he wants him; for he said, ‘I am the Son of Elohim.’&#160;” 
-<span class="v">44&#160;</span>The robbers also who were crucified with him cast on him the same reproach. 
-</p><p>
-<span class="v">45&#160;</span>Now from the sixth hour<span class="f">+ \fr 27:45 \ft noon</span> there was darkness over all the land until the ninth hour.<span class="f">+ \fr 27:45 \ft 3:00 p.m.</span> 
-<span class="v">46&#160;</span>About the ninth hour Yahushua cried with a loud voice, saying, <span class="wj">“Eli, Eli, lima</span><span class="f">+ \fr 27:46 \ft TR reads “lama” instead of “lima”</span> <span class="wj">sabachthani?” </span> That is, <span class="wj">“My Elohim, my Elohim, why have you forsaken me?”</span><span class="x">+ \xo 27:46 \xt Psalm 22:1</span> 
-</p><p>
-<span class="v">47&#160;</span>Some of them who stood there, when they heard it, said, “This man is calling Elijah.” 
-</p><p>
-<span class="v">48&#160;</span>Immediately one of them ran and took a sponge, filled it with vinegar, put it on a reed, and gave him a drink. 
-<span class="v">49&#160;</span>The rest said, “Let him be. Let’s see whether Elijah comes to save him.” 
-</p><p>
-<span class="v">50&#160;</span>Yahushua cried again with a loud voice, and yielded up his spirit. 
-</p><p>
-<span class="v">51&#160;</span>Behold, the veil of the temple was torn in two from the top to the bottom. The earth quaked and the rocks were split. 
-<span class="v">52&#160;</span>The tombs were opened, and many bodies of the saints who had fallen asleep were raised; 
-<span class="v">53&#160;</span>and coming out of the tombs after his resurrection, they entered into the set-apart city and appeared to many. 
-</p><p>
-<span class="v">54&#160;</span>Now the centurion and those who were with him watching Yahushua, when they saw the earthquake and the things that were done, were terrified, saying, “Truly this was the Son of Elohim!” 
-</p><p>
-<span class="v">55&#160;</span>Many women were there watching from afar, who had followed Yahushua from Galilee, serving him. 
-<span class="v">56&#160;</span>Among them were Mary Magdalene, Mary the mother of James and Joses, and the mother of the sons of Zebedee. 
-</p><p>
-<span class="v">57&#160;</span>When evening had come, a rich man from Arimathaea named Joseph, who himself was also Yahushua’s disciple, came. 
-<span class="v">58&#160;</span>This man went to Pilate and asked for Yahushua’s body. Then Pilate commanded the body to be given up. 
-<span class="v">59&#160;</span>Joseph took the body and wrapped it in a clean linen cloth 
-<span class="v">60&#160;</span>and laid it in his own new tomb, which he had cut out in the rock. Then he rolled a large stone against the door of the tomb, and departed. 
-<span class="v">61&#160;</span>Mary Magdalene was there, and the other Mary, sitting opposite the tomb. 
-</p><p>
-<span class="v">62&#160;</span>Now on the next day, which was the day after the Preparation Day, the chief priests and the Pharisees were gathered together to Pilate, 
-<span class="v">63&#160;</span>saying, “Sir, we remember what that deceiver said while he was still alive: ‘After three days I will rise again.’ 
-<span class="v">64&#160;</span>Command therefore that the tomb be made secure until the third day, lest perhaps his disciples come at night and steal him away, and tell the people, ‘He is risen from the dead;’ and the last deception will be worse than the first.” 
-</p><p>
-<span class="v">65&#160;</span>Pilate said to them, “You have a guard. Go, make it as secure as you can.” 
-<span class="v">66&#160;</span>So they went with the guard and made the tomb secure, sealing the stone. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>Now after the Sabbath, as it began to dawn on the first day of the week, Mary Magdalene and the other Mary came to see the tomb. 
-<span class="v">2&#160;</span>Behold, there was a great earthquake, for an angel of the Lord descended from the sky and came and rolled away the stone from the door and sat on it. 
-<span class="v">3&#160;</span>His appearance was like lightning, and his clothing white as snow. 
-<span class="v">4&#160;</span>For fear of him, the guards shook, and became like dead men. 
-<span class="v">5&#160;</span>The angel answered the women, “Don’t be afraid, for I know that you seek Yahushua, who has been crucified. 
-<span class="v">6&#160;</span>He is not here, for he has risen, just like he said. Come, see the place where the Lord was lying. 
-<span class="v">7&#160;</span>Go quickly and tell his disciples, ‘He has risen from the dead, and behold, he goes before you into Galilee; there you will see him.’ Behold, I have told you.” 
-</p><p>
-<span class="v">8&#160;</span>They departed quickly from the tomb with fear and great joy, and ran to bring his disciples word. 
-<span class="v">9&#160;</span>As they went to tell his disciples, behold, Yahushua met them, saying, <span class="wj">“Rejoice!”</span> 
-</p><p>They came and took hold of his feet, and worshiped him. 
-</p><p>
-<span class="v">10&#160;</span>Then Yahushua said to them, <span class="wj">“Don’t be afraid. Go tell my brothers </span><span class="f">+ \fr 28:10 \ft The word for “brothers” here may be also correctly translated “brothers and sisters” or “siblings.”</span> <span class="wj">that they should go into Galilee, and there they will see me.”</span> 
-</p><p>
-<span class="v">11&#160;</span>Now while they were going, behold, some of the guards came into the city and told the chief priests all the things that had happened. 
-<span class="v">12&#160;</span>When they were assembled with the elders and had taken counsel, they gave a large amount of silver to the soldiers, 
-<span class="v">13&#160;</span>saying, “Say that his disciples came by night and stole him away while we slept. 
-<span class="v">14&#160;</span>If this comes to the governor’s ears, we will persuade him and make you free of worry.” 
-<span class="v">15&#160;</span>So they took the money and did as they were told. This saying was spread abroad among the Jews, and continues until today. 
-</p><p>
-<span class="v">16&#160;</span>But the eleven disciples went into Galilee, to the mountain where Yahushua had sent them. 
-<span class="v">17&#160;</span>When they saw him, they bowed down to him; but some doubted. 
-<span class="v">18&#160;</span>Yahushua came to them and spoke to them, saying, <span class="wj">“All authority has been given to me in heaven and on earth. </span> 
-<span class="v">19&#160;</span><span class="wj">Go</span><span class="f">+ \fr 28:19 \ft TR and NU add “therefore”</span> <span class="wj"> </span> 
-<span class="v">20&#160;</span><span class="wj">and teach them to carry out all the things which I have commanded you forever.”</span> </div><script src="../main.js"></script></body></html>
+</div><div class="p">
+<sup>12&#160;</sup><span class="wj">“What do you think? If a man has one hundred sheep, and one of them goes astray, doesn’t he leave the ninety-nine, go to the mountains, and seek that which has gone astray? </span> 
+<sup>13&#160;</sup><span class="wj">If he finds it, most certainly I tell you, he rejoices over it more than over the ninety-nine which have not gone astray. </span> 
+<sup>14&#160;</sup><span class="wj">Even so it is not the will of your Father who is in heaven that one of these little ones should perish.</span> 
+</div><div class="p">
+<sup>15&#160;</sup><span class="wj">“If your brother sins against you, go, show him his fault between you and him alone. If he listens to you, you have gained back your brother. </span> 
+<sup>16&#160;</sup><span class="wj">But if he doesn’t listen, take one or two more with you, that at the mouth of two or three witnesses every word may be established.</span> 
+<sup>17&#160;</sup><span class="wj">If he refuses to listen to them, tell it to the assembly. If he refuses to hear the assembly also, let him be to you as a Gentile or a tax collector. </span> 
+<sup>18&#160;</sup><span class="wj">Most certainly I tell you, whatever things you bind on earth will have been bound in heaven, and whatever things you release on earth will have been released in heaven. </span> 
+<sup>19&#160;</sup><span class="wj">Again, assuredly I tell you, that if two of you will agree on earth concerning anything that they will ask, it will be done for them by my Father who is in heaven. </span> 
+<sup>20&#160;</sup><span class="wj">For where two or three are gathered together in my name, there I am in the middle of them.”</span> 
+</div><div class="p">
+<sup>21&#160;</sup>Then Peter came and said to him, “Lord, how often shall my brother sin against me, and I forgive him? Until seven times?” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahushua said to him, <span class="wj">“I don’t tell you until seven times, but, until seventy times seven. </span> 
+<sup>23&#160;</sup><span class="wj">Therefore the Kingdom of Heaven is like a certain king who wanted to settle accounts with his servants. </span> 
+<sup>24&#160;</sup><span class="wj">When he had begun to settle, one was brought to him who owed him ten thousand talents.</span> 
+<sup>25&#160;</sup><span class="wj">But because he couldn’t pay, his lord commanded him to be sold, with his woman, his children, and all that he had, and payment to be made. </span> 
+<sup>26&#160;</sup><span class="wj">The servant therefore fell down and knelt before him, saying, ‘Lord, have patience with me, and I will repay you all!’ </span> 
+<sup>27&#160;</sup><span class="wj">The lord of that servant, being moved with compassion, released him and forgave him the debt.</span> 
+</div><div class="p">
+<sup>28&#160;</sup><span class="wj">“But that servant went out and found one of his fellow servants who owed him one hundred denarii,</span> <span class="wj">and he grabbed him and took him by the throat, saying, ‘Pay me what you owe!’</span> 
+</div><div class="p">
+<sup>29&#160;</sup><span class="wj">“So his fellow servant fell down at his feet and begged him, saying, ‘Have patience with me, and I will repay you!’ </span> 
+<sup>30&#160;</sup><span class="wj">He would not, but went and cast him into prison until he should pay back that which was due. </span> 
+<sup>31&#160;</sup><span class="wj">So when his fellow servants saw what was done, they were exceedingly sorry, and came and told their lord all that was done. </span> 
+<sup>32&#160;</sup><span class="wj">Then his lord called him in and said to him, ‘You wicked servant! I forgave you all that debt because you begged me. </span> 
+<sup>33&#160;</sup><span class="wj">Shouldn’t you also have had mercy on your fellow servant, even as I had mercy on you?’ </span> 
+<sup>34&#160;</sup><span class="wj">His lord was angry, and delivered him to the tormentors until he should pay all that was due to him. </span> 
+<sup>35&#160;</sup><span class="wj">So my heavenly Father will also do to you, if you don’t each forgive your brother from your hearts for his misdeeds.”</span> 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahushua had finished these words, he departed from Galilee and came into the borders of Judea beyond the Jordan. 
+<sup>2&#160;</sup>Great multitudes followed him, and he healed them there. 
+</div><div class="p">
+<sup>3&#160;</sup>Pharisees came to him, testing him and saying, “Is it lawful for a man to divorce his woman for any reason?” 
+</div><div class="p">
+<sup>4&#160;</sup>He answered, <span class="wj">“Haven’t you read that he who made them from the beginning made them male and female,</span> 
+<sup>5&#160;</sup><span class="wj">and said, ‘For this cause a man shall leave his father and mother, and shall be joined to his woman; and the two shall become one flesh’?</span> 
+<sup>6&#160;</sup><span class="wj">So that they are no more two, but one flesh. What therefore Elohim has joined together, don’t let man tear apart.”</span> 
+</div><div class="p">
+<sup>7&#160;</sup>They asked him, “Why then did Moses command us to give her a certificate of divorce and divorce her?” 
+</div><div class="p">
+<sup>8&#160;</sup>He said to them, <span class="wj">“Moses, because of the hardness of your hearts, allowed you to put away your women, but from the beginning it has not been so. </span> 
+<sup>9&#160;</sup><span class="wj">I tell you that whoever puts away his woman, except for sexual immorality, and marries another, commits adultery; and he who marries her when she is put away commits adultery.”</span> 
+</div><div class="p">
+<sup>10&#160;</sup>His disciples said to him, “If this is the case of the man with his woman, it is not expedient to marry.” 
+</div><div class="p">
+<sup>11&#160;</sup>But he said to them, <span class="wj">“Not all men can receive this saying, but those to whom it is given. </span> 
+<sup>12&#160;</sup><span class="wj">For there are eunuchs who were born that way from their mother’s womb, and there are eunuchs who were made eunuchs by men; and there are eunuchs who made themselves eunuchs for the Kingdom of Heaven’s sake. He who is able to receive it, let him receive it.”</span> 
+</div><div class="p">
+<sup>13&#160;</sup>Then little children were brought to him that he should lay his hands on them and pray; and the disciples rebuked them. 
+<sup>14&#160;</sup>But Yahushua said, <span class="wj">“Allow the little children, and don’t forbid them to come to me; for the Kingdom of Heaven belongs to ones like these.”</span> 
+<sup>15&#160;</sup>He laid his hands on them, and departed from there. 
+</div><div class="p">
+<sup>16&#160;</sup>Behold, one came to him and said, “Good teacher, what good thing shall I do, that I may have eternal life?” 
+</div><div class="p">
+<sup>17&#160;</sup>He said to him, <span class="wj">“Why do you call me good?</span> <span class="wj">No one is good but one, Elohim the Father. But if you want to enter into life, keep the commandments.” </span> 
+</div><div class="p">
+<sup>18&#160;</sup>He said to him, “Which ones?” 
+</div><div class="p">Yahushua said, <span class="wj">“&#160;‘You shall not murder.’ ‘You shall not commit adultery.’ ‘You shall not steal.’ ‘You shall not offer false testimony.’ </span> 
+<sup>19&#160;</sup><span class="wj">‘Honor your father and your mother.’</span> 
+</div><div class="p">
+<sup>20&#160;</sup>The young man said to him, “All these things I have observed from my youth. What do I still lack?” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahushua said to him, <span class="wj">“If you want to be perfect, go, sell what you have, and give to the poor, and you will have treasure in heaven; and come, follow me.”</span> 
+<sup>22&#160;</sup>But when the young man heard this, he went away sad, for he was one who had great possessions. 
+</div><div class="p">
+<sup>23&#160;</sup>Yahushua said to his disciples, <span class="wj">“Most certainly I say to you, a rich man will enter into the Kingdom of Heaven with difficulty. </span> 
+<sup>24&#160;</sup><span class="wj">Again I tell you, it is easier for a camel to go through a needle’s eye than for a rich man to enter into Elohim’s Kingdom.”</span> 
+</div><div class="p">
+<sup>25&#160;</sup>When the disciples heard it, they were exceedingly astonished, saying, “Who then can be saved?” 
+</div><div class="p">
+<sup>26&#160;</sup>Looking at them, Yahushua said, <span class="wj">“With men this is impossible, but with Elohim all things are possible.”</span> 
+</div><div class="p">
+<sup>27&#160;</sup>Then Peter answered, “Behold, we have left everything and followed you. What then will we have?” 
+</div><div class="p">
+<sup>28&#160;</sup>Yahushua said to them, <span class="wj">“Most certainly I tell you that you who have followed me, in the regeneration when the Son of Man will sit on the throne of his glory, you also will sit on twelve thrones, judging the twelve tribes of Israel. </span> 
+<sup>29&#160;</sup><span class="wj">Everyone who has left houses, or brothers, or sisters, or father, or mother, or woman, or children, or lands, for my name’s sake, will receive one hundred times, and will inherit eternal life. </span> 
+<sup>30&#160;</sup><span class="wj">But many will be last who are first, and first who are last. </span> 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“For the Kingdom of Heaven is like a man who was the master of a household, who went out early in the morning to hire laborers for his vineyard. </span> 
+<sup>2&#160;</sup><span class="wj">When he had agreed with the laborers for a denarius</span> <span class="wj">a day, he sent them into his vineyard. </span> 
+<sup>3&#160;</sup><span class="wj">He went out about the third hour,</span> <span class="wj">and saw others standing idle in the marketplace. </span> 
+<sup>4&#160;</sup><span class="wj">He said to them, ‘You also go into the vineyard, and whatever is right I will give you.’ So they went their way. </span> 
+<sup>5&#160;</sup><span class="wj">Again he went out about the sixth and the ninth hour,</span> <span class="wj">and did likewise. </span> 
+<sup>6&#160;</sup><span class="wj">About the eleventh hour</span> <span class="wj">he went out and found others standing idle. He said to them, ‘Why do you stand here all day idle?’ </span> 
+</div><div class="p">
+<sup>7&#160;</sup><span class="wj">“They said to him, ‘Because no one has hired us.’</span> 
+</div><div class="p"><span class="wj">“He said to them, ‘You also go into the vineyard, and you will receive whatever is right.’ </span> 
+</div><div class="p">
+<sup>8&#160;</sup><span class="wj">“When evening had come, the lord of the vineyard said to his manager, ‘Call the laborers and pay them their wages, beginning from the last to the first.’</span> 
+<sup>9&#160;</sup><span class="wj">“When those who were hired at about the eleventh hour came, they each received a denarius. </span> 
+<sup>10&#160;</sup><span class="wj">When the first came, they supposed that they would receive more; and they likewise each received a denarius. </span> 
+<sup>11&#160;</sup><span class="wj">When they received it, they murmured against the master of the household, </span> 
+<sup>12&#160;</sup><span class="wj">saying, ‘These last have spent one hour, and you have made them equal to us who have borne the burden of the day and the scorching heat!’ </span> 
+</div><div class="p">
+<sup>13&#160;</sup><span class="wj">“But he answered one of them, ‘Friend, I am doing you no wrong. Didn’t you agree with me for a denarius? </span> 
+<sup>14&#160;</sup><span class="wj">Take that which is yours, and go your way. It is my desire to give to this last just as much as to you. </span> 
+<sup>15&#160;</sup><span class="wj">Isn’t it lawful for me to do what I want to with what I own? Or is your eye evil, because I am good?’ </span> 
+<sup>16&#160;</sup><span class="wj">So the last will be first, and the first last. For many are called, but few are chosen.”</span> 
+</div><div class="p">
+<sup>17&#160;</sup>As Yahushua was going up to Jerusalem, he took the twelve disciples aside, and on the way he said to them, 
+<sup>18&#160;</sup><span class="wj">“Behold, we are going up to Jerusalem, and the Son of Man will be delivered to the chief priests and scribes, and they will condemn him to death, </span> 
+<sup>19&#160;</sup><span class="wj">and will hand him over to the Gentiles to mock, to scourge, and to crucify; and the third day he will be raised up.”</span> 
+</div><div class="p">
+<sup>20&#160;</sup>Then the mother of the sons of Zebedee came to him with her sons, kneeling and asking a certain thing of him. 
+<sup>21&#160;</sup>He said to her, <span class="wj">“What do you want?”</span> 
+</div><div class="p">She said to him, “Command that these, my two sons, may sit, one on your right hand and one on your left hand, in your Kingdom.” 
+</div><div class="p">
+<sup>22&#160;</sup>But Yahushua answered, <span class="wj">“You don’t know what you are asking. Are you able to drink the cup that I am about to drink, and be baptized with the baptism that I am baptized with?”</span> 
+</div><div class="p">They said to him, “We are able.” 
+</div><div class="p">
+<sup>23&#160;</sup>He said to them, <span class="wj">“You will indeed drink my cup, and be baptized with the baptism that I am baptized with; but to sit on my right hand and on my left hand is not mine to give, but it is for whom it has been prepared by my Father.”</span> 
+</div><div class="p">
+<sup>24&#160;</sup>When the ten heard it, they were indignant with the two brothers. 
+</div><div class="p">
+<sup>25&#160;</sup>But Yahushua summoned them, and said, <span class="wj">“You know that the rulers of the nations lord it over them, and their great ones exercise authority over them. </span> 
+<sup>26&#160;</sup><span class="wj">It shall not be so among you; but whoever desires to become great among you shall be</span> <span class="wj">your servant. </span> 
+<sup>27&#160;</sup><span class="wj">Whoever desires to be first among you shall be your bondservant, </span> 
+<sup>28&#160;</sup><span class="wj">even as the Son of Man came not to be served, but to serve, and to give his life as a ransom for many.”</span> 
+</div><div class="p">
+<sup>29&#160;</sup>As they went out from Jericho, a great multitude followed him. 
+<sup>30&#160;</sup>Behold, two blind men sitting by the road, when they heard that Yahushua was passing by, cried out, “Lord, have mercy on us, you son of David!” 
+<sup>31&#160;</sup>The multitude rebuked them, telling them that they should be quiet, but they cried out even more, “Lord, have mercy on us, you son of David!” 
+</div><div class="p">
+<sup>32&#160;</sup>Yahushua stood still and called them, and asked, <span class="wj">“What do you want me to do for you?”</span> 
+</div><div class="p">
+<sup>33&#160;</sup>They told him, “Lord, that our eyes may be opened.” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua, being moved with compassion, touched their eyes; and immediately their eyes received their sight, and they followed him. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>When they came near to Jerusalem and came to Bethsphage, to the Mount of Olives, then Yahushua sent two disciples, 
+<sup>2&#160;</sup>saying to them, <span class="wj">“Go into the village that is opposite you, and immediately you will find a donkey tied, and a colt with her. Untie them and bring them to me. </span> 
+<sup>3&#160;</sup><span class="wj">If anyone says anything to you, you shall say, ‘The Lord needs them,’ and immediately he will send them.”</span> 
+</div><div class="p">
+<sup>4&#160;</sup>All this was done that it might be fulfilled which was spoken through the prophet, saying, 
+</div><div class="q1">
+<sup>5&#160;</sup>“Tell the daughter of Zion, 
+</div><div class="q2">behold, your King comes to you, 
+</div><div class="q2">humble, and riding on a donkey, 
+</div><div class="q2">on a colt, the foal of a donkey.” 
+</div><div class="p">
+<sup>6&#160;</sup>The disciples went and did just as Yahushua commanded them, 
+<sup>7&#160;</sup>and brought the donkey and the colt and laid their clothes on them; and he sat on them. 
+<sup>8&#160;</sup>A very great multitude spread their clothes on the road. Others cut branches from the trees and spread them on the road. 
+<sup>9&#160;</sup>The multitudes who went in front of him, and those who followed, kept shouting, “Hosanna to the son of David! Blessed is he who comes in the name of the Lord! Hosanna in the highest!” 
+</div><div class="p">
+<sup>10&#160;</sup>When he had come into Jerusalem, all the city was stirred up, saying, “Who is this?” 
+</div><div class="p">
+<sup>11&#160;</sup>The multitudes said, “This is the prophet, Yahushua, from Nazareth of Galilee.” 
+</div><div class="p">
+<sup>12&#160;</sup>Yahushua entered into the temple of Elohim and drove out all of those who sold and bought in the temple, and overthrew the money changers’ tables and the seats of those who sold the doves. 
+<sup>13&#160;</sup>He said to them, <span class="wj">“It is written, ‘My house shall be called a house of prayer,’</span> 
+</div><div class="p">
+<sup>14&#160;</sup>The lame and the blind came to him in the temple, and he healed them. 
+<sup>15&#160;</sup>But when the chief priests and the scribes saw the wonderful things that he did, and the children who were crying in the temple and saying, “Hosanna to the son of David!” they were indignant, 
+<sup>16&#160;</sup>and said to him, “Do you hear what these are saying?” 
+</div><div class="p">Yahushua said to them, <span class="wj">“Yes. Did you never read, ‘Out of the mouth of children and nursing babies, you have perfected praise’?”</span> 
+</div><div class="p">
+<sup>17&#160;</sup>He left them and went out of the city to Bethany, and camped there. 
+</div><div class="p">
+<sup>18&#160;</sup>Now in the morning, as he returned to the city, he was hungry. 
+<sup>19&#160;</sup>Seeing a fig tree by the road, he came to it and found nothing on it but leaves. He said to it, <span class="wj">“Let there be no fruit from you forever!” </span> 
+</div><div class="p">Immediately the fig tree withered away. 
+</div><div class="p">
+<sup>20&#160;</sup>When the disciples saw it, they marveled, saying, “How did the fig tree immediately wither away?” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahushua answered them, <span class="wj">“Most certainly I tell you, if you have faith and don’t doubt, you will not only do what was done to the fig tree, but even if you told this mountain, ‘Be taken up and cast into the sea,’ it would be done. </span> 
+<sup>22&#160;</sup><span class="wj">All things, whatever you ask in prayer, believing, you will receive.”</span> 
+</div><div class="p">
+<sup>23&#160;</sup>When he had come into the temple, the chief priests and the elders of the people came to him as he was teaching, and said, “By what authority do you do these things? Who gave you this authority?” 
+</div><div class="p">
+<sup>24&#160;</sup>Yahushua answered them, <span class="wj">“I also will ask you one question, which if you tell me, I likewise will tell you by what authority I do these things. </span> 
+<sup>25&#160;</sup><span class="wj">The baptism of John, where was it from? From heaven or from men?” </span> 
+</div><div class="p">They reasoned with themselves, saying, “If we say, ‘From heaven,’ he will ask us, ‘Why then did you not believe him?’ 
+<sup>26&#160;</sup>But if we say, ‘From men,’ we fear the multitude, for all hold John as a prophet.” 
+<sup>27&#160;</sup>They answered Yahushua, and said, “We don’t know.” 
+</div><div class="p">He also said to them, <span class="wj">“Neither will I tell you by what authority I do these things. </span> 
+<sup>28&#160;</sup><span class="wj">But what do you think? A man had two sons, and he came to the first, and said, ‘Son, go work today in my vineyard.’ </span> 
+<sup>29&#160;</sup><span class="wj">He answered, ‘I will not,’ but afterward he changed his mind, and went. </span> 
+<sup>30&#160;</sup><span class="wj">He came to the second, and said the same thing. He answered, ‘I’m going, sir,’ but he didn’t go. </span> 
+<sup>31&#160;</sup><span class="wj">Which of the two did the will of his father?”</span> 
+</div><div class="p">They said to him, “The first.” 
+</div><div class="p">Yahushua said to them, <span class="wj">“Most certainly I tell you that the tax collectors and the prostitutes are entering into Elohim’s Kingdom before you. </span> 
+<sup>32&#160;</sup><span class="wj">For John came to you in the way of righteousness, and you didn’t believe him; but the tax collectors and the prostitutes believed him. When you saw it, you didn’t even repent afterward, that you might believe him. </span> 
+</div><div class="p">
+<sup>33&#160;</sup><span class="wj">“Hear another parable. There was a man who was a master of a household who planted a vineyard, set a hedge about it, dug a wine press in it, built a tower, leased it out to farmers, and went into another country. </span> 
+<sup>34&#160;</sup><span class="wj">When the season for the fruit came near, he sent his servants to the farmers to receive his fruit. </span> 
+<sup>35&#160;</sup><span class="wj">The farmers took his servants, beat one, killed another, and stoned another. </span> 
+<sup>36&#160;</sup><span class="wj">Again, he sent other servants more than the first; and they treated them the same way. </span> 
+<sup>37&#160;</sup><span class="wj">But afterward he sent to them his son, saying, ‘They will respect my son.’ </span> 
+<sup>38&#160;</sup><span class="wj">But the farmers, when they saw the son, said among themselves, ‘This is the heir. Come, let’s kill him and seize his inheritance.’ </span> 
+<sup>39&#160;</sup><span class="wj">So they took him and threw him out of the vineyard, then killed him. </span> 
+<sup>40&#160;</sup><span class="wj">When therefore the lord of the vineyard comes, what will he do to those farmers?”</span> 
+</div><div class="p">
+<sup>41&#160;</sup>They told him, “He will miserably destroy those miserable men, and will lease out the vineyard to other farmers who will give him the fruit in its season.” 
+</div><div class="p">
+<sup>42&#160;</sup>Yahushua said to them, <span class="wj">“Did you never read in the Scriptures, </span> 
+</div><div class="q1"><span class="wj">‘The stone which the builders rejected</span> 
+</div><div class="q2"><span class="wj">was made the head of the corner.</span> 
+</div><div class="q1"><span class="wj">This was from the Lord.</span> 
+</div><div class="q2"><span class="wj">It is marvelous in our eyes’?</span> 
+</div><div class="p">
+<sup>43&#160;</sup><span class="wj">“Therefore I tell you, Elohim’s Kingdom will be taken away from you and will be given to a nation producing its fruit. </span> 
+<sup>44&#160;</sup><span class="wj">He who falls on this stone will be broken to pieces, but on whomever it will fall, it will scatter him as dust.”</span> 
+</div><div class="p">
+<sup>45&#160;</sup>When the chief priests and the Pharisees heard his parables, they perceived that he spoke about them. 
+<sup>46&#160;</sup>When they sought to seize him, they feared the multitudes, because they considered him to be a prophet. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahushua answered and spoke to them again in parables, saying, 
+<sup>2&#160;</sup><span class="wj">“The Kingdom of Heaven is like a certain king, who made a wedding feast for his son, </span> 
+<sup>3&#160;</sup><span class="wj">and sent out his servants to call those who were invited to the wedding feast, but they would not come. </span> 
+<sup>4&#160;</sup><span class="wj">Again he sent out other servants, saying, ‘Tell those who are invited, “Behold, I have prepared my dinner. My cattle and my fatlings are killed, and all things are ready. Come to the wedding feast!”&#160;’ </span> 
+<sup>5&#160;</sup><span class="wj">But they made light of it, and went their ways, one to his own farm, another to his merchandise; </span> 
+<sup>6&#160;</sup><span class="wj">and the rest grabbed his servants, treated them shamefully, and killed them. </span> 
+<sup>7&#160;</sup><span class="wj">When the king heard that, he was angry, and sent his armies, destroyed those murderers, and burned their city.</span> 
+</div><div class="p">
+<sup>8&#160;</sup><span class="wj">“Then he said to his servants, ‘The wedding is ready, but those who were invited weren’t worthy. </span> 
+<sup>9&#160;</sup><span class="wj">Go therefore to the intersections of the highways, and as many as you may find, invite to the wedding feast.’ </span> 
+<sup>10&#160;</sup><span class="wj">Those servants went out into the highways and gathered together as many as they found, both bad and good. The wedding was filled with guests. </span> 
+</div><div class="p">
+<sup>11&#160;</sup><span class="wj">“But when the king came in to see the guests, he saw there a man who didn’t have on wedding clothing, </span> 
+<sup>12&#160;</sup><span class="wj">and he said to him, ‘Friend, how did you come in here not wearing wedding clothing?’ He was speechless. </span> 
+<sup>13&#160;</sup><span class="wj">Then the king said to the servants, ‘Bind him hand and foot, take him away, and throw him into the outer darkness. That is where the weeping and grinding of teeth will be.’ </span> 
+<sup>14&#160;</sup><span class="wj">For many are called, but few chosen.”</span> 
+</div><div class="p">
+<sup>15&#160;</sup>Then the Pharisees went and took counsel how they might entrap him in his talk. 
+<sup>16&#160;</sup>They sent their disciples to him, along with the Herodians, saying, “Teacher, we know that you are honest, and teach the way of Elohim in truth, no matter whom you teach; for you aren’t partial to anyone. 
+<sup>17&#160;</sup>Tell us therefore, what do you think? Is it lawful to pay taxes to Caesar, or not?” 
+</div><div class="p">
+<sup>18&#160;</sup>But Yahushua perceived their wickedness, and said, <span class="wj">“Why do you test me, you hypocrites? </span> 
+<sup>19&#160;</sup><span class="wj">Show me the tax money.”</span> 
+</div><div class="p">They brought to him a denarius. 
+</div><div class="p">
+<sup>20&#160;</sup>He asked them, <span class="wj">“Whose is this image and inscription?”</span> 
+</div><div class="p">
+<sup>21&#160;</sup>They said to him, “Caesar’s.” 
+</div><div class="p">Then he said to them, <span class="wj">“Give therefore to Caesar the things that are Caesar’s, and to Elohim the things that are Elohim’s.”</span> 
+</div><div class="p">
+<sup>22&#160;</sup>When they heard it, they marveled, and left him and went away. 
+</div><div class="p">
+<sup>23&#160;</sup>On that day Sadducees (those who say that there is no resurrection) came to him. They asked him, 
+<sup>24&#160;</sup>saying, “Teacher, Moses said, ‘If a man dies, having no children, his brother shall marry his woman and raise up offspring for his brother.’ 
+<sup>25&#160;</sup>Now there were with us seven brothers. The first married and died, and having no offspring left his woman to his brother. 
+<sup>26&#160;</sup>In the same way, the second also, and the third, to the seventh. 
+<sup>27&#160;</sup>After them all, the woman died. 
+<sup>28&#160;</sup>In the resurrection therefore, whose woman will she be of the seven? For they all had her.” 
+</div><div class="p">
+<sup>29&#160;</sup>But Yahushua answered them, <span class="wj">“You are mistaken, not knowing the Scriptures, nor the power of Elohim. </span> 
+<sup>30&#160;</sup><span class="wj">For in the resurrection they neither marry nor are given in marriage, but are like Elohim’s angels in heaven. </span> 
+<sup>31&#160;</sup><span class="wj">But concerning the resurrection of the dead, haven’t you read that which was spoken to you by Elohim, saying, </span> 
+<sup>32&#160;</sup><span class="wj">‘I am the Elohim of Abraham, and the Elohim of Isaac, and the Elohim of Jacob’?</span> <span class="wj">Elohim is not the Elohim of the dead, but of the living.”</span> 
+</div><div class="p">
+<sup>33&#160;</sup>When the multitudes heard it, they were astonished at his teaching. 
+</div><div class="p">
+<sup>34&#160;</sup>But the Pharisees, when they heard that he had silenced the Sadducees, gathered themselves together. 
+<sup>35&#160;</sup>One of them, a lawyer, asked him a question, testing him. 
+<sup>36&#160;</sup>“Teacher, which is the greatest commandment in the law?” 
+</div><div class="p">
+<sup>37&#160;</sup>Yahushua said to him, <span class="wj">“&#160;‘You shall love the Lord your Elohim with all your heart, with all your soul, and with all your mind.’</span> 
+<sup>38&#160;</sup><span class="wj">This is the first and great commandment. </span> 
+<sup>39&#160;</sup><span class="wj">A second likewise is this, ‘You shall love your neighbor as yourself.’</span> 
+<sup>40&#160;</sup><span class="wj">The whole law and the prophets depend on these two commandments.” </span> 
+</div><div class="p">
+<sup>41&#160;</sup>Now while the Pharisees were gathered together, Yahushua asked them a question, 
+<sup>42&#160;</sup>saying, <span class="wj">“What do you think of the Christ? Whose son is he?” </span> 
+</div><div class="p">They said to him, “Of David.” 
+</div><div class="p">
+<sup>43&#160;</sup>He said to them, <span class="wj">“How then does David in the Spirit call him Lord, saying,</span> 
+</div><div class="q1">
+<sup>44&#160;</sup><span class="wj">‘The Lord said to my Lord,</span> 
+</div><div class="q2"><span class="wj">sit on my right hand,</span> 
+</div><div class="q2"><span class="wj">until I make your enemies a footstool for your feet’?</span> 
+</div><div class="p">
+<sup>45&#160;</sup><span class="wj">“If then David calls him Lord, how is he his son?”</span> 
+</div><div class="p">
+<sup>46&#160;</sup>No one was able to answer him a word, neither did any man dare ask him any more questions from that day forward. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Yahushua spoke to the multitudes and to his disciples, 
+<sup>2&#160;</sup>saying, <span class="wj">“The scribes and the Pharisees sit on Moses’ seat. </span> 
+<sup>3&#160;</sup><span class="wj">All things therefore whatever he tells you to observe, observe and do, but don’t do their works; for they say, and don’t do. </span> 
+<sup>4&#160;</sup><span class="wj">For they bind heavy burdens that are grievous to be borne, and lay them on men’s shoulders; but they themselves will not lift a finger to help them. </span> 
+<sup>5&#160;</sup><span class="wj">But they do all their works to be seen by men. They make their phylacteries</span> <span class="wj">of their garments, </span> 
+<sup>6&#160;</sup><span class="wj">and love the place of honor at feasts, the best seats in the synagogues, </span> 
+<sup>7&#160;</sup><span class="wj">the salutations in the marketplaces, and to be called ‘Rabbi, Rabbi’</span> <span class="wj">by men. </span> 
+<sup>8&#160;</sup><span class="wj">But you are not to be called ‘Rabbi’, for one is your teacher, the Christ, and all of you are brothers. </span> 
+<sup>9&#160;</sup><span class="wj">Call no man on the earth your father, for one is your Father, he who is in heaven. </span> 
+<sup>10&#160;</sup><span class="wj">Neither be called masters, for one is your master, the Christ. </span> 
+<sup>11&#160;</sup><span class="wj">But he who is greatest among you will be your servant. </span> 
+<sup>12&#160;</sup><span class="wj">Whoever exalts himself will be humbled, and whoever humbles himself will be exalted.</span> 
+</div><div class="p">
+<sup>13&#160;</sup><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you devour widows’ houses, and as a pretense you make long prayers. Therefore you will receive greater condemnation.</span> 
+</div><div class="p">
+<sup>14&#160;</sup><span class="wj">“But woe to you, scribes and Pharisees, hypocrites! Because you shut up the Kingdom of Heaven against men; for you don’t enter in yourselves, neither do you allow those who are entering in to enter.</span> 
+<sup>15&#160;</sup><span class="wj">Woe to you, scribes and Pharisees, hypocrites! For you travel around by sea and land to make one proselyte; and when he becomes one, you make him twice as much a son of Gehenna</span> <span class="wj">as yourselves. </span> 
+</div><div class="p">
+<sup>16&#160;</sup><span class="wj">“Woe to you, you blind guides, who say, ‘Whoever swears by the temple, it is nothing; but whoever swears by the gold of the temple, he is obligated.’ </span> 
+<sup>17&#160;</sup><span class="wj">You blind fools! For which is greater, the gold or the temple that sanctifies the gold? </span> 
+<sup>18&#160;</sup><span class="wj">And, ‘Whoever swears by the altar, it is nothing; but whoever swears by the gift that is on it, he is obligated.’ </span> 
+<sup>19&#160;</sup><span class="wj">You blind fools! For which is greater, the gift, or the altar that sanctifies the gift? </span> 
+<sup>20&#160;</sup><span class="wj">He therefore who swears by the altar, swears by it and by everything on it. </span> 
+<sup>21&#160;</sup><span class="wj">He who swears by the temple, swears by it and by him who has been living</span> <span class="wj">in it. </span> 
+<sup>22&#160;</sup><span class="wj">He who swears by heaven, swears by the throne of Elohim and by him who sits on it.</span> 
+</div><div class="p">
+<sup>23&#160;</sup><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you tithe mint, dill, and cumin,</span> <span class="wj">and have left undone the weightier matters of the law: justice, mercy, and faith. But you ought to have done these, and not to have left the other undone. </span> 
+<sup>24&#160;</sup><span class="wj">You blind guides, who strain out a gnat, and swallow a camel! </span> 
+</div><div class="p">
+<sup>25&#160;</sup><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you clean the outside of the cup and of the platter, but within they are full of extortion and unrighteousness.</span> 
+<sup>26&#160;</sup><span class="wj">You blind Pharisee, first clean the inside of the cup and of the platter, that its outside may become clean also.</span> 
+</div><div class="p">
+<sup>27&#160;</sup><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you are like whitened tombs, which outwardly appear beautiful, but inwardly are full of dead men’s bones and of all uncleanness. </span> 
+<sup>28&#160;</sup><span class="wj">Even so you also outwardly appear righteous to men, but inwardly you are full of hypocrisy and iniquity.</span> 
+</div><div class="p">
+<sup>29&#160;</sup><span class="wj">“Woe to you, scribes and Pharisees, hypocrites! For you build the tombs of the prophets and decorate the tombs of the righteous, </span> 
+<sup>30&#160;</sup><span class="wj">and say, ‘If we had lived in the days of our fathers, we wouldn’t have been partakers with them in the blood of the prophets.’ </span> 
+<sup>31&#160;</sup><span class="wj">Therefore you testify to yourselves that you are children of those who killed the prophets. </span> 
+<sup>32&#160;</sup><span class="wj">Fill up, then, the measure of your fathers. </span> 
+<sup>33&#160;</sup><span class="wj">You serpents, you offspring of vipers, how will you escape the judgment of Gehenna?</span> 
+<sup>34&#160;</sup><span class="wj">Therefore, behold, I send to you prophets, wise men, and scribes. Some of them you will kill and crucify; and some of them you will scourge in your synagogues and persecute from city to city, </span> 
+<sup>35&#160;</sup><span class="wj">that on you may come all the righteous blood shed on the earth, from the blood of righteous Abel to the blood of Zachariah son of Barachiah, whom you killed between the sanctuary and the altar. </span> 
+<sup>36&#160;</sup><span class="wj">Most certainly I tell you, all these things will come upon this generation.</span> 
+</div><div class="p">
+<sup>37&#160;</sup><span class="wj">“Jerusalem, Jerusalem, who kills the prophets and stones those who are sent to her! How often I would have gathered your children together, even as a hen gathers her chicks under her wings, and you would not! </span> 
+<sup>38&#160;</sup><span class="wj">Behold, your house is left to you desolate. </span> 
+<sup>39&#160;</sup><span class="wj">For I tell you, you will not see me from now on, until you say, ‘Blessed is he who comes in the name of the Lord!’&#160;”</span> 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahushua went out from the temple, and was going on his way. His disciples came to him to show him the buildings of the temple. 
+<sup>2&#160;</sup>But he answered them, <span class="wj">“You see all of these things, don’t you? Most certainly I tell you, there will not be left here one stone on another, that will not be thrown down.”</span> 
+</div><div class="p">
+<sup>3&#160;</sup>As he sat on the Mount of Olives, the disciples came to him privately, saying, “Tell us, when will these things be? What is the sign of your coming, and of the end of the age?” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahushua answered them, <span class="wj">“Be careful that no one leads you astray. </span> 
+<sup>5&#160;</sup><span class="wj">For many will come in my name, saying, ‘I am the Christ,’ and will lead many astray. </span> 
+<sup>6&#160;</sup><span class="wj">You will hear of wars and rumors of wars. See that you aren’t troubled, for all this must happen, but the end is not yet. </span> 
+<sup>7&#160;</sup><span class="wj">For nation will rise against nation, and kingdom against kingdom; and there will be famines, plagues, and earthquakes in various places. </span> 
+<sup>8&#160;</sup><span class="wj">But all these things are the beginning of birth pains. </span> 
+</div><div class="p">
+<sup>9&#160;</sup><span class="wj">“Then they will deliver you up to oppression and will kill you. You will be hated by all of the nations for my name’s sake. </span> 
+<sup>10&#160;</sup><span class="wj">Then many will stumble, and will deliver up one another, and will hate one another. </span> 
+<sup>11&#160;</sup><span class="wj">Many false prophets will arise and will lead many astray. </span> 
+<sup>12&#160;</sup><span class="wj">Because iniquity will be multiplied, the love of many will grow cold. </span> 
+<sup>13&#160;</sup><span class="wj">But he who endures to the end will be saved. </span> 
+<sup>14&#160;</sup><span class="wj">This Good News of the Kingdom will be preached in the whole world for a testimony to all the nations, and then the end will come.</span> 
+</div><div class="p">
+<sup>15&#160;</sup><span class="wj">“When, therefore, you see the abomination of desolation,</span> <span class="wj">which was spoken of through Daniel the prophet, standing in the set-apart place (let the reader understand), </span> 
+<sup>16&#160;</sup><span class="wj">then let those who are in Judea flee to the mountains. </span> 
+<sup>17&#160;</sup><span class="wj">Let him who is on the housetop not go down to take out the things that are in his house. </span> 
+<sup>18&#160;</sup><span class="wj">Let him who is in the field not return back to get his clothes. </span> 
+<sup>19&#160;</sup><span class="wj">But woe to those who are with child and to nursing mothers in those days! </span> 
+<sup>20&#160;</sup><span class="wj">Pray that your flight will not be in the winter nor on a Sabbath, </span> 
+<sup>21&#160;</sup><span class="wj">for then there will be great suffering,</span> <span class="wj">such as has not been from the beginning of the world until now, no, nor ever will be. </span> 
+<sup>22&#160;</sup><span class="wj">Unless those days had been shortened, no flesh would have been saved. But for the sake of the chosen ones, those days will be shortened. </span> 
+</div><div class="p">
+<sup>23&#160;</sup><span class="wj">“Then if any man tells you, ‘Behold, here is the Christ!’ or, ‘There!’ don’t believe it. </span> 
+<sup>24&#160;</sup><span class="wj">For false christs and false prophets will arise, and they will show great signs and wonders, so as to lead astray, if possible, even the chosen ones.</span> 
+</div><div class="p">
+<sup>25&#160;</sup><span class="wj">“Behold, I have told you beforehand. </span> 
+</div><div class="p">
+<sup>26&#160;</sup><span class="wj">“If therefore they tell you, ‘Behold, he is in the wilderness,’ don’t go out; or ‘Behold, he is in the inner rooms,’ don’t believe it. </span> 
+<sup>27&#160;</sup><span class="wj">For as the lightning flashes from the east, and is seen even to the west, so will the coming of the Son of Man be. </span> 
+<sup>28&#160;</sup><span class="wj">For wherever the carcass is, that is where the vultures</span> <span class="wj">gather together. </span> 
+</div><div class="p">
+<sup>29&#160;</sup><span class="wj">“But immediately after the suffering</span> <span class="wj">of those days, the sun will be darkened, the moon will not give its light, the stars will fall from the sky, and the powers of the heavens will be shaken;</span> 
+<sup>30&#160;</sup><span class="wj">and then the sign of the Son of Man will appear in the sky. Then all the tribes of the earth will mourn, and they will see the Son of Man coming on the clouds of the sky with power and great glory. </span> 
+<sup>31&#160;</sup><span class="wj">He will send out his angels with a great sound of a trumpet, and they will gather together his chosen ones from the four winds, from one end of the sky to the other.</span> 
+</div><div class="p">
+<sup>32&#160;</sup><span class="wj">“Now from the fig tree learn this parable: When its branch has now become tender and produces its leaves, you know that the summer is near. </span> 
+<sup>33&#160;</sup><span class="wj">Even so you also, when you see all these things, know that he is near, even at the doors. </span> 
+<sup>34&#160;</sup><span class="wj">Most certainly I tell you, this generation</span> <span class="wj">will not pass away until all these things are accomplished. </span> 
+<sup>35&#160;</sup><span class="wj">Heaven and earth will pass away, but my words will not pass away. </span> 
+</div><div class="p">
+<sup>36&#160;</sup><span class="wj">“But no one knows of that day and hour, not even the angels of heaven,</span> <span class="wj">but my Father only.</span> 
+<sup>37&#160;</sup><span class="wj">As the days of Noah were, so will the coming of the Son of Man be. </span> 
+<sup>38&#160;</sup><span class="wj">For as in those days which were before the flood they were eating and drinking, marrying and giving in marriage, until the day that Noah entered into the ship, </span> 
+<sup>39&#160;</sup><span class="wj">and they didn’t know until the flood came and took them all away, so will the coming of the Son of Man be. </span> 
+<sup>40&#160;</sup><span class="wj">Then two men will be in the field: one will be taken and one will be left. </span> 
+<sup>41&#160;</sup><span class="wj">Two women will be grinding at the mill: one will be taken and one will be left. </span> 
+<sup>42&#160;</sup><span class="wj">Watch therefore, for you don’t know in what hour your Lord comes. </span> 
+<sup>43&#160;</sup><span class="wj">But know this, that if the master of the house had known in what watch of the night the thief was coming, he would have watched, and would not have allowed his house to be broken into. </span> 
+<sup>44&#160;</sup><span class="wj">Therefore also be ready, for in an hour that you don’t expect, the Son of Man will come.</span> 
+</div><div class="p">
+<sup>45&#160;</sup><span class="wj">“Who then is the faithful and wise servant, whom his lord has set over his household, to give them their food in due season? </span> 
+<sup>46&#160;</sup><span class="wj">Blessed is that servant whom his lord finds doing so when he comes. </span> 
+<sup>47&#160;</sup><span class="wj">Most certainly I tell you that he will set him over all that he has. </span> 
+<sup>48&#160;</sup><span class="wj">But if that evil servant should say in his heart, ‘My lord is delaying his coming,’ </span> 
+<sup>49&#160;</sup><span class="wj">and begins to beat his fellow servants, and eat and drink with the drunkards, </span> 
+<sup>50&#160;</sup><span class="wj">the lord of that servant will come in a day when he doesn’t expect it and in an hour when he doesn’t know it, </span> 
+<sup>51&#160;</sup><span class="wj">and will cut him in pieces and appoint his portion with the hypocrites. That is where the weeping and grinding of teeth will be. </span> 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“Then the Kingdom of Heaven will be like ten virgins who took their lamps and went out to meet the bridegroom. </span> 
+<sup>2&#160;</sup><span class="wj">Five of them were foolish, and five were wise. </span> 
+<sup>3&#160;</sup><span class="wj">Those who were foolish, when they took their lamps, took no oil with them, </span> 
+<sup>4&#160;</sup><span class="wj">but the wise took oil in their vessels with their lamps. </span> 
+<sup>5&#160;</sup><span class="wj">Now while the bridegroom delayed, they all slumbered and slept. </span> 
+<sup>6&#160;</sup><span class="wj">But at midnight there was a cry, ‘Behold! The bridegroom is coming! Come out to meet him!’ </span> 
+<sup>7&#160;</sup><span class="wj">Then all those virgins arose, and trimmed their lamps.</span> 
+<sup>8&#160;</sup><span class="wj">The foolish said to the wise, ‘Give us some of your oil, for our lamps are going out.’ </span> 
+<sup>9&#160;</sup><span class="wj">But the wise answered, saying, ‘What if there isn’t enough for us and you? You go rather to those who sell, and buy for yourselves.’ </span> 
+<sup>10&#160;</sup><span class="wj">While they went away to buy, the bridegroom came, and those who were ready went in with him to the wedding feast, and the door was shut. </span> 
+<sup>11&#160;</sup><span class="wj">Afterward the other virgins also came, saying, ‘Lord, Lord, open to us.’ </span> 
+<sup>12&#160;</sup><span class="wj">But he answered, ‘Most certainly I tell you, I don’t know you.’ </span> 
+<sup>13&#160;</sup><span class="wj">Watch therefore, for you don’t know the day nor the hour in which the Son of Man is coming.</span> 
+</div><div class="p">
+<sup>14&#160;</sup><span class="wj">“For it is like a man going into another country, who called his own servants and entrusted his goods to them. </span> 
+<sup>15&#160;</sup><span class="wj">To one he gave five talents,</span> <span class="wj">to another two, to another one, to each according to his own ability. Then he went on his journey. </span> 
+<sup>16&#160;</sup><span class="wj">Immediately he who received the five talents went and traded with them, and made another five talents. </span> 
+<sup>17&#160;</sup><span class="wj">In the same way, he also who got the two gained another two. </span> 
+<sup>18&#160;</sup><span class="wj">But he who received the one talent went away and dug in the earth and hid his lord’s money.</span> 
+</div><div class="p">
+<sup>19&#160;</sup><span class="wj">“Now after a long time the lord of those servants came, and settled accounts with them. </span> 
+<sup>20&#160;</sup><span class="wj">He who received the five talents came and brought another five talents, saying, ‘Lord, you delivered to me five talents. Behold, I have gained another five talents in addition to them.’</span> 
+</div><div class="p">
+<sup>21&#160;</sup><span class="wj">“His lord said to him, ‘Well done, good and faithful servant. You have been faithful over a few things, I will set you over many things. Enter into the joy of your lord.’</span> 
+</div><div class="p">
+<sup>22&#160;</sup><span class="wj">“He also who got the two talents came and said, ‘Lord, you delivered to me two talents. Behold, I have gained another two talents in addition to them.’ </span> 
+</div><div class="p">
+<sup>23&#160;</sup><span class="wj">“His lord said to him, ‘Well done, good and faithful servant. You have been faithful over a few things. I will set you over many things. Enter into the joy of your lord.’</span> 
+</div><div class="p">
+<sup>24&#160;</sup><span class="wj">“He also who had received the one talent came and said, ‘Lord, I knew you that you are a hard man, reaping where you didn’t sow, and gathering where you didn’t scatter. </span> 
+<sup>25&#160;</sup><span class="wj">I was afraid, and went away and hid your talent in the earth. Behold, you have what is yours.’</span> 
+</div><div class="p">
+<sup>26&#160;</sup><span class="wj">“But his lord answered him, ‘You wicked and slothful servant. You knew that I reap where I didn’t sow, and gather where I didn’t scatter. </span> 
+<sup>27&#160;</sup><span class="wj">You ought therefore to have deposited my money with the bankers, and at my coming I should have received back my own with interest. </span> 
+<sup>28&#160;</sup><span class="wj">Take away therefore the talent from him and give it to him who has the ten talents. </span> 
+<sup>29&#160;</sup><span class="wj">For to everyone who has will be given, and he will have abundance, but from him who doesn’t have, even that which he has will be taken away. </span> 
+<sup>30&#160;</sup><span class="wj">Throw out the unprofitable servant into the outer darkness, where there will be weeping and gnashing of teeth.’</span> 
+</div><div class="p">
+<sup>31&#160;</sup><span class="wj">“But when the Son of Man comes in his glory, and all the set-apart angels with him, then he will sit on the throne of his glory. </span> 
+<sup>32&#160;</sup><span class="wj">Before him all the nations will be gathered, and he will separate them one from another, as a shepherd separates the sheep from the goats. </span> 
+<sup>33&#160;</sup><span class="wj">He will set the sheep on his right hand, but the goats on the left. </span> 
+<sup>34&#160;</sup><span class="wj">Then the King will tell those on his right hand, ‘Come, blessed of my Father, inherit the Kingdom prepared for you from the foundation of the world; </span> 
+<sup>35&#160;</sup><span class="wj">for I was hungry and you gave me food to eat. I was thirsty and you gave me drink. I was a stranger and you took me in. </span> 
+<sup>36&#160;</sup><span class="wj">I was naked and you clothed me. I was sick and you visited me. I was in prison and you came to me.’</span> 
+</div><div class="p">
+<sup>37&#160;</sup><span class="wj">“Then the righteous will answer him, saying, ‘Lord, when did we see you hungry and feed you, or thirsty and give you a drink? </span> 
+<sup>38&#160;</sup><span class="wj">When did we see you as a stranger and take you in, or naked and clothe you? </span> 
+<sup>39&#160;</sup><span class="wj">When did we see you sick or in prison and come to you?’</span> 
+</div><div class="p">
+<sup>40&#160;</sup><span class="wj">“The King will answer them, ‘Most certainly I tell you, because you did it to one of the least of these my brothers,</span> <span class="wj">you did it to me.’ </span> 
+<sup>41&#160;</sup><span class="wj">Then he will say also to those on the left hand, ‘Depart from me, you cursed, into the eternal fire which is prepared for the devil and his angels; </span> 
+<sup>42&#160;</sup><span class="wj">for I was hungry, and you didn’t give me food to eat; I was thirsty, and you gave me no drink; </span> 
+<sup>43&#160;</sup><span class="wj">I was a stranger, and you didn’t take me in; naked, and you didn’t clothe me; sick, and in prison, and you didn’t visit me.’</span> 
+</div><div class="p">
+<sup>44&#160;</sup><span class="wj">“Then they will also answer, saying, ‘Lord, when did we see you hungry, or thirsty, or a stranger, or naked, or sick, or in prison, and didn’t help you?’</span> 
+</div><div class="p">
+<sup>45&#160;</sup><span class="wj">“Then he will answer them, saying, ‘Most certainly I tell you, because you didn’t do it to one of the least of these, you didn’t do it to me.’ </span> 
+<sup>46&#160;</sup><span class="wj">These will go away into eternal punishment, but the righteous into eternal life.”</span> 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>When Yahushua had finished all these words, he said to his disciples, 
+<sup>2&#160;</sup><span class="wj">“You know that after two days the Passover is coming, and the Son of Man will be delivered up to be crucified.”</span> 
+</div><div class="p">
+<sup>3&#160;</sup>Then the chief priests, the scribes, and the elders of the people were gathered together in the court of the high priest, who was called Caiaphas. 
+<sup>4&#160;</sup>They took counsel together that they might take Yahushua by deceit and kill him. 
+<sup>5&#160;</sup>But they said, “Not during the feast, lest a riot occur among the people.” 
+</div><div class="p">
+<sup>6&#160;</sup>Now when Yahushua was in Bethany, in the house of Simon the leper, 
+<sup>7&#160;</sup>a woman came to him having an alabaster jar of very expensive ointment, and she poured it on his head as he sat at the table. 
+<sup>8&#160;</sup>But when his disciples saw this, they were indignant, saying, “Why this waste? 
+<sup>9&#160;</sup>For this ointment might have been sold for much and given to the poor.” 
+</div><div class="p">
+<sup>10&#160;</sup>However, knowing this, Yahushua said to them, <span class="wj">“Why do you trouble the woman? She has done a good work for me. </span> 
+<sup>11&#160;</sup><span class="wj">For you always have the poor with you, but you don’t always have me. </span> 
+<sup>12&#160;</sup><span class="wj">For in pouring this ointment on my body, she did it to prepare me for burial. </span> 
+<sup>13&#160;</sup><span class="wj">Most certainly I tell you, wherever this Good News is preached in the whole world, what this woman has done will also be spoken of as a memorial of her.”</span> 
+</div><div class="p">
+<sup>14&#160;</sup>Then one of the twelve, who was called Judas Iscariot, went to the chief priests 
+<sup>15&#160;</sup>and said, “What are you willing to give me if I deliver him to you?” So they weighed out for him thirty pieces of silver. 
+<sup>16&#160;</sup>From that time he sought opportunity to betray him. 
+</div><div class="p">
+<sup>17&#160;</sup>Now on the first day of unleavened bread, the disciples came to Yahushua, saying to him, “Where do you want us to prepare for you to eat the Passover?” 
+</div><div class="p">
+<sup>18&#160;</sup>He said, <span class="wj">“Go into the city to a certain person, and tell him, ‘The Teacher says, “My time is at hand. I will keep the Passover at your house with my disciples.”&#160;’&#160;”</span> 
+</div><div class="p">
+<sup>19&#160;</sup>The disciples did as Yahushua commanded them, and they prepared the Passover. 
+</div><div class="p">
+<sup>20&#160;</sup>Now when evening had come, he was reclining at the table with the twelve disciples. 
+<sup>21&#160;</sup>As they were eating, he said, <span class="wj">“Most certainly I tell you that one of you will betray me.”</span> 
+</div><div class="p">
+<sup>22&#160;</sup>They were exceedingly sorrowful, and each began to ask him, “It isn’t me, is it, Lord?” 
+</div><div class="p">
+<sup>23&#160;</sup>He answered, <span class="wj">“He who dipped his hand with me in the dish will betray me. </span> 
+<sup>24&#160;</sup><span class="wj">The Son of Man goes even as it is written of him, but woe to that man through whom the Son of Man is betrayed! It would be better for that man if he had not been born.”</span> 
+</div><div class="p">
+<sup>25&#160;</sup>Judas, who betrayed him, answered, “It isn’t me, is it, Rabbi?” 
+</div><div class="p">He said to him, <span class="wj">“You said it.”</span> 
+</div><div class="p">
+<sup>26&#160;</sup>As they were eating, Yahushua took bread, gave thanks for it, and broke it. He gave to the disciples and said, <span class="wj">“Take, eat; this is my body.”</span> 
+<sup>27&#160;</sup>He took the cup, gave thanks, and gave to them, saying, <span class="wj">“All of you drink it, </span> 
+<sup>28&#160;</sup><span class="wj">for this is my blood of the new covenant, which is poured out for many for the remission of sins. </span> 
+<sup>29&#160;</sup><span class="wj">But I tell you that I will not drink of this fruit of the vine from now on, until that day when I drink it anew with you in my Father’s Kingdom.” </span> 
+</div><div class="p">
+<sup>30&#160;</sup>When they had sung a hymn, they went out to the Mount of Olives. 
+</div><div class="p">
+<sup>31&#160;</sup>Then Yahushua said to them, <span class="wj">“All of you will be made to stumble because of me tonight, for it is written, ‘I will strike the shepherd, and the sheep of the flock will be scattered.’</span> 
+<sup>32&#160;</sup><span class="wj">But after I am raised up, I will go before you into Galilee.” </span> 
+</div><div class="p">
+<sup>33&#160;</sup>But Peter answered him, “Even if all will be made to stumble because of you, I will never be made to stumble.” 
+</div><div class="p">
+<sup>34&#160;</sup>Yahushua said to him, <span class="wj">“Most certainly I tell you that tonight, before the rooster crows, you will deny me three times.”</span> 
+</div><div class="p">
+<sup>35&#160;</sup>Peter said to him, “Even if I must die with you, I will not deny you.” All of the disciples also said likewise. 
+</div><div class="p">
+<sup>36&#160;</sup>Then Yahushua came with them to a place called Gethsemane, and said to his disciples, <span class="wj">“Sit here, while I go there and pray.”</span> 
+<sup>37&#160;</sup>He took with him Peter and the two sons of Zebedee, and began to be sorrowful and severely troubled. 
+<sup>38&#160;</sup>Then he said to them, <span class="wj">“My soul is exceedingly sorrowful, even to death. Stay here and watch with me.”</span> 
+</div><div class="p">
+<sup>39&#160;</sup>He went forward a little, fell on his face, and prayed, saying, <span class="wj">“My Father, if it is possible, let this cup pass away from me; nevertheless, not what I desire, but what you desire.”</span> 
+</div><div class="p">
+<sup>40&#160;</sup>He came to the disciples and found them sleeping, and said to Peter, <span class="wj">“What, couldn’t you watch with me for one hour? </span> 
+<sup>41&#160;</sup><span class="wj">Watch and pray, that you don’t enter into temptation. The spirit indeed is willing, but the flesh is weak.”</span> 
+</div><div class="p">
+<sup>42&#160;</sup>Again, a second time he went away and prayed, saying, <span class="wj">“My Father, if this cup can’t pass away from me unless I drink it, your desire be done.” </span> 
+</div><div class="p">
+<sup>43&#160;</sup>He came again and found them sleeping, for their eyes were heavy. 
+<sup>44&#160;</sup>He left them again, went away, and prayed a third time, saying the same words. 
+<sup>45&#160;</sup>Then he came to his disciples and said to them, <span class="wj">“Are you still sleeping and resting? Behold, the hour is at hand, and the Son of Man is betrayed into the hands of sinners. </span> 
+<sup>46&#160;</sup><span class="wj">Arise, let’s be going. Behold, he who betrays me is at hand.” </span> 
+</div><div class="p">
+<sup>47&#160;</sup>While he was still speaking, behold, Judas, one of the twelve, came, and with him a great multitude with swords and clubs, from the chief priests and elders of the people. 
+<sup>48&#160;</sup>Now he who betrayed him had given them a sign, saying, “Whoever I kiss, he is the one. Seize him.” 
+<sup>49&#160;</sup>Immediately he came to Yahushua, and said, “Greetings, Rabbi!” and kissed him. 
+</div><div class="p">
+<sup>50&#160;</sup>Yahushua said to him, <span class="wj">“Friend, why are you here?”</span> 
+</div><div class="p">Then they came and laid hands on Yahushua, and took him. 
+<sup>51&#160;</sup>Behold, one of those who were with Yahushua stretched out his hand and drew his sword, and struck the servant of the high priest, and cut off his ear. 
+</div><div class="p">
+<sup>52&#160;</sup>Then Yahushua said to him, <span class="wj">“Put your sword back into its place, for all those who take the sword will die by the sword. </span> 
+<sup>53&#160;</sup><span class="wj">Or do you think that I couldn’t ask my Father, and he would even now send me more than twelve legions of angels? </span> 
+<sup>54&#160;</sup><span class="wj">How then would the Scriptures be fulfilled that it must be so?” </span> 
+</div><div class="p">
+<sup>55&#160;</sup>In that hour Yahushua said to the multitudes, <span class="wj">“Have you come out as against a robber with swords and clubs to seize me? I sat daily in the temple teaching, and you didn’t arrest me. </span> 
+<sup>56&#160;</sup><span class="wj">But all this has happened that the Scriptures of the prophets might be fulfilled.”</span> 
+</div><div class="p">Then all the disciples left him and fled. 
+</div><div class="p">
+<sup>57&#160;</sup>Those who had taken Yahushua led him away to Caiaphas the high priest, where the scribes and the elders were gathered together. 
+<sup>58&#160;</sup>But Peter followed him from a distance to the court of the high priest, and entered in and sat with the officers, to see the end. 
+</div><div class="p">
+<sup>59&#160;</sup>Now the chief priests, the elders, and the whole council sought false testimony against Yahushua, that they might put him to death, 
+<sup>60&#160;</sup>and they found none. Even though many false witnesses came forward, they found none. But at last two false witnesses came forward 
+<sup>61&#160;</sup>and said, “This man said, ‘I am able to destroy the temple of Elohim, and to build it in three days.’&#160;” 
+</div><div class="p">
+<sup>62&#160;</sup>The high priest stood up and said to him, “Have you no answer? What is this that these testify against you?” 
+<sup>63&#160;</sup>But Yahushua stayed silent. The high priest answered him, “I adjure you by the living Elohim that you tell us whether you are the Christ, the Son of Elohim.” 
+</div><div class="p">
+<sup>64&#160;</sup>Yahushua said to him, <span class="wj">“You have said so. Nevertheless, I tell you, after this you will see the Son of Man sitting at the right hand of Yahweh, and coming on the clouds of the sky.”</span> 
+</div><div class="p">
+<sup>65&#160;</sup>Then the high priest tore his clothing, saying, “He has spoken blasphemy! Why do we need any more witnesses? Behold, now you have heard his blasphemy. 
+<sup>66&#160;</sup>What do you think?” 
+</div><div class="p">They answered, “He is worthy of death!” 
+<sup>67&#160;</sup>Then they spat in his face and beat him with their fists, and some slapped him, 
+<sup>68&#160;</sup>saying, “Prophesy to us, you Christ! Who hit you?” 
+</div><div class="p">
+<sup>69&#160;</sup>Now Peter was sitting outside in the court, and a maid came to him, saying, “You were also with Yahushua, the Galilean!” 
+</div><div class="p">
+<sup>70&#160;</sup>But he denied it before them all, saying, “I don’t know what you are talking about.” 
+</div><div class="p">
+<sup>71&#160;</sup>When he had gone out onto the porch, someone else saw him and said to those who were there, “This man also was with Yahushua of Nazareth.” 
+</div><div class="p">
+<sup>72&#160;</sup>Again he denied it with an oath, “I don’t know the man.” 
+</div><div class="p">
+<sup>73&#160;</sup>After a little while those who stood by came and said to Peter, “Surely you are also one of them, for your speech makes you known.” 
+</div><div class="p">
+<sup>74&#160;</sup>Then he began to curse and to swear, “I don’t know the man!” 
+</div><div class="p">Immediately the rooster crowed. 
+<sup>75&#160;</sup>Peter remembered the word which Yahushua had said to him, <span class="wj">“Before the rooster crows, you will deny me three times.”</span> Then he went out and wept bitterly. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when morning had come, all the chief priests and the elders of the people took counsel against Yahushua to put him to death. 
+<sup>2&#160;</sup>They bound him, led him away, and delivered him up to Pontius Pilate, the governor. 
+</div><div class="p">
+<sup>3&#160;</sup>Then Judas, who betrayed him, when he saw that Yahushua was condemned, felt remorse, and brought back the thirty pieces of silver to the chief priests and elders, 
+<sup>4&#160;</sup>saying, “I have sinned in that I betrayed innocent blood.” 
+</div><div class="p">But they said, “What is that to us? You see to it.” 
+</div><div class="p">
+<sup>5&#160;</sup>He threw down the pieces of silver in the sanctuary and departed. Then he went away and hanged himself. 
+</div><div class="p">
+<sup>6&#160;</sup>The chief priests took the pieces of silver and said, “It’s not lawful to put them into the treasury, since it is the price of blood.” 
+<sup>7&#160;</sup>They took counsel, and bought the potter’s field with them to bury strangers in. 
+<sup>8&#160;</sup>Therefore that field has been called “The Field of Blood” to this day. 
+<sup>9&#160;</sup>Then that which was spoken through Jeremiah the prophet was fulfilled, saying, 
+</div><div class="q1">“They took the thirty pieces of silver, 
+</div><div class="q2">the price of him upon whom a price had been set, 
+</div><div class="q2">whom some of the children of Israel priced, 
+</div><div class="q1">
+<sup>10&#160;</sup>and they gave them for the potter’s field, 
+</div><div class="q2">as the Lord commanded me.” 
+</div><div class="p">
+<sup>11&#160;</sup>Now Yahushua stood before the governor; and the governor asked him, saying, “Are you the King of the Jews?” 
+</div><div class="p">Yahushua said to him, <span class="wj">“So you say.”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>When he was accused by the chief priests and elders, he answered nothing. 
+<sup>13&#160;</sup>Then Pilate said to him, “Don’t you hear how many things they testify against you?” 
+</div><div class="p">
+<sup>14&#160;</sup>He gave him no answer, not even one word, so that the governor marveled greatly. 
+</div><div class="p">
+<sup>15&#160;</sup>Now at the feast the governor was accustomed to release to the multitude one prisoner whom they desired. 
+<sup>16&#160;</sup>They had then a notable prisoner called Barabbas. 
+<sup>17&#160;</sup>When therefore they were gathered together, Pilate said to them, “Whom do you want me to release to you? Barabbas, or Yahushua who is called Christ?” 
+<sup>18&#160;</sup>For he knew that because of envy they had delivered him up. 
+</div><div class="p">
+<sup>19&#160;</sup>While he was sitting on the judgment seat, his woman sent to him, saying, “Have nothing to do with that righteous man, for I have suffered many things today in a dream because of him.” 
+</div><div class="p">
+<sup>20&#160;</sup>Now the chief priests and the elders persuaded the multitudes to ask for Barabbas and destroy Yahushua. 
+<sup>21&#160;</sup>But the governor answered them, “Which of the two do you want me to release to you?” 
+</div><div class="p">They said, “Barabbas!” 
+</div><div class="p">
+<sup>22&#160;</sup>Pilate said to them, “What then shall I do to Yahushua who is called Christ?” 
+</div><div class="p">They all said to him, “Let him be crucified!” 
+</div><div class="p">
+<sup>23&#160;</sup>But the governor said, “Why? What evil has he done?” 
+</div><div class="p">But they cried out exceedingly, saying, “Let him be crucified!” 
+</div><div class="p">
+<sup>24&#160;</sup>So when Pilate saw that nothing was being gained, but rather that a disturbance was starting, he took water and washed his hands before the multitude, saying, “I am innocent of the blood of this righteous person. You see to it.” 
+</div><div class="p">
+<sup>25&#160;</sup>All the people answered, “May his blood be on us and on our children!” 
+</div><div class="p">
+<sup>26&#160;</sup>Then he released Barabbas to them, but Yahushua he flogged and delivered to be crucified. 
+</div><div class="p">
+<sup>27&#160;</sup>Then the governor’s soldiers took Yahushua into the Praetorium, and gathered the whole garrison together against him. 
+<sup>28&#160;</sup>They stripped him and put a scarlet robe on him. 
+<sup>29&#160;</sup>They braided a crown of thorns and put it on his head, and a reed in his right hand; and they kneeled down before him and mocked him, saying, “Hail, King of the Jews!” 
+<sup>30&#160;</sup>They spat on him, and took the reed and struck him on the head. 
+<sup>31&#160;</sup>When they had mocked him, they took the robe off him, and put his clothes on him, and led him away to crucify him. 
+</div><div class="p">
+<sup>32&#160;</sup>As they came out, they found a man of Cyrene, Simon by name, and they compelled him to go with them, that he might carry his cross. 
+<sup>33&#160;</sup>When they came to a place called “Golgotha”, that is to say, “The place of a skull,” 
+<sup>34&#160;</sup>they gave him sour wine When he had tasted it, he would not drink. 
+<sup>35&#160;</sup>When they had crucified him, they divided his clothing among them, casting lots, 
+<sup>36&#160;</sup>and they sat and watched him there. 
+<sup>37&#160;</sup>They set up over his head the accusation against him written, “THIS IS YAHUSHUA, THE KING OF THE JEWS.” 
+</div><div class="p">
+<sup>38&#160;</sup>Then there were two robbers crucified with him, one on his right hand and one on the left. 
+</div><div class="p">
+<sup>39&#160;</sup>Those who passed by blasphemed him, wagging their heads 
+<sup>40&#160;</sup>and saying, “You who destroy the temple and build it in three days, save yourself! If you are the Son of Elohim, come down from the cross!” 
+</div><div class="p">
+<sup>41&#160;</sup>Likewise the chief priests also mocking with the scribes, the Pharisees, and the elders, said, 
+<sup>42&#160;</sup>“He saved others, but he can’t save himself. If he is the King of Israel, let him come down from the cross now, and we will believe in him. 
+<sup>43&#160;</sup>He trusts in Elohim. Let Elohim deliver him now, if he wants him; for he said, ‘I am the Son of Elohim.’&#160;” 
+<sup>44&#160;</sup>The robbers also who were crucified with him cast on him the same reproach. 
+</div><div class="p">
+<sup>45&#160;</sup>Now from the sixth hour 
+<sup>46&#160;</sup>About the ninth hour Yahushua cried with a loud voice, saying, <span class="wj">“Eli, Eli, lima</span> <span class="wj">sabachthani?” </span> That is, <span class="wj">“My Elohim, my Elohim, why have you forsaken me?”</span> 
+</div><div class="p">
+<sup>47&#160;</sup>Some of them who stood there, when they heard it, said, “This man is calling Elijah.” 
+</div><div class="p">
+<sup>48&#160;</sup>Immediately one of them ran and took a sponge, filled it with vinegar, put it on a reed, and gave him a drink. 
+<sup>49&#160;</sup>The rest said, “Let him be. Let’s see whether Elijah comes to save him.” 
+</div><div class="p">
+<sup>50&#160;</sup>Yahushua cried again with a loud voice, and yielded up his spirit. 
+</div><div class="p">
+<sup>51&#160;</sup>Behold, the veil of the temple was torn in two from the top to the bottom. The earth quaked and the rocks were split. 
+<sup>52&#160;</sup>The tombs were opened, and many bodies of the saints who had fallen asleep were raised; 
+<sup>53&#160;</sup>and coming out of the tombs after his resurrection, they entered into the set-apart city and appeared to many. 
+</div><div class="p">
+<sup>54&#160;</sup>Now the centurion and those who were with him watching Yahushua, when they saw the earthquake and the things that were done, were terrified, saying, “Truly this was the Son of Elohim!” 
+</div><div class="p">
+<sup>55&#160;</sup>Many women were there watching from afar, who had followed Yahushua from Galilee, serving him. 
+<sup>56&#160;</sup>Among them were Mary Magdalene, Mary the mother of James and Joses, and the mother of the sons of Zebedee. 
+</div><div class="p">
+<sup>57&#160;</sup>When evening had come, a rich man from Arimathaea named Joseph, who himself was also Yahushua’s disciple, came. 
+<sup>58&#160;</sup>This man went to Pilate and asked for Yahushua’s body. Then Pilate commanded the body to be given up. 
+<sup>59&#160;</sup>Joseph took the body and wrapped it in a clean linen cloth 
+<sup>60&#160;</sup>and laid it in his own new tomb, which he had cut out in the rock. Then he rolled a large stone against the door of the tomb, and departed. 
+<sup>61&#160;</sup>Mary Magdalene was there, and the other Mary, sitting opposite the tomb. 
+</div><div class="p">
+<sup>62&#160;</sup>Now on the next day, which was the day after the Preparation Day, the chief priests and the Pharisees were gathered together to Pilate, 
+<sup>63&#160;</sup>saying, “Sir, we remember what that deceiver said while he was still alive: ‘After three days I will rise again.’ 
+<sup>64&#160;</sup>Command therefore that the tomb be made secure until the third day, lest perhaps his disciples come at night and steal him away, and tell the people, ‘He is risen from the dead;’ and the last deception will be worse than the first.” 
+</div><div class="p">
+<sup>65&#160;</sup>Pilate said to them, “You have a guard. Go, make it as secure as you can.” 
+<sup>66&#160;</sup>So they went with the guard and made the tomb secure, sealing the stone. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>Now after the Sabbath, as it began to dawn on the first day of the week, Mary Magdalene and the other Mary came to see the tomb. 
+<sup>2&#160;</sup>Behold, there was a great earthquake, for an angel of the Lord descended from the sky and came and rolled away the stone from the door and sat on it. 
+<sup>3&#160;</sup>His appearance was like lightning, and his clothing white as snow. 
+<sup>4&#160;</sup>For fear of him, the guards shook, and became like dead men. 
+<sup>5&#160;</sup>The angel answered the women, “Don’t be afraid, for I know that you seek Yahushua, who has been crucified. 
+<sup>6&#160;</sup>He is not here, for he has risen, just like he said. Come, see the place where the Lord was lying. 
+<sup>7&#160;</sup>Go quickly and tell his disciples, ‘He has risen from the dead, and behold, he goes before you into Galilee; there you will see him.’ Behold, I have told you.” 
+</div><div class="p">
+<sup>8&#160;</sup>They departed quickly from the tomb with fear and great joy, and ran to bring his disciples word. 
+<sup>9&#160;</sup>As they went to tell his disciples, behold, Yahushua met them, saying, <span class="wj">“Rejoice!”</span> 
+</div><div class="p">They came and took hold of his feet, and worshiped him. 
+</div><div class="p">
+<sup>10&#160;</sup>Then Yahushua said to them, <span class="wj">“Don’t be afraid. Go tell my brothers </span> <span class="wj">that they should go into Galilee, and there they will see me.”</span> 
+</div><div class="p">
+<sup>11&#160;</sup>Now while they were going, behold, some of the guards came into the city and told the chief priests all the things that had happened. 
+<sup>12&#160;</sup>When they were assembled with the elders and had taken counsel, they gave a large amount of silver to the soldiers, 
+<sup>13&#160;</sup>saying, “Say that his disciples came by night and stole him away while we slept. 
+<sup>14&#160;</sup>If this comes to the governor’s ears, we will persuade him and make you free of worry.” 
+<sup>15&#160;</sup>So they took the money and did as they were told. This saying was spread abroad among the Jews, and continues until today. 
+</div><div class="p">
+<sup>16&#160;</sup>But the eleven disciples went into Galilee, to the mountain where Yahushua had sent them. 
+<sup>17&#160;</sup>When they saw him, they bowed down to him; but some doubted. 
+<sup>18&#160;</sup>Yahushua came to them and spoke to them, saying, <span class="wj">“All authority has been given to me in heaven and on earth. </span> 
+<sup>19&#160;</sup><span class="wj">Go</span> <span class="wj"> </span> 
+<sup>20&#160;</sup><span class="wj">and teach them to carry out all the things which I have commanded you forever.”</span> </div></div><script src="../main.js"></script></body></html>

--- a/book/micah.html
+++ b/book/micah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Micah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,494 +53,502 @@
 <div class="main">
 <!-- MIC World English Scripture (WES) -->
 <h1 class="booklabel">Micah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word that came to Micah of Morasheth in the days of Jotham, Ahaz, and Hezekiah, kings of Judah, which he saw concerning Samaria and Jerusalem. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear, you peoples, all of you! 
-</p><p class="q2">Listen, O earth, and all that is therein. 
-</p><p class="q1">Let the Lord<span class="f">+ \fr 1:2 \ft The word translated “Lord” is “Adonai.”</span> Yahweh be witness against you, 
-</p><p class="q2">the Lord from his set-apart temple. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For behold,<span class="f">+ \fr 1:3 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> Yahweh comes out of his place, 
-</p><p class="q2">and will come down and tread on the high places of the earth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The mountains melt under him, 
-</p><p class="q2">and the valleys split apart like wax before the fire, 
-</p><p class="q2">like waters that are poured down a steep place. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“All this is for the disobedience of Jacob, 
-</p><p class="q2">and for the sins of the house of Israel. 
-</p><p class="q1">What is the disobedience of Jacob? 
-</p><p class="q2">Isn’t it Samaria? 
-</p><p class="q1">And what are the high places of Judah? 
-</p><p class="q2">Aren’t they Jerusalem? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Therefore I will make Samaria like a rubble heap of the field, 
-</p><p class="q2">like places for planting vineyards; 
-</p><p class="q1">and I will pour down its stones into the valley, 
-</p><p class="q2">and I will uncover its foundations. 
-</p><p class="q1">
-<span class="v">7&#160;</span>All her idols will be beaten to pieces, 
-</p><p class="q2">all her temple gifts will be burned with fire, 
-</p><p class="q2">and I will destroy all her images; 
-</p><p class="q1">for of the hire of a prostitute has she gathered them, 
-</p><p class="q2">and to the hire of a prostitute shall they return.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>For this I will lament and wail. 
-</p><p class="q2">I will go stripped and naked. 
-</p><p class="q2">I will howl like the jackals 
-</p><p class="q2">and mourn like the ostriches. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For her wounds are incurable; 
-</p><p class="q2">for it has come even to Judah. 
-</p><p class="q1">It reaches to the gate of my people, 
-</p><p class="q2">even to Jerusalem. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Don’t tell it in Gath. 
-</p><p class="q2">Don’t weep at all. 
-</p><p class="q2">At Beth Ophrah<span class="f">+ \fr 1:10 \ft Beth Ophrah means literally “House of Dust.”</span> I have rolled myself in the dust. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Pass on, inhabitant of Shaphir, in nakedness and shame. 
-</p><p class="q2">The inhabitant of Zaanan won’t come out. 
-</p><p class="q2">The wailing of Beth Ezel will take from you his protection. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For the inhabitant of Maroth waits anxiously for good, 
-</p><p class="q2">because evil has come down from Yahweh to the gate of Jerusalem. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Harness the chariot to the swift steed, inhabitant of Lachish. 
-</p><p class="q2">She was the beginning of sin to the daughter of Zion; 
-</p><p class="q2">for the transgressions of Israel were found in you. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Therefore you will give a parting gift to Moresheth Gath. 
-</p><p class="q2">The houses of Achzib will be a deceitful thing to the kings of Israel. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will yet bring a conqueror to you, inhabitants of Mareshah. 
-</p><p class="q2">The glory of Israel will come to Adullam. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Shave your heads, 
-</p><p class="q2">and cut off your hair for the children of your delight. 
-</p><p class="q1">Enlarge your baldness like the vulture, 
-</p><p class="q2">for they have gone into captivity from you! 
-</p><div class="b"> &#160; </div>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Yahweh’s word that came to Micah of Morasheth in the days of Jotham, Ahaz, and Hezekiah, kings of Judah, which he saw concerning Samaria and Jerusalem. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear, you peoples, all of you! 
+</div><div class="q2">Listen, O earth, and all that is therein. 
+</div><div class="q1">Let the Lord Yahweh be witness against you, 
+</div><div class="q2">the Lord from his set-apart temple. 
+</div><div class="q1">
+<sup>3&#160;</sup>For behold, Yahweh comes out of his place, 
+</div><div class="q2">and will come down and tread on the high places of the earth. 
+</div><div class="q1">
+<sup>4&#160;</sup>The mountains melt under him, 
+</div><div class="q2">and the valleys split apart like wax before the fire, 
+</div><div class="q2">like waters that are poured down a steep place. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“All this is for the disobedience of Jacob, 
+</div><div class="q2">and for the sins of the house of Israel. 
+</div><div class="q1">What is the disobedience of Jacob? 
+</div><div class="q2">Isn’t it Samaria? 
+</div><div class="q1">And what are the high places of Judah? 
+</div><div class="q2">Aren’t they Jerusalem? 
+</div><div class="q1">
+<sup>6&#160;</sup>Therefore I will make Samaria like a rubble heap of the field, 
+</div><div class="q2">like places for planting vineyards; 
+</div><div class="q1">and I will pour down its stones into the valley, 
+</div><div class="q2">and I will uncover its foundations. 
+</div><div class="q1">
+<sup>7&#160;</sup>All her idols will be beaten to pieces, 
+</div><div class="q2">all her temple gifts will be burned with fire, 
+</div><div class="q2">and I will destroy all her images; 
+</div><div class="q1">for of the hire of a prostitute has she gathered them, 
+</div><div class="q2">and to the hire of a prostitute shall they return.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>For this I will lament and wail. 
+</div><div class="q2">I will go stripped and naked. 
+</div><div class="q2">I will howl like the jackals 
+</div><div class="q2">and mourn like the ostriches. 
+</div><div class="q1">
+<sup>9&#160;</sup>For her wounds are incurable; 
+</div><div class="q2">for it has come even to Judah. 
+</div><div class="q1">It reaches to the gate of my people, 
+</div><div class="q2">even to Jerusalem. 
+</div><div class="q1">
+<sup>10&#160;</sup>Don’t tell it in Gath. 
+</div><div class="q2">Don’t weep at all. 
+</div><div class="q2">At Beth Ophrah I have rolled myself in the dust. 
+</div><div class="q1">
+<sup>11&#160;</sup>Pass on, inhabitant of Shaphir, in nakedness and shame. 
+</div><div class="q2">The inhabitant of Zaanan won’t come out. 
+</div><div class="q2">The wailing of Beth Ezel will take from you his protection. 
+</div><div class="q1">
+<sup>12&#160;</sup>For the inhabitant of Maroth waits anxiously for good, 
+</div><div class="q2">because evil has come down from Yahweh to the gate of Jerusalem. 
+</div><div class="q1">
+<sup>13&#160;</sup>Harness the chariot to the swift steed, inhabitant of Lachish. 
+</div><div class="q2">She was the beginning of sin to the daughter of Zion; 
+</div><div class="q2">for the transgressions of Israel were found in you. 
+</div><div class="q1">
+<sup>14&#160;</sup>Therefore you will give a parting gift to Moresheth Gath. 
+</div><div class="q2">The houses of Achzib will be a deceitful thing to the kings of Israel. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will yet bring a conqueror to you, inhabitants of Mareshah. 
+</div><div class="q2">The glory of Israel will come to Adullam. 
+</div><div class="q1">
+<sup>16&#160;</sup>Shave your heads, 
+</div><div class="q2">and cut off your hair for the children of your delight. 
+</div><div class="q1">Enlarge your baldness like the vulture, 
+</div><div class="q2">for they have gone into captivity from you! 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="2">2</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Woe to those who devise iniquity 
-</p><p class="q2">and work evil on their beds! 
-</p><p class="q1">When the morning is light, they practice it, 
-</p><p class="q2">because it is in the power of their hand. 
-</p><p class="q1">
-<span class="v">2&#160;</span>They covet fields and seize them, 
-</p><p class="q2">and houses, then take them away. 
-</p><p class="q1">They oppress a man and his house, 
-</p><p class="q2">even a man and his heritage. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Therefore Yahweh says: 
-</p><p class="q1">“Behold, I am planning against these people a disaster, 
-</p><p class="q2">from which you will not remove your necks, 
-</p><p class="q2">neither will you walk haughtily, 
-</p><p class="q2">for it is an evil time. 
-</p><p class="q1">
-<span class="v">4&#160;</span>In that day they will take up a parable against you, 
-</p><p class="q2">and lament with a doleful lamentation, saying, 
-</p><p class="q2">‘We are utterly ruined! 
-</p><p class="q2">My people’s possession is divided up. 
-</p><p class="q2">Indeed he takes it from me and assigns our fields to traitors!’&#160;” 
-</p><p class="q1">
-<span class="v">5&#160;</span>Therefore you will have no one who divides the land by lot in Yahweh’s assembly. 
-</p><p class="q1">
-<span class="v">6&#160;</span>“Don’t prophesy!”—they prophesy—</p><p class="q2">“Don’t prophesy about these things. 
-</p><p class="q2">Disgrace won’t overtake us.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>Shall it be said, O house of Jacob, 
-</p><p class="q2">“Is Yahweh’s Spirit angry? 
-</p><p class="q2">Are these his doings? 
-</p><p class="q2">Don’t my words do good to him who walks blamelessly?” 
-</p><p class="q1">
-<span class="v">8&#160;</span>But lately my people have risen up as an enemy. 
-</p><p class="q2">You strip the robe and clothing from those who pass by without a care, returning from battle. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You drive the women of my people out from their pleasant houses; 
-</p><p class="q2">from their young children you take away my blessing forever. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Arise, and depart! 
-</p><p class="q2">For this is not your resting place, 
-</p><p class="q2">because of uncleanness that destroys, 
-</p><p class="q2">even with a grievous destruction. 
-</p><p class="q1">
-<span class="v">11&#160;</span>If a man walking in a spirit of falsehood lies, saying, 
-</p><p class="q2">“I will prophesy to you of wine and of strong drink,” 
-</p><p class="q2">he would be the prophet of this people. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will surely assemble all of you, Jacob. 
-</p><p class="q2">I will surely gather the remnant of Israel. 
-</p><p class="q1">I will put them together as the sheep of Bozrah, 
-</p><p class="q2">as a flock in the middle of their pasture. 
-</p><p class="q2">They will swarm with people. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He who breaks open the way goes up before them. 
-</p><p class="q2">They break through the gate, and go out. 
-</p><p class="q2">Their king passes on before them, 
-</p><p class="q2">with Yahweh at their head. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>I said, 
-</p><p class="q1">“Please listen, you heads of Jacob, 
-</p><p class="q2">and rulers of the house of Israel: 
-</p><p class="q2">Isn’t it for you to know justice? 
-</p><p class="q1">
-<span class="v">2&#160;</span>You who hate the good, 
-</p><p class="q2">and love the evil; 
-</p><p class="q2">who tear off their skin, 
-</p><p class="q2">and their flesh from off their bones; 
-</p><p class="q2">
-<span class="v">3&#160;</span>who also eat the flesh of my people, 
-</p><p class="q2">and peel their skin from off them, 
-</p><p class="q2">and break their bones, 
-</p><p class="q2">and chop them in pieces, as for the pot, 
-</p><p class="q2">and as meat within the cauldron. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Then they will cry to Yahweh, 
-</p><p class="q2">but he will not answer them. 
-</p><p class="q1">Yes, he will hide his face from them at that time, 
-</p><p class="q2">because they made their deeds evil.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh says concerning the prophets who lead my people astray—for those who feed their teeth, they proclaim, “Peace!” and whoever doesn’t provide for their mouths, they prepare war against him: 
-</p><p class="q1">
-<span class="v">6&#160;</span>“Therefore night is over you, with no vision, 
-</p><p class="q2">and it is dark to you, that you may not divine; 
-</p><p class="q2">and the sun will go down on the prophets, 
-</p><p class="q2">and the day will be black over them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The seers shall be disappointed, 
-</p><p class="q2">and the diviners confounded. 
-</p><p class="q1">Yes, they shall all cover their lips, 
-</p><p class="q2">for there is no answer from Elohim.”<span class="f">+ \fr 3:7 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p class="q1">
-<span class="v">8&#160;</span>But as for me, I am full of power by Yahweh’s Spirit, 
-</p><p class="q2">and of judgment, and of might, 
-</p><p class="q2">to declare to Jacob his disobedience, 
-</p><p class="q2">and to Israel his sin. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Please listen to this, you heads of the house of Jacob, 
-</p><p class="q2">and rulers of the house of Israel, 
-</p><p class="q2">who abhor justice, 
-</p><p class="q2">and pervert all equity, 
-</p><p class="q2">
-<span class="v">10&#160;</span>who build up Zion with blood, 
-</p><p class="q2">and Jerusalem with iniquity. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Her leaders judge for bribes, 
-</p><p class="q2">and her priests teach for a price, 
-</p><p class="q2">and her prophets of it tell fortunes for money; 
-</p><p class="q1">yet they lean on Yahweh, and say, 
-</p><p class="q2">“Isn’t Yahweh among us? 
-</p><p class="q2">No disaster will come on us.” 
-</p><p class="q1">
-<span class="v">12&#160;</span>Therefore Zion for your sake will be plowed like a field, 
-</p><p class="q2">and Jerusalem will become heaps of rubble, 
-</p><p class="q2">and the mountain of the temple like the high places of a forest. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Woe to those who devise iniquity 
+</div><div class="q2">and work evil on their beds! 
+</div><div class="q1">When the morning is light, they practice it, 
+</div><div class="q2">because it is in the power of their hand. 
+</div><div class="q1">
+<sup>2&#160;</sup>They covet fields and seize them, 
+</div><div class="q2">and houses, then take them away. 
+</div><div class="q1">They oppress a man and his house, 
+</div><div class="q2">even a man and his heritage. 
+</div><div class="q1">
+<sup>3&#160;</sup>Therefore Yahweh says: 
+</div><div class="q1">“Behold, I am planning against these people a disaster, 
+</div><div class="q2">from which you will not remove your necks, 
+</div><div class="q2">neither will you walk haughtily, 
+</div><div class="q2">for it is an evil time. 
+</div><div class="q1">
+<sup>4&#160;</sup>In that day they will take up a parable against you, 
+</div><div class="q2">and lament with a doleful lamentation, saying, 
+</div><div class="q2">‘We are utterly ruined! 
+</div><div class="q2">My people’s possession is divided up. 
+</div><div class="q2">Indeed he takes it from me and assigns our fields to traitors!’&#160;” 
+</div><div class="q1">
+<sup>5&#160;</sup>Therefore you will have no one who divides the land by lot in Yahweh’s assembly. 
+</div><div class="q1">
+<sup>6&#160;</sup>“Don’t prophesy!”—they prophesy—</div><div class="q2">“Don’t prophesy about these things. 
+</div><div class="q2">Disgrace won’t overtake us.” 
+</div><div class="q1">
+<sup>7&#160;</sup>Shall it be said, O house of Jacob, 
+</div><div class="q2">“Is Yahweh’s Spirit angry? 
+</div><div class="q2">Are these his doings? 
+</div><div class="q2">Don’t my words do good to him who walks blamelessly?” 
+</div><div class="q1">
+<sup>8&#160;</sup>But lately my people have risen up as an enemy. 
+</div><div class="q2">You strip the robe and clothing from those who pass by without a care, returning from battle. 
+</div><div class="q1">
+<sup>9&#160;</sup>You drive the women of my people out from their pleasant houses; 
+</div><div class="q2">from their young children you take away my blessing forever. 
+</div><div class="q1">
+<sup>10&#160;</sup>Arise, and depart! 
+</div><div class="q2">For this is not your resting place, 
+</div><div class="q2">because of uncleanness that destroys, 
+</div><div class="q2">even with a grievous destruction. 
+</div><div class="q1">
+<sup>11&#160;</sup>If a man walking in a spirit of falsehood lies, saying, 
+</div><div class="q2">“I will prophesy to you of wine and of strong drink,” 
+</div><div class="q2">he would be the prophet of this people. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will surely assemble all of you, Jacob. 
+</div><div class="q2">I will surely gather the remnant of Israel. 
+</div><div class="q1">I will put them together as the sheep of Bozrah, 
+</div><div class="q2">as a flock in the middle of their pasture. 
+</div><div class="q2">They will swarm with people. 
+</div><div class="q1">
+<sup>13&#160;</sup>He who breaks open the way goes up before them. 
+</div><div class="q2">They break through the gate, and go out. 
+</div><div class="q2">Their king passes on before them, 
+</div><div class="q2">with Yahweh at their head. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>I said, 
+</div><div class="q1">“Please listen, you heads of Jacob, 
+</div><div class="q2">and rulers of the house of Israel: 
+</div><div class="q2">Isn’t it for you to know justice? 
+</div><div class="q1">
+<sup>2&#160;</sup>You who hate the good, 
+</div><div class="q2">and love the evil; 
+</div><div class="q2">who tear off their skin, 
+</div><div class="q2">and their flesh from off their bones; 
+</div><div class="q2">
+<sup>3&#160;</sup>who also eat the flesh of my people, 
+</div><div class="q2">and peel their skin from off them, 
+</div><div class="q2">and break their bones, 
+</div><div class="q2">and chop them in pieces, as for the pot, 
+</div><div class="q2">and as meat within the cauldron. 
+</div><div class="q1">
+<sup>4&#160;</sup>Then they will cry to Yahweh, 
+</div><div class="q2">but he will not answer them. 
+</div><div class="q1">Yes, he will hide his face from them at that time, 
+</div><div class="q2">because they made their deeds evil.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh says concerning the prophets who lead my people astray—for those who feed their teeth, they proclaim, “Peace!” and whoever doesn’t provide for their mouths, they prepare war against him: 
+</div><div class="q1">
+<sup>6&#160;</sup>“Therefore night is over you, with no vision, 
+</div><div class="q2">and it is dark to you, that you may not divine; 
+</div><div class="q2">and the sun will go down on the prophets, 
+</div><div class="q2">and the day will be black over them. 
+</div><div class="q1">
+<sup>7&#160;</sup>The seers shall be disappointed, 
+</div><div class="q2">and the diviners confounded. 
+</div><div class="q1">Yes, they shall all cover their lips, 
+</div><div class="q2">for there is no answer from Elohim.” 
+</div><div class="q1">
+<sup>8&#160;</sup>But as for me, I am full of power by Yahweh’s Spirit, 
+</div><div class="q2">and of judgment, and of might, 
+</div><div class="q2">to declare to Jacob his disobedience, 
+</div><div class="q2">and to Israel his sin. 
+</div><div class="q1">
+<sup>9&#160;</sup>Please listen to this, you heads of the house of Jacob, 
+</div><div class="q2">and rulers of the house of Israel, 
+</div><div class="q2">who abhor justice, 
+</div><div class="q2">and pervert all equity, 
+</div><div class="q2">
+<sup>10&#160;</sup>who build up Zion with blood, 
+</div><div class="q2">and Jerusalem with iniquity. 
+</div><div class="q1">
+<sup>11&#160;</sup>Her leaders judge for bribes, 
+</div><div class="q2">and her priests teach for a price, 
+</div><div class="q2">and her prophets of it tell fortunes for money; 
+</div><div class="q1">yet they lean on Yahweh, and say, 
+</div><div class="q2">“Isn’t Yahweh among us? 
+</div><div class="q2">No disaster will come on us.” 
+</div><div class="q1">
+<sup>12&#160;</sup>Therefore Zion for your sake will be plowed like a field, 
+</div><div class="q2">and Jerusalem will become heaps of rubble, 
+</div><div class="q2">and the mountain of the temple like the high places of a forest. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="4">4</h2>
-<p class="q1">
-<span class="v">1&#160;</span>But in the latter days, 
-</p><p class="q2">it will happen that the mountain of Yahweh’s temple will be established on the top of the mountains, 
-</p><p class="q2">and it will be exalted above the hills; 
-</p><p class="q2">and peoples will stream to it. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Many nations will go and say, 
-</p><p class="q2">“Come! Let’s go up to the mountain of Yahweh, 
-</p><p class="q2">and to the house of the Elohim of Jacob; 
-</p><p class="q2">and he will teach us of his ways, 
-</p><p class="q2">and we will walk in his paths.” 
-</p><p class="q1">For the law will go out of Zion, 
-</p><p class="q2">and Yahweh’s word from Jerusalem; 
-</p><p class="q1">
-<span class="v">3&#160;</span>and he will judge between many peoples, 
-</p><p class="q2">and will decide concerning strong nations afar off. 
-</p><p class="q2">They will beat their swords into plowshares, 
-</p><p class="q2">and their spears into pruning hooks. 
-</p><p class="q1">Nation will not lift up sword against nation, 
-</p><p class="q2">neither will they learn war any more. 
-</p><p class="q1">
-<span class="v">4&#160;</span>But every man will sit under his vine and under his fig tree. 
-</p><p class="q2">No one will make them afraid, 
-</p><p class="q2">for the mouth of Yahweh of Armies has spoken. 
-<span class="v">5&#160;</span>Indeed all the nations may walk in the name of their elohims, 
-</p><p class="q2">but we will walk in the name of Yahweh our Elohim forever and ever. 
-</p><p class="q1">
-<span class="v">6&#160;</span>“In that day,” says Yahweh, 
-</p><p class="q2">“I will assemble that which is lame, 
-</p><p class="q2">and I will gather that which is driven away, 
-</p><p class="q2">and that which I have afflicted; 
-</p><p class="q2">
-<span class="v">7&#160;</span>and I will make that which was lame a remnant, 
-</p><p class="q2">and that which was cast far off a strong nation: 
-</p><p class="q2">and Yahweh will reign over them on Mount Zion from then on, even forever.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>You, tower of the flock, the hill of the daughter of Zion, 
-</p><p class="q2">to you it will come. 
-</p><p class="q1">Yes, the former dominion will come, 
-</p><p class="q2">the kingdom of the daughter of Jerusalem. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Now why do you cry out aloud? 
-</p><p class="q2">Is there no king in you? 
-</p><p class="q2">Has your counselor perished, 
-</p><p class="q2">that pains have taken hold of you as of a woman in travail? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Be in pain, and labor to give birth, daughter of Zion, 
-</p><p class="q2">like a woman in travail; 
-</p><p class="q2">for now you will go out of the city, 
-</p><p class="q2">and will dwell in the field, 
-</p><p class="q2">and will come even to Babylon. 
-</p><p class="q1">There you will be rescued. 
-</p><p class="q2">There Yahweh will redeem you from the hand of your enemies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Now many nations have assembled against you, that say, 
-</p><p class="q2">“Let her be defiled, 
-</p><p class="q2">and let our eye gloat over Zion.” 
-</p><p class="q1">
-<span class="v">12&#160;</span>But they don’t know the thoughts of Yahweh, 
-</p><p class="q2">neither do they understand his counsel; 
-</p><p class="q2">for he has gathered them like the sheaves to the threshing floor. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Arise and thresh, daughter of Zion, 
-</p><p class="q2">for I will make your horn iron, 
-</p><p class="q2">and I will make your hoofs bronze. 
-</p><p class="q1">You will beat in pieces many peoples. 
-</p><p class="q1">I will devote their gain to Yahweh, 
-</p><p class="q2">and their substance to the Lord of the whole earth. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>But in the latter days, 
+</div><div class="q2">it will happen that the mountain of Yahweh’s temple will be established on the top of the mountains, 
+</div><div class="q2">and it will be exalted above the hills; 
+</div><div class="q2">and peoples will stream to it. 
+</div><div class="q1">
+<sup>2&#160;</sup>Many nations will go and say, 
+</div><div class="q2">“Come! Let’s go up to the mountain of Yahweh, 
+</div><div class="q2">and to the house of the Elohim of Jacob; 
+</div><div class="q2">and he will teach us of his ways, 
+</div><div class="q2">and we will walk in his paths.” 
+</div><div class="q1">For the law will go out of Zion, 
+</div><div class="q2">and Yahweh’s word from Jerusalem; 
+</div><div class="q1">
+<sup>3&#160;</sup>and he will judge between many peoples, 
+</div><div class="q2">and will decide concerning strong nations afar off. 
+</div><div class="q2">They will beat their swords into plowshares, 
+</div><div class="q2">and their spears into pruning hooks. 
+</div><div class="q1">Nation will not lift up sword against nation, 
+</div><div class="q2">neither will they learn war any more. 
+</div><div class="q1">
+<sup>4&#160;</sup>But every man will sit under his vine and under his fig tree. 
+</div><div class="q2">No one will make them afraid, 
+</div><div class="q2">for the mouth of Yahweh of Armies has spoken. 
+<sup>5&#160;</sup>Indeed all the nations may walk in the name of their elohims, 
+</div><div class="q2">but we will walk in the name of Yahweh our Elohim forever and ever. 
+</div><div class="q1">
+<sup>6&#160;</sup>“In that day,” says Yahweh, 
+</div><div class="q2">“I will assemble that which is lame, 
+</div><div class="q2">and I will gather that which is driven away, 
+</div><div class="q2">and that which I have afflicted; 
+</div><div class="q2">
+<sup>7&#160;</sup>and I will make that which was lame a remnant, 
+</div><div class="q2">and that which was cast far off a strong nation: 
+</div><div class="q2">and Yahweh will reign over them on Mount Zion from then on, even forever.” 
+</div><div class="q1">
+<sup>8&#160;</sup>You, tower of the flock, the hill of the daughter of Zion, 
+</div><div class="q2">to you it will come. 
+</div><div class="q1">Yes, the former dominion will come, 
+</div><div class="q2">the kingdom of the daughter of Jerusalem. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Now why do you cry out aloud? 
+</div><div class="q2">Is there no king in you? 
+</div><div class="q2">Has your counselor perished, 
+</div><div class="q2">that pains have taken hold of you as of a woman in travail? 
+</div><div class="q1">
+<sup>10&#160;</sup>Be in pain, and labor to give birth, daughter of Zion, 
+</div><div class="q2">like a woman in travail; 
+</div><div class="q2">for now you will go out of the city, 
+</div><div class="q2">and will dwell in the field, 
+</div><div class="q2">and will come even to Babylon. 
+</div><div class="q1">There you will be rescued. 
+</div><div class="q2">There Yahweh will redeem you from the hand of your enemies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Now many nations have assembled against you, that say, 
+</div><div class="q2">“Let her be defiled, 
+</div><div class="q2">and let our eye gloat over Zion.” 
+</div><div class="q1">
+<sup>12&#160;</sup>But they don’t know the thoughts of Yahweh, 
+</div><div class="q2">neither do they understand his counsel; 
+</div><div class="q2">for he has gathered them like the sheaves to the threshing floor. 
+</div><div class="q1">
+<sup>13&#160;</sup>Arise and thresh, daughter of Zion, 
+</div><div class="q2">for I will make your horn iron, 
+</div><div class="q2">and I will make your hoofs bronze. 
+</div><div class="q1">You will beat in pieces many peoples. 
+</div><div class="q1">I will devote their gain to Yahweh, 
+</div><div class="q2">and their substance to the Lord of the whole earth. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="5">5</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Now you shall gather yourself in troops, 
-</p><p class="q2">daughter of troops. 
-</p><p class="q1">He has laid siege against us. 
-</p><p class="q2">They will strike the judge of Israel with a rod on the cheek. 
-</p><p class="q1">
-<span class="v">2&#160;</span>But you, Bethlehem Ephrathah, 
-</p><p class="q2">being small among the clans of Judah, 
-</p><p class="q2">out of you one will come out to me who is to be ruler in Israel; 
-</p><p class="q2">whose goings out are from of old, from ancient times. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Therefore he will abandon them until the time that she who is in labor gives birth. 
-</p><p class="q2">Then the rest of his brothers will return to the children of Israel. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He shall stand, and shall shepherd in the strength of Yahweh, 
-</p><p class="q2">in the majesty of the name of Yahweh his Elohim. 
-</p><p class="q2">They will live, for then he will be great to the ends of the earth. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He will be our peace when Assyria invades our land 
-</p><p class="q2">and when he marches through our fortresses, 
-</p><p class="q2">then we will raise against him seven shepherds, 
-</p><p class="q2">and eight leaders of men. 
-</p><p class="q1">
-<span class="v">6&#160;</span>They will rule the land of Assyria with the sword, 
-</p><p class="q2">and the land of Nimrod in its gates. 
-</p><p class="q1">He will deliver us from the Assyrian, 
-</p><p class="q2">when he invades our land, 
-</p><p class="q2">and when he marches within our border. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The remnant of Jacob will be among many peoples 
-</p><p class="q2">like dew from Yahweh, 
-</p><p class="q2">like showers on the grass, 
-</p><p class="q2">that don’t wait for man 
-</p><p class="q2">nor wait for the sons of men. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The remnant of Jacob will be among the nations, 
-</p><p class="q2">among many peoples, 
-</p><p class="q2">like a lion among the animals of the forest, 
-</p><p class="q2">like a young lion among the flocks of sheep; 
-</p><p class="q2">who, if he goes through, treads down and tears in pieces, 
-</p><p class="q2">and there is no one to deliver. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Let your hand be lifted up above your adversaries, 
-</p><p class="q2">and let all of your enemies be cut off. 
-</p><p class="q1">
-<span class="v">10&#160;</span>“It will happen in that day”, says Yahweh, 
-</p><p class="q2">“that I will cut off your horses from among you 
-</p><p class="q2">and will destroy your chariots. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I will cut off the cities of your land 
-</p><p class="q2">and will tear down all your strongholds. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will destroy witchcraft from your hand. 
-</p><p class="q2">You shall have no soothsayers. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I will cut off your engraved images and your pillars from among you; 
-</p><p class="q2">and you shall no more worship the work of your hands. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will uproot your Asherah poles from among you; 
-</p><p class="q2">and I will destroy your cities. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will execute vengeance in anger 
-</p><p class="q2">and wrath on the nations that didn’t listen.” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Listen now to what Yahweh says: 
-</p><p class="q1">“Arise, plead your case before the mountains, 
-</p><p class="q2">and let the hills hear what you have to say. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear, you mountains, Yahweh’s indictment, 
-</p><p class="q2">and you enduring foundations of the earth; 
-</p><p class="q2">for Yahweh has a case against his people, 
-</p><p class="q2">and he will contend with Israel. 
-</p><p class="q1">
-<span class="v">3&#160;</span>My people, what have I done to you? 
-</p><p class="q2">How have I burdened you? 
-</p><p class="q2">Answer me! 
-</p><p class="q1">
-<span class="v">4&#160;</span>For I brought you up out of the land of Egypt, 
-</p><p class="q2">and redeemed you out of the house of bondage. 
-</p><p class="q2">I sent before you Moses, Aaron, and Miriam. 
-</p><p class="q1">
-<span class="v">5&#160;</span>My people, remember now what Balak king of Moab devised, 
-</p><p class="q2">and what Balaam the son of Beor answered him from Shittim to Gilgal, 
-</p><p class="q2">that you may know the righteous acts of Yahweh.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>How shall I come before Yahweh, 
-</p><p class="q2">and bow myself before the exalted Elohim? 
-</p><p class="q1">Shall I come before him with burnt offerings, 
-</p><p class="q2">with calves a year old? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Will Yahweh be pleased with thousands of rams? 
-</p><p class="q2">With tens of thousands of rivers of oil? 
-</p><p class="q1">Shall I give my firstborn for my disobedience? 
-</p><p class="q2">The fruit of my body for the sin of my soul? 
-</p><p class="q1">
-<span class="v">8&#160;</span>He has shown you, O man, what is good. 
-</p><p class="q2">What does Yahweh require of you, but to act justly, 
-</p><p class="q2">to love mercy, and to walk humbly with your Elohim? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Yahweh’s voice calls to the city—</p><p class="q2">and wisdom fears your name—</p><p class="q1">“Listen to the rod, 
-</p><p class="q2">and he who appointed it. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Are there yet treasures of wickedness in the house of the wicked, 
-</p><p class="q2">and a short ephah<span class="f">+ \fr 6:10 \ft An ephah is a measure of volume (about 22 liters or about 2/3 of a bushel), and a short ephah is made smaller than a full ephah for the purpose of cheating customers.</span> that is accursed? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Shall I tolerate dishonest scales, 
-</p><p class="q2">and a bag of deceitful weights? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Her rich men are full of violence, 
-</p><p class="q2">her inhabitants speak lies, 
-</p><p class="q2">and their tongue is deceitful in their speech. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Therefore I also have struck you with a grievous wound. 
-</p><p class="q2">I have made you desolate because of your sins. 
-</p><p class="q1">
-<span class="v">14&#160;</span>You shall eat, but not be satisfied. 
-</p><p class="q2">Your hunger will be within you. 
-</p><p class="q2">You will store up, but not save, 
-</p><p class="q2">and that which you save I will give up to the sword. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You will sow, but won’t reap. 
-</p><p class="q2">You will tread the olives, but won’t anoint yourself with oil; 
-</p><p class="q2">and crush grapes, but won’t drink the wine. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For the statutes of Omri are kept, 
-</p><p class="q2">and all the works of Ahab’s house. 
-</p><p class="q2">You walk in their counsels, 
-</p><p class="q2">that I may make you a ruin, 
-</p><p class="q2">and your inhabitants a hissing. 
-</p><p class="q2">You will bear the reproach of my people.” 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Now you shall gather yourself in troops, 
+</div><div class="q2">daughter of troops. 
+</div><div class="q1">He has laid siege against us. 
+</div><div class="q2">They will strike the judge of Israel with a rod on the cheek. 
+</div><div class="q1">
+<sup>2&#160;</sup>But you, Bethlehem Ephrathah, 
+</div><div class="q2">being small among the clans of Judah, 
+</div><div class="q2">out of you one will come out to me who is to be ruler in Israel; 
+</div><div class="q2">whose goings out are from of old, from ancient times. 
+</div><div class="q1">
+<sup>3&#160;</sup>Therefore he will abandon them until the time that she who is in labor gives birth. 
+</div><div class="q2">Then the rest of his brothers will return to the children of Israel. 
+</div><div class="q1">
+<sup>4&#160;</sup>He shall stand, and shall shepherd in the strength of Yahweh, 
+</div><div class="q2">in the majesty of the name of Yahweh his Elohim. 
+</div><div class="q2">They will live, for then he will be great to the ends of the earth. 
+</div><div class="q1">
+<sup>5&#160;</sup>He will be our peace when Assyria invades our land 
+</div><div class="q2">and when he marches through our fortresses, 
+</div><div class="q2">then we will raise against him seven shepherds, 
+</div><div class="q2">and eight leaders of men. 
+</div><div class="q1">
+<sup>6&#160;</sup>They will rule the land of Assyria with the sword, 
+</div><div class="q2">and the land of Nimrod in its gates. 
+</div><div class="q1">He will deliver us from the Assyrian, 
+</div><div class="q2">when he invades our land, 
+</div><div class="q2">and when he marches within our border. 
+</div><div class="q1">
+<sup>7&#160;</sup>The remnant of Jacob will be among many peoples 
+</div><div class="q2">like dew from Yahweh, 
+</div><div class="q2">like showers on the grass, 
+</div><div class="q2">that don’t wait for man 
+</div><div class="q2">nor wait for the sons of men. 
+</div><div class="q1">
+<sup>8&#160;</sup>The remnant of Jacob will be among the nations, 
+</div><div class="q2">among many peoples, 
+</div><div class="q2">like a lion among the animals of the forest, 
+</div><div class="q2">like a young lion among the flocks of sheep; 
+</div><div class="q2">who, if he goes through, treads down and tears in pieces, 
+</div><div class="q2">and there is no one to deliver. 
+</div><div class="q1">
+<sup>9&#160;</sup>Let your hand be lifted up above your adversaries, 
+</div><div class="q2">and let all of your enemies be cut off. 
+</div><div class="q1">
+<sup>10&#160;</sup>“It will happen in that day”, says Yahweh, 
+</div><div class="q2">“that I will cut off your horses from among you 
+</div><div class="q2">and will destroy your chariots. 
+</div><div class="q1">
+<sup>11&#160;</sup>I will cut off the cities of your land 
+</div><div class="q2">and will tear down all your strongholds. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will destroy witchcraft from your hand. 
+</div><div class="q2">You shall have no soothsayers. 
+</div><div class="q1">
+<sup>13&#160;</sup>I will cut off your engraved images and your pillars from among you; 
+</div><div class="q2">and you shall no more worship the work of your hands. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will uproot your Asherah poles from among you; 
+</div><div class="q2">and I will destroy your cities. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will execute vengeance in anger 
+</div><div class="q2">and wrath on the nations that didn’t listen.” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Listen now to what Yahweh says: 
+</div><div class="q1">“Arise, plead your case before the mountains, 
+</div><div class="q2">and let the hills hear what you have to say. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear, you mountains, Yahweh’s indictment, 
+</div><div class="q2">and you enduring foundations of the earth; 
+</div><div class="q2">for Yahweh has a case against his people, 
+</div><div class="q2">and he will contend with Israel. 
+</div><div class="q1">
+<sup>3&#160;</sup>My people, what have I done to you? 
+</div><div class="q2">How have I burdened you? 
+</div><div class="q2">Answer me! 
+</div><div class="q1">
+<sup>4&#160;</sup>For I brought you up out of the land of Egypt, 
+</div><div class="q2">and redeemed you out of the house of bondage. 
+</div><div class="q2">I sent before you Moses, Aaron, and Miriam. 
+</div><div class="q1">
+<sup>5&#160;</sup>My people, remember now what Balak king of Moab devised, 
+</div><div class="q2">and what Balaam the son of Beor answered him from Shittim to Gilgal, 
+</div><div class="q2">that you may know the righteous acts of Yahweh.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>How shall I come before Yahweh, 
+</div><div class="q2">and bow myself before the exalted Elohim? 
+</div><div class="q1">Shall I come before him with burnt offerings, 
+</div><div class="q2">with calves a year old? 
+</div><div class="q1">
+<sup>7&#160;</sup>Will Yahweh be pleased with thousands of rams? 
+</div><div class="q2">With tens of thousands of rivers of oil? 
+</div><div class="q1">Shall I give my firstborn for my disobedience? 
+</div><div class="q2">The fruit of my body for the sin of my soul? 
+</div><div class="q1">
+<sup>8&#160;</sup>He has shown you, O man, what is good. 
+</div><div class="q2">What does Yahweh require of you, but to act justly, 
+</div><div class="q2">to love mercy, and to walk humbly with your Elohim? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Yahweh’s voice calls to the city—</div><div class="q2">and wisdom fears your name—</div><div class="q1">“Listen to the rod, 
+</div><div class="q2">and he who appointed it. 
+</div><div class="q1">
+<sup>10&#160;</sup>Are there yet treasures of wickedness in the house of the wicked, 
+</div><div class="q2">and a short ephah that is accursed? 
+</div><div class="q1">
+<sup>11&#160;</sup>Shall I tolerate dishonest scales, 
+</div><div class="q2">and a bag of deceitful weights? 
+</div><div class="q1">
+<sup>12&#160;</sup>Her rich men are full of violence, 
+</div><div class="q2">her inhabitants speak lies, 
+</div><div class="q2">and their tongue is deceitful in their speech. 
+</div><div class="q1">
+<sup>13&#160;</sup>Therefore I also have struck you with a grievous wound. 
+</div><div class="q2">I have made you desolate because of your sins. 
+</div><div class="q1">
+<sup>14&#160;</sup>You shall eat, but not be satisfied. 
+</div><div class="q2">Your hunger will be within you. 
+</div><div class="q2">You will store up, but not save, 
+</div><div class="q2">and that which you save I will give up to the sword. 
+</div><div class="q1">
+<sup>15&#160;</sup>You will sow, but won’t reap. 
+</div><div class="q2">You will tread the olives, but won’t anoint yourself with oil; 
+</div><div class="q2">and crush grapes, but won’t drink the wine. 
+</div><div class="q1">
+<sup>16&#160;</sup>For the statutes of Omri are kept, 
+</div><div class="q2">and all the works of Ahab’s house. 
+</div><div class="q2">You walk in their counsels, 
+</div><div class="q2">that I may make you a ruin, 
+</div><div class="q2">and your inhabitants a hissing. 
+</div><div class="q2">You will bear the reproach of my people.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="7">7</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Misery is mine! 
-</p><p class="q2">Indeed, I am like one who gathers the summer fruits, as gleanings of the vineyard. 
-</p><p class="q2">There is no cluster of grapes to eat. 
-</p><p class="q2">My soul desires to eat the early fig. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The elohimly man has perished out of the earth, 
-</p><p class="q2">and there is no one upright among men. 
-</p><p class="q2">They all lie in wait for blood; 
-</p><p class="q2">every man hunts his brother with a net. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Their hands are on that which is evil to do it diligently. 
-</p><p class="q2">The ruler and judge ask for a bribe. 
-</p><p class="q1">The powerful man dictates the evil desire of his soul. 
-</p><p class="q2">Thus they conspire together. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The best of them is like a brier. 
-</p><p class="q2">The most upright is worse than a thorn hedge. 
-</p><p class="q1">The day of your watchmen, 
-</p><p class="q2">even your visitation, has come; 
-</p><p class="q2">now is the time of their confusion. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Don’t trust in a neighbor. 
-</p><p class="q2">Don’t put confidence in a friend. 
-</p><p class="q2">With the woman lying in your embrace, 
-</p><p class="q2">be careful of the words of your mouth! 
-</p><p class="q1">
-<span class="v">6&#160;</span>For the son dishonors the father, 
-</p><p class="q2">the daughter rises up against her mother, 
-</p><p class="q2">the daughter-in-law against her mother-in-law; 
-</p><p class="q2">a man’s enemies are the men of his own house. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But as for me, I will look to Yahweh. 
-</p><p class="q2">I will wait for the Elohim of my salvation. 
-</p><p class="q2">My Elohim will hear me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Don’t rejoice against me, my enemy. 
-</p><p class="q2">When I fall, I will arise. 
-</p><p class="q2">When I sit in darkness, Yahweh will be a light to me. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will bear the indignation of Yahweh, 
-</p><p class="q2">because I have sinned against him, 
-</p><p class="q2">until he pleads my case and executes judgment for me. 
-</p><p class="q2">He will bring me out to the light. 
-</p><p class="q2">I will see his righteousness. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Then my enemy will see it, 
-</p><p class="q2">and shame will cover her who said to me, 
-</p><p class="q2">“Where is Yahweh your Elohim?” 
-</p><p class="q1">My eyes will see her. 
-</p><p class="q2">Now she will be trodden down like the mire of the streets. 
-</p><p class="q1">
-<span class="v">11&#160;</span>A day to build your walls! 
-</p><p class="q2">In that day, he will extend your boundary. 
-</p><p class="q1">
-<span class="v">12&#160;</span>In that day they will come to you from Assyria and the cities of Egypt, 
-</p><p class="q2">and from Egypt even to the River, 
-</p><p class="q2">and from sea to sea, 
-</p><p class="q2">and mountain to mountain. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yet the land will be desolate because of those who dwell therein, 
-</p><p class="q2">for the fruit of their doings. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Shepherd your people with your staff, 
-</p><p class="q2">the flock of your heritage, 
-</p><p class="q2">who dwell by themselves in a forest. 
-</p><p class="q1">Let them feed in the middle of fertile pasture land, 
-</p><p class="q2">in Bashan and Gilead, as in the days of old. 
-</p><p class="q1">
-<span class="v">15&#160;</span>“As in the days of your coming out of the land of Egypt, 
-</p><p class="q2">I will show them marvelous things.” 
-</p><p class="q1">
-<span class="v">16&#160;</span>The nations will see and be ashamed of all their might. 
-</p><p class="q2">They will lay their hand on their mouth. 
-</p><p class="q2">Their ears will be deaf. 
-</p><p class="q1">
-<span class="v">17&#160;</span>They will lick the dust like a serpent. 
-</p><p class="q2">Like crawling things of the earth, they will come trembling out of their dens. 
-</p><p class="q2">They will come with fear to Yahweh our Elohim, 
-</p><p class="q2">and will be afraid because of you. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Who is an Elohim like you, who pardons iniquity, 
-</p><p class="q2">and passes over the disobedience of the remnant of his heritage? 
-</p><p class="q1">He doesn’t retain his anger forever, 
-</p><p class="q2">because he delights in loving kindness. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He will again have compassion on us. 
-</p><p class="q2">He will tread our iniquities under foot. 
-</p><p class="q2">You will cast all their sins into the depths of the sea. 
-</p><p class="q1">
-<span class="v">20&#160;</span>You will give truth to Jacob, 
-</p><p class="q2">and mercy to Abraham, 
-</p><p class="q2">as you have sworn to our fathers from the days of old. </div><script src="../main.js"></script></body></html>
+<div class="q1">
+<sup>1&#160;</sup>Misery is mine! 
+</div><div class="q2">Indeed, I am like one who gathers the summer fruits, as gleanings of the vineyard. 
+</div><div class="q2">There is no cluster of grapes to eat. 
+</div><div class="q2">My soul desires to eat the early fig. 
+</div><div class="q1">
+<sup>2&#160;</sup>The elohimly man has perished out of the earth, 
+</div><div class="q2">and there is no one upright among men. 
+</div><div class="q2">They all lie in wait for blood; 
+</div><div class="q2">every man hunts his brother with a net. 
+</div><div class="q1">
+<sup>3&#160;</sup>Their hands are on that which is evil to do it diligently. 
+</div><div class="q2">The ruler and judge ask for a bribe. 
+</div><div class="q1">The powerful man dictates the evil desire of his soul. 
+</div><div class="q2">Thus they conspire together. 
+</div><div class="q1">
+<sup>4&#160;</sup>The best of them is like a brier. 
+</div><div class="q2">The most upright is worse than a thorn hedge. 
+</div><div class="q1">The day of your watchmen, 
+</div><div class="q2">even your visitation, has come; 
+</div><div class="q2">now is the time of their confusion. 
+</div><div class="q1">
+<sup>5&#160;</sup>Don’t trust in a neighbor. 
+</div><div class="q2">Don’t put confidence in a friend. 
+</div><div class="q2">With the woman lying in your embrace, 
+</div><div class="q2">be careful of the words of your mouth! 
+</div><div class="q1">
+<sup>6&#160;</sup>For the son dishonors the father, 
+</div><div class="q2">the daughter rises up against her mother, 
+</div><div class="q2">the daughter-in-law against her mother-in-law; 
+</div><div class="q2">a man’s enemies are the men of his own house. 
+</div><div class="q1">
+<sup>7&#160;</sup>But as for me, I will look to Yahweh. 
+</div><div class="q2">I will wait for the Elohim of my salvation. 
+</div><div class="q2">My Elohim will hear me. 
+</div><div class="q1">
+<sup>8&#160;</sup>Don’t rejoice against me, my enemy. 
+</div><div class="q2">When I fall, I will arise. 
+</div><div class="q2">When I sit in darkness, Yahweh will be a light to me. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will bear the indignation of Yahweh, 
+</div><div class="q2">because I have sinned against him, 
+</div><div class="q2">until he pleads my case and executes judgment for me. 
+</div><div class="q2">He will bring me out to the light. 
+</div><div class="q2">I will see his righteousness. 
+</div><div class="q1">
+<sup>10&#160;</sup>Then my enemy will see it, 
+</div><div class="q2">and shame will cover her who said to me, 
+</div><div class="q2">“Where is Yahweh your Elohim?” 
+</div><div class="q1">My eyes will see her. 
+</div><div class="q2">Now she will be trodden down like the mire of the streets. 
+</div><div class="q1">
+<sup>11&#160;</sup>A day to build your walls! 
+</div><div class="q2">In that day, he will extend your boundary. 
+</div><div class="q1">
+<sup>12&#160;</sup>In that day they will come to you from Assyria and the cities of Egypt, 
+</div><div class="q2">and from Egypt even to the River, 
+</div><div class="q2">and from sea to sea, 
+</div><div class="q2">and mountain to mountain. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yet the land will be desolate because of those who dwell therein, 
+</div><div class="q2">for the fruit of their doings. 
+</div><div class="q1">
+<sup>14&#160;</sup>Shepherd your people with your staff, 
+</div><div class="q2">the flock of your heritage, 
+</div><div class="q2">who dwell by themselves in a forest. 
+</div><div class="q1">Let them feed in the middle of fertile pasture land, 
+</div><div class="q2">in Bashan and Gilead, as in the days of old. 
+</div><div class="q1">
+<sup>15&#160;</sup>“As in the days of your coming out of the land of Egypt, 
+</div><div class="q2">I will show them marvelous things.” 
+</div><div class="q1">
+<sup>16&#160;</sup>The nations will see and be ashamed of all their might. 
+</div><div class="q2">They will lay their hand on their mouth. 
+</div><div class="q2">Their ears will be deaf. 
+</div><div class="q1">
+<sup>17&#160;</sup>They will lick the dust like a serpent. 
+</div><div class="q2">Like crawling things of the earth, they will come trembling out of their dens. 
+</div><div class="q2">They will come with fear to Yahweh our Elohim, 
+</div><div class="q2">and will be afraid because of you. 
+</div><div class="q1">
+<sup>18&#160;</sup>Who is an Elohim like you, who pardons iniquity, 
+</div><div class="q2">and passes over the disobedience of the remnant of his heritage? 
+</div><div class="q1">He doesn’t retain his anger forever, 
+</div><div class="q2">because he delights in loving kindness. 
+</div><div class="q1">
+<sup>19&#160;</sup>He will again have compassion on us. 
+</div><div class="q2">He will tread our iniquities under foot. 
+</div><div class="q2">You will cast all their sins into the depths of the sea. 
+</div><div class="q1">
+<sup>20&#160;</sup>You will give truth to Jacob, 
+</div><div class="q2">and mercy to Abraham, 
+</div><div class="q2">as you have sworn to our fathers from the days of old. </div></div><script src="../main.js"></script></body></html>

--- a/book/nahum.html
+++ b/book/nahum.html
@@ -3,6 +3,47 @@
 <head>
 <title>Nahum</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,64 +53,68 @@
 <div class="main">
 <!-- NAM World English Scripture (WES) -->
 <h1 class="booklabel">Nahum</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>A revelation about Nineveh. The book of the vision of Nahum the Elkoshite. 
-<span class="v">2&#160;</span>Yahweh<span class="f">+ \fr 1:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> is a jealous Elohim<span class="f">+ \fr 1:2 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> and avenges. Yahweh avenges and is full of wrath. Yahweh takes vengeance on his adversaries, and he maintains wrath against his enemies. 
-<span class="v">3&#160;</span>Yahweh is slow to anger, and great in power, and will by no means leave the guilty unpunished. Yahweh has his way in the whirlwind and in the storm, and the clouds are the dust of his feet. 
-<span class="v">4&#160;</span>He rebukes the sea and makes it dry, and dries up all the rivers. Bashan and Carmel languish. The flower of Lebanon languishes. 
-<span class="v">5&#160;</span>The mountains quake before him, and the hills melt away. The earth trembles at his presence, yes, the world, and all who dwell in it. 
-<span class="v">6&#160;</span>Who can stand before his indignation? Who can endure the fierceness of his anger? His wrath is poured out like fire, and the rocks are broken apart by him. 
-<span class="v">7&#160;</span>Yahweh is good, a stronghold in the day of trouble; and he knows those who take refuge in him. 
-<span class="v">8&#160;</span>But with an overflowing flood, he will make a full end of her place, and will pursue his enemies into darkness. 
-<span class="v">9&#160;</span>What do you plot against Yahweh? He will make a full end. Affliction won’t rise up the second time. 
-<span class="v">10&#160;</span>For entangled like thorns, and drunken as with their drink, they are consumed utterly like dry stubble. 
-<span class="v">11&#160;</span>One has gone out of you who devises evil against Yahweh, who counsels wickedness. 
-</p><p>
-<span class="v">12&#160;</span>Yahweh says: “Though they are in full strength and likewise many, even so they will be cut down and pass away. Though I have afflicted you, I will afflict you no more. 
-<span class="v">13&#160;</span>Now I will break his yoke from off you, and will burst your bonds apart.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh has commanded concerning you: “No more descendants will bear your name. Out of the house of your elohims, I will cut off the engraved image and the molten image. I will make your grave, for you are vile.” 
-</p><p>
-<span class="v">15&#160;</span>Behold,<span class="f">+ \fr 1:15 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> on the mountains the feet of him who brings good news, who publishes peace! Keep your feasts, Judah! Perform your vows, for the wicked one will no more pass through you. He is utterly cut off. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>He who dashes in pieces has come up against you. Keep the fortress! Watch the way! Strengthen your waist! Fortify your power mightily! 
-</p><p>
-<span class="v">2&#160;</span>For Yahweh restores the excellency of Jacob as the excellency of Israel, for the destroyers have destroyed them and ruined their vine branches. 
-</p><p>
-<span class="v">3&#160;</span>The shield of his mighty men is made red. The valiant men are in scarlet. The chariots flash with steel in the day of his preparation, and the pine spears are brandished. 
-<span class="v">4&#160;</span>The chariots rage in the streets. They rush back and forth in the wide ways. Their appearance is like torches. They run like the lightnings. 
-<span class="v">5&#160;</span>He summons his picked troops. They stumble on their way. They dash to its wall, and the protective shield is put in place. 
-<span class="v">6&#160;</span>The gates of the rivers are opened, and the palace is dissolved. 
-<span class="v">7&#160;</span>It is decreed: she is uncovered, she is carried away; and her servants moan as with the voice of doves, beating on their breasts. 
-<span class="v">8&#160;</span>But Nineveh has been from of old like a pool of water, yet they flee away. “Stop! Stop!” they cry, but no one looks back. 
-<span class="v">9&#160;</span>Take the plunder of silver. Take the plunder of gold, for there is no end of treasure, an abundance of every precious thing. 
-<span class="v">10&#160;</span>She is empty, void, and waste. The heart melts, the knees knock together, their bodies and faces have grown pale. 
-<span class="v">11&#160;</span>Where is the den of the lions, and the feeding place of the young lions, where the lion and the lioness walked with the lion’s cubs, and no one made them afraid? 
-<span class="v">12&#160;</span>The lion tore in pieces enough for his cubs, and strangled prey for his lionesses, and filled his caves with the kill and his dens with prey. 
-<span class="v">13&#160;</span>“Behold, I am against you,” says Yahweh of Armies, “and I will burn her chariots in the smoke, and the sword will devour your young lions; and I will cut off your prey from the earth, and the voice of your messengers will no longer be heard.” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Woe to the bloody city! It is all full of lies and robbery—no end to the prey. 
-<span class="v">2&#160;</span>The noise of the whip, the noise of the rattling of wheels, prancing horses, and bounding chariots, 
-<span class="v">3&#160;</span>the horseman charging, and the flashing sword, the glittering spear, and a multitude of slain, and a great heap of corpses, and there is no end of the bodies. They stumble on their bodies 
-<span class="v">4&#160;</span>because of the multitude of the prostitution of the alluring prostitute, the mistress of witchcraft, who sells nations through her prostitution, and families through her witchcraft. 
-<span class="v">5&#160;</span>“Behold, I am against you,” says Yahweh of Armies, “and I will lift your skirts over your face. I will show the nations your nakedness, and the kingdoms your shame. 
-<span class="v">6&#160;</span>I will throw abominable filth on you and make you vile, and will make you a spectacle. 
-<span class="v">7&#160;</span>It will happen that all those who look at you will flee from you, and say, ‘Nineveh is laid waste! Who will mourn for her?’ Where will I seek comforters for you?” 
-</p><p>
-<span class="v">8&#160;</span>Are you better than No-Amon,<span class="f">+ \fr 3:8 \ft or, Thebes</span> who was situated among the rivers,<span class="f">+ \fr 3:8 \ft or, Nile</span> who had the waters around her, whose rampart was the sea, and her wall was of the sea? 
-<span class="v">9&#160;</span>Cush and Egypt were her boundless strength. Put and Libya were her helpers. 
-<span class="v">10&#160;</span>Yet was she carried away. She went into captivity. Her young children also were dashed in pieces at the head of all the streets, and they cast lots for her honorable men, and all her great men were bound in chains. 
-<span class="v">11&#160;</span>You also will be drunken. You will be hidden. You also will seek a stronghold because of the enemy. 
-<span class="v">12&#160;</span>All your fortresses will be like fig trees with the first-ripe figs. If they are shaken, they fall into the mouth of the eater. 
-<span class="v">13&#160;</span>Behold, your troops among you are women. The gates of your land are set wide open to your enemies. The fire has devoured your bars. 
-</p><p>
-<span class="v">14&#160;</span>Draw water for the siege. Strengthen your fortresses. Go into the clay, and tread the mortar. Make the brick kiln strong. 
-<span class="v">15&#160;</span>There the fire will devour you. The sword will cut you off. It will devour you like the grasshopper. Multiply like grasshoppers. Multiply like the locust. 
-<span class="v">16&#160;</span>You have increased your merchants more than the stars of the skies. The grasshopper strips and flees away. 
-<span class="v">17&#160;</span>Your guards are like the locusts, and your officials like the swarms of locusts, which settle on the walls on a cold day, but when the sun appears, they flee away, and their place is not known where they are. 
-</p><p>
-<span class="v">18&#160;</span>Your shepherds slumber, king of Assyria. Your nobles lie down. Your people are scattered on the mountains, and there is no one to gather them. 
-<span class="v">19&#160;</span>There is no healing your wound, for your injury is fatal. All who hear the report of you clap their hands over you, for who hasn’t felt your endless cruelty? </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>A revelation about Nineveh. The book of the vision of Nahum the Elkoshite. 
+<sup>2&#160;</sup>Yahweh and avenges. Yahweh avenges and is full of wrath. Yahweh takes vengeance on his adversaries, and he maintains wrath against his enemies. 
+<sup>3&#160;</sup>Yahweh is slow to anger, and great in power, and will by no means leave the guilty unpunished. Yahweh has his way in the whirlwind and in the storm, and the clouds are the dust of his feet. 
+<sup>4&#160;</sup>He rebukes the sea and makes it dry, and dries up all the rivers. Bashan and Carmel languish. The flower of Lebanon languishes. 
+<sup>5&#160;</sup>The mountains quake before him, and the hills melt away. The earth trembles at his presence, yes, the world, and all who dwell in it. 
+<sup>6&#160;</sup>Who can stand before his indignation? Who can endure the fierceness of his anger? His wrath is poured out like fire, and the rocks are broken apart by him. 
+<sup>7&#160;</sup>Yahweh is good, a stronghold in the day of trouble; and he knows those who take refuge in him. 
+<sup>8&#160;</sup>But with an overflowing flood, he will make a full end of her place, and will pursue his enemies into darkness. 
+<sup>9&#160;</sup>What do you plot against Yahweh? He will make a full end. Affliction won’t rise up the second time. 
+<sup>10&#160;</sup>For entangled like thorns, and drunken as with their drink, they are consumed utterly like dry stubble. 
+<sup>11&#160;</sup>One has gone out of you who devises evil against Yahweh, who counsels wickedness. 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh says: “Though they are in full strength and likewise many, even so they will be cut down and pass away. Though I have afflicted you, I will afflict you no more. 
+<sup>13&#160;</sup>Now I will break his yoke from off you, and will burst your bonds apart.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh has commanded concerning you: “No more descendants will bear your name. Out of the house of your elohims, I will cut off the engraved image and the molten image. I will make your grave, for you are vile.” 
+</div><div class="p">
+<sup>15&#160;</sup>Behold, on the mountains the feet of him who brings good news, who publishes peace! Keep your feasts, Judah! Perform your vows, for the wicked one will no more pass through you. He is utterly cut off. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>He who dashes in pieces has come up against you. Keep the fortress! Watch the way! Strengthen your waist! Fortify your power mightily! 
+</div><div class="p">
+<sup>2&#160;</sup>For Yahweh restores the excellency of Jacob as the excellency of Israel, for the destroyers have destroyed them and ruined their vine branches. 
+</div><div class="p">
+<sup>3&#160;</sup>The shield of his mighty men is made red. The valiant men are in scarlet. The chariots flash with steel in the day of his preparation, and the pine spears are brandished. 
+<sup>4&#160;</sup>The chariots rage in the streets. They rush back and forth in the wide ways. Their appearance is like torches. They run like the lightnings. 
+<sup>5&#160;</sup>He summons his picked troops. They stumble on their way. They dash to its wall, and the protective shield is put in place. 
+<sup>6&#160;</sup>The gates of the rivers are opened, and the palace is dissolved. 
+<sup>7&#160;</sup>It is decreed: she is uncovered, she is carried away; and her servants moan as with the voice of doves, beating on their breasts. 
+<sup>8&#160;</sup>But Nineveh has been from of old like a pool of water, yet they flee away. “Stop! Stop!” they cry, but no one looks back. 
+<sup>9&#160;</sup>Take the plunder of silver. Take the plunder of gold, for there is no end of treasure, an abundance of every precious thing. 
+<sup>10&#160;</sup>She is empty, void, and waste. The heart melts, the knees knock together, their bodies and faces have grown pale. 
+<sup>11&#160;</sup>Where is the den of the lions, and the feeding place of the young lions, where the lion and the lioness walked with the lion’s cubs, and no one made them afraid? 
+<sup>12&#160;</sup>The lion tore in pieces enough for his cubs, and strangled prey for his lionesses, and filled his caves with the kill and his dens with prey. 
+<sup>13&#160;</sup>“Behold, I am against you,” says Yahweh of Armies, “and I will burn her chariots in the smoke, and the sword will devour your young lions; and I will cut off your prey from the earth, and the voice of your messengers will no longer be heard.” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Woe to the bloody city! It is all full of lies and robbery—no end to the prey. 
+<sup>2&#160;</sup>The noise of the whip, the noise of the rattling of wheels, prancing horses, and bounding chariots, 
+<sup>3&#160;</sup>the horseman charging, and the flashing sword, the glittering spear, and a multitude of slain, and a great heap of corpses, and there is no end of the bodies. They stumble on their bodies 
+<sup>4&#160;</sup>because of the multitude of the prostitution of the alluring prostitute, the mistress of witchcraft, who sells nations through her prostitution, and families through her witchcraft. 
+<sup>5&#160;</sup>“Behold, I am against you,” says Yahweh of Armies, “and I will lift your skirts over your face. I will show the nations your nakedness, and the kingdoms your shame. 
+<sup>6&#160;</sup>I will throw abominable filth on you and make you vile, and will make you a spectacle. 
+<sup>7&#160;</sup>It will happen that all those who look at you will flee from you, and say, ‘Nineveh is laid waste! Who will mourn for her?’ Where will I seek comforters for you?” 
+</div><div class="p">
+<sup>8&#160;</sup>Are you better than No-Amon, who had the waters around her, whose rampart was the sea, and her wall was of the sea? 
+<sup>9&#160;</sup>Cush and Egypt were her boundless strength. Put and Libya were her helpers. 
+<sup>10&#160;</sup>Yet was she carried away. She went into captivity. Her young children also were dashed in pieces at the head of all the streets, and they cast lots for her honorable men, and all her great men were bound in chains. 
+<sup>11&#160;</sup>You also will be drunken. You will be hidden. You also will seek a stronghold because of the enemy. 
+<sup>12&#160;</sup>All your fortresses will be like fig trees with the first-ripe figs. If they are shaken, they fall into the mouth of the eater. 
+<sup>13&#160;</sup>Behold, your troops among you are women. The gates of your land are set wide open to your enemies. The fire has devoured your bars. 
+</div><div class="p">
+<sup>14&#160;</sup>Draw water for the siege. Strengthen your fortresses. Go into the clay, and tread the mortar. Make the brick kiln strong. 
+<sup>15&#160;</sup>There the fire will devour you. The sword will cut you off. It will devour you like the grasshopper. Multiply like grasshoppers. Multiply like the locust. 
+<sup>16&#160;</sup>You have increased your merchants more than the stars of the skies. The grasshopper strips and flees away. 
+<sup>17&#160;</sup>Your guards are like the locusts, and your officials like the swarms of locusts, which settle on the walls on a cold day, but when the sun appears, they flee away, and their place is not known where they are. 
+</div><div class="p">
+<sup>18&#160;</sup>Your shepherds slumber, king of Assyria. Your nobles lie down. Your people are scattered on the mountains, and there is no one to gather them. 
+<sup>19&#160;</sup>There is no healing your wound, for your injury is fatal. All who hear the report of you clap their hands over you, for who hasn’t felt your endless cruelty? </div></div><script src="../main.js"></script></body></html>

--- a/book/nehemiah.html
+++ b/book/nehemiah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Nehemiah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,570 +53,584 @@
 <div class="main">
 <!-- NEH World English Scripture (WES) -->
 <h1 class="booklabel">Nehemiah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The words of Nehemiah the son of Hacaliah. 
-</p><p>Now in the month Chislev, in the twentieth year, as I was in Susa the palace, 
-<span class="v">2&#160;</span>Hanani, one of my brothers, came, he and certain men out of Judah; and I asked them about the Jews who had escaped, who were left of the captivity, and concerning Jerusalem. 
-<span class="v">3&#160;</span>They said to me, “The remnant who are left of the captivity there in the province are in great affliction and reproach. The wall of Jerusalem is also broken down, and its gates are burned with fire.” 
-</p><p>
-<span class="v">4&#160;</span>When I heard these words, I sat down and wept, and mourned several days; and I fasted and prayed before the Elohim<span class="f">+ \fr 1:4 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> of heaven, 
-<span class="v">5&#160;</span>and said, “I beg you, Yahweh,<span class="f">+ \fr 1:5 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> the Elohim of heaven, the great and awesome Elohim who keeps covenant and loving kindness with those who love him and keep his commandments, 
-<span class="v">6&#160;</span>let your ear now be attentive and your eyes open, that you may listen to the prayer of your servant which I pray before you at this time, day and night, for the children of Israel your servants, while I confess the sins of the children of Israel which we have sinned against you. Yes, I and my father’s house have sinned. 
-<span class="v">7&#160;</span>We have dealt very corruptly against you, and have not kept the commandments, nor the statutes, nor the ordinances, which you commanded your servant Moses. 
-</p><p>
-<span class="v">8&#160;</span>“Remember, I beg you, the word that you commanded your servant Moses, saying, ‘If you trespass, I will scatter you among the peoples; 
-<span class="v">9&#160;</span>but if you return to me, and keep my commandments and do them, though your outcasts were in the uttermost part of the heavens, yet I will gather them from there, and will bring them to the place that I have chosen, to cause my name to dwell there.’ 
-</p><p>
-<span class="v">10&#160;</span>“Now these are your servants and your people, whom you have redeemed by your great power and by your strong hand. 
-<span class="v">11&#160;</span>Lord,<span class="f">+ \fr 1:11 \ft The word translated “Lord” is “Adonai.”</span> I beg you, let your ear be attentive now to the prayer of your servant, and to the prayer of your servants who delight to fear your name; and please prosper your servant today, and grant him mercy in the sight of this man.” 
-</p><p>Now I was cup bearer to the king. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>In the month Nisan, in the twentieth year of Artaxerxes the king, when wine was before him, I picked up the wine, and gave it to the king. Now I had not been sad before in his presence. 
-<span class="v">2&#160;</span>The king said to me, “Why is your face sad, since you are not sick? This is nothing else but sorrow of heart.” 
-</p><p>Then I was very much afraid. 
-<span class="v">3&#160;</span>I said to the king, “Let the king live forever! Why shouldn’t my face be sad, when the city, the place of my fathers’ tombs, lies waste, and its gates have been consumed with fire?” 
-</p><p>
-<span class="v">4&#160;</span>Then the king said to me, “What is your request?” 
-</p><p>So I prayed to the Elohim of heaven. 
-<span class="v">5&#160;</span>I said to the king, “If it pleases the king, and if your servant has found favor in your sight, I ask that you would send me to Judah, to the city of my fathers’ tombs, that I may build it.” 
-</p><p>
-<span class="v">6&#160;</span>The king said to me (the queen was also sitting by him), “How long will your journey be? When will you return?” 
-</p><p>So it pleased the king to send me, and I set a time for him. 
-<span class="v">7&#160;</span>Moreover I said to the king, “If it pleases the king, let letters be given me to the governors beyond the River, that they may let me pass through until I come to Judah; 
-<span class="v">8&#160;</span>and a letter to Asaph the keeper of the king’s forest, that he may give me timber to make beams for the gates of the citadel by the temple, for the wall of the city, and for the house that I will occupy.” 
-</p><p>The king granted my requests, because of the good hand of my Elohim on me. 
-<span class="v">9&#160;</span>Then I came to the governors beyond the River, and gave them the king’s letters. Now the king had sent captains of the army and horsemen with me. 
-<span class="v">10&#160;</span>When Sanballat the Horonite and Tobiah the Ammonite servant heard of it, it grieved them exceedingly, because a man had come to seek the welfare of the children of Israel. 
-</p><p>
-<span class="v">11&#160;</span>So I came to Jerusalem, and was there three days. 
-<span class="v">12&#160;</span>I arose in the night, I and a few men with me. I didn’t tell anyone what my Elohim put into my heart to do for Jerusalem. There wasn’t any animal with me except the animal that I rode on. 
-<span class="v">13&#160;</span>I went out by night by the valley gate toward the jackal’s well, then to the dung gate; and I inspected the walls of Jerusalem, which were broken down, and its gates were consumed with fire. 
-<span class="v">14&#160;</span>Then I went on to the spring gate and to the king’s pool, but there was no place for the animal that was under me to pass. 
-<span class="v">15&#160;</span>Then I went up in the night by the brook and inspected the wall; and I turned back, and entered by the valley gate, and so returned. 
-<span class="v">16&#160;</span>The rulers didn’t know where I went, or what I did. I had not as yet told it to the Jews, nor to the priests, nor to the nobles, nor to the rulers, nor to the rest who did the work. 
-</p><p>
-<span class="v">17&#160;</span>Then I said to them, “You see the bad situation that we are in, how Jerusalem lies waste, and its gates are burned with fire. Come, let’s build up the wall of Jerusalem, that we won’t be disgraced.” 
-<span class="v">18&#160;</span>I told them about the hand of my Elohim which was good on me, and also about the king’s words that he had spoken to me. 
-</p><p>They said, “Let’s rise up and build.” So they strengthened their hands for the good work. 
-</p><p>
-<span class="v">19&#160;</span>But when Sanballat the Horonite, Tobiah the Ammonite servant, and Geshem the Arabian, heard it, they ridiculed us and despised us, and said, “What is this thing that you are doing? Will you rebel against the king?” 
-</p><p>
-<span class="v">20&#160;</span>Then I answered them, and said to them, “The Elohim of heaven will prosper us. Therefore we, his servants, will arise and build; but you have no portion, nor right, nor memorial in Jerusalem.” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Then Eliashib the high priest rose up with his brothers the priests, and they built the sheep gate. They sanctified it, and set up its doors. They sanctified it even to the tower of Hammeah, to the tower of Hananel. 
-<span class="v">2&#160;</span>Next to him the men of Jericho built. Next to them Zaccur the son of Imri built. 
-</p><p>
-<span class="v">3&#160;</span>The sons of Hassenaah built the fish gate. They laid its beams, and set up its doors, its bolts, and its bars. 
-<span class="v">4&#160;</span>Next to them, Meremoth the son of Uriah, the son of Hakkoz made repairs. Next to them, Meshullam the son of Berechiah, the son of Meshezabel made repairs. Next to them, Zadok the son of Baana made repairs. 
-<span class="v">5&#160;</span>Next to them, the Tekoites made repairs; but their nobles didn’t put their necks to the Lord’s work. 
-</p><p>
-<span class="v">6&#160;</span>Joiada the son of Paseah and Meshullam the son of Besodeiah repaired the old gate. They laid its beams and set up its doors, its bolts, and its bars. 
-<span class="v">7&#160;</span>Next to them, Melatiah the Gibeonite and Jadon the Meronothite, the men of Gibeon and of Mizpah, repaired the residence of the governor beyond the River. 
-<span class="v">8&#160;</span>Next to him, Uzziel the son of Harhaiah, goldsmiths, made repairs. Next to him, Hananiah, one of the perfumers, made repairs, and they fortified Jerusalem even to the wide wall. 
-<span class="v">9&#160;</span>Next to them, Rephaiah the son of Hur, the ruler of half the district of Jerusalem, made repairs. 
-<span class="v">10&#160;</span>Next to them, Jedaiah the son of Harumaph made repairs across from his house. Next to him, Hattush the son of Hashabneiah made repairs. 
-<span class="v">11&#160;</span>Malchijah the son of Harim and Hasshub the son of Pahathmoab repaired another portion and the tower of the furnaces. 
-<span class="v">12&#160;</span>Next to him, Shallum the son of Hallohesh, the ruler of half the district of Jerusalem, he and his daughters made repairs. 
-</p><p>
-<span class="v">13&#160;</span>Hanun and the inhabitants of Zanoah repaired the valley gate. They built it, and set up its doors, its bolts, and its bars, and one thousand cubits<span class="f">+ \fr 3:13 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> of the wall to the dung gate. 
-</p><p>
-<span class="v">14&#160;</span>Malchijah the son of Rechab, the ruler of the district of Beth Haccherem, repaired the dung gate. He built it, and set up its doors, its bolts, and its bars. 
-</p><p>
-<span class="v">15&#160;</span>Shallun the son of Colhozeh, the ruler of the district of Mizpah, repaired the spring gate. He built it, covered it, and set up its doors, its bolts, and its bars; and he repaired the wall of the pool of Shelah by the king’s garden, even to the stairs that go down from David’s city. 
-<span class="v">16&#160;</span>After him, Nehemiah the son of Azbuk, the ruler of half the district of Beth Zur, made repairs to the place opposite the tombs of David, and to the pool that was made, and to the house of the mighty men. 
-<span class="v">17&#160;</span>After him, the Levites—Rehum the son of Bani made repairs. Next to him, Hashabiah, the ruler of half the district of Keilah, made repairs for his district. 
-<span class="v">18&#160;</span>After him, their brothers, Bavvai the son of Henadad, the ruler of half the district of Keilah made repairs. 
-<span class="v">19&#160;</span>Next to him, Ezer the son of Jeshua, the ruler of Mizpah, repaired another portion across from the ascent to the armory at the turning of the wall. 
-<span class="v">20&#160;</span>After him, Baruch the son of Zabbai earnestly repaired another portion, from the turning of the wall to the door of the house of Eliashib the high priest. 
-<span class="v">21&#160;</span>After him, Meremoth the son of Uriah the son of Hakkoz repaired another portion, from the door of the house of Eliashib even to the end of the house of Eliashib. 
-<span class="v">22&#160;</span>After him, the priests, the men of the surrounding area made repairs. 
-<span class="v">23&#160;</span>After them, Benjamin and Hasshub made repairs across from their house. After them, Azariah the son of Maaseiah the son of Ananiah made repairs beside his own house. 
-<span class="v">24&#160;</span>After him, Binnui the son of Henadad repaired another portion, from the house of Azariah to the turning of the wall, and to the corner. 
-<span class="v">25&#160;</span>Palal the son of Uzai made repairs opposite the turning of the wall, and the tower that stands out from the upper house of the king, which is by the court of the guard. After him Pedaiah the son of Parosh made repairs. 
-<span class="v">26&#160;</span>(Now the temple servants lived in Ophel, to the place opposite the water gate toward the east, and the tower that stands out.) 
-<span class="v">27&#160;</span>After him the Tekoites repaired another portion, opposite the great tower that stands out, and to the wall of Ophel. 
-</p><p>
-<span class="v">28&#160;</span>Above the horse gate, the priests made repairs, everyone across from his own house. 
-<span class="v">29&#160;</span>After them, Zadok the son of Immer made repairs across from his own house. After him, Shemaiah the son of Shecaniah, the keeper of the east gate, made repairs. 
-<span class="v">30&#160;</span>After him, Hananiah the son of Shelemiah, and Hanun, the sixth son of Zalaph, repaired another portion. After him, Meshullam the son of Berechiah made repairs across from his room. 
-<span class="v">31&#160;</span>After him, Malchijah, one of the goldsmiths to the house of the temple servants, and of the merchants, made repairs opposite the gate of Hammiphkad and to the ascent of the corner. 
-<span class="v">32&#160;</span>Between the ascent of the corner and the sheep gate, the goldsmiths and the merchants made repairs. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>But when Sanballat heard that we were building the wall, he was angry, and was very indignant, and mocked the Jews. 
-<span class="v">2&#160;</span>He spoke before his brothers and the army of Samaria, and said, “What are these feeble Jews doing? Will they fortify themselves? Will they sacrifice? Will they finish in a day? Will they revive the stones out of the heaps of rubbish, since they are burned?” 
-</p><p>
-<span class="v">3&#160;</span>Now Tobiah the Ammonite was by him, and he said, “What they are building, if a fox climbed up it, he would break down their stone wall.” 
-</p><p>
-<span class="v">4&#160;</span>“Hear, our Elohim, for we are despised. Turn back their reproach on their own head. Give them up for a plunder in a land of captivity. 
-<span class="v">5&#160;</span>Don’t cover their iniquity. Don’t let their sin be blotted out from before you; for they have insulted the builders.” 
-</p><p>
-<span class="v">6&#160;</span>So we built the wall; and all the wall was joined together to half its height, for the people had a mind to work. 
-</p><p>
-<span class="v">7&#160;</span>But when Sanballat, Tobiah, the Arabians, the Ammonites, and the Ashdodites heard that the repairing of the walls of Jerusalem went forward, and that the breaches began to be filled, they were very angry; 
-<span class="v">8&#160;</span>and they all conspired together to come and fight against Jerusalem, and to cause confusion among us. 
-<span class="v">9&#160;</span>But we made our prayer to our Elohim, and set a watch against them day and night because of them. 
-</p><p>
-<span class="v">10&#160;</span>Judah said, “The strength of the bearers of burdens is fading and there is much rubble, so that we are not able to build the wall.” 
-<span class="v">11&#160;</span>Our adversaries said, “They will not know or see, until we come in among them and kill them, and cause the work to cease.” 
-</p><p>
-<span class="v">12&#160;</span>When the Jews who lived by them came, they said to us ten times from all places, “Wherever you turn, they will attack us.” 
-</p><p>
-<span class="v">13&#160;</span>Therefore I set guards in the lowest parts of the space behind the wall, in the open places. I set the people by family groups with their swords, their spears, and their bows. 
-<span class="v">14&#160;</span>I looked, and rose up, and said to the nobles, to the rulers, and to the rest of the people, “Don’t be afraid of them! Remember the Lord, who is great and awesome, and fight for your brothers, your sons, your daughters, your women, and your houses.” 
-</p><p>
-<span class="v">15&#160;</span>When our enemies heard that it was known to us, and Elohim had brought their counsel to nothing, all of us returned to the wall, everyone to his work. 
-<span class="v">16&#160;</span>From that time forth, half of my servants did the work, and half of them held the spears, the shields, the bows, and the coats of mail; and the rulers were behind all the house of Judah. 
-<span class="v">17&#160;</span>Those who built the wall, and those who bore burdens loaded themselves; everyone with one of his hands did the work, and with the other held his weapon. 
-<span class="v">18&#160;</span>Among the builders, everyone wore his sword at his side, and so built. He who sounded the trumpet was by me. 
-<span class="v">19&#160;</span>I said to the nobles, and to the rulers and to the rest of the people, “The work is great and widely spread out, and we are separated on the wall, far from one another. 
-<span class="v">20&#160;</span>Wherever you hear the sound of the trumpet, rally there to us. Our Elohim will fight for us.” 
-</p><p>
-<span class="v">21&#160;</span>So we did the work. Half of the people held the spears from the rising of the morning until the stars appeared. 
-<span class="v">22&#160;</span>Likewise at the same time I said to the people, “Let everyone with his servant lodge within Jerusalem, that in the night they may be a guard to us, and may labor in the day.” 
-<span class="v">23&#160;</span>So neither I, nor my brothers, nor my servants, nor the men of the guard who followed me took off our clothes. Everyone took his weapon to the water. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Then there arose a great cry of the people and of their women against their brothers the Jews. 
-<span class="v">2&#160;</span>For there were some who said, “We, our sons and our daughters, are many. Let us get grain, that we may eat and live.” 
-<span class="v">3&#160;</span>There were also some who said, “We are mortgaging our fields, our vineyards, and our houses. Let us get grain, because of the famine.” 
-<span class="v">4&#160;</span>There were also some who said, “We have borrowed money for the king’s tribute using our fields and our vineyards as collateral. 
-<span class="v">5&#160;</span>Yet now our flesh is as the flesh of our brothers, our children as their children. Behold,<span class="f">+ \fr 5:5 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> we bring our sons and our daughters into bondage to be servants, and some of our daughters have been brought into bondage. It is also not in our power to help it, because other men have our fields and our vineyards.” 
-</p><p>
-<span class="v">6&#160;</span>I was very angry when I heard their cry and these words. 
-<span class="v">7&#160;</span>Then I consulted with myself, and contended with the nobles and the rulers, and said to them, “You exact usury, everyone of his brother.” I held a great assembly against them. 
-<span class="v">8&#160;</span>I said to them, “We, after our ability, have redeemed our brothers the Jews that were sold to the nations; and would you even sell your brothers, and should they be sold to us?” Then they held their peace, and found not a word to say. 
-<span class="v">9&#160;</span>Also I said, “The thing that you do is not good. Shouldn’t you walk in the fear of our Elohim because of the reproach of the nations, our enemies? 
-<span class="v">10&#160;</span>I likewise, my brothers and my servants, lend them money and grain. Please let us stop this usury. 
-<span class="v">11&#160;</span>Please restore to them, even today, their fields, their vineyards, their olive groves, and their houses, also the hundredth part of the money, and of the grain, the new wine, and the oil, that you are charging them.” 
-</p><p>
-<span class="v">12&#160;</span>Then they said, “We will restore them, and will require nothing of them. We will do so, even as you say.” 
-</p><p>Then I called the priests, and took an oath of them, that they would do according to this promise. 
-<span class="v">13&#160;</span>Also I shook out my lap, and said, “So may Elohim shake out every man from his house, and from his labor, that doesn’t perform this promise; even may he be shaken out and emptied like this.” 
-</p><p>All the assembly said, “Amen,” and praised Yahweh. The people did according to this promise. 
-</p><p>
-<span class="v">14&#160;</span>Moreover from the time that I was appointed to be their governor in the land of Judah, from the twentieth year even to the thirty-second year of Artaxerxes the king, that is, twelve years, I and my brothers have not eaten the bread of the governor. 
-<span class="v">15&#160;</span>But the former governors who were before me were supported by the people, and took bread and wine from them, plus forty shekels<span class="f">+ \fr 5:15 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of silver; yes, even their servants ruled over the people, but I didn’t do so, because of the fear of Elohim. 
-<span class="v">16&#160;</span>Yes, I also continued in the work of this wall. We didn’t buy any land. All my servants were gathered there to the work. 
-<span class="v">17&#160;</span>Moreover there were at my table, of the Jews and the rulers, one hundred fifty men, in addition to those who came to us from among the nations that were around us. 
-<span class="v">18&#160;</span>Now that which was prepared for one day was one ox and six choice sheep. Also fowls were prepared for me, and once in ten days a store of all sorts of wine. Yet for all this, I didn’t demand the governor’s pay, because the bondage was heavy on this people. 
-<span class="v">19&#160;</span>Remember me, my Elohim, for all the good that I have done for this people. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Now when it was reported to Sanballat, Tobiah, Geshem the Arabian, and to the rest of our enemies that I had built the wall, and that there was no breach left in it (though even to that time I had not set up the doors in the gates), 
-<span class="v">2&#160;</span>Sanballat and Geshem sent to me, saying, “Come! Let’s meet together in the villages in the plain of Ono.” But they intended to harm me. 
-</p><p>
-<span class="v">3&#160;</span>I sent messengers to them, saying, “I am doing a great work, so that I can’t come down. Why should the work cease while I leave it and come down to you?” 
-</p><p>
-<span class="v">4&#160;</span>They sent to me four times like this; and I answered them the same way. 
-<span class="v">5&#160;</span>Then Sanballat sent his servant to me the same way the fifth time with an open letter in his hand, 
-<span class="v">6&#160;</span>in which was written, “It is reported among the nations, and Gashmu says it, that you and the Jews intend to rebel. Because of that, you are building the wall. You would be their king, according to these words. 
-<span class="v">7&#160;</span>You have also appointed prophets to proclaim of you at Jerusalem, saying, ‘There is a king in Judah!’ Now it will be reported to the king according to these words. Come now therefore, and let’s take counsel together.” 
-</p><p>
-<span class="v">8&#160;</span>Then I sent to him, saying, “There are no such things done as you say, but you imagine them out of your own heart.” 
-<span class="v">9&#160;</span>For they all would have made us afraid, saying, “Their hands will be weakened from the work, that it not be done.” But now, strengthen my hands. 
-</p><p>
-<span class="v">10&#160;</span>I went to the house of Shemaiah the son of Delaiah the son of Mehetabel, who was shut in at his home; and he said, “Let us meet together in Elohim’s house, within the temple, and let’s shut the doors of the temple; for they will come to kill you. Yes, in the night they will come to kill you.” 
-</p><p>
-<span class="v">11&#160;</span>I said, “Should a man like me flee? Who is there that, being such as I, would go into the temple to save his life? I will not go in.” 
-<span class="v">12&#160;</span>I discerned, and behold, Elohim had not sent him, but he pronounced this prophecy against me. Tobiah and Sanballat had hired him. 
-<span class="v">13&#160;</span>He was hired so that I would be afraid, do so, and sin, and that they might have material for an evil report, that they might reproach me. 
-<span class="v">14&#160;</span>“Remember, my Elohim, Tobiah and Sanballat according to these their works, and also the prophetess Noadiah and the rest of the prophets that would have put me in fear.” 
-</p><p>
-<span class="v">15&#160;</span>So the wall was finished in the twenty-fifth day of Elul, in fifty-two days. 
-<span class="v">16&#160;</span>When all our enemies heard of it, all the nations that were around us were afraid, and they lost their confidence; for they perceived that this work was done by our Elohim. 
-<span class="v">17&#160;</span>Moreover in those days the nobles of Judah sent many letters to Tobiah, and Tobiah’s letters came to them. 
-<span class="v">18&#160;</span>For there were many in Judah sworn to him because he was the son-in-law of Shecaniah the son of Arah; and his son Jehohanan had taken the daughter of Meshullam the son of Berechiah as woman. 
-<span class="v">19&#160;</span>Also they spoke of his good deeds before me, and reported my words to him. Tobiah sent letters to put me in fear. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>Now when the wall was built and I had set up the doors, and the gatekeepers and the singers and the Levites were appointed, 
-<span class="v">2&#160;</span>I put my brother Hanani, and Hananiah the governor of the fortress, in charge of Jerusalem; for he was a faithful man and feared Elohim above many. 
-<span class="v">3&#160;</span>I said to them, “Don’t let the gates of Jerusalem be opened until the sun is hot; and while they stand guard, let them shut the doors, and you bar them; and appoint watches of the inhabitants of Jerusalem, everyone in his watch, with everyone near his house.” 
-</p><p>
-<span class="v">4&#160;</span>Now the city was wide and large; but the people were few therein, and the houses were not built. 
-</p><p>
-<span class="v">5&#160;</span>My Elohim put into my heart to gather together the nobles, and the rulers, and the people, that they might be listed by genealogy. I found the book of the genealogy of those who came up at the first, and I found this written in it: 
-</p><p>
-<span class="v">6&#160;</span>These are the children of the province who went up out of the captivity of those who had been carried away, whom Nebuchadnezzar the king of Babylon had carried away, and who returned to Jerusalem and to Judah, everyone to his city, 
-<span class="v">7&#160;</span>who came with Zerubbabel, Jeshua, Nehemiah, Azariah, Raamiah, Nahamani, Mordecai, Bilshan, Mispereth, Bigvai, Nehum, and Baanah. 
-</p><p>The number of the men of the people of Israel: 
-</p><p class="li1">
-<span class="v">8&#160;</span>The children of Parosh: two thousand one hundred seventy-two. 
-</p><p class="li1">
-<span class="v">9&#160;</span>The children of Shephatiah: three hundred seventy-two. 
-</p><p class="li1">
-<span class="v">10&#160;</span>The children of Arah: six hundred fifty-two. 
-</p><p class="li1">
-<span class="v">11&#160;</span>The children of Pahathmoab, of the children of Jeshua and Joab: two thousand eight hundred eighteen. 
-</p><p class="li1">
-<span class="v">12&#160;</span>The children of Elam: one thousand two hundred fifty-four. 
-</p><p class="li1">
-<span class="v">13&#160;</span>The children of Zattu: eight hundred forty-five. 
-</p><p class="li1">
-<span class="v">14&#160;</span>The children of Zaccai: seven hundred sixty. 
-</p><p class="li1">
-<span class="v">15&#160;</span>The children of Binnui: six hundred forty-eight. 
-</p><p class="li1">
-<span class="v">16&#160;</span>The children of Bebai: six hundred twenty-eight. 
-</p><p class="li1">
-<span class="v">17&#160;</span>The children of Azgad: two thousand three hundred twenty-two. 
-</p><p class="li1">
-<span class="v">18&#160;</span>The children of Adonikam: six hundred sixty-seven. 
-</p><p class="li1">
-<span class="v">19&#160;</span>The children of Bigvai: two thousand sixty-seven. 
-</p><p class="li1">
-<span class="v">20&#160;</span>The children of Adin: six hundred fifty-five. 
-</p><p class="li1">
-<span class="v">21&#160;</span>The children of Ater: of Hezekiah, ninety-eight. 
-</p><p class="li1">
-<span class="v">22&#160;</span>The children of Hashum: three hundred twenty-eight. 
-</p><p class="li1">
-<span class="v">23&#160;</span>The children of Bezai: three hundred twenty-four. 
-</p><p class="li1">
-<span class="v">24&#160;</span>The children of Hariph: one hundred twelve. 
-</p><p class="li1">
-<span class="v">25&#160;</span>The children of Gibeon: ninety-five. 
-</p><p class="li1">
-<span class="v">26&#160;</span>The men of Bethlehem and Netophah: one hundred eighty-eight. 
-</p><p class="li1">
-<span class="v">27&#160;</span>The men of Anathoth: one hundred twenty-eight. 
-</p><p class="li1">
-<span class="v">28&#160;</span>The men of Beth Azmaveth: forty-two. 
-</p><p class="li1">
-<span class="v">29&#160;</span>The men of Kiriath Jearim, Chephirah, and Beeroth: seven hundred forty-three. 
-</p><p class="li1">
-<span class="v">30&#160;</span>The men of Ramah and Geba: six hundred twenty-one. 
-</p><p class="li1">
-<span class="v">31&#160;</span>The men of Michmas: one hundred twenty-two. 
-</p><p class="li1">
-<span class="v">32&#160;</span>The men of Bethel and Ai: one hundred twenty-three. 
-</p><p class="li1">
-<span class="v">33&#160;</span>The men of the other Nebo: fifty-two. 
-</p><p class="li1">
-<span class="v">34&#160;</span>The children of the other Elam: one thousand two hundred fifty-four. 
-</p><p class="li1">
-<span class="v">35&#160;</span>The children of Harim: three hundred twenty. 
-</p><p class="li1">
-<span class="v">36&#160;</span>The children of Jericho: three hundred forty-five. 
-</p><p class="li1">
-<span class="v">37&#160;</span>The children of Lod, Hadid, and Ono: seven hundred twenty-one. 
-</p><p class="li1">
-<span class="v">38&#160;</span>The children of Senaah: three thousand nine hundred thirty. 
-</p><div class="b"> &#160; </div>
-<p class="li1">
-<span class="v">39&#160;</span>The priests: The children of Jedaiah, of the house of Jeshua: nine hundred seventy-three. 
-</p><p class="li1">
-<span class="v">40&#160;</span>The children of Immer: one thousand fifty-two. 
-</p><p class="li1">
-<span class="v">41&#160;</span>The children of Pashhur: one thousand two hundred forty-seven. 
-</p><p class="li1">
-<span class="v">42&#160;</span>The children of Harim: one thousand seventeen. 
-</p><div class="b"> &#160; </div>
-<p class="li1">
-<span class="v">43&#160;</span>The Levites: the children of Jeshua, of Kadmiel, of the children of Hodevah: seventy-four. 
-</p><p class="li1">
-<span class="v">44&#160;</span>The singers: the children of Asaph: one hundred forty-eight. 
-</p><p class="li1">
-<span class="v">45&#160;</span>The gatekeepers: the children of Shallum, the children of Ater, the children of Talmon, the children of Akkub, the children of Hatita, the children of Shobai: one hundred thirty-eight. 
-</p><p>
-<span class="v">46&#160;</span>The temple servants: the children of Ziha, the children of Hasupha, the children of Tabbaoth, 
-<span class="v">47&#160;</span>the children of Keros, the children of Sia, the children of Padon, 
-<span class="v">48&#160;</span>the children of Lebana, the children of Hagaba, the children of Salmai, 
-<span class="v">49&#160;</span>the children of Hanan, the children of Giddel, the children of Gahar, 
-<span class="v">50&#160;</span>the children of Reaiah, the children of Rezin, the children of Nekoda, 
-<span class="v">51&#160;</span>the children of Gazzam, the children of Uzza, the children of Paseah, 
-<span class="v">52&#160;</span>the children of Besai, the children of Meunim, the children of Nephushesim, 
-<span class="v">53&#160;</span>the children of Bakbuk, the children of Hakupha, the children of Harhur, 
-<span class="v">54&#160;</span>the children of Bazlith, the children of Mehida, the children of Harsha, 
-<span class="v">55&#160;</span>the children of Barkos, the children of Sisera, the children of Temah, 
-<span class="v">56&#160;</span>the children of Neziah, and the children of Hatipha. 
-</p><p>
-<span class="v">57&#160;</span>The children of Solomon’s servants: the children of Sotai, the children of Sophereth, the children of Perida, 
-<span class="v">58&#160;</span>the children of Jaala, the children of Darkon, the children of Giddel, 
-<span class="v">59&#160;</span>the children of Shephatiah, the children of Hattil, the children of Pochereth Hazzebaim, and the children of Amon. 
-<span class="v">60&#160;</span>All the temple servants and the children of Solomon’s servants were three hundred ninety-two. 
-</p><p>
-<span class="v">61&#160;</span>These were those who went up from Tel Melah, Tel Harsha, Cherub, Addon, and Immer; but they could not show their fathers’ houses, nor their offspring,<span class="f">+ \fr 7:61 \ft or, seed</span> whether they were of Israel: 
-</p><p class="li1">
-<span class="v">62&#160;</span>The children of Delaiah, the children of Tobiah, the children of Nekoda: six hundred forty-two. 
-</p><p class="li1">
-<span class="v">63&#160;</span>Of the priests: the children of Hobaiah, the children of Hakkoz, the children of Barzillai, who took a woman of the daughters of Barzillai the Gileadite, and was called after their name. 
-</p><p>
-<span class="v">64&#160;</span>These searched for their genealogical records, but couldn’t find them. Therefore they were deemed disqualified and removed from the priesthood. 
-<span class="v">65&#160;</span>The governor told them not to eat of the most set-apart things until a priest stood up to minister with Urim and Thummim. 
-</p><p>
-<span class="v">66&#160;</span>The whole assembly together was forty-two thousand three hundred sixty, 
-<span class="v">67&#160;</span>in addition to their male servants and their female servants, of whom there were seven thousand three hundred thirty-seven. They had two hundred forty-five singing men and singing women. 
-<span class="v">68&#160;</span>Their horses were seven hundred thirty-six; their mules, two hundred forty-five; 
-<span class="v">69&#160;</span>their camels, four hundred thirty-five; their donkeys, six thousand seven hundred twenty. 
-</p><p>
-<span class="v">70&#160;</span>Some from among the heads of fathers’ households gave to the work. The governor gave to the treasury one thousand darics of gold,<span class="f">+ \fr 7:70 \ft a daric was a gold coin issued by a Persian king, weighing about 8.4 grams or about 0.27 troy ounces each.</span> fifty basins, and five hundred thirty priests’ garments. 
-<span class="v">71&#160;</span>Some of the heads of fathers’ households gave into the treasury of the work twenty thousand darics of gold, and two thousand two hundred minas<span class="f">+ \fr 7:71 \ft A mina is about 600 grams or 1.3 U. S. pounds, so 2,200 minas is about 1.3 metric tons.</span> of silver. 
-<span class="v">72&#160;</span>That which the rest of the people gave was twenty thousand darics of gold, plus two thousand minas of silver, and sixty-seven priests’ garments. 
-</p><p>
-<span class="v">73&#160;</span>So the priests, the Levites, the gatekeepers, the singers, some of the people, the temple servants, and all Israel lived in their cities. 
-</p><p>When the seventh month had come, the children of Israel were in their cities. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>All the people gathered themselves together as one man into the wide place that was in front of the water gate; and they spoke to Ezra the scribe to bring the book of the law of Moses, which Yahweh had commanded to Israel. 
-<span class="v">2&#160;</span>Ezra the priest brought the law before the assembly, both men and women, and all who could hear with understanding, on the first day of the seventh month. 
-<span class="v">3&#160;</span>He read from it before the wide place that was in front of the water gate from early morning until midday, in the presence of the men and the women, and of those who could understand. The ears of all the people were attentive to the book of the law. 
-<span class="v">4&#160;</span>Ezra the scribe stood on a pulpit of wood, which they had made for the purpose; and beside him stood Mattithiah, Shema, Anaiah, Uriah, Hilkiah, and Maaseiah, on his right hand; and on his left hand, Pedaiah, Mishael, Malchijah, Hashum, Hashbaddanah, Zechariah, and Meshullam. 
-<span class="v">5&#160;</span>Ezra opened the book in the sight of all the people (for he was above all the people), and when he opened it, all the people stood up. 
-<span class="v">6&#160;</span>Then Ezra blessed Yahweh, the great Elohim. 
-</p><p>All the people answered, “Amen, Amen,” with the lifting up of their hands. They bowed their heads, and worshiped Yahweh with their faces to the ground. 
-<span class="v">7&#160;</span>Also Jeshua, Bani, Sherebiah, Jamin, Akkub, Shabbethai, Hodiah, Maaseiah, Kelita, Azariah, Jozabad, Hanan, Pelaiah, and the Levites, caused the people to understand the law; and the people stayed in their place. 
-<span class="v">8&#160;</span>They read in the book, in the law of Elohim, distinctly; and they gave the sense, so that they understood the reading. 
-</p><p>
-<span class="v">9&#160;</span>Nehemiah, who was the governor, Ezra the priest and scribe, and the Levites who taught the people said to all the people, “Today is set-apart to Yahweh your Elohim. Don’t mourn, nor weep.” For all the people wept when they heard the words of the law. 
-<span class="v">10&#160;</span>Then he said to them, “Go your way. Eat the fat, drink the sweet, and send portions to him for whom nothing is prepared, for today is set-apart to our Lord. Don’t be grieved, for the joy of Yahweh is your strength.” 
-</p><p>
-<span class="v">11&#160;</span>So the Levites calmed all the people, saying, “Hold your peace, for the day is set-apart. Don’t be grieved.” 
-</p><p>
-<span class="v">12&#160;</span>All the people went their way to eat, to drink, to send portions, and to celebrate, because they had understood the words that were declared to them. 
-</p><p>
-<span class="v">13&#160;</span>On the second day, the heads of fathers’ households of all the people, the priests, and the Levites were gathered together to Ezra the scribe, to study the words of the law. 
-<span class="v">14&#160;</span>They found written in the law how Yahweh had commanded by Moses that the children of Israel should dwell in booths in the feast of the seventh month; 
-<span class="v">15&#160;</span>and that they should publish and proclaim in all their cities and in Jerusalem, saying, “Go out to the mountain, and get olive branches, branches of wild olive, myrtle branches, palm branches, and branches of thick trees, to make temporary shelters,<span class="f">+ \fr 8:15 \ft or, booths</span> as it is written.” 
-</p><p>
-<span class="v">16&#160;</span>So the people went out and brought them, and made themselves temporary shelters,<span class="f">+ \fr 8:16 \ft or, booths</span> everyone on the roof of his house, in their courts, in the courts of Elohim’s house, in the wide place of the water gate, and in the wide place of Ephraim’s gate. 
-<span class="v">17&#160;</span>All the assembly of those who had come back out of the captivity made temporary shelters<span class="f">+ \fr 8:17 \ft or, booths</span> and lived in the temporary shelters, for since the days of Joshua the son of Nun to that day the children of Israel had not done so. There was very great gladness. 
-<span class="v">18&#160;</span>Also day by day, from the first day to the last day, he read in the book of the law of Elohim. They kept the feast seven days; and on the eighth day was a solemn assembly, according to the ordinance. 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Now in the twenty-fourth day of this month the children of Israel were assembled with fasting, with sackcloth, and dirt on them. 
-<span class="v">2&#160;</span>The offspring of Israel separated themselves from all foreigners and stood and confessed their sins and the iniquities of their fathers. 
-<span class="v">3&#160;</span>They stood up in their place, and read in the book of the law of Yahweh their Elohim a fourth part of the day; and a fourth part they confessed and worshiped Yahweh their Elohim. 
-<span class="v">4&#160;</span>Then Jeshua, Bani, Kadmiel, Shebaniah, Bunni, Sherebiah, Bani, and Chenani of the Levites stood up on the stairs, and cried with a loud voice to Yahweh their Elohim. 
-</p><p>
-<span class="v">5&#160;</span>Then the Levites, Jeshua, and Kadmiel, Bani, Hashabneiah, Sherebiah, Hodiah, Shebaniah, and Pethahiah, said, “Stand up and bless Yahweh your Elohim from everlasting to everlasting! Blessed be your glorious name, which is exalted above all blessing and praise! 
-<span class="v">6&#160;</span>You are Yahweh, even you alone. You have made heaven, the heaven of heavens, with all their army, the earth and all things that are on it, the seas and all that is in them, and you preserve them all. The army of heaven worships you. 
-<span class="v">7&#160;</span>You are Yahweh, the Elohim who chose Abram, brought him out of Ur of the Chaldees, gave him the name of Abraham, 
-<span class="v">8&#160;</span>found his heart faithful before you, and made a covenant with him to give the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Jebusite, and the Girgashite, to give it to his offspring, and have performed your words, for you are righteous. 
-</p><p>
-<span class="v">9&#160;</span>“You saw the affliction of our fathers in Egypt, and heard their cry by the Red Sea, 
-<span class="v">10&#160;</span>and showed signs and wonders against Pharaoh, against all his servants, and against all the people of his land, for you knew that they dealt proudly against them, and made a name for yourself, as it is today. 
-<span class="v">11&#160;</span>You divided the sea before them, so that they went through the middle of the sea on the dry land; and you cast their pursuers into the depths, as a stone into the mighty waters. 
-<span class="v">12&#160;</span>Moreover, in a pillar of cloud you led them by day; and in a pillar of fire by night, to give them light in the way in which they should go. 
-</p><p>
-<span class="v">13&#160;</span>“You also came down on Mount Sinai, and spoke with them from heaven, and gave them right ordinances and true laws, good statutes and commandments, 
-<span class="v">14&#160;</span>and made known to them your set-apart Sabbath, and commanded them commandments, statutes, and a law, by Moses your servant, 
-<span class="v">15&#160;</span>and gave them bread from the sky for their hunger, and brought water out of the rock for them for their thirst, and commanded them that they should go in to possess the land which you had sworn to give them. 
-</p><p>
-<span class="v">16&#160;</span>“But they and our fathers behaved proudly, hardened their neck, didn’t listen to your commandments, 
-<span class="v">17&#160;</span>and refused to obey. They weren’t mindful of your wonders that you did among them, but hardened their neck, and in their rebellion appointed a captain to return to their bondage. But you are an Elohim ready to pardon, gracious and merciful, slow to anger, and abundant in loving kindness, and didn’t forsake them. 
-<span class="v">18&#160;</span>Yes, when they had made themselves a molded calf, and said, ‘This is your Elohim who brought you up out of Egypt,’ and had committed awful blasphemies, 
-<span class="v">19&#160;</span>yet you in your manifold mercies didn’t forsake them in the wilderness. The pillar of cloud didn’t depart from over them by day, to lead them in the way; neither did the pillar of fire by night, to show them light, and the way in which they should go. 
-<span class="v">20&#160;</span>You gave also your good Spirit to instruct them, and didn’t withhold your manna from their mouth, and gave them water for their thirst. 
-</p><p>
-<span class="v">21&#160;</span>“Yes, forty years you sustained them in the wilderness. They lacked nothing. Their clothes didn’t grow old, and their feet didn’t swell. 
-<span class="v">22&#160;</span>Moreover you gave them kingdoms and peoples, which you allotted according to their portions. So they possessed the land of Sihon, even the land of the king of Heshbon, and the land of Og king of Bashan. 
-<span class="v">23&#160;</span>You also multiplied their children as the stars of the sky, and brought them into the land concerning which you said to their fathers that they should go in to possess it. 
-</p><p>
-<span class="v">24&#160;</span>“So the children went in and possessed the land; and you subdued before them the inhabitants of the land, the Canaanites, and gave them into their hands, with their kings and the peoples of the land, that they might do with them as they pleased. 
-<span class="v">25&#160;</span>They took fortified cities and a rich land, and possessed houses full of all good things, cisterns dug out, vineyards, olive groves, and fruit trees in abundance. So they ate, were filled, became fat, and delighted themselves in your great goodness. 
-</p><p>
-<span class="v">26&#160;</span>“Nevertheless they were disobedient and rebelled against you, cast your law behind their back, killed your prophets that testified against them to turn them again to you, and they committed awful blasphemies. 
-<span class="v">27&#160;</span>Therefore you delivered them into the hand of their adversaries, who distressed them. In the time of their trouble, when they cried to you, you heard from heaven; and according to your manifold mercies you gave them saviors who saved them out of the hands of their adversaries. 
-<span class="v">28&#160;</span>But after they had rest, they did evil again before you; therefore you left them in the hands of their enemies, so that they had the dominion over them; yet when they returned and cried to you, you heard from heaven; and many times you delivered them according to your mercies, 
-<span class="v">29&#160;</span>and testified against them, that you might bring them again to your law. Yet they were arrogant, and didn’t listen to your commandments, but sinned against your ordinances (which if a man does, he shall live in them), turned their backs, stiffened their neck, and would not hear. 
-<span class="v">30&#160;</span>Yet many years you put up with them, and testified against them by your Spirit through your prophets. Yet they would not listen. Therefore you gave them into the hand of the peoples of the lands. 
-</p><p>
-<span class="v">31&#160;</span>“Nevertheless in your manifold mercies you didn’t make a full end of them, nor forsake them; for you are a gracious and merciful Elohim. 
-</p><p>
-<span class="v">32&#160;</span>Now therefore, our Elohim, the great, the mighty, and the awesome Elohim, who keeps covenant and loving kindness, don’t let all the travail seem little before you that has come on us, on our kings, on our princes, on our priests, on our prophets, on our fathers, and on all your people, since the time of the kings of Assyria to this day. 
-<span class="v">33&#160;</span>However you are just in all that has come on us; for you have dealt truly, but we have done wickedly. 
-<span class="v">34&#160;</span>Also our kings, our princes, our priests, and our fathers have not kept your law, nor listened to your commandments and your testimonies with which you testified against them. 
-<span class="v">35&#160;</span>For they have not served you in their kingdom, and in your great goodness that you gave them, and in the large and rich land which you gave before them. They didn’t turn from their wicked works. 
-</p><p>
-<span class="v">36&#160;</span>“Behold, we are servants today, and as for the land that you gave to our fathers to eat its fruit and its good, behold, we are servants in it. 
-<span class="v">37&#160;</span>It yields much increase to the kings whom you have set over us because of our sins. Also they have power over our bodies and over our livestock, at their pleasure, and we are in great distress. 
-<span class="v">38&#160;</span>Yet for all this, we make a sure covenant, and write it; and our princes, our Levites, and our priests, seal it.” 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Now those who sealed were: Nehemiah the governor, the son of Hacaliah, and Zedekiah, 
-<span class="v">2&#160;</span>Seraiah, Azariah, Jeremiah, 
-<span class="v">3&#160;</span>Pashhur, Amariah, Malchijah, 
-<span class="v">4&#160;</span>Hattush, Shebaniah, Malluch, 
-<span class="v">5&#160;</span>Harim, Meremoth, Obadiah, 
-<span class="v">6&#160;</span>Daniel, Ginnethon, Baruch, 
-<span class="v">7&#160;</span>Meshullam, Abijah, Mijamin, 
-<span class="v">8&#160;</span>Maaziah, Bilgai, and Shemaiah. These were the priests. 
-<span class="v">9&#160;</span>The Levites: Jeshua the son of Azaniah, Binnui of the sons of Henadad, Kadmiel; 
-<span class="v">10&#160;</span>and their brothers, Shebaniah, Hodiah, Kelita, Pelaiah, Hanan, 
-<span class="v">11&#160;</span>Mica, Rehob, Hashabiah, 
-<span class="v">12&#160;</span>Zaccur, Sherebiah, Shebaniah, 
-<span class="v">13&#160;</span>Hodiah, Bani, and Beninu. 
-<span class="v">14&#160;</span>The chiefs of the people: Parosh, Pahathmoab, Elam, Zattu, Bani, 
-<span class="v">15&#160;</span>Bunni, Azgad, Bebai, 
-<span class="v">16&#160;</span>Adonijah, Bigvai, Adin, 
-<span class="v">17&#160;</span>Ater, Hezekiah, Azzur, 
-<span class="v">18&#160;</span>Hodiah, Hashum, Bezai, 
-<span class="v">19&#160;</span>Hariph, Anathoth, Nobai, 
-<span class="v">20&#160;</span>Magpiash, Meshullam, Hezir, 
-<span class="v">21&#160;</span>Meshezabel, Zadok, Jaddua, 
-<span class="v">22&#160;</span>Pelatiah, Hanan, Anaiah, 
-<span class="v">23&#160;</span>Hoshea, Hananiah, Hasshub, 
-<span class="v">24&#160;</span>Hallohesh, Pilha, Shobek, 
-<span class="v">25&#160;</span>Rehum, Hashabnah, Maaseiah, 
-<span class="v">26&#160;</span>Ahiah, Hanan, Anan, 
-<span class="v">27&#160;</span>Malluch, Harim, and Baanah. 
-</p><p>
-<span class="v">28&#160;</span>The rest of the people, the priests, the Levites, the gatekeepers, the singers, the temple servants, and all those who had separated themselves from the peoples of the lands to the law of Elohim, their women, their sons, and their daughters—everyone who had knowledge and understanding—<span class="v">29&#160;</span>joined with their brothers, their nobles, and entered into a curse and into an oath, to walk in Elohim’s law, which was given by Moses the servant of Elohim, and to observe and do all the commandments of Yahweh our Lord, and his ordinances and his statutes; 
-<span class="v">30&#160;</span>and that we would not give our daughters to the peoples of the land, nor take their daughters for our sons; 
-<span class="v">31&#160;</span>and if the peoples of the land bring wares or any grain on the Sabbath day to sell, that we would not buy from them on the Sabbath, or on a set-apart day; and that we would forego the seventh year crops and the exaction of every debt. 
-</p><p>
-<span class="v">32&#160;</span>Also we made ordinances for ourselves, to charge ourselves yearly with the third part of a shekel<span class="f">+ \fr 10:32 \ft A shekel is about 10 grams or about 0.35 ounces.</span> for the service of the house of our Elohim: 
-<span class="v">33&#160;</span>for the show bread, for the continual meal offering, for the continual burnt offering, for the Sabbaths, for the new moons, for the set feasts, for the set-apart things, for the sin offerings to make atonement for Israel, and for all the work of the house of our Elohim. 
-<span class="v">34&#160;</span>We, the priests, the Levites, and the people, cast lots for the wood offering, to bring it into the house of our Elohim, according to our fathers’ houses, at times appointed year by year, to burn on Yahweh our Elohim’s altar, as it is written in the law; 
-<span class="v">35&#160;</span>and to bring the first fruits of our ground and the first fruits of all fruit of all kinds of trees, year by year, to Yahweh’s house; 
-<span class="v">36&#160;</span>also the firstborn of our sons and of our livestock, as it is written in the law, and the firstborn of our herds and of our flocks, to bring to the house of our Elohim, to the priests who minister in the house of our Elohim; 
-<span class="v">37&#160;</span>and that we should bring the first fruits of our dough, our wave offerings, the fruit of all kinds of trees, and the new wine and the oil, to the priests, to the rooms of the house of our Elohim; and the tithes of our ground to the Levites; for they, the Levites, take the tithes in all our farming villages. 
-<span class="v">38&#160;</span>The priest, the descendent of Aaron, shall be with the Levites when the Levites take tithes. The Levites shall bring up the tithe of the tithes to the house of our Elohim, to the rooms, into the treasure house. 
-<span class="v">39&#160;</span>For the children of Israel and the children of Levi shall bring the wave offering of the grain, of the new wine, and of the oil, to the rooms where the vessels of the sanctuary are, and the priests who minister, with the gatekeepers and the singers. We will not forsake the house of our Elohim. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>The princes of the people lived in Jerusalem. The rest of the people also cast lots to bring one of ten to dwell in Jerusalem, the set-apart city, and nine parts in the other cities. 
-<span class="v">2&#160;</span>The people blessed all the men who willingly offered themselves to dwell in Jerusalem. 
-</p><p>
-<span class="v">3&#160;</span>Now these are the chiefs of the province who lived in Jerusalem; but in the cities of Judah, everyone lived in his possession in their cities—Israel, the priests, the Levites, the temple servants, and the children of Solomon’s servants. 
-<span class="v">4&#160;</span>Some of the children of Judah and of the children of Benjamin lived in Jerusalem. Of the children of Judah: Athaiah the son of Uzziah, the son of Zechariah, the son of Amariah, the son of Shephatiah, the son of Mahalalel, of the children of Perez; 
-<span class="v">5&#160;</span>and Maaseiah the son of Baruch, the son of Colhozeh, the son of Hazaiah, the son of Adaiah, the son of Joiarib, the son of Zechariah, the son of the Shilonite. 
-<span class="v">6&#160;</span>All the sons of Perez who lived in Jerusalem were four hundred sixty-eight valiant men. 
-</p><p>
-<span class="v">7&#160;</span>These are the sons of Benjamin: Sallu the son of Meshullam, the son of Joed, the son of Pedaiah, the son of Kolaiah, the son of Maaseiah, the son of Ithiel, the son of Jeshaiah. 
-<span class="v">8&#160;</span>After him Gabbai and Sallai, nine hundred twenty-eight. 
-<span class="v">9&#160;</span>Joel the son of Zichri was their overseer; and Judah the son of Hassenuah was second over the city. 
-</p><p>
-<span class="v">10&#160;</span>Of the priests: Jedaiah the son of Joiarib, Jachin, 
-<span class="v">11&#160;</span>Seraiah the son of Hilkiah, the son of Meshullam, the son of Zadok, the son of Meraioth, the son of Ahitub, the ruler of Elohim’s house, 
-<span class="v">12&#160;</span>and their brothers who did the work of the house, eight hundred twenty-two; and Adaiah the son of Jeroham, the son of Pelaliah, the son of Amzi, the son of Zechariah, the son of Pashhur, the son of Malchijah, 
-<span class="v">13&#160;</span>and his brothers, chiefs of fathers’ households, two hundred forty-two; and Amashsai the son of Azarel, the son of Ahzai, the son of Meshillemoth, the son of Immer, 
-<span class="v">14&#160;</span>and their brothers, mighty men of valor, one hundred twenty-eight; and their overseer was Zabdiel, the son of Haggedolim. 
-</p><p>
-<span class="v">15&#160;</span>Of the Levites: Shemaiah the son of Hasshub, the son of Azrikam, the son of Hashabiah, the son of Bunni; 
-<span class="v">16&#160;</span>and Shabbethai and Jozabad, of the chiefs of the Levites, who had the oversight of the outward business of Elohim’s house; 
-<span class="v">17&#160;</span>and Mattaniah the son of Mica, the son of Zabdi, the son of Asaph, who was the chief to begin the thanksgiving in prayer, and Bakbukiah, the second among his brothers; and Abda the son of Shammua, the son of Galal, the son of Jeduthun. 
-<span class="v">18&#160;</span>All the Levites in the set-apart city were two hundred eighty-four. 
-</p><p>
-<span class="v">19&#160;</span>Moreover the gatekeepers, Akkub, Talmon, and their brothers, who kept watch at the gates, were one hundred seventy-two. 
-<span class="v">20&#160;</span>The residue of Israel, of the priests, and the Levites were in all the cities of Judah, everyone in his inheritance. 
-<span class="v">21&#160;</span>But the temple servants lived in Ophel; and Ziha and Gishpa were over the temple servants. 
-</p><p>
-<span class="v">22&#160;</span>The overseer also of the Levites at Jerusalem was Uzzi the son of Bani, the son of Hashabiah, the son of Mattaniah, the son of Mica, of the sons of Asaph, the singers responsible for the service of Elohim’s house. 
-<span class="v">23&#160;</span>For there was a commandment from the king concerning them, and a settled provision for the singers, as every day required. 
-<span class="v">24&#160;</span>Pethahiah the son of Meshezabel, of the children of Zerah the son of Judah, was at the king’s hand in all matters concerning the people. 
-</p><p>
-<span class="v">25&#160;</span>As for the villages with their fields, some of the children of Judah lived in Kiriath Arba and its towns, in Dibon and its towns, in Jekabzeel and its villages, 
-<span class="v">26&#160;</span>in Jeshua, in Moladah, Beth Pelet, 
-<span class="v">27&#160;</span>in Hazar Shual, in Beersheba and its towns, 
-<span class="v">28&#160;</span>in Ziklag, in Meconah and in its towns, 
-<span class="v">29&#160;</span>in En Rimmon, in Zorah, in Jarmuth, 
-<span class="v">30&#160;</span>Zanoah, Adullam, and their villages, Lachish and its fields, and Azekah and its towns. So they encamped from Beersheba to the valley of Hinnom. 
-<span class="v">31&#160;</span>The children of Benjamin also lived from Geba onward, at Michmash and Aija, and at Bethel and its towns, 
-<span class="v">32&#160;</span>at Anathoth, Nob, Ananiah, 
-<span class="v">33&#160;</span>Hazor, Ramah, Gittaim, 
-<span class="v">34&#160;</span>Hadid, Zeboim, Neballat, 
-<span class="v">35&#160;</span>Lod, and Ono, the valley of craftsmen. 
-<span class="v">36&#160;</span>Of the Levites, certain divisions in Judah settled in Benjamin’s territory. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Now these are the priests and the Levites who went up with Zerubbabel the son of Shealtiel, and Jeshua: Seraiah, Jeremiah, Ezra, 
-<span class="v">2&#160;</span>Amariah, Malluch, Hattush, 
-<span class="v">3&#160;</span>Shecaniah, Rehum, Meremoth, 
-<span class="v">4&#160;</span>Iddo, Ginnethoi, Abijah, 
-<span class="v">5&#160;</span>Mijamin, Maadiah, Bilgah, 
-<span class="v">6&#160;</span>Shemaiah, Joiarib, Jedaiah, 
-<span class="v">7&#160;</span>Sallu, Amok, Hilkiah, and Jedaiah. These were the chiefs of the priests and of their brothers in the days of Jeshua. 
-</p><p>
-<span class="v">8&#160;</span>Moreover the Levites were Jeshua, Binnui, Kadmiel, Sherebiah, Judah, and Mattaniah, who was over the thanksgiving songs, he and his brothers. 
-<span class="v">9&#160;</span>Also Bakbukiah and Unno, their brothers, were close to them according to their offices. 
-<span class="v">10&#160;</span>Jeshua brought forth Joiakim, and Joiakim brought forth Eliashib, and Eliashib brought forth Joiada, 
-<span class="v">11&#160;</span>and Joiada brought forth Jonathan, and Jonathan brought forth Jaddua. 
-</p><p>
-<span class="v">12&#160;</span>In the days of Joiakim were priests, heads of fathers’ households: of Seraiah, Meraiah; of Jeremiah, Hananiah; 
-<span class="v">13&#160;</span>of Ezra, Meshullam; of Amariah, Jehohanan; 
-<span class="v">14&#160;</span>of Malluchi, Jonathan; of Shebaniah, Joseph; 
-<span class="v">15&#160;</span>of Harim, Adna; of Meraioth, Helkai; 
-<span class="v">16&#160;</span>of Iddo, Zechariah; of Ginnethon, Meshullam; 
-<span class="v">17&#160;</span>of Abijah, Zichri; of Miniamin, of Moadiah, Piltai; 
-<span class="v">18&#160;</span>of Bilgah, Shammua; of Shemaiah, Jehonathan; 
-<span class="v">19&#160;</span>of Joiarib, Mattenai; of Jedaiah, Uzzi; 
-<span class="v">20&#160;</span>of Sallai, Kallai; of Amok, Eber; 
-<span class="v">21&#160;</span>of Hilkiah, Hashabiah; of Jedaiah, Nethanel. 
-</p><p>
-<span class="v">22&#160;</span>As for the Levites, in the days of Eliashib, Joiada, Johanan, and Jaddua, there were recorded the heads of fathers’ households; also the priests, in the reign of Darius the Persian. 
-<span class="v">23&#160;</span>The sons of Levi, heads of fathers’ households, were written in the book of the chronicles, even until the days of Johanan the son of Eliashib. 
-<span class="v">24&#160;</span>The chiefs of the Levites: Hashabiah, Sherebiah, and Jeshua the son of Kadmiel, with their brothers close to them, to praise and give thanks according to the commandment of David the man of Elohim, section next to section. 
-<span class="v">25&#160;</span>Mattaniah, Bakbukiah, Obadiah, Meshullam, Talmon, and Akkub were gatekeepers keeping the watch at the storehouses of the gates. 
-<span class="v">26&#160;</span>These were in the days of Joiakim the son of Jeshua, the son of Jozadak, and in the days of Nehemiah the governor, and of Ezra the priest and scribe. 
-</p><p>
-<span class="v">27&#160;</span>At the dedication of the wall of Jerusalem, they sought the Levites out of all their places, to bring them to Jerusalem to keep the dedication with gladness, both with giving thanks and with singing, with cymbals, stringed instruments, and with harps. 
-<span class="v">28&#160;</span>The sons of the singers gathered themselves together, both out of the plain around Jerusalem and from the villages of the Netophathites; 
-<span class="v">29&#160;</span>also from Beth Gilgal and out of the fields of Geba and Azmaveth, for the singers had built themselves villages around Jerusalem. 
-<span class="v">30&#160;</span>The priests and the Levites purified themselves; and they purified the people, the gates, and the wall. 
-</p><p>
-<span class="v">31&#160;</span>Then I brought the princes of Judah up on the wall, and appointed two great companies who gave thanks and went in procession. One went on the right hand on the wall toward the dung gate; 
-<span class="v">32&#160;</span>and after them went Hoshaiah, with half of the princes of Judah, 
-<span class="v">33&#160;</span>and Azariah, Ezra, and Meshullam, 
-<span class="v">34&#160;</span>Judah, Benjamin, Shemaiah, Jeremiah, 
-<span class="v">35&#160;</span>and some of the priests’ sons with trumpets: Zechariah the son of Jonathan, the son of Shemaiah, the son of Mattaniah, the son of Micaiah, the son of Zaccur, the son of Asaph; 
-<span class="v">36&#160;</span>and his brothers, Shemaiah, Azarel, Milalai, Gilalai, Maai, Nethanel, Judah, and Hanani, with the musical instruments of David the man of Elohim; and Ezra the scribe was before them. 
-<span class="v">37&#160;</span>By the spring gate, and straight before them, they went up by the stairs of David’s city, at the ascent of the wall, above David’s house, even to the water gate eastward. 
-</p><p>
-<span class="v">38&#160;</span>The other company of those who gave thanks went to meet them, and I after them, with the half of the people on the wall above the tower of the furnaces, even to the wide wall, 
-<span class="v">39&#160;</span>and above the gate of Ephraim, and by the old gate, and by the fish gate, the tower of Hananel, and the tower of Hammeah, even to the sheep gate; and they stood still in the gate of the guard. 
-<span class="v">40&#160;</span>So the two companies of those who gave thanks in Elohim’s house stood, and I and the half of the rulers with me; 
-<span class="v">41&#160;</span>and the priests, Eliakim, Maaseiah, Miniamin, Micaiah, Elioenai, Zechariah, and Hananiah, with trumpets; 
-<span class="v">42&#160;</span>and Maaseiah, Shemaiah, Eleazar, Uzzi, Jehohanan, Malchijah, Elam, and Ezer. The singers sang loud, with Jezrahiah their overseer. 
-<span class="v">43&#160;</span>They offered great sacrifices that day, and rejoiced, for Elohim had made them rejoice with great joy; and the women and the children also rejoiced, so that the joy of Jerusalem was heard even far away. 
-</p><p>
-<span class="v">44&#160;</span>On that day, men were appointed over the rooms for the treasures, for the wave offerings, for the first fruits, and for the tithes, to gather into them according to the fields of the cities the portions appointed by the law for the priests and Levites; for Judah rejoiced for the priests and for the Levites who served. 
-<span class="v">45&#160;</span>They performed the duty of their Elohim and the duty of the purification, and so did the singers and the gatekeepers, according to the commandment of David and of Solomon his son. 
-<span class="v">46&#160;</span>For in the days of David and Asaph of old there was a chief of the singers, and songs of praise and thanksgiving to Elohim. 
-<span class="v">47&#160;</span>All Israel in the days of Zerubbabel and in the days of Nehemiah gave the portions of the singers and the gatekeepers, as every day required; and they set apart that which was for the Levites; and the Levites set apart that which was for the sons of Aaron. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>On that day they read in the book of Moses in the hearing of the people; and it was found written in it that an Ammonite and a Moabite should not enter into the assembly of Elohim forever, 
-<span class="v">2&#160;</span>because they didn’t meet the children of Israel with bread and with water, but hired Balaam against them to curse them; however, our Elohim turned the curse into a blessing. 
-<span class="v">3&#160;</span>It came to pass, when they had heard the law, that they separated all the mixed multitude from Israel. 
-</p><p>
-<span class="v">4&#160;</span>Now before this, Eliashib the priest, who was appointed over the rooms of the house of our Elohim, being allied to Tobiah, 
-<span class="v">5&#160;</span>had prepared for him a great room, where before they laid the meal offerings, the frankincense, the vessels, and the tithes of the grain, the new wine, and the oil, which were given by commandment to the Levites, the singers, and the gatekeepers; and the wave offerings for the priests. 
-<span class="v">6&#160;</span>But in all this, I was not at Jerusalem; for in the thirty-second year of Artaxerxes king of Babylon I went to the king; and after some days I asked leave of the king, 
-<span class="v">7&#160;</span>and I came to Jerusalem, and understood the evil that Eliashib had done for Tobiah, in preparing him a room in the courts of Elohim’s house. 
-<span class="v">8&#160;</span>It grieved me severely. Therefore I threw all Tobiah’s household stuff out of the room. 
-<span class="v">9&#160;</span>Then I commanded, and they cleansed the rooms. I brought into them the vessels of Elohim’s house, with the meal offerings and the frankincense again. 
-</p><p>
-<span class="v">10&#160;</span>I perceived that the portions of the Levites had not been given them, so that the Levites and the singers, who did the work, had each fled to his field. 
-<span class="v">11&#160;</span>Then I contended with the rulers, and said, “Why is Elohim’s house forsaken?” I gathered them together, and set them in their place. 
-<span class="v">12&#160;</span>Then all Judah brought the tithe of the grain, the new wine, and the oil to the treasuries. 
-<span class="v">13&#160;</span>I made treasurers over the treasuries, Shelemiah the priest, and Zadok the scribe, and of the Levites, Pedaiah: and next to them was Hanan the son of Zaccur, the son of Mattaniah; for they were counted faithful, and their business was to distribute to their brothers. 
-</p><p>
-<span class="v">14&#160;</span>Remember me, my Elohim, concerning this, and don’t wipe out my good deeds that I have done for the house of my Elohim, and for its observances. 
-</p><p>
-<span class="v">15&#160;</span>In those days I saw some men treading wine presses on the Sabbath in Judah, bringing in sheaves, and loading donkeys with wine, grapes, figs, and all kinds of burdens which they brought into Jerusalem on the Sabbath day; and I testified against them in the day in which they sold food. 
-<span class="v">16&#160;</span>Some men of Tyre also lived there, who brought in fish and all kinds of wares, and sold on the Sabbath to the children of Judah, and in Jerusalem. 
-<span class="v">17&#160;</span>Then I contended with the nobles of Judah, and said to them, “What evil thing is this that you do, and profane the Sabbath day? 
-<span class="v">18&#160;</span>Didn’t your fathers do this, and didn’t our Elohim bring all this evil on us and on this city? Yet you bring more wrath on Israel by profaning the Sabbath.” 
-</p><p>
-<span class="v">19&#160;</span>It came to pass that when the gates of Jerusalem began to be dark before the Sabbath, I commanded that the doors should be shut, and commanded that they should not be opened until after the Sabbath. I set some of my servants over the gates, so that no burden should be brought in on the Sabbath day. 
-<span class="v">20&#160;</span>So the merchants and sellers of all kinds of wares camped outside of Jerusalem once or twice. 
-<span class="v">21&#160;</span>Then I testified against them, and said to them, “Why do you stay around the wall? If you do so again, I will lay hands on you.” From that time on, they didn’t come on the Sabbath. 
-<span class="v">22&#160;</span>I commanded the Levites that they should purify themselves, and that they should come and keep the gates, to sanctify the Sabbath day. Remember me for this also, my Elohim, and spare me according to the greatness of your loving kindness. 
-</p><p>
-<span class="v">23&#160;</span>In those days I also saw the Jews who had married women of Ashdod, of Ammon, and of Moab; 
-<span class="v">24&#160;</span>and their children spoke half in the speech of Ashdod, and could not speak in the Jews’ language, but according to the language of each people. 
-<span class="v">25&#160;</span>I contended with them, cursed them, struck certain of them, plucked off their hair, and made them swear by Elohim, “You shall not give your daughters to their sons, nor take their daughters for your sons, or for yourselves. 
-<span class="v">26&#160;</span>Didn’t Solomon king of Israel sin by these things? Yet among many nations there was no king like him, and he was loved by his Elohim, and Elohim made him king over all Israel. Nevertheless foreign women caused even him to sin. 
-<span class="v">27&#160;</span>Shall we then listen to you to do all this great evil, to trespass against our Elohim in marrying foreign women?” 
-</p><p>
-<span class="v">28&#160;</span>One of the sons of Joiada, the son of Eliashib the high priest, was son-in-law to Sanballat the Horonite; therefore I chased him from me. 
-<span class="v">29&#160;</span>Remember them, my Elohim, because they have defiled the priesthood and the covenant of the priesthood and of the Levites. 
-</p><p>
-<span class="v">30&#160;</span>Thus I cleansed them from all foreigners and appointed duties for the priests and for the Levites, everyone in his work; 
-<span class="v">31&#160;</span>and for the wood offering, at appointed times, and for the first fruits. Remember me, my Elohim, for good. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The words of Nehemiah the son of Hacaliah. 
+</div><div class="p">Now in the month Chislev, in the twentieth year, as I was in Susa the palace, 
+<sup>2&#160;</sup>Hanani, one of my brothers, came, he and certain men out of Judah; and I asked them about the Jews who had escaped, who were left of the captivity, and concerning Jerusalem. 
+<sup>3&#160;</sup>They said to me, “The remnant who are left of the captivity there in the province are in great affliction and reproach. The wall of Jerusalem is also broken down, and its gates are burned with fire.” 
+</div><div class="p">
+<sup>4&#160;</sup>When I heard these words, I sat down and wept, and mourned several days; and I fasted and prayed before the Elohim of heaven, 
+<sup>5&#160;</sup>and said, “I beg you, Yahweh, the Elohim of heaven, the great and awesome Elohim who keeps covenant and loving kindness with those who love him and keep his commandments, 
+<sup>6&#160;</sup>let your ear now be attentive and your eyes open, that you may listen to the prayer of your servant which I pray before you at this time, day and night, for the children of Israel your servants, while I confess the sins of the children of Israel which we have sinned against you. Yes, I and my father’s house have sinned. 
+<sup>7&#160;</sup>We have dealt very corruptly against you, and have not kept the commandments, nor the statutes, nor the ordinances, which you commanded your servant Moses. 
+</div><div class="p">
+<sup>8&#160;</sup>“Remember, I beg you, the word that you commanded your servant Moses, saying, ‘If you trespass, I will scatter you among the peoples; 
+<sup>9&#160;</sup>but if you return to me, and keep my commandments and do them, though your outcasts were in the uttermost part of the heavens, yet I will gather them from there, and will bring them to the place that I have chosen, to cause my name to dwell there.’ 
+</div><div class="p">
+<sup>10&#160;</sup>“Now these are your servants and your people, whom you have redeemed by your great power and by your strong hand. 
+<sup>11&#160;</sup>Lord, I beg you, let your ear be attentive now to the prayer of your servant, and to the prayer of your servants who delight to fear your name; and please prosper your servant today, and grant him mercy in the sight of this man.” 
+</div><div class="p">Now I was cup bearer to the king. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>In the month Nisan, in the twentieth year of Artaxerxes the king, when wine was before him, I picked up the wine, and gave it to the king. Now I had not been sad before in his presence. 
+<sup>2&#160;</sup>The king said to me, “Why is your face sad, since you are not sick? This is nothing else but sorrow of heart.” 
+</div><div class="p">Then I was very much afraid. 
+<sup>3&#160;</sup>I said to the king, “Let the king live forever! Why shouldn’t my face be sad, when the city, the place of my fathers’ tombs, lies waste, and its gates have been consumed with fire?” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the king said to me, “What is your request?” 
+</div><div class="p">So I prayed to the Elohim of heaven. 
+<sup>5&#160;</sup>I said to the king, “If it pleases the king, and if your servant has found favor in your sight, I ask that you would send me to Judah, to the city of my fathers’ tombs, that I may build it.” 
+</div><div class="p">
+<sup>6&#160;</sup>The king said to me (the queen was also sitting by him), “How long will your journey be? When will you return?” 
+</div><div class="p">So it pleased the king to send me, and I set a time for him. 
+<sup>7&#160;</sup>Moreover I said to the king, “If it pleases the king, let letters be given me to the governors beyond the River, that they may let me pass through until I come to Judah; 
+<sup>8&#160;</sup>and a letter to Asaph the keeper of the king’s forest, that he may give me timber to make beams for the gates of the citadel by the temple, for the wall of the city, and for the house that I will occupy.” 
+</div><div class="p">The king granted my requests, because of the good hand of my Elohim on me. 
+<sup>9&#160;</sup>Then I came to the governors beyond the River, and gave them the king’s letters. Now the king had sent captains of the army and horsemen with me. 
+<sup>10&#160;</sup>When Sanballat the Horonite and Tobiah the Ammonite servant heard of it, it grieved them exceedingly, because a man had come to seek the welfare of the children of Israel. 
+</div><div class="p">
+<sup>11&#160;</sup>So I came to Jerusalem, and was there three days. 
+<sup>12&#160;</sup>I arose in the night, I and a few men with me. I didn’t tell anyone what my Elohim put into my heart to do for Jerusalem. There wasn’t any animal with me except the animal that I rode on. 
+<sup>13&#160;</sup>I went out by night by the valley gate toward the jackal’s well, then to the dung gate; and I inspected the walls of Jerusalem, which were broken down, and its gates were consumed with fire. 
+<sup>14&#160;</sup>Then I went on to the spring gate and to the king’s pool, but there was no place for the animal that was under me to pass. 
+<sup>15&#160;</sup>Then I went up in the night by the brook and inspected the wall; and I turned back, and entered by the valley gate, and so returned. 
+<sup>16&#160;</sup>The rulers didn’t know where I went, or what I did. I had not as yet told it to the Jews, nor to the priests, nor to the nobles, nor to the rulers, nor to the rest who did the work. 
+</div><div class="p">
+<sup>17&#160;</sup>Then I said to them, “You see the bad situation that we are in, how Jerusalem lies waste, and its gates are burned with fire. Come, let’s build up the wall of Jerusalem, that we won’t be disgraced.” 
+<sup>18&#160;</sup>I told them about the hand of my Elohim which was good on me, and also about the king’s words that he had spoken to me. 
+</div><div class="p">They said, “Let’s rise up and build.” So they strengthened their hands for the good work. 
+</div><div class="p">
+<sup>19&#160;</sup>But when Sanballat the Horonite, Tobiah the Ammonite servant, and Geshem the Arabian, heard it, they ridiculed us and despised us, and said, “What is this thing that you are doing? Will you rebel against the king?” 
+</div><div class="p">
+<sup>20&#160;</sup>Then I answered them, and said to them, “The Elohim of heaven will prosper us. Therefore we, his servants, will arise and build; but you have no portion, nor right, nor memorial in Jerusalem.” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Then Eliashib the high priest rose up with his brothers the priests, and they built the sheep gate. They sanctified it, and set up its doors. They sanctified it even to the tower of Hammeah, to the tower of Hananel. 
+<sup>2&#160;</sup>Next to him the men of Jericho built. Next to them Zaccur the son of Imri built. 
+</div><div class="p">
+<sup>3&#160;</sup>The sons of Hassenaah built the fish gate. They laid its beams, and set up its doors, its bolts, and its bars. 
+<sup>4&#160;</sup>Next to them, Meremoth the son of Uriah, the son of Hakkoz made repairs. Next to them, Meshullam the son of Berechiah, the son of Meshezabel made repairs. Next to them, Zadok the son of Baana made repairs. 
+<sup>5&#160;</sup>Next to them, the Tekoites made repairs; but their nobles didn’t put their necks to the Lord’s work. 
+</div><div class="p">
+<sup>6&#160;</sup>Joiada the son of Paseah and Meshullam the son of Besodeiah repaired the old gate. They laid its beams and set up its doors, its bolts, and its bars. 
+<sup>7&#160;</sup>Next to them, Melatiah the Gibeonite and Jadon the Meronothite, the men of Gibeon and of Mizpah, repaired the residence of the governor beyond the River. 
+<sup>8&#160;</sup>Next to him, Uzziel the son of Harhaiah, goldsmiths, made repairs. Next to him, Hananiah, one of the perfumers, made repairs, and they fortified Jerusalem even to the wide wall. 
+<sup>9&#160;</sup>Next to them, Rephaiah the son of Hur, the ruler of half the district of Jerusalem, made repairs. 
+<sup>10&#160;</sup>Next to them, Jedaiah the son of Harumaph made repairs across from his house. Next to him, Hattush the son of Hashabneiah made repairs. 
+<sup>11&#160;</sup>Malchijah the son of Harim and Hasshub the son of Pahathmoab repaired another portion and the tower of the furnaces. 
+<sup>12&#160;</sup>Next to him, Shallum the son of Hallohesh, the ruler of half the district of Jerusalem, he and his daughters made repairs. 
+</div><div class="p">
+<sup>13&#160;</sup>Hanun and the inhabitants of Zanoah repaired the valley gate. They built it, and set up its doors, its bolts, and its bars, and one thousand cubits of the wall to the dung gate. 
+</div><div class="p">
+<sup>14&#160;</sup>Malchijah the son of Rechab, the ruler of the district of Beth Haccherem, repaired the dung gate. He built it, and set up its doors, its bolts, and its bars. 
+</div><div class="p">
+<sup>15&#160;</sup>Shallun the son of Colhozeh, the ruler of the district of Mizpah, repaired the spring gate. He built it, covered it, and set up its doors, its bolts, and its bars; and he repaired the wall of the pool of Shelah by the king’s garden, even to the stairs that go down from David’s city. 
+<sup>16&#160;</sup>After him, Nehemiah the son of Azbuk, the ruler of half the district of Beth Zur, made repairs to the place opposite the tombs of David, and to the pool that was made, and to the house of the mighty men. 
+<sup>17&#160;</sup>After him, the Levites—Rehum the son of Bani made repairs. Next to him, Hashabiah, the ruler of half the district of Keilah, made repairs for his district. 
+<sup>18&#160;</sup>After him, their brothers, Bavvai the son of Henadad, the ruler of half the district of Keilah made repairs. 
+<sup>19&#160;</sup>Next to him, Ezer the son of Jeshua, the ruler of Mizpah, repaired another portion across from the ascent to the armory at the turning of the wall. 
+<sup>20&#160;</sup>After him, Baruch the son of Zabbai earnestly repaired another portion, from the turning of the wall to the door of the house of Eliashib the high priest. 
+<sup>21&#160;</sup>After him, Meremoth the son of Uriah the son of Hakkoz repaired another portion, from the door of the house of Eliashib even to the end of the house of Eliashib. 
+<sup>22&#160;</sup>After him, the priests, the men of the surrounding area made repairs. 
+<sup>23&#160;</sup>After them, Benjamin and Hasshub made repairs across from their house. After them, Azariah the son of Maaseiah the son of Ananiah made repairs beside his own house. 
+<sup>24&#160;</sup>After him, Binnui the son of Henadad repaired another portion, from the house of Azariah to the turning of the wall, and to the corner. 
+<sup>25&#160;</sup>Palal the son of Uzai made repairs opposite the turning of the wall, and the tower that stands out from the upper house of the king, which is by the court of the guard. After him Pedaiah the son of Parosh made repairs. 
+<sup>26&#160;</sup>(Now the temple servants lived in Ophel, to the place opposite the water gate toward the east, and the tower that stands out.) 
+<sup>27&#160;</sup>After him the Tekoites repaired another portion, opposite the great tower that stands out, and to the wall of Ophel. 
+</div><div class="p">
+<sup>28&#160;</sup>Above the horse gate, the priests made repairs, everyone across from his own house. 
+<sup>29&#160;</sup>After them, Zadok the son of Immer made repairs across from his own house. After him, Shemaiah the son of Shecaniah, the keeper of the east gate, made repairs. 
+<sup>30&#160;</sup>After him, Hananiah the son of Shelemiah, and Hanun, the sixth son of Zalaph, repaired another portion. After him, Meshullam the son of Berechiah made repairs across from his room. 
+<sup>31&#160;</sup>After him, Malchijah, one of the goldsmiths to the house of the temple servants, and of the merchants, made repairs opposite the gate of Hammiphkad and to the ascent of the corner. 
+<sup>32&#160;</sup>Between the ascent of the corner and the sheep gate, the goldsmiths and the merchants made repairs. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>But when Sanballat heard that we were building the wall, he was angry, and was very indignant, and mocked the Jews. 
+<sup>2&#160;</sup>He spoke before his brothers and the army of Samaria, and said, “What are these feeble Jews doing? Will they fortify themselves? Will they sacrifice? Will they finish in a day? Will they revive the stones out of the heaps of rubbish, since they are burned?” 
+</div><div class="p">
+<sup>3&#160;</sup>Now Tobiah the Ammonite was by him, and he said, “What they are building, if a fox climbed up it, he would break down their stone wall.” 
+</div><div class="p">
+<sup>4&#160;</sup>“Hear, our Elohim, for we are despised. Turn back their reproach on their own head. Give them up for a plunder in a land of captivity. 
+<sup>5&#160;</sup>Don’t cover their iniquity. Don’t let their sin be blotted out from before you; for they have insulted the builders.” 
+</div><div class="p">
+<sup>6&#160;</sup>So we built the wall; and all the wall was joined together to half its height, for the people had a mind to work. 
+</div><div class="p">
+<sup>7&#160;</sup>But when Sanballat, Tobiah, the Arabians, the Ammonites, and the Ashdodites heard that the repairing of the walls of Jerusalem went forward, and that the breaches began to be filled, they were very angry; 
+<sup>8&#160;</sup>and they all conspired together to come and fight against Jerusalem, and to cause confusion among us. 
+<sup>9&#160;</sup>But we made our prayer to our Elohim, and set a watch against them day and night because of them. 
+</div><div class="p">
+<sup>10&#160;</sup>Judah said, “The strength of the bearers of burdens is fading and there is much rubble, so that we are not able to build the wall.” 
+<sup>11&#160;</sup>Our adversaries said, “They will not know or see, until we come in among them and kill them, and cause the work to cease.” 
+</div><div class="p">
+<sup>12&#160;</sup>When the Jews who lived by them came, they said to us ten times from all places, “Wherever you turn, they will attack us.” 
+</div><div class="p">
+<sup>13&#160;</sup>Therefore I set guards in the lowest parts of the space behind the wall, in the open places. I set the people by family groups with their swords, their spears, and their bows. 
+<sup>14&#160;</sup>I looked, and rose up, and said to the nobles, to the rulers, and to the rest of the people, “Don’t be afraid of them! Remember the Lord, who is great and awesome, and fight for your brothers, your sons, your daughters, your women, and your houses.” 
+</div><div class="p">
+<sup>15&#160;</sup>When our enemies heard that it was known to us, and Elohim had brought their counsel to nothing, all of us returned to the wall, everyone to his work. 
+<sup>16&#160;</sup>From that time forth, half of my servants did the work, and half of them held the spears, the shields, the bows, and the coats of mail; and the rulers were behind all the house of Judah. 
+<sup>17&#160;</sup>Those who built the wall, and those who bore burdens loaded themselves; everyone with one of his hands did the work, and with the other held his weapon. 
+<sup>18&#160;</sup>Among the builders, everyone wore his sword at his side, and so built. He who sounded the trumpet was by me. 
+<sup>19&#160;</sup>I said to the nobles, and to the rulers and to the rest of the people, “The work is great and widely spread out, and we are separated on the wall, far from one another. 
+<sup>20&#160;</sup>Wherever you hear the sound of the trumpet, rally there to us. Our Elohim will fight for us.” 
+</div><div class="p">
+<sup>21&#160;</sup>So we did the work. Half of the people held the spears from the rising of the morning until the stars appeared. 
+<sup>22&#160;</sup>Likewise at the same time I said to the people, “Let everyone with his servant lodge within Jerusalem, that in the night they may be a guard to us, and may labor in the day.” 
+<sup>23&#160;</sup>So neither I, nor my brothers, nor my servants, nor the men of the guard who followed me took off our clothes. Everyone took his weapon to the water. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Then there arose a great cry of the people and of their women against their brothers the Jews. 
+<sup>2&#160;</sup>For there were some who said, “We, our sons and our daughters, are many. Let us get grain, that we may eat and live.” 
+<sup>3&#160;</sup>There were also some who said, “We are mortgaging our fields, our vineyards, and our houses. Let us get grain, because of the famine.” 
+<sup>4&#160;</sup>There were also some who said, “We have borrowed money for the king’s tribute using our fields and our vineyards as collateral. 
+<sup>5&#160;</sup>Yet now our flesh is as the flesh of our brothers, our children as their children. Behold, we bring our sons and our daughters into bondage to be servants, and some of our daughters have been brought into bondage. It is also not in our power to help it, because other men have our fields and our vineyards.” 
+</div><div class="p">
+<sup>6&#160;</sup>I was very angry when I heard their cry and these words. 
+<sup>7&#160;</sup>Then I consulted with myself, and contended with the nobles and the rulers, and said to them, “You exact usury, everyone of his brother.” I held a great assembly against them. 
+<sup>8&#160;</sup>I said to them, “We, after our ability, have redeemed our brothers the Jews that were sold to the nations; and would you even sell your brothers, and should they be sold to us?” Then they held their peace, and found not a word to say. 
+<sup>9&#160;</sup>Also I said, “The thing that you do is not good. Shouldn’t you walk in the fear of our Elohim because of the reproach of the nations, our enemies? 
+<sup>10&#160;</sup>I likewise, my brothers and my servants, lend them money and grain. Please let us stop this usury. 
+<sup>11&#160;</sup>Please restore to them, even today, their fields, their vineyards, their olive groves, and their houses, also the hundredth part of the money, and of the grain, the new wine, and the oil, that you are charging them.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then they said, “We will restore them, and will require nothing of them. We will do so, even as you say.” 
+</div><div class="p">Then I called the priests, and took an oath of them, that they would do according to this promise. 
+<sup>13&#160;</sup>Also I shook out my lap, and said, “So may Elohim shake out every man from his house, and from his labor, that doesn’t perform this promise; even may he be shaken out and emptied like this.” 
+</div><div class="p">All the assembly said, “Amen,” and praised Yahweh. The people did according to this promise. 
+</div><div class="p">
+<sup>14&#160;</sup>Moreover from the time that I was appointed to be their governor in the land of Judah, from the twentieth year even to the thirty-second year of Artaxerxes the king, that is, twelve years, I and my brothers have not eaten the bread of the governor. 
+<sup>15&#160;</sup>But the former governors who were before me were supported by the people, and took bread and wine from them, plus forty shekels of silver; yes, even their servants ruled over the people, but I didn’t do so, because of the fear of Elohim. 
+<sup>16&#160;</sup>Yes, I also continued in the work of this wall. We didn’t buy any land. All my servants were gathered there to the work. 
+<sup>17&#160;</sup>Moreover there were at my table, of the Jews and the rulers, one hundred fifty men, in addition to those who came to us from among the nations that were around us. 
+<sup>18&#160;</sup>Now that which was prepared for one day was one ox and six choice sheep. Also fowls were prepared for me, and once in ten days a store of all sorts of wine. Yet for all this, I didn’t demand the governor’s pay, because the bondage was heavy on this people. 
+<sup>19&#160;</sup>Remember me, my Elohim, for all the good that I have done for this people. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when it was reported to Sanballat, Tobiah, Geshem the Arabian, and to the rest of our enemies that I had built the wall, and that there was no breach left in it (though even to that time I had not set up the doors in the gates), 
+<sup>2&#160;</sup>Sanballat and Geshem sent to me, saying, “Come! Let’s meet together in the villages in the plain of Ono.” But they intended to harm me. 
+</div><div class="p">
+<sup>3&#160;</sup>I sent messengers to them, saying, “I am doing a great work, so that I can’t come down. Why should the work cease while I leave it and come down to you?” 
+</div><div class="p">
+<sup>4&#160;</sup>They sent to me four times like this; and I answered them the same way. 
+<sup>5&#160;</sup>Then Sanballat sent his servant to me the same way the fifth time with an open letter in his hand, 
+<sup>6&#160;</sup>in which was written, “It is reported among the nations, and Gashmu says it, that you and the Jews intend to rebel. Because of that, you are building the wall. You would be their king, according to these words. 
+<sup>7&#160;</sup>You have also appointed prophets to proclaim of you at Jerusalem, saying, ‘There is a king in Judah!’ Now it will be reported to the king according to these words. Come now therefore, and let’s take counsel together.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then I sent to him, saying, “There are no such things done as you say, but you imagine them out of your own heart.” 
+<sup>9&#160;</sup>For they all would have made us afraid, saying, “Their hands will be weakened from the work, that it not be done.” But now, strengthen my hands. 
+</div><div class="p">
+<sup>10&#160;</sup>I went to the house of Shemaiah the son of Delaiah the son of Mehetabel, who was shut in at his home; and he said, “Let us meet together in Elohim’s house, within the temple, and let’s shut the doors of the temple; for they will come to kill you. Yes, in the night they will come to kill you.” 
+</div><div class="p">
+<sup>11&#160;</sup>I said, “Should a man like me flee? Who is there that, being such as I, would go into the temple to save his life? I will not go in.” 
+<sup>12&#160;</sup>I discerned, and behold, Elohim had not sent him, but he pronounced this prophecy against me. Tobiah and Sanballat had hired him. 
+<sup>13&#160;</sup>He was hired so that I would be afraid, do so, and sin, and that they might have material for an evil report, that they might reproach me. 
+<sup>14&#160;</sup>“Remember, my Elohim, Tobiah and Sanballat according to these their works, and also the prophetess Noadiah and the rest of the prophets that would have put me in fear.” 
+</div><div class="p">
+<sup>15&#160;</sup>So the wall was finished in the twenty-fifth day of Elul, in fifty-two days. 
+<sup>16&#160;</sup>When all our enemies heard of it, all the nations that were around us were afraid, and they lost their confidence; for they perceived that this work was done by our Elohim. 
+<sup>17&#160;</sup>Moreover in those days the nobles of Judah sent many letters to Tobiah, and Tobiah’s letters came to them. 
+<sup>18&#160;</sup>For there were many in Judah sworn to him because he was the son-in-law of Shecaniah the son of Arah; and his son Jehohanan had taken the daughter of Meshullam the son of Berechiah as woman. 
+<sup>19&#160;</sup>Also they spoke of his good deeds before me, and reported my words to him. Tobiah sent letters to put me in fear. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>Now when the wall was built and I had set up the doors, and the gatekeepers and the singers and the Levites were appointed, 
+<sup>2&#160;</sup>I put my brother Hanani, and Hananiah the governor of the fortress, in charge of Jerusalem; for he was a faithful man and feared Elohim above many. 
+<sup>3&#160;</sup>I said to them, “Don’t let the gates of Jerusalem be opened until the sun is hot; and while they stand guard, let them shut the doors, and you bar them; and appoint watches of the inhabitants of Jerusalem, everyone in his watch, with everyone near his house.” 
+</div><div class="p">
+<sup>4&#160;</sup>Now the city was wide and large; but the people were few therein, and the houses were not built. 
+</div><div class="p">
+<sup>5&#160;</sup>My Elohim put into my heart to gather together the nobles, and the rulers, and the people, that they might be listed by genealogy. I found the book of the genealogy of those who came up at the first, and I found this written in it: 
+</div><div class="p">
+<sup>6&#160;</sup>These are the children of the province who went up out of the captivity of those who had been carried away, whom Nebuchadnezzar the king of Babylon had carried away, and who returned to Jerusalem and to Judah, everyone to his city, 
+<sup>7&#160;</sup>who came with Zerubbabel, Jeshua, Nehemiah, Azariah, Raamiah, Nahamani, Mordecai, Bilshan, Mispereth, Bigvai, Nehum, and Baanah. 
+</div><div class="p">The number of the men of the people of Israel: 
+</div><div class="li1">
+<sup>8&#160;</sup>The children of Parosh: two thousand one hundred seventy-two. 
+</div><div class="li1">
+<sup>9&#160;</sup>The children of Shephatiah: three hundred seventy-two. 
+</div><div class="li1">
+<sup>10&#160;</sup>The children of Arah: six hundred fifty-two. 
+</div><div class="li1">
+<sup>11&#160;</sup>The children of Pahathmoab, of the children of Jeshua and Joab: two thousand eight hundred eighteen. 
+</div><div class="li1">
+<sup>12&#160;</sup>The children of Elam: one thousand two hundred fifty-four. 
+</div><div class="li1">
+<sup>13&#160;</sup>The children of Zattu: eight hundred forty-five. 
+</div><div class="li1">
+<sup>14&#160;</sup>The children of Zaccai: seven hundred sixty. 
+</div><div class="li1">
+<sup>15&#160;</sup>The children of Binnui: six hundred forty-eight. 
+</div><div class="li1">
+<sup>16&#160;</sup>The children of Bebai: six hundred twenty-eight. 
+</div><div class="li1">
+<sup>17&#160;</sup>The children of Azgad: two thousand three hundred twenty-two. 
+</div><div class="li1">
+<sup>18&#160;</sup>The children of Adonikam: six hundred sixty-seven. 
+</div><div class="li1">
+<sup>19&#160;</sup>The children of Bigvai: two thousand sixty-seven. 
+</div><div class="li1">
+<sup>20&#160;</sup>The children of Adin: six hundred fifty-five. 
+</div><div class="li1">
+<sup>21&#160;</sup>The children of Ater: of Hezekiah, ninety-eight. 
+</div><div class="li1">
+<sup>22&#160;</sup>The children of Hashum: three hundred twenty-eight. 
+</div><div class="li1">
+<sup>23&#160;</sup>The children of Bezai: three hundred twenty-four. 
+</div><div class="li1">
+<sup>24&#160;</sup>The children of Hariph: one hundred twelve. 
+</div><div class="li1">
+<sup>25&#160;</sup>The children of Gibeon: ninety-five. 
+</div><div class="li1">
+<sup>26&#160;</sup>The men of Bethlehem and Netophah: one hundred eighty-eight. 
+</div><div class="li1">
+<sup>27&#160;</sup>The men of Anathoth: one hundred twenty-eight. 
+</div><div class="li1">
+<sup>28&#160;</sup>The men of Beth Azmaveth: forty-two. 
+</div><div class="li1">
+<sup>29&#160;</sup>The men of Kiriath Jearim, Chephirah, and Beeroth: seven hundred forty-three. 
+</div><div class="li1">
+<sup>30&#160;</sup>The men of Ramah and Geba: six hundred twenty-one. 
+</div><div class="li1">
+<sup>31&#160;</sup>The men of Michmas: one hundred twenty-two. 
+</div><div class="li1">
+<sup>32&#160;</sup>The men of Bethel and Ai: one hundred twenty-three. 
+</div><div class="li1">
+<sup>33&#160;</sup>The men of the other Nebo: fifty-two. 
+</div><div class="li1">
+<sup>34&#160;</sup>The children of the other Elam: one thousand two hundred fifty-four. 
+</div><div class="li1">
+<sup>35&#160;</sup>The children of Harim: three hundred twenty. 
+</div><div class="li1">
+<sup>36&#160;</sup>The children of Jericho: three hundred forty-five. 
+</div><div class="li1">
+<sup>37&#160;</sup>The children of Lod, Hadid, and Ono: seven hundred twenty-one. 
+</div><div class="li1">
+<sup>38&#160;</sup>The children of Senaah: three thousand nine hundred thirty. 
+</div><div class="b"> &#160; </div>
+<div class="li1">
+<sup>39&#160;</sup>The priests: The children of Jedaiah, of the house of Jeshua: nine hundred seventy-three. 
+</div><div class="li1">
+<sup>40&#160;</sup>The children of Immer: one thousand fifty-two. 
+</div><div class="li1">
+<sup>41&#160;</sup>The children of Pashhur: one thousand two hundred forty-seven. 
+</div><div class="li1">
+<sup>42&#160;</sup>The children of Harim: one thousand seventeen. 
+</div><div class="b"> &#160; </div>
+<div class="li1">
+<sup>43&#160;</sup>The Levites: the children of Jeshua, of Kadmiel, of the children of Hodevah: seventy-four. 
+</div><div class="li1">
+<sup>44&#160;</sup>The singers: the children of Asaph: one hundred forty-eight. 
+</div><div class="li1">
+<sup>45&#160;</sup>The gatekeepers: the children of Shallum, the children of Ater, the children of Talmon, the children of Akkub, the children of Hatita, the children of Shobai: one hundred thirty-eight. 
+</div><div class="p">
+<sup>46&#160;</sup>The temple servants: the children of Ziha, the children of Hasupha, the children of Tabbaoth, 
+<sup>47&#160;</sup>the children of Keros, the children of Sia, the children of Padon, 
+<sup>48&#160;</sup>the children of Lebana, the children of Hagaba, the children of Salmai, 
+<sup>49&#160;</sup>the children of Hanan, the children of Giddel, the children of Gahar, 
+<sup>50&#160;</sup>the children of Reaiah, the children of Rezin, the children of Nekoda, 
+<sup>51&#160;</sup>the children of Gazzam, the children of Uzza, the children of Paseah, 
+<sup>52&#160;</sup>the children of Besai, the children of Meunim, the children of Nephushesim, 
+<sup>53&#160;</sup>the children of Bakbuk, the children of Hakupha, the children of Harhur, 
+<sup>54&#160;</sup>the children of Bazlith, the children of Mehida, the children of Harsha, 
+<sup>55&#160;</sup>the children of Barkos, the children of Sisera, the children of Temah, 
+<sup>56&#160;</sup>the children of Neziah, and the children of Hatipha. 
+</div><div class="p">
+<sup>57&#160;</sup>The children of Solomon’s servants: the children of Sotai, the children of Sophereth, the children of Perida, 
+<sup>58&#160;</sup>the children of Jaala, the children of Darkon, the children of Giddel, 
+<sup>59&#160;</sup>the children of Shephatiah, the children of Hattil, the children of Pochereth Hazzebaim, and the children of Amon. 
+<sup>60&#160;</sup>All the temple servants and the children of Solomon’s servants were three hundred ninety-two. 
+</div><div class="p">
+<sup>61&#160;</sup>These were those who went up from Tel Melah, Tel Harsha, Cherub, Addon, and Immer; but they could not show their fathers’ houses, nor their offspring, whether they were of Israel: 
+</div><div class="li1">
+<sup>62&#160;</sup>The children of Delaiah, the children of Tobiah, the children of Nekoda: six hundred forty-two. 
+</div><div class="li1">
+<sup>63&#160;</sup>Of the priests: the children of Hobaiah, the children of Hakkoz, the children of Barzillai, who took a woman of the daughters of Barzillai the Gileadite, and was called after their name. 
+</div><div class="p">
+<sup>64&#160;</sup>These searched for their genealogical records, but couldn’t find them. Therefore they were deemed disqualified and removed from the priesthood. 
+<sup>65&#160;</sup>The governor told them not to eat of the most set-apart things until a priest stood up to minister with Urim and Thummim. 
+</div><div class="p">
+<sup>66&#160;</sup>The whole assembly together was forty-two thousand three hundred sixty, 
+<sup>67&#160;</sup>in addition to their male servants and their female servants, of whom there were seven thousand three hundred thirty-seven. They had two hundred forty-five singing men and singing women. 
+<sup>68&#160;</sup>Their horses were seven hundred thirty-six; their mules, two hundred forty-five; 
+<sup>69&#160;</sup>their camels, four hundred thirty-five; their donkeys, six thousand seven hundred twenty. 
+</div><div class="p">
+<sup>70&#160;</sup>Some from among the heads of fathers’ households gave to the work. The governor gave to the treasury one thousand darics of gold, fifty basins, and five hundred thirty priests’ garments. 
+<sup>71&#160;</sup>Some of the heads of fathers’ households gave into the treasury of the work twenty thousand darics of gold, and two thousand two hundred minas of silver. 
+<sup>72&#160;</sup>That which the rest of the people gave was twenty thousand darics of gold, plus two thousand minas of silver, and sixty-seven priests’ garments. 
+</div><div class="p">
+<sup>73&#160;</sup>So the priests, the Levites, the gatekeepers, the singers, some of the people, the temple servants, and all Israel lived in their cities. 
+</div><div class="p">When the seventh month had come, the children of Israel were in their cities. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>All the people gathered themselves together as one man into the wide place that was in front of the water gate; and they spoke to Ezra the scribe to bring the book of the law of Moses, which Yahweh had commanded to Israel. 
+<sup>2&#160;</sup>Ezra the priest brought the law before the assembly, both men and women, and all who could hear with understanding, on the first day of the seventh month. 
+<sup>3&#160;</sup>He read from it before the wide place that was in front of the water gate from early morning until midday, in the presence of the men and the women, and of those who could understand. The ears of all the people were attentive to the book of the law. 
+<sup>4&#160;</sup>Ezra the scribe stood on a pulpit of wood, which they had made for the purpose; and beside him stood Mattithiah, Shema, Anaiah, Uriah, Hilkiah, and Maaseiah, on his right hand; and on his left hand, Pedaiah, Mishael, Malchijah, Hashum, Hashbaddanah, Zechariah, and Meshullam. 
+<sup>5&#160;</sup>Ezra opened the book in the sight of all the people (for he was above all the people), and when he opened it, all the people stood up. 
+<sup>6&#160;</sup>Then Ezra blessed Yahweh, the great Elohim. 
+</div><div class="p">All the people answered, “Amen, Amen,” with the lifting up of their hands. They bowed their heads, and worshiped Yahweh with their faces to the ground. 
+<sup>7&#160;</sup>Also Jeshua, Bani, Sherebiah, Jamin, Akkub, Shabbethai, Hodiah, Maaseiah, Kelita, Azariah, Jozabad, Hanan, Pelaiah, and the Levites, caused the people to understand the law; and the people stayed in their place. 
+<sup>8&#160;</sup>They read in the book, in the law of Elohim, distinctly; and they gave the sense, so that they understood the reading. 
+</div><div class="p">
+<sup>9&#160;</sup>Nehemiah, who was the governor, Ezra the priest and scribe, and the Levites who taught the people said to all the people, “Today is set-apart to Yahweh your Elohim. Don’t mourn, nor weep.” For all the people wept when they heard the words of the law. 
+<sup>10&#160;</sup>Then he said to them, “Go your way. Eat the fat, drink the sweet, and send portions to him for whom nothing is prepared, for today is set-apart to our Lord. Don’t be grieved, for the joy of Yahweh is your strength.” 
+</div><div class="p">
+<sup>11&#160;</sup>So the Levites calmed all the people, saying, “Hold your peace, for the day is set-apart. Don’t be grieved.” 
+</div><div class="p">
+<sup>12&#160;</sup>All the people went their way to eat, to drink, to send portions, and to celebrate, because they had understood the words that were declared to them. 
+</div><div class="p">
+<sup>13&#160;</sup>On the second day, the heads of fathers’ households of all the people, the priests, and the Levites were gathered together to Ezra the scribe, to study the words of the law. 
+<sup>14&#160;</sup>They found written in the law how Yahweh had commanded by Moses that the children of Israel should dwell in booths in the feast of the seventh month; 
+<sup>15&#160;</sup>and that they should publish and proclaim in all their cities and in Jerusalem, saying, “Go out to the mountain, and get olive branches, branches of wild olive, myrtle branches, palm branches, and branches of thick trees, to make temporary shelters, as it is written.” 
+</div><div class="p">
+<sup>16&#160;</sup>So the people went out and brought them, and made themselves temporary shelters, everyone on the roof of his house, in their courts, in the courts of Elohim’s house, in the wide place of the water gate, and in the wide place of Ephraim’s gate. 
+<sup>17&#160;</sup>All the assembly of those who had come back out of the captivity made temporary shelters and lived in the temporary shelters, for since the days of Joshua the son of Nun to that day the children of Israel had not done so. There was very great gladness. 
+<sup>18&#160;</sup>Also day by day, from the first day to the last day, he read in the book of the law of Elohim. They kept the feast seven days; and on the eighth day was a solemn assembly, according to the ordinance. 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Now in the twenty-fourth day of this month the children of Israel were assembled with fasting, with sackcloth, and dirt on them. 
+<sup>2&#160;</sup>The offspring of Israel separated themselves from all foreigners and stood and confessed their sins and the iniquities of their fathers. 
+<sup>3&#160;</sup>They stood up in their place, and read in the book of the law of Yahweh their Elohim a fourth part of the day; and a fourth part they confessed and worshiped Yahweh their Elohim. 
+<sup>4&#160;</sup>Then Jeshua, Bani, Kadmiel, Shebaniah, Bunni, Sherebiah, Bani, and Chenani of the Levites stood up on the stairs, and cried with a loud voice to Yahweh their Elohim. 
+</div><div class="p">
+<sup>5&#160;</sup>Then the Levites, Jeshua, and Kadmiel, Bani, Hashabneiah, Sherebiah, Hodiah, Shebaniah, and Pethahiah, said, “Stand up and bless Yahweh your Elohim from everlasting to everlasting! Blessed be your glorious name, which is exalted above all blessing and praise! 
+<sup>6&#160;</sup>You are Yahweh, even you alone. You have made heaven, the heaven of heavens, with all their army, the earth and all things that are on it, the seas and all that is in them, and you preserve them all. The army of heaven worships you. 
+<sup>7&#160;</sup>You are Yahweh, the Elohim who chose Abram, brought him out of Ur of the Chaldees, gave him the name of Abraham, 
+<sup>8&#160;</sup>found his heart faithful before you, and made a covenant with him to give the land of the Canaanite, the Hittite, the Amorite, the Perizzite, the Jebusite, and the Girgashite, to give it to his offspring, and have performed your words, for you are righteous. 
+</div><div class="p">
+<sup>9&#160;</sup>“You saw the affliction of our fathers in Egypt, and heard their cry by the Red Sea, 
+<sup>10&#160;</sup>and showed signs and wonders against Pharaoh, against all his servants, and against all the people of his land, for you knew that they dealt proudly against them, and made a name for yourself, as it is today. 
+<sup>11&#160;</sup>You divided the sea before them, so that they went through the middle of the sea on the dry land; and you cast their pursuers into the depths, as a stone into the mighty waters. 
+<sup>12&#160;</sup>Moreover, in a pillar of cloud you led them by day; and in a pillar of fire by night, to give them light in the way in which they should go. 
+</div><div class="p">
+<sup>13&#160;</sup>“You also came down on Mount Sinai, and spoke with them from heaven, and gave them right ordinances and true laws, good statutes and commandments, 
+<sup>14&#160;</sup>and made known to them your set-apart Sabbath, and commanded them commandments, statutes, and a law, by Moses your servant, 
+<sup>15&#160;</sup>and gave them bread from the sky for their hunger, and brought water out of the rock for them for their thirst, and commanded them that they should go in to possess the land which you had sworn to give them. 
+</div><div class="p">
+<sup>16&#160;</sup>“But they and our fathers behaved proudly, hardened their neck, didn’t listen to your commandments, 
+<sup>17&#160;</sup>and refused to obey. They weren’t mindful of your wonders that you did among them, but hardened their neck, and in their rebellion appointed a captain to return to their bondage. But you are an Elohim ready to pardon, gracious and merciful, slow to anger, and abundant in loving kindness, and didn’t forsake them. 
+<sup>18&#160;</sup>Yes, when they had made themselves a molded calf, and said, ‘This is your Elohim who brought you up out of Egypt,’ and had committed awful blasphemies, 
+<sup>19&#160;</sup>yet you in your manifold mercies didn’t forsake them in the wilderness. The pillar of cloud didn’t depart from over them by day, to lead them in the way; neither did the pillar of fire by night, to show them light, and the way in which they should go. 
+<sup>20&#160;</sup>You gave also your good Spirit to instruct them, and didn’t withhold your manna from their mouth, and gave them water for their thirst. 
+</div><div class="p">
+<sup>21&#160;</sup>“Yes, forty years you sustained them in the wilderness. They lacked nothing. Their clothes didn’t grow old, and their feet didn’t swell. 
+<sup>22&#160;</sup>Moreover you gave them kingdoms and peoples, which you allotted according to their portions. So they possessed the land of Sihon, even the land of the king of Heshbon, and the land of Og king of Bashan. 
+<sup>23&#160;</sup>You also multiplied their children as the stars of the sky, and brought them into the land concerning which you said to their fathers that they should go in to possess it. 
+</div><div class="p">
+<sup>24&#160;</sup>“So the children went in and possessed the land; and you subdued before them the inhabitants of the land, the Canaanites, and gave them into their hands, with their kings and the peoples of the land, that they might do with them as they pleased. 
+<sup>25&#160;</sup>They took fortified cities and a rich land, and possessed houses full of all good things, cisterns dug out, vineyards, olive groves, and fruit trees in abundance. So they ate, were filled, became fat, and delighted themselves in your great goodness. 
+</div><div class="p">
+<sup>26&#160;</sup>“Nevertheless they were disobedient and rebelled against you, cast your law behind their back, killed your prophets that testified against them to turn them again to you, and they committed awful blasphemies. 
+<sup>27&#160;</sup>Therefore you delivered them into the hand of their adversaries, who distressed them. In the time of their trouble, when they cried to you, you heard from heaven; and according to your manifold mercies you gave them saviors who saved them out of the hands of their adversaries. 
+<sup>28&#160;</sup>But after they had rest, they did evil again before you; therefore you left them in the hands of their enemies, so that they had the dominion over them; yet when they returned and cried to you, you heard from heaven; and many times you delivered them according to your mercies, 
+<sup>29&#160;</sup>and testified against them, that you might bring them again to your law. Yet they were arrogant, and didn’t listen to your commandments, but sinned against your ordinances (which if a man does, he shall live in them), turned their backs, stiffened their neck, and would not hear. 
+<sup>30&#160;</sup>Yet many years you put up with them, and testified against them by your Spirit through your prophets. Yet they would not listen. Therefore you gave them into the hand of the peoples of the lands. 
+</div><div class="p">
+<sup>31&#160;</sup>“Nevertheless in your manifold mercies you didn’t make a full end of them, nor forsake them; for you are a gracious and merciful Elohim. 
+</div><div class="p">
+<sup>32&#160;</sup>Now therefore, our Elohim, the great, the mighty, and the awesome Elohim, who keeps covenant and loving kindness, don’t let all the travail seem little before you that has come on us, on our kings, on our princes, on our priests, on our prophets, on our fathers, and on all your people, since the time of the kings of Assyria to this day. 
+<sup>33&#160;</sup>However you are just in all that has come on us; for you have dealt truly, but we have done wickedly. 
+<sup>34&#160;</sup>Also our kings, our princes, our priests, and our fathers have not kept your law, nor listened to your commandments and your testimonies with which you testified against them. 
+<sup>35&#160;</sup>For they have not served you in their kingdom, and in your great goodness that you gave them, and in the large and rich land which you gave before them. They didn’t turn from their wicked works. 
+</div><div class="p">
+<sup>36&#160;</sup>“Behold, we are servants today, and as for the land that you gave to our fathers to eat its fruit and its good, behold, we are servants in it. 
+<sup>37&#160;</sup>It yields much increase to the kings whom you have set over us because of our sins. Also they have power over our bodies and over our livestock, at their pleasure, and we are in great distress. 
+<sup>38&#160;</sup>Yet for all this, we make a sure covenant, and write it; and our princes, our Levites, and our priests, seal it.” 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Now those who sealed were: Nehemiah the governor, the son of Hacaliah, and Zedekiah, 
+<sup>2&#160;</sup>Seraiah, Azariah, Jeremiah, 
+<sup>3&#160;</sup>Pashhur, Amariah, Malchijah, 
+<sup>4&#160;</sup>Hattush, Shebaniah, Malluch, 
+<sup>5&#160;</sup>Harim, Meremoth, Obadiah, 
+<sup>6&#160;</sup>Daniel, Ginnethon, Baruch, 
+<sup>7&#160;</sup>Meshullam, Abijah, Mijamin, 
+<sup>8&#160;</sup>Maaziah, Bilgai, and Shemaiah. These were the priests. 
+<sup>9&#160;</sup>The Levites: Jeshua the son of Azaniah, Binnui of the sons of Henadad, Kadmiel; 
+<sup>10&#160;</sup>and their brothers, Shebaniah, Hodiah, Kelita, Pelaiah, Hanan, 
+<sup>11&#160;</sup>Mica, Rehob, Hashabiah, 
+<sup>12&#160;</sup>Zaccur, Sherebiah, Shebaniah, 
+<sup>13&#160;</sup>Hodiah, Bani, and Beninu. 
+<sup>14&#160;</sup>The chiefs of the people: Parosh, Pahathmoab, Elam, Zattu, Bani, 
+<sup>15&#160;</sup>Bunni, Azgad, Bebai, 
+<sup>16&#160;</sup>Adonijah, Bigvai, Adin, 
+<sup>17&#160;</sup>Ater, Hezekiah, Azzur, 
+<sup>18&#160;</sup>Hodiah, Hashum, Bezai, 
+<sup>19&#160;</sup>Hariph, Anathoth, Nobai, 
+<sup>20&#160;</sup>Magpiash, Meshullam, Hezir, 
+<sup>21&#160;</sup>Meshezabel, Zadok, Jaddua, 
+<sup>22&#160;</sup>Pelatiah, Hanan, Anaiah, 
+<sup>23&#160;</sup>Hoshea, Hananiah, Hasshub, 
+<sup>24&#160;</sup>Hallohesh, Pilha, Shobek, 
+<sup>25&#160;</sup>Rehum, Hashabnah, Maaseiah, 
+<sup>26&#160;</sup>Ahiah, Hanan, Anan, 
+<sup>27&#160;</sup>Malluch, Harim, and Baanah. 
+</div><div class="p">
+<sup>28&#160;</sup>The rest of the people, the priests, the Levites, the gatekeepers, the singers, the temple servants, and all those who had separated themselves from the peoples of the lands to the law of Elohim, their women, their sons, and their daughters—everyone who had knowledge and understanding—<sup>29&#160;</sup>joined with their brothers, their nobles, and entered into a curse and into an oath, to walk in Elohim’s law, which was given by Moses the servant of Elohim, and to observe and do all the commandments of Yahweh our Lord, and his ordinances and his statutes; 
+<sup>30&#160;</sup>and that we would not give our daughters to the peoples of the land, nor take their daughters for our sons; 
+<sup>31&#160;</sup>and if the peoples of the land bring wares or any grain on the Sabbath day to sell, that we would not buy from them on the Sabbath, or on a set-apart day; and that we would forego the seventh year crops and the exaction of every debt. 
+</div><div class="p">
+<sup>32&#160;</sup>Also we made ordinances for ourselves, to charge ourselves yearly with the third part of a shekel for the service of the house of our Elohim: 
+<sup>33&#160;</sup>for the show bread, for the continual meal offering, for the continual burnt offering, for the Sabbaths, for the new moons, for the set feasts, for the set-apart things, for the sin offerings to make atonement for Israel, and for all the work of the house of our Elohim. 
+<sup>34&#160;</sup>We, the priests, the Levites, and the people, cast lots for the wood offering, to bring it into the house of our Elohim, according to our fathers’ houses, at times appointed year by year, to burn on Yahweh our Elohim’s altar, as it is written in the law; 
+<sup>35&#160;</sup>and to bring the first fruits of our ground and the first fruits of all fruit of all kinds of trees, year by year, to Yahweh’s house; 
+<sup>36&#160;</sup>also the firstborn of our sons and of our livestock, as it is written in the law, and the firstborn of our herds and of our flocks, to bring to the house of our Elohim, to the priests who minister in the house of our Elohim; 
+<sup>37&#160;</sup>and that we should bring the first fruits of our dough, our wave offerings, the fruit of all kinds of trees, and the new wine and the oil, to the priests, to the rooms of the house of our Elohim; and the tithes of our ground to the Levites; for they, the Levites, take the tithes in all our farming villages. 
+<sup>38&#160;</sup>The priest, the descendent of Aaron, shall be with the Levites when the Levites take tithes. The Levites shall bring up the tithe of the tithes to the house of our Elohim, to the rooms, into the treasure house. 
+<sup>39&#160;</sup>For the children of Israel and the children of Levi shall bring the wave offering of the grain, of the new wine, and of the oil, to the rooms where the vessels of the sanctuary are, and the priests who minister, with the gatekeepers and the singers. We will not forsake the house of our Elohim. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>The princes of the people lived in Jerusalem. The rest of the people also cast lots to bring one of ten to dwell in Jerusalem, the set-apart city, and nine parts in the other cities. 
+<sup>2&#160;</sup>The people blessed all the men who willingly offered themselves to dwell in Jerusalem. 
+</div><div class="p">
+<sup>3&#160;</sup>Now these are the chiefs of the province who lived in Jerusalem; but in the cities of Judah, everyone lived in his possession in their cities—Israel, the priests, the Levites, the temple servants, and the children of Solomon’s servants. 
+<sup>4&#160;</sup>Some of the children of Judah and of the children of Benjamin lived in Jerusalem. Of the children of Judah: Athaiah the son of Uzziah, the son of Zechariah, the son of Amariah, the son of Shephatiah, the son of Mahalalel, of the children of Perez; 
+<sup>5&#160;</sup>and Maaseiah the son of Baruch, the son of Colhozeh, the son of Hazaiah, the son of Adaiah, the son of Joiarib, the son of Zechariah, the son of the Shilonite. 
+<sup>6&#160;</sup>All the sons of Perez who lived in Jerusalem were four hundred sixty-eight valiant men. 
+</div><div class="p">
+<sup>7&#160;</sup>These are the sons of Benjamin: Sallu the son of Meshullam, the son of Joed, the son of Pedaiah, the son of Kolaiah, the son of Maaseiah, the son of Ithiel, the son of Jeshaiah. 
+<sup>8&#160;</sup>After him Gabbai and Sallai, nine hundred twenty-eight. 
+<sup>9&#160;</sup>Joel the son of Zichri was their overseer; and Judah the son of Hassenuah was second over the city. 
+</div><div class="p">
+<sup>10&#160;</sup>Of the priests: Jedaiah the son of Joiarib, Jachin, 
+<sup>11&#160;</sup>Seraiah the son of Hilkiah, the son of Meshullam, the son of Zadok, the son of Meraioth, the son of Ahitub, the ruler of Elohim’s house, 
+<sup>12&#160;</sup>and their brothers who did the work of the house, eight hundred twenty-two; and Adaiah the son of Jeroham, the son of Pelaliah, the son of Amzi, the son of Zechariah, the son of Pashhur, the son of Malchijah, 
+<sup>13&#160;</sup>and his brothers, chiefs of fathers’ households, two hundred forty-two; and Amashsai the son of Azarel, the son of Ahzai, the son of Meshillemoth, the son of Immer, 
+<sup>14&#160;</sup>and their brothers, mighty men of valor, one hundred twenty-eight; and their overseer was Zabdiel, the son of Haggedolim. 
+</div><div class="p">
+<sup>15&#160;</sup>Of the Levites: Shemaiah the son of Hasshub, the son of Azrikam, the son of Hashabiah, the son of Bunni; 
+<sup>16&#160;</sup>and Shabbethai and Jozabad, of the chiefs of the Levites, who had the oversight of the outward business of Elohim’s house; 
+<sup>17&#160;</sup>and Mattaniah the son of Mica, the son of Zabdi, the son of Asaph, who was the chief to begin the thanksgiving in prayer, and Bakbukiah, the second among his brothers; and Abda the son of Shammua, the son of Galal, the son of Jeduthun. 
+<sup>18&#160;</sup>All the Levites in the set-apart city were two hundred eighty-four. 
+</div><div class="p">
+<sup>19&#160;</sup>Moreover the gatekeepers, Akkub, Talmon, and their brothers, who kept watch at the gates, were one hundred seventy-two. 
+<sup>20&#160;</sup>The residue of Israel, of the priests, and the Levites were in all the cities of Judah, everyone in his inheritance. 
+<sup>21&#160;</sup>But the temple servants lived in Ophel; and Ziha and Gishpa were over the temple servants. 
+</div><div class="p">
+<sup>22&#160;</sup>The overseer also of the Levites at Jerusalem was Uzzi the son of Bani, the son of Hashabiah, the son of Mattaniah, the son of Mica, of the sons of Asaph, the singers responsible for the service of Elohim’s house. 
+<sup>23&#160;</sup>For there was a commandment from the king concerning them, and a settled provision for the singers, as every day required. 
+<sup>24&#160;</sup>Pethahiah the son of Meshezabel, of the children of Zerah the son of Judah, was at the king’s hand in all matters concerning the people. 
+</div><div class="p">
+<sup>25&#160;</sup>As for the villages with their fields, some of the children of Judah lived in Kiriath Arba and its towns, in Dibon and its towns, in Jekabzeel and its villages, 
+<sup>26&#160;</sup>in Jeshua, in Moladah, Beth Pelet, 
+<sup>27&#160;</sup>in Hazar Shual, in Beersheba and its towns, 
+<sup>28&#160;</sup>in Ziklag, in Meconah and in its towns, 
+<sup>29&#160;</sup>in En Rimmon, in Zorah, in Jarmuth, 
+<sup>30&#160;</sup>Zanoah, Adullam, and their villages, Lachish and its fields, and Azekah and its towns. So they encamped from Beersheba to the valley of Hinnom. 
+<sup>31&#160;</sup>The children of Benjamin also lived from Geba onward, at Michmash and Aija, and at Bethel and its towns, 
+<sup>32&#160;</sup>at Anathoth, Nob, Ananiah, 
+<sup>33&#160;</sup>Hazor, Ramah, Gittaim, 
+<sup>34&#160;</sup>Hadid, Zeboim, Neballat, 
+<sup>35&#160;</sup>Lod, and Ono, the valley of craftsmen. 
+<sup>36&#160;</sup>Of the Levites, certain divisions in Judah settled in Benjamin’s territory. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Now these are the priests and the Levites who went up with Zerubbabel the son of Shealtiel, and Jeshua: Seraiah, Jeremiah, Ezra, 
+<sup>2&#160;</sup>Amariah, Malluch, Hattush, 
+<sup>3&#160;</sup>Shecaniah, Rehum, Meremoth, 
+<sup>4&#160;</sup>Iddo, Ginnethoi, Abijah, 
+<sup>5&#160;</sup>Mijamin, Maadiah, Bilgah, 
+<sup>6&#160;</sup>Shemaiah, Joiarib, Jedaiah, 
+<sup>7&#160;</sup>Sallu, Amok, Hilkiah, and Jedaiah. These were the chiefs of the priests and of their brothers in the days of Jeshua. 
+</div><div class="p">
+<sup>8&#160;</sup>Moreover the Levites were Jeshua, Binnui, Kadmiel, Sherebiah, Judah, and Mattaniah, who was over the thanksgiving songs, he and his brothers. 
+<sup>9&#160;</sup>Also Bakbukiah and Unno, their brothers, were close to them according to their offices. 
+<sup>10&#160;</sup>Jeshua brought forth Joiakim, and Joiakim brought forth Eliashib, and Eliashib brought forth Joiada, 
+<sup>11&#160;</sup>and Joiada brought forth Jonathan, and Jonathan brought forth Jaddua. 
+</div><div class="p">
+<sup>12&#160;</sup>In the days of Joiakim were priests, heads of fathers’ households: of Seraiah, Meraiah; of Jeremiah, Hananiah; 
+<sup>13&#160;</sup>of Ezra, Meshullam; of Amariah, Jehohanan; 
+<sup>14&#160;</sup>of Malluchi, Jonathan; of Shebaniah, Joseph; 
+<sup>15&#160;</sup>of Harim, Adna; of Meraioth, Helkai; 
+<sup>16&#160;</sup>of Iddo, Zechariah; of Ginnethon, Meshullam; 
+<sup>17&#160;</sup>of Abijah, Zichri; of Miniamin, of Moadiah, Piltai; 
+<sup>18&#160;</sup>of Bilgah, Shammua; of Shemaiah, Jehonathan; 
+<sup>19&#160;</sup>of Joiarib, Mattenai; of Jedaiah, Uzzi; 
+<sup>20&#160;</sup>of Sallai, Kallai; of Amok, Eber; 
+<sup>21&#160;</sup>of Hilkiah, Hashabiah; of Jedaiah, Nethanel. 
+</div><div class="p">
+<sup>22&#160;</sup>As for the Levites, in the days of Eliashib, Joiada, Johanan, and Jaddua, there were recorded the heads of fathers’ households; also the priests, in the reign of Darius the Persian. 
+<sup>23&#160;</sup>The sons of Levi, heads of fathers’ households, were written in the book of the chronicles, even until the days of Johanan the son of Eliashib. 
+<sup>24&#160;</sup>The chiefs of the Levites: Hashabiah, Sherebiah, and Jeshua the son of Kadmiel, with their brothers close to them, to praise and give thanks according to the commandment of David the man of Elohim, section next to section. 
+<sup>25&#160;</sup>Mattaniah, Bakbukiah, Obadiah, Meshullam, Talmon, and Akkub were gatekeepers keeping the watch at the storehouses of the gates. 
+<sup>26&#160;</sup>These were in the days of Joiakim the son of Jeshua, the son of Jozadak, and in the days of Nehemiah the governor, and of Ezra the priest and scribe. 
+</div><div class="p">
+<sup>27&#160;</sup>At the dedication of the wall of Jerusalem, they sought the Levites out of all their places, to bring them to Jerusalem to keep the dedication with gladness, both with giving thanks and with singing, with cymbals, stringed instruments, and with harps. 
+<sup>28&#160;</sup>The sons of the singers gathered themselves together, both out of the plain around Jerusalem and from the villages of the Netophathites; 
+<sup>29&#160;</sup>also from Beth Gilgal and out of the fields of Geba and Azmaveth, for the singers had built themselves villages around Jerusalem. 
+<sup>30&#160;</sup>The priests and the Levites purified themselves; and they purified the people, the gates, and the wall. 
+</div><div class="p">
+<sup>31&#160;</sup>Then I brought the princes of Judah up on the wall, and appointed two great companies who gave thanks and went in procession. One went on the right hand on the wall toward the dung gate; 
+<sup>32&#160;</sup>and after them went Hoshaiah, with half of the princes of Judah, 
+<sup>33&#160;</sup>and Azariah, Ezra, and Meshullam, 
+<sup>34&#160;</sup>Judah, Benjamin, Shemaiah, Jeremiah, 
+<sup>35&#160;</sup>and some of the priests’ sons with trumpets: Zechariah the son of Jonathan, the son of Shemaiah, the son of Mattaniah, the son of Micaiah, the son of Zaccur, the son of Asaph; 
+<sup>36&#160;</sup>and his brothers, Shemaiah, Azarel, Milalai, Gilalai, Maai, Nethanel, Judah, and Hanani, with the musical instruments of David the man of Elohim; and Ezra the scribe was before them. 
+<sup>37&#160;</sup>By the spring gate, and straight before them, they went up by the stairs of David’s city, at the ascent of the wall, above David’s house, even to the water gate eastward. 
+</div><div class="p">
+<sup>38&#160;</sup>The other company of those who gave thanks went to meet them, and I after them, with the half of the people on the wall above the tower of the furnaces, even to the wide wall, 
+<sup>39&#160;</sup>and above the gate of Ephraim, and by the old gate, and by the fish gate, the tower of Hananel, and the tower of Hammeah, even to the sheep gate; and they stood still in the gate of the guard. 
+<sup>40&#160;</sup>So the two companies of those who gave thanks in Elohim’s house stood, and I and the half of the rulers with me; 
+<sup>41&#160;</sup>and the priests, Eliakim, Maaseiah, Miniamin, Micaiah, Elioenai, Zechariah, and Hananiah, with trumpets; 
+<sup>42&#160;</sup>and Maaseiah, Shemaiah, Eleazar, Uzzi, Jehohanan, Malchijah, Elam, and Ezer. The singers sang loud, with Jezrahiah their overseer. 
+<sup>43&#160;</sup>They offered great sacrifices that day, and rejoiced, for Elohim had made them rejoice with great joy; and the women and the children also rejoiced, so that the joy of Jerusalem was heard even far away. 
+</div><div class="p">
+<sup>44&#160;</sup>On that day, men were appointed over the rooms for the treasures, for the wave offerings, for the first fruits, and for the tithes, to gather into them according to the fields of the cities the portions appointed by the law for the priests and Levites; for Judah rejoiced for the priests and for the Levites who served. 
+<sup>45&#160;</sup>They performed the duty of their Elohim and the duty of the purification, and so did the singers and the gatekeepers, according to the commandment of David and of Solomon his son. 
+<sup>46&#160;</sup>For in the days of David and Asaph of old there was a chief of the singers, and songs of praise and thanksgiving to Elohim. 
+<sup>47&#160;</sup>All Israel in the days of Zerubbabel and in the days of Nehemiah gave the portions of the singers and the gatekeepers, as every day required; and they set apart that which was for the Levites; and the Levites set apart that which was for the sons of Aaron. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>On that day they read in the book of Moses in the hearing of the people; and it was found written in it that an Ammonite and a Moabite should not enter into the assembly of Elohim forever, 
+<sup>2&#160;</sup>because they didn’t meet the children of Israel with bread and with water, but hired Balaam against them to curse them; however, our Elohim turned the curse into a blessing. 
+<sup>3&#160;</sup>It came to pass, when they had heard the law, that they separated all the mixed multitude from Israel. 
+</div><div class="p">
+<sup>4&#160;</sup>Now before this, Eliashib the priest, who was appointed over the rooms of the house of our Elohim, being allied to Tobiah, 
+<sup>5&#160;</sup>had prepared for him a great room, where before they laid the meal offerings, the frankincense, the vessels, and the tithes of the grain, the new wine, and the oil, which were given by commandment to the Levites, the singers, and the gatekeepers; and the wave offerings for the priests. 
+<sup>6&#160;</sup>But in all this, I was not at Jerusalem; for in the thirty-second year of Artaxerxes king of Babylon I went to the king; and after some days I asked leave of the king, 
+<sup>7&#160;</sup>and I came to Jerusalem, and understood the evil that Eliashib had done for Tobiah, in preparing him a room in the courts of Elohim’s house. 
+<sup>8&#160;</sup>It grieved me severely. Therefore I threw all Tobiah’s household stuff out of the room. 
+<sup>9&#160;</sup>Then I commanded, and they cleansed the rooms. I brought into them the vessels of Elohim’s house, with the meal offerings and the frankincense again. 
+</div><div class="p">
+<sup>10&#160;</sup>I perceived that the portions of the Levites had not been given them, so that the Levites and the singers, who did the work, had each fled to his field. 
+<sup>11&#160;</sup>Then I contended with the rulers, and said, “Why is Elohim’s house forsaken?” I gathered them together, and set them in their place. 
+<sup>12&#160;</sup>Then all Judah brought the tithe of the grain, the new wine, and the oil to the treasuries. 
+<sup>13&#160;</sup>I made treasurers over the treasuries, Shelemiah the priest, and Zadok the scribe, and of the Levites, Pedaiah: and next to them was Hanan the son of Zaccur, the son of Mattaniah; for they were counted faithful, and their business was to distribute to their brothers. 
+</div><div class="p">
+<sup>14&#160;</sup>Remember me, my Elohim, concerning this, and don’t wipe out my good deeds that I have done for the house of my Elohim, and for its observances. 
+</div><div class="p">
+<sup>15&#160;</sup>In those days I saw some men treading wine presses on the Sabbath in Judah, bringing in sheaves, and loading donkeys with wine, grapes, figs, and all kinds of burdens which they brought into Jerusalem on the Sabbath day; and I testified against them in the day in which they sold food. 
+<sup>16&#160;</sup>Some men of Tyre also lived there, who brought in fish and all kinds of wares, and sold on the Sabbath to the children of Judah, and in Jerusalem. 
+<sup>17&#160;</sup>Then I contended with the nobles of Judah, and said to them, “What evil thing is this that you do, and profane the Sabbath day? 
+<sup>18&#160;</sup>Didn’t your fathers do this, and didn’t our Elohim bring all this evil on us and on this city? Yet you bring more wrath on Israel by profaning the Sabbath.” 
+</div><div class="p">
+<sup>19&#160;</sup>It came to pass that when the gates of Jerusalem began to be dark before the Sabbath, I commanded that the doors should be shut, and commanded that they should not be opened until after the Sabbath. I set some of my servants over the gates, so that no burden should be brought in on the Sabbath day. 
+<sup>20&#160;</sup>So the merchants and sellers of all kinds of wares camped outside of Jerusalem once or twice. 
+<sup>21&#160;</sup>Then I testified against them, and said to them, “Why do you stay around the wall? If you do so again, I will lay hands on you.” From that time on, they didn’t come on the Sabbath. 
+<sup>22&#160;</sup>I commanded the Levites that they should purify themselves, and that they should come and keep the gates, to sanctify the Sabbath day. Remember me for this also, my Elohim, and spare me according to the greatness of your loving kindness. 
+</div><div class="p">
+<sup>23&#160;</sup>In those days I also saw the Jews who had married women of Ashdod, of Ammon, and of Moab; 
+<sup>24&#160;</sup>and their children spoke half in the speech of Ashdod, and could not speak in the Jews’ language, but according to the language of each people. 
+<sup>25&#160;</sup>I contended with them, cursed them, struck certain of them, plucked off their hair, and made them swear by Elohim, “You shall not give your daughters to their sons, nor take their daughters for your sons, or for yourselves. 
+<sup>26&#160;</sup>Didn’t Solomon king of Israel sin by these things? Yet among many nations there was no king like him, and he was loved by his Elohim, and Elohim made him king over all Israel. Nevertheless foreign women caused even him to sin. 
+<sup>27&#160;</sup>Shall we then listen to you to do all this great evil, to trespass against our Elohim in marrying foreign women?” 
+</div><div class="p">
+<sup>28&#160;</sup>One of the sons of Joiada, the son of Eliashib the high priest, was son-in-law to Sanballat the Horonite; therefore I chased him from me. 
+<sup>29&#160;</sup>Remember them, my Elohim, because they have defiled the priesthood and the covenant of the priesthood and of the Levites. 
+</div><div class="p">
+<sup>30&#160;</sup>Thus I cleansed them from all foreigners and appointed duties for the priests and for the Levites, everyone in his work; 
+<sup>31&#160;</sup>and for the wood offering, at appointed times, and for the first fruits. Remember me, my Elohim, for good. </div></div><script src="../main.js"></script></body></html>

--- a/book/numbers.html
+++ b/book/numbers.html
@@ -3,6 +3,47 @@
 <head>
 <title>Numbers</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,1932 +53,1969 @@
 <div class="main">
 <!-- NUM World English Scripture (WES) -->
 <h1 class="booklabel">Numbers</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Yahweh<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> spoke to Moses in the wilderness of Sinai, in the Tent of Meeting, on the first day of the second month, in the second year after they had come out of the land of Egypt, saying, 
-<span class="v">2&#160;</span>“Take a census of all the congregation of the children of Israel, by their families, by their fathers’ houses, according to the number of the names, every male, one by one, 
-<span class="v">3&#160;</span>from twenty years old and upward, all who are able to go out to war in Israel. You and Aaron shall count them by their divisions. 
-<span class="v">4&#160;</span>With you there shall be a man of every tribe, each one head of his fathers’ house. 
-<span class="v">5&#160;</span>These are the names of the men who shall stand with you: 
-</p><p>Of Reuben: Elizur the son of Shedeur. 
-</p><p>
-<span class="v">6&#160;</span>Of Simeon: Shelumiel the son of Zurishaddai. 
-</p><p>
-<span class="v">7&#160;</span>Of Judah: Nahshon the son of Amminadab. 
-</p><p>
-<span class="v">8&#160;</span>Of Issachar: Nethanel the son of Zuar. 
-</p><p>
-<span class="v">9&#160;</span>Of Zebulun: Eliab the son of Helon. 
-</p><p>
-<span class="v">10&#160;</span>Of the children of Joseph: of Ephraim: Elishama the son of Ammihud; of Manasseh: Gamaliel the son of Pedahzur. 
-</p><p>
-<span class="v">11&#160;</span>Of Benjamin: Abidan the son of Gideoni. 
-</p><p>
-<span class="v">12&#160;</span>Of Dan: Ahiezer the son of Ammishaddai. 
-</p><p>
-<span class="v">13&#160;</span>Of Asher: Pagiel the son of Ochran. 
-</p><p>
-<span class="v">14&#160;</span>Of Gad: Eliasaph the son of Deuel. 
-</p><p>
-<span class="v">15&#160;</span>Of Naphtali: Ahira the son of Enan.” 
-</p><p>
-<span class="v">16&#160;</span>These are those who were called of the congregation, the princes<span class="f">+ \fr 1:16 \ft or, chiefs, or, leaders</span> of the tribes of their fathers; they were the heads of the thousands of Israel. 
-<span class="v">17&#160;</span>Moses and Aaron took these men who are mentioned by name. 
-<span class="v">18&#160;</span>They assembled all the congregation together on the first day of the second month; and they declared their ancestry by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, one by one. 
-<span class="v">19&#160;</span>As Yahweh commanded Moses, so he counted them in the wilderness of Sinai. 
-</p><p>
-<span class="v">20&#160;</span>The children of Reuben, Israel’s firstborn, their generations, by their families, by their fathers’ houses, according to the number of the names, one by one, every male from twenty years old and upward, all who were able to go out to war: 
-<span class="v">21&#160;</span>those who were counted of them, of the tribe of Reuben, were forty-six thousand five hundred. 
-</p><p>
-<span class="v">22&#160;</span>Of the children of Simeon, their generations, by their families, by their fathers’ houses, those who were counted of it, according to the number of the names, one by one, every male from twenty years old and upward, all who were able to go out to war: 
-<span class="v">23&#160;</span>those who were counted of them, of the tribe of Simeon, were fifty-nine thousand three hundred. 
-</p><p>
-<span class="v">24&#160;</span>Of the children of Gad, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">25&#160;</span>those who were counted of them, of the tribe of Gad, were forty-five thousand six hundred fifty. 
-</p><p>
-<span class="v">26&#160;</span>Of the children of Judah, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">27&#160;</span>those who were counted of them, of the tribe of Judah, were seventy-four thousand six hundred. 
-</p><p>
-<span class="v">28&#160;</span>Of the children of Issachar, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">29&#160;</span>those who were counted of them, of the tribe of Issachar, were fifty-four thousand four hundred. 
-</p><p>
-<span class="v">30&#160;</span>Of the children of Zebulun, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">31&#160;</span>those who were counted of them, of the tribe of Zebulun, were fifty-seven thousand four hundred. 
-</p><p>
-<span class="v">32&#160;</span>Of the children of Joseph: of the children of Ephraim, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">33&#160;</span>those who were counted of them, of the tribe of Ephraim, were forty thousand five hundred. 
-</p><p>
-<span class="v">34&#160;</span>Of the children of Manasseh, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">35&#160;</span>those who were counted of them, of the tribe of Manasseh, were thirty-two thousand two hundred. 
-</p><p>
-<span class="v">36&#160;</span>Of the children of Benjamin, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">37&#160;</span>those who were counted of them, of the tribe of Benjamin, were thirty-five thousand four hundred. 
-</p><p>
-<span class="v">38&#160;</span>Of the children of Dan, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">39&#160;</span>those who were counted of them, of the tribe of Dan, were sixty-two thousand seven hundred. 
-</p><p>
-<span class="v">40&#160;</span>Of the children of Asher, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">41&#160;</span>those who were counted of them, of the tribe of Asher, were forty-one thousand five hundred. 
-</p><p>
-<span class="v">42&#160;</span>Of the children of Naphtali, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
-<span class="v">43&#160;</span>those who were counted of them, of the tribe of Naphtali, were fifty-three thousand four hundred. 
-</p><p>
-<span class="v">44&#160;</span>These are those who were counted, whom Moses and Aaron counted, and the twelve men who were princes of Israel, each one for his fathers’ house. 
-<span class="v">45&#160;</span>So all those who were counted of the children of Israel by their fathers’ houses, from twenty years old and upward, all who were able to go out to war in Israel—<span class="v">46&#160;</span>all those who were counted were six hundred three thousand five hundred fifty. 
-<span class="v">47&#160;</span>But the Levites after the tribe of their fathers were not counted among them. 
-<span class="v">48&#160;</span>For Yahweh spoke to Moses, saying, 
-<span class="v">49&#160;</span>“Only the tribe of Levi you shall not count, neither shall you take a census of them among the children of Israel; 
-<span class="v">50&#160;</span>but appoint the Levites over the Tabernacle of the Testimony, and over all its furnishings, and over all that belongs to it. They shall carry the tabernacle and all its furnishings; and they shall take care of it, and shall encamp around it. 
-<span class="v">51&#160;</span>When the tabernacle is to move, the Levites shall take it down; and when the tabernacle is to be set up, the Levites shall set it up. The stranger who comes near shall be put to death. 
-<span class="v">52&#160;</span>The children of Israel shall pitch their tents, every man by his own camp, and every man by his own standard, according to their divisions. 
-<span class="v">53&#160;</span>But the Levites shall encamp around the Tabernacle of the Testimony, that there may be no wrath on the congregation of the children of Israel. The Levites shall be responsible for the Tabernacle of the Testimony.” 
-</p><p>
-<span class="v">54&#160;</span>Thus the children of Israel did. According to all that Yahweh commanded Moses, so they did. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">2&#160;</span>“The children of Israel shall encamp every man by his own standard, with the banners of their fathers’ houses. They shall encamp around the Tent of Meeting at a distance from it. 
-</p><p>
-<span class="v">3&#160;</span>“Those who encamp on the east side toward the sunrise shall be of the standard of the camp of Judah, according to their divisions. The prince of the children of Judah shall be Nahshon the son of Amminadab. 
-<span class="v">4&#160;</span>His division, and those who were counted of them, were seventy-four thousand six hundred. 
-</p><p>
-<span class="v">5&#160;</span>“Those who encamp next to him shall be the tribe of Issachar. The prince of the children of Issachar shall be Nethanel the son of Zuar. 
-<span class="v">6&#160;</span>His division, and those who were counted of it, were fifty-four thousand four hundred. 
-</p><p>
-<span class="v">7&#160;</span>“The tribe of Zebulun: the prince of the children of Zebulun shall be Eliab the son of Helon. 
-<span class="v">8&#160;</span>His division, and those who were counted of it, were fifty-seven thousand four hundred. 
-</p><p>
-<span class="v">9&#160;</span>“All who were counted of the camp of Judah were one hundred eighty-six thousand four hundred, according to their divisions. They shall set out first. 
-</p><p>
-<span class="v">10&#160;</span>“On the south side shall be the standard of the camp of Reuben according to their divisions. The prince of the children of Reuben shall be Elizur the son of Shedeur. 
-<span class="v">11&#160;</span>His division, and those who were counted of it, were forty-six thousand five hundred. 
-</p><p>
-<span class="v">12&#160;</span>“Those who encamp next to him shall be the tribe of Simeon. The prince of the children of Simeon shall be Shelumiel the son of Zurishaddai. 
-<span class="v">13&#160;</span>His division, and those who were counted of them, were fifty-nine thousand three hundred. 
-</p><p>
-<span class="v">14&#160;</span>“The tribe of Gad: the prince of the children of Gad shall be Eliasaph the son of Reuel. 
-<span class="v">15&#160;</span>His division, and those who were counted of them, were forty-five thousand six hundred fifty. 
-</p><p>
-<span class="v">16&#160;</span>“All who were counted of the camp of Reuben were one hundred fifty-one thousand four hundred fifty, according to their armies. They shall set out second. 
-</p><p>
-<span class="v">17&#160;</span>“Then the Tent of Meeting shall set out, with the camp of the Levites in the middle of the camps. As they encamp, so shall they set out, every man in his place, by their standards. 
-</p><p>
-<span class="v">18&#160;</span>“On the west side shall be the standard of the camp of Ephraim according to their divisions. The prince of the children of Ephraim shall be Elishama the son of Ammihud. 
-<span class="v">19&#160;</span>His division, and those who were counted of them, were forty thousand five hundred. 
-</p><p>
-<span class="v">20&#160;</span>“Next to him shall be the tribe of Manasseh. The prince of the children of Manasseh shall be Gamaliel the son of Pedahzur. 
-<span class="v">21&#160;</span>His division, and those who were counted of them, were thirty-two thousand two hundred. 
-</p><p>
-<span class="v">22&#160;</span>“The tribe of Benjamin: the prince of the children of Benjamin shall be Abidan the son of Gideoni. 
-<span class="v">23&#160;</span>His army, and those who were counted of them, were thirty-five thousand four hundred. 
-</p><p>
-<span class="v">24&#160;</span>“All who were counted of the camp of Ephraim were one hundred eight thousand one hundred, according to their divisions. They shall set out third. 
-</p><p>
-<span class="v">25&#160;</span>“On the north side shall be the standard of the camp of Dan according to their divisions. The prince of the children of Dan shall be Ahiezer the son of Ammishaddai. 
-<span class="v">26&#160;</span>His division, and those who were counted of them, were sixty-two thousand seven hundred. 
-</p><p>
-<span class="v">27&#160;</span>“Those who encamp next to him shall be the tribe of Asher. The prince of the children of Asher shall be Pagiel the son of Ochran. 
-<span class="v">28&#160;</span>His division, and those who were counted of them, were forty-one thousand five hundred. 
-</p><p>
-<span class="v">29&#160;</span>“The tribe of Naphtali: the prince of the children of Naphtali shall be Ahira the son of Enan. 
-<span class="v">30&#160;</span>His division, and those who were counted of them, were fifty-three thousand four hundred. 
-</p><p>
-<span class="v">31&#160;</span>“All who were counted of the camp of Dan were one hundred fifty-seven thousand six hundred. They shall set out last by their standards.” 
-</p><p>
-<span class="v">32&#160;</span>These are those who were counted of the children of Israel by their fathers’ houses. All who were counted of the camps according to their armies were six hundred three thousand five hundred fifty. 
-<span class="v">33&#160;</span>But the Levites were not counted among the children of Israel, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">34&#160;</span>Thus the children of Israel did. According to all that Yahweh commanded Moses, so they encamped by their standards, and so they set out, everyone by their families, according to their fathers’ houses. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Now this is the history of the generations of Aaron and Moses in the day that Yahweh spoke with Moses in Mount Sinai. 
-<span class="v">2&#160;</span>These are the names of the sons of Aaron: Nadab the firstborn, and Abihu, Eleazar, and Ithamar. 
-</p><p>
-<span class="v">3&#160;</span>These are the names of the sons of Aaron, the priests who were anointed, whom he consecrated to minister in the priest’s office. 
-<span class="v">4&#160;</span>Nadab and Abihu died before Yahweh when they offered strange fire before Yahweh in the wilderness of Sinai, and they had no children. Eleazar and Ithamar ministered in the priest’s office in the presence of Aaron their father. 
-</p><p>
-<span class="v">5&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">6&#160;</span>“Bring the tribe of Levi near, and set them before Aaron the priest, that they may minister to him. 
-<span class="v">7&#160;</span>They shall keep his requirements, and the requirements of the whole congregation before the Tent of Meeting, to do the service of the tabernacle. 
-<span class="v">8&#160;</span>They shall keep all the furnishings of the Tent of Meeting, and the obligations of the children of Israel, to do the service of the tabernacle. 
-<span class="v">9&#160;</span>You shall give the Levites to Aaron and to his sons. They are wholly given to him on the behalf of the children of Israel. 
-<span class="v">10&#160;</span>You shall appoint Aaron and his sons, and they shall keep their priesthood, but the stranger who comes near shall be put to death.” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">12&#160;</span>“Behold,<span class="f">+ \fr 3:12 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I have taken the Levites from among the children of Israel instead of all the firstborn who open the womb among the children of Israel; and the Levites shall be mine, 
-<span class="v">13&#160;</span>for all the firstborn are mine. On the day that I struck down all the firstborn in the land of Egypt I made set-apart to me all the firstborn in Israel, both man and animal. They shall be mine. I am Yahweh.” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh spoke to Moses in the wilderness of Sinai, saying, 
-<span class="v">15&#160;</span>“Count the children of Levi by their fathers’ houses, by their families. You shall count every male from a month old and upward.” 
-</p><p>
-<span class="v">16&#160;</span>Moses counted them according to Yahweh’s word, as he was commanded. 
-</p><p>
-<span class="v">17&#160;</span>These were the sons of Levi by their names: Gershon, Kohath, and Merari. 
-</p><p>
-<span class="v">18&#160;</span>These are the names of the sons of Gershon by their families: Libni and Shimei. 
-</p><p>
-<span class="v">19&#160;</span>The sons of Kohath by their families: Amram, Izhar, Hebron, and Uzziel. 
-</p><p>
-<span class="v">20&#160;</span>The sons of Merari by their families: Mahli and Mushi. 
-</p><p>These are the families of the Levites according to their fathers’ houses. 
-</p><p>
-<span class="v">21&#160;</span>Of Gershon was the family of the Libnites, and the family of the Shimeites. These are the families of the Gershonites. 
-</p><p>
-<span class="v">22&#160;</span>Those who were counted of them, according to the number of all the males from a month old and upward, even those who were counted of them were seven thousand five hundred. 
-</p><p>
-<span class="v">23&#160;</span>The families of the Gershonites shall encamp behind the tabernacle westward. 
-</p><p>
-<span class="v">24&#160;</span>Eliasaph the son of Lael shall be the prince of the fathers’ house of the Gershonites. 
-<span class="v">25&#160;</span>The duty of the sons of Gershon in the Tent of Meeting shall be the tabernacle, the tent, its covering, the screen for the door of the Tent of Meeting, 
-<span class="v">26&#160;</span>the hangings of the court, the screen for the door of the court which is by the tabernacle and around the altar, and its cords for all of its service. 
-</p><p>
-<span class="v">27&#160;</span>Of Kohath was the family of the Amramites, the family of the Izharites, the family of the Hebronites, and the family of the Uzzielites. These are the families of the Kohathites. 
-<span class="v">28&#160;</span>According to the number of all the males from a month old and upward, there were eight thousand six hundred keeping the requirements of the sanctuary. 
-</p><p>
-<span class="v">29&#160;</span>The families of the sons of Kohath shall encamp on the south side of the tabernacle. 
-<span class="v">30&#160;</span>The prince of the fathers’ house of the families of the Kohathites shall be Elizaphan the son of Uzziel. 
-<span class="v">31&#160;</span>Their duty shall be the ark, the table, the lamp stand, the altars, the vessels of the sanctuary with which they minister, the screen, and all its service. 
-<span class="v">32&#160;</span>Eleazar the son of Aaron the priest shall be prince of the princes of the Levites, with the oversight of those who keep the requirements of the sanctuary. 
-</p><p>
-<span class="v">33&#160;</span>Of Merari was the family of the Mahlites and the family of the Mushites. These are the families of Merari. 
-<span class="v">34&#160;</span>Those who were counted of them, according to the number of all the males from a month old and upward, were six thousand two hundred.<span class="f">+ \fr 3:34 \ft + 22,000 is the sum rounded to 2 significant digits. The sum of the Gershonites, Kohathites, and Merarites given above is 22,300, but the traditional Hebrew text has the number rounded to 2 significant digits, not 3 significant digits.</span> 
-</p><p>
-<span class="v">35&#160;</span>The prince of the fathers’ house of the families of Merari was Zuriel the son of Abihail. They shall encamp on the north side of the tabernacle. 
-<span class="v">36&#160;</span>The appointed duty of the sons of Merari shall be the tabernacle’s boards, its bars, its pillars, its sockets, all its instruments, all its service, 
-<span class="v">37&#160;</span>the pillars of the court around it, their sockets, their pins, and their cords. 
-</p><p>
-<span class="v">38&#160;</span>Those who encamp before the tabernacle eastward, in front of the Tent of Meeting toward the sunrise, shall be Moses, with Aaron and his sons, keeping the requirements of the sanctuary for the duty of the children of Israel. The outsider who comes near shall be put to death. 
-<span class="v">39&#160;</span>All who were counted of the Levites, whom Moses and Aaron counted at the commandment of Yahweh, by their families, all the males from a month old and upward, were twenty-two thousand. 
-</p><p>
-<span class="v">40&#160;</span>Yahweh said to Moses, “Count all the firstborn males of the children of Israel from a month old and upward, and take the number of their names. 
-<span class="v">41&#160;</span>You shall take the Levites for me—I am Yahweh—instead of all the firstborn among the children of Israel; and the livestock of the Levites instead of all the firstborn among the livestock of the children of Israel.” 
-</p><p>
-<span class="v">42&#160;</span>Moses counted, as Yahweh commanded him, all the firstborn among the children of Israel. 
-<span class="v">43&#160;</span>All the firstborn males according to the number of names from a month old and upward, of those who were counted of them, were twenty-two thousand two hundred seventy-three. 
-</p><p>
-<span class="v">44&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">45&#160;</span>“Take the Levites instead of all the firstborn among the children of Israel, and the livestock of the Levites instead of their livestock; and the Levites shall be mine. I am Yahweh. 
-<span class="v">46&#160;</span>For the redemption of the two hundred seventy-three of the firstborn of the children of Israel who exceed the number of the Levites, 
-<span class="v">47&#160;</span>you shall take five shekels apiece for each one; according to the shekel<span class="f">+ \fr 3:47 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of the sanctuary you shall take them (the shekel is twenty gerahs<span class="f">+ \fr 3:47 \ft A gerah is about 0.5 grams or about 7.7 grains.</span>); 
-<span class="v">48&#160;</span>and you shall give the money, with which their remainder is redeemed, to Aaron and to his sons.” 
-</p><p>
-<span class="v">49&#160;</span>Moses took the redemption money from those who exceeded the number of those who were redeemed by the Levites; 
-<span class="v">50&#160;</span>from the firstborn of the children of Israel he took the money, one thousand three hundred sixty-five shekels,<span class="f">+ \fr 3:50 \ft A shekel is about 10 grams or about 0.35 ounces, so 1365 shekels is about 13.65 kilograms or about 30 pounds.</span> according to the shekel of the sanctuary; 
-<span class="v">51&#160;</span>and Moses gave the redemption money to Aaron and to his sons, according to Yahweh’s word, as Yahweh commanded Moses. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">2&#160;</span>“Take a census of the sons of Kohath from among the sons of Levi, by their families, by their fathers’ houses, 
-<span class="v">3&#160;</span>from thirty years old and upward even until fifty years old, all who enter into the service to do the work in the Tent of Meeting. 
-</p><p>
-<span class="v">4&#160;</span>“This is the service of the sons of Kohath in the Tent of Meeting, regarding the most set-apart things. 
-<span class="v">5&#160;</span>When the camp moves forward, Aaron shall go in with his sons; and they shall take down the veil of the screen, cover the ark of the Testimony with it, 
-<span class="v">6&#160;</span>put a covering of sealskin on it, spread a blue cloth over it, and put in its poles. 
-</p><p>
-<span class="v">7&#160;</span>“On the table of show bread they shall spread a blue cloth, and put on it the dishes, the spoons, the bowls, and the cups with which to pour out; and the continual bread shall be on it. 
-<span class="v">8&#160;</span>They shall spread on them a scarlet cloth, and cover it with a covering of sealskin, and shall put in its poles. 
-</p><p>
-<span class="v">9&#160;</span>“They shall take a blue cloth and cover the lamp stand of the light, its lamps, its snuffers, its snuff dishes, and all its oil vessels, with which they minister to it. 
-<span class="v">10&#160;</span>They shall put it and all its vessels within a covering of sealskin, and shall put it on the frame. 
-</p><p>
-<span class="v">11&#160;</span>“On the golden altar they shall spread a blue cloth, and cover it with a covering of sealskin, and shall put in its poles. 
-</p><p>
-<span class="v">12&#160;</span>“They shall take all the vessels of ministry with which they minister in the sanctuary, and put them in a blue cloth, cover them with a covering of sealskin, and shall put them on the frame. 
-</p><p>
-<span class="v">13&#160;</span>“They shall take away the ashes from the altar, and spread a purple cloth on it. 
-<span class="v">14&#160;</span>They shall put on it all its vessels with which they minister about it, the fire pans, the meat hooks, the shovels, and the basins—all the vessels of the altar; and they shall spread on it a covering of sealskin, and put in its poles. 
-</p><p>
-<span class="v">15&#160;</span>“When Aaron and his sons have finished covering the sanctuary and all the furniture of the sanctuary, as the camp moves forward; after that, the sons of Kohath shall come to carry it; but they shall not touch the sanctuary, lest they die. The sons of Kohath shall carry these things belonging to the Tent of Meeting. 
-</p><p>
-<span class="v">16&#160;</span>“The duty of Eleazar the son of Aaron the priest shall be the oil for the light, the sweet incense, the continual meal offering, and the anointing oil, the requirements of all the tabernacle, and of all that is in it, the sanctuary, and its furnishings.” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">18&#160;</span>“Don’t cut off the tribe of the families of the Kohathites from among the Levites; 
-<span class="v">19&#160;</span>but do this to them, that they may live, and not die, when they approach the most set-apart things: Aaron and his sons shall go in and appoint everyone to his service and to his burden; 
-<span class="v">20&#160;</span>but they shall not go in to see the sanctuary even for a moment, lest they die.” 
-</p><p>
-<span class="v">21&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">22&#160;</span>“Take a census of the sons of Gershon also, by their fathers’ houses, by their families; 
-<span class="v">23&#160;</span>you shall count them from thirty years old and upward until fifty years old: all who enter in to wait on the service, to do the work in the Tent of Meeting. 
-</p><p>
-<span class="v">24&#160;</span>“This is the service of the families of the Gershonites, in serving and in bearing burdens: 
-<span class="v">25&#160;</span>they shall carry the curtains of the tabernacle and the Tent of Meeting, its covering, the covering of sealskin that is on it, the screen for the door of the Tent of Meeting, 
-<span class="v">26&#160;</span>the hangings of the court, the screen for the door of the gate of the court which is by the tabernacle and around the altar, their cords, and all the instruments of their service, and whatever shall be done with them. They shall serve in there. 
-<span class="v">27&#160;</span>At the commandment of Aaron and his sons shall be all the service of the sons of the Gershonites, in all their burden and in all their service; and you shall appoint their duty to them in all their responsibilities. 
-<span class="v">28&#160;</span>This is the service of the families of the sons of the Gershonites in the Tent of Meeting. Their duty shall be under the hand of Ithamar the son of Aaron the priest. 
-</p><p>
-<span class="v">29&#160;</span>“As for the sons of Merari, you shall count them by their families, by their fathers’ houses; 
-<span class="v">30&#160;</span>you shall count them from thirty years old and upward even to fifty years old—everyone who enters on the service, to do the work of the Tent of Meeting. 
-<span class="v">31&#160;</span>This is the duty of their burden, according to all their service in the Tent of Meeting: the tabernacle’s boards, its bars, its pillars, its sockets, 
-<span class="v">32&#160;</span>the pillars of the court around it, their sockets, their pins, their cords, with all their instruments, and with all their service. You shall appoint the instruments of the duty of their burden to them by name. 
-<span class="v">33&#160;</span>This is the service of the families of the sons of Merari, according to all their service in the Tent of Meeting, under the hand of Ithamar the son of Aaron the priest.” 
-</p><p>
-<span class="v">34&#160;</span>Moses and Aaron and the princes of the congregation counted the sons of the Kohathites by their families, and by their fathers’ houses, 
-<span class="v">35&#160;</span>from thirty years old and upward even to fifty years old, everyone who entered into the service for work in the Tent of Meeting. 
-<span class="v">36&#160;</span>Those who were counted of them by their families were two thousand seven hundred fifty. 
-<span class="v">37&#160;</span>These are those who were counted of the families of the Kohathites, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
-</p><p>
-<span class="v">38&#160;</span>Those who were counted of the sons of Gershon, by their families, and by their fathers’ houses, 
-<span class="v">39&#160;</span>from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
-<span class="v">40&#160;</span>even those who were counted of them, by their families, by their fathers’ houses, were two thousand six hundred thirty. 
-<span class="v">41&#160;</span>These are those who were counted of the families of the sons of Gershon, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh. 
-</p><p>
-<span class="v">42&#160;</span>Those who were counted of the families of the sons of Merari, by their families, by their fathers’ houses, 
-<span class="v">43&#160;</span>from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
-<span class="v">44&#160;</span>even those who were counted of them by their families, were three thousand two hundred. 
-<span class="v">45&#160;</span>These are those who were counted of the families of the sons of Merari, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
-</p><p>
-<span class="v">46&#160;</span>All those who were counted of the Levites whom Moses and Aaron and the princes of Israel counted, by their families and by their fathers’ houses, 
-<span class="v">47&#160;</span>from thirty years old and upward even to fifty years old, everyone who entered in to do the work of service and the work of bearing burdens in the Tent of Meeting, 
-<span class="v">48&#160;</span>even those who were counted of them, were eight thousand five hundred eighty. 
-<span class="v">49&#160;</span>According to the commandment of Yahweh they were counted by Moses, everyone according to his service and according to his burden. Thus they were counted by him, as Yahweh commanded Moses. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Command the children of Israel that they put out of the camp every leper, everyone who has a discharge, and whoever is unclean by a corpse. 
-<span class="v">3&#160;</span>You shall put both male and female outside of the camp so that they don’t defile their camp, in the midst of which I dwell.” 
-</p><p>
-<span class="v">4&#160;</span>The children of Israel did so, and put them outside of the camp; as Yahweh spoke to Moses, so the children of Israel did. 
-</p><p>
-<span class="v">5&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">6&#160;</span>“Speak to the children of Israel: ‘When a man or woman commits any sin that men commit, so as to trespass against Yahweh, and that soul is guilty, 
-<span class="v">7&#160;</span>then he shall confess his sin which he has done; and he shall make restitution for his guilt in full, add to it the fifth part of it, and give it to him in respect of whom he has been guilty. 
-<span class="v">8&#160;</span>But if the man has no kinsman to whom restitution may be made for the guilt, the restitution for guilt which is made to Yahweh shall be the priest’s, in addition to the ram of the atonement, by which atonement shall be made for him. 
-<span class="v">9&#160;</span>Every heave offering of all the set-apart things of the children of Israel, which they present to the priest, shall be his. 
-<span class="v">10&#160;</span>Every man’s set-apart things shall be his; whatever any man gives the priest, it shall be his.’&#160;” 
-</p><p>
-<span class="v">11&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">12&#160;</span>“Speak to the children of Israel, and tell them: ‘If any man’s woman goes astray and is unfaithful to him, 
-<span class="v">13&#160;</span>and a man lies with her carnally, and it is hidden from the eyes of her man and this is kept concealed, and she is defiled, there is no witness against her, and she isn’t taken in the act; 
-<span class="v">14&#160;</span>and the spirit of jealousy comes on him, and he is jealous of his woman and she is defiled; or if the spirit of jealousy comes on him, and he is jealous of his woman and she isn’t defiled; 
-<span class="v">15&#160;</span>then the man shall bring his woman to the priest, and shall bring her offering for her: one tenth of an ephah<span class="f">+ \fr 5:15 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of barley meal. He shall pour no oil on it, nor put frankincense on it, for it is a meal offering of jealousy, a meal offering of memorial, bringing iniquity to memory. 
-<span class="v">16&#160;</span>The priest shall bring her near, and set her before Yahweh. 
-<span class="v">17&#160;</span>The priest shall take set-apart water in an earthen vessel; and the priest shall take some of the dust that is on the floor of the tabernacle and put it into the water. 
-<span class="v">18&#160;</span>The priest shall set the woman before Yahweh, and let the hair of the woman’s head go loose, and put the meal offering of memorial in her hands, which is the meal offering of jealousy. The priest shall have in his hand the water of bitterness that brings a curse. 
-<span class="v">19&#160;</span>The priest shall cause her to take an oath and shall tell the woman, “If no man has lain with you, and if you haven’t gone aside to uncleanness, being under your man’s authority, be free from this water of bitterness that brings a curse. 
-<span class="v">20&#160;</span>But if you have gone astray, being under your man’s authority, and if you are defiled, and some man has lain with you besides your man—” 
-<span class="v">21&#160;</span>then the priest shall cause the woman to swear with the oath of cursing, and the priest shall tell the woman, “May Yahweh make you a curse and an oath among your people, when Yahweh allows your thigh to fall away, and your body to swell; 
-<span class="v">22&#160;</span>and this water that brings a curse will go into your bowels, and make your body swell, and your thigh fall away.” The woman shall say, “Amen, Amen.” 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘The priest shall write these curses in a book, and he shall wipe them into the water of bitterness. 
-<span class="v">24&#160;</span>He shall make the woman drink the water of bitterness that causes the curse; and the water that causes the curse shall enter into her and become bitter. 
-<span class="v">25&#160;</span>The priest shall take the meal offering of jealousy out of the woman’s hand, and shall wave the meal offering before Yahweh, and bring it to the altar. 
-<span class="v">26&#160;</span>The priest shall take a handful of the meal offering, as its memorial portion, and burn it on the altar, and afterward shall make the woman drink the water. 
-<span class="v">27&#160;</span>When he has made her drink the water, then it shall happen, if she is defiled and has committed a trespass against her man, that the water that causes the curse will enter into her and become bitter, and her body will swell, and her thigh will fall away; and the woman will be a curse among her people. 
-<span class="v">28&#160;</span>If the woman isn’t defiled, but is clean; then she shall be free, and shall conceive offspring.<span class="f">+ \fr 5:28 \ft or, seed</span> 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘This is the law of jealousy, when a woman, being under her man, goes astray, and is defiled, 
-<span class="v">30&#160;</span>or when the spirit of jealousy comes on a man, and he is jealous of his woman; then he shall set the woman before Yahweh, and the priest shall execute on her all this law. 
-<span class="v">31&#160;</span>The man shall be free from iniquity, and that woman shall bear her iniquity.’&#160;” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and tell them: ‘When either man or woman shall make a special vow, the vow of a Nazirite, to separate himself to Yahweh, 
-<span class="v">3&#160;</span>he shall separate himself from wine and strong drink. He shall drink no vinegar of wine, or vinegar of fermented drink, neither shall he drink any juice of grapes, nor eat fresh grapes or dried. 
-<span class="v">4&#160;</span>All the days of his separation he shall eat nothing that is made of the grapevine, from the seeds even to the skins. 
-</p><p>
-<span class="v">5&#160;</span>“&#160;‘All the days of his vow of separation no razor shall come on his head, until the days are fulfilled in which he separates himself to Yahweh. He shall be set-apart. He shall let the locks of the hair of his head grow long. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘All the days that he separates himself to Yahweh he shall not go near a dead body. 
-<span class="v">7&#160;</span>He shall not make himself unclean for his father, or for his mother, for his brother, or for his sister, when they die, because his separation to Elohim<span class="f">+ \fr 6:7 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> is on his head. 
-<span class="v">8&#160;</span>All the days of his separation he is set-apart to Yahweh. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘If any man dies very suddenly beside him, and he defiles the head of his separation, then he shall shave his head in the day of his cleansing. On the seventh day he shall shave it. 
-<span class="v">10&#160;</span>On the eighth day he shall bring two turtledoves or two young pigeons to the priest, to the door of the Tent of Meeting. 
-<span class="v">11&#160;</span>The priest shall offer one for a sin offering, and the other for a burnt offering, and make atonement for him, because he sinned by reason of the dead, and shall make his head set-apart that same day. 
-<span class="v">12&#160;</span>He shall separate to Yahweh the days of his separation, and shall bring a male lamb a year old for a trespass offering; but the former days shall be void, because his separation was defiled. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘This is the law of the Nazirite: when the days of his separation are fulfilled, he shall be brought to the door of the Tent of Meeting, 
-<span class="v">14&#160;</span>and he shall offer his offering to Yahweh: one male lamb a year old without defect for a burnt offering, one ewe lamb a year old without defect for a sin offering, one ram without defect for peace offerings, 
-<span class="v">15&#160;</span>a basket of unleavened bread, cakes of fine flour mixed with oil, and unleavened wafers anointed with oil with their meal offering and their drink offerings. 
-<span class="v">16&#160;</span>The priest shall present them before Yahweh, and shall offer his sin offering and his burnt offering. 
-<span class="v">17&#160;</span>He shall offer the ram for a sacrifice of peace offerings to Yahweh, with the basket of unleavened bread. The priest shall offer also its meal offering and its drink offering. 
-<span class="v">18&#160;</span>The Nazirite shall shave the head of his separation at the door of the Tent of Meeting, take the hair of the head of his separation, and put it on the fire which is under the sacrifice of peace offerings. 
-<span class="v">19&#160;</span>The priest shall take the boiled shoulder of the ram, one unleavened cake out of the basket, and one unleavened wafer, and shall put them on the hands of the Nazirite after he has shaved the head of his separation; 
-<span class="v">20&#160;</span>and the priest shall wave them for a wave offering before Yahweh. They are set-apart for the priest, together with the breast that is waved and the thigh that is offered. After that the Nazirite may drink wine. 
-</p><p>
-<span class="v">21&#160;</span>“&#160;‘This is the law of the Nazirite who vows and of his offering to Yahweh for his separation, in addition to that which he is able to afford. According to his vow which he vows, so he must do after the law of his separation.’&#160;” 
-</p><p>
-<span class="v">22&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">23&#160;</span>“Speak to Aaron and to his sons, saying, ‘This is how you shall bless the children of Israel.’ You shall tell them, 
-</p><p class="q1">
-<span class="v">24&#160;</span>‘Yahweh bless you, and keep you. 
-</p><p class="q2">
-<span class="v">25&#160;</span>Yahweh make his face to shine on you, 
-</p><p class="q2">and be gracious to you. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Yahweh lift up his face toward you, 
-</p><p class="q2">and give you peace.’ 
-</p><p>
-<span class="v">27&#160;</span>“So they shall put my name on the children of Israel; and I will bless them.” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>On the day that Moses had finished setting up the tabernacle, and had anointed it and sanctified it with all its furniture, and the altar with all its vessels, and had anointed and sanctified them; 
-<span class="v">2&#160;</span>the princes of Israel, the heads of their fathers’ houses, gave offerings. These were the princes of the tribes. These are they who were over those who were counted; 
-<span class="v">3&#160;</span>and they brought their offering before Yahweh, six covered wagons and twelve oxen; a wagon for every two of the princes, and for each one an ox. They presented them before the tabernacle. 
-<span class="v">4&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">5&#160;</span>“Accept these from them, that they may be used in doing the service of the Tent of Meeting; and you shall give them to the Levites, to every man according to his service.” 
-</p><p>
-<span class="v">6&#160;</span>Moses took the wagons and the oxen, and gave them to the Levites. 
-<span class="v">7&#160;</span>He gave two wagons and four oxen to the sons of Gershon, according to their service. 
-<span class="v">8&#160;</span>He gave four wagons and eight oxen to the sons of Merari, according to their service, under the direction of Ithamar the son of Aaron the priest. 
-<span class="v">9&#160;</span>But to the sons of Kohath he gave none, because the service of the sanctuary belonged to them; they carried it on their shoulders. 
-</p><p>
-<span class="v">10&#160;</span>The princes gave offerings for the dedication of the altar in the day that it was anointed. The princes gave their offerings before the altar. 
-</p><p>
-<span class="v">11&#160;</span>Yahweh said to Moses, “They shall offer their offering, each prince on his day, for the dedication of the altar.” 
-</p><p>
-<span class="v">12&#160;</span>He who offered his offering the first day was Nahshon the son of Amminadab, of the tribe of Judah, 
-<span class="v">13&#160;</span>and his offering was: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels,<span class="f">+ \fr 7:13 \ft A shekel is about 10 grams or about 0.35 ounces.</span> 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">14&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">15&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">16&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">17&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Nahshon the son of Amminadab. 
-</p><p>
-<span class="v">18&#160;</span>On the second day Nethanel the son of Zuar, prince of Issachar, gave his offering. 
-<span class="v">19&#160;</span>He offered for his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">20&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">21&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">22&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">23&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, five male lambs a year old. This was the offering of Nethanel the son of Zuar. 
-</p><p>
-<span class="v">24&#160;</span>On the third day Eliab the son of Helon, prince of the children of Zebulun, 
-<span class="v">25&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was a hundred and thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">26&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">27&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">28&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">29&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Eliab the son of Helon. 
-</p><p>
-<span class="v">30&#160;</span>On the fourth day Elizur the son of Shedeur, prince of the children of Reuben, 
-<span class="v">31&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">32&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">33&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">34&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">35&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Elizur the son of Shedeur. 
-</p><p>
-<span class="v">36&#160;</span>On the fifth day Shelumiel the son of Zurishaddai, prince of the children of Simeon, 
-<span class="v">37&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">38&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">39&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">40&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">41&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old: this was the offering of Shelumiel the son of Zurishaddai. 
-</p><p>
-<span class="v">42&#160;</span>On the sixth day, Eliasaph the son of Deuel, prince of the children of Gad, 
-<span class="v">43&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">44&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">45&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">46&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">47&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Eliasaph the son of Deuel. 
-</p><p>
-<span class="v">48&#160;</span>On the seventh day Elishama the son of Ammihud, prince of the children of Ephraim, 
-<span class="v">49&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">50&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">51&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">52&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">53&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Elishama the son of Ammihud. 
-</p><p>
-<span class="v">54&#160;</span>On the eighth day Gamaliel the son of Pedahzur, prince of the children of Manasseh, 
-<span class="v">55&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">56&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">57&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">58&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">59&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Gamaliel the son of Pedahzur. 
-</p><p>
-<span class="v">60&#160;</span>On the ninth day Abidan the son of Gideoni, prince of the children of Benjamin, 
-<span class="v">61&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">62&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">63&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">64&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">65&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Abidan the son of Gideoni. 
-</p><p>
-<span class="v">66&#160;</span>On the tenth day Ahiezer the son of Ammishaddai, prince of the children of Dan, 
-<span class="v">67&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">68&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">69&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">70&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">71&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Ahiezer the son of Ammishaddai. 
-</p><p>
-<span class="v">72&#160;</span>On the eleventh day Pagiel the son of Ochran, prince of the children of Asher, 
-<span class="v">73&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">74&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">75&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">76&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">77&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Pagiel the son of Ochran. 
-</p><p>
-<span class="v">78&#160;</span>On the twelfth day Ahira the son of Enan, prince of the children of Naphtali, 
-<span class="v">79&#160;</span>gave his offering: 
-</p><p>one silver platter, the weight of which was one hundred thirty shekels, 
-</p><p>one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
-</p><p>
-<span class="v">80&#160;</span>one golden ladle of ten shekels, full of incense; 
-</p><p>
-<span class="v">81&#160;</span>one young bull, 
-</p><p>one ram, 
-</p><p>one male lamb a year old, for a burnt offering; 
-</p><p>
-<span class="v">82&#160;</span>one male goat for a sin offering; 
-</p><p>
-<span class="v">83&#160;</span>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Ahira the son of Enan. 
-</p><p>
-<span class="v">84&#160;</span>This was the dedication offering of the altar, on the day when it was anointed, by the princes of Israel: twelve silver platters, twelve silver bowls, twelve golden ladles; 
-<span class="v">85&#160;</span>each silver platter weighing one hundred thirty shekels, and each bowl seventy; all the silver of the vessels two thousand four hundred shekels, according to the shekel of the sanctuary; 
-<span class="v">86&#160;</span>the twelve golden ladles, full of incense, weighing ten shekels apiece, according to the shekel of the sanctuary; all the gold of the ladles weighed one hundred twenty shekels; 
-<span class="v">87&#160;</span>all the cattle for the burnt offering twelve bulls, the rams twelve, the male lambs a year old twelve, and their meal offering; and twelve male goats for a sin offering; 
-<span class="v">88&#160;</span>and all the cattle for the sacrifice of peace offerings: twenty-four bulls, sixty rams, sixty male goats, and sixty male lambs a year old. This was the dedication offering of the altar, after it was anointed. 
-</p><p>
-<span class="v">89&#160;</span>When Moses went into the Tent of Meeting to speak with Yahweh, he heard his voice speaking to him from above the mercy seat that was on the ark of the Testimony, from between the two cherubim; and he spoke to him. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to Aaron, and tell him, ‘When you light the lamps, the seven lamps shall give light in front of the lamp stand.’&#160;” 
-</p><p>
-<span class="v">3&#160;</span>Aaron did so. He lit its lamps to light the area in front of the lamp stand, as Yahweh commanded Moses. 
-<span class="v">4&#160;</span>This was the workmanship of the lamp stand, beaten work of gold. From its base to its flowers, it was beaten work. He made the lamp stand according to the pattern which Yahweh had shown Moses. 
-</p><p>
-<span class="v">5&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">6&#160;</span>“Take the Levites from among the children of Israel, and cleanse them. 
-<span class="v">7&#160;</span>You shall do this to them to cleanse them: sprinkle the water of cleansing on them, let them shave their whole bodies with a razor, let them wash their clothes, and cleanse themselves. 
-<span class="v">8&#160;</span>Then let them take a young bull and its meal offering, fine flour mixed with oil; and another young bull you shall take for a sin offering. 
-<span class="v">9&#160;</span>You shall present the Levites before the Tent of Meeting. You shall assemble the whole congregation of the children of Israel. 
-<span class="v">10&#160;</span>You shall present the Levites before Yahweh. The children of Israel shall lay their hands on the Levites, 
-<span class="v">11&#160;</span>and Aaron shall offer the Levites before Yahweh for a wave offering on the behalf of the children of Israel, that it may be theirs to do the service of Yahweh. 
-</p><p>
-<span class="v">12&#160;</span>“The Levites shall lay their hands on the heads of the bulls, and you shall offer the one for a sin offering and the other for a burnt offering to Yahweh, to make atonement for the Levites. 
-<span class="v">13&#160;</span>You shall set the Levites before Aaron and before his sons, and offer them as a wave offering to Yahweh. 
-<span class="v">14&#160;</span>Thus you shall separate the Levites from among the children of Israel, and the Levites shall be mine. 
-</p><p>
-<span class="v">15&#160;</span>“After that, the Levites shall go in to do the service of the Tent of Meeting. You shall cleanse them, and offer them as a wave offering. 
-<span class="v">16&#160;</span>For they are wholly given to me from among the children of Israel; instead of all who open the womb, even the firstborn of all the children of Israel, I have taken them to me. 
-<span class="v">17&#160;</span>For all the firstborn among the children of Israel are mine, both man and animal. On the day that I struck all the firstborn in the land of Egypt, I sanctified them for myself. 
-<span class="v">18&#160;</span>I have taken the Levites instead of all the firstborn among the children of Israel. 
-<span class="v">19&#160;</span>I have given the Levites as a gift to Aaron and to his sons from among the children of Israel, to do the service of the children of Israel in the Tent of Meeting, and to make atonement for the children of Israel, so that there will be no plague among the children of Israel when the children of Israel come near to the sanctuary.” 
-</p><p>
-<span class="v">20&#160;</span>Moses, and Aaron, and all the congregation of the children of Israel did so to the Levites. According to all that Yahweh commanded Moses concerning the Levites, so the children of Israel did to them. 
-<span class="v">21&#160;</span>The Levites purified themselves from sin, and they washed their clothes; and Aaron offered them for a wave offering before Yahweh and Aaron made atonement for them to cleanse them. 
-<span class="v">22&#160;</span>After that, the Levites went in to do their service in the Tent of Meeting before Aaron and before his sons: as Yahweh had commanded Moses concerning the Levites, so they did to them. 
-</p><p>
-<span class="v">23&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">24&#160;</span>“This is what is assigned to the Levites: from twenty-five years old and upward they shall go in to wait on the service in the work of the Tent of Meeting; 
-<span class="v">25&#160;</span>and from the age of fifty years they shall retire from doing the work, and shall serve no more, 
-<span class="v">26&#160;</span>but shall assist their brothers in the Tent of Meeting, to perform the duty, and shall perform no service. This is how you shall have the Levites do their duties.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses in the wilderness of Sinai, in the first month of the second year after they had come out of the land of Egypt, saying, 
-<span class="v">2&#160;</span>“Let the children of Israel keep the Passover in its appointed season. 
-<span class="v">3&#160;</span>On the fourteenth day of this month, at evening, you shall keep it in its appointed season. You shall keep it according to all its statutes and according to all its ordinances.” 
-</p><p>
-<span class="v">4&#160;</span>Moses told the children of Israel that they should keep the Passover. 
-<span class="v">5&#160;</span>They kept the Passover in the first month, on the fourteenth day of the month at evening, in the wilderness of Sinai. According to all that Yahweh commanded Moses, so the children of Israel did. 
-<span class="v">6&#160;</span>There were certain men who were unclean because of the dead body of a man, so that they could not keep the Passover on that day, and they came before Moses and Aaron on that day. 
-<span class="v">7&#160;</span>Those men said to him, “We are unclean because of the dead body of a man. Why are we kept back, that we may not offer the offering of Yahweh in its appointed season among the children of Israel?” 
-</p><p>
-<span class="v">8&#160;</span>Moses answered them, “Wait, that I may hear what Yahweh will command concerning you.” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">10&#160;</span>“Say to the children of Israel, ‘If any man of you or of your generations is unclean by reason of a dead body, or is on a journey far away, he shall still keep the Passover to Yahweh. 
-<span class="v">11&#160;</span>In the second month, on the fourteenth day at evening they shall keep it; they shall eat it with unleavened bread and bitter herbs. 
-<span class="v">12&#160;</span>They shall leave none of it until the morning, nor break a bone of it. According to all the statute of the Passover they shall keep it. 
-<span class="v">13&#160;</span>But the man who is clean, and is not on a journey, and fails to keep the Passover, that soul shall be cut off from his people. Because he didn’t offer the offering of Yahweh in its appointed season, that man shall bear his sin. 
-</p><p>
-<span class="v">14&#160;</span>“&#160;‘If a foreigner lives among you and desires to keep the Passover to Yahweh, then he shall do so according to the statute of the Passover, and according to its ordinance. You shall have one statute, both for the foreigner and for him who is born in the land.’&#160;” 
-</p><p>
-<span class="v">15&#160;</span>On the day that the tabernacle was raised up, the cloud covered the tabernacle, even the Tent of the Testimony. At evening it was over the tabernacle, as it were the appearance of fire, until morning. 
-<span class="v">16&#160;</span>So it was continually. The cloud covered it, and the appearance of fire by night. 
-<span class="v">17&#160;</span>Whenever the cloud was taken up from over the Tent, then after that the children of Israel traveled; and in the place where the cloud remained, there the children of Israel encamped. 
-<span class="v">18&#160;</span>At the commandment of Yahweh, the children of Israel traveled, and at the commandment of Yahweh they encamped. As long as the cloud remained on the tabernacle they remained encamped. 
-<span class="v">19&#160;</span>When the cloud stayed on the tabernacle many days, then the children of Israel kept Yahweh’s command, and didn’t travel. 
-<span class="v">20&#160;</span>Sometimes the cloud was a few days on the tabernacle; then according to the commandment of Yahweh they remained encamped, and according to the commandment of Yahweh they traveled. 
-<span class="v">21&#160;</span>Sometimes the cloud was from evening until morning; and when the cloud was taken up in the morning, they traveled; or by day and by night, when the cloud was taken up, they traveled. 
-<span class="v">22&#160;</span>Whether it was two days, or a month, or a year that the cloud stayed on the tabernacle, remaining on it, the children of Israel remained encamped, and didn’t travel; but when it was taken up, they traveled. 
-<span class="v">23&#160;</span>At the commandment of Yahweh they encamped, and at the commandment of Yahweh they traveled. They kept Yahweh’s command, at the commandment of Yahweh by Moses. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Make two trumpets of silver. You shall make them of beaten work. You shall use them for the calling of the congregation and for the journeying of the camps. 
-<span class="v">3&#160;</span>When they blow them, all the congregation shall gather themselves to you at the door of the Tent of Meeting. 
-<span class="v">4&#160;</span>If they blow just one, then the princes, the heads of the thousands of Israel, shall gather themselves to you. 
-<span class="v">5&#160;</span>When you blow an alarm, the camps that lie on the east side shall go forward. 
-<span class="v">6&#160;</span>When you blow an alarm the second time, the camps that lie on the south side shall go forward. They shall blow an alarm for their journeys. 
-<span class="v">7&#160;</span>But when the assembly is to be gathered together, you shall blow, but you shall not sound an alarm. 
-</p><p>
-<span class="v">8&#160;</span>“The sons of Aaron, the priests, shall blow the trumpets. This shall be to you for a statute forever throughout your generations. 
-<span class="v">9&#160;</span>When you go to war in your land against the adversary who oppresses you, then you shall sound an alarm with the trumpets. Then you will be remembered before Yahweh your Elohim, and you will be saved from your enemies. 
-</p><p>
-<span class="v">10&#160;</span>“Also in the day of your gladness, and in your set feasts, and in the beginnings of your months, you shall blow the trumpets over your burnt offerings, and over the sacrifices of your peace offerings; and they shall be to you for a memorial before your Elohim. I am Yahweh your Elohim.” 
-</p><p>
-<span class="v">11&#160;</span>In the second year, in the second month, on the twentieth day of the month, the cloud was taken up from over the tabernacle of the covenant. 
-<span class="v">12&#160;</span>The children of Israel went forward on their journeys out of the wilderness of Sinai; and the cloud stayed in the wilderness of Paran. 
-<span class="v">13&#160;</span>They first went forward according to the commandment of Yahweh by Moses. 
-</p><p>
-<span class="v">14&#160;</span>First, the standard of the camp of the children of Judah went forward according to their armies. Nahshon the son of Amminadab was over his army. 
-<span class="v">15&#160;</span>Nethanel the son of Zuar was over the army of the tribe of the children of Issachar. 
-<span class="v">16&#160;</span>Eliab the son of Helon was over the army of the tribe of the children of Zebulun. 
-<span class="v">17&#160;</span>The tabernacle was taken down; and the sons of Gershon and the sons of Merari, who bore the tabernacle, went forward. 
-<span class="v">18&#160;</span>The standard of the camp of Reuben went forward according to their armies. Elizur the son of Shedeur was over his army. 
-<span class="v">19&#160;</span>Shelumiel the son of Zurishaddai was over the army of the tribe of the children of Simeon. 
-<span class="v">20&#160;</span>Eliasaph the son of Deuel was over the army of the tribe of the children of Gad. 
-</p><p>
-<span class="v">21&#160;</span>The Kohathites set forward, bearing the sanctuary. The others set up the tabernacle before they arrived. 
-</p><p>
-<span class="v">22&#160;</span>The standard of the camp of the children of Ephraim set forward according to their armies. Elishama the son of Ammihud was over his army. 
-<span class="v">23&#160;</span>Gamaliel the son of Pedahzur was over the army of the tribe of the children of Manasseh. 
-<span class="v">24&#160;</span>Abidan the son of Gideoni was over the army of the tribe of the children of Benjamin. 
-</p><p>
-<span class="v">25&#160;</span>The standard of the camp of the children of Dan, which was the rear guard of all the camps, set forward according to their armies. Ahiezer the son of Ammishaddai was over his army. 
-<span class="v">26&#160;</span>Pagiel the son of Ochran was over the army of the tribe of the children of Asher. 
-<span class="v">27&#160;</span>Ahira the son of Enan was over the army of the tribe of the children of Naphtali. 
-<span class="v">28&#160;</span>Thus were the travels of the children of Israel according to their armies; and they went forward. 
-</p><p>
-<span class="v">29&#160;</span>Moses said to Hobab, the son of Reuel the Midianite, Moses’ father-in-law, “We are journeying to the place of which Yahweh said, ‘I will give it to you.’ Come with us, and we will treat you well; for Yahweh has spoken good concerning Israel.” 
-</p><p>
-<span class="v">30&#160;</span>He said to him, “I will not go; but I will depart to my own land, and to my relatives.” 
-</p><p>
-<span class="v">31&#160;</span>Moses said, “Don’t leave us, please; because you know how we are to encamp in the wilderness, and you can be our eyes. 
-<span class="v">32&#160;</span>It shall be, if you go with us—yes, it shall be—that whatever good Yahweh does to us, we will do the same to you.” 
-</p><p>
-<span class="v">33&#160;</span>They set forward from the Mount of Yahweh three days’ journey. The ark of Yahweh’s covenant went before them three days’ journey, to seek out a resting place for them. 
-<span class="v">34&#160;</span>The cloud of Yahweh was over them by day, when they set forward from the camp. 
-<span class="v">35&#160;</span>When the ark went forward, Moses said, “Rise up, Yahweh, and let your enemies be scattered! Let those who hate you flee before you!” 
-<span class="v">36&#160;</span>When it rested, he said, “Return, Yahweh, to the ten thousands of the thousands of Israel.” 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>The people were complaining in the ears of Yahweh. When Yahweh heard it, his anger burned; and Yahweh’s fire burned among them, and consumed some of the outskirts of the camp. 
-<span class="v">2&#160;</span>The people cried to Moses; and Moses prayed to Yahweh, and the fire abated. 
-<span class="v">3&#160;</span>The name of that place was called Taberah,<span class="f">+ \fr 11:3 \ft Taberah means “burning” </span> because Yahweh’s fire burned among them. 
-</p><p>
-<span class="v">4&#160;</span>The mixed multitude that was among them lusted exceedingly; and the children of Israel also wept again, and said, “Who will give us meat to eat? 
-<span class="v">5&#160;</span>We remember the fish, which we ate in Egypt for nothing; the cucumbers, and the melons, and the leeks, and the onions, and the garlic; 
-<span class="v">6&#160;</span>but now we have lost our appetite. There is nothing at all except this manna to look at.” 
-<span class="v">7&#160;</span>The manna was like coriander seed, and it looked like bdellium.<span class="f">+ \fr 11:7 \ft Bdellium is a resin extracted from certain African trees.</span> 
-<span class="v">8&#160;</span>The people went around, gathered it, and ground it in mills, or beat it in mortars, and boiled it in pots, and made cakes of it. Its taste was like the taste of fresh oil. 
-<span class="v">9&#160;</span>When the dew fell on the camp in the night, the manna fell on it. 
-</p><p>
-<span class="v">10&#160;</span>Moses heard the people weeping throughout their families, every man at the door of his tent; and Yahweh’s anger burned greatly; and Moses was displeased. 
-<span class="v">11&#160;</span>Moses said to Yahweh, “Why have you treated your servant so badly? Why haven’t I found favor in your sight, that you lay the burden of all this people on me? 
-<span class="v">12&#160;</span>Have I conceived all this people? Have I brought them out, that you should tell me, ‘Carry them in your bosom, as a nurse carries a nursing infant, to the land which you swore to their fathers’? 
-<span class="v">13&#160;</span>Where could I get meat to give all these people? For they weep before me, saying, ‘Give us meat, that we may eat.’ 
-<span class="v">14&#160;</span>I am not able to bear all this people alone, because it is too heavy for me. 
-<span class="v">15&#160;</span>If you treat me this way, please kill me right now, if I have found favor in your sight; and don’t let me see my wretchedness.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh said to Moses, “Gather to me seventy men of the elders of Israel, whom you know to be the elders of the people and officers over them; and bring them to the Tent of Meeting, that they may stand there with you. 
-<span class="v">17&#160;</span>I will come down and talk with you there. I will take of the Spirit which is on you, and will put it on them; and they shall bear the burden of the people with you, that you don’t bear it yourself alone. 
-</p><p>
-<span class="v">18&#160;</span>“Say to the people, ‘Sanctify yourselves in preparation for tomorrow, and you will eat meat; for you have wept in the ears of Yahweh, saying, “Who will give us meat to eat? For it was well with us in Egypt.” Therefore Yahweh will give you meat, and you will eat. 
-<span class="v">19&#160;</span>You will not eat just one day, or two days, or five days, or ten days, or twenty days, 
-<span class="v">20&#160;</span>but a whole month, until it comes out at your nostrils, and it is loathsome to you; because you have rejected Yahweh who is among you, and have wept before him, saying, “Why did we come out of Egypt?”&#160;’&#160;” 
-</p><p>
-<span class="v">21&#160;</span>Moses said, “The people, among whom I am, are six hundred thousand men on foot; and you have said, ‘I will give them meat, that they may eat a whole month.’ 
-<span class="v">22&#160;</span>Shall flocks and herds be slaughtered for them, to be sufficient for them? Shall all the fish of the sea be gathered together for them, to be sufficient for them?” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh said to Moses, “Has Yahweh’s hand grown short? Now you will see whether my word will happen to you or not.” 
-</p><p>
-<span class="v">24&#160;</span>Moses went out, and told the people Yahweh’s words; and he gathered seventy men of the elders of the people, and set them around the Tent. 
-<span class="v">25&#160;</span>Yahweh came down in the cloud, and spoke to him, and took of the Spirit that was on him, and put it on the seventy elders. When the Spirit rested on them, they prophesied, but they did so no more. 
-<span class="v">26&#160;</span>But two men remained in the camp. The name of one was Eldad, and the name of the other Medad; and the Spirit rested on them. They were of those who were written, but had not gone out to the Tent; and they prophesied in the camp. 
-<span class="v">27&#160;</span>A young man ran, and told Moses, and said, “Eldad and Medad are prophesying in the camp!” 
-</p><p>
-<span class="v">28&#160;</span>Joshua the son of Nun, the servant of Moses, one of his chosen men, answered, “My lord Moses, forbid them!” 
-</p><p>
-<span class="v">29&#160;</span>Moses said to him, “Are you jealous for my sake? I wish that all Yahweh’s people were prophets, that Yahweh would put his Spirit on them!” 
-</p><p>
-<span class="v">30&#160;</span>Moses went into the camp, he and the elders of Israel. 
-<span class="v">31&#160;</span>A wind from Yahweh went out and brought quails from the sea, and let them fall by the camp, about a day’s journey on this side, and a day’s journey on the other side, around the camp, and about two cubits<span class="f">+ \fr 11:31 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> above the surface of the earth. 
-<span class="v">32&#160;</span>The people rose up all that day, and all of that night, and all the next day, and gathered the quails. He who gathered least gathered ten homers;<span class="f">+ \fr 11:32 \ft 1 homer is about 220 liters or 6 bushels</span> and they spread them all out for themselves around the camp. 
-<span class="v">33&#160;</span>While the meat was still between their teeth, before it was chewed, Yahweh’s anger burned against the people, and Yahweh struck the people with a very great plague. 
-<span class="v">34&#160;</span>The name of that place was called Kibroth Hattaavah,<span class="f">+ \fr 11:34 \ft Kibroth Hattaavah means “graves of lust”</span> because there they buried the people who lusted. 
-</p><p>
-<span class="v">35&#160;</span>From Kibroth Hattaavah the people traveled to Hazeroth; and they stayed at Hazeroth. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>Miriam and Aaron spoke against Moses because of the Cushite woman whom he had married; for he had married a Cushite woman. 
-<span class="v">2&#160;</span>They said, “Has Yahweh indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahweh heard it. 
-</p><p>
-<span class="v">3&#160;</span>Now the man Moses was very humble, more than all the men who were on the surface of the earth. 
-<span class="v">4&#160;</span>Yahweh spoke suddenly to Moses, to Aaron, and to Miriam, “You three come out to the Tent of Meeting!” 
-</p><p>The three of them came out. 
-<span class="v">5&#160;</span>Yahweh came down in a pillar of cloud, and stood at the door of the Tent, and called Aaron and Miriam; and they both came forward. 
-<span class="v">6&#160;</span>He said, “Now hear my words. If there is a prophet among you, I, Yahweh, will make myself known to him in a vision. I will speak with him in a dream. 
-<span class="v">7&#160;</span>My servant Moses is not so. He is faithful in all my house. 
-<span class="v">8&#160;</span>With him, I will speak mouth to mouth, even plainly, and not in riddles; and he shall see Yahweh’s form. Why then were you not afraid to speak against my servant, against Moses?” 
-<span class="v">9&#160;</span>Yahweh’s anger burned against them; and he departed. 
-</p><p>
-<span class="v">10&#160;</span>The cloud departed from over the Tent; and behold, Miriam was leprous, as white as snow. Aaron looked at Miriam, and behold, she was leprous. 
-</p><p>
-<span class="v">11&#160;</span>Aaron said to Moses, “Oh, my lord, please don’t count this sin against us, in which we have done foolishly, and in which we have sinned. 
-<span class="v">12&#160;</span>Let her not, I pray, be as one dead, of whom the flesh is half consumed when he comes out of his mother’s womb.” 
-</p><p>
-<span class="v">13&#160;</span>Moses cried to Yahweh, saying, “Heal her, Elohim, I beg you!” 
-</p><p>
-<span class="v">14&#160;</span>Yahweh said to Moses, “If her father had but spit in her face, shouldn’t she be ashamed seven days? Let her be shut up outside of the camp seven days, and after that she shall be brought in again.” 
-</p><p>
-<span class="v">15&#160;</span>Miriam was shut up outside of the camp seven days, and the people didn’t travel until Miriam was brought in again. 
-<span class="v">16&#160;</span>Afterward the people traveled from Hazeroth, and encamped in the wilderness of Paran. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Send men, that they may spy out the land of Canaan, which I give to the children of Israel. Of every tribe of their fathers, you shall send a man, every one a prince among them.” 
-</p><p>
-<span class="v">3&#160;</span>Moses sent them from the wilderness of Paran according to the commandment of Yahweh. All of them were men who were heads of the children of Israel. 
-<span class="v">4&#160;</span>These were their names: 
-</p><p class="m">Of the tribe of Reuben, Shammua the son of Zaccur. 
-</p><p class="m">
-<span class="v">5&#160;</span>Of the tribe of Simeon, Shaphat the son of Hori. 
-</p><p class="m">
-<span class="v">6&#160;</span>Of the tribe of Judah, Caleb the son of Jephunneh. 
-</p><p class="m">
-<span class="v">7&#160;</span>Of the tribe of Issachar, Igal the son of Joseph. 
-</p><p class="m">
-<span class="v">8&#160;</span>Of the tribe of Ephraim, Hoshea the son of Nun. 
-</p><p class="m">
-<span class="v">9&#160;</span>Of the tribe of Benjamin, Palti the son of Raphu. 
-</p><p class="m">
-<span class="v">10&#160;</span>Of the tribe of Zebulun, Gaddiel the son of Sodi. 
-</p><p class="m">
-<span class="v">11&#160;</span>Of the tribe of Joseph, of the tribe of Manasseh, Gaddi the son of Susi. 
-</p><p class="m">
-<span class="v">12&#160;</span>Of the tribe of Dan, Ammiel the son of Gemalli. 
-</p><p class="m">
-<span class="v">13&#160;</span>Of the tribe of Asher, Sethur the son of Michael. 
-</p><p class="m">
-<span class="v">14&#160;</span>Of the tribe of Naphtali, Nahbi the son of Vophsi. 
-</p><p class="m">
-<span class="v">15&#160;</span>Of the tribe of Gad, Geuel the son of Machi. 
-</p><p class="m">
-<span class="v">16&#160;</span>These are the names of the men who Moses sent to spy out the land. Moses called Hoshea the son of Nun Joshua. 
-<span class="v">17&#160;</span>Moses sent them to spy out the land of Canaan, and said to them, “Go up this way by the South, and go up into the hill country. 
-<span class="v">18&#160;</span>See the land, what it is; and the people who dwell therein, whether they are strong or weak, whether they are few or many; 
-<span class="v">19&#160;</span>and what the land is that they dwell in, whether it is good or bad; and what cities they are that they dwell in, whether in camps, or in strongholds; 
-<span class="v">20&#160;</span>and what the land is, whether it is fertile or poor, whether there is wood therein, or not. Be courageous, and bring some of the fruit of the land.” Now the time was the time of the first-ripe grapes. 
-</p><p>
-<span class="v">21&#160;</span>So they went up, and spied out the land from the wilderness of Zin to Rehob, to the entrance of Hamath. 
-<span class="v">22&#160;</span>They went up by the South, and came to Hebron; and Ahiman, Sheshai, and Talmai, the children of Anak, were there. (Now Hebron was built seven years before Zoan in Egypt.) 
-<span class="v">23&#160;</span>They came to the valley of Eshcol, and cut down from there a branch with one cluster of grapes, and they bore it on a staff between two. They also brought some of the pomegranates and figs. 
-<span class="v">24&#160;</span>That place was called the valley of Eshcol, because of the cluster which the children of Israel cut down from there. 
-<span class="v">25&#160;</span>They returned from spying out the land at the end of forty days. 
-<span class="v">26&#160;</span>They went and came to Moses, to Aaron, and to all the congregation of the children of Israel, to the wilderness of Paran, to Kadesh; and brought back word to them and to all the congregation. They showed them the fruit of the land. 
-<span class="v">27&#160;</span>They told him, and said, “We came to the land where you sent us. Surely it flows with milk and honey, and this is its fruit. 
-<span class="v">28&#160;</span>However, the people who dwell in the land are strong, and the cities are fortified and very large. Moreover, we saw the children of Anak there. 
-<span class="v">29&#160;</span>Amalek dwells in the land of the South. The Hittite, the Jebusite, and the Amorite dwell in the hill country. The Canaanite dwells by the sea, and along the side of the Jordan.” 
-</p><p>
-<span class="v">30&#160;</span>Caleb stilled the people before Moses, and said, “Let’s go up at once, and possess it; for we are well able to overcome it!” 
-</p><p>
-<span class="v">31&#160;</span>But the men who went up with him said, “We aren’t able to go up against the people; for they are stronger than we.” 
-<span class="v">32&#160;</span>They brought up an evil report of the land which they had spied out to the children of Israel, saying, “The land, through which we have gone to spy it out, is a land that eats up its inhabitants; and all the people who we saw in it are men of great stature. 
-<span class="v">33&#160;</span>There we saw the Nephilim,<span class="f">+ \fr 13:33 \ft or, giants</span> the sons of Anak, who come from the Nephilim.<span class="f">+ \fr 13:33 \ft or, giants</span> We were in our own sight as grasshoppers, and so we were in their sight.” 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>All the congregation lifted up their voice, and cried; and the people wept that night. 
-<span class="v">2&#160;</span>All the children of Israel murmured against Moses and against Aaron. The whole congregation said to them, “We wish that we had died in the land of Egypt, or that we had died in this wilderness! 
-<span class="v">3&#160;</span>Why does Yahweh bring us to this land, to fall by the sword? Our women and our little ones will be captured or killed! Wouldn’t it be better for us to return into Egypt?” 
-<span class="v">4&#160;</span>They said to one another, “Let’s choose a leader, and let’s return into Egypt.” 
-</p><p>
-<span class="v">5&#160;</span>Then Moses and Aaron fell on their faces before all the assembly of the congregation of the children of Israel. 
-</p><p>
-<span class="v">6&#160;</span>Joshua the son of Nun and Caleb the son of Jephunneh, who were of those who spied out the land, tore their clothes. 
-<span class="v">7&#160;</span>They spoke to all the congregation of the children of Israel, saying, “The land, which we passed through to spy it out, is an exceedingly good land. 
-<span class="v">8&#160;</span>If Yahweh delights in us, then he will bring us into this land, and give it to us: a land which flows with milk and honey. 
-<span class="v">9&#160;</span>Only don’t rebel against Yahweh, neither fear the people of the land; for they are bread for us. Their defense is removed from over them, and Yahweh is with us. Don’t fear them.” 
-</p><p>
-<span class="v">10&#160;</span>But all the congregation threatened to stone them with stones. 
-</p><p>Yahweh’s glory appeared in the Tent of Meeting to all the children of Israel. 
-<span class="v">11&#160;</span>Yahweh said to Moses, “How long will this people despise me? How long will they not believe in me, for all the signs which I have worked among them? 
-<span class="v">12&#160;</span>I will strike them with the pestilence, and disinherit them, and will make of you a nation greater and mightier than they.” 
-</p><p>
-<span class="v">13&#160;</span>Moses said to Yahweh, “Then the Egyptians will hear it; for you brought up this people in your might from among them. 
-<span class="v">14&#160;</span>They will tell it to the inhabitants of this land. They have heard that you Yahweh are among this people; for you Yahweh are seen face to face, and your cloud stands over them, and you go before them, in a pillar of cloud by day, and in a pillar of fire by night. 
-<span class="v">15&#160;</span>Now if you killed this people as one man, then the nations which have heard the fame of you will speak, saying, 
-<span class="v">16&#160;</span>‘Because Yahweh was not able to bring this people into the land which he swore to them, therefore he has slain them in the wilderness.’ 
-<span class="v">17&#160;</span>Now please let the power of the Lord<span class="f">+ \fr 14:17 \ft The word translated “Lord” is “Adonai.”</span> be great, according as you have spoken, saying, 
-<span class="v">18&#160;</span>‘Yahweh is slow to anger, and abundant in loving kindness, forgiving iniquity and disobedience; and he will by no means clear the guilty, visiting the iniquity of the fathers on the children, on the third and on the fourth generation.’ 
-<span class="v">19&#160;</span>Please pardon the iniquity of this people according to the greatness of your loving kindness, and just as you have forgiven this people, from Egypt even until now.” 
-</p><p>
-<span class="v">20&#160;</span>Yahweh said, “I have pardoned according to your word; 
-<span class="v">21&#160;</span>but in very deed—as I live, and as all the earth shall be filled with Yahweh’s glory—<span class="v">22&#160;</span>because all those men who have seen my glory and my signs, which I worked in Egypt and in the wilderness, yet have tempted me these ten times, and have not listened to my voice; 
-<span class="v">23&#160;</span>surely they shall not see the land which I swore to their fathers, neither shall any of those who despised me see it. 
-<span class="v">24&#160;</span>But my servant Caleb, because he had another spirit with him, and has followed me fully, him I will bring into the land into which he went. His offspring shall possess it. 
-<span class="v">25&#160;</span>Since the Amalekite and the Canaanite dwell in the valley, tomorrow turn and go into the wilderness by the way to the Red Sea.” 
-<span class="v">26&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">27&#160;</span>“How long shall I bear with this evil congregation that complain against me? I have heard the complaints of the children of Israel, which they complain against me. 
-<span class="v">28&#160;</span>Tell them, ‘As I live, says Yahweh, surely as you have spoken in my ears, so I will do to you. 
-<span class="v">29&#160;</span>Your dead bodies shall fall in this wilderness; and all who were counted of you, according to your whole number, from twenty years old and upward, who have complained against me, 
-<span class="v">30&#160;</span>surely you shall not come into the land concerning which I swore that I would make you dwell therein, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
-<span class="v">31&#160;</span>But I will bring in your little ones that you said should be captured or killed, and they shall know the land which you have rejected. 
-<span class="v">32&#160;</span>But as for you, your dead bodies shall fall in this wilderness. 
-<span class="v">33&#160;</span>Your children shall be wanderers in the wilderness forty years, and shall bear your prostitution, until your dead bodies are consumed in the wilderness. 
-<span class="v">34&#160;</span>After the number of the days in which you spied out the land, even forty days, for every day a year, you will bear your iniquities, even forty years, and you will know my alienation.’ 
-<span class="v">35&#160;</span>I, Yahweh, have spoken. I will surely do this to all this evil congregation who are gathered together against me. In this wilderness they shall be consumed, and there they shall die.” 
-</p><p>
-<span class="v">36&#160;</span>The men whom Moses sent to spy out the land, who returned and made all the congregation to murmur against him by bringing up an evil report against the land, 
-<span class="v">37&#160;</span>even those men who brought up an evil report of the land, died by the plague before Yahweh. 
-<span class="v">38&#160;</span>But Joshua the son of Nun and Caleb the son of Jephunneh remained alive of those men who went to spy out the land. 
-</p><p>
-<span class="v">39&#160;</span>Moses told these words to all the children of Israel, and the people mourned greatly. 
-<span class="v">40&#160;</span>They rose up early in the morning and went up to the top of the mountain, saying, “Behold, we are here, and will go up to the place which Yahweh has promised; for we have sinned.” 
-</p><p>
-<span class="v">41&#160;</span>Moses said, “Why now do you disobey the commandment of Yahweh, since it shall not prosper? 
-<span class="v">42&#160;</span>Don’t go up, for Yahweh isn’t among you; that way you won’t be struck down before your enemies. 
-<span class="v">43&#160;</span>For there the Amalekite and the Canaanite are before you, and you will fall by the sword because you turned back from following Yahweh; therefore Yahweh will not be with you.” 
-</p><p>
-<span class="v">44&#160;</span>But they presumed to go up to the top of the mountain. Nevertheless, the ark of Yahweh’s covenant and Moses didn’t depart out of the camp. 
-<span class="v">45&#160;</span>Then the Amalekites came down, and the Canaanites who lived in that mountain, and struck them and beat them down even to Hormah. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and tell them, ‘When you have come into the land of your habitations, which I give to you, 
-<span class="v">3&#160;</span>and will make an offering by fire to Yahweh—a burnt offering, or a sacrifice, to accomplish a vow, or as a free will offering, or in your set feasts, to make a pleasant aroma to Yahweh, of the herd, or of the flock—<span class="v">4&#160;</span>then he who offers his offering shall offer to Yahweh a meal offering of one tenth of an ephah<span class="f">+ \fr 15:4 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour mixed with one fourth of a hin<span class="f">+ \fr 15:4 \ft A hin is about 6.5 liters or 1.7 gallons.</span> of oil. 
-<span class="v">5&#160;</span>You shall prepare wine for the drink offering, one fourth of a hin, with the burnt offering or for the sacrifice, for each lamb. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘For a ram, you shall prepare for a meal offering two tenths of an ephah<span class="f">+ \fr 15:6 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour mixed with the third part of a hin of oil; 
-<span class="v">7&#160;</span>and for the drink offering you shall offer the third part of a hin of wine, of a pleasant aroma to Yahweh. 
-<span class="v">8&#160;</span>When you prepare a bull for a burnt offering or for a sacrifice, to accomplish a vow, or for peace offerings to Yahweh, 
-<span class="v">9&#160;</span>then he shall offer with the bull a meal offering of three tenths of an ephah<span class="f">+ \fr 15:9 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour mixed with half a hin of oil; 
-<span class="v">10&#160;</span>and you shall offer for the drink offering half a hin of wine, for an offering made by fire, of a pleasant aroma to Yahweh. 
-<span class="v">11&#160;</span>Thus it shall be done for each bull, for each ram, for each of the male lambs, or of the young goats. 
-<span class="v">12&#160;</span>According to the number that you shall prepare, so you shall do to everyone according to their number. 
-</p><p>
-<span class="v">13&#160;</span>“&#160;‘All who are native-born shall do these things in this way, in offering an offering made by fire, of a pleasant aroma to Yahweh. 
-<span class="v">14&#160;</span>If a stranger lives as a foreigner with you, or whoever may be among you throughout your generations, and will offer an offering made by fire, of a pleasant aroma to Yahweh, as you do, so he shall do. 
-<span class="v">15&#160;</span>For the assembly, there shall be one statute for you and for the stranger who lives as a foreigner, a statute forever throughout your generations. As you are, so the foreigner shall be before Yahweh. 
-<span class="v">16&#160;</span>One law and one ordinance shall be for you and for the stranger who lives as a foreigner with you.’&#160;” 
-</p><p>
-<span class="v">17&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">18&#160;</span>“Speak to the children of Israel, and tell them, ‘When you come into the land where I bring you, 
-<span class="v">19&#160;</span>then it shall be that when you eat of the bread of the land, you shall offer up a wave offering to Yahweh. 
-<span class="v">20&#160;</span>Of the first of your dough you shall offer up a cake for a wave offering. As the wave offering of the threshing floor, so you shall heave it. 
-<span class="v">21&#160;</span>Of the first of your dough, you shall give to Yahweh a wave offering throughout your generations. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘When you err, and don’t observe all these commandments which Yahweh has spoken to Moses—<span class="v">23&#160;</span>even all that Yahweh has commanded you by Moses, from the day that Yahweh gave commandment and onward throughout your generations—<span class="v">24&#160;</span>then it shall be, if it was done unwittingly, without the knowledge of the congregation, that all the congregation shall offer one young bull for a burnt offering, for a pleasant aroma to Yahweh, with its meal offering and its drink offering, according to the ordinance, and one male goat for a sin offering. 
-<span class="v">25&#160;</span>The priest shall make atonement for all the congregation of the children of Israel, and they shall be forgiven; for it was an error, and they have brought their offering, an offering made by fire to Yahweh, and their sin offering before Yahweh, for their error. 
-<span class="v">26&#160;</span>All the congregation of the children of Israel shall be forgiven, as well as the stranger who lives as a foreigner among them; for with regard to all the people, it was done unwittingly. 
-</p><p>
-<span class="v">27&#160;</span>“&#160;‘If a person sins unwittingly, then he shall offer a female goat a year old for a sin offering. 
-<span class="v">28&#160;</span>The priest shall make atonement for the soul who errs when he sins unwittingly before Yahweh. He shall make atonement for him; and he shall be forgiven. 
-<span class="v">29&#160;</span>You shall have one law for him who does anything unwittingly, for him who is native-born among the children of Israel, and for the stranger who lives as a foreigner among them. 
-</p><p>
-<span class="v">30&#160;</span>“&#160;‘But the soul who does anything with a high hand, whether he is native-born or a foreigner, blasphemes Yahweh. That soul shall be cut off from among his people. 
-<span class="v">31&#160;</span>Because he has despised Yahweh’s word, and has broken his commandment, that soul shall be utterly cut off. His iniquity shall be on him.’&#160;” 
-</p><p>
-<span class="v">32&#160;</span>While the children of Israel were in the wilderness, they found a man gathering sticks on the Sabbath day. 
-<span class="v">33&#160;</span>Those who found him gathering sticks brought him to Moses and Aaron, and to all the congregation. 
-<span class="v">34&#160;</span>They put him in custody, because it had not been declared what should be done to him. 
-</p><p>
-<span class="v">35&#160;</span>Yahweh said to Moses, “The man shall surely be put to death. All the congregation shall stone him with stones outside of the camp.” 
-<span class="v">36&#160;</span>All the congregation brought him outside of the camp, and stoned him to death with stones, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">37&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">38&#160;</span>“Speak to the children of Israel, and tell them that they should make themselves fringes<span class="f">+ \fr 15:38 \ft or, tassels (Hebrew צִיצִ֛ת)</span> on the borders of their garments throughout their generations, and that they put on the fringe<span class="f">+ \fr 15:38 \ft or, tassel</span> of each border a cord of blue. 
-<span class="v">39&#160;</span>It shall be to you for a fringe,<span class="f">+ \fr 15:39 \ft or, tassel</span> that you may see it, and remember all Yahweh’s commandments, and do them; and that you don’t follow your own heart and your own eyes, after which you used to play the prostitute; 
-<span class="v">40&#160;</span>so that you may remember and do all my commandments, and be set-apart to your Elohim. 
-<span class="v">41&#160;</span>I am Yahweh your Elohim, who brought you out of the land of Egypt, to be your Elohim: I am Yahweh your Elohim.” 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>Now Korah, the son of Izhar, the son of Kohath, the son of Levi, with Dathan and Abiram, the sons of Eliab, and On, the son of Peleth, sons of Reuben, took some men. 
-<span class="v">2&#160;</span>They rose up before Moses, with some of the children of Israel, two hundred fifty princes of the congregation, called to the assembly, men of renown. 
-<span class="v">3&#160;</span>They assembled themselves together against Moses and against Aaron, and said to them, “You take too much on yourself, since all the congregation are set-apart, everyone of them, and Yahweh is among them! Why do you lift yourselves up above Yahweh’s assembly?” 
-</p><p>
-<span class="v">4&#160;</span>When Moses heard it, he fell on his face. 
-<span class="v">5&#160;</span>He said to Korah and to all his company, “In the morning, Yahweh will show who are his, and who is set-apart, and will cause him to come near to him. Even him whom he shall choose, he will cause to come near to him. 
-<span class="v">6&#160;</span>Do this: have Korah and all his company take censers, 
-<span class="v">7&#160;</span>put fire in them, and put incense on them before Yahweh tomorrow. It shall be that the man whom Yahweh chooses, he shall be set-apart. You have gone too far, you sons of Levi!” 
-</p><p>
-<span class="v">8&#160;</span>Moses said to Korah, “Hear now, you sons of Levi! 
-<span class="v">9&#160;</span>Is it a small thing to you that the Elohim of Israel has separated you from the congregation of Israel, to bring you near to himself, to do the service of Yahweh’s tabernacle, and to stand before the congregation to minister to them; 
-<span class="v">10&#160;</span>and that he has brought you near, and all your brothers the sons of Levi with you? Do you seek the priesthood also? 
-<span class="v">11&#160;</span>Therefore you and all your company have gathered together against Yahweh! What is Aaron that you complain against him?” 
-</p><p>
-<span class="v">12&#160;</span>Moses sent to call Dathan and Abiram, the sons of Eliab; and they said, “We won’t come up! 
-<span class="v">13&#160;</span>Is it a small thing that you have brought us up out of a land flowing with milk and honey, to kill us in the wilderness, but you must also make yourself a prince over us? 
-<span class="v">14&#160;</span>Moreover you haven’t brought us into a land flowing with milk and honey, nor given us inheritance of fields and vineyards. Will you put out the eyes of these men? We won’t come up.” 
-</p><p>
-<span class="v">15&#160;</span>Moses was very angry, and said to Yahweh, “Don’t respect their offering. I have not taken one donkey from them, neither have I hurt one of them.” 
-</p><p>
-<span class="v">16&#160;</span>Moses said to Korah, “You and all your company go before Yahweh, you, and they, and Aaron, tomorrow. 
-<span class="v">17&#160;</span>Each man take his censer and put incense on it, and each man bring before Yahweh his censer, two hundred fifty censers; you also, and Aaron, each with his censer.” 
-</p><p>
-<span class="v">18&#160;</span>They each took his censer, and put fire in it, and laid incense on it, and stood at the door of the Tent of Meeting with Moses and Aaron. 
-<span class="v">19&#160;</span>Korah assembled all the congregation opposite them to the door of the Tent of Meeting. 
-</p><p>Yahweh’s glory appeared to all the congregation. 
-<span class="v">20&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">21&#160;</span>“Separate yourselves from among this congregation, that I may consume them in a moment!” 
-</p><p>
-<span class="v">22&#160;</span>They fell on their faces, and said, “Elohim, the Elohim of the spirits of all flesh, shall one man sin, and will you be angry with all the congregation?” 
-</p><p>
-<span class="v">23&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">24&#160;</span>“Speak to the congregation, saying, ‘Get away from around the tent of Korah, Dathan, and Abiram!’&#160;” 
-</p><p>
-<span class="v">25&#160;</span>Moses rose up and went to Dathan and Abiram; and the elders of Israel followed him. 
-<span class="v">26&#160;</span>He spoke to the congregation, saying, “Depart, please, from the tents of these wicked men, and touch nothing of theirs, lest you be consumed in all their sins!” 
-</p><p>
-<span class="v">27&#160;</span>So they went away from the tent of Korah, Dathan, and Abiram, on every side. Dathan and Abiram came out, and stood at the door of their tents with their women, their sons, and their little ones. 
-</p><p>
-<span class="v">28&#160;</span>Moses said, “Hereby you shall know that Yahweh has sent me to do all these works; for they are not from my own mind. 
-<span class="v">29&#160;</span>If these men die the common death of all men, or if they experience what all men experience, then Yahweh hasn’t sent me. 
-<span class="v">30&#160;</span>But if Yahweh makes a new thing, and the ground opens its mouth, and swallows them up with all that belong to them, and they go down alive into Sheol,<span class="f">+ \fr 16:30 \ft Sheol is the place of the dead.</span> then you shall understand that these men have despised Yahweh.” 
-</p><p>
-<span class="v">31&#160;</span>As he finished speaking all these words, the ground that was under them split apart. 
-<span class="v">32&#160;</span>The earth opened its mouth and swallowed them up with their households, all of Korah’s men, and all their goods. 
-<span class="v">33&#160;</span>So they, and all that belonged to them went down alive into Sheol.<span class="f">+ \fr 16:33 \ft Sheol is the place of the dead.</span> The earth closed on them, and they perished from among the assembly. 
-<span class="v">34&#160;</span>All Israel that were around them fled at their cry; for they said, “Lest the earth swallow us up!” 
-<span class="v">35&#160;</span>Fire came out from Yahweh, and devoured the two hundred fifty men who offered the incense. 
-</p><p>
-<span class="v">36&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">37&#160;</span>“Speak to Eleazar the son of Aaron the priest, that he take up the censers out of the burning, and scatter the fire away from the camp; for they are set-apart, 
-<span class="v">38&#160;</span>even the censers of those who sinned against their own lives. Let them be beaten into plates for a covering of the altar, for they offered them before Yahweh. Therefore they are set-apart. They shall be a sign to the children of Israel.” 
-</p><p>
-<span class="v">39&#160;</span>Eleazar the priest took the bronze censers which those who were burned had offered; and they beat them out for a covering of the altar, 
-<span class="v">40&#160;</span>to be a memorial to the children of Israel, to the end that no stranger who isn’t of the offspring of Aaron, would come near to burn incense before Yahweh, that he not be as Korah and as his company; as Yahweh spoke to him by Moses. 
-</p><p>
-<span class="v">41&#160;</span>But on the next day all the congregation of the children of Israel complained against Moses and against Aaron, saying, “You have killed Yahweh’s people!” 
-</p><p>
-<span class="v">42&#160;</span>When the congregation was assembled against Moses and against Aaron, they looked toward the Tent of Meeting. Behold, the cloud covered it, and Yahweh’s glory appeared. 
-<span class="v">43&#160;</span>Moses and Aaron came to the front of the Tent of Meeting. 
-<span class="v">44&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">45&#160;</span>“Get away from among this congregation, that I may consume them in a moment!” They fell on their faces. 
-</p><p>
-<span class="v">46&#160;</span>Moses said to Aaron, “Take your censer, put fire from the altar in it, lay incense on it, carry it quickly to the congregation, and make atonement for them; for wrath has gone out from Yahweh! The plague has begun.” 
-</p><p>
-<span class="v">47&#160;</span>Aaron did as Moses said, and ran into the middle of the assembly. The plague had already begun among the people. He put on the incense, and made atonement for the people. 
-<span class="v">48&#160;</span>He stood between the dead and the living; and the plague was stayed. 
-<span class="v">49&#160;</span>Now those who died by the plague were fourteen thousand seven hundred, in addition to those who died about the matter of Korah. 
-<span class="v">50&#160;</span>Aaron returned to Moses to the door of the Tent of Meeting, and the plague was stopped. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Speak to the children of Israel, and take rods from them, one for each fathers’ house, of all their princes according to their fathers’ houses, twelve rods. Write each man’s name on his rod. 
-<span class="v">3&#160;</span>You shall write Aaron’s name on Levi’s rod. There shall be one rod for each head of their fathers’ houses. 
-<span class="v">4&#160;</span>You shall lay them up in the Tent of Meeting before the covenant, where I meet with you. 
-<span class="v">5&#160;</span>It shall happen that the rod of the man whom I shall choose shall bud. I will make the murmurings of the children of Israel, which they murmur against you, cease from me.” 
-</p><p>
-<span class="v">6&#160;</span>Moses spoke to the children of Israel; and all their princes gave him rods, for each prince one, according to their fathers’ houses, a total of twelve rods. Aaron’s rod was among their rods. 
-<span class="v">7&#160;</span>Moses laid up the rods before Yahweh in the Tent of the Testimony. 
-</p><p>
-<span class="v">8&#160;</span>On the next day, Moses went into the Tent of the Testimony; and behold, Aaron’s rod for the house of Levi had sprouted, budded, produced blossoms, and bore ripe almonds. 
-<span class="v">9&#160;</span>Moses brought out all the rods from before Yahweh to all the children of Israel. They looked, and each man took his rod. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh said to Moses, “Put back the rod of Aaron before the covenant, to be kept for a token against the children of rebellion; that you may make an end of their complaining against me, that they not die.” 
-<span class="v">11&#160;</span>Moses did so. As Yahweh commanded him, so he did. 
-</p><p>
-<span class="v">12&#160;</span>The children of Israel spoke to Moses, saying, “Behold, we perish! We are undone! We are all undone! 
-<span class="v">13&#160;</span>Everyone who keeps approaching Yahweh’s tabernacle, dies! Will we all perish?” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh said to Aaron, “You and your sons and your fathers’ house with you shall bear the iniquity of the sanctuary; and you and your sons with you shall bear the iniquity of your priesthood. 
-<span class="v">2&#160;</span>Bring your brothers also, the tribe of Levi, the tribe of your father, near with you, that they may be joined to you, and minister to you; but you and your sons with you shall be before the Tent of the Testimony. 
-<span class="v">3&#160;</span>They shall keep your commands and the duty of the whole Tent; only they shall not come near to the vessels of the sanctuary and to the altar, that they not die, neither they nor you. 
-<span class="v">4&#160;</span>They shall be joined to you and keep the responsibility of the Tent of Meeting, for all the service of the Tent. A stranger shall not come near to you. 
-</p><p>
-<span class="v">5&#160;</span>“You shall perform the duty of the sanctuary and the duty of the altar, that there be no more wrath on the children of Israel. 
-<span class="v">6&#160;</span>Behold, I myself have taken your brothers the Levites from among the children of Israel. They are a gift to you, dedicated to Yahweh, to do the service of the Tent of Meeting. 
-<span class="v">7&#160;</span>You and your sons with you shall keep your priesthood for everything of the altar, and for that within the veil. You shall serve. I give you the service of the priesthood as a gift. The stranger who comes near shall be put to death.” 
-</p><p>
-<span class="v">8&#160;</span>Yahweh spoke to Aaron, “Behold, I myself have given you the command of my wave offerings, even all the set-apart things of the children of Israel. I have given them to you by reason of the anointing, and to your sons, as a portion forever. 
-<span class="v">9&#160;</span>This shall be yours of the most set-apart things from the fire: every offering of theirs, even every meal offering of theirs, and every sin offering of theirs, and every trespass offering of theirs, which they shall render to me, shall be most set-apart for you and for your sons. 
-<span class="v">10&#160;</span>You shall eat of it like the most set-apart things. Every male shall eat of it. It shall be set-apart to you. 
-</p><p>
-<span class="v">11&#160;</span>“This is yours, too: the wave offering of their gift, even all the wave offerings of the children of Israel. I have given them to you, and to your sons and to your daughters with you, as a portion forever. Everyone who is clean in your house shall eat of it. 
-</p><p>
-<span class="v">12&#160;</span>“I have given to you all the best of the oil, all the best of the vintage, and of the grain, the first fruits of them which they give to Yahweh. 
-<span class="v">13&#160;</span>The first-ripe fruits of all that is in their land, which they bring to Yahweh, shall be yours. Everyone who is clean in your house shall eat of it. 
-</p><p>
-<span class="v">14&#160;</span>“Everything devoted in Israel shall be yours. 
-<span class="v">15&#160;</span>Everything that opens the womb, of all flesh which they offer to Yahweh, both of man and animal, shall be yours. Nevertheless, you shall surely redeem the firstborn of man, and you shall redeem the firstborn of unclean animals. 
-<span class="v">16&#160;</span>You shall redeem those who are to be redeemed of them from a month old, according to your estimation, for five shekels of money, according to the shekel<span class="f">+ \fr 18:16 \ft A shekel is about 10 grams or about 0.35 ounces.</span> of the sanctuary, which weighs twenty gerahs.<span class="f">+ \fr 18:16 \ft A gerah is about 0.5 grams or about 7.7 grains.</span> 
-</p><p>
-<span class="v">17&#160;</span>“But you shall not redeem the firstborn of a cow, or the firstborn of a sheep, or the firstborn of a goat. They are set-apart. You shall sprinkle their blood on the altar, and shall burn their fat for an offering made by fire, for a pleasant aroma to Yahweh. 
-<span class="v">18&#160;</span>Their meat shall be yours, as the wave offering breast and as the right thigh, it shall be yours. 
-<span class="v">19&#160;</span>All the wave offerings of the set-apart things which the children of Israel offer to Yahweh, I have given you and your sons and your daughters with you, as a portion forever. It is a covenant of salt forever before Yahweh to you and to your offspring with you.” 
-</p><p>
-<span class="v">20&#160;</span>Yahweh said to Aaron, “You shall have no inheritance in their land, neither shall you have any portion among them. I am your portion and your inheritance among the children of Israel. 
-</p><p>
-<span class="v">21&#160;</span>“To the children of Levi, behold, I have given all the tithe in Israel for an inheritance, in return for their service which they serve, even the service of the Tent of Meeting. 
-<span class="v">22&#160;</span>Henceforth the children of Israel shall not come near the Tent of Meeting, lest they bear sin, and die. 
-<span class="v">23&#160;</span>But the Levites shall do the service of the Tent of Meeting, and they shall bear their iniquity. It shall be a statute forever throughout your generations. Among the children of Israel, they shall have no inheritance. 
-<span class="v">24&#160;</span>For the tithe of the children of Israel, which they offer as a wave offering to Yahweh, I have given to the Levites for an inheritance. Therefore I have said to them, ‘Among the children of Israel they shall have no inheritance.’&#160;” 
-</p><p>
-<span class="v">25&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">26&#160;</span>“Moreover you shall speak to the Levites, and tell them, ‘When you take of the children of Israel the tithe which I have given you from them for your inheritance, then you shall offer up a wave offering of it for Yahweh, a tithe of the tithe. 
-<span class="v">27&#160;</span>Your wave offering shall be credited to you, as though it were the grain of the threshing floor, and as the fullness of the wine press. 
-<span class="v">28&#160;</span>Thus you also shall offer a wave offering to Yahweh of all your tithes, which you receive of the children of Israel; and of it you shall give Yahweh’s wave offering to Aaron the priest. 
-<span class="v">29&#160;</span>Out of all your gifts, you shall offer every wave offering to Yahweh, of all its best parts, even the set-apart part of it.’ 
-</p><p>
-<span class="v">30&#160;</span>“Therefore you shall tell them, ‘When you heave its best from it, then it shall be credited to the Levites as the increase of the threshing floor, and as the increase of the wine press. 
-<span class="v">31&#160;</span>You may eat it anywhere, you and your households, for it is your reward in return for your service in the Tent of Meeting. 
-<span class="v">32&#160;</span>You shall bear no sin by reason of it, when you have heaved from it its best. You shall not profane the set-apart things of the children of Israel, that you not die.’&#160;” 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses and to Aaron, saying, 
-<span class="v">2&#160;</span>“This is the statute of the law which Yahweh has commanded. Tell the children of Israel to bring you a red heifer without spot, in which is no defect, and which was never yoked. 
-<span class="v">3&#160;</span>You shall give her to Eleazar the priest, and he shall bring her outside of the camp, and one shall kill her before his face. 
-<span class="v">4&#160;</span>Eleazar the priest shall take some of her blood with his finger, and sprinkle her blood toward the front of the Tent of Meeting seven times. 
-<span class="v">5&#160;</span>One shall burn the heifer in his sight; her skin, and her meat, and her blood, with her dung, shall he burn. 
-<span class="v">6&#160;</span>The priest shall take cedar wood, hyssop, and scarlet, and cast it into the middle of the burning of the heifer. 
-<span class="v">7&#160;</span>Then the priest shall wash his clothes, and he shall bathe his flesh in water, and afterward he shall come into the camp, and the priest shall be unclean until the evening. 
-<span class="v">8&#160;</span>He who burns her shall wash his clothes in water, and bathe his flesh in water, and shall be unclean until the evening. 
-</p><p>
-<span class="v">9&#160;</span>“A man who is clean shall gather up the ashes of the heifer, and lay them up outside of the camp in a clean place; and it shall be kept for the congregation of the children of Israel for use in water for cleansing impurity. It is a sin offering. 
-<span class="v">10&#160;</span>He who gathers the ashes of the heifer shall wash his clothes, and be unclean until the evening. It shall be to the children of Israel, and to the stranger who lives as a foreigner among them, for a statute forever. 
-</p><p>
-<span class="v">11&#160;</span>“He who touches the dead body of any man shall be unclean seven days. 
-<span class="v">12&#160;</span>He shall purify himself with water on the third day, and on the seventh day he shall be clean; but if he doesn’t purify himself the third day, then the seventh day he shall not be clean. 
-<span class="v">13&#160;</span>Whoever touches a dead person, the body of a man who has died, and doesn’t purify himself, defiles Yahweh’s tabernacle; and that soul shall be cut off from Israel; because the water for impurity was not sprinkled on him, he shall be unclean. His uncleanness is yet on him. 
-</p><p>
-<span class="v">14&#160;</span>“This is the law when a man dies in a tent: everyone who comes into the tent, and everyone who is in the tent, shall be unclean seven days. 
-<span class="v">15&#160;</span>Every open vessel, which has no covering bound on it, is unclean. 
-</p><p>
-<span class="v">16&#160;</span>“Whoever in the open field touches one who is slain with a sword, or a dead body, or a bone of a man, or a grave, shall be unclean seven days. 
-</p><p>
-<span class="v">17&#160;</span>“For the unclean, they shall take of the ashes of the burning of the sin offering; and running water shall be poured on them in a vessel. 
-<span class="v">18&#160;</span>A clean person shall take hyssop, dip it in the water, and sprinkle it on the tent, on all the vessels, on the persons who were there, and on him who touched the bone, or the slain, or the dead, or the grave. 
-<span class="v">19&#160;</span>The clean person shall sprinkle on the unclean on the third day, and on the seventh day. On the seventh day, he shall purify him. He shall wash his clothes and bathe himself in water, and shall be clean at evening. 
-<span class="v">20&#160;</span>But the man who shall be unclean, and shall not purify himself, that soul shall be cut off from among the assembly, because he has defiled the sanctuary of Yahweh. The water for impurity has not been sprinkled on him. He is unclean. 
-<span class="v">21&#160;</span>It shall be a perpetual statute to them. He who sprinkles the water for impurity shall wash his clothes, and he who touches the water for impurity shall be unclean until evening. 
-</p><p>
-<span class="v">22&#160;</span>“Whatever the unclean person touches shall be unclean; and the soul that touches it shall be unclean until evening.” 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>The children of Israel, even the whole congregation, came into the wilderness of Zin in the first month. The people stayed in Kadesh. Miriam died there, and was buried there. 
-<span class="v">2&#160;</span>There was no water for the congregation; and they assembled themselves together against Moses and against Aaron. 
-<span class="v">3&#160;</span>The people quarreled with Moses, and spoke, saying, “We wish that we had died when our brothers died before Yahweh! 
-<span class="v">4&#160;</span>Why have you brought Yahweh’s assembly into this wilderness, that we should die there, we and our animals? 
-<span class="v">5&#160;</span>Why have you made us to come up out of Egypt, to bring us in to this evil place? It is no place of seed, or of figs, or of vines, or of pomegranates; neither is there any water to drink.” 
-</p><p>
-<span class="v">6&#160;</span>Moses and Aaron went from the presence of the assembly to the door of the Tent of Meeting, and fell on their faces. Yahweh’s glory appeared to them. 
-<span class="v">7&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">8&#160;</span>“Take the rod, and assemble the congregation, you, and Aaron your brother, and speak to the rock before their eyes, that it pour out its water. You shall bring water to them out of the rock; so you shall give the congregation and their livestock drink.” 
-</p><p>
-<span class="v">9&#160;</span>Moses took the rod from before Yahweh, as he commanded him. 
-<span class="v">10&#160;</span>Moses and Aaron gathered the assembly together before the rock, and he said to them, “Hear now, you rebels! Shall we bring water out of this rock for you?” 
-<span class="v">11&#160;</span>Moses lifted up his hand, and struck the rock with his rod twice, and water came out abundantly. The congregation and their livestock drank. 
-</p><p>
-<span class="v">12&#160;</span>Yahweh said to Moses and Aaron, “Because you didn’t believe in me, to sanctify me in the eyes of the children of Israel, therefore you shall not bring this assembly into the land which I have given them.” 
-</p><p>
-<span class="v">13&#160;</span>These are the waters of Meribah;<span class="f">+ \fr 20:13 \ft “Meribah” means “quarreling”.</span> because the children of Israel strove with Yahweh, and he was sanctified in them. 
-</p><p>
-<span class="v">14&#160;</span>Moses sent messengers from Kadesh to the king of Edom, saying: 
-</p><p>“Your brother Israel says: You know all the travail that has happened to us; 
-<span class="v">15&#160;</span>how our fathers went down into Egypt, and we lived in Egypt a long time. The Egyptians mistreated us and our fathers. 
-<span class="v">16&#160;</span>When we cried to Yahweh, he heard our voice, sent an angel, and brought us out of Egypt. Behold, we are in Kadesh, a city in the edge of your border. 
-</p><p>
-<span class="v">17&#160;</span>“Please let us pass through your land. We will not pass through field or through vineyard, neither will we drink from the water of the wells. We will go along the king’s highway. We will not turn away to the right hand nor to the left, until we have passed your border.” 
-</p><p>
-<span class="v">18&#160;</span>Edom said to him, “You shall not pass through me, lest I come out with the sword against you.” 
-</p><p>
-<span class="v">19&#160;</span>The children of Israel said to him, “We will go up by the highway; and if we drink your water, I and my livestock, then I will give its price. Only let me, without doing anything else, pass through on my feet.” 
-</p><p>
-<span class="v">20&#160;</span>He said, “You shall not pass through.” Edom came out against him with many people, and with a strong hand. 
-<span class="v">21&#160;</span>Thus Edom refused to give Israel passage through his border, so Israel turned away from him. 
-</p><p>
-<span class="v">22&#160;</span>They traveled from Kadesh, and the children of Israel, even the whole congregation, came to Mount Hor. 
-<span class="v">23&#160;</span>Yahweh spoke to Moses and Aaron in Mount Hor, by the border of the land of Edom, saying, 
-<span class="v">24&#160;</span>“Aaron shall be gathered to his people; for he shall not enter into the land which I have given to the children of Israel, because you rebelled against my word at the waters of Meribah. 
-<span class="v">25&#160;</span>Take Aaron and Eleazar his son, and bring them up to Mount Hor; 
-<span class="v">26&#160;</span>and strip Aaron of his garments, and put them on Eleazar his son. Aaron shall be gathered, and shall die there.” 
-</p><p>
-<span class="v">27&#160;</span>Moses did as Yahweh commanded. They went up onto Mount Hor in the sight of all the congregation. 
-<span class="v">28&#160;</span>Moses stripped Aaron of his garments, and put them on Eleazar his son. Aaron died there on the top of the mountain, and Moses and Eleazar came down from the mountain. 
-<span class="v">29&#160;</span>When all the congregation saw that Aaron was dead, they wept for Aaron thirty days, even all the house of Israel. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>The Canaanite, the king of Arad, who lived in the South, heard that Israel came by the way of Atharim. He fought against Israel, and took some of them captive. 
-<span class="v">2&#160;</span>Israel vowed a vow to Yahweh, and said, “If you will indeed deliver this people into my hand, then I will utterly destroy their cities.” 
-<span class="v">3&#160;</span>Yahweh listened to the voice of Israel, and delivered up the Canaanites; and they utterly destroyed them and their cities. The name of the place was called Hormah.<span class="f">+ \fr 21:3 \ft “Hormah” means “destruction”.</span> 
-</p><p>
-<span class="v">4&#160;</span>They traveled from Mount Hor by the way to the Red Sea, to go around the land of Edom. The soul of the people was very discouraged because of the journey. 
-<span class="v">5&#160;</span>The people spoke against Elohim and against Moses: “Why have you brought us up out of Egypt to die in the wilderness? For there is no bread, there is no water, and our soul loathes this disgusting food!” 
-</p><p>
-<span class="v">6&#160;</span>Yahweh sent venomous snakes among the people, and they bit the people. Many people of Israel died. 
-<span class="v">7&#160;</span>The people came to Moses, and said, “We have sinned, because we have spoken against Yahweh and against you. Pray to Yahweh, that he take away the serpents from us.” Moses prayed for the people. 
-</p><p>
-<span class="v">8&#160;</span>Yahweh said to Moses, “Make a venomous snake, and set it on a pole. It shall happen that everyone who is bitten, when he sees it, shall live.” 
-<span class="v">9&#160;</span>Moses made a serpent of bronze, and set it on the pole. If a serpent had bitten any man, when he looked at the serpent of bronze, he lived. 
-</p><p>
-<span class="v">10&#160;</span>The children of Israel traveled, and encamped in Oboth. 
-<span class="v">11&#160;</span>They traveled from Oboth, and encamped at Iyeabarim, in the wilderness which is before Moab, toward the sunrise. 
-<span class="v">12&#160;</span>From there they traveled, and encamped in the valley of Zered. 
-<span class="v">13&#160;</span>From there they traveled, and encamped on the other side of the Arnon, which is in the wilderness that comes out of the border of the Amorites; for the Arnon is the border of Moab, between Moab and the Amorites. 
-<span class="v">14&#160;</span>Therefore it is said in <span class="bk">The Book of the Wars of Yahweh</span>, “Vaheb in Suphah, the valleys of the Arnon, 
-<span class="v">15&#160;</span>the slope of the valleys that incline toward the dwelling of Ar, leans on the border of Moab.” 
-</p><p>
-<span class="v">16&#160;</span>From there they traveled to Beer; that is the well of which Yahweh said to Moses, “Gather the people together, and I will give them water.” 
-</p><p>
-<span class="v">17&#160;</span>Then Israel sang this song: 
-</p><p class="q1">“Spring up, well! Sing to it, 
-</p><p class="q2">
-<span class="v">18&#160;</span>the well, which the princes dug, 
-</p><p class="q2">which the nobles of the people dug, 
-</p><p class="q2">with the scepter, and with their poles.” 
-</p><p>From the wilderness they traveled to Mattanah; 
-<span class="v">19&#160;</span>and from Mattanah to Nahaliel; and from Nahaliel to Bamoth; 
-<span class="v">20&#160;</span>and from Bamoth to the valley that is in the field of Moab, to the top of Pisgah, which looks down on the desert. 
-<span class="v">21&#160;</span>Israel sent messengers to Sihon king of the Amorites, saying, 
-<span class="v">22&#160;</span>“Let me pass through your land. We will not turn away into field or vineyard. We will not drink of the water of the wells. We will go by the king’s highway, until we have passed your border.” 
-</p><p>
-<span class="v">23&#160;</span>Sihon would not allow Israel to pass through his border, but Sihon gathered all his people together, and went out against Israel into the wilderness, and came to Jahaz. He fought against Israel. 
-<span class="v">24&#160;</span>Israel struck him with the edge of the sword, and possessed his land from the Arnon to the Jabbok, even to the children of Ammon; for the border of the children of Ammon was fortified. 
-<span class="v">25&#160;</span>Israel took all these cities. Israel lived in all the cities of the Amorites, in Heshbon, and in all its villages. 
-<span class="v">26&#160;</span>For Heshbon was the city of Sihon the king of the Amorites, who had fought against the former king of Moab, and taken all his land out of his hand, even to the Arnon. 
-<span class="v">27&#160;</span>Therefore those who speak in proverbs say, 
-</p><p class="q1">“Come to Heshbon. 
-</p><p class="q2">Let the city of Sihon be built and established; 
-</p><p class="q1">
-<span class="v">28&#160;</span>for a fire has gone out of Heshbon, 
-</p><p class="q2">a flame from the city of Sihon. 
-</p><p class="q1">It has devoured Ar of Moab, 
-</p><p class="q2">The owners of the high places of the Arnon. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Woe to you, Moab! 
-</p><p class="q2">You are undone, people of Chemosh! 
-</p><p class="q1">He has given his sons as fugitives, 
-</p><p class="q2">and his daughters into captivity, 
-</p><p class="q2">to Sihon king of the Amorites. 
-</p><p class="q1">
-<span class="v">30&#160;</span>We have shot at them. 
-</p><p class="q2">Heshbon has perished even to Dibon. 
-</p><p class="q1">We have laid waste even to Nophah, 
-</p><p class="q2">Which reaches to Medeba.” 
-</p><p>
-<span class="v">31&#160;</span>Thus Israel lived in the land of the Amorites. 
-<span class="v">32&#160;</span>Moses sent to spy out Jazer. They took its villages, and drove out the Amorites who were there. 
-<span class="v">33&#160;</span>They turned and went up by the way of Bashan. Og the king of Bashan went out against them, he and all his people, to battle at Edrei. 
-</p><p>
-<span class="v">34&#160;</span>Yahweh said to Moses, “Don’t fear him, for I have delivered him into your hand, with all his people, and his land. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
-</p><p>
-<span class="v">35&#160;</span>So they struck him, with his sons and all his people, until there were no survivors; and they possessed his land. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>The children of Israel traveled, and encamped in the plains of Moab beyond the Jordan at Jericho. 
-<span class="v">2&#160;</span>Balak the son of Zippor saw all that Israel had done to the Amorites. 
-<span class="v">3&#160;</span>Moab was very afraid of the people, because they were many. Moab was distressed because of the children of Israel. 
-<span class="v">4&#160;</span>Moab said to the elders of Midian, “Now this multitude will lick up all that is around us, as the ox licks up the grass of the field.” 
-</p><p>Balak the son of Zippor was king of Moab at that time. 
-<span class="v">5&#160;</span>He sent messengers to Balaam the son of Beor, to Pethor, which is by the River, to the land of the children of his people, to call him, saying, “Behold, there is a people who came out of Egypt. Behold, they cover the surface of the earth, and they are staying opposite me. 
-<span class="v">6&#160;</span>Please come now therefore, and curse this people for me; for they are too mighty for me. Perhaps I shall prevail, that we may strike them, and that I may drive them out of the land; for I know that he whom you bless is blessed, and he whom you curse is cursed.” 
-</p><p>
-<span class="v">7&#160;</span>The elders of Moab and the elders of Midian departed with the rewards of divination in their hand. They came to Balaam, and spoke to him the words of Balak. 
-</p><p>
-<span class="v">8&#160;</span>He said to them, “Lodge here this night, and I will bring you word again, as Yahweh shall speak to me.” The princes of Moab stayed with Balaam. 
-</p><p>
-<span class="v">9&#160;</span>Elohim came to Balaam, and said, “Who are these men with you?” 
-</p><p>
-<span class="v">10&#160;</span>Balaam said to Elohim, “Balak the son of Zippor, king of Moab, has said to me, 
-<span class="v">11&#160;</span>‘Behold, the people that has come out of Egypt covers the surface of the earth. Now, come curse them for me. Perhaps I shall be able to fight against them, and shall drive them out.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Elohim said to Balaam, “You shall not go with them. You shall not curse the people, for they are blessed.” 
-</p><p>
-<span class="v">13&#160;</span>Balaam rose up in the morning, and said to the princes of Balak, “Go to your land; for Yahweh refuses to permit me to go with you.” 
-</p><p>
-<span class="v">14&#160;</span>The princes of Moab rose up, and they went to Balak, and said, “Balaam refuses to come with us.” 
-</p><p>
-<span class="v">15&#160;</span>Balak again sent princes, more, and more honorable than they. 
-<span class="v">16&#160;</span>They came to Balaam, and said to him, “Balak the son of Zippor says, ‘Please let nothing hinder you from coming to me, 
-<span class="v">17&#160;</span>for I will promote you to very great honor, and whatever you say to me I will do. Please come therefore, and curse this people for me.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Balaam answered the servants of Balak, “If Balak would give me his house full of silver and gold, I can’t go beyond the word of Yahweh my Elohim, to do less or more. 
-<span class="v">19&#160;</span>Now therefore please stay here tonight as well, that I may know what else Yahweh will speak to me.” 
-</p><p>
-<span class="v">20&#160;</span>Elohim came to Balaam at night, and said to him, “If the men have come to call you, rise up, go with them; but only the word which I speak to you, that you shall do.” 
-</p><p>
-<span class="v">21&#160;</span>Balaam rose up in the morning, and saddled his donkey, and went with the princes of Moab. 
-<span class="v">22&#160;</span>Elohim’s anger burned because he went; and Yahweh’s angel placed himself in the way as an adversary against him. Now he was riding on his donkey, and his two servants were with him. 
-<span class="v">23&#160;</span>The donkey saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and the donkey turned out of the path, and went into the field. Balaam struck the donkey, to turn her into the path. 
-<span class="v">24&#160;</span>Then Yahweh’s angel stood in a narrow path between the vineyards, a wall being on this side, and a wall on that side. 
-<span class="v">25&#160;</span>The donkey saw Yahweh’s angel, and she thrust herself to the wall, and crushed Balaam’s foot against the wall. He struck her again. 
-</p><p>
-<span class="v">26&#160;</span>Yahweh’s angel went further, and stood in a narrow place, where there was no way to turn either to the right hand or to the left. 
-<span class="v">27&#160;</span>The donkey saw Yahweh’s angel, and she lay down under Balaam. Balaam’s anger burned, and he struck the donkey with his staff. 
-</p><p>
-<span class="v">28&#160;</span>Yahweh opened the mouth of the donkey, and she said to Balaam, “What have I done to you, that you have struck me these three times?” 
-</p><p>
-<span class="v">29&#160;</span>Balaam said to the donkey, “Because you have mocked me, I wish there were a sword in my hand, for now I would have killed you.” 
-</p><p>
-<span class="v">30&#160;</span>The donkey said to Balaam, “Am I not your donkey, on which you have ridden all your life long until today? Was I ever in the habit of doing so to you?” 
-</p><p>He said, “No.” 
-</p><p>
-<span class="v">31&#160;</span>Then Yahweh opened the eyes of Balaam, and he saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and he bowed his head, and fell on his face. 
-<span class="v">32&#160;</span>Yahweh’s angel said to him, “Why have you struck your donkey these three times? Behold, I have come out as an adversary, because your way is perverse before me. 
-<span class="v">33&#160;</span>The donkey saw me, and turned away before me these three times. Unless she had turned away from me, surely now I would have killed you, and saved her alive.” 
-</p><p>
-<span class="v">34&#160;</span>Balaam said to Yahweh’s angel, “I have sinned; for I didn’t know that you stood in the way against me. Now therefore, if it displeases you, I will go back again.” 
-</p><p>
-<span class="v">35&#160;</span>Yahweh’s angel said to Balaam, “Go with the men; but you shall only speak the word that I shall speak to you.” 
-</p><p>So Balaam went with the princes of Balak. 
-<span class="v">36&#160;</span>When Balak heard that Balaam had come, he went out to meet him to the City of Moab, which is on the border of the Arnon, which is in the utmost part of the border. 
-<span class="v">37&#160;</span>Balak said to Balaam, “Didn’t I earnestly send for you to summon you? Why didn’t you come to me? Am I not able indeed to promote you to honor?” 
-</p><p>
-<span class="v">38&#160;</span>Balaam said to Balak, “Behold, I have come to you. Have I now any power at all to speak anything? I will speak the word that Elohim puts in my mouth.” 
-</p><p>
-<span class="v">39&#160;</span>Balaam went with Balak, and they came to Kiriath Huzoth. 
-<span class="v">40&#160;</span>Balak sacrificed cattle and sheep, and sent to Balaam, and to the princes who were with him. 
-<span class="v">41&#160;</span>In the morning, Balak took Balaam, and brought him up into the high places of Baal; and he saw from there part of the people. 
-</p><h2 class="chapterlabel" id="23">23</h2>
-<p>
-<span class="v">1&#160;</span>Balaam said to Balak, “Build here seven altars for me, and prepare here seven bulls and seven rams for me.” 
-</p><p>
-<span class="v">2&#160;</span>Balak did as Balaam had spoken; and Balak and Balaam offered on every altar a bull and a ram. 
-<span class="v">3&#160;</span>Balaam said to Balak, “Stand by your burnt offering, and I will go. Perhaps Yahweh will come to meet me. Whatever he shows me I will tell you.” 
-</p><p>He went to a bare height. 
-<span class="v">4&#160;</span>Elohim met Balaam, and he said to him, “I have prepared the seven altars, and I have offered up a bull and a ram on every altar.” 
-</p><p>
-<span class="v">5&#160;</span>Yahweh put a word in Balaam’s mouth, and said, “Return to Balak, and thus you shall speak.” 
-</p><p>
-<span class="v">6&#160;</span>He returned to him, and behold, he was standing by his burnt offering, he, and all the princes of Moab. 
-<span class="v">7&#160;</span>He took up his parable, and said, 
-</p><p class="q1">“From Aram has Balak brought me, 
-</p><p class="q2">the king of Moab from the mountains of the East. 
-</p><p class="q1">Come, curse Jacob for me. 
-</p><p class="q2">Come, defy Israel. 
-</p><p class="q1">
-<span class="v">8&#160;</span>How shall I curse whom Elohim has not cursed? 
-</p><p class="q2">How shall I defy whom Yahweh has not defied? 
-</p><p class="q1">
-<span class="v">9&#160;</span>For from the top of the rocks I see him. 
-</p><p class="q2">From the hills I see him. 
-</p><p class="q1">Behold, it is a people that dwells alone, 
-</p><p class="q2">and shall not be listed among the nations. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Who can count the dust of Jacob, 
-</p><p class="q2">or count the fourth part of Israel? 
-</p><p class="q1">Let me die the death of the righteous! 
-</p><p class="q2">Let my last end be like his!” 
-</p><p>
-<span class="v">11&#160;</span>Balak said to Balaam, “What have you done to me? I took you to curse my enemies, and behold, you have blessed them altogether.” 
-</p><p>
-<span class="v">12&#160;</span>He answered and said, “Must I not take heed to speak that which Yahweh puts in my mouth?” 
-</p><p>
-<span class="v">13&#160;</span>Balak said to him, “Please come with me to another place, where you may see them. You shall see just part of them, and shall not see them all. Curse them from there for me.” 
-</p><p>
-<span class="v">14&#160;</span>He took him into the field of Zophim, to the top of Pisgah, and built seven altars, and offered up a bull and a ram on every altar. 
-<span class="v">15&#160;</span>He said to Balak, “Stand here by your burnt offering, while I meet Elohim over there.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh met Balaam, and put a word in his mouth, and said, “Return to Balak, and say this.” 
-</p><p>
-<span class="v">17&#160;</span>He came to him, and behold, he was standing by his burnt offering, and the princes of Moab with him. Balak said to him, “What has Yahweh spoken?” 
-</p><p>
-<span class="v">18&#160;</span>He took up his parable, and said, 
-</p><p class="q1">“Rise up, Balak, and hear! 
-</p><p class="q2">Listen to me, you son of Zippor. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Elohim is not a man, that he should lie, 
-</p><p class="q2">nor a son of man, that he should repent. 
-</p><p class="q1">Has he said, and he won’t do it? 
-</p><p class="q2">Or has he spoken, and he won’t make it good? 
-</p><p class="q1">
-<span class="v">20&#160;</span>Behold, I have received a command to bless. 
-</p><p class="q2">He has blessed, and I can’t reverse it. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He has not seen iniquity in Jacob. 
-</p><p class="q2">Neither has he seen perverseness in Israel. 
-</p><p class="q1">Yahweh his Elohim is with him. 
-</p><p class="q2">The shout of a king is among them. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Elohim brings them out of Egypt. 
-</p><p class="q2">He has as it were the strength of the wild ox. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Surely there is no enchantment with Jacob; 
-</p><p class="q2">neither is there any divination with Israel. 
-</p><p class="q1">Now it shall be said of Jacob and of Israel, 
-</p><p class="q2">‘What has Elohim done!’ 
-</p><p class="q1">
-<span class="v">24&#160;</span>Behold, a people rises up as a lioness. 
-</p><p class="q2">As a lion he lifts himself up. 
-</p><p class="q1">He shall not lie down until he eats of the prey, 
-</p><p class="q2">and drinks the blood of the slain.” 
-</p><p>
-<span class="v">25&#160;</span>Balak said to Balaam, “Neither curse them at all, nor bless them at all.” 
-</p><p>
-<span class="v">26&#160;</span>But Balaam answered Balak, “Didn’t I tell you, saying, ‘All that Yahweh speaks, that I must do’?” 
-</p><p>
-<span class="v">27&#160;</span>Balak said to Balaam, “Come now, I will take you to another place; perhaps it will please Elohim that you may curse them for me from there.” 
-</p><p>
-<span class="v">28&#160;</span>Balak took Balaam to the top of Peor, that looks down on the desert. 
-<span class="v">29&#160;</span>Balaam said to Balak, “Build seven altars for me here, and prepare seven bulls and seven rams for me here.” 
-</p><p>
-<span class="v">30&#160;</span>Balak did as Balaam had said, and offered up a bull and a ram on every altar. 
-</p><h2 class="chapterlabel" id="24">24</h2>
-<p>
-<span class="v">1&#160;</span>When Balaam saw that it pleased Yahweh to bless Israel, he didn’t go, as at the other times, to use divination, but he set his face toward the wilderness. 
-<span class="v">2&#160;</span>Balaam lifted up his eyes, and he saw Israel dwelling according to their tribes; and the Spirit of Elohim came on him. 
-<span class="v">3&#160;</span>He took up his parable, and said, 
-</p><p class="q1">“Balaam the son of Beor says, 
-</p><p class="q2">the man whose eyes are open says; 
-</p><p class="q1">
-<span class="v">4&#160;</span>he says, who hears the words of Elohim, 
-</p><p class="q2">who sees the vision of the Almighty, 
-</p><p class="q2">falling down, and having his eyes open: 
-</p><p class="q1">
-<span class="v">5&#160;</span>How goodly are your tents, Jacob, 
-</p><p class="q2">and your dwellings, Israel! 
-</p><p class="q1">
-<span class="v">6&#160;</span>As valleys they are spread out, 
-</p><p class="q2">as gardens by the riverside, 
-</p><p class="q2">as aloes which Yahweh has planted, 
-</p><p class="q2">as cedar trees beside the waters. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Water shall flow from his buckets. 
-</p><p class="q2">His seed shall be in many waters. 
-</p><p class="q1">His king shall be higher than Agag. 
-</p><p class="q2">His kingdom shall be exalted. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Elohim brings him out of Egypt. 
-</p><p class="q2">He has as it were the strength of the wild ox. 
-</p><p class="q1">He shall consume the nations his adversaries, 
-</p><p class="q2">shall break their bones in pieces, 
-</p><p class="q2">and pierce them with his arrows. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He couched, he lay down as a lion, 
-</p><p class="q2">as a lioness; 
-</p><p class="q2">who shall rouse him up? 
-</p><p class="q1">Everyone who blesses you is blessed. 
-</p><p class="q2">Everyone who curses you is cursed.” 
-</p><p>
-<span class="v">10&#160;</span>Balak’s anger burned against Balaam, and he struck his hands together. Balak said to Balaam, “I called you to curse my enemies, and, behold, you have altogether blessed them these three times. 
-<span class="v">11&#160;</span>Therefore, flee to your place, now! I thought to promote you to great honor; but, behold, Yahweh has kept you back from honor.” 
-</p><p>
-<span class="v">12&#160;</span>Balaam said to Balak, “Didn’t I also tell your messengers whom you sent to me, saying, 
-<span class="v">13&#160;</span>‘If Balak would give me his house full of silver and gold, I can’t go beyond Yahweh’s word, to do either good or bad from my own mind. I will say what Yahweh says’? 
-<span class="v">14&#160;</span>Now, behold, I go to my people. Come, I will inform you what this people shall do to your people in the latter days.” 
-</p><p>
-<span class="v">15&#160;</span>He took up his parable, and said, 
-</p><p class="q1">“Balaam the son of Beor says, 
-</p><p class="q2">the man whose eyes are open says; 
-</p><p class="q2">
-<span class="v">16&#160;</span>he says, who hears the words of Elohim, 
-</p><p class="q2">knows the knowledge of the Most High, 
-</p><p class="q2">and who sees the vision of the Almighty, 
-</p><p class="q2">falling down, and having his eyes open: 
-</p><p class="q1">
-<span class="v">17&#160;</span>I see him, but not now. 
-</p><p class="q2">I see him, but not near. 
-</p><p class="q1">A star will come out of Jacob. 
-</p><p class="q2">A scepter will rise out of Israel, 
-</p><p class="q1">and shall strike through the corners of Moab, 
-</p><p class="q2">and crush all the sons of Sheth. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Edom shall be a possession. 
-</p><p class="q2">Seir, his enemy, also shall be a possession, 
-</p><p class="q2">while Israel does valiantly. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Out of Jacob shall one have dominion, 
-</p><p class="q2">and shall destroy the remnant from the city.” 
-</p><p>
-<span class="v">20&#160;</span>He looked at Amalek, and took up his parable, and said, 
-</p><p class="q1">“Amalek was the first of the nations, 
-</p><p class="q2">but his latter end shall come to destruction.” 
-</p><p>
-<span class="v">21&#160;</span>He looked at the Kenite, and took up his parable, and said, 
-</p><p class="q1">“Your dwelling place is strong. 
-</p><p class="q2">Your nest is set in the rock. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Nevertheless Kain shall be wasted, 
-</p><p class="q2">until Asshur carries you away captive.” 
-</p><p>
-<span class="v">23&#160;</span>He took up his parable, and said, 
-</p><p class="q1">“Alas, who shall live when Elohim does this? 
-</p><p class="q2">
-<span class="v">24&#160;</span>But ships shall come from the coast of Kittim. 
-</p><p class="q1">They shall afflict Asshur, and shall afflict Eber. 
-</p><p class="q2">He also shall come to destruction.” 
-</p><p>
-<span class="v">25&#160;</span>Balaam rose up, and went and returned to his place; and Balak also went his way. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>Israel stayed in Shittim; and the people began to play the prostitute with the daughters of Moab; 
-<span class="v">2&#160;</span>for they called the people to the sacrifices of their elohims. The people ate and bowed down to their elohims. 
-<span class="v">3&#160;</span>Israel joined himself to Baal Peor, and Yahweh’s anger burned against Israel. 
-<span class="v">4&#160;</span>Yahweh said to Moses, “Take all the chiefs of the people, and hang them up to Yahweh before the sun, that the fierce anger of Yahweh may turn away from Israel.” 
-</p><p>
-<span class="v">5&#160;</span>Moses said to the judges of Israel, “Everyone kill his men who have joined themselves to Baal Peor.” 
-</p><p>
-<span class="v">6&#160;</span>Behold, one of the children of Israel came and brought to his brothers a Midianite woman in the sight of Moses, and in the sight of all the congregation of the children of Israel, while they were weeping at the door of the Tent of Meeting. 
-<span class="v">7&#160;</span>When Phinehas, the son of Eleazar, the son of Aaron the priest, saw it, he rose up from the middle of the congregation, and took a spear in his hand. 
-<span class="v">8&#160;</span>He went after the man of Israel into the pavilion, and thrust both of them through, the man of Israel, and the woman through her body. So the plague was stopped among the children of Israel. 
-<span class="v">9&#160;</span>Those who died by the plague were twenty-four thousand. 
-</p><p>
-<span class="v">10&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">11&#160;</span>“Phinehas, the son of Eleazar, the son of Aaron the priest, has turned my wrath away from the children of Israel, in that he was jealous with my jealousy among them, so that I didn’t consume the children of Israel in my jealousy. 
-<span class="v">12&#160;</span>Therefore say, ‘Behold, I give to him my covenant of peace. 
-<span class="v">13&#160;</span>It shall be to him, and to his offspring after him, the covenant of an everlasting priesthood, because he was jealous for his Elohim, and made atonement for the children of Israel.’&#160;” 
-</p><p>
-<span class="v">14&#160;</span>Now the name of the man of Israel that was slain, who was slain with the Midianite woman, was Zimri, the son of Salu, a prince of a fathers’ house among the Simeonites. 
-<span class="v">15&#160;</span>The name of the Midianite woman who was slain was Cozbi, the daughter of Zur. He was head of the people of a fathers’ house in Midian. 
-</p><p>
-<span class="v">16&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">17&#160;</span>“Harass the Midianites, and strike them; 
-<span class="v">18&#160;</span>for they harassed you with their wiles, wherein they have deceived you in the matter of Peor, and in the incident regarding Cozbi, the daughter of the prince of Midian, their sister, who was slain on the day of the plague in the matter of Peor.” 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p>
-<span class="v">1&#160;</span>After the plague, Yahweh spoke to Moses and to Eleazar the son of Aaron the priest, saying, 
-<span class="v">2&#160;</span>“Take a census of all the congregation of the children of Israel, from twenty years old and upward, by their fathers’ houses, all who are able to go out to war in Israel.” 
-<span class="v">3&#160;</span>Moses and Eleazar the priest spoke with them in the plains of Moab by the Jordan at Jericho, saying, 
-<span class="v">4&#160;</span>“Take a census, from twenty years old and upward, as Yahweh commanded Moses and the children of Israel.” 
-</p><p>These are those who came out of the land of Egypt. 
-<span class="v">5&#160;</span>Reuben, the firstborn of Israel; the sons of Reuben: of Hanoch, the family of the Hanochites; of Pallu, the family of the Palluites; 
-<span class="v">6&#160;</span>of Hezron, the family of the Hezronites; of Carmi, the family of the Carmites. 
-<span class="v">7&#160;</span>These are the families of the Reubenites; and those who were counted of them were forty-three thousand seven hundred thirty. 
-<span class="v">8&#160;</span>The son of Pallu: Eliab. 
-<span class="v">9&#160;</span>The sons of Eliab: Nemuel, Dathan, and Abiram. These are that Dathan and Abiram who were called by the congregation, who rebelled against Moses and against Aaron in the company of Korah when they rebelled against Yahweh; 
-<span class="v">10&#160;</span>and the earth opened its mouth, and swallowed them up together with Korah when that company died; at the time the fire devoured two hundred fifty men, and they became a sign. 
-<span class="v">11&#160;</span>Notwithstanding, the sons of Korah didn’t die. 
-<span class="v">12&#160;</span>The sons of Simeon after their families: of Nemuel, the family of the Nemuelites; of Jamin, the family of the Jaminites; of Jachin, the family of the Jachinites; 
-<span class="v">13&#160;</span>of Zerah, the family of the Zerahites; of Shaul, the family of the Shaulites. 
-<span class="v">14&#160;</span>These are the families of the Simeonites, twenty-two thousand two hundred. 
-<span class="v">15&#160;</span>The sons of Gad after their families: of Zephon, the family of the Zephonites; of Haggi, the family of the Haggites; of Shuni, the family of the Shunites; 
-<span class="v">16&#160;</span>of Ozni, the family of the Oznites; of Eri, the family of the Erites; 
-<span class="v">17&#160;</span>of Arod, the family of the Arodites; of Areli, the family of the Arelites. 
-<span class="v">18&#160;</span>These are the families of the sons of Gad according to those who were counted of them, forty thousand and five hundred. 
-<span class="v">19&#160;</span>The sons of Judah: Er and Onan. Er and Onan died in the land of Canaan. 
-<span class="v">20&#160;</span>The sons of Judah after their families were: of Shelah, the family of the Shelanites; of Perez, the family of the Perezites; of Zerah, the family of the Zerahites. 
-<span class="v">21&#160;</span>The sons of Perez were: of Hezron, the family of the Hezronites; of Hamul, the family of the Hamulites. 
-<span class="v">22&#160;</span>These are the families of Judah according to those who were counted of them, seventy-six thousand five hundred. 
-<span class="v">23&#160;</span>The sons of Issachar after their families: of Tola, the family of the Tolaites; of Puvah, the family of the Punites; 
-<span class="v">24&#160;</span>of Jashub, the family of the Jashubites; of Shimron, the family of the Shimronites. 
-<span class="v">25&#160;</span>These are the families of Issachar according to those who were counted of them, sixty-four thousand three hundred. 
-<span class="v">26&#160;</span>The sons of Zebulun after their families: of Sered, the family of the Seredites; of Elon, the family of the Elonites; of Jahleel, the family of the Jahleelites. 
-<span class="v">27&#160;</span>These are the families of the Zebulunites according to those who were counted of them, sixty thousand five hundred. 
-<span class="v">28&#160;</span>The sons of Joseph after their families: Manasseh and Ephraim. 
-<span class="v">29&#160;</span>The sons of Manasseh: of Machir, the family of the Machirites; and Machir brought forth Gilead; of Gilead, the family of the Gileadites. 
-<span class="v">30&#160;</span>These are the sons of Gilead: of Iezer, the family of the Iezerites; of Helek, the family of the Helekites; 
-<span class="v">31&#160;</span>and Asriel, the family of the Asrielites; and Shechem, the family of the Shechemites; 
-<span class="v">32&#160;</span>and Shemida, the family of the Shemidaites; and Hepher, the family of the Hepherites. 
-<span class="v">33&#160;</span>Zelophehad the son of Hepher had no sons, but daughters: and the names of the daughters of Zelophehad were Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
-<span class="v">34&#160;</span>These are the families of Manasseh. Those who were counted of them were fifty-two thousand seven hundred. 
-<span class="v">35&#160;</span>These are the sons of Ephraim after their families: of Shuthelah, the family of the Shuthelahites; of Becher, the family of the Becherites; of Tahan, the family of the Tahanites. 
-<span class="v">36&#160;</span>These are the sons of Shuthelah: of Eran, the family of the Eranites. 
-<span class="v">37&#160;</span>These are the families of the sons of Ephraim according to those who were counted of them, thirty-two thousand five hundred. These are the sons of Joseph after their families. 
-<span class="v">38&#160;</span>The sons of Benjamin after their families: of Bela, the family of the Belaites; of Ashbel, the family of the Ashbelites; of Ahiram, the family of the Ahiramites; 
-<span class="v">39&#160;</span>of Shephupham, the family of the Shuphamites; of Hupham, the family of the Huphamites. 
-<span class="v">40&#160;</span>The sons of Bela were Ard and Naaman: the family of the Ardites; and of Naaman, the family of the Naamites. 
-<span class="v">41&#160;</span>These are the sons of Benjamin after their families; and those who were counted of them were forty-five thousand six hundred. 
-<span class="v">42&#160;</span>These are the sons of Dan after their families: of Shuham, the family of the Shuhamites. These are the families of Dan after their families. 
-<span class="v">43&#160;</span>All the families of the Shuhamites, according to those who were counted of them, were sixty-four thousand four hundred. 
-<span class="v">44&#160;</span>The sons of Asher after their families: of Imnah, the family of the Imnites; of Ishvi, the family of the Ishvites; of Beriah, the family of the Berites. 
-<span class="v">45&#160;</span>Of the sons of Beriah: of Heber, the family of the Heberites; of Malchiel, the family of the Malchielites. 
-<span class="v">46&#160;</span>The name of the daughter of Asher was Serah. 
-<span class="v">47&#160;</span>These are the families of the sons of Asher according to those who were counted of them, fifty-three thousand four hundred. 
-<span class="v">48&#160;</span>The sons of Naphtali after their families: of Jahzeel, the family of the Jahzeelites; of Guni, the family of the Gunites; 
-<span class="v">49&#160;</span>of Jezer, the family of the Jezerites; of Shillem, the family of the Shillemites. 
-<span class="v">50&#160;</span>These are the families of Naphtali according to their families; and those who were counted of them were forty-five thousand four hundred. 
-<span class="v">51&#160;</span>These are those who were counted of the children of Israel, six hundred one thousand seven hundred thirty. 
-</p><p>
-<span class="v">52&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">53&#160;</span>“To these the land shall be divided for an inheritance according to the number of names. 
-<span class="v">54&#160;</span>To the more you shall give the more inheritance, and to the fewer you shall give the less inheritance. To everyone according to those who were counted of him shall his inheritance be given. 
-<span class="v">55&#160;</span>Notwithstanding, the land shall be divided by lot. According to the names of the tribes of their fathers they shall inherit. 
-<span class="v">56&#160;</span>According to the lot shall their inheritance be divided between the more and the fewer.” 
-</p><p>
-<span class="v">57&#160;</span>These are those who were counted of the Levites after their families: of Gershon, the family of the Gershonites; of Kohath, the family of the Kohathites; of Merari, the family of the Merarites. 
-<span class="v">58&#160;</span>These are the families of Levi: the family of the Libnites, the family of the Hebronites, the family of the Mahlites, the family of the Mushites, and the family of the Korahites. Kohath brought forth Amram. 
-<span class="v">59&#160;</span>The name of Amram’s woman was Jochebed, the daughter of Levi, who was born to Levi in Egypt. She bore to Amram Aaron and Moses, and Miriam their sister. 
-<span class="v">60&#160;</span>To Aaron were born Nadab and Abihu, Eleazar and Ithamar. 
-<span class="v">61&#160;</span>Nadab and Abihu died when they offered strange fire before Yahweh. 
-<span class="v">62&#160;</span>Those who were counted of them were twenty-three thousand, every male from a month old and upward; for they were not counted among the children of Israel, because there was no inheritance given them among the children of Israel. 
-<span class="v">63&#160;</span>These are those who were counted by Moses and Eleazar the priest, who counted the children of Israel in the plains of Moab by the Jordan at Jericho. 
-<span class="v">64&#160;</span>But among these there was not a man of them who were counted by Moses and Aaron the priest, who counted the children of Israel in the wilderness of Sinai. 
-<span class="v">65&#160;</span>For Yahweh had said of them, “They shall surely die in the wilderness.” There was not a man left of them, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p>
-<span class="v">1&#160;</span>Then the daughters of Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, of the families of Manasseh the son of Joseph came near. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
-<span class="v">2&#160;</span>They stood before Moses, before Eleazar the priest, and before the princes and all the congregation, at the door of the Tent of Meeting, saying, 
-<span class="v">3&#160;</span>“Our father died in the wilderness. He was not among the company of those who gathered themselves together against Yahweh in the company of Korah, but he died in his own sin. He had no sons. 
-<span class="v">4&#160;</span>Why should the name of our father be taken away from among his family, because he had no son? Give to us a possession among the brothers of our father.” 
-</p><p>
-<span class="v">5&#160;</span>Moses brought their cause before Yahweh. 
-<span class="v">6&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">7&#160;</span>“The daughters of Zelophehad speak right. You shall surely give them a possession of an inheritance among their father’s brothers. You shall cause the inheritance of their father to pass to them. 
-<span class="v">8&#160;</span>You shall speak to the children of Israel, saying, ‘If a man dies, and has no son, then you shall cause his inheritance to pass to his daughter. 
-<span class="v">9&#160;</span>If he has no daughter, then you shall give his inheritance to his brothers. 
-<span class="v">10&#160;</span>If he has no brothers, then you shall give his inheritance to his father’s brothers. 
-<span class="v">11&#160;</span>If his father has no brothers, then you shall give his inheritance to his kinsman who is next to him of his family, and he shall possess it. This shall be a statute and ordinance for the children of Israel, as Yahweh commanded Moses.’&#160;” 
-</p><p>
-<span class="v">12&#160;</span>Yahweh said to Moses, “Go up into this mountain of Abarim, and see the land which I have given to the children of Israel. 
-<span class="v">13&#160;</span>When you have seen it, you also shall be gathered to your people, as Aaron your brother was gathered; 
-<span class="v">14&#160;</span>because in the strife of the congregation, you rebelled against my word in the wilderness of Zin, to honor me as set-apart at the waters before their eyes.” (These are the waters of Meribah of Kadesh in the wilderness of Zin.) 
-</p><p>
-<span class="v">15&#160;</span>Moses spoke to Yahweh, saying, 
-<span class="v">16&#160;</span>“Let Yahweh, the Elohim of the spirits of all flesh, appoint a man over the congregation, 
-<span class="v">17&#160;</span>who may go out before them, and who may come in before them, and who may lead them out, and who may bring them in, that the congregation of Yahweh may not be as sheep which have no shepherd.” 
-</p><p>
-<span class="v">18&#160;</span>Yahweh said to Moses, “Take Joshua the son of Nun, a man in whom is the Spirit, and lay your hand on him. 
-<span class="v">19&#160;</span>Set him before Eleazar the priest, and before all the congregation; and commission him in their sight. 
-<span class="v">20&#160;</span>You shall give authority to him, that all the congregation of the children of Israel may obey. 
-<span class="v">21&#160;</span>He shall stand before Eleazar the priest, who shall inquire for him by the judgment of the Urim before Yahweh. At his word they shall go out, and at his word they shall come in, both he and all the children of Israel with him, even all the congregation.” 
-</p><p>
-<span class="v">22&#160;</span>Moses did as Yahweh commanded him. He took Joshua, and set him before Eleazar the priest and before all the congregation. 
-<span class="v">23&#160;</span>He laid his hands on him and commissioned him, as Yahweh spoke by Moses. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Command the children of Israel, and tell them, ‘See that you present my offering, my food for my offerings made by fire, as a pleasant aroma to me, in their due season.’ 
-<span class="v">3&#160;</span>You shall tell them, ‘This is the offering made by fire which you shall offer to Yahweh: male lambs a year old without defect, two day by day, for a continual burnt offering. 
-<span class="v">4&#160;</span>You shall offer the one lamb in the morning, and you shall offer the other lamb at evening, 
-<span class="v">5&#160;</span>with one tenth of an ephah<span class="f">+ \fr 28:5 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour for a meal offering, mixed with the fourth part of a hin<span class="f">+ \fr 28:5 \ft A hin is about 6.5 liters or 1.7 gallons.</span> of beaten oil. 
-<span class="v">6&#160;</span>It is a continual burnt offering which was ordained in Mount Sinai for a pleasant aroma, an offering made by fire to Yahweh. 
-<span class="v">7&#160;</span>Its drink offering shall be the fourth part of a hin<span class="f">+ \fr 28:7 \ft One hin is about 6.5 liters, so 1/4 hin is about 1.6 liters or 1.7 quarts.</span> for each lamb. You shall pour out a drink offering of strong drink to Yahweh in the set-apart place. 
-<span class="v">8&#160;</span>The other lamb you shall offer at evening. As the meal offering of the morning, and as its drink offering, you shall offer it, an offering made by fire, for a pleasant aroma to Yahweh. 
-</p><p>
-<span class="v">9&#160;</span>“&#160;‘On the Sabbath day, you shall offer two male lambs a year old without defect, and two tenths of an ephah<span class="f">+ \fr 28:9 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour for a meal offering mixed with oil, and its drink offering: 
-<span class="v">10&#160;</span>this is the burnt offering of every Sabbath, in addition to the continual burnt offering and its drink offering. 
-</p><p>
-<span class="v">11&#160;</span>“&#160;‘In the beginnings of your months, you shall offer a burnt offering to Yahweh: two young bulls, one ram, seven male lambs a year old without defect, 
-<span class="v">12&#160;</span>and three tenths of an ephah<span class="f">+ \fr 28:12 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of fine flour for a meal offering mixed with oil, for each bull; and two tenth parts of fine flour for a meal offering mixed with oil, for the one ram; 
-<span class="v">13&#160;</span>and one tenth part of fine flour mixed with oil for a meal offering to every lamb, as a burnt offering of a pleasant aroma, an offering made by fire to Yahweh. 
-<span class="v">14&#160;</span>Their drink offerings shall be half a hin of wine for a bull, the third part of a hin for the ram, and the fourth part of a hin for a lamb. This is the burnt offering of every month throughout the months of the year. 
-<span class="v">15&#160;</span>Also, one male goat for a sin offering to Yahweh shall be offered in addition to the continual burnt offering and its drink offering. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘In the first month, on the fourteenth day of the month, is Yahweh’s Passover. 
-<span class="v">17&#160;</span>On the fifteenth day of this month shall be a feast. Unleavened bread shall be eaten for seven days. 
-<span class="v">18&#160;</span>In the first day shall be a set-apart convocation. You shall do no regular work, 
-<span class="v">19&#160;</span>but you shall offer an offering made by fire, a burnt offering to Yahweh: two young bulls, one ram, and seven male lambs a year old. They shall be without defect, 
-<span class="v">20&#160;</span>with their meal offering, fine flour mixed with oil. You shall offer three tenths for a bull, and two tenths for the ram. 
-<span class="v">21&#160;</span>You shall offer one tenth for every lamb of the seven lambs; 
-<span class="v">22&#160;</span>and one male goat for a sin offering, to make atonement for you. 
-<span class="v">23&#160;</span>You shall offer these in addition to the burnt offering of the morning, which is for a continual burnt offering. 
-<span class="v">24&#160;</span>In this way you shall offer daily, for seven days, the food of the offering made by fire, of a pleasant aroma to Yahweh. It shall be offered in addition to the continual burnt offering and its drink offering. 
-<span class="v">25&#160;</span>On the seventh day you shall have a set-apart convocation. You shall do no regular work. 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘Also in the day of the first fruits, when you offer a new meal offering to Yahweh in your feast of weeks, you shall have a set-apart convocation. You shall do no regular work; 
-<span class="v">27&#160;</span>but you shall offer a burnt offering for a pleasant aroma to Yahweh: two young bulls, one ram, seven male lambs a year old; 
-<span class="v">28&#160;</span>and their meal offering, fine flour mixed with oil, three tenths for each bull, two tenths for the one ram, 
-<span class="v">29&#160;</span>one tenth for every lamb of the seven lambs; 
-<span class="v">30&#160;</span>and one male goat, to make atonement for you. 
-<span class="v">31&#160;</span>Besides the continual burnt offering and its meal offering, you shall offer them and their drink offerings. See that they are without defect. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p>
-<span class="v">1&#160;</span>“&#160;‘In the seventh month, on the first day of the month, you shall have a set-apart convocation; you shall do no regular work. It is a day of blowing of trumpets to you. 
-<span class="v">2&#160;</span>You shall offer a burnt offering for a pleasant aroma to Yahweh: one young bull, one ram, seven male lambs a year old without defect; 
-<span class="v">3&#160;</span>and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the ram, 
-<span class="v">4&#160;</span>and one tenth for every lamb of the seven lambs; 
-<span class="v">5&#160;</span>and one male goat for a sin offering, to make atonement for you; 
-<span class="v">6&#160;</span>in addition to the burnt offering of the new moon with its meal offering, and the continual burnt offering with its meal offering, and their drink offerings, according to their ordinance, for a pleasant aroma, an offering made by fire to Yahweh. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘On the tenth day of this seventh month you shall have a set-apart convocation. You shall afflict your souls. You shall do no kind of work; 
-<span class="v">8&#160;</span>but you shall offer a burnt offering to Yahweh for a pleasant aroma: one young bull, one ram, seven male lambs a year old, all without defect; 
-<span class="v">9&#160;</span>and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the one ram, 
-<span class="v">10&#160;</span>one tenth for every lamb of the seven lambs; 
-<span class="v">11&#160;</span>one male goat for a sin offering, in addition to the sin offering of atonement, and the continual burnt offering, and its meal offering, and their drink offerings. 
-</p><p>
-<span class="v">12&#160;</span>“&#160;‘On the fifteenth day of the seventh month you shall have a set-apart convocation. You shall do no regular work. You shall keep a feast to Yahweh seven days. 
-<span class="v">13&#160;</span>You shall offer a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh: thirteen young bulls, two rams, fourteen male lambs a year old, all without defect; 
-<span class="v">14&#160;</span>and their meal offering, fine flour mixed with oil: three tenths for every bull of the thirteen bulls, two tenths for each ram of the two rams, 
-<span class="v">15&#160;</span>and one tenth for every lamb of the fourteen lambs; 
-<span class="v">16&#160;</span>and one male goat for a sin offering, in addition to the continual burnt offering, its meal offering, and its drink offering. 
-</p><p>
-<span class="v">17&#160;</span>“&#160;‘On the second day you shall offer twelve young bulls, two rams, and fourteen male lambs a year old without defect; 
-<span class="v">18&#160;</span>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance; 
-<span class="v">19&#160;</span>and one male goat for a sin offering, in addition to the continual burnt offering, with its meal offering and their drink offerings. 
-</p><p>
-<span class="v">20&#160;</span>“&#160;‘On the third day: eleven bulls, two rams, fourteen male lambs a year old without defect; 
-<span class="v">21&#160;</span>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance; 
-<span class="v">22&#160;</span>and one male goat for a sin offering, in addition to the continual burnt offering, and its meal offering, and its drink offering. 
-</p><p>
-<span class="v">23&#160;</span>“&#160;‘On the fourth day ten bulls, two rams, fourteen male lambs a year old without defect; 
-<span class="v">24&#160;</span>their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance; 
-<span class="v">25&#160;</span>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and its drink offering. 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘On the fifth day: nine bulls, two rams, fourteen male lambs a year old without defect; 
-<span class="v">27&#160;</span>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance, 
-<span class="v">28&#160;</span>and one male goat for a sin offering, in addition to the continual burnt offering, and its meal offering, and its drink offering. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘On the sixth day: eight bulls, two rams, fourteen male lambs a year old without defect; 
-<span class="v">30&#160;</span>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance, 
-<span class="v">31&#160;</span>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and the drink offerings of it. 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘On the seventh day: seven bulls, two rams, fourteen male lambs a year old without defect; 
-<span class="v">33&#160;</span>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance, 
-<span class="v">34&#160;</span>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and its drink offering. 
-</p><p>
-<span class="v">35&#160;</span>“&#160;‘On the eighth day you shall have a solemn assembly. You shall do no regular work; 
-<span class="v">36&#160;</span>but you shall offer a burnt offering, an offering made by fire, a pleasant aroma to Yahweh: one bull, one ram, seven male lambs a year old without defect; 
-<span class="v">37&#160;</span>their meal offering and their drink offerings for the bull, for the ram, and for the lambs, shall be according to their number, after the ordinance, 
-<span class="v">38&#160;</span>and one male goat for a sin offering, in addition to the continual burnt offering, with its meal offering, and its drink offering. 
-</p><p>
-<span class="v">39&#160;</span>“&#160;‘You shall offer these to Yahweh in your set feasts—in addition to your vows and your free will offerings—for your burnt offerings, your meal offerings, your drink offerings, and your peace offerings.’&#160;” 
-</p><p>
-<span class="v">40&#160;</span>Moses told the children of Israel according to all that Yahweh commanded Moses. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>Moses spoke to the heads of the tribes of the children of Israel, saying, “This is the thing which Yahweh has commanded. 
-<span class="v">2&#160;</span>When a man vows a vow to Yahweh, or swears an oath to bind his soul with a bond, he shall not break his word. He shall do according to all that proceeds out of his mouth. 
-</p><p>
-<span class="v">3&#160;</span>“Also, when a woman vows a vow to Yahweh and binds herself by a pledge, being in her father’s house, in her youth, 
-<span class="v">4&#160;</span>and her father hears her vow and her pledge with which she has bound her soul, and her father says nothing to her, then all her vows shall stand, and every pledge with which she has bound her soul shall stand. 
-<span class="v">5&#160;</span>But if her father forbids her in the day that he hears, none of her vows or of her pledges with which she has bound her soul, shall stand. Yahweh will forgive her, because her father has forbidden her. 
-</p><p>
-<span class="v">6&#160;</span>“If she has a man, while her vows are on her, or the rash utterance of her lips with which she has bound her soul, 
-<span class="v">7&#160;</span>and her man hears it, and says nothing to her in the day that he hears it; then her vows shall stand, and her pledges with which she has bound her soul shall stand. 
-<span class="v">8&#160;</span>But if her man forbids her in the day that he hears it, then he makes void her vow which is on her and the rash utterance of her lips, with which she has bound her soul. Yahweh will forgive her. 
-</p><p>
-<span class="v">9&#160;</span>“But the vow of a widow, or of her who is divorced, everything with which she has bound her soul shall stand against her. 
-</p><p>
-<span class="v">10&#160;</span>“If she vowed in her man’s house or bound her soul by a bond with an oath, 
-<span class="v">11&#160;</span>and her man heard it, and held his peace at her and didn’t disallow her, then all her vows shall stand, and every pledge with which she bound her soul shall stand. 
-<span class="v">12&#160;</span>But if her man made them null and void in the day that he heard them, then whatever proceeded out of her lips concerning her vows, or concerning the bond of her soul, shall not stand. Her man has made them void. Yahweh will forgive her. 
-<span class="v">13&#160;</span>Every vow, and every binding oath to afflict the soul, her man may establish it, or her man may make it void. 
-<span class="v">14&#160;</span>But if her man says nothing to her from day to day, then he establishes all her vows or all her pledges which are on her. He has established them, because he said nothing to her in the day that he heard them. 
-<span class="v">15&#160;</span>But if he makes them null and void after he has heard them, then he shall bear her iniquity.” 
-</p><p>
-<span class="v">16&#160;</span>These are the statutes which Yahweh commanded Moses, between a man and his woman, between a father and his daughter, being in her youth, in her father’s house. 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Avenge the children of Israel on the Midianites. Afterward you shall be gathered to your people.” 
-</p><p>
-<span class="v">3&#160;</span>Moses spoke to the people, saying, “Arm men from among you for war, that they may go against Midian, to execute Yahweh’s vengeance on Midian. 
-<span class="v">4&#160;</span>You shall send one thousand out of every tribe, throughout all the tribes of Israel, to the war.” 
-<span class="v">5&#160;</span>So there were delivered, out of the thousands of Israel, a thousand from every tribe, twelve thousand armed for war. 
-<span class="v">6&#160;</span>Moses sent them, one thousand of every tribe, to the war with Phinehas the son of Eleazar the priest, to the war, with the vessels of the sanctuary and the trumpets for the alarm in his hand. 
-<span class="v">7&#160;</span>They fought against Midian, as Yahweh commanded Moses. They killed every male. 
-<span class="v">8&#160;</span>They killed the kings of Midian with the rest of their slain: Evi, Rekem, Zur, Hur, and Reba, the five kings of Midian. They also killed Balaam the son of Beor with the sword. 
-<span class="v">9&#160;</span>The children of Israel took the women of Midian captive with their little ones; and all their livestock, all their flocks, and all their goods, they took as plunder. 
-<span class="v">10&#160;</span>All their cities in the places in which they lived, and all their encampments, they burned with fire. 
-<span class="v">11&#160;</span>They took all the captives, and all the plunder, both of man and of animal. 
-<span class="v">12&#160;</span>They brought the captives with the prey and the plunder, to Moses, and to Eleazar the priest, and to the congregation of the children of Israel, to the camp at the plains of Moab, which are by the Jordan at Jericho. 
-<span class="v">13&#160;</span>Moses and Eleazar the priest, with all the princes of the congregation, went out to meet them outside of the camp. 
-<span class="v">14&#160;</span>Moses was angry with the officers of the army, the captains of thousands and the captains of hundreds, who came from the service of the war. 
-<span class="v">15&#160;</span>Moses said to them, “Have you saved all the women alive? 
-<span class="v">16&#160;</span>Behold, these caused the children of Israel, through the counsel of Balaam, to commit trespass against Yahweh in the matter of Peor, and so the plague was among the congregation of Yahweh. 
-<span class="v">17&#160;</span>Now therefore kill every male among the little ones, and kill every woman who has known man by lying with him. 
-<span class="v">18&#160;</span>But all the girls, who have not known man by lying with him, keep alive for yourselves. 
-</p><p>
-<span class="v">19&#160;</span>“Encamp outside of the camp for seven days. Whoever has killed any person, and whoever has touched any slain, purify yourselves on the third day and on the seventh day, you and your captives. 
-<span class="v">20&#160;</span>You shall purify every garment, and all that is made of skin, and all work of goats’ hair, and all things made of wood.” 
-</p><p>
-<span class="v">21&#160;</span>Eleazar the priest said to the men of war who went to the battle, “This is the statute of the law which Yahweh has commanded Moses. 
-<span class="v">22&#160;</span>However the gold, and the silver, the bronze, the iron, the tin, and the lead, 
-<span class="v">23&#160;</span>everything that may withstand the fire, you shall make to go through the fire, and it shall be clean; nevertheless it shall be purified with the water for impurity. All that doesn’t withstand the fire you shall make to go through the water. 
-<span class="v">24&#160;</span>You shall wash your clothes on the seventh day, and you shall be clean. Afterward you shall come into the camp.” 
-</p><p>
-<span class="v">25&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">26&#160;</span>“Count the plunder that was taken, both of man and of animal, you, and Eleazar the priest, and the heads of the fathers’ households of the congregation; 
-<span class="v">27&#160;</span>and divide the plunder into two parts: between the men skilled in war, who went out to battle, and all the congregation. 
-<span class="v">28&#160;</span>Levy a tribute to Yahweh of the men of war who went out to battle: one soul of five hundred; of the persons, of the cattle, of the donkeys, and of the flocks. 
-<span class="v">29&#160;</span>Take it from their half, and give it to Eleazar the priest, for Yahweh’s wave offering. 
-<span class="v">30&#160;</span>Of the children of Israel’s half, you shall take one drawn out of every fifty, of the persons, of the cattle, of the donkeys, and of the flocks, of all the livestock, and give them to the Levites, who perform the duty of Yahweh’s tabernacle.” 
-</p><p>
-<span class="v">31&#160;</span>Moses and Eleazar the priest did as Yahweh commanded Moses. 
-</p><p>
-<span class="v">32&#160;</span>Now the plunder, over and above the booty which the men of war took, was six hundred seventy-five thousand sheep, 
-<span class="v">33&#160;</span>seventy-two thousand head of cattle, 
-<span class="v">34&#160;</span>sixty-one thousand donkeys, 
-<span class="v">35&#160;</span>and thirty-two thousand persons in all, of the women who had not known man by lying with him. 
-<span class="v">36&#160;</span>The half, which was the portion of those who went out to war, was in number three hundred thirty-seven thousand five hundred sheep; 
-<span class="v">37&#160;</span>and Yahweh’s tribute of the sheep was six hundred seventy-five. 
-<span class="v">38&#160;</span>The cattle were thirty-six thousand, of which Yahweh’s tribute was seventy-two. 
-<span class="v">39&#160;</span>The donkeys were thirty thousand five hundred, of which Yahweh’s tribute was sixty-one. 
-<span class="v">40&#160;</span>The persons were sixteen thousand, of whom Yahweh’s tribute was thirty-two persons. 
-<span class="v">41&#160;</span>Moses gave the tribute, which was Yahweh’s wave offering, to Eleazar the priest, as Yahweh commanded Moses. 
-<span class="v">42&#160;</span>Of the children of Israel’s half, which Moses divided off from the men who fought 
-<span class="v">43&#160;</span>(now the congregation’s half was three hundred thirty-seven thousand five hundred sheep, 
-<span class="v">44&#160;</span>thirty-six thousand head of cattle, 
-<span class="v">45&#160;</span>thirty thousand five hundred donkeys, 
-<span class="v">46&#160;</span>and sixteen thousand persons), 
-<span class="v">47&#160;</span>even of the children of Israel’s half, Moses took one drawn out of every fifty, both of man and of animal, and gave them to the Levites, who performed the duty of Yahweh’s tabernacle, as Yahweh commanded Moses. 
-</p><p>
-<span class="v">48&#160;</span>The officers who were over the thousands of the army, the captains of thousands, and the captains of hundreds, came near to Moses. 
-<span class="v">49&#160;</span>They said to Moses, “Your servants have taken the sum of the men of war who are under our command, and there lacks not one man of us. 
-<span class="v">50&#160;</span>We have brought Yahweh’s offering, what every man found: gold ornaments, armlets, bracelets, signet rings, earrings, and necklaces, to make atonement for our souls before Yahweh.” 
-</p><p>
-<span class="v">51&#160;</span>Moses and Eleazar the priest took their gold, even all worked jewels. 
-<span class="v">52&#160;</span>All the gold of the wave offering that they offered up to Yahweh, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred fifty shekels.<span class="f">+ \fr 31:52 \ft A shekel is about 10 grams or about 0.35 ounces, so 16,750 shekels is about 167.5 kilograms or about 368.5 pounds.</span> 
-<span class="v">53&#160;</span>The men of war had taken booty, every man for himself. 
-<span class="v">54&#160;</span>Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the Tent of Meeting for a memorial for the children of Israel before Yahweh. 
-</p><h2 class="chapterlabel" id="32">32</h2>
-<p>
-<span class="v">1&#160;</span>Now the children of Reuben and the children of Gad had a very great multitude of livestock. They saw the land of Jazer, and the land of Gilead. Behold, the place was a place for livestock. 
-<span class="v">2&#160;</span>Then the children of Gad and the children of Reuben came and spoke to Moses, and to Eleazar the priest, and to the princes of the congregation, saying, 
-<span class="v">3&#160;</span>“Ataroth, Dibon, Jazer, Nimrah, Heshbon, Elealeh, Sebam, Nebo, and Beon, 
-<span class="v">4&#160;</span>the land which Yahweh struck before the congregation of Israel, is a land for livestock; and your servants have livestock.” 
-<span class="v">5&#160;</span>They said, “If we have found favor in your sight, let this land be given to your servants for a possession. Don’t bring us over the Jordan.” 
-</p><p>
-<span class="v">6&#160;</span>Moses said to the children of Gad, and to the children of Reuben, “Shall your brothers go to war while you sit here? 
-<span class="v">7&#160;</span>Why do you discourage the heart of the children of Israel from going over into the land which Yahweh has given them? 
-<span class="v">8&#160;</span>Your fathers did so when I sent them from Kadesh Barnea to see the land. 
-<span class="v">9&#160;</span>For when they went up to the valley of Eshcol, and saw the land, they discouraged the heart of the children of Israel, that they should not go into the land which Yahweh had given them. 
-<span class="v">10&#160;</span>Yahweh’s anger burned in that day, and he swore, saying, 
-<span class="v">11&#160;</span>‘Surely none of the men who came up out of Egypt, from twenty years old and upward, shall see the land which I swore to Abraham, to Isaac, and to Jacob; because they have not wholly followed me, 
-<span class="v">12&#160;</span>except Caleb the son of Jephunneh the Kenizzite, and Joshua the son of Nun, because they have followed Yahweh completely.’ 
-<span class="v">13&#160;</span>Yahweh’s anger burned against Israel, and he made them wander back and forth in the wilderness forty years, until all the generation who had done evil in Yahweh’s sight was consumed. 
-</p><p>
-<span class="v">14&#160;</span>“Behold, you have risen up in your fathers’ place, an increase of sinful men, to increase the fierce anger of Yahweh toward Israel. 
-<span class="v">15&#160;</span>For if you turn away from after him, he will yet again leave them in the wilderness; and you will destroy all these people.” 
-</p><p>
-<span class="v">16&#160;</span>They came near to him, and said, “We will build sheepfolds here for our livestock, and cities for our little ones; 
-<span class="v">17&#160;</span>but we ourselves will be ready armed to go before the children of Israel, until we have brought them to their place. Our little ones shall dwell in the fortified cities because of the inhabitants of the land. 
-<span class="v">18&#160;</span>We will not return to our houses until the children of Israel have all received their inheritance. 
-<span class="v">19&#160;</span>For we will not inherit with them on the other side of the Jordan and beyond, because our inheritance has come to us on this side of the Jordan eastward.” 
-</p><p>
-<span class="v">20&#160;</span>Moses said to them: “If you will do this thing, if you will arm yourselves to go before Yahweh to the war, 
-<span class="v">21&#160;</span>and every one of your armed men will pass over the Jordan before Yahweh until he has driven out his enemies from before him, 
-<span class="v">22&#160;</span>and the land is subdued before Yahweh; then afterward you shall return, and be clear of obligation to Yahweh and to Israel. Then this land shall be your possession before Yahweh. 
-</p><p>
-<span class="v">23&#160;</span>“But if you will not do so, behold, you have sinned against Yahweh; and be sure your sin will find you out. 
-<span class="v">24&#160;</span>Build cities for your little ones, and folds for your sheep; and do that which has proceeded out of your mouth.” 
-</p><p>
-<span class="v">25&#160;</span>The children of Gad and the children of Reuben spoke to Moses, saying, “Your servants will do as my lord commands. 
-<span class="v">26&#160;</span>Our little ones, our women, our flocks, and all our livestock shall be there in the cities of Gilead; 
-<span class="v">27&#160;</span>but your servants will pass over, every man who is armed for war, before Yahweh to battle, as my lord says.” 
-</p><p>
-<span class="v">28&#160;</span>So Moses commanded concerning them to Eleazar the priest, and to Joshua the son of Nun, and to the heads of the fathers’ households of the tribes of the children of Israel. 
-<span class="v">29&#160;</span>Moses said to them, “If the children of Gad and the children of Reuben will pass with you over the Jordan, every man who is armed to battle before Yahweh, and the land is subdued before you, then you shall give them the land of Gilead for a possession; 
-<span class="v">30&#160;</span>but if they will not pass over with you armed, they shall have possessions among you in the land of Canaan.” 
-</p><p>
-<span class="v">31&#160;</span>The children of Gad and the children of Reuben answered, saying, “As Yahweh has said to your servants, so will we do. 
-<span class="v">32&#160;</span>We will pass over armed before Yahweh into the land of Canaan, and the possession of our inheritance shall remain with us beyond the Jordan.” 
-</p><p>
-<span class="v">33&#160;</span>Moses gave to them, even to the children of Gad, and to the children of Reuben, and to the half-tribe of Manasseh the son of Joseph, the kingdom of Sihon king of the Amorites, and the kingdom of Og king of Bashan; the land, according to its cities and borders, even the cities of the surrounding land. 
-<span class="v">34&#160;</span>The children of Gad built Dibon, Ataroth, Aroer, 
-<span class="v">35&#160;</span>Atroth-shophan, Jazer, Jogbehah, 
-<span class="v">36&#160;</span>Beth Nimrah, and Beth Haran: fortified cities and folds for sheep. 
-<span class="v">37&#160;</span>The children of Reuben built Heshbon, Elealeh, Kiriathaim, 
-<span class="v">38&#160;</span>Nebo, and Baal Meon, (their names being changed), and Sibmah. They gave other names to the cities which they built. 
-<span class="v">39&#160;</span>The children of Machir the son of Manasseh went to Gilead, took it, and dispossessed the Amorites who were therein. 
-<span class="v">40&#160;</span>Moses gave Gilead to Machir the son of Manasseh; and he lived therein. 
-<span class="v">41&#160;</span>Jair the son of Manasseh went and took its villages, and called them Havvoth Jair. 
-<span class="v">42&#160;</span>Nobah went and took Kenath and its villages, and called it Nobah, after his own name. 
-</p><h2 class="chapterlabel" id="33">33</h2>
-<p>
-<span class="v">1&#160;</span>These are the journeys of the children of Israel, when they went out of the land of Egypt by their armies under the hand of Moses and Aaron. 
-<span class="v">2&#160;</span>Moses wrote the starting points of their journeys by the commandment of Yahweh. These are their journeys according to their starting points. 
-<span class="v">3&#160;</span>They traveled from Rameses in the first month, on the fifteenth day of the first month; on the next day after the Passover, the children of Israel went out with a high hand in the sight of all the Egyptians, 
-<span class="v">4&#160;</span>while the Egyptians were burying all their firstborn, whom Yahweh had struck among them. Yahweh also executed judgments on their elohims. 
-<span class="v">5&#160;</span>The children of Israel traveled from Rameses, and encamped in Succoth. 
-<span class="v">6&#160;</span>They traveled from Succoth, and encamped in Etham, which is in the edge of the wilderness. 
-<span class="v">7&#160;</span>They traveled from Etham, and turned back to Pihahiroth, which is before Baal Zephon, and they encamped before Migdol. 
-<span class="v">8&#160;</span>They traveled from before Hahiroth, and crossed through the middle of the sea into the wilderness. They went three days’ journey in the wilderness of Etham, and encamped in Marah. 
-<span class="v">9&#160;</span>They traveled from Marah, and came to Elim. In Elim, there were twelve springs of water and seventy palm trees, and they encamped there. 
-<span class="v">10&#160;</span>They traveled from Elim, and encamped by the Red Sea. 
-<span class="v">11&#160;</span>They traveled from the Red Sea, and encamped in the wilderness of Sin. 
-<span class="v">12&#160;</span>They traveled from the wilderness of Sin, and encamped in Dophkah. 
-<span class="v">13&#160;</span>They traveled from Dophkah, and encamped in Alush. 
-<span class="v">14&#160;</span>They traveled from Alush, and encamped in Rephidim, where there was no water for the people to drink. 
-<span class="v">15&#160;</span>They traveled from Rephidim, and encamped in the wilderness of Sinai. 
-<span class="v">16&#160;</span>They traveled from the wilderness of Sinai, and encamped in Kibroth Hattaavah. 
-<span class="v">17&#160;</span>They traveled from Kibroth Hattaavah, and encamped in Hazeroth. 
-<span class="v">18&#160;</span>They traveled from Hazeroth, and encamped in Rithmah. 
-<span class="v">19&#160;</span>They traveled from Rithmah, and encamped in Rimmon Perez. 
-<span class="v">20&#160;</span>They traveled from Rimmon Perez, and encamped in Libnah. 
-<span class="v">21&#160;</span>They traveled from Libnah, and encamped in Rissah. 
-<span class="v">22&#160;</span>They traveled from Rissah, and encamped in Kehelathah. 
-<span class="v">23&#160;</span>They traveled from Kehelathah, and encamped in Mount Shepher. 
-<span class="v">24&#160;</span>They traveled from Mount Shepher, and encamped in Haradah. 
-<span class="v">25&#160;</span>They traveled from Haradah, and encamped in Makheloth. 
-<span class="v">26&#160;</span>They traveled from Makheloth, and encamped in Tahath. 
-<span class="v">27&#160;</span>They traveled from Tahath, and encamped in Terah. 
-<span class="v">28&#160;</span>They traveled from Terah, and encamped in Mithkah. 
-<span class="v">29&#160;</span>They traveled from Mithkah, and encamped in Hashmonah. 
-<span class="v">30&#160;</span>They traveled from Hashmonah, and encamped in Moseroth. 
-<span class="v">31&#160;</span>They traveled from Moseroth, and encamped in Bene Jaakan. 
-<span class="v">32&#160;</span>They traveled from Bene Jaakan, and encamped in Hor Haggidgad. 
-<span class="v">33&#160;</span>They traveled from Hor Haggidgad, and encamped in Jotbathah. 
-<span class="v">34&#160;</span>They traveled from Jotbathah, and encamped in Abronah. 
-<span class="v">35&#160;</span>They traveled from Abronah, and encamped in Ezion Geber. 
-<span class="v">36&#160;</span>They traveled from Ezion Geber, and encamped at Kadesh in the wilderness of Zin. 
-<span class="v">37&#160;</span>They traveled from Kadesh, and encamped in Mount Hor, in the edge of the land of Edom. 
-<span class="v">38&#160;</span>Aaron the priest went up into Mount Hor at the commandment of Yahweh and died there, in the fortieth year after the children of Israel had come out of the land of Egypt, in the fifth month, on the first day of the month. 
-<span class="v">39&#160;</span>Aaron was one hundred twenty-three years old when he died in Mount Hor. 
-<span class="v">40&#160;</span>The Canaanite king of Arad, who lived in the South in the land of Canaan, heard of the coming of the children of Israel. 
-<span class="v">41&#160;</span>They traveled from Mount Hor, and encamped in Zalmonah. 
-<span class="v">42&#160;</span>They traveled from Zalmonah, and encamped in Punon. 
-<span class="v">43&#160;</span>They traveled from Punon, and encamped in Oboth. 
-<span class="v">44&#160;</span>They traveled from Oboth, and encamped in Iye Abarim, in the border of Moab. 
-<span class="v">45&#160;</span>They traveled from Iyim, and encamped in Dibon Gad. 
-<span class="v">46&#160;</span>They traveled from Dibon Gad, and encamped in Almon Diblathaim. 
-<span class="v">47&#160;</span>They traveled from Almon Diblathaim, and encamped in the mountains of Abarim, before Nebo. 
-<span class="v">48&#160;</span>They traveled from the mountains of Abarim, and encamped in the plains of Moab by the Jordan at Jericho. 
-<span class="v">49&#160;</span>They encamped by the Jordan, from Beth Jeshimoth even to Abel Shittim in the plains of Moab. 
-<span class="v">50&#160;</span>Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
-<span class="v">51&#160;</span>Speak to the children of Israel, and tell them, “When you pass over the Jordan into the land of Canaan, 
-<span class="v">52&#160;</span>then you shall drive out all the inhabitants of the land from before you, destroy all their stone idols, destroy all their molten images, and demolish all their high places. 
-<span class="v">53&#160;</span>You shall take possession of the land, and dwell therein; for I have given the land to you to possess it. 
-<span class="v">54&#160;</span>You shall inherit the land by lot according to your families; to the larger groups you shall give a larger inheritance, and to the smaller you shall give a smaller inheritance. Wherever the lot falls to any man, that shall be his. You shall inherit according to the tribes of your fathers. 
-</p><p>
-<span class="v">55&#160;</span>“But if you do not drive out the inhabitants of the land from before you, then those you let remain of them will be like pricks in your eyes and thorns in your sides. They will harass you in the land in which you dwell. 
-<span class="v">56&#160;</span>It shall happen that as I thought to do to them, so I will do to you.” 
-</p><h2 class="chapterlabel" id="34">34</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">2&#160;</span>“Command the children of Israel, and tell them, ‘When you come into the land of Canaan (this is the land that shall fall to you for an inheritance, even the land of Canaan according to its borders), 
-<span class="v">3&#160;</span>then your south quarter shall be from the wilderness of Zin along by the side of Edom, and your south border shall be from the end of the Salt Sea eastward. 
-<span class="v">4&#160;</span>Your border shall turn about southward of the ascent of Akrabbim, and pass along to Zin; and it shall pass southward of Kadesh Barnea; and it shall go from there to Hazar Addar, and pass along to Azmon. 
-<span class="v">5&#160;</span>The border shall turn about from Azmon to the brook of Egypt, and it shall end at the sea. 
-</p><p>
-<span class="v">6&#160;</span>“&#160;‘For the western border, you shall have the great sea and its border. This shall be your west border. 
-</p><p>
-<span class="v">7&#160;</span>“&#160;‘This shall be your north border: from the great sea you shall mark out for yourselves Mount Hor. 
-<span class="v">8&#160;</span>From Mount Hor you shall mark out to the entrance of Hamath; and the border shall pass by Zedad. 
-<span class="v">9&#160;</span>Then the border shall go to Ziphron, and it shall end at Hazar Enan. This shall be your north border. 
-</p><p>
-<span class="v">10&#160;</span>“&#160;‘You shall mark out your east border from Hazar Enan to Shepham. 
-<span class="v">11&#160;</span>The border shall go down from Shepham to Riblah, on the east side of Ain. The border shall go down, and shall reach to the side of the sea of Chinnereth eastward. 
-<span class="v">12&#160;</span>The border shall go down to the Jordan, and end at the Salt Sea. This shall be your land according to its borders around it.’&#160;” 
-</p><p>
-<span class="v">13&#160;</span>Moses commanded the children of Israel, saying, “This is the land which you shall inherit by lot, which Yahweh has commanded to give to the nine tribes, and to the half-tribe; 
-<span class="v">14&#160;</span>for the tribe of the children of Reuben according to their fathers’ houses, the tribe of the children of Gad according to their fathers’ houses, and the half-tribe of Manasseh have received their inheritance. 
-<span class="v">15&#160;</span>The two tribes and the half-tribe have received their inheritance beyond the Jordan at Jericho eastward, toward the sunrise.” 
-</p><p>
-<span class="v">16&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">17&#160;</span>“These are the names of the men who shall divide the land to you for inheritance: Eleazar the priest, and Joshua the son of Nun. 
-<span class="v">18&#160;</span>You shall take one prince of every tribe, to divide the land for inheritance. 
-<span class="v">19&#160;</span>These are the names of the men: Of the tribe of Judah, Caleb the son of Jephunneh. 
-<span class="v">20&#160;</span>Of the tribe of the children of Simeon, Shemuel the son of Ammihud. 
-<span class="v">21&#160;</span>Of the tribe of Benjamin, Elidad the son of Chislon. 
-<span class="v">22&#160;</span>Of the tribe of the children of Dan a prince, Bukki the son of Jogli. 
-<span class="v">23&#160;</span>Of the children of Joseph: of the tribe of the children of Manasseh a prince, Hanniel the son of Ephod. 
-<span class="v">24&#160;</span>Of the tribe of the children of Ephraim a prince, Kemuel the son of Shiphtan. 
-<span class="v">25&#160;</span>Of the tribe of the children of Zebulun a prince, Elizaphan the son of Parnach. 
-<span class="v">26&#160;</span>Of the tribe of the children of Issachar a prince, Paltiel the son of Azzan. 
-<span class="v">27&#160;</span>Of the tribe of the children of Asher a prince, Ahihud the son of Shelomi. 
-<span class="v">28&#160;</span>Of the tribe of the children of Naphtali a prince, Pedahel the son of Ammihud.” 
-<span class="v">29&#160;</span>These are they whom Yahweh commanded to divide the inheritance to the children of Israel in the land of Canaan. 
-</p><h2 class="chapterlabel" id="35">35</h2>
-<p>
-<span class="v">1&#160;</span>Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
-<span class="v">2&#160;</span>“Command the children of Israel to give to the Levites cities to dwell in out of their inheritance. You shall give pasture lands for the cities around them to the Levites. 
-<span class="v">3&#160;</span>They shall have the cities to dwell in. Their pasture lands shall be for their livestock, and for their possessions, and for all their animals. 
-</p><p>
-<span class="v">4&#160;</span>“The pasture lands of the cities, which you shall give to the Levites, shall be from the wall of the city and outward one thousand cubits<span class="f">+ \fr 35:4 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> around it. 
-<span class="v">5&#160;</span>You shall measure outside of the city for the east side two thousand cubits, and for the south side two thousand cubits, and for the west side two thousand cubits, and for the north side two thousand cubits, the city being in the middle. This shall be the pasture lands of their cities. 
-</p><p>
-<span class="v">6&#160;</span>“The cities which you shall give to the Levites, they shall be the six cities of refuge, which you shall give for the man slayer to flee to. Besides them you shall give forty-two cities. 
-<span class="v">7&#160;</span>All the cities which you shall give to the Levites shall be forty-eight cities together with their pasture lands. 
-<span class="v">8&#160;</span>Concerning the cities which you shall give of the possession of the children of Israel, from the many you shall take many, and from the few you shall take few. Everyone according to his inheritance which he inherits shall give some of his cities to the Levites.” 
-<span class="v">9&#160;</span>Yahweh spoke to Moses, saying, 
-<span class="v">10&#160;</span>“Speak to the children of Israel, and tell them, ‘When you pass over the Jordan into the land of Canaan, 
-<span class="v">11&#160;</span>then you shall appoint for yourselves cities to be cities of refuge for you, that the man slayer who kills any person unwittingly may flee there. 
-<span class="v">12&#160;</span>The cities shall be for your refuge from the avenger, that the man slayer not die until he stands before the congregation for judgment. 
-<span class="v">13&#160;</span>The cities which you shall give shall be for you six cities of refuge. 
-<span class="v">14&#160;</span>You shall give three cities beyond the Jordan, and you shall give three cities in the land of Canaan. They shall be cities of refuge. 
-<span class="v">15&#160;</span>These six cities shall be refuge for the children of Israel, for the stranger, and for the foreigner living among them, that everyone who kills any person unwittingly may flee there. 
-</p><p>
-<span class="v">16&#160;</span>“&#160;‘But if he struck him with an instrument of iron, so that he died, he is a murderer. The murderer shall surely be put to death. 
-<span class="v">17&#160;</span>If he struck him with a stone in the hand, by which a man may die, and he died, he is a murderer. The murderer shall surely be put to death. 
-<span class="v">18&#160;</span>Or if he struck him with a weapon of wood in the hand, by which a man may die, and he died, he is a murderer. The murderer shall surely be put to death. 
-<span class="v">19&#160;</span>The avenger of blood shall himself put the murderer to death. When he meets him, he shall put him to death. 
-<span class="v">20&#160;</span>If he shoved him out of hatred, or hurled something at him while lying in wait, so that he died, 
-<span class="v">21&#160;</span>or in hostility struck him with his hand, so that he died, he who struck him shall surely be put to death. He is a murderer. The avenger of blood shall put the murderer to death when he meets him. 
-</p><p>
-<span class="v">22&#160;</span>“&#160;‘But if he shoved him suddenly without hostility, or hurled on him anything without lying in wait, 
-<span class="v">23&#160;</span>or with any stone, by which a man may die, not seeing him, and cast it on him so that he died, and he was not his enemy and not seeking his harm, 
-<span class="v">24&#160;</span>then the congregation shall judge between the striker and the avenger of blood according to these ordinances. 
-<span class="v">25&#160;</span>The congregation shall deliver the man slayer out of the hand of the avenger of blood, and the congregation shall restore him to his city of refuge, where he had fled. He shall dwell therein until the death of the high priest, who was anointed with the set-apart oil. 
-</p><p>
-<span class="v">26&#160;</span>“&#160;‘But if the man slayer shall at any time go beyond the border of his city of refuge where he flees, 
-<span class="v">27&#160;</span>and the avenger of blood finds him outside of the border of his city of refuge, and the avenger of blood kills the man slayer, he shall not be guilty of blood, 
-<span class="v">28&#160;</span>because he should have remained in his city of refuge until the death of the high priest. But after the death of the high priest, the man slayer shall return into the land of his possession. 
-</p><p>
-<span class="v">29&#160;</span>“&#160;‘These things shall be for a statute and ordinance to you throughout your generations in all your dwellings. 
-</p><p>
-<span class="v">30&#160;</span>“&#160;‘Whoever kills any person, the murderer shall be slain based on the testimony of witnesses; but one witness shall not testify alone against any person so that he dies. 
-</p><p>
-<span class="v">31&#160;</span>“&#160;‘Moreover you shall take no ransom for the life of a murderer who is guilty of death. He shall surely be put to death. 
-</p><p>
-<span class="v">32&#160;</span>“&#160;‘You shall take no ransom for him who has fled to his city of refuge, that he may come again to dwell in the land before the death of the priest. 
-</p><p>
-<span class="v">33&#160;</span>“&#160;‘So you shall not pollute the land where you live; for blood pollutes the land. No atonement can be made for the land for the blood that is shed in it, but by the blood of him who shed it. 
-<span class="v">34&#160;</span>You shall not defile the land which you inhabit, where I dwell; for I, Yahweh, dwell among the children of Israel.’&#160;” 
-</p><h2 class="chapterlabel" id="36">36</h2>
-<p>
-<span class="v">1&#160;</span>The heads of the fathers’ households of the family of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near and spoke before Moses and before the princes, the heads of the fathers’ households of the children of Israel. 
-<span class="v">2&#160;</span>They said, “Yahweh commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahweh to give the inheritance of Zelophehad our brother to his daughters. 
-<span class="v">3&#160;</span>If they are married to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
-<span class="v">4&#160;</span>When the jubilee of the children of Israel comes, then their inheritance will be added to the inheritance of the tribe to which they shall belong. So their inheritance will be taken away from the inheritance of the tribe of our fathers.” 
-</p><p>
-<span class="v">5&#160;</span>Moses commanded the children of Israel according to Yahweh’s word, saying, “The tribe of the sons of Joseph speak what is right. 
-<span class="v">6&#160;</span>This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be married to whom they think best, only they shall marry into the family of the tribe of their father. 
-<span class="v">7&#160;</span>So shall no inheritance of the children of Israel move from tribe to tribe; for the children of Israel shall all keep the inheritance of the tribe of his fathers. 
-<span class="v">8&#160;</span>Every daughter who possesses an inheritance in any tribe of the children of Israel shall be woman to one of the family of the tribe of her father, that the children of Israel may each possess the inheritance of his fathers. 
-<span class="v">9&#160;</span>So shall no inheritance move from one tribe to another tribe; for the tribes of the children of Israel shall each keep his own inheritance.’&#160;” 
-</p><p>
-<span class="v">10&#160;</span>The daughters of Zelophehad did as Yahweh commanded Moses: 
-<span class="v">11&#160;</span>for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were married to their father’s brothers’ sons. 
-<span class="v">12&#160;</span>They were married into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
-</p><p>
-<span class="v">13&#160;</span>These are the commandments and the ordinances which Yahweh commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Yahweh spoke to Moses in the wilderness of Sinai, in the Tent of Meeting, on the first day of the second month, in the second year after they had come out of the land of Egypt, saying, 
+<sup>2&#160;</sup>“Take a census of all the congregation of the children of Israel, by their families, by their fathers’ houses, according to the number of the names, every male, one by one, 
+<sup>3&#160;</sup>from twenty years old and upward, all who are able to go out to war in Israel. You and Aaron shall count them by their divisions. 
+<sup>4&#160;</sup>With you there shall be a man of every tribe, each one head of his fathers’ house. 
+<sup>5&#160;</sup>These are the names of the men who shall stand with you: 
+</div><div class="p">Of Reuben: Elizur the son of Shedeur. 
+</div><div class="p">
+<sup>6&#160;</sup>Of Simeon: Shelumiel the son of Zurishaddai. 
+</div><div class="p">
+<sup>7&#160;</sup>Of Judah: Nahshon the son of Amminadab. 
+</div><div class="p">
+<sup>8&#160;</sup>Of Issachar: Nethanel the son of Zuar. 
+</div><div class="p">
+<sup>9&#160;</sup>Of Zebulun: Eliab the son of Helon. 
+</div><div class="p">
+<sup>10&#160;</sup>Of the children of Joseph: of Ephraim: Elishama the son of Ammihud; of Manasseh: Gamaliel the son of Pedahzur. 
+</div><div class="p">
+<sup>11&#160;</sup>Of Benjamin: Abidan the son of Gideoni. 
+</div><div class="p">
+<sup>12&#160;</sup>Of Dan: Ahiezer the son of Ammishaddai. 
+</div><div class="p">
+<sup>13&#160;</sup>Of Asher: Pagiel the son of Ochran. 
+</div><div class="p">
+<sup>14&#160;</sup>Of Gad: Eliasaph the son of Deuel. 
+</div><div class="p">
+<sup>15&#160;</sup>Of Naphtali: Ahira the son of Enan.” 
+</div><div class="p">
+<sup>16&#160;</sup>These are those who were called of the congregation, the princes of the tribes of their fathers; they were the heads of the thousands of Israel. 
+<sup>17&#160;</sup>Moses and Aaron took these men who are mentioned by name. 
+<sup>18&#160;</sup>They assembled all the congregation together on the first day of the second month; and they declared their ancestry by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, one by one. 
+<sup>19&#160;</sup>As Yahweh commanded Moses, so he counted them in the wilderness of Sinai. 
+</div><div class="p">
+<sup>20&#160;</sup>The children of Reuben, Israel’s firstborn, their generations, by their families, by their fathers’ houses, according to the number of the names, one by one, every male from twenty years old and upward, all who were able to go out to war: 
+<sup>21&#160;</sup>those who were counted of them, of the tribe of Reuben, were forty-six thousand five hundred. 
+</div><div class="p">
+<sup>22&#160;</sup>Of the children of Simeon, their generations, by their families, by their fathers’ houses, those who were counted of it, according to the number of the names, one by one, every male from twenty years old and upward, all who were able to go out to war: 
+<sup>23&#160;</sup>those who were counted of them, of the tribe of Simeon, were fifty-nine thousand three hundred. 
+</div><div class="p">
+<sup>24&#160;</sup>Of the children of Gad, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>25&#160;</sup>those who were counted of them, of the tribe of Gad, were forty-five thousand six hundred fifty. 
+</div><div class="p">
+<sup>26&#160;</sup>Of the children of Judah, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>27&#160;</sup>those who were counted of them, of the tribe of Judah, were seventy-four thousand six hundred. 
+</div><div class="p">
+<sup>28&#160;</sup>Of the children of Issachar, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>29&#160;</sup>those who were counted of them, of the tribe of Issachar, were fifty-four thousand four hundred. 
+</div><div class="p">
+<sup>30&#160;</sup>Of the children of Zebulun, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>31&#160;</sup>those who were counted of them, of the tribe of Zebulun, were fifty-seven thousand four hundred. 
+</div><div class="p">
+<sup>32&#160;</sup>Of the children of Joseph: of the children of Ephraim, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>33&#160;</sup>those who were counted of them, of the tribe of Ephraim, were forty thousand five hundred. 
+</div><div class="p">
+<sup>34&#160;</sup>Of the children of Manasseh, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>35&#160;</sup>those who were counted of them, of the tribe of Manasseh, were thirty-two thousand two hundred. 
+</div><div class="p">
+<sup>36&#160;</sup>Of the children of Benjamin, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>37&#160;</sup>those who were counted of them, of the tribe of Benjamin, were thirty-five thousand four hundred. 
+</div><div class="p">
+<sup>38&#160;</sup>Of the children of Dan, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>39&#160;</sup>those who were counted of them, of the tribe of Dan, were sixty-two thousand seven hundred. 
+</div><div class="p">
+<sup>40&#160;</sup>Of the children of Asher, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>41&#160;</sup>those who were counted of them, of the tribe of Asher, were forty-one thousand five hundred. 
+</div><div class="p">
+<sup>42&#160;</sup>Of the children of Naphtali, their generations, by their families, by their fathers’ houses, according to the number of the names, from twenty years old and upward, all who were able to go out to war: 
+<sup>43&#160;</sup>those who were counted of them, of the tribe of Naphtali, were fifty-three thousand four hundred. 
+</div><div class="p">
+<sup>44&#160;</sup>These are those who were counted, whom Moses and Aaron counted, and the twelve men who were princes of Israel, each one for his fathers’ house. 
+<sup>45&#160;</sup>So all those who were counted of the children of Israel by their fathers’ houses, from twenty years old and upward, all who were able to go out to war in Israel—<sup>46&#160;</sup>all those who were counted were six hundred three thousand five hundred fifty. 
+<sup>47&#160;</sup>But the Levites after the tribe of their fathers were not counted among them. 
+<sup>48&#160;</sup>For Yahweh spoke to Moses, saying, 
+<sup>49&#160;</sup>“Only the tribe of Levi you shall not count, neither shall you take a census of them among the children of Israel; 
+<sup>50&#160;</sup>but appoint the Levites over the Tabernacle of the Testimony, and over all its furnishings, and over all that belongs to it. They shall carry the tabernacle and all its furnishings; and they shall take care of it, and shall encamp around it. 
+<sup>51&#160;</sup>When the tabernacle is to move, the Levites shall take it down; and when the tabernacle is to be set up, the Levites shall set it up. The stranger who comes near shall be put to death. 
+<sup>52&#160;</sup>The children of Israel shall pitch their tents, every man by his own camp, and every man by his own standard, according to their divisions. 
+<sup>53&#160;</sup>But the Levites shall encamp around the Tabernacle of the Testimony, that there may be no wrath on the congregation of the children of Israel. The Levites shall be responsible for the Tabernacle of the Testimony.” 
+</div><div class="p">
+<sup>54&#160;</sup>Thus the children of Israel did. According to all that Yahweh commanded Moses, so they did. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>2&#160;</sup>“The children of Israel shall encamp every man by his own standard, with the banners of their fathers’ houses. They shall encamp around the Tent of Meeting at a distance from it. 
+</div><div class="p">
+<sup>3&#160;</sup>“Those who encamp on the east side toward the sunrise shall be of the standard of the camp of Judah, according to their divisions. The prince of the children of Judah shall be Nahshon the son of Amminadab. 
+<sup>4&#160;</sup>His division, and those who were counted of them, were seventy-four thousand six hundred. 
+</div><div class="p">
+<sup>5&#160;</sup>“Those who encamp next to him shall be the tribe of Issachar. The prince of the children of Issachar shall be Nethanel the son of Zuar. 
+<sup>6&#160;</sup>His division, and those who were counted of it, were fifty-four thousand four hundred. 
+</div><div class="p">
+<sup>7&#160;</sup>“The tribe of Zebulun: the prince of the children of Zebulun shall be Eliab the son of Helon. 
+<sup>8&#160;</sup>His division, and those who were counted of it, were fifty-seven thousand four hundred. 
+</div><div class="p">
+<sup>9&#160;</sup>“All who were counted of the camp of Judah were one hundred eighty-six thousand four hundred, according to their divisions. They shall set out first. 
+</div><div class="p">
+<sup>10&#160;</sup>“On the south side shall be the standard of the camp of Reuben according to their divisions. The prince of the children of Reuben shall be Elizur the son of Shedeur. 
+<sup>11&#160;</sup>His division, and those who were counted of it, were forty-six thousand five hundred. 
+</div><div class="p">
+<sup>12&#160;</sup>“Those who encamp next to him shall be the tribe of Simeon. The prince of the children of Simeon shall be Shelumiel the son of Zurishaddai. 
+<sup>13&#160;</sup>His division, and those who were counted of them, were fifty-nine thousand three hundred. 
+</div><div class="p">
+<sup>14&#160;</sup>“The tribe of Gad: the prince of the children of Gad shall be Eliasaph the son of Reuel. 
+<sup>15&#160;</sup>His division, and those who were counted of them, were forty-five thousand six hundred fifty. 
+</div><div class="p">
+<sup>16&#160;</sup>“All who were counted of the camp of Reuben were one hundred fifty-one thousand four hundred fifty, according to their armies. They shall set out second. 
+</div><div class="p">
+<sup>17&#160;</sup>“Then the Tent of Meeting shall set out, with the camp of the Levites in the middle of the camps. As they encamp, so shall they set out, every man in his place, by their standards. 
+</div><div class="p">
+<sup>18&#160;</sup>“On the west side shall be the standard of the camp of Ephraim according to their divisions. The prince of the children of Ephraim shall be Elishama the son of Ammihud. 
+<sup>19&#160;</sup>His division, and those who were counted of them, were forty thousand five hundred. 
+</div><div class="p">
+<sup>20&#160;</sup>“Next to him shall be the tribe of Manasseh. The prince of the children of Manasseh shall be Gamaliel the son of Pedahzur. 
+<sup>21&#160;</sup>His division, and those who were counted of them, were thirty-two thousand two hundred. 
+</div><div class="p">
+<sup>22&#160;</sup>“The tribe of Benjamin: the prince of the children of Benjamin shall be Abidan the son of Gideoni. 
+<sup>23&#160;</sup>His army, and those who were counted of them, were thirty-five thousand four hundred. 
+</div><div class="p">
+<sup>24&#160;</sup>“All who were counted of the camp of Ephraim were one hundred eight thousand one hundred, according to their divisions. They shall set out third. 
+</div><div class="p">
+<sup>25&#160;</sup>“On the north side shall be the standard of the camp of Dan according to their divisions. The prince of the children of Dan shall be Ahiezer the son of Ammishaddai. 
+<sup>26&#160;</sup>His division, and those who were counted of them, were sixty-two thousand seven hundred. 
+</div><div class="p">
+<sup>27&#160;</sup>“Those who encamp next to him shall be the tribe of Asher. The prince of the children of Asher shall be Pagiel the son of Ochran. 
+<sup>28&#160;</sup>His division, and those who were counted of them, were forty-one thousand five hundred. 
+</div><div class="p">
+<sup>29&#160;</sup>“The tribe of Naphtali: the prince of the children of Naphtali shall be Ahira the son of Enan. 
+<sup>30&#160;</sup>His division, and those who were counted of them, were fifty-three thousand four hundred. 
+</div><div class="p">
+<sup>31&#160;</sup>“All who were counted of the camp of Dan were one hundred fifty-seven thousand six hundred. They shall set out last by their standards.” 
+</div><div class="p">
+<sup>32&#160;</sup>These are those who were counted of the children of Israel by their fathers’ houses. All who were counted of the camps according to their armies were six hundred three thousand five hundred fifty. 
+<sup>33&#160;</sup>But the Levites were not counted among the children of Israel, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>34&#160;</sup>Thus the children of Israel did. According to all that Yahweh commanded Moses, so they encamped by their standards, and so they set out, everyone by their families, according to their fathers’ houses. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Now this is the history of the generations of Aaron and Moses in the day that Yahweh spoke with Moses in Mount Sinai. 
+<sup>2&#160;</sup>These are the names of the sons of Aaron: Nadab the firstborn, and Abihu, Eleazar, and Ithamar. 
+</div><div class="p">
+<sup>3&#160;</sup>These are the names of the sons of Aaron, the priests who were anointed, whom he consecrated to minister in the priest’s office. 
+<sup>4&#160;</sup>Nadab and Abihu died before Yahweh when they offered strange fire before Yahweh in the wilderness of Sinai, and they had no children. Eleazar and Ithamar ministered in the priest’s office in the presence of Aaron their father. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>6&#160;</sup>“Bring the tribe of Levi near, and set them before Aaron the priest, that they may minister to him. 
+<sup>7&#160;</sup>They shall keep his requirements, and the requirements of the whole congregation before the Tent of Meeting, to do the service of the tabernacle. 
+<sup>8&#160;</sup>They shall keep all the furnishings of the Tent of Meeting, and the obligations of the children of Israel, to do the service of the tabernacle. 
+<sup>9&#160;</sup>You shall give the Levites to Aaron and to his sons. They are wholly given to him on the behalf of the children of Israel. 
+<sup>10&#160;</sup>You shall appoint Aaron and his sons, and they shall keep their priesthood, but the stranger who comes near shall be put to death.” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>12&#160;</sup>“Behold, I have taken the Levites from among the children of Israel instead of all the firstborn who open the womb among the children of Israel; and the Levites shall be mine, 
+<sup>13&#160;</sup>for all the firstborn are mine. On the day that I struck down all the firstborn in the land of Egypt I made set-apart to me all the firstborn in Israel, both man and animal. They shall be mine. I am Yahweh.” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh spoke to Moses in the wilderness of Sinai, saying, 
+<sup>15&#160;</sup>“Count the children of Levi by their fathers’ houses, by their families. You shall count every male from a month old and upward.” 
+</div><div class="p">
+<sup>16&#160;</sup>Moses counted them according to Yahweh’s word, as he was commanded. 
+</div><div class="p">
+<sup>17&#160;</sup>These were the sons of Levi by their names: Gershon, Kohath, and Merari. 
+</div><div class="p">
+<sup>18&#160;</sup>These are the names of the sons of Gershon by their families: Libni and Shimei. 
+</div><div class="p">
+<sup>19&#160;</sup>The sons of Kohath by their families: Amram, Izhar, Hebron, and Uzziel. 
+</div><div class="p">
+<sup>20&#160;</sup>The sons of Merari by their families: Mahli and Mushi. 
+</div><div class="p">These are the families of the Levites according to their fathers’ houses. 
+</div><div class="p">
+<sup>21&#160;</sup>Of Gershon was the family of the Libnites, and the family of the Shimeites. These are the families of the Gershonites. 
+</div><div class="p">
+<sup>22&#160;</sup>Those who were counted of them, according to the number of all the males from a month old and upward, even those who were counted of them were seven thousand five hundred. 
+</div><div class="p">
+<sup>23&#160;</sup>The families of the Gershonites shall encamp behind the tabernacle westward. 
+</div><div class="p">
+<sup>24&#160;</sup>Eliasaph the son of Lael shall be the prince of the fathers’ house of the Gershonites. 
+<sup>25&#160;</sup>The duty of the sons of Gershon in the Tent of Meeting shall be the tabernacle, the tent, its covering, the screen for the door of the Tent of Meeting, 
+<sup>26&#160;</sup>the hangings of the court, the screen for the door of the court which is by the tabernacle and around the altar, and its cords for all of its service. 
+</div><div class="p">
+<sup>27&#160;</sup>Of Kohath was the family of the Amramites, the family of the Izharites, the family of the Hebronites, and the family of the Uzzielites. These are the families of the Kohathites. 
+<sup>28&#160;</sup>According to the number of all the males from a month old and upward, there were eight thousand six hundred keeping the requirements of the sanctuary. 
+</div><div class="p">
+<sup>29&#160;</sup>The families of the sons of Kohath shall encamp on the south side of the tabernacle. 
+<sup>30&#160;</sup>The prince of the fathers’ house of the families of the Kohathites shall be Elizaphan the son of Uzziel. 
+<sup>31&#160;</sup>Their duty shall be the ark, the table, the lamp stand, the altars, the vessels of the sanctuary with which they minister, the screen, and all its service. 
+<sup>32&#160;</sup>Eleazar the son of Aaron the priest shall be prince of the princes of the Levites, with the oversight of those who keep the requirements of the sanctuary. 
+</div><div class="p">
+<sup>33&#160;</sup>Of Merari was the family of the Mahlites and the family of the Mushites. These are the families of Merari. 
+<sup>34&#160;</sup>Those who were counted of them, according to the number of all the males from a month old and upward, were six thousand two hundred. 
+</div><div class="p">
+<sup>35&#160;</sup>The prince of the fathers’ house of the families of Merari was Zuriel the son of Abihail. They shall encamp on the north side of the tabernacle. 
+<sup>36&#160;</sup>The appointed duty of the sons of Merari shall be the tabernacle’s boards, its bars, its pillars, its sockets, all its instruments, all its service, 
+<sup>37&#160;</sup>the pillars of the court around it, their sockets, their pins, and their cords. 
+</div><div class="p">
+<sup>38&#160;</sup>Those who encamp before the tabernacle eastward, in front of the Tent of Meeting toward the sunrise, shall be Moses, with Aaron and his sons, keeping the requirements of the sanctuary for the duty of the children of Israel. The outsider who comes near shall be put to death. 
+<sup>39&#160;</sup>All who were counted of the Levites, whom Moses and Aaron counted at the commandment of Yahweh, by their families, all the males from a month old and upward, were twenty-two thousand. 
+</div><div class="p">
+<sup>40&#160;</sup>Yahweh said to Moses, “Count all the firstborn males of the children of Israel from a month old and upward, and take the number of their names. 
+<sup>41&#160;</sup>You shall take the Levites for me—I am Yahweh—instead of all the firstborn among the children of Israel; and the livestock of the Levites instead of all the firstborn among the livestock of the children of Israel.” 
+</div><div class="p">
+<sup>42&#160;</sup>Moses counted, as Yahweh commanded him, all the firstborn among the children of Israel. 
+<sup>43&#160;</sup>All the firstborn males according to the number of names from a month old and upward, of those who were counted of them, were twenty-two thousand two hundred seventy-three. 
+</div><div class="p">
+<sup>44&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>45&#160;</sup>“Take the Levites instead of all the firstborn among the children of Israel, and the livestock of the Levites instead of their livestock; and the Levites shall be mine. I am Yahweh. 
+<sup>46&#160;</sup>For the redemption of the two hundred seventy-three of the firstborn of the children of Israel who exceed the number of the Levites, 
+<sup>47&#160;</sup>you shall take five shekels apiece for each one; according to the shekel); 
+<sup>48&#160;</sup>and you shall give the money, with which their remainder is redeemed, to Aaron and to his sons.” 
+</div><div class="p">
+<sup>49&#160;</sup>Moses took the redemption money from those who exceeded the number of those who were redeemed by the Levites; 
+<sup>50&#160;</sup>from the firstborn of the children of Israel he took the money, one thousand three hundred sixty-five shekels, according to the shekel of the sanctuary; 
+<sup>51&#160;</sup>and Moses gave the redemption money to Aaron and to his sons, according to Yahweh’s word, as Yahweh commanded Moses. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>2&#160;</sup>“Take a census of the sons of Kohath from among the sons of Levi, by their families, by their fathers’ houses, 
+<sup>3&#160;</sup>from thirty years old and upward even until fifty years old, all who enter into the service to do the work in the Tent of Meeting. 
+</div><div class="p">
+<sup>4&#160;</sup>“This is the service of the sons of Kohath in the Tent of Meeting, regarding the most set-apart things. 
+<sup>5&#160;</sup>When the camp moves forward, Aaron shall go in with his sons; and they shall take down the veil of the screen, cover the ark of the Testimony with it, 
+<sup>6&#160;</sup>put a covering of sealskin on it, spread a blue cloth over it, and put in its poles. 
+</div><div class="p">
+<sup>7&#160;</sup>“On the table of show bread they shall spread a blue cloth, and put on it the dishes, the spoons, the bowls, and the cups with which to pour out; and the continual bread shall be on it. 
+<sup>8&#160;</sup>They shall spread on them a scarlet cloth, and cover it with a covering of sealskin, and shall put in its poles. 
+</div><div class="p">
+<sup>9&#160;</sup>“They shall take a blue cloth and cover the lamp stand of the light, its lamps, its snuffers, its snuff dishes, and all its oil vessels, with which they minister to it. 
+<sup>10&#160;</sup>They shall put it and all its vessels within a covering of sealskin, and shall put it on the frame. 
+</div><div class="p">
+<sup>11&#160;</sup>“On the golden altar they shall spread a blue cloth, and cover it with a covering of sealskin, and shall put in its poles. 
+</div><div class="p">
+<sup>12&#160;</sup>“They shall take all the vessels of ministry with which they minister in the sanctuary, and put them in a blue cloth, cover them with a covering of sealskin, and shall put them on the frame. 
+</div><div class="p">
+<sup>13&#160;</sup>“They shall take away the ashes from the altar, and spread a purple cloth on it. 
+<sup>14&#160;</sup>They shall put on it all its vessels with which they minister about it, the fire pans, the meat hooks, the shovels, and the basins—all the vessels of the altar; and they shall spread on it a covering of sealskin, and put in its poles. 
+</div><div class="p">
+<sup>15&#160;</sup>“When Aaron and his sons have finished covering the sanctuary and all the furniture of the sanctuary, as the camp moves forward; after that, the sons of Kohath shall come to carry it; but they shall not touch the sanctuary, lest they die. The sons of Kohath shall carry these things belonging to the Tent of Meeting. 
+</div><div class="p">
+<sup>16&#160;</sup>“The duty of Eleazar the son of Aaron the priest shall be the oil for the light, the sweet incense, the continual meal offering, and the anointing oil, the requirements of all the tabernacle, and of all that is in it, the sanctuary, and its furnishings.” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>18&#160;</sup>“Don’t cut off the tribe of the families of the Kohathites from among the Levites; 
+<sup>19&#160;</sup>but do this to them, that they may live, and not die, when they approach the most set-apart things: Aaron and his sons shall go in and appoint everyone to his service and to his burden; 
+<sup>20&#160;</sup>but they shall not go in to see the sanctuary even for a moment, lest they die.” 
+</div><div class="p">
+<sup>21&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>22&#160;</sup>“Take a census of the sons of Gershon also, by their fathers’ houses, by their families; 
+<sup>23&#160;</sup>you shall count them from thirty years old and upward until fifty years old: all who enter in to wait on the service, to do the work in the Tent of Meeting. 
+</div><div class="p">
+<sup>24&#160;</sup>“This is the service of the families of the Gershonites, in serving and in bearing burdens: 
+<sup>25&#160;</sup>they shall carry the curtains of the tabernacle and the Tent of Meeting, its covering, the covering of sealskin that is on it, the screen for the door of the Tent of Meeting, 
+<sup>26&#160;</sup>the hangings of the court, the screen for the door of the gate of the court which is by the tabernacle and around the altar, their cords, and all the instruments of their service, and whatever shall be done with them. They shall serve in there. 
+<sup>27&#160;</sup>At the commandment of Aaron and his sons shall be all the service of the sons of the Gershonites, in all their burden and in all their service; and you shall appoint their duty to them in all their responsibilities. 
+<sup>28&#160;</sup>This is the service of the families of the sons of the Gershonites in the Tent of Meeting. Their duty shall be under the hand of Ithamar the son of Aaron the priest. 
+</div><div class="p">
+<sup>29&#160;</sup>“As for the sons of Merari, you shall count them by their families, by their fathers’ houses; 
+<sup>30&#160;</sup>you shall count them from thirty years old and upward even to fifty years old—everyone who enters on the service, to do the work of the Tent of Meeting. 
+<sup>31&#160;</sup>This is the duty of their burden, according to all their service in the Tent of Meeting: the tabernacle’s boards, its bars, its pillars, its sockets, 
+<sup>32&#160;</sup>the pillars of the court around it, their sockets, their pins, their cords, with all their instruments, and with all their service. You shall appoint the instruments of the duty of their burden to them by name. 
+<sup>33&#160;</sup>This is the service of the families of the sons of Merari, according to all their service in the Tent of Meeting, under the hand of Ithamar the son of Aaron the priest.” 
+</div><div class="p">
+<sup>34&#160;</sup>Moses and Aaron and the princes of the congregation counted the sons of the Kohathites by their families, and by their fathers’ houses, 
+<sup>35&#160;</sup>from thirty years old and upward even to fifty years old, everyone who entered into the service for work in the Tent of Meeting. 
+<sup>36&#160;</sup>Those who were counted of them by their families were two thousand seven hundred fifty. 
+<sup>37&#160;</sup>These are those who were counted of the families of the Kohathites, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
+</div><div class="p">
+<sup>38&#160;</sup>Those who were counted of the sons of Gershon, by their families, and by their fathers’ houses, 
+<sup>39&#160;</sup>from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
+<sup>40&#160;</sup>even those who were counted of them, by their families, by their fathers’ houses, were two thousand six hundred thirty. 
+<sup>41&#160;</sup>These are those who were counted of the families of the sons of Gershon, all who served in the Tent of Meeting, whom Moses and Aaron counted according to the commandment of Yahweh. 
+</div><div class="p">
+<sup>42&#160;</sup>Those who were counted of the families of the sons of Merari, by their families, by their fathers’ houses, 
+<sup>43&#160;</sup>from thirty years old and upward even to fifty years old—everyone who entered into the service for work in the Tent of Meeting, 
+<sup>44&#160;</sup>even those who were counted of them by their families, were three thousand two hundred. 
+<sup>45&#160;</sup>These are those who were counted of the families of the sons of Merari, whom Moses and Aaron counted according to the commandment of Yahweh by Moses. 
+</div><div class="p">
+<sup>46&#160;</sup>All those who were counted of the Levites whom Moses and Aaron and the princes of Israel counted, by their families and by their fathers’ houses, 
+<sup>47&#160;</sup>from thirty years old and upward even to fifty years old, everyone who entered in to do the work of service and the work of bearing burdens in the Tent of Meeting, 
+<sup>48&#160;</sup>even those who were counted of them, were eight thousand five hundred eighty. 
+<sup>49&#160;</sup>According to the commandment of Yahweh they were counted by Moses, everyone according to his service and according to his burden. Thus they were counted by him, as Yahweh commanded Moses. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Command the children of Israel that they put out of the camp every leper, everyone who has a discharge, and whoever is unclean by a corpse. 
+<sup>3&#160;</sup>You shall put both male and female outside of the camp so that they don’t defile their camp, in the midst of which I dwell.” 
+</div><div class="p">
+<sup>4&#160;</sup>The children of Israel did so, and put them outside of the camp; as Yahweh spoke to Moses, so the children of Israel did. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>6&#160;</sup>“Speak to the children of Israel: ‘When a man or woman commits any sin that men commit, so as to trespass against Yahweh, and that soul is guilty, 
+<sup>7&#160;</sup>then he shall confess his sin which he has done; and he shall make restitution for his guilt in full, add to it the fifth part of it, and give it to him in respect of whom he has been guilty. 
+<sup>8&#160;</sup>But if the man has no kinsman to whom restitution may be made for the guilt, the restitution for guilt which is made to Yahweh shall be the priest’s, in addition to the ram of the atonement, by which atonement shall be made for him. 
+<sup>9&#160;</sup>Every heave offering of all the set-apart things of the children of Israel, which they present to the priest, shall be his. 
+<sup>10&#160;</sup>Every man’s set-apart things shall be his; whatever any man gives the priest, it shall be his.’&#160;” 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>12&#160;</sup>“Speak to the children of Israel, and tell them: ‘If any man’s woman goes astray and is unfaithful to him, 
+<sup>13&#160;</sup>and a man lies with her carnally, and it is hidden from the eyes of her man and this is kept concealed, and she is defiled, there is no witness against her, and she isn’t taken in the act; 
+<sup>14&#160;</sup>and the spirit of jealousy comes on him, and he is jealous of his woman and she is defiled; or if the spirit of jealousy comes on him, and he is jealous of his woman and she isn’t defiled; 
+<sup>15&#160;</sup>then the man shall bring his woman to the priest, and shall bring her offering for her: one tenth of an ephah of barley meal. He shall pour no oil on it, nor put frankincense on it, for it is a meal offering of jealousy, a meal offering of memorial, bringing iniquity to memory. 
+<sup>16&#160;</sup>The priest shall bring her near, and set her before Yahweh. 
+<sup>17&#160;</sup>The priest shall take set-apart water in an earthen vessel; and the priest shall take some of the dust that is on the floor of the tabernacle and put it into the water. 
+<sup>18&#160;</sup>The priest shall set the woman before Yahweh, and let the hair of the woman’s head go loose, and put the meal offering of memorial in her hands, which is the meal offering of jealousy. The priest shall have in his hand the water of bitterness that brings a curse. 
+<sup>19&#160;</sup>The priest shall cause her to take an oath and shall tell the woman, “If no man has lain with you, and if you haven’t gone aside to uncleanness, being under your man’s authority, be free from this water of bitterness that brings a curse. 
+<sup>20&#160;</sup>But if you have gone astray, being under your man’s authority, and if you are defiled, and some man has lain with you besides your man—” 
+<sup>21&#160;</sup>then the priest shall cause the woman to swear with the oath of cursing, and the priest shall tell the woman, “May Yahweh make you a curse and an oath among your people, when Yahweh allows your thigh to fall away, and your body to swell; 
+<sup>22&#160;</sup>and this water that brings a curse will go into your bowels, and make your body swell, and your thigh fall away.” The woman shall say, “Amen, Amen.” 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘The priest shall write these curses in a book, and he shall wipe them into the water of bitterness. 
+<sup>24&#160;</sup>He shall make the woman drink the water of bitterness that causes the curse; and the water that causes the curse shall enter into her and become bitter. 
+<sup>25&#160;</sup>The priest shall take the meal offering of jealousy out of the woman’s hand, and shall wave the meal offering before Yahweh, and bring it to the altar. 
+<sup>26&#160;</sup>The priest shall take a handful of the meal offering, as its memorial portion, and burn it on the altar, and afterward shall make the woman drink the water. 
+<sup>27&#160;</sup>When he has made her drink the water, then it shall happen, if she is defiled and has committed a trespass against her man, that the water that causes the curse will enter into her and become bitter, and her body will swell, and her thigh will fall away; and the woman will be a curse among her people. 
+<sup>28&#160;</sup>If the woman isn’t defiled, but is clean; then she shall be free, and shall conceive offspring. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘This is the law of jealousy, when a woman, being under her man, goes astray, and is defiled, 
+<sup>30&#160;</sup>or when the spirit of jealousy comes on a man, and he is jealous of his woman; then he shall set the woman before Yahweh, and the priest shall execute on her all this law. 
+<sup>31&#160;</sup>The man shall be free from iniquity, and that woman shall bear her iniquity.’&#160;” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them: ‘When either man or woman shall make a special vow, the vow of a Nazirite, to separate himself to Yahweh, 
+<sup>3&#160;</sup>he shall separate himself from wine and strong drink. He shall drink no vinegar of wine, or vinegar of fermented drink, neither shall he drink any juice of grapes, nor eat fresh grapes or dried. 
+<sup>4&#160;</sup>All the days of his separation he shall eat nothing that is made of the grapevine, from the seeds even to the skins. 
+</div><div class="p">
+<sup>5&#160;</sup>“&#160;‘All the days of his vow of separation no razor shall come on his head, until the days are fulfilled in which he separates himself to Yahweh. He shall be set-apart. He shall let the locks of the hair of his head grow long. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘All the days that he separates himself to Yahweh he shall not go near a dead body. 
+<sup>7&#160;</sup>He shall not make himself unclean for his father, or for his mother, for his brother, or for his sister, when they die, because his separation to Elohim is on his head. 
+<sup>8&#160;</sup>All the days of his separation he is set-apart to Yahweh. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘If any man dies very suddenly beside him, and he defiles the head of his separation, then he shall shave his head in the day of his cleansing. On the seventh day he shall shave it. 
+<sup>10&#160;</sup>On the eighth day he shall bring two turtledoves or two young pigeons to the priest, to the door of the Tent of Meeting. 
+<sup>11&#160;</sup>The priest shall offer one for a sin offering, and the other for a burnt offering, and make atonement for him, because he sinned by reason of the dead, and shall make his head set-apart that same day. 
+<sup>12&#160;</sup>He shall separate to Yahweh the days of his separation, and shall bring a male lamb a year old for a trespass offering; but the former days shall be void, because his separation was defiled. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘This is the law of the Nazirite: when the days of his separation are fulfilled, he shall be brought to the door of the Tent of Meeting, 
+<sup>14&#160;</sup>and he shall offer his offering to Yahweh: one male lamb a year old without defect for a burnt offering, one ewe lamb a year old without defect for a sin offering, one ram without defect for peace offerings, 
+<sup>15&#160;</sup>a basket of unleavened bread, cakes of fine flour mixed with oil, and unleavened wafers anointed with oil with their meal offering and their drink offerings. 
+<sup>16&#160;</sup>The priest shall present them before Yahweh, and shall offer his sin offering and his burnt offering. 
+<sup>17&#160;</sup>He shall offer the ram for a sacrifice of peace offerings to Yahweh, with the basket of unleavened bread. The priest shall offer also its meal offering and its drink offering. 
+<sup>18&#160;</sup>The Nazirite shall shave the head of his separation at the door of the Tent of Meeting, take the hair of the head of his separation, and put it on the fire which is under the sacrifice of peace offerings. 
+<sup>19&#160;</sup>The priest shall take the boiled shoulder of the ram, one unleavened cake out of the basket, and one unleavened wafer, and shall put them on the hands of the Nazirite after he has shaved the head of his separation; 
+<sup>20&#160;</sup>and the priest shall wave them for a wave offering before Yahweh. They are set-apart for the priest, together with the breast that is waved and the thigh that is offered. After that the Nazirite may drink wine. 
+</div><div class="p">
+<sup>21&#160;</sup>“&#160;‘This is the law of the Nazirite who vows and of his offering to Yahweh for his separation, in addition to that which he is able to afford. According to his vow which he vows, so he must do after the law of his separation.’&#160;” 
+</div><div class="p">
+<sup>22&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>23&#160;</sup>“Speak to Aaron and to his sons, saying, ‘This is how you shall bless the children of Israel.’ You shall tell them, 
+</div><div class="q1">
+<sup>24&#160;</sup>‘Yahweh bless you, and keep you. 
+</div><div class="q2">
+<sup>25&#160;</sup>Yahweh make his face to shine on you, 
+</div><div class="q2">and be gracious to you. 
+</div><div class="q1">
+<sup>26&#160;</sup>Yahweh lift up his face toward you, 
+</div><div class="q2">and give you peace.’ 
+</div><div class="p">
+<sup>27&#160;</sup>“So they shall put my name on the children of Israel; and I will bless them.” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>On the day that Moses had finished setting up the tabernacle, and had anointed it and sanctified it with all its furniture, and the altar with all its vessels, and had anointed and sanctified them; 
+<sup>2&#160;</sup>the princes of Israel, the heads of their fathers’ houses, gave offerings. These were the princes of the tribes. These are they who were over those who were counted; 
+<sup>3&#160;</sup>and they brought their offering before Yahweh, six covered wagons and twelve oxen; a wagon for every two of the princes, and for each one an ox. They presented them before the tabernacle. 
+<sup>4&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>5&#160;</sup>“Accept these from them, that they may be used in doing the service of the Tent of Meeting; and you shall give them to the Levites, to every man according to his service.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses took the wagons and the oxen, and gave them to the Levites. 
+<sup>7&#160;</sup>He gave two wagons and four oxen to the sons of Gershon, according to their service. 
+<sup>8&#160;</sup>He gave four wagons and eight oxen to the sons of Merari, according to their service, under the direction of Ithamar the son of Aaron the priest. 
+<sup>9&#160;</sup>But to the sons of Kohath he gave none, because the service of the sanctuary belonged to them; they carried it on their shoulders. 
+</div><div class="p">
+<sup>10&#160;</sup>The princes gave offerings for the dedication of the altar in the day that it was anointed. The princes gave their offerings before the altar. 
+</div><div class="p">
+<sup>11&#160;</sup>Yahweh said to Moses, “They shall offer their offering, each prince on his day, for the dedication of the altar.” 
+</div><div class="p">
+<sup>12&#160;</sup>He who offered his offering the first day was Nahshon the son of Amminadab, of the tribe of Judah, 
+<sup>13&#160;</sup>and his offering was: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>14&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>15&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>16&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>17&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Nahshon the son of Amminadab. 
+</div><div class="p">
+<sup>18&#160;</sup>On the second day Nethanel the son of Zuar, prince of Issachar, gave his offering. 
+<sup>19&#160;</sup>He offered for his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>20&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>21&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>22&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>23&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, five male lambs a year old. This was the offering of Nethanel the son of Zuar. 
+</div><div class="p">
+<sup>24&#160;</sup>On the third day Eliab the son of Helon, prince of the children of Zebulun, 
+<sup>25&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was a hundred and thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>26&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>27&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>28&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>29&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Eliab the son of Helon. 
+</div><div class="p">
+<sup>30&#160;</sup>On the fourth day Elizur the son of Shedeur, prince of the children of Reuben, 
+<sup>31&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>32&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>33&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>34&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>35&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Elizur the son of Shedeur. 
+</div><div class="p">
+<sup>36&#160;</sup>On the fifth day Shelumiel the son of Zurishaddai, prince of the children of Simeon, 
+<sup>37&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>38&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>39&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>40&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>41&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old: this was the offering of Shelumiel the son of Zurishaddai. 
+</div><div class="p">
+<sup>42&#160;</sup>On the sixth day, Eliasaph the son of Deuel, prince of the children of Gad, 
+<sup>43&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>44&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>45&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>46&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>47&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Eliasaph the son of Deuel. 
+</div><div class="p">
+<sup>48&#160;</sup>On the seventh day Elishama the son of Ammihud, prince of the children of Ephraim, 
+<sup>49&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>50&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>51&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>52&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>53&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Elishama the son of Ammihud. 
+</div><div class="p">
+<sup>54&#160;</sup>On the eighth day Gamaliel the son of Pedahzur, prince of the children of Manasseh, 
+<sup>55&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>56&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>57&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>58&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>59&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Gamaliel the son of Pedahzur. 
+</div><div class="p">
+<sup>60&#160;</sup>On the ninth day Abidan the son of Gideoni, prince of the children of Benjamin, 
+<sup>61&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>62&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>63&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>64&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>65&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Abidan the son of Gideoni. 
+</div><div class="p">
+<sup>66&#160;</sup>On the tenth day Ahiezer the son of Ammishaddai, prince of the children of Dan, 
+<sup>67&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>68&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>69&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>70&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>71&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Ahiezer the son of Ammishaddai. 
+</div><div class="p">
+<sup>72&#160;</sup>On the eleventh day Pagiel the son of Ochran, prince of the children of Asher, 
+<sup>73&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>74&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>75&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>76&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>77&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Pagiel the son of Ochran. 
+</div><div class="p">
+<sup>78&#160;</sup>On the twelfth day Ahira the son of Enan, prince of the children of Naphtali, 
+<sup>79&#160;</sup>gave his offering: 
+</div><div class="p">one silver platter, the weight of which was one hundred thirty shekels, 
+</div><div class="p">one silver bowl of seventy shekels, according to the shekel of the sanctuary, both of them full of fine flour mixed with oil for a meal offering; 
+</div><div class="p">
+<sup>80&#160;</sup>one golden ladle of ten shekels, full of incense; 
+</div><div class="p">
+<sup>81&#160;</sup>one young bull, 
+</div><div class="p">one ram, 
+</div><div class="p">one male lamb a year old, for a burnt offering; 
+</div><div class="p">
+<sup>82&#160;</sup>one male goat for a sin offering; 
+</div><div class="p">
+<sup>83&#160;</sup>and for the sacrifice of peace offerings, two head of cattle, five rams, five male goats, and five male lambs a year old. This was the offering of Ahira the son of Enan. 
+</div><div class="p">
+<sup>84&#160;</sup>This was the dedication offering of the altar, on the day when it was anointed, by the princes of Israel: twelve silver platters, twelve silver bowls, twelve golden ladles; 
+<sup>85&#160;</sup>each silver platter weighing one hundred thirty shekels, and each bowl seventy; all the silver of the vessels two thousand four hundred shekels, according to the shekel of the sanctuary; 
+<sup>86&#160;</sup>the twelve golden ladles, full of incense, weighing ten shekels apiece, according to the shekel of the sanctuary; all the gold of the ladles weighed one hundred twenty shekels; 
+<sup>87&#160;</sup>all the cattle for the burnt offering twelve bulls, the rams twelve, the male lambs a year old twelve, and their meal offering; and twelve male goats for a sin offering; 
+<sup>88&#160;</sup>and all the cattle for the sacrifice of peace offerings: twenty-four bulls, sixty rams, sixty male goats, and sixty male lambs a year old. This was the dedication offering of the altar, after it was anointed. 
+</div><div class="p">
+<sup>89&#160;</sup>When Moses went into the Tent of Meeting to speak with Yahweh, he heard his voice speaking to him from above the mercy seat that was on the ark of the Testimony, from between the two cherubim; and he spoke to him. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to Aaron, and tell him, ‘When you light the lamps, the seven lamps shall give light in front of the lamp stand.’&#160;” 
+</div><div class="p">
+<sup>3&#160;</sup>Aaron did so. He lit its lamps to light the area in front of the lamp stand, as Yahweh commanded Moses. 
+<sup>4&#160;</sup>This was the workmanship of the lamp stand, beaten work of gold. From its base to its flowers, it was beaten work. He made the lamp stand according to the pattern which Yahweh had shown Moses. 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>6&#160;</sup>“Take the Levites from among the children of Israel, and cleanse them. 
+<sup>7&#160;</sup>You shall do this to them to cleanse them: sprinkle the water of cleansing on them, let them shave their whole bodies with a razor, let them wash their clothes, and cleanse themselves. 
+<sup>8&#160;</sup>Then let them take a young bull and its meal offering, fine flour mixed with oil; and another young bull you shall take for a sin offering. 
+<sup>9&#160;</sup>You shall present the Levites before the Tent of Meeting. You shall assemble the whole congregation of the children of Israel. 
+<sup>10&#160;</sup>You shall present the Levites before Yahweh. The children of Israel shall lay their hands on the Levites, 
+<sup>11&#160;</sup>and Aaron shall offer the Levites before Yahweh for a wave offering on the behalf of the children of Israel, that it may be theirs to do the service of Yahweh. 
+</div><div class="p">
+<sup>12&#160;</sup>“The Levites shall lay their hands on the heads of the bulls, and you shall offer the one for a sin offering and the other for a burnt offering to Yahweh, to make atonement for the Levites. 
+<sup>13&#160;</sup>You shall set the Levites before Aaron and before his sons, and offer them as a wave offering to Yahweh. 
+<sup>14&#160;</sup>Thus you shall separate the Levites from among the children of Israel, and the Levites shall be mine. 
+</div><div class="p">
+<sup>15&#160;</sup>“After that, the Levites shall go in to do the service of the Tent of Meeting. You shall cleanse them, and offer them as a wave offering. 
+<sup>16&#160;</sup>For they are wholly given to me from among the children of Israel; instead of all who open the womb, even the firstborn of all the children of Israel, I have taken them to me. 
+<sup>17&#160;</sup>For all the firstborn among the children of Israel are mine, both man and animal. On the day that I struck all the firstborn in the land of Egypt, I sanctified them for myself. 
+<sup>18&#160;</sup>I have taken the Levites instead of all the firstborn among the children of Israel. 
+<sup>19&#160;</sup>I have given the Levites as a gift to Aaron and to his sons from among the children of Israel, to do the service of the children of Israel in the Tent of Meeting, and to make atonement for the children of Israel, so that there will be no plague among the children of Israel when the children of Israel come near to the sanctuary.” 
+</div><div class="p">
+<sup>20&#160;</sup>Moses, and Aaron, and all the congregation of the children of Israel did so to the Levites. According to all that Yahweh commanded Moses concerning the Levites, so the children of Israel did to them. 
+<sup>21&#160;</sup>The Levites purified themselves from sin, and they washed their clothes; and Aaron offered them for a wave offering before Yahweh and Aaron made atonement for them to cleanse them. 
+<sup>22&#160;</sup>After that, the Levites went in to do their service in the Tent of Meeting before Aaron and before his sons: as Yahweh had commanded Moses concerning the Levites, so they did to them. 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>24&#160;</sup>“This is what is assigned to the Levites: from twenty-five years old and upward they shall go in to wait on the service in the work of the Tent of Meeting; 
+<sup>25&#160;</sup>and from the age of fifty years they shall retire from doing the work, and shall serve no more, 
+<sup>26&#160;</sup>but shall assist their brothers in the Tent of Meeting, to perform the duty, and shall perform no service. This is how you shall have the Levites do their duties.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses in the wilderness of Sinai, in the first month of the second year after they had come out of the land of Egypt, saying, 
+<sup>2&#160;</sup>“Let the children of Israel keep the Passover in its appointed season. 
+<sup>3&#160;</sup>On the fourteenth day of this month, at evening, you shall keep it in its appointed season. You shall keep it according to all its statutes and according to all its ordinances.” 
+</div><div class="p">
+<sup>4&#160;</sup>Moses told the children of Israel that they should keep the Passover. 
+<sup>5&#160;</sup>They kept the Passover in the first month, on the fourteenth day of the month at evening, in the wilderness of Sinai. According to all that Yahweh commanded Moses, so the children of Israel did. 
+<sup>6&#160;</sup>There were certain men who were unclean because of the dead body of a man, so that they could not keep the Passover on that day, and they came before Moses and Aaron on that day. 
+<sup>7&#160;</sup>Those men said to him, “We are unclean because of the dead body of a man. Why are we kept back, that we may not offer the offering of Yahweh in its appointed season among the children of Israel?” 
+</div><div class="p">
+<sup>8&#160;</sup>Moses answered them, “Wait, that I may hear what Yahweh will command concerning you.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>10&#160;</sup>“Say to the children of Israel, ‘If any man of you or of your generations is unclean by reason of a dead body, or is on a journey far away, he shall still keep the Passover to Yahweh. 
+<sup>11&#160;</sup>In the second month, on the fourteenth day at evening they shall keep it; they shall eat it with unleavened bread and bitter herbs. 
+<sup>12&#160;</sup>They shall leave none of it until the morning, nor break a bone of it. According to all the statute of the Passover they shall keep it. 
+<sup>13&#160;</sup>But the man who is clean, and is not on a journey, and fails to keep the Passover, that soul shall be cut off from his people. Because he didn’t offer the offering of Yahweh in its appointed season, that man shall bear his sin. 
+</div><div class="p">
+<sup>14&#160;</sup>“&#160;‘If a foreigner lives among you and desires to keep the Passover to Yahweh, then he shall do so according to the statute of the Passover, and according to its ordinance. You shall have one statute, both for the foreigner and for him who is born in the land.’&#160;” 
+</div><div class="p">
+<sup>15&#160;</sup>On the day that the tabernacle was raised up, the cloud covered the tabernacle, even the Tent of the Testimony. At evening it was over the tabernacle, as it were the appearance of fire, until morning. 
+<sup>16&#160;</sup>So it was continually. The cloud covered it, and the appearance of fire by night. 
+<sup>17&#160;</sup>Whenever the cloud was taken up from over the Tent, then after that the children of Israel traveled; and in the place where the cloud remained, there the children of Israel encamped. 
+<sup>18&#160;</sup>At the commandment of Yahweh, the children of Israel traveled, and at the commandment of Yahweh they encamped. As long as the cloud remained on the tabernacle they remained encamped. 
+<sup>19&#160;</sup>When the cloud stayed on the tabernacle many days, then the children of Israel kept Yahweh’s command, and didn’t travel. 
+<sup>20&#160;</sup>Sometimes the cloud was a few days on the tabernacle; then according to the commandment of Yahweh they remained encamped, and according to the commandment of Yahweh they traveled. 
+<sup>21&#160;</sup>Sometimes the cloud was from evening until morning; and when the cloud was taken up in the morning, they traveled; or by day and by night, when the cloud was taken up, they traveled. 
+<sup>22&#160;</sup>Whether it was two days, or a month, or a year that the cloud stayed on the tabernacle, remaining on it, the children of Israel remained encamped, and didn’t travel; but when it was taken up, they traveled. 
+<sup>23&#160;</sup>At the commandment of Yahweh they encamped, and at the commandment of Yahweh they traveled. They kept Yahweh’s command, at the commandment of Yahweh by Moses. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Make two trumpets of silver. You shall make them of beaten work. You shall use them for the calling of the congregation and for the journeying of the camps. 
+<sup>3&#160;</sup>When they blow them, all the congregation shall gather themselves to you at the door of the Tent of Meeting. 
+<sup>4&#160;</sup>If they blow just one, then the princes, the heads of the thousands of Israel, shall gather themselves to you. 
+<sup>5&#160;</sup>When you blow an alarm, the camps that lie on the east side shall go forward. 
+<sup>6&#160;</sup>When you blow an alarm the second time, the camps that lie on the south side shall go forward. They shall blow an alarm for their journeys. 
+<sup>7&#160;</sup>But when the assembly is to be gathered together, you shall blow, but you shall not sound an alarm. 
+</div><div class="p">
+<sup>8&#160;</sup>“The sons of Aaron, the priests, shall blow the trumpets. This shall be to you for a statute forever throughout your generations. 
+<sup>9&#160;</sup>When you go to war in your land against the adversary who oppresses you, then you shall sound an alarm with the trumpets. Then you will be remembered before Yahweh your Elohim, and you will be saved from your enemies. 
+</div><div class="p">
+<sup>10&#160;</sup>“Also in the day of your gladness, and in your set feasts, and in the beginnings of your months, you shall blow the trumpets over your burnt offerings, and over the sacrifices of your peace offerings; and they shall be to you for a memorial before your Elohim. I am Yahweh your Elohim.” 
+</div><div class="p">
+<sup>11&#160;</sup>In the second year, in the second month, on the twentieth day of the month, the cloud was taken up from over the tabernacle of the covenant. 
+<sup>12&#160;</sup>The children of Israel went forward on their journeys out of the wilderness of Sinai; and the cloud stayed in the wilderness of Paran. 
+<sup>13&#160;</sup>They first went forward according to the commandment of Yahweh by Moses. 
+</div><div class="p">
+<sup>14&#160;</sup>First, the standard of the camp of the children of Judah went forward according to their armies. Nahshon the son of Amminadab was over his army. 
+<sup>15&#160;</sup>Nethanel the son of Zuar was over the army of the tribe of the children of Issachar. 
+<sup>16&#160;</sup>Eliab the son of Helon was over the army of the tribe of the children of Zebulun. 
+<sup>17&#160;</sup>The tabernacle was taken down; and the sons of Gershon and the sons of Merari, who bore the tabernacle, went forward. 
+<sup>18&#160;</sup>The standard of the camp of Reuben went forward according to their armies. Elizur the son of Shedeur was over his army. 
+<sup>19&#160;</sup>Shelumiel the son of Zurishaddai was over the army of the tribe of the children of Simeon. 
+<sup>20&#160;</sup>Eliasaph the son of Deuel was over the army of the tribe of the children of Gad. 
+</div><div class="p">
+<sup>21&#160;</sup>The Kohathites set forward, bearing the sanctuary. The others set up the tabernacle before they arrived. 
+</div><div class="p">
+<sup>22&#160;</sup>The standard of the camp of the children of Ephraim set forward according to their armies. Elishama the son of Ammihud was over his army. 
+<sup>23&#160;</sup>Gamaliel the son of Pedahzur was over the army of the tribe of the children of Manasseh. 
+<sup>24&#160;</sup>Abidan the son of Gideoni was over the army of the tribe of the children of Benjamin. 
+</div><div class="p">
+<sup>25&#160;</sup>The standard of the camp of the children of Dan, which was the rear guard of all the camps, set forward according to their armies. Ahiezer the son of Ammishaddai was over his army. 
+<sup>26&#160;</sup>Pagiel the son of Ochran was over the army of the tribe of the children of Asher. 
+<sup>27&#160;</sup>Ahira the son of Enan was over the army of the tribe of the children of Naphtali. 
+<sup>28&#160;</sup>Thus were the travels of the children of Israel according to their armies; and they went forward. 
+</div><div class="p">
+<sup>29&#160;</sup>Moses said to Hobab, the son of Reuel the Midianite, Moses’ father-in-law, “We are journeying to the place of which Yahweh said, ‘I will give it to you.’ Come with us, and we will treat you well; for Yahweh has spoken good concerning Israel.” 
+</div><div class="p">
+<sup>30&#160;</sup>He said to him, “I will not go; but I will depart to my own land, and to my relatives.” 
+</div><div class="p">
+<sup>31&#160;</sup>Moses said, “Don’t leave us, please; because you know how we are to encamp in the wilderness, and you can be our eyes. 
+<sup>32&#160;</sup>It shall be, if you go with us—yes, it shall be—that whatever good Yahweh does to us, we will do the same to you.” 
+</div><div class="p">
+<sup>33&#160;</sup>They set forward from the Mount of Yahweh three days’ journey. The ark of Yahweh’s covenant went before them three days’ journey, to seek out a resting place for them. 
+<sup>34&#160;</sup>The cloud of Yahweh was over them by day, when they set forward from the camp. 
+<sup>35&#160;</sup>When the ark went forward, Moses said, “Rise up, Yahweh, and let your enemies be scattered! Let those who hate you flee before you!” 
+<sup>36&#160;</sup>When it rested, he said, “Return, Yahweh, to the ten thousands of the thousands of Israel.” 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>The people were complaining in the ears of Yahweh. When Yahweh heard it, his anger burned; and Yahweh’s fire burned among them, and consumed some of the outskirts of the camp. 
+<sup>2&#160;</sup>The people cried to Moses; and Moses prayed to Yahweh, and the fire abated. 
+<sup>3&#160;</sup>The name of that place was called Taberah, because Yahweh’s fire burned among them. 
+</div><div class="p">
+<sup>4&#160;</sup>The mixed multitude that was among them lusted exceedingly; and the children of Israel also wept again, and said, “Who will give us meat to eat? 
+<sup>5&#160;</sup>We remember the fish, which we ate in Egypt for nothing; the cucumbers, and the melons, and the leeks, and the onions, and the garlic; 
+<sup>6&#160;</sup>but now we have lost our appetite. There is nothing at all except this manna to look at.” 
+<sup>7&#160;</sup>The manna was like coriander seed, and it looked like bdellium. 
+<sup>8&#160;</sup>The people went around, gathered it, and ground it in mills, or beat it in mortars, and boiled it in pots, and made cakes of it. Its taste was like the taste of fresh oil. 
+<sup>9&#160;</sup>When the dew fell on the camp in the night, the manna fell on it. 
+</div><div class="p">
+<sup>10&#160;</sup>Moses heard the people weeping throughout their families, every man at the door of his tent; and Yahweh’s anger burned greatly; and Moses was displeased. 
+<sup>11&#160;</sup>Moses said to Yahweh, “Why have you treated your servant so badly? Why haven’t I found favor in your sight, that you lay the burden of all this people on me? 
+<sup>12&#160;</sup>Have I conceived all this people? Have I brought them out, that you should tell me, ‘Carry them in your bosom, as a nurse carries a nursing infant, to the land which you swore to their fathers’? 
+<sup>13&#160;</sup>Where could I get meat to give all these people? For they weep before me, saying, ‘Give us meat, that we may eat.’ 
+<sup>14&#160;</sup>I am not able to bear all this people alone, because it is too heavy for me. 
+<sup>15&#160;</sup>If you treat me this way, please kill me right now, if I have found favor in your sight; and don’t let me see my wretchedness.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh said to Moses, “Gather to me seventy men of the elders of Israel, whom you know to be the elders of the people and officers over them; and bring them to the Tent of Meeting, that they may stand there with you. 
+<sup>17&#160;</sup>I will come down and talk with you there. I will take of the Spirit which is on you, and will put it on them; and they shall bear the burden of the people with you, that you don’t bear it yourself alone. 
+</div><div class="p">
+<sup>18&#160;</sup>“Say to the people, ‘Sanctify yourselves in preparation for tomorrow, and you will eat meat; for you have wept in the ears of Yahweh, saying, “Who will give us meat to eat? For it was well with us in Egypt.” Therefore Yahweh will give you meat, and you will eat. 
+<sup>19&#160;</sup>You will not eat just one day, or two days, or five days, or ten days, or twenty days, 
+<sup>20&#160;</sup>but a whole month, until it comes out at your nostrils, and it is loathsome to you; because you have rejected Yahweh who is among you, and have wept before him, saying, “Why did we come out of Egypt?”&#160;’&#160;” 
+</div><div class="p">
+<sup>21&#160;</sup>Moses said, “The people, among whom I am, are six hundred thousand men on foot; and you have said, ‘I will give them meat, that they may eat a whole month.’ 
+<sup>22&#160;</sup>Shall flocks and herds be slaughtered for them, to be sufficient for them? Shall all the fish of the sea be gathered together for them, to be sufficient for them?” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh said to Moses, “Has Yahweh’s hand grown short? Now you will see whether my word will happen to you or not.” 
+</div><div class="p">
+<sup>24&#160;</sup>Moses went out, and told the people Yahweh’s words; and he gathered seventy men of the elders of the people, and set them around the Tent. 
+<sup>25&#160;</sup>Yahweh came down in the cloud, and spoke to him, and took of the Spirit that was on him, and put it on the seventy elders. When the Spirit rested on them, they prophesied, but they did so no more. 
+<sup>26&#160;</sup>But two men remained in the camp. The name of one was Eldad, and the name of the other Medad; and the Spirit rested on them. They were of those who were written, but had not gone out to the Tent; and they prophesied in the camp. 
+<sup>27&#160;</sup>A young man ran, and told Moses, and said, “Eldad and Medad are prophesying in the camp!” 
+</div><div class="p">
+<sup>28&#160;</sup>Joshua the son of Nun, the servant of Moses, one of his chosen men, answered, “My lord Moses, forbid them!” 
+</div><div class="p">
+<sup>29&#160;</sup>Moses said to him, “Are you jealous for my sake? I wish that all Yahweh’s people were prophets, that Yahweh would put his Spirit on them!” 
+</div><div class="p">
+<sup>30&#160;</sup>Moses went into the camp, he and the elders of Israel. 
+<sup>31&#160;</sup>A wind from Yahweh went out and brought quails from the sea, and let them fall by the camp, about a day’s journey on this side, and a day’s journey on the other side, around the camp, and about two cubits above the surface of the earth. 
+<sup>32&#160;</sup>The people rose up all that day, and all of that night, and all the next day, and gathered the quails. He who gathered least gathered ten homers; and they spread them all out for themselves around the camp. 
+<sup>33&#160;</sup>While the meat was still between their teeth, before it was chewed, Yahweh’s anger burned against the people, and Yahweh struck the people with a very great plague. 
+<sup>34&#160;</sup>The name of that place was called Kibroth Hattaavah, because there they buried the people who lusted. 
+</div><div class="p">
+<sup>35&#160;</sup>From Kibroth Hattaavah the people traveled to Hazeroth; and they stayed at Hazeroth. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>Miriam and Aaron spoke against Moses because of the Cushite woman whom he had married; for he had married a Cushite woman. 
+<sup>2&#160;</sup>They said, “Has Yahweh indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahweh heard it. 
+</div><div class="p">
+<sup>3&#160;</sup>Now the man Moses was very humble, more than all the men who were on the surface of the earth. 
+<sup>4&#160;</sup>Yahweh spoke suddenly to Moses, to Aaron, and to Miriam, “You three come out to the Tent of Meeting!” 
+</div><div class="p">The three of them came out. 
+<sup>5&#160;</sup>Yahweh came down in a pillar of cloud, and stood at the door of the Tent, and called Aaron and Miriam; and they both came forward. 
+<sup>6&#160;</sup>He said, “Now hear my words. If there is a prophet among you, I, Yahweh, will make myself known to him in a vision. I will speak with him in a dream. 
+<sup>7&#160;</sup>My servant Moses is not so. He is faithful in all my house. 
+<sup>8&#160;</sup>With him, I will speak mouth to mouth, even plainly, and not in riddles; and he shall see Yahweh’s form. Why then were you not afraid to speak against my servant, against Moses?” 
+<sup>9&#160;</sup>Yahweh’s anger burned against them; and he departed. 
+</div><div class="p">
+<sup>10&#160;</sup>The cloud departed from over the Tent; and behold, Miriam was leprous, as white as snow. Aaron looked at Miriam, and behold, she was leprous. 
+</div><div class="p">
+<sup>11&#160;</sup>Aaron said to Moses, “Oh, my lord, please don’t count this sin against us, in which we have done foolishly, and in which we have sinned. 
+<sup>12&#160;</sup>Let her not, I pray, be as one dead, of whom the flesh is half consumed when he comes out of his mother’s womb.” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses cried to Yahweh, saying, “Heal her, Elohim, I beg you!” 
+</div><div class="p">
+<sup>14&#160;</sup>Yahweh said to Moses, “If her father had but spit in her face, shouldn’t she be ashamed seven days? Let her be shut up outside of the camp seven days, and after that she shall be brought in again.” 
+</div><div class="p">
+<sup>15&#160;</sup>Miriam was shut up outside of the camp seven days, and the people didn’t travel until Miriam was brought in again. 
+<sup>16&#160;</sup>Afterward the people traveled from Hazeroth, and encamped in the wilderness of Paran. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Send men, that they may spy out the land of Canaan, which I give to the children of Israel. Of every tribe of their fathers, you shall send a man, every one a prince among them.” 
+</div><div class="p">
+<sup>3&#160;</sup>Moses sent them from the wilderness of Paran according to the commandment of Yahweh. All of them were men who were heads of the children of Israel. 
+<sup>4&#160;</sup>These were their names: 
+</div><div class="m">Of the tribe of Reuben, Shammua the son of Zaccur. 
+</div><div class="m">
+<sup>5&#160;</sup>Of the tribe of Simeon, Shaphat the son of Hori. 
+</div><div class="m">
+<sup>6&#160;</sup>Of the tribe of Judah, Caleb the son of Jephunneh. 
+</div><div class="m">
+<sup>7&#160;</sup>Of the tribe of Issachar, Igal the son of Joseph. 
+</div><div class="m">
+<sup>8&#160;</sup>Of the tribe of Ephraim, Hoshea the son of Nun. 
+</div><div class="m">
+<sup>9&#160;</sup>Of the tribe of Benjamin, Palti the son of Raphu. 
+</div><div class="m">
+<sup>10&#160;</sup>Of the tribe of Zebulun, Gaddiel the son of Sodi. 
+</div><div class="m">
+<sup>11&#160;</sup>Of the tribe of Joseph, of the tribe of Manasseh, Gaddi the son of Susi. 
+</div><div class="m">
+<sup>12&#160;</sup>Of the tribe of Dan, Ammiel the son of Gemalli. 
+</div><div class="m">
+<sup>13&#160;</sup>Of the tribe of Asher, Sethur the son of Michael. 
+</div><div class="m">
+<sup>14&#160;</sup>Of the tribe of Naphtali, Nahbi the son of Vophsi. 
+</div><div class="m">
+<sup>15&#160;</sup>Of the tribe of Gad, Geuel the son of Machi. 
+</div><div class="m">
+<sup>16&#160;</sup>These are the names of the men who Moses sent to spy out the land. Moses called Hoshea the son of Nun Joshua. 
+<sup>17&#160;</sup>Moses sent them to spy out the land of Canaan, and said to them, “Go up this way by the South, and go up into the hill country. 
+<sup>18&#160;</sup>See the land, what it is; and the people who dwell therein, whether they are strong or weak, whether they are few or many; 
+<sup>19&#160;</sup>and what the land is that they dwell in, whether it is good or bad; and what cities they are that they dwell in, whether in camps, or in strongholds; 
+<sup>20&#160;</sup>and what the land is, whether it is fertile or poor, whether there is wood therein, or not. Be courageous, and bring some of the fruit of the land.” Now the time was the time of the first-ripe grapes. 
+</div><div class="p">
+<sup>21&#160;</sup>So they went up, and spied out the land from the wilderness of Zin to Rehob, to the entrance of Hamath. 
+<sup>22&#160;</sup>They went up by the South, and came to Hebron; and Ahiman, Sheshai, and Talmai, the children of Anak, were there. (Now Hebron was built seven years before Zoan in Egypt.) 
+<sup>23&#160;</sup>They came to the valley of Eshcol, and cut down from there a branch with one cluster of grapes, and they bore it on a staff between two. They also brought some of the pomegranates and figs. 
+<sup>24&#160;</sup>That place was called the valley of Eshcol, because of the cluster which the children of Israel cut down from there. 
+<sup>25&#160;</sup>They returned from spying out the land at the end of forty days. 
+<sup>26&#160;</sup>They went and came to Moses, to Aaron, and to all the congregation of the children of Israel, to the wilderness of Paran, to Kadesh; and brought back word to them and to all the congregation. They showed them the fruit of the land. 
+<sup>27&#160;</sup>They told him, and said, “We came to the land where you sent us. Surely it flows with milk and honey, and this is its fruit. 
+<sup>28&#160;</sup>However, the people who dwell in the land are strong, and the cities are fortified and very large. Moreover, we saw the children of Anak there. 
+<sup>29&#160;</sup>Amalek dwells in the land of the South. The Hittite, the Jebusite, and the Amorite dwell in the hill country. The Canaanite dwells by the sea, and along the side of the Jordan.” 
+</div><div class="p">
+<sup>30&#160;</sup>Caleb stilled the people before Moses, and said, “Let’s go up at once, and possess it; for we are well able to overcome it!” 
+</div><div class="p">
+<sup>31&#160;</sup>But the men who went up with him said, “We aren’t able to go up against the people; for they are stronger than we.” 
+<sup>32&#160;</sup>They brought up an evil report of the land which they had spied out to the children of Israel, saying, “The land, through which we have gone to spy it out, is a land that eats up its inhabitants; and all the people who we saw in it are men of great stature. 
+<sup>33&#160;</sup>There we saw the Nephilim, We were in our own sight as grasshoppers, and so we were in their sight.” 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>All the congregation lifted up their voice, and cried; and the people wept that night. 
+<sup>2&#160;</sup>All the children of Israel murmured against Moses and against Aaron. The whole congregation said to them, “We wish that we had died in the land of Egypt, or that we had died in this wilderness! 
+<sup>3&#160;</sup>Why does Yahweh bring us to this land, to fall by the sword? Our women and our little ones will be captured or killed! Wouldn’t it be better for us to return into Egypt?” 
+<sup>4&#160;</sup>They said to one another, “Let’s choose a leader, and let’s return into Egypt.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then Moses and Aaron fell on their faces before all the assembly of the congregation of the children of Israel. 
+</div><div class="p">
+<sup>6&#160;</sup>Joshua the son of Nun and Caleb the son of Jephunneh, who were of those who spied out the land, tore their clothes. 
+<sup>7&#160;</sup>They spoke to all the congregation of the children of Israel, saying, “The land, which we passed through to spy it out, is an exceedingly good land. 
+<sup>8&#160;</sup>If Yahweh delights in us, then he will bring us into this land, and give it to us: a land which flows with milk and honey. 
+<sup>9&#160;</sup>Only don’t rebel against Yahweh, neither fear the people of the land; for they are bread for us. Their defense is removed from over them, and Yahweh is with us. Don’t fear them.” 
+</div><div class="p">
+<sup>10&#160;</sup>But all the congregation threatened to stone them with stones. 
+</div><div class="p">Yahweh’s glory appeared in the Tent of Meeting to all the children of Israel. 
+<sup>11&#160;</sup>Yahweh said to Moses, “How long will this people despise me? How long will they not believe in me, for all the signs which I have worked among them? 
+<sup>12&#160;</sup>I will strike them with the pestilence, and disinherit them, and will make of you a nation greater and mightier than they.” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses said to Yahweh, “Then the Egyptians will hear it; for you brought up this people in your might from among them. 
+<sup>14&#160;</sup>They will tell it to the inhabitants of this land. They have heard that you Yahweh are among this people; for you Yahweh are seen face to face, and your cloud stands over them, and you go before them, in a pillar of cloud by day, and in a pillar of fire by night. 
+<sup>15&#160;</sup>Now if you killed this people as one man, then the nations which have heard the fame of you will speak, saying, 
+<sup>16&#160;</sup>‘Because Yahweh was not able to bring this people into the land which he swore to them, therefore he has slain them in the wilderness.’ 
+<sup>17&#160;</sup>Now please let the power of the Lord be great, according as you have spoken, saying, 
+<sup>18&#160;</sup>‘Yahweh is slow to anger, and abundant in loving kindness, forgiving iniquity and disobedience; and he will by no means clear the guilty, visiting the iniquity of the fathers on the children, on the third and on the fourth generation.’ 
+<sup>19&#160;</sup>Please pardon the iniquity of this people according to the greatness of your loving kindness, and just as you have forgiven this people, from Egypt even until now.” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh said, “I have pardoned according to your word; 
+<sup>21&#160;</sup>but in very deed—as I live, and as all the earth shall be filled with Yahweh’s glory—<sup>22&#160;</sup>because all those men who have seen my glory and my signs, which I worked in Egypt and in the wilderness, yet have tempted me these ten times, and have not listened to my voice; 
+<sup>23&#160;</sup>surely they shall not see the land which I swore to their fathers, neither shall any of those who despised me see it. 
+<sup>24&#160;</sup>But my servant Caleb, because he had another spirit with him, and has followed me fully, him I will bring into the land into which he went. His offspring shall possess it. 
+<sup>25&#160;</sup>Since the Amalekite and the Canaanite dwell in the valley, tomorrow turn and go into the wilderness by the way to the Red Sea.” 
+<sup>26&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>27&#160;</sup>“How long shall I bear with this evil congregation that complain against me? I have heard the complaints of the children of Israel, which they complain against me. 
+<sup>28&#160;</sup>Tell them, ‘As I live, says Yahweh, surely as you have spoken in my ears, so I will do to you. 
+<sup>29&#160;</sup>Your dead bodies shall fall in this wilderness; and all who were counted of you, according to your whole number, from twenty years old and upward, who have complained against me, 
+<sup>30&#160;</sup>surely you shall not come into the land concerning which I swore that I would make you dwell therein, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
+<sup>31&#160;</sup>But I will bring in your little ones that you said should be captured or killed, and they shall know the land which you have rejected. 
+<sup>32&#160;</sup>But as for you, your dead bodies shall fall in this wilderness. 
+<sup>33&#160;</sup>Your children shall be wanderers in the wilderness forty years, and shall bear your prostitution, until your dead bodies are consumed in the wilderness. 
+<sup>34&#160;</sup>After the number of the days in which you spied out the land, even forty days, for every day a year, you will bear your iniquities, even forty years, and you will know my alienation.’ 
+<sup>35&#160;</sup>I, Yahweh, have spoken. I will surely do this to all this evil congregation who are gathered together against me. In this wilderness they shall be consumed, and there they shall die.” 
+</div><div class="p">
+<sup>36&#160;</sup>The men whom Moses sent to spy out the land, who returned and made all the congregation to murmur against him by bringing up an evil report against the land, 
+<sup>37&#160;</sup>even those men who brought up an evil report of the land, died by the plague before Yahweh. 
+<sup>38&#160;</sup>But Joshua the son of Nun and Caleb the son of Jephunneh remained alive of those men who went to spy out the land. 
+</div><div class="p">
+<sup>39&#160;</sup>Moses told these words to all the children of Israel, and the people mourned greatly. 
+<sup>40&#160;</sup>They rose up early in the morning and went up to the top of the mountain, saying, “Behold, we are here, and will go up to the place which Yahweh has promised; for we have sinned.” 
+</div><div class="p">
+<sup>41&#160;</sup>Moses said, “Why now do you disobey the commandment of Yahweh, since it shall not prosper? 
+<sup>42&#160;</sup>Don’t go up, for Yahweh isn’t among you; that way you won’t be struck down before your enemies. 
+<sup>43&#160;</sup>For there the Amalekite and the Canaanite are before you, and you will fall by the sword because you turned back from following Yahweh; therefore Yahweh will not be with you.” 
+</div><div class="p">
+<sup>44&#160;</sup>But they presumed to go up to the top of the mountain. Nevertheless, the ark of Yahweh’s covenant and Moses didn’t depart out of the camp. 
+<sup>45&#160;</sup>Then the Amalekites came down, and the Canaanites who lived in that mountain, and struck them and beat them down even to Hormah. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you have come into the land of your habitations, which I give to you, 
+<sup>3&#160;</sup>and will make an offering by fire to Yahweh—a burnt offering, or a sacrifice, to accomplish a vow, or as a free will offering, or in your set feasts, to make a pleasant aroma to Yahweh, of the herd, or of the flock—<sup>4&#160;</sup>then he who offers his offering shall offer to Yahweh a meal offering of one tenth of an ephah of oil. 
+<sup>5&#160;</sup>You shall prepare wine for the drink offering, one fourth of a hin, with the burnt offering or for the sacrifice, for each lamb. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘For a ram, you shall prepare for a meal offering two tenths of an ephah of fine flour mixed with the third part of a hin of oil; 
+<sup>7&#160;</sup>and for the drink offering you shall offer the third part of a hin of wine, of a pleasant aroma to Yahweh. 
+<sup>8&#160;</sup>When you prepare a bull for a burnt offering or for a sacrifice, to accomplish a vow, or for peace offerings to Yahweh, 
+<sup>9&#160;</sup>then he shall offer with the bull a meal offering of three tenths of an ephah of fine flour mixed with half a hin of oil; 
+<sup>10&#160;</sup>and you shall offer for the drink offering half a hin of wine, for an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>11&#160;</sup>Thus it shall be done for each bull, for each ram, for each of the male lambs, or of the young goats. 
+<sup>12&#160;</sup>According to the number that you shall prepare, so you shall do to everyone according to their number. 
+</div><div class="p">
+<sup>13&#160;</sup>“&#160;‘All who are native-born shall do these things in this way, in offering an offering made by fire, of a pleasant aroma to Yahweh. 
+<sup>14&#160;</sup>If a stranger lives as a foreigner with you, or whoever may be among you throughout your generations, and will offer an offering made by fire, of a pleasant aroma to Yahweh, as you do, so he shall do. 
+<sup>15&#160;</sup>For the assembly, there shall be one statute for you and for the stranger who lives as a foreigner, a statute forever throughout your generations. As you are, so the foreigner shall be before Yahweh. 
+<sup>16&#160;</sup>One law and one ordinance shall be for you and for the stranger who lives as a foreigner with you.’&#160;” 
+</div><div class="p">
+<sup>17&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>18&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you come into the land where I bring you, 
+<sup>19&#160;</sup>then it shall be that when you eat of the bread of the land, you shall offer up a wave offering to Yahweh. 
+<sup>20&#160;</sup>Of the first of your dough you shall offer up a cake for a wave offering. As the wave offering of the threshing floor, so you shall heave it. 
+<sup>21&#160;</sup>Of the first of your dough, you shall give to Yahweh a wave offering throughout your generations. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘When you err, and don’t observe all these commandments which Yahweh has spoken to Moses—<sup>23&#160;</sup>even all that Yahweh has commanded you by Moses, from the day that Yahweh gave commandment and onward throughout your generations—<sup>24&#160;</sup>then it shall be, if it was done unwittingly, without the knowledge of the congregation, that all the congregation shall offer one young bull for a burnt offering, for a pleasant aroma to Yahweh, with its meal offering and its drink offering, according to the ordinance, and one male goat for a sin offering. 
+<sup>25&#160;</sup>The priest shall make atonement for all the congregation of the children of Israel, and they shall be forgiven; for it was an error, and they have brought their offering, an offering made by fire to Yahweh, and their sin offering before Yahweh, for their error. 
+<sup>26&#160;</sup>All the congregation of the children of Israel shall be forgiven, as well as the stranger who lives as a foreigner among them; for with regard to all the people, it was done unwittingly. 
+</div><div class="p">
+<sup>27&#160;</sup>“&#160;‘If a person sins unwittingly, then he shall offer a female goat a year old for a sin offering. 
+<sup>28&#160;</sup>The priest shall make atonement for the soul who errs when he sins unwittingly before Yahweh. He shall make atonement for him; and he shall be forgiven. 
+<sup>29&#160;</sup>You shall have one law for him who does anything unwittingly, for him who is native-born among the children of Israel, and for the stranger who lives as a foreigner among them. 
+</div><div class="p">
+<sup>30&#160;</sup>“&#160;‘But the soul who does anything with a high hand, whether he is native-born or a foreigner, blasphemes Yahweh. That soul shall be cut off from among his people. 
+<sup>31&#160;</sup>Because he has despised Yahweh’s word, and has broken his commandment, that soul shall be utterly cut off. His iniquity shall be on him.’&#160;” 
+</div><div class="p">
+<sup>32&#160;</sup>While the children of Israel were in the wilderness, they found a man gathering sticks on the Sabbath day. 
+<sup>33&#160;</sup>Those who found him gathering sticks brought him to Moses and Aaron, and to all the congregation. 
+<sup>34&#160;</sup>They put him in custody, because it had not been declared what should be done to him. 
+</div><div class="p">
+<sup>35&#160;</sup>Yahweh said to Moses, “The man shall surely be put to death. All the congregation shall stone him with stones outside of the camp.” 
+<sup>36&#160;</sup>All the congregation brought him outside of the camp, and stoned him to death with stones, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>37&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>38&#160;</sup>“Speak to the children of Israel, and tell them that they should make themselves fringes of each border a cord of blue. 
+<sup>39&#160;</sup>It shall be to you for a fringe, that you may see it, and remember all Yahweh’s commandments, and do them; and that you don’t follow your own heart and your own eyes, after which you used to play the prostitute; 
+<sup>40&#160;</sup>so that you may remember and do all my commandments, and be set-apart to your Elohim. 
+<sup>41&#160;</sup>I am Yahweh your Elohim, who brought you out of the land of Egypt, to be your Elohim: I am Yahweh your Elohim.” 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Korah, the son of Izhar, the son of Kohath, the son of Levi, with Dathan and Abiram, the sons of Eliab, and On, the son of Peleth, sons of Reuben, took some men. 
+<sup>2&#160;</sup>They rose up before Moses, with some of the children of Israel, two hundred fifty princes of the congregation, called to the assembly, men of renown. 
+<sup>3&#160;</sup>They assembled themselves together against Moses and against Aaron, and said to them, “You take too much on yourself, since all the congregation are set-apart, everyone of them, and Yahweh is among them! Why do you lift yourselves up above Yahweh’s assembly?” 
+</div><div class="p">
+<sup>4&#160;</sup>When Moses heard it, he fell on his face. 
+<sup>5&#160;</sup>He said to Korah and to all his company, “In the morning, Yahweh will show who are his, and who is set-apart, and will cause him to come near to him. Even him whom he shall choose, he will cause to come near to him. 
+<sup>6&#160;</sup>Do this: have Korah and all his company take censers, 
+<sup>7&#160;</sup>put fire in them, and put incense on them before Yahweh tomorrow. It shall be that the man whom Yahweh chooses, he shall be set-apart. You have gone too far, you sons of Levi!” 
+</div><div class="p">
+<sup>8&#160;</sup>Moses said to Korah, “Hear now, you sons of Levi! 
+<sup>9&#160;</sup>Is it a small thing to you that the Elohim of Israel has separated you from the congregation of Israel, to bring you near to himself, to do the service of Yahweh’s tabernacle, and to stand before the congregation to minister to them; 
+<sup>10&#160;</sup>and that he has brought you near, and all your brothers the sons of Levi with you? Do you seek the priesthood also? 
+<sup>11&#160;</sup>Therefore you and all your company have gathered together against Yahweh! What is Aaron that you complain against him?” 
+</div><div class="p">
+<sup>12&#160;</sup>Moses sent to call Dathan and Abiram, the sons of Eliab; and they said, “We won’t come up! 
+<sup>13&#160;</sup>Is it a small thing that you have brought us up out of a land flowing with milk and honey, to kill us in the wilderness, but you must also make yourself a prince over us? 
+<sup>14&#160;</sup>Moreover you haven’t brought us into a land flowing with milk and honey, nor given us inheritance of fields and vineyards. Will you put out the eyes of these men? We won’t come up.” 
+</div><div class="p">
+<sup>15&#160;</sup>Moses was very angry, and said to Yahweh, “Don’t respect their offering. I have not taken one donkey from them, neither have I hurt one of them.” 
+</div><div class="p">
+<sup>16&#160;</sup>Moses said to Korah, “You and all your company go before Yahweh, you, and they, and Aaron, tomorrow. 
+<sup>17&#160;</sup>Each man take his censer and put incense on it, and each man bring before Yahweh his censer, two hundred fifty censers; you also, and Aaron, each with his censer.” 
+</div><div class="p">
+<sup>18&#160;</sup>They each took his censer, and put fire in it, and laid incense on it, and stood at the door of the Tent of Meeting with Moses and Aaron. 
+<sup>19&#160;</sup>Korah assembled all the congregation opposite them to the door of the Tent of Meeting. 
+</div><div class="p">Yahweh’s glory appeared to all the congregation. 
+<sup>20&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>21&#160;</sup>“Separate yourselves from among this congregation, that I may consume them in a moment!” 
+</div><div class="p">
+<sup>22&#160;</sup>They fell on their faces, and said, “Elohim, the Elohim of the spirits of all flesh, shall one man sin, and will you be angry with all the congregation?” 
+</div><div class="p">
+<sup>23&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>24&#160;</sup>“Speak to the congregation, saying, ‘Get away from around the tent of Korah, Dathan, and Abiram!’&#160;” 
+</div><div class="p">
+<sup>25&#160;</sup>Moses rose up and went to Dathan and Abiram; and the elders of Israel followed him. 
+<sup>26&#160;</sup>He spoke to the congregation, saying, “Depart, please, from the tents of these wicked men, and touch nothing of theirs, lest you be consumed in all their sins!” 
+</div><div class="p">
+<sup>27&#160;</sup>So they went away from the tent of Korah, Dathan, and Abiram, on every side. Dathan and Abiram came out, and stood at the door of their tents with their women, their sons, and their little ones. 
+</div><div class="p">
+<sup>28&#160;</sup>Moses said, “Hereby you shall know that Yahweh has sent me to do all these works; for they are not from my own mind. 
+<sup>29&#160;</sup>If these men die the common death of all men, or if they experience what all men experience, then Yahweh hasn’t sent me. 
+<sup>30&#160;</sup>But if Yahweh makes a new thing, and the ground opens its mouth, and swallows them up with all that belong to them, and they go down alive into Sheol, then you shall understand that these men have despised Yahweh.” 
+</div><div class="p">
+<sup>31&#160;</sup>As he finished speaking all these words, the ground that was under them split apart. 
+<sup>32&#160;</sup>The earth opened its mouth and swallowed them up with their households, all of Korah’s men, and all their goods. 
+<sup>33&#160;</sup>So they, and all that belonged to them went down alive into Sheol. The earth closed on them, and they perished from among the assembly. 
+<sup>34&#160;</sup>All Israel that were around them fled at their cry; for they said, “Lest the earth swallow us up!” 
+<sup>35&#160;</sup>Fire came out from Yahweh, and devoured the two hundred fifty men who offered the incense. 
+</div><div class="p">
+<sup>36&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>37&#160;</sup>“Speak to Eleazar the son of Aaron the priest, that he take up the censers out of the burning, and scatter the fire away from the camp; for they are set-apart, 
+<sup>38&#160;</sup>even the censers of those who sinned against their own lives. Let them be beaten into plates for a covering of the altar, for they offered them before Yahweh. Therefore they are set-apart. They shall be a sign to the children of Israel.” 
+</div><div class="p">
+<sup>39&#160;</sup>Eleazar the priest took the bronze censers which those who were burned had offered; and they beat them out for a covering of the altar, 
+<sup>40&#160;</sup>to be a memorial to the children of Israel, to the end that no stranger who isn’t of the offspring of Aaron, would come near to burn incense before Yahweh, that he not be as Korah and as his company; as Yahweh spoke to him by Moses. 
+</div><div class="p">
+<sup>41&#160;</sup>But on the next day all the congregation of the children of Israel complained against Moses and against Aaron, saying, “You have killed Yahweh’s people!” 
+</div><div class="p">
+<sup>42&#160;</sup>When the congregation was assembled against Moses and against Aaron, they looked toward the Tent of Meeting. Behold, the cloud covered it, and Yahweh’s glory appeared. 
+<sup>43&#160;</sup>Moses and Aaron came to the front of the Tent of Meeting. 
+<sup>44&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>45&#160;</sup>“Get away from among this congregation, that I may consume them in a moment!” They fell on their faces. 
+</div><div class="p">
+<sup>46&#160;</sup>Moses said to Aaron, “Take your censer, put fire from the altar in it, lay incense on it, carry it quickly to the congregation, and make atonement for them; for wrath has gone out from Yahweh! The plague has begun.” 
+</div><div class="p">
+<sup>47&#160;</sup>Aaron did as Moses said, and ran into the middle of the assembly. The plague had already begun among the people. He put on the incense, and made atonement for the people. 
+<sup>48&#160;</sup>He stood between the dead and the living; and the plague was stayed. 
+<sup>49&#160;</sup>Now those who died by the plague were fourteen thousand seven hundred, in addition to those who died about the matter of Korah. 
+<sup>50&#160;</sup>Aaron returned to Moses to the door of the Tent of Meeting, and the plague was stopped. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Speak to the children of Israel, and take rods from them, one for each fathers’ house, of all their princes according to their fathers’ houses, twelve rods. Write each man’s name on his rod. 
+<sup>3&#160;</sup>You shall write Aaron’s name on Levi’s rod. There shall be one rod for each head of their fathers’ houses. 
+<sup>4&#160;</sup>You shall lay them up in the Tent of Meeting before the covenant, where I meet with you. 
+<sup>5&#160;</sup>It shall happen that the rod of the man whom I shall choose shall bud. I will make the murmurings of the children of Israel, which they murmur against you, cease from me.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses spoke to the children of Israel; and all their princes gave him rods, for each prince one, according to their fathers’ houses, a total of twelve rods. Aaron’s rod was among their rods. 
+<sup>7&#160;</sup>Moses laid up the rods before Yahweh in the Tent of the Testimony. 
+</div><div class="p">
+<sup>8&#160;</sup>On the next day, Moses went into the Tent of the Testimony; and behold, Aaron’s rod for the house of Levi had sprouted, budded, produced blossoms, and bore ripe almonds. 
+<sup>9&#160;</sup>Moses brought out all the rods from before Yahweh to all the children of Israel. They looked, and each man took his rod. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh said to Moses, “Put back the rod of Aaron before the covenant, to be kept for a token against the children of rebellion; that you may make an end of their complaining against me, that they not die.” 
+<sup>11&#160;</sup>Moses did so. As Yahweh commanded him, so he did. 
+</div><div class="p">
+<sup>12&#160;</sup>The children of Israel spoke to Moses, saying, “Behold, we perish! We are undone! We are all undone! 
+<sup>13&#160;</sup>Everyone who keeps approaching Yahweh’s tabernacle, dies! Will we all perish?” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh said to Aaron, “You and your sons and your fathers’ house with you shall bear the iniquity of the sanctuary; and you and your sons with you shall bear the iniquity of your priesthood. 
+<sup>2&#160;</sup>Bring your brothers also, the tribe of Levi, the tribe of your father, near with you, that they may be joined to you, and minister to you; but you and your sons with you shall be before the Tent of the Testimony. 
+<sup>3&#160;</sup>They shall keep your commands and the duty of the whole Tent; only they shall not come near to the vessels of the sanctuary and to the altar, that they not die, neither they nor you. 
+<sup>4&#160;</sup>They shall be joined to you and keep the responsibility of the Tent of Meeting, for all the service of the Tent. A stranger shall not come near to you. 
+</div><div class="p">
+<sup>5&#160;</sup>“You shall perform the duty of the sanctuary and the duty of the altar, that there be no more wrath on the children of Israel. 
+<sup>6&#160;</sup>Behold, I myself have taken your brothers the Levites from among the children of Israel. They are a gift to you, dedicated to Yahweh, to do the service of the Tent of Meeting. 
+<sup>7&#160;</sup>You and your sons with you shall keep your priesthood for everything of the altar, and for that within the veil. You shall serve. I give you the service of the priesthood as a gift. The stranger who comes near shall be put to death.” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh spoke to Aaron, “Behold, I myself have given you the command of my wave offerings, even all the set-apart things of the children of Israel. I have given them to you by reason of the anointing, and to your sons, as a portion forever. 
+<sup>9&#160;</sup>This shall be yours of the most set-apart things from the fire: every offering of theirs, even every meal offering of theirs, and every sin offering of theirs, and every trespass offering of theirs, which they shall render to me, shall be most set-apart for you and for your sons. 
+<sup>10&#160;</sup>You shall eat of it like the most set-apart things. Every male shall eat of it. It shall be set-apart to you. 
+</div><div class="p">
+<sup>11&#160;</sup>“This is yours, too: the wave offering of their gift, even all the wave offerings of the children of Israel. I have given them to you, and to your sons and to your daughters with you, as a portion forever. Everyone who is clean in your house shall eat of it. 
+</div><div class="p">
+<sup>12&#160;</sup>“I have given to you all the best of the oil, all the best of the vintage, and of the grain, the first fruits of them which they give to Yahweh. 
+<sup>13&#160;</sup>The first-ripe fruits of all that is in their land, which they bring to Yahweh, shall be yours. Everyone who is clean in your house shall eat of it. 
+</div><div class="p">
+<sup>14&#160;</sup>“Everything devoted in Israel shall be yours. 
+<sup>15&#160;</sup>Everything that opens the womb, of all flesh which they offer to Yahweh, both of man and animal, shall be yours. Nevertheless, you shall surely redeem the firstborn of man, and you shall redeem the firstborn of unclean animals. 
+<sup>16&#160;</sup>You shall redeem those who are to be redeemed of them from a month old, according to your estimation, for five shekels of money, according to the shekel 
+</div><div class="p">
+<sup>17&#160;</sup>“But you shall not redeem the firstborn of a cow, or the firstborn of a sheep, or the firstborn of a goat. They are set-apart. You shall sprinkle their blood on the altar, and shall burn their fat for an offering made by fire, for a pleasant aroma to Yahweh. 
+<sup>18&#160;</sup>Their meat shall be yours, as the wave offering breast and as the right thigh, it shall be yours. 
+<sup>19&#160;</sup>All the wave offerings of the set-apart things which the children of Israel offer to Yahweh, I have given you and your sons and your daughters with you, as a portion forever. It is a covenant of salt forever before Yahweh to you and to your offspring with you.” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh said to Aaron, “You shall have no inheritance in their land, neither shall you have any portion among them. I am your portion and your inheritance among the children of Israel. 
+</div><div class="p">
+<sup>21&#160;</sup>“To the children of Levi, behold, I have given all the tithe in Israel for an inheritance, in return for their service which they serve, even the service of the Tent of Meeting. 
+<sup>22&#160;</sup>Henceforth the children of Israel shall not come near the Tent of Meeting, lest they bear sin, and die. 
+<sup>23&#160;</sup>But the Levites shall do the service of the Tent of Meeting, and they shall bear their iniquity. It shall be a statute forever throughout your generations. Among the children of Israel, they shall have no inheritance. 
+<sup>24&#160;</sup>For the tithe of the children of Israel, which they offer as a wave offering to Yahweh, I have given to the Levites for an inheritance. Therefore I have said to them, ‘Among the children of Israel they shall have no inheritance.’&#160;” 
+</div><div class="p">
+<sup>25&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>26&#160;</sup>“Moreover you shall speak to the Levites, and tell them, ‘When you take of the children of Israel the tithe which I have given you from them for your inheritance, then you shall offer up a wave offering of it for Yahweh, a tithe of the tithe. 
+<sup>27&#160;</sup>Your wave offering shall be credited to you, as though it were the grain of the threshing floor, and as the fullness of the wine press. 
+<sup>28&#160;</sup>Thus you also shall offer a wave offering to Yahweh of all your tithes, which you receive of the children of Israel; and of it you shall give Yahweh’s wave offering to Aaron the priest. 
+<sup>29&#160;</sup>Out of all your gifts, you shall offer every wave offering to Yahweh, of all its best parts, even the set-apart part of it.’ 
+</div><div class="p">
+<sup>30&#160;</sup>“Therefore you shall tell them, ‘When you heave its best from it, then it shall be credited to the Levites as the increase of the threshing floor, and as the increase of the wine press. 
+<sup>31&#160;</sup>You may eat it anywhere, you and your households, for it is your reward in return for your service in the Tent of Meeting. 
+<sup>32&#160;</sup>You shall bear no sin by reason of it, when you have heaved from it its best. You shall not profane the set-apart things of the children of Israel, that you not die.’&#160;” 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses and to Aaron, saying, 
+<sup>2&#160;</sup>“This is the statute of the law which Yahweh has commanded. Tell the children of Israel to bring you a red heifer without spot, in which is no defect, and which was never yoked. 
+<sup>3&#160;</sup>You shall give her to Eleazar the priest, and he shall bring her outside of the camp, and one shall kill her before his face. 
+<sup>4&#160;</sup>Eleazar the priest shall take some of her blood with his finger, and sprinkle her blood toward the front of the Tent of Meeting seven times. 
+<sup>5&#160;</sup>One shall burn the heifer in his sight; her skin, and her meat, and her blood, with her dung, shall he burn. 
+<sup>6&#160;</sup>The priest shall take cedar wood, hyssop, and scarlet, and cast it into the middle of the burning of the heifer. 
+<sup>7&#160;</sup>Then the priest shall wash his clothes, and he shall bathe his flesh in water, and afterward he shall come into the camp, and the priest shall be unclean until the evening. 
+<sup>8&#160;</sup>He who burns her shall wash his clothes in water, and bathe his flesh in water, and shall be unclean until the evening. 
+</div><div class="p">
+<sup>9&#160;</sup>“A man who is clean shall gather up the ashes of the heifer, and lay them up outside of the camp in a clean place; and it shall be kept for the congregation of the children of Israel for use in water for cleansing impurity. It is a sin offering. 
+<sup>10&#160;</sup>He who gathers the ashes of the heifer shall wash his clothes, and be unclean until the evening. It shall be to the children of Israel, and to the stranger who lives as a foreigner among them, for a statute forever. 
+</div><div class="p">
+<sup>11&#160;</sup>“He who touches the dead body of any man shall be unclean seven days. 
+<sup>12&#160;</sup>He shall purify himself with water on the third day, and on the seventh day he shall be clean; but if he doesn’t purify himself the third day, then the seventh day he shall not be clean. 
+<sup>13&#160;</sup>Whoever touches a dead person, the body of a man who has died, and doesn’t purify himself, defiles Yahweh’s tabernacle; and that soul shall be cut off from Israel; because the water for impurity was not sprinkled on him, he shall be unclean. His uncleanness is yet on him. 
+</div><div class="p">
+<sup>14&#160;</sup>“This is the law when a man dies in a tent: everyone who comes into the tent, and everyone who is in the tent, shall be unclean seven days. 
+<sup>15&#160;</sup>Every open vessel, which has no covering bound on it, is unclean. 
+</div><div class="p">
+<sup>16&#160;</sup>“Whoever in the open field touches one who is slain with a sword, or a dead body, or a bone of a man, or a grave, shall be unclean seven days. 
+</div><div class="p">
+<sup>17&#160;</sup>“For the unclean, they shall take of the ashes of the burning of the sin offering; and running water shall be poured on them in a vessel. 
+<sup>18&#160;</sup>A clean person shall take hyssop, dip it in the water, and sprinkle it on the tent, on all the vessels, on the persons who were there, and on him who touched the bone, or the slain, or the dead, or the grave. 
+<sup>19&#160;</sup>The clean person shall sprinkle on the unclean on the third day, and on the seventh day. On the seventh day, he shall purify him. He shall wash his clothes and bathe himself in water, and shall be clean at evening. 
+<sup>20&#160;</sup>But the man who shall be unclean, and shall not purify himself, that soul shall be cut off from among the assembly, because he has defiled the sanctuary of Yahweh. The water for impurity has not been sprinkled on him. He is unclean. 
+<sup>21&#160;</sup>It shall be a perpetual statute to them. He who sprinkles the water for impurity shall wash his clothes, and he who touches the water for impurity shall be unclean until evening. 
+</div><div class="p">
+<sup>22&#160;</sup>“Whatever the unclean person touches shall be unclean; and the soul that touches it shall be unclean until evening.” 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>The children of Israel, even the whole congregation, came into the wilderness of Zin in the first month. The people stayed in Kadesh. Miriam died there, and was buried there. 
+<sup>2&#160;</sup>There was no water for the congregation; and they assembled themselves together against Moses and against Aaron. 
+<sup>3&#160;</sup>The people quarreled with Moses, and spoke, saying, “We wish that we had died when our brothers died before Yahweh! 
+<sup>4&#160;</sup>Why have you brought Yahweh’s assembly into this wilderness, that we should die there, we and our animals? 
+<sup>5&#160;</sup>Why have you made us to come up out of Egypt, to bring us in to this evil place? It is no place of seed, or of figs, or of vines, or of pomegranates; neither is there any water to drink.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses and Aaron went from the presence of the assembly to the door of the Tent of Meeting, and fell on their faces. Yahweh’s glory appeared to them. 
+<sup>7&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>8&#160;</sup>“Take the rod, and assemble the congregation, you, and Aaron your brother, and speak to the rock before their eyes, that it pour out its water. You shall bring water to them out of the rock; so you shall give the congregation and their livestock drink.” 
+</div><div class="p">
+<sup>9&#160;</sup>Moses took the rod from before Yahweh, as he commanded him. 
+<sup>10&#160;</sup>Moses and Aaron gathered the assembly together before the rock, and he said to them, “Hear now, you rebels! Shall we bring water out of this rock for you?” 
+<sup>11&#160;</sup>Moses lifted up his hand, and struck the rock with his rod twice, and water came out abundantly. The congregation and their livestock drank. 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh said to Moses and Aaron, “Because you didn’t believe in me, to sanctify me in the eyes of the children of Israel, therefore you shall not bring this assembly into the land which I have given them.” 
+</div><div class="p">
+<sup>13&#160;</sup>These are the waters of Meribah; because the children of Israel strove with Yahweh, and he was sanctified in them. 
+</div><div class="p">
+<sup>14&#160;</sup>Moses sent messengers from Kadesh to the king of Edom, saying: 
+</div><div class="p">“Your brother Israel says: You know all the travail that has happened to us; 
+<sup>15&#160;</sup>how our fathers went down into Egypt, and we lived in Egypt a long time. The Egyptians mistreated us and our fathers. 
+<sup>16&#160;</sup>When we cried to Yahweh, he heard our voice, sent an angel, and brought us out of Egypt. Behold, we are in Kadesh, a city in the edge of your border. 
+</div><div class="p">
+<sup>17&#160;</sup>“Please let us pass through your land. We will not pass through field or through vineyard, neither will we drink from the water of the wells. We will go along the king’s highway. We will not turn away to the right hand nor to the left, until we have passed your border.” 
+</div><div class="p">
+<sup>18&#160;</sup>Edom said to him, “You shall not pass through me, lest I come out with the sword against you.” 
+</div><div class="p">
+<sup>19&#160;</sup>The children of Israel said to him, “We will go up by the highway; and if we drink your water, I and my livestock, then I will give its price. Only let me, without doing anything else, pass through on my feet.” 
+</div><div class="p">
+<sup>20&#160;</sup>He said, “You shall not pass through.” Edom came out against him with many people, and with a strong hand. 
+<sup>21&#160;</sup>Thus Edom refused to give Israel passage through his border, so Israel turned away from him. 
+</div><div class="p">
+<sup>22&#160;</sup>They traveled from Kadesh, and the children of Israel, even the whole congregation, came to Mount Hor. 
+<sup>23&#160;</sup>Yahweh spoke to Moses and Aaron in Mount Hor, by the border of the land of Edom, saying, 
+<sup>24&#160;</sup>“Aaron shall be gathered to his people; for he shall not enter into the land which I have given to the children of Israel, because you rebelled against my word at the waters of Meribah. 
+<sup>25&#160;</sup>Take Aaron and Eleazar his son, and bring them up to Mount Hor; 
+<sup>26&#160;</sup>and strip Aaron of his garments, and put them on Eleazar his son. Aaron shall be gathered, and shall die there.” 
+</div><div class="p">
+<sup>27&#160;</sup>Moses did as Yahweh commanded. They went up onto Mount Hor in the sight of all the congregation. 
+<sup>28&#160;</sup>Moses stripped Aaron of his garments, and put them on Eleazar his son. Aaron died there on the top of the mountain, and Moses and Eleazar came down from the mountain. 
+<sup>29&#160;</sup>When all the congregation saw that Aaron was dead, they wept for Aaron thirty days, even all the house of Israel. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>The Canaanite, the king of Arad, who lived in the South, heard that Israel came by the way of Atharim. He fought against Israel, and took some of them captive. 
+<sup>2&#160;</sup>Israel vowed a vow to Yahweh, and said, “If you will indeed deliver this people into my hand, then I will utterly destroy their cities.” 
+<sup>3&#160;</sup>Yahweh listened to the voice of Israel, and delivered up the Canaanites; and they utterly destroyed them and their cities. The name of the place was called Hormah. 
+</div><div class="p">
+<sup>4&#160;</sup>They traveled from Mount Hor by the way to the Red Sea, to go around the land of Edom. The soul of the people was very discouraged because of the journey. 
+<sup>5&#160;</sup>The people spoke against Elohim and against Moses: “Why have you brought us up out of Egypt to die in the wilderness? For there is no bread, there is no water, and our soul loathes this disgusting food!” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh sent venomous snakes among the people, and they bit the people. Many people of Israel died. 
+<sup>7&#160;</sup>The people came to Moses, and said, “We have sinned, because we have spoken against Yahweh and against you. Pray to Yahweh, that he take away the serpents from us.” Moses prayed for the people. 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh said to Moses, “Make a venomous snake, and set it on a pole. It shall happen that everyone who is bitten, when he sees it, shall live.” 
+<sup>9&#160;</sup>Moses made a serpent of bronze, and set it on the pole. If a serpent had bitten any man, when he looked at the serpent of bronze, he lived. 
+</div><div class="p">
+<sup>10&#160;</sup>The children of Israel traveled, and encamped in Oboth. 
+<sup>11&#160;</sup>They traveled from Oboth, and encamped at Iyeabarim, in the wilderness which is before Moab, toward the sunrise. 
+<sup>12&#160;</sup>From there they traveled, and encamped in the valley of Zered. 
+<sup>13&#160;</sup>From there they traveled, and encamped on the other side of the Arnon, which is in the wilderness that comes out of the border of the Amorites; for the Arnon is the border of Moab, between Moab and the Amorites. 
+<sup>14&#160;</sup>Therefore it is said in <span class="bk">The Book of the Wars of Yahweh</span>, “Vaheb in Suphah, the valleys of the Arnon, 
+<sup>15&#160;</sup>the slope of the valleys that incline toward the dwelling of Ar, leans on the border of Moab.” 
+</div><div class="p">
+<sup>16&#160;</sup>From there they traveled to Beer; that is the well of which Yahweh said to Moses, “Gather the people together, and I will give them water.” 
+</div><div class="p">
+<sup>17&#160;</sup>Then Israel sang this song: 
+</div><div class="q1">“Spring up, well! Sing to it, 
+</div><div class="q2">
+<sup>18&#160;</sup>the well, which the princes dug, 
+</div><div class="q2">which the nobles of the people dug, 
+</div><div class="q2">with the scepter, and with their poles.” 
+</div><div class="p">From the wilderness they traveled to Mattanah; 
+<sup>19&#160;</sup>and from Mattanah to Nahaliel; and from Nahaliel to Bamoth; 
+<sup>20&#160;</sup>and from Bamoth to the valley that is in the field of Moab, to the top of Pisgah, which looks down on the desert. 
+<sup>21&#160;</sup>Israel sent messengers to Sihon king of the Amorites, saying, 
+<sup>22&#160;</sup>“Let me pass through your land. We will not turn away into field or vineyard. We will not drink of the water of the wells. We will go by the king’s highway, until we have passed your border.” 
+</div><div class="p">
+<sup>23&#160;</sup>Sihon would not allow Israel to pass through his border, but Sihon gathered all his people together, and went out against Israel into the wilderness, and came to Jahaz. He fought against Israel. 
+<sup>24&#160;</sup>Israel struck him with the edge of the sword, and possessed his land from the Arnon to the Jabbok, even to the children of Ammon; for the border of the children of Ammon was fortified. 
+<sup>25&#160;</sup>Israel took all these cities. Israel lived in all the cities of the Amorites, in Heshbon, and in all its villages. 
+<sup>26&#160;</sup>For Heshbon was the city of Sihon the king of the Amorites, who had fought against the former king of Moab, and taken all his land out of his hand, even to the Arnon. 
+<sup>27&#160;</sup>Therefore those who speak in proverbs say, 
+</div><div class="q1">“Come to Heshbon. 
+</div><div class="q2">Let the city of Sihon be built and established; 
+</div><div class="q1">
+<sup>28&#160;</sup>for a fire has gone out of Heshbon, 
+</div><div class="q2">a flame from the city of Sihon. 
+</div><div class="q1">It has devoured Ar of Moab, 
+</div><div class="q2">The owners of the high places of the Arnon. 
+</div><div class="q1">
+<sup>29&#160;</sup>Woe to you, Moab! 
+</div><div class="q2">You are undone, people of Chemosh! 
+</div><div class="q1">He has given his sons as fugitives, 
+</div><div class="q2">and his daughters into captivity, 
+</div><div class="q2">to Sihon king of the Amorites. 
+</div><div class="q1">
+<sup>30&#160;</sup>We have shot at them. 
+</div><div class="q2">Heshbon has perished even to Dibon. 
+</div><div class="q1">We have laid waste even to Nophah, 
+</div><div class="q2">Which reaches to Medeba.” 
+</div><div class="p">
+<sup>31&#160;</sup>Thus Israel lived in the land of the Amorites. 
+<sup>32&#160;</sup>Moses sent to spy out Jazer. They took its villages, and drove out the Amorites who were there. 
+<sup>33&#160;</sup>They turned and went up by the way of Bashan. Og the king of Bashan went out against them, he and all his people, to battle at Edrei. 
+</div><div class="p">
+<sup>34&#160;</sup>Yahweh said to Moses, “Don’t fear him, for I have delivered him into your hand, with all his people, and his land. You shall do to him as you did to Sihon king of the Amorites, who lived at Heshbon.” 
+</div><div class="p">
+<sup>35&#160;</sup>So they struck him, with his sons and all his people, until there were no survivors; and they possessed his land. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>The children of Israel traveled, and encamped in the plains of Moab beyond the Jordan at Jericho. 
+<sup>2&#160;</sup>Balak the son of Zippor saw all that Israel had done to the Amorites. 
+<sup>3&#160;</sup>Moab was very afraid of the people, because they were many. Moab was distressed because of the children of Israel. 
+<sup>4&#160;</sup>Moab said to the elders of Midian, “Now this multitude will lick up all that is around us, as the ox licks up the grass of the field.” 
+</div><div class="p">Balak the son of Zippor was king of Moab at that time. 
+<sup>5&#160;</sup>He sent messengers to Balaam the son of Beor, to Pethor, which is by the River, to the land of the children of his people, to call him, saying, “Behold, there is a people who came out of Egypt. Behold, they cover the surface of the earth, and they are staying opposite me. 
+<sup>6&#160;</sup>Please come now therefore, and curse this people for me; for they are too mighty for me. Perhaps I shall prevail, that we may strike them, and that I may drive them out of the land; for I know that he whom you bless is blessed, and he whom you curse is cursed.” 
+</div><div class="p">
+<sup>7&#160;</sup>The elders of Moab and the elders of Midian departed with the rewards of divination in their hand. They came to Balaam, and spoke to him the words of Balak. 
+</div><div class="p">
+<sup>8&#160;</sup>He said to them, “Lodge here this night, and I will bring you word again, as Yahweh shall speak to me.” The princes of Moab stayed with Balaam. 
+</div><div class="p">
+<sup>9&#160;</sup>Elohim came to Balaam, and said, “Who are these men with you?” 
+</div><div class="p">
+<sup>10&#160;</sup>Balaam said to Elohim, “Balak the son of Zippor, king of Moab, has said to me, 
+<sup>11&#160;</sup>‘Behold, the people that has come out of Egypt covers the surface of the earth. Now, come curse them for me. Perhaps I shall be able to fight against them, and shall drive them out.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Elohim said to Balaam, “You shall not go with them. You shall not curse the people, for they are blessed.” 
+</div><div class="p">
+<sup>13&#160;</sup>Balaam rose up in the morning, and said to the princes of Balak, “Go to your land; for Yahweh refuses to permit me to go with you.” 
+</div><div class="p">
+<sup>14&#160;</sup>The princes of Moab rose up, and they went to Balak, and said, “Balaam refuses to come with us.” 
+</div><div class="p">
+<sup>15&#160;</sup>Balak again sent princes, more, and more honorable than they. 
+<sup>16&#160;</sup>They came to Balaam, and said to him, “Balak the son of Zippor says, ‘Please let nothing hinder you from coming to me, 
+<sup>17&#160;</sup>for I will promote you to very great honor, and whatever you say to me I will do. Please come therefore, and curse this people for me.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Balaam answered the servants of Balak, “If Balak would give me his house full of silver and gold, I can’t go beyond the word of Yahweh my Elohim, to do less or more. 
+<sup>19&#160;</sup>Now therefore please stay here tonight as well, that I may know what else Yahweh will speak to me.” 
+</div><div class="p">
+<sup>20&#160;</sup>Elohim came to Balaam at night, and said to him, “If the men have come to call you, rise up, go with them; but only the word which I speak to you, that you shall do.” 
+</div><div class="p">
+<sup>21&#160;</sup>Balaam rose up in the morning, and saddled his donkey, and went with the princes of Moab. 
+<sup>22&#160;</sup>Elohim’s anger burned because he went; and Yahweh’s angel placed himself in the way as an adversary against him. Now he was riding on his donkey, and his two servants were with him. 
+<sup>23&#160;</sup>The donkey saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and the donkey turned out of the path, and went into the field. Balaam struck the donkey, to turn her into the path. 
+<sup>24&#160;</sup>Then Yahweh’s angel stood in a narrow path between the vineyards, a wall being on this side, and a wall on that side. 
+<sup>25&#160;</sup>The donkey saw Yahweh’s angel, and she thrust herself to the wall, and crushed Balaam’s foot against the wall. He struck her again. 
+</div><div class="p">
+<sup>26&#160;</sup>Yahweh’s angel went further, and stood in a narrow place, where there was no way to turn either to the right hand or to the left. 
+<sup>27&#160;</sup>The donkey saw Yahweh’s angel, and she lay down under Balaam. Balaam’s anger burned, and he struck the donkey with his staff. 
+</div><div class="p">
+<sup>28&#160;</sup>Yahweh opened the mouth of the donkey, and she said to Balaam, “What have I done to you, that you have struck me these three times?” 
+</div><div class="p">
+<sup>29&#160;</sup>Balaam said to the donkey, “Because you have mocked me, I wish there were a sword in my hand, for now I would have killed you.” 
+</div><div class="p">
+<sup>30&#160;</sup>The donkey said to Balaam, “Am I not your donkey, on which you have ridden all your life long until today? Was I ever in the habit of doing so to you?” 
+</div><div class="p">He said, “No.” 
+</div><div class="p">
+<sup>31&#160;</sup>Then Yahweh opened the eyes of Balaam, and he saw Yahweh’s angel standing in the way, with his sword drawn in his hand; and he bowed his head, and fell on his face. 
+<sup>32&#160;</sup>Yahweh’s angel said to him, “Why have you struck your donkey these three times? Behold, I have come out as an adversary, because your way is perverse before me. 
+<sup>33&#160;</sup>The donkey saw me, and turned away before me these three times. Unless she had turned away from me, surely now I would have killed you, and saved her alive.” 
+</div><div class="p">
+<sup>34&#160;</sup>Balaam said to Yahweh’s angel, “I have sinned; for I didn’t know that you stood in the way against me. Now therefore, if it displeases you, I will go back again.” 
+</div><div class="p">
+<sup>35&#160;</sup>Yahweh’s angel said to Balaam, “Go with the men; but you shall only speak the word that I shall speak to you.” 
+</div><div class="p">So Balaam went with the princes of Balak. 
+<sup>36&#160;</sup>When Balak heard that Balaam had come, he went out to meet him to the City of Moab, which is on the border of the Arnon, which is in the utmost part of the border. 
+<sup>37&#160;</sup>Balak said to Balaam, “Didn’t I earnestly send for you to summon you? Why didn’t you come to me? Am I not able indeed to promote you to honor?” 
+</div><div class="p">
+<sup>38&#160;</sup>Balaam said to Balak, “Behold, I have come to you. Have I now any power at all to speak anything? I will speak the word that Elohim puts in my mouth.” 
+</div><div class="p">
+<sup>39&#160;</sup>Balaam went with Balak, and they came to Kiriath Huzoth. 
+<sup>40&#160;</sup>Balak sacrificed cattle and sheep, and sent to Balaam, and to the princes who were with him. 
+<sup>41&#160;</sup>In the morning, Balak took Balaam, and brought him up into the high places of Baal; and he saw from there part of the people. 
+</div><h2 class="chapterlabel" id="23">23</h2>
+<div class="p">
+<sup>1&#160;</sup>Balaam said to Balak, “Build here seven altars for me, and prepare here seven bulls and seven rams for me.” 
+</div><div class="p">
+<sup>2&#160;</sup>Balak did as Balaam had spoken; and Balak and Balaam offered on every altar a bull and a ram. 
+<sup>3&#160;</sup>Balaam said to Balak, “Stand by your burnt offering, and I will go. Perhaps Yahweh will come to meet me. Whatever he shows me I will tell you.” 
+</div><div class="p">He went to a bare height. 
+<sup>4&#160;</sup>Elohim met Balaam, and he said to him, “I have prepared the seven altars, and I have offered up a bull and a ram on every altar.” 
+</div><div class="p">
+<sup>5&#160;</sup>Yahweh put a word in Balaam’s mouth, and said, “Return to Balak, and thus you shall speak.” 
+</div><div class="p">
+<sup>6&#160;</sup>He returned to him, and behold, he was standing by his burnt offering, he, and all the princes of Moab. 
+<sup>7&#160;</sup>He took up his parable, and said, 
+</div><div class="q1">“From Aram has Balak brought me, 
+</div><div class="q2">the king of Moab from the mountains of the East. 
+</div><div class="q1">Come, curse Jacob for me. 
+</div><div class="q2">Come, defy Israel. 
+</div><div class="q1">
+<sup>8&#160;</sup>How shall I curse whom Elohim has not cursed? 
+</div><div class="q2">How shall I defy whom Yahweh has not defied? 
+</div><div class="q1">
+<sup>9&#160;</sup>For from the top of the rocks I see him. 
+</div><div class="q2">From the hills I see him. 
+</div><div class="q1">Behold, it is a people that dwells alone, 
+</div><div class="q2">and shall not be listed among the nations. 
+</div><div class="q1">
+<sup>10&#160;</sup>Who can count the dust of Jacob, 
+</div><div class="q2">or count the fourth part of Israel? 
+</div><div class="q1">Let me die the death of the righteous! 
+</div><div class="q2">Let my last end be like his!” 
+</div><div class="p">
+<sup>11&#160;</sup>Balak said to Balaam, “What have you done to me? I took you to curse my enemies, and behold, you have blessed them altogether.” 
+</div><div class="p">
+<sup>12&#160;</sup>He answered and said, “Must I not take heed to speak that which Yahweh puts in my mouth?” 
+</div><div class="p">
+<sup>13&#160;</sup>Balak said to him, “Please come with me to another place, where you may see them. You shall see just part of them, and shall not see them all. Curse them from there for me.” 
+</div><div class="p">
+<sup>14&#160;</sup>He took him into the field of Zophim, to the top of Pisgah, and built seven altars, and offered up a bull and a ram on every altar. 
+<sup>15&#160;</sup>He said to Balak, “Stand here by your burnt offering, while I meet Elohim over there.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh met Balaam, and put a word in his mouth, and said, “Return to Balak, and say this.” 
+</div><div class="p">
+<sup>17&#160;</sup>He came to him, and behold, he was standing by his burnt offering, and the princes of Moab with him. Balak said to him, “What has Yahweh spoken?” 
+</div><div class="p">
+<sup>18&#160;</sup>He took up his parable, and said, 
+</div><div class="q1">“Rise up, Balak, and hear! 
+</div><div class="q2">Listen to me, you son of Zippor. 
+</div><div class="q1">
+<sup>19&#160;</sup>Elohim is not a man, that he should lie, 
+</div><div class="q2">nor a son of man, that he should repent. 
+</div><div class="q1">Has he said, and he won’t do it? 
+</div><div class="q2">Or has he spoken, and he won’t make it good? 
+</div><div class="q1">
+<sup>20&#160;</sup>Behold, I have received a command to bless. 
+</div><div class="q2">He has blessed, and I can’t reverse it. 
+</div><div class="q1">
+<sup>21&#160;</sup>He has not seen iniquity in Jacob. 
+</div><div class="q2">Neither has he seen perverseness in Israel. 
+</div><div class="q1">Yahweh his Elohim is with him. 
+</div><div class="q2">The shout of a king is among them. 
+</div><div class="q1">
+<sup>22&#160;</sup>Elohim brings them out of Egypt. 
+</div><div class="q2">He has as it were the strength of the wild ox. 
+</div><div class="q1">
+<sup>23&#160;</sup>Surely there is no enchantment with Jacob; 
+</div><div class="q2">neither is there any divination with Israel. 
+</div><div class="q1">Now it shall be said of Jacob and of Israel, 
+</div><div class="q2">‘What has Elohim done!’ 
+</div><div class="q1">
+<sup>24&#160;</sup>Behold, a people rises up as a lioness. 
+</div><div class="q2">As a lion he lifts himself up. 
+</div><div class="q1">He shall not lie down until he eats of the prey, 
+</div><div class="q2">and drinks the blood of the slain.” 
+</div><div class="p">
+<sup>25&#160;</sup>Balak said to Balaam, “Neither curse them at all, nor bless them at all.” 
+</div><div class="p">
+<sup>26&#160;</sup>But Balaam answered Balak, “Didn’t I tell you, saying, ‘All that Yahweh speaks, that I must do’?” 
+</div><div class="p">
+<sup>27&#160;</sup>Balak said to Balaam, “Come now, I will take you to another place; perhaps it will please Elohim that you may curse them for me from there.” 
+</div><div class="p">
+<sup>28&#160;</sup>Balak took Balaam to the top of Peor, that looks down on the desert. 
+<sup>29&#160;</sup>Balaam said to Balak, “Build seven altars for me here, and prepare seven bulls and seven rams for me here.” 
+</div><div class="p">
+<sup>30&#160;</sup>Balak did as Balaam had said, and offered up a bull and a ram on every altar. 
+</div><h2 class="chapterlabel" id="24">24</h2>
+<div class="p">
+<sup>1&#160;</sup>When Balaam saw that it pleased Yahweh to bless Israel, he didn’t go, as at the other times, to use divination, but he set his face toward the wilderness. 
+<sup>2&#160;</sup>Balaam lifted up his eyes, and he saw Israel dwelling according to their tribes; and the Spirit of Elohim came on him. 
+<sup>3&#160;</sup>He took up his parable, and said, 
+</div><div class="q1">“Balaam the son of Beor says, 
+</div><div class="q2">the man whose eyes are open says; 
+</div><div class="q1">
+<sup>4&#160;</sup>he says, who hears the words of Elohim, 
+</div><div class="q2">who sees the vision of the Almighty, 
+</div><div class="q2">falling down, and having his eyes open: 
+</div><div class="q1">
+<sup>5&#160;</sup>How goodly are your tents, Jacob, 
+</div><div class="q2">and your dwellings, Israel! 
+</div><div class="q1">
+<sup>6&#160;</sup>As valleys they are spread out, 
+</div><div class="q2">as gardens by the riverside, 
+</div><div class="q2">as aloes which Yahweh has planted, 
+</div><div class="q2">as cedar trees beside the waters. 
+</div><div class="q1">
+<sup>7&#160;</sup>Water shall flow from his buckets. 
+</div><div class="q2">His seed shall be in many waters. 
+</div><div class="q1">His king shall be higher than Agag. 
+</div><div class="q2">His kingdom shall be exalted. 
+</div><div class="q1">
+<sup>8&#160;</sup>Elohim brings him out of Egypt. 
+</div><div class="q2">He has as it were the strength of the wild ox. 
+</div><div class="q1">He shall consume the nations his adversaries, 
+</div><div class="q2">shall break their bones in pieces, 
+</div><div class="q2">and pierce them with his arrows. 
+</div><div class="q1">
+<sup>9&#160;</sup>He couched, he lay down as a lion, 
+</div><div class="q2">as a lioness; 
+</div><div class="q2">who shall rouse him up? 
+</div><div class="q1">Everyone who blesses you is blessed. 
+</div><div class="q2">Everyone who curses you is cursed.” 
+</div><div class="p">
+<sup>10&#160;</sup>Balak’s anger burned against Balaam, and he struck his hands together. Balak said to Balaam, “I called you to curse my enemies, and, behold, you have altogether blessed them these three times. 
+<sup>11&#160;</sup>Therefore, flee to your place, now! I thought to promote you to great honor; but, behold, Yahweh has kept you back from honor.” 
+</div><div class="p">
+<sup>12&#160;</sup>Balaam said to Balak, “Didn’t I also tell your messengers whom you sent to me, saying, 
+<sup>13&#160;</sup>‘If Balak would give me his house full of silver and gold, I can’t go beyond Yahweh’s word, to do either good or bad from my own mind. I will say what Yahweh says’? 
+<sup>14&#160;</sup>Now, behold, I go to my people. Come, I will inform you what this people shall do to your people in the latter days.” 
+</div><div class="p">
+<sup>15&#160;</sup>He took up his parable, and said, 
+</div><div class="q1">“Balaam the son of Beor says, 
+</div><div class="q2">the man whose eyes are open says; 
+</div><div class="q2">
+<sup>16&#160;</sup>he says, who hears the words of Elohim, 
+</div><div class="q2">knows the knowledge of the Most High, 
+</div><div class="q2">and who sees the vision of the Almighty, 
+</div><div class="q2">falling down, and having his eyes open: 
+</div><div class="q1">
+<sup>17&#160;</sup>I see him, but not now. 
+</div><div class="q2">I see him, but not near. 
+</div><div class="q1">A star will come out of Jacob. 
+</div><div class="q2">A scepter will rise out of Israel, 
+</div><div class="q1">and shall strike through the corners of Moab, 
+</div><div class="q2">and crush all the sons of Sheth. 
+</div><div class="q1">
+<sup>18&#160;</sup>Edom shall be a possession. 
+</div><div class="q2">Seir, his enemy, also shall be a possession, 
+</div><div class="q2">while Israel does valiantly. 
+</div><div class="q1">
+<sup>19&#160;</sup>Out of Jacob shall one have dominion, 
+</div><div class="q2">and shall destroy the remnant from the city.” 
+</div><div class="p">
+<sup>20&#160;</sup>He looked at Amalek, and took up his parable, and said, 
+</div><div class="q1">“Amalek was the first of the nations, 
+</div><div class="q2">but his latter end shall come to destruction.” 
+</div><div class="p">
+<sup>21&#160;</sup>He looked at the Kenite, and took up his parable, and said, 
+</div><div class="q1">“Your dwelling place is strong. 
+</div><div class="q2">Your nest is set in the rock. 
+</div><div class="q1">
+<sup>22&#160;</sup>Nevertheless Kain shall be wasted, 
+</div><div class="q2">until Asshur carries you away captive.” 
+</div><div class="p">
+<sup>23&#160;</sup>He took up his parable, and said, 
+</div><div class="q1">“Alas, who shall live when Elohim does this? 
+</div><div class="q2">
+<sup>24&#160;</sup>But ships shall come from the coast of Kittim. 
+</div><div class="q1">They shall afflict Asshur, and shall afflict Eber. 
+</div><div class="q2">He also shall come to destruction.” 
+</div><div class="p">
+<sup>25&#160;</sup>Balaam rose up, and went and returned to his place; and Balak also went his way. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>Israel stayed in Shittim; and the people began to play the prostitute with the daughters of Moab; 
+<sup>2&#160;</sup>for they called the people to the sacrifices of their elohims. The people ate and bowed down to their elohims. 
+<sup>3&#160;</sup>Israel joined himself to Baal Peor, and Yahweh’s anger burned against Israel. 
+<sup>4&#160;</sup>Yahweh said to Moses, “Take all the chiefs of the people, and hang them up to Yahweh before the sun, that the fierce anger of Yahweh may turn away from Israel.” 
+</div><div class="p">
+<sup>5&#160;</sup>Moses said to the judges of Israel, “Everyone kill his men who have joined themselves to Baal Peor.” 
+</div><div class="p">
+<sup>6&#160;</sup>Behold, one of the children of Israel came and brought to his brothers a Midianite woman in the sight of Moses, and in the sight of all the congregation of the children of Israel, while they were weeping at the door of the Tent of Meeting. 
+<sup>7&#160;</sup>When Phinehas, the son of Eleazar, the son of Aaron the priest, saw it, he rose up from the middle of the congregation, and took a spear in his hand. 
+<sup>8&#160;</sup>He went after the man of Israel into the pavilion, and thrust both of them through, the man of Israel, and the woman through her body. So the plague was stopped among the children of Israel. 
+<sup>9&#160;</sup>Those who died by the plague were twenty-four thousand. 
+</div><div class="p">
+<sup>10&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>11&#160;</sup>“Phinehas, the son of Eleazar, the son of Aaron the priest, has turned my wrath away from the children of Israel, in that he was jealous with my jealousy among them, so that I didn’t consume the children of Israel in my jealousy. 
+<sup>12&#160;</sup>Therefore say, ‘Behold, I give to him my covenant of peace. 
+<sup>13&#160;</sup>It shall be to him, and to his offspring after him, the covenant of an everlasting priesthood, because he was jealous for his Elohim, and made atonement for the children of Israel.’&#160;” 
+</div><div class="p">
+<sup>14&#160;</sup>Now the name of the man of Israel that was slain, who was slain with the Midianite woman, was Zimri, the son of Salu, a prince of a fathers’ house among the Simeonites. 
+<sup>15&#160;</sup>The name of the Midianite woman who was slain was Cozbi, the daughter of Zur. He was head of the people of a fathers’ house in Midian. 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>17&#160;</sup>“Harass the Midianites, and strike them; 
+<sup>18&#160;</sup>for they harassed you with their wiles, wherein they have deceived you in the matter of Peor, and in the incident regarding Cozbi, the daughter of the prince of Midian, their sister, who was slain on the day of the plague in the matter of Peor.” 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="p">
+<sup>1&#160;</sup>After the plague, Yahweh spoke to Moses and to Eleazar the son of Aaron the priest, saying, 
+<sup>2&#160;</sup>“Take a census of all the congregation of the children of Israel, from twenty years old and upward, by their fathers’ houses, all who are able to go out to war in Israel.” 
+<sup>3&#160;</sup>Moses and Eleazar the priest spoke with them in the plains of Moab by the Jordan at Jericho, saying, 
+<sup>4&#160;</sup>“Take a census, from twenty years old and upward, as Yahweh commanded Moses and the children of Israel.” 
+</div><div class="p">These are those who came out of the land of Egypt. 
+<sup>5&#160;</sup>Reuben, the firstborn of Israel; the sons of Reuben: of Hanoch, the family of the Hanochites; of Pallu, the family of the Palluites; 
+<sup>6&#160;</sup>of Hezron, the family of the Hezronites; of Carmi, the family of the Carmites. 
+<sup>7&#160;</sup>These are the families of the Reubenites; and those who were counted of them were forty-three thousand seven hundred thirty. 
+<sup>8&#160;</sup>The son of Pallu: Eliab. 
+<sup>9&#160;</sup>The sons of Eliab: Nemuel, Dathan, and Abiram. These are that Dathan and Abiram who were called by the congregation, who rebelled against Moses and against Aaron in the company of Korah when they rebelled against Yahweh; 
+<sup>10&#160;</sup>and the earth opened its mouth, and swallowed them up together with Korah when that company died; at the time the fire devoured two hundred fifty men, and they became a sign. 
+<sup>11&#160;</sup>Notwithstanding, the sons of Korah didn’t die. 
+<sup>12&#160;</sup>The sons of Simeon after their families: of Nemuel, the family of the Nemuelites; of Jamin, the family of the Jaminites; of Jachin, the family of the Jachinites; 
+<sup>13&#160;</sup>of Zerah, the family of the Zerahites; of Shaul, the family of the Shaulites. 
+<sup>14&#160;</sup>These are the families of the Simeonites, twenty-two thousand two hundred. 
+<sup>15&#160;</sup>The sons of Gad after their families: of Zephon, the family of the Zephonites; of Haggi, the family of the Haggites; of Shuni, the family of the Shunites; 
+<sup>16&#160;</sup>of Ozni, the family of the Oznites; of Eri, the family of the Erites; 
+<sup>17&#160;</sup>of Arod, the family of the Arodites; of Areli, the family of the Arelites. 
+<sup>18&#160;</sup>These are the families of the sons of Gad according to those who were counted of them, forty thousand and five hundred. 
+<sup>19&#160;</sup>The sons of Judah: Er and Onan. Er and Onan died in the land of Canaan. 
+<sup>20&#160;</sup>The sons of Judah after their families were: of Shelah, the family of the Shelanites; of Perez, the family of the Perezites; of Zerah, the family of the Zerahites. 
+<sup>21&#160;</sup>The sons of Perez were: of Hezron, the family of the Hezronites; of Hamul, the family of the Hamulites. 
+<sup>22&#160;</sup>These are the families of Judah according to those who were counted of them, seventy-six thousand five hundred. 
+<sup>23&#160;</sup>The sons of Issachar after their families: of Tola, the family of the Tolaites; of Puvah, the family of the Punites; 
+<sup>24&#160;</sup>of Jashub, the family of the Jashubites; of Shimron, the family of the Shimronites. 
+<sup>25&#160;</sup>These are the families of Issachar according to those who were counted of them, sixty-four thousand three hundred. 
+<sup>26&#160;</sup>The sons of Zebulun after their families: of Sered, the family of the Seredites; of Elon, the family of the Elonites; of Jahleel, the family of the Jahleelites. 
+<sup>27&#160;</sup>These are the families of the Zebulunites according to those who were counted of them, sixty thousand five hundred. 
+<sup>28&#160;</sup>The sons of Joseph after their families: Manasseh and Ephraim. 
+<sup>29&#160;</sup>The sons of Manasseh: of Machir, the family of the Machirites; and Machir brought forth Gilead; of Gilead, the family of the Gileadites. 
+<sup>30&#160;</sup>These are the sons of Gilead: of Iezer, the family of the Iezerites; of Helek, the family of the Helekites; 
+<sup>31&#160;</sup>and Asriel, the family of the Asrielites; and Shechem, the family of the Shechemites; 
+<sup>32&#160;</sup>and Shemida, the family of the Shemidaites; and Hepher, the family of the Hepherites. 
+<sup>33&#160;</sup>Zelophehad the son of Hepher had no sons, but daughters: and the names of the daughters of Zelophehad were Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
+<sup>34&#160;</sup>These are the families of Manasseh. Those who were counted of them were fifty-two thousand seven hundred. 
+<sup>35&#160;</sup>These are the sons of Ephraim after their families: of Shuthelah, the family of the Shuthelahites; of Becher, the family of the Becherites; of Tahan, the family of the Tahanites. 
+<sup>36&#160;</sup>These are the sons of Shuthelah: of Eran, the family of the Eranites. 
+<sup>37&#160;</sup>These are the families of the sons of Ephraim according to those who were counted of them, thirty-two thousand five hundred. These are the sons of Joseph after their families. 
+<sup>38&#160;</sup>The sons of Benjamin after their families: of Bela, the family of the Belaites; of Ashbel, the family of the Ashbelites; of Ahiram, the family of the Ahiramites; 
+<sup>39&#160;</sup>of Shephupham, the family of the Shuphamites; of Hupham, the family of the Huphamites. 
+<sup>40&#160;</sup>The sons of Bela were Ard and Naaman: the family of the Ardites; and of Naaman, the family of the Naamites. 
+<sup>41&#160;</sup>These are the sons of Benjamin after their families; and those who were counted of them were forty-five thousand six hundred. 
+<sup>42&#160;</sup>These are the sons of Dan after their families: of Shuham, the family of the Shuhamites. These are the families of Dan after their families. 
+<sup>43&#160;</sup>All the families of the Shuhamites, according to those who were counted of them, were sixty-four thousand four hundred. 
+<sup>44&#160;</sup>The sons of Asher after their families: of Imnah, the family of the Imnites; of Ishvi, the family of the Ishvites; of Beriah, the family of the Berites. 
+<sup>45&#160;</sup>Of the sons of Beriah: of Heber, the family of the Heberites; of Malchiel, the family of the Malchielites. 
+<sup>46&#160;</sup>The name of the daughter of Asher was Serah. 
+<sup>47&#160;</sup>These are the families of the sons of Asher according to those who were counted of them, fifty-three thousand four hundred. 
+<sup>48&#160;</sup>The sons of Naphtali after their families: of Jahzeel, the family of the Jahzeelites; of Guni, the family of the Gunites; 
+<sup>49&#160;</sup>of Jezer, the family of the Jezerites; of Shillem, the family of the Shillemites. 
+<sup>50&#160;</sup>These are the families of Naphtali according to their families; and those who were counted of them were forty-five thousand four hundred. 
+<sup>51&#160;</sup>These are those who were counted of the children of Israel, six hundred one thousand seven hundred thirty. 
+</div><div class="p">
+<sup>52&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>53&#160;</sup>“To these the land shall be divided for an inheritance according to the number of names. 
+<sup>54&#160;</sup>To the more you shall give the more inheritance, and to the fewer you shall give the less inheritance. To everyone according to those who were counted of him shall his inheritance be given. 
+<sup>55&#160;</sup>Notwithstanding, the land shall be divided by lot. According to the names of the tribes of their fathers they shall inherit. 
+<sup>56&#160;</sup>According to the lot shall their inheritance be divided between the more and the fewer.” 
+</div><div class="p">
+<sup>57&#160;</sup>These are those who were counted of the Levites after their families: of Gershon, the family of the Gershonites; of Kohath, the family of the Kohathites; of Merari, the family of the Merarites. 
+<sup>58&#160;</sup>These are the families of Levi: the family of the Libnites, the family of the Hebronites, the family of the Mahlites, the family of the Mushites, and the family of the Korahites. Kohath brought forth Amram. 
+<sup>59&#160;</sup>The name of Amram’s woman was Jochebed, the daughter of Levi, who was born to Levi in Egypt. She bore to Amram Aaron and Moses, and Miriam their sister. 
+<sup>60&#160;</sup>To Aaron were born Nadab and Abihu, Eleazar and Ithamar. 
+<sup>61&#160;</sup>Nadab and Abihu died when they offered strange fire before Yahweh. 
+<sup>62&#160;</sup>Those who were counted of them were twenty-three thousand, every male from a month old and upward; for they were not counted among the children of Israel, because there was no inheritance given them among the children of Israel. 
+<sup>63&#160;</sup>These are those who were counted by Moses and Eleazar the priest, who counted the children of Israel in the plains of Moab by the Jordan at Jericho. 
+<sup>64&#160;</sup>But among these there was not a man of them who were counted by Moses and Aaron the priest, who counted the children of Israel in the wilderness of Sinai. 
+<sup>65&#160;</sup>For Yahweh had said of them, “They shall surely die in the wilderness.” There was not a man left of them, except Caleb the son of Jephunneh, and Joshua the son of Nun. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="p">
+<sup>1&#160;</sup>Then the daughters of Zelophehad, the son of Hepher, the son of Gilead, the son of Machir, the son of Manasseh, of the families of Manasseh the son of Joseph came near. These are the names of his daughters: Mahlah, Noah, Hoglah, Milcah, and Tirzah. 
+<sup>2&#160;</sup>They stood before Moses, before Eleazar the priest, and before the princes and all the congregation, at the door of the Tent of Meeting, saying, 
+<sup>3&#160;</sup>“Our father died in the wilderness. He was not among the company of those who gathered themselves together against Yahweh in the company of Korah, but he died in his own sin. He had no sons. 
+<sup>4&#160;</sup>Why should the name of our father be taken away from among his family, because he had no son? Give to us a possession among the brothers of our father.” 
+</div><div class="p">
+<sup>5&#160;</sup>Moses brought their cause before Yahweh. 
+<sup>6&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>7&#160;</sup>“The daughters of Zelophehad speak right. You shall surely give them a possession of an inheritance among their father’s brothers. You shall cause the inheritance of their father to pass to them. 
+<sup>8&#160;</sup>You shall speak to the children of Israel, saying, ‘If a man dies, and has no son, then you shall cause his inheritance to pass to his daughter. 
+<sup>9&#160;</sup>If he has no daughter, then you shall give his inheritance to his brothers. 
+<sup>10&#160;</sup>If he has no brothers, then you shall give his inheritance to his father’s brothers. 
+<sup>11&#160;</sup>If his father has no brothers, then you shall give his inheritance to his kinsman who is next to him of his family, and he shall possess it. This shall be a statute and ordinance for the children of Israel, as Yahweh commanded Moses.’&#160;” 
+</div><div class="p">
+<sup>12&#160;</sup>Yahweh said to Moses, “Go up into this mountain of Abarim, and see the land which I have given to the children of Israel. 
+<sup>13&#160;</sup>When you have seen it, you also shall be gathered to your people, as Aaron your brother was gathered; 
+<sup>14&#160;</sup>because in the strife of the congregation, you rebelled against my word in the wilderness of Zin, to honor me as set-apart at the waters before their eyes.” (These are the waters of Meribah of Kadesh in the wilderness of Zin.) 
+</div><div class="p">
+<sup>15&#160;</sup>Moses spoke to Yahweh, saying, 
+<sup>16&#160;</sup>“Let Yahweh, the Elohim of the spirits of all flesh, appoint a man over the congregation, 
+<sup>17&#160;</sup>who may go out before them, and who may come in before them, and who may lead them out, and who may bring them in, that the congregation of Yahweh may not be as sheep which have no shepherd.” 
+</div><div class="p">
+<sup>18&#160;</sup>Yahweh said to Moses, “Take Joshua the son of Nun, a man in whom is the Spirit, and lay your hand on him. 
+<sup>19&#160;</sup>Set him before Eleazar the priest, and before all the congregation; and commission him in their sight. 
+<sup>20&#160;</sup>You shall give authority to him, that all the congregation of the children of Israel may obey. 
+<sup>21&#160;</sup>He shall stand before Eleazar the priest, who shall inquire for him by the judgment of the Urim before Yahweh. At his word they shall go out, and at his word they shall come in, both he and all the children of Israel with him, even all the congregation.” 
+</div><div class="p">
+<sup>22&#160;</sup>Moses did as Yahweh commanded him. He took Joshua, and set him before Eleazar the priest and before all the congregation. 
+<sup>23&#160;</sup>He laid his hands on him and commissioned him, as Yahweh spoke by Moses. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Command the children of Israel, and tell them, ‘See that you present my offering, my food for my offerings made by fire, as a pleasant aroma to me, in their due season.’ 
+<sup>3&#160;</sup>You shall tell them, ‘This is the offering made by fire which you shall offer to Yahweh: male lambs a year old without defect, two day by day, for a continual burnt offering. 
+<sup>4&#160;</sup>You shall offer the one lamb in the morning, and you shall offer the other lamb at evening, 
+<sup>5&#160;</sup>with one tenth of an ephah of beaten oil. 
+<sup>6&#160;</sup>It is a continual burnt offering which was ordained in Mount Sinai for a pleasant aroma, an offering made by fire to Yahweh. 
+<sup>7&#160;</sup>Its drink offering shall be the fourth part of a hin for each lamb. You shall pour out a drink offering of strong drink to Yahweh in the set-apart place. 
+<sup>8&#160;</sup>The other lamb you shall offer at evening. As the meal offering of the morning, and as its drink offering, you shall offer it, an offering made by fire, for a pleasant aroma to Yahweh. 
+</div><div class="p">
+<sup>9&#160;</sup>“&#160;‘On the Sabbath day, you shall offer two male lambs a year old without defect, and two tenths of an ephah of fine flour for a meal offering mixed with oil, and its drink offering: 
+<sup>10&#160;</sup>this is the burnt offering of every Sabbath, in addition to the continual burnt offering and its drink offering. 
+</div><div class="p">
+<sup>11&#160;</sup>“&#160;‘In the beginnings of your months, you shall offer a burnt offering to Yahweh: two young bulls, one ram, seven male lambs a year old without defect, 
+<sup>12&#160;</sup>and three tenths of an ephah of fine flour for a meal offering mixed with oil, for each bull; and two tenth parts of fine flour for a meal offering mixed with oil, for the one ram; 
+<sup>13&#160;</sup>and one tenth part of fine flour mixed with oil for a meal offering to every lamb, as a burnt offering of a pleasant aroma, an offering made by fire to Yahweh. 
+<sup>14&#160;</sup>Their drink offerings shall be half a hin of wine for a bull, the third part of a hin for the ram, and the fourth part of a hin for a lamb. This is the burnt offering of every month throughout the months of the year. 
+<sup>15&#160;</sup>Also, one male goat for a sin offering to Yahweh shall be offered in addition to the continual burnt offering and its drink offering. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘In the first month, on the fourteenth day of the month, is Yahweh’s Passover. 
+<sup>17&#160;</sup>On the fifteenth day of this month shall be a feast. Unleavened bread shall be eaten for seven days. 
+<sup>18&#160;</sup>In the first day shall be a set-apart convocation. You shall do no regular work, 
+<sup>19&#160;</sup>but you shall offer an offering made by fire, a burnt offering to Yahweh: two young bulls, one ram, and seven male lambs a year old. They shall be without defect, 
+<sup>20&#160;</sup>with their meal offering, fine flour mixed with oil. You shall offer three tenths for a bull, and two tenths for the ram. 
+<sup>21&#160;</sup>You shall offer one tenth for every lamb of the seven lambs; 
+<sup>22&#160;</sup>and one male goat for a sin offering, to make atonement for you. 
+<sup>23&#160;</sup>You shall offer these in addition to the burnt offering of the morning, which is for a continual burnt offering. 
+<sup>24&#160;</sup>In this way you shall offer daily, for seven days, the food of the offering made by fire, of a pleasant aroma to Yahweh. It shall be offered in addition to the continual burnt offering and its drink offering. 
+<sup>25&#160;</sup>On the seventh day you shall have a set-apart convocation. You shall do no regular work. 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘Also in the day of the first fruits, when you offer a new meal offering to Yahweh in your feast of weeks, you shall have a set-apart convocation. You shall do no regular work; 
+<sup>27&#160;</sup>but you shall offer a burnt offering for a pleasant aroma to Yahweh: two young bulls, one ram, seven male lambs a year old; 
+<sup>28&#160;</sup>and their meal offering, fine flour mixed with oil, three tenths for each bull, two tenths for the one ram, 
+<sup>29&#160;</sup>one tenth for every lamb of the seven lambs; 
+<sup>30&#160;</sup>and one male goat, to make atonement for you. 
+<sup>31&#160;</sup>Besides the continual burnt offering and its meal offering, you shall offer them and their drink offerings. See that they are without defect. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="p">
+<sup>1&#160;</sup>“&#160;‘In the seventh month, on the first day of the month, you shall have a set-apart convocation; you shall do no regular work. It is a day of blowing of trumpets to you. 
+<sup>2&#160;</sup>You shall offer a burnt offering for a pleasant aroma to Yahweh: one young bull, one ram, seven male lambs a year old without defect; 
+<sup>3&#160;</sup>and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the ram, 
+<sup>4&#160;</sup>and one tenth for every lamb of the seven lambs; 
+<sup>5&#160;</sup>and one male goat for a sin offering, to make atonement for you; 
+<sup>6&#160;</sup>in addition to the burnt offering of the new moon with its meal offering, and the continual burnt offering with its meal offering, and their drink offerings, according to their ordinance, for a pleasant aroma, an offering made by fire to Yahweh. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘On the tenth day of this seventh month you shall have a set-apart convocation. You shall afflict your souls. You shall do no kind of work; 
+<sup>8&#160;</sup>but you shall offer a burnt offering to Yahweh for a pleasant aroma: one young bull, one ram, seven male lambs a year old, all without defect; 
+<sup>9&#160;</sup>and their meal offering, fine flour mixed with oil: three tenths for the bull, two tenths for the one ram, 
+<sup>10&#160;</sup>one tenth for every lamb of the seven lambs; 
+<sup>11&#160;</sup>one male goat for a sin offering, in addition to the sin offering of atonement, and the continual burnt offering, and its meal offering, and their drink offerings. 
+</div><div class="p">
+<sup>12&#160;</sup>“&#160;‘On the fifteenth day of the seventh month you shall have a set-apart convocation. You shall do no regular work. You shall keep a feast to Yahweh seven days. 
+<sup>13&#160;</sup>You shall offer a burnt offering, an offering made by fire, of a pleasant aroma to Yahweh: thirteen young bulls, two rams, fourteen male lambs a year old, all without defect; 
+<sup>14&#160;</sup>and their meal offering, fine flour mixed with oil: three tenths for every bull of the thirteen bulls, two tenths for each ram of the two rams, 
+<sup>15&#160;</sup>and one tenth for every lamb of the fourteen lambs; 
+<sup>16&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, its meal offering, and its drink offering. 
+</div><div class="p">
+<sup>17&#160;</sup>“&#160;‘On the second day you shall offer twelve young bulls, two rams, and fourteen male lambs a year old without defect; 
+<sup>18&#160;</sup>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance; 
+<sup>19&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, with its meal offering and their drink offerings. 
+</div><div class="p">
+<sup>20&#160;</sup>“&#160;‘On the third day: eleven bulls, two rams, fourteen male lambs a year old without defect; 
+<sup>21&#160;</sup>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance; 
+<sup>22&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, and its meal offering, and its drink offering. 
+</div><div class="p">
+<sup>23&#160;</sup>“&#160;‘On the fourth day ten bulls, two rams, fourteen male lambs a year old without defect; 
+<sup>24&#160;</sup>their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance; 
+<sup>25&#160;</sup>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and its drink offering. 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘On the fifth day: nine bulls, two rams, fourteen male lambs a year old without defect; 
+<sup>27&#160;</sup>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance, 
+<sup>28&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, and its meal offering, and its drink offering. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘On the sixth day: eight bulls, two rams, fourteen male lambs a year old without defect; 
+<sup>30&#160;</sup>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance, 
+<sup>31&#160;</sup>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and the drink offerings of it. 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘On the seventh day: seven bulls, two rams, fourteen male lambs a year old without defect; 
+<sup>33&#160;</sup>and their meal offering and their drink offerings for the bulls, for the rams, and for the lambs, according to their number, after the ordinance, 
+<sup>34&#160;</sup>and one male goat for a sin offering; in addition to the continual burnt offering, its meal offering, and its drink offering. 
+</div><div class="p">
+<sup>35&#160;</sup>“&#160;‘On the eighth day you shall have a solemn assembly. You shall do no regular work; 
+<sup>36&#160;</sup>but you shall offer a burnt offering, an offering made by fire, a pleasant aroma to Yahweh: one bull, one ram, seven male lambs a year old without defect; 
+<sup>37&#160;</sup>their meal offering and their drink offerings for the bull, for the ram, and for the lambs, shall be according to their number, after the ordinance, 
+<sup>38&#160;</sup>and one male goat for a sin offering, in addition to the continual burnt offering, with its meal offering, and its drink offering. 
+</div><div class="p">
+<sup>39&#160;</sup>“&#160;‘You shall offer these to Yahweh in your set feasts—in addition to your vows and your free will offerings—for your burnt offerings, your meal offerings, your drink offerings, and your peace offerings.’&#160;” 
+</div><div class="p">
+<sup>40&#160;</sup>Moses told the children of Israel according to all that Yahweh commanded Moses. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>Moses spoke to the heads of the tribes of the children of Israel, saying, “This is the thing which Yahweh has commanded. 
+<sup>2&#160;</sup>When a man vows a vow to Yahweh, or swears an oath to bind his soul with a bond, he shall not break his word. He shall do according to all that proceeds out of his mouth. 
+</div><div class="p">
+<sup>3&#160;</sup>“Also, when a woman vows a vow to Yahweh and binds herself by a pledge, being in her father’s house, in her youth, 
+<sup>4&#160;</sup>and her father hears her vow and her pledge with which she has bound her soul, and her father says nothing to her, then all her vows shall stand, and every pledge with which she has bound her soul shall stand. 
+<sup>5&#160;</sup>But if her father forbids her in the day that he hears, none of her vows or of her pledges with which she has bound her soul, shall stand. Yahweh will forgive her, because her father has forbidden her. 
+</div><div class="p">
+<sup>6&#160;</sup>“If she has a man, while her vows are on her, or the rash utterance of her lips with which she has bound her soul, 
+<sup>7&#160;</sup>and her man hears it, and says nothing to her in the day that he hears it; then her vows shall stand, and her pledges with which she has bound her soul shall stand. 
+<sup>8&#160;</sup>But if her man forbids her in the day that he hears it, then he makes void her vow which is on her and the rash utterance of her lips, with which she has bound her soul. Yahweh will forgive her. 
+</div><div class="p">
+<sup>9&#160;</sup>“But the vow of a widow, or of her who is divorced, everything with which she has bound her soul shall stand against her. 
+</div><div class="p">
+<sup>10&#160;</sup>“If she vowed in her man’s house or bound her soul by a bond with an oath, 
+<sup>11&#160;</sup>and her man heard it, and held his peace at her and didn’t disallow her, then all her vows shall stand, and every pledge with which she bound her soul shall stand. 
+<sup>12&#160;</sup>But if her man made them null and void in the day that he heard them, then whatever proceeded out of her lips concerning her vows, or concerning the bond of her soul, shall not stand. Her man has made them void. Yahweh will forgive her. 
+<sup>13&#160;</sup>Every vow, and every binding oath to afflict the soul, her man may establish it, or her man may make it void. 
+<sup>14&#160;</sup>But if her man says nothing to her from day to day, then he establishes all her vows or all her pledges which are on her. He has established them, because he said nothing to her in the day that he heard them. 
+<sup>15&#160;</sup>But if he makes them null and void after he has heard them, then he shall bear her iniquity.” 
+</div><div class="p">
+<sup>16&#160;</sup>These are the statutes which Yahweh commanded Moses, between a man and his woman, between a father and his daughter, being in her youth, in her father’s house. 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Avenge the children of Israel on the Midianites. Afterward you shall be gathered to your people.” 
+</div><div class="p">
+<sup>3&#160;</sup>Moses spoke to the people, saying, “Arm men from among you for war, that they may go against Midian, to execute Yahweh’s vengeance on Midian. 
+<sup>4&#160;</sup>You shall send one thousand out of every tribe, throughout all the tribes of Israel, to the war.” 
+<sup>5&#160;</sup>So there were delivered, out of the thousands of Israel, a thousand from every tribe, twelve thousand armed for war. 
+<sup>6&#160;</sup>Moses sent them, one thousand of every tribe, to the war with Phinehas the son of Eleazar the priest, to the war, with the vessels of the sanctuary and the trumpets for the alarm in his hand. 
+<sup>7&#160;</sup>They fought against Midian, as Yahweh commanded Moses. They killed every male. 
+<sup>8&#160;</sup>They killed the kings of Midian with the rest of their slain: Evi, Rekem, Zur, Hur, and Reba, the five kings of Midian. They also killed Balaam the son of Beor with the sword. 
+<sup>9&#160;</sup>The children of Israel took the women of Midian captive with their little ones; and all their livestock, all their flocks, and all their goods, they took as plunder. 
+<sup>10&#160;</sup>All their cities in the places in which they lived, and all their encampments, they burned with fire. 
+<sup>11&#160;</sup>They took all the captives, and all the plunder, both of man and of animal. 
+<sup>12&#160;</sup>They brought the captives with the prey and the plunder, to Moses, and to Eleazar the priest, and to the congregation of the children of Israel, to the camp at the plains of Moab, which are by the Jordan at Jericho. 
+<sup>13&#160;</sup>Moses and Eleazar the priest, with all the princes of the congregation, went out to meet them outside of the camp. 
+<sup>14&#160;</sup>Moses was angry with the officers of the army, the captains of thousands and the captains of hundreds, who came from the service of the war. 
+<sup>15&#160;</sup>Moses said to them, “Have you saved all the women alive? 
+<sup>16&#160;</sup>Behold, these caused the children of Israel, through the counsel of Balaam, to commit trespass against Yahweh in the matter of Peor, and so the plague was among the congregation of Yahweh. 
+<sup>17&#160;</sup>Now therefore kill every male among the little ones, and kill every woman who has known man by lying with him. 
+<sup>18&#160;</sup>But all the girls, who have not known man by lying with him, keep alive for yourselves. 
+</div><div class="p">
+<sup>19&#160;</sup>“Encamp outside of the camp for seven days. Whoever has killed any person, and whoever has touched any slain, purify yourselves on the third day and on the seventh day, you and your captives. 
+<sup>20&#160;</sup>You shall purify every garment, and all that is made of skin, and all work of goats’ hair, and all things made of wood.” 
+</div><div class="p">
+<sup>21&#160;</sup>Eleazar the priest said to the men of war who went to the battle, “This is the statute of the law which Yahweh has commanded Moses. 
+<sup>22&#160;</sup>However the gold, and the silver, the bronze, the iron, the tin, and the lead, 
+<sup>23&#160;</sup>everything that may withstand the fire, you shall make to go through the fire, and it shall be clean; nevertheless it shall be purified with the water for impurity. All that doesn’t withstand the fire you shall make to go through the water. 
+<sup>24&#160;</sup>You shall wash your clothes on the seventh day, and you shall be clean. Afterward you shall come into the camp.” 
+</div><div class="p">
+<sup>25&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>26&#160;</sup>“Count the plunder that was taken, both of man and of animal, you, and Eleazar the priest, and the heads of the fathers’ households of the congregation; 
+<sup>27&#160;</sup>and divide the plunder into two parts: between the men skilled in war, who went out to battle, and all the congregation. 
+<sup>28&#160;</sup>Levy a tribute to Yahweh of the men of war who went out to battle: one soul of five hundred; of the persons, of the cattle, of the donkeys, and of the flocks. 
+<sup>29&#160;</sup>Take it from their half, and give it to Eleazar the priest, for Yahweh’s wave offering. 
+<sup>30&#160;</sup>Of the children of Israel’s half, you shall take one drawn out of every fifty, of the persons, of the cattle, of the donkeys, and of the flocks, of all the livestock, and give them to the Levites, who perform the duty of Yahweh’s tabernacle.” 
+</div><div class="p">
+<sup>31&#160;</sup>Moses and Eleazar the priest did as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>32&#160;</sup>Now the plunder, over and above the booty which the men of war took, was six hundred seventy-five thousand sheep, 
+<sup>33&#160;</sup>seventy-two thousand head of cattle, 
+<sup>34&#160;</sup>sixty-one thousand donkeys, 
+<sup>35&#160;</sup>and thirty-two thousand persons in all, of the women who had not known man by lying with him. 
+<sup>36&#160;</sup>The half, which was the portion of those who went out to war, was in number three hundred thirty-seven thousand five hundred sheep; 
+<sup>37&#160;</sup>and Yahweh’s tribute of the sheep was six hundred seventy-five. 
+<sup>38&#160;</sup>The cattle were thirty-six thousand, of which Yahweh’s tribute was seventy-two. 
+<sup>39&#160;</sup>The donkeys were thirty thousand five hundred, of which Yahweh’s tribute was sixty-one. 
+<sup>40&#160;</sup>The persons were sixteen thousand, of whom Yahweh’s tribute was thirty-two persons. 
+<sup>41&#160;</sup>Moses gave the tribute, which was Yahweh’s wave offering, to Eleazar the priest, as Yahweh commanded Moses. 
+<sup>42&#160;</sup>Of the children of Israel’s half, which Moses divided off from the men who fought 
+<sup>43&#160;</sup>(now the congregation’s half was three hundred thirty-seven thousand five hundred sheep, 
+<sup>44&#160;</sup>thirty-six thousand head of cattle, 
+<sup>45&#160;</sup>thirty thousand five hundred donkeys, 
+<sup>46&#160;</sup>and sixteen thousand persons), 
+<sup>47&#160;</sup>even of the children of Israel’s half, Moses took one drawn out of every fifty, both of man and of animal, and gave them to the Levites, who performed the duty of Yahweh’s tabernacle, as Yahweh commanded Moses. 
+</div><div class="p">
+<sup>48&#160;</sup>The officers who were over the thousands of the army, the captains of thousands, and the captains of hundreds, came near to Moses. 
+<sup>49&#160;</sup>They said to Moses, “Your servants have taken the sum of the men of war who are under our command, and there lacks not one man of us. 
+<sup>50&#160;</sup>We have brought Yahweh’s offering, what every man found: gold ornaments, armlets, bracelets, signet rings, earrings, and necklaces, to make atonement for our souls before Yahweh.” 
+</div><div class="p">
+<sup>51&#160;</sup>Moses and Eleazar the priest took their gold, even all worked jewels. 
+<sup>52&#160;</sup>All the gold of the wave offering that they offered up to Yahweh, of the captains of thousands, and of the captains of hundreds, was sixteen thousand seven hundred fifty shekels. 
+<sup>53&#160;</sup>The men of war had taken booty, every man for himself. 
+<sup>54&#160;</sup>Moses and Eleazar the priest took the gold of the captains of thousands and of hundreds, and brought it into the Tent of Meeting for a memorial for the children of Israel before Yahweh. 
+</div><h2 class="chapterlabel" id="32">32</h2>
+<div class="p">
+<sup>1&#160;</sup>Now the children of Reuben and the children of Gad had a very great multitude of livestock. They saw the land of Jazer, and the land of Gilead. Behold, the place was a place for livestock. 
+<sup>2&#160;</sup>Then the children of Gad and the children of Reuben came and spoke to Moses, and to Eleazar the priest, and to the princes of the congregation, saying, 
+<sup>3&#160;</sup>“Ataroth, Dibon, Jazer, Nimrah, Heshbon, Elealeh, Sebam, Nebo, and Beon, 
+<sup>4&#160;</sup>the land which Yahweh struck before the congregation of Israel, is a land for livestock; and your servants have livestock.” 
+<sup>5&#160;</sup>They said, “If we have found favor in your sight, let this land be given to your servants for a possession. Don’t bring us over the Jordan.” 
+</div><div class="p">
+<sup>6&#160;</sup>Moses said to the children of Gad, and to the children of Reuben, “Shall your brothers go to war while you sit here? 
+<sup>7&#160;</sup>Why do you discourage the heart of the children of Israel from going over into the land which Yahweh has given them? 
+<sup>8&#160;</sup>Your fathers did so when I sent them from Kadesh Barnea to see the land. 
+<sup>9&#160;</sup>For when they went up to the valley of Eshcol, and saw the land, they discouraged the heart of the children of Israel, that they should not go into the land which Yahweh had given them. 
+<sup>10&#160;</sup>Yahweh’s anger burned in that day, and he swore, saying, 
+<sup>11&#160;</sup>‘Surely none of the men who came up out of Egypt, from twenty years old and upward, shall see the land which I swore to Abraham, to Isaac, and to Jacob; because they have not wholly followed me, 
+<sup>12&#160;</sup>except Caleb the son of Jephunneh the Kenizzite, and Joshua the son of Nun, because they have followed Yahweh completely.’ 
+<sup>13&#160;</sup>Yahweh’s anger burned against Israel, and he made them wander back and forth in the wilderness forty years, until all the generation who had done evil in Yahweh’s sight was consumed. 
+</div><div class="p">
+<sup>14&#160;</sup>“Behold, you have risen up in your fathers’ place, an increase of sinful men, to increase the fierce anger of Yahweh toward Israel. 
+<sup>15&#160;</sup>For if you turn away from after him, he will yet again leave them in the wilderness; and you will destroy all these people.” 
+</div><div class="p">
+<sup>16&#160;</sup>They came near to him, and said, “We will build sheepfolds here for our livestock, and cities for our little ones; 
+<sup>17&#160;</sup>but we ourselves will be ready armed to go before the children of Israel, until we have brought them to their place. Our little ones shall dwell in the fortified cities because of the inhabitants of the land. 
+<sup>18&#160;</sup>We will not return to our houses until the children of Israel have all received their inheritance. 
+<sup>19&#160;</sup>For we will not inherit with them on the other side of the Jordan and beyond, because our inheritance has come to us on this side of the Jordan eastward.” 
+</div><div class="p">
+<sup>20&#160;</sup>Moses said to them: “If you will do this thing, if you will arm yourselves to go before Yahweh to the war, 
+<sup>21&#160;</sup>and every one of your armed men will pass over the Jordan before Yahweh until he has driven out his enemies from before him, 
+<sup>22&#160;</sup>and the land is subdued before Yahweh; then afterward you shall return, and be clear of obligation to Yahweh and to Israel. Then this land shall be your possession before Yahweh. 
+</div><div class="p">
+<sup>23&#160;</sup>“But if you will not do so, behold, you have sinned against Yahweh; and be sure your sin will find you out. 
+<sup>24&#160;</sup>Build cities for your little ones, and folds for your sheep; and do that which has proceeded out of your mouth.” 
+</div><div class="p">
+<sup>25&#160;</sup>The children of Gad and the children of Reuben spoke to Moses, saying, “Your servants will do as my lord commands. 
+<sup>26&#160;</sup>Our little ones, our women, our flocks, and all our livestock shall be there in the cities of Gilead; 
+<sup>27&#160;</sup>but your servants will pass over, every man who is armed for war, before Yahweh to battle, as my lord says.” 
+</div><div class="p">
+<sup>28&#160;</sup>So Moses commanded concerning them to Eleazar the priest, and to Joshua the son of Nun, and to the heads of the fathers’ households of the tribes of the children of Israel. 
+<sup>29&#160;</sup>Moses said to them, “If the children of Gad and the children of Reuben will pass with you over the Jordan, every man who is armed to battle before Yahweh, and the land is subdued before you, then you shall give them the land of Gilead for a possession; 
+<sup>30&#160;</sup>but if they will not pass over with you armed, they shall have possessions among you in the land of Canaan.” 
+</div><div class="p">
+<sup>31&#160;</sup>The children of Gad and the children of Reuben answered, saying, “As Yahweh has said to your servants, so will we do. 
+<sup>32&#160;</sup>We will pass over armed before Yahweh into the land of Canaan, and the possession of our inheritance shall remain with us beyond the Jordan.” 
+</div><div class="p">
+<sup>33&#160;</sup>Moses gave to them, even to the children of Gad, and to the children of Reuben, and to the half-tribe of Manasseh the son of Joseph, the kingdom of Sihon king of the Amorites, and the kingdom of Og king of Bashan; the land, according to its cities and borders, even the cities of the surrounding land. 
+<sup>34&#160;</sup>The children of Gad built Dibon, Ataroth, Aroer, 
+<sup>35&#160;</sup>Atroth-shophan, Jazer, Jogbehah, 
+<sup>36&#160;</sup>Beth Nimrah, and Beth Haran: fortified cities and folds for sheep. 
+<sup>37&#160;</sup>The children of Reuben built Heshbon, Elealeh, Kiriathaim, 
+<sup>38&#160;</sup>Nebo, and Baal Meon, (their names being changed), and Sibmah. They gave other names to the cities which they built. 
+<sup>39&#160;</sup>The children of Machir the son of Manasseh went to Gilead, took it, and dispossessed the Amorites who were therein. 
+<sup>40&#160;</sup>Moses gave Gilead to Machir the son of Manasseh; and he lived therein. 
+<sup>41&#160;</sup>Jair the son of Manasseh went and took its villages, and called them Havvoth Jair. 
+<sup>42&#160;</sup>Nobah went and took Kenath and its villages, and called it Nobah, after his own name. 
+</div><h2 class="chapterlabel" id="33">33</h2>
+<div class="p">
+<sup>1&#160;</sup>These are the journeys of the children of Israel, when they went out of the land of Egypt by their armies under the hand of Moses and Aaron. 
+<sup>2&#160;</sup>Moses wrote the starting points of their journeys by the commandment of Yahweh. These are their journeys according to their starting points. 
+<sup>3&#160;</sup>They traveled from Rameses in the first month, on the fifteenth day of the first month; on the next day after the Passover, the children of Israel went out with a high hand in the sight of all the Egyptians, 
+<sup>4&#160;</sup>while the Egyptians were burying all their firstborn, whom Yahweh had struck among them. Yahweh also executed judgments on their elohims. 
+<sup>5&#160;</sup>The children of Israel traveled from Rameses, and encamped in Succoth. 
+<sup>6&#160;</sup>They traveled from Succoth, and encamped in Etham, which is in the edge of the wilderness. 
+<sup>7&#160;</sup>They traveled from Etham, and turned back to Pihahiroth, which is before Baal Zephon, and they encamped before Migdol. 
+<sup>8&#160;</sup>They traveled from before Hahiroth, and crossed through the middle of the sea into the wilderness. They went three days’ journey in the wilderness of Etham, and encamped in Marah. 
+<sup>9&#160;</sup>They traveled from Marah, and came to Elim. In Elim, there were twelve springs of water and seventy palm trees, and they encamped there. 
+<sup>10&#160;</sup>They traveled from Elim, and encamped by the Red Sea. 
+<sup>11&#160;</sup>They traveled from the Red Sea, and encamped in the wilderness of Sin. 
+<sup>12&#160;</sup>They traveled from the wilderness of Sin, and encamped in Dophkah. 
+<sup>13&#160;</sup>They traveled from Dophkah, and encamped in Alush. 
+<sup>14&#160;</sup>They traveled from Alush, and encamped in Rephidim, where there was no water for the people to drink. 
+<sup>15&#160;</sup>They traveled from Rephidim, and encamped in the wilderness of Sinai. 
+<sup>16&#160;</sup>They traveled from the wilderness of Sinai, and encamped in Kibroth Hattaavah. 
+<sup>17&#160;</sup>They traveled from Kibroth Hattaavah, and encamped in Hazeroth. 
+<sup>18&#160;</sup>They traveled from Hazeroth, and encamped in Rithmah. 
+<sup>19&#160;</sup>They traveled from Rithmah, and encamped in Rimmon Perez. 
+<sup>20&#160;</sup>They traveled from Rimmon Perez, and encamped in Libnah. 
+<sup>21&#160;</sup>They traveled from Libnah, and encamped in Rissah. 
+<sup>22&#160;</sup>They traveled from Rissah, and encamped in Kehelathah. 
+<sup>23&#160;</sup>They traveled from Kehelathah, and encamped in Mount Shepher. 
+<sup>24&#160;</sup>They traveled from Mount Shepher, and encamped in Haradah. 
+<sup>25&#160;</sup>They traveled from Haradah, and encamped in Makheloth. 
+<sup>26&#160;</sup>They traveled from Makheloth, and encamped in Tahath. 
+<sup>27&#160;</sup>They traveled from Tahath, and encamped in Terah. 
+<sup>28&#160;</sup>They traveled from Terah, and encamped in Mithkah. 
+<sup>29&#160;</sup>They traveled from Mithkah, and encamped in Hashmonah. 
+<sup>30&#160;</sup>They traveled from Hashmonah, and encamped in Moseroth. 
+<sup>31&#160;</sup>They traveled from Moseroth, and encamped in Bene Jaakan. 
+<sup>32&#160;</sup>They traveled from Bene Jaakan, and encamped in Hor Haggidgad. 
+<sup>33&#160;</sup>They traveled from Hor Haggidgad, and encamped in Jotbathah. 
+<sup>34&#160;</sup>They traveled from Jotbathah, and encamped in Abronah. 
+<sup>35&#160;</sup>They traveled from Abronah, and encamped in Ezion Geber. 
+<sup>36&#160;</sup>They traveled from Ezion Geber, and encamped at Kadesh in the wilderness of Zin. 
+<sup>37&#160;</sup>They traveled from Kadesh, and encamped in Mount Hor, in the edge of the land of Edom. 
+<sup>38&#160;</sup>Aaron the priest went up into Mount Hor at the commandment of Yahweh and died there, in the fortieth year after the children of Israel had come out of the land of Egypt, in the fifth month, on the first day of the month. 
+<sup>39&#160;</sup>Aaron was one hundred twenty-three years old when he died in Mount Hor. 
+<sup>40&#160;</sup>The Canaanite king of Arad, who lived in the South in the land of Canaan, heard of the coming of the children of Israel. 
+<sup>41&#160;</sup>They traveled from Mount Hor, and encamped in Zalmonah. 
+<sup>42&#160;</sup>They traveled from Zalmonah, and encamped in Punon. 
+<sup>43&#160;</sup>They traveled from Punon, and encamped in Oboth. 
+<sup>44&#160;</sup>They traveled from Oboth, and encamped in Iye Abarim, in the border of Moab. 
+<sup>45&#160;</sup>They traveled from Iyim, and encamped in Dibon Gad. 
+<sup>46&#160;</sup>They traveled from Dibon Gad, and encamped in Almon Diblathaim. 
+<sup>47&#160;</sup>They traveled from Almon Diblathaim, and encamped in the mountains of Abarim, before Nebo. 
+<sup>48&#160;</sup>They traveled from the mountains of Abarim, and encamped in the plains of Moab by the Jordan at Jericho. 
+<sup>49&#160;</sup>They encamped by the Jordan, from Beth Jeshimoth even to Abel Shittim in the plains of Moab. 
+<sup>50&#160;</sup>Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
+<sup>51&#160;</sup>Speak to the children of Israel, and tell them, “When you pass over the Jordan into the land of Canaan, 
+<sup>52&#160;</sup>then you shall drive out all the inhabitants of the land from before you, destroy all their stone idols, destroy all their molten images, and demolish all their high places. 
+<sup>53&#160;</sup>You shall take possession of the land, and dwell therein; for I have given the land to you to possess it. 
+<sup>54&#160;</sup>You shall inherit the land by lot according to your families; to the larger groups you shall give a larger inheritance, and to the smaller you shall give a smaller inheritance. Wherever the lot falls to any man, that shall be his. You shall inherit according to the tribes of your fathers. 
+</div><div class="p">
+<sup>55&#160;</sup>“But if you do not drive out the inhabitants of the land from before you, then those you let remain of them will be like pricks in your eyes and thorns in your sides. They will harass you in the land in which you dwell. 
+<sup>56&#160;</sup>It shall happen that as I thought to do to them, so I will do to you.” 
+</div><h2 class="chapterlabel" id="34">34</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>2&#160;</sup>“Command the children of Israel, and tell them, ‘When you come into the land of Canaan (this is the land that shall fall to you for an inheritance, even the land of Canaan according to its borders), 
+<sup>3&#160;</sup>then your south quarter shall be from the wilderness of Zin along by the side of Edom, and your south border shall be from the end of the Salt Sea eastward. 
+<sup>4&#160;</sup>Your border shall turn about southward of the ascent of Akrabbim, and pass along to Zin; and it shall pass southward of Kadesh Barnea; and it shall go from there to Hazar Addar, and pass along to Azmon. 
+<sup>5&#160;</sup>The border shall turn about from Azmon to the brook of Egypt, and it shall end at the sea. 
+</div><div class="p">
+<sup>6&#160;</sup>“&#160;‘For the western border, you shall have the great sea and its border. This shall be your west border. 
+</div><div class="p">
+<sup>7&#160;</sup>“&#160;‘This shall be your north border: from the great sea you shall mark out for yourselves Mount Hor. 
+<sup>8&#160;</sup>From Mount Hor you shall mark out to the entrance of Hamath; and the border shall pass by Zedad. 
+<sup>9&#160;</sup>Then the border shall go to Ziphron, and it shall end at Hazar Enan. This shall be your north border. 
+</div><div class="p">
+<sup>10&#160;</sup>“&#160;‘You shall mark out your east border from Hazar Enan to Shepham. 
+<sup>11&#160;</sup>The border shall go down from Shepham to Riblah, on the east side of Ain. The border shall go down, and shall reach to the side of the sea of Chinnereth eastward. 
+<sup>12&#160;</sup>The border shall go down to the Jordan, and end at the Salt Sea. This shall be your land according to its borders around it.’&#160;” 
+</div><div class="p">
+<sup>13&#160;</sup>Moses commanded the children of Israel, saying, “This is the land which you shall inherit by lot, which Yahweh has commanded to give to the nine tribes, and to the half-tribe; 
+<sup>14&#160;</sup>for the tribe of the children of Reuben according to their fathers’ houses, the tribe of the children of Gad according to their fathers’ houses, and the half-tribe of Manasseh have received their inheritance. 
+<sup>15&#160;</sup>The two tribes and the half-tribe have received their inheritance beyond the Jordan at Jericho eastward, toward the sunrise.” 
+</div><div class="p">
+<sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>17&#160;</sup>“These are the names of the men who shall divide the land to you for inheritance: Eleazar the priest, and Joshua the son of Nun. 
+<sup>18&#160;</sup>You shall take one prince of every tribe, to divide the land for inheritance. 
+<sup>19&#160;</sup>These are the names of the men: Of the tribe of Judah, Caleb the son of Jephunneh. 
+<sup>20&#160;</sup>Of the tribe of the children of Simeon, Shemuel the son of Ammihud. 
+<sup>21&#160;</sup>Of the tribe of Benjamin, Elidad the son of Chislon. 
+<sup>22&#160;</sup>Of the tribe of the children of Dan a prince, Bukki the son of Jogli. 
+<sup>23&#160;</sup>Of the children of Joseph: of the tribe of the children of Manasseh a prince, Hanniel the son of Ephod. 
+<sup>24&#160;</sup>Of the tribe of the children of Ephraim a prince, Kemuel the son of Shiphtan. 
+<sup>25&#160;</sup>Of the tribe of the children of Zebulun a prince, Elizaphan the son of Parnach. 
+<sup>26&#160;</sup>Of the tribe of the children of Issachar a prince, Paltiel the son of Azzan. 
+<sup>27&#160;</sup>Of the tribe of the children of Asher a prince, Ahihud the son of Shelomi. 
+<sup>28&#160;</sup>Of the tribe of the children of Naphtali a prince, Pedahel the son of Ammihud.” 
+<sup>29&#160;</sup>These are they whom Yahweh commanded to divide the inheritance to the children of Israel in the land of Canaan. 
+</div><h2 class="chapterlabel" id="35">35</h2>
+<div class="p">
+<sup>1&#160;</sup>Yahweh spoke to Moses in the plains of Moab by the Jordan at Jericho, saying, 
+<sup>2&#160;</sup>“Command the children of Israel to give to the Levites cities to dwell in out of their inheritance. You shall give pasture lands for the cities around them to the Levites. 
+<sup>3&#160;</sup>They shall have the cities to dwell in. Their pasture lands shall be for their livestock, and for their possessions, and for all their animals. 
+</div><div class="p">
+<sup>4&#160;</sup>“The pasture lands of the cities, which you shall give to the Levites, shall be from the wall of the city and outward one thousand cubits around it. 
+<sup>5&#160;</sup>You shall measure outside of the city for the east side two thousand cubits, and for the south side two thousand cubits, and for the west side two thousand cubits, and for the north side two thousand cubits, the city being in the middle. This shall be the pasture lands of their cities. 
+</div><div class="p">
+<sup>6&#160;</sup>“The cities which you shall give to the Levites, they shall be the six cities of refuge, which you shall give for the man slayer to flee to. Besides them you shall give forty-two cities. 
+<sup>7&#160;</sup>All the cities which you shall give to the Levites shall be forty-eight cities together with their pasture lands. 
+<sup>8&#160;</sup>Concerning the cities which you shall give of the possession of the children of Israel, from the many you shall take many, and from the few you shall take few. Everyone according to his inheritance which he inherits shall give some of his cities to the Levites.” 
+<sup>9&#160;</sup>Yahweh spoke to Moses, saying, 
+<sup>10&#160;</sup>“Speak to the children of Israel, and tell them, ‘When you pass over the Jordan into the land of Canaan, 
+<sup>11&#160;</sup>then you shall appoint for yourselves cities to be cities of refuge for you, that the man slayer who kills any person unwittingly may flee there. 
+<sup>12&#160;</sup>The cities shall be for your refuge from the avenger, that the man slayer not die until he stands before the congregation for judgment. 
+<sup>13&#160;</sup>The cities which you shall give shall be for you six cities of refuge. 
+<sup>14&#160;</sup>You shall give three cities beyond the Jordan, and you shall give three cities in the land of Canaan. They shall be cities of refuge. 
+<sup>15&#160;</sup>These six cities shall be refuge for the children of Israel, for the stranger, and for the foreigner living among them, that everyone who kills any person unwittingly may flee there. 
+</div><div class="p">
+<sup>16&#160;</sup>“&#160;‘But if he struck him with an instrument of iron, so that he died, he is a murderer. The murderer shall surely be put to death. 
+<sup>17&#160;</sup>If he struck him with a stone in the hand, by which a man may die, and he died, he is a murderer. The murderer shall surely be put to death. 
+<sup>18&#160;</sup>Or if he struck him with a weapon of wood in the hand, by which a man may die, and he died, he is a murderer. The murderer shall surely be put to death. 
+<sup>19&#160;</sup>The avenger of blood shall himself put the murderer to death. When he meets him, he shall put him to death. 
+<sup>20&#160;</sup>If he shoved him out of hatred, or hurled something at him while lying in wait, so that he died, 
+<sup>21&#160;</sup>or in hostility struck him with his hand, so that he died, he who struck him shall surely be put to death. He is a murderer. The avenger of blood shall put the murderer to death when he meets him. 
+</div><div class="p">
+<sup>22&#160;</sup>“&#160;‘But if he shoved him suddenly without hostility, or hurled on him anything without lying in wait, 
+<sup>23&#160;</sup>or with any stone, by which a man may die, not seeing him, and cast it on him so that he died, and he was not his enemy and not seeking his harm, 
+<sup>24&#160;</sup>then the congregation shall judge between the striker and the avenger of blood according to these ordinances. 
+<sup>25&#160;</sup>The congregation shall deliver the man slayer out of the hand of the avenger of blood, and the congregation shall restore him to his city of refuge, where he had fled. He shall dwell therein until the death of the high priest, who was anointed with the set-apart oil. 
+</div><div class="p">
+<sup>26&#160;</sup>“&#160;‘But if the man slayer shall at any time go beyond the border of his city of refuge where he flees, 
+<sup>27&#160;</sup>and the avenger of blood finds him outside of the border of his city of refuge, and the avenger of blood kills the man slayer, he shall not be guilty of blood, 
+<sup>28&#160;</sup>because he should have remained in his city of refuge until the death of the high priest. But after the death of the high priest, the man slayer shall return into the land of his possession. 
+</div><div class="p">
+<sup>29&#160;</sup>“&#160;‘These things shall be for a statute and ordinance to you throughout your generations in all your dwellings. 
+</div><div class="p">
+<sup>30&#160;</sup>“&#160;‘Whoever kills any person, the murderer shall be slain based on the testimony of witnesses; but one witness shall not testify alone against any person so that he dies. 
+</div><div class="p">
+<sup>31&#160;</sup>“&#160;‘Moreover you shall take no ransom for the life of a murderer who is guilty of death. He shall surely be put to death. 
+</div><div class="p">
+<sup>32&#160;</sup>“&#160;‘You shall take no ransom for him who has fled to his city of refuge, that he may come again to dwell in the land before the death of the priest. 
+</div><div class="p">
+<sup>33&#160;</sup>“&#160;‘So you shall not pollute the land where you live; for blood pollutes the land. No atonement can be made for the land for the blood that is shed in it, but by the blood of him who shed it. 
+<sup>34&#160;</sup>You shall not defile the land which you inhabit, where I dwell; for I, Yahweh, dwell among the children of Israel.’&#160;” 
+</div><h2 class="chapterlabel" id="36">36</h2>
+<div class="p">
+<sup>1&#160;</sup>The heads of the fathers’ households of the family of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near and spoke before Moses and before the princes, the heads of the fathers’ households of the children of Israel. 
+<sup>2&#160;</sup>They said, “Yahweh commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahweh to give the inheritance of Zelophehad our brother to his daughters. 
+<sup>3&#160;</sup>If they are married to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
+<sup>4&#160;</sup>When the jubilee of the children of Israel comes, then their inheritance will be added to the inheritance of the tribe to which they shall belong. So their inheritance will be taken away from the inheritance of the tribe of our fathers.” 
+</div><div class="p">
+<sup>5&#160;</sup>Moses commanded the children of Israel according to Yahweh’s word, saying, “The tribe of the sons of Joseph speak what is right. 
+<sup>6&#160;</sup>This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be married to whom they think best, only they shall marry into the family of the tribe of their father. 
+<sup>7&#160;</sup>So shall no inheritance of the children of Israel move from tribe to tribe; for the children of Israel shall all keep the inheritance of the tribe of his fathers. 
+<sup>8&#160;</sup>Every daughter who possesses an inheritance in any tribe of the children of Israel shall be woman to one of the family of the tribe of her father, that the children of Israel may each possess the inheritance of his fathers. 
+<sup>9&#160;</sup>So shall no inheritance move from one tribe to another tribe; for the tribes of the children of Israel shall each keep his own inheritance.’&#160;” 
+</div><div class="p">
+<sup>10&#160;</sup>The daughters of Zelophehad did as Yahweh commanded Moses: 
+<sup>11&#160;</sup>for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were married to their father’s brothers’ sons. 
+<sup>12&#160;</sup>They were married into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
+</div><div class="p">
+<sup>13&#160;</sup>These are the commandments and the ordinances which Yahweh commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. </div></div><script src="../main.js"></script></body></html>

--- a/book/obadiah.html
+++ b/book/obadiah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Obadiah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,28 +53,30 @@
 <div class="main">
 <!-- OBA World English Scripture (WES) -->
 <h1 class="booklabel">Obadiah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The vision of Obadiah. This is what the Lord<span class="f">+ \fr 1:1 \ft The word translated “Lord” is “Adonai.”</span> Yahweh<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> says about Edom. We have heard news from Yahweh, and an ambassador is sent among the nations, saying, “Arise, and let’s rise up against her in battle. 
-<span class="v">2&#160;</span>Behold,<span class="f">+ \fr 1:2 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I have made you small among the nations. You are greatly despised. 
-<span class="v">3&#160;</span>The pride of your heart has deceived you, you who dwell in the clefts of the rock, whose habitation is high, who says in his heart, ‘Who will bring me down to the ground?’ 
-<span class="v">4&#160;</span>Though you mount on high as the eagle, and though your nest is set among the stars, I will bring you down from there,” says Yahweh. 
-<span class="v">5&#160;</span>“If thieves came to you, if robbers by night—oh, what disaster awaits you—wouldn’t they only steal until they had enough? If grape pickers came to you, wouldn’t they leave some gleaning grapes? 
-<span class="v">6&#160;</span>How Esau will be ransacked! How his hidden treasures are sought out! 
-<span class="v">7&#160;</span>All the men of your alliance have brought you on your way, even to the border. The men who were at peace with you have deceived you, and prevailed against you. Friends who eat your bread lay a snare under you. There is no understanding in him.” 
-</p><p>
-<span class="v">8&#160;</span>“Won’t I in that day”, says Yahweh, “destroy the wise men out of Edom, and understanding out of the mountain of Esau? 
-<span class="v">9&#160;</span>Your mighty men, Teman, will be dismayed, to the end that everyone may be cut off from the mountain of Esau by slaughter. 
-<span class="v">10&#160;</span>For the violence done to your brother Jacob, shame will cover you, and you will be cut off forever. 
-<span class="v">11&#160;</span>In the day that you stood on the other side, in the day that strangers carried away his substance and foreigners entered into his gates and cast lots for Jerusalem, even you were like one of them. 
-<span class="v">12&#160;</span>But don’t look down on your brother in the day of his disaster, and don’t rejoice over the children of Judah in the day of their destruction. Don’t speak proudly in the day of distress. 
-<span class="v">13&#160;</span>Don’t enter into the gate of my people in the day of their calamity. Don’t look down on their affliction in the day of their calamity, neither seize their wealth on the day of their calamity. 
-<span class="v">14&#160;</span>Don’t stand in the crossroads to cut off those of his who escape. Don’t deliver up those of his who remain in the day of distress. 
-<span class="v">15&#160;</span>For the day of Yahweh is near all the nations! As you have done, it will be done to you. Your deeds will return upon your own head. 
-<span class="v">16&#160;</span>For as you have drunk on my set-apart mountain, so all the nations will drink continually. Yes, they will drink, swallow down, and will be as though they had not been. 
-<span class="v">17&#160;</span>But in Mount Zion, there will be those who escape, and it will be set-apart. The house of Jacob will possess their possessions. 
-<span class="v">18&#160;</span>The house of Jacob will be a fire, the house of Joseph a flame, and the house of Esau for stubble. They will burn among them and devour them. There will not be any remaining to the house of Esau.” Indeed, Yahweh has spoken. 
-</p><p>
-<span class="v">19&#160;</span>Those of the South will possess the mountain of Esau, and those of the lowland, the Philistines. They will possess the field of Ephraim, and the field of Samaria. Benjamin will possess Gilead. 
-<span class="v">20&#160;</span>The captives of this army of the children of Israel, who are among the Canaanites, will possess even to Zarephath; and the captives of Jerusalem, who are in Sepharad, will possess the cities of the Negev. 
-<span class="v">21&#160;</span>Saviors will go up on Mount Zion to judge the mountains of Esau, and the kingdom will be Yahweh’s. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The vision of Obadiah. This is what the Lord says about Edom. We have heard news from Yahweh, and an ambassador is sent among the nations, saying, “Arise, and let’s rise up against her in battle. 
+<sup>2&#160;</sup>Behold, I have made you small among the nations. You are greatly despised. 
+<sup>3&#160;</sup>The pride of your heart has deceived you, you who dwell in the clefts of the rock, whose habitation is high, who says in his heart, ‘Who will bring me down to the ground?’ 
+<sup>4&#160;</sup>Though you mount on high as the eagle, and though your nest is set among the stars, I will bring you down from there,” says Yahweh. 
+<sup>5&#160;</sup>“If thieves came to you, if robbers by night—oh, what disaster awaits you—wouldn’t they only steal until they had enough? If grape pickers came to you, wouldn’t they leave some gleaning grapes? 
+<sup>6&#160;</sup>How Esau will be ransacked! How his hidden treasures are sought out! 
+<sup>7&#160;</sup>All the men of your alliance have brought you on your way, even to the border. The men who were at peace with you have deceived you, and prevailed against you. Friends who eat your bread lay a snare under you. There is no understanding in him.” 
+</div><div class="p">
+<sup>8&#160;</sup>“Won’t I in that day”, says Yahweh, “destroy the wise men out of Edom, and understanding out of the mountain of Esau? 
+<sup>9&#160;</sup>Your mighty men, Teman, will be dismayed, to the end that everyone may be cut off from the mountain of Esau by slaughter. 
+<sup>10&#160;</sup>For the violence done to your brother Jacob, shame will cover you, and you will be cut off forever. 
+<sup>11&#160;</sup>In the day that you stood on the other side, in the day that strangers carried away his substance and foreigners entered into his gates and cast lots for Jerusalem, even you were like one of them. 
+<sup>12&#160;</sup>But don’t look down on your brother in the day of his disaster, and don’t rejoice over the children of Judah in the day of their destruction. Don’t speak proudly in the day of distress. 
+<sup>13&#160;</sup>Don’t enter into the gate of my people in the day of their calamity. Don’t look down on their affliction in the day of their calamity, neither seize their wealth on the day of their calamity. 
+<sup>14&#160;</sup>Don’t stand in the crossroads to cut off those of his who escape. Don’t deliver up those of his who remain in the day of distress. 
+<sup>15&#160;</sup>For the day of Yahweh is near all the nations! As you have done, it will be done to you. Your deeds will return upon your own head. 
+<sup>16&#160;</sup>For as you have drunk on my set-apart mountain, so all the nations will drink continually. Yes, they will drink, swallow down, and will be as though they had not been. 
+<sup>17&#160;</sup>But in Mount Zion, there will be those who escape, and it will be set-apart. The house of Jacob will possess their possessions. 
+<sup>18&#160;</sup>The house of Jacob will be a fire, the house of Joseph a flame, and the house of Esau for stubble. They will burn among them and devour them. There will not be any remaining to the house of Esau.” Indeed, Yahweh has spoken. 
+</div><div class="p">
+<sup>19&#160;</sup>Those of the South will possess the mountain of Esau, and those of the lowland, the Philistines. They will possess the field of Ephraim, and the field of Samaria. Benjamin will possess Gilead. 
+<sup>20&#160;</sup>The captives of this army of the children of Israel, who are among the Canaanites, will possess even to Zarephath; and the captives of Jerusalem, who are in Sepharad, will possess the cities of the Negev. 
+<sup>21&#160;</sup>Saviors will go up on Mount Zion to judge the mountains of Esau, and the kingdom will be Yahweh’s. </div></div><script src="../main.js"></script></body></html>

--- a/book/proverbs.html
+++ b/book/proverbs.html
@@ -3,6 +3,47 @@
 <head>
 <title>Proverbs</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,2892 +53,2924 @@
 <div class="main">
 <!-- PRO World English Scripture (WES) -->
 <h1 class="booklabel">Proverbs</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The proverbs of Solomon, the son of David, king of Israel: 
-</p><p class="q1">
-<span class="v">2&#160;</span>to know wisdom and instruction; 
-</p><p class="q2">to discern the words of understanding; 
-</p><p class="q1">
-<span class="v">3&#160;</span>to receive instruction in wise dealing, 
-</p><p class="q2">in righteousness, justice, and equity; 
-</p><p class="q1">
-<span class="v">4&#160;</span>to give prudence to the simple, 
-</p><p class="q2">knowledge and discretion to the young man—</p><p class="q1">
-<span class="v">5&#160;</span>that the wise man may hear, and increase in learning; 
-</p><p class="q2">that the man of understanding may attain to sound counsel; 
-</p><p class="q1">
-<span class="v">6&#160;</span>to understand a proverb and parables, 
-</p><p class="q2">the words and riddles of the wise. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>The fear of Yahweh<span class="f">+ \fr 1:7 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> is the beginning of knowledge, 
-</p><p class="q2">but the foolish despise wisdom and instruction. 
-</p><p class="q1">
-<span class="v">8&#160;</span>My son, listen to your father’s instruction, 
-</p><p class="q2">and don’t forsake your mother’s teaching; 
-</p><p class="q1">
-<span class="v">9&#160;</span>for they will be a garland to grace your head, 
-</p><p class="q2">and chains around your neck. 
-</p><p class="q1">
-<span class="v">10&#160;</span>My son, if sinners entice you, 
-</p><p class="q2">don’t consent. 
-</p><p class="q1">
-<span class="v">11&#160;</span>If they say, “Come with us. 
-</p><p class="q2">Let’s lie in wait for blood. 
-</p><p class="q2">Let’s lurk secretly for the innocent without cause. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Let’s swallow them up alive like Sheol,<span class="f">+ \fr 1:12 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">and whole, like those who go down into the pit. 
-</p><p class="q1">
-<span class="v">13&#160;</span>We’ll find all valuable wealth. 
-</p><p class="q2">We’ll fill our houses with plunder. 
-</p><p class="q1">
-<span class="v">14&#160;</span>You shall cast your lot among us. 
-</p><p class="q2">We’ll all have one purse”—</p><p class="q1">
-<span class="v">15&#160;</span>my son, don’t walk on the path with them. 
-</p><p class="q2">Keep your foot from their path, 
-</p><p class="q1">
-<span class="v">16&#160;</span>for their feet run to evil. 
-</p><p class="q2">They hurry to shed blood. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For the net is spread in vain in the sight of any bird; 
-</p><p class="q1">
-<span class="v">18&#160;</span>but these lay in wait for their own blood. 
-</p><p class="q2">They lurk secretly for their own lives. 
-</p><p class="q1">
-<span class="v">19&#160;</span>So are the ways of everyone who is greedy for gain. 
-</p><p class="q2">It takes away the life of its owners. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>Wisdom calls aloud in the street. 
-</p><p class="q2">She utters her voice in the public squares. 
-</p><p class="q1">
-<span class="v">21&#160;</span>She calls at the head of noisy places. 
-</p><p class="q2">At the entrance of the city gates, she utters her words: 
-</p><p class="q1">
-<span class="v">22&#160;</span>“How long, you simple ones, will you love simplicity? 
-</p><p class="q2">How long will mockers delight themselves in mockery, 
-</p><p class="q2">and fools hate knowledge? 
-</p><p class="q1">
-<span class="v">23&#160;</span>Turn at my reproof. 
-</p><p class="q2">Behold,<span class="f">+ \fr 1:23 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> I will pour out my spirit on you. 
-</p><p class="q2">I will make known my words to you. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Because I have called, and you have refused; 
-</p><p class="q2">I have stretched out my hand, and no one has paid attention; 
-</p><p class="q1">
-<span class="v">25&#160;</span>but you have ignored all my counsel, 
-</p><p class="q2">and wanted none of my reproof; 
-</p><p class="q1">
-<span class="v">26&#160;</span>I also will laugh at your disaster. 
-</p><p class="q2">I will mock when calamity overtakes you, 
-</p><p class="q1">
-<span class="v">27&#160;</span>when calamity overtakes you like a storm, 
-</p><p class="q2">when your disaster comes on like a whirlwind, 
-</p><p class="q2">when distress and anguish come on you. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Then they will call on me, but I will not answer. 
-</p><p class="q2">They will seek me diligently, but they will not find me, 
-</p><p class="q1">
-<span class="v">29&#160;</span>because they hated knowledge, 
-</p><p class="q2">and didn’t choose the fear of Yahweh. 
-</p><p class="q1">
-<span class="v">30&#160;</span>They wanted none of my counsel. 
-</p><p class="q2">They despised all my reproof. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Therefore they will eat of the fruit of their own way, 
-</p><p class="q2">and be filled with their own schemes. 
-</p><p class="q1">
-<span class="v">32&#160;</span>For the backsliding of the simple will kill them. 
-</p><p class="q2">The careless ease of fools will destroy them. 
-</p><p class="q1">
-<span class="v">33&#160;</span>But whoever listens to me will dwell securely, 
-</p><p class="q2">and will be at ease, without fear of harm.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p class="q1">
-<span class="v">1&#160;</span>My son, if you will receive my words, 
-</p><p class="q2">and store up my commandments within you, 
-</p><p class="q1">
-<span class="v">2&#160;</span>so as to turn your ear to wisdom, 
-</p><p class="q2">and apply your heart to understanding; 
-</p><p class="q1">
-<span class="v">3&#160;</span>yes, if you call out for discernment, 
-</p><p class="q2">and lift up your voice for understanding; 
-</p><p class="q1">
-<span class="v">4&#160;</span>if you seek her as silver, 
-</p><p class="q2">and search for her as for hidden treasures; 
-</p><p class="q1">
-<span class="v">5&#160;</span>then you will understand the fear of Yahweh, 
-</p><p class="q2">and find the knowledge of Elohim.<span class="f">+ \fr 2:5 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p class="q1">
-<span class="v">6&#160;</span>For Yahweh gives wisdom. 
-</p><p class="q2">Out of his mouth comes knowledge and understanding. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He lays up sound wisdom for the upright. 
-</p><p class="q2">He is a shield to those who walk in integrity, 
-</p><p class="q1">
-<span class="v">8&#160;</span>that he may guard the paths of justice, 
-</p><p class="q2">and preserve the way of his saints. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Then you will understand righteousness and justice, 
-</p><p class="q2">equity and every good path. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For wisdom will enter into your heart. 
-</p><p class="q2">Knowledge will be pleasant to your soul. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Discretion will watch over you. 
-</p><p class="q2">Understanding will keep you, 
-</p><p class="q1">
-<span class="v">12&#160;</span>to deliver you from the way of evil, 
-</p><p class="q2">from the men who speak perverse things, 
-</p><p class="q1">
-<span class="v">13&#160;</span>who forsake the paths of uprightness, 
-</p><p class="q2">to walk in the ways of darkness, 
-</p><p class="q1">
-<span class="v">14&#160;</span>who rejoice to do evil, 
-</p><p class="q2">and delight in the perverseness of evil, 
-</p><p class="q1">
-<span class="v">15&#160;</span>who are crooked in their ways, 
-</p><p class="q2">and wayward in their paths, 
-</p><p class="q1">
-<span class="v">16&#160;</span>to deliver you from the strange woman, 
-</p><p class="q2">even from the foreigner who flatters with her words, 
-</p><p class="q1">
-<span class="v">17&#160;</span>who forsakes the friend of her youth, 
-</p><p class="q2">and forgets the covenant of her Elohim; 
-</p><p class="q1">
-<span class="v">18&#160;</span>for her house leads down to death, 
-</p><p class="q2">her paths to the departed spirits. 
-</p><p class="q1">
-<span class="v">19&#160;</span>None who go to her return again, 
-</p><p class="q2">neither do they attain to the paths of life. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Therefore walk in the way of good men, 
-</p><p class="q2">and keep the paths of the righteous. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For the upright will dwell in the land. 
-</p><p class="q2">The perfect will remain in it. 
-</p><p class="q1">
-<span class="v">22&#160;</span>But the wicked will be cut off from the land. 
-</p><p class="q2">The treacherous will be rooted out of it. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p class="q1">
-<span class="v">1&#160;</span>My son, don’t forget my teaching, 
-</p><p class="q2">but let your heart keep my commandments, 
-</p><p class="q1">
-<span class="v">2&#160;</span>for they will add to you length of days, 
-</p><p class="q2">years of life, and peace. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Don’t let kindness and truth forsake you. 
-</p><p class="q2">Bind them around your neck. 
-</p><p class="q2">Write them on the tablet of your heart. 
-</p><p class="q1">
-<span class="v">4&#160;</span>So you will find favor, 
-</p><p class="q2">and good understanding in the sight of Elohim and man. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Trust in Yahweh with all your heart, 
-</p><p class="q2">and don’t lean on your own understanding. 
-</p><p class="q1">
-<span class="v">6&#160;</span>In all your ways acknowledge him, 
-</p><p class="q2">and he will make your paths straight. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Don’t be wise in your own eyes. 
-</p><p class="q2">Fear Yahweh, and depart from evil. 
-</p><p class="q1">
-<span class="v">8&#160;</span>It will be health to your body, 
-</p><p class="q2">and nourishment to your bones. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Honor Yahweh with your substance, 
-</p><p class="q2">with the first fruits of all your increase; 
-</p><p class="q1">
-<span class="v">10&#160;</span>so your barns will be filled with plenty, 
-</p><p class="q2">and your vats will overflow with new wine. 
-</p><p class="q1">
-<span class="v">11&#160;</span>My son, don’t despise Yahweh’s discipline, 
-</p><p class="q2">neither be weary of his correction; 
-</p><p class="q1">
-<span class="v">12&#160;</span>for whom Yahweh loves, he corrects, 
-</p><p class="q2">even as a father reproves the son in whom he delights. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Happy is the man who finds wisdom, 
-</p><p class="q2">the man who gets understanding. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For her good profit is better than getting silver, 
-</p><p class="q2">and her return is better than fine gold. 
-</p><p class="q1">
-<span class="v">15&#160;</span>She is more precious than rubies. 
-</p><p class="q2">None of the things you can desire are to be compared to her. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Length of days is in her right hand. 
-</p><p class="q2">In her left hand are riches and honor. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Her ways are ways of pleasantness. 
-</p><p class="q2">All her paths are peace. 
-</p><p class="q1">
-<span class="v">18&#160;</span>She is a tree of life to those who lay hold of her. 
-</p><p class="q2">Happy is everyone who retains her. 
-</p><p class="q1">
-<span class="v">19&#160;</span>By wisdom Yahweh founded the earth. 
-</p><p class="q2">By understanding, he established the heavens. 
-</p><p class="q1">
-<span class="v">20&#160;</span>By his knowledge, the depths were broken up, 
-</p><p class="q2">and the skies drop down the dew. 
-</p><p class="q1">
-<span class="v">21&#160;</span>My son, let them not depart from your eyes. 
-</p><p class="q2">Keep sound wisdom and discretion, 
-</p><p class="q1">
-<span class="v">22&#160;</span>so they will be life to your soul, 
-</p><p class="q2">and grace for your neck. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Then you shall walk in your way securely. 
-</p><p class="q2">Your foot won’t stumble. 
-</p><p class="q1">
-<span class="v">24&#160;</span>When you lie down, you will not be afraid. 
-</p><p class="q2">Yes, you will lie down, and your sleep will be sweet. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Don’t be afraid of sudden fear, 
-</p><p class="q2">neither of the desolation of the wicked, when it comes; 
-</p><p class="q1">
-<span class="v">26&#160;</span>for Yahweh will be your confidence, 
-</p><p class="q2">and will keep your foot from being taken. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">27&#160;</span>Don’t withhold good from those to whom it is due, 
-</p><p class="q2">when it is in the power of your hand to do it. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Don’t say to your neighbor, “Go, and come again; 
-</p><p class="q2">tomorrow I will give it to you,” 
-</p><p class="q2">when you have it by you. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Don’t devise evil against your neighbor, 
-</p><p class="q2">since he dwells securely by you. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Don’t strive with a man without cause, 
-</p><p class="q2">if he has done you no harm. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Don’t envy the man of violence. 
-</p><p class="q2">Choose none of his ways. 
-</p><p class="q1">
-<span class="v">32&#160;</span>For the perverse is an abomination to Yahweh, 
-</p><p class="q2">but his friendship is with the upright. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Yahweh’s curse is in the house of the wicked, 
-</p><p class="q2">but he blesses the habitation of the righteous. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Surely he mocks the mockers, 
-</p><p class="q2">but he gives grace to the humble. 
-</p><p class="q1">
-<span class="v">35&#160;</span>The wise will inherit glory, 
-</p><p class="q2">but shame will be the promotion of fools. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Listen, sons, to a father’s instruction. 
-</p><p class="q2">Pay attention and know understanding; 
-</p><p class="q1">
-<span class="v">2&#160;</span>for I give you sound learning. 
-</p><p class="q2">Don’t forsake my law. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For I was a son to my father, 
-</p><p class="q2">tender and an only child in the sight of my mother. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He taught me, and said to me: 
-</p><p class="q2">“Let your heart retain my words. 
-</p><p class="q2">Keep my commandments, and live. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Get wisdom. 
-</p><p class="q2">Get understanding. 
-</p><p class="q2">Don’t forget, and don’t deviate from the words of my mouth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Don’t forsake her, and she will preserve you. 
-</p><p class="q2">Love her, and she will keep you. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Wisdom is supreme. 
-</p><p class="q2">Get wisdom. 
-</p><p class="q2">Yes, though it costs all your possessions, get understanding. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Esteem her, and she will exalt you. 
-</p><p class="q2">She will bring you to honor when you embrace her. 
-</p><p class="q1">
-<span class="v">9&#160;</span>She will give to your head a garland of grace. 
-</p><p class="q2">She will deliver a crown of splendor to you.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Listen, my son, and receive my sayings. 
-</p><p class="q2">The years of your life will be many. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I have taught you in the way of wisdom. 
-</p><p class="q2">I have led you in straight paths. 
-</p><p class="q1">
-<span class="v">12&#160;</span>When you go, your steps will not be hampered. 
-</p><p class="q2">When you run, you will not stumble. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Take firm hold of instruction. 
-</p><p class="q2">Don’t let her go. 
-</p><p class="q2">Keep her, for she is your life. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Don’t enter into the path of the wicked. 
-</p><p class="q2">Don’t walk in the way of evil men. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Avoid it, and don’t pass by it. 
-</p><p class="q2">Turn from it, and pass on. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For they don’t sleep unless they do evil. 
-</p><p class="q2">Their sleep is taken away, unless they make someone fall. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For they eat the bread of wickedness 
-</p><p class="q2">and drink the wine of violence. 
-</p><p class="q1">
-<span class="v">18&#160;</span>But the path of the righteous is like the dawning light 
-</p><p class="q2">that shines more and more until the perfect day. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The way of the wicked is like darkness. 
-</p><p class="q2">They don’t know what they stumble over. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>My son, attend to my words. 
-</p><p class="q2">Turn your ear to my sayings. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Let them not depart from your eyes. 
-</p><p class="q2">Keep them in the center of your heart. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For they are life to those who find them, 
-</p><p class="q2">and health to their whole body. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Keep your heart with all diligence, 
-</p><p class="q2">for out of it is the wellspring of life. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Put away from yourself a perverse mouth. 
-</p><p class="q2">Put corrupt lips far from you. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Let your eyes look straight ahead. 
-</p><p class="q2">Fix your gaze directly before you. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Make the path of your feet level. 
-</p><p class="q2">Let all of your ways be established. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Don’t turn to the right hand nor to the left. 
-</p><p class="q2">Remove your foot from evil. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p class="q1">
-<span class="v">1&#160;</span>My son, pay attention to my wisdom. 
-</p><p class="q2">Turn your ear to my understanding, 
-</p><p class="q1">
-<span class="v">2&#160;</span>that you may maintain discretion, 
-</p><p class="q2">that your lips may preserve knowledge. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For the lips of an adulteress drip honey. 
-</p><p class="q2">Her mouth is smoother than oil, 
-</p><p class="q1">
-<span class="v">4&#160;</span>but in the end she is as bitter as wormwood, 
-</p><p class="q2">and as sharp as a two-edged sword. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Her feet go down to death. 
-</p><p class="q2">Her steps lead straight to Sheol.<span class="f">+ \fr 5:5 \ft Sheol is the place of the dead. </span> 
-</p><p class="q1">
-<span class="v">6&#160;</span>She gives no thought to the way of life. 
-</p><p class="q2">Her ways are crooked, and she doesn’t know it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Now therefore, my sons, listen to me. 
-</p><p class="q2">Don’t depart from the words of my mouth. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Remove your way far from her. 
-</p><p class="q2">Don’t come near the door of her house, 
-</p><p class="q1">
-<span class="v">9&#160;</span>lest you give your honor to others, 
-</p><p class="q2">and your years to the cruel one; 
-</p><p class="q1">
-<span class="v">10&#160;</span>lest strangers feast on your wealth, 
-</p><p class="q2">and your labors enrich another man’s house. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You will groan at your latter end, 
-</p><p class="q2">when your flesh and your body are consumed, 
-</p><p class="q1">
-<span class="v">12&#160;</span>and say, “How I have hated instruction, 
-</p><p class="q2">and my heart despised reproof. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I haven’t obeyed the voice of my teachers, 
-</p><p class="q2">nor turned my ear to those who instructed me! 
-</p><p class="q1">
-<span class="v">14&#160;</span>I have come to the brink of utter ruin, 
-</p><p class="q2">among the gathered assembly.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>Drink water out of your own cistern, 
-</p><p class="q2">running water out of your own well. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Should your springs overflow in the streets, 
-</p><p class="q2">streams of water in the public squares? 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let them be for yourself alone, 
-</p><p class="q2">not for strangers with you. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Let your spring be blessed. 
-</p><p class="q2">Rejoice in the woman of your youth. 
-</p><p class="q1">
-<span class="v">19&#160;</span>A loving doe and a graceful deer—</p><p class="q2">let her breasts satisfy you at all times. 
-</p><p class="q2">Be captivated always with her love. 
-</p><p class="q1">
-<span class="v">20&#160;</span>For why should you, my son, be captivated with an adulteress? 
-</p><p class="q2">Why embrace the bosom of another? 
-</p><p class="q1">
-<span class="v">21&#160;</span>For the ways of man are before Yahweh’s eyes. 
-</p><p class="q2">He examines all his paths. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The evil deeds of the wicked ensnare him. 
-</p><p class="q2">The cords of his sin hold him firmly. 
-</p><p class="q1">
-<span class="v">23&#160;</span>He will die for lack of instruction. 
-</p><p class="q2">In the greatness of his folly, he will go astray. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p class="q1">
-<span class="v">1&#160;</span>My son, if you have become collateral for your neighbor, 
-</p><p class="q2">if you have struck your hands in pledge for a stranger, 
-</p><p class="q1">
-<span class="v">2&#160;</span>you are trapped by the words of your mouth; 
-</p><p class="q2">you are ensnared with the words of your mouth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Do this now, my son, and deliver yourself, 
-</p><p class="q2">since you have come into the hand of your neighbor. 
-</p><p class="q1">Go, humble yourself. 
-</p><p class="q2">Press your plea with your neighbor. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Give no sleep to your eyes, 
-</p><p class="q2">nor slumber to your eyelids. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Free yourself, like a gazelle from the hand of the hunter, 
-</p><p class="q2">like a bird from the snare of the fowler. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Go to the ant, you sluggard. 
-</p><p class="q2">Consider her ways, and be wise; 
-</p><p class="q1">
-<span class="v">7&#160;</span>which having no chief, overseer, or ruler, 
-</p><p class="q2">
-<span class="v">8&#160;</span>provides her bread in the summer, 
-</p><p class="q2">and gathers her food in the harvest. 
-</p><p class="q1">
-<span class="v">9&#160;</span>How long will you sleep, sluggard? 
-</p><p class="q2">When will you arise out of your sleep? 
-</p><p class="q1">
-<span class="v">10&#160;</span>A little sleep, a little slumber, 
-</p><p class="q2">a little folding of the hands to sleep—</p><p class="q1">
-<span class="v">11&#160;</span>so your poverty will come as a robber, 
-</p><p class="q2">and your scarcity as an armed man. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>A worthless person, a man of iniquity, 
-</p><p class="q2">is he who walks with a perverse mouth, 
-</p><p class="q1">
-<span class="v">13&#160;</span>who winks with his eyes, who signals with his feet, 
-</p><p class="q2">who motions with his fingers, 
-</p><p class="q1">
-<span class="v">14&#160;</span>in whose heart is perverseness, 
-</p><p class="q2">who devises evil continually, 
-</p><p class="q2">who always sows discord. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Therefore his calamity will come suddenly. 
-</p><p class="q2">He will be broken suddenly, and that without remedy. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>There are six things which Yahweh hates; 
-</p><p class="q2">yes, seven which are an abomination to him: 
-</p><p class="q1">
-<span class="v">17&#160;</span>arrogant eyes, a lying tongue, 
-</p><p class="q2">hands that shed innocent blood, 
-</p><p class="q1">
-<span class="v">18&#160;</span>a heart that devises wicked schemes, 
-</p><p class="q2">feet that are swift in running to mischief, 
-</p><p class="q1">
-<span class="v">19&#160;</span>a false witness who utters lies, 
-</p><p class="q2">and he who sows discord among brothers. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>My son, keep your father’s commandment, 
-</p><p class="q2">and don’t forsake your mother’s teaching. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Bind them continually on your heart. 
-</p><p class="q2">Tie them around your neck. 
-</p><p class="q1">
-<span class="v">22&#160;</span>When you walk, it will lead you. 
-</p><p class="q2">When you sleep, it will watch over you. 
-</p><p class="q2">When you awake, it will talk with you. 
-</p><p class="q1">
-<span class="v">23&#160;</span>For the commandment is a lamp, 
-</p><p class="q2">and the law is light. 
-</p><p class="q2">Reproofs of instruction are the way of life, 
-</p><p class="q1">
-<span class="v">24&#160;</span>to keep you from the immoral woman, 
-</p><p class="q2">from the flattery of the wayward woman’s tongue. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Don’t lust after her beauty in your heart, 
-</p><p class="q2">neither let her captivate you with her eyelids. 
-</p><p class="q1">
-<span class="v">26&#160;</span>For a prostitute reduces you to a piece of bread. 
-</p><p class="q2">The adulteress hunts for your precious life. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Can a man scoop fire into his lap, 
-</p><p class="q2">and his clothes not be burned? 
-</p><p class="q1">
-<span class="v">28&#160;</span>Or can one walk on hot coals, 
-</p><p class="q2">and his feet not be scorched? 
-</p><p class="q1">
-<span class="v">29&#160;</span>So is he who goes in to his neighbor’s woman. 
-</p><p class="q2">Whoever touches her will not be unpunished. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Men don’t despise a thief 
-</p><p class="q2">if he steals to satisfy himself when he is hungry, 
-</p><p class="q1">
-<span class="v">31&#160;</span>but if he is found, he shall restore seven times. 
-</p><p class="q2">He shall give all the wealth of his house. 
-</p><p class="q1">
-<span class="v">32&#160;</span>He who commits adultery with a woman is void of understanding. 
-</p><p class="q2">He who does it destroys his own soul. 
-</p><p class="q1">
-<span class="v">33&#160;</span>He will get wounds and dishonor. 
-</p><p class="q2">His reproach will not be wiped away. 
-</p><p class="q1">
-<span class="v">34&#160;</span>For jealousy arouses the fury of the man. 
-</p><p class="q2">He won’t spare in the day of vengeance. 
-</p><p class="q1">
-<span class="v">35&#160;</span>He won’t regard any ransom, 
-</p><p class="q2">neither will he rest content, though you give many gifts. 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p class="q1">
-<span class="v">1&#160;</span>My son, keep my words. 
-</p><p class="q2">Lay up my commandments within you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Keep my commandments and live! 
-</p><p class="q2">Guard my teaching as the apple of your eye. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Bind them on your fingers. 
-</p><p class="q2">Write them on the tablet of your heart. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Tell wisdom, “You are my sister.” 
-</p><p class="q2">Call understanding your relative, 
-</p><p class="q1">
-<span class="v">5&#160;</span>that they may keep you from the strange woman, 
-</p><p class="q2">from the foreigner who flatters with her words. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For at the window of my house, 
-</p><p class="q2">I looked out through my lattice. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I saw among the simple ones. 
-</p><p class="q2">I discerned among the youths a young man void of understanding, 
-</p><p class="q1">
-<span class="v">8&#160;</span>passing through the street near her corner, 
-</p><p class="q2">he went the way to her house, 
-</p><p class="q1">
-<span class="v">9&#160;</span>in the twilight, in the evening of the day, 
-</p><p class="q2">in the middle of the night and in the darkness. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Behold, there a woman met him with the attire of a prostitute, 
-</p><p class="q2">and with crafty intent. 
-</p><p class="q1">
-<span class="v">11&#160;</span>She is loud and defiant. 
-</p><p class="q2">Her feet don’t stay in her house. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Now she is in the streets, now in the squares, 
-</p><p class="q2">and lurking at every corner. 
-</p><p class="q1">
-<span class="v">13&#160;</span>So she caught him, and kissed him. 
-</p><p class="q2">With an impudent face she said to him: 
-</p><p class="q1">
-<span class="v">14&#160;</span>“Sacrifices of peace offerings are with me. 
-</p><p class="q2">Today I have paid my vows. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Therefore I came out to meet you, 
-</p><p class="q2">to diligently seek your face, 
-</p><p class="q2">and I have found you. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I have spread my couch with carpets of tapestry, 
-</p><p class="q2">with striped cloths of the yarn of Egypt. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I have perfumed my bed with myrrh, aloes, and cinnamon. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Come, let’s take our fill of loving until the morning. 
-</p><p class="q2">Let’s solace ourselves with loving. 
-</p><p class="q1">
-<span class="v">19&#160;</span>For my man isn’t at home. 
-</p><p class="q2">He has gone on a long journey. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He has taken a bag of money with him. 
-</p><p class="q2">He will come home at the full moon.” 
-</p><p class="q1">
-<span class="v">21&#160;</span>With persuasive words, she led him astray. 
-</p><p class="q2">With the flattering of her lips, she seduced him. 
-</p><p class="q1">
-<span class="v">22&#160;</span>He followed her immediately, 
-</p><p class="q2">as an ox goes to the slaughter, 
-</p><p class="q2">as a fool stepping into a noose. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Until an arrow strikes through his liver, 
-</p><p class="q2">as a bird hurries to the snare, 
-</p><p class="q2">and doesn’t know that it will cost his life. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>Now therefore, sons, listen to me. 
-</p><p class="q2">Pay attention to the words of my mouth. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Don’t let your heart turn to her ways. 
-</p><p class="q2">Don’t go astray in her paths, 
-</p><p class="q1">
-<span class="v">26&#160;</span>for she has thrown down many wounded. 
-</p><p class="q2">Yes, all her slain are a mighty army. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Her house is the way to Sheol,<span class="f">+ \fr 7:27 \ft Sheol is the place of the dead. </span> 
-</p><p class="q2">going down to the rooms of death. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Doesn’t wisdom cry out? 
-</p><p class="q2">Doesn’t understanding raise her voice? 
-</p><p class="q1">
-<span class="v">2&#160;</span>On the top of high places by the way, 
-</p><p class="q2">where the paths meet, she stands. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Beside the gates, at the entry of the city, 
-</p><p class="q2">at the entry doors, she cries aloud: 
-</p><p class="q1">
-<span class="v">4&#160;</span>“I call to you men! 
-</p><p class="q2">I send my voice to the sons of mankind. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You simple, understand prudence! 
-</p><p class="q2">You fools, be of an understanding heart! 
-</p><p class="q1">
-<span class="v">6&#160;</span>Hear, for I will speak excellent things. 
-</p><p class="q2">The opening of my lips is for right things. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For my mouth speaks truth. 
-</p><p class="q2">Wickedness is an abomination to my lips. 
-</p><p class="q1">
-<span class="v">8&#160;</span>All the words of my mouth are in righteousness. 
-</p><p class="q2">There is nothing crooked or perverse in them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They are all plain to him who understands, 
-</p><p class="q2">right to those who find knowledge. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Receive my instruction rather than silver, 
-</p><p class="q2">knowledge rather than choice gold. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For wisdom is better than rubies. 
-</p><p class="q2">All the things that may be desired can’t be compared to it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>“I, wisdom, have made prudence my dwelling. 
-</p><p class="q2">Find out knowledge and discretion. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The fear of Yahweh is to hate evil. 
-</p><p class="q2">I hate pride, arrogance, the evil way, and the perverse mouth. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Counsel and sound knowledge are mine. 
-</p><p class="q2">I have understanding and power. 
-</p><p class="q1">
-<span class="v">15&#160;</span>By me kings reign, 
-</p><p class="q2">and princes decree justice. 
-</p><p class="q1">
-<span class="v">16&#160;</span>By me princes rule, 
-</p><p class="q2">nobles, and all the righteous rulers of the earth. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I love those who love me. 
-</p><p class="q2">Those who seek me diligently will find me. 
-</p><p class="q1">
-<span class="v">18&#160;</span>With me are riches, honor, 
-</p><p class="q2">enduring wealth, and prosperity. 
-</p><p class="q1">
-<span class="v">19&#160;</span>My fruit is better than gold, yes, than fine gold, 
-</p><p class="q2">my yield than choice silver. 
-</p><p class="q1">
-<span class="v">20&#160;</span>I walk in the way of righteousness, 
-</p><p class="q2">in the middle of the paths of justice, 
-</p><p class="q1">
-<span class="v">21&#160;</span>that I may give wealth to those who love me. 
-</p><p class="q2">I fill their treasuries. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“Yahweh possessed me in the beginning of his work, 
-</p><p class="q2">before his deeds of old. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I was set up from everlasting, from the beginning, 
-</p><p class="q2">before the earth existed. 
-</p><p class="q1">
-<span class="v">24&#160;</span>When there were no depths, I was born, 
-</p><p class="q2">when there were no springs abounding with water. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Before the mountains were settled in place, 
-</p><p class="q2">before the hills, I was born; 
-</p><p class="q1">
-<span class="v">26&#160;</span>while as yet he had not made the earth, nor the fields, 
-</p><p class="q2">nor the beginning of the dust of the world. 
-</p><p class="q1">
-<span class="v">27&#160;</span>When he established the heavens, I was there. 
-</p><p class="q2">When he set a circle on the surface of the deep, 
-</p><p class="q1">
-<span class="v">28&#160;</span>when he established the clouds above, 
-</p><p class="q2">when the springs of the deep became strong, 
-</p><p class="q1">
-<span class="v">29&#160;</span>when he gave to the sea its boundary, 
-</p><p class="q2">that the waters should not violate his commandment, 
-</p><p class="q2">when he marked out the foundations of the earth, 
-</p><p class="q1">
-<span class="v">30&#160;</span>then I was the craftsman by his side. 
-</p><p class="q2">I was a delight day by day, 
-</p><p class="q2">always rejoicing before him, 
-</p><p class="q1">
-<span class="v">31&#160;</span>rejoicing in his whole world. 
-</p><p class="q2">My delight was with the sons of men. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">32&#160;</span>“Now therefore, my sons, listen to me, 
-</p><p class="q2">for blessed are those who keep my ways. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Hear instruction, and be wise. 
-</p><p class="q2">Don’t refuse it. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Blessed is the man who hears me, 
-</p><p class="q2">watching daily at my gates, 
-</p><p class="q2">waiting at my door posts. 
-</p><p class="q1">
-<span class="v">35&#160;</span>For whoever finds me finds life, 
-</p><p class="q2">and will obtain favor from Yahweh. 
-</p><p class="q1">
-<span class="v">36&#160;</span>But he who sins against me wrongs his own soul. 
-</p><p class="q2">All those who hate me love death.” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Wisdom has built her house. 
-</p><p class="q2">She has carved out her seven pillars. 
-</p><p class="q1">
-<span class="v">2&#160;</span>She has prepared her meat. 
-</p><p class="q2">She has mixed her wine. 
-</p><p class="q2">She has also set her table. 
-</p><p class="q1">
-<span class="v">3&#160;</span>She has sent out her maidens. 
-</p><p class="q2">She cries from the highest places of the city: 
-</p><p class="q1">
-<span class="v">4&#160;</span>“Whoever is simple, let him turn in here!” 
-</p><p class="q2">As for him who is void of understanding, she says to him, 
-</p><p class="q1">
-<span class="v">5&#160;</span>“Come, eat some of my bread, 
-</p><p class="q2">Drink some of the wine which I have mixed! 
-</p><p class="q1">
-<span class="v">6&#160;</span>Leave your simple ways, and live. 
-</p><p class="q2">Walk in the way of understanding.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>One who corrects a mocker invites insult. 
-</p><p class="q2">One who reproves a wicked man invites abuse. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Don’t reprove a scoffer, lest he hate you. 
-</p><p class="q2">Reprove a wise person, and he will love you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Instruct a wise person, and he will be still wiser. 
-</p><p class="q2">Teach a righteous person, and he will increase in learning. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The fear of Yahweh is the beginning of wisdom. 
-</p><p class="q2">The knowledge of the Set-Apart One is understanding. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For by me your days will be multiplied. 
-</p><p class="q2">The years of your life will be increased. 
-</p><p class="q1">
-<span class="v">12&#160;</span>If you are wise, you are wise for yourself. 
-</p><p class="q2">If you mock, you alone will bear it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>The foolish woman is loud, 
-</p><p class="q2">undisciplined, and knows nothing. 
-</p><p class="q1">
-<span class="v">14&#160;</span>She sits at the door of her house, 
-</p><p class="q2">on a seat in the high places of the city, 
-</p><p class="q1">
-<span class="v">15&#160;</span>to call to those who pass by, 
-</p><p class="q2">who go straight on their ways, 
-</p><p class="q1">
-<span class="v">16&#160;</span>“Whoever is simple, let him turn in here.” 
-</p><p class="q2">As for him who is void of understanding, she says to him, 
-</p><p class="q1">
-<span class="v">17&#160;</span>“Stolen water is sweet. 
-</p><p class="q2">Food eaten in secret is pleasant.” 
-</p><p class="q1">
-<span class="v">18&#160;</span>But he doesn’t know that the departed spirits are there, 
-</p><p class="q2">that her guests are in the depths of Sheol.<span class="f">+ \fr 9:18 \ft Sheol is the place of the dead.</span> 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>The proverbs of Solomon. 
-</p><p class="q1">A wise son makes a glad father; 
-</p><p class="q2">but a foolish son brings grief to his mother. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Treasures of wickedness profit nothing, 
-</p><p class="q2">but righteousness delivers from death. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh will not allow the soul of the righteous to go hungry, 
-</p><p class="q2">but he thrusts away the desire of the wicked. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He becomes poor who works with a lazy hand, 
-</p><p class="q2">but the hand of the diligent brings wealth. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He who gathers in summer is a wise son, 
-</p><p class="q2">but he who sleeps during the harvest is a son who causes shame. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Blessings are on the head of the righteous, 
-</p><p class="q2">but violence covers the mouth of the wicked. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The memory of the righteous is blessed, 
-</p><p class="q2">but the name of the wicked will rot. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The wise in heart accept commandments, 
-</p><p class="q2">but a chattering fool will fall. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He who walks blamelessly walks surely, 
-</p><p class="q2">but he who perverts his ways will be found out. 
-</p><p class="q1">
-<span class="v">10&#160;</span>One who winks with the eye causes sorrow, 
-</p><p class="q2">but a chattering fool will fall. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The mouth of the righteous is a spring of life, 
-</p><p class="q2">but violence covers the mouth of the wicked. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Hatred stirs up strife, 
-</p><p class="q2">but love covers all wrongs. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Wisdom is found on the lips of him who has discernment, 
-</p><p class="q2">but a rod is for the back of him who is void of understanding. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Wise men lay up knowledge, 
-</p><p class="q2">but the mouth of the foolish is near ruin. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The rich man’s wealth is his strong city. 
-</p><p class="q2">The destruction of the poor is their poverty. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The labor of the righteous leads to life. 
-</p><p class="q2">The increase of the wicked leads to sin. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He is in the way of life who heeds correction, 
-</p><p class="q2">but he who forsakes reproof leads others astray. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He who hides hatred has lying lips. 
-</p><p class="q2">He who utters a slander is a fool. 
-</p><p class="q1">
-<span class="v">19&#160;</span>In the multitude of words there is no lack of disobedience, 
-</p><p class="q2">but he who restrains his lips does wisely. 
-</p><p class="q1">
-<span class="v">20&#160;</span>The tongue of the righteous is like choice silver. 
-</p><p class="q2">The heart of the wicked is of little worth. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The lips of the righteous feed many, 
-</p><p class="q2">but the foolish die for lack of understanding. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Yahweh’s blessing brings wealth, 
-</p><p class="q2">and he adds no trouble to it. 
-</p><p class="q1">
-<span class="v">23&#160;</span>It is a fool’s pleasure to do wickedness, 
-</p><p class="q2">but wisdom is a man of understanding’s pleasure. 
-</p><p class="q1">
-<span class="v">24&#160;</span>What the wicked fear will overtake them, 
-</p><p class="q2">but the desire of the righteous will be granted. 
-</p><p class="q1">
-<span class="v">25&#160;</span>When the whirlwind passes, the wicked is no more; 
-</p><p class="q2">but the righteous stand firm forever. 
-</p><p class="q1">
-<span class="v">26&#160;</span>As vinegar to the teeth, and as smoke to the eyes, 
-</p><p class="q2">so is the sluggard to those who send him. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The fear of Yahweh prolongs days, 
-</p><p class="q2">but the years of the wicked shall be shortened. 
-</p><p class="q1">
-<span class="v">28&#160;</span>The prospect of the righteous is joy, 
-</p><p class="q2">but the hope of the wicked will perish. 
-</p><p class="q1">
-<span class="v">29&#160;</span>The way of Yahweh is a stronghold to the upright, 
-</p><p class="q2">but it is a destruction to the workers of iniquity. 
-</p><p class="q1">
-<span class="v">30&#160;</span>The righteous will never be removed, 
-</p><p class="q2">but the wicked will not dwell in the land. 
-</p><p class="q1">
-<span class="v">31&#160;</span>The mouth of the righteous produces wisdom, 
-</p><p class="q2">but the perverse tongue will be cut off. 
-</p><p class="q1">
-<span class="v">32&#160;</span>The lips of the righteous know what is acceptable, 
-</p><p class="q2">but the mouth of the wicked is perverse. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p class="q1">
-<span class="v">1&#160;</span>A false balance is an abomination to Yahweh, 
-</p><p class="q2">but accurate weights are his delight. 
-</p><p class="q1">
-<span class="v">2&#160;</span>When pride comes, then comes shame, 
-</p><p class="q2">but with humility comes wisdom. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The integrity of the upright shall guide them, 
-</p><p class="q2">but the perverseness of the treacherous shall destroy them. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Riches don’t profit in the day of wrath, 
-</p><p class="q2">but righteousness delivers from death. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The righteousness of the blameless will direct his way, 
-</p><p class="q2">but the wicked shall fall by his own wickedness. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The righteousness of the upright shall deliver them, 
-</p><p class="q2">but the unfaithful will be trapped by evil desires. 
-</p><p class="q1">
-<span class="v">7&#160;</span>When a wicked man dies, hope perishes, 
-</p><p class="q2">and expectation of power comes to nothing. 
-</p><p class="q1">
-<span class="v">8&#160;</span>A righteous person is delivered out of trouble, 
-</p><p class="q2">and the wicked takes his place. 
-</p><p class="q1">
-<span class="v">9&#160;</span>With his mouth the elohimless man destroys his neighbor, 
-</p><p class="q2">but the righteous will be delivered through knowledge. 
-</p><p class="q1">
-<span class="v">10&#160;</span>When it goes well with the righteous, the city rejoices. 
-</p><p class="q2">When the wicked perish, there is shouting. 
-</p><p class="q1">
-<span class="v">11&#160;</span>By the blessing of the upright, the city is exalted, 
-</p><p class="q2">but it is overthrown by the mouth of the wicked. 
-</p><p class="q1">
-<span class="v">12&#160;</span>One who despises his neighbor is void of wisdom, 
-</p><p class="q2">but a man of understanding holds his peace. 
-</p><p class="q1">
-<span class="v">13&#160;</span>One who brings gossip betrays a confidence, 
-</p><p class="q2">but one who is of a trustworthy spirit is one who keeps a secret. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Where there is no wise guidance, the nation falls, 
-</p><p class="q2">but in the multitude of counselors there is victory. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He who is collateral for a stranger will suffer for it, 
-</p><p class="q2">but he who refuses pledges of collateral is secure. 
-</p><p class="q1">
-<span class="v">16&#160;</span>A gracious woman obtains honor, 
-</p><p class="q2">but violent men obtain riches. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The merciful man does good to his own soul, 
-</p><p class="q2">but he who is cruel troubles his own flesh. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Wicked people earn deceitful wages, 
-</p><p class="q2">but one who sows righteousness reaps a sure reward. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He who is truly righteous gets life. 
-</p><p class="q2">He who pursues evil gets death. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Those who are perverse in heart are an abomination to Yahweh, 
-</p><p class="q2">but those whose ways are blameless are his delight. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Most certainly, the evil man will not be unpunished, 
-</p><p class="q2">but the offspring<span class="f">+ \fr 11:21 \ft or, seed</span> of the righteous will be delivered. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Like a gold ring in a pig’s snout, 
-</p><p class="q2">is a beautiful woman who lacks discretion. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The desire of the righteous is only good. 
-</p><p class="q2">The expectation of the wicked is wrath. 
-</p><p class="q1">
-<span class="v">24&#160;</span>There is one who scatters, and increases yet more. 
-</p><p class="q2">There is one who withholds more than is appropriate, but gains poverty. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The liberal soul shall be made fat. 
-</p><p class="q2">He who waters shall be watered also himself. 
-</p><p class="q1">
-<span class="v">26&#160;</span>People curse someone who withholds grain, 
-</p><p class="q2">but blessing will be on the head of him who sells it. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He who diligently seeks good seeks favor, 
-</p><p class="q2">but he who searches after evil, it shall come to him. 
-</p><p class="q1">
-<span class="v">28&#160;</span>He who trusts in his riches will fall, 
-</p><p class="q2">but the righteous shall flourish as the green leaf. 
-</p><p class="q1">
-<span class="v">29&#160;</span>He who troubles his own house shall inherit the wind. 
-</p><p class="q2">The foolish shall be servant to the wise of heart. 
-</p><p class="q1">
-<span class="v">30&#160;</span>The fruit of the righteous is a tree of life. 
-</p><p class="q2">He who is wise wins souls. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Behold, the righteous shall be repaid in the earth, 
-</p><p class="q2">how much more the wicked and the sinner! 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Whoever loves correction loves knowledge, 
-</p><p class="q2">but he who hates reproof is stupid. 
-</p><p class="q1">
-<span class="v">2&#160;</span>A good man shall obtain favor from Yahweh, 
-</p><p class="q2">but he will condemn a man of wicked plans. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A man shall not be established by wickedness, 
-</p><p class="q2">but the root of the righteous shall not be moved. 
-</p><p class="q1">
-<span class="v">4&#160;</span>A worthy woman is the crown of her owner, 
-</p><p class="q2">but a disgraceful woman is as rottenness in his bones. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The thoughts of the righteous are just, 
-</p><p class="q2">but the advice of the wicked is deceitful. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The words of the wicked are about lying in wait for blood, 
-</p><p class="q2">but the speech of the upright rescues them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The wicked are overthrown, and are no more, 
-</p><p class="q2">but the house of the righteous shall stand. 
-</p><p class="q1">
-<span class="v">8&#160;</span>A man shall be commended according to his wisdom, 
-</p><p class="q2">but he who has a warped mind shall be despised. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Better is he who is little known, and has a servant, 
-</p><p class="q2">than he who honors himself and lacks bread. 
-</p><p class="q1">
-<span class="v">10&#160;</span>A righteous man respects the life of his animal, 
-</p><p class="q2">but the tender mercies of the wicked are cruel. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He who tills his land shall have plenty of bread, 
-</p><p class="q2">but he who chases fantasies is void of understanding. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The wicked desires the plunder of evil men, 
-</p><p class="q2">but the root of the righteous flourishes. 
-</p><p class="q1">
-<span class="v">13&#160;</span>An evil man is trapped by sinfulness of lips, 
-</p><p class="q2">but the righteous shall come out of trouble. 
-</p><p class="q1">
-<span class="v">14&#160;</span>A man shall be satisfied with good by the fruit of his mouth. 
-</p><p class="q2">The work of a man’s hands shall be rewarded to him. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The way of a fool is right in his own eyes, 
-</p><p class="q2">but he who is wise listens to counsel. 
-</p><p class="q1">
-<span class="v">16&#160;</span>A fool shows his annoyance the same day, 
-</p><p class="q2">but one who overlooks an insult is prudent. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He who is truthful testifies honestly, 
-</p><p class="q2">but a false witness lies. 
-</p><p class="q1">
-<span class="v">18&#160;</span>There is one who speaks rashly like the piercing of a sword, 
-</p><p class="q2">but the tongue of the wise heals. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Truth’s lips will be established forever, 
-</p><p class="q2">but a lying tongue is only momentary. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Deceit is in the heart of those who plot evil, 
-</p><p class="q2">but joy comes to the promoters of peace. 
-</p><p class="q1">
-<span class="v">21&#160;</span>No mischief shall happen to the righteous, 
-</p><p class="q2">but the wicked shall be filled with evil. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Lying lips are an abomination to Yahweh, 
-</p><p class="q2">but those who do the truth are his delight. 
-</p><p class="q1">
-<span class="v">23&#160;</span>A prudent man keeps his knowledge, 
-</p><p class="q2">but the hearts of fools proclaim foolishness. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The hands of the diligent ones shall rule, 
-</p><p class="q2">but laziness ends in slave labor. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Anxiety in a man’s heart weighs it down, 
-</p><p class="q2">but a kind word makes it glad. 
-</p><p class="q1">
-<span class="v">26&#160;</span>A righteous person is cautious in friendship, 
-</p><p class="q2">but the way of the wicked leads them astray. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The slothful man doesn’t roast his game, 
-</p><p class="q2">but the possessions of diligent men are prized. 
-</p><p class="q1">
-<span class="v">28&#160;</span>In the way of righteousness is life; 
-</p><p class="q2">in its path there is no death. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p class="q1">
-<span class="v">1&#160;</span>A wise son listens to his father’s instruction, 
-</p><p class="q2">but a scoffer doesn’t listen to rebuke. 
-</p><p class="q1">
-<span class="v">2&#160;</span>By the fruit of his lips, a man enjoys good things, 
-</p><p class="q2">but the unfaithful crave violence. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He who guards his mouth guards his soul. 
-</p><p class="q2">One who opens wide his lips comes to ruin. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The soul of the sluggard desires, and has nothing, 
-</p><p class="q2">but the desire of the diligent shall be fully satisfied. 
-</p><p class="q1">
-<span class="v">5&#160;</span>A righteous man hates lies, 
-</p><p class="q2">but a wicked man brings shame and disgrace. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Righteousness guards the way of integrity, 
-</p><p class="q2">but wickedness overthrows the sinner. 
-</p><p class="q1">
-<span class="v">7&#160;</span>There are some who pretend to be rich, yet have nothing. 
-</p><p class="q2">There are some who pretend to be poor, yet have great wealth. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The ransom of a man’s life is his riches, 
-</p><p class="q2">but the poor hear no threats. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The light of the righteous shines brightly, 
-</p><p class="q2">but the lamp of the wicked is snuffed out. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Pride only breeds quarrels, 
-</p><p class="q2">but wisdom is with people who take advice. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Wealth gained dishonestly dwindles away, 
-</p><p class="q2">but he who gathers by hand makes it grow. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Hope deferred makes the heart sick, 
-</p><p class="q2">but when longing is fulfilled, it is a tree of life. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Whoever despises instruction will pay for it, 
-</p><p class="q2">but he who respects a command will be rewarded. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The teaching of the wise is a spring of life, 
-</p><p class="q2">to turn from the snares of death. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Good understanding wins favor, 
-</p><p class="q2">but the way of the unfaithful is hard. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Every prudent man acts from knowledge, 
-</p><p class="q2">but a fool exposes folly. 
-</p><p class="q1">
-<span class="v">17&#160;</span>A wicked messenger falls into trouble, 
-</p><p class="q2">but a trustworthy envoy gains healing. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Poverty and shame come to him who refuses discipline, 
-</p><p class="q2">but he who heeds correction shall be honored. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Longing fulfilled is sweet to the soul, 
-</p><p class="q2">but fools detest turning from evil. 
-</p><p class="q1">
-<span class="v">20&#160;</span>One who walks with wise men grows wise, 
-</p><p class="q2">but a companion of fools suffers harm. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Misfortune pursues sinners, 
-</p><p class="q2">but prosperity rewards the righteous. 
-</p><p class="q1">
-<span class="v">22&#160;</span>A good man leaves an inheritance to his children’s children, 
-</p><p class="q2">but the wealth of the sinner is stored for the righteous. 
-</p><p class="q1">
-<span class="v">23&#160;</span>An abundance of food is in poor people’s fields, 
-</p><p class="q2">but injustice sweeps it away. 
-</p><p class="q1">
-<span class="v">24&#160;</span>One who spares the rod hates his son, 
-</p><p class="q2">but one who loves him is careful to discipline him. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The righteous one eats to the satisfying of his soul, 
-</p><p class="q2">but the belly of the wicked goes hungry. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Every wise woman builds her house, 
-</p><p class="q2">but the foolish one tears it down with her own hands. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He who walks in his uprightness fears Yahweh, 
-</p><p class="q2">but he who is perverse in his ways despises him. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The fool’s talk brings a rod to his back, 
-</p><p class="q2">but the lips of the wise protect them. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Where no oxen are, the crib is clean, 
-</p><p class="q2">but much increase is by the strength of the ox. 
-</p><p class="q1">
-<span class="v">5&#160;</span>A truthful witness will not lie, 
-</p><p class="q2">but a false witness pours out lies. 
-</p><p class="q1">
-<span class="v">6&#160;</span>A scoffer seeks wisdom, and doesn’t find it, 
-</p><p class="q2">but knowledge comes easily to a discerning person. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Stay away from a foolish man, 
-</p><p class="q2">for you won’t find knowledge on his lips. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The wisdom of the prudent is to think about his way, 
-</p><p class="q2">but the folly of fools is deceit. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Fools mock at making atonement for sins, 
-</p><p class="q2">but among the upright there is good will. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The heart knows its own bitterness and joy; 
-</p><p class="q2">he will not share these with a stranger. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The house of the wicked will be overthrown, 
-</p><p class="q2">but the tent of the upright will flourish. 
-</p><p class="q1">
-<span class="v">12&#160;</span>There is a way which seems right to a man, 
-</p><p class="q2">but in the end it leads to death. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Even in laughter the heart may be sorrowful, 
-</p><p class="q2">and mirth may end in heaviness. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The unfaithful will be repaid for his own ways; 
-</p><p class="q2">likewise a good man will be rewarded for his ways. 
-</p><p class="q1">
-<span class="v">15&#160;</span>A simple man believes everything, 
-</p><p class="q2">but the prudent man carefully considers his ways. 
-</p><p class="q1">
-<span class="v">16&#160;</span>A wise man fears and shuns evil, 
-</p><p class="q2">but the fool is hot headed and reckless. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He who is quick to become angry will commit folly, 
-</p><p class="q2">and a crafty man is hated. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The simple inherit folly, 
-</p><p class="q2">but the prudent are crowned with knowledge. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The evil bow down before the good, 
-</p><p class="q2">and the wicked at the gates of the righteous. 
-</p><p class="q1">
-<span class="v">20&#160;</span>The poor person is shunned even by his own neighbor, 
-</p><p class="q2">but the rich person has many friends. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He who despises his neighbor sins, 
-</p><p class="q2">but he who has pity on the poor is blessed. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Don’t they go astray who plot evil? 
-</p><p class="q2">But love and faithfulness belong to those who plan good. 
-</p><p class="q1">
-<span class="v">23&#160;</span>In all hard work there is profit, 
-</p><p class="q2">but the talk of the lips leads only to poverty. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The crown of the wise is their riches, 
-</p><p class="q2">but the folly of fools crowns them with folly. 
-</p><p class="q1">
-<span class="v">25&#160;</span>A truthful witness saves souls, 
-</p><p class="q2">but a false witness is deceitful. 
-</p><p class="q1">
-<span class="v">26&#160;</span>In the fear of Yahweh is a secure fortress, 
-</p><p class="q2">and he will be a refuge for his children. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The fear of Yahweh is a fountain of life, 
-</p><p class="q2">turning people from the snares of death. 
-</p><p class="q1">
-<span class="v">28&#160;</span>In the multitude of people is the king’s glory, 
-</p><p class="q2">but in the lack of people is the destruction of the prince. 
-</p><p class="q1">
-<span class="v">29&#160;</span>He who is slow to anger has great understanding, 
-</p><p class="q2">but he who has a quick temper displays folly. 
-</p><p class="q1">
-<span class="v">30&#160;</span>The life of the body is a heart at peace, 
-</p><p class="q2">but envy rots the bones. 
-</p><p class="q1">
-<span class="v">31&#160;</span>He who oppresses the poor shows contempt for his Maker, 
-</p><p class="q2">but he who is kind to the needy honors him. 
-</p><p class="q1">
-<span class="v">32&#160;</span>The wicked is brought down in his calamity, 
-</p><p class="q2">but in death, the righteous has a refuge. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Wisdom rests in the heart of one who has understanding, 
-</p><p class="q2">and is even made known in the inward part of fools. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Righteousness exalts a nation, 
-</p><p class="q2">but sin is a disgrace to any people. 
-</p><p class="q1">
-<span class="v">35&#160;</span>The king’s favor is toward a servant who deals wisely, 
-</p><p class="q2">but his wrath is toward one who causes shame. 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p class="q1">
-<span class="v">1&#160;</span>A gentle answer turns away wrath, 
-</p><p class="q2">but a harsh word stirs up anger. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The tongue of the wise commends knowledge, 
-</p><p class="q2">but the mouths of fools gush out folly. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh’s eyes are everywhere, 
-</p><p class="q2">keeping watch on the evil and the good. 
-</p><p class="q1">
-<span class="v">4&#160;</span>A gentle tongue is a tree of life, 
-</p><p class="q2">but deceit in it crushes the spirit. 
-</p><p class="q1">
-<span class="v">5&#160;</span>A fool despises his father’s correction, 
-</p><p class="q2">but he who heeds reproof shows prudence. 
-</p><p class="q1">
-<span class="v">6&#160;</span>In the house of the righteous is much treasure, 
-</p><p class="q2">but the income of the wicked brings trouble. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The lips of the wise spread knowledge; 
-</p><p class="q2">not so with the heart of fools. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The sacrifice made by the wicked is an abomination to Yahweh, 
-</p><p class="q2">but the prayer of the upright is his delight. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The way of the wicked is an abomination to Yahweh, 
-</p><p class="q2">but he loves him who follows after righteousness. 
-</p><p class="q1">
-<span class="v">10&#160;</span>There is stern discipline for one who forsakes the way. 
-</p><p class="q2">Whoever hates reproof shall die. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Sheol<span class="f">+ \fr 15:11 \ft Sheol is the place of the dead.</span> and Abaddon are before Yahweh—</p><p class="q2">how much more then the hearts of the children of men! 
-</p><p class="q1">
-<span class="v">12&#160;</span>A scoffer doesn’t love to be reproved; 
-</p><p class="q2">he will not go to the wise. 
-</p><p class="q1">
-<span class="v">13&#160;</span>A glad heart makes a cheerful face, 
-</p><p class="q2">but an aching heart breaks the spirit. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The heart of one who has understanding seeks knowledge, 
-</p><p class="q2">but the mouths of fools feed on folly. 
-</p><p class="q1">
-<span class="v">15&#160;</span>All the days of the afflicted are wretched, 
-</p><p class="q2">but one who has a cheerful heart enjoys a continual feast. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Better is little, with the fear of Yahweh, 
-</p><p class="q2">than great treasure with trouble. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Better is a dinner of herbs, where love is, 
-</p><p class="q2">than a fattened calf with hatred. 
-</p><p class="q1">
-<span class="v">18&#160;</span>A wrathful man stirs up contention, 
-</p><p class="q2">but one who is slow to anger appeases strife. 
-</p><p class="q1">
-<span class="v">19&#160;</span>The way of the sluggard is like a thorn patch, 
-</p><p class="q2">but the path of the upright is a highway. 
-</p><p class="q1">
-<span class="v">20&#160;</span>A wise son makes a father glad, 
-</p><p class="q2">but a foolish man despises his mother. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Folly is joy to one who is void of wisdom, 
-</p><p class="q2">but a man of understanding keeps his way straight. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Where there is no counsel, plans fail; 
-</p><p class="q2">but in a multitude of counselors they are established. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Joy comes to a man with the reply of his mouth. 
-</p><p class="q2">How good is a word at the right time! 
-</p><p class="q1">
-<span class="v">24&#160;</span>The path of life leads upward for the wise, 
-</p><p class="q2">to keep him from going downward to Sheol.<span class="f">+ \fr 15:24 \ft Sheol is the place of the dead.</span> 
-</p><p class="q1">
-<span class="v">25&#160;</span>Yahweh will uproot the house of the proud, 
-</p><p class="q2">but he will keep the widow’s borders intact. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Yahweh detests the thoughts of the wicked, 
-</p><p class="q2">but the thoughts of the pure are pleasing. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He who is greedy for gain troubles his own house, 
-</p><p class="q2">but he who hates bribes will live. 
-</p><p class="q1">
-<span class="v">28&#160;</span>The heart of the righteous weighs answers, 
-</p><p class="q2">but the mouth of the wicked gushes out evil. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Yahweh is far from the wicked, 
-</p><p class="q2">but he hears the prayer of the righteous. 
-</p><p class="q1">
-<span class="v">30&#160;</span>The light of the eyes rejoices the heart. 
-</p><p class="q2">Good news gives health to the bones. 
-</p><p class="q1">
-<span class="v">31&#160;</span>The ear that listens to reproof lives, 
-</p><p class="q2">and will be at home among the wise. 
-</p><p class="q1">
-<span class="v">32&#160;</span>He who refuses correction despises his own soul, 
-</p><p class="q2">but he who listens to reproof gets understanding. 
-</p><p class="q1">
-<span class="v">33&#160;</span>The fear of Yahweh teaches wisdom. 
-</p><p class="q2">Before honor is humility. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p class="q1">
-<span class="v">1&#160;</span>The plans of the heart belong to man, 
-</p><p class="q2">but the answer of the tongue is from Yahweh. 
-</p><p class="q1">
-<span class="v">2&#160;</span>All the ways of a man are clean in his own eyes, 
-</p><p class="q2">but Yahweh weighs the motives. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Commit your deeds to Yahweh, 
-</p><p class="q2">and your plans shall succeed. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh has made everything for its own end—</p><p class="q2">yes, even the wicked for the day of evil. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Everyone who is proud in heart is an abomination to Yahweh; 
-</p><p class="q2">they shall certainly not be unpunished. 
-</p><p class="q1">
-<span class="v">6&#160;</span>By mercy and truth iniquity is atoned for. 
-</p><p class="q2">By the fear of Yahweh men depart from evil. 
-</p><p class="q1">
-<span class="v">7&#160;</span>When a man’s ways please Yahweh, 
-</p><p class="q2">he makes even his enemies to be at peace with him. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Better is a little with righteousness, 
-</p><p class="q2">than great revenues with injustice. 
-</p><p class="q1">
-<span class="v">9&#160;</span>A man’s heart plans his course, 
-</p><p class="q2">but Yahweh directs his steps. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Inspired judgments are on the lips of the king. 
-</p><p class="q2">He shall not betray his mouth. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Honest balances and scales are Yahweh’s; 
-</p><p class="q2">all the weights in the bag are his work. 
-</p><p class="q1">
-<span class="v">12&#160;</span>It is an abomination for kings to do wrong, 
-</p><p class="q2">for the throne is established by righteousness. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Righteous lips are the delight of kings. 
-</p><p class="q2">They value one who speaks the truth. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The king’s wrath is a messenger of death, 
-</p><p class="q2">but a wise man will pacify it. 
-</p><p class="q1">
-<span class="v">15&#160;</span>In the light of the king’s face is life. 
-</p><p class="q2">His favor is like a cloud of the spring rain. 
-</p><p class="q1">
-<span class="v">16&#160;</span>How much better it is to get wisdom than gold! 
-</p><p class="q2">Yes, to get understanding is to be chosen rather than silver. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The highway of the upright is to depart from evil. 
-</p><p class="q2">He who keeps his way preserves his soul. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Pride goes before destruction, 
-</p><p class="q2">and an arrogant spirit before a fall. 
-</p><p class="q1">
-<span class="v">19&#160;</span>It is better to be of a lowly spirit with the poor, 
-</p><p class="q2">than to divide the plunder with the proud. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He who heeds the Word finds prosperity. 
-</p><p class="q2">Whoever trusts in Yahweh is blessed. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The wise in heart shall be called prudent. 
-</p><p class="q2">Pleasantness of the lips promotes instruction. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Understanding is a fountain of life to one who has it, 
-</p><p class="q2">but the punishment of fools is their folly. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The heart of the wise instructs his mouth, 
-</p><p class="q2">and adds learning to his lips. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Pleasant words are a honeycomb, 
-</p><p class="q2">sweet to the soul, and health to the bones. 
-</p><p class="q1">
-<span class="v">25&#160;</span>There is a way which seems right to a man, 
-</p><p class="q2">but in the end it leads to death. 
-</p><p class="q1">
-<span class="v">26&#160;</span>The appetite of the laboring man labors for him, 
-</p><p class="q2">for his mouth urges him on. 
-</p><p class="q1">
-<span class="v">27&#160;</span>A worthless man devises mischief. 
-</p><p class="q2">His speech is like a scorching fire. 
-</p><p class="q1">
-<span class="v">28&#160;</span>A perverse man stirs up strife. 
-</p><p class="q2">A whisperer separates close friends. 
-</p><p class="q1">
-<span class="v">29&#160;</span>A man of violence entices his neighbor, 
-</p><p class="q2">and leads him in a way that is not good. 
-</p><p class="q1">
-<span class="v">30&#160;</span>One who winks his eyes to plot perversities, 
-</p><p class="q2">one who compresses his lips, is bent on evil. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Gray hair is a crown of glory. 
-</p><p class="q2">It is attained by a life of righteousness. 
-</p><p class="q1">
-<span class="v">32&#160;</span>One who is slow to anger is better than the mighty; 
-</p><p class="q2">one who rules his spirit, than he who takes a city. 
-</p><p class="q1">
-<span class="v">33&#160;</span>The lot is cast into the lap, 
-</p><p class="q2">but its every decision is from Yahweh. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Better is a dry morsel with quietness, 
-</p><p class="q2">than a house full of feasting with strife. 
-</p><p class="q1">
-<span class="v">2&#160;</span>A servant who deals wisely will rule over a son who causes shame, 
-</p><p class="q2">and shall have a part in the inheritance among the brothers. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The refining pot is for silver, and the furnace for gold, 
-</p><p class="q2">but Yahweh tests the hearts. 
-</p><p class="q1">
-<span class="v">4&#160;</span>An evildoer heeds wicked lips. 
-</p><p class="q2">A liar gives ear to a mischievous tongue. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Whoever mocks the poor reproaches his Maker. 
-</p><p class="q2">He who is glad at calamity shall not be unpunished. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Children’s children are the crown of old men; 
-</p><p class="q2">the glory of children is their parents. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Excellent speech isn’t fitting for a fool, 
-</p><p class="q2">much less do lying lips fit a prince. 
-</p><p class="q1">
-<span class="v">8&#160;</span>A gift is a precious stone in the eyes of him who gives it; 
-</p><p class="q2">wherever he turns, he prospers. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He who covers an offense promotes love; 
-</p><p class="q2">but he who repeats a matter separates best friends. 
-</p><p class="q1">
-<span class="v">10&#160;</span>A rebuke enters deeper into one who has understanding 
-</p><p class="q2">than a hundred lashes into a fool. 
-</p><p class="q1">
-<span class="v">11&#160;</span>An evil man seeks only rebellion; 
-</p><p class="q2">therefore a cruel messenger shall be sent against him. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Let a bear robbed of her cubs meet a man, 
-</p><p class="q2">rather than a fool in his folly. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Whoever rewards evil for good, 
-</p><p class="q2">evil shall not depart from his house. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The beginning of strife is like breaching a dam, 
-</p><p class="q2">therefore stop contention before quarreling breaks out. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He who justifies the wicked, and he who condemns the righteous, 
-</p><p class="q2">both of them alike are an abomination to Yahweh. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Why is there money in the hand of a fool to buy wisdom, 
-</p><p class="q2">since he has no understanding? 
-</p><p class="q1">
-<span class="v">17&#160;</span>A friend loves at all times; 
-</p><p class="q2">and a brother is born for adversity. 
-</p><p class="q1">
-<span class="v">18&#160;</span>A man void of understanding strikes hands, 
-</p><p class="q2">and becomes collateral in the presence of his neighbor. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He who loves disobedience loves strife. 
-</p><p class="q2">One who builds a high gate seeks destruction. 
-</p><p class="q1">
-<span class="v">20&#160;</span>One who has a perverse heart doesn’t find prosperity, 
-</p><p class="q2">and one who has a deceitful tongue falls into trouble. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He who becomes the father of a fool grieves. 
-</p><p class="q2">The father of a fool has no joy. 
-</p><p class="q1">
-<span class="v">22&#160;</span>A cheerful heart makes good medicine, 
-</p><p class="q2">but a crushed spirit dries up the bones. 
-</p><p class="q1">
-<span class="v">23&#160;</span>A wicked man receives a bribe in secret, 
-</p><p class="q2">to pervert the ways of justice. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Wisdom is before the face of one who has understanding, 
-</p><p class="q2">but the eyes of a fool wander to the ends of the earth. 
-</p><p class="q1">
-<span class="v">25&#160;</span>A foolish son brings grief to his father, 
-</p><p class="q2">and bitterness to her who bore him. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Also to punish the righteous is not good, 
-</p><p class="q2">nor to flog officials for their integrity. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He who spares his words has knowledge. 
-</p><p class="q2">He who is even tempered is a man of understanding. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Even a fool, when he keeps silent, is counted wise. 
-</p><p class="q2">When he shuts his lips, he is thought to be discerning. 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p class="q1">
-<span class="v">1&#160;</span>A man who isolates himself pursues selfishness, 
-</p><p class="q2">and defies all sound judgment. 
-</p><p class="q1">
-<span class="v">2&#160;</span>A fool has no delight in understanding, 
-</p><p class="q2">but only in revealing his own opinion. 
-</p><p class="q1">
-<span class="v">3&#160;</span>When wickedness comes, contempt also comes, 
-</p><p class="q2">and with shame comes disgrace. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The words of a man’s mouth are like deep waters. 
-</p><p class="q2">The fountain of wisdom is like a flowing brook. 
-</p><p class="q1">
-<span class="v">5&#160;</span>To be partial to the faces of the wicked is not good, 
-</p><p class="q2">nor to deprive the innocent of justice. 
-</p><p class="q1">
-<span class="v">6&#160;</span>A fool’s lips come into strife, 
-</p><p class="q2">and his mouth invites beatings. 
-</p><p class="q1">
-<span class="v">7&#160;</span>A fool’s mouth is his destruction, 
-</p><p class="q2">and his lips are a snare to his soul. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The words of a gossip are like dainty morsels: 
-</p><p class="q2">they go down into a person’s innermost parts. 
-</p><p class="q1">
-<span class="v">9&#160;</span>One who is slack in his work 
-</p><p class="q2">is brother to him who is a master of destruction. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Yahweh’s name is a strong tower: 
-</p><p class="q2">the righteous run to him, and are safe. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The rich man’s wealth is his strong city, 
-</p><p class="q2">like an unscalable wall in his own imagination. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Before destruction the heart of man is proud, 
-</p><p class="q2">but before honor is humility. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He who answers before he hears, 
-</p><p class="q2">that is folly and shame to him. 
-</p><p class="q1">
-<span class="v">14&#160;</span>A man’s spirit will sustain him in sickness, 
-</p><p class="q2">but a crushed spirit, who can bear? 
-</p><p class="q1">
-<span class="v">15&#160;</span>The heart of the discerning gets knowledge. 
-</p><p class="q2">The ear of the wise seeks knowledge. 
-</p><p class="q1">
-<span class="v">16&#160;</span>A man’s gift makes room for him, 
-</p><p class="q2">and brings him before great men. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He who pleads his cause first seems right—</p><p class="q2">until another comes and questions him. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The lot settles disputes, 
-</p><p class="q2">and keeps strong ones apart. 
-</p><p class="q1">
-<span class="v">19&#160;</span>A brother offended is more difficult than a fortified city. 
-</p><p class="q2">Disputes are like the bars of a fortress. 
-</p><p class="q1">
-<span class="v">20&#160;</span>A man’s stomach is filled with the fruit of his mouth. 
-</p><p class="q2">With the harvest of his lips he is satisfied. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Death and life are in the power of the tongue; 
-</p><p class="q2">those who love it will eat its fruit. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Whoever finds a woman finds a good thing, 
-</p><p class="q2">and obtains favor of Yahweh. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The poor plead for mercy, 
-</p><p class="q2">but the rich answer harshly. 
-</p><p class="q1">
-<span class="v">24&#160;</span>A man of many companions may be ruined, 
-</p><p class="q2">but there is a friend who sticks closer than a brother. 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Better is the poor who walks in his integrity 
-</p><p class="q2">than he who is perverse in his lips and is a fool. 
-</p><p class="q1">
-<span class="v">2&#160;</span>It isn’t good to have zeal without knowledge, 
-</p><p class="q2">nor being hasty with one’s feet and missing the way. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The foolishness of man subverts his way; 
-</p><p class="q2">his heart rages against Yahweh. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Wealth adds many friends, 
-</p><p class="q2">but the poor is separated from his friend. 
-</p><p class="q1">
-<span class="v">5&#160;</span>A false witness shall not be unpunished. 
-</p><p class="q2">He who pours out lies shall not go free. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Many will entreat the favor of a ruler, 
-</p><p class="q2">and everyone is a friend to a man who gives gifts. 
-</p><p class="q1">
-<span class="v">7&#160;</span>All the relatives of the poor shun him; 
-</p><p class="q2">how much more do his friends avoid him! 
-</p><p class="q2">He pursues them with pleas, but they are gone. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He who gets wisdom loves his own soul. 
-</p><p class="q2">He who keeps understanding shall find good. 
-</p><p class="q1">
-<span class="v">9&#160;</span>A false witness shall not be unpunished. 
-</p><p class="q2">He who utters lies shall perish. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Delicate living is not appropriate for a fool, 
-</p><p class="q2">much less for a servant to have rule over princes. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The discretion of a man makes him slow to anger. 
-</p><p class="q2">It is his glory to overlook an offense. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The king’s wrath is like the roaring of a lion, 
-</p><p class="q2">but his favor is like dew on the grass. 
-</p><p class="q1">
-<span class="v">13&#160;</span>A foolish son is the calamity of his father. 
-</p><p class="q2">A woman’s quarrels are a continual dripping. 
-</p><p class="q1">
-<span class="v">14&#160;</span>House and riches are an inheritance from fathers, 
-</p><p class="q2">but a prudent woman is from Yahweh. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Slothfulness casts into a deep sleep. 
-</p><p class="q2">The idle soul shall suffer hunger. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He who keeps the commandment keeps his soul, 
-</p><p class="q2">but he who is contemptuous in his ways shall die. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He who has pity on the poor lends to Yahweh; 
-</p><p class="q2">he will reward him. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Discipline your son, for there is hope; 
-</p><p class="q2">don’t be a willing party to his death. 
-</p><p class="q1">
-<span class="v">19&#160;</span>A hot-tempered man must pay the penalty, 
-</p><p class="q2">for if you rescue him, you must do it again. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Listen to counsel and receive instruction, 
-</p><p class="q2">that you may be wise in your latter end. 
-</p><p class="q1">
-<span class="v">21&#160;</span>There are many plans in a man’s heart, 
-</p><p class="q2">but Yahweh’s counsel will prevail. 
-</p><p class="q1">
-<span class="v">22&#160;</span>That which makes a man to be desired is his kindness. 
-</p><p class="q2">A poor man is better than a liar. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The fear of Yahweh leads to life, then contentment; 
-</p><p class="q2">he rests and will not be touched by trouble. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The sluggard buries his hand in the dish; 
-</p><p class="q2">he will not so much as bring it to his mouth again. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Flog a scoffer, and the simple will learn prudence; 
-</p><p class="q2">rebuke one who has understanding, and he will gain knowledge. 
-</p><p class="q1">
-<span class="v">26&#160;</span>He who robs his father and drives away his mother 
-</p><p class="q2">is a son who causes shame and brings reproach. 
-</p><p class="q1">
-<span class="v">27&#160;</span>If you stop listening to instruction, my son, 
-</p><p class="q2">you will stray from the words of knowledge. 
-</p><p class="q1">
-<span class="v">28&#160;</span>A corrupt witness mocks justice, 
-</p><p class="q2">and the mouth of the wicked gulps down iniquity. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Penalties are prepared for scoffers, 
-</p><p class="q2">and beatings for the backs of fools. 
-</p><div class="b"> &#160; </div>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The proverbs of Solomon, the son of David, king of Israel: 
+</div><div class="q1">
+<sup>2&#160;</sup>to know wisdom and instruction; 
+</div><div class="q2">to discern the words of understanding; 
+</div><div class="q1">
+<sup>3&#160;</sup>to receive instruction in wise dealing, 
+</div><div class="q2">in righteousness, justice, and equity; 
+</div><div class="q1">
+<sup>4&#160;</sup>to give prudence to the simple, 
+</div><div class="q2">knowledge and discretion to the young man—</div><div class="q1">
+<sup>5&#160;</sup>that the wise man may hear, and increase in learning; 
+</div><div class="q2">that the man of understanding may attain to sound counsel; 
+</div><div class="q1">
+<sup>6&#160;</sup>to understand a proverb and parables, 
+</div><div class="q2">the words and riddles of the wise. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>The fear of Yahweh is the beginning of knowledge, 
+</div><div class="q2">but the foolish despise wisdom and instruction. 
+</div><div class="q1">
+<sup>8&#160;</sup>My son, listen to your father’s instruction, 
+</div><div class="q2">and don’t forsake your mother’s teaching; 
+</div><div class="q1">
+<sup>9&#160;</sup>for they will be a garland to grace your head, 
+</div><div class="q2">and chains around your neck. 
+</div><div class="q1">
+<sup>10&#160;</sup>My son, if sinners entice you, 
+</div><div class="q2">don’t consent. 
+</div><div class="q1">
+<sup>11&#160;</sup>If they say, “Come with us. 
+</div><div class="q2">Let’s lie in wait for blood. 
+</div><div class="q2">Let’s lurk secretly for the innocent without cause. 
+</div><div class="q1">
+<sup>12&#160;</sup>Let’s swallow them up alive like Sheol, 
+</div><div class="q2">and whole, like those who go down into the pit. 
+</div><div class="q1">
+<sup>13&#160;</sup>We’ll find all valuable wealth. 
+</div><div class="q2">We’ll fill our houses with plunder. 
+</div><div class="q1">
+<sup>14&#160;</sup>You shall cast your lot among us. 
+</div><div class="q2">We’ll all have one purse”—</div><div class="q1">
+<sup>15&#160;</sup>my son, don’t walk on the path with them. 
+</div><div class="q2">Keep your foot from their path, 
+</div><div class="q1">
+<sup>16&#160;</sup>for their feet run to evil. 
+</div><div class="q2">They hurry to shed blood. 
+</div><div class="q1">
+<sup>17&#160;</sup>For the net is spread in vain in the sight of any bird; 
+</div><div class="q1">
+<sup>18&#160;</sup>but these lay in wait for their own blood. 
+</div><div class="q2">They lurk secretly for their own lives. 
+</div><div class="q1">
+<sup>19&#160;</sup>So are the ways of everyone who is greedy for gain. 
+</div><div class="q2">It takes away the life of its owners. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>Wisdom calls aloud in the street. 
+</div><div class="q2">She utters her voice in the public squares. 
+</div><div class="q1">
+<sup>21&#160;</sup>She calls at the head of noisy places. 
+</div><div class="q2">At the entrance of the city gates, she utters her words: 
+</div><div class="q1">
+<sup>22&#160;</sup>“How long, you simple ones, will you love simplicity? 
+</div><div class="q2">How long will mockers delight themselves in mockery, 
+</div><div class="q2">and fools hate knowledge? 
+</div><div class="q1">
+<sup>23&#160;</sup>Turn at my reproof. 
+</div><div class="q2">Behold, I will pour out my spirit on you. 
+</div><div class="q2">I will make known my words to you. 
+</div><div class="q1">
+<sup>24&#160;</sup>Because I have called, and you have refused; 
+</div><div class="q2">I have stretched out my hand, and no one has paid attention; 
+</div><div class="q1">
+<sup>25&#160;</sup>but you have ignored all my counsel, 
+</div><div class="q2">and wanted none of my reproof; 
+</div><div class="q1">
+<sup>26&#160;</sup>I also will laugh at your disaster. 
+</div><div class="q2">I will mock when calamity overtakes you, 
+</div><div class="q1">
+<sup>27&#160;</sup>when calamity overtakes you like a storm, 
+</div><div class="q2">when your disaster comes on like a whirlwind, 
+</div><div class="q2">when distress and anguish come on you. 
+</div><div class="q1">
+<sup>28&#160;</sup>Then they will call on me, but I will not answer. 
+</div><div class="q2">They will seek me diligently, but they will not find me, 
+</div><div class="q1">
+<sup>29&#160;</sup>because they hated knowledge, 
+</div><div class="q2">and didn’t choose the fear of Yahweh. 
+</div><div class="q1">
+<sup>30&#160;</sup>They wanted none of my counsel. 
+</div><div class="q2">They despised all my reproof. 
+</div><div class="q1">
+<sup>31&#160;</sup>Therefore they will eat of the fruit of their own way, 
+</div><div class="q2">and be filled with their own schemes. 
+</div><div class="q1">
+<sup>32&#160;</sup>For the backsliding of the simple will kill them. 
+</div><div class="q2">The careless ease of fools will destroy them. 
+</div><div class="q1">
+<sup>33&#160;</sup>But whoever listens to me will dwell securely, 
+</div><div class="q2">and will be at ease, without fear of harm.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="q1">
+<sup>1&#160;</sup>My son, if you will receive my words, 
+</div><div class="q2">and store up my commandments within you, 
+</div><div class="q1">
+<sup>2&#160;</sup>so as to turn your ear to wisdom, 
+</div><div class="q2">and apply your heart to understanding; 
+</div><div class="q1">
+<sup>3&#160;</sup>yes, if you call out for discernment, 
+</div><div class="q2">and lift up your voice for understanding; 
+</div><div class="q1">
+<sup>4&#160;</sup>if you seek her as silver, 
+</div><div class="q2">and search for her as for hidden treasures; 
+</div><div class="q1">
+<sup>5&#160;</sup>then you will understand the fear of Yahweh, 
+</div><div class="q2">and find the knowledge of Elohim. 
+</div><div class="q1">
+<sup>6&#160;</sup>For Yahweh gives wisdom. 
+</div><div class="q2">Out of his mouth comes knowledge and understanding. 
+</div><div class="q1">
+<sup>7&#160;</sup>He lays up sound wisdom for the upright. 
+</div><div class="q2">He is a shield to those who walk in integrity, 
+</div><div class="q1">
+<sup>8&#160;</sup>that he may guard the paths of justice, 
+</div><div class="q2">and preserve the way of his saints. 
+</div><div class="q1">
+<sup>9&#160;</sup>Then you will understand righteousness and justice, 
+</div><div class="q2">equity and every good path. 
+</div><div class="q1">
+<sup>10&#160;</sup>For wisdom will enter into your heart. 
+</div><div class="q2">Knowledge will be pleasant to your soul. 
+</div><div class="q1">
+<sup>11&#160;</sup>Discretion will watch over you. 
+</div><div class="q2">Understanding will keep you, 
+</div><div class="q1">
+<sup>12&#160;</sup>to deliver you from the way of evil, 
+</div><div class="q2">from the men who speak perverse things, 
+</div><div class="q1">
+<sup>13&#160;</sup>who forsake the paths of uprightness, 
+</div><div class="q2">to walk in the ways of darkness, 
+</div><div class="q1">
+<sup>14&#160;</sup>who rejoice to do evil, 
+</div><div class="q2">and delight in the perverseness of evil, 
+</div><div class="q1">
+<sup>15&#160;</sup>who are crooked in their ways, 
+</div><div class="q2">and wayward in their paths, 
+</div><div class="q1">
+<sup>16&#160;</sup>to deliver you from the strange woman, 
+</div><div class="q2">even from the foreigner who flatters with her words, 
+</div><div class="q1">
+<sup>17&#160;</sup>who forsakes the friend of her youth, 
+</div><div class="q2">and forgets the covenant of her Elohim; 
+</div><div class="q1">
+<sup>18&#160;</sup>for her house leads down to death, 
+</div><div class="q2">her paths to the departed spirits. 
+</div><div class="q1">
+<sup>19&#160;</sup>None who go to her return again, 
+</div><div class="q2">neither do they attain to the paths of life. 
+</div><div class="q1">
+<sup>20&#160;</sup>Therefore walk in the way of good men, 
+</div><div class="q2">and keep the paths of the righteous. 
+</div><div class="q1">
+<sup>21&#160;</sup>For the upright will dwell in the land. 
+</div><div class="q2">The perfect will remain in it. 
+</div><div class="q1">
+<sup>22&#160;</sup>But the wicked will be cut off from the land. 
+</div><div class="q2">The treacherous will be rooted out of it. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="q1">
+<sup>1&#160;</sup>My son, don’t forget my teaching, 
+</div><div class="q2">but let your heart keep my commandments, 
+</div><div class="q1">
+<sup>2&#160;</sup>for they will add to you length of days, 
+</div><div class="q2">years of life, and peace. 
+</div><div class="q1">
+<sup>3&#160;</sup>Don’t let kindness and truth forsake you. 
+</div><div class="q2">Bind them around your neck. 
+</div><div class="q2">Write them on the tablet of your heart. 
+</div><div class="q1">
+<sup>4&#160;</sup>So you will find favor, 
+</div><div class="q2">and good understanding in the sight of Elohim and man. 
+</div><div class="q1">
+<sup>5&#160;</sup>Trust in Yahweh with all your heart, 
+</div><div class="q2">and don’t lean on your own understanding. 
+</div><div class="q1">
+<sup>6&#160;</sup>In all your ways acknowledge him, 
+</div><div class="q2">and he will make your paths straight. 
+</div><div class="q1">
+<sup>7&#160;</sup>Don’t be wise in your own eyes. 
+</div><div class="q2">Fear Yahweh, and depart from evil. 
+</div><div class="q1">
+<sup>8&#160;</sup>It will be health to your body, 
+</div><div class="q2">and nourishment to your bones. 
+</div><div class="q1">
+<sup>9&#160;</sup>Honor Yahweh with your substance, 
+</div><div class="q2">with the first fruits of all your increase; 
+</div><div class="q1">
+<sup>10&#160;</sup>so your barns will be filled with plenty, 
+</div><div class="q2">and your vats will overflow with new wine. 
+</div><div class="q1">
+<sup>11&#160;</sup>My son, don’t despise Yahweh’s discipline, 
+</div><div class="q2">neither be weary of his correction; 
+</div><div class="q1">
+<sup>12&#160;</sup>for whom Yahweh loves, he corrects, 
+</div><div class="q2">even as a father reproves the son in whom he delights. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Happy is the man who finds wisdom, 
+</div><div class="q2">the man who gets understanding. 
+</div><div class="q1">
+<sup>14&#160;</sup>For her good profit is better than getting silver, 
+</div><div class="q2">and her return is better than fine gold. 
+</div><div class="q1">
+<sup>15&#160;</sup>She is more precious than rubies. 
+</div><div class="q2">None of the things you can desire are to be compared to her. 
+</div><div class="q1">
+<sup>16&#160;</sup>Length of days is in her right hand. 
+</div><div class="q2">In her left hand are riches and honor. 
+</div><div class="q1">
+<sup>17&#160;</sup>Her ways are ways of pleasantness. 
+</div><div class="q2">All her paths are peace. 
+</div><div class="q1">
+<sup>18&#160;</sup>She is a tree of life to those who lay hold of her. 
+</div><div class="q2">Happy is everyone who retains her. 
+</div><div class="q1">
+<sup>19&#160;</sup>By wisdom Yahweh founded the earth. 
+</div><div class="q2">By understanding, he established the heavens. 
+</div><div class="q1">
+<sup>20&#160;</sup>By his knowledge, the depths were broken up, 
+</div><div class="q2">and the skies drop down the dew. 
+</div><div class="q1">
+<sup>21&#160;</sup>My son, let them not depart from your eyes. 
+</div><div class="q2">Keep sound wisdom and discretion, 
+</div><div class="q1">
+<sup>22&#160;</sup>so they will be life to your soul, 
+</div><div class="q2">and grace for your neck. 
+</div><div class="q1">
+<sup>23&#160;</sup>Then you shall walk in your way securely. 
+</div><div class="q2">Your foot won’t stumble. 
+</div><div class="q1">
+<sup>24&#160;</sup>When you lie down, you will not be afraid. 
+</div><div class="q2">Yes, you will lie down, and your sleep will be sweet. 
+</div><div class="q1">
+<sup>25&#160;</sup>Don’t be afraid of sudden fear, 
+</div><div class="q2">neither of the desolation of the wicked, when it comes; 
+</div><div class="q1">
+<sup>26&#160;</sup>for Yahweh will be your confidence, 
+</div><div class="q2">and will keep your foot from being taken. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>27&#160;</sup>Don’t withhold good from those to whom it is due, 
+</div><div class="q2">when it is in the power of your hand to do it. 
+</div><div class="q1">
+<sup>28&#160;</sup>Don’t say to your neighbor, “Go, and come again; 
+</div><div class="q2">tomorrow I will give it to you,” 
+</div><div class="q2">when you have it by you. 
+</div><div class="q1">
+<sup>29&#160;</sup>Don’t devise evil against your neighbor, 
+</div><div class="q2">since he dwells securely by you. 
+</div><div class="q1">
+<sup>30&#160;</sup>Don’t strive with a man without cause, 
+</div><div class="q2">if he has done you no harm. 
+</div><div class="q1">
+<sup>31&#160;</sup>Don’t envy the man of violence. 
+</div><div class="q2">Choose none of his ways. 
+</div><div class="q1">
+<sup>32&#160;</sup>For the perverse is an abomination to Yahweh, 
+</div><div class="q2">but his friendship is with the upright. 
+</div><div class="q1">
+<sup>33&#160;</sup>Yahweh’s curse is in the house of the wicked, 
+</div><div class="q2">but he blesses the habitation of the righteous. 
+</div><div class="q1">
+<sup>34&#160;</sup>Surely he mocks the mockers, 
+</div><div class="q2">but he gives grace to the humble. 
+</div><div class="q1">
+<sup>35&#160;</sup>The wise will inherit glory, 
+</div><div class="q2">but shame will be the promotion of fools. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="q1">
+<sup>1&#160;</sup>Listen, sons, to a father’s instruction. 
+</div><div class="q2">Pay attention and know understanding; 
+</div><div class="q1">
+<sup>2&#160;</sup>for I give you sound learning. 
+</div><div class="q2">Don’t forsake my law. 
+</div><div class="q1">
+<sup>3&#160;</sup>For I was a son to my father, 
+</div><div class="q2">tender and an only child in the sight of my mother. 
+</div><div class="q1">
+<sup>4&#160;</sup>He taught me, and said to me: 
+</div><div class="q2">“Let your heart retain my words. 
+</div><div class="q2">Keep my commandments, and live. 
+</div><div class="q1">
+<sup>5&#160;</sup>Get wisdom. 
+</div><div class="q2">Get understanding. 
+</div><div class="q2">Don’t forget, and don’t deviate from the words of my mouth. 
+</div><div class="q1">
+<sup>6&#160;</sup>Don’t forsake her, and she will preserve you. 
+</div><div class="q2">Love her, and she will keep you. 
+</div><div class="q1">
+<sup>7&#160;</sup>Wisdom is supreme. 
+</div><div class="q2">Get wisdom. 
+</div><div class="q2">Yes, though it costs all your possessions, get understanding. 
+</div><div class="q1">
+<sup>8&#160;</sup>Esteem her, and she will exalt you. 
+</div><div class="q2">She will bring you to honor when you embrace her. 
+</div><div class="q1">
+<sup>9&#160;</sup>She will give to your head a garland of grace. 
+</div><div class="q2">She will deliver a crown of splendor to you.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Listen, my son, and receive my sayings. 
+</div><div class="q2">The years of your life will be many. 
+</div><div class="q1">
+<sup>11&#160;</sup>I have taught you in the way of wisdom. 
+</div><div class="q2">I have led you in straight paths. 
+</div><div class="q1">
+<sup>12&#160;</sup>When you go, your steps will not be hampered. 
+</div><div class="q2">When you run, you will not stumble. 
+</div><div class="q1">
+<sup>13&#160;</sup>Take firm hold of instruction. 
+</div><div class="q2">Don’t let her go. 
+</div><div class="q2">Keep her, for she is your life. 
+</div><div class="q1">
+<sup>14&#160;</sup>Don’t enter into the path of the wicked. 
+</div><div class="q2">Don’t walk in the way of evil men. 
+</div><div class="q1">
+<sup>15&#160;</sup>Avoid it, and don’t pass by it. 
+</div><div class="q2">Turn from it, and pass on. 
+</div><div class="q1">
+<sup>16&#160;</sup>For they don’t sleep unless they do evil. 
+</div><div class="q2">Their sleep is taken away, unless they make someone fall. 
+</div><div class="q1">
+<sup>17&#160;</sup>For they eat the bread of wickedness 
+</div><div class="q2">and drink the wine of violence. 
+</div><div class="q1">
+<sup>18&#160;</sup>But the path of the righteous is like the dawning light 
+</div><div class="q2">that shines more and more until the perfect day. 
+</div><div class="q1">
+<sup>19&#160;</sup>The way of the wicked is like darkness. 
+</div><div class="q2">They don’t know what they stumble over. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>My son, attend to my words. 
+</div><div class="q2">Turn your ear to my sayings. 
+</div><div class="q1">
+<sup>21&#160;</sup>Let them not depart from your eyes. 
+</div><div class="q2">Keep them in the center of your heart. 
+</div><div class="q1">
+<sup>22&#160;</sup>For they are life to those who find them, 
+</div><div class="q2">and health to their whole body. 
+</div><div class="q1">
+<sup>23&#160;</sup>Keep your heart with all diligence, 
+</div><div class="q2">for out of it is the wellspring of life. 
+</div><div class="q1">
+<sup>24&#160;</sup>Put away from yourself a perverse mouth. 
+</div><div class="q2">Put corrupt lips far from you. 
+</div><div class="q1">
+<sup>25&#160;</sup>Let your eyes look straight ahead. 
+</div><div class="q2">Fix your gaze directly before you. 
+</div><div class="q1">
+<sup>26&#160;</sup>Make the path of your feet level. 
+</div><div class="q2">Let all of your ways be established. 
+</div><div class="q1">
+<sup>27&#160;</sup>Don’t turn to the right hand nor to the left. 
+</div><div class="q2">Remove your foot from evil. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="q1">
+<sup>1&#160;</sup>My son, pay attention to my wisdom. 
+</div><div class="q2">Turn your ear to my understanding, 
+</div><div class="q1">
+<sup>2&#160;</sup>that you may maintain discretion, 
+</div><div class="q2">that your lips may preserve knowledge. 
+</div><div class="q1">
+<sup>3&#160;</sup>For the lips of an adulteress drip honey. 
+</div><div class="q2">Her mouth is smoother than oil, 
+</div><div class="q1">
+<sup>4&#160;</sup>but in the end she is as bitter as wormwood, 
+</div><div class="q2">and as sharp as a two-edged sword. 
+</div><div class="q1">
+<sup>5&#160;</sup>Her feet go down to death. 
+</div><div class="q2">Her steps lead straight to Sheol. 
+</div><div class="q1">
+<sup>6&#160;</sup>She gives no thought to the way of life. 
+</div><div class="q2">Her ways are crooked, and she doesn’t know it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Now therefore, my sons, listen to me. 
+</div><div class="q2">Don’t depart from the words of my mouth. 
+</div><div class="q1">
+<sup>8&#160;</sup>Remove your way far from her. 
+</div><div class="q2">Don’t come near the door of her house, 
+</div><div class="q1">
+<sup>9&#160;</sup>lest you give your honor to others, 
+</div><div class="q2">and your years to the cruel one; 
+</div><div class="q1">
+<sup>10&#160;</sup>lest strangers feast on your wealth, 
+</div><div class="q2">and your labors enrich another man’s house. 
+</div><div class="q1">
+<sup>11&#160;</sup>You will groan at your latter end, 
+</div><div class="q2">when your flesh and your body are consumed, 
+</div><div class="q1">
+<sup>12&#160;</sup>and say, “How I have hated instruction, 
+</div><div class="q2">and my heart despised reproof. 
+</div><div class="q1">
+<sup>13&#160;</sup>I haven’t obeyed the voice of my teachers, 
+</div><div class="q2">nor turned my ear to those who instructed me! 
+</div><div class="q1">
+<sup>14&#160;</sup>I have come to the brink of utter ruin, 
+</div><div class="q2">among the gathered assembly.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>Drink water out of your own cistern, 
+</div><div class="q2">running water out of your own well. 
+</div><div class="q1">
+<sup>16&#160;</sup>Should your springs overflow in the streets, 
+</div><div class="q2">streams of water in the public squares? 
+</div><div class="q1">
+<sup>17&#160;</sup>Let them be for yourself alone, 
+</div><div class="q2">not for strangers with you. 
+</div><div class="q1">
+<sup>18&#160;</sup>Let your spring be blessed. 
+</div><div class="q2">Rejoice in the woman of your youth. 
+</div><div class="q1">
+<sup>19&#160;</sup>A loving doe and a graceful deer—</div><div class="q2">let her breasts satisfy you at all times. 
+</div><div class="q2">Be captivated always with her love. 
+</div><div class="q1">
+<sup>20&#160;</sup>For why should you, my son, be captivated with an adulteress? 
+</div><div class="q2">Why embrace the bosom of another? 
+</div><div class="q1">
+<sup>21&#160;</sup>For the ways of man are before Yahweh’s eyes. 
+</div><div class="q2">He examines all his paths. 
+</div><div class="q1">
+<sup>22&#160;</sup>The evil deeds of the wicked ensnare him. 
+</div><div class="q2">The cords of his sin hold him firmly. 
+</div><div class="q1">
+<sup>23&#160;</sup>He will die for lack of instruction. 
+</div><div class="q2">In the greatness of his folly, he will go astray. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="q1">
+<sup>1&#160;</sup>My son, if you have become collateral for your neighbor, 
+</div><div class="q2">if you have struck your hands in pledge for a stranger, 
+</div><div class="q1">
+<sup>2&#160;</sup>you are trapped by the words of your mouth; 
+</div><div class="q2">you are ensnared with the words of your mouth. 
+</div><div class="q1">
+<sup>3&#160;</sup>Do this now, my son, and deliver yourself, 
+</div><div class="q2">since you have come into the hand of your neighbor. 
+</div><div class="q1">Go, humble yourself. 
+</div><div class="q2">Press your plea with your neighbor. 
+</div><div class="q1">
+<sup>4&#160;</sup>Give no sleep to your eyes, 
+</div><div class="q2">nor slumber to your eyelids. 
+</div><div class="q1">
+<sup>5&#160;</sup>Free yourself, like a gazelle from the hand of the hunter, 
+</div><div class="q2">like a bird from the snare of the fowler. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Go to the ant, you sluggard. 
+</div><div class="q2">Consider her ways, and be wise; 
+</div><div class="q1">
+<sup>7&#160;</sup>which having no chief, overseer, or ruler, 
+</div><div class="q2">
+<sup>8&#160;</sup>provides her bread in the summer, 
+</div><div class="q2">and gathers her food in the harvest. 
+</div><div class="q1">
+<sup>9&#160;</sup>How long will you sleep, sluggard? 
+</div><div class="q2">When will you arise out of your sleep? 
+</div><div class="q1">
+<sup>10&#160;</sup>A little sleep, a little slumber, 
+</div><div class="q2">a little folding of the hands to sleep—</div><div class="q1">
+<sup>11&#160;</sup>so your poverty will come as a robber, 
+</div><div class="q2">and your scarcity as an armed man. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>A worthless person, a man of iniquity, 
+</div><div class="q2">is he who walks with a perverse mouth, 
+</div><div class="q1">
+<sup>13&#160;</sup>who winks with his eyes, who signals with his feet, 
+</div><div class="q2">who motions with his fingers, 
+</div><div class="q1">
+<sup>14&#160;</sup>in whose heart is perverseness, 
+</div><div class="q2">who devises evil continually, 
+</div><div class="q2">who always sows discord. 
+</div><div class="q1">
+<sup>15&#160;</sup>Therefore his calamity will come suddenly. 
+</div><div class="q2">He will be broken suddenly, and that without remedy. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>There are six things which Yahweh hates; 
+</div><div class="q2">yes, seven which are an abomination to him: 
+</div><div class="q1">
+<sup>17&#160;</sup>arrogant eyes, a lying tongue, 
+</div><div class="q2">hands that shed innocent blood, 
+</div><div class="q1">
+<sup>18&#160;</sup>a heart that devises wicked schemes, 
+</div><div class="q2">feet that are swift in running to mischief, 
+</div><div class="q1">
+<sup>19&#160;</sup>a false witness who utters lies, 
+</div><div class="q2">and he who sows discord among brothers. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>My son, keep your father’s commandment, 
+</div><div class="q2">and don’t forsake your mother’s teaching. 
+</div><div class="q1">
+<sup>21&#160;</sup>Bind them continually on your heart. 
+</div><div class="q2">Tie them around your neck. 
+</div><div class="q1">
+<sup>22&#160;</sup>When you walk, it will lead you. 
+</div><div class="q2">When you sleep, it will watch over you. 
+</div><div class="q2">When you awake, it will talk with you. 
+</div><div class="q1">
+<sup>23&#160;</sup>For the commandment is a lamp, 
+</div><div class="q2">and the law is light. 
+</div><div class="q2">Reproofs of instruction are the way of life, 
+</div><div class="q1">
+<sup>24&#160;</sup>to keep you from the immoral woman, 
+</div><div class="q2">from the flattery of the wayward woman’s tongue. 
+</div><div class="q1">
+<sup>25&#160;</sup>Don’t lust after her beauty in your heart, 
+</div><div class="q2">neither let her captivate you with her eyelids. 
+</div><div class="q1">
+<sup>26&#160;</sup>For a prostitute reduces you to a piece of bread. 
+</div><div class="q2">The adulteress hunts for your precious life. 
+</div><div class="q1">
+<sup>27&#160;</sup>Can a man scoop fire into his lap, 
+</div><div class="q2">and his clothes not be burned? 
+</div><div class="q1">
+<sup>28&#160;</sup>Or can one walk on hot coals, 
+</div><div class="q2">and his feet not be scorched? 
+</div><div class="q1">
+<sup>29&#160;</sup>So is he who goes in to his neighbor’s woman. 
+</div><div class="q2">Whoever touches her will not be unpunished. 
+</div><div class="q1">
+<sup>30&#160;</sup>Men don’t despise a thief 
+</div><div class="q2">if he steals to satisfy himself when he is hungry, 
+</div><div class="q1">
+<sup>31&#160;</sup>but if he is found, he shall restore seven times. 
+</div><div class="q2">He shall give all the wealth of his house. 
+</div><div class="q1">
+<sup>32&#160;</sup>He who commits adultery with a woman is void of understanding. 
+</div><div class="q2">He who does it destroys his own soul. 
+</div><div class="q1">
+<sup>33&#160;</sup>He will get wounds and dishonor. 
+</div><div class="q2">His reproach will not be wiped away. 
+</div><div class="q1">
+<sup>34&#160;</sup>For jealousy arouses the fury of the man. 
+</div><div class="q2">He won’t spare in the day of vengeance. 
+</div><div class="q1">
+<sup>35&#160;</sup>He won’t regard any ransom, 
+</div><div class="q2">neither will he rest content, though you give many gifts. 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="q1">
+<sup>1&#160;</sup>My son, keep my words. 
+</div><div class="q2">Lay up my commandments within you. 
+</div><div class="q1">
+<sup>2&#160;</sup>Keep my commandments and live! 
+</div><div class="q2">Guard my teaching as the apple of your eye. 
+</div><div class="q1">
+<sup>3&#160;</sup>Bind them on your fingers. 
+</div><div class="q2">Write them on the tablet of your heart. 
+</div><div class="q1">
+<sup>4&#160;</sup>Tell wisdom, “You are my sister.” 
+</div><div class="q2">Call understanding your relative, 
+</div><div class="q1">
+<sup>5&#160;</sup>that they may keep you from the strange woman, 
+</div><div class="q2">from the foreigner who flatters with her words. 
+</div><div class="q1">
+<sup>6&#160;</sup>For at the window of my house, 
+</div><div class="q2">I looked out through my lattice. 
+</div><div class="q1">
+<sup>7&#160;</sup>I saw among the simple ones. 
+</div><div class="q2">I discerned among the youths a young man void of understanding, 
+</div><div class="q1">
+<sup>8&#160;</sup>passing through the street near her corner, 
+</div><div class="q2">he went the way to her house, 
+</div><div class="q1">
+<sup>9&#160;</sup>in the twilight, in the evening of the day, 
+</div><div class="q2">in the middle of the night and in the darkness. 
+</div><div class="q1">
+<sup>10&#160;</sup>Behold, there a woman met him with the attire of a prostitute, 
+</div><div class="q2">and with crafty intent. 
+</div><div class="q1">
+<sup>11&#160;</sup>She is loud and defiant. 
+</div><div class="q2">Her feet don’t stay in her house. 
+</div><div class="q1">
+<sup>12&#160;</sup>Now she is in the streets, now in the squares, 
+</div><div class="q2">and lurking at every corner. 
+</div><div class="q1">
+<sup>13&#160;</sup>So she caught him, and kissed him. 
+</div><div class="q2">With an impudent face she said to him: 
+</div><div class="q1">
+<sup>14&#160;</sup>“Sacrifices of peace offerings are with me. 
+</div><div class="q2">Today I have paid my vows. 
+</div><div class="q1">
+<sup>15&#160;</sup>Therefore I came out to meet you, 
+</div><div class="q2">to diligently seek your face, 
+</div><div class="q2">and I have found you. 
+</div><div class="q1">
+<sup>16&#160;</sup>I have spread my couch with carpets of tapestry, 
+</div><div class="q2">with striped cloths of the yarn of Egypt. 
+</div><div class="q1">
+<sup>17&#160;</sup>I have perfumed my bed with myrrh, aloes, and cinnamon. 
+</div><div class="q1">
+<sup>18&#160;</sup>Come, let’s take our fill of loving until the morning. 
+</div><div class="q2">Let’s solace ourselves with loving. 
+</div><div class="q1">
+<sup>19&#160;</sup>For my man isn’t at home. 
+</div><div class="q2">He has gone on a long journey. 
+</div><div class="q1">
+<sup>20&#160;</sup>He has taken a bag of money with him. 
+</div><div class="q2">He will come home at the full moon.” 
+</div><div class="q1">
+<sup>21&#160;</sup>With persuasive words, she led him astray. 
+</div><div class="q2">With the flattering of her lips, she seduced him. 
+</div><div class="q1">
+<sup>22&#160;</sup>He followed her immediately, 
+</div><div class="q2">as an ox goes to the slaughter, 
+</div><div class="q2">as a fool stepping into a noose. 
+</div><div class="q1">
+<sup>23&#160;</sup>Until an arrow strikes through his liver, 
+</div><div class="q2">as a bird hurries to the snare, 
+</div><div class="q2">and doesn’t know that it will cost his life. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>Now therefore, sons, listen to me. 
+</div><div class="q2">Pay attention to the words of my mouth. 
+</div><div class="q1">
+<sup>25&#160;</sup>Don’t let your heart turn to her ways. 
+</div><div class="q2">Don’t go astray in her paths, 
+</div><div class="q1">
+<sup>26&#160;</sup>for she has thrown down many wounded. 
+</div><div class="q2">Yes, all her slain are a mighty army. 
+</div><div class="q1">
+<sup>27&#160;</sup>Her house is the way to Sheol, 
+</div><div class="q2">going down to the rooms of death. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="q1">
+<sup>1&#160;</sup>Doesn’t wisdom cry out? 
+</div><div class="q2">Doesn’t understanding raise her voice? 
+</div><div class="q1">
+<sup>2&#160;</sup>On the top of high places by the way, 
+</div><div class="q2">where the paths meet, she stands. 
+</div><div class="q1">
+<sup>3&#160;</sup>Beside the gates, at the entry of the city, 
+</div><div class="q2">at the entry doors, she cries aloud: 
+</div><div class="q1">
+<sup>4&#160;</sup>“I call to you men! 
+</div><div class="q2">I send my voice to the sons of mankind. 
+</div><div class="q1">
+<sup>5&#160;</sup>You simple, understand prudence! 
+</div><div class="q2">You fools, be of an understanding heart! 
+</div><div class="q1">
+<sup>6&#160;</sup>Hear, for I will speak excellent things. 
+</div><div class="q2">The opening of my lips is for right things. 
+</div><div class="q1">
+<sup>7&#160;</sup>For my mouth speaks truth. 
+</div><div class="q2">Wickedness is an abomination to my lips. 
+</div><div class="q1">
+<sup>8&#160;</sup>All the words of my mouth are in righteousness. 
+</div><div class="q2">There is nothing crooked or perverse in them. 
+</div><div class="q1">
+<sup>9&#160;</sup>They are all plain to him who understands, 
+</div><div class="q2">right to those who find knowledge. 
+</div><div class="q1">
+<sup>10&#160;</sup>Receive my instruction rather than silver, 
+</div><div class="q2">knowledge rather than choice gold. 
+</div><div class="q1">
+<sup>11&#160;</sup>For wisdom is better than rubies. 
+</div><div class="q2">All the things that may be desired can’t be compared to it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>“I, wisdom, have made prudence my dwelling. 
+</div><div class="q2">Find out knowledge and discretion. 
+</div><div class="q1">
+<sup>13&#160;</sup>The fear of Yahweh is to hate evil. 
+</div><div class="q2">I hate pride, arrogance, the evil way, and the perverse mouth. 
+</div><div class="q1">
+<sup>14&#160;</sup>Counsel and sound knowledge are mine. 
+</div><div class="q2">I have understanding and power. 
+</div><div class="q1">
+<sup>15&#160;</sup>By me kings reign, 
+</div><div class="q2">and princes decree justice. 
+</div><div class="q1">
+<sup>16&#160;</sup>By me princes rule, 
+</div><div class="q2">nobles, and all the righteous rulers of the earth. 
+</div><div class="q1">
+<sup>17&#160;</sup>I love those who love me. 
+</div><div class="q2">Those who seek me diligently will find me. 
+</div><div class="q1">
+<sup>18&#160;</sup>With me are riches, honor, 
+</div><div class="q2">enduring wealth, and prosperity. 
+</div><div class="q1">
+<sup>19&#160;</sup>My fruit is better than gold, yes, than fine gold, 
+</div><div class="q2">my yield than choice silver. 
+</div><div class="q1">
+<sup>20&#160;</sup>I walk in the way of righteousness, 
+</div><div class="q2">in the middle of the paths of justice, 
+</div><div class="q1">
+<sup>21&#160;</sup>that I may give wealth to those who love me. 
+</div><div class="q2">I fill their treasuries. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“Yahweh possessed me in the beginning of his work, 
+</div><div class="q2">before his deeds of old. 
+</div><div class="q1">
+<sup>23&#160;</sup>I was set up from everlasting, from the beginning, 
+</div><div class="q2">before the earth existed. 
+</div><div class="q1">
+<sup>24&#160;</sup>When there were no depths, I was born, 
+</div><div class="q2">when there were no springs abounding with water. 
+</div><div class="q1">
+<sup>25&#160;</sup>Before the mountains were settled in place, 
+</div><div class="q2">before the hills, I was born; 
+</div><div class="q1">
+<sup>26&#160;</sup>while as yet he had not made the earth, nor the fields, 
+</div><div class="q2">nor the beginning of the dust of the world. 
+</div><div class="q1">
+<sup>27&#160;</sup>When he established the heavens, I was there. 
+</div><div class="q2">When he set a circle on the surface of the deep, 
+</div><div class="q1">
+<sup>28&#160;</sup>when he established the clouds above, 
+</div><div class="q2">when the springs of the deep became strong, 
+</div><div class="q1">
+<sup>29&#160;</sup>when he gave to the sea its boundary, 
+</div><div class="q2">that the waters should not violate his commandment, 
+</div><div class="q2">when he marked out the foundations of the earth, 
+</div><div class="q1">
+<sup>30&#160;</sup>then I was the craftsman by his side. 
+</div><div class="q2">I was a delight day by day, 
+</div><div class="q2">always rejoicing before him, 
+</div><div class="q1">
+<sup>31&#160;</sup>rejoicing in his whole world. 
+</div><div class="q2">My delight was with the sons of men. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>32&#160;</sup>“Now therefore, my sons, listen to me, 
+</div><div class="q2">for blessed are those who keep my ways. 
+</div><div class="q1">
+<sup>33&#160;</sup>Hear instruction, and be wise. 
+</div><div class="q2">Don’t refuse it. 
+</div><div class="q1">
+<sup>34&#160;</sup>Blessed is the man who hears me, 
+</div><div class="q2">watching daily at my gates, 
+</div><div class="q2">waiting at my door posts. 
+</div><div class="q1">
+<sup>35&#160;</sup>For whoever finds me finds life, 
+</div><div class="q2">and will obtain favor from Yahweh. 
+</div><div class="q1">
+<sup>36&#160;</sup>But he who sins against me wrongs his own soul. 
+</div><div class="q2">All those who hate me love death.” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="q1">
+<sup>1&#160;</sup>Wisdom has built her house. 
+</div><div class="q2">She has carved out her seven pillars. 
+</div><div class="q1">
+<sup>2&#160;</sup>She has prepared her meat. 
+</div><div class="q2">She has mixed her wine. 
+</div><div class="q2">She has also set her table. 
+</div><div class="q1">
+<sup>3&#160;</sup>She has sent out her maidens. 
+</div><div class="q2">She cries from the highest places of the city: 
+</div><div class="q1">
+<sup>4&#160;</sup>“Whoever is simple, let him turn in here!” 
+</div><div class="q2">As for him who is void of understanding, she says to him, 
+</div><div class="q1">
+<sup>5&#160;</sup>“Come, eat some of my bread, 
+</div><div class="q2">Drink some of the wine which I have mixed! 
+</div><div class="q1">
+<sup>6&#160;</sup>Leave your simple ways, and live. 
+</div><div class="q2">Walk in the way of understanding.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>One who corrects a mocker invites insult. 
+</div><div class="q2">One who reproves a wicked man invites abuse. 
+</div><div class="q1">
+<sup>8&#160;</sup>Don’t reprove a scoffer, lest he hate you. 
+</div><div class="q2">Reprove a wise person, and he will love you. 
+</div><div class="q1">
+<sup>9&#160;</sup>Instruct a wise person, and he will be still wiser. 
+</div><div class="q2">Teach a righteous person, and he will increase in learning. 
+</div><div class="q1">
+<sup>10&#160;</sup>The fear of Yahweh is the beginning of wisdom. 
+</div><div class="q2">The knowledge of the Set-Apart One is understanding. 
+</div><div class="q1">
+<sup>11&#160;</sup>For by me your days will be multiplied. 
+</div><div class="q2">The years of your life will be increased. 
+</div><div class="q1">
+<sup>12&#160;</sup>If you are wise, you are wise for yourself. 
+</div><div class="q2">If you mock, you alone will bear it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>The foolish woman is loud, 
+</div><div class="q2">undisciplined, and knows nothing. 
+</div><div class="q1">
+<sup>14&#160;</sup>She sits at the door of her house, 
+</div><div class="q2">on a seat in the high places of the city, 
+</div><div class="q1">
+<sup>15&#160;</sup>to call to those who pass by, 
+</div><div class="q2">who go straight on their ways, 
+</div><div class="q1">
+<sup>16&#160;</sup>“Whoever is simple, let him turn in here.” 
+</div><div class="q2">As for him who is void of understanding, she says to him, 
+</div><div class="q1">
+<sup>17&#160;</sup>“Stolen water is sweet. 
+</div><div class="q2">Food eaten in secret is pleasant.” 
+</div><div class="q1">
+<sup>18&#160;</sup>But he doesn’t know that the departed spirits are there, 
+</div><div class="q2">that her guests are in the depths of Sheol. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>The proverbs of Solomon. 
+</div><div class="q1">A wise son makes a glad father; 
+</div><div class="q2">but a foolish son brings grief to his mother. 
+</div><div class="q1">
+<sup>2&#160;</sup>Treasures of wickedness profit nothing, 
+</div><div class="q2">but righteousness delivers from death. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh will not allow the soul of the righteous to go hungry, 
+</div><div class="q2">but he thrusts away the desire of the wicked. 
+</div><div class="q1">
+<sup>4&#160;</sup>He becomes poor who works with a lazy hand, 
+</div><div class="q2">but the hand of the diligent brings wealth. 
+</div><div class="q1">
+<sup>5&#160;</sup>He who gathers in summer is a wise son, 
+</div><div class="q2">but he who sleeps during the harvest is a son who causes shame. 
+</div><div class="q1">
+<sup>6&#160;</sup>Blessings are on the head of the righteous, 
+</div><div class="q2">but violence covers the mouth of the wicked. 
+</div><div class="q1">
+<sup>7&#160;</sup>The memory of the righteous is blessed, 
+</div><div class="q2">but the name of the wicked will rot. 
+</div><div class="q1">
+<sup>8&#160;</sup>The wise in heart accept commandments, 
+</div><div class="q2">but a chattering fool will fall. 
+</div><div class="q1">
+<sup>9&#160;</sup>He who walks blamelessly walks surely, 
+</div><div class="q2">but he who perverts his ways will be found out. 
+</div><div class="q1">
+<sup>10&#160;</sup>One who winks with the eye causes sorrow, 
+</div><div class="q2">but a chattering fool will fall. 
+</div><div class="q1">
+<sup>11&#160;</sup>The mouth of the righteous is a spring of life, 
+</div><div class="q2">but violence covers the mouth of the wicked. 
+</div><div class="q1">
+<sup>12&#160;</sup>Hatred stirs up strife, 
+</div><div class="q2">but love covers all wrongs. 
+</div><div class="q1">
+<sup>13&#160;</sup>Wisdom is found on the lips of him who has discernment, 
+</div><div class="q2">but a rod is for the back of him who is void of understanding. 
+</div><div class="q1">
+<sup>14&#160;</sup>Wise men lay up knowledge, 
+</div><div class="q2">but the mouth of the foolish is near ruin. 
+</div><div class="q1">
+<sup>15&#160;</sup>The rich man’s wealth is his strong city. 
+</div><div class="q2">The destruction of the poor is their poverty. 
+</div><div class="q1">
+<sup>16&#160;</sup>The labor of the righteous leads to life. 
+</div><div class="q2">The increase of the wicked leads to sin. 
+</div><div class="q1">
+<sup>17&#160;</sup>He is in the way of life who heeds correction, 
+</div><div class="q2">but he who forsakes reproof leads others astray. 
+</div><div class="q1">
+<sup>18&#160;</sup>He who hides hatred has lying lips. 
+</div><div class="q2">He who utters a slander is a fool. 
+</div><div class="q1">
+<sup>19&#160;</sup>In the multitude of words there is no lack of disobedience, 
+</div><div class="q2">but he who restrains his lips does wisely. 
+</div><div class="q1">
+<sup>20&#160;</sup>The tongue of the righteous is like choice silver. 
+</div><div class="q2">The heart of the wicked is of little worth. 
+</div><div class="q1">
+<sup>21&#160;</sup>The lips of the righteous feed many, 
+</div><div class="q2">but the foolish die for lack of understanding. 
+</div><div class="q1">
+<sup>22&#160;</sup>Yahweh’s blessing brings wealth, 
+</div><div class="q2">and he adds no trouble to it. 
+</div><div class="q1">
+<sup>23&#160;</sup>It is a fool’s pleasure to do wickedness, 
+</div><div class="q2">but wisdom is a man of understanding’s pleasure. 
+</div><div class="q1">
+<sup>24&#160;</sup>What the wicked fear will overtake them, 
+</div><div class="q2">but the desire of the righteous will be granted. 
+</div><div class="q1">
+<sup>25&#160;</sup>When the whirlwind passes, the wicked is no more; 
+</div><div class="q2">but the righteous stand firm forever. 
+</div><div class="q1">
+<sup>26&#160;</sup>As vinegar to the teeth, and as smoke to the eyes, 
+</div><div class="q2">so is the sluggard to those who send him. 
+</div><div class="q1">
+<sup>27&#160;</sup>The fear of Yahweh prolongs days, 
+</div><div class="q2">but the years of the wicked shall be shortened. 
+</div><div class="q1">
+<sup>28&#160;</sup>The prospect of the righteous is joy, 
+</div><div class="q2">but the hope of the wicked will perish. 
+</div><div class="q1">
+<sup>29&#160;</sup>The way of Yahweh is a stronghold to the upright, 
+</div><div class="q2">but it is a destruction to the workers of iniquity. 
+</div><div class="q1">
+<sup>30&#160;</sup>The righteous will never be removed, 
+</div><div class="q2">but the wicked will not dwell in the land. 
+</div><div class="q1">
+<sup>31&#160;</sup>The mouth of the righteous produces wisdom, 
+</div><div class="q2">but the perverse tongue will be cut off. 
+</div><div class="q1">
+<sup>32&#160;</sup>The lips of the righteous know what is acceptable, 
+</div><div class="q2">but the mouth of the wicked is perverse. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="q1">
+<sup>1&#160;</sup>A false balance is an abomination to Yahweh, 
+</div><div class="q2">but accurate weights are his delight. 
+</div><div class="q1">
+<sup>2&#160;</sup>When pride comes, then comes shame, 
+</div><div class="q2">but with humility comes wisdom. 
+</div><div class="q1">
+<sup>3&#160;</sup>The integrity of the upright shall guide them, 
+</div><div class="q2">but the perverseness of the treacherous shall destroy them. 
+</div><div class="q1">
+<sup>4&#160;</sup>Riches don’t profit in the day of wrath, 
+</div><div class="q2">but righteousness delivers from death. 
+</div><div class="q1">
+<sup>5&#160;</sup>The righteousness of the blameless will direct his way, 
+</div><div class="q2">but the wicked shall fall by his own wickedness. 
+</div><div class="q1">
+<sup>6&#160;</sup>The righteousness of the upright shall deliver them, 
+</div><div class="q2">but the unfaithful will be trapped by evil desires. 
+</div><div class="q1">
+<sup>7&#160;</sup>When a wicked man dies, hope perishes, 
+</div><div class="q2">and expectation of power comes to nothing. 
+</div><div class="q1">
+<sup>8&#160;</sup>A righteous person is delivered out of trouble, 
+</div><div class="q2">and the wicked takes his place. 
+</div><div class="q1">
+<sup>9&#160;</sup>With his mouth the elohimless man destroys his neighbor, 
+</div><div class="q2">but the righteous will be delivered through knowledge. 
+</div><div class="q1">
+<sup>10&#160;</sup>When it goes well with the righteous, the city rejoices. 
+</div><div class="q2">When the wicked perish, there is shouting. 
+</div><div class="q1">
+<sup>11&#160;</sup>By the blessing of the upright, the city is exalted, 
+</div><div class="q2">but it is overthrown by the mouth of the wicked. 
+</div><div class="q1">
+<sup>12&#160;</sup>One who despises his neighbor is void of wisdom, 
+</div><div class="q2">but a man of understanding holds his peace. 
+</div><div class="q1">
+<sup>13&#160;</sup>One who brings gossip betrays a confidence, 
+</div><div class="q2">but one who is of a trustworthy spirit is one who keeps a secret. 
+</div><div class="q1">
+<sup>14&#160;</sup>Where there is no wise guidance, the nation falls, 
+</div><div class="q2">but in the multitude of counselors there is victory. 
+</div><div class="q1">
+<sup>15&#160;</sup>He who is collateral for a stranger will suffer for it, 
+</div><div class="q2">but he who refuses pledges of collateral is secure. 
+</div><div class="q1">
+<sup>16&#160;</sup>A gracious woman obtains honor, 
+</div><div class="q2">but violent men obtain riches. 
+</div><div class="q1">
+<sup>17&#160;</sup>The merciful man does good to his own soul, 
+</div><div class="q2">but he who is cruel troubles his own flesh. 
+</div><div class="q1">
+<sup>18&#160;</sup>Wicked people earn deceitful wages, 
+</div><div class="q2">but one who sows righteousness reaps a sure reward. 
+</div><div class="q1">
+<sup>19&#160;</sup>He who is truly righteous gets life. 
+</div><div class="q2">He who pursues evil gets death. 
+</div><div class="q1">
+<sup>20&#160;</sup>Those who are perverse in heart are an abomination to Yahweh, 
+</div><div class="q2">but those whose ways are blameless are his delight. 
+</div><div class="q1">
+<sup>21&#160;</sup>Most certainly, the evil man will not be unpunished, 
+</div><div class="q2">but the offspring of the righteous will be delivered. 
+</div><div class="q1">
+<sup>22&#160;</sup>Like a gold ring in a pig’s snout, 
+</div><div class="q2">is a beautiful woman who lacks discretion. 
+</div><div class="q1">
+<sup>23&#160;</sup>The desire of the righteous is only good. 
+</div><div class="q2">The expectation of the wicked is wrath. 
+</div><div class="q1">
+<sup>24&#160;</sup>There is one who scatters, and increases yet more. 
+</div><div class="q2">There is one who withholds more than is appropriate, but gains poverty. 
+</div><div class="q1">
+<sup>25&#160;</sup>The liberal soul shall be made fat. 
+</div><div class="q2">He who waters shall be watered also himself. 
+</div><div class="q1">
+<sup>26&#160;</sup>People curse someone who withholds grain, 
+</div><div class="q2">but blessing will be on the head of him who sells it. 
+</div><div class="q1">
+<sup>27&#160;</sup>He who diligently seeks good seeks favor, 
+</div><div class="q2">but he who searches after evil, it shall come to him. 
+</div><div class="q1">
+<sup>28&#160;</sup>He who trusts in his riches will fall, 
+</div><div class="q2">but the righteous shall flourish as the green leaf. 
+</div><div class="q1">
+<sup>29&#160;</sup>He who troubles his own house shall inherit the wind. 
+</div><div class="q2">The foolish shall be servant to the wise of heart. 
+</div><div class="q1">
+<sup>30&#160;</sup>The fruit of the righteous is a tree of life. 
+</div><div class="q2">He who is wise wins souls. 
+</div><div class="q1">
+<sup>31&#160;</sup>Behold, the righteous shall be repaid in the earth, 
+</div><div class="q2">how much more the wicked and the sinner! 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="q1">
+<sup>1&#160;</sup>Whoever loves correction loves knowledge, 
+</div><div class="q2">but he who hates reproof is stupid. 
+</div><div class="q1">
+<sup>2&#160;</sup>A good man shall obtain favor from Yahweh, 
+</div><div class="q2">but he will condemn a man of wicked plans. 
+</div><div class="q1">
+<sup>3&#160;</sup>A man shall not be established by wickedness, 
+</div><div class="q2">but the root of the righteous shall not be moved. 
+</div><div class="q1">
+<sup>4&#160;</sup>A worthy woman is the crown of her owner, 
+</div><div class="q2">but a disgraceful woman is as rottenness in his bones. 
+</div><div class="q1">
+<sup>5&#160;</sup>The thoughts of the righteous are just, 
+</div><div class="q2">but the advice of the wicked is deceitful. 
+</div><div class="q1">
+<sup>6&#160;</sup>The words of the wicked are about lying in wait for blood, 
+</div><div class="q2">but the speech of the upright rescues them. 
+</div><div class="q1">
+<sup>7&#160;</sup>The wicked are overthrown, and are no more, 
+</div><div class="q2">but the house of the righteous shall stand. 
+</div><div class="q1">
+<sup>8&#160;</sup>A man shall be commended according to his wisdom, 
+</div><div class="q2">but he who has a warped mind shall be despised. 
+</div><div class="q1">
+<sup>9&#160;</sup>Better is he who is little known, and has a servant, 
+</div><div class="q2">than he who honors himself and lacks bread. 
+</div><div class="q1">
+<sup>10&#160;</sup>A righteous man respects the life of his animal, 
+</div><div class="q2">but the tender mercies of the wicked are cruel. 
+</div><div class="q1">
+<sup>11&#160;</sup>He who tills his land shall have plenty of bread, 
+</div><div class="q2">but he who chases fantasies is void of understanding. 
+</div><div class="q1">
+<sup>12&#160;</sup>The wicked desires the plunder of evil men, 
+</div><div class="q2">but the root of the righteous flourishes. 
+</div><div class="q1">
+<sup>13&#160;</sup>An evil man is trapped by sinfulness of lips, 
+</div><div class="q2">but the righteous shall come out of trouble. 
+</div><div class="q1">
+<sup>14&#160;</sup>A man shall be satisfied with good by the fruit of his mouth. 
+</div><div class="q2">The work of a man’s hands shall be rewarded to him. 
+</div><div class="q1">
+<sup>15&#160;</sup>The way of a fool is right in his own eyes, 
+</div><div class="q2">but he who is wise listens to counsel. 
+</div><div class="q1">
+<sup>16&#160;</sup>A fool shows his annoyance the same day, 
+</div><div class="q2">but one who overlooks an insult is prudent. 
+</div><div class="q1">
+<sup>17&#160;</sup>He who is truthful testifies honestly, 
+</div><div class="q2">but a false witness lies. 
+</div><div class="q1">
+<sup>18&#160;</sup>There is one who speaks rashly like the piercing of a sword, 
+</div><div class="q2">but the tongue of the wise heals. 
+</div><div class="q1">
+<sup>19&#160;</sup>Truth’s lips will be established forever, 
+</div><div class="q2">but a lying tongue is only momentary. 
+</div><div class="q1">
+<sup>20&#160;</sup>Deceit is in the heart of those who plot evil, 
+</div><div class="q2">but joy comes to the promoters of peace. 
+</div><div class="q1">
+<sup>21&#160;</sup>No mischief shall happen to the righteous, 
+</div><div class="q2">but the wicked shall be filled with evil. 
+</div><div class="q1">
+<sup>22&#160;</sup>Lying lips are an abomination to Yahweh, 
+</div><div class="q2">but those who do the truth are his delight. 
+</div><div class="q1">
+<sup>23&#160;</sup>A prudent man keeps his knowledge, 
+</div><div class="q2">but the hearts of fools proclaim foolishness. 
+</div><div class="q1">
+<sup>24&#160;</sup>The hands of the diligent ones shall rule, 
+</div><div class="q2">but laziness ends in slave labor. 
+</div><div class="q1">
+<sup>25&#160;</sup>Anxiety in a man’s heart weighs it down, 
+</div><div class="q2">but a kind word makes it glad. 
+</div><div class="q1">
+<sup>26&#160;</sup>A righteous person is cautious in friendship, 
+</div><div class="q2">but the way of the wicked leads them astray. 
+</div><div class="q1">
+<sup>27&#160;</sup>The slothful man doesn’t roast his game, 
+</div><div class="q2">but the possessions of diligent men are prized. 
+</div><div class="q1">
+<sup>28&#160;</sup>In the way of righteousness is life; 
+</div><div class="q2">in its path there is no death. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="q1">
+<sup>1&#160;</sup>A wise son listens to his father’s instruction, 
+</div><div class="q2">but a scoffer doesn’t listen to rebuke. 
+</div><div class="q1">
+<sup>2&#160;</sup>By the fruit of his lips, a man enjoys good things, 
+</div><div class="q2">but the unfaithful crave violence. 
+</div><div class="q1">
+<sup>3&#160;</sup>He who guards his mouth guards his soul. 
+</div><div class="q2">One who opens wide his lips comes to ruin. 
+</div><div class="q1">
+<sup>4&#160;</sup>The soul of the sluggard desires, and has nothing, 
+</div><div class="q2">but the desire of the diligent shall be fully satisfied. 
+</div><div class="q1">
+<sup>5&#160;</sup>A righteous man hates lies, 
+</div><div class="q2">but a wicked man brings shame and disgrace. 
+</div><div class="q1">
+<sup>6&#160;</sup>Righteousness guards the way of integrity, 
+</div><div class="q2">but wickedness overthrows the sinner. 
+</div><div class="q1">
+<sup>7&#160;</sup>There are some who pretend to be rich, yet have nothing. 
+</div><div class="q2">There are some who pretend to be poor, yet have great wealth. 
+</div><div class="q1">
+<sup>8&#160;</sup>The ransom of a man’s life is his riches, 
+</div><div class="q2">but the poor hear no threats. 
+</div><div class="q1">
+<sup>9&#160;</sup>The light of the righteous shines brightly, 
+</div><div class="q2">but the lamp of the wicked is snuffed out. 
+</div><div class="q1">
+<sup>10&#160;</sup>Pride only breeds quarrels, 
+</div><div class="q2">but wisdom is with people who take advice. 
+</div><div class="q1">
+<sup>11&#160;</sup>Wealth gained dishonestly dwindles away, 
+</div><div class="q2">but he who gathers by hand makes it grow. 
+</div><div class="q1">
+<sup>12&#160;</sup>Hope deferred makes the heart sick, 
+</div><div class="q2">but when longing is fulfilled, it is a tree of life. 
+</div><div class="q1">
+<sup>13&#160;</sup>Whoever despises instruction will pay for it, 
+</div><div class="q2">but he who respects a command will be rewarded. 
+</div><div class="q1">
+<sup>14&#160;</sup>The teaching of the wise is a spring of life, 
+</div><div class="q2">to turn from the snares of death. 
+</div><div class="q1">
+<sup>15&#160;</sup>Good understanding wins favor, 
+</div><div class="q2">but the way of the unfaithful is hard. 
+</div><div class="q1">
+<sup>16&#160;</sup>Every prudent man acts from knowledge, 
+</div><div class="q2">but a fool exposes folly. 
+</div><div class="q1">
+<sup>17&#160;</sup>A wicked messenger falls into trouble, 
+</div><div class="q2">but a trustworthy envoy gains healing. 
+</div><div class="q1">
+<sup>18&#160;</sup>Poverty and shame come to him who refuses discipline, 
+</div><div class="q2">but he who heeds correction shall be honored. 
+</div><div class="q1">
+<sup>19&#160;</sup>Longing fulfilled is sweet to the soul, 
+</div><div class="q2">but fools detest turning from evil. 
+</div><div class="q1">
+<sup>20&#160;</sup>One who walks with wise men grows wise, 
+</div><div class="q2">but a companion of fools suffers harm. 
+</div><div class="q1">
+<sup>21&#160;</sup>Misfortune pursues sinners, 
+</div><div class="q2">but prosperity rewards the righteous. 
+</div><div class="q1">
+<sup>22&#160;</sup>A good man leaves an inheritance to his children’s children, 
+</div><div class="q2">but the wealth of the sinner is stored for the righteous. 
+</div><div class="q1">
+<sup>23&#160;</sup>An abundance of food is in poor people’s fields, 
+</div><div class="q2">but injustice sweeps it away. 
+</div><div class="q1">
+<sup>24&#160;</sup>One who spares the rod hates his son, 
+</div><div class="q2">but one who loves him is careful to discipline him. 
+</div><div class="q1">
+<sup>25&#160;</sup>The righteous one eats to the satisfying of his soul, 
+</div><div class="q2">but the belly of the wicked goes hungry. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="q1">
+<sup>1&#160;</sup>Every wise woman builds her house, 
+</div><div class="q2">but the foolish one tears it down with her own hands. 
+</div><div class="q1">
+<sup>2&#160;</sup>He who walks in his uprightness fears Yahweh, 
+</div><div class="q2">but he who is perverse in his ways despises him. 
+</div><div class="q1">
+<sup>3&#160;</sup>The fool’s talk brings a rod to his back, 
+</div><div class="q2">but the lips of the wise protect them. 
+</div><div class="q1">
+<sup>4&#160;</sup>Where no oxen are, the crib is clean, 
+</div><div class="q2">but much increase is by the strength of the ox. 
+</div><div class="q1">
+<sup>5&#160;</sup>A truthful witness will not lie, 
+</div><div class="q2">but a false witness pours out lies. 
+</div><div class="q1">
+<sup>6&#160;</sup>A scoffer seeks wisdom, and doesn’t find it, 
+</div><div class="q2">but knowledge comes easily to a discerning person. 
+</div><div class="q1">
+<sup>7&#160;</sup>Stay away from a foolish man, 
+</div><div class="q2">for you won’t find knowledge on his lips. 
+</div><div class="q1">
+<sup>8&#160;</sup>The wisdom of the prudent is to think about his way, 
+</div><div class="q2">but the folly of fools is deceit. 
+</div><div class="q1">
+<sup>9&#160;</sup>Fools mock at making atonement for sins, 
+</div><div class="q2">but among the upright there is good will. 
+</div><div class="q1">
+<sup>10&#160;</sup>The heart knows its own bitterness and joy; 
+</div><div class="q2">he will not share these with a stranger. 
+</div><div class="q1">
+<sup>11&#160;</sup>The house of the wicked will be overthrown, 
+</div><div class="q2">but the tent of the upright will flourish. 
+</div><div class="q1">
+<sup>12&#160;</sup>There is a way which seems right to a man, 
+</div><div class="q2">but in the end it leads to death. 
+</div><div class="q1">
+<sup>13&#160;</sup>Even in laughter the heart may be sorrowful, 
+</div><div class="q2">and mirth may end in heaviness. 
+</div><div class="q1">
+<sup>14&#160;</sup>The unfaithful will be repaid for his own ways; 
+</div><div class="q2">likewise a good man will be rewarded for his ways. 
+</div><div class="q1">
+<sup>15&#160;</sup>A simple man believes everything, 
+</div><div class="q2">but the prudent man carefully considers his ways. 
+</div><div class="q1">
+<sup>16&#160;</sup>A wise man fears and shuns evil, 
+</div><div class="q2">but the fool is hot headed and reckless. 
+</div><div class="q1">
+<sup>17&#160;</sup>He who is quick to become angry will commit folly, 
+</div><div class="q2">and a crafty man is hated. 
+</div><div class="q1">
+<sup>18&#160;</sup>The simple inherit folly, 
+</div><div class="q2">but the prudent are crowned with knowledge. 
+</div><div class="q1">
+<sup>19&#160;</sup>The evil bow down before the good, 
+</div><div class="q2">and the wicked at the gates of the righteous. 
+</div><div class="q1">
+<sup>20&#160;</sup>The poor person is shunned even by his own neighbor, 
+</div><div class="q2">but the rich person has many friends. 
+</div><div class="q1">
+<sup>21&#160;</sup>He who despises his neighbor sins, 
+</div><div class="q2">but he who has pity on the poor is blessed. 
+</div><div class="q1">
+<sup>22&#160;</sup>Don’t they go astray who plot evil? 
+</div><div class="q2">But love and faithfulness belong to those who plan good. 
+</div><div class="q1">
+<sup>23&#160;</sup>In all hard work there is profit, 
+</div><div class="q2">but the talk of the lips leads only to poverty. 
+</div><div class="q1">
+<sup>24&#160;</sup>The crown of the wise is their riches, 
+</div><div class="q2">but the folly of fools crowns them with folly. 
+</div><div class="q1">
+<sup>25&#160;</sup>A truthful witness saves souls, 
+</div><div class="q2">but a false witness is deceitful. 
+</div><div class="q1">
+<sup>26&#160;</sup>In the fear of Yahweh is a secure fortress, 
+</div><div class="q2">and he will be a refuge for his children. 
+</div><div class="q1">
+<sup>27&#160;</sup>The fear of Yahweh is a fountain of life, 
+</div><div class="q2">turning people from the snares of death. 
+</div><div class="q1">
+<sup>28&#160;</sup>In the multitude of people is the king’s glory, 
+</div><div class="q2">but in the lack of people is the destruction of the prince. 
+</div><div class="q1">
+<sup>29&#160;</sup>He who is slow to anger has great understanding, 
+</div><div class="q2">but he who has a quick temper displays folly. 
+</div><div class="q1">
+<sup>30&#160;</sup>The life of the body is a heart at peace, 
+</div><div class="q2">but envy rots the bones. 
+</div><div class="q1">
+<sup>31&#160;</sup>He who oppresses the poor shows contempt for his Maker, 
+</div><div class="q2">but he who is kind to the needy honors him. 
+</div><div class="q1">
+<sup>32&#160;</sup>The wicked is brought down in his calamity, 
+</div><div class="q2">but in death, the righteous has a refuge. 
+</div><div class="q1">
+<sup>33&#160;</sup>Wisdom rests in the heart of one who has understanding, 
+</div><div class="q2">and is even made known in the inward part of fools. 
+</div><div class="q1">
+<sup>34&#160;</sup>Righteousness exalts a nation, 
+</div><div class="q2">but sin is a disgrace to any people. 
+</div><div class="q1">
+<sup>35&#160;</sup>The king’s favor is toward a servant who deals wisely, 
+</div><div class="q2">but his wrath is toward one who causes shame. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="q1">
+<sup>1&#160;</sup>A gentle answer turns away wrath, 
+</div><div class="q2">but a harsh word stirs up anger. 
+</div><div class="q1">
+<sup>2&#160;</sup>The tongue of the wise commends knowledge, 
+</div><div class="q2">but the mouths of fools gush out folly. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh’s eyes are everywhere, 
+</div><div class="q2">keeping watch on the evil and the good. 
+</div><div class="q1">
+<sup>4&#160;</sup>A gentle tongue is a tree of life, 
+</div><div class="q2">but deceit in it crushes the spirit. 
+</div><div class="q1">
+<sup>5&#160;</sup>A fool despises his father’s correction, 
+</div><div class="q2">but he who heeds reproof shows prudence. 
+</div><div class="q1">
+<sup>6&#160;</sup>In the house of the righteous is much treasure, 
+</div><div class="q2">but the income of the wicked brings trouble. 
+</div><div class="q1">
+<sup>7&#160;</sup>The lips of the wise spread knowledge; 
+</div><div class="q2">not so with the heart of fools. 
+</div><div class="q1">
+<sup>8&#160;</sup>The sacrifice made by the wicked is an abomination to Yahweh, 
+</div><div class="q2">but the prayer of the upright is his delight. 
+</div><div class="q1">
+<sup>9&#160;</sup>The way of the wicked is an abomination to Yahweh, 
+</div><div class="q2">but he loves him who follows after righteousness. 
+</div><div class="q1">
+<sup>10&#160;</sup>There is stern discipline for one who forsakes the way. 
+</div><div class="q2">Whoever hates reproof shall die. 
+</div><div class="q1">
+<sup>11&#160;</sup>Sheol and Abaddon are before Yahweh—</div><div class="q2">how much more then the hearts of the children of men! 
+</div><div class="q1">
+<sup>12&#160;</sup>A scoffer doesn’t love to be reproved; 
+</div><div class="q2">he will not go to the wise. 
+</div><div class="q1">
+<sup>13&#160;</sup>A glad heart makes a cheerful face, 
+</div><div class="q2">but an aching heart breaks the spirit. 
+</div><div class="q1">
+<sup>14&#160;</sup>The heart of one who has understanding seeks knowledge, 
+</div><div class="q2">but the mouths of fools feed on folly. 
+</div><div class="q1">
+<sup>15&#160;</sup>All the days of the afflicted are wretched, 
+</div><div class="q2">but one who has a cheerful heart enjoys a continual feast. 
+</div><div class="q1">
+<sup>16&#160;</sup>Better is little, with the fear of Yahweh, 
+</div><div class="q2">than great treasure with trouble. 
+</div><div class="q1">
+<sup>17&#160;</sup>Better is a dinner of herbs, where love is, 
+</div><div class="q2">than a fattened calf with hatred. 
+</div><div class="q1">
+<sup>18&#160;</sup>A wrathful man stirs up contention, 
+</div><div class="q2">but one who is slow to anger appeases strife. 
+</div><div class="q1">
+<sup>19&#160;</sup>The way of the sluggard is like a thorn patch, 
+</div><div class="q2">but the path of the upright is a highway. 
+</div><div class="q1">
+<sup>20&#160;</sup>A wise son makes a father glad, 
+</div><div class="q2">but a foolish man despises his mother. 
+</div><div class="q1">
+<sup>21&#160;</sup>Folly is joy to one who is void of wisdom, 
+</div><div class="q2">but a man of understanding keeps his way straight. 
+</div><div class="q1">
+<sup>22&#160;</sup>Where there is no counsel, plans fail; 
+</div><div class="q2">but in a multitude of counselors they are established. 
+</div><div class="q1">
+<sup>23&#160;</sup>Joy comes to a man with the reply of his mouth. 
+</div><div class="q2">How good is a word at the right time! 
+</div><div class="q1">
+<sup>24&#160;</sup>The path of life leads upward for the wise, 
+</div><div class="q2">to keep him from going downward to Sheol. 
+</div><div class="q1">
+<sup>25&#160;</sup>Yahweh will uproot the house of the proud, 
+</div><div class="q2">but he will keep the widow’s borders intact. 
+</div><div class="q1">
+<sup>26&#160;</sup>Yahweh detests the thoughts of the wicked, 
+</div><div class="q2">but the thoughts of the pure are pleasing. 
+</div><div class="q1">
+<sup>27&#160;</sup>He who is greedy for gain troubles his own house, 
+</div><div class="q2">but he who hates bribes will live. 
+</div><div class="q1">
+<sup>28&#160;</sup>The heart of the righteous weighs answers, 
+</div><div class="q2">but the mouth of the wicked gushes out evil. 
+</div><div class="q1">
+<sup>29&#160;</sup>Yahweh is far from the wicked, 
+</div><div class="q2">but he hears the prayer of the righteous. 
+</div><div class="q1">
+<sup>30&#160;</sup>The light of the eyes rejoices the heart. 
+</div><div class="q2">Good news gives health to the bones. 
+</div><div class="q1">
+<sup>31&#160;</sup>The ear that listens to reproof lives, 
+</div><div class="q2">and will be at home among the wise. 
+</div><div class="q1">
+<sup>32&#160;</sup>He who refuses correction despises his own soul, 
+</div><div class="q2">but he who listens to reproof gets understanding. 
+</div><div class="q1">
+<sup>33&#160;</sup>The fear of Yahweh teaches wisdom. 
+</div><div class="q2">Before honor is humility. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="q1">
+<sup>1&#160;</sup>The plans of the heart belong to man, 
+</div><div class="q2">but the answer of the tongue is from Yahweh. 
+</div><div class="q1">
+<sup>2&#160;</sup>All the ways of a man are clean in his own eyes, 
+</div><div class="q2">but Yahweh weighs the motives. 
+</div><div class="q1">
+<sup>3&#160;</sup>Commit your deeds to Yahweh, 
+</div><div class="q2">and your plans shall succeed. 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh has made everything for its own end—</div><div class="q2">yes, even the wicked for the day of evil. 
+</div><div class="q1">
+<sup>5&#160;</sup>Everyone who is proud in heart is an abomination to Yahweh; 
+</div><div class="q2">they shall certainly not be unpunished. 
+</div><div class="q1">
+<sup>6&#160;</sup>By mercy and truth iniquity is atoned for. 
+</div><div class="q2">By the fear of Yahweh men depart from evil. 
+</div><div class="q1">
+<sup>7&#160;</sup>When a man’s ways please Yahweh, 
+</div><div class="q2">he makes even his enemies to be at peace with him. 
+</div><div class="q1">
+<sup>8&#160;</sup>Better is a little with righteousness, 
+</div><div class="q2">than great revenues with injustice. 
+</div><div class="q1">
+<sup>9&#160;</sup>A man’s heart plans his course, 
+</div><div class="q2">but Yahweh directs his steps. 
+</div><div class="q1">
+<sup>10&#160;</sup>Inspired judgments are on the lips of the king. 
+</div><div class="q2">He shall not betray his mouth. 
+</div><div class="q1">
+<sup>11&#160;</sup>Honest balances and scales are Yahweh’s; 
+</div><div class="q2">all the weights in the bag are his work. 
+</div><div class="q1">
+<sup>12&#160;</sup>It is an abomination for kings to do wrong, 
+</div><div class="q2">for the throne is established by righteousness. 
+</div><div class="q1">
+<sup>13&#160;</sup>Righteous lips are the delight of kings. 
+</div><div class="q2">They value one who speaks the truth. 
+</div><div class="q1">
+<sup>14&#160;</sup>The king’s wrath is a messenger of death, 
+</div><div class="q2">but a wise man will pacify it. 
+</div><div class="q1">
+<sup>15&#160;</sup>In the light of the king’s face is life. 
+</div><div class="q2">His favor is like a cloud of the spring rain. 
+</div><div class="q1">
+<sup>16&#160;</sup>How much better it is to get wisdom than gold! 
+</div><div class="q2">Yes, to get understanding is to be chosen rather than silver. 
+</div><div class="q1">
+<sup>17&#160;</sup>The highway of the upright is to depart from evil. 
+</div><div class="q2">He who keeps his way preserves his soul. 
+</div><div class="q1">
+<sup>18&#160;</sup>Pride goes before destruction, 
+</div><div class="q2">and an arrogant spirit before a fall. 
+</div><div class="q1">
+<sup>19&#160;</sup>It is better to be of a lowly spirit with the poor, 
+</div><div class="q2">than to divide the plunder with the proud. 
+</div><div class="q1">
+<sup>20&#160;</sup>He who heeds the Word finds prosperity. 
+</div><div class="q2">Whoever trusts in Yahweh is blessed. 
+</div><div class="q1">
+<sup>21&#160;</sup>The wise in heart shall be called prudent. 
+</div><div class="q2">Pleasantness of the lips promotes instruction. 
+</div><div class="q1">
+<sup>22&#160;</sup>Understanding is a fountain of life to one who has it, 
+</div><div class="q2">but the punishment of fools is their folly. 
+</div><div class="q1">
+<sup>23&#160;</sup>The heart of the wise instructs his mouth, 
+</div><div class="q2">and adds learning to his lips. 
+</div><div class="q1">
+<sup>24&#160;</sup>Pleasant words are a honeycomb, 
+</div><div class="q2">sweet to the soul, and health to the bones. 
+</div><div class="q1">
+<sup>25&#160;</sup>There is a way which seems right to a man, 
+</div><div class="q2">but in the end it leads to death. 
+</div><div class="q1">
+<sup>26&#160;</sup>The appetite of the laboring man labors for him, 
+</div><div class="q2">for his mouth urges him on. 
+</div><div class="q1">
+<sup>27&#160;</sup>A worthless man devises mischief. 
+</div><div class="q2">His speech is like a scorching fire. 
+</div><div class="q1">
+<sup>28&#160;</sup>A perverse man stirs up strife. 
+</div><div class="q2">A whisperer separates close friends. 
+</div><div class="q1">
+<sup>29&#160;</sup>A man of violence entices his neighbor, 
+</div><div class="q2">and leads him in a way that is not good. 
+</div><div class="q1">
+<sup>30&#160;</sup>One who winks his eyes to plot perversities, 
+</div><div class="q2">one who compresses his lips, is bent on evil. 
+</div><div class="q1">
+<sup>31&#160;</sup>Gray hair is a crown of glory. 
+</div><div class="q2">It is attained by a life of righteousness. 
+</div><div class="q1">
+<sup>32&#160;</sup>One who is slow to anger is better than the mighty; 
+</div><div class="q2">one who rules his spirit, than he who takes a city. 
+</div><div class="q1">
+<sup>33&#160;</sup>The lot is cast into the lap, 
+</div><div class="q2">but its every decision is from Yahweh. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="q1">
+<sup>1&#160;</sup>Better is a dry morsel with quietness, 
+</div><div class="q2">than a house full of feasting with strife. 
+</div><div class="q1">
+<sup>2&#160;</sup>A servant who deals wisely will rule over a son who causes shame, 
+</div><div class="q2">and shall have a part in the inheritance among the brothers. 
+</div><div class="q1">
+<sup>3&#160;</sup>The refining pot is for silver, and the furnace for gold, 
+</div><div class="q2">but Yahweh tests the hearts. 
+</div><div class="q1">
+<sup>4&#160;</sup>An evildoer heeds wicked lips. 
+</div><div class="q2">A liar gives ear to a mischievous tongue. 
+</div><div class="q1">
+<sup>5&#160;</sup>Whoever mocks the poor reproaches his Maker. 
+</div><div class="q2">He who is glad at calamity shall not be unpunished. 
+</div><div class="q1">
+<sup>6&#160;</sup>Children’s children are the crown of old men; 
+</div><div class="q2">the glory of children is their parents. 
+</div><div class="q1">
+<sup>7&#160;</sup>Excellent speech isn’t fitting for a fool, 
+</div><div class="q2">much less do lying lips fit a prince. 
+</div><div class="q1">
+<sup>8&#160;</sup>A gift is a precious stone in the eyes of him who gives it; 
+</div><div class="q2">wherever he turns, he prospers. 
+</div><div class="q1">
+<sup>9&#160;</sup>He who covers an offense promotes love; 
+</div><div class="q2">but he who repeats a matter separates best friends. 
+</div><div class="q1">
+<sup>10&#160;</sup>A rebuke enters deeper into one who has understanding 
+</div><div class="q2">than a hundred lashes into a fool. 
+</div><div class="q1">
+<sup>11&#160;</sup>An evil man seeks only rebellion; 
+</div><div class="q2">therefore a cruel messenger shall be sent against him. 
+</div><div class="q1">
+<sup>12&#160;</sup>Let a bear robbed of her cubs meet a man, 
+</div><div class="q2">rather than a fool in his folly. 
+</div><div class="q1">
+<sup>13&#160;</sup>Whoever rewards evil for good, 
+</div><div class="q2">evil shall not depart from his house. 
+</div><div class="q1">
+<sup>14&#160;</sup>The beginning of strife is like breaching a dam, 
+</div><div class="q2">therefore stop contention before quarreling breaks out. 
+</div><div class="q1">
+<sup>15&#160;</sup>He who justifies the wicked, and he who condemns the righteous, 
+</div><div class="q2">both of them alike are an abomination to Yahweh. 
+</div><div class="q1">
+<sup>16&#160;</sup>Why is there money in the hand of a fool to buy wisdom, 
+</div><div class="q2">since he has no understanding? 
+</div><div class="q1">
+<sup>17&#160;</sup>A friend loves at all times; 
+</div><div class="q2">and a brother is born for adversity. 
+</div><div class="q1">
+<sup>18&#160;</sup>A man void of understanding strikes hands, 
+</div><div class="q2">and becomes collateral in the presence of his neighbor. 
+</div><div class="q1">
+<sup>19&#160;</sup>He who loves disobedience loves strife. 
+</div><div class="q2">One who builds a high gate seeks destruction. 
+</div><div class="q1">
+<sup>20&#160;</sup>One who has a perverse heart doesn’t find prosperity, 
+</div><div class="q2">and one who has a deceitful tongue falls into trouble. 
+</div><div class="q1">
+<sup>21&#160;</sup>He who becomes the father of a fool grieves. 
+</div><div class="q2">The father of a fool has no joy. 
+</div><div class="q1">
+<sup>22&#160;</sup>A cheerful heart makes good medicine, 
+</div><div class="q2">but a crushed spirit dries up the bones. 
+</div><div class="q1">
+<sup>23&#160;</sup>A wicked man receives a bribe in secret, 
+</div><div class="q2">to pervert the ways of justice. 
+</div><div class="q1">
+<sup>24&#160;</sup>Wisdom is before the face of one who has understanding, 
+</div><div class="q2">but the eyes of a fool wander to the ends of the earth. 
+</div><div class="q1">
+<sup>25&#160;</sup>A foolish son brings grief to his father, 
+</div><div class="q2">and bitterness to her who bore him. 
+</div><div class="q1">
+<sup>26&#160;</sup>Also to punish the righteous is not good, 
+</div><div class="q2">nor to flog officials for their integrity. 
+</div><div class="q1">
+<sup>27&#160;</sup>He who spares his words has knowledge. 
+</div><div class="q2">He who is even tempered is a man of understanding. 
+</div><div class="q1">
+<sup>28&#160;</sup>Even a fool, when he keeps silent, is counted wise. 
+</div><div class="q2">When he shuts his lips, he is thought to be discerning. 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="q1">
+<sup>1&#160;</sup>A man who isolates himself pursues selfishness, 
+</div><div class="q2">and defies all sound judgment. 
+</div><div class="q1">
+<sup>2&#160;</sup>A fool has no delight in understanding, 
+</div><div class="q2">but only in revealing his own opinion. 
+</div><div class="q1">
+<sup>3&#160;</sup>When wickedness comes, contempt also comes, 
+</div><div class="q2">and with shame comes disgrace. 
+</div><div class="q1">
+<sup>4&#160;</sup>The words of a man’s mouth are like deep waters. 
+</div><div class="q2">The fountain of wisdom is like a flowing brook. 
+</div><div class="q1">
+<sup>5&#160;</sup>To be partial to the faces of the wicked is not good, 
+</div><div class="q2">nor to deprive the innocent of justice. 
+</div><div class="q1">
+<sup>6&#160;</sup>A fool’s lips come into strife, 
+</div><div class="q2">and his mouth invites beatings. 
+</div><div class="q1">
+<sup>7&#160;</sup>A fool’s mouth is his destruction, 
+</div><div class="q2">and his lips are a snare to his soul. 
+</div><div class="q1">
+<sup>8&#160;</sup>The words of a gossip are like dainty morsels: 
+</div><div class="q2">they go down into a person’s innermost parts. 
+</div><div class="q1">
+<sup>9&#160;</sup>One who is slack in his work 
+</div><div class="q2">is brother to him who is a master of destruction. 
+</div><div class="q1">
+<sup>10&#160;</sup>Yahweh’s name is a strong tower: 
+</div><div class="q2">the righteous run to him, and are safe. 
+</div><div class="q1">
+<sup>11&#160;</sup>The rich man’s wealth is his strong city, 
+</div><div class="q2">like an unscalable wall in his own imagination. 
+</div><div class="q1">
+<sup>12&#160;</sup>Before destruction the heart of man is proud, 
+</div><div class="q2">but before honor is humility. 
+</div><div class="q1">
+<sup>13&#160;</sup>He who answers before he hears, 
+</div><div class="q2">that is folly and shame to him. 
+</div><div class="q1">
+<sup>14&#160;</sup>A man’s spirit will sustain him in sickness, 
+</div><div class="q2">but a crushed spirit, who can bear? 
+</div><div class="q1">
+<sup>15&#160;</sup>The heart of the discerning gets knowledge. 
+</div><div class="q2">The ear of the wise seeks knowledge. 
+</div><div class="q1">
+<sup>16&#160;</sup>A man’s gift makes room for him, 
+</div><div class="q2">and brings him before great men. 
+</div><div class="q1">
+<sup>17&#160;</sup>He who pleads his cause first seems right—</div><div class="q2">until another comes and questions him. 
+</div><div class="q1">
+<sup>18&#160;</sup>The lot settles disputes, 
+</div><div class="q2">and keeps strong ones apart. 
+</div><div class="q1">
+<sup>19&#160;</sup>A brother offended is more difficult than a fortified city. 
+</div><div class="q2">Disputes are like the bars of a fortress. 
+</div><div class="q1">
+<sup>20&#160;</sup>A man’s stomach is filled with the fruit of his mouth. 
+</div><div class="q2">With the harvest of his lips he is satisfied. 
+</div><div class="q1">
+<sup>21&#160;</sup>Death and life are in the power of the tongue; 
+</div><div class="q2">those who love it will eat its fruit. 
+</div><div class="q1">
+<sup>22&#160;</sup>Whoever finds a woman finds a good thing, 
+</div><div class="q2">and obtains favor of Yahweh. 
+</div><div class="q1">
+<sup>23&#160;</sup>The poor plead for mercy, 
+</div><div class="q2">but the rich answer harshly. 
+</div><div class="q1">
+<sup>24&#160;</sup>A man of many companions may be ruined, 
+</div><div class="q2">but there is a friend who sticks closer than a brother. 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="q1">
+<sup>1&#160;</sup>Better is the poor who walks in his integrity 
+</div><div class="q2">than he who is perverse in his lips and is a fool. 
+</div><div class="q1">
+<sup>2&#160;</sup>It isn’t good to have zeal without knowledge, 
+</div><div class="q2">nor being hasty with one’s feet and missing the way. 
+</div><div class="q1">
+<sup>3&#160;</sup>The foolishness of man subverts his way; 
+</div><div class="q2">his heart rages against Yahweh. 
+</div><div class="q1">
+<sup>4&#160;</sup>Wealth adds many friends, 
+</div><div class="q2">but the poor is separated from his friend. 
+</div><div class="q1">
+<sup>5&#160;</sup>A false witness shall not be unpunished. 
+</div><div class="q2">He who pours out lies shall not go free. 
+</div><div class="q1">
+<sup>6&#160;</sup>Many will entreat the favor of a ruler, 
+</div><div class="q2">and everyone is a friend to a man who gives gifts. 
+</div><div class="q1">
+<sup>7&#160;</sup>All the relatives of the poor shun him; 
+</div><div class="q2">how much more do his friends avoid him! 
+</div><div class="q2">He pursues them with pleas, but they are gone. 
+</div><div class="q1">
+<sup>8&#160;</sup>He who gets wisdom loves his own soul. 
+</div><div class="q2">He who keeps understanding shall find good. 
+</div><div class="q1">
+<sup>9&#160;</sup>A false witness shall not be unpunished. 
+</div><div class="q2">He who utters lies shall perish. 
+</div><div class="q1">
+<sup>10&#160;</sup>Delicate living is not appropriate for a fool, 
+</div><div class="q2">much less for a servant to have rule over princes. 
+</div><div class="q1">
+<sup>11&#160;</sup>The discretion of a man makes him slow to anger. 
+</div><div class="q2">It is his glory to overlook an offense. 
+</div><div class="q1">
+<sup>12&#160;</sup>The king’s wrath is like the roaring of a lion, 
+</div><div class="q2">but his favor is like dew on the grass. 
+</div><div class="q1">
+<sup>13&#160;</sup>A foolish son is the calamity of his father. 
+</div><div class="q2">A woman’s quarrels are a continual dripping. 
+</div><div class="q1">
+<sup>14&#160;</sup>House and riches are an inheritance from fathers, 
+</div><div class="q2">but a prudent woman is from Yahweh. 
+</div><div class="q1">
+<sup>15&#160;</sup>Slothfulness casts into a deep sleep. 
+</div><div class="q2">The idle soul shall suffer hunger. 
+</div><div class="q1">
+<sup>16&#160;</sup>He who keeps the commandment keeps his soul, 
+</div><div class="q2">but he who is contemptuous in his ways shall die. 
+</div><div class="q1">
+<sup>17&#160;</sup>He who has pity on the poor lends to Yahweh; 
+</div><div class="q2">he will reward him. 
+</div><div class="q1">
+<sup>18&#160;</sup>Discipline your son, for there is hope; 
+</div><div class="q2">don’t be a willing party to his death. 
+</div><div class="q1">
+<sup>19&#160;</sup>A hot-tempered man must pay the penalty, 
+</div><div class="q2">for if you rescue him, you must do it again. 
+</div><div class="q1">
+<sup>20&#160;</sup>Listen to counsel and receive instruction, 
+</div><div class="q2">that you may be wise in your latter end. 
+</div><div class="q1">
+<sup>21&#160;</sup>There are many plans in a man’s heart, 
+</div><div class="q2">but Yahweh’s counsel will prevail. 
+</div><div class="q1">
+<sup>22&#160;</sup>That which makes a man to be desired is his kindness. 
+</div><div class="q2">A poor man is better than a liar. 
+</div><div class="q1">
+<sup>23&#160;</sup>The fear of Yahweh leads to life, then contentment; 
+</div><div class="q2">he rests and will not be touched by trouble. 
+</div><div class="q1">
+<sup>24&#160;</sup>The sluggard buries his hand in the dish; 
+</div><div class="q2">he will not so much as bring it to his mouth again. 
+</div><div class="q1">
+<sup>25&#160;</sup>Flog a scoffer, and the simple will learn prudence; 
+</div><div class="q2">rebuke one who has understanding, and he will gain knowledge. 
+</div><div class="q1">
+<sup>26&#160;</sup>He who robs his father and drives away his mother 
+</div><div class="q2">is a son who causes shame and brings reproach. 
+</div><div class="q1">
+<sup>27&#160;</sup>If you stop listening to instruction, my son, 
+</div><div class="q2">you will stray from the words of knowledge. 
+</div><div class="q1">
+<sup>28&#160;</sup>A corrupt witness mocks justice, 
+</div><div class="q2">and the mouth of the wicked gulps down iniquity. 
+</div><div class="q1">
+<sup>29&#160;</sup>Penalties are prepared for scoffers, 
+</div><div class="q2">and beatings for the backs of fools. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="20">20</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Wine is a mocker and beer is a brawler. 
-</p><p class="q2">Whoever is led astray by them is not wise. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The terror of a king is like the roaring of a lion. 
-</p><p class="q2">He who provokes him to anger forfeits his own life. 
-</p><p class="q1">
-<span class="v">3&#160;</span>It is an honor for a man to keep aloof from strife, 
-</p><p class="q2">but every fool will be quarreling. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The sluggard will not plow by reason of the winter; 
-</p><p class="q2">therefore he shall beg in harvest, and have nothing. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Counsel in the heart of man is like deep water, 
-</p><p class="q2">but a man of understanding will draw it out. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Many men claim to be men of unfailing love, 
-</p><p class="q2">but who can find a faithful man? 
-</p><p class="q1">
-<span class="v">7&#160;</span>A righteous man walks in integrity. 
-</p><p class="q2">Blessed are his children after him. 
-</p><p class="q1">
-<span class="v">8&#160;</span>A king who sits on the throne of judgment 
-</p><p class="q2">scatters away all evil with his eyes. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Who can say, “I have made my heart pure. 
-</p><p class="q2">I am clean and without sin”? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Differing weights and differing measures, 
-</p><p class="q2">both of them alike are an abomination to Yahweh. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Even a child makes himself known by his doings, 
-</p><p class="q2">whether his work is pure, and whether it is right. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The hearing ear, and the seeing eye, 
-</p><p class="q2">Yahweh has made even both of them. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Don’t love sleep, lest you come to poverty. 
-</p><p class="q2">Open your eyes, and you shall be satisfied with bread. 
-</p><p class="q1">
-<span class="v">14&#160;</span>“It’s no good, it’s no good,” says the buyer; 
-</p><p class="q2">but when he is gone his way, then he boasts. 
-</p><p class="q1">
-<span class="v">15&#160;</span>There is gold and abundance of rubies, 
-</p><p class="q2">but the lips of knowledge are a rare jewel. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Take the garment of one who puts up collateral for a stranger; 
-</p><p class="q2">and hold him in pledge for a wayward woman. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Fraudulent food is sweet to a man, 
-</p><p class="q2">but afterwards his mouth is filled with gravel. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Plans are established by advice; 
-</p><p class="q2">by wise guidance you wage war! 
-</p><p class="q1">
-<span class="v">19&#160;</span>He who goes about as a tale-bearer reveals secrets; 
-</p><p class="q2">therefore don’t keep company with him who opens wide his lips. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Whoever curses his father or his mother, 
-</p><p class="q2">his lamp shall be put out in blackness of darkness. 
-</p><p class="q1">
-<span class="v">21&#160;</span>An inheritance quickly gained at the beginning 
-</p><p class="q2">won’t be blessed in the end. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Don’t say, “I will pay back evil.” 
-</p><p class="q2">Wait for Yahweh, and he will save you. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Yahweh detests differing weights, 
-</p><p class="q2">and dishonest scales are not pleasing. 
-</p><p class="q1">
-<span class="v">24&#160;</span>A man’s steps are from Yahweh; 
-</p><p class="q2">how then can man understand his way? 
-</p><p class="q1">
-<span class="v">25&#160;</span>It is a snare to a man to make a rash dedication, 
-</p><p class="q2">then later to consider his vows. 
-</p><p class="q1">
-<span class="v">26&#160;</span>A wise king winnows out the wicked, 
-</p><p class="q2">and drives the threshing wheel over them. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The spirit of man is Yahweh’s lamp, 
-</p><p class="q2">searching all his innermost parts. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Love and faithfulness keep the king safe. 
-</p><p class="q2">His throne is sustained by love. 
-</p><p class="q1">
-<span class="v">29&#160;</span>The glory of young men is their strength. 
-</p><p class="q2">The splendor of old men is their gray hair. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Wounding blows cleanse away evil, 
-</p><p class="q2">and beatings purge the innermost parts. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Wine is a mocker and beer is a brawler. 
+</div><div class="q2">Whoever is led astray by them is not wise. 
+</div><div class="q1">
+<sup>2&#160;</sup>The terror of a king is like the roaring of a lion. 
+</div><div class="q2">He who provokes him to anger forfeits his own life. 
+</div><div class="q1">
+<sup>3&#160;</sup>It is an honor for a man to keep aloof from strife, 
+</div><div class="q2">but every fool will be quarreling. 
+</div><div class="q1">
+<sup>4&#160;</sup>The sluggard will not plow by reason of the winter; 
+</div><div class="q2">therefore he shall beg in harvest, and have nothing. 
+</div><div class="q1">
+<sup>5&#160;</sup>Counsel in the heart of man is like deep water, 
+</div><div class="q2">but a man of understanding will draw it out. 
+</div><div class="q1">
+<sup>6&#160;</sup>Many men claim to be men of unfailing love, 
+</div><div class="q2">but who can find a faithful man? 
+</div><div class="q1">
+<sup>7&#160;</sup>A righteous man walks in integrity. 
+</div><div class="q2">Blessed are his children after him. 
+</div><div class="q1">
+<sup>8&#160;</sup>A king who sits on the throne of judgment 
+</div><div class="q2">scatters away all evil with his eyes. 
+</div><div class="q1">
+<sup>9&#160;</sup>Who can say, “I have made my heart pure. 
+</div><div class="q2">I am clean and without sin”? 
+</div><div class="q1">
+<sup>10&#160;</sup>Differing weights and differing measures, 
+</div><div class="q2">both of them alike are an abomination to Yahweh. 
+</div><div class="q1">
+<sup>11&#160;</sup>Even a child makes himself known by his doings, 
+</div><div class="q2">whether his work is pure, and whether it is right. 
+</div><div class="q1">
+<sup>12&#160;</sup>The hearing ear, and the seeing eye, 
+</div><div class="q2">Yahweh has made even both of them. 
+</div><div class="q1">
+<sup>13&#160;</sup>Don’t love sleep, lest you come to poverty. 
+</div><div class="q2">Open your eyes, and you shall be satisfied with bread. 
+</div><div class="q1">
+<sup>14&#160;</sup>“It’s no good, it’s no good,” says the buyer; 
+</div><div class="q2">but when he is gone his way, then he boasts. 
+</div><div class="q1">
+<sup>15&#160;</sup>There is gold and abundance of rubies, 
+</div><div class="q2">but the lips of knowledge are a rare jewel. 
+</div><div class="q1">
+<sup>16&#160;</sup>Take the garment of one who puts up collateral for a stranger; 
+</div><div class="q2">and hold him in pledge for a wayward woman. 
+</div><div class="q1">
+<sup>17&#160;</sup>Fraudulent food is sweet to a man, 
+</div><div class="q2">but afterwards his mouth is filled with gravel. 
+</div><div class="q1">
+<sup>18&#160;</sup>Plans are established by advice; 
+</div><div class="q2">by wise guidance you wage war! 
+</div><div class="q1">
+<sup>19&#160;</sup>He who goes about as a tale-bearer reveals secrets; 
+</div><div class="q2">therefore don’t keep company with him who opens wide his lips. 
+</div><div class="q1">
+<sup>20&#160;</sup>Whoever curses his father or his mother, 
+</div><div class="q2">his lamp shall be put out in blackness of darkness. 
+</div><div class="q1">
+<sup>21&#160;</sup>An inheritance quickly gained at the beginning 
+</div><div class="q2">won’t be blessed in the end. 
+</div><div class="q1">
+<sup>22&#160;</sup>Don’t say, “I will pay back evil.” 
+</div><div class="q2">Wait for Yahweh, and he will save you. 
+</div><div class="q1">
+<sup>23&#160;</sup>Yahweh detests differing weights, 
+</div><div class="q2">and dishonest scales are not pleasing. 
+</div><div class="q1">
+<sup>24&#160;</sup>A man’s steps are from Yahweh; 
+</div><div class="q2">how then can man understand his way? 
+</div><div class="q1">
+<sup>25&#160;</sup>It is a snare to a man to make a rash dedication, 
+</div><div class="q2">then later to consider his vows. 
+</div><div class="q1">
+<sup>26&#160;</sup>A wise king winnows out the wicked, 
+</div><div class="q2">and drives the threshing wheel over them. 
+</div><div class="q1">
+<sup>27&#160;</sup>The spirit of man is Yahweh’s lamp, 
+</div><div class="q2">searching all his innermost parts. 
+</div><div class="q1">
+<sup>28&#160;</sup>Love and faithfulness keep the king safe. 
+</div><div class="q2">His throne is sustained by love. 
+</div><div class="q1">
+<sup>29&#160;</sup>The glory of young men is their strength. 
+</div><div class="q2">The splendor of old men is their gray hair. 
+</div><div class="q1">
+<sup>30&#160;</sup>Wounding blows cleanse away evil, 
+</div><div class="q2">and beatings purge the innermost parts. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="21">21</h2>
-<p class="q1">
-<span class="v">1&#160;</span>The king’s heart is in Yahweh’s hand like the watercourses. 
-</p><p class="q2">He turns it wherever he desires. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Every way of a man is right in his own eyes, 
-</p><p class="q2">but Yahweh weighs the hearts. 
-</p><p class="q1">
-<span class="v">3&#160;</span>To do righteousness and justice 
-</p><p class="q2">is more acceptable to Yahweh than sacrifice. 
-</p><p class="q1">
-<span class="v">4&#160;</span>A high look and a proud heart, 
-</p><p class="q2">the lamp of the wicked, is sin. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The plans of the diligent surely lead to profit; 
-</p><p class="q2">and everyone who is hasty surely rushes to poverty. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Getting treasures by a lying tongue 
-</p><p class="q2">is a fleeting vapor for those who seek death. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The violence of the wicked will drive them away, 
-</p><p class="q2">because they refuse to do what is right. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The way of the guilty is devious, 
-</p><p class="q2">but the conduct of the innocent is upright. 
-</p><p class="q1">
-<span class="v">9&#160;</span>It is better to dwell in the corner of the housetop 
-</p><p class="q2">than to share a house with a contentious woman. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The soul of the wicked desires evil; 
-</p><p class="q2">his neighbor finds no mercy in his eyes. 
-</p><p class="q1">
-<span class="v">11&#160;</span>When the mocker is punished, the simple gains wisdom. 
-</p><p class="q2">When the wise is instructed, he receives knowledge. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The Righteous One considers the house of the wicked, 
-</p><p class="q2">and brings the wicked to ruin. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Whoever stops his ears at the cry of the poor, 
-</p><p class="q2">he will also cry out, but shall not be heard. 
-</p><p class="q1">
-<span class="v">14&#160;</span>A gift in secret pacifies anger, 
-</p><p class="q2">and a bribe in the cloak, strong wrath. 
-</p><p class="q1">
-<span class="v">15&#160;</span>It is joy to the righteous to do justice; 
-</p><p class="q2">but it is a destruction to the workers of iniquity. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The man who wanders out of the way of understanding 
-</p><p class="q2">shall rest in the assembly of the departed spirits. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He who loves pleasure will be a poor man. 
-</p><p class="q2">He who loves wine and oil won’t be rich. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The wicked is a ransom for the righteous, 
-</p><p class="q2">the treacherous for the upright. 
-</p><p class="q1">
-<span class="v">19&#160;</span>It is better to dwell in a desert land, 
-</p><p class="q2">than with a contentious and fretful woman. 
-</p><p class="q1">
-<span class="v">20&#160;</span>There is precious treasure and oil in the dwelling of the wise, 
-</p><p class="q2">but a foolish man swallows it up. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He who follows after righteousness and kindness 
-</p><p class="q2">finds life, righteousness, and honor. 
-</p><p class="q1">
-<span class="v">22&#160;</span>A wise man scales the city of the mighty, 
-</p><p class="q2">and brings down the strength of its confidence. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Whoever guards his mouth and his tongue 
-</p><p class="q2">keeps his soul from troubles. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The proud and arrogant man—“Scoffer” is his name—</p><p class="q2">he works in the arrogance of pride. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The desire of the sluggard kills him, 
-</p><p class="q2">for his hands refuse to labor. 
-</p><p class="q1">
-<span class="v">26&#160;</span>There are those who covet greedily all day long; 
-</p><p class="q2">but the righteous give and don’t withhold. 
-</p><p class="q1">
-<span class="v">27&#160;</span>The sacrifice of the wicked is an abomination—</p><p class="q2">how much more, when he brings it with a wicked mind! 
-</p><p class="q1">
-<span class="v">28&#160;</span>A false witness will perish. 
-</p><p class="q2">A man who listens speaks to eternity. 
-</p><p class="q1">
-<span class="v">29&#160;</span>A wicked man hardens his face; 
-</p><p class="q2">but as for the upright, he establishes his ways. 
-</p><p class="q1">
-<span class="v">30&#160;</span>There is no wisdom nor understanding 
-</p><p class="q2">nor counsel against Yahweh. 
-</p><p class="q1">
-<span class="v">31&#160;</span>The horse is prepared for the day of battle; 
-</p><p class="q2">but victory is with Yahweh. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>The king’s heart is in Yahweh’s hand like the watercourses. 
+</div><div class="q2">He turns it wherever he desires. 
+</div><div class="q1">
+<sup>2&#160;</sup>Every way of a man is right in his own eyes, 
+</div><div class="q2">but Yahweh weighs the hearts. 
+</div><div class="q1">
+<sup>3&#160;</sup>To do righteousness and justice 
+</div><div class="q2">is more acceptable to Yahweh than sacrifice. 
+</div><div class="q1">
+<sup>4&#160;</sup>A high look and a proud heart, 
+</div><div class="q2">the lamp of the wicked, is sin. 
+</div><div class="q1">
+<sup>5&#160;</sup>The plans of the diligent surely lead to profit; 
+</div><div class="q2">and everyone who is hasty surely rushes to poverty. 
+</div><div class="q1">
+<sup>6&#160;</sup>Getting treasures by a lying tongue 
+</div><div class="q2">is a fleeting vapor for those who seek death. 
+</div><div class="q1">
+<sup>7&#160;</sup>The violence of the wicked will drive them away, 
+</div><div class="q2">because they refuse to do what is right. 
+</div><div class="q1">
+<sup>8&#160;</sup>The way of the guilty is devious, 
+</div><div class="q2">but the conduct of the innocent is upright. 
+</div><div class="q1">
+<sup>9&#160;</sup>It is better to dwell in the corner of the housetop 
+</div><div class="q2">than to share a house with a contentious woman. 
+</div><div class="q1">
+<sup>10&#160;</sup>The soul of the wicked desires evil; 
+</div><div class="q2">his neighbor finds no mercy in his eyes. 
+</div><div class="q1">
+<sup>11&#160;</sup>When the mocker is punished, the simple gains wisdom. 
+</div><div class="q2">When the wise is instructed, he receives knowledge. 
+</div><div class="q1">
+<sup>12&#160;</sup>The Righteous One considers the house of the wicked, 
+</div><div class="q2">and brings the wicked to ruin. 
+</div><div class="q1">
+<sup>13&#160;</sup>Whoever stops his ears at the cry of the poor, 
+</div><div class="q2">he will also cry out, but shall not be heard. 
+</div><div class="q1">
+<sup>14&#160;</sup>A gift in secret pacifies anger, 
+</div><div class="q2">and a bribe in the cloak, strong wrath. 
+</div><div class="q1">
+<sup>15&#160;</sup>It is joy to the righteous to do justice; 
+</div><div class="q2">but it is a destruction to the workers of iniquity. 
+</div><div class="q1">
+<sup>16&#160;</sup>The man who wanders out of the way of understanding 
+</div><div class="q2">shall rest in the assembly of the departed spirits. 
+</div><div class="q1">
+<sup>17&#160;</sup>He who loves pleasure will be a poor man. 
+</div><div class="q2">He who loves wine and oil won’t be rich. 
+</div><div class="q1">
+<sup>18&#160;</sup>The wicked is a ransom for the righteous, 
+</div><div class="q2">the treacherous for the upright. 
+</div><div class="q1">
+<sup>19&#160;</sup>It is better to dwell in a desert land, 
+</div><div class="q2">than with a contentious and fretful woman. 
+</div><div class="q1">
+<sup>20&#160;</sup>There is precious treasure and oil in the dwelling of the wise, 
+</div><div class="q2">but a foolish man swallows it up. 
+</div><div class="q1">
+<sup>21&#160;</sup>He who follows after righteousness and kindness 
+</div><div class="q2">finds life, righteousness, and honor. 
+</div><div class="q1">
+<sup>22&#160;</sup>A wise man scales the city of the mighty, 
+</div><div class="q2">and brings down the strength of its confidence. 
+</div><div class="q1">
+<sup>23&#160;</sup>Whoever guards his mouth and his tongue 
+</div><div class="q2">keeps his soul from troubles. 
+</div><div class="q1">
+<sup>24&#160;</sup>The proud and arrogant man—“Scoffer” is his name—</div><div class="q2">he works in the arrogance of pride. 
+</div><div class="q1">
+<sup>25&#160;</sup>The desire of the sluggard kills him, 
+</div><div class="q2">for his hands refuse to labor. 
+</div><div class="q1">
+<sup>26&#160;</sup>There are those who covet greedily all day long; 
+</div><div class="q2">but the righteous give and don’t withhold. 
+</div><div class="q1">
+<sup>27&#160;</sup>The sacrifice of the wicked is an abomination—</div><div class="q2">how much more, when he brings it with a wicked mind! 
+</div><div class="q1">
+<sup>28&#160;</sup>A false witness will perish. 
+</div><div class="q2">A man who listens speaks to eternity. 
+</div><div class="q1">
+<sup>29&#160;</sup>A wicked man hardens his face; 
+</div><div class="q2">but as for the upright, he establishes his ways. 
+</div><div class="q1">
+<sup>30&#160;</sup>There is no wisdom nor understanding 
+</div><div class="q2">nor counsel against Yahweh. 
+</div><div class="q1">
+<sup>31&#160;</sup>The horse is prepared for the day of battle; 
+</div><div class="q2">but victory is with Yahweh. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="22">22</h2>
-<p class="q1">
-<span class="v">1&#160;</span>A good name is more desirable than great riches, 
-</p><p class="q2">and loving favor is better than silver and gold. 
-</p><p class="q1">
-<span class="v">2&#160;</span>The rich and the poor have this in common: 
-</p><p class="q2">Yahweh is the maker of them all. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A prudent man sees danger and hides himself; 
-</p><p class="q2">but the simple pass on, and suffer for it. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The result of humility and the fear of Yahweh 
-</p><p class="q2">is wealth, honor, and life. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Thorns and snares are in the path of the wicked; 
-</p><p class="q2">whoever guards his soul stays from them. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Train up a child in the way he should go, 
-</p><p class="q2">and when he is old he will not depart from it. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The rich rule over the poor. 
-</p><p class="q2">The borrower is servant to the lender. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He who sows wickedness reaps trouble, 
-</p><p class="q2">and the rod of his fury will be destroyed. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He who has a generous eye will be blessed, 
-</p><p class="q2">for he shares his food with the poor. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Drive out the mocker, and strife will go out; 
-</p><p class="q2">yes, quarrels and insults will stop. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He who loves purity of heart and speaks gracefully 
-</p><p class="q2">is the king’s friend. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yahweh’s eyes watch over knowledge, 
-</p><p class="q2">but he frustrates the words of the unfaithful. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The sluggard says, “There is a lion outside! 
-</p><p class="q2">I will be killed in the streets!” 
-</p><p class="q1">
-<span class="v">14&#160;</span>The mouth of an adulteress is a deep pit. 
-</p><p class="q2">He who is under Yahweh’s wrath will fall into it. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Folly is bound up in the heart of a child; 
-</p><p class="q2">the rod of discipline drives it far from him. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Whoever oppresses the poor for his own increase and whoever gives to the rich, 
-</p><p class="q2">both come to poverty. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Turn your ear, and listen to the words of the wise. 
-</p><p class="q2">Apply your heart to my teaching. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For it is a pleasant thing if you keep them within you, 
-</p><p class="q2">if all of them are ready on your lips. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I teach you today, even you, 
-</p><p class="q2">so that your trust may be in Yahweh. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Haven’t I written to you thirty excellent things 
-</p><p class="q2">of counsel and knowledge, 
-</p><p class="q1">
-<span class="v">21&#160;</span>To teach you truth, reliable words, 
-</p><p class="q2">to give sound answers to the ones who sent you? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>Don’t exploit the poor because he is poor; 
-</p><p class="q2">and don’t crush the needy in court; 
-</p><p class="q1">
-<span class="v">23&#160;</span>for Yahweh will plead their case, 
-</p><p class="q2">and plunder the life of those who plunder them. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>Don’t befriend a hot-tempered man. 
-</p><p class="q2">Don’t associate with one who harbors anger, 
-</p><p class="q1">
-<span class="v">25&#160;</span>lest you learn his ways 
-</p><p class="q2">and ensnare your soul. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">26&#160;</span>Don’t you be one of those who strike hands, 
-</p><p class="q2">of those who are collateral for debts. 
-</p><p class="q1">
-<span class="v">27&#160;</span>If you don’t have means to pay, 
-</p><p class="q2">why should he take away your bed from under you? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>Don’t move the ancient boundary stone 
-</p><p class="q2">which your fathers have set up. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">29&#160;</span>Do you see a man skilled in his work? 
-</p><p class="q2">He will serve kings. 
-</p><p class="q2">He won’t serve obscure men. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>A good name is more desirable than great riches, 
+</div><div class="q2">and loving favor is better than silver and gold. 
+</div><div class="q1">
+<sup>2&#160;</sup>The rich and the poor have this in common: 
+</div><div class="q2">Yahweh is the maker of them all. 
+</div><div class="q1">
+<sup>3&#160;</sup>A prudent man sees danger and hides himself; 
+</div><div class="q2">but the simple pass on, and suffer for it. 
+</div><div class="q1">
+<sup>4&#160;</sup>The result of humility and the fear of Yahweh 
+</div><div class="q2">is wealth, honor, and life. 
+</div><div class="q1">
+<sup>5&#160;</sup>Thorns and snares are in the path of the wicked; 
+</div><div class="q2">whoever guards his soul stays from them. 
+</div><div class="q1">
+<sup>6&#160;</sup>Train up a child in the way he should go, 
+</div><div class="q2">and when he is old he will not depart from it. 
+</div><div class="q1">
+<sup>7&#160;</sup>The rich rule over the poor. 
+</div><div class="q2">The borrower is servant to the lender. 
+</div><div class="q1">
+<sup>8&#160;</sup>He who sows wickedness reaps trouble, 
+</div><div class="q2">and the rod of his fury will be destroyed. 
+</div><div class="q1">
+<sup>9&#160;</sup>He who has a generous eye will be blessed, 
+</div><div class="q2">for he shares his food with the poor. 
+</div><div class="q1">
+<sup>10&#160;</sup>Drive out the mocker, and strife will go out; 
+</div><div class="q2">yes, quarrels and insults will stop. 
+</div><div class="q1">
+<sup>11&#160;</sup>He who loves purity of heart and speaks gracefully 
+</div><div class="q2">is the king’s friend. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yahweh’s eyes watch over knowledge, 
+</div><div class="q2">but he frustrates the words of the unfaithful. 
+</div><div class="q1">
+<sup>13&#160;</sup>The sluggard says, “There is a lion outside! 
+</div><div class="q2">I will be killed in the streets!” 
+</div><div class="q1">
+<sup>14&#160;</sup>The mouth of an adulteress is a deep pit. 
+</div><div class="q2">He who is under Yahweh’s wrath will fall into it. 
+</div><div class="q1">
+<sup>15&#160;</sup>Folly is bound up in the heart of a child; 
+</div><div class="q2">the rod of discipline drives it far from him. 
+</div><div class="q1">
+<sup>16&#160;</sup>Whoever oppresses the poor for his own increase and whoever gives to the rich, 
+</div><div class="q2">both come to poverty. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Turn your ear, and listen to the words of the wise. 
+</div><div class="q2">Apply your heart to my teaching. 
+</div><div class="q1">
+<sup>18&#160;</sup>For it is a pleasant thing if you keep them within you, 
+</div><div class="q2">if all of them are ready on your lips. 
+</div><div class="q1">
+<sup>19&#160;</sup>I teach you today, even you, 
+</div><div class="q2">so that your trust may be in Yahweh. 
+</div><div class="q1">
+<sup>20&#160;</sup>Haven’t I written to you thirty excellent things 
+</div><div class="q2">of counsel and knowledge, 
+</div><div class="q1">
+<sup>21&#160;</sup>To teach you truth, reliable words, 
+</div><div class="q2">to give sound answers to the ones who sent you? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>Don’t exploit the poor because he is poor; 
+</div><div class="q2">and don’t crush the needy in court; 
+</div><div class="q1">
+<sup>23&#160;</sup>for Yahweh will plead their case, 
+</div><div class="q2">and plunder the life of those who plunder them. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>Don’t befriend a hot-tempered man. 
+</div><div class="q2">Don’t associate with one who harbors anger, 
+</div><div class="q1">
+<sup>25&#160;</sup>lest you learn his ways 
+</div><div class="q2">and ensnare your soul. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>26&#160;</sup>Don’t you be one of those who strike hands, 
+</div><div class="q2">of those who are collateral for debts. 
+</div><div class="q1">
+<sup>27&#160;</sup>If you don’t have means to pay, 
+</div><div class="q2">why should he take away your bed from under you? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>Don’t move the ancient boundary stone 
+</div><div class="q2">which your fathers have set up. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>29&#160;</sup>Do you see a man skilled in his work? 
+</div><div class="q2">He will serve kings. 
+</div><div class="q2">He won’t serve obscure men. 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="23">23</h2>
-<p class="q1">
-<span class="v">1&#160;</span>When you sit to eat with a ruler, 
-</p><p class="q2">consider diligently what is before you; 
-</p><p class="q1">
-<span class="v">2&#160;</span>put a knife to your throat 
-</p><p class="q2">if you are a man given to appetite. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Don’t be desirous of his dainties, 
-</p><p class="q2">since they are deceitful food. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Don’t weary yourself to be rich. 
-</p><p class="q2">In your wisdom, show restraint. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why do you set your eyes on that which is not? 
-</p><p class="q2">For it certainly sprouts wings like an eagle and flies in the sky. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Don’t eat the food of him who has a stingy eye, 
-</p><p class="q2">and don’t crave his delicacies, 
-</p><p class="q2">
-<span class="v">7&#160;</span>for as he thinks about the cost, so he is. 
-</p><p class="q2">“Eat and drink!” he says to you, 
-</p><p class="q2">but his heart is not with you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You will vomit up the morsel which you have eaten 
-</p><p class="q2">and waste your pleasant words. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Don’t speak in the ears of a fool, 
-</p><p class="q2">for he will despise the wisdom of your words. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Don’t move the ancient boundary stone. 
-</p><p class="q2">Don’t encroach on the fields of the fatherless, 
-</p><p class="q1">
-<span class="v">11&#160;</span>for their Defender is strong. 
-</p><p class="q2">He will plead their case against you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Apply your heart to instruction, 
-</p><p class="q2">and your ears to the words of knowledge. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Don’t withhold correction from a child. 
-</p><p class="q2">If you punish him with the rod, he will not die. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Punish him with the rod, 
-</p><p class="q2">and save his soul from Sheol.<span class="f">+ \fr 23:14 \ft Sheol is the place of the dead.</span> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>My son, if your heart is wise, 
-</p><p class="q2">then my heart will be glad, even mine. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yes, my heart will rejoice 
-</p><p class="q2">when your lips speak what is right. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Don’t let your heart envy sinners, 
-</p><p class="q2">but rather fear Yahweh all day long. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Indeed surely there is a future hope, 
-</p><p class="q2">and your hope will not be cut off. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Listen, my son, and be wise, 
-</p><p class="q2">and keep your heart on the right path! 
-</p><p class="q1">
-<span class="v">20&#160;</span>Don’t be among ones drinking too much wine, 
-</p><p class="q2">or those who gorge themselves on meat; 
-</p><p class="q1">
-<span class="v">21&#160;</span>for the drunkard and the glutton shall become poor; 
-</p><p class="q2">and drowsiness clothes them in rags. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Listen to your father who gave you life, 
-</p><p class="q2">and don’t despise your mother when she is old. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Buy the truth, and don’t sell it. 
-</p><p class="q2">Get wisdom, discipline, and understanding. 
-</p><p class="q1">
-<span class="v">24&#160;</span>The father of the righteous has great joy. 
-</p><p class="q2">Whoever fathers a wise child delights in him. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Let your father and your mother be glad! 
-</p><p class="q2">Let her who bore you rejoice! 
-</p><p class="q1">
-<span class="v">26&#160;</span>My son, give me your heart; 
-</p><p class="q2">and let your eyes keep in my ways. 
-</p><p class="q1">
-<span class="v">27&#160;</span>For a prostitute is a deep pit; 
-</p><p class="q2">and a wayward woman is a narrow well. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Yes, she lies in wait like a robber, 
-</p><p class="q2">and increases the unfaithful among men. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">29&#160;</span>Who has woe? 
-</p><p class="q2">Who has sorrow? 
-</p><p class="q2">Who has strife? 
-</p><p class="q2">Who has complaints? 
-</p><p class="q2">Who has needless bruises? 
-</p><p class="q2">Who has bloodshot eyes? 
-</p><p class="q1">
-<span class="v">30&#160;</span>Those who stay long at the wine; 
-</p><p class="q2">those who go to seek out mixed wine. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Don’t look at the wine when it is red, 
-</p><p class="q2">when it sparkles in the cup, 
-</p><p class="q2">when it goes down smoothly. 
-</p><p class="q1">
-<span class="v">32&#160;</span>In the end, it bites like a snake, 
-</p><p class="q2">and poisons like a viper. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Your eyes will see strange things, 
-</p><p class="q2">and your mind will imagine confusing things. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Yes, you will be as he who lies down in the middle of the sea, 
-</p><p class="q2">or as he who lies on top of the rigging: 
-</p><p class="q1">
-<span class="v">35&#160;</span>“They hit me, and I was not hurt! 
-</p><p class="q2">They beat me, and I don’t feel it! 
-</p><p class="q2">When will I wake up? I can do it again. 
-</p><p class="q2">I will look for more.” 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>When you sit to eat with a ruler, 
+</div><div class="q2">consider diligently what is before you; 
+</div><div class="q1">
+<sup>2&#160;</sup>put a knife to your throat 
+</div><div class="q2">if you are a man given to appetite. 
+</div><div class="q1">
+<sup>3&#160;</sup>Don’t be desirous of his dainties, 
+</div><div class="q2">since they are deceitful food. 
+</div><div class="q1">
+<sup>4&#160;</sup>Don’t weary yourself to be rich. 
+</div><div class="q2">In your wisdom, show restraint. 
+</div><div class="q1">
+<sup>5&#160;</sup>Why do you set your eyes on that which is not? 
+</div><div class="q2">For it certainly sprouts wings like an eagle and flies in the sky. 
+</div><div class="q1">
+<sup>6&#160;</sup>Don’t eat the food of him who has a stingy eye, 
+</div><div class="q2">and don’t crave his delicacies, 
+</div><div class="q2">
+<sup>7&#160;</sup>for as he thinks about the cost, so he is. 
+</div><div class="q2">“Eat and drink!” he says to you, 
+</div><div class="q2">but his heart is not with you. 
+</div><div class="q1">
+<sup>8&#160;</sup>You will vomit up the morsel which you have eaten 
+</div><div class="q2">and waste your pleasant words. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Don’t speak in the ears of a fool, 
+</div><div class="q2">for he will despise the wisdom of your words. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Don’t move the ancient boundary stone. 
+</div><div class="q2">Don’t encroach on the fields of the fatherless, 
+</div><div class="q1">
+<sup>11&#160;</sup>for their Defender is strong. 
+</div><div class="q2">He will plead their case against you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Apply your heart to instruction, 
+</div><div class="q2">and your ears to the words of knowledge. 
+</div><div class="q1">
+<sup>13&#160;</sup>Don’t withhold correction from a child. 
+</div><div class="q2">If you punish him with the rod, he will not die. 
+</div><div class="q1">
+<sup>14&#160;</sup>Punish him with the rod, 
+</div><div class="q2">and save his soul from Sheol. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>My son, if your heart is wise, 
+</div><div class="q2">then my heart will be glad, even mine. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yes, my heart will rejoice 
+</div><div class="q2">when your lips speak what is right. 
+</div><div class="q1">
+<sup>17&#160;</sup>Don’t let your heart envy sinners, 
+</div><div class="q2">but rather fear Yahweh all day long. 
+</div><div class="q1">
+<sup>18&#160;</sup>Indeed surely there is a future hope, 
+</div><div class="q2">and your hope will not be cut off. 
+</div><div class="q1">
+<sup>19&#160;</sup>Listen, my son, and be wise, 
+</div><div class="q2">and keep your heart on the right path! 
+</div><div class="q1">
+<sup>20&#160;</sup>Don’t be among ones drinking too much wine, 
+</div><div class="q2">or those who gorge themselves on meat; 
+</div><div class="q1">
+<sup>21&#160;</sup>for the drunkard and the glutton shall become poor; 
+</div><div class="q2">and drowsiness clothes them in rags. 
+</div><div class="q1">
+<sup>22&#160;</sup>Listen to your father who gave you life, 
+</div><div class="q2">and don’t despise your mother when she is old. 
+</div><div class="q1">
+<sup>23&#160;</sup>Buy the truth, and don’t sell it. 
+</div><div class="q2">Get wisdom, discipline, and understanding. 
+</div><div class="q1">
+<sup>24&#160;</sup>The father of the righteous has great joy. 
+</div><div class="q2">Whoever fathers a wise child delights in him. 
+</div><div class="q1">
+<sup>25&#160;</sup>Let your father and your mother be glad! 
+</div><div class="q2">Let her who bore you rejoice! 
+</div><div class="q1">
+<sup>26&#160;</sup>My son, give me your heart; 
+</div><div class="q2">and let your eyes keep in my ways. 
+</div><div class="q1">
+<sup>27&#160;</sup>For a prostitute is a deep pit; 
+</div><div class="q2">and a wayward woman is a narrow well. 
+</div><div class="q1">
+<sup>28&#160;</sup>Yes, she lies in wait like a robber, 
+</div><div class="q2">and increases the unfaithful among men. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>29&#160;</sup>Who has woe? 
+</div><div class="q2">Who has sorrow? 
+</div><div class="q2">Who has strife? 
+</div><div class="q2">Who has complaints? 
+</div><div class="q2">Who has needless bruises? 
+</div><div class="q2">Who has bloodshot eyes? 
+</div><div class="q1">
+<sup>30&#160;</sup>Those who stay long at the wine; 
+</div><div class="q2">those who go to seek out mixed wine. 
+</div><div class="q1">
+<sup>31&#160;</sup>Don’t look at the wine when it is red, 
+</div><div class="q2">when it sparkles in the cup, 
+</div><div class="q2">when it goes down smoothly. 
+</div><div class="q1">
+<sup>32&#160;</sup>In the end, it bites like a snake, 
+</div><div class="q2">and poisons like a viper. 
+</div><div class="q1">
+<sup>33&#160;</sup>Your eyes will see strange things, 
+</div><div class="q2">and your mind will imagine confusing things. 
+</div><div class="q1">
+<sup>34&#160;</sup>Yes, you will be as he who lies down in the middle of the sea, 
+</div><div class="q2">or as he who lies on top of the rigging: 
+</div><div class="q1">
+<sup>35&#160;</sup>“They hit me, and I was not hurt! 
+</div><div class="q2">They beat me, and I don’t feel it! 
+</div><div class="q2">When will I wake up? I can do it again. 
+</div><div class="q2">I will look for more.” 
+</div><div class="b"> &#160; </div>
 <h2 class="chapterlabel" id="24">24</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Don’t be envious of evil men, 
-</p><p class="q2">neither desire to be with them; 
-</p><p class="q1">
-<span class="v">2&#160;</span>for their hearts plot violence 
-</p><p class="q2">and their lips talk about mischief. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Through wisdom a house is built; 
-</p><p class="q2">by understanding it is established; 
-</p><p class="q1">
-<span class="v">4&#160;</span>by knowledge the rooms are filled 
-</p><p class="q2">with all rare and beautiful treasure. 
-</p><p class="q1">
-<span class="v">5&#160;</span>A wise man has great power. 
-</p><p class="q2">A knowledgeable man increases strength, 
-</p><p class="q1">
-<span class="v">6&#160;</span>for by wise guidance you wage your war, 
-</p><p class="q2">and victory is in many advisors. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Wisdom is too high for a fool. 
-</p><p class="q2">He doesn’t open his mouth in the gate. 
-</p><p class="q1">
-<span class="v">8&#160;</span>One who plots to do evil 
-</p><p class="q2">will be called a schemer. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The schemes of folly are sin. 
-</p><p class="q2">The mocker is detested by men. 
-</p><p class="q1">
-<span class="v">10&#160;</span>If you falter in the time of trouble, 
-</p><p class="q2">your strength is small. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Rescue those who are being led away to death! 
-</p><p class="q2">Indeed, hold back those who are staggering to the slaughter! 
-</p><p class="q1">
-<span class="v">12&#160;</span>If you say, “Behold, we didn’t know this,” 
-</p><p class="q2">doesn’t he who weighs the hearts consider it? 
-</p><p class="q1">He who keeps your soul, doesn’t he know it? 
-</p><p class="q2">Shall he not render to every man according to his work? 
-</p><p class="q1">
-<span class="v">13&#160;</span>My son, eat honey, for it is good, 
-</p><p class="q2">the droppings of the honeycomb, which are sweet to your taste; 
-</p><p class="q1">
-<span class="v">14&#160;</span>so you shall know wisdom to be to your soul. 
-</p><p class="q2">If you have found it, then there will be a reward: 
-</p><p class="q2">Your hope will not be cut off. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Don’t lay in wait, wicked man, against the habitation of the righteous. 
-</p><p class="q2">Don’t destroy his resting place; 
-</p><p class="q1">
-<span class="v">16&#160;</span>for a righteous man falls seven times and rises up again, 
-</p><p class="q2">but the wicked are overthrown by calamity. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Don’t rejoice when your enemy falls. 
-</p><p class="q2">Don’t let your heart be glad when he is overthrown, 
-</p><p class="q1">
-<span class="v">18&#160;</span>lest Yahweh see it, and it displease him, 
-</p><p class="q2">and he turn away his wrath from him. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Don’t fret yourself because of evildoers, 
-</p><p class="q2">neither be envious of the wicked; 
-</p><p class="q1">
-<span class="v">20&#160;</span>for there will be no reward to the evil man. 
-</p><p class="q2">The lamp of the wicked will be snuffed out. 
-</p><p class="q1">
-<span class="v">21&#160;</span>My son, fear Yahweh and the king. 
-</p><p class="q2">Don’t join those who are rebellious, 
-</p><p class="q1">
-<span class="v">22&#160;</span>for their calamity will rise suddenly. 
-</p><p class="q2">Who knows what destruction may come from them both? 
-</p><div class="b"> &#160; </div>
-<p>
-<span class="v">23&#160;</span>These also are sayings of the wise: 
-</p><div class="b"> &#160; </div>
-<p class="q1">To show partiality in judgment is not good. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He who says to the wicked, “You are righteous,” 
-</p><p class="q2">peoples will curse him, and nations will abhor him—</p><p class="q1">
-<span class="v">25&#160;</span>but it will go well with those who convict the guilty, 
-</p><p class="q2">and a rich blessing will come on them. 
-</p><p class="q1">
-<span class="v">26&#160;</span>An honest answer 
-</p><p class="q2">is like a kiss on the lips. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Prepare your work outside, 
-</p><p class="q2">and get your fields ready. 
-</p><p class="q2">Afterwards, build your house. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Don’t be a witness against your neighbor without cause. 
-</p><p class="q2">Don’t deceive with your lips. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Don’t say, “I will do to him as he has done to me; 
-</p><p class="q2">I will repay the man according to his work.” 
-</p><p class="q1">
-<span class="v">30&#160;</span>I went by the field of the sluggard, 
-</p><p class="q2">by the vineyard of the man void of understanding. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Behold, it was all grown over with thorns. 
-</p><p class="q2">Its surface was covered with nettles, 
-</p><p class="q2">and its stone wall was broken down. 
-</p><p class="q1">
-<span class="v">32&#160;</span>Then I saw, and considered well. 
-</p><p class="q2">I saw, and received instruction: 
-</p><p class="q1">
-<span class="v">33&#160;</span>a little sleep, a little slumber, 
-</p><p class="q2">a little folding of the hands to sleep, 
-</p><p class="q1">
-<span class="v">34&#160;</span>so your poverty will come as a robber 
-</p><p class="q2">and your want as an armed man. 
-</p><h2 class="chapterlabel" id="25">25</h2>
-<p>
-<span class="v">1&#160;</span>These also are proverbs of Solomon, which the men of Hezekiah king of Judah copied out. 
-</p><p class="q1">
-<span class="v">2&#160;</span>It is the glory of Elohim to conceal a thing, 
-</p><p class="q2">but the glory of kings is to search out a matter. 
-</p><p class="q1">
-<span class="v">3&#160;</span>As the heavens for height, and the earth for depth, 
-</p><p class="q2">so the hearts of kings are unsearchable. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Take away the dross from the silver, 
-</p><p class="q2">and material comes out for the refiner. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Take away the wicked from the king’s presence, 
-</p><p class="q2">and his throne will be established in righteousness. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Don’t exalt yourself in the presence of the king, 
-</p><p class="q2">or claim a place among great men; 
-</p><p class="q1">
-<span class="v">7&#160;</span>for it is better that it be said to you, “Come up here,” 
-</p><p class="q2">than that you should be put lower in the presence of the prince, 
-</p><p class="q2">whom your eyes have seen. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Don’t be hasty in bringing charges to court. 
-</p><p class="q2">What will you do in the end when your neighbor shames you? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Debate your case with your neighbor, 
-</p><p class="q2">and don’t betray the confidence of another, 
-</p><p class="q2">
-<span class="v">10&#160;</span>lest one who hears it put you to shame, 
-</p><p class="q2">and your bad reputation never depart. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>A word fitly spoken 
-</p><p class="q2">is like apples of gold in settings of silver. 
-</p><p class="q1">
-<span class="v">12&#160;</span>As an earring of gold, and an ornament of fine gold, 
-</p><p class="q2">so is a wise reprover to an obedient ear. 
-</p><p class="q1">
-<span class="v">13&#160;</span>As the cold of snow in the time of harvest, 
-</p><p class="q2">so is a faithful messenger to those who send him; 
-</p><p class="q2">for he refreshes the soul of his masters. 
-</p><p class="q1">
-<span class="v">14&#160;</span>As clouds and wind without rain, 
-</p><p class="q2">so is he who boasts of gifts deceptively. 
-</p><p class="q1">
-<span class="v">15&#160;</span>By patience a ruler is persuaded. 
-</p><p class="q2">A soft tongue breaks the bone. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Have you found honey? 
-</p><p class="q2">Eat as much as is sufficient for you, 
-</p><p class="q2">lest you eat too much, and vomit it. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let your foot be seldom in your neighbor’s house, 
-</p><p class="q2">lest he be weary of you, and hate you. 
-</p><p class="q1">
-<span class="v">18&#160;</span>A man who gives false testimony against his neighbor 
-</p><p class="q2">is like a club, a sword, or a sharp arrow. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Confidence in someone unfaithful in time of trouble 
-</p><p class="q2">is like a bad tooth or a lame foot. 
-</p><p class="q1">
-<span class="v">20&#160;</span>As one who takes away a garment in cold weather, 
-</p><p class="q2">or vinegar on soda, 
-</p><p class="q2">so is one who sings songs to a heavy heart. 
-</p><p class="q1">
-<span class="v">21&#160;</span>If your enemy is hungry, give him food to eat. 
-</p><p class="q2">If he is thirsty, give him water to drink; 
-</p><p class="q1">
-<span class="v">22&#160;</span>for you will heap coals of fire on his head, 
-</p><p class="q2">and Yahweh will reward you. 
-</p><p class="q1">
-<span class="v">23&#160;</span>The north wind produces rain; 
-</p><p class="q2">so a backbiting tongue brings an angry face. 
-</p><p class="q1">
-<span class="v">24&#160;</span>It is better to dwell in the corner of the housetop 
-</p><p class="q2">than to share a house with a contentious woman. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Like cold water to a thirsty soul, 
-</p><p class="q2">so is good news from a far country. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Like a muddied spring and a polluted well, 
-</p><p class="q2">so is a righteous man who gives way before the wicked. 
-</p><p class="q1">
-<span class="v">27&#160;</span>It is not good to eat much honey, 
-</p><p class="q2">nor is it honorable to seek one’s own honor. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Like a city that is broken down and without walls 
-</p><p class="q2">is a man whose spirit is without restraint. 
-</p><h2 class="chapterlabel" id="26">26</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Like snow in summer, and as rain in harvest, 
-</p><p class="q2">so honor is not fitting for a fool. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Like a fluttering sparrow, 
-</p><p class="q2">like a darting swallow, 
-</p><p class="q2">so the undeserved curse doesn’t come to rest. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A whip is for the horse, 
-</p><p class="q2">a bridle for the donkey, 
-</p><p class="q2">and a rod for the back of fools! 
-</p><p class="q1">
-<span class="v">4&#160;</span>Don’t answer a fool according to his folly, 
-</p><p class="q2">lest you also be like him. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Answer a fool according to his folly, 
-</p><p class="q2">lest he be wise in his own eyes. 
-</p><p class="q1">
-<span class="v">6&#160;</span>One who sends a message by the hand of a fool 
-</p><p class="q2">is cutting off feet and drinking violence. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Like the legs of the lame that hang loose, 
-</p><p class="q2">so is a parable in the mouth of fools. 
-</p><p class="q1">
-<span class="v">8&#160;</span>As one who binds a stone in a sling, 
-</p><p class="q2">so is he who gives honor to a fool. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Like a thorn bush that goes into the hand of a drunkard, 
-</p><p class="q2">so is a parable in the mouth of fools. 
-</p><p class="q1">
-<span class="v">10&#160;</span>As an archer who wounds all, 
-</p><p class="q2">so is he who hires a fool 
-</p><p class="q2">or he who hires those who pass by. 
-</p><p class="q1">
-<span class="v">11&#160;</span>As a dog that returns to his vomit, 
-</p><p class="q2">so is a fool who repeats his folly. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Do you see a man wise in his own eyes? 
-</p><p class="q2">There is more hope for a fool than for him. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The sluggard says, “There is a lion in the road! 
-</p><p class="q2">A fierce lion roams the streets!” 
-</p><p class="q1">
-<span class="v">14&#160;</span>As the door turns on its hinges, 
-</p><p class="q2">so does the sluggard on his bed. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The sluggard buries his hand in the dish. 
-</p><p class="q2">He is too lazy to bring it back to his mouth. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The sluggard is wiser in his own eyes 
-</p><p class="q2">than seven men who answer with discretion. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Like one who grabs a dog’s ears 
-</p><p class="q2">is one who passes by and meddles in a quarrel not his own. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Like a madman who shoots torches, arrows, and death, 
-</p><p class="q2">
-<span class="v">19&#160;</span>is the man who deceives his neighbor and says, “Am I not joking?” 
-</p><p class="q1">
-<span class="v">20&#160;</span>For lack of wood a fire goes out. 
-</p><p class="q2">Without gossip, a quarrel dies down. 
-</p><p class="q1">
-<span class="v">21&#160;</span>As coals are to hot embers, 
-</p><p class="q2">and wood to fire, 
-</p><p class="q2">so is a contentious man to kindling strife. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The words of a whisperer are as dainty morsels, 
-</p><p class="q2">they go down into the innermost parts. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Like silver dross on an earthen vessel 
-</p><p class="q2">are the lips of a fervent one with an evil heart. 
-</p><p class="q1">
-<span class="v">24&#160;</span>A malicious man disguises himself with his lips, 
-</p><p class="q2">but he harbors evil in his heart. 
-</p><p class="q1">
-<span class="v">25&#160;</span>When his speech is charming, don’t believe him, 
-</p><p class="q2">for there are seven abominations in his heart. 
-</p><p class="q1">
-<span class="v">26&#160;</span>His malice may be concealed by deception, 
-</p><p class="q2">but his wickedness will be exposed in the assembly. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Whoever digs a pit shall fall into it. 
-</p><p class="q2">Whoever rolls a stone, it will come back on him. 
-</p><p class="q1">
-<span class="v">28&#160;</span>A lying tongue hates those it hurts; 
-</p><p class="q2">and a flattering mouth works ruin. 
-</p><h2 class="chapterlabel" id="27">27</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Don’t boast about tomorrow; 
-</p><p class="q2">for you don’t know what a day may bring. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let another man praise you, 
-</p><p class="q2">and not your own mouth; 
-</p><p class="q2">a stranger, and not your own lips. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A stone is heavy, 
-</p><p class="q2">and sand is a burden; 
-</p><p class="q2">but a fool’s provocation is heavier than both. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Wrath is cruel, 
-</p><p class="q2">and anger is overwhelming; 
-</p><p class="q2">but who is able to stand before jealousy? 
-</p><p class="q1">
-<span class="v">5&#160;</span>Better is open rebuke 
-</p><p class="q2">than hidden love. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The wounds of a friend are faithful, 
-</p><p class="q2">although the kisses of an enemy are profuse. 
-</p><p class="q1">
-<span class="v">7&#160;</span>A full soul loathes a honeycomb; 
-</p><p class="q2">but to a hungry soul, every bitter thing is sweet. 
-</p><p class="q1">
-<span class="v">8&#160;</span>As a bird that wanders from her nest, 
-</p><p class="q2">so is a man who wanders from his home. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Perfume and incense bring joy to the heart; 
-</p><p class="q2">so does earnest counsel from a man’s friend. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Don’t forsake your friend and your father’s friend. 
-</p><p class="q2">Don’t go to your brother’s house in the day of your disaster. 
-</p><p class="q2">A neighbor who is near is better than a distant brother. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Be wise, my son, 
-</p><p class="q2">and bring joy to my heart, 
-</p><p class="q2">then I can answer my tormentor. 
-</p><p class="q1">
-<span class="v">12&#160;</span>A prudent man sees danger and takes refuge; 
-</p><p class="q2">but the simple pass on, and suffer for it. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Take his garment when he puts up collateral for a stranger. 
-</p><p class="q2">Hold it for a wayward woman! 
-</p><p class="q1">
-<span class="v">14&#160;</span>He who blesses his neighbor with a loud voice early in the morning, 
-</p><p class="q2">it will be taken as a curse by him. 
-</p><p class="q1">
-<span class="v">15&#160;</span>A continual dropping on a rainy day 
-</p><p class="q2">and a contentious woman are alike: 
-</p><p class="q1">
-<span class="v">16&#160;</span>restraining her is like restraining the wind, 
-</p><p class="q2">or like grasping oil in his right hand. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Iron sharpens iron; 
-</p><p class="q2">so a man sharpens his friend’s countenance. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Whoever tends the fig tree shall eat its fruit. 
-</p><p class="q2">He who looks after his master shall be honored. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Like water reflects a face, 
-</p><p class="q2">so a man’s heart reflects the man. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Sheol<span class="f">+ \fr 27:20 \ft Sheol is the place of the dead.</span> and Abaddon are never satisfied; 
-</p><p class="q2">and a man’s eyes are never satisfied. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The crucible is for silver, 
-</p><p class="q2">and the furnace for gold; 
-</p><p class="q2">but man is refined by his praise. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Though you grind a fool in a mortar with a pestle along with grain, 
-</p><p class="q2">yet his foolishness will not be removed from him. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>Know well the state of your flocks, 
-</p><p class="q2">and pay attention to your herds, 
-</p><p class="q1">
-<span class="v">24&#160;</span>for riches are not forever, 
-</p><p class="q2">nor does the crown endure to all generations. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The hay is removed, and the new growth appears, 
-</p><p class="q2">the grasses of the hills are gathered in. 
-</p><p class="q1">
-<span class="v">26&#160;</span>The lambs are for your clothing, 
-</p><p class="q2">and the goats are the price of a field. 
-</p><p class="q1">
-<span class="v">27&#160;</span>There will be plenty of goats’ milk for your food, 
-</p><p class="q2">for your family’s food, 
-</p><p class="q2">and for the nourishment of your servant girls. 
-</p><h2 class="chapterlabel" id="28">28</h2>
-<p class="q1">
-<span class="v">1&#160;</span>The wicked flee when no one pursues; 
-</p><p class="q2">but the righteous are as bold as a lion. 
-</p><p class="q1">
-<span class="v">2&#160;</span>In rebellion, a land has many rulers, 
-</p><p class="q2">but order is maintained by a man of understanding and knowledge. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A needy man who oppresses the poor 
-</p><p class="q2">is like a driving rain which leaves no crops. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Those who forsake the law praise the wicked; 
-</p><p class="q2">but those who keep the law contend with them. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Evil men don’t understand justice; 
-</p><p class="q2">but those who seek Yahweh understand it fully. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Better is the poor who walks in his integrity 
-</p><p class="q2">than he who is perverse in his ways, and he is rich. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Whoever keeps the law is a wise son; 
-</p><p class="q2">but he who is a companion of gluttons shames his father. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He who increases his wealth by excessive interest 
-</p><p class="q2">gathers it for one who has pity on the poor. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He who turns away his ear from hearing the law, 
-</p><p class="q2">even his prayer is an abomination. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Whoever causes the upright to go astray in an evil way, 
-</p><p class="q2">he will fall into his own trap; 
-</p><p class="q2">but the blameless will inherit good. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The rich man is wise in his own eyes; 
-</p><p class="q2">but the poor who has understanding sees through him. 
-</p><p class="q1">
-<span class="v">12&#160;</span>When the righteous triumph, there is great glory; 
-</p><p class="q2">but when the wicked rise, men hide themselves. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He who conceals his sins doesn’t prosper, 
-</p><p class="q2">but whoever confesses and renounces them finds mercy. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Blessed is the man who always fears; 
-</p><p class="q2">but one who hardens his heart falls into trouble. 
-</p><p class="q1">
-<span class="v">15&#160;</span>As a roaring lion or a charging bear, 
-</p><p class="q2">so is a wicked ruler over helpless people. 
-</p><p class="q1">
-<span class="v">16&#160;</span>A tyrannical ruler lacks judgment. 
-</p><p class="q2">One who hates ill-gotten gain will have long days. 
-</p><p class="q1">
-<span class="v">17&#160;</span>A man who is tormented by blood guilt will be a fugitive until death. 
-</p><p class="q2">No one will support him. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Whoever walks blamelessly is kept safe; 
-</p><p class="q2">but one with perverse ways will fall suddenly. 
-</p><p class="q1">
-<span class="v">19&#160;</span>One who works his land will have an abundance of food; 
-</p><p class="q2">but one who chases fantasies will have his fill of poverty. 
-</p><p class="q1">
-<span class="v">20&#160;</span>A faithful man is rich with blessings; 
-</p><p class="q2">but one who is eager to be rich will not go unpunished. 
-</p><p class="q1">
-<span class="v">21&#160;</span>To show partiality is not good, 
-</p><p class="q2">yet a man will do wrong for a piece of bread. 
-</p><p class="q1">
-<span class="v">22&#160;</span>A stingy man hurries after riches, 
-</p><p class="q2">and doesn’t know that poverty waits for him. 
-</p><p class="q1">
-<span class="v">23&#160;</span>One who rebukes a man will afterward find more favor 
-</p><p class="q2">than one who flatters with the tongue. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Whoever robs his father or his mother and says, “It’s not wrong,” 
-</p><p class="q2">is a partner with a destroyer. 
-</p><p class="q1">
-<span class="v">25&#160;</span>One who is greedy stirs up strife; 
-</p><p class="q2">but one who trusts in Yahweh will prosper. 
-</p><p class="q1">
-<span class="v">26&#160;</span>One who trusts in himself is a fool; 
-</p><p class="q2">but one who walks in wisdom is kept safe. 
-</p><p class="q1">
-<span class="v">27&#160;</span>One who gives to the poor has no lack; 
-</p><p class="q2">but one who closes his eyes will have many curses. 
-</p><p class="q1">
-<span class="v">28&#160;</span>When the wicked rise, men hide themselves; 
-</p><p class="q2">but when they perish, the righteous thrive. 
-</p><h2 class="chapterlabel" id="29">29</h2>
-<p class="q1">
-<span class="v">1&#160;</span>He who is often rebuked and stiffens his neck 
-</p><p class="q2">will be destroyed suddenly, with no remedy. 
-</p><p class="q1">
-<span class="v">2&#160;</span>When the righteous thrive, the people rejoice; 
-</p><p class="q2">but when the wicked rule, the people groan. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Whoever loves wisdom brings joy to his father; 
-</p><p class="q2">but a companion of prostitutes squanders his wealth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The king by justice makes the land stable, 
-</p><p class="q2">but he who takes bribes tears it down. 
-</p><p class="q1">
-<span class="v">5&#160;</span>A man who flatters his neighbor 
-</p><p class="q2">spreads a net for his feet. 
-</p><p class="q1">
-<span class="v">6&#160;</span>An evil man is snared by his sin, 
-</p><p class="q2">but the righteous can sing and be glad. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The righteous care about justice for the poor. 
-</p><p class="q2">The wicked aren’t concerned about knowledge. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Mockers stir up a city, 
-</p><p class="q2">but wise men turn away anger. 
-</p><p class="q1">
-<span class="v">9&#160;</span>If a wise man goes to court with a foolish man, 
-</p><p class="q2">the fool rages or scoffs, and there is no peace. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The bloodthirsty hate a man of integrity; 
-</p><p class="q2">and they seek the life of the upright. 
-</p><p class="q1">
-<span class="v">11&#160;</span>A fool vents all of his anger, 
-</p><p class="q2">but a wise man brings himself under control. 
-</p><p class="q1">
-<span class="v">12&#160;</span>If a ruler listens to lies, 
-</p><p class="q2">all of his officials are wicked. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The poor man and the oppressor have this in common: 
-</p><p class="q2">Yahweh gives sight to the eyes of both. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The king who fairly judges the poor, 
-</p><p class="q2">his throne shall be established forever. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The rod of correction gives wisdom, 
-</p><p class="q2">but a child left to himself causes shame to his mother. 
-</p><p class="q1">
-<span class="v">16&#160;</span>When the wicked increase, sin increases; 
-</p><p class="q2">but the righteous will see their downfall. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Correct your son, and he will give you peace; 
-</p><p class="q2">yes, he will bring delight to your soul. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Where there is no revelation, the people cast off restraint; 
-</p><p class="q2">but one who keeps the law is blessed. 
-</p><p class="q1">
-<span class="v">19&#160;</span>A servant can’t be corrected by words. 
-</p><p class="q2">Though he understands, yet he will not respond. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Do you see a man who is hasty in his words? 
-</p><p class="q2">There is more hope for a fool than for him. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He who pampers his servant from youth 
-</p><p class="q2">will have him become a son in the end. 
-</p><p class="q1">
-<span class="v">22&#160;</span>An angry man stirs up strife, 
-</p><p class="q2">and a wrathful man abounds in sin. 
-</p><p class="q1">
-<span class="v">23&#160;</span>A man’s pride brings him low, 
-</p><p class="q2">but one of lowly spirit gains honor. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Whoever is an accomplice of a thief is an enemy of his own soul. 
-</p><p class="q2">He takes an oath, but dares not testify. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The fear of man proves to be a snare, 
-</p><p class="q2">but whoever puts his trust in Yahweh is kept safe. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Many seek the ruler’s favor, 
-</p><p class="q2">but a man’s justice comes from Yahweh. 
-</p><p class="q1">
-<span class="v">27&#160;</span>A dishonest man detests the righteous, 
-</p><p class="q2">and the upright in their ways detest the wicked. 
-</p><h2 class="chapterlabel" id="30">30</h2>
-<p>
-<span class="v">1&#160;</span>The words of Agur the son of Jakeh, the revelation: 
-</p><p class="q1">the man says to Ithiel, 
-</p><p class="q2">to Ithiel and Ucal: 
-</p><p class="q1">
-<span class="v">2&#160;</span>“Surely I am the most ignorant man, 
-</p><p class="q2">and don’t have a man’s understanding. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I have not learned wisdom, 
-</p><p class="q2">neither do I have the knowledge of the Set-Apart One. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Who has ascended up into heaven, and descended? 
-</p><p class="q2">Who has gathered the wind in his fists? 
-</p><p class="q2">Who has bound the waters in his garment? 
-</p><p class="q2">Who has established all the ends of the earth? 
-</p><p class="q2">What is his name, and what is his son’s name, if you know? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>“Every word of Elohim is flawless. 
-</p><p class="q2">He is a shield to those who take refuge in him. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Don’t you add to his words, 
-</p><p class="q2">lest he reprove you, and you be found a liar. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Two things I have asked of you. 
-</p><p class="q2">Don’t deny me before I die. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Remove far from me falsehood and lies. 
-</p><p class="q2">Give me neither poverty nor riches. 
-</p><p class="q2">Feed me with the food that is needful for me, 
-</p><p class="q1">
-<span class="v">9&#160;</span>lest I be full, deny you, and say, ‘Who is Yahweh?’ 
-</p><p class="q2">or lest I be poor, and steal, 
-</p><p class="q2">and so dishonor the name of my Elohim. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>“Don’t slander a servant to his master, 
-</p><p class="q2">lest he curse you, and you be held guilty. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>There is a generation that curses their father, 
-</p><p class="q2">and doesn’t bless their mother. 
-</p><p class="q1">
-<span class="v">12&#160;</span>There is a generation that is pure in their own eyes, 
-</p><p class="q2">yet are not washed from their filthiness. 
-</p><p class="q1">
-<span class="v">13&#160;</span>There is a generation, oh how lofty are their eyes! 
-</p><p class="q2">Their eyelids are lifted up. 
-</p><p class="q1">
-<span class="v">14&#160;</span>There is a generation whose teeth are like swords, 
-</p><p class="q2">and their jaws like knives, 
-</p><p class="q2">to devour the poor from the earth, and the needy from among men. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>“The leech has two daughters: 
-</p><p class="q2">‘Give, give.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">“There are three things that are never satisfied; 
-</p><p class="q2">four that don’t say, ‘Enough!’: 
-</p><p class="q2">
-<span class="v">16&#160;</span>Sheol,<span class="f">+ \fr 30:16 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">the barren womb, 
-</p><p class="q2">the earth that is not satisfied with water, 
-</p><p class="q2">and the fire that doesn’t say, ‘Enough!’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>“The eye that mocks at his father, 
-</p><p class="q2">and scorns obedience to his mother, 
-</p><p class="q2">the ravens of the valley shall pick it out, 
-</p><p class="q2">the young eagles shall eat it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>“There are three things which are too amazing for me, 
-</p><p class="q2">four which I don’t understand: 
-</p><p class="q2">
-<span class="v">19&#160;</span>The way of an eagle in the air, 
-</p><p class="q2">the way of a serpent on a rock, 
-</p><p class="q2">the way of a ship in the middle of the sea, 
-</p><p class="q2">and the way of a man with a maiden. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>“So is the way of an adulterous woman: 
-</p><p class="q2">She eats and wipes her mouth, 
-</p><p class="q2">and says, ‘I have done nothing wrong.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>“For three things the earth trembles, 
-</p><p class="q2">and under four, it can’t bear up: 
-</p><p class="q2">
-<span class="v">22&#160;</span>For a servant when he is king, 
-</p><p class="q2">a fool when he is filled with food, 
-</p><p class="q2">
-<span class="v">23&#160;</span>for an unloved woman when she is married, 
-</p><p class="q2">and a servant who is heir to her mistress. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">24&#160;</span>“There are four things which are little on the earth, 
-</p><p class="q2">but they are exceedingly wise: 
-</p><p class="q2">
-<span class="v">25&#160;</span>The ants are not a strong people, 
-</p><p class="q2">yet they provide their food in the summer. 
-</p><p class="q2">
-<span class="v">26&#160;</span>The hyraxes are but a feeble folk, 
-</p><p class="q2">yet make they their houses in the rocks. 
-</p><p class="q2">
-<span class="v">27&#160;</span>The locusts have no king, 
-</p><p class="q2">yet they advance in ranks. 
-</p><p class="q2">
-<span class="v">28&#160;</span>You can catch a lizard with your hands, 
-</p><p class="q2">yet it is in kings’ palaces. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">29&#160;</span>“There are three things which are stately in their march, 
-</p><p class="q2">four which are stately in going: 
-</p><p class="q2">
-<span class="v">30&#160;</span>The lion, which is mightiest among animals, 
-</p><p class="q2">and doesn’t turn away for any; 
-</p><p class="q2">
-<span class="v">31&#160;</span>the greyhound; 
-</p><p class="q2">the male goat; 
-</p><p class="q2">and the king against whom there is no rising up. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">32&#160;</span>“If you have done foolishly in lifting up yourself, 
-</p><p class="q2">or if you have thought evil, 
-</p><p class="q1">put your hand over your mouth. 
-</p><p class="q2">
-<span class="v">33&#160;</span>For as the churning of milk produces butter, 
-</p><p class="q2">and the wringing of the nose produces blood, 
-</p><p class="q2">so the forcing of wrath produces strife.” 
-</p><h2 class="chapterlabel" id="31">31</h2>
-<p>
-<span class="v">1&#160;</span>The words of King Lemuel—the revelation which his mother taught him: 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">2&#160;</span>“Oh, my son! 
-</p><p class="q2">Oh, son of my womb! 
-</p><p class="q2">Oh, son of my vows! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Don’t give your strength to women, 
-</p><p class="q2">nor your ways to that which destroys kings. 
-</p><p class="q1">
-<span class="v">4&#160;</span>It is not for kings, Lemuel, 
-</p><p class="q2">it is not for kings to drink wine, 
-</p><p class="q2">nor for princes to say, ‘Where is strong drink?’ 
-</p><p class="q1">
-<span class="v">5&#160;</span>lest they drink, and forget the law, 
-</p><p class="q2">and pervert the justice due to anyone who is afflicted. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Give strong drink to him who is ready to perish, 
-</p><p class="q2">and wine to the bitter in soul. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Let him drink, and forget his poverty, 
-</p><p class="q2">and remember his misery no more. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Open your mouth for the mute, 
-</p><p class="q2">in the cause of all who are left desolate. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Open your mouth, judge righteously, 
-</p><p class="q2">and serve justice to the poor and needy.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span><span class="f">+ \fr 31:10 \ft Proverbs 31:10-31 form an acrostic, with each verse starting with each letter of the Hebrew alphabet, in order.</span>Who can find a worthy woman? 
-</p><p class="q2">For her value is far above rubies. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The heart of her owner trusts in her. 
-</p><p class="q2">He shall have no lack of gain. 
-</p><p class="q1">
-<span class="v">12&#160;</span>She does him good, and not harm, 
-</p><p class="q2">all the days of her life. 
-</p><p class="q1">
-<span class="v">13&#160;</span>She seeks wool and flax, 
-</p><p class="q2">and works eagerly with her hands. 
-</p><p class="q1">
-<span class="v">14&#160;</span>She is like the merchant ships. 
-</p><p class="q2">She brings her bread from afar. 
-</p><p class="q1">
-<span class="v">15&#160;</span>She rises also while it is yet night, 
-</p><p class="q2">gives food to her household, 
-</p><p class="q2">and portions for her servant girls. 
-</p><p class="q1">
-<span class="v">16&#160;</span>She considers a field, and buys it. 
-</p><p class="q2">With the fruit of her hands, she plants a vineyard. 
-</p><p class="q1">
-<span class="v">17&#160;</span>She arms her waist with strength, 
-</p><p class="q2">and makes her arms strong. 
-</p><p class="q1">
-<span class="v">18&#160;</span>She perceives that her merchandise is profitable. 
-</p><p class="q2">Her lamp doesn’t go out by night. 
-</p><p class="q1">
-<span class="v">19&#160;</span>She lays her hands to the distaff, 
-</p><p class="q2">and her hands hold the spindle. 
-</p><p class="q1">
-<span class="v">20&#160;</span>She opens her arms to the poor; 
-</p><p class="q2">yes, she extends her hands to the needy. 
-</p><p class="q1">
-<span class="v">21&#160;</span>She is not afraid of the snow for her household, 
-</p><p class="q2">for all her household are clothed with scarlet. 
-</p><p class="q1">
-<span class="v">22&#160;</span>She makes for herself carpets of tapestry. 
-</p><p class="q2">Her clothing is fine linen and purple. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Her owner is respected in the gates, 
-</p><p class="q2">when he sits among the elders of the land. 
-</p><p class="q1">
-<span class="v">24&#160;</span>She makes linen garments and sells them, 
-</p><p class="q2">and delivers sashes to the merchant. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Strength and dignity are her clothing. 
-</p><p class="q2">She laughs at the time to come. 
-</p><p class="q1">
-<span class="v">26&#160;</span>She opens her mouth with wisdom. 
-</p><p class="q2">Kind instruction is on her tongue. 
-</p><p class="q1">
-<span class="v">27&#160;</span>She looks well to the ways of her household, 
-</p><p class="q2">and doesn’t eat the bread of idleness. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Her children rise up and call her blessed. 
-</p><p class="q2">Her owner also praises her: 
-</p><p class="q1">
-<span class="v">29&#160;</span>“Many women do noble things, 
-</p><p class="q2">but you excel them all.” 
-</p><p class="q1">
-<span class="v">30&#160;</span>Charm is deceitful, and beauty is vain; 
-</p><p class="q2">but a woman who fears Yahweh, she shall be praised. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Give her of the fruit of her hands! 
-</p><p class="q2">Let her works praise her in the gates! </div><script src="../main.js"></script></body></html>
+<div class="q1">
+<sup>1&#160;</sup>Don’t be envious of evil men, 
+</div><div class="q2">neither desire to be with them; 
+</div><div class="q1">
+<sup>2&#160;</sup>for their hearts plot violence 
+</div><div class="q2">and their lips talk about mischief. 
+</div><div class="q1">
+<sup>3&#160;</sup>Through wisdom a house is built; 
+</div><div class="q2">by understanding it is established; 
+</div><div class="q1">
+<sup>4&#160;</sup>by knowledge the rooms are filled 
+</div><div class="q2">with all rare and beautiful treasure. 
+</div><div class="q1">
+<sup>5&#160;</sup>A wise man has great power. 
+</div><div class="q2">A knowledgeable man increases strength, 
+</div><div class="q1">
+<sup>6&#160;</sup>for by wise guidance you wage your war, 
+</div><div class="q2">and victory is in many advisors. 
+</div><div class="q1">
+<sup>7&#160;</sup>Wisdom is too high for a fool. 
+</div><div class="q2">He doesn’t open his mouth in the gate. 
+</div><div class="q1">
+<sup>8&#160;</sup>One who plots to do evil 
+</div><div class="q2">will be called a schemer. 
+</div><div class="q1">
+<sup>9&#160;</sup>The schemes of folly are sin. 
+</div><div class="q2">The mocker is detested by men. 
+</div><div class="q1">
+<sup>10&#160;</sup>If you falter in the time of trouble, 
+</div><div class="q2">your strength is small. 
+</div><div class="q1">
+<sup>11&#160;</sup>Rescue those who are being led away to death! 
+</div><div class="q2">Indeed, hold back those who are staggering to the slaughter! 
+</div><div class="q1">
+<sup>12&#160;</sup>If you say, “Behold, we didn’t know this,” 
+</div><div class="q2">doesn’t he who weighs the hearts consider it? 
+</div><div class="q1">He who keeps your soul, doesn’t he know it? 
+</div><div class="q2">Shall he not render to every man according to his work? 
+</div><div class="q1">
+<sup>13&#160;</sup>My son, eat honey, for it is good, 
+</div><div class="q2">the droppings of the honeycomb, which are sweet to your taste; 
+</div><div class="q1">
+<sup>14&#160;</sup>so you shall know wisdom to be to your soul. 
+</div><div class="q2">If you have found it, then there will be a reward: 
+</div><div class="q2">Your hope will not be cut off. 
+</div><div class="q1">
+<sup>15&#160;</sup>Don’t lay in wait, wicked man, against the habitation of the righteous. 
+</div><div class="q2">Don’t destroy his resting place; 
+</div><div class="q1">
+<sup>16&#160;</sup>for a righteous man falls seven times and rises up again, 
+</div><div class="q2">but the wicked are overthrown by calamity. 
+</div><div class="q1">
+<sup>17&#160;</sup>Don’t rejoice when your enemy falls. 
+</div><div class="q2">Don’t let your heart be glad when he is overthrown, 
+</div><div class="q1">
+<sup>18&#160;</sup>lest Yahweh see it, and it displease him, 
+</div><div class="q2">and he turn away his wrath from him. 
+</div><div class="q1">
+<sup>19&#160;</sup>Don’t fret yourself because of evildoers, 
+</div><div class="q2">neither be envious of the wicked; 
+</div><div class="q1">
+<sup>20&#160;</sup>for there will be no reward to the evil man. 
+</div><div class="q2">The lamp of the wicked will be snuffed out. 
+</div><div class="q1">
+<sup>21&#160;</sup>My son, fear Yahweh and the king. 
+</div><div class="q2">Don’t join those who are rebellious, 
+</div><div class="q1">
+<sup>22&#160;</sup>for their calamity will rise suddenly. 
+</div><div class="q2">Who knows what destruction may come from them both? 
+</div><div class="b"> &#160; </div>
+<div class="p">
+<sup>23&#160;</sup>These also are sayings of the wise: 
+</div><div class="b"> &#160; </div>
+<div class="q1">To show partiality in judgment is not good. 
+</div><div class="q1">
+<sup>24&#160;</sup>He who says to the wicked, “You are righteous,” 
+</div><div class="q2">peoples will curse him, and nations will abhor him—</div><div class="q1">
+<sup>25&#160;</sup>but it will go well with those who convict the guilty, 
+</div><div class="q2">and a rich blessing will come on them. 
+</div><div class="q1">
+<sup>26&#160;</sup>An honest answer 
+</div><div class="q2">is like a kiss on the lips. 
+</div><div class="q1">
+<sup>27&#160;</sup>Prepare your work outside, 
+</div><div class="q2">and get your fields ready. 
+</div><div class="q2">Afterwards, build your house. 
+</div><div class="q1">
+<sup>28&#160;</sup>Don’t be a witness against your neighbor without cause. 
+</div><div class="q2">Don’t deceive with your lips. 
+</div><div class="q1">
+<sup>29&#160;</sup>Don’t say, “I will do to him as he has done to me; 
+</div><div class="q2">I will repay the man according to his work.” 
+</div><div class="q1">
+<sup>30&#160;</sup>I went by the field of the sluggard, 
+</div><div class="q2">by the vineyard of the man void of understanding. 
+</div><div class="q1">
+<sup>31&#160;</sup>Behold, it was all grown over with thorns. 
+</div><div class="q2">Its surface was covered with nettles, 
+</div><div class="q2">and its stone wall was broken down. 
+</div><div class="q1">
+<sup>32&#160;</sup>Then I saw, and considered well. 
+</div><div class="q2">I saw, and received instruction: 
+</div><div class="q1">
+<sup>33&#160;</sup>a little sleep, a little slumber, 
+</div><div class="q2">a little folding of the hands to sleep, 
+</div><div class="q1">
+<sup>34&#160;</sup>so your poverty will come as a robber 
+</div><div class="q2">and your want as an armed man. 
+</div><h2 class="chapterlabel" id="25">25</h2>
+<div class="p">
+<sup>1&#160;</sup>These also are proverbs of Solomon, which the men of Hezekiah king of Judah copied out. 
+</div><div class="q1">
+<sup>2&#160;</sup>It is the glory of Elohim to conceal a thing, 
+</div><div class="q2">but the glory of kings is to search out a matter. 
+</div><div class="q1">
+<sup>3&#160;</sup>As the heavens for height, and the earth for depth, 
+</div><div class="q2">so the hearts of kings are unsearchable. 
+</div><div class="q1">
+<sup>4&#160;</sup>Take away the dross from the silver, 
+</div><div class="q2">and material comes out for the refiner. 
+</div><div class="q1">
+<sup>5&#160;</sup>Take away the wicked from the king’s presence, 
+</div><div class="q2">and his throne will be established in righteousness. 
+</div><div class="q1">
+<sup>6&#160;</sup>Don’t exalt yourself in the presence of the king, 
+</div><div class="q2">or claim a place among great men; 
+</div><div class="q1">
+<sup>7&#160;</sup>for it is better that it be said to you, “Come up here,” 
+</div><div class="q2">than that you should be put lower in the presence of the prince, 
+</div><div class="q2">whom your eyes have seen. 
+</div><div class="q1">
+<sup>8&#160;</sup>Don’t be hasty in bringing charges to court. 
+</div><div class="q2">What will you do in the end when your neighbor shames you? 
+</div><div class="q1">
+<sup>9&#160;</sup>Debate your case with your neighbor, 
+</div><div class="q2">and don’t betray the confidence of another, 
+</div><div class="q2">
+<sup>10&#160;</sup>lest one who hears it put you to shame, 
+</div><div class="q2">and your bad reputation never depart. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>A word fitly spoken 
+</div><div class="q2">is like apples of gold in settings of silver. 
+</div><div class="q1">
+<sup>12&#160;</sup>As an earring of gold, and an ornament of fine gold, 
+</div><div class="q2">so is a wise reprover to an obedient ear. 
+</div><div class="q1">
+<sup>13&#160;</sup>As the cold of snow in the time of harvest, 
+</div><div class="q2">so is a faithful messenger to those who send him; 
+</div><div class="q2">for he refreshes the soul of his masters. 
+</div><div class="q1">
+<sup>14&#160;</sup>As clouds and wind without rain, 
+</div><div class="q2">so is he who boasts of gifts deceptively. 
+</div><div class="q1">
+<sup>15&#160;</sup>By patience a ruler is persuaded. 
+</div><div class="q2">A soft tongue breaks the bone. 
+</div><div class="q1">
+<sup>16&#160;</sup>Have you found honey? 
+</div><div class="q2">Eat as much as is sufficient for you, 
+</div><div class="q2">lest you eat too much, and vomit it. 
+</div><div class="q1">
+<sup>17&#160;</sup>Let your foot be seldom in your neighbor’s house, 
+</div><div class="q2">lest he be weary of you, and hate you. 
+</div><div class="q1">
+<sup>18&#160;</sup>A man who gives false testimony against his neighbor 
+</div><div class="q2">is like a club, a sword, or a sharp arrow. 
+</div><div class="q1">
+<sup>19&#160;</sup>Confidence in someone unfaithful in time of trouble 
+</div><div class="q2">is like a bad tooth or a lame foot. 
+</div><div class="q1">
+<sup>20&#160;</sup>As one who takes away a garment in cold weather, 
+</div><div class="q2">or vinegar on soda, 
+</div><div class="q2">so is one who sings songs to a heavy heart. 
+</div><div class="q1">
+<sup>21&#160;</sup>If your enemy is hungry, give him food to eat. 
+</div><div class="q2">If he is thirsty, give him water to drink; 
+</div><div class="q1">
+<sup>22&#160;</sup>for you will heap coals of fire on his head, 
+</div><div class="q2">and Yahweh will reward you. 
+</div><div class="q1">
+<sup>23&#160;</sup>The north wind produces rain; 
+</div><div class="q2">so a backbiting tongue brings an angry face. 
+</div><div class="q1">
+<sup>24&#160;</sup>It is better to dwell in the corner of the housetop 
+</div><div class="q2">than to share a house with a contentious woman. 
+</div><div class="q1">
+<sup>25&#160;</sup>Like cold water to a thirsty soul, 
+</div><div class="q2">so is good news from a far country. 
+</div><div class="q1">
+<sup>26&#160;</sup>Like a muddied spring and a polluted well, 
+</div><div class="q2">so is a righteous man who gives way before the wicked. 
+</div><div class="q1">
+<sup>27&#160;</sup>It is not good to eat much honey, 
+</div><div class="q2">nor is it honorable to seek one’s own honor. 
+</div><div class="q1">
+<sup>28&#160;</sup>Like a city that is broken down and without walls 
+</div><div class="q2">is a man whose spirit is without restraint. 
+</div><h2 class="chapterlabel" id="26">26</h2>
+<div class="q1">
+<sup>1&#160;</sup>Like snow in summer, and as rain in harvest, 
+</div><div class="q2">so honor is not fitting for a fool. 
+</div><div class="q1">
+<sup>2&#160;</sup>Like a fluttering sparrow, 
+</div><div class="q2">like a darting swallow, 
+</div><div class="q2">so the undeserved curse doesn’t come to rest. 
+</div><div class="q1">
+<sup>3&#160;</sup>A whip is for the horse, 
+</div><div class="q2">a bridle for the donkey, 
+</div><div class="q2">and a rod for the back of fools! 
+</div><div class="q1">
+<sup>4&#160;</sup>Don’t answer a fool according to his folly, 
+</div><div class="q2">lest you also be like him. 
+</div><div class="q1">
+<sup>5&#160;</sup>Answer a fool according to his folly, 
+</div><div class="q2">lest he be wise in his own eyes. 
+</div><div class="q1">
+<sup>6&#160;</sup>One who sends a message by the hand of a fool 
+</div><div class="q2">is cutting off feet and drinking violence. 
+</div><div class="q1">
+<sup>7&#160;</sup>Like the legs of the lame that hang loose, 
+</div><div class="q2">so is a parable in the mouth of fools. 
+</div><div class="q1">
+<sup>8&#160;</sup>As one who binds a stone in a sling, 
+</div><div class="q2">so is he who gives honor to a fool. 
+</div><div class="q1">
+<sup>9&#160;</sup>Like a thorn bush that goes into the hand of a drunkard, 
+</div><div class="q2">so is a parable in the mouth of fools. 
+</div><div class="q1">
+<sup>10&#160;</sup>As an archer who wounds all, 
+</div><div class="q2">so is he who hires a fool 
+</div><div class="q2">or he who hires those who pass by. 
+</div><div class="q1">
+<sup>11&#160;</sup>As a dog that returns to his vomit, 
+</div><div class="q2">so is a fool who repeats his folly. 
+</div><div class="q1">
+<sup>12&#160;</sup>Do you see a man wise in his own eyes? 
+</div><div class="q2">There is more hope for a fool than for him. 
+</div><div class="q1">
+<sup>13&#160;</sup>The sluggard says, “There is a lion in the road! 
+</div><div class="q2">A fierce lion roams the streets!” 
+</div><div class="q1">
+<sup>14&#160;</sup>As the door turns on its hinges, 
+</div><div class="q2">so does the sluggard on his bed. 
+</div><div class="q1">
+<sup>15&#160;</sup>The sluggard buries his hand in the dish. 
+</div><div class="q2">He is too lazy to bring it back to his mouth. 
+</div><div class="q1">
+<sup>16&#160;</sup>The sluggard is wiser in his own eyes 
+</div><div class="q2">than seven men who answer with discretion. 
+</div><div class="q1">
+<sup>17&#160;</sup>Like one who grabs a dog’s ears 
+</div><div class="q2">is one who passes by and meddles in a quarrel not his own. 
+</div><div class="q1">
+<sup>18&#160;</sup>Like a madman who shoots torches, arrows, and death, 
+</div><div class="q2">
+<sup>19&#160;</sup>is the man who deceives his neighbor and says, “Am I not joking?” 
+</div><div class="q1">
+<sup>20&#160;</sup>For lack of wood a fire goes out. 
+</div><div class="q2">Without gossip, a quarrel dies down. 
+</div><div class="q1">
+<sup>21&#160;</sup>As coals are to hot embers, 
+</div><div class="q2">and wood to fire, 
+</div><div class="q2">so is a contentious man to kindling strife. 
+</div><div class="q1">
+<sup>22&#160;</sup>The words of a whisperer are as dainty morsels, 
+</div><div class="q2">they go down into the innermost parts. 
+</div><div class="q1">
+<sup>23&#160;</sup>Like silver dross on an earthen vessel 
+</div><div class="q2">are the lips of a fervent one with an evil heart. 
+</div><div class="q1">
+<sup>24&#160;</sup>A malicious man disguises himself with his lips, 
+</div><div class="q2">but he harbors evil in his heart. 
+</div><div class="q1">
+<sup>25&#160;</sup>When his speech is charming, don’t believe him, 
+</div><div class="q2">for there are seven abominations in his heart. 
+</div><div class="q1">
+<sup>26&#160;</sup>His malice may be concealed by deception, 
+</div><div class="q2">but his wickedness will be exposed in the assembly. 
+</div><div class="q1">
+<sup>27&#160;</sup>Whoever digs a pit shall fall into it. 
+</div><div class="q2">Whoever rolls a stone, it will come back on him. 
+</div><div class="q1">
+<sup>28&#160;</sup>A lying tongue hates those it hurts; 
+</div><div class="q2">and a flattering mouth works ruin. 
+</div><h2 class="chapterlabel" id="27">27</h2>
+<div class="q1">
+<sup>1&#160;</sup>Don’t boast about tomorrow; 
+</div><div class="q2">for you don’t know what a day may bring. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let another man praise you, 
+</div><div class="q2">and not your own mouth; 
+</div><div class="q2">a stranger, and not your own lips. 
+</div><div class="q1">
+<sup>3&#160;</sup>A stone is heavy, 
+</div><div class="q2">and sand is a burden; 
+</div><div class="q2">but a fool’s provocation is heavier than both. 
+</div><div class="q1">
+<sup>4&#160;</sup>Wrath is cruel, 
+</div><div class="q2">and anger is overwhelming; 
+</div><div class="q2">but who is able to stand before jealousy? 
+</div><div class="q1">
+<sup>5&#160;</sup>Better is open rebuke 
+</div><div class="q2">than hidden love. 
+</div><div class="q1">
+<sup>6&#160;</sup>The wounds of a friend are faithful, 
+</div><div class="q2">although the kisses of an enemy are profuse. 
+</div><div class="q1">
+<sup>7&#160;</sup>A full soul loathes a honeycomb; 
+</div><div class="q2">but to a hungry soul, every bitter thing is sweet. 
+</div><div class="q1">
+<sup>8&#160;</sup>As a bird that wanders from her nest, 
+</div><div class="q2">so is a man who wanders from his home. 
+</div><div class="q1">
+<sup>9&#160;</sup>Perfume and incense bring joy to the heart; 
+</div><div class="q2">so does earnest counsel from a man’s friend. 
+</div><div class="q1">
+<sup>10&#160;</sup>Don’t forsake your friend and your father’s friend. 
+</div><div class="q2">Don’t go to your brother’s house in the day of your disaster. 
+</div><div class="q2">A neighbor who is near is better than a distant brother. 
+</div><div class="q1">
+<sup>11&#160;</sup>Be wise, my son, 
+</div><div class="q2">and bring joy to my heart, 
+</div><div class="q2">then I can answer my tormentor. 
+</div><div class="q1">
+<sup>12&#160;</sup>A prudent man sees danger and takes refuge; 
+</div><div class="q2">but the simple pass on, and suffer for it. 
+</div><div class="q1">
+<sup>13&#160;</sup>Take his garment when he puts up collateral for a stranger. 
+</div><div class="q2">Hold it for a wayward woman! 
+</div><div class="q1">
+<sup>14&#160;</sup>He who blesses his neighbor with a loud voice early in the morning, 
+</div><div class="q2">it will be taken as a curse by him. 
+</div><div class="q1">
+<sup>15&#160;</sup>A continual dropping on a rainy day 
+</div><div class="q2">and a contentious woman are alike: 
+</div><div class="q1">
+<sup>16&#160;</sup>restraining her is like restraining the wind, 
+</div><div class="q2">or like grasping oil in his right hand. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Iron sharpens iron; 
+</div><div class="q2">so a man sharpens his friend’s countenance. 
+</div><div class="q1">
+<sup>18&#160;</sup>Whoever tends the fig tree shall eat its fruit. 
+</div><div class="q2">He who looks after his master shall be honored. 
+</div><div class="q1">
+<sup>19&#160;</sup>Like water reflects a face, 
+</div><div class="q2">so a man’s heart reflects the man. 
+</div><div class="q1">
+<sup>20&#160;</sup>Sheol and Abaddon are never satisfied; 
+</div><div class="q2">and a man’s eyes are never satisfied. 
+</div><div class="q1">
+<sup>21&#160;</sup>The crucible is for silver, 
+</div><div class="q2">and the furnace for gold; 
+</div><div class="q2">but man is refined by his praise. 
+</div><div class="q1">
+<sup>22&#160;</sup>Though you grind a fool in a mortar with a pestle along with grain, 
+</div><div class="q2">yet his foolishness will not be removed from him. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>Know well the state of your flocks, 
+</div><div class="q2">and pay attention to your herds, 
+</div><div class="q1">
+<sup>24&#160;</sup>for riches are not forever, 
+</div><div class="q2">nor does the crown endure to all generations. 
+</div><div class="q1">
+<sup>25&#160;</sup>The hay is removed, and the new growth appears, 
+</div><div class="q2">the grasses of the hills are gathered in. 
+</div><div class="q1">
+<sup>26&#160;</sup>The lambs are for your clothing, 
+</div><div class="q2">and the goats are the price of a field. 
+</div><div class="q1">
+<sup>27&#160;</sup>There will be plenty of goats’ milk for your food, 
+</div><div class="q2">for your family’s food, 
+</div><div class="q2">and for the nourishment of your servant girls. 
+</div><h2 class="chapterlabel" id="28">28</h2>
+<div class="q1">
+<sup>1&#160;</sup>The wicked flee when no one pursues; 
+</div><div class="q2">but the righteous are as bold as a lion. 
+</div><div class="q1">
+<sup>2&#160;</sup>In rebellion, a land has many rulers, 
+</div><div class="q2">but order is maintained by a man of understanding and knowledge. 
+</div><div class="q1">
+<sup>3&#160;</sup>A needy man who oppresses the poor 
+</div><div class="q2">is like a driving rain which leaves no crops. 
+</div><div class="q1">
+<sup>4&#160;</sup>Those who forsake the law praise the wicked; 
+</div><div class="q2">but those who keep the law contend with them. 
+</div><div class="q1">
+<sup>5&#160;</sup>Evil men don’t understand justice; 
+</div><div class="q2">but those who seek Yahweh understand it fully. 
+</div><div class="q1">
+<sup>6&#160;</sup>Better is the poor who walks in his integrity 
+</div><div class="q2">than he who is perverse in his ways, and he is rich. 
+</div><div class="q1">
+<sup>7&#160;</sup>Whoever keeps the law is a wise son; 
+</div><div class="q2">but he who is a companion of gluttons shames his father. 
+</div><div class="q1">
+<sup>8&#160;</sup>He who increases his wealth by excessive interest 
+</div><div class="q2">gathers it for one who has pity on the poor. 
+</div><div class="q1">
+<sup>9&#160;</sup>He who turns away his ear from hearing the law, 
+</div><div class="q2">even his prayer is an abomination. 
+</div><div class="q1">
+<sup>10&#160;</sup>Whoever causes the upright to go astray in an evil way, 
+</div><div class="q2">he will fall into his own trap; 
+</div><div class="q2">but the blameless will inherit good. 
+</div><div class="q1">
+<sup>11&#160;</sup>The rich man is wise in his own eyes; 
+</div><div class="q2">but the poor who has understanding sees through him. 
+</div><div class="q1">
+<sup>12&#160;</sup>When the righteous triumph, there is great glory; 
+</div><div class="q2">but when the wicked rise, men hide themselves. 
+</div><div class="q1">
+<sup>13&#160;</sup>He who conceals his sins doesn’t prosper, 
+</div><div class="q2">but whoever confesses and renounces them finds mercy. 
+</div><div class="q1">
+<sup>14&#160;</sup>Blessed is the man who always fears; 
+</div><div class="q2">but one who hardens his heart falls into trouble. 
+</div><div class="q1">
+<sup>15&#160;</sup>As a roaring lion or a charging bear, 
+</div><div class="q2">so is a wicked ruler over helpless people. 
+</div><div class="q1">
+<sup>16&#160;</sup>A tyrannical ruler lacks judgment. 
+</div><div class="q2">One who hates ill-gotten gain will have long days. 
+</div><div class="q1">
+<sup>17&#160;</sup>A man who is tormented by blood guilt will be a fugitive until death. 
+</div><div class="q2">No one will support him. 
+</div><div class="q1">
+<sup>18&#160;</sup>Whoever walks blamelessly is kept safe; 
+</div><div class="q2">but one with perverse ways will fall suddenly. 
+</div><div class="q1">
+<sup>19&#160;</sup>One who works his land will have an abundance of food; 
+</div><div class="q2">but one who chases fantasies will have his fill of poverty. 
+</div><div class="q1">
+<sup>20&#160;</sup>A faithful man is rich with blessings; 
+</div><div class="q2">but one who is eager to be rich will not go unpunished. 
+</div><div class="q1">
+<sup>21&#160;</sup>To show partiality is not good, 
+</div><div class="q2">yet a man will do wrong for a piece of bread. 
+</div><div class="q1">
+<sup>22&#160;</sup>A stingy man hurries after riches, 
+</div><div class="q2">and doesn’t know that poverty waits for him. 
+</div><div class="q1">
+<sup>23&#160;</sup>One who rebukes a man will afterward find more favor 
+</div><div class="q2">than one who flatters with the tongue. 
+</div><div class="q1">
+<sup>24&#160;</sup>Whoever robs his father or his mother and says, “It’s not wrong,” 
+</div><div class="q2">is a partner with a destroyer. 
+</div><div class="q1">
+<sup>25&#160;</sup>One who is greedy stirs up strife; 
+</div><div class="q2">but one who trusts in Yahweh will prosper. 
+</div><div class="q1">
+<sup>26&#160;</sup>One who trusts in himself is a fool; 
+</div><div class="q2">but one who walks in wisdom is kept safe. 
+</div><div class="q1">
+<sup>27&#160;</sup>One who gives to the poor has no lack; 
+</div><div class="q2">but one who closes his eyes will have many curses. 
+</div><div class="q1">
+<sup>28&#160;</sup>When the wicked rise, men hide themselves; 
+</div><div class="q2">but when they perish, the righteous thrive. 
+</div><h2 class="chapterlabel" id="29">29</h2>
+<div class="q1">
+<sup>1&#160;</sup>He who is often rebuked and stiffens his neck 
+</div><div class="q2">will be destroyed suddenly, with no remedy. 
+</div><div class="q1">
+<sup>2&#160;</sup>When the righteous thrive, the people rejoice; 
+</div><div class="q2">but when the wicked rule, the people groan. 
+</div><div class="q1">
+<sup>3&#160;</sup>Whoever loves wisdom brings joy to his father; 
+</div><div class="q2">but a companion of prostitutes squanders his wealth. 
+</div><div class="q1">
+<sup>4&#160;</sup>The king by justice makes the land stable, 
+</div><div class="q2">but he who takes bribes tears it down. 
+</div><div class="q1">
+<sup>5&#160;</sup>A man who flatters his neighbor 
+</div><div class="q2">spreads a net for his feet. 
+</div><div class="q1">
+<sup>6&#160;</sup>An evil man is snared by his sin, 
+</div><div class="q2">but the righteous can sing and be glad. 
+</div><div class="q1">
+<sup>7&#160;</sup>The righteous care about justice for the poor. 
+</div><div class="q2">The wicked aren’t concerned about knowledge. 
+</div><div class="q1">
+<sup>8&#160;</sup>Mockers stir up a city, 
+</div><div class="q2">but wise men turn away anger. 
+</div><div class="q1">
+<sup>9&#160;</sup>If a wise man goes to court with a foolish man, 
+</div><div class="q2">the fool rages or scoffs, and there is no peace. 
+</div><div class="q1">
+<sup>10&#160;</sup>The bloodthirsty hate a man of integrity; 
+</div><div class="q2">and they seek the life of the upright. 
+</div><div class="q1">
+<sup>11&#160;</sup>A fool vents all of his anger, 
+</div><div class="q2">but a wise man brings himself under control. 
+</div><div class="q1">
+<sup>12&#160;</sup>If a ruler listens to lies, 
+</div><div class="q2">all of his officials are wicked. 
+</div><div class="q1">
+<sup>13&#160;</sup>The poor man and the oppressor have this in common: 
+</div><div class="q2">Yahweh gives sight to the eyes of both. 
+</div><div class="q1">
+<sup>14&#160;</sup>The king who fairly judges the poor, 
+</div><div class="q2">his throne shall be established forever. 
+</div><div class="q1">
+<sup>15&#160;</sup>The rod of correction gives wisdom, 
+</div><div class="q2">but a child left to himself causes shame to his mother. 
+</div><div class="q1">
+<sup>16&#160;</sup>When the wicked increase, sin increases; 
+</div><div class="q2">but the righteous will see their downfall. 
+</div><div class="q1">
+<sup>17&#160;</sup>Correct your son, and he will give you peace; 
+</div><div class="q2">yes, he will bring delight to your soul. 
+</div><div class="q1">
+<sup>18&#160;</sup>Where there is no revelation, the people cast off restraint; 
+</div><div class="q2">but one who keeps the law is blessed. 
+</div><div class="q1">
+<sup>19&#160;</sup>A servant can’t be corrected by words. 
+</div><div class="q2">Though he understands, yet he will not respond. 
+</div><div class="q1">
+<sup>20&#160;</sup>Do you see a man who is hasty in his words? 
+</div><div class="q2">There is more hope for a fool than for him. 
+</div><div class="q1">
+<sup>21&#160;</sup>He who pampers his servant from youth 
+</div><div class="q2">will have him become a son in the end. 
+</div><div class="q1">
+<sup>22&#160;</sup>An angry man stirs up strife, 
+</div><div class="q2">and a wrathful man abounds in sin. 
+</div><div class="q1">
+<sup>23&#160;</sup>A man’s pride brings him low, 
+</div><div class="q2">but one of lowly spirit gains honor. 
+</div><div class="q1">
+<sup>24&#160;</sup>Whoever is an accomplice of a thief is an enemy of his own soul. 
+</div><div class="q2">He takes an oath, but dares not testify. 
+</div><div class="q1">
+<sup>25&#160;</sup>The fear of man proves to be a snare, 
+</div><div class="q2">but whoever puts his trust in Yahweh is kept safe. 
+</div><div class="q1">
+<sup>26&#160;</sup>Many seek the ruler’s favor, 
+</div><div class="q2">but a man’s justice comes from Yahweh. 
+</div><div class="q1">
+<sup>27&#160;</sup>A dishonest man detests the righteous, 
+</div><div class="q2">and the upright in their ways detest the wicked. 
+</div><h2 class="chapterlabel" id="30">30</h2>
+<div class="p">
+<sup>1&#160;</sup>The words of Agur the son of Jakeh, the revelation: 
+</div><div class="q1">the man says to Ithiel, 
+</div><div class="q2">to Ithiel and Ucal: 
+</div><div class="q1">
+<sup>2&#160;</sup>“Surely I am the most ignorant man, 
+</div><div class="q2">and don’t have a man’s understanding. 
+</div><div class="q1">
+<sup>3&#160;</sup>I have not learned wisdom, 
+</div><div class="q2">neither do I have the knowledge of the Set-Apart One. 
+</div><div class="q1">
+<sup>4&#160;</sup>Who has ascended up into heaven, and descended? 
+</div><div class="q2">Who has gathered the wind in his fists? 
+</div><div class="q2">Who has bound the waters in his garment? 
+</div><div class="q2">Who has established all the ends of the earth? 
+</div><div class="q2">What is his name, and what is his son’s name, if you know? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>“Every word of Elohim is flawless. 
+</div><div class="q2">He is a shield to those who take refuge in him. 
+</div><div class="q1">
+<sup>6&#160;</sup>Don’t you add to his words, 
+</div><div class="q2">lest he reprove you, and you be found a liar. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Two things I have asked of you. 
+</div><div class="q2">Don’t deny me before I die. 
+</div><div class="q1">
+<sup>8&#160;</sup>Remove far from me falsehood and lies. 
+</div><div class="q2">Give me neither poverty nor riches. 
+</div><div class="q2">Feed me with the food that is needful for me, 
+</div><div class="q1">
+<sup>9&#160;</sup>lest I be full, deny you, and say, ‘Who is Yahweh?’ 
+</div><div class="q2">or lest I be poor, and steal, 
+</div><div class="q2">and so dishonor the name of my Elohim. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>“Don’t slander a servant to his master, 
+</div><div class="q2">lest he curse you, and you be held guilty. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>There is a generation that curses their father, 
+</div><div class="q2">and doesn’t bless their mother. 
+</div><div class="q1">
+<sup>12&#160;</sup>There is a generation that is pure in their own eyes, 
+</div><div class="q2">yet are not washed from their filthiness. 
+</div><div class="q1">
+<sup>13&#160;</sup>There is a generation, oh how lofty are their eyes! 
+</div><div class="q2">Their eyelids are lifted up. 
+</div><div class="q1">
+<sup>14&#160;</sup>There is a generation whose teeth are like swords, 
+</div><div class="q2">and their jaws like knives, 
+</div><div class="q2">to devour the poor from the earth, and the needy from among men. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>“The leech has two daughters: 
+</div><div class="q2">‘Give, give.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">“There are three things that are never satisfied; 
+</div><div class="q2">four that don’t say, ‘Enough!’: 
+</div><div class="q2">
+<sup>16&#160;</sup>Sheol, 
+</div><div class="q2">the barren womb, 
+</div><div class="q2">the earth that is not satisfied with water, 
+</div><div class="q2">and the fire that doesn’t say, ‘Enough!’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>“The eye that mocks at his father, 
+</div><div class="q2">and scorns obedience to his mother, 
+</div><div class="q2">the ravens of the valley shall pick it out, 
+</div><div class="q2">the young eagles shall eat it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>“There are three things which are too amazing for me, 
+</div><div class="q2">four which I don’t understand: 
+</div><div class="q2">
+<sup>19&#160;</sup>The way of an eagle in the air, 
+</div><div class="q2">the way of a serpent on a rock, 
+</div><div class="q2">the way of a ship in the middle of the sea, 
+</div><div class="q2">and the way of a man with a maiden. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>“So is the way of an adulterous woman: 
+</div><div class="q2">She eats and wipes her mouth, 
+</div><div class="q2">and says, ‘I have done nothing wrong.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>“For three things the earth trembles, 
+</div><div class="q2">and under four, it can’t bear up: 
+</div><div class="q2">
+<sup>22&#160;</sup>For a servant when he is king, 
+</div><div class="q2">a fool when he is filled with food, 
+</div><div class="q2">
+<sup>23&#160;</sup>for an unloved woman when she is married, 
+</div><div class="q2">and a servant who is heir to her mistress. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>24&#160;</sup>“There are four things which are little on the earth, 
+</div><div class="q2">but they are exceedingly wise: 
+</div><div class="q2">
+<sup>25&#160;</sup>The ants are not a strong people, 
+</div><div class="q2">yet they provide their food in the summer. 
+</div><div class="q2">
+<sup>26&#160;</sup>The hyraxes are but a feeble folk, 
+</div><div class="q2">yet make they their houses in the rocks. 
+</div><div class="q2">
+<sup>27&#160;</sup>The locusts have no king, 
+</div><div class="q2">yet they advance in ranks. 
+</div><div class="q2">
+<sup>28&#160;</sup>You can catch a lizard with your hands, 
+</div><div class="q2">yet it is in kings’ palaces. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>29&#160;</sup>“There are three things which are stately in their march, 
+</div><div class="q2">four which are stately in going: 
+</div><div class="q2">
+<sup>30&#160;</sup>The lion, which is mightiest among animals, 
+</div><div class="q2">and doesn’t turn away for any; 
+</div><div class="q2">
+<sup>31&#160;</sup>the greyhound; 
+</div><div class="q2">the male goat; 
+</div><div class="q2">and the king against whom there is no rising up. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>32&#160;</sup>“If you have done foolishly in lifting up yourself, 
+</div><div class="q2">or if you have thought evil, 
+</div><div class="q1">put your hand over your mouth. 
+</div><div class="q2">
+<sup>33&#160;</sup>For as the churning of milk produces butter, 
+</div><div class="q2">and the wringing of the nose produces blood, 
+</div><div class="q2">so the forcing of wrath produces strife.” 
+</div><h2 class="chapterlabel" id="31">31</h2>
+<div class="p">
+<sup>1&#160;</sup>The words of King Lemuel—the revelation which his mother taught him: 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>2&#160;</sup>“Oh, my son! 
+</div><div class="q2">Oh, son of my womb! 
+</div><div class="q2">Oh, son of my vows! 
+</div><div class="q1">
+<sup>3&#160;</sup>Don’t give your strength to women, 
+</div><div class="q2">nor your ways to that which destroys kings. 
+</div><div class="q1">
+<sup>4&#160;</sup>It is not for kings, Lemuel, 
+</div><div class="q2">it is not for kings to drink wine, 
+</div><div class="q2">nor for princes to say, ‘Where is strong drink?’ 
+</div><div class="q1">
+<sup>5&#160;</sup>lest they drink, and forget the law, 
+</div><div class="q2">and pervert the justice due to anyone who is afflicted. 
+</div><div class="q1">
+<sup>6&#160;</sup>Give strong drink to him who is ready to perish, 
+</div><div class="q2">and wine to the bitter in soul. 
+</div><div class="q1">
+<sup>7&#160;</sup>Let him drink, and forget his poverty, 
+</div><div class="q2">and remember his misery no more. 
+</div><div class="q1">
+<sup>8&#160;</sup>Open your mouth for the mute, 
+</div><div class="q2">in the cause of all who are left desolate. 
+</div><div class="q1">
+<sup>9&#160;</sup>Open your mouth, judge righteously, 
+</div><div class="q2">and serve justice to the poor and needy.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Who can find a worthy woman? 
+</div><div class="q2">For her value is far above rubies. 
+</div><div class="q1">
+<sup>11&#160;</sup>The heart of her owner trusts in her. 
+</div><div class="q2">He shall have no lack of gain. 
+</div><div class="q1">
+<sup>12&#160;</sup>She does him good, and not harm, 
+</div><div class="q2">all the days of her life. 
+</div><div class="q1">
+<sup>13&#160;</sup>She seeks wool and flax, 
+</div><div class="q2">and works eagerly with her hands. 
+</div><div class="q1">
+<sup>14&#160;</sup>She is like the merchant ships. 
+</div><div class="q2">She brings her bread from afar. 
+</div><div class="q1">
+<sup>15&#160;</sup>She rises also while it is yet night, 
+</div><div class="q2">gives food to her household, 
+</div><div class="q2">and portions for her servant girls. 
+</div><div class="q1">
+<sup>16&#160;</sup>She considers a field, and buys it. 
+</div><div class="q2">With the fruit of her hands, she plants a vineyard. 
+</div><div class="q1">
+<sup>17&#160;</sup>She arms her waist with strength, 
+</div><div class="q2">and makes her arms strong. 
+</div><div class="q1">
+<sup>18&#160;</sup>She perceives that her merchandise is profitable. 
+</div><div class="q2">Her lamp doesn’t go out by night. 
+</div><div class="q1">
+<sup>19&#160;</sup>She lays her hands to the distaff, 
+</div><div class="q2">and her hands hold the spindle. 
+</div><div class="q1">
+<sup>20&#160;</sup>She opens her arms to the poor; 
+</div><div class="q2">yes, she extends her hands to the needy. 
+</div><div class="q1">
+<sup>21&#160;</sup>She is not afraid of the snow for her household, 
+</div><div class="q2">for all her household are clothed with scarlet. 
+</div><div class="q1">
+<sup>22&#160;</sup>She makes for herself carpets of tapestry. 
+</div><div class="q2">Her clothing is fine linen and purple. 
+</div><div class="q1">
+<sup>23&#160;</sup>Her owner is respected in the gates, 
+</div><div class="q2">when he sits among the elders of the land. 
+</div><div class="q1">
+<sup>24&#160;</sup>She makes linen garments and sells them, 
+</div><div class="q2">and delivers sashes to the merchant. 
+</div><div class="q1">
+<sup>25&#160;</sup>Strength and dignity are her clothing. 
+</div><div class="q2">She laughs at the time to come. 
+</div><div class="q1">
+<sup>26&#160;</sup>She opens her mouth with wisdom. 
+</div><div class="q2">Kind instruction is on her tongue. 
+</div><div class="q1">
+<sup>27&#160;</sup>She looks well to the ways of her household, 
+</div><div class="q2">and doesn’t eat the bread of idleness. 
+</div><div class="q1">
+<sup>28&#160;</sup>Her children rise up and call her blessed. 
+</div><div class="q2">Her owner also praises her: 
+</div><div class="q1">
+<sup>29&#160;</sup>“Many women do noble things, 
+</div><div class="q2">but you excel them all.” 
+</div><div class="q1">
+<sup>30&#160;</sup>Charm is deceitful, and beauty is vain; 
+</div><div class="q2">but a woman who fears Yahweh, she shall be praised. 
+</div><div class="q1">
+<sup>31&#160;</sup>Give her of the fruit of her hands! 
+</div><div class="q2">Let her works praise her in the gates! </div></div><script src="../main.js"></script></body></html>

--- a/book/psalms.html
+++ b/book/psalms.html
@@ -3,6 +3,47 @@
 <head>
 <title>Psalms</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,8316 +53,8467 @@
 <div class="main">
 <!-- PSA World English Scripture (WES) -->
 <h1 class="booklabel">Psalms</h1>
+<div class="psalmlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+<a href="#23">23</a>
+<a href="#24">24</a>
+<a href="#25">25</a>
+<a href="#26">26</a>
+<a href="#27">27</a>
+<a href="#28">28</a>
+<a href="#29">29</a>
+<a href="#30">30</a>
+<a href="#31">31</a>
+<a href="#32">32</a>
+<a href="#33">33</a>
+<a href="#34">34</a>
+<a href="#35">35</a>
+<a href="#36">36</a>
+<a href="#37">37</a>
+<a href="#38">38</a>
+<a href="#39">39</a>
+<a href="#40">40</a>
+<a href="#41">41</a>
+<a href="#42">42</a>
+<a href="#43">43</a>
+<a href="#44">44</a>
+<a href="#45">45</a>
+<a href="#46">46</a>
+<a href="#47">47</a>
+<a href="#48">48</a>
+<a href="#49">49</a>
+<a href="#50">50</a>
+<a href="#51">51</a>
+<a href="#52">52</a>
+<a href="#53">53</a>
+<a href="#54">54</a>
+<a href="#55">55</a>
+<a href="#56">56</a>
+<a href="#57">57</a>
+<a href="#58">58</a>
+<a href="#59">59</a>
+<a href="#60">60</a>
+<a href="#61">61</a>
+<a href="#62">62</a>
+<a href="#63">63</a>
+<a href="#64">64</a>
+<a href="#65">65</a>
+<a href="#66">66</a>
+<a href="#67">67</a>
+<a href="#68">68</a>
+<a href="#69">69</a>
+<a href="#70">70</a>
+<a href="#71">71</a>
+<a href="#72">72</a>
+<a href="#73">73</a>
+<a href="#74">74</a>
+<a href="#75">75</a>
+<a href="#76">76</a>
+<a href="#77">77</a>
+<a href="#78">78</a>
+<a href="#79">79</a>
+<a href="#80">80</a>
+<a href="#81">81</a>
+<a href="#82">82</a>
+<a href="#83">83</a>
+<a href="#84">84</a>
+<a href="#85">85</a>
+<a href="#86">86</a>
+<a href="#87">87</a>
+<a href="#88">88</a>
+<a href="#89">89</a>
+<a href="#90">90</a>
+<a href="#91">91</a>
+<a href="#92">92</a>
+<a href="#93">93</a>
+<a href="#94">94</a>
+<a href="#95">95</a>
+<a href="#96">96</a>
+<a href="#97">97</a>
+<a href="#98">98</a>
+<a href="#99">99</a>
+<a href="#100">100</a>
+<a href="#101">101</a>
+<a href="#102">102</a>
+<a href="#103">103</a>
+<a href="#104">104</a>
+<a href="#105">105</a>
+<a href="#106">106</a>
+<a href="#107">107</a>
+<a href="#108">108</a>
+<a href="#109">109</a>
+<a href="#110">110</a>
+<a href="#111">111</a>
+<a href="#112">112</a>
+<a href="#113">113</a>
+<a href="#114">114</a>
+<a href="#115">115</a>
+<a href="#116">116</a>
+<a href="#117">117</a>
+<a href="#118">118</a>
+<a href="#119">119</a>
+<a href="#120">120</a>
+<a href="#121">121</a>
+<a href="#122">122</a>
+<a href="#123">123</a>
+<a href="#124">124</a>
+<a href="#125">125</a>
+<a href="#126">126</a>
+<a href="#127">127</a>
+<a href="#128">128</a>
+<a href="#129">129</a>
+<a href="#130">130</a>
+<a href="#131">131</a>
+<a href="#132">132</a>
+<a href="#133">133</a>
+<a href="#134">134</a>
+<a href="#135">135</a>
+<a href="#136">136</a>
+<a href="#137">137</a>
+<a href="#138">138</a>
+<a href="#139">139</a>
+<a href="#140">140</a>
+<a href="#141">141</a>
+<a href="#142">142</a>
+<a href="#143">143</a>
+<a href="#144">144</a>
+<a href="#145">145</a>
+<a href="#146">146</a>
+<a href="#147">147</a>
+<a href="#148">148</a>
+<a href="#149">149</a>
+<a href="#150">150</a>
+</div><h2 class="ms1">BOOK 1</h2>
 <h2 class="psalmlabel" id="1">1</h2>
-<h2 class="ms1">BOOK 1</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Blessed is the man who doesn’t walk in the counsel of the wicked, 
-</p><p class="q2">nor stand on the path of sinners, 
-</p><p class="q2">nor sit in the seat of scoffers; 
-</p><p class="q1">
-<span class="v">2&#160;</span>but his delight is in Yahweh’s<span class="f">+ \fr 1:2 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> law. 
-</p><p class="q2">On his law he meditates day and night. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He will be like a tree planted by the streams of water, 
-</p><p class="q2">that produces its fruit in its season, 
-</p><p class="q2">whose leaf also does not wither. 
-</p><p class="q2">Whatever he does shall prosper. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The wicked are not so, 
-</p><p class="q2">but are like the chaff which the wind drives away. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Therefore the wicked shall not stand in the judgment, 
-</p><p class="q2">nor sinners in the congregation of the righteous. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For Yahweh knows the way of the righteous, 
-</p><p class="q2">but the way of the wicked shall perish. 
-</p><h2 class="psalmlabel" id="2">2</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Why do the nations rage, 
-</p><p class="q2">and the peoples plot a vain thing? 
-</p><p class="q1">
-<span class="v">2&#160;</span>The kings of the earth take a stand, 
-</p><p class="q2">and the rulers take counsel together, 
-</p><p class="q2">against Yahweh, and against his Anointed,<span class="f">+ \fr 2:2 \ft The word “Anointed” is the same as the word for “Messiah” or “Christ”</span> saying, 
-</p><p class="q1">
-<span class="v">3&#160;</span>“Let’s break their bonds apart, 
-</p><p class="q2">and cast their cords from us.” 
-</p><p class="q1">
-<span class="v">4&#160;</span>He who sits in the heavens will laugh. 
-</p><p class="q2">The Lord<span class="f">+ \fr 2:4 \ft The word translated “Lord” is “Adonai.”</span> will have them in derision. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Then he will speak to them in his anger, 
-</p><p class="q2">and terrify them in his wrath: 
-</p><p class="q1">
-<span class="v">6&#160;</span>“Yet I have set my King on my set-apart hill of Zion.” 
-</p><p class="q2">
-<span class="v">7&#160;</span>I will tell of the decree: 
-</p><p class="q1">Yahweh said to me, “You are my son. 
-</p><p class="q2">Today I have become your father. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Ask of me, and I will give the nations for your inheritance, 
-</p><p class="q2">the uttermost parts of the earth for your possession. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You shall break them with a rod of iron. 
-</p><p class="q2">You shall dash them in pieces like a potter’s vessel.” 
-</p><p class="q1">
-<span class="v">10&#160;</span>Now therefore be wise, you kings. 
-</p><p class="q2">Be instructed, you judges of the earth. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Serve Yahweh with fear, 
-</p><p class="q2">and rejoice with trembling. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Give sincere homage to the Son,<span class="f">+ \fr 2:12 \ft or, Kiss the son</span> lest he be angry, and you perish on the way, 
-</p><p class="q2">for his wrath will soon be kindled. 
-</p><p class="q2">Blessed are all those who take refuge in him. 
-</p><h2 class="psalmlabel" id="3">3</h2>
-<p class="d">A Psalm by David, when he fled from Absalom his son. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, how my adversaries have increased! 
-</p><p class="q2">Many are those who rise up against me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Many there are who say of my soul, 
-</p><p class="q2">“There is no help for him in Elohim.”<span class="f">+ \fr 3:2 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">3&#160;</span>But you, Yahweh, are a shield around me, 
-</p><p class="q2">my glory, and the one who lifts up my head. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I cry to Yahweh with my voice, 
-</p><p class="q2">and he answers me out of his set-apart hill. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>I laid myself down and slept. 
-</p><p class="q2">I awakened, for Yahweh sustains me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I will not be afraid of tens of thousands of people 
-</p><p class="q2">who have set themselves against me on every side. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Arise, Yahweh! 
-</p><p class="q2">Save me, my Elohim! 
-</p><p class="q1">For you have struck all of my enemies on the cheek bone. 
-</p><p class="q2">You have broken the teeth of the wicked. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Salvation belongs to Yahweh. 
-</p><p class="q2">May your blessing be on your people. </p><p class="qs">Selah.</p> 
-</p><h2 class="psalmlabel" id="4">4</h2>
-<p class="d">For the Chief Musician; on stringed instruments. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Answer me when I call, Elohim of my righteousness. 
-</p><p class="q2">Give me relief from my distress. 
-</p><p class="q2">Have mercy on me, and hear my prayer. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You sons of men, how long shall my glory be turned into dishonor? 
-</p><p class="q2">Will you love vanity and seek after falsehood? </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">3&#160;</span>But know that Yahweh has set apart for himself him who is elohimly; 
-</p><p class="q2">Yahweh will hear when I call to him. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Stand in awe, and don’t sin. 
-</p><p class="q2">Search your own heart on your bed, and be still. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>Offer the sacrifices of righteousness. 
-</p><p class="q2">Put your trust in Yahweh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Many say, “Who will show us any good?” 
-</p><p class="q2">Yahweh, let the light of your face shine on us. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You have put gladness in my heart, 
-</p><p class="q2">more than when their grain and their new wine are increased. 
-</p><p class="q1">
-<span class="v">8&#160;</span>In peace I will both lay myself down and sleep, 
-</p><p class="q2">for you alone, Yahweh, make me live in safety. 
-</p><h2 class="psalmlabel" id="5">5</h2>
-<p class="d">For the Chief Musician, with the flutes. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Give ear to my words, Yahweh. 
-</p><p class="q2">Consider my meditation. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Listen to the voice of my cry, my King and my Elohim, 
-</p><p class="q2">for I pray to you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh, in the morning you will hear my voice. 
-</p><p class="q2">In the morning I will lay my requests before you, and will watch expectantly. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For you are not an Elohim who has pleasure in wickedness. 
-</p><p class="q2">Evil can’t live with you. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The arrogant will not stand in your sight. 
-</p><p class="q2">You hate all workers of iniquity. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You will destroy those who speak lies. 
-</p><p class="q2">Yahweh abhors the bloodthirsty and deceitful man. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But as for me, in the abundance of your loving kindness I will come into your house. 
-</p><p class="q2">I will bow toward your set-apart temple in reverence of you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Lead me, Yahweh, in your righteousness because of my enemies. 
-</p><p class="q2">Make your way straight before my face. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For there is no faithfulness in their mouth. 
-</p><p class="q2">Their heart is destruction. 
-</p><p class="q2">Their throat is an open tomb. 
-</p><p class="q2">They flatter with their tongue. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Hold them guilty, Elohim. 
-</p><p class="q2">Let them fall by their own counsels. 
-</p><p class="q1">Thrust them out in the multitude of their transgressions, 
-</p><p class="q2">for they have rebelled against you. 
-</p><p class="q1">
-<span class="v">11&#160;</span>But let all those who take refuge in you rejoice. 
-</p><p class="q2">Let them always shout for joy, because you defend them. 
-</p><p class="q1">Let them also who love your name be joyful in you. 
-</p><p class="q2">
-<span class="v">12&#160;</span>For you will bless the righteous. 
-</p><p class="q1">Yahweh, you will surround him with favor as with a shield. 
-</p><h2 class="psalmlabel" id="6">6</h2>
-<p class="d">For the Chief Musician; on stringed instruments, upon the eight-stringed lyre. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, don’t rebuke me in your anger, 
-</p><p class="q2">neither discipline me in your wrath. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Have mercy on me, Yahweh, for I am faint. 
-</p><p class="q2">Yahweh, heal me, for my bones are troubled. 
-</p><p class="q1">
-<span class="v">3&#160;</span>My soul is also in great anguish. 
-</p><p class="q2">But you, Yahweh—how long? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Return, Yahweh. Deliver my soul, 
-</p><p class="q2">and save me for your loving kindness’ sake. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For in death there is no memory of you. 
-</p><p class="q2">In Sheol,<span class="f">+ \fr 6:5 \ft Sheol is the place of the dead.</span> who shall give you thanks? 
-</p><p class="q1">
-<span class="v">6&#160;</span>I am weary with my groaning. 
-</p><p class="q2">Every night I flood my bed. 
-</p><p class="q2">I drench my couch with my tears. 
-</p><p class="q1">
-<span class="v">7&#160;</span>My eye wastes away because of grief. 
-</p><p class="q2">It grows old because of all my adversaries. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Depart from me, all you workers of iniquity, 
-</p><p class="q2">for Yahweh has heard the voice of my weeping. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yahweh has heard my supplication. 
-</p><p class="q2">Yahweh accepts my prayer. 
-</p><p class="q1">
-<span class="v">10&#160;</span>May all my enemies be ashamed and dismayed. 
-</p><p class="q2">They shall turn back, they shall be disgraced suddenly. 
-</p><h2 class="psalmlabel" id="7">7</h2>
-<p class="d">A meditation by David, which he sang to Yahweh, concerning the words of Cush, the Benjamite. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, my Elohim, I take refuge in you. 
-</p><p class="q2">Save me from all those who pursue me, and deliver me, 
-</p><p class="q1">
-<span class="v">2&#160;</span>lest they tear apart my soul like a lion, 
-</p><p class="q2">ripping it in pieces, while there is no one to deliver. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh, my Elohim, if I have done this, 
-</p><p class="q2">if there is iniquity in my hands, 
-</p><p class="q1">
-<span class="v">4&#160;</span>if I have rewarded evil to him who was at peace with me 
-</p><p class="q2">(yes, I have delivered him who without cause was my adversary), 
-</p><p class="q2">
-<span class="v">5&#160;</span>let the enemy pursue my soul, and overtake it; 
-</p><p class="q1">yes, let him tread my life down to the earth, 
-</p><p class="q2">and lay my glory in the dust. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">6&#160;</span>Arise, Yahweh, in your anger. 
-</p><p class="q2">Lift up yourself against the rage of my adversaries. 
-</p><p class="q1">Awake for me. You have commanded judgment. 
-</p><p class="q2">
-<span class="v">7&#160;</span>Let the congregation of the peoples surround you. 
-</p><p class="q2">Rule over them on high. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh administers judgment to the peoples. 
-</p><p class="q2">Judge me, Yahweh, according to my righteousness, 
-</p><p class="q2">and to my integrity that is in me. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Oh let the wickedness of the wicked come to an end, 
-</p><p class="q2">but establish the righteous; 
-</p><p class="q2">their minds and hearts are searched by the righteous Elohim. 
-</p><p class="q1">
-<span class="v">10&#160;</span>My shield is with Elohim, 
-</p><p class="q2">who saves the upright in heart. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Elohim is a righteous judge, 
-</p><p class="q2">yes, an Elohim who has indignation every day. 
-</p><p class="q1">
-<span class="v">12&#160;</span>If a man doesn’t repent, he will sharpen his sword; 
-</p><p class="q2">he has bent and strung his bow. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He has also prepared for himself the instruments of death. 
-</p><p class="q2">He makes ready his flaming arrows. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Behold,<span class="f">+ \fr 7:14 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> he travails with iniquity. 
-</p><p class="q2">Yes, he has conceived mischief, 
-</p><p class="q2">and brought out falsehood. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He has dug a hole, 
-</p><p class="q2">and has fallen into the pit which he made. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The trouble he causes shall return to his own head. 
-</p><p class="q2">His violence shall come down on the crown of his own head. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will give thanks to Yahweh according to his righteousness, 
-</p><p class="q2">and will sing praise to the name of Yahweh Most High. 
-</p><h2 class="psalmlabel" id="8">8</h2>
-<p class="d">For the Chief Musician; on an instrument of Gath. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, our Lord, how majestic is your name in all the earth! 
-</p><p class="q2">You have set your glory above the heavens! 
-</p><p class="q1">
-<span class="v">2&#160;</span>From the lips of babes and infants you have established strength, 
-</p><p class="q2">because of your adversaries, that you might silence the enemy and the avenger. 
-</p><p class="q1">
-<span class="v">3&#160;</span>When I consider your heavens, the work of your fingers, 
-</p><p class="q2">the moon and the stars, which you have ordained, 
-</p><p class="q1">
-<span class="v">4&#160;</span>what is man, that you think of him? 
-</p><p class="q2">What is the son of man, that you care for him? 
-</p><p class="q1">
-<span class="v">5&#160;</span>For you have made him a little lower than the angels,<span class="f">+ \fr 8:5 \ft Hebrew: Elohim. The word Elohim, used here, usually means “Elohim”, but can also mean “elohims”, “princes”, or “angels”. The Septuagint reads “angels” here. See also the quote from the Septuagint in Hebrews 2:7.</span> 
-</p><p class="q2">and crowned him with glory and honor. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You make him ruler over the works of your hands. 
-</p><p class="q2">You have put all things under his feet: 
-</p><p class="q1">
-<span class="v">7&#160;</span>All sheep and cattle, 
-</p><p class="q2">yes, and the animals of the field, 
-</p><p class="q2">
-<span class="v">8&#160;</span>the birds of the sky, the fish of the sea, 
-</p><p class="q2">and whatever passes through the paths of the seas. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yahweh, our Lord, 
-</p><p class="q2">how majestic is your name in all the earth! 
-</p><h2 class="psalmlabel" id="9">9</h2>
-<p class="d">For the Chief Musician. Set to “The Death of the Son.” A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will give thanks to Yahweh with my whole heart. 
-</p><p class="q2">I will tell of all your marvelous works. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will be glad and rejoice in you. 
-</p><p class="q2">I will sing praise to your name, O Most High. 
-</p><p class="q1">
-<span class="v">3&#160;</span>When my enemies turn back, 
-</p><p class="q2">they stumble and perish in your presence. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For you have maintained my just cause. 
-</p><p class="q2">You sit on the throne judging righteously. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You have rebuked the nations. 
-</p><p class="q2">You have destroyed the wicked. 
-</p><p class="q2">You have blotted out their name forever and ever. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The enemy is overtaken by endless ruin. 
-</p><p class="q2">The very memory of the cities which you have overthrown has perished. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But Yahweh reigns forever. 
-</p><p class="q2">He has prepared his throne for judgment. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He will judge the world in righteousness. 
-</p><p class="q2">He will administer judgment to the peoples in uprightness. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yahweh will also be a high tower for the oppressed; 
-</p><p class="q2">a high tower in times of trouble. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Those who know your name will put their trust in you, 
-</p><p class="q2">for you, Yahweh, have not forsaken those who seek you. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Sing praises to Yahweh, who dwells in Zion, 
-</p><p class="q2">and declare among the people what he has done. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For he who avenges blood remembers them. 
-</p><p class="q2">He doesn’t forget the cry of the afflicted. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Have mercy on me, Yahweh. 
-</p><p class="q2">See my affliction by those who hate me, 
-</p><p class="q1">and lift me up from the gates of death, 
-</p><p class="q2">
-<span class="v">14&#160;</span>that I may show all of your praise. 
-</p><p class="q2">I will rejoice in your salvation in the gates of the daughter of Zion. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The nations have sunk down in the pit that they made. 
-</p><p class="q2">In the net which they hid, their own foot is taken. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yahweh has made himself known. 
-</p><p class="q2">He has executed judgment. 
-</p><p class="q2">The wicked is snared by the work of his own hands. </p><p class="qs">Meditation. Selah.</p> 
-</p><p class="q1">
-<span class="v">17&#160;</span>The wicked shall be turned back to Sheol,<span class="f">+ \fr 9:17 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">even all the nations that forget Elohim. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For the needy shall not always be forgotten, 
-</p><p class="q2">nor the hope of the poor perish forever. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Arise, Yahweh! Don’t let man prevail. 
-</p><p class="q2">Let the nations be judged in your sight. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Put them in fear, Yahweh. 
-</p><p class="q2">Let the nations know that they are only men. </p><p class="qs">Selah.</p> 
-</p><h2 class="psalmlabel" id="10">10</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Why do you stand far off, Yahweh? 
-</p><p class="q2">Why do you hide yourself in times of trouble? 
-</p><p class="q1">
-<span class="v">2&#160;</span>In arrogance, the wicked hunt down the weak. 
-</p><p class="q2">They are caught in the schemes that they devise. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For the wicked boasts of his heart’s cravings. 
-</p><p class="q2">He blesses the greedy and condemns Yahweh. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The wicked, in the pride of his face, 
-</p><p class="q2">has no room in his thoughts for Elohim. 
-</p><p class="q1">
-<span class="v">5&#160;</span>His ways are prosperous at all times. 
-</p><p class="q2">He is arrogant, and your laws are far from his sight. 
-</p><p class="q1">As for all his adversaries, he sneers at them. 
-</p><p class="q2">
-<span class="v">6&#160;</span>He says in his heart, “I shall not be shaken. 
-</p><p class="q2">For generations I shall have no trouble.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>His mouth is full of cursing, deceit, and oppression. 
-</p><p class="q2">Under his tongue is mischief and iniquity. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He lies in wait near the villages. 
-</p><p class="q2">From ambushes, he murders the innocent. 
-</p><p class="q1">His eyes are secretly set against the helpless. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He lurks in secret as a lion in his ambush. 
-</p><p class="q2">He lies in wait to catch the helpless. 
-</p><p class="q2">He catches the helpless when he draws him in his net. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The helpless are crushed. 
-</p><p class="q2">They collapse. 
-</p><p class="q2">They fall under his strength. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He says in his heart, “Elohim has forgotten. 
-</p><p class="q2">He hides his face. 
-</p><p class="q2">He will never see it.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Arise, Yahweh! 
-</p><p class="q2">Elohim, lift up your hand! 
-</p><p class="q2">Don’t forget the helpless. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Why does the wicked person condemn Elohim, 
-</p><p class="q2">and say in his heart, “Elohim won’t call me into account”? 
-</p><p class="q1">
-<span class="v">14&#160;</span>But you do see trouble and grief. 
-</p><p class="q2">You consider it to take it into your hand. 
-</p><p class="q2">You help the victim and the fatherless. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Break the arm of the wicked. 
-</p><p class="q2">As for the evil man, seek out his wickedness until you find none. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yahweh is King forever and ever! 
-</p><p class="q2">The nations will perish out of his land. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Yahweh, you have heard the desire of the humble. 
-</p><p class="q2">You will prepare their heart. 
-</p><p class="q2">You will cause your ear to hear, 
-</p><p class="q2">
-<span class="v">18&#160;</span>to judge the fatherless and the oppressed, 
-</p><p class="q2">that man who is of the earth may terrify no more. 
-</p><h2 class="psalmlabel" id="11">11</h2>
-<p class="d">For the Chief Musician. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>In Yahweh, I take refuge. 
-</p><p class="q2">How can you say to my soul, “Flee as a bird to your mountain”? 
-</p><p class="q1">
-<span class="v">2&#160;</span>For, behold, the wicked bend their bows. 
-</p><p class="q2">They set their arrows on the strings, 
-</p><p class="q2">that they may shoot in darkness at the upright in heart. 
-</p><p class="q1">
-<span class="v">3&#160;</span>If the foundations are destroyed, 
-</p><p class="q2">what can the righteous do? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh is in his set-apart temple. 
-</p><p class="q2">Yahweh is on his throne in heaven. 
-</p><p class="q1">His eyes observe. 
-</p><p class="q2">His eyes examine the children of men. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh examines the righteous, 
-</p><p class="q2">but his soul hates the wicked and him who loves violence. 
-</p><p class="q1">
-<span class="v">6&#160;</span>On the wicked he will rain blazing coals; 
-</p><p class="q2">fire, sulfur, and scorching wind shall be the portion of their cup. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For Yahweh is righteous. 
-</p><p class="q2">He loves righteousness. 
-</p><p class="q2">The upright shall see his face. 
-</p><h2 class="psalmlabel" id="12">12</h2>
-<p class="d">For the Chief Musician; upon an eight-stringed lyre. A Psalm of David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Help, Yahweh; for the elohimly man ceases. 
-</p><p class="q2">For the faithful fail from among the children of men. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Everyone lies to his neighbor. 
-</p><p class="q2">They speak with flattering lips, and with a double heart. 
-</p><p class="q1">
-<span class="v">3&#160;</span>May Yahweh cut off all flattering lips, 
-</p><p class="q2">and the tongue that boasts, 
-</p><p class="q1">
-<span class="v">4&#160;</span>who have said, “With our tongue we will prevail. 
-</p><p class="q2">Our lips are our own. 
-</p><p class="q2">Who is lord over us?” 
-</p><p class="q1">
-<span class="v">5&#160;</span>“Because of the oppression of the weak and because of the groaning of the needy, 
-</p><p class="q2">I will now arise,” says Yahweh; 
-</p><p class="q1">“I will set him in safety from those who malign him.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh’s words are flawless words, 
-</p><p class="q2">as silver refined in a clay furnace, purified seven times. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You will keep them, Yahweh. 
-</p><p class="q2">You will preserve them from this generation forever. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The wicked walk on every side, 
-</p><p class="q2">when what is vile is exalted among the sons of men. 
-</p><h2 class="psalmlabel" id="13">13</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>How long, Yahweh? 
-</p><p class="q2">Will you forget me forever? 
-</p><p class="q2">How long will you hide your face from me? 
-</p><p class="q1">
-<span class="v">2&#160;</span>How long shall I take counsel in my soul, 
-</p><p class="q2">having sorrow in my heart every day? 
-</p><p class="q2">How long shall my enemy triumph over me? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Behold, and answer me, Yahweh, my Elohim. 
-</p><p class="q2">Give light to my eyes, lest I sleep in death; 
-</p><p class="q2">
-<span class="v">4&#160;</span>lest my enemy say, “I have prevailed against him;” 
-</p><p class="q2">lest my adversaries rejoice when I fall. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>But I trust in your loving kindness. 
-</p><p class="q2">My heart rejoices in your salvation. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I will sing to Yahweh, 
-</p><p class="q2">because he has been good to me. 
-</p><h2 class="psalmlabel" id="14">14</h2>
-<p class="d">For the Chief Musician. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>The fool has said in his heart, “There is no Elohim.” 
-</p><p class="q2">They are corrupt. 
-</p><p class="q2">They have done abominable deeds. 
-</p><p class="q2">There is no one who does good. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh looked down from heaven on the children of men, 
-</p><p class="q2">to see if there were any who understood, 
-</p><p class="q2">who sought after Elohim. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They have all gone aside. 
-</p><p class="q2">They have together become corrupt. 
-</p><p class="q2">There is no one who does good, no, not one. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Have all the workers of iniquity no knowledge, 
-</p><p class="q2">who eat up my people as they eat bread, 
-</p><p class="q2">and don’t call on Yahweh? 
-</p><p class="q1">
-<span class="v">5&#160;</span>There they were in great fear, 
-</p><p class="q2">for Elohim is in the generation of the righteous. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You frustrate the plan of the poor, 
-</p><p class="q2">because Yahweh is his refuge. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Oh that the salvation of Israel would come out of Zion! 
-</p><p class="q2">When Yahweh restores the fortunes of his people, 
-</p><p class="q2">then Jacob shall rejoice, and Israel shall be glad. 
-</p><h2 class="psalmlabel" id="15">15</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, who shall dwell in your sanctuary? 
-</p><p class="q2">Who shall live on your set-apart hill? 
-</p><p class="q1">
-<span class="v">2&#160;</span>He who walks blamelessly and does what is right, 
-</p><p class="q2">and speaks truth in his heart; 
-</p><p class="q1">
-<span class="v">3&#160;</span>he who doesn’t slander with his tongue, 
-</p><p class="q2">nor does evil to his friend, 
-</p><p class="q2">nor casts slurs against his fellow man; 
-</p><p class="q1">
-<span class="v">4&#160;</span>in whose eyes a vile man is despised, 
-</p><p class="q2">but who honors those who fear Yahweh; 
-</p><p class="q2">he who keeps an oath even when it hurts, and doesn’t change; 
-</p><p class="q1">
-<span class="v">5&#160;</span>he who doesn’t lend out his money for usury, 
-</p><p class="q2">nor take a bribe against the innocent. 
-</p><div class="b"> &#160; </div>
-<p class="q1">He who does these things shall never be shaken. 
-</p><h2 class="psalmlabel" id="16">16</h2>
-<p class="d">A Poem by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Preserve me, Elohim, for I take refuge in you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>My soul, you have said to Yahweh, “You are my Lord. 
-</p><p class="q2">Apart from you I have no good thing.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>As for the saints who are in the earth, 
-</p><p class="q2">they are the excellent ones in whom is all my delight. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>Their sorrows shall be multiplied who give gifts to another elohim. 
-</p><p class="q2">Their drink offerings of blood I will not offer, 
-</p><p class="q2">nor take their names on my lips. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh assigned my portion and my cup. 
-</p><p class="q2">You made my lot secure. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>The lines have fallen to me in pleasant places. 
-</p><p class="q2">Yes, I have a good inheritance. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I will bless Yahweh, who has given me counsel. 
-</p><p class="q2">Yes, my heart instructs me in the night seasons. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I have set Yahweh always before me. 
-</p><p class="q2">Because he is at my right hand, I shall not be moved. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Therefore my heart is glad, and my tongue rejoices. 
-</p><p class="q2">My body shall also dwell in safety. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For you will not leave my soul in Sheol,<span class="f">+ \fr 16:10 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">neither will you allow your set-apart one to see corruption. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You will show me the path of life. 
-</p><p class="q2">In your presence is fullness of joy. 
-</p><p class="q1">In your right hand there are pleasures forever more. 
-</p><h2 class="psalmlabel" id="17">17</h2>
-<p class="d">A Prayer by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear, Yahweh, my righteous plea. 
-</p><p class="q2">Give ear to my prayer that doesn’t go out of deceitful lips. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let my sentence come out of your presence. 
-</p><p class="q2">Let your eyes look on equity. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You have proved my heart. 
-</p><p class="q2">You have visited me in the night. 
-</p><p class="q2">You have tried me, and found nothing. 
-</p><p class="q2">I have resolved that my mouth shall not disobey. 
-</p><p class="q1">
-<span class="v">4&#160;</span>As for the deeds of men, by the word of your lips, 
-</p><p class="q2">I have kept myself from the ways of the violent. 
-</p><p class="q1">
-<span class="v">5&#160;</span>My steps have held fast to your paths. 
-</p><p class="q2">My feet have not slipped. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I have called on you, for you will answer me, Elohim. 
-</p><p class="q2">Turn your ear to me. 
-</p><p class="q2">Hear my speech. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Show your marvelous loving kindness, 
-</p><p class="q2">you who save those who take refuge by your right hand from their enemies. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Keep me as the apple of your eye. 
-</p><p class="q2">Hide me under the shadow of your wings, 
-</p><p class="q1">
-<span class="v">9&#160;</span>from the wicked who oppress me, 
-</p><p class="q2">my deadly enemies, who surround me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They close up their callous hearts. 
-</p><p class="q2">With their mouth they speak proudly. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They have now surrounded us in our steps. 
-</p><p class="q2">They set their eyes to cast us down to the earth. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He is like a lion that is greedy of his prey, 
-</p><p class="q2">as it were a young lion lurking in secret places. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Arise, Yahweh, confront him. 
-</p><p class="q2">Cast him down. 
-</p><p class="q1">Deliver my soul from the wicked by your sword, 
-</p><p class="q2">
-<span class="v">14&#160;</span>from men by your hand, Yahweh, 
-</p><p class="q2">from men of the world, whose portion is in this life. 
-</p><p class="q1">You fill the belly of your cherished ones. 
-</p><p class="q2">Your sons have plenty, 
-</p><p class="q2">and they store up wealth for their children. 
-</p><p class="q1">
-<span class="v">15&#160;</span>As for me, I shall see your face in righteousness. 
-</p><p class="q2">I shall be satisfied, when I awake, with seeing your form. 
-</p><h2 class="psalmlabel" id="18">18</h2>
-<p class="d">For the Chief Musician. By David the servant of Yahweh, who spoke to Yahweh the words of this song in the day that Yahweh delivered him from the hand of all his enemies, and from the hand of Saul. He said, 
-</p><p class="q1">
-<span class="v">1&#160;</span>I love you, Yahweh, my strength. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh is my rock, my fortress, and my deliverer; 
-</p><p class="q2">my Elohim, my rock, in whom I take refuge; 
-</p><p class="q2">my shield, and the horn of my salvation, my high tower. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I call on Yahweh, who is worthy to be praised; 
-</p><p class="q2">and I am saved from my enemies. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The cords of death surrounded me. 
-</p><p class="q2">The floods of unelohimliness made me afraid. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The cords of Sheol<span class="f">+ \fr 18:5 \ft Sheol is the place of the dead.</span> were around me. 
-</p><p class="q2">The snares of death came on me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>In my distress I called on Yahweh, 
-</p><p class="q2">and cried to my Elohim. 
-</p><p class="q1">He heard my voice out of his temple. 
-</p><p class="q2">My cry before him came into his ears. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Then the earth shook and trembled. 
-</p><p class="q2">The foundations also of the mountains quaked and were shaken, 
-</p><p class="q2">because he was angry. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Smoke went out of his nostrils. 
-</p><p class="q2">Consuming fire came out of his mouth. 
-</p><p class="q2">Coals were kindled by it. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He bowed the heavens also, and came down. 
-</p><p class="q2">Thick darkness was under his feet. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He rode on a cherub, and flew. 
-</p><p class="q2">Yes, he soared on the wings of the wind. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He made darkness his hiding place, his pavilion around him, 
-</p><p class="q2">darkness of waters, thick clouds of the skies. 
-</p><p class="q1">
-<span class="v">12&#160;</span>At the brightness before him his thick clouds passed, 
-</p><p class="q2">hailstones and coals of fire. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yahweh also thundered in the sky. 
-</p><p class="q2">The Most High uttered his voice: 
-</p><p class="q2">hailstones and coals of fire. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He sent out his arrows, and scattered them. 
-</p><p class="q2">He routed them with great lightning bolts. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Then the channels of waters appeared. 
-</p><p class="q2">The foundations of the world were laid bare at your rebuke, Yahweh, 
-</p><p class="q2">at the blast of the breath of your nostrils. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He sent from on high. 
-</p><p class="q2">He took me. 
-</p><p class="q2">He drew me out of many waters. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He delivered me from my strong enemy, 
-</p><p class="q2">from those who hated me; for they were too mighty for me. 
-</p><p class="q1">
-<span class="v">18&#160;</span>They came on me in the day of my calamity, 
-</p><p class="q2">but Yahweh was my support. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He brought me out also into a large place. 
-</p><p class="q2">He delivered me, because he delighted in me. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Yahweh has rewarded me according to my righteousness. 
-</p><p class="q2">According to the cleanness of my hands, he has recompensed me. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For I have kept the ways of Yahweh, 
-</p><p class="q2">and have not wickedly departed from my Elohim. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For all his ordinances were before me. 
-</p><p class="q2">I didn’t put away his statutes from me. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I was also blameless with him. 
-</p><p class="q2">I kept myself from my iniquity. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Therefore Yahweh has rewarded me according to my righteousness, 
-</p><p class="q2">according to the cleanness of my hands in his eyesight. 
-</p><p class="q1">
-<span class="v">25&#160;</span>With the merciful you will show yourself merciful. 
-</p><p class="q2">With the perfect man, you will show yourself perfect. 
-</p><p class="q1">
-<span class="v">26&#160;</span>With the pure, you will show yourself pure. 
-</p><p class="q2">With the crooked you will show yourself shrewd. 
-</p><p class="q1">
-<span class="v">27&#160;</span>For you will save the afflicted people, 
-</p><p class="q2">but the arrogant eyes you will bring down. 
-</p><p class="q1">
-<span class="v">28&#160;</span>For you will light my lamp, Yahweh. 
-</p><p class="q2">My Elohim will light up my darkness. 
-</p><p class="q1">
-<span class="v">29&#160;</span>For by you, I advance through a troop. 
-</p><p class="q2">By my Elohim, I leap over a wall. 
-</p><p class="q1">
-<span class="v">30&#160;</span>As for Elohim, his way is perfect. 
-</p><p class="q2">Yahweh’s word is tried. 
-</p><p class="q2">He is a shield to all those who take refuge in him. 
-</p><p class="q1">
-<span class="v">31&#160;</span>For who is Elohim, except Yahweh? 
-</p><p class="q2">Who is a rock, besides our Elohim, 
-</p><p class="q2">
-<span class="v">32&#160;</span>the Elohim who arms me with strength, and makes my way perfect? 
-</p><p class="q1">
-<span class="v">33&#160;</span>He makes my feet like deer’s feet, 
-</p><p class="q2">and sets me on my high places. 
-</p><p class="q1">
-<span class="v">34&#160;</span>He teaches my hands to war, 
-</p><p class="q2">so that my arms bend a bow of bronze. 
-</p><p class="q1">
-<span class="v">35&#160;</span>You have also given me the shield of your salvation. 
-</p><p class="q2">Your right hand sustains me. 
-</p><p class="q2">Your gentleness has made me great. 
-</p><p class="q1">
-<span class="v">36&#160;</span>You have enlarged my steps under me, 
-</p><p class="q2">My feet have not slipped. 
-</p><p class="q1">
-<span class="v">37&#160;</span>I will pursue my enemies, and overtake them. 
-</p><p class="q2">I won’t turn away until they are consumed. 
-</p><p class="q1">
-<span class="v">38&#160;</span>I will strike them through, so that they will not be able to rise. 
-</p><p class="q2">They shall fall under my feet. 
-</p><p class="q1">
-<span class="v">39&#160;</span>For you have armed me with strength to the battle. 
-</p><p class="q2">You have subdued under me those who rose up against me. 
-</p><p class="q1">
-<span class="v">40&#160;</span>You have also made my enemies turn their backs to me, 
-</p><p class="q2">that I might cut off those who hate me. 
-</p><p class="q1">
-<span class="v">41&#160;</span>They cried, but there was no one to save; 
-</p><p class="q2">even to Yahweh, but he didn’t answer them. 
-</p><p class="q1">
-<span class="v">42&#160;</span>Then I beat them small as the dust before the wind. 
-</p><p class="q2">I cast them out as the mire of the streets. 
-</p><p class="q1">
-<span class="v">43&#160;</span>You have delivered me from the strivings of the people. 
-</p><p class="q2">You have made me the head of the nations. 
-</p><p class="q1">A people whom I have not known shall serve me. 
-</p><p class="q2">
-<span class="v">44&#160;</span>As soon as they hear of me they shall obey me. 
-</p><p class="q2">The foreigners shall submit themselves to me. 
-</p><p class="q1">
-<span class="v">45&#160;</span>The foreigners shall fade away, 
-</p><p class="q2">and shall come trembling out of their strongholds. 
-</p><p class="q1">
-<span class="v">46&#160;</span>Yahweh lives! Blessed be my rock. 
-</p><p class="q2">Exalted be the Elohim of my salvation, 
-</p><p class="q1">
-<span class="v">47&#160;</span>even the Elohim who executes vengeance for me, 
-</p><p class="q2">and subdues peoples under me. 
-</p><p class="q1">
-<span class="v">48&#160;</span>He rescues me from my enemies. 
-</p><p class="q2">Yes, you lift me up above those who rise up against me. 
-</p><p class="q2">You deliver me from the violent man. 
-</p><p class="q1">
-<span class="v">49&#160;</span>Therefore I will give thanks to you, Yahweh, among the nations, 
-</p><p class="q2">and will sing praises to your name. 
-</p><p class="q1">
-<span class="v">50&#160;</span>He gives great deliverance to his king, 
-</p><p class="q2">and shows loving kindness to his anointed, 
-</p><p class="q2">to David and to his offspring,<span class="f">+ \fr 18:50 \ft or, seed</span> forever more. 
-</p><h2 class="psalmlabel" id="19">19</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>The heavens declare the glory of Elohim. 
-</p><p class="q2">The expanse shows his handiwork. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Day after day they pour out speech, 
-</p><p class="q2">and night after night they display knowledge. 
-</p><p class="q1">
-<span class="v">3&#160;</span>There is no speech nor language 
-</p><p class="q2">where their voice is not heard. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Their voice has gone out through all the earth, 
-</p><p class="q2">their words to the end of the world. 
-</p><p class="q1">In them he has set a tent for the sun, 
-</p><p class="q2">
-<span class="v">5&#160;</span>which is as a bridegroom coming out of his room, 
-</p><p class="q2">like a strong man rejoicing to run his course. 
-</p><p class="q1">
-<span class="v">6&#160;</span>His going out is from the end of the heavens, 
-</p><p class="q2">his circuit to its ends. 
-</p><p class="q2">There is nothing hidden from its heat. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Yahweh’s law is perfect, restoring the soul. 
-</p><p class="q2">Yahweh’s covenant is sure, making wise the simple. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh’s precepts are right, rejoicing the heart. 
-</p><p class="q2">Yahweh’s commandment is pure, enlightening the eyes. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The fear of Yahweh is clean, enduring forever. 
-</p><p class="q2">Yahweh’s ordinances are true, and righteous altogether. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They are more to be desired than gold, yes, than much fine gold, 
-</p><p class="q2">sweeter also than honey and the extract of the honeycomb. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Moreover your servant is warned by them. 
-</p><p class="q2">In keeping them there is great reward. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Who can discern his errors? 
-</p><p class="q2">Forgive me from hidden errors. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Keep back your servant also from presumptuous sins. 
-</p><p class="q2">Let them not have dominion over me. 
-</p><p class="q1">Then I will be upright. 
-</p><p class="q2">I will be blameless and innocent of great transgression. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Let the words of my mouth and the meditation of my heart 
-</p><p class="q2">be acceptable in your sight, 
-</p><p class="q2">Yahweh, my rock, and my redeemer. 
-</p><h2 class="psalmlabel" id="20">20</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>May Yahweh answer you in the day of trouble. 
-</p><p class="q2">May the name of the Elohim of Jacob set you up on high, 
-</p><p class="q2">
-<span class="v">2&#160;</span>send you help from the sanctuary, 
-</p><p class="q2">grant you support from Zion, 
-</p><p class="q2">
-<span class="v">3&#160;</span>remember all your offerings, 
-</p><p class="q2">and accept your burned sacrifice. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>May he grant you your heart’s desire, 
-</p><p class="q2">and fulfill all your counsel. 
-</p><p class="q1">
-<span class="v">5&#160;</span>We will triumph in your salvation. 
-</p><p class="q2">In the name of our Elohim, we will set up our banners. 
-</p><p class="q2">May Yahweh grant all your requests. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Now I know that Yahweh saves his anointed. 
-</p><p class="q2">He will answer him from his set-apart heaven, 
-</p><p class="q2">with the saving strength of his right hand. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Some trust in chariots, and some in horses, 
-</p><p class="q2">but we trust in the name of Yahweh our Elohim. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They are bowed down and fallen, 
-</p><p class="q2">but we rise up, and stand upright. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Save, Yahweh! 
-</p><p class="q2">Let the King answer us when we call! 
-</p><h2 class="psalmlabel" id="21">21</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>The king rejoices in your strength, Yahweh! 
-</p><p class="q2">How greatly he rejoices in your salvation! 
-</p><p class="q1">
-<span class="v">2&#160;</span>You have given him his heart’s desire, 
-</p><p class="q2">and have not withheld the request of his lips. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">3&#160;</span>For you meet him with the blessings of goodness. 
-</p><p class="q2">You set a crown of fine gold on his head. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He asked life of you and you gave it to him, 
-</p><p class="q2">even length of days forever and ever. 
-</p><p class="q1">
-<span class="v">5&#160;</span>His glory is great in your salvation. 
-</p><p class="q2">You lay honor and majesty on him. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For you make him most blessed forever. 
-</p><p class="q2">You make him glad with joy in your presence. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For the king trusts in Yahweh. 
-</p><p class="q2">Through the loving kindness of the Most High, he shall not be moved. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Your hand will find out all of your enemies. 
-</p><p class="q2">Your right hand will find out those who hate you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You will make them as a fiery furnace in the time of your anger. 
-</p><p class="q2">Yahweh will swallow them up in his wrath. 
-</p><p class="q2">The fire shall devour them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You will destroy their descendants from the earth, 
-</p><p class="q2">their posterity from among the children of men. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For they intended evil against you. 
-</p><p class="q2">They plotted evil against you which cannot succeed. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For you will make them turn their back, 
-</p><p class="q2">when you aim drawn bows at their face. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Be exalted, Yahweh, in your strength, 
-</p><p class="q2">so we will sing and praise your power. 
-</p><h2 class="psalmlabel" id="22">22</h2>
-<p class="d">For the Chief Musician; set to “The Doe of the Morning.” A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>My Elohim, my Elohim, why have you forsaken me? 
-</p><p class="q2">Why are you so far from helping me, and from the words of my groaning? 
-</p><p class="q1">
-<span class="v">2&#160;</span>My Elohim, I cry in the daytime, but you don’t answer; 
-</p><p class="q2">in the night season, and am not silent. 
-</p><p class="q1">
-<span class="v">3&#160;</span>But you are set-apart, 
-</p><p class="q2">you who inhabit the praises of Israel. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Our fathers trusted in you. 
-</p><p class="q2">They trusted, and you delivered them. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They cried to you, and were delivered. 
-</p><p class="q2">They trusted in you, and were not disappointed. 
-</p><p class="q1">
-<span class="v">6&#160;</span>But I am a worm, and no man; 
-</p><p class="q2">a reproach of men, and despised by the people. 
-</p><p class="q1">
-<span class="v">7&#160;</span>All those who see me mock me. 
-</p><p class="q2">They insult me with their lips. They shake their heads, saying, 
-</p><p class="q2">
-<span class="v">8&#160;</span>“He trusts in Yahweh. 
-</p><p class="q2">Let him deliver him. 
-</p><p class="q2">Let him rescue him, since he delights in him.” 
-</p><p class="q1">
-<span class="v">9&#160;</span>But you brought me out of the womb. 
-</p><p class="q2">You made me trust while at my mother’s breasts. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I was thrown on you from my mother’s womb. 
-</p><p class="q2">You are my Elohim since my mother bore me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Don’t be far from me, for trouble is near. 
-</p><p class="q2">For there is no one to help. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Many bulls have surrounded me. 
-</p><p class="q2">Strong bulls of Bashan have encircled me. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They open their mouths wide against me, 
-</p><p class="q2">lions tearing prey and roaring. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I am poured out like water. 
-</p><p class="q2">All my bones are out of joint. 
-</p><p class="q1">My heart is like wax. 
-</p><p class="q2">It is melted within me. 
-</p><p class="q1">
-<span class="v">15&#160;</span>My strength is dried up like a potsherd. 
-</p><p class="q2">My tongue sticks to the roof of my mouth. 
-</p><p class="q1">You have brought me into the dust of death. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For dogs have surrounded me. 
-</p><p class="q2">A company of evildoers have enclosed me. 
-</p><p class="q2">They have pierced my hands and feet.<span class="f">+ \fr 22:16 \ft So Dead Sea Scrolls. Masoretic Text reads, “Like a lion, they pin my hands and feet.”</span> 
-</p><p class="q1">
-<span class="v">17&#160;</span>I can count all of my bones. 
-</p><p class="q1">They look and stare at me. 
-</p><p class="q1">
-<span class="v">18&#160;</span>They divide my garments among them. 
-</p><p class="q2">They cast lots for my clothing. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>But don’t be far off, Yahweh. 
-</p><p class="q2">You are my help. Hurry to help me! 
-</p><p class="q1">
-<span class="v">20&#160;</span>Deliver my soul from the sword, 
-</p><p class="q2">my precious life from the power of the dog. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Save me from the lion’s mouth! 
-</p><p class="q2">Yes, you have rescued me from the horns of the wild oxen. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>I will declare your name to my brothers. 
-</p><p class="q2">Among the assembly, I will praise you. 
-</p><p class="q1">
-<span class="v">23&#160;</span>You who fear Yahweh, praise him! 
-</p><p class="q2">All you descendants of Jacob, glorify him! 
-</p><p class="q2">Stand in awe of him, all you descendants of Israel! 
-</p><p class="q1">
-<span class="v">24&#160;</span>For he has not despised nor abhorred the affliction of the afflicted, 
-</p><p class="q2">neither has he hidden his face from him; 
-</p><p class="q2">but when he cried to him, he heard. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">25&#160;</span>My praise of you comes in the great assembly. 
-</p><p class="q2">I will pay my vows before those who fear him. 
-</p><p class="q1">
-<span class="v">26&#160;</span>The humble shall eat and be satisfied. 
-</p><p class="q2">They shall praise Yahweh who seek after him. 
-</p><p class="q2">Let your hearts live forever. 
-</p><p class="q1">
-<span class="v">27&#160;</span>All the ends of the earth shall remember and turn to Yahweh. 
-</p><p class="q2">All the relatives of the nations shall worship before you. 
-</p><p class="q1">
-<span class="v">28&#160;</span>For the kingdom is Yahweh’s. 
-</p><p class="q2">He is the ruler over the nations. 
-</p><p class="q1">
-<span class="v">29&#160;</span>All the rich ones of the earth shall eat and worship. 
-</p><p class="q2">All those who go down to the dust shall bow before him, 
-</p><p class="q2">even he who can’t keep his soul alive. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Posterity shall serve him. 
-</p><p class="q2">Future generations shall be told about the Lord. 
-</p><p class="q1">
-<span class="v">31&#160;</span>They shall come and shall declare his righteousness to a people that shall be born, 
-</p><p class="q2">for he has done it. 
-</p><h2 class="psalmlabel" id="23">23</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh is my shepherd; 
-</p><p class="q2">I shall lack nothing. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He makes me lie down in green pastures. 
-</p><p class="q2">He leads me beside still waters. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He restores my soul. 
-</p><p class="q2">He guides me in the paths of righteousness for his name’s sake. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Even though I walk through the valley of the shadow of death, 
-</p><p class="q2">I will fear no evil, for you are with me. 
-</p><p class="q1">Your rod and your staff, 
-</p><p class="q2">they comfort me. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You prepare a table before me 
-</p><p class="q2">in the presence of my enemies. 
-</p><p class="q1">You anoint my head with oil. 
-</p><p class="q2">My cup runs over. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Surely goodness and loving kindness shall follow me all the days of my life, 
-</p><p class="q2">and I will dwell in Yahweh’s house forever. 
-</p><h2 class="psalmlabel" id="24">24</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>The earth is Yahweh’s, with its fullness; 
-</p><p class="q2">the world, and those who dwell in it. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For he has founded it on the seas, 
-</p><p class="q2">and established it on the floods. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>Who may ascend to Yahweh’s hill? 
-</p><p class="q2">Who may stand in his set-apart place? 
-</p><p class="q1">
-<span class="v">4&#160;</span>He who has clean hands and a pure heart; 
-</p><p class="q2">who has not lifted up his soul to falsehood, 
-</p><p class="q2">and has not sworn deceitfully. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He shall receive a blessing from Yahweh, 
-</p><p class="q2">righteousness from the Elohim of his salvation. 
-</p><p class="q1">
-<span class="v">6&#160;</span>This is the generation of those who seek Him, 
-</p><p class="q2">who seek your face—even Jacob. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Lift up your heads, you gates! 
-</p><p class="q2">Be lifted up, you everlasting doors, 
-</p><p class="q2">and the King of glory will come in. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Who is the King of glory? 
-</p><p class="q2">Yahweh strong and mighty, 
-</p><p class="q2">Yahweh mighty in battle. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Lift up your heads, you gates; 
-</p><p class="q2">yes, lift them up, you everlasting doors, 
-</p><p class="q2">and the King of glory will come in. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Who is this King of glory? 
-</p><p class="q2">Yahweh of Armies is the King of glory! </p><p class="qs">Selah.</p> 
-</p><h2 class="psalmlabel" id="25">25</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>To you, Yahweh, I lift up my soul. 
-</p><p class="q1">
-<span class="v">2&#160;</span>My Elohim, I have trusted in you. 
-</p><p class="q2">Don’t let me be shamed. 
-</p><p class="q2">Don’t let my enemies triumph over me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yes, no one who waits for you will be shamed. 
-</p><p class="q2">They will be shamed who deal treacherously without cause. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>Show me your ways, Yahweh. 
-</p><p class="q2">Teach me your paths. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Guide me in your truth, and teach me, 
-</p><p class="q2">for you are the Elohim of my salvation. 
-</p><p class="q2">I wait for you all day long. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh, remember your tender mercies and your loving kindness, 
-</p><p class="q2">for they are from old times. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Don’t remember the sins of my youth, nor my transgressions. 
-</p><p class="q2">Remember me according to your loving kindness, 
-</p><p class="q2">for your goodness’ sake, Yahweh. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Good and upright is Yahweh, 
-</p><p class="q2">therefore he will instruct sinners in the way. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He will guide the humble in justice. 
-</p><p class="q2">He will teach the humble his way. 
-</p><p class="q1">
-<span class="v">10&#160;</span>All the paths of Yahweh are loving kindness and truth 
-</p><p class="q2">to such as keep his covenant and his testimonies. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For your name’s sake, Yahweh, 
-</p><p class="q2">pardon my iniquity, for it is great. 
-</p><p class="q1">
-<span class="v">12&#160;</span>What man is he who fears Yahweh? 
-</p><p class="q2">He shall instruct him in the way that he shall choose. 
-</p><p class="q1">
-<span class="v">13&#160;</span>His soul will dwell at ease. 
-</p><p class="q2">His offspring will inherit the land. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The friendship of Yahweh is with those who fear him. 
-</p><p class="q2">He will show them his covenant. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>My eyes are ever on Yahweh, 
-</p><p class="q2">for he will pluck my feet out of the net. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Turn to me, and have mercy on me, 
-</p><p class="q2">for I am desolate and afflicted. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The troubles of my heart are enlarged. 
-</p><p class="q2">Oh bring me out of my distresses. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Consider my affliction and my travail. 
-</p><p class="q2">Forgive all my sins. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Consider my enemies, for they are many. 
-</p><p class="q2">They hate me with cruel hatred. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Oh keep my soul, and deliver me. 
-</p><p class="q2">Let me not be disappointed, for I take refuge in you. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Let integrity and uprightness preserve me, 
-</p><p class="q2">for I wait for you. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Elohim, redeem Israel 
-</p><p class="q2">out of all his troubles. 
-</p><h2 class="psalmlabel" id="26">26</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Judge me, Yahweh, for I have walked in my integrity. 
-</p><p class="q2">I have trusted also in Yahweh without wavering. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Examine me, Yahweh, and prove me. 
-</p><p class="q2">Try my heart and my mind. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For your loving kindness is before my eyes. 
-</p><p class="q2">I have walked in your truth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I have not sat with deceitful men, 
-</p><p class="q2">neither will I go in with hypocrites. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I hate the assembly of evildoers, 
-</p><p class="q2">and will not sit with the wicked. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I will wash my hands in innocence, 
-</p><p class="q2">so I will go about your altar, Yahweh, 
-</p><p class="q2">
-<span class="v">7&#160;</span>that I may make the voice of thanksgiving to be heard 
-</p><p class="q2">and tell of all your wondrous deeds. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh, I love the habitation of your house, 
-</p><p class="q2">the place where your glory dwells. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Don’t gather my soul with sinners, 
-</p><p class="q2">nor my life with bloodthirsty men 
-</p><p class="q2">
-<span class="v">10&#160;</span>in whose hands is wickedness; 
-</p><p class="q2">their right hand is full of bribes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>But as for me, I will walk in my integrity. 
-</p><p class="q2">Redeem me, and be merciful to me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>My foot stands in an even place. 
-</p><p class="q2">In the congregations I will bless Yahweh. 
-</p><h2 class="psalmlabel" id="27">27</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh is my light and my salvation. 
-</p><p class="q2">Whom shall I fear? 
-</p><p class="q1">Yahweh is the strength of my life. 
-</p><p class="q2">Of whom shall I be afraid? 
-</p><p class="q1">
-<span class="v">2&#160;</span>When evildoers came at me to eat up my flesh, 
-</p><p class="q2">even my adversaries and my foes, they stumbled and fell. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Though an army should encamp against me, 
-</p><p class="q2">my heart shall not fear. 
-</p><p class="q1">Though war should rise against me, 
-</p><p class="q2">even then I will be confident. 
-</p><p class="q1">
-<span class="v">4&#160;</span>One thing I have asked of Yahweh, that I will seek after: 
-</p><p class="q2">that I may dwell in Yahweh’s house all the days of my life, 
-</p><p class="q2">to see Yahweh’s beauty, 
-</p><p class="q2">and to inquire in his temple. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For in the day of trouble, he will keep me secretly in his pavilion. 
-</p><p class="q2">In the secret place of his tabernacle, he will hide me. 
-</p><p class="q2">He will lift me up on a rock. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Now my head will be lifted up above my enemies around me. 
-</p><p class="q1">I will offer sacrifices of joy in his tent. 
-</p><p class="q2">I will sing, yes, I will sing praises to Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Hear, Yahweh, when I cry with my voice. 
-</p><p class="q2">Have mercy also on me, and answer me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>When you said, “Seek my face,” 
-</p><p class="q2">my heart said to you, “I will seek your face, Yahweh.” 
-</p><p class="q1">
-<span class="v">9&#160;</span>Don’t hide your face from me. 
-</p><p class="q2">Don’t put your servant away in anger. 
-</p><p class="q1">You have been my help. 
-</p><p class="q2">Don’t abandon me, 
-</p><p class="q2">neither forsake me, Elohim of my salvation. 
-</p><p class="q1">
-<span class="v">10&#160;</span>When my father and my mother forsake me, 
-</p><p class="q2">then Yahweh will take me up. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Teach me your way, Yahweh. 
-</p><p class="q2">Lead me in a straight path, because of my enemies. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Don’t deliver me over to the desire of my adversaries, 
-</p><p class="q2">for false witnesses have risen up against me, 
-</p><p class="q2">such as breathe out cruelty. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I am still confident of this: 
-</p><p class="q2">I will see the goodness of Yahweh in the land of the living. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Wait for Yahweh. 
-</p><p class="q2">Be strong, and let your heart take courage. 
-</p><p class="q1">Yes, wait for Yahweh. 
-</p><h2 class="psalmlabel" id="28">28</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>To you, Yahweh, I call. 
-</p><p class="q2">My rock, don’t be deaf to me, 
-</p><p class="q2">lest, if you are silent to me, 
-</p><p class="q2">I would become like those who go down into the pit. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear the voice of my petitions, when I cry to you, 
-</p><p class="q2">when I lift up my hands toward your Most Set-Apart Place. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Don’t draw me away with the wicked, 
-</p><p class="q2">with the workers of iniquity who speak peace with their neighbors, 
-</p><p class="q2">but mischief is in their hearts. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Give them according to their work, and according to the wickedness of their doings. 
-</p><p class="q2">Give them according to the operation of their hands. 
-</p><p class="q2">Bring back on them what they deserve. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Because they don’t respect the works of Yahweh, 
-</p><p class="q2">nor the operation of his hands, 
-</p><p class="q2">he will break them down and not build them up. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Blessed be Yahweh, 
-</p><p class="q2">because he has heard the voice of my petitions. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh is my strength and my shield. 
-</p><p class="q2">My heart has trusted in him, and I am helped. 
-</p><p class="q1">Therefore my heart greatly rejoices. 
-</p><p class="q2">With my song I will thank him. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh is their strength. 
-</p><p class="q2">He is a stronghold of salvation to his anointed. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Save your people, 
-</p><p class="q2">and bless your inheritance. 
-</p><p class="q1">Be their shepherd also, 
-</p><p class="q2">and bear them up forever. 
-</p><h2 class="psalmlabel" id="29">29</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Ascribe to Yahweh, you sons of the mighty, 
-</p><p class="q2">ascribe to Yahweh glory and strength. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Ascribe to Yahweh the glory due to his name. 
-</p><p class="q2">Worship Yahweh in set-apart array. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>Yahweh’s voice is on the waters. 
-</p><p class="q2">The Elohim of glory thunders, even Yahweh on many waters. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh’s voice is powerful. 
-</p><p class="q2">Yahweh’s voice is full of majesty. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh’s voice breaks the cedars. 
-</p><p class="q2">Yes, Yahweh breaks in pieces the cedars of Lebanon. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He makes them also to skip like a calf; 
-</p><p class="q2">Lebanon and Sirion like a young, wild ox. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh’s voice strikes with flashes of lightning. 
-</p><p class="q2">
-<span class="v">8&#160;</span>Yahweh’s voice shakes the wilderness. 
-</p><p class="q2">Yahweh shakes the wilderness of Kadesh. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yahweh’s voice makes the deer calve, 
-</p><p class="q2">and strips the forests bare. 
-</p><p class="q2">In his temple everything says, “Glory!” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Yahweh sat enthroned at the Flood. 
-</p><p class="q2">Yes, Yahweh sits as King forever. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh will give strength to his people. 
-</p><p class="q2">Yahweh will bless his people with peace. 
-</p><h2 class="psalmlabel" id="30">30</h2>
-<p class="d">A Psalm. A Song for the Dedication of the Temple. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will extol you, Yahweh, for you have raised me up, 
-</p><p class="q2">and have not made my foes to rejoice over me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh my Elohim, I cried to you, 
-</p><p class="q2">and you have healed me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh, you have brought up my soul from Sheol.<span class="f">+ \fr 30:3 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">You have kept me alive, that I should not go down to the pit. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Sing praise to Yahweh, you saints of his. 
-</p><p class="q2">Give thanks to his set-apart name. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For his anger is but for a moment. 
-</p><p class="q2">His favor is for a lifetime. 
-</p><p class="q1">Weeping may stay for the night, 
-</p><p class="q2">but joy comes in the morning. 
-</p><p class="q1">
-<span class="v">6&#160;</span>As for me, I said in my prosperity, 
-</p><p class="q2">“I shall never be moved.” 
-</p><p class="q1">
-<span class="v">7&#160;</span>You, Yahweh, when you favored me, made my mountain stand strong; 
-</p><p class="q2">but when you hid your face, I was troubled. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I cried to you, Yahweh. 
-</p><p class="q2">I made supplication to the Lord: 
-</p><p class="q1">
-<span class="v">9&#160;</span>“What profit is there in my destruction, if I go down to the pit? 
-</p><p class="q2">Shall the dust praise you? 
-</p><p class="q2">Shall it declare your truth? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Hear, Yahweh, and have mercy on me. 
-</p><p class="q2">Yahweh, be my helper.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>You have turned my mourning into dancing for me. 
-</p><p class="q2">You have removed my sackcloth, and clothed me with gladness, 
-</p><p class="q2">
-<span class="v">12&#160;</span>to the end that my heart may sing praise to you, and not be silent. 
-</p><p class="q1">Yahweh my Elohim, I will give thanks to you forever! 
-</p><h2 class="psalmlabel" id="31">31</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>In you, Yahweh, I take refuge. 
-</p><p class="q2">Let me never be disappointed. 
-</p><p class="q2">Deliver me in your righteousness. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Bow down your ear to me. 
-</p><p class="q2">Deliver me speedily. 
-</p><p class="q1">Be to me a strong rock, 
-</p><p class="q2">a house of defense to save me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For you are my rock and my fortress, 
-</p><p class="q2">therefore for your name’s sake lead me and guide me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Pluck me out of the net that they have laid secretly for me, 
-</p><p class="q2">for you are my stronghold. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Into your hand I commend my spirit. 
-</p><p class="q2">You redeem me, Yahweh, Elohim of truth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I hate those who regard lying vanities, 
-</p><p class="q2">but I trust in Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I will be glad and rejoice in your loving kindness, 
-</p><p class="q2">for you have seen my affliction. 
-</p><p class="q2">You have known my soul in adversities. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You have not shut me up into the hand of the enemy. 
-</p><p class="q2">You have set my feet in a large place. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Have mercy on me, Yahweh, for I am in distress. 
-</p><p class="q2">My eye, my soul, and my body waste away with grief. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For my life is spent with sorrow, 
-</p><p class="q2">my years with sighing. 
-</p><p class="q1">My strength fails because of my iniquity. 
-</p><p class="q2">My bones are wasted away. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Because of all my adversaries I have become utterly contemptible to my neighbors, 
-</p><p class="q2">a horror to my acquaintances. 
-</p><p class="q2">Those who saw me on the street fled from me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I am forgotten from their hearts like a dead man. 
-</p><p class="q2">I am like broken pottery. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For I have heard the slander of many, terror on every side, 
-</p><p class="q2">while they conspire together against me, 
-</p><p class="q2">they plot to take away my life. 
-</p><p class="q1">
-<span class="v">14&#160;</span>But I trust in you, Yahweh. 
-</p><p class="q2">I said, “You are my Elohim.” 
-</p><p class="q1">
-<span class="v">15&#160;</span>My times are in your hand. 
-</p><p class="q2">Deliver me from the hand of my enemies, and from those who persecute me. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Make your face to shine on your servant. 
-</p><p class="q2">Save me in your loving kindness. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let me not be disappointed, Yahweh, for I have called on you. 
-</p><p class="q2">Let the wicked be disappointed. 
-</p><p class="q2">Let them be silent in Sheol.<span class="f">+ \fr 31:17 \ft Sheol is the place of the dead.</span> 
-</p><p class="q1">
-<span class="v">18&#160;</span>Let the lying lips be mute, 
-</p><p class="q2">which speak against the righteous insolently, with pride and contempt. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Oh how great is your goodness, 
-</p><p class="q2">which you have laid up for those who fear you, 
-</p><p class="q2">which you have worked for those who take refuge in you, 
-</p><p class="q2">before the sons of men! 
-</p><p class="q1">
-<span class="v">20&#160;</span>In the shelter of your presence you will hide them from the plotting of man. 
-</p><p class="q2">You will keep them secretly in a dwelling away from the strife of tongues. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Praise be to Yahweh, 
-</p><p class="q2">for he has shown me his marvelous loving kindness in a strong city. 
-</p><p class="q1">
-<span class="v">22&#160;</span>As for me, I said in my haste, “I am cut off from before your eyes.” 
-</p><p class="q2">Nevertheless you heard the voice of my petitions when I cried to you. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Oh love Yahweh, all you his saints! 
-</p><p class="q2">Yahweh preserves the faithful, 
-</p><p class="q1">and fully recompenses him who behaves arrogantly. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Be strong, and let your heart take courage, 
-</p><p class="q2">all you who hope in Yahweh. 
-</p><h2 class="psalmlabel" id="32">32</h2>
-<p class="d">By David. A contemplative psalm. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Blessed is he whose disobedience is forgiven, 
-</p><p class="q2">whose sin is covered. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Blessed is the man to whom Yahweh doesn’t impute iniquity, 
-</p><p class="q2">in whose spirit there is no deceit. 
-</p><p class="q1">
-<span class="v">3&#160;</span>When I kept silence, my bones wasted away through my groaning all day long. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For day and night your hand was heavy on me. 
-</p><p class="q2">My strength was sapped in the heat of summer. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>I acknowledged my sin to you. 
-</p><p class="q2">I didn’t hide my iniquity. 
-</p><p class="q1">I said, I will confess my transgressions to Yahweh, 
-</p><p class="q2">and you forgave the iniquity of my sin. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">6&#160;</span>For this, let everyone who is elohimly pray to you in a time when you may be found. 
-</p><p class="q2">Surely when the great waters overflow, they shall not reach to him. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You are my hiding place. 
-</p><p class="q2">You will preserve me from trouble. 
-</p><p class="q2">You will surround me with songs of deliverance. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will instruct you and teach you in the way which you shall go. 
-</p><p class="q2">I will counsel you with my eye on you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Don’t be like the horse, or like the mule, which have no understanding, 
-</p><p class="q2">who are controlled by bit and bridle, or else they will not come near to you. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Many sorrows come to the wicked, 
-</p><p class="q2">but loving kindness shall surround him who trusts in Yahweh. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Be glad in Yahweh, and rejoice, you righteous! 
-</p><p class="q2">Shout for joy, all you who are upright in heart! 
-</p><h2 class="psalmlabel" id="33">33</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Rejoice in Yahweh, you righteous! 
-</p><p class="q2">Praise is fitting for the upright. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Give thanks to Yahweh with the lyre. 
-</p><p class="q2">Sing praises to him with the harp of ten strings. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Sing to him a new song. 
-</p><p class="q2">Play skillfully with a shout of joy! 
-</p><p class="q1">
-<span class="v">4&#160;</span>For Yahweh’s word is right. 
-</p><p class="q2">All his work is done in faithfulness. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He loves righteousness and justice. 
-</p><p class="q2">The earth is full of the loving kindness of Yahweh. 
-</p><p class="q1">
-<span class="v">6&#160;</span>By Yahweh’s word, the heavens were made: 
-</p><p class="q2">all their army by the breath of his mouth. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He gathers the waters of the sea together as a heap. 
-</p><p class="q2">He lays up the deeps in storehouses. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let all the earth fear Yahweh. 
-</p><p class="q2">Let all the inhabitants of the world stand in awe of him. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For he spoke, and it was done. 
-</p><p class="q2">He commanded, and it stood firm. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Yahweh brings the counsel of the nations to nothing. 
-</p><p class="q2">He makes the thoughts of the peoples to be of no effect. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The counsel of Yahweh stands fast forever, 
-</p><p class="q2">the thoughts of his heart to all generations. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Blessed is the nation whose Elohim is Yahweh, 
-</p><p class="q2">the people whom he has chosen for his own inheritance. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Yahweh looks from heaven. 
-</p><p class="q2">He sees all the sons of men. 
-</p><p class="q1">
-<span class="v">14&#160;</span>From the place of his habitation he looks out on all the inhabitants of the earth, 
-</p><p class="q2">
-<span class="v">15&#160;</span>he who fashions all of their hearts; 
-</p><p class="q2">and he considers all of their works. 
-</p><p class="q1">
-<span class="v">16&#160;</span>There is no king saved by the multitude of an army. 
-</p><p class="q2">A mighty man is not delivered by great strength. 
-</p><p class="q1">
-<span class="v">17&#160;</span>A horse is a vain thing for safety, 
-</p><p class="q2">neither does he deliver any by his great power. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Behold, Yahweh’s eye is on those who fear him, 
-</p><p class="q2">on those who hope in his loving kindness, 
-</p><p class="q2">
-<span class="v">19&#160;</span>to deliver their soul from death, 
-</p><p class="q2">to keep them alive in famine. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Our soul has waited for Yahweh. 
-</p><p class="q2">He is our help and our shield. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For our heart rejoices in him, 
-</p><p class="q2">because we have trusted in his set-apart name. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Let your loving kindness be on us, Yahweh, 
-</p><p class="q2">since we have hoped in you. 
-</p><h2 class="psalmlabel" id="34">34</h2>
-<p class="d">By David; when he pretended to be insane before Abimelech, who drove him away, and he departed. 
-</p><p class="q1">
-<span class="v">1&#160;</span><span class="f">+ \fr 34:1 \ft Psalm 34 is an acrostic poem, with each verse starting with a letter of the alphabet (ordered from Alef to Tav).</span> I will bless Yahweh at all times. 
-</p><p class="q2">His praise will always be in my mouth. 
-</p><p class="q1">
-<span class="v">2&#160;</span>My soul shall boast in Yahweh. 
-</p><p class="q2">The humble shall hear of it and be glad. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Oh magnify Yahweh with me. 
-</p><p class="q2">Let’s exalt his name together. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I sought Yahweh, and he answered me, 
-</p><p class="q2">and delivered me from all my fears. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They looked to him, and were radiant. 
-</p><p class="q2">Their faces shall never be covered with shame. 
-</p><p class="q1">
-<span class="v">6&#160;</span>This poor man cried, and Yahweh heard him, 
-</p><p class="q2">and saved him out of all his troubles. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh’s angel encamps around those who fear him, 
-</p><p class="q2">and delivers them. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Oh taste and see that Yahweh is good. 
-</p><p class="q2">Blessed is the man who takes refuge in him. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Oh fear Yahweh, you his saints, 
-</p><p class="q2">for there is no lack with those who fear him. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The young lions do lack, and suffer hunger, 
-</p><p class="q2">but those who seek Yahweh shall not lack any good thing. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>Come, you children, listen to me. 
-</p><p class="q2">I will teach you the fear of Yahweh. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Who is someone who desires life, 
-</p><p class="q2">and loves many days, that he may see good? 
-</p><p class="q1">
-<span class="v">13&#160;</span>Keep your tongue from evil, 
-</p><p class="q2">and your lips from speaking lies. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Depart from evil, and do good. 
-</p><p class="q2">Seek peace, and pursue it. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Yahweh’s eyes are toward the righteous. 
-</p><p class="q2">His ears listen to their cry. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yahweh’s face is against those who do evil, 
-</p><p class="q2">to cut off their memory from the earth. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The righteous cry, and Yahweh hears, 
-</p><p class="q2">and delivers them out of all their troubles. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yahweh is near to those who have a broken heart, 
-</p><p class="q2">and saves those who have a crushed spirit. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Many are the afflictions of the righteous, 
-</p><p class="q2">but Yahweh delivers him out of them all. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He protects all of his bones. 
-</p><p class="q2">Not one of them is broken. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Evil shall kill the wicked. 
-</p><p class="q2">Those who hate the righteous shall be condemned. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Yahweh redeems the soul of his servants. 
-</p><p class="q2">None of those who take refuge in him shall be condemned. 
-</p><h2 class="psalmlabel" id="35">35</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Contend, Yahweh, with those who contend with me. 
-</p><p class="q2">Fight against those who fight against me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Take hold of shield and buckler, 
-</p><p class="q2">and stand up for my help. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Brandish the spear and block those who pursue me. 
-</p><p class="q2">Tell my soul, “I am your salvation.” 
-</p><p class="q1">
-<span class="v">4&#160;</span>Let those who seek after my soul be disappointed and brought to dishonor. 
-</p><p class="q2">Let those who plot my ruin be turned back and confounded. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let them be as chaff before the wind, 
-</p><p class="q2">Yahweh’s angel driving them on. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Let their way be dark and slippery, 
-</p><p class="q2">Yahweh’s angel pursuing them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For without cause they have hidden their net in a pit for me. 
-</p><p class="q2">Without cause they have dug a pit for my soul. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let destruction come on him unawares. 
-</p><p class="q2">Let his net that he has hidden catch himself. 
-</p><p class="q2">Let him fall into that destruction. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>My soul shall be joyful in Yahweh. 
-</p><p class="q2">It shall rejoice in his salvation. 
-</p><p class="q1">
-<span class="v">10&#160;</span>All my bones shall say, “Yahweh, who is like you, 
-</p><p class="q2">who delivers the poor from him who is too strong for him; 
-</p><p class="q2">yes, the poor and the needy from him who robs him?” 
-</p><p class="q1">
-<span class="v">11&#160;</span>Unrighteous witnesses rise up. 
-</p><p class="q2">They ask me about things that I don’t know about. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They reward me evil for good, 
-</p><p class="q2">to the bereaving of my soul. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>But as for me, when they were sick, my clothing was sackcloth. 
-</p><p class="q2">I afflicted my soul with fasting. 
-</p><p class="q2">My prayer returned into my own bosom. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I behaved myself as though it had been my friend or my brother. 
-</p><p class="q2">I bowed down mourning, as one who mourns his mother. 
-</p><p class="q1">
-<span class="v">15&#160;</span>But in my adversity, they rejoiced, and gathered themselves together. 
-</p><p class="q2">The attackers gathered themselves together against me, and I didn’t know it. 
-</p><p class="q2">They tore at me, and didn’t cease. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Like the profane mockers in feasts, 
-</p><p class="q2">they gnashed their teeth at me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Lord, how long will you look on? 
-</p><p class="q2">Rescue my soul from their destruction, 
-</p><p class="q2">my precious life from the lions. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I will give you thanks in the great assembly. 
-</p><p class="q2">I will praise you among many people. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Don’t let those who are my enemies wrongfully rejoice over me; 
-</p><p class="q2">neither let those who hate me without a cause wink their eyes. 
-</p><p class="q1">
-<span class="v">20&#160;</span>For they don’t speak peace, 
-</p><p class="q2">but they devise deceitful words against those who are quiet in the land. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Yes, they opened their mouth wide against me. 
-</p><p class="q2">They said, “Aha! Aha! Our eye has seen it!” 
-</p><p class="q1">
-<span class="v">22&#160;</span>You have seen it, Yahweh. Don’t keep silent. 
-</p><p class="q2">Lord, don’t be far from me. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Wake up! Rise up to defend me, my Elohim! 
-</p><p class="q2">My Lord, contend for me! 
-</p><p class="q1">
-<span class="v">24&#160;</span>Vindicate me, Yahweh my Elohim, according to your righteousness. 
-</p><p class="q2">Don’t let them gloat over me. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Don’t let them say in their heart, “Aha! That’s the way we want it!” 
-</p><p class="q2">Don’t let them say, “We have swallowed him up!” 
-</p><p class="q1">
-<span class="v">26&#160;</span>Let them be disappointed and confounded together who rejoice at my calamity. 
-</p><p class="q2">Let them be clothed with shame and dishonor who magnify themselves against me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">27&#160;</span>Let those who favor my righteous cause shout for joy and be glad. 
-</p><p class="q2">Yes, let them say continually, “May Yahweh be magnified, 
-</p><p class="q2">who has pleasure in the prosperity of his servant!” 
-</p><p class="q1">
-<span class="v">28&#160;</span>My tongue shall talk about your righteousness and about your praise all day long. 
-</p><h2 class="psalmlabel" id="36">36</h2>
-<p class="d">For the Chief Musician. By David, the servant of Yahweh. 
-</p><p class="q1">
-<span class="v">1&#160;</span>A revelation is within my heart about the disobedience of the wicked: 
-</p><p class="q2">There is no fear of Elohim before his eyes. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For he flatters himself in his own eyes, 
-</p><p class="q2">too much to detect and hate his sin. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The words of his mouth are iniquity and deceit. 
-</p><p class="q2">He has ceased to be wise and to do good. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He plots iniquity on his bed. 
-</p><p class="q2">He sets himself in a way that is not good. 
-</p><p class="q2">He doesn’t abhor evil. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Your loving kindness, Yahweh, is in the heavens. 
-</p><p class="q2">Your faithfulness reaches to the skies. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Your righteousness is like the mountains of Elohim. 
-</p><p class="q2">Your judgments are like a great deep. 
-</p><p class="q2">Yahweh, you preserve man and animal. 
-</p><p class="q1">
-<span class="v">7&#160;</span>How precious is your loving kindness, Elohim! 
-</p><p class="q2">The children of men take refuge under the shadow of your wings. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They shall be abundantly satisfied with the abundance of your house. 
-</p><p class="q2">You will make them drink of the river of your pleasures. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For with you is the spring of life. 
-</p><p class="q2">In your light we will see light. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Oh continue your loving kindness to those who know you, 
-</p><p class="q2">your righteousness to the upright in heart. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Don’t let the foot of pride come against me. 
-</p><p class="q2">Don’t let the hand of the wicked drive me away. 
-</p><p class="q1">
-<span class="v">12&#160;</span>There the workers of iniquity are fallen. 
-</p><p class="q2">They are thrust down, and shall not be able to rise. 
-</p><h2 class="psalmlabel" id="37">37</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Don’t fret because of evildoers, 
-</p><p class="q2">neither be envious against those who work unrighteousness. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For they shall soon be cut down like the grass, 
-</p><p class="q2">and wither like the green herb. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Trust in Yahweh, and do good. 
-</p><p class="q2">Dwell in the land, and enjoy safe pasture. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Also delight yourself in Yahweh, 
-</p><p class="q2">and he will give you the desires of your heart. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Commit your way to Yahweh. 
-</p><p class="q2">Trust also in him, and he will do this: 
-</p><p class="q1">
-<span class="v">6&#160;</span>he will make your righteousness shine out like light, 
-</p><p class="q2">and your justice as the noon day sun. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Rest in Yahweh, and wait patiently for him. 
-</p><p class="q2">Don’t fret because of him who prospers in his way, 
-</p><p class="q2">because of the man who makes wicked plots happen. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Cease from anger, and forsake wrath. 
-</p><p class="q2">Don’t fret; it leads only to evildoing. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For evildoers shall be cut off, 
-</p><p class="q2">but those who wait for Yahweh shall inherit the land. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For yet a little while, and the wicked will be no more. 
-</p><p class="q2">Yes, though you look for his place, he isn’t there. 
-</p><p class="q1">
-<span class="v">11&#160;</span>But the humble shall inherit the land, 
-</p><p class="q2">and shall delight themselves in the abundance of peace. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The wicked plots against the just, 
-</p><p class="q2">and gnashes at him with his teeth. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The Lord will laugh at him, 
-</p><p class="q2">for he sees that his day is coming. 
-</p><p class="q1">
-<span class="v">14&#160;</span>The wicked have drawn out the sword, and have bent their bow, 
-</p><p class="q2">to cast down the poor and needy, 
-</p><p class="q2">to kill those who are upright on the path. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Their sword shall enter into their own heart. 
-</p><p class="q2">Their bows shall be broken. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Better is a little that the righteous has, 
-</p><p class="q2">than the abundance of many wicked. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For the arms of the wicked shall be broken, 
-</p><p class="q2">but Yahweh upholds the righteous. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yahweh knows the days of the perfect. 
-</p><p class="q2">Their inheritance shall be forever. 
-</p><p class="q1">
-<span class="v">19&#160;</span>They shall not be disappointed in the time of evil. 
-</p><p class="q2">In the days of famine they shall be satisfied. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">20&#160;</span>But the wicked shall perish. 
-</p><p class="q2">The enemies of Yahweh shall be like the beauty of the fields. 
-</p><p class="q2">They will vanish—</p><p class="q2">vanish like smoke. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The wicked borrow, and don’t pay back, 
-</p><p class="q2">but the righteous give generously. 
-</p><p class="q1">
-<span class="v">22&#160;</span>For such as are blessed by him shall inherit the land. 
-</p><p class="q2">Those who are cursed by him shall be cut off. 
-</p><p class="q1">
-<span class="v">23&#160;</span>A man’s steps are established by Yahweh. 
-</p><p class="q2">He delights in his way. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Though he stumble, he shall not fall, 
-</p><p class="q2">for Yahweh holds him up with his hand. 
-</p><p class="q1">
-<span class="v">25&#160;</span>I have been young, and now am old, 
-</p><p class="q2">yet I have not seen the righteous forsaken, 
-</p><p class="q2">nor his children begging for bread. 
-</p><p class="q1">
-<span class="v">26&#160;</span>All day long he deals graciously, and lends. 
-</p><p class="q2">His offspring is blessed. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Depart from evil, and do good. 
-</p><p class="q2">Live securely forever. 
-</p><p class="q1">
-<span class="v">28&#160;</span>For Yahweh loves justice, 
-</p><p class="q2">and doesn’t forsake his saints. 
-</p><p class="q2">They are preserved forever, 
-</p><p class="q2">but the children of the wicked shall be cut off. 
-</p><p class="q1">
-<span class="v">29&#160;</span>The righteous shall inherit the land, 
-</p><p class="q2">and live in it forever. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">30&#160;</span>The mouth of the righteous talks of wisdom. 
-</p><p class="q2">His tongue speaks justice. 
-</p><p class="q1">
-<span class="v">31&#160;</span>The law of his Elohim is in his heart. 
-</p><p class="q2">None of his steps shall slide. 
-</p><p class="q1">
-<span class="v">32&#160;</span>The wicked watch the righteous, 
-</p><p class="q2">and seek to kill him. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Yahweh will not leave him in his hand, 
-</p><p class="q2">nor condemn him when he is judged. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Wait for Yahweh, and keep his way, 
-</p><p class="q2">and he will exalt you to inherit the land. 
-</p><p class="q2">When the wicked are cut off, you shall see it. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">35&#160;</span>I have seen the wicked in great power, 
-</p><p class="q2">spreading himself like a green tree in its native soil. 
-</p><p class="q1">
-<span class="v">36&#160;</span>But he passed away, and behold, he was not. 
-</p><p class="q2">Yes, I sought him, but he could not be found. 
-</p><p class="q1">
-<span class="v">37&#160;</span>Mark the perfect man, and see the upright, 
-</p><p class="q2">for there is a future for the man of peace. 
-</p><p class="q1">
-<span class="v">38&#160;</span>As for transgressors, they shall be destroyed together. 
-</p><p class="q2">The future of the wicked shall be cut off. 
-</p><p class="q1">
-<span class="v">39&#160;</span>But the salvation of the righteous is from Yahweh. 
-</p><p class="q2">He is their stronghold in the time of trouble. 
-</p><p class="q1">
-<span class="v">40&#160;</span>Yahweh helps them and rescues them. 
-</p><p class="q2">He rescues them from the wicked and saves them, 
-</p><p class="q2">because they have taken refuge in him. 
-</p><h2 class="psalmlabel" id="38">38</h2>
-<p class="d">A Psalm by David, for a memorial. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, don’t rebuke me in your wrath, 
-</p><p class="q2">neither chasten me in your hot displeasure. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For your arrows have pierced me, 
-</p><p class="q2">your hand presses hard on me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>There is no soundness in my flesh because of your indignation, 
-</p><p class="q2">neither is there any health in my bones because of my sin. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For my iniquities have gone over my head. 
-</p><p class="q2">As a heavy burden, they are too heavy for me. 
-</p><p class="q1">
-<span class="v">5&#160;</span>My wounds are loathsome and corrupt 
-</p><p class="q2">because of my foolishness. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I am in pain and bowed down greatly. 
-</p><p class="q2">I go mourning all day long. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For my waist is filled with burning. 
-</p><p class="q2">There is no soundness in my flesh. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I am faint and severely bruised. 
-</p><p class="q2">I have groaned by reason of the anguish of my heart. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Lord, all my desire is before you. 
-</p><p class="q2">My groaning is not hidden from you. 
-</p><p class="q1">
-<span class="v">10&#160;</span>My heart throbs. 
-</p><p class="q2">My strength fails me. 
-</p><p class="q2">As for the light of my eyes, it has also left me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>My lovers and my friends stand aloof from my plague. 
-</p><p class="q2">My kinsmen stand far away. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They also who seek after my life lay snares. 
-</p><p class="q2">Those who seek my hurt speak mischievous things, 
-</p><p class="q2">and meditate deceits all day long. 
-</p><p class="q1">
-<span class="v">13&#160;</span>But I, as a deaf man, don’t hear. 
-</p><p class="q2">I am as a mute man who doesn’t open his mouth. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yes, I am as a man who doesn’t hear, 
-</p><p class="q2">in whose mouth are no reproofs. 
-</p><p class="q1">
-<span class="v">15&#160;</span>For I hope in you, Yahweh. 
-</p><p class="q2">You will answer, Lord my Elohim. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For I said, “Don’t let them gloat over me, 
-</p><p class="q2">or exalt themselves over me when my foot slips.” 
-</p><p class="q1">
-<span class="v">17&#160;</span>For I am ready to fall. 
-</p><p class="q2">My pain is continually before me. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For I will declare my iniquity. 
-</p><p class="q2">I will be sorry for my sin. 
-</p><p class="q1">
-<span class="v">19&#160;</span>But my enemies are vigorous and many. 
-</p><p class="q2">Those who hate me without reason are numerous. 
-</p><p class="q1">
-<span class="v">20&#160;</span>They who render evil for good are also adversaries to me, 
-</p><p class="q2">because I follow what is good. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Don’t forsake me, Yahweh. 
-</p><p class="q2">My Elohim, don’t be far from me. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Hurry to help me, 
-</p><p class="q2">Lord, my salvation. 
-</p><h2 class="psalmlabel" id="39">39</h2>
-<p class="d">For the Chief Musician. For Jeduthun. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I said, “I will watch my ways, so that I don’t sin with my tongue. 
-</p><p class="q2">I will keep my mouth with a bridle while the wicked is before me.” 
-</p><p class="q1">
-<span class="v">2&#160;</span>I was mute with silence. 
-</p><p class="q2">I held my peace, even from good. 
-</p><p class="q2">My sorrow was stirred. 
-</p><p class="q1">
-<span class="v">3&#160;</span>My heart was hot within me. 
-</p><p class="q2">While I meditated, the fire burned. 
-</p><p class="q1">I spoke with my tongue: 
-</p><p class="q2">
-<span class="v">4&#160;</span>“Yahweh, show me my end, 
-</p><p class="q2">what is the measure of my days. 
-</p><p class="q2">Let me know how frail I am. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Behold, you have made my days hand widths. 
-</p><p class="q2">My lifetime is as nothing before you. 
-</p><p class="q1">Surely every man stands as a breath.” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">6&#160;</span>“Surely every man walks like a shadow. 
-</p><p class="q2">Surely they busy themselves in vain. 
-</p><p class="q2">He heaps up, and doesn’t know who shall gather. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Now, Lord, what do I wait for? 
-</p><p class="q2">My hope is in you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Deliver me from all my transgressions. 
-</p><p class="q2">Don’t make me the reproach of the foolish. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I was mute. 
-</p><p class="q2">I didn’t open my mouth, 
-</p><p class="q2">because you did it. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Remove your scourge away from me. 
-</p><p class="q2">I am overcome by the blow of your hand. 
-</p><p class="q1">
-<span class="v">11&#160;</span>When you rebuke and correct man for iniquity, 
-</p><p class="q2">you consume his wealth like a moth. 
-</p><p class="q1">Surely every man is but a breath.” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Hear my prayer, Yahweh, and give ear to my cry. 
-</p><p class="q2">Don’t be silent at my tears. 
-</p><p class="q1">For I am a stranger with you, 
-</p><p class="q2">a foreigner, as all my fathers were. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Oh spare me, that I may recover strength, 
-</p><p class="q2">before I go away and exist no more.” 
-</p><h2 class="psalmlabel" id="40">40</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I waited patiently for Yahweh. 
-</p><p class="q2">He turned to me, and heard my cry. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He brought me up also out of a horrible pit, 
-</p><p class="q2">out of the miry clay. 
-</p><p class="q1">He set my feet on a rock, 
-</p><p class="q2">and gave me a firm place to stand. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He has put a new song in my mouth, even praise to our Elohim. 
-</p><p class="q2">Many shall see it, and fear, and shall trust in Yahweh. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Blessed is the man who makes Yahweh his trust, 
-</p><p class="q2">and doesn’t respect the proud, nor such as turn away to lies. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Many, Yahweh, my Elohim, are the wonderful works which you have done, 
-</p><p class="q2">and your thoughts which are toward us. 
-</p><p class="q1">They can’t be declared back to you. 
-</p><p class="q2">If I would declare and speak of them, they are more than can be counted. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Sacrifice and offering you didn’t desire. 
-</p><p class="q2">You have opened my ears. 
-</p><p class="q2">You have not required burnt offering and sin offering. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Then I said, “Behold, I have come. 
-</p><p class="q2">It is written about me in the book in the scroll. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I delight to do your will, my Elohim. 
-</p><p class="q2">Yes, your law is within my heart.” 
-</p><p class="q1">
-<span class="v">9&#160;</span>I have proclaimed glad news of righteousness in the great assembly. 
-</p><p class="q2">Behold, I will not seal my lips, Yahweh, you know. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I have not hidden your righteousness within my heart. 
-</p><p class="q2">I have declared your faithfulness and your salvation. 
-</p><p class="q2">I have not concealed your loving kindness and your truth from the great assembly. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Don’t withhold your tender mercies from me, Yahweh. 
-</p><p class="q2">Let your loving kindness and your truth continually preserve me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For innumerable evils have surrounded me. 
-</p><p class="q2">My iniquities have overtaken me, so that I am not able to look up. 
-</p><p class="q1">They are more than the hairs of my head. 
-</p><p class="q2">My heart has failed me. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Be pleased, Yahweh, to deliver me. 
-</p><p class="q2">Hurry to help me, Yahweh. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Let them be disappointed and confounded together who seek after my soul to destroy it. 
-</p><p class="q2">Let them be turned backward and brought to dishonor who delight in my hurt. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Let them be desolate by reason of their shame that tell me, “Aha! Aha!” 
-</p><p class="q1">
-<span class="v">16&#160;</span>Let all those who seek you rejoice and be glad in you. 
-</p><p class="q2">Let such as love your salvation say continually, “Let Yahweh be exalted!” 
-</p><p class="q1">
-<span class="v">17&#160;</span>But I am poor and needy. 
-</p><p class="q2">May the Lord think about me. 
-</p><p class="q1">You are my help and my deliverer. 
-</p><p class="q2">Don’t delay, my Elohim. 
-</p><h2 class="psalmlabel" id="41">41</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Blessed is he who considers the poor. 
-</p><p class="q2">Yahweh will deliver him in the day of evil. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh will preserve him, and keep him alive. 
-</p><p class="q2">He shall be blessed on the earth, 
-</p><p class="q2">and he will not surrender him to the will of his enemies. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh will sustain him on his sickbed, 
-</p><p class="q2">and restore him from his bed of illness. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I said, “Yahweh, have mercy on me! 
-</p><p class="q2">Heal me, for I have sinned against you.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>My enemies speak evil against me: 
-</p><p class="q2">“When will he die, and his name perish?” 
-</p><p class="q1">
-<span class="v">6&#160;</span>If he comes to see me, he speaks falsehood. 
-</p><p class="q2">His heart gathers iniquity to itself. 
-</p><p class="q2">When he goes abroad, he tells it. 
-</p><p class="q1">
-<span class="v">7&#160;</span>All who hate me whisper together against me. 
-</p><p class="q2">They imagine the worst for me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>“An evil disease”, they say, “has afflicted him. 
-</p><p class="q2">Now that he lies he shall rise up no more.” 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yes, my own familiar friend, in whom I trusted, 
-</p><p class="q2">who ate bread with me, 
-</p><p class="q2">has lifted up his heel against me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>But you, Yahweh, have mercy on me, and raise me up, 
-</p><p class="q2">that I may repay them. 
-</p><p class="q1">
-<span class="v">11&#160;</span>By this I know that you delight in me, 
-</p><p class="q2">because my enemy doesn’t triumph over me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>As for me, you uphold me in my integrity, 
-</p><p class="q2">and set me in your presence forever. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>Blessed be Yahweh, the Elohim of Israel, 
-</p><p class="q2">from everlasting and to everlasting! 
-</p><p class="q1">Amen and amen. 
+<div class="q1">
+<sup>1&#160;</sup>Blessed is the man who doesn’t walk in the counsel of the wicked, 
+</div><div class="q2">nor stand on the path of sinners, 
+</div><div class="q2">nor sit in the seat of scoffers; 
+</div><div class="q1">
+<sup>2&#160;</sup>but his delight is in Yahweh’s law. 
+</div><div class="q2">On his law he meditates day and night. 
+</div><div class="q1">
+<sup>3&#160;</sup>He will be like a tree planted by the streams of water, 
+</div><div class="q2">that produces its fruit in its season, 
+</div><div class="q2">whose leaf also does not wither. 
+</div><div class="q2">Whatever he does shall prosper. 
+</div><div class="q1">
+<sup>4&#160;</sup>The wicked are not so, 
+</div><div class="q2">but are like the chaff which the wind drives away. 
+</div><div class="q1">
+<sup>5&#160;</sup>Therefore the wicked shall not stand in the judgment, 
+</div><div class="q2">nor sinners in the congregation of the righteous. 
+</div><div class="q1">
+<sup>6&#160;</sup>For Yahweh knows the way of the righteous, 
+</div><div class="q2">but the way of the wicked shall perish. 
+</div><h2 class="psalmlabel" id="2">2</h2>
+<div class="q1">
+<sup>1&#160;</sup>Why do the nations rage, 
+</div><div class="q2">and the peoples plot a vain thing? 
+</div><div class="q1">
+<sup>2&#160;</sup>The kings of the earth take a stand, 
+</div><div class="q2">and the rulers take counsel together, 
+</div><div class="q2">against Yahweh, and against his Anointed, saying, 
+</div><div class="q1">
+<sup>3&#160;</sup>“Let’s break their bonds apart, 
+</div><div class="q2">and cast their cords from us.” 
+</div><div class="q1">
+<sup>4&#160;</sup>He who sits in the heavens will laugh. 
+</div><div class="q2">The Lord will have them in derision. 
+</div><div class="q1">
+<sup>5&#160;</sup>Then he will speak to them in his anger, 
+</div><div class="q2">and terrify them in his wrath: 
+</div><div class="q1">
+<sup>6&#160;</sup>“Yet I have set my King on my set-apart hill of Zion.” 
+</div><div class="q2">
+<sup>7&#160;</sup>I will tell of the decree: 
+</div><div class="q1">Yahweh said to me, “You are my son. 
+</div><div class="q2">Today I have become your father. 
+</div><div class="q1">
+<sup>8&#160;</sup>Ask of me, and I will give the nations for your inheritance, 
+</div><div class="q2">the uttermost parts of the earth for your possession. 
+</div><div class="q1">
+<sup>9&#160;</sup>You shall break them with a rod of iron. 
+</div><div class="q2">You shall dash them in pieces like a potter’s vessel.” 
+</div><div class="q1">
+<sup>10&#160;</sup>Now therefore be wise, you kings. 
+</div><div class="q2">Be instructed, you judges of the earth. 
+</div><div class="q1">
+<sup>11&#160;</sup>Serve Yahweh with fear, 
+</div><div class="q2">and rejoice with trembling. 
+</div><div class="q1">
+<sup>12&#160;</sup>Give sincere homage to the Son, lest he be angry, and you perish on the way, 
+</div><div class="q2">for his wrath will soon be kindled. 
+</div><div class="q2">Blessed are all those who take refuge in him. 
+</div><h2 class="psalmlabel" id="3">3</h2>
+<div class="d">A Psalm by David, when he fled from Absalom his son. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, how my adversaries have increased! 
+</div><div class="q2">Many are those who rise up against me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Many there are who say of my soul, 
+</div><div class="q2">“There is no help for him in Elohim.” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>3&#160;</sup>But you, Yahweh, are a shield around me, 
+</div><div class="q2">my glory, and the one who lifts up my head. 
+</div><div class="q1">
+<sup>4&#160;</sup>I cry to Yahweh with my voice, 
+</div><div class="q2">and he answers me out of his set-apart hill. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>I laid myself down and slept. 
+</div><div class="q2">I awakened, for Yahweh sustains me. 
+</div><div class="q1">
+<sup>6&#160;</sup>I will not be afraid of tens of thousands of people 
+</div><div class="q2">who have set themselves against me on every side. 
+</div><div class="q1">
+<sup>7&#160;</sup>Arise, Yahweh! 
+</div><div class="q2">Save me, my Elohim! 
+</div><div class="q1">For you have struck all of my enemies on the cheek bone. 
+</div><div class="q2">You have broken the teeth of the wicked. 
+</div><div class="q1">
+<sup>8&#160;</sup>Salvation belongs to Yahweh. 
+</div><div class="q2">May your blessing be on your people. </div><div class="qs">Selah. 
+</div><h2 class="psalmlabel" id="4">4</h2>
+<div class="d">For the Chief Musician; on stringed instruments. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Answer me when I call, Elohim of my righteousness. 
+</div><div class="q2">Give me relief from my distress. 
+</div><div class="q2">Have mercy on me, and hear my prayer. 
+</div><div class="q1">
+<sup>2&#160;</sup>You sons of men, how long shall my glory be turned into dishonor? 
+</div><div class="q2">Will you love vanity and seek after falsehood? </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>3&#160;</sup>But know that Yahweh has set apart for himself him who is elohimly; 
+</div><div class="q2">Yahweh will hear when I call to him. 
+</div><div class="q1">
+<sup>4&#160;</sup>Stand in awe, and don’t sin. 
+</div><div class="q2">Search your own heart on your bed, and be still. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>Offer the sacrifices of righteousness. 
+</div><div class="q2">Put your trust in Yahweh. 
+</div><div class="q1">
+<sup>6&#160;</sup>Many say, “Who will show us any good?” 
+</div><div class="q2">Yahweh, let the light of your face shine on us. 
+</div><div class="q1">
+<sup>7&#160;</sup>You have put gladness in my heart, 
+</div><div class="q2">more than when their grain and their new wine are increased. 
+</div><div class="q1">
+<sup>8&#160;</sup>In peace I will both lay myself down and sleep, 
+</div><div class="q2">for you alone, Yahweh, make me live in safety. 
+</div><h2 class="psalmlabel" id="5">5</h2>
+<div class="d">For the Chief Musician, with the flutes. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Give ear to my words, Yahweh. 
+</div><div class="q2">Consider my meditation. 
+</div><div class="q1">
+<sup>2&#160;</sup>Listen to the voice of my cry, my King and my Elohim, 
+</div><div class="q2">for I pray to you. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh, in the morning you will hear my voice. 
+</div><div class="q2">In the morning I will lay my requests before you, and will watch expectantly. 
+</div><div class="q1">
+<sup>4&#160;</sup>For you are not an Elohim who has pleasure in wickedness. 
+</div><div class="q2">Evil can’t live with you. 
+</div><div class="q1">
+<sup>5&#160;</sup>The arrogant will not stand in your sight. 
+</div><div class="q2">You hate all workers of iniquity. 
+</div><div class="q1">
+<sup>6&#160;</sup>You will destroy those who speak lies. 
+</div><div class="q2">Yahweh abhors the bloodthirsty and deceitful man. 
+</div><div class="q1">
+<sup>7&#160;</sup>But as for me, in the abundance of your loving kindness I will come into your house. 
+</div><div class="q2">I will bow toward your set-apart temple in reverence of you. 
+</div><div class="q1">
+<sup>8&#160;</sup>Lead me, Yahweh, in your righteousness because of my enemies. 
+</div><div class="q2">Make your way straight before my face. 
+</div><div class="q1">
+<sup>9&#160;</sup>For there is no faithfulness in their mouth. 
+</div><div class="q2">Their heart is destruction. 
+</div><div class="q2">Their throat is an open tomb. 
+</div><div class="q2">They flatter with their tongue. 
+</div><div class="q1">
+<sup>10&#160;</sup>Hold them guilty, Elohim. 
+</div><div class="q2">Let them fall by their own counsels. 
+</div><div class="q1">Thrust them out in the multitude of their transgressions, 
+</div><div class="q2">for they have rebelled against you. 
+</div><div class="q1">
+<sup>11&#160;</sup>But let all those who take refuge in you rejoice. 
+</div><div class="q2">Let them always shout for joy, because you defend them. 
+</div><div class="q1">Let them also who love your name be joyful in you. 
+</div><div class="q2">
+<sup>12&#160;</sup>For you will bless the righteous. 
+</div><div class="q1">Yahweh, you will surround him with favor as with a shield. 
+</div><h2 class="psalmlabel" id="6">6</h2>
+<div class="d">For the Chief Musician; on stringed instruments, upon the eight-stringed lyre. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, don’t rebuke me in your anger, 
+</div><div class="q2">neither discipline me in your wrath. 
+</div><div class="q1">
+<sup>2&#160;</sup>Have mercy on me, Yahweh, for I am faint. 
+</div><div class="q2">Yahweh, heal me, for my bones are troubled. 
+</div><div class="q1">
+<sup>3&#160;</sup>My soul is also in great anguish. 
+</div><div class="q2">But you, Yahweh—how long? 
+</div><div class="q1">
+<sup>4&#160;</sup>Return, Yahweh. Deliver my soul, 
+</div><div class="q2">and save me for your loving kindness’ sake. 
+</div><div class="q1">
+<sup>5&#160;</sup>For in death there is no memory of you. 
+</div><div class="q2">In Sheol, who shall give you thanks? 
+</div><div class="q1">
+<sup>6&#160;</sup>I am weary with my groaning. 
+</div><div class="q2">Every night I flood my bed. 
+</div><div class="q2">I drench my couch with my tears. 
+</div><div class="q1">
+<sup>7&#160;</sup>My eye wastes away because of grief. 
+</div><div class="q2">It grows old because of all my adversaries. 
+</div><div class="q1">
+<sup>8&#160;</sup>Depart from me, all you workers of iniquity, 
+</div><div class="q2">for Yahweh has heard the voice of my weeping. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yahweh has heard my supplication. 
+</div><div class="q2">Yahweh accepts my prayer. 
+</div><div class="q1">
+<sup>10&#160;</sup>May all my enemies be ashamed and dismayed. 
+</div><div class="q2">They shall turn back, they shall be disgraced suddenly. 
+</div><h2 class="psalmlabel" id="7">7</h2>
+<div class="d">A meditation by David, which he sang to Yahweh, concerning the words of Cush, the Benjamite. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, my Elohim, I take refuge in you. 
+</div><div class="q2">Save me from all those who pursue me, and deliver me, 
+</div><div class="q1">
+<sup>2&#160;</sup>lest they tear apart my soul like a lion, 
+</div><div class="q2">ripping it in pieces, while there is no one to deliver. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh, my Elohim, if I have done this, 
+</div><div class="q2">if there is iniquity in my hands, 
+</div><div class="q1">
+<sup>4&#160;</sup>if I have rewarded evil to him who was at peace with me 
+</div><div class="q2">(yes, I have delivered him who without cause was my adversary), 
+</div><div class="q2">
+<sup>5&#160;</sup>let the enemy pursue my soul, and overtake it; 
+</div><div class="q1">yes, let him tread my life down to the earth, 
+</div><div class="q2">and lay my glory in the dust. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>6&#160;</sup>Arise, Yahweh, in your anger. 
+</div><div class="q2">Lift up yourself against the rage of my adversaries. 
+</div><div class="q1">Awake for me. You have commanded judgment. 
+</div><div class="q2">
+<sup>7&#160;</sup>Let the congregation of the peoples surround you. 
+</div><div class="q2">Rule over them on high. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh administers judgment to the peoples. 
+</div><div class="q2">Judge me, Yahweh, according to my righteousness, 
+</div><div class="q2">and to my integrity that is in me. 
+</div><div class="q1">
+<sup>9&#160;</sup>Oh let the wickedness of the wicked come to an end, 
+</div><div class="q2">but establish the righteous; 
+</div><div class="q2">their minds and hearts are searched by the righteous Elohim. 
+</div><div class="q1">
+<sup>10&#160;</sup>My shield is with Elohim, 
+</div><div class="q2">who saves the upright in heart. 
+</div><div class="q1">
+<sup>11&#160;</sup>Elohim is a righteous judge, 
+</div><div class="q2">yes, an Elohim who has indignation every day. 
+</div><div class="q1">
+<sup>12&#160;</sup>If a man doesn’t repent, he will sharpen his sword; 
+</div><div class="q2">he has bent and strung his bow. 
+</div><div class="q1">
+<sup>13&#160;</sup>He has also prepared for himself the instruments of death. 
+</div><div class="q2">He makes ready his flaming arrows. 
+</div><div class="q1">
+<sup>14&#160;</sup>Behold, he travails with iniquity. 
+</div><div class="q2">Yes, he has conceived mischief, 
+</div><div class="q2">and brought out falsehood. 
+</div><div class="q1">
+<sup>15&#160;</sup>He has dug a hole, 
+</div><div class="q2">and has fallen into the pit which he made. 
+</div><div class="q1">
+<sup>16&#160;</sup>The trouble he causes shall return to his own head. 
+</div><div class="q2">His violence shall come down on the crown of his own head. 
+</div><div class="q1">
+<sup>17&#160;</sup>I will give thanks to Yahweh according to his righteousness, 
+</div><div class="q2">and will sing praise to the name of Yahweh Most High. 
+</div><h2 class="psalmlabel" id="8">8</h2>
+<div class="d">For the Chief Musician; on an instrument of Gath. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, our Lord, how majestic is your name in all the earth! 
+</div><div class="q2">You have set your glory above the heavens! 
+</div><div class="q1">
+<sup>2&#160;</sup>From the lips of babes and infants you have established strength, 
+</div><div class="q2">because of your adversaries, that you might silence the enemy and the avenger. 
+</div><div class="q1">
+<sup>3&#160;</sup>When I consider your heavens, the work of your fingers, 
+</div><div class="q2">the moon and the stars, which you have ordained, 
+</div><div class="q1">
+<sup>4&#160;</sup>what is man, that you think of him? 
+</div><div class="q2">What is the son of man, that you care for him? 
+</div><div class="q1">
+<sup>5&#160;</sup>For you have made him a little lower than the angels, 
+</div><div class="q2">and crowned him with glory and honor. 
+</div><div class="q1">
+<sup>6&#160;</sup>You make him ruler over the works of your hands. 
+</div><div class="q2">You have put all things under his feet: 
+</div><div class="q1">
+<sup>7&#160;</sup>All sheep and cattle, 
+</div><div class="q2">yes, and the animals of the field, 
+</div><div class="q2">
+<sup>8&#160;</sup>the birds of the sky, the fish of the sea, 
+</div><div class="q2">and whatever passes through the paths of the seas. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yahweh, our Lord, 
+</div><div class="q2">how majestic is your name in all the earth! 
+</div><h2 class="psalmlabel" id="9">9</h2>
+<div class="d">For the Chief Musician. Set to “The Death of the Son.” A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will give thanks to Yahweh with my whole heart. 
+</div><div class="q2">I will tell of all your marvelous works. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will be glad and rejoice in you. 
+</div><div class="q2">I will sing praise to your name, O Most High. 
+</div><div class="q1">
+<sup>3&#160;</sup>When my enemies turn back, 
+</div><div class="q2">they stumble and perish in your presence. 
+</div><div class="q1">
+<sup>4&#160;</sup>For you have maintained my just cause. 
+</div><div class="q2">You sit on the throne judging righteously. 
+</div><div class="q1">
+<sup>5&#160;</sup>You have rebuked the nations. 
+</div><div class="q2">You have destroyed the wicked. 
+</div><div class="q2">You have blotted out their name forever and ever. 
+</div><div class="q1">
+<sup>6&#160;</sup>The enemy is overtaken by endless ruin. 
+</div><div class="q2">The very memory of the cities which you have overthrown has perished. 
+</div><div class="q1">
+<sup>7&#160;</sup>But Yahweh reigns forever. 
+</div><div class="q2">He has prepared his throne for judgment. 
+</div><div class="q1">
+<sup>8&#160;</sup>He will judge the world in righteousness. 
+</div><div class="q2">He will administer judgment to the peoples in uprightness. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yahweh will also be a high tower for the oppressed; 
+</div><div class="q2">a high tower in times of trouble. 
+</div><div class="q1">
+<sup>10&#160;</sup>Those who know your name will put their trust in you, 
+</div><div class="q2">for you, Yahweh, have not forsaken those who seek you. 
+</div><div class="q1">
+<sup>11&#160;</sup>Sing praises to Yahweh, who dwells in Zion, 
+</div><div class="q2">and declare among the people what he has done. 
+</div><div class="q1">
+<sup>12&#160;</sup>For he who avenges blood remembers them. 
+</div><div class="q2">He doesn’t forget the cry of the afflicted. 
+</div><div class="q1">
+<sup>13&#160;</sup>Have mercy on me, Yahweh. 
+</div><div class="q2">See my affliction by those who hate me, 
+</div><div class="q1">and lift me up from the gates of death, 
+</div><div class="q2">
+<sup>14&#160;</sup>that I may show all of your praise. 
+</div><div class="q2">I will rejoice in your salvation in the gates of the daughter of Zion. 
+</div><div class="q1">
+<sup>15&#160;</sup>The nations have sunk down in the pit that they made. 
+</div><div class="q2">In the net which they hid, their own foot is taken. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yahweh has made himself known. 
+</div><div class="q2">He has executed judgment. 
+</div><div class="q2">The wicked is snared by the work of his own hands. </div><div class="qs">Meditation. Selah. 
+</div><div class="q1">
+<sup>17&#160;</sup>The wicked shall be turned back to Sheol, 
+</div><div class="q2">even all the nations that forget Elohim. 
+</div><div class="q1">
+<sup>18&#160;</sup>For the needy shall not always be forgotten, 
+</div><div class="q2">nor the hope of the poor perish forever. 
+</div><div class="q1">
+<sup>19&#160;</sup>Arise, Yahweh! Don’t let man prevail. 
+</div><div class="q2">Let the nations be judged in your sight. 
+</div><div class="q1">
+<sup>20&#160;</sup>Put them in fear, Yahweh. 
+</div><div class="q2">Let the nations know that they are only men. </div><div class="qs">Selah. 
+</div><h2 class="psalmlabel" id="10">10</h2>
+<div class="q1">
+<sup>1&#160;</sup>Why do you stand far off, Yahweh? 
+</div><div class="q2">Why do you hide yourself in times of trouble? 
+</div><div class="q1">
+<sup>2&#160;</sup>In arrogance, the wicked hunt down the weak. 
+</div><div class="q2">They are caught in the schemes that they devise. 
+</div><div class="q1">
+<sup>3&#160;</sup>For the wicked boasts of his heart’s cravings. 
+</div><div class="q2">He blesses the greedy and condemns Yahweh. 
+</div><div class="q1">
+<sup>4&#160;</sup>The wicked, in the pride of his face, 
+</div><div class="q2">has no room in his thoughts for Elohim. 
+</div><div class="q1">
+<sup>5&#160;</sup>His ways are prosperous at all times. 
+</div><div class="q2">He is arrogant, and your laws are far from his sight. 
+</div><div class="q1">As for all his adversaries, he sneers at them. 
+</div><div class="q2">
+<sup>6&#160;</sup>He says in his heart, “I shall not be shaken. 
+</div><div class="q2">For generations I shall have no trouble.” 
+</div><div class="q1">
+<sup>7&#160;</sup>His mouth is full of cursing, deceit, and oppression. 
+</div><div class="q2">Under his tongue is mischief and iniquity. 
+</div><div class="q1">
+<sup>8&#160;</sup>He lies in wait near the villages. 
+</div><div class="q2">From ambushes, he murders the innocent. 
+</div><div class="q1">His eyes are secretly set against the helpless. 
+</div><div class="q1">
+<sup>9&#160;</sup>He lurks in secret as a lion in his ambush. 
+</div><div class="q2">He lies in wait to catch the helpless. 
+</div><div class="q2">He catches the helpless when he draws him in his net. 
+</div><div class="q1">
+<sup>10&#160;</sup>The helpless are crushed. 
+</div><div class="q2">They collapse. 
+</div><div class="q2">They fall under his strength. 
+</div><div class="q1">
+<sup>11&#160;</sup>He says in his heart, “Elohim has forgotten. 
+</div><div class="q2">He hides his face. 
+</div><div class="q2">He will never see it.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Arise, Yahweh! 
+</div><div class="q2">Elohim, lift up your hand! 
+</div><div class="q2">Don’t forget the helpless. 
+</div><div class="q1">
+<sup>13&#160;</sup>Why does the wicked person condemn Elohim, 
+</div><div class="q2">and say in his heart, “Elohim won’t call me into account”? 
+</div><div class="q1">
+<sup>14&#160;</sup>But you do see trouble and grief. 
+</div><div class="q2">You consider it to take it into your hand. 
+</div><div class="q2">You help the victim and the fatherless. 
+</div><div class="q1">
+<sup>15&#160;</sup>Break the arm of the wicked. 
+</div><div class="q2">As for the evil man, seek out his wickedness until you find none. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yahweh is King forever and ever! 
+</div><div class="q2">The nations will perish out of his land. 
+</div><div class="q1">
+<sup>17&#160;</sup>Yahweh, you have heard the desire of the humble. 
+</div><div class="q2">You will prepare their heart. 
+</div><div class="q2">You will cause your ear to hear, 
+</div><div class="q2">
+<sup>18&#160;</sup>to judge the fatherless and the oppressed, 
+</div><div class="q2">that man who is of the earth may terrify no more. 
+</div><h2 class="psalmlabel" id="11">11</h2>
+<div class="d">For the Chief Musician. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>In Yahweh, I take refuge. 
+</div><div class="q2">How can you say to my soul, “Flee as a bird to your mountain”? 
+</div><div class="q1">
+<sup>2&#160;</sup>For, behold, the wicked bend their bows. 
+</div><div class="q2">They set their arrows on the strings, 
+</div><div class="q2">that they may shoot in darkness at the upright in heart. 
+</div><div class="q1">
+<sup>3&#160;</sup>If the foundations are destroyed, 
+</div><div class="q2">what can the righteous do? 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh is in his set-apart temple. 
+</div><div class="q2">Yahweh is on his throne in heaven. 
+</div><div class="q1">His eyes observe. 
+</div><div class="q2">His eyes examine the children of men. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh examines the righteous, 
+</div><div class="q2">but his soul hates the wicked and him who loves violence. 
+</div><div class="q1">
+<sup>6&#160;</sup>On the wicked he will rain blazing coals; 
+</div><div class="q2">fire, sulfur, and scorching wind shall be the portion of their cup. 
+</div><div class="q1">
+<sup>7&#160;</sup>For Yahweh is righteous. 
+</div><div class="q2">He loves righteousness. 
+</div><div class="q2">The upright shall see his face. 
+</div><h2 class="psalmlabel" id="12">12</h2>
+<div class="d">For the Chief Musician; upon an eight-stringed lyre. A Psalm of David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Help, Yahweh; for the elohimly man ceases. 
+</div><div class="q2">For the faithful fail from among the children of men. 
+</div><div class="q1">
+<sup>2&#160;</sup>Everyone lies to his neighbor. 
+</div><div class="q2">They speak with flattering lips, and with a double heart. 
+</div><div class="q1">
+<sup>3&#160;</sup>May Yahweh cut off all flattering lips, 
+</div><div class="q2">and the tongue that boasts, 
+</div><div class="q1">
+<sup>4&#160;</sup>who have said, “With our tongue we will prevail. 
+</div><div class="q2">Our lips are our own. 
+</div><div class="q2">Who is lord over us?” 
+</div><div class="q1">
+<sup>5&#160;</sup>“Because of the oppression of the weak and because of the groaning of the needy, 
+</div><div class="q2">I will now arise,” says Yahweh; 
+</div><div class="q1">“I will set him in safety from those who malign him.” 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh’s words are flawless words, 
+</div><div class="q2">as silver refined in a clay furnace, purified seven times. 
+</div><div class="q1">
+<sup>7&#160;</sup>You will keep them, Yahweh. 
+</div><div class="q2">You will preserve them from this generation forever. 
+</div><div class="q1">
+<sup>8&#160;</sup>The wicked walk on every side, 
+</div><div class="q2">when what is vile is exalted among the sons of men. 
+</div><h2 class="psalmlabel" id="13">13</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>How long, Yahweh? 
+</div><div class="q2">Will you forget me forever? 
+</div><div class="q2">How long will you hide your face from me? 
+</div><div class="q1">
+<sup>2&#160;</sup>How long shall I take counsel in my soul, 
+</div><div class="q2">having sorrow in my heart every day? 
+</div><div class="q2">How long shall my enemy triumph over me? 
+</div><div class="q1">
+<sup>3&#160;</sup>Behold, and answer me, Yahweh, my Elohim. 
+</div><div class="q2">Give light to my eyes, lest I sleep in death; 
+</div><div class="q2">
+<sup>4&#160;</sup>lest my enemy say, “I have prevailed against him;” 
+</div><div class="q2">lest my adversaries rejoice when I fall. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>But I trust in your loving kindness. 
+</div><div class="q2">My heart rejoices in your salvation. 
+</div><div class="q1">
+<sup>6&#160;</sup>I will sing to Yahweh, 
+</div><div class="q2">because he has been good to me. 
+</div><h2 class="psalmlabel" id="14">14</h2>
+<div class="d">For the Chief Musician. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>The fool has said in his heart, “There is no Elohim.” 
+</div><div class="q2">They are corrupt. 
+</div><div class="q2">They have done abominable deeds. 
+</div><div class="q2">There is no one who does good. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh looked down from heaven on the children of men, 
+</div><div class="q2">to see if there were any who understood, 
+</div><div class="q2">who sought after Elohim. 
+</div><div class="q1">
+<sup>3&#160;</sup>They have all gone aside. 
+</div><div class="q2">They have together become corrupt. 
+</div><div class="q2">There is no one who does good, no, not one. 
+</div><div class="q1">
+<sup>4&#160;</sup>Have all the workers of iniquity no knowledge, 
+</div><div class="q2">who eat up my people as they eat bread, 
+</div><div class="q2">and don’t call on Yahweh? 
+</div><div class="q1">
+<sup>5&#160;</sup>There they were in great fear, 
+</div><div class="q2">for Elohim is in the generation of the righteous. 
+</div><div class="q1">
+<sup>6&#160;</sup>You frustrate the plan of the poor, 
+</div><div class="q2">because Yahweh is his refuge. 
+</div><div class="q1">
+<sup>7&#160;</sup>Oh that the salvation of Israel would come out of Zion! 
+</div><div class="q2">When Yahweh restores the fortunes of his people, 
+</div><div class="q2">then Jacob shall rejoice, and Israel shall be glad. 
+</div><h2 class="psalmlabel" id="15">15</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, who shall dwell in your sanctuary? 
+</div><div class="q2">Who shall live on your set-apart hill? 
+</div><div class="q1">
+<sup>2&#160;</sup>He who walks blamelessly and does what is right, 
+</div><div class="q2">and speaks truth in his heart; 
+</div><div class="q1">
+<sup>3&#160;</sup>he who doesn’t slander with his tongue, 
+</div><div class="q2">nor does evil to his friend, 
+</div><div class="q2">nor casts slurs against his fellow man; 
+</div><div class="q1">
+<sup>4&#160;</sup>in whose eyes a vile man is despised, 
+</div><div class="q2">but who honors those who fear Yahweh; 
+</div><div class="q2">he who keeps an oath even when it hurts, and doesn’t change; 
+</div><div class="q1">
+<sup>5&#160;</sup>he who doesn’t lend out his money for usury, 
+</div><div class="q2">nor take a bribe against the innocent. 
+</div><div class="b"> &#160; </div>
+<div class="q1">He who does these things shall never be shaken. 
+</div><h2 class="psalmlabel" id="16">16</h2>
+<div class="d">A Poem by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Preserve me, Elohim, for I take refuge in you. 
+</div><div class="q1">
+<sup>2&#160;</sup>My soul, you have said to Yahweh, “You are my Lord. 
+</div><div class="q2">Apart from you I have no good thing.” 
+</div><div class="q1">
+<sup>3&#160;</sup>As for the saints who are in the earth, 
+</div><div class="q2">they are the excellent ones in whom is all my delight. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>Their sorrows shall be multiplied who give gifts to another elohim. 
+</div><div class="q2">Their drink offerings of blood I will not offer, 
+</div><div class="q2">nor take their names on my lips. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh assigned my portion and my cup. 
+</div><div class="q2">You made my lot secure. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>The lines have fallen to me in pleasant places. 
+</div><div class="q2">Yes, I have a good inheritance. 
+</div><div class="q1">
+<sup>7&#160;</sup>I will bless Yahweh, who has given me counsel. 
+</div><div class="q2">Yes, my heart instructs me in the night seasons. 
+</div><div class="q1">
+<sup>8&#160;</sup>I have set Yahweh always before me. 
+</div><div class="q2">Because he is at my right hand, I shall not be moved. 
+</div><div class="q1">
+<sup>9&#160;</sup>Therefore my heart is glad, and my tongue rejoices. 
+</div><div class="q2">My body shall also dwell in safety. 
+</div><div class="q1">
+<sup>10&#160;</sup>For you will not leave my soul in Sheol, 
+</div><div class="q2">neither will you allow your set-apart one to see corruption. 
+</div><div class="q1">
+<sup>11&#160;</sup>You will show me the path of life. 
+</div><div class="q2">In your presence is fullness of joy. 
+</div><div class="q1">In your right hand there are pleasures forever more. 
+</div><h2 class="psalmlabel" id="17">17</h2>
+<div class="d">A Prayer by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear, Yahweh, my righteous plea. 
+</div><div class="q2">Give ear to my prayer that doesn’t go out of deceitful lips. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let my sentence come out of your presence. 
+</div><div class="q2">Let your eyes look on equity. 
+</div><div class="q1">
+<sup>3&#160;</sup>You have proved my heart. 
+</div><div class="q2">You have visited me in the night. 
+</div><div class="q2">You have tried me, and found nothing. 
+</div><div class="q2">I have resolved that my mouth shall not disobey. 
+</div><div class="q1">
+<sup>4&#160;</sup>As for the deeds of men, by the word of your lips, 
+</div><div class="q2">I have kept myself from the ways of the violent. 
+</div><div class="q1">
+<sup>5&#160;</sup>My steps have held fast to your paths. 
+</div><div class="q2">My feet have not slipped. 
+</div><div class="q1">
+<sup>6&#160;</sup>I have called on you, for you will answer me, Elohim. 
+</div><div class="q2">Turn your ear to me. 
+</div><div class="q2">Hear my speech. 
+</div><div class="q1">
+<sup>7&#160;</sup>Show your marvelous loving kindness, 
+</div><div class="q2">you who save those who take refuge by your right hand from their enemies. 
+</div><div class="q1">
+<sup>8&#160;</sup>Keep me as the apple of your eye. 
+</div><div class="q2">Hide me under the shadow of your wings, 
+</div><div class="q1">
+<sup>9&#160;</sup>from the wicked who oppress me, 
+</div><div class="q2">my deadly enemies, who surround me. 
+</div><div class="q1">
+<sup>10&#160;</sup>They close up their callous hearts. 
+</div><div class="q2">With their mouth they speak proudly. 
+</div><div class="q1">
+<sup>11&#160;</sup>They have now surrounded us in our steps. 
+</div><div class="q2">They set their eyes to cast us down to the earth. 
+</div><div class="q1">
+<sup>12&#160;</sup>He is like a lion that is greedy of his prey, 
+</div><div class="q2">as it were a young lion lurking in secret places. 
+</div><div class="q1">
+<sup>13&#160;</sup>Arise, Yahweh, confront him. 
+</div><div class="q2">Cast him down. 
+</div><div class="q1">Deliver my soul from the wicked by your sword, 
+</div><div class="q2">
+<sup>14&#160;</sup>from men by your hand, Yahweh, 
+</div><div class="q2">from men of the world, whose portion is in this life. 
+</div><div class="q1">You fill the belly of your cherished ones. 
+</div><div class="q2">Your sons have plenty, 
+</div><div class="q2">and they store up wealth for their children. 
+</div><div class="q1">
+<sup>15&#160;</sup>As for me, I shall see your face in righteousness. 
+</div><div class="q2">I shall be satisfied, when I awake, with seeing your form. 
+</div><h2 class="psalmlabel" id="18">18</h2>
+<div class="d">For the Chief Musician. By David the servant of Yahweh, who spoke to Yahweh the words of this song in the day that Yahweh delivered him from the hand of all his enemies, and from the hand of Saul. He said, 
+</div><div class="q1">
+<sup>1&#160;</sup>I love you, Yahweh, my strength. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh is my rock, my fortress, and my deliverer; 
+</div><div class="q2">my Elohim, my rock, in whom I take refuge; 
+</div><div class="q2">my shield, and the horn of my salvation, my high tower. 
+</div><div class="q1">
+<sup>3&#160;</sup>I call on Yahweh, who is worthy to be praised; 
+</div><div class="q2">and I am saved from my enemies. 
+</div><div class="q1">
+<sup>4&#160;</sup>The cords of death surrounded me. 
+</div><div class="q2">The floods of unelohimliness made me afraid. 
+</div><div class="q1">
+<sup>5&#160;</sup>The cords of Sheol were around me. 
+</div><div class="q2">The snares of death came on me. 
+</div><div class="q1">
+<sup>6&#160;</sup>In my distress I called on Yahweh, 
+</div><div class="q2">and cried to my Elohim. 
+</div><div class="q1">He heard my voice out of his temple. 
+</div><div class="q2">My cry before him came into his ears. 
+</div><div class="q1">
+<sup>7&#160;</sup>Then the earth shook and trembled. 
+</div><div class="q2">The foundations also of the mountains quaked and were shaken, 
+</div><div class="q2">because he was angry. 
+</div><div class="q1">
+<sup>8&#160;</sup>Smoke went out of his nostrils. 
+</div><div class="q2">Consuming fire came out of his mouth. 
+</div><div class="q2">Coals were kindled by it. 
+</div><div class="q1">
+<sup>9&#160;</sup>He bowed the heavens also, and came down. 
+</div><div class="q2">Thick darkness was under his feet. 
+</div><div class="q1">
+<sup>10&#160;</sup>He rode on a cherub, and flew. 
+</div><div class="q2">Yes, he soared on the wings of the wind. 
+</div><div class="q1">
+<sup>11&#160;</sup>He made darkness his hiding place, his pavilion around him, 
+</div><div class="q2">darkness of waters, thick clouds of the skies. 
+</div><div class="q1">
+<sup>12&#160;</sup>At the brightness before him his thick clouds passed, 
+</div><div class="q2">hailstones and coals of fire. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yahweh also thundered in the sky. 
+</div><div class="q2">The Most High uttered his voice: 
+</div><div class="q2">hailstones and coals of fire. 
+</div><div class="q1">
+<sup>14&#160;</sup>He sent out his arrows, and scattered them. 
+</div><div class="q2">He routed them with great lightning bolts. 
+</div><div class="q1">
+<sup>15&#160;</sup>Then the channels of waters appeared. 
+</div><div class="q2">The foundations of the world were laid bare at your rebuke, Yahweh, 
+</div><div class="q2">at the blast of the breath of your nostrils. 
+</div><div class="q1">
+<sup>16&#160;</sup>He sent from on high. 
+</div><div class="q2">He took me. 
+</div><div class="q2">He drew me out of many waters. 
+</div><div class="q1">
+<sup>17&#160;</sup>He delivered me from my strong enemy, 
+</div><div class="q2">from those who hated me; for they were too mighty for me. 
+</div><div class="q1">
+<sup>18&#160;</sup>They came on me in the day of my calamity, 
+</div><div class="q2">but Yahweh was my support. 
+</div><div class="q1">
+<sup>19&#160;</sup>He brought me out also into a large place. 
+</div><div class="q2">He delivered me, because he delighted in me. 
+</div><div class="q1">
+<sup>20&#160;</sup>Yahweh has rewarded me according to my righteousness. 
+</div><div class="q2">According to the cleanness of my hands, he has recompensed me. 
+</div><div class="q1">
+<sup>21&#160;</sup>For I have kept the ways of Yahweh, 
+</div><div class="q2">and have not wickedly departed from my Elohim. 
+</div><div class="q1">
+<sup>22&#160;</sup>For all his ordinances were before me. 
+</div><div class="q2">I didn’t put away his statutes from me. 
+</div><div class="q1">
+<sup>23&#160;</sup>I was also blameless with him. 
+</div><div class="q2">I kept myself from my iniquity. 
+</div><div class="q1">
+<sup>24&#160;</sup>Therefore Yahweh has rewarded me according to my righteousness, 
+</div><div class="q2">according to the cleanness of my hands in his eyesight. 
+</div><div class="q1">
+<sup>25&#160;</sup>With the merciful you will show yourself merciful. 
+</div><div class="q2">With the perfect man, you will show yourself perfect. 
+</div><div class="q1">
+<sup>26&#160;</sup>With the pure, you will show yourself pure. 
+</div><div class="q2">With the crooked you will show yourself shrewd. 
+</div><div class="q1">
+<sup>27&#160;</sup>For you will save the afflicted people, 
+</div><div class="q2">but the arrogant eyes you will bring down. 
+</div><div class="q1">
+<sup>28&#160;</sup>For you will light my lamp, Yahweh. 
+</div><div class="q2">My Elohim will light up my darkness. 
+</div><div class="q1">
+<sup>29&#160;</sup>For by you, I advance through a troop. 
+</div><div class="q2">By my Elohim, I leap over a wall. 
+</div><div class="q1">
+<sup>30&#160;</sup>As for Elohim, his way is perfect. 
+</div><div class="q2">Yahweh’s word is tried. 
+</div><div class="q2">He is a shield to all those who take refuge in him. 
+</div><div class="q1">
+<sup>31&#160;</sup>For who is Elohim, except Yahweh? 
+</div><div class="q2">Who is a rock, besides our Elohim, 
+</div><div class="q2">
+<sup>32&#160;</sup>the Elohim who arms me with strength, and makes my way perfect? 
+</div><div class="q1">
+<sup>33&#160;</sup>He makes my feet like deer’s feet, 
+</div><div class="q2">and sets me on my high places. 
+</div><div class="q1">
+<sup>34&#160;</sup>He teaches my hands to war, 
+</div><div class="q2">so that my arms bend a bow of bronze. 
+</div><div class="q1">
+<sup>35&#160;</sup>You have also given me the shield of your salvation. 
+</div><div class="q2">Your right hand sustains me. 
+</div><div class="q2">Your gentleness has made me great. 
+</div><div class="q1">
+<sup>36&#160;</sup>You have enlarged my steps under me, 
+</div><div class="q2">My feet have not slipped. 
+</div><div class="q1">
+<sup>37&#160;</sup>I will pursue my enemies, and overtake them. 
+</div><div class="q2">I won’t turn away until they are consumed. 
+</div><div class="q1">
+<sup>38&#160;</sup>I will strike them through, so that they will not be able to rise. 
+</div><div class="q2">They shall fall under my feet. 
+</div><div class="q1">
+<sup>39&#160;</sup>For you have armed me with strength to the battle. 
+</div><div class="q2">You have subdued under me those who rose up against me. 
+</div><div class="q1">
+<sup>40&#160;</sup>You have also made my enemies turn their backs to me, 
+</div><div class="q2">that I might cut off those who hate me. 
+</div><div class="q1">
+<sup>41&#160;</sup>They cried, but there was no one to save; 
+</div><div class="q2">even to Yahweh, but he didn’t answer them. 
+</div><div class="q1">
+<sup>42&#160;</sup>Then I beat them small as the dust before the wind. 
+</div><div class="q2">I cast them out as the mire of the streets. 
+</div><div class="q1">
+<sup>43&#160;</sup>You have delivered me from the strivings of the people. 
+</div><div class="q2">You have made me the head of the nations. 
+</div><div class="q1">A people whom I have not known shall serve me. 
+</div><div class="q2">
+<sup>44&#160;</sup>As soon as they hear of me they shall obey me. 
+</div><div class="q2">The foreigners shall submit themselves to me. 
+</div><div class="q1">
+<sup>45&#160;</sup>The foreigners shall fade away, 
+</div><div class="q2">and shall come trembling out of their strongholds. 
+</div><div class="q1">
+<sup>46&#160;</sup>Yahweh lives! Blessed be my rock. 
+</div><div class="q2">Exalted be the Elohim of my salvation, 
+</div><div class="q1">
+<sup>47&#160;</sup>even the Elohim who executes vengeance for me, 
+</div><div class="q2">and subdues peoples under me. 
+</div><div class="q1">
+<sup>48&#160;</sup>He rescues me from my enemies. 
+</div><div class="q2">Yes, you lift me up above those who rise up against me. 
+</div><div class="q2">You deliver me from the violent man. 
+</div><div class="q1">
+<sup>49&#160;</sup>Therefore I will give thanks to you, Yahweh, among the nations, 
+</div><div class="q2">and will sing praises to your name. 
+</div><div class="q1">
+<sup>50&#160;</sup>He gives great deliverance to his king, 
+</div><div class="q2">and shows loving kindness to his anointed, 
+</div><div class="q2">to David and to his offspring, forever more. 
+</div><h2 class="psalmlabel" id="19">19</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>The heavens declare the glory of Elohim. 
+</div><div class="q2">The expanse shows his handiwork. 
+</div><div class="q1">
+<sup>2&#160;</sup>Day after day they pour out speech, 
+</div><div class="q2">and night after night they display knowledge. 
+</div><div class="q1">
+<sup>3&#160;</sup>There is no speech nor language 
+</div><div class="q2">where their voice is not heard. 
+</div><div class="q1">
+<sup>4&#160;</sup>Their voice has gone out through all the earth, 
+</div><div class="q2">their words to the end of the world. 
+</div><div class="q1">In them he has set a tent for the sun, 
+</div><div class="q2">
+<sup>5&#160;</sup>which is as a bridegroom coming out of his room, 
+</div><div class="q2">like a strong man rejoicing to run his course. 
+</div><div class="q1">
+<sup>6&#160;</sup>His going out is from the end of the heavens, 
+</div><div class="q2">his circuit to its ends. 
+</div><div class="q2">There is nothing hidden from its heat. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Yahweh’s law is perfect, restoring the soul. 
+</div><div class="q2">Yahweh’s covenant is sure, making wise the simple. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh’s precepts are right, rejoicing the heart. 
+</div><div class="q2">Yahweh’s commandment is pure, enlightening the eyes. 
+</div><div class="q1">
+<sup>9&#160;</sup>The fear of Yahweh is clean, enduring forever. 
+</div><div class="q2">Yahweh’s ordinances are true, and righteous altogether. 
+</div><div class="q1">
+<sup>10&#160;</sup>They are more to be desired than gold, yes, than much fine gold, 
+</div><div class="q2">sweeter also than honey and the extract of the honeycomb. 
+</div><div class="q1">
+<sup>11&#160;</sup>Moreover your servant is warned by them. 
+</div><div class="q2">In keeping them there is great reward. 
+</div><div class="q1">
+<sup>12&#160;</sup>Who can discern his errors? 
+</div><div class="q2">Forgive me from hidden errors. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Keep back your servant also from presumptuous sins. 
+</div><div class="q2">Let them not have dominion over me. 
+</div><div class="q1">Then I will be upright. 
+</div><div class="q2">I will be blameless and innocent of great transgression. 
+</div><div class="q1">
+<sup>14&#160;</sup>Let the words of my mouth and the meditation of my heart 
+</div><div class="q2">be acceptable in your sight, 
+</div><div class="q2">Yahweh, my rock, and my redeemer. 
+</div><h2 class="psalmlabel" id="20">20</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>May Yahweh answer you in the day of trouble. 
+</div><div class="q2">May the name of the Elohim of Jacob set you up on high, 
+</div><div class="q2">
+<sup>2&#160;</sup>send you help from the sanctuary, 
+</div><div class="q2">grant you support from Zion, 
+</div><div class="q2">
+<sup>3&#160;</sup>remember all your offerings, 
+</div><div class="q2">and accept your burned sacrifice. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>May he grant you your heart’s desire, 
+</div><div class="q2">and fulfill all your counsel. 
+</div><div class="q1">
+<sup>5&#160;</sup>We will triumph in your salvation. 
+</div><div class="q2">In the name of our Elohim, we will set up our banners. 
+</div><div class="q2">May Yahweh grant all your requests. 
+</div><div class="q1">
+<sup>6&#160;</sup>Now I know that Yahweh saves his anointed. 
+</div><div class="q2">He will answer him from his set-apart heaven, 
+</div><div class="q2">with the saving strength of his right hand. 
+</div><div class="q1">
+<sup>7&#160;</sup>Some trust in chariots, and some in horses, 
+</div><div class="q2">but we trust in the name of Yahweh our Elohim. 
+</div><div class="q1">
+<sup>8&#160;</sup>They are bowed down and fallen, 
+</div><div class="q2">but we rise up, and stand upright. 
+</div><div class="q1">
+<sup>9&#160;</sup>Save, Yahweh! 
+</div><div class="q2">Let the King answer us when we call! 
+</div><h2 class="psalmlabel" id="21">21</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>The king rejoices in your strength, Yahweh! 
+</div><div class="q2">How greatly he rejoices in your salvation! 
+</div><div class="q1">
+<sup>2&#160;</sup>You have given him his heart’s desire, 
+</div><div class="q2">and have not withheld the request of his lips. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>3&#160;</sup>For you meet him with the blessings of goodness. 
+</div><div class="q2">You set a crown of fine gold on his head. 
+</div><div class="q1">
+<sup>4&#160;</sup>He asked life of you and you gave it to him, 
+</div><div class="q2">even length of days forever and ever. 
+</div><div class="q1">
+<sup>5&#160;</sup>His glory is great in your salvation. 
+</div><div class="q2">You lay honor and majesty on him. 
+</div><div class="q1">
+<sup>6&#160;</sup>For you make him most blessed forever. 
+</div><div class="q2">You make him glad with joy in your presence. 
+</div><div class="q1">
+<sup>7&#160;</sup>For the king trusts in Yahweh. 
+</div><div class="q2">Through the loving kindness of the Most High, he shall not be moved. 
+</div><div class="q1">
+<sup>8&#160;</sup>Your hand will find out all of your enemies. 
+</div><div class="q2">Your right hand will find out those who hate you. 
+</div><div class="q1">
+<sup>9&#160;</sup>You will make them as a fiery furnace in the time of your anger. 
+</div><div class="q2">Yahweh will swallow them up in his wrath. 
+</div><div class="q2">The fire shall devour them. 
+</div><div class="q1">
+<sup>10&#160;</sup>You will destroy their descendants from the earth, 
+</div><div class="q2">their posterity from among the children of men. 
+</div><div class="q1">
+<sup>11&#160;</sup>For they intended evil against you. 
+</div><div class="q2">They plotted evil against you which cannot succeed. 
+</div><div class="q1">
+<sup>12&#160;</sup>For you will make them turn their back, 
+</div><div class="q2">when you aim drawn bows at their face. 
+</div><div class="q1">
+<sup>13&#160;</sup>Be exalted, Yahweh, in your strength, 
+</div><div class="q2">so we will sing and praise your power. 
+</div><h2 class="psalmlabel" id="22">22</h2>
+<div class="d">For the Chief Musician; set to “The Doe of the Morning.” A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>My Elohim, my Elohim, why have you forsaken me? 
+</div><div class="q2">Why are you so far from helping me, and from the words of my groaning? 
+</div><div class="q1">
+<sup>2&#160;</sup>My Elohim, I cry in the daytime, but you don’t answer; 
+</div><div class="q2">in the night season, and am not silent. 
+</div><div class="q1">
+<sup>3&#160;</sup>But you are set-apart, 
+</div><div class="q2">you who inhabit the praises of Israel. 
+</div><div class="q1">
+<sup>4&#160;</sup>Our fathers trusted in you. 
+</div><div class="q2">They trusted, and you delivered them. 
+</div><div class="q1">
+<sup>5&#160;</sup>They cried to you, and were delivered. 
+</div><div class="q2">They trusted in you, and were not disappointed. 
+</div><div class="q1">
+<sup>6&#160;</sup>But I am a worm, and no man; 
+</div><div class="q2">a reproach of men, and despised by the people. 
+</div><div class="q1">
+<sup>7&#160;</sup>All those who see me mock me. 
+</div><div class="q2">They insult me with their lips. They shake their heads, saying, 
+</div><div class="q2">
+<sup>8&#160;</sup>“He trusts in Yahweh. 
+</div><div class="q2">Let him deliver him. 
+</div><div class="q2">Let him rescue him, since he delights in him.” 
+</div><div class="q1">
+<sup>9&#160;</sup>But you brought me out of the womb. 
+</div><div class="q2">You made me trust while at my mother’s breasts. 
+</div><div class="q1">
+<sup>10&#160;</sup>I was thrown on you from my mother’s womb. 
+</div><div class="q2">You are my Elohim since my mother bore me. 
+</div><div class="q1">
+<sup>11&#160;</sup>Don’t be far from me, for trouble is near. 
+</div><div class="q2">For there is no one to help. 
+</div><div class="q1">
+<sup>12&#160;</sup>Many bulls have surrounded me. 
+</div><div class="q2">Strong bulls of Bashan have encircled me. 
+</div><div class="q1">
+<sup>13&#160;</sup>They open their mouths wide against me, 
+</div><div class="q2">lions tearing prey and roaring. 
+</div><div class="q1">
+<sup>14&#160;</sup>I am poured out like water. 
+</div><div class="q2">All my bones are out of joint. 
+</div><div class="q1">My heart is like wax. 
+</div><div class="q2">It is melted within me. 
+</div><div class="q1">
+<sup>15&#160;</sup>My strength is dried up like a potsherd. 
+</div><div class="q2">My tongue sticks to the roof of my mouth. 
+</div><div class="q1">You have brought me into the dust of death. 
+</div><div class="q1">
+<sup>16&#160;</sup>For dogs have surrounded me. 
+</div><div class="q2">A company of evildoers have enclosed me. 
+</div><div class="q2">They have pierced my hands and feet. 
+</div><div class="q1">
+<sup>17&#160;</sup>I can count all of my bones. 
+</div><div class="q1">They look and stare at me. 
+</div><div class="q1">
+<sup>18&#160;</sup>They divide my garments among them. 
+</div><div class="q2">They cast lots for my clothing. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>But don’t be far off, Yahweh. 
+</div><div class="q2">You are my help. Hurry to help me! 
+</div><div class="q1">
+<sup>20&#160;</sup>Deliver my soul from the sword, 
+</div><div class="q2">my precious life from the power of the dog. 
+</div><div class="q1">
+<sup>21&#160;</sup>Save me from the lion’s mouth! 
+</div><div class="q2">Yes, you have rescued me from the horns of the wild oxen. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>I will declare your name to my brothers. 
+</div><div class="q2">Among the assembly, I will praise you. 
+</div><div class="q1">
+<sup>23&#160;</sup>You who fear Yahweh, praise him! 
+</div><div class="q2">All you descendants of Jacob, glorify him! 
+</div><div class="q2">Stand in awe of him, all you descendants of Israel! 
+</div><div class="q1">
+<sup>24&#160;</sup>For he has not despised nor abhorred the affliction of the afflicted, 
+</div><div class="q2">neither has he hidden his face from him; 
+</div><div class="q2">but when he cried to him, he heard. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>25&#160;</sup>My praise of you comes in the great assembly. 
+</div><div class="q2">I will pay my vows before those who fear him. 
+</div><div class="q1">
+<sup>26&#160;</sup>The humble shall eat and be satisfied. 
+</div><div class="q2">They shall praise Yahweh who seek after him. 
+</div><div class="q2">Let your hearts live forever. 
+</div><div class="q1">
+<sup>27&#160;</sup>All the ends of the earth shall remember and turn to Yahweh. 
+</div><div class="q2">All the relatives of the nations shall worship before you. 
+</div><div class="q1">
+<sup>28&#160;</sup>For the kingdom is Yahweh’s. 
+</div><div class="q2">He is the ruler over the nations. 
+</div><div class="q1">
+<sup>29&#160;</sup>All the rich ones of the earth shall eat and worship. 
+</div><div class="q2">All those who go down to the dust shall bow before him, 
+</div><div class="q2">even he who can’t keep his soul alive. 
+</div><div class="q1">
+<sup>30&#160;</sup>Posterity shall serve him. 
+</div><div class="q2">Future generations shall be told about the Lord. 
+</div><div class="q1">
+<sup>31&#160;</sup>They shall come and shall declare his righteousness to a people that shall be born, 
+</div><div class="q2">for he has done it. 
+</div><h2 class="psalmlabel" id="23">23</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh is my shepherd; 
+</div><div class="q2">I shall lack nothing. 
+</div><div class="q1">
+<sup>2&#160;</sup>He makes me lie down in green pastures. 
+</div><div class="q2">He leads me beside still waters. 
+</div><div class="q1">
+<sup>3&#160;</sup>He restores my soul. 
+</div><div class="q2">He guides me in the paths of righteousness for his name’s sake. 
+</div><div class="q1">
+<sup>4&#160;</sup>Even though I walk through the valley of the shadow of death, 
+</div><div class="q2">I will fear no evil, for you are with me. 
+</div><div class="q1">Your rod and your staff, 
+</div><div class="q2">they comfort me. 
+</div><div class="q1">
+<sup>5&#160;</sup>You prepare a table before me 
+</div><div class="q2">in the presence of my enemies. 
+</div><div class="q1">You anoint my head with oil. 
+</div><div class="q2">My cup runs over. 
+</div><div class="q1">
+<sup>6&#160;</sup>Surely goodness and loving kindness shall follow me all the days of my life, 
+</div><div class="q2">and I will dwell in Yahweh’s house forever. 
+</div><h2 class="psalmlabel" id="24">24</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>The earth is Yahweh’s, with its fullness; 
+</div><div class="q2">the world, and those who dwell in it. 
+</div><div class="q1">
+<sup>2&#160;</sup>For he has founded it on the seas, 
+</div><div class="q2">and established it on the floods. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>Who may ascend to Yahweh’s hill? 
+</div><div class="q2">Who may stand in his set-apart place? 
+</div><div class="q1">
+<sup>4&#160;</sup>He who has clean hands and a pure heart; 
+</div><div class="q2">who has not lifted up his soul to falsehood, 
+</div><div class="q2">and has not sworn deceitfully. 
+</div><div class="q1">
+<sup>5&#160;</sup>He shall receive a blessing from Yahweh, 
+</div><div class="q2">righteousness from the Elohim of his salvation. 
+</div><div class="q1">
+<sup>6&#160;</sup>This is the generation of those who seek Him, 
+</div><div class="q2">who seek your face—even Jacob. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Lift up your heads, you gates! 
+</div><div class="q2">Be lifted up, you everlasting doors, 
+</div><div class="q2">and the King of glory will come in. 
+</div><div class="q1">
+<sup>8&#160;</sup>Who is the King of glory? 
+</div><div class="q2">Yahweh strong and mighty, 
+</div><div class="q2">Yahweh mighty in battle. 
+</div><div class="q1">
+<sup>9&#160;</sup>Lift up your heads, you gates; 
+</div><div class="q2">yes, lift them up, you everlasting doors, 
+</div><div class="q2">and the King of glory will come in. 
+</div><div class="q1">
+<sup>10&#160;</sup>Who is this King of glory? 
+</div><div class="q2">Yahweh of Armies is the King of glory! </div><div class="qs">Selah. 
+</div><h2 class="psalmlabel" id="25">25</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>To you, Yahweh, I lift up my soul. 
+</div><div class="q1">
+<sup>2&#160;</sup>My Elohim, I have trusted in you. 
+</div><div class="q2">Don’t let me be shamed. 
+</div><div class="q2">Don’t let my enemies triumph over me. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yes, no one who waits for you will be shamed. 
+</div><div class="q2">They will be shamed who deal treacherously without cause. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>Show me your ways, Yahweh. 
+</div><div class="q2">Teach me your paths. 
+</div><div class="q1">
+<sup>5&#160;</sup>Guide me in your truth, and teach me, 
+</div><div class="q2">for you are the Elohim of my salvation. 
+</div><div class="q2">I wait for you all day long. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh, remember your tender mercies and your loving kindness, 
+</div><div class="q2">for they are from old times. 
+</div><div class="q1">
+<sup>7&#160;</sup>Don’t remember the sins of my youth, nor my transgressions. 
+</div><div class="q2">Remember me according to your loving kindness, 
+</div><div class="q2">for your goodness’ sake, Yahweh. 
+</div><div class="q1">
+<sup>8&#160;</sup>Good and upright is Yahweh, 
+</div><div class="q2">therefore he will instruct sinners in the way. 
+</div><div class="q1">
+<sup>9&#160;</sup>He will guide the humble in justice. 
+</div><div class="q2">He will teach the humble his way. 
+</div><div class="q1">
+<sup>10&#160;</sup>All the paths of Yahweh are loving kindness and truth 
+</div><div class="q2">to such as keep his covenant and his testimonies. 
+</div><div class="q1">
+<sup>11&#160;</sup>For your name’s sake, Yahweh, 
+</div><div class="q2">pardon my iniquity, for it is great. 
+</div><div class="q1">
+<sup>12&#160;</sup>What man is he who fears Yahweh? 
+</div><div class="q2">He shall instruct him in the way that he shall choose. 
+</div><div class="q1">
+<sup>13&#160;</sup>His soul will dwell at ease. 
+</div><div class="q2">His offspring will inherit the land. 
+</div><div class="q1">
+<sup>14&#160;</sup>The friendship of Yahweh is with those who fear him. 
+</div><div class="q2">He will show them his covenant. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>My eyes are ever on Yahweh, 
+</div><div class="q2">for he will pluck my feet out of the net. 
+</div><div class="q1">
+<sup>16&#160;</sup>Turn to me, and have mercy on me, 
+</div><div class="q2">for I am desolate and afflicted. 
+</div><div class="q1">
+<sup>17&#160;</sup>The troubles of my heart are enlarged. 
+</div><div class="q2">Oh bring me out of my distresses. 
+</div><div class="q1">
+<sup>18&#160;</sup>Consider my affliction and my travail. 
+</div><div class="q2">Forgive all my sins. 
+</div><div class="q1">
+<sup>19&#160;</sup>Consider my enemies, for they are many. 
+</div><div class="q2">They hate me with cruel hatred. 
+</div><div class="q1">
+<sup>20&#160;</sup>Oh keep my soul, and deliver me. 
+</div><div class="q2">Let me not be disappointed, for I take refuge in you. 
+</div><div class="q1">
+<sup>21&#160;</sup>Let integrity and uprightness preserve me, 
+</div><div class="q2">for I wait for you. 
+</div><div class="q1">
+<sup>22&#160;</sup>Elohim, redeem Israel 
+</div><div class="q2">out of all his troubles. 
+</div><h2 class="psalmlabel" id="26">26</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Judge me, Yahweh, for I have walked in my integrity. 
+</div><div class="q2">I have trusted also in Yahweh without wavering. 
+</div><div class="q1">
+<sup>2&#160;</sup>Examine me, Yahweh, and prove me. 
+</div><div class="q2">Try my heart and my mind. 
+</div><div class="q1">
+<sup>3&#160;</sup>For your loving kindness is before my eyes. 
+</div><div class="q2">I have walked in your truth. 
+</div><div class="q1">
+<sup>4&#160;</sup>I have not sat with deceitful men, 
+</div><div class="q2">neither will I go in with hypocrites. 
+</div><div class="q1">
+<sup>5&#160;</sup>I hate the assembly of evildoers, 
+</div><div class="q2">and will not sit with the wicked. 
+</div><div class="q1">
+<sup>6&#160;</sup>I will wash my hands in innocence, 
+</div><div class="q2">so I will go about your altar, Yahweh, 
+</div><div class="q2">
+<sup>7&#160;</sup>that I may make the voice of thanksgiving to be heard 
+</div><div class="q2">and tell of all your wondrous deeds. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh, I love the habitation of your house, 
+</div><div class="q2">the place where your glory dwells. 
+</div><div class="q1">
+<sup>9&#160;</sup>Don’t gather my soul with sinners, 
+</div><div class="q2">nor my life with bloodthirsty men 
+</div><div class="q2">
+<sup>10&#160;</sup>in whose hands is wickedness; 
+</div><div class="q2">their right hand is full of bribes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>But as for me, I will walk in my integrity. 
+</div><div class="q2">Redeem me, and be merciful to me. 
+</div><div class="q1">
+<sup>12&#160;</sup>My foot stands in an even place. 
+</div><div class="q2">In the congregations I will bless Yahweh. 
+</div><h2 class="psalmlabel" id="27">27</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh is my light and my salvation. 
+</div><div class="q2">Whom shall I fear? 
+</div><div class="q1">Yahweh is the strength of my life. 
+</div><div class="q2">Of whom shall I be afraid? 
+</div><div class="q1">
+<sup>2&#160;</sup>When evildoers came at me to eat up my flesh, 
+</div><div class="q2">even my adversaries and my foes, they stumbled and fell. 
+</div><div class="q1">
+<sup>3&#160;</sup>Though an army should encamp against me, 
+</div><div class="q2">my heart shall not fear. 
+</div><div class="q1">Though war should rise against me, 
+</div><div class="q2">even then I will be confident. 
+</div><div class="q1">
+<sup>4&#160;</sup>One thing I have asked of Yahweh, that I will seek after: 
+</div><div class="q2">that I may dwell in Yahweh’s house all the days of my life, 
+</div><div class="q2">to see Yahweh’s beauty, 
+</div><div class="q2">and to inquire in his temple. 
+</div><div class="q1">
+<sup>5&#160;</sup>For in the day of trouble, he will keep me secretly in his pavilion. 
+</div><div class="q2">In the secret place of his tabernacle, he will hide me. 
+</div><div class="q2">He will lift me up on a rock. 
+</div><div class="q1">
+<sup>6&#160;</sup>Now my head will be lifted up above my enemies around me. 
+</div><div class="q1">I will offer sacrifices of joy in his tent. 
+</div><div class="q2">I will sing, yes, I will sing praises to Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Hear, Yahweh, when I cry with my voice. 
+</div><div class="q2">Have mercy also on me, and answer me. 
+</div><div class="q1">
+<sup>8&#160;</sup>When you said, “Seek my face,” 
+</div><div class="q2">my heart said to you, “I will seek your face, Yahweh.” 
+</div><div class="q1">
+<sup>9&#160;</sup>Don’t hide your face from me. 
+</div><div class="q2">Don’t put your servant away in anger. 
+</div><div class="q1">You have been my help. 
+</div><div class="q2">Don’t abandon me, 
+</div><div class="q2">neither forsake me, Elohim of my salvation. 
+</div><div class="q1">
+<sup>10&#160;</sup>When my father and my mother forsake me, 
+</div><div class="q2">then Yahweh will take me up. 
+</div><div class="q1">
+<sup>11&#160;</sup>Teach me your way, Yahweh. 
+</div><div class="q2">Lead me in a straight path, because of my enemies. 
+</div><div class="q1">
+<sup>12&#160;</sup>Don’t deliver me over to the desire of my adversaries, 
+</div><div class="q2">for false witnesses have risen up against me, 
+</div><div class="q2">such as breathe out cruelty. 
+</div><div class="q1">
+<sup>13&#160;</sup>I am still confident of this: 
+</div><div class="q2">I will see the goodness of Yahweh in the land of the living. 
+</div><div class="q1">
+<sup>14&#160;</sup>Wait for Yahweh. 
+</div><div class="q2">Be strong, and let your heart take courage. 
+</div><div class="q1">Yes, wait for Yahweh. 
+</div><h2 class="psalmlabel" id="28">28</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>To you, Yahweh, I call. 
+</div><div class="q2">My rock, don’t be deaf to me, 
+</div><div class="q2">lest, if you are silent to me, 
+</div><div class="q2">I would become like those who go down into the pit. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear the voice of my petitions, when I cry to you, 
+</div><div class="q2">when I lift up my hands toward your Most Set-Apart Place. 
+</div><div class="q1">
+<sup>3&#160;</sup>Don’t draw me away with the wicked, 
+</div><div class="q2">with the workers of iniquity who speak peace with their neighbors, 
+</div><div class="q2">but mischief is in their hearts. 
+</div><div class="q1">
+<sup>4&#160;</sup>Give them according to their work, and according to the wickedness of their doings. 
+</div><div class="q2">Give them according to the operation of their hands. 
+</div><div class="q2">Bring back on them what they deserve. 
+</div><div class="q1">
+<sup>5&#160;</sup>Because they don’t respect the works of Yahweh, 
+</div><div class="q2">nor the operation of his hands, 
+</div><div class="q2">he will break them down and not build them up. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Blessed be Yahweh, 
+</div><div class="q2">because he has heard the voice of my petitions. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh is my strength and my shield. 
+</div><div class="q2">My heart has trusted in him, and I am helped. 
+</div><div class="q1">Therefore my heart greatly rejoices. 
+</div><div class="q2">With my song I will thank him. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh is their strength. 
+</div><div class="q2">He is a stronghold of salvation to his anointed. 
+</div><div class="q1">
+<sup>9&#160;</sup>Save your people, 
+</div><div class="q2">and bless your inheritance. 
+</div><div class="q1">Be their shepherd also, 
+</div><div class="q2">and bear them up forever. 
+</div><h2 class="psalmlabel" id="29">29</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Ascribe to Yahweh, you sons of the mighty, 
+</div><div class="q2">ascribe to Yahweh glory and strength. 
+</div><div class="q1">
+<sup>2&#160;</sup>Ascribe to Yahweh the glory due to his name. 
+</div><div class="q2">Worship Yahweh in set-apart array. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>Yahweh’s voice is on the waters. 
+</div><div class="q2">The Elohim of glory thunders, even Yahweh on many waters. 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh’s voice is powerful. 
+</div><div class="q2">Yahweh’s voice is full of majesty. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh’s voice breaks the cedars. 
+</div><div class="q2">Yes, Yahweh breaks in pieces the cedars of Lebanon. 
+</div><div class="q1">
+<sup>6&#160;</sup>He makes them also to skip like a calf; 
+</div><div class="q2">Lebanon and Sirion like a young, wild ox. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh’s voice strikes with flashes of lightning. 
+</div><div class="q2">
+<sup>8&#160;</sup>Yahweh’s voice shakes the wilderness. 
+</div><div class="q2">Yahweh shakes the wilderness of Kadesh. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yahweh’s voice makes the deer calve, 
+</div><div class="q2">and strips the forests bare. 
+</div><div class="q2">In his temple everything says, “Glory!” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Yahweh sat enthroned at the Flood. 
+</div><div class="q2">Yes, Yahweh sits as King forever. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh will give strength to his people. 
+</div><div class="q2">Yahweh will bless his people with peace. 
+</div><h2 class="psalmlabel" id="30">30</h2>
+<div class="d">A Psalm. A Song for the Dedication of the Temple. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will extol you, Yahweh, for you have raised me up, 
+</div><div class="q2">and have not made my foes to rejoice over me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh my Elohim, I cried to you, 
+</div><div class="q2">and you have healed me. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh, you have brought up my soul from Sheol. 
+</div><div class="q2">You have kept me alive, that I should not go down to the pit. 
+</div><div class="q1">
+<sup>4&#160;</sup>Sing praise to Yahweh, you saints of his. 
+</div><div class="q2">Give thanks to his set-apart name. 
+</div><div class="q1">
+<sup>5&#160;</sup>For his anger is but for a moment. 
+</div><div class="q2">His favor is for a lifetime. 
+</div><div class="q1">Weeping may stay for the night, 
+</div><div class="q2">but joy comes in the morning. 
+</div><div class="q1">
+<sup>6&#160;</sup>As for me, I said in my prosperity, 
+</div><div class="q2">“I shall never be moved.” 
+</div><div class="q1">
+<sup>7&#160;</sup>You, Yahweh, when you favored me, made my mountain stand strong; 
+</div><div class="q2">but when you hid your face, I was troubled. 
+</div><div class="q1">
+<sup>8&#160;</sup>I cried to you, Yahweh. 
+</div><div class="q2">I made supplication to the Lord: 
+</div><div class="q1">
+<sup>9&#160;</sup>“What profit is there in my destruction, if I go down to the pit? 
+</div><div class="q2">Shall the dust praise you? 
+</div><div class="q2">Shall it declare your truth? 
+</div><div class="q1">
+<sup>10&#160;</sup>Hear, Yahweh, and have mercy on me. 
+</div><div class="q2">Yahweh, be my helper.” 
+</div><div class="q1">
+<sup>11&#160;</sup>You have turned my mourning into dancing for me. 
+</div><div class="q2">You have removed my sackcloth, and clothed me with gladness, 
+</div><div class="q2">
+<sup>12&#160;</sup>to the end that my heart may sing praise to you, and not be silent. 
+</div><div class="q1">Yahweh my Elohim, I will give thanks to you forever! 
+</div><h2 class="psalmlabel" id="31">31</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>In you, Yahweh, I take refuge. 
+</div><div class="q2">Let me never be disappointed. 
+</div><div class="q2">Deliver me in your righteousness. 
+</div><div class="q1">
+<sup>2&#160;</sup>Bow down your ear to me. 
+</div><div class="q2">Deliver me speedily. 
+</div><div class="q1">Be to me a strong rock, 
+</div><div class="q2">a house of defense to save me. 
+</div><div class="q1">
+<sup>3&#160;</sup>For you are my rock and my fortress, 
+</div><div class="q2">therefore for your name’s sake lead me and guide me. 
+</div><div class="q1">
+<sup>4&#160;</sup>Pluck me out of the net that they have laid secretly for me, 
+</div><div class="q2">for you are my stronghold. 
+</div><div class="q1">
+<sup>5&#160;</sup>Into your hand I commend my spirit. 
+</div><div class="q2">You redeem me, Yahweh, Elohim of truth. 
+</div><div class="q1">
+<sup>6&#160;</sup>I hate those who regard lying vanities, 
+</div><div class="q2">but I trust in Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>I will be glad and rejoice in your loving kindness, 
+</div><div class="q2">for you have seen my affliction. 
+</div><div class="q2">You have known my soul in adversities. 
+</div><div class="q1">
+<sup>8&#160;</sup>You have not shut me up into the hand of the enemy. 
+</div><div class="q2">You have set my feet in a large place. 
+</div><div class="q1">
+<sup>9&#160;</sup>Have mercy on me, Yahweh, for I am in distress. 
+</div><div class="q2">My eye, my soul, and my body waste away with grief. 
+</div><div class="q1">
+<sup>10&#160;</sup>For my life is spent with sorrow, 
+</div><div class="q2">my years with sighing. 
+</div><div class="q1">My strength fails because of my iniquity. 
+</div><div class="q2">My bones are wasted away. 
+</div><div class="q1">
+<sup>11&#160;</sup>Because of all my adversaries I have become utterly contemptible to my neighbors, 
+</div><div class="q2">a horror to my acquaintances. 
+</div><div class="q2">Those who saw me on the street fled from me. 
+</div><div class="q1">
+<sup>12&#160;</sup>I am forgotten from their hearts like a dead man. 
+</div><div class="q2">I am like broken pottery. 
+</div><div class="q1">
+<sup>13&#160;</sup>For I have heard the slander of many, terror on every side, 
+</div><div class="q2">while they conspire together against me, 
+</div><div class="q2">they plot to take away my life. 
+</div><div class="q1">
+<sup>14&#160;</sup>But I trust in you, Yahweh. 
+</div><div class="q2">I said, “You are my Elohim.” 
+</div><div class="q1">
+<sup>15&#160;</sup>My times are in your hand. 
+</div><div class="q2">Deliver me from the hand of my enemies, and from those who persecute me. 
+</div><div class="q1">
+<sup>16&#160;</sup>Make your face to shine on your servant. 
+</div><div class="q2">Save me in your loving kindness. 
+</div><div class="q1">
+<sup>17&#160;</sup>Let me not be disappointed, Yahweh, for I have called on you. 
+</div><div class="q2">Let the wicked be disappointed. 
+</div><div class="q2">Let them be silent in Sheol. 
+</div><div class="q1">
+<sup>18&#160;</sup>Let the lying lips be mute, 
+</div><div class="q2">which speak against the righteous insolently, with pride and contempt. 
+</div><div class="q1">
+<sup>19&#160;</sup>Oh how great is your goodness, 
+</div><div class="q2">which you have laid up for those who fear you, 
+</div><div class="q2">which you have worked for those who take refuge in you, 
+</div><div class="q2">before the sons of men! 
+</div><div class="q1">
+<sup>20&#160;</sup>In the shelter of your presence you will hide them from the plotting of man. 
+</div><div class="q2">You will keep them secretly in a dwelling away from the strife of tongues. 
+</div><div class="q1">
+<sup>21&#160;</sup>Praise be to Yahweh, 
+</div><div class="q2">for he has shown me his marvelous loving kindness in a strong city. 
+</div><div class="q1">
+<sup>22&#160;</sup>As for me, I said in my haste, “I am cut off from before your eyes.” 
+</div><div class="q2">Nevertheless you heard the voice of my petitions when I cried to you. 
+</div><div class="q1">
+<sup>23&#160;</sup>Oh love Yahweh, all you his saints! 
+</div><div class="q2">Yahweh preserves the faithful, 
+</div><div class="q1">and fully recompenses him who behaves arrogantly. 
+</div><div class="q1">
+<sup>24&#160;</sup>Be strong, and let your heart take courage, 
+</div><div class="q2">all you who hope in Yahweh. 
+</div><h2 class="psalmlabel" id="32">32</h2>
+<div class="d">By David. A contemplative psalm. 
+</div><div class="q1">
+<sup>1&#160;</sup>Blessed is he whose disobedience is forgiven, 
+</div><div class="q2">whose sin is covered. 
+</div><div class="q1">
+<sup>2&#160;</sup>Blessed is the man to whom Yahweh doesn’t impute iniquity, 
+</div><div class="q2">in whose spirit there is no deceit. 
+</div><div class="q1">
+<sup>3&#160;</sup>When I kept silence, my bones wasted away through my groaning all day long. 
+</div><div class="q1">
+<sup>4&#160;</sup>For day and night your hand was heavy on me. 
+</div><div class="q2">My strength was sapped in the heat of summer. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>I acknowledged my sin to you. 
+</div><div class="q2">I didn’t hide my iniquity. 
+</div><div class="q1">I said, I will confess my transgressions to Yahweh, 
+</div><div class="q2">and you forgave the iniquity of my sin. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>6&#160;</sup>For this, let everyone who is elohimly pray to you in a time when you may be found. 
+</div><div class="q2">Surely when the great waters overflow, they shall not reach to him. 
+</div><div class="q1">
+<sup>7&#160;</sup>You are my hiding place. 
+</div><div class="q2">You will preserve me from trouble. 
+</div><div class="q2">You will surround me with songs of deliverance. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will instruct you and teach you in the way which you shall go. 
+</div><div class="q2">I will counsel you with my eye on you. 
+</div><div class="q1">
+<sup>9&#160;</sup>Don’t be like the horse, or like the mule, which have no understanding, 
+</div><div class="q2">who are controlled by bit and bridle, or else they will not come near to you. 
+</div><div class="q1">
+<sup>10&#160;</sup>Many sorrows come to the wicked, 
+</div><div class="q2">but loving kindness shall surround him who trusts in Yahweh. 
+</div><div class="q1">
+<sup>11&#160;</sup>Be glad in Yahweh, and rejoice, you righteous! 
+</div><div class="q2">Shout for joy, all you who are upright in heart! 
+</div><h2 class="psalmlabel" id="33">33</h2>
+<div class="q1">
+<sup>1&#160;</sup>Rejoice in Yahweh, you righteous! 
+</div><div class="q2">Praise is fitting for the upright. 
+</div><div class="q1">
+<sup>2&#160;</sup>Give thanks to Yahweh with the lyre. 
+</div><div class="q2">Sing praises to him with the harp of ten strings. 
+</div><div class="q1">
+<sup>3&#160;</sup>Sing to him a new song. 
+</div><div class="q2">Play skillfully with a shout of joy! 
+</div><div class="q1">
+<sup>4&#160;</sup>For Yahweh’s word is right. 
+</div><div class="q2">All his work is done in faithfulness. 
+</div><div class="q1">
+<sup>5&#160;</sup>He loves righteousness and justice. 
+</div><div class="q2">The earth is full of the loving kindness of Yahweh. 
+</div><div class="q1">
+<sup>6&#160;</sup>By Yahweh’s word, the heavens were made: 
+</div><div class="q2">all their army by the breath of his mouth. 
+</div><div class="q1">
+<sup>7&#160;</sup>He gathers the waters of the sea together as a heap. 
+</div><div class="q2">He lays up the deeps in storehouses. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let all the earth fear Yahweh. 
+</div><div class="q2">Let all the inhabitants of the world stand in awe of him. 
+</div><div class="q1">
+<sup>9&#160;</sup>For he spoke, and it was done. 
+</div><div class="q2">He commanded, and it stood firm. 
+</div><div class="q1">
+<sup>10&#160;</sup>Yahweh brings the counsel of the nations to nothing. 
+</div><div class="q2">He makes the thoughts of the peoples to be of no effect. 
+</div><div class="q1">
+<sup>11&#160;</sup>The counsel of Yahweh stands fast forever, 
+</div><div class="q2">the thoughts of his heart to all generations. 
+</div><div class="q1">
+<sup>12&#160;</sup>Blessed is the nation whose Elohim is Yahweh, 
+</div><div class="q2">the people whom he has chosen for his own inheritance. 
+</div><div class="q1">
+<sup>13&#160;</sup>Yahweh looks from heaven. 
+</div><div class="q2">He sees all the sons of men. 
+</div><div class="q1">
+<sup>14&#160;</sup>From the place of his habitation he looks out on all the inhabitants of the earth, 
+</div><div class="q2">
+<sup>15&#160;</sup>he who fashions all of their hearts; 
+</div><div class="q2">and he considers all of their works. 
+</div><div class="q1">
+<sup>16&#160;</sup>There is no king saved by the multitude of an army. 
+</div><div class="q2">A mighty man is not delivered by great strength. 
+</div><div class="q1">
+<sup>17&#160;</sup>A horse is a vain thing for safety, 
+</div><div class="q2">neither does he deliver any by his great power. 
+</div><div class="q1">
+<sup>18&#160;</sup>Behold, Yahweh’s eye is on those who fear him, 
+</div><div class="q2">on those who hope in his loving kindness, 
+</div><div class="q2">
+<sup>19&#160;</sup>to deliver their soul from death, 
+</div><div class="q2">to keep them alive in famine. 
+</div><div class="q1">
+<sup>20&#160;</sup>Our soul has waited for Yahweh. 
+</div><div class="q2">He is our help and our shield. 
+</div><div class="q1">
+<sup>21&#160;</sup>For our heart rejoices in him, 
+</div><div class="q2">because we have trusted in his set-apart name. 
+</div><div class="q1">
+<sup>22&#160;</sup>Let your loving kindness be on us, Yahweh, 
+</div><div class="q2">since we have hoped in you. 
+</div><h2 class="psalmlabel" id="34">34</h2>
+<div class="d">By David; when he pretended to be insane before Abimelech, who drove him away, and he departed. 
+</div><div class="q1">
+<sup>1&#160;</sup> I will bless Yahweh at all times. 
+</div><div class="q2">His praise will always be in my mouth. 
+</div><div class="q1">
+<sup>2&#160;</sup>My soul shall boast in Yahweh. 
+</div><div class="q2">The humble shall hear of it and be glad. 
+</div><div class="q1">
+<sup>3&#160;</sup>Oh magnify Yahweh with me. 
+</div><div class="q2">Let’s exalt his name together. 
+</div><div class="q1">
+<sup>4&#160;</sup>I sought Yahweh, and he answered me, 
+</div><div class="q2">and delivered me from all my fears. 
+</div><div class="q1">
+<sup>5&#160;</sup>They looked to him, and were radiant. 
+</div><div class="q2">Their faces shall never be covered with shame. 
+</div><div class="q1">
+<sup>6&#160;</sup>This poor man cried, and Yahweh heard him, 
+</div><div class="q2">and saved him out of all his troubles. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh’s angel encamps around those who fear him, 
+</div><div class="q2">and delivers them. 
+</div><div class="q1">
+<sup>8&#160;</sup>Oh taste and see that Yahweh is good. 
+</div><div class="q2">Blessed is the man who takes refuge in him. 
+</div><div class="q1">
+<sup>9&#160;</sup>Oh fear Yahweh, you his saints, 
+</div><div class="q2">for there is no lack with those who fear him. 
+</div><div class="q1">
+<sup>10&#160;</sup>The young lions do lack, and suffer hunger, 
+</div><div class="q2">but those who seek Yahweh shall not lack any good thing. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>Come, you children, listen to me. 
+</div><div class="q2">I will teach you the fear of Yahweh. 
+</div><div class="q1">
+<sup>12&#160;</sup>Who is someone who desires life, 
+</div><div class="q2">and loves many days, that he may see good? 
+</div><div class="q1">
+<sup>13&#160;</sup>Keep your tongue from evil, 
+</div><div class="q2">and your lips from speaking lies. 
+</div><div class="q1">
+<sup>14&#160;</sup>Depart from evil, and do good. 
+</div><div class="q2">Seek peace, and pursue it. 
+</div><div class="q1">
+<sup>15&#160;</sup>Yahweh’s eyes are toward the righteous. 
+</div><div class="q2">His ears listen to their cry. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yahweh’s face is against those who do evil, 
+</div><div class="q2">to cut off their memory from the earth. 
+</div><div class="q1">
+<sup>17&#160;</sup>The righteous cry, and Yahweh hears, 
+</div><div class="q2">and delivers them out of all their troubles. 
+</div><div class="q1">
+<sup>18&#160;</sup>Yahweh is near to those who have a broken heart, 
+</div><div class="q2">and saves those who have a crushed spirit. 
+</div><div class="q1">
+<sup>19&#160;</sup>Many are the afflictions of the righteous, 
+</div><div class="q2">but Yahweh delivers him out of them all. 
+</div><div class="q1">
+<sup>20&#160;</sup>He protects all of his bones. 
+</div><div class="q2">Not one of them is broken. 
+</div><div class="q1">
+<sup>21&#160;</sup>Evil shall kill the wicked. 
+</div><div class="q2">Those who hate the righteous shall be condemned. 
+</div><div class="q1">
+<sup>22&#160;</sup>Yahweh redeems the soul of his servants. 
+</div><div class="q2">None of those who take refuge in him shall be condemned. 
+</div><h2 class="psalmlabel" id="35">35</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Contend, Yahweh, with those who contend with me. 
+</div><div class="q2">Fight against those who fight against me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Take hold of shield and buckler, 
+</div><div class="q2">and stand up for my help. 
+</div><div class="q1">
+<sup>3&#160;</sup>Brandish the spear and block those who pursue me. 
+</div><div class="q2">Tell my soul, “I am your salvation.” 
+</div><div class="q1">
+<sup>4&#160;</sup>Let those who seek after my soul be disappointed and brought to dishonor. 
+</div><div class="q2">Let those who plot my ruin be turned back and confounded. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let them be as chaff before the wind, 
+</div><div class="q2">Yahweh’s angel driving them on. 
+</div><div class="q1">
+<sup>6&#160;</sup>Let their way be dark and slippery, 
+</div><div class="q2">Yahweh’s angel pursuing them. 
+</div><div class="q1">
+<sup>7&#160;</sup>For without cause they have hidden their net in a pit for me. 
+</div><div class="q2">Without cause they have dug a pit for my soul. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let destruction come on him unawares. 
+</div><div class="q2">Let his net that he has hidden catch himself. 
+</div><div class="q2">Let him fall into that destruction. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>My soul shall be joyful in Yahweh. 
+</div><div class="q2">It shall rejoice in his salvation. 
+</div><div class="q1">
+<sup>10&#160;</sup>All my bones shall say, “Yahweh, who is like you, 
+</div><div class="q2">who delivers the poor from him who is too strong for him; 
+</div><div class="q2">yes, the poor and the needy from him who robs him?” 
+</div><div class="q1">
+<sup>11&#160;</sup>Unrighteous witnesses rise up. 
+</div><div class="q2">They ask me about things that I don’t know about. 
+</div><div class="q1">
+<sup>12&#160;</sup>They reward me evil for good, 
+</div><div class="q2">to the bereaving of my soul. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>But as for me, when they were sick, my clothing was sackcloth. 
+</div><div class="q2">I afflicted my soul with fasting. 
+</div><div class="q2">My prayer returned into my own bosom. 
+</div><div class="q1">
+<sup>14&#160;</sup>I behaved myself as though it had been my friend or my brother. 
+</div><div class="q2">I bowed down mourning, as one who mourns his mother. 
+</div><div class="q1">
+<sup>15&#160;</sup>But in my adversity, they rejoiced, and gathered themselves together. 
+</div><div class="q2">The attackers gathered themselves together against me, and I didn’t know it. 
+</div><div class="q2">They tore at me, and didn’t cease. 
+</div><div class="q1">
+<sup>16&#160;</sup>Like the profane mockers in feasts, 
+</div><div class="q2">they gnashed their teeth at me. 
+</div><div class="q1">
+<sup>17&#160;</sup>Lord, how long will you look on? 
+</div><div class="q2">Rescue my soul from their destruction, 
+</div><div class="q2">my precious life from the lions. 
+</div><div class="q1">
+<sup>18&#160;</sup>I will give you thanks in the great assembly. 
+</div><div class="q2">I will praise you among many people. 
+</div><div class="q1">
+<sup>19&#160;</sup>Don’t let those who are my enemies wrongfully rejoice over me; 
+</div><div class="q2">neither let those who hate me without a cause wink their eyes. 
+</div><div class="q1">
+<sup>20&#160;</sup>For they don’t speak peace, 
+</div><div class="q2">but they devise deceitful words against those who are quiet in the land. 
+</div><div class="q1">
+<sup>21&#160;</sup>Yes, they opened their mouth wide against me. 
+</div><div class="q2">They said, “Aha! Aha! Our eye has seen it!” 
+</div><div class="q1">
+<sup>22&#160;</sup>You have seen it, Yahweh. Don’t keep silent. 
+</div><div class="q2">Lord, don’t be far from me. 
+</div><div class="q1">
+<sup>23&#160;</sup>Wake up! Rise up to defend me, my Elohim! 
+</div><div class="q2">My Lord, contend for me! 
+</div><div class="q1">
+<sup>24&#160;</sup>Vindicate me, Yahweh my Elohim, according to your righteousness. 
+</div><div class="q2">Don’t let them gloat over me. 
+</div><div class="q1">
+<sup>25&#160;</sup>Don’t let them say in their heart, “Aha! That’s the way we want it!” 
+</div><div class="q2">Don’t let them say, “We have swallowed him up!” 
+</div><div class="q1">
+<sup>26&#160;</sup>Let them be disappointed and confounded together who rejoice at my calamity. 
+</div><div class="q2">Let them be clothed with shame and dishonor who magnify themselves against me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>27&#160;</sup>Let those who favor my righteous cause shout for joy and be glad. 
+</div><div class="q2">Yes, let them say continually, “May Yahweh be magnified, 
+</div><div class="q2">who has pleasure in the prosperity of his servant!” 
+</div><div class="q1">
+<sup>28&#160;</sup>My tongue shall talk about your righteousness and about your praise all day long. 
+</div><h2 class="psalmlabel" id="36">36</h2>
+<div class="d">For the Chief Musician. By David, the servant of Yahweh. 
+</div><div class="q1">
+<sup>1&#160;</sup>A revelation is within my heart about the disobedience of the wicked: 
+</div><div class="q2">There is no fear of Elohim before his eyes. 
+</div><div class="q1">
+<sup>2&#160;</sup>For he flatters himself in his own eyes, 
+</div><div class="q2">too much to detect and hate his sin. 
+</div><div class="q1">
+<sup>3&#160;</sup>The words of his mouth are iniquity and deceit. 
+</div><div class="q2">He has ceased to be wise and to do good. 
+</div><div class="q1">
+<sup>4&#160;</sup>He plots iniquity on his bed. 
+</div><div class="q2">He sets himself in a way that is not good. 
+</div><div class="q2">He doesn’t abhor evil. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Your loving kindness, Yahweh, is in the heavens. 
+</div><div class="q2">Your faithfulness reaches to the skies. 
+</div><div class="q1">
+<sup>6&#160;</sup>Your righteousness is like the mountains of Elohim. 
+</div><div class="q2">Your judgments are like a great deep. 
+</div><div class="q2">Yahweh, you preserve man and animal. 
+</div><div class="q1">
+<sup>7&#160;</sup>How precious is your loving kindness, Elohim! 
+</div><div class="q2">The children of men take refuge under the shadow of your wings. 
+</div><div class="q1">
+<sup>8&#160;</sup>They shall be abundantly satisfied with the abundance of your house. 
+</div><div class="q2">You will make them drink of the river of your pleasures. 
+</div><div class="q1">
+<sup>9&#160;</sup>For with you is the spring of life. 
+</div><div class="q2">In your light we will see light. 
+</div><div class="q1">
+<sup>10&#160;</sup>Oh continue your loving kindness to those who know you, 
+</div><div class="q2">your righteousness to the upright in heart. 
+</div><div class="q1">
+<sup>11&#160;</sup>Don’t let the foot of pride come against me. 
+</div><div class="q2">Don’t let the hand of the wicked drive me away. 
+</div><div class="q1">
+<sup>12&#160;</sup>There the workers of iniquity are fallen. 
+</div><div class="q2">They are thrust down, and shall not be able to rise. 
+</div><h2 class="psalmlabel" id="37">37</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Don’t fret because of evildoers, 
+</div><div class="q2">neither be envious against those who work unrighteousness. 
+</div><div class="q1">
+<sup>2&#160;</sup>For they shall soon be cut down like the grass, 
+</div><div class="q2">and wither like the green herb. 
+</div><div class="q1">
+<sup>3&#160;</sup>Trust in Yahweh, and do good. 
+</div><div class="q2">Dwell in the land, and enjoy safe pasture. 
+</div><div class="q1">
+<sup>4&#160;</sup>Also delight yourself in Yahweh, 
+</div><div class="q2">and he will give you the desires of your heart. 
+</div><div class="q1">
+<sup>5&#160;</sup>Commit your way to Yahweh. 
+</div><div class="q2">Trust also in him, and he will do this: 
+</div><div class="q1">
+<sup>6&#160;</sup>he will make your righteousness shine out like light, 
+</div><div class="q2">and your justice as the noon day sun. 
+</div><div class="q1">
+<sup>7&#160;</sup>Rest in Yahweh, and wait patiently for him. 
+</div><div class="q2">Don’t fret because of him who prospers in his way, 
+</div><div class="q2">because of the man who makes wicked plots happen. 
+</div><div class="q1">
+<sup>8&#160;</sup>Cease from anger, and forsake wrath. 
+</div><div class="q2">Don’t fret; it leads only to evildoing. 
+</div><div class="q1">
+<sup>9&#160;</sup>For evildoers shall be cut off, 
+</div><div class="q2">but those who wait for Yahweh shall inherit the land. 
+</div><div class="q1">
+<sup>10&#160;</sup>For yet a little while, and the wicked will be no more. 
+</div><div class="q2">Yes, though you look for his place, he isn’t there. 
+</div><div class="q1">
+<sup>11&#160;</sup>But the humble shall inherit the land, 
+</div><div class="q2">and shall delight themselves in the abundance of peace. 
+</div><div class="q1">
+<sup>12&#160;</sup>The wicked plots against the just, 
+</div><div class="q2">and gnashes at him with his teeth. 
+</div><div class="q1">
+<sup>13&#160;</sup>The Lord will laugh at him, 
+</div><div class="q2">for he sees that his day is coming. 
+</div><div class="q1">
+<sup>14&#160;</sup>The wicked have drawn out the sword, and have bent their bow, 
+</div><div class="q2">to cast down the poor and needy, 
+</div><div class="q2">to kill those who are upright on the path. 
+</div><div class="q1">
+<sup>15&#160;</sup>Their sword shall enter into their own heart. 
+</div><div class="q2">Their bows shall be broken. 
+</div><div class="q1">
+<sup>16&#160;</sup>Better is a little that the righteous has, 
+</div><div class="q2">than the abundance of many wicked. 
+</div><div class="q1">
+<sup>17&#160;</sup>For the arms of the wicked shall be broken, 
+</div><div class="q2">but Yahweh upholds the righteous. 
+</div><div class="q1">
+<sup>18&#160;</sup>Yahweh knows the days of the perfect. 
+</div><div class="q2">Their inheritance shall be forever. 
+</div><div class="q1">
+<sup>19&#160;</sup>They shall not be disappointed in the time of evil. 
+</div><div class="q2">In the days of famine they shall be satisfied. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>20&#160;</sup>But the wicked shall perish. 
+</div><div class="q2">The enemies of Yahweh shall be like the beauty of the fields. 
+</div><div class="q2">They will vanish—</div><div class="q2">vanish like smoke. 
+</div><div class="q1">
+<sup>21&#160;</sup>The wicked borrow, and don’t pay back, 
+</div><div class="q2">but the righteous give generously. 
+</div><div class="q1">
+<sup>22&#160;</sup>For such as are blessed by him shall inherit the land. 
+</div><div class="q2">Those who are cursed by him shall be cut off. 
+</div><div class="q1">
+<sup>23&#160;</sup>A man’s steps are established by Yahweh. 
+</div><div class="q2">He delights in his way. 
+</div><div class="q1">
+<sup>24&#160;</sup>Though he stumble, he shall not fall, 
+</div><div class="q2">for Yahweh holds him up with his hand. 
+</div><div class="q1">
+<sup>25&#160;</sup>I have been young, and now am old, 
+</div><div class="q2">yet I have not seen the righteous forsaken, 
+</div><div class="q2">nor his children begging for bread. 
+</div><div class="q1">
+<sup>26&#160;</sup>All day long he deals graciously, and lends. 
+</div><div class="q2">His offspring is blessed. 
+</div><div class="q1">
+<sup>27&#160;</sup>Depart from evil, and do good. 
+</div><div class="q2">Live securely forever. 
+</div><div class="q1">
+<sup>28&#160;</sup>For Yahweh loves justice, 
+</div><div class="q2">and doesn’t forsake his saints. 
+</div><div class="q2">They are preserved forever, 
+</div><div class="q2">but the children of the wicked shall be cut off. 
+</div><div class="q1">
+<sup>29&#160;</sup>The righteous shall inherit the land, 
+</div><div class="q2">and live in it forever. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>30&#160;</sup>The mouth of the righteous talks of wisdom. 
+</div><div class="q2">His tongue speaks justice. 
+</div><div class="q1">
+<sup>31&#160;</sup>The law of his Elohim is in his heart. 
+</div><div class="q2">None of his steps shall slide. 
+</div><div class="q1">
+<sup>32&#160;</sup>The wicked watch the righteous, 
+</div><div class="q2">and seek to kill him. 
+</div><div class="q1">
+<sup>33&#160;</sup>Yahweh will not leave him in his hand, 
+</div><div class="q2">nor condemn him when he is judged. 
+</div><div class="q1">
+<sup>34&#160;</sup>Wait for Yahweh, and keep his way, 
+</div><div class="q2">and he will exalt you to inherit the land. 
+</div><div class="q2">When the wicked are cut off, you shall see it. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>35&#160;</sup>I have seen the wicked in great power, 
+</div><div class="q2">spreading himself like a green tree in its native soil. 
+</div><div class="q1">
+<sup>36&#160;</sup>But he passed away, and behold, he was not. 
+</div><div class="q2">Yes, I sought him, but he could not be found. 
+</div><div class="q1">
+<sup>37&#160;</sup>Mark the perfect man, and see the upright, 
+</div><div class="q2">for there is a future for the man of peace. 
+</div><div class="q1">
+<sup>38&#160;</sup>As for transgressors, they shall be destroyed together. 
+</div><div class="q2">The future of the wicked shall be cut off. 
+</div><div class="q1">
+<sup>39&#160;</sup>But the salvation of the righteous is from Yahweh. 
+</div><div class="q2">He is their stronghold in the time of trouble. 
+</div><div class="q1">
+<sup>40&#160;</sup>Yahweh helps them and rescues them. 
+</div><div class="q2">He rescues them from the wicked and saves them, 
+</div><div class="q2">because they have taken refuge in him. 
+</div><h2 class="psalmlabel" id="38">38</h2>
+<div class="d">A Psalm by David, for a memorial. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, don’t rebuke me in your wrath, 
+</div><div class="q2">neither chasten me in your hot displeasure. 
+</div><div class="q1">
+<sup>2&#160;</sup>For your arrows have pierced me, 
+</div><div class="q2">your hand presses hard on me. 
+</div><div class="q1">
+<sup>3&#160;</sup>There is no soundness in my flesh because of your indignation, 
+</div><div class="q2">neither is there any health in my bones because of my sin. 
+</div><div class="q1">
+<sup>4&#160;</sup>For my iniquities have gone over my head. 
+</div><div class="q2">As a heavy burden, they are too heavy for me. 
+</div><div class="q1">
+<sup>5&#160;</sup>My wounds are loathsome and corrupt 
+</div><div class="q2">because of my foolishness. 
+</div><div class="q1">
+<sup>6&#160;</sup>I am in pain and bowed down greatly. 
+</div><div class="q2">I go mourning all day long. 
+</div><div class="q1">
+<sup>7&#160;</sup>For my waist is filled with burning. 
+</div><div class="q2">There is no soundness in my flesh. 
+</div><div class="q1">
+<sup>8&#160;</sup>I am faint and severely bruised. 
+</div><div class="q2">I have groaned by reason of the anguish of my heart. 
+</div><div class="q1">
+<sup>9&#160;</sup>Lord, all my desire is before you. 
+</div><div class="q2">My groaning is not hidden from you. 
+</div><div class="q1">
+<sup>10&#160;</sup>My heart throbs. 
+</div><div class="q2">My strength fails me. 
+</div><div class="q2">As for the light of my eyes, it has also left me. 
+</div><div class="q1">
+<sup>11&#160;</sup>My lovers and my friends stand aloof from my plague. 
+</div><div class="q2">My kinsmen stand far away. 
+</div><div class="q1">
+<sup>12&#160;</sup>They also who seek after my life lay snares. 
+</div><div class="q2">Those who seek my hurt speak mischievous things, 
+</div><div class="q2">and meditate deceits all day long. 
+</div><div class="q1">
+<sup>13&#160;</sup>But I, as a deaf man, don’t hear. 
+</div><div class="q2">I am as a mute man who doesn’t open his mouth. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yes, I am as a man who doesn’t hear, 
+</div><div class="q2">in whose mouth are no reproofs. 
+</div><div class="q1">
+<sup>15&#160;</sup>For I hope in you, Yahweh. 
+</div><div class="q2">You will answer, Lord my Elohim. 
+</div><div class="q1">
+<sup>16&#160;</sup>For I said, “Don’t let them gloat over me, 
+</div><div class="q2">or exalt themselves over me when my foot slips.” 
+</div><div class="q1">
+<sup>17&#160;</sup>For I am ready to fall. 
+</div><div class="q2">My pain is continually before me. 
+</div><div class="q1">
+<sup>18&#160;</sup>For I will declare my iniquity. 
+</div><div class="q2">I will be sorry for my sin. 
+</div><div class="q1">
+<sup>19&#160;</sup>But my enemies are vigorous and many. 
+</div><div class="q2">Those who hate me without reason are numerous. 
+</div><div class="q1">
+<sup>20&#160;</sup>They who render evil for good are also adversaries to me, 
+</div><div class="q2">because I follow what is good. 
+</div><div class="q1">
+<sup>21&#160;</sup>Don’t forsake me, Yahweh. 
+</div><div class="q2">My Elohim, don’t be far from me. 
+</div><div class="q1">
+<sup>22&#160;</sup>Hurry to help me, 
+</div><div class="q2">Lord, my salvation. 
+</div><h2 class="psalmlabel" id="39">39</h2>
+<div class="d">For the Chief Musician. For Jeduthun. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I said, “I will watch my ways, so that I don’t sin with my tongue. 
+</div><div class="q2">I will keep my mouth with a bridle while the wicked is before me.” 
+</div><div class="q1">
+<sup>2&#160;</sup>I was mute with silence. 
+</div><div class="q2">I held my peace, even from good. 
+</div><div class="q2">My sorrow was stirred. 
+</div><div class="q1">
+<sup>3&#160;</sup>My heart was hot within me. 
+</div><div class="q2">While I meditated, the fire burned. 
+</div><div class="q1">I spoke with my tongue: 
+</div><div class="q2">
+<sup>4&#160;</sup>“Yahweh, show me my end, 
+</div><div class="q2">what is the measure of my days. 
+</div><div class="q2">Let me know how frail I am. 
+</div><div class="q1">
+<sup>5&#160;</sup>Behold, you have made my days hand widths. 
+</div><div class="q2">My lifetime is as nothing before you. 
+</div><div class="q1">Surely every man stands as a breath.” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>6&#160;</sup>“Surely every man walks like a shadow. 
+</div><div class="q2">Surely they busy themselves in vain. 
+</div><div class="q2">He heaps up, and doesn’t know who shall gather. 
+</div><div class="q1">
+<sup>7&#160;</sup>Now, Lord, what do I wait for? 
+</div><div class="q2">My hope is in you. 
+</div><div class="q1">
+<sup>8&#160;</sup>Deliver me from all my transgressions. 
+</div><div class="q2">Don’t make me the reproach of the foolish. 
+</div><div class="q1">
+<sup>9&#160;</sup>I was mute. 
+</div><div class="q2">I didn’t open my mouth, 
+</div><div class="q2">because you did it. 
+</div><div class="q1">
+<sup>10&#160;</sup>Remove your scourge away from me. 
+</div><div class="q2">I am overcome by the blow of your hand. 
+</div><div class="q1">
+<sup>11&#160;</sup>When you rebuke and correct man for iniquity, 
+</div><div class="q2">you consume his wealth like a moth. 
+</div><div class="q1">Surely every man is but a breath.” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>12&#160;</sup>“Hear my prayer, Yahweh, and give ear to my cry. 
+</div><div class="q2">Don’t be silent at my tears. 
+</div><div class="q1">For I am a stranger with you, 
+</div><div class="q2">a foreigner, as all my fathers were. 
+</div><div class="q1">
+<sup>13&#160;</sup>Oh spare me, that I may recover strength, 
+</div><div class="q2">before I go away and exist no more.” 
+</div><h2 class="psalmlabel" id="40">40</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I waited patiently for Yahweh. 
+</div><div class="q2">He turned to me, and heard my cry. 
+</div><div class="q1">
+<sup>2&#160;</sup>He brought me up also out of a horrible pit, 
+</div><div class="q2">out of the miry clay. 
+</div><div class="q1">He set my feet on a rock, 
+</div><div class="q2">and gave me a firm place to stand. 
+</div><div class="q1">
+<sup>3&#160;</sup>He has put a new song in my mouth, even praise to our Elohim. 
+</div><div class="q2">Many shall see it, and fear, and shall trust in Yahweh. 
+</div><div class="q1">
+<sup>4&#160;</sup>Blessed is the man who makes Yahweh his trust, 
+</div><div class="q2">and doesn’t respect the proud, nor such as turn away to lies. 
+</div><div class="q1">
+<sup>5&#160;</sup>Many, Yahweh, my Elohim, are the wonderful works which you have done, 
+</div><div class="q2">and your thoughts which are toward us. 
+</div><div class="q1">They can’t be declared back to you. 
+</div><div class="q2">If I would declare and speak of them, they are more than can be counted. 
+</div><div class="q1">
+<sup>6&#160;</sup>Sacrifice and offering you didn’t desire. 
+</div><div class="q2">You have opened my ears. 
+</div><div class="q2">You have not required burnt offering and sin offering. 
+</div><div class="q1">
+<sup>7&#160;</sup>Then I said, “Behold, I have come. 
+</div><div class="q2">It is written about me in the book in the scroll. 
+</div><div class="q1">
+<sup>8&#160;</sup>I delight to do your will, my Elohim. 
+</div><div class="q2">Yes, your law is within my heart.” 
+</div><div class="q1">
+<sup>9&#160;</sup>I have proclaimed glad news of righteousness in the great assembly. 
+</div><div class="q2">Behold, I will not seal my lips, Yahweh, you know. 
+</div><div class="q1">
+<sup>10&#160;</sup>I have not hidden your righteousness within my heart. 
+</div><div class="q2">I have declared your faithfulness and your salvation. 
+</div><div class="q2">I have not concealed your loving kindness and your truth from the great assembly. 
+</div><div class="q1">
+<sup>11&#160;</sup>Don’t withhold your tender mercies from me, Yahweh. 
+</div><div class="q2">Let your loving kindness and your truth continually preserve me. 
+</div><div class="q1">
+<sup>12&#160;</sup>For innumerable evils have surrounded me. 
+</div><div class="q2">My iniquities have overtaken me, so that I am not able to look up. 
+</div><div class="q1">They are more than the hairs of my head. 
+</div><div class="q2">My heart has failed me. 
+</div><div class="q1">
+<sup>13&#160;</sup>Be pleased, Yahweh, to deliver me. 
+</div><div class="q2">Hurry to help me, Yahweh. 
+</div><div class="q1">
+<sup>14&#160;</sup>Let them be disappointed and confounded together who seek after my soul to destroy it. 
+</div><div class="q2">Let them be turned backward and brought to dishonor who delight in my hurt. 
+</div><div class="q1">
+<sup>15&#160;</sup>Let them be desolate by reason of their shame that tell me, “Aha! Aha!” 
+</div><div class="q1">
+<sup>16&#160;</sup>Let all those who seek you rejoice and be glad in you. 
+</div><div class="q2">Let such as love your salvation say continually, “Let Yahweh be exalted!” 
+</div><div class="q1">
+<sup>17&#160;</sup>But I am poor and needy. 
+</div><div class="q2">May the Lord think about me. 
+</div><div class="q1">You are my help and my deliverer. 
+</div><div class="q2">Don’t delay, my Elohim. 
+</div><h2 class="psalmlabel" id="41">41</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Blessed is he who considers the poor. 
+</div><div class="q2">Yahweh will deliver him in the day of evil. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh will preserve him, and keep him alive. 
+</div><div class="q2">He shall be blessed on the earth, 
+</div><div class="q2">and he will not surrender him to the will of his enemies. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh will sustain him on his sickbed, 
+</div><div class="q2">and restore him from his bed of illness. 
+</div><div class="q1">
+<sup>4&#160;</sup>I said, “Yahweh, have mercy on me! 
+</div><div class="q2">Heal me, for I have sinned against you.” 
+</div><div class="q1">
+<sup>5&#160;</sup>My enemies speak evil against me: 
+</div><div class="q2">“When will he die, and his name perish?” 
+</div><div class="q1">
+<sup>6&#160;</sup>If he comes to see me, he speaks falsehood. 
+</div><div class="q2">His heart gathers iniquity to itself. 
+</div><div class="q2">When he goes abroad, he tells it. 
+</div><div class="q1">
+<sup>7&#160;</sup>All who hate me whisper together against me. 
+</div><div class="q2">They imagine the worst for me. 
+</div><div class="q1">
+<sup>8&#160;</sup>“An evil disease”, they say, “has afflicted him. 
+</div><div class="q2">Now that he lies he shall rise up no more.” 
+</div><div class="q1">
+<sup>9&#160;</sup>Yes, my own familiar friend, in whom I trusted, 
+</div><div class="q2">who ate bread with me, 
+</div><div class="q2">has lifted up his heel against me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>But you, Yahweh, have mercy on me, and raise me up, 
+</div><div class="q2">that I may repay them. 
+</div><div class="q1">
+<sup>11&#160;</sup>By this I know that you delight in me, 
+</div><div class="q2">because my enemy doesn’t triumph over me. 
+</div><div class="q1">
+<sup>12&#160;</sup>As for me, you uphold me in my integrity, 
+</div><div class="q2">and set me in your presence forever. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>Blessed be Yahweh, the Elohim of Israel, 
+</div><div class="q2">from everlasting and to everlasting! 
+</div><div class="q1">Amen and amen. 
+</div><h2 class="ms1">BOOK 2</h2>
 <h2 class="psalmlabel" id="42">42</h2>
-<h2 class="ms1">BOOK 2</h2>
-</p><p class="d">For the Chief Musician. A contemplation by the sons of Korah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>As the deer pants for the water brooks, 
-</p><p class="q2">so my soul pants after you, Elohim.<span class="f">+ \fr 42:1 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p class="q1">
-<span class="v">2&#160;</span>My soul thirsts for Elohim, for the living Elohim. 
-</p><p class="q2">When shall I come and appear before Elohim? 
-</p><p class="q1">
-<span class="v">3&#160;</span>My tears have been my food day and night, 
-</p><p class="q2">while they continually ask me, “Where is your Elohim?” 
-</p><p class="q1">
-<span class="v">4&#160;</span>These things I remember, and pour out my soul within me, 
-</p><p class="q2">how I used to go with the crowd, and led them to Elohim’s house, 
-</p><p class="q2">with the voice of joy and praise, a multitude keeping a set-apart day. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why are you in despair, my soul? 
-</p><p class="q2">Why are you disturbed within me? 
-</p><p class="q1">Hope in Elohim! 
-</p><p class="q2">For I shall still praise him for the saving help of his presence. 
-</p><p class="q1">
-<span class="v">6&#160;</span>My Elohim, my soul is in despair within me. 
-</p><p class="q2">Therefore I remember you from the land of the Jordan, 
-</p><p class="q2">the heights of Hermon, from the hill Mizar. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Deep calls to deep at the noise of your waterfalls. 
-</p><p class="q2">All your waves and your billows have swept over me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Yahweh<span class="f">+ \fr 42:8 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> will command his loving kindness in the daytime. 
-</p><p class="q2">In the night his song shall be with me: 
-</p><p class="q2">a prayer to the Elohim of my life. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will ask Elohim, my rock, “Why have you forgotten me? 
-</p><p class="q2">Why do I go mourning because of the oppression of the enemy?” 
-</p><p class="q1">
-<span class="v">10&#160;</span>As with a sword in my bones, my adversaries reproach me, 
-</p><p class="q2">while they continually ask me, “Where is your Elohim?” 
-</p><p class="q1">
-<span class="v">11&#160;</span>Why are you in despair, my soul? 
-</p><p class="q2">Why are you disturbed within me? 
-</p><p class="q1">Hope in Elohim! For I shall still praise him, 
-</p><p class="q2">the saving help of my countenance, and my Elohim. 
-</p><h2 class="psalmlabel" id="43">43</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Vindicate me, Elohim, and plead my cause against an unelohimly nation. 
-</p><p class="q2">Oh, deliver me from deceitful and wicked men. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For you are the Elohim of my strength. Why have you rejected me? 
-</p><p class="q2">Why do I go mourning because of the oppression of the enemy? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Oh, send out your light and your truth. 
-</p><p class="q2">Let them lead me. 
-</p><p class="q2">Let them bring me to your set-apart hill, 
-</p><p class="q2">to your tents. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Then I will go to the altar of Elohim, 
-</p><p class="q2">to Elohim, my exceeding joy. 
-</p><p class="q1">I will praise you on the harp, Elohim, my Elohim. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why are you in despair, my soul? 
-</p><p class="q2">Why are you disturbed within me? 
-</p><p class="q1">Hope in Elohim! 
-</p><p class="q2">For I shall still praise him: 
-</p><p class="q2">my Savior, my helper, and my Elohim. 
-</p><h2 class="psalmlabel" id="44">44</h2>
-<p class="d">For the Chief Musician. By the sons of Korah. A contemplative psalm. 
-</p><p class="q1">
-<span class="v">1&#160;</span>We have heard with our ears, Elohim; 
-</p><p class="q2">our fathers have told us what work you did in their days, 
-</p><p class="q2">in the days of old. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You drove out the nations with your hand, 
-</p><p class="q2">but you planted them. 
-</p><p class="q1">You afflicted the peoples, 
-</p><p class="q2">but you spread them abroad. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For they didn’t get the land in possession by their own sword, 
-</p><p class="q2">neither did their own arm save them; 
-</p><p class="q1">but your right hand, your arm, and the light of your face, 
-</p><p class="q2">because you were favorable to them. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Elohim, you are my King. 
-</p><p class="q2">Command victories for Jacob! 
-</p><p class="q1">
-<span class="v">5&#160;</span>Through you, we will push down our adversaries. 
-</p><p class="q2">Through your name, we will tread down those who rise up against us. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For I will not trust in my bow, 
-</p><p class="q2">neither will my sword save me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But you have saved us from our adversaries, 
-</p><p class="q2">and have shamed those who hate us. 
-</p><p class="q1">
-<span class="v">8&#160;</span>In Elohim we have made our boast all day long. 
-</p><p class="q2">We will give thanks to your name forever. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>But now you rejected us, and brought us to dishonor, 
-</p><p class="q2">and don’t go out with our armies. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You make us turn back from the adversary. 
-</p><p class="q2">Those who hate us take plunder for themselves. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You have made us like sheep for food, 
-</p><p class="q2">and have scattered us among the nations. 
-</p><p class="q1">
-<span class="v">12&#160;</span>You sell your people for nothing, 
-</p><p class="q2">and have gained nothing from their sale. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You make us a reproach to our neighbors, 
-</p><p class="q2">a scoffing and a derision to those who are around us. 
-</p><p class="q1">
-<span class="v">14&#160;</span>You make us a byword among the nations, 
-</p><p class="q2">a shaking of the head among the peoples. 
-</p><p class="q1">
-<span class="v">15&#160;</span>All day long my dishonor is before me, 
-</p><p class="q2">and shame covers my face, 
-</p><p class="q2">
-<span class="v">16&#160;</span>at the taunt of one who reproaches and verbally abuses, 
-</p><p class="q2">because of the enemy and the avenger. 
-</p><p class="q1">
-<span class="v">17&#160;</span>All this has come on us, 
-</p><p class="q2">yet we haven’t forgotten you. 
-</p><p class="q2">We haven’t been false to your covenant. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Our heart has not turned back, 
-</p><p class="q2">neither have our steps strayed from your path, 
-</p><p class="q2">
-<span class="v">19&#160;</span>though you have crushed us in the haunt of jackals, 
-</p><p class="q2">and covered us with the shadow of death. 
-</p><p class="q1">
-<span class="v">20&#160;</span>If we have forgotten the name of our Elohim, 
-</p><p class="q2">or spread out our hands to a strange elohim, 
-</p><p class="q2">
-<span class="v">21&#160;</span>won’t Elohim search this out? 
-</p><p class="q2">For he knows the secrets of the heart. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Yes, for your sake we are killed all day long. 
-</p><p class="q2">We are regarded as sheep for the slaughter. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Wake up! 
-</p><p class="q2">Why do you sleep, Lord?<span class="f">+ \fr 44:23 \ft The word translated “Lord” is “Adonai.” </span> 
-</p><p class="q1">Arise! 
-</p><p class="q2">Don’t reject us forever. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Why do you hide your face, 
-</p><p class="q2">and forget our affliction and our oppression? 
-</p><p class="q1">
-<span class="v">25&#160;</span>For our soul is bowed down to the dust. 
-</p><p class="q2">Our body clings to the earth. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Rise up to help us. 
-</p><p class="q2">Redeem us for your loving kindness’ sake. 
-</p><h2 class="psalmlabel" id="45">45</h2>
-<p class="d">For the Chief Musician. Set to “The Lilies.” A contemplation by the sons of Korah. A wedding song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>My heart overflows with a noble theme. 
-</p><p class="q2">I recite my verses for the king. 
-</p><p class="q2">My tongue is like the pen of a skillful writer. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You are the most excellent of the sons of men. 
-</p><p class="q2">Grace has anointed your lips, 
-</p><p class="q2">therefore Elohim has blessed you forever. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Strap your sword on your thigh, O mighty one, 
-</p><p class="q2">in your splendor and your majesty. 
-</p><p class="q1">
-<span class="v">4&#160;</span>In your majesty ride on victoriously on behalf of truth, humility, and righteousness. 
-</p><p class="q2">Let your right hand display awesome deeds. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Your arrows are sharp. 
-</p><p class="q2">The nations fall under you, with arrows in the heart of the king’s enemies. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Your throne, Elohim, is forever and ever. 
-</p><p class="q2">A scepter of equity is the scepter of your kingdom. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You have loved righteousness, and hated wickedness. 
-</p><p class="q2">Therefore Elohim, your Elohim, has anointed you with the oil of gladness above your fellows. 
-</p><p class="q1">
-<span class="v">8&#160;</span>All your garments smell like myrrh, aloes, and cassia. 
-</p><p class="q2">Out of ivory palaces stringed instruments have made you glad. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Kings’ daughters are among your honorable women. 
-</p><p class="q2">At your right hand the queen stands in gold of Ophir. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Listen, daughter, consider, and turn your ear. 
-</p><p class="q2">Forget your own people, and also your father’s house. 
-</p><p class="q2">
-<span class="v">11&#160;</span>So the king will desire your beauty, 
-</p><p class="q2">honor him, for he is your lord. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The daughter of Tyre comes with a gift. 
-</p><p class="q2">The rich among the people entreat your favor. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The princess inside is all glorious. 
-</p><p class="q2">Her clothing is interwoven with gold. 
-</p><p class="q1">
-<span class="v">14&#160;</span>She shall be led to the king in embroidered work. 
-</p><p class="q2">The virgins, her companions who follow her, shall be brought to you. 
-</p><p class="q1">
-<span class="v">15&#160;</span>With gladness and rejoicing they shall be led. 
-</p><p class="q2">They shall enter into the king’s palace. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Your sons will take the place of your fathers. 
-</p><p class="q2">You shall make them princes in all the earth. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will make your name to be remembered in all generations. 
-</p><p class="q2">Therefore the peoples shall give you thanks forever and ever. 
-</p><h2 class="psalmlabel" id="46">46</h2>
-<p class="d">For the Chief Musician. By the sons of Korah. According to Alamoth.<span class="f">+ \fr 46:0 \ft Alamoth is a musical term.</span> 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim is our refuge and strength, 
-</p><p class="q2">a very present help in trouble. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Therefore we won’t be afraid, though the earth changes, 
-</p><p class="q2">though the mountains are shaken into the heart of the seas; 
-</p><p class="q2">
-<span class="v">3&#160;</span>though its waters roar and are troubled, 
-</p><p class="q2">though the mountains tremble with their swelling. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>There is a river, the streams of which make the city of Elohim glad, 
-</p><p class="q2">the set-apart place of the tents of the Most High. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Elohim is within her. She shall not be moved. 
-</p><p class="q2">Elohim will help her at dawn. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The nations raged. The kingdoms were moved. 
-</p><p class="q2">He lifted his voice and the earth melted. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh of Armies is with us. 
-</p><p class="q2">The Elohim of Jacob is our refuge. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>Come, see Yahweh’s works, 
-</p><p class="q2">what desolations he has made in the earth. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He makes wars cease to the end of the earth. 
-</p><p class="q2">He breaks the bow, and shatters the spear. 
-</p><p class="q2">He burns the chariots in the fire. 
-</p><p class="q1">
-<span class="v">10&#160;</span>“Be still, and know that I am Elohim. 
-</p><p class="q2">I will be exalted among the nations. 
-</p><p class="q2">I will be exalted in the earth.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh of Armies is with us. 
-</p><p class="q2">The Elohim of Jacob is our refuge. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
+<div class="d">For the Chief Musician. A contemplation by the sons of Korah. 
+</div><div class="q1">
+<sup>1&#160;</sup>As the deer pants for the water brooks, 
+</div><div class="q2">so my soul pants after you, Elohim. 
+</div><div class="q1">
+<sup>2&#160;</sup>My soul thirsts for Elohim, for the living Elohim. 
+</div><div class="q2">When shall I come and appear before Elohim? 
+</div><div class="q1">
+<sup>3&#160;</sup>My tears have been my food day and night, 
+</div><div class="q2">while they continually ask me, “Where is your Elohim?” 
+</div><div class="q1">
+<sup>4&#160;</sup>These things I remember, and pour out my soul within me, 
+</div><div class="q2">how I used to go with the crowd, and led them to Elohim’s house, 
+</div><div class="q2">with the voice of joy and praise, a multitude keeping a set-apart day. 
+</div><div class="q1">
+<sup>5&#160;</sup>Why are you in despair, my soul? 
+</div><div class="q2">Why are you disturbed within me? 
+</div><div class="q1">Hope in Elohim! 
+</div><div class="q2">For I shall still praise him for the saving help of his presence. 
+</div><div class="q1">
+<sup>6&#160;</sup>My Elohim, my soul is in despair within me. 
+</div><div class="q2">Therefore I remember you from the land of the Jordan, 
+</div><div class="q2">the heights of Hermon, from the hill Mizar. 
+</div><div class="q1">
+<sup>7&#160;</sup>Deep calls to deep at the noise of your waterfalls. 
+</div><div class="q2">All your waves and your billows have swept over me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Yahweh will command his loving kindness in the daytime. 
+</div><div class="q2">In the night his song shall be with me: 
+</div><div class="q2">a prayer to the Elohim of my life. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will ask Elohim, my rock, “Why have you forgotten me? 
+</div><div class="q2">Why do I go mourning because of the oppression of the enemy?” 
+</div><div class="q1">
+<sup>10&#160;</sup>As with a sword in my bones, my adversaries reproach me, 
+</div><div class="q2">while they continually ask me, “Where is your Elohim?” 
+</div><div class="q1">
+<sup>11&#160;</sup>Why are you in despair, my soul? 
+</div><div class="q2">Why are you disturbed within me? 
+</div><div class="q1">Hope in Elohim! For I shall still praise him, 
+</div><div class="q2">the saving help of my countenance, and my Elohim. 
+</div><h2 class="psalmlabel" id="43">43</h2>
+<div class="q1">
+<sup>1&#160;</sup>Vindicate me, Elohim, and plead my cause against an unelohimly nation. 
+</div><div class="q2">Oh, deliver me from deceitful and wicked men. 
+</div><div class="q1">
+<sup>2&#160;</sup>For you are the Elohim of my strength. Why have you rejected me? 
+</div><div class="q2">Why do I go mourning because of the oppression of the enemy? 
+</div><div class="q1">
+<sup>3&#160;</sup>Oh, send out your light and your truth. 
+</div><div class="q2">Let them lead me. 
+</div><div class="q2">Let them bring me to your set-apart hill, 
+</div><div class="q2">to your tents. 
+</div><div class="q1">
+<sup>4&#160;</sup>Then I will go to the altar of Elohim, 
+</div><div class="q2">to Elohim, my exceeding joy. 
+</div><div class="q1">I will praise you on the harp, Elohim, my Elohim. 
+</div><div class="q1">
+<sup>5&#160;</sup>Why are you in despair, my soul? 
+</div><div class="q2">Why are you disturbed within me? 
+</div><div class="q1">Hope in Elohim! 
+</div><div class="q2">For I shall still praise him: 
+</div><div class="q2">my Savior, my helper, and my Elohim. 
+</div><h2 class="psalmlabel" id="44">44</h2>
+<div class="d">For the Chief Musician. By the sons of Korah. A contemplative psalm. 
+</div><div class="q1">
+<sup>1&#160;</sup>We have heard with our ears, Elohim; 
+</div><div class="q2">our fathers have told us what work you did in their days, 
+</div><div class="q2">in the days of old. 
+</div><div class="q1">
+<sup>2&#160;</sup>You drove out the nations with your hand, 
+</div><div class="q2">but you planted them. 
+</div><div class="q1">You afflicted the peoples, 
+</div><div class="q2">but you spread them abroad. 
+</div><div class="q1">
+<sup>3&#160;</sup>For they didn’t get the land in possession by their own sword, 
+</div><div class="q2">neither did their own arm save them; 
+</div><div class="q1">but your right hand, your arm, and the light of your face, 
+</div><div class="q2">because you were favorable to them. 
+</div><div class="q1">
+<sup>4&#160;</sup>Elohim, you are my King. 
+</div><div class="q2">Command victories for Jacob! 
+</div><div class="q1">
+<sup>5&#160;</sup>Through you, we will push down our adversaries. 
+</div><div class="q2">Through your name, we will tread down those who rise up against us. 
+</div><div class="q1">
+<sup>6&#160;</sup>For I will not trust in my bow, 
+</div><div class="q2">neither will my sword save me. 
+</div><div class="q1">
+<sup>7&#160;</sup>But you have saved us from our adversaries, 
+</div><div class="q2">and have shamed those who hate us. 
+</div><div class="q1">
+<sup>8&#160;</sup>In Elohim we have made our boast all day long. 
+</div><div class="q2">We will give thanks to your name forever. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>But now you rejected us, and brought us to dishonor, 
+</div><div class="q2">and don’t go out with our armies. 
+</div><div class="q1">
+<sup>10&#160;</sup>You make us turn back from the adversary. 
+</div><div class="q2">Those who hate us take plunder for themselves. 
+</div><div class="q1">
+<sup>11&#160;</sup>You have made us like sheep for food, 
+</div><div class="q2">and have scattered us among the nations. 
+</div><div class="q1">
+<sup>12&#160;</sup>You sell your people for nothing, 
+</div><div class="q2">and have gained nothing from their sale. 
+</div><div class="q1">
+<sup>13&#160;</sup>You make us a reproach to our neighbors, 
+</div><div class="q2">a scoffing and a derision to those who are around us. 
+</div><div class="q1">
+<sup>14&#160;</sup>You make us a byword among the nations, 
+</div><div class="q2">a shaking of the head among the peoples. 
+</div><div class="q1">
+<sup>15&#160;</sup>All day long my dishonor is before me, 
+</div><div class="q2">and shame covers my face, 
+</div><div class="q2">
+<sup>16&#160;</sup>at the taunt of one who reproaches and verbally abuses, 
+</div><div class="q2">because of the enemy and the avenger. 
+</div><div class="q1">
+<sup>17&#160;</sup>All this has come on us, 
+</div><div class="q2">yet we haven’t forgotten you. 
+</div><div class="q2">We haven’t been false to your covenant. 
+</div><div class="q1">
+<sup>18&#160;</sup>Our heart has not turned back, 
+</div><div class="q2">neither have our steps strayed from your path, 
+</div><div class="q2">
+<sup>19&#160;</sup>though you have crushed us in the haunt of jackals, 
+</div><div class="q2">and covered us with the shadow of death. 
+</div><div class="q1">
+<sup>20&#160;</sup>If we have forgotten the name of our Elohim, 
+</div><div class="q2">or spread out our hands to a strange elohim, 
+</div><div class="q2">
+<sup>21&#160;</sup>won’t Elohim search this out? 
+</div><div class="q2">For he knows the secrets of the heart. 
+</div><div class="q1">
+<sup>22&#160;</sup>Yes, for your sake we are killed all day long. 
+</div><div class="q2">We are regarded as sheep for the slaughter. 
+</div><div class="q1">
+<sup>23&#160;</sup>Wake up! 
+</div><div class="q2">Why do you sleep, Lord? 
+</div><div class="q1">Arise! 
+</div><div class="q2">Don’t reject us forever. 
+</div><div class="q1">
+<sup>24&#160;</sup>Why do you hide your face, 
+</div><div class="q2">and forget our affliction and our oppression? 
+</div><div class="q1">
+<sup>25&#160;</sup>For our soul is bowed down to the dust. 
+</div><div class="q2">Our body clings to the earth. 
+</div><div class="q1">
+<sup>26&#160;</sup>Rise up to help us. 
+</div><div class="q2">Redeem us for your loving kindness’ sake. 
+</div><h2 class="psalmlabel" id="45">45</h2>
+<div class="d">For the Chief Musician. Set to “The Lilies.” A contemplation by the sons of Korah. A wedding song. 
+</div><div class="q1">
+<sup>1&#160;</sup>My heart overflows with a noble theme. 
+</div><div class="q2">I recite my verses for the king. 
+</div><div class="q2">My tongue is like the pen of a skillful writer. 
+</div><div class="q1">
+<sup>2&#160;</sup>You are the most excellent of the sons of men. 
+</div><div class="q2">Grace has anointed your lips, 
+</div><div class="q2">therefore Elohim has blessed you forever. 
+</div><div class="q1">
+<sup>3&#160;</sup>Strap your sword on your thigh, O mighty one, 
+</div><div class="q2">in your splendor and your majesty. 
+</div><div class="q1">
+<sup>4&#160;</sup>In your majesty ride on victoriously on behalf of truth, humility, and righteousness. 
+</div><div class="q2">Let your right hand display awesome deeds. 
+</div><div class="q1">
+<sup>5&#160;</sup>Your arrows are sharp. 
+</div><div class="q2">The nations fall under you, with arrows in the heart of the king’s enemies. 
+</div><div class="q1">
+<sup>6&#160;</sup>Your throne, Elohim, is forever and ever. 
+</div><div class="q2">A scepter of equity is the scepter of your kingdom. 
+</div><div class="q1">
+<sup>7&#160;</sup>You have loved righteousness, and hated wickedness. 
+</div><div class="q2">Therefore Elohim, your Elohim, has anointed you with the oil of gladness above your fellows. 
+</div><div class="q1">
+<sup>8&#160;</sup>All your garments smell like myrrh, aloes, and cassia. 
+</div><div class="q2">Out of ivory palaces stringed instruments have made you glad. 
+</div><div class="q1">
+<sup>9&#160;</sup>Kings’ daughters are among your honorable women. 
+</div><div class="q2">At your right hand the queen stands in gold of Ophir. 
+</div><div class="q1">
+<sup>10&#160;</sup>Listen, daughter, consider, and turn your ear. 
+</div><div class="q2">Forget your own people, and also your father’s house. 
+</div><div class="q2">
+<sup>11&#160;</sup>So the king will desire your beauty, 
+</div><div class="q2">honor him, for he is your lord. 
+</div><div class="q1">
+<sup>12&#160;</sup>The daughter of Tyre comes with a gift. 
+</div><div class="q2">The rich among the people entreat your favor. 
+</div><div class="q1">
+<sup>13&#160;</sup>The princess inside is all glorious. 
+</div><div class="q2">Her clothing is interwoven with gold. 
+</div><div class="q1">
+<sup>14&#160;</sup>She shall be led to the king in embroidered work. 
+</div><div class="q2">The virgins, her companions who follow her, shall be brought to you. 
+</div><div class="q1">
+<sup>15&#160;</sup>With gladness and rejoicing they shall be led. 
+</div><div class="q2">They shall enter into the king’s palace. 
+</div><div class="q1">
+<sup>16&#160;</sup>Your sons will take the place of your fathers. 
+</div><div class="q2">You shall make them princes in all the earth. 
+</div><div class="q1">
+<sup>17&#160;</sup>I will make your name to be remembered in all generations. 
+</div><div class="q2">Therefore the peoples shall give you thanks forever and ever. 
+</div><h2 class="psalmlabel" id="46">46</h2>
+<div class="d">For the Chief Musician. By the sons of Korah. According to Alamoth. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim is our refuge and strength, 
+</div><div class="q2">a very present help in trouble. 
+</div><div class="q1">
+<sup>2&#160;</sup>Therefore we won’t be afraid, though the earth changes, 
+</div><div class="q2">though the mountains are shaken into the heart of the seas; 
+</div><div class="q2">
+<sup>3&#160;</sup>though its waters roar and are troubled, 
+</div><div class="q2">though the mountains tremble with their swelling. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>There is a river, the streams of which make the city of Elohim glad, 
+</div><div class="q2">the set-apart place of the tents of the Most High. 
+</div><div class="q1">
+<sup>5&#160;</sup>Elohim is within her. She shall not be moved. 
+</div><div class="q2">Elohim will help her at dawn. 
+</div><div class="q1">
+<sup>6&#160;</sup>The nations raged. The kingdoms were moved. 
+</div><div class="q2">He lifted his voice and the earth melted. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh of Armies is with us. 
+</div><div class="q2">The Elohim of Jacob is our refuge. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>Come, see Yahweh’s works, 
+</div><div class="q2">what desolations he has made in the earth. 
+</div><div class="q1">
+<sup>9&#160;</sup>He makes wars cease to the end of the earth. 
+</div><div class="q2">He breaks the bow, and shatters the spear. 
+</div><div class="q2">He burns the chariots in the fire. 
+</div><div class="q1">
+<sup>10&#160;</sup>“Be still, and know that I am Elohim. 
+</div><div class="q2">I will be exalted among the nations. 
+</div><div class="q2">I will be exalted in the earth.” 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh of Armies is with us. 
+</div><div class="q2">The Elohim of Jacob is our refuge. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="47">47</h2>
-<p class="d">For the Chief Musician. A Psalm by the sons of Korah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Oh clap your hands, all you nations. 
-</p><p class="q2">Shout to Elohim with the voice of triumph! 
-</p><p class="q1">
-<span class="v">2&#160;</span>For Yahweh Most High is awesome. 
-</p><p class="q2">He is a great King over all the earth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He subdues nations under us, 
-</p><p class="q2">and peoples under our feet. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He chooses our inheritance for us, 
-</p><p class="q2">the glory of Jacob whom he loved. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>Elohim has gone up with a shout, 
-</p><p class="q2">Yahweh with the sound of a trumpet. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Sing praises to Elohim! Sing praises! 
-</p><p class="q2">Sing praises to our King! Sing praises! 
-</p><p class="q1">
-<span class="v">7&#160;</span>For Elohim is the King of all the earth. 
-</p><p class="q2">Sing praises with understanding. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Elohim reigns over the nations. 
-</p><p class="q2">Elohim sits on his set-apart throne. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The princes of the peoples are gathered together, 
-</p><p class="q1">the people of the Elohim of Abraham. 
-</p><p class="q2">For the shields of the earth belong to Elohim. 
-</p><p class="q2">He is greatly exalted! 
-</p><h2 class="psalmlabel" id="48">48</h2>
-<p class="d">A Song. A Psalm by the sons of Korah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Great is Yahweh, and greatly to be praised, 
-</p><p class="q2">in the city of our Elohim, in his set-apart mountain. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Beautiful in elevation, the joy of the whole earth, 
-</p><p class="q2">is Mount Zion, on the north sides, 
-</p><p class="q2">the city of the great King. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Elohim has shown himself in her citadels as a refuge. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For, behold, the kings assembled themselves, 
-</p><p class="q2">they passed by together. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They saw it, then they were amazed. 
-</p><p class="q2">They were dismayed. 
-</p><p class="q2">They hurried away. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Trembling took hold of them there, 
-</p><p class="q2">pain, as of a woman in travail. 
-</p><p class="q1">
-<span class="v">7&#160;</span>With the east wind, you break the ships of Tarshish. 
-</p><p class="q1">
-<span class="v">8&#160;</span>As we have heard, so we have seen, 
-</p><p class="q2">in the city of Yahweh of Armies, in the city of our Elohim. 
-</p><p class="q1">Elohim will establish it forever. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">9&#160;</span>We have thought about your loving kindness, Elohim, 
-</p><p class="q2">in the middle of your temple. 
-</p><p class="q1">
-<span class="v">10&#160;</span>As is your name, Elohim, 
-</p><p class="q2">so is your praise to the ends of the earth. 
-</p><p class="q2">Your right hand is full of righteousness. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Let Mount Zion be glad! 
-</p><p class="q2">Let the daughters of Judah rejoice because of your judgments. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Walk about Zion, and go around her. 
-</p><p class="q2">Number its towers. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Notice her bulwarks. 
-</p><p class="q2">Consider her palaces, 
-</p><p class="q2">that you may tell it to the next generation. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For this Elohim is our Elohim forever and ever. 
-</p><p class="q2">He will be our guide even to death. 
-</p><h2 class="psalmlabel" id="49">49</h2>
-<p class="d">For the Chief Musician. A Psalm by the sons of Korah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear this, all you peoples. 
-</p><p class="q2">Listen, all you inhabitants of the world, 
-</p><p class="q2">
-<span class="v">2&#160;</span>both low and high, 
-</p><p class="q2">rich and poor together. 
-</p><p class="q1">
-<span class="v">3&#160;</span>My mouth will speak words of wisdom. 
-</p><p class="q2">My heart will utter understanding. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will incline my ear to a proverb. 
-</p><p class="q2">I will solve my riddle on the harp. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Why should I fear in the days of evil, 
-</p><p class="q2">when iniquity at my heels surrounds me? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Those who trust in their wealth, 
-</p><p class="q2">and boast in the multitude of their riches—</p><p class="q2">
-<span class="v">7&#160;</span>none of them can by any means redeem his brother, 
-</p><p class="q2">nor give Elohim a ransom for him. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For the redemption of their life is costly, 
-</p><p class="q2">no payment is ever enough, 
-</p><p class="q2">
-<span class="v">9&#160;</span>that he should live on forever, 
-</p><p class="q2">that he should not see corruption. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For he sees that wise men die; 
-</p><p class="q2">likewise the fool and the senseless perish, 
-</p><p class="q2">and leave their wealth to others. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Their inward thought is that their houses will endure forever, 
-</p><p class="q2">and their dwelling places to all generations. 
-</p><p class="q2">They name their lands after themselves. 
-</p><p class="q1">
-<span class="v">12&#160;</span>But man, despite his riches, doesn’t endure. 
-</p><p class="q2">He is like the animals that perish. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>This is the destiny of those who are foolish, 
-</p><p class="q2">and of those who approve their sayings. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">14&#160;</span>They are appointed as a flock for Sheol.<span class="f">+ \fr 49:14 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">Death shall be their shepherd. 
-</p><p class="q1">The upright shall have dominion over them in the morning. 
-</p><p class="q2">Their beauty shall decay in Sheol,<span class="f">+ \fr 49:14 \ft Sheol is the place of the dead. </span> 
-</p><p class="q2">far from their mansion. 
-</p><p class="q1">
-<span class="v">15&#160;</span>But Elohim will redeem my soul from the power of Sheol,<span class="f">+ \fr 49:15 \ft Sheol is the place of the dead.</span> 
-</p><p class="q2">for he will receive me. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">16&#160;</span>Don’t be afraid when a man is made rich, 
-</p><p class="q2">when the glory of his house is increased; 
-</p><p class="q1">
-<span class="v">17&#160;</span>for when he dies he will carry nothing away. 
-</p><p class="q2">His glory won’t descend after him. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Though while he lived he blessed his soul—</p><p class="q2">and men praise you when you do well for yourself—</p><p class="q2">
-<span class="v">19&#160;</span>he shall go to the generation of his fathers. 
-</p><p class="q2">They shall never see the light. 
-</p><p class="q1">
-<span class="v">20&#160;</span>A man who has riches without understanding, 
-</p><p class="q2">is like the animals that perish. 
-</p><h2 class="psalmlabel" id="50">50</h2>
-<p class="d">A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>The Mighty One, Elohim, Yahweh, speaks, 
-</p><p class="q2">and calls the earth from sunrise to sunset. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Out of Zion, the perfection of beauty, 
-</p><p class="q2">Elohim shines out. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Our Elohim comes, and does not keep silent. 
-</p><p class="q2">A fire devours before him. 
-</p><p class="q2">It is very stormy around him. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He calls to the heavens above, 
-</p><p class="q2">to the earth, that he may judge his people: 
-</p><p class="q1">
-<span class="v">5&#160;</span>“Gather my saints together to me, 
-</p><p class="q2">those who have made a covenant with me by sacrifice.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>The heavens shall declare his righteousness, 
-</p><p class="q2">for Elohim himself is judge. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">7&#160;</span>“Hear, my people, and I will speak. 
-</p><p class="q2">Israel, I will testify against you. 
-</p><p class="q1">I am Elohim, your Elohim. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I don’t rebuke you for your sacrifices. 
-</p><p class="q2">Your burnt offerings are continually before me. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I have no need for a bull from your stall, 
-</p><p class="q2">nor male goats from your pens. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For every animal of the forest is mine, 
-</p><p class="q2">and the livestock on a thousand hills. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I know all the birds of the mountains. 
-</p><p class="q2">The wild animals of the field are mine. 
-</p><p class="q1">
-<span class="v">12&#160;</span>If I were hungry, I would not tell you, 
-</p><p class="q2">for the world is mine, and all that is in it. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Will I eat the meat of bulls, 
-</p><p class="q2">or drink the blood of goats? 
-</p><p class="q1">
-<span class="v">14&#160;</span>Offer to Elohim the sacrifice of thanksgiving. 
-</p><p class="q2">Pay your vows to the Most High. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Call on me in the day of trouble. 
-</p><p class="q2">I will deliver you, and you will honor me.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>But to the wicked Elohim says, 
-</p><p class="q2">“What right do you have to declare my statutes, 
-</p><p class="q2">that you have taken my covenant on your lips, 
-</p><p class="q2">
-<span class="v">17&#160;</span>since you hate instruction, 
-</p><p class="q2">and throw my words behind you? 
-</p><p class="q1">
-<span class="v">18&#160;</span>When you saw a thief, you consented with him, 
-</p><p class="q2">and have participated with adulterers. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>“You give your mouth to evil. 
-</p><p class="q2">Your tongue frames deceit. 
-</p><p class="q1">
-<span class="v">20&#160;</span>You sit and speak against your brother. 
-</p><p class="q2">You slander your own mother’s son. 
-</p><p class="q1">
-<span class="v">21&#160;</span>You have done these things, and I kept silent. 
-</p><p class="q2">You thought that I was just like you. 
-</p><p class="q2">I will rebuke you, and accuse you in front of your eyes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>“Now consider this, you who forget Elohim, 
-</p><p class="q2">lest I tear you into pieces, and there be no one to deliver. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Whoever offers the sacrifice of thanksgiving glorifies me, 
-</p><p class="q2">and prepares his way so that I will show Elohim’s salvation to him.” 
-</p><h2 class="psalmlabel" id="51">51</h2>
-<p class="d">For the Chief Musician. A Psalm by David, when Nathan the prophet came to him, after he had gone in to Bathsheba. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Have mercy on me, Elohim, according to your loving kindness. 
-</p><p class="q2">According to the multitude of your tender mercies, blot out my transgressions. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Wash me thoroughly from my iniquity. 
-</p><p class="q2">Cleanse me from my sin. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For I know my transgressions. 
-</p><p class="q2">My sin is constantly before me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Against you, and you only, I have sinned, 
-</p><p class="q2">and done that which is evil in your sight, 
-</p><p class="q1">so you may be proved right when you speak, 
-</p><p class="q2">and justified when you judge. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Behold, I was born in iniquity. 
-</p><p class="q2">My mother conceived me in sin. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Behold, you desire truth in the inward parts. 
-</p><p class="q2">You teach me wisdom in the inmost place. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Purify me with hyssop, and I will be clean. 
-</p><p class="q2">Wash me, and I will be whiter than snow. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let me hear joy and gladness, 
-</p><p class="q2">that the bones which you have broken may rejoice. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Hide your face from my sins, 
-</p><p class="q2">and blot out all of my iniquities. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Create in me a clean heart, O Elohim. 
-</p><p class="q2">Renew a right spirit within me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Don’t throw me from your presence, 
-</p><p class="q2">and don’t take your Set-Apart Spirit from me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Restore to me the joy of your salvation. 
-</p><p class="q2">Uphold me with a willing spirit. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Then I will teach transgressors your ways. 
-</p><p class="q2">Sinners will be converted to you. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Deliver me from the guilt of bloodshed, O Elohim, the Elohim of my salvation. 
-</p><p class="q2">My tongue will sing aloud of your righteousness. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Lord, open my lips. 
-</p><p class="q2">My mouth will declare your praise. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For you don’t delight in sacrifice, or else I would give it. 
-</p><p class="q2">You have no pleasure in burnt offering. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The sacrifices of Elohim are a broken spirit. 
-</p><p class="q2">O Elohim, you will not despise a broken and contrite heart. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>Do well in your good pleasure to Zion. 
-</p><p class="q2">Build the walls of Jerusalem. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Then you will delight in the sacrifices of righteousness, 
-</p><p class="q2">in burnt offerings and in whole burnt offerings. 
-</p><p class="q1">Then they will offer bulls on your altar. 
-</p><h2 class="psalmlabel" id="52">52</h2>
-<p class="d">For the Chief Musician. A contemplation by David, when Doeg the Edomite came and told Saul, “David has come to Ahimelech’s house.” 
-</p><p class="q1">
-<span class="v">1&#160;</span>Why do you boast of mischief, mighty man? 
-</p><p class="q2">Elohim’s loving kindness endures continually. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Your tongue plots destruction, 
-</p><p class="q2">like a sharp razor, working deceitfully. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You love evil more than good, 
-</p><p class="q2">lying rather than speaking the truth. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>You love all devouring words, 
-</p><p class="q2">you deceitful tongue. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Elohim will likewise destroy you forever. 
-</p><p class="q2">He will take you up, and pluck you out of your tent, 
-</p><p class="q2">and root you out of the land of the living. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">6&#160;</span>The righteous also will see it, and fear, 
-</p><p class="q2">and laugh at him, saying, 
-</p><p class="q1">
-<span class="v">7&#160;</span>“Behold, this is the man who didn’t make Elohim his strength, 
-</p><p class="q2">but trusted in the abundance of his riches, 
-</p><p class="q2">and strengthened himself in his wickedness.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>But as for me, I am like a green olive tree in Elohim’s house. 
-</p><p class="q2">I trust in Elohim’s loving kindness forever and ever. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will give you thanks forever, because you have done it. 
-</p><p class="q2">I will hope in your name, for it is good, 
-</p><p class="q2">in the presence of your saints. 
-</p><h2 class="psalmlabel" id="53">53</h2>
-<p class="d">For the Chief Musician. To the tune of “Mahalath.” A contemplation by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>The fool has said in his heart, “There is no Elohim.” 
-</p><p class="q2">They are corrupt, and have done abominable iniquity. 
-</p><p class="q2">There is no one who does good. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Elohim looks down from heaven on the children of men, 
-</p><p class="q2">to see if there are any who understood, 
-</p><p class="q2">who seek after Elohim. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Every one of them has gone back. 
-</p><p class="q2">They have become filthy together. 
-</p><p class="q2">There is no one who does good, no, not one. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Have the workers of iniquity no knowledge, 
-</p><p class="q2">who eat up my people as they eat bread, 
-</p><p class="q2">and don’t call on Elohim? 
-</p><p class="q1">
-<span class="v">5&#160;</span>There they were in great fear, where no fear was, 
-</p><p class="q2">for Elohim has scattered the bones of him who encamps against you. 
-</p><p class="q1">You have put them to shame, 
-</p><p class="q2">because Elohim has rejected them. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Oh that the salvation of Israel would come out of Zion! 
-</p><p class="q2">When Elohim brings back his people from captivity, 
-</p><p class="q2">then Jacob shall rejoice, 
-</p><p class="q2">and Israel shall be glad. 
-</p><h2 class="psalmlabel" id="54">54</h2>
-<p class="d">For the Chief Musician. On stringed instruments. A contemplation by David, when the Ziphites came and said to Saul, “Isn’t David hiding himself among us?” 
-</p><p class="q1">
-<span class="v">1&#160;</span>Save me, Elohim, by your name. 
-</p><p class="q2">Vindicate me in your might. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hear my prayer, Elohim. 
-</p><p class="q2">Listen to the words of my mouth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For strangers have risen up against me. 
-</p><p class="q2">Violent men have sought after my soul. 
-</p><p class="q2">They haven’t set Elohim before them. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>Behold, Elohim is my helper. 
-</p><p class="q2">The Lord is the one who sustains my soul. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He will repay the evil to my enemies. 
-</p><p class="q2">Destroy them in your truth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>With a free will offering, I will sacrifice to you. 
-</p><p class="q2">I will give thanks to your name, Yahweh, for it is good. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For he has delivered me out of all trouble. 
-</p><p class="q2">My eye has seen triumph over my enemies. 
-</p><h2 class="psalmlabel" id="55">55</h2>
-<p class="d">For the Chief Musician. On stringed instruments. A contemplation by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Listen to my prayer, Elohim. 
-</p><p class="q2">Don’t hide yourself from my supplication. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Attend to me, and answer me. 
-</p><p class="q2">I am restless in my complaint, 
-</p><p class="q2">and moan 
-<span class="v">3&#160;</span>because of the voice of the enemy, 
-</p><p class="q2">because of the oppression of the wicked. 
-</p><p class="q1">For they bring suffering on me. 
-</p><p class="q2">In anger they hold a grudge against me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>My heart is severely pained within me. 
-</p><p class="q2">The terrors of death have fallen on me. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Fearfulness and trembling have come on me. 
-</p><p class="q2">Horror has overwhelmed me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I said, “Oh that I had wings like a dove! 
-</p><p class="q2">Then I would fly away, and be at rest. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Behold, then I would wander far off. 
-</p><p class="q2">I would lodge in the wilderness.” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">8&#160;</span>“I would hurry to a shelter from the stormy wind and storm.” 
-</p><p class="q1">
-<span class="v">9&#160;</span>Confuse them, Lord, and confound their language, 
-</p><p class="q2">for I have seen violence and strife in the city. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Day and night they prowl around on its walls. 
-</p><p class="q2">Malice and abuse are also within her. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Destructive forces are within her. 
-</p><p class="q2">Threats and lies don’t depart from her streets. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For it was not an enemy who insulted me, 
-</p><p class="q2">then I could have endured it. 
-</p><p class="q1">Neither was it he who hated me who raised himself up against me, 
-</p><p class="q2">then I would have hidden myself from him. 
-</p><p class="q1">
-<span class="v">13&#160;</span>But it was you, a man like me, 
-</p><p class="q2">my companion, and my familiar friend. 
-</p><p class="q1">
-<span class="v">14&#160;</span>We took sweet fellowship together. 
-</p><p class="q2">We walked in Elohim’s house with company. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Let death come suddenly on them. 
-</p><p class="q2">Let them go down alive into Sheol.<span class="f">+ \fr 55:15 \ft Sheol is the place of the dead. </span> 
-</p><p class="q2">For wickedness is among them, in their dwelling. 
-</p><p class="q1">
-<span class="v">16&#160;</span>As for me, I will call on Elohim. 
-</p><p class="q2">Yahweh will save me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Evening, morning, and at noon, I will cry out in distress. 
-</p><p class="q2">He will hear my voice. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He has redeemed my soul in peace from the battle that was against me, 
-</p><p class="q2">although there are many who oppose me. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Elohim, who is enthroned forever, 
-</p><p class="q2">will hear and answer them. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">They never change 
-</p><p class="q2">and don’t fear Elohim. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He raises his hands against his friends. 
-</p><p class="q2">He has violated his covenant. 
-</p><p class="q1">
-<span class="v">21&#160;</span>His mouth was smooth as butter, 
-</p><p class="q2">but his heart was war. 
-</p><p class="q1">His words were softer than oil, 
-</p><p class="q2">yet they were drawn swords. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>Cast your burden on Yahweh and he will sustain you. 
-</p><p class="q2">He will never allow the righteous to be moved. 
-</p><p class="q1">
-<span class="v">23&#160;</span>But you, Elohim, will bring them down into the pit of destruction. 
-</p><p class="q2">Bloodthirsty and deceitful men shall not live out half their days, 
-</p><p class="q2">but I will trust in you. 
-</p><h2 class="psalmlabel" id="56">56</h2>
-<p class="d">For the Chief Musician. To the tune of “Silent Dove in Distant Lands.” A poem by David, when the Philistines seized him in Gath. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Be merciful to me, Elohim, for man wants to swallow me up. 
-</p><p class="q2">All day long, he attacks and oppresses me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>My enemies want to swallow me up all day long, 
-</p><p class="q2">for they are many who fight proudly against me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>When I am afraid, 
-</p><p class="q2">I will put my trust in you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>In Elohim, I praise his word. 
-</p><p class="q2">In Elohim, I put my trust. 
-</p><p class="q1">I will not be afraid. 
-</p><p class="q2">What can flesh do to me? 
-</p><p class="q1">
-<span class="v">5&#160;</span>All day long they twist my words. 
-</p><p class="q2">All their thoughts are against me for evil. 
-</p><p class="q1">
-<span class="v">6&#160;</span>They conspire and lurk, 
-</p><p class="q2">watching my steps. 
-</p><p class="q2">They are eager to take my life. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Shall they escape by iniquity? 
-</p><p class="q2">In anger cast down the peoples, Elohim. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You count my wanderings. 
-</p><p class="q2">You put my tears into your container. 
-</p><p class="q2">Aren’t they in your book? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Then my enemies shall turn back in the day that I call. 
-</p><p class="q2">I know this: that Elohim is for me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>In Elohim, I will praise his word. 
-</p><p class="q2">In Yahweh, I will praise his word. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I have put my trust in Elohim. 
-</p><p class="q2">I will not be afraid. 
-</p><p class="q2">What can man do to me? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Your vows are on me, Elohim. 
-</p><p class="q2">I will give thank offerings to you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For you have delivered my soul from death, 
-</p><p class="q2">and prevented my feet from falling, 
-</p><p class="q2">that I may walk before Elohim in the light of the living. 
-</p><h2 class="psalmlabel" id="57">57</h2>
-<p class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A poem by David, when he fled from Saul, in the cave. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Be merciful to me, Elohim, be merciful to me, 
-</p><p class="q2">for my soul takes refuge in you. 
-</p><p class="q1">Yes, in the shadow of your wings, I will take refuge, 
-</p><p class="q2">until disaster has passed. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I cry out to Elohim Most High, 
-</p><p class="q1">to Elohim who accomplishes my requests for me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He will send from heaven, and save me, 
-</p><p class="q2">he rebukes the one who is pursuing me. </p><p class="qs">Selah.</p> 
-</p><p class="q1">Elohim will send out his loving kindness and his truth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>My soul is among lions. 
-</p><p class="q2">I lie among those who are set on fire, 
-</p><p class="q2">even the sons of men, whose teeth are spears and arrows, 
-</p><p class="q2">and their tongue a sharp sword. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Be exalted, Elohim, above the heavens! 
-</p><p class="q2">Let your glory be above all the earth! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>They have prepared a net for my steps. 
-</p><p class="q2">My soul is bowed down. 
-</p><p class="q1">They dig a pit before me. 
-</p><p class="q2">They fall into the middle of it themselves. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">7&#160;</span>My heart is steadfast, Elohim. 
-</p><p class="q2">My heart is steadfast. 
-</p><p class="q2">I will sing, yes, I will sing praises. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Wake up, my glory! Wake up, lute and harp! 
-</p><p class="q2">I will wake up the dawn. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will give thanks to you, Lord, among the peoples. 
-</p><p class="q2">I will sing praises to you among the nations. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For your great loving kindness reaches to the heavens, 
-</p><p class="q2">and your truth to the skies. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Be exalted, Elohim, above the heavens. 
-</p><p class="q2">Let your glory be over all the earth. 
-</p><h2 class="psalmlabel" id="58">58</h2>
-<p class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A poem by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Do you indeed speak righteousness, silent ones? 
-</p><p class="q2">Do you judge blamelessly, you sons of men? 
-</p><p class="q1">
-<span class="v">2&#160;</span>No, in your heart you plot injustice. 
-</p><p class="q2">You measure out the violence of your hands in the earth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The wicked go astray from the womb. 
-</p><p class="q2">They are wayward as soon as they are born, speaking lies. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Their poison is like the poison of a snake, 
-</p><p class="q2">like a deaf cobra that stops its ear, 
-</p><p class="q2">
-<span class="v">5&#160;</span>which doesn’t listen to the voice of charmers, 
-</p><p class="q2">no matter how skillful the charmer may be. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Break their teeth, Elohim, in their mouth. 
-</p><p class="q2">Break out the great teeth of the young lions, Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Let them vanish like water that flows away. 
-</p><p class="q2">When they draw the bow, let their arrows be made blunt. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let them be like a snail which melts and passes away, 
-</p><p class="q2">like the stillborn child, who has not seen the sun. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Before your pots can feel the heat of the thorns, 
-</p><p class="q2">he will sweep away the green and the burning alike. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The righteous shall rejoice when he sees the vengeance. 
-</p><p class="q2">He shall wash his feet in the blood of the wicked, 
-</p><p class="q1">
-<span class="v">11&#160;</span>so that men shall say, “Most certainly there is a reward for the righteous. 
-</p><p class="q2">Most certainly there is an Elohim who judges the earth.” 
-</p><h2 class="psalmlabel" id="59">59</h2>
-<p class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A poem by David, when Saul sent, and they watched the house to kill him. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Deliver me from my enemies, my Elohim. 
-</p><p class="q2">Set me on high from those who rise up against me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Deliver me from the workers of iniquity. 
-</p><p class="q2">Save me from the bloodthirsty men. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For, behold, they lie in wait for my soul. 
-</p><p class="q2">The mighty gather themselves together against me, 
-</p><p class="q2">not for my disobedience, nor for my sin, Yahweh. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I have done no wrong, yet they are ready to attack me. 
-</p><p class="q2">Rise up, behold, and help me! 
-</p><p class="q1">
-<span class="v">5&#160;</span>You, Yahweh Elohim of Armies, the Elohim of Israel, 
-</p><p class="q2">rouse yourself to punish the nations. 
-</p><p class="q2">Show no mercy to the wicked traitors. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">6&#160;</span>They return at evening, howling like dogs, 
-</p><p class="q2">and prowl around the city. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Behold, they spew with their mouth. 
-</p><p class="q2">Swords are in their lips, 
-</p><p class="q2">“For”, they say, “who hears us?” 
-</p><p class="q1">
-<span class="v">8&#160;</span>But you, Yahweh, laugh at them. 
-</p><p class="q2">You scoff at all the nations. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Oh, my Strength, I watch for you, 
-</p><p class="q2">for Elohim is my high tower. 
-</p><p class="q1">
-<span class="v">10&#160;</span>My Elohim will go before me with his loving kindness. 
-</p><p class="q2">Elohim will let me look at my enemies in triumph. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Don’t kill them, or my people may forget. 
-</p><p class="q2">Scatter them by your power, and bring them down, Lord our shield. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For the sin of their mouth, and the words of their lips, 
-</p><p class="q2">let them be caught in their pride, 
-</p><p class="q2">for the curses and lies which they utter. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Consume them in wrath. 
-</p><p class="q2">Consume them, and they will be no more. 
-</p><p class="q1">Let them know that Elohim rules in Jacob, 
-</p><p class="q2">to the ends of the earth. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">14&#160;</span>At evening let them return. 
-</p><p class="q2">Let them howl like a dog, and go around the city. 
-</p><p class="q1">
-<span class="v">15&#160;</span>They shall wander up and down for food, 
-</p><p class="q2">and wait all night if they aren’t satisfied. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>But I will sing of your strength. 
-</p><p class="q2">Yes, I will sing aloud of your loving kindness in the morning. 
-</p><p class="q1">For you have been my high tower, 
-</p><p class="q2">a refuge in the day of my distress. 
-</p><p class="q1">
-<span class="v">17&#160;</span>To you, my strength, I will sing praises. 
-</p><p class="q2">For Elohim is my high tower, the Elohim of my mercy. 
-</p><h2 class="psalmlabel" id="60">60</h2>
-<p class="d">For the Chief Musician. To the tune of “The Lily of the Covenant.” A teaching poem by David, when he fought with Aram Naharaim and with Aram Zobah, and Joab returned, and killed twelve thousand of Edom in the Valley of Salt. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim, you have rejected us. 
-</p><p class="q2">You have broken us down. 
-</p><p class="q1">You have been angry. 
-</p><p class="q2">Restore us, again. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You have made the land tremble. 
-</p><p class="q2">You have torn it. 
-</p><p class="q1">Mend its fractures, 
-</p><p class="q2">for it quakes. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You have shown your people hard things. 
-</p><p class="q2">You have made us drink the wine that makes us stagger. 
-</p><p class="q1">
-<span class="v">4&#160;</span>You have given a banner to those who fear you, 
-</p><p class="q2">that it may be displayed because of the truth. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>So that your beloved may be delivered, 
-</p><p class="q2">save with your right hand, and answer us. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Elohim has spoken from his sanctuary: 
-</p><p class="q2">“I will triumph. 
-</p><p class="q2">I will divide Shechem, 
-</p><p class="q2">and measure out the valley of Succoth. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Gilead is mine, and Manasseh is mine. 
-</p><p class="q2">Ephraim also is the defense of my head. 
-</p><p class="q2">Judah is my scepter. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Moab is my wash basin. 
-</p><p class="q2">I will throw my sandal on Edom. 
-</p><p class="q2">I shout in triumph over Philistia.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Who will bring me into the strong city? 
-</p><p class="q2">Who has led me to Edom? 
-</p><p class="q1">
-<span class="v">10&#160;</span>Haven’t you, Elohim, rejected us? 
-</p><p class="q2">You don’t go out with our armies, Elohim. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Give us help against the adversary, 
-</p><p class="q2">for the help of man is vain. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Through Elohim we will do valiantly, 
-</p><p class="q2">for it is he who will tread down our adversaries. 
-</p><h2 class="psalmlabel" id="61">61</h2>
-<p class="d">For the Chief Musician. For a stringed instrument. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear my cry, Elohim. 
-</p><p class="q2">Listen to my prayer. 
-</p><p class="q1">
-<span class="v">2&#160;</span>From the end of the earth, I will call to you when my heart is overwhelmed. 
-</p><p class="q2">Lead me to the rock that is higher than I. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For you have been a refuge for me, 
-</p><p class="q2">a strong tower from the enemy. 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will dwell in your tent forever. 
-</p><p class="q2">I will take refuge in the shelter of your wings. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>For you, Elohim, have heard my vows. 
-</p><p class="q2">You have given me the heritage of those who fear your name. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You will prolong the king’s life. 
-</p><p class="q2">His years will be for generations. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He shall be enthroned in Elohim’s presence forever. 
-</p><p class="q2">Appoint your loving kindness and truth, that they may preserve him. 
-</p><p class="q1">
-<span class="v">8&#160;</span>So I will sing praise to your name forever, 
-</p><p class="q2">that I may fulfill my vows daily. 
-</p><h2 class="psalmlabel" id="62">62</h2>
-<p class="d">For the Chief Musician. To Jeduthun. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>My soul rests in Elohim alone. 
-</p><p class="q2">My salvation is from him. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He alone is my rock, my salvation, and my fortress. 
-</p><p class="q2">I will never be greatly shaken. 
-</p><p class="q1">
-<span class="v">3&#160;</span>How long will you assault a man? 
-</p><p class="q2">Would all of you throw him down, 
-</p><p class="q2">like a leaning wall, like a tottering fence? 
-</p><p class="q1">
-<span class="v">4&#160;</span>They fully intend to throw him down from his lofty place. 
-</p><p class="q2">They delight in lies. 
-</p><p class="q2">They bless with their mouth, but they curse inwardly. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>My soul, wait in silence for Elohim alone, 
-</p><p class="q2">for my expectation is from him. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He alone is my rock and my salvation, my fortress. 
-</p><p class="q2">I will not be shaken. 
-</p><p class="q1">
-<span class="v">7&#160;</span>My salvation and my honor is with Elohim. 
-</p><p class="q2">The rock of my strength, and my refuge, is in Elohim. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Trust in him at all times, you people. 
-</p><p class="q2">Pour out your heart before him. 
-</p><p class="q2">Elohim is a refuge for us. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">9&#160;</span>Surely men of low degree are just a breath, 
-</p><p class="q2">and men of high degree are a lie. 
-</p><p class="q1">In the balances they will go up. 
-</p><p class="q2">They are together lighter than a breath. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Don’t trust in oppression. 
-</p><p class="q2">Don’t become vain in robbery. 
-</p><p class="q1">If riches increase, 
-</p><p class="q2">don’t set your heart on them. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Elohim has spoken once; 
-</p><p class="q2">twice I have heard this, 
-</p><p class="q2">that power belongs to Elohim. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Also to you, Lord, belongs loving kindness, 
-</p><p class="q2">for you reward every man according to his work. 
-</p><h2 class="psalmlabel" id="63">63</h2>
-<p class="d">A Psalm by David, when he was in the desert of Judah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim, you are my Elohim. 
-</p><p class="q2">I will earnestly seek you. 
-</p><p class="q1">My soul thirsts for you. 
-</p><p class="q2">My flesh longs for you, 
-</p><p class="q2">in a dry and weary land, where there is no water. 
-</p><p class="q1">
-<span class="v">2&#160;</span>So I have seen you in the sanctuary, 
-</p><p class="q2">watching your power and your glory. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Because your loving kindness is better than life, 
-</p><p class="q2">my lips shall praise you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>So I will bless you while I live. 
-</p><p class="q2">I will lift up my hands in your name. 
-</p><p class="q1">
-<span class="v">5&#160;</span>My soul shall be satisfied as with the richest food. 
-</p><p class="q2">My mouth shall praise you with joyful lips, 
-</p><p class="q2">
-<span class="v">6&#160;</span>when I remember you on my bed, 
-</p><p class="q2">and think about you in the night watches. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For you have been my help. 
-</p><p class="q2">I will rejoice in the shadow of your wings. 
-</p><p class="q1">
-<span class="v">8&#160;</span>My soul stays close to you. 
-</p><p class="q2">Your right hand holds me up. 
-</p><p class="q1">
-<span class="v">9&#160;</span>But those who seek my soul to destroy it 
-</p><p class="q2">shall go into the lower parts of the earth. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They shall be given over to the power of the sword. 
-</p><p class="q2">They shall be jackal food. 
-</p><p class="q1">
-<span class="v">11&#160;</span>But the king shall rejoice in Elohim. 
-</p><p class="q2">Everyone who swears by him will praise him, 
-</p><p class="q2">for the mouth of those who speak lies shall be silenced. 
-</p><h2 class="psalmlabel" id="64">64</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear my voice, Elohim, in my complaint. 
-</p><p class="q2">Preserve my life from fear of the enemy. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Hide me from the conspiracy of the wicked, 
-</p><p class="q2">from the noisy crowd of the ones doing evil; 
-</p><p class="q1">
-<span class="v">3&#160;</span>who sharpen their tongue like a sword, 
-</p><p class="q2">and aim their arrows, deadly words, 
-</p><p class="q2">
-<span class="v">4&#160;</span>to shoot innocent men from ambushes. 
-</p><p class="q2">They shoot at him suddenly and fearlessly. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They encourage themselves in evil plans. 
-</p><p class="q2">They talk about laying snares secretly. 
-</p><p class="q2">They say, “Who will see them?” 
-</p><p class="q1">
-<span class="v">6&#160;</span>They plot injustice, saying, “We have made a perfect plan!” 
-</p><p class="q2">Surely man’s mind and heart are cunning. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But Elohim will shoot at them. 
-</p><p class="q2">They will be suddenly struck down with an arrow. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Their own tongues shall ruin them. 
-</p><p class="q2">All who see them will shake their heads. 
-</p><p class="q1">
-<span class="v">9&#160;</span>All mankind shall be afraid. 
-</p><p class="q2">They shall declare the work of Elohim, 
-</p><p class="q2">and shall wisely ponder what he has done. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The righteous shall be glad in Yahweh, 
-</p><p class="q2">and shall take refuge in him. 
-</p><p class="q2">All the upright in heart shall praise him! 
-</p><h2 class="psalmlabel" id="65">65</h2>
-<p class="d">For the Chief Musician. A Psalm by David. A song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Praise waits for you, Elohim, in Zion. 
-</p><p class="q2">Vows shall be performed to you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You who hear prayer, 
-</p><p class="q2">all men will come to you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Sins overwhelmed me, 
-</p><p class="q2">but you atoned for our transgressions. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Blessed is the one whom you choose and cause to come near, 
-</p><p class="q2">that he may live in your courts. 
-</p><p class="q2">We will be filled with the goodness of your house, 
-</p><p class="q2">your set-apart temple. 
-</p><p class="q1">
-<span class="v">5&#160;</span>By awesome deeds of righteousness, you answer us, 
-</p><p class="q2">Elohim of our salvation. 
-</p><p class="q1">You who are the hope of all the ends of the earth, 
-</p><p class="q2">of those who are far away on the sea. 
-</p><p class="q1">
-<span class="v">6&#160;</span>By your power, you form the mountains, 
-</p><p class="q2">having armed yourself with strength. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You still the roaring of the seas, 
-</p><p class="q2">the roaring of their waves, 
-</p><p class="q2">and the turmoil of the nations. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They also who dwell in faraway places are afraid at your wonders. 
-</p><p class="q2">You call the morning’s dawn and the evening with songs of joy. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You visit the earth, and water it. 
-</p><p class="q2">You greatly enrich it. 
-</p><p class="q1">The river of Elohim is full of water. 
-</p><p class="q2">You provide them grain, for so you have ordained it. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You drench its furrows. 
-</p><p class="q2">You level its ridges. 
-</p><p class="q2">You soften it with showers. 
-</p><p class="q2">You bless it with a crop. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You crown the year with your bounty. 
-</p><p class="q2">Your carts overflow with abundance. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The wilderness grasslands overflow. 
-</p><p class="q2">The hills are clothed with gladness. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The pastures are covered with flocks. 
-</p><p class="q2">The valleys also are clothed with grain. 
-</p><p class="q1">They shout for joy! 
-</p><p class="q2">They also sing. 
-</p><h2 class="psalmlabel" id="66">66</h2>
-<p class="d">For the Chief Musician. A song. A Psalm. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Make a joyful shout to Elohim, all the earth! 
-</p><p class="q2">
-<span class="v">2&#160;</span>Sing to the glory of his name! 
-</p><p class="q2">Offer glory and praise! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Tell Elohim, “How awesome are your deeds! 
-</p><p class="q2">Through the greatness of your power, your enemies submit themselves to you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>All the earth will worship you, 
-</p><p class="q2">and will sing to you; 
-</p><p class="q2">they will sing to your name.” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>Come, and see Elohim’s deeds—</p><p class="q2">awesome work on behalf of the children of men. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He turned the sea into dry land. 
-</p><p class="q2">They went through the river on foot. 
-</p><p class="q2">There, we rejoiced in him. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He rules by his might forever. 
-</p><p class="q2">His eyes watch the nations. 
-</p><p class="q2">Don’t let the rebellious rise up against him. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">8&#160;</span>Praise our Elohim, you peoples! 
-</p><p class="q2">Make the sound of his praise heard, 
-</p><p class="q1">
-<span class="v">9&#160;</span>who preserves our life among the living, 
-</p><p class="q2">and doesn’t allow our feet to be moved. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For you, Elohim, have tested us. 
-</p><p class="q2">You have refined us, as silver is refined. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You brought us into prison. 
-</p><p class="q2">You laid a burden on our backs. 
-</p><p class="q1">
-<span class="v">12&#160;</span>You allowed men to ride over our heads. 
-</p><p class="q2">We went through fire and through water, 
-</p><p class="q2">but you brought us to the place of abundance. 
-</p><p class="q1">
-<span class="v">13&#160;</span>I will come into your temple with burnt offerings. 
-</p><p class="q2">I will pay my vows to you, 
-<span class="v">14&#160;</span>which my lips promised, 
-</p><p class="q2">and my mouth spoke, when I was in distress. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will offer to you burnt offerings of fat animals, 
-</p><p class="q2">with the offering of rams, 
-</p><p class="q2">I will offer bulls with goats. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">16&#160;</span>Come and hear, all you who fear Elohim. 
-</p><p class="q2">I will declare what he has done for my soul. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I cried to him with my mouth. 
-</p><p class="q2">He was extolled with my tongue. 
-</p><p class="q1">
-<span class="v">18&#160;</span>If I cherished sin in my heart, 
-</p><p class="q2">the Lord wouldn’t have listened. 
-</p><p class="q1">
-<span class="v">19&#160;</span>But most certainly, Elohim has listened. 
-</p><p class="q2">He has heard the voice of my prayer. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Blessed be Elohim, who has not turned away my prayer, 
-</p><p class="q2">nor his loving kindness from me. 
-</p><h2 class="psalmlabel" id="67">67</h2>
-<p class="d">For the Chief Musician. With stringed instruments. A Psalm. A song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>May Elohim be merciful to us, bless us, 
-</p><p class="q2">and cause his face to shine on us. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">2&#160;</span>That your way may be known on earth, 
-</p><p class="q2">and your salvation among all nations, 
-</p><p class="q1">
-<span class="v">3&#160;</span>let the peoples praise you, Elohim. 
-</p><p class="q2">Let all the peoples praise you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Oh let the nations be glad and sing for joy, 
-</p><p class="q2">for you will judge the peoples with equity, 
-</p><p class="q2">and govern the nations on earth. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let the peoples praise you, Elohim. 
-</p><p class="q2">Let all the peoples praise you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The earth has yielded its increase. 
-</p><p class="q2">Elohim, even our own Elohim, will bless us. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Elohim will bless us. 
-</p><p class="q2">All the ends of the earth shall fear him. 
-</p><h2 class="psalmlabel" id="68">68</h2>
-<p class="d">For the Chief Musician. A Psalm by David. A song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Let Elohim arise! 
-</p><p class="q2">Let his enemies be scattered! 
-</p><p class="q2">Let them who hate him also flee before him. 
-</p><p class="q1">
-<span class="v">2&#160;</span>As smoke is driven away, 
-</p><p class="q2">so drive them away. 
-</p><p class="q1">As wax melts before the fire, 
-</p><p class="q2">so let the wicked perish at the presence of Elohim. 
-</p><p class="q1">
-<span class="v">3&#160;</span>But let the righteous be glad. 
-</p><p class="q2">Let them rejoice before Elohim. 
-</p><p class="q2">Yes, let them rejoice with gladness. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Sing to Elohim! Sing praises to his name! 
-</p><p class="q2">Extol him who rides on the clouds: 
-</p><p class="q1">to Yah, his name! 
-</p><p class="q2">Rejoice before him! 
-</p><p class="q1">
-<span class="v">5&#160;</span>A father of the fatherless, and a defender of the widows, 
-</p><p class="q2">is Elohim in his set-apart habitation. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Elohim sets the lonely in families. 
-</p><p class="q1">He brings out the prisoners with singing, 
-</p><p class="q2">but the rebellious dwell in a sun-scorched land. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>Elohim, when you went out before your people, 
-</p><p class="q2">when you marched through the wilderness... </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">8&#160;</span>The earth trembled. 
-</p><p class="q2">The sky also poured down rain at the presence of the Elohim of Sinai—</p><p class="q2">at the presence of Elohim, the Elohim of Israel. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You, Elohim, sent a plentiful rain. 
-</p><p class="q2">You confirmed your inheritance when it was weary. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Your congregation lived therein. 
-</p><p class="q2">You, Elohim, prepared your goodness for the poor. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The Lord announced the word. 
-</p><p class="q2">The ones who proclaim it are a great company. 
-</p><p class="q1">
-<span class="v">12&#160;</span>“Kings of armies flee! They flee!” 
-</p><p class="q2">She who waits at home divides the plunder, 
-</p><p class="q2">
-<span class="v">13&#160;</span>while you sleep among the camp fires, 
-</p><p class="q2">the wings of a dove sheathed with silver, 
-</p><p class="q2">her feathers with shining gold. 
-</p><p class="q1">
-<span class="v">14&#160;</span>When the Almighty scattered kings in her, 
-</p><p class="q2">it snowed on Zalmon. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The mountains of Bashan are majestic mountains. 
-</p><p class="q2">The mountains of Bashan are rugged. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Why do you look in envy, you rugged mountains, 
-</p><p class="q2">at the mountain where Elohim chooses to reign? 
-</p><p class="q2">Yes, Yahweh will dwell there forever. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The chariots of Elohim are tens of thousands and thousands of thousands. 
-</p><p class="q2">The Lord is among them, from Sinai, into the sanctuary. 
-</p><p class="q1">
-<span class="v">18&#160;</span>You have ascended on high. 
-</p><p class="q2">You have led away captives. 
-</p><p class="q1">You have received gifts among people, 
-</p><p class="q2">yes, among the rebellious also, that Yah Elohim might dwell there. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Blessed be the Lord, who daily bears our burdens, 
-</p><p class="q2">even the Elohim who is our salvation. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">20&#160;</span>Elohim is to us an Elohim of deliverance. 
-</p><p class="q2">To Yahweh, the Lord, belongs escape from death. 
-</p><p class="q1">
-<span class="v">21&#160;</span>But Elohim will strike through the head of his enemies, 
-</p><p class="q2">the hairy scalp of such a one as still continues in his guiltiness. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The Lord said, “I will bring you again from Bashan, 
-</p><p class="q2">I will bring you again from the depths of the sea, 
-</p><p class="q1">
-<span class="v">23&#160;</span>that you may crush them, dipping your foot in blood, 
-</p><p class="q2">that the tongues of your dogs may have their portion from your enemies.” 
-</p><p class="q1">
-<span class="v">24&#160;</span>They have seen your processions, Elohim, 
-</p><p class="q2">even the processions of my Elohim, my King, into the sanctuary. 
-</p><p class="q1">
-<span class="v">25&#160;</span>The singers went before, the minstrels followed after, 
-</p><p class="q2">among the ladies playing with tambourines, 
-</p><p class="q1">
-<span class="v">26&#160;</span>“Bless Elohim in the congregations, 
-</p><p class="q2">even the Lord in the assembly of Israel!” 
-</p><p class="q1">
-<span class="v">27&#160;</span>There is little Benjamin, their ruler, 
-</p><p class="q2">the princes of Judah, their council, 
-</p><p class="q2">the princes of Zebulun, and the princes of Naphtali. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">28&#160;</span>Your Elohim has commanded your strength. 
-</p><p class="q2">Strengthen, Elohim, that which you have done for us. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Because of your temple at Jerusalem, 
-</p><p class="q2">kings shall bring presents to you. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Rebuke the wild animal of the reeds, 
-</p><p class="q2">the multitude of the bulls with the calves of the peoples. 
-</p><p class="q1">Trample under foot the bars of silver. 
-</p><p class="q2">Scatter the nations who delight in war. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Princes shall come out of Egypt. 
-</p><p class="q2">Ethiopia shall hurry to stretch out her hands to Elohim. 
-</p><p class="q1">
-<span class="v">32&#160;</span>Sing to Elohim, you kingdoms of the earth! 
-</p><p class="q2">Sing praises to the Lord—</p><p class="qs">Selah—</p></p><p class="q1"><span class="v">33&#160;</span>to him who rides on the heaven of heavens, which are of old; 
-</p><p class="q2">behold, he utters his voice, a mighty voice. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Ascribe strength to Elohim! 
-</p><p class="q2">His excellency is over Israel, 
-</p><p class="q2">his strength is in the skies. 
-</p><p class="q1">
-<span class="v">35&#160;</span>You are awesome, Elohim, in your sanctuaries. 
-</p><p class="q2">The Elohim of Israel gives strength and power to his people. 
-</p><p class="q2">Praise be to Elohim! 
-</p><h2 class="psalmlabel" id="69">69</h2>
-<p class="d">For the Chief Musician. To the tune of “Lilies.” By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Save me, Elohim, 
-</p><p class="q2">for the waters have come up to my neck! 
-</p><p class="q1">
-<span class="v">2&#160;</span>I sink in deep mire, where there is no foothold. 
-</p><p class="q2">I have come into deep waters, where the floods overflow me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I am weary with my crying. 
-</p><p class="q2">My throat is dry. 
-</p><p class="q2">My eyes fail looking for my Elohim. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Those who hate me without a cause are more than the hairs of my head. 
-</p><p class="q2">Those who want to cut me off, being my enemies wrongfully, are mighty. 
-</p><p class="q2">I have to restore what I didn’t take away. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Elohim, you know my foolishness. 
-</p><p class="q2">My sins aren’t hidden from you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Don’t let those who wait for you be shamed through me, Lord Yahweh of Armies. 
-</p><p class="q2">Don’t let those who seek you be brought to dishonor through me, Elohim of Israel. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Because for your sake, I have borne reproach. 
-</p><p class="q2">Shame has covered my face. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I have become a stranger to my brothers, 
-</p><p class="q2">an alien to my mother’s children. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For the zeal of your house consumes me. 
-</p><p class="q2">The reproaches of those who reproach you have fallen on me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>When I wept and I fasted, 
-</p><p class="q2">that was to my reproach. 
-</p><p class="q1">
-<span class="v">11&#160;</span>When I made sackcloth my clothing, 
-</p><p class="q2">I became a byword to them. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Those who sit in the gate talk about me. 
-</p><p class="q2">I am the song of the drunkards. 
-</p><p class="q1">
-<span class="v">13&#160;</span>But as for me, my prayer is to you, Yahweh, in an acceptable time. 
-</p><p class="q2">Elohim, in the abundance of your loving kindness, answer me in the truth of your salvation. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Deliver me out of the mire, and don’t let me sink. 
-</p><p class="q2">Let me be delivered from those who hate me, and out of the deep waters. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Don’t let the flood waters overwhelm me, 
-</p><p class="q2">neither let the deep swallow me up. 
-</p><p class="q2">Don’t let the pit shut its mouth on me. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Answer me, Yahweh, for your loving kindness is good. 
-</p><p class="q2">According to the multitude of your tender mercies, turn to me. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Don’t hide your face from your servant, 
-</p><p class="q2">for I am in distress. 
-</p><p class="q2">Answer me speedily! 
-</p><p class="q1">
-<span class="v">18&#160;</span>Draw near to my soul and redeem it. 
-</p><p class="q2">Ransom me because of my enemies. 
-</p><p class="q1">
-<span class="v">19&#160;</span>You know my reproach, my shame, and my dishonor. 
-</p><p class="q2">My adversaries are all before you. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Reproach has broken my heart, and I am full of heaviness. 
-</p><p class="q2">I looked for some to take pity, but there was none; 
-</p><p class="q2">for comforters, but I found none. 
-</p><p class="q1">
-<span class="v">21&#160;</span>They also gave me poison for my food. 
-</p><p class="q2">In my thirst, they gave me vinegar to drink. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Let their table before them become a snare. 
-</p><p class="q2">May it become a retribution and a trap. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Let their eyes be darkened, so that they can’t see. 
-</p><p class="q2">Let their backs be continually bent. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Pour out your indignation on them. 
-</p><p class="q2">Let the fierceness of your anger overtake them. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Let their habitation be desolate. 
-</p><p class="q2">Let no one dwell in their tents. 
-</p><p class="q1">
-<span class="v">26&#160;</span>For they persecute him whom you have wounded. 
-</p><p class="q2">They tell of the sorrow of those whom you have hurt. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Charge them with crime upon crime. 
-</p><p class="q2">Don’t let them come into your righteousness. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Let them be blotted out of the book of life, 
-</p><p class="q2">and not be written with the righteous. 
-</p><p class="q1">
-<span class="v">29&#160;</span>But I am in pain and distress. 
-</p><p class="q2">Let your salvation, Elohim, protect me. 
-</p><p class="q1">
-<span class="v">30&#160;</span>I will praise the name of Elohim with a song, 
-</p><p class="q2">and will magnify him with thanksgiving. 
-</p><p class="q1">
-<span class="v">31&#160;</span>It will please Yahweh better than an ox, 
-</p><p class="q2">or a bull that has horns and hoofs. 
-</p><p class="q1">
-<span class="v">32&#160;</span>The humble have seen it, and are glad. 
-</p><p class="q2">You who seek after Elohim, let your heart live. 
-</p><p class="q1">
-<span class="v">33&#160;</span>For Yahweh hears the needy, 
-</p><p class="q2">and doesn’t despise his captive people. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Let heaven and earth praise him; 
-</p><p class="q2">the seas, and everything that moves therein! 
-</p><p class="q1">
-<span class="v">35&#160;</span>For Elohim will save Zion, and build the cities of Judah. 
-</p><p class="q2">They shall settle there, and own it. 
-</p><p class="q1">
-<span class="v">36&#160;</span>The children also of his servants shall inherit it. 
-</p><p class="q2">Those who love his name shall dwell therein. 
-</p><h2 class="psalmlabel" id="70">70</h2>
-<p class="d">For the Chief Musician. By David. A reminder. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hurry, Elohim, to deliver me. 
-</p><p class="q2">Come quickly to help me, Yahweh. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let them be disappointed and confounded who seek my soul. 
-</p><p class="q2">Let those who desire my ruin be turned back in disgrace. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Let them be turned because of their shame 
-</p><p class="q2">who say, “Aha! Aha!” 
-</p><p class="q1">
-<span class="v">4&#160;</span>Let all those who seek you rejoice and be glad in you. 
-</p><p class="q2">Let those who love your salvation continually say, 
-</p><p class="q2">“Let Elohim be exalted!” 
-</p><p class="q1">
-<span class="v">5&#160;</span>But I am poor and needy. 
-</p><p class="q2">Come to me quickly, Elohim. 
-</p><p class="q1">You are my help and my deliverer. 
-</p><p class="q2">Yahweh, don’t delay. 
-</p><div class="b"> &#160; </div>
+<div class="d">For the Chief Musician. A Psalm by the sons of Korah. 
+</div><div class="q1">
+<sup>1&#160;</sup>Oh clap your hands, all you nations. 
+</div><div class="q2">Shout to Elohim with the voice of triumph! 
+</div><div class="q1">
+<sup>2&#160;</sup>For Yahweh Most High is awesome. 
+</div><div class="q2">He is a great King over all the earth. 
+</div><div class="q1">
+<sup>3&#160;</sup>He subdues nations under us, 
+</div><div class="q2">and peoples under our feet. 
+</div><div class="q1">
+<sup>4&#160;</sup>He chooses our inheritance for us, 
+</div><div class="q2">the glory of Jacob whom he loved. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>Elohim has gone up with a shout, 
+</div><div class="q2">Yahweh with the sound of a trumpet. 
+</div><div class="q1">
+<sup>6&#160;</sup>Sing praises to Elohim! Sing praises! 
+</div><div class="q2">Sing praises to our King! Sing praises! 
+</div><div class="q1">
+<sup>7&#160;</sup>For Elohim is the King of all the earth. 
+</div><div class="q2">Sing praises with understanding. 
+</div><div class="q1">
+<sup>8&#160;</sup>Elohim reigns over the nations. 
+</div><div class="q2">Elohim sits on his set-apart throne. 
+</div><div class="q1">
+<sup>9&#160;</sup>The princes of the peoples are gathered together, 
+</div><div class="q1">the people of the Elohim of Abraham. 
+</div><div class="q2">For the shields of the earth belong to Elohim. 
+</div><div class="q2">He is greatly exalted! 
+</div><h2 class="psalmlabel" id="48">48</h2>
+<div class="d">A Song. A Psalm by the sons of Korah. 
+</div><div class="q1">
+<sup>1&#160;</sup>Great is Yahweh, and greatly to be praised, 
+</div><div class="q2">in the city of our Elohim, in his set-apart mountain. 
+</div><div class="q1">
+<sup>2&#160;</sup>Beautiful in elevation, the joy of the whole earth, 
+</div><div class="q2">is Mount Zion, on the north sides, 
+</div><div class="q2">the city of the great King. 
+</div><div class="q1">
+<sup>3&#160;</sup>Elohim has shown himself in her citadels as a refuge. 
+</div><div class="q1">
+<sup>4&#160;</sup>For, behold, the kings assembled themselves, 
+</div><div class="q2">they passed by together. 
+</div><div class="q1">
+<sup>5&#160;</sup>They saw it, then they were amazed. 
+</div><div class="q2">They were dismayed. 
+</div><div class="q2">They hurried away. 
+</div><div class="q1">
+<sup>6&#160;</sup>Trembling took hold of them there, 
+</div><div class="q2">pain, as of a woman in travail. 
+</div><div class="q1">
+<sup>7&#160;</sup>With the east wind, you break the ships of Tarshish. 
+</div><div class="q1">
+<sup>8&#160;</sup>As we have heard, so we have seen, 
+</div><div class="q2">in the city of Yahweh of Armies, in the city of our Elohim. 
+</div><div class="q1">Elohim will establish it forever. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>9&#160;</sup>We have thought about your loving kindness, Elohim, 
+</div><div class="q2">in the middle of your temple. 
+</div><div class="q1">
+<sup>10&#160;</sup>As is your name, Elohim, 
+</div><div class="q2">so is your praise to the ends of the earth. 
+</div><div class="q2">Your right hand is full of righteousness. 
+</div><div class="q1">
+<sup>11&#160;</sup>Let Mount Zion be glad! 
+</div><div class="q2">Let the daughters of Judah rejoice because of your judgments. 
+</div><div class="q1">
+<sup>12&#160;</sup>Walk about Zion, and go around her. 
+</div><div class="q2">Number its towers. 
+</div><div class="q1">
+<sup>13&#160;</sup>Notice her bulwarks. 
+</div><div class="q2">Consider her palaces, 
+</div><div class="q2">that you may tell it to the next generation. 
+</div><div class="q1">
+<sup>14&#160;</sup>For this Elohim is our Elohim forever and ever. 
+</div><div class="q2">He will be our guide even to death. 
+</div><h2 class="psalmlabel" id="49">49</h2>
+<div class="d">For the Chief Musician. A Psalm by the sons of Korah. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear this, all you peoples. 
+</div><div class="q2">Listen, all you inhabitants of the world, 
+</div><div class="q2">
+<sup>2&#160;</sup>both low and high, 
+</div><div class="q2">rich and poor together. 
+</div><div class="q1">
+<sup>3&#160;</sup>My mouth will speak words of wisdom. 
+</div><div class="q2">My heart will utter understanding. 
+</div><div class="q1">
+<sup>4&#160;</sup>I will incline my ear to a proverb. 
+</div><div class="q2">I will solve my riddle on the harp. 
+</div><div class="q1">
+<sup>5&#160;</sup>Why should I fear in the days of evil, 
+</div><div class="q2">when iniquity at my heels surrounds me? 
+</div><div class="q1">
+<sup>6&#160;</sup>Those who trust in their wealth, 
+</div><div class="q2">and boast in the multitude of their riches—</div><div class="q2">
+<sup>7&#160;</sup>none of them can by any means redeem his brother, 
+</div><div class="q2">nor give Elohim a ransom for him. 
+</div><div class="q1">
+<sup>8&#160;</sup>For the redemption of their life is costly, 
+</div><div class="q2">no payment is ever enough, 
+</div><div class="q2">
+<sup>9&#160;</sup>that he should live on forever, 
+</div><div class="q2">that he should not see corruption. 
+</div><div class="q1">
+<sup>10&#160;</sup>For he sees that wise men die; 
+</div><div class="q2">likewise the fool and the senseless perish, 
+</div><div class="q2">and leave their wealth to others. 
+</div><div class="q1">
+<sup>11&#160;</sup>Their inward thought is that their houses will endure forever, 
+</div><div class="q2">and their dwelling places to all generations. 
+</div><div class="q2">They name their lands after themselves. 
+</div><div class="q1">
+<sup>12&#160;</sup>But man, despite his riches, doesn’t endure. 
+</div><div class="q2">He is like the animals that perish. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>This is the destiny of those who are foolish, 
+</div><div class="q2">and of those who approve their sayings. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>14&#160;</sup>They are appointed as a flock for Sheol. 
+</div><div class="q2">Death shall be their shepherd. 
+</div><div class="q1">The upright shall have dominion over them in the morning. 
+</div><div class="q2">Their beauty shall decay in Sheol, 
+</div><div class="q2">far from their mansion. 
+</div><div class="q1">
+<sup>15&#160;</sup>But Elohim will redeem my soul from the power of Sheol, 
+</div><div class="q2">for he will receive me. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>16&#160;</sup>Don’t be afraid when a man is made rich, 
+</div><div class="q2">when the glory of his house is increased; 
+</div><div class="q1">
+<sup>17&#160;</sup>for when he dies he will carry nothing away. 
+</div><div class="q2">His glory won’t descend after him. 
+</div><div class="q1">
+<sup>18&#160;</sup>Though while he lived he blessed his soul—</div><div class="q2">and men praise you when you do well for yourself—</div><div class="q2">
+<sup>19&#160;</sup>he shall go to the generation of his fathers. 
+</div><div class="q2">They shall never see the light. 
+</div><div class="q1">
+<sup>20&#160;</sup>A man who has riches without understanding, 
+</div><div class="q2">is like the animals that perish. 
+</div><h2 class="psalmlabel" id="50">50</h2>
+<div class="d">A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>The Mighty One, Elohim, Yahweh, speaks, 
+</div><div class="q2">and calls the earth from sunrise to sunset. 
+</div><div class="q1">
+<sup>2&#160;</sup>Out of Zion, the perfection of beauty, 
+</div><div class="q2">Elohim shines out. 
+</div><div class="q1">
+<sup>3&#160;</sup>Our Elohim comes, and does not keep silent. 
+</div><div class="q2">A fire devours before him. 
+</div><div class="q2">It is very stormy around him. 
+</div><div class="q1">
+<sup>4&#160;</sup>He calls to the heavens above, 
+</div><div class="q2">to the earth, that he may judge his people: 
+</div><div class="q1">
+<sup>5&#160;</sup>“Gather my saints together to me, 
+</div><div class="q2">those who have made a covenant with me by sacrifice.” 
+</div><div class="q1">
+<sup>6&#160;</sup>The heavens shall declare his righteousness, 
+</div><div class="q2">for Elohim himself is judge. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>7&#160;</sup>“Hear, my people, and I will speak. 
+</div><div class="q2">Israel, I will testify against you. 
+</div><div class="q1">I am Elohim, your Elohim. 
+</div><div class="q1">
+<sup>8&#160;</sup>I don’t rebuke you for your sacrifices. 
+</div><div class="q2">Your burnt offerings are continually before me. 
+</div><div class="q1">
+<sup>9&#160;</sup>I have no need for a bull from your stall, 
+</div><div class="q2">nor male goats from your pens. 
+</div><div class="q1">
+<sup>10&#160;</sup>For every animal of the forest is mine, 
+</div><div class="q2">and the livestock on a thousand hills. 
+</div><div class="q1">
+<sup>11&#160;</sup>I know all the birds of the mountains. 
+</div><div class="q2">The wild animals of the field are mine. 
+</div><div class="q1">
+<sup>12&#160;</sup>If I were hungry, I would not tell you, 
+</div><div class="q2">for the world is mine, and all that is in it. 
+</div><div class="q1">
+<sup>13&#160;</sup>Will I eat the meat of bulls, 
+</div><div class="q2">or drink the blood of goats? 
+</div><div class="q1">
+<sup>14&#160;</sup>Offer to Elohim the sacrifice of thanksgiving. 
+</div><div class="q2">Pay your vows to the Most High. 
+</div><div class="q1">
+<sup>15&#160;</sup>Call on me in the day of trouble. 
+</div><div class="q2">I will deliver you, and you will honor me.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>But to the wicked Elohim says, 
+</div><div class="q2">“What right do you have to declare my statutes, 
+</div><div class="q2">that you have taken my covenant on your lips, 
+</div><div class="q2">
+<sup>17&#160;</sup>since you hate instruction, 
+</div><div class="q2">and throw my words behind you? 
+</div><div class="q1">
+<sup>18&#160;</sup>When you saw a thief, you consented with him, 
+</div><div class="q2">and have participated with adulterers. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>“You give your mouth to evil. 
+</div><div class="q2">Your tongue frames deceit. 
+</div><div class="q1">
+<sup>20&#160;</sup>You sit and speak against your brother. 
+</div><div class="q2">You slander your own mother’s son. 
+</div><div class="q1">
+<sup>21&#160;</sup>You have done these things, and I kept silent. 
+</div><div class="q2">You thought that I was just like you. 
+</div><div class="q2">I will rebuke you, and accuse you in front of your eyes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>“Now consider this, you who forget Elohim, 
+</div><div class="q2">lest I tear you into pieces, and there be no one to deliver. 
+</div><div class="q1">
+<sup>23&#160;</sup>Whoever offers the sacrifice of thanksgiving glorifies me, 
+</div><div class="q2">and prepares his way so that I will show Elohim’s salvation to him.” 
+</div><h2 class="psalmlabel" id="51">51</h2>
+<div class="d">For the Chief Musician. A Psalm by David, when Nathan the prophet came to him, after he had gone in to Bathsheba. 
+</div><div class="q1">
+<sup>1&#160;</sup>Have mercy on me, Elohim, according to your loving kindness. 
+</div><div class="q2">According to the multitude of your tender mercies, blot out my transgressions. 
+</div><div class="q1">
+<sup>2&#160;</sup>Wash me thoroughly from my iniquity. 
+</div><div class="q2">Cleanse me from my sin. 
+</div><div class="q1">
+<sup>3&#160;</sup>For I know my transgressions. 
+</div><div class="q2">My sin is constantly before me. 
+</div><div class="q1">
+<sup>4&#160;</sup>Against you, and you only, I have sinned, 
+</div><div class="q2">and done that which is evil in your sight, 
+</div><div class="q1">so you may be proved right when you speak, 
+</div><div class="q2">and justified when you judge. 
+</div><div class="q1">
+<sup>5&#160;</sup>Behold, I was born in iniquity. 
+</div><div class="q2">My mother conceived me in sin. 
+</div><div class="q1">
+<sup>6&#160;</sup>Behold, you desire truth in the inward parts. 
+</div><div class="q2">You teach me wisdom in the inmost place. 
+</div><div class="q1">
+<sup>7&#160;</sup>Purify me with hyssop, and I will be clean. 
+</div><div class="q2">Wash me, and I will be whiter than snow. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let me hear joy and gladness, 
+</div><div class="q2">that the bones which you have broken may rejoice. 
+</div><div class="q1">
+<sup>9&#160;</sup>Hide your face from my sins, 
+</div><div class="q2">and blot out all of my iniquities. 
+</div><div class="q1">
+<sup>10&#160;</sup>Create in me a clean heart, O Elohim. 
+</div><div class="q2">Renew a right spirit within me. 
+</div><div class="q1">
+<sup>11&#160;</sup>Don’t throw me from your presence, 
+</div><div class="q2">and don’t take your Set-Apart Spirit from me. 
+</div><div class="q1">
+<sup>12&#160;</sup>Restore to me the joy of your salvation. 
+</div><div class="q2">Uphold me with a willing spirit. 
+</div><div class="q1">
+<sup>13&#160;</sup>Then I will teach transgressors your ways. 
+</div><div class="q2">Sinners will be converted to you. 
+</div><div class="q1">
+<sup>14&#160;</sup>Deliver me from the guilt of bloodshed, O Elohim, the Elohim of my salvation. 
+</div><div class="q2">My tongue will sing aloud of your righteousness. 
+</div><div class="q1">
+<sup>15&#160;</sup>Lord, open my lips. 
+</div><div class="q2">My mouth will declare your praise. 
+</div><div class="q1">
+<sup>16&#160;</sup>For you don’t delight in sacrifice, or else I would give it. 
+</div><div class="q2">You have no pleasure in burnt offering. 
+</div><div class="q1">
+<sup>17&#160;</sup>The sacrifices of Elohim are a broken spirit. 
+</div><div class="q2">O Elohim, you will not despise a broken and contrite heart. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>Do well in your good pleasure to Zion. 
+</div><div class="q2">Build the walls of Jerusalem. 
+</div><div class="q1">
+<sup>19&#160;</sup>Then you will delight in the sacrifices of righteousness, 
+</div><div class="q2">in burnt offerings and in whole burnt offerings. 
+</div><div class="q1">Then they will offer bulls on your altar. 
+</div><h2 class="psalmlabel" id="52">52</h2>
+<div class="d">For the Chief Musician. A contemplation by David, when Doeg the Edomite came and told Saul, “David has come to Ahimelech’s house.” 
+</div><div class="q1">
+<sup>1&#160;</sup>Why do you boast of mischief, mighty man? 
+</div><div class="q2">Elohim’s loving kindness endures continually. 
+</div><div class="q1">
+<sup>2&#160;</sup>Your tongue plots destruction, 
+</div><div class="q2">like a sharp razor, working deceitfully. 
+</div><div class="q1">
+<sup>3&#160;</sup>You love evil more than good, 
+</div><div class="q2">lying rather than speaking the truth. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>You love all devouring words, 
+</div><div class="q2">you deceitful tongue. 
+</div><div class="q1">
+<sup>5&#160;</sup>Elohim will likewise destroy you forever. 
+</div><div class="q2">He will take you up, and pluck you out of your tent, 
+</div><div class="q2">and root you out of the land of the living. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>6&#160;</sup>The righteous also will see it, and fear, 
+</div><div class="q2">and laugh at him, saying, 
+</div><div class="q1">
+<sup>7&#160;</sup>“Behold, this is the man who didn’t make Elohim his strength, 
+</div><div class="q2">but trusted in the abundance of his riches, 
+</div><div class="q2">and strengthened himself in his wickedness.” 
+</div><div class="q1">
+<sup>8&#160;</sup>But as for me, I am like a green olive tree in Elohim’s house. 
+</div><div class="q2">I trust in Elohim’s loving kindness forever and ever. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will give you thanks forever, because you have done it. 
+</div><div class="q2">I will hope in your name, for it is good, 
+</div><div class="q2">in the presence of your saints. 
+</div><h2 class="psalmlabel" id="53">53</h2>
+<div class="d">For the Chief Musician. To the tune of “Mahalath.” A contemplation by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>The fool has said in his heart, “There is no Elohim.” 
+</div><div class="q2">They are corrupt, and have done abominable iniquity. 
+</div><div class="q2">There is no one who does good. 
+</div><div class="q1">
+<sup>2&#160;</sup>Elohim looks down from heaven on the children of men, 
+</div><div class="q2">to see if there are any who understood, 
+</div><div class="q2">who seek after Elohim. 
+</div><div class="q1">
+<sup>3&#160;</sup>Every one of them has gone back. 
+</div><div class="q2">They have become filthy together. 
+</div><div class="q2">There is no one who does good, no, not one. 
+</div><div class="q1">
+<sup>4&#160;</sup>Have the workers of iniquity no knowledge, 
+</div><div class="q2">who eat up my people as they eat bread, 
+</div><div class="q2">and don’t call on Elohim? 
+</div><div class="q1">
+<sup>5&#160;</sup>There they were in great fear, where no fear was, 
+</div><div class="q2">for Elohim has scattered the bones of him who encamps against you. 
+</div><div class="q1">You have put them to shame, 
+</div><div class="q2">because Elohim has rejected them. 
+</div><div class="q1">
+<sup>6&#160;</sup>Oh that the salvation of Israel would come out of Zion! 
+</div><div class="q2">When Elohim brings back his people from captivity, 
+</div><div class="q2">then Jacob shall rejoice, 
+</div><div class="q2">and Israel shall be glad. 
+</div><h2 class="psalmlabel" id="54">54</h2>
+<div class="d">For the Chief Musician. On stringed instruments. A contemplation by David, when the Ziphites came and said to Saul, “Isn’t David hiding himself among us?” 
+</div><div class="q1">
+<sup>1&#160;</sup>Save me, Elohim, by your name. 
+</div><div class="q2">Vindicate me in your might. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hear my prayer, Elohim. 
+</div><div class="q2">Listen to the words of my mouth. 
+</div><div class="q1">
+<sup>3&#160;</sup>For strangers have risen up against me. 
+</div><div class="q2">Violent men have sought after my soul. 
+</div><div class="q2">They haven’t set Elohim before them. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>Behold, Elohim is my helper. 
+</div><div class="q2">The Lord is the one who sustains my soul. 
+</div><div class="q1">
+<sup>5&#160;</sup>He will repay the evil to my enemies. 
+</div><div class="q2">Destroy them in your truth. 
+</div><div class="q1">
+<sup>6&#160;</sup>With a free will offering, I will sacrifice to you. 
+</div><div class="q2">I will give thanks to your name, Yahweh, for it is good. 
+</div><div class="q1">
+<sup>7&#160;</sup>For he has delivered me out of all trouble. 
+</div><div class="q2">My eye has seen triumph over my enemies. 
+</div><h2 class="psalmlabel" id="55">55</h2>
+<div class="d">For the Chief Musician. On stringed instruments. A contemplation by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Listen to my prayer, Elohim. 
+</div><div class="q2">Don’t hide yourself from my supplication. 
+</div><div class="q1">
+<sup>2&#160;</sup>Attend to me, and answer me. 
+</div><div class="q2">I am restless in my complaint, 
+</div><div class="q2">and moan 
+<sup>3&#160;</sup>because of the voice of the enemy, 
+</div><div class="q2">because of the oppression of the wicked. 
+</div><div class="q1">For they bring suffering on me. 
+</div><div class="q2">In anger they hold a grudge against me. 
+</div><div class="q1">
+<sup>4&#160;</sup>My heart is severely pained within me. 
+</div><div class="q2">The terrors of death have fallen on me. 
+</div><div class="q1">
+<sup>5&#160;</sup>Fearfulness and trembling have come on me. 
+</div><div class="q2">Horror has overwhelmed me. 
+</div><div class="q1">
+<sup>6&#160;</sup>I said, “Oh that I had wings like a dove! 
+</div><div class="q2">Then I would fly away, and be at rest. 
+</div><div class="q1">
+<sup>7&#160;</sup>Behold, then I would wander far off. 
+</div><div class="q2">I would lodge in the wilderness.” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>8&#160;</sup>“I would hurry to a shelter from the stormy wind and storm.” 
+</div><div class="q1">
+<sup>9&#160;</sup>Confuse them, Lord, and confound their language, 
+</div><div class="q2">for I have seen violence and strife in the city. 
+</div><div class="q1">
+<sup>10&#160;</sup>Day and night they prowl around on its walls. 
+</div><div class="q2">Malice and abuse are also within her. 
+</div><div class="q1">
+<sup>11&#160;</sup>Destructive forces are within her. 
+</div><div class="q2">Threats and lies don’t depart from her streets. 
+</div><div class="q1">
+<sup>12&#160;</sup>For it was not an enemy who insulted me, 
+</div><div class="q2">then I could have endured it. 
+</div><div class="q1">Neither was it he who hated me who raised himself up against me, 
+</div><div class="q2">then I would have hidden myself from him. 
+</div><div class="q1">
+<sup>13&#160;</sup>But it was you, a man like me, 
+</div><div class="q2">my companion, and my familiar friend. 
+</div><div class="q1">
+<sup>14&#160;</sup>We took sweet fellowship together. 
+</div><div class="q2">We walked in Elohim’s house with company. 
+</div><div class="q1">
+<sup>15&#160;</sup>Let death come suddenly on them. 
+</div><div class="q2">Let them go down alive into Sheol. 
+</div><div class="q2">For wickedness is among them, in their dwelling. 
+</div><div class="q1">
+<sup>16&#160;</sup>As for me, I will call on Elohim. 
+</div><div class="q2">Yahweh will save me. 
+</div><div class="q1">
+<sup>17&#160;</sup>Evening, morning, and at noon, I will cry out in distress. 
+</div><div class="q2">He will hear my voice. 
+</div><div class="q1">
+<sup>18&#160;</sup>He has redeemed my soul in peace from the battle that was against me, 
+</div><div class="q2">although there are many who oppose me. 
+</div><div class="q1">
+<sup>19&#160;</sup>Elohim, who is enthroned forever, 
+</div><div class="q2">will hear and answer them. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">They never change 
+</div><div class="q2">and don’t fear Elohim. 
+</div><div class="q1">
+<sup>20&#160;</sup>He raises his hands against his friends. 
+</div><div class="q2">He has violated his covenant. 
+</div><div class="q1">
+<sup>21&#160;</sup>His mouth was smooth as butter, 
+</div><div class="q2">but his heart was war. 
+</div><div class="q1">His words were softer than oil, 
+</div><div class="q2">yet they were drawn swords. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>Cast your burden on Yahweh and he will sustain you. 
+</div><div class="q2">He will never allow the righteous to be moved. 
+</div><div class="q1">
+<sup>23&#160;</sup>But you, Elohim, will bring them down into the pit of destruction. 
+</div><div class="q2">Bloodthirsty and deceitful men shall not live out half their days, 
+</div><div class="q2">but I will trust in you. 
+</div><h2 class="psalmlabel" id="56">56</h2>
+<div class="d">For the Chief Musician. To the tune of “Silent Dove in Distant Lands.” A poem by David, when the Philistines seized him in Gath. 
+</div><div class="q1">
+<sup>1&#160;</sup>Be merciful to me, Elohim, for man wants to swallow me up. 
+</div><div class="q2">All day long, he attacks and oppresses me. 
+</div><div class="q1">
+<sup>2&#160;</sup>My enemies want to swallow me up all day long, 
+</div><div class="q2">for they are many who fight proudly against me. 
+</div><div class="q1">
+<sup>3&#160;</sup>When I am afraid, 
+</div><div class="q2">I will put my trust in you. 
+</div><div class="q1">
+<sup>4&#160;</sup>In Elohim, I praise his word. 
+</div><div class="q2">In Elohim, I put my trust. 
+</div><div class="q1">I will not be afraid. 
+</div><div class="q2">What can flesh do to me? 
+</div><div class="q1">
+<sup>5&#160;</sup>All day long they twist my words. 
+</div><div class="q2">All their thoughts are against me for evil. 
+</div><div class="q1">
+<sup>6&#160;</sup>They conspire and lurk, 
+</div><div class="q2">watching my steps. 
+</div><div class="q2">They are eager to take my life. 
+</div><div class="q1">
+<sup>7&#160;</sup>Shall they escape by iniquity? 
+</div><div class="q2">In anger cast down the peoples, Elohim. 
+</div><div class="q1">
+<sup>8&#160;</sup>You count my wanderings. 
+</div><div class="q2">You put my tears into your container. 
+</div><div class="q2">Aren’t they in your book? 
+</div><div class="q1">
+<sup>9&#160;</sup>Then my enemies shall turn back in the day that I call. 
+</div><div class="q2">I know this: that Elohim is for me. 
+</div><div class="q1">
+<sup>10&#160;</sup>In Elohim, I will praise his word. 
+</div><div class="q2">In Yahweh, I will praise his word. 
+</div><div class="q1">
+<sup>11&#160;</sup>I have put my trust in Elohim. 
+</div><div class="q2">I will not be afraid. 
+</div><div class="q2">What can man do to me? 
+</div><div class="q1">
+<sup>12&#160;</sup>Your vows are on me, Elohim. 
+</div><div class="q2">I will give thank offerings to you. 
+</div><div class="q1">
+<sup>13&#160;</sup>For you have delivered my soul from death, 
+</div><div class="q2">and prevented my feet from falling, 
+</div><div class="q2">that I may walk before Elohim in the light of the living. 
+</div><h2 class="psalmlabel" id="57">57</h2>
+<div class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A poem by David, when he fled from Saul, in the cave. 
+</div><div class="q1">
+<sup>1&#160;</sup>Be merciful to me, Elohim, be merciful to me, 
+</div><div class="q2">for my soul takes refuge in you. 
+</div><div class="q1">Yes, in the shadow of your wings, I will take refuge, 
+</div><div class="q2">until disaster has passed. 
+</div><div class="q1">
+<sup>2&#160;</sup>I cry out to Elohim Most High, 
+</div><div class="q1">to Elohim who accomplishes my requests for me. 
+</div><div class="q1">
+<sup>3&#160;</sup>He will send from heaven, and save me, 
+</div><div class="q2">he rebukes the one who is pursuing me. </div><div class="qs">Selah. 
+</div><div class="q1">Elohim will send out his loving kindness and his truth. 
+</div><div class="q1">
+<sup>4&#160;</sup>My soul is among lions. 
+</div><div class="q2">I lie among those who are set on fire, 
+</div><div class="q2">even the sons of men, whose teeth are spears and arrows, 
+</div><div class="q2">and their tongue a sharp sword. 
+</div><div class="q1">
+<sup>5&#160;</sup>Be exalted, Elohim, above the heavens! 
+</div><div class="q2">Let your glory be above all the earth! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>They have prepared a net for my steps. 
+</div><div class="q2">My soul is bowed down. 
+</div><div class="q1">They dig a pit before me. 
+</div><div class="q2">They fall into the middle of it themselves. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>7&#160;</sup>My heart is steadfast, Elohim. 
+</div><div class="q2">My heart is steadfast. 
+</div><div class="q2">I will sing, yes, I will sing praises. 
+</div><div class="q1">
+<sup>8&#160;</sup>Wake up, my glory! Wake up, lute and harp! 
+</div><div class="q2">I will wake up the dawn. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will give thanks to you, Lord, among the peoples. 
+</div><div class="q2">I will sing praises to you among the nations. 
+</div><div class="q1">
+<sup>10&#160;</sup>For your great loving kindness reaches to the heavens, 
+</div><div class="q2">and your truth to the skies. 
+</div><div class="q1">
+<sup>11&#160;</sup>Be exalted, Elohim, above the heavens. 
+</div><div class="q2">Let your glory be over all the earth. 
+</div><h2 class="psalmlabel" id="58">58</h2>
+<div class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A poem by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Do you indeed speak righteousness, silent ones? 
+</div><div class="q2">Do you judge blamelessly, you sons of men? 
+</div><div class="q1">
+<sup>2&#160;</sup>No, in your heart you plot injustice. 
+</div><div class="q2">You measure out the violence of your hands in the earth. 
+</div><div class="q1">
+<sup>3&#160;</sup>The wicked go astray from the womb. 
+</div><div class="q2">They are wayward as soon as they are born, speaking lies. 
+</div><div class="q1">
+<sup>4&#160;</sup>Their poison is like the poison of a snake, 
+</div><div class="q2">like a deaf cobra that stops its ear, 
+</div><div class="q2">
+<sup>5&#160;</sup>which doesn’t listen to the voice of charmers, 
+</div><div class="q2">no matter how skillful the charmer may be. 
+</div><div class="q1">
+<sup>6&#160;</sup>Break their teeth, Elohim, in their mouth. 
+</div><div class="q2">Break out the great teeth of the young lions, Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>Let them vanish like water that flows away. 
+</div><div class="q2">When they draw the bow, let their arrows be made blunt. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let them be like a snail which melts and passes away, 
+</div><div class="q2">like the stillborn child, who has not seen the sun. 
+</div><div class="q1">
+<sup>9&#160;</sup>Before your pots can feel the heat of the thorns, 
+</div><div class="q2">he will sweep away the green and the burning alike. 
+</div><div class="q1">
+<sup>10&#160;</sup>The righteous shall rejoice when he sees the vengeance. 
+</div><div class="q2">He shall wash his feet in the blood of the wicked, 
+</div><div class="q1">
+<sup>11&#160;</sup>so that men shall say, “Most certainly there is a reward for the righteous. 
+</div><div class="q2">Most certainly there is an Elohim who judges the earth.” 
+</div><h2 class="psalmlabel" id="59">59</h2>
+<div class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A poem by David, when Saul sent, and they watched the house to kill him. 
+</div><div class="q1">
+<sup>1&#160;</sup>Deliver me from my enemies, my Elohim. 
+</div><div class="q2">Set me on high from those who rise up against me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Deliver me from the workers of iniquity. 
+</div><div class="q2">Save me from the bloodthirsty men. 
+</div><div class="q1">
+<sup>3&#160;</sup>For, behold, they lie in wait for my soul. 
+</div><div class="q2">The mighty gather themselves together against me, 
+</div><div class="q2">not for my disobedience, nor for my sin, Yahweh. 
+</div><div class="q1">
+<sup>4&#160;</sup>I have done no wrong, yet they are ready to attack me. 
+</div><div class="q2">Rise up, behold, and help me! 
+</div><div class="q1">
+<sup>5&#160;</sup>You, Yahweh Elohim of Armies, the Elohim of Israel, 
+</div><div class="q2">rouse yourself to punish the nations. 
+</div><div class="q2">Show no mercy to the wicked traitors. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>6&#160;</sup>They return at evening, howling like dogs, 
+</div><div class="q2">and prowl around the city. 
+</div><div class="q1">
+<sup>7&#160;</sup>Behold, they spew with their mouth. 
+</div><div class="q2">Swords are in their lips, 
+</div><div class="q2">“For”, they say, “who hears us?” 
+</div><div class="q1">
+<sup>8&#160;</sup>But you, Yahweh, laugh at them. 
+</div><div class="q2">You scoff at all the nations. 
+</div><div class="q1">
+<sup>9&#160;</sup>Oh, my Strength, I watch for you, 
+</div><div class="q2">for Elohim is my high tower. 
+</div><div class="q1">
+<sup>10&#160;</sup>My Elohim will go before me with his loving kindness. 
+</div><div class="q2">Elohim will let me look at my enemies in triumph. 
+</div><div class="q1">
+<sup>11&#160;</sup>Don’t kill them, or my people may forget. 
+</div><div class="q2">Scatter them by your power, and bring them down, Lord our shield. 
+</div><div class="q1">
+<sup>12&#160;</sup>For the sin of their mouth, and the words of their lips, 
+</div><div class="q2">let them be caught in their pride, 
+</div><div class="q2">for the curses and lies which they utter. 
+</div><div class="q1">
+<sup>13&#160;</sup>Consume them in wrath. 
+</div><div class="q2">Consume them, and they will be no more. 
+</div><div class="q1">Let them know that Elohim rules in Jacob, 
+</div><div class="q2">to the ends of the earth. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>14&#160;</sup>At evening let them return. 
+</div><div class="q2">Let them howl like a dog, and go around the city. 
+</div><div class="q1">
+<sup>15&#160;</sup>They shall wander up and down for food, 
+</div><div class="q2">and wait all night if they aren’t satisfied. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>But I will sing of your strength. 
+</div><div class="q2">Yes, I will sing aloud of your loving kindness in the morning. 
+</div><div class="q1">For you have been my high tower, 
+</div><div class="q2">a refuge in the day of my distress. 
+</div><div class="q1">
+<sup>17&#160;</sup>To you, my strength, I will sing praises. 
+</div><div class="q2">For Elohim is my high tower, the Elohim of my mercy. 
+</div><h2 class="psalmlabel" id="60">60</h2>
+<div class="d">For the Chief Musician. To the tune of “The Lily of the Covenant.” A teaching poem by David, when he fought with Aram Naharaim and with Aram Zobah, and Joab returned, and killed twelve thousand of Edom in the Valley of Salt. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim, you have rejected us. 
+</div><div class="q2">You have broken us down. 
+</div><div class="q1">You have been angry. 
+</div><div class="q2">Restore us, again. 
+</div><div class="q1">
+<sup>2&#160;</sup>You have made the land tremble. 
+</div><div class="q2">You have torn it. 
+</div><div class="q1">Mend its fractures, 
+</div><div class="q2">for it quakes. 
+</div><div class="q1">
+<sup>3&#160;</sup>You have shown your people hard things. 
+</div><div class="q2">You have made us drink the wine that makes us stagger. 
+</div><div class="q1">
+<sup>4&#160;</sup>You have given a banner to those who fear you, 
+</div><div class="q2">that it may be displayed because of the truth. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>So that your beloved may be delivered, 
+</div><div class="q2">save with your right hand, and answer us. 
+</div><div class="q1">
+<sup>6&#160;</sup>Elohim has spoken from his sanctuary: 
+</div><div class="q2">“I will triumph. 
+</div><div class="q2">I will divide Shechem, 
+</div><div class="q2">and measure out the valley of Succoth. 
+</div><div class="q1">
+<sup>7&#160;</sup>Gilead is mine, and Manasseh is mine. 
+</div><div class="q2">Ephraim also is the defense of my head. 
+</div><div class="q2">Judah is my scepter. 
+</div><div class="q1">
+<sup>8&#160;</sup>Moab is my wash basin. 
+</div><div class="q2">I will throw my sandal on Edom. 
+</div><div class="q2">I shout in triumph over Philistia.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Who will bring me into the strong city? 
+</div><div class="q2">Who has led me to Edom? 
+</div><div class="q1">
+<sup>10&#160;</sup>Haven’t you, Elohim, rejected us? 
+</div><div class="q2">You don’t go out with our armies, Elohim. 
+</div><div class="q1">
+<sup>11&#160;</sup>Give us help against the adversary, 
+</div><div class="q2">for the help of man is vain. 
+</div><div class="q1">
+<sup>12&#160;</sup>Through Elohim we will do valiantly, 
+</div><div class="q2">for it is he who will tread down our adversaries. 
+</div><h2 class="psalmlabel" id="61">61</h2>
+<div class="d">For the Chief Musician. For a stringed instrument. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear my cry, Elohim. 
+</div><div class="q2">Listen to my prayer. 
+</div><div class="q1">
+<sup>2&#160;</sup>From the end of the earth, I will call to you when my heart is overwhelmed. 
+</div><div class="q2">Lead me to the rock that is higher than I. 
+</div><div class="q1">
+<sup>3&#160;</sup>For you have been a refuge for me, 
+</div><div class="q2">a strong tower from the enemy. 
+</div><div class="q1">
+<sup>4&#160;</sup>I will dwell in your tent forever. 
+</div><div class="q2">I will take refuge in the shelter of your wings. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>For you, Elohim, have heard my vows. 
+</div><div class="q2">You have given me the heritage of those who fear your name. 
+</div><div class="q1">
+<sup>6&#160;</sup>You will prolong the king’s life. 
+</div><div class="q2">His years will be for generations. 
+</div><div class="q1">
+<sup>7&#160;</sup>He shall be enthroned in Elohim’s presence forever. 
+</div><div class="q2">Appoint your loving kindness and truth, that they may preserve him. 
+</div><div class="q1">
+<sup>8&#160;</sup>So I will sing praise to your name forever, 
+</div><div class="q2">that I may fulfill my vows daily. 
+</div><h2 class="psalmlabel" id="62">62</h2>
+<div class="d">For the Chief Musician. To Jeduthun. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>My soul rests in Elohim alone. 
+</div><div class="q2">My salvation is from him. 
+</div><div class="q1">
+<sup>2&#160;</sup>He alone is my rock, my salvation, and my fortress. 
+</div><div class="q2">I will never be greatly shaken. 
+</div><div class="q1">
+<sup>3&#160;</sup>How long will you assault a man? 
+</div><div class="q2">Would all of you throw him down, 
+</div><div class="q2">like a leaning wall, like a tottering fence? 
+</div><div class="q1">
+<sup>4&#160;</sup>They fully intend to throw him down from his lofty place. 
+</div><div class="q2">They delight in lies. 
+</div><div class="q2">They bless with their mouth, but they curse inwardly. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>My soul, wait in silence for Elohim alone, 
+</div><div class="q2">for my expectation is from him. 
+</div><div class="q1">
+<sup>6&#160;</sup>He alone is my rock and my salvation, my fortress. 
+</div><div class="q2">I will not be shaken. 
+</div><div class="q1">
+<sup>7&#160;</sup>My salvation and my honor is with Elohim. 
+</div><div class="q2">The rock of my strength, and my refuge, is in Elohim. 
+</div><div class="q1">
+<sup>8&#160;</sup>Trust in him at all times, you people. 
+</div><div class="q2">Pour out your heart before him. 
+</div><div class="q2">Elohim is a refuge for us. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>9&#160;</sup>Surely men of low degree are just a breath, 
+</div><div class="q2">and men of high degree are a lie. 
+</div><div class="q1">In the balances they will go up. 
+</div><div class="q2">They are together lighter than a breath. 
+</div><div class="q1">
+<sup>10&#160;</sup>Don’t trust in oppression. 
+</div><div class="q2">Don’t become vain in robbery. 
+</div><div class="q1">If riches increase, 
+</div><div class="q2">don’t set your heart on them. 
+</div><div class="q1">
+<sup>11&#160;</sup>Elohim has spoken once; 
+</div><div class="q2">twice I have heard this, 
+</div><div class="q2">that power belongs to Elohim. 
+</div><div class="q1">
+<sup>12&#160;</sup>Also to you, Lord, belongs loving kindness, 
+</div><div class="q2">for you reward every man according to his work. 
+</div><h2 class="psalmlabel" id="63">63</h2>
+<div class="d">A Psalm by David, when he was in the desert of Judah. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim, you are my Elohim. 
+</div><div class="q2">I will earnestly seek you. 
+</div><div class="q1">My soul thirsts for you. 
+</div><div class="q2">My flesh longs for you, 
+</div><div class="q2">in a dry and weary land, where there is no water. 
+</div><div class="q1">
+<sup>2&#160;</sup>So I have seen you in the sanctuary, 
+</div><div class="q2">watching your power and your glory. 
+</div><div class="q1">
+<sup>3&#160;</sup>Because your loving kindness is better than life, 
+</div><div class="q2">my lips shall praise you. 
+</div><div class="q1">
+<sup>4&#160;</sup>So I will bless you while I live. 
+</div><div class="q2">I will lift up my hands in your name. 
+</div><div class="q1">
+<sup>5&#160;</sup>My soul shall be satisfied as with the richest food. 
+</div><div class="q2">My mouth shall praise you with joyful lips, 
+</div><div class="q2">
+<sup>6&#160;</sup>when I remember you on my bed, 
+</div><div class="q2">and think about you in the night watches. 
+</div><div class="q1">
+<sup>7&#160;</sup>For you have been my help. 
+</div><div class="q2">I will rejoice in the shadow of your wings. 
+</div><div class="q1">
+<sup>8&#160;</sup>My soul stays close to you. 
+</div><div class="q2">Your right hand holds me up. 
+</div><div class="q1">
+<sup>9&#160;</sup>But those who seek my soul to destroy it 
+</div><div class="q2">shall go into the lower parts of the earth. 
+</div><div class="q1">
+<sup>10&#160;</sup>They shall be given over to the power of the sword. 
+</div><div class="q2">They shall be jackal food. 
+</div><div class="q1">
+<sup>11&#160;</sup>But the king shall rejoice in Elohim. 
+</div><div class="q2">Everyone who swears by him will praise him, 
+</div><div class="q2">for the mouth of those who speak lies shall be silenced. 
+</div><h2 class="psalmlabel" id="64">64</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear my voice, Elohim, in my complaint. 
+</div><div class="q2">Preserve my life from fear of the enemy. 
+</div><div class="q1">
+<sup>2&#160;</sup>Hide me from the conspiracy of the wicked, 
+</div><div class="q2">from the noisy crowd of the ones doing evil; 
+</div><div class="q1">
+<sup>3&#160;</sup>who sharpen their tongue like a sword, 
+</div><div class="q2">and aim their arrows, deadly words, 
+</div><div class="q2">
+<sup>4&#160;</sup>to shoot innocent men from ambushes. 
+</div><div class="q2">They shoot at him suddenly and fearlessly. 
+</div><div class="q1">
+<sup>5&#160;</sup>They encourage themselves in evil plans. 
+</div><div class="q2">They talk about laying snares secretly. 
+</div><div class="q2">They say, “Who will see them?” 
+</div><div class="q1">
+<sup>6&#160;</sup>They plot injustice, saying, “We have made a perfect plan!” 
+</div><div class="q2">Surely man’s mind and heart are cunning. 
+</div><div class="q1">
+<sup>7&#160;</sup>But Elohim will shoot at them. 
+</div><div class="q2">They will be suddenly struck down with an arrow. 
+</div><div class="q1">
+<sup>8&#160;</sup>Their own tongues shall ruin them. 
+</div><div class="q2">All who see them will shake their heads. 
+</div><div class="q1">
+<sup>9&#160;</sup>All mankind shall be afraid. 
+</div><div class="q2">They shall declare the work of Elohim, 
+</div><div class="q2">and shall wisely ponder what he has done. 
+</div><div class="q1">
+<sup>10&#160;</sup>The righteous shall be glad in Yahweh, 
+</div><div class="q2">and shall take refuge in him. 
+</div><div class="q2">All the upright in heart shall praise him! 
+</div><h2 class="psalmlabel" id="65">65</h2>
+<div class="d">For the Chief Musician. A Psalm by David. A song. 
+</div><div class="q1">
+<sup>1&#160;</sup>Praise waits for you, Elohim, in Zion. 
+</div><div class="q2">Vows shall be performed to you. 
+</div><div class="q1">
+<sup>2&#160;</sup>You who hear prayer, 
+</div><div class="q2">all men will come to you. 
+</div><div class="q1">
+<sup>3&#160;</sup>Sins overwhelmed me, 
+</div><div class="q2">but you atoned for our transgressions. 
+</div><div class="q1">
+<sup>4&#160;</sup>Blessed is the one whom you choose and cause to come near, 
+</div><div class="q2">that he may live in your courts. 
+</div><div class="q2">We will be filled with the goodness of your house, 
+</div><div class="q2">your set-apart temple. 
+</div><div class="q1">
+<sup>5&#160;</sup>By awesome deeds of righteousness, you answer us, 
+</div><div class="q2">Elohim of our salvation. 
+</div><div class="q1">You who are the hope of all the ends of the earth, 
+</div><div class="q2">of those who are far away on the sea. 
+</div><div class="q1">
+<sup>6&#160;</sup>By your power, you form the mountains, 
+</div><div class="q2">having armed yourself with strength. 
+</div><div class="q1">
+<sup>7&#160;</sup>You still the roaring of the seas, 
+</div><div class="q2">the roaring of their waves, 
+</div><div class="q2">and the turmoil of the nations. 
+</div><div class="q1">
+<sup>8&#160;</sup>They also who dwell in faraway places are afraid at your wonders. 
+</div><div class="q2">You call the morning’s dawn and the evening with songs of joy. 
+</div><div class="q1">
+<sup>9&#160;</sup>You visit the earth, and water it. 
+</div><div class="q2">You greatly enrich it. 
+</div><div class="q1">The river of Elohim is full of water. 
+</div><div class="q2">You provide them grain, for so you have ordained it. 
+</div><div class="q1">
+<sup>10&#160;</sup>You drench its furrows. 
+</div><div class="q2">You level its ridges. 
+</div><div class="q2">You soften it with showers. 
+</div><div class="q2">You bless it with a crop. 
+</div><div class="q1">
+<sup>11&#160;</sup>You crown the year with your bounty. 
+</div><div class="q2">Your carts overflow with abundance. 
+</div><div class="q1">
+<sup>12&#160;</sup>The wilderness grasslands overflow. 
+</div><div class="q2">The hills are clothed with gladness. 
+</div><div class="q1">
+<sup>13&#160;</sup>The pastures are covered with flocks. 
+</div><div class="q2">The valleys also are clothed with grain. 
+</div><div class="q1">They shout for joy! 
+</div><div class="q2">They also sing. 
+</div><h2 class="psalmlabel" id="66">66</h2>
+<div class="d">For the Chief Musician. A song. A Psalm. 
+</div><div class="q1">
+<sup>1&#160;</sup>Make a joyful shout to Elohim, all the earth! 
+</div><div class="q2">
+<sup>2&#160;</sup>Sing to the glory of his name! 
+</div><div class="q2">Offer glory and praise! 
+</div><div class="q1">
+<sup>3&#160;</sup>Tell Elohim, “How awesome are your deeds! 
+</div><div class="q2">Through the greatness of your power, your enemies submit themselves to you. 
+</div><div class="q1">
+<sup>4&#160;</sup>All the earth will worship you, 
+</div><div class="q2">and will sing to you; 
+</div><div class="q2">they will sing to your name.” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>Come, and see Elohim’s deeds—</div><div class="q2">awesome work on behalf of the children of men. 
+</div><div class="q1">
+<sup>6&#160;</sup>He turned the sea into dry land. 
+</div><div class="q2">They went through the river on foot. 
+</div><div class="q2">There, we rejoiced in him. 
+</div><div class="q1">
+<sup>7&#160;</sup>He rules by his might forever. 
+</div><div class="q2">His eyes watch the nations. 
+</div><div class="q2">Don’t let the rebellious rise up against him. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>8&#160;</sup>Praise our Elohim, you peoples! 
+</div><div class="q2">Make the sound of his praise heard, 
+</div><div class="q1">
+<sup>9&#160;</sup>who preserves our life among the living, 
+</div><div class="q2">and doesn’t allow our feet to be moved. 
+</div><div class="q1">
+<sup>10&#160;</sup>For you, Elohim, have tested us. 
+</div><div class="q2">You have refined us, as silver is refined. 
+</div><div class="q1">
+<sup>11&#160;</sup>You brought us into prison. 
+</div><div class="q2">You laid a burden on our backs. 
+</div><div class="q1">
+<sup>12&#160;</sup>You allowed men to ride over our heads. 
+</div><div class="q2">We went through fire and through water, 
+</div><div class="q2">but you brought us to the place of abundance. 
+</div><div class="q1">
+<sup>13&#160;</sup>I will come into your temple with burnt offerings. 
+</div><div class="q2">I will pay my vows to you, 
+<sup>14&#160;</sup>which my lips promised, 
+</div><div class="q2">and my mouth spoke, when I was in distress. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will offer to you burnt offerings of fat animals, 
+</div><div class="q2">with the offering of rams, 
+</div><div class="q2">I will offer bulls with goats. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>16&#160;</sup>Come and hear, all you who fear Elohim. 
+</div><div class="q2">I will declare what he has done for my soul. 
+</div><div class="q1">
+<sup>17&#160;</sup>I cried to him with my mouth. 
+</div><div class="q2">He was extolled with my tongue. 
+</div><div class="q1">
+<sup>18&#160;</sup>If I cherished sin in my heart, 
+</div><div class="q2">the Lord wouldn’t have listened. 
+</div><div class="q1">
+<sup>19&#160;</sup>But most certainly, Elohim has listened. 
+</div><div class="q2">He has heard the voice of my prayer. 
+</div><div class="q1">
+<sup>20&#160;</sup>Blessed be Elohim, who has not turned away my prayer, 
+</div><div class="q2">nor his loving kindness from me. 
+</div><h2 class="psalmlabel" id="67">67</h2>
+<div class="d">For the Chief Musician. With stringed instruments. A Psalm. A song. 
+</div><div class="q1">
+<sup>1&#160;</sup>May Elohim be merciful to us, bless us, 
+</div><div class="q2">and cause his face to shine on us. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>2&#160;</sup>That your way may be known on earth, 
+</div><div class="q2">and your salvation among all nations, 
+</div><div class="q1">
+<sup>3&#160;</sup>let the peoples praise you, Elohim. 
+</div><div class="q2">Let all the peoples praise you. 
+</div><div class="q1">
+<sup>4&#160;</sup>Oh let the nations be glad and sing for joy, 
+</div><div class="q2">for you will judge the peoples with equity, 
+</div><div class="q2">and govern the nations on earth. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let the peoples praise you, Elohim. 
+</div><div class="q2">Let all the peoples praise you. 
+</div><div class="q1">
+<sup>6&#160;</sup>The earth has yielded its increase. 
+</div><div class="q2">Elohim, even our own Elohim, will bless us. 
+</div><div class="q1">
+<sup>7&#160;</sup>Elohim will bless us. 
+</div><div class="q2">All the ends of the earth shall fear him. 
+</div><h2 class="psalmlabel" id="68">68</h2>
+<div class="d">For the Chief Musician. A Psalm by David. A song. 
+</div><div class="q1">
+<sup>1&#160;</sup>Let Elohim arise! 
+</div><div class="q2">Let his enemies be scattered! 
+</div><div class="q2">Let them who hate him also flee before him. 
+</div><div class="q1">
+<sup>2&#160;</sup>As smoke is driven away, 
+</div><div class="q2">so drive them away. 
+</div><div class="q1">As wax melts before the fire, 
+</div><div class="q2">so let the wicked perish at the presence of Elohim. 
+</div><div class="q1">
+<sup>3&#160;</sup>But let the righteous be glad. 
+</div><div class="q2">Let them rejoice before Elohim. 
+</div><div class="q2">Yes, let them rejoice with gladness. 
+</div><div class="q1">
+<sup>4&#160;</sup>Sing to Elohim! Sing praises to his name! 
+</div><div class="q2">Extol him who rides on the clouds: 
+</div><div class="q1">to Yah, his name! 
+</div><div class="q2">Rejoice before him! 
+</div><div class="q1">
+<sup>5&#160;</sup>A father of the fatherless, and a defender of the widows, 
+</div><div class="q2">is Elohim in his set-apart habitation. 
+</div><div class="q1">
+<sup>6&#160;</sup>Elohim sets the lonely in families. 
+</div><div class="q1">He brings out the prisoners with singing, 
+</div><div class="q2">but the rebellious dwell in a sun-scorched land. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>Elohim, when you went out before your people, 
+</div><div class="q2">when you marched through the wilderness... </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>8&#160;</sup>The earth trembled. 
+</div><div class="q2">The sky also poured down rain at the presence of the Elohim of Sinai—</div><div class="q2">at the presence of Elohim, the Elohim of Israel. 
+</div><div class="q1">
+<sup>9&#160;</sup>You, Elohim, sent a plentiful rain. 
+</div><div class="q2">You confirmed your inheritance when it was weary. 
+</div><div class="q1">
+<sup>10&#160;</sup>Your congregation lived therein. 
+</div><div class="q2">You, Elohim, prepared your goodness for the poor. 
+</div><div class="q1">
+<sup>11&#160;</sup>The Lord announced the word. 
+</div><div class="q2">The ones who proclaim it are a great company. 
+</div><div class="q1">
+<sup>12&#160;</sup>“Kings of armies flee! They flee!” 
+</div><div class="q2">She who waits at home divides the plunder, 
+</div><div class="q2">
+<sup>13&#160;</sup>while you sleep among the camp fires, 
+</div><div class="q2">the wings of a dove sheathed with silver, 
+</div><div class="q2">her feathers with shining gold. 
+</div><div class="q1">
+<sup>14&#160;</sup>When the Almighty scattered kings in her, 
+</div><div class="q2">it snowed on Zalmon. 
+</div><div class="q1">
+<sup>15&#160;</sup>The mountains of Bashan are majestic mountains. 
+</div><div class="q2">The mountains of Bashan are rugged. 
+</div><div class="q1">
+<sup>16&#160;</sup>Why do you look in envy, you rugged mountains, 
+</div><div class="q2">at the mountain where Elohim chooses to reign? 
+</div><div class="q2">Yes, Yahweh will dwell there forever. 
+</div><div class="q1">
+<sup>17&#160;</sup>The chariots of Elohim are tens of thousands and thousands of thousands. 
+</div><div class="q2">The Lord is among them, from Sinai, into the sanctuary. 
+</div><div class="q1">
+<sup>18&#160;</sup>You have ascended on high. 
+</div><div class="q2">You have led away captives. 
+</div><div class="q1">You have received gifts among people, 
+</div><div class="q2">yes, among the rebellious also, that Yah Elohim might dwell there. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Blessed be the Lord, who daily bears our burdens, 
+</div><div class="q2">even the Elohim who is our salvation. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>20&#160;</sup>Elohim is to us an Elohim of deliverance. 
+</div><div class="q2">To Yahweh, the Lord, belongs escape from death. 
+</div><div class="q1">
+<sup>21&#160;</sup>But Elohim will strike through the head of his enemies, 
+</div><div class="q2">the hairy scalp of such a one as still continues in his guiltiness. 
+</div><div class="q1">
+<sup>22&#160;</sup>The Lord said, “I will bring you again from Bashan, 
+</div><div class="q2">I will bring you again from the depths of the sea, 
+</div><div class="q1">
+<sup>23&#160;</sup>that you may crush them, dipping your foot in blood, 
+</div><div class="q2">that the tongues of your dogs may have their portion from your enemies.” 
+</div><div class="q1">
+<sup>24&#160;</sup>They have seen your processions, Elohim, 
+</div><div class="q2">even the processions of my Elohim, my King, into the sanctuary. 
+</div><div class="q1">
+<sup>25&#160;</sup>The singers went before, the minstrels followed after, 
+</div><div class="q2">among the ladies playing with tambourines, 
+</div><div class="q1">
+<sup>26&#160;</sup>“Bless Elohim in the congregations, 
+</div><div class="q2">even the Lord in the assembly of Israel!” 
+</div><div class="q1">
+<sup>27&#160;</sup>There is little Benjamin, their ruler, 
+</div><div class="q2">the princes of Judah, their council, 
+</div><div class="q2">the princes of Zebulun, and the princes of Naphtali. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>28&#160;</sup>Your Elohim has commanded your strength. 
+</div><div class="q2">Strengthen, Elohim, that which you have done for us. 
+</div><div class="q1">
+<sup>29&#160;</sup>Because of your temple at Jerusalem, 
+</div><div class="q2">kings shall bring presents to you. 
+</div><div class="q1">
+<sup>30&#160;</sup>Rebuke the wild animal of the reeds, 
+</div><div class="q2">the multitude of the bulls with the calves of the peoples. 
+</div><div class="q1">Trample under foot the bars of silver. 
+</div><div class="q2">Scatter the nations who delight in war. 
+</div><div class="q1">
+<sup>31&#160;</sup>Princes shall come out of Egypt. 
+</div><div class="q2">Ethiopia shall hurry to stretch out her hands to Elohim. 
+</div><div class="q1">
+<sup>32&#160;</sup>Sing to Elohim, you kingdoms of the earth! 
+</div><div class="q2">Sing praises to the Lord—</div><div class="qs">Selah—</div><div class="q1"><sup>33&#160;</sup>to him who rides on the heaven of heavens, which are of old; 
+</div><div class="q2">behold, he utters his voice, a mighty voice. 
+</div><div class="q1">
+<sup>34&#160;</sup>Ascribe strength to Elohim! 
+</div><div class="q2">His excellency is over Israel, 
+</div><div class="q2">his strength is in the skies. 
+</div><div class="q1">
+<sup>35&#160;</sup>You are awesome, Elohim, in your sanctuaries. 
+</div><div class="q2">The Elohim of Israel gives strength and power to his people. 
+</div><div class="q2">Praise be to Elohim! 
+</div><h2 class="psalmlabel" id="69">69</h2>
+<div class="d">For the Chief Musician. To the tune of “Lilies.” By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Save me, Elohim, 
+</div><div class="q2">for the waters have come up to my neck! 
+</div><div class="q1">
+<sup>2&#160;</sup>I sink in deep mire, where there is no foothold. 
+</div><div class="q2">I have come into deep waters, where the floods overflow me. 
+</div><div class="q1">
+<sup>3&#160;</sup>I am weary with my crying. 
+</div><div class="q2">My throat is dry. 
+</div><div class="q2">My eyes fail looking for my Elohim. 
+</div><div class="q1">
+<sup>4&#160;</sup>Those who hate me without a cause are more than the hairs of my head. 
+</div><div class="q2">Those who want to cut me off, being my enemies wrongfully, are mighty. 
+</div><div class="q2">I have to restore what I didn’t take away. 
+</div><div class="q1">
+<sup>5&#160;</sup>Elohim, you know my foolishness. 
+</div><div class="q2">My sins aren’t hidden from you. 
+</div><div class="q1">
+<sup>6&#160;</sup>Don’t let those who wait for you be shamed through me, Lord Yahweh of Armies. 
+</div><div class="q2">Don’t let those who seek you be brought to dishonor through me, Elohim of Israel. 
+</div><div class="q1">
+<sup>7&#160;</sup>Because for your sake, I have borne reproach. 
+</div><div class="q2">Shame has covered my face. 
+</div><div class="q1">
+<sup>8&#160;</sup>I have become a stranger to my brothers, 
+</div><div class="q2">an alien to my mother’s children. 
+</div><div class="q1">
+<sup>9&#160;</sup>For the zeal of your house consumes me. 
+</div><div class="q2">The reproaches of those who reproach you have fallen on me. 
+</div><div class="q1">
+<sup>10&#160;</sup>When I wept and I fasted, 
+</div><div class="q2">that was to my reproach. 
+</div><div class="q1">
+<sup>11&#160;</sup>When I made sackcloth my clothing, 
+</div><div class="q2">I became a byword to them. 
+</div><div class="q1">
+<sup>12&#160;</sup>Those who sit in the gate talk about me. 
+</div><div class="q2">I am the song of the drunkards. 
+</div><div class="q1">
+<sup>13&#160;</sup>But as for me, my prayer is to you, Yahweh, in an acceptable time. 
+</div><div class="q2">Elohim, in the abundance of your loving kindness, answer me in the truth of your salvation. 
+</div><div class="q1">
+<sup>14&#160;</sup>Deliver me out of the mire, and don’t let me sink. 
+</div><div class="q2">Let me be delivered from those who hate me, and out of the deep waters. 
+</div><div class="q1">
+<sup>15&#160;</sup>Don’t let the flood waters overwhelm me, 
+</div><div class="q2">neither let the deep swallow me up. 
+</div><div class="q2">Don’t let the pit shut its mouth on me. 
+</div><div class="q1">
+<sup>16&#160;</sup>Answer me, Yahweh, for your loving kindness is good. 
+</div><div class="q2">According to the multitude of your tender mercies, turn to me. 
+</div><div class="q1">
+<sup>17&#160;</sup>Don’t hide your face from your servant, 
+</div><div class="q2">for I am in distress. 
+</div><div class="q2">Answer me speedily! 
+</div><div class="q1">
+<sup>18&#160;</sup>Draw near to my soul and redeem it. 
+</div><div class="q2">Ransom me because of my enemies. 
+</div><div class="q1">
+<sup>19&#160;</sup>You know my reproach, my shame, and my dishonor. 
+</div><div class="q2">My adversaries are all before you. 
+</div><div class="q1">
+<sup>20&#160;</sup>Reproach has broken my heart, and I am full of heaviness. 
+</div><div class="q2">I looked for some to take pity, but there was none; 
+</div><div class="q2">for comforters, but I found none. 
+</div><div class="q1">
+<sup>21&#160;</sup>They also gave me poison for my food. 
+</div><div class="q2">In my thirst, they gave me vinegar to drink. 
+</div><div class="q1">
+<sup>22&#160;</sup>Let their table before them become a snare. 
+</div><div class="q2">May it become a retribution and a trap. 
+</div><div class="q1">
+<sup>23&#160;</sup>Let their eyes be darkened, so that they can’t see. 
+</div><div class="q2">Let their backs be continually bent. 
+</div><div class="q1">
+<sup>24&#160;</sup>Pour out your indignation on them. 
+</div><div class="q2">Let the fierceness of your anger overtake them. 
+</div><div class="q1">
+<sup>25&#160;</sup>Let their habitation be desolate. 
+</div><div class="q2">Let no one dwell in their tents. 
+</div><div class="q1">
+<sup>26&#160;</sup>For they persecute him whom you have wounded. 
+</div><div class="q2">They tell of the sorrow of those whom you have hurt. 
+</div><div class="q1">
+<sup>27&#160;</sup>Charge them with crime upon crime. 
+</div><div class="q2">Don’t let them come into your righteousness. 
+</div><div class="q1">
+<sup>28&#160;</sup>Let them be blotted out of the book of life, 
+</div><div class="q2">and not be written with the righteous. 
+</div><div class="q1">
+<sup>29&#160;</sup>But I am in pain and distress. 
+</div><div class="q2">Let your salvation, Elohim, protect me. 
+</div><div class="q1">
+<sup>30&#160;</sup>I will praise the name of Elohim with a song, 
+</div><div class="q2">and will magnify him with thanksgiving. 
+</div><div class="q1">
+<sup>31&#160;</sup>It will please Yahweh better than an ox, 
+</div><div class="q2">or a bull that has horns and hoofs. 
+</div><div class="q1">
+<sup>32&#160;</sup>The humble have seen it, and are glad. 
+</div><div class="q2">You who seek after Elohim, let your heart live. 
+</div><div class="q1">
+<sup>33&#160;</sup>For Yahweh hears the needy, 
+</div><div class="q2">and doesn’t despise his captive people. 
+</div><div class="q1">
+<sup>34&#160;</sup>Let heaven and earth praise him; 
+</div><div class="q2">the seas, and everything that moves therein! 
+</div><div class="q1">
+<sup>35&#160;</sup>For Elohim will save Zion, and build the cities of Judah. 
+</div><div class="q2">They shall settle there, and own it. 
+</div><div class="q1">
+<sup>36&#160;</sup>The children also of his servants shall inherit it. 
+</div><div class="q2">Those who love his name shall dwell therein. 
+</div><h2 class="psalmlabel" id="70">70</h2>
+<div class="d">For the Chief Musician. By David. A reminder. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hurry, Elohim, to deliver me. 
+</div><div class="q2">Come quickly to help me, Yahweh. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let them be disappointed and confounded who seek my soul. 
+</div><div class="q2">Let those who desire my ruin be turned back in disgrace. 
+</div><div class="q1">
+<sup>3&#160;</sup>Let them be turned because of their shame 
+</div><div class="q2">who say, “Aha! Aha!” 
+</div><div class="q1">
+<sup>4&#160;</sup>Let all those who seek you rejoice and be glad in you. 
+</div><div class="q2">Let those who love your salvation continually say, 
+</div><div class="q2">“Let Elohim be exalted!” 
+</div><div class="q1">
+<sup>5&#160;</sup>But I am poor and needy. 
+</div><div class="q2">Come to me quickly, Elohim. 
+</div><div class="q1">You are my help and my deliverer. 
+</div><div class="q2">Yahweh, don’t delay. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="71">71</h2>
-<p class="q1">
-<span class="v">1&#160;</span>In you, Yahweh, I take refuge. 
-</p><p class="q2">Never let me be disappointed. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Deliver me in your righteousness, and rescue me. 
-</p><p class="q2">Turn your ear to me, and save me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Be to me a rock of refuge to which I may always go. 
-</p><p class="q2">Give the command to save me, 
-</p><p class="q2">for you are my rock and my fortress. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Rescue me, my Elohim, from the hand of the wicked, 
-</p><p class="q2">from the hand of the unrighteous and cruel man. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For you are my hope, Lord Yahweh, 
-</p><p class="q2">my confidence from my youth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I have relied on you from the womb. 
-</p><p class="q2">You are he who took me out of my mother’s womb. 
-</p><p class="q2">I will always praise you. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I am a marvel to many, 
-</p><p class="q2">but you are my strong refuge. 
-</p><p class="q1">
-<span class="v">8&#160;</span>My mouth shall be filled with your praise, 
-</p><p class="q2">with your honor all day long. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Don’t reject me in my old age. 
-</p><p class="q2">Don’t forsake me when my strength fails. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For my enemies talk about me. 
-</p><p class="q2">Those who watch for my soul conspire together, 
-</p><p class="q2">
-<span class="v">11&#160;</span>saying, “Elohim has forsaken him. 
-</p><p class="q2">Pursue and take him, for no one will rescue him.” 
-</p><p class="q1">
-<span class="v">12&#160;</span>Elohim, don’t be far from me. 
-</p><p class="q2">My Elohim, hurry to help me. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Let my accusers be disappointed and consumed. 
-</p><p class="q2">Let them be covered with disgrace and scorn who want to harm me. 
-</p><p class="q1">
-<span class="v">14&#160;</span>But I will always hope, 
-</p><p class="q2">and will add to all of your praise. 
-</p><p class="q1">
-<span class="v">15&#160;</span>My mouth will tell about your righteousness, 
-</p><p class="q2">and of your salvation all day, 
-</p><p class="q2">though I don’t know its full measure. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will come with the mighty acts of the Lord Yahweh. 
-</p><p class="q2">I will make mention of your righteousness, even of yours alone. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Elohim, you have taught me from my youth. 
-</p><p class="q2">Until now, I have declared your wondrous works. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yes, even when I am old and gray-haired, Elohim, don’t forsake me, 
-</p><p class="q2">until I have declared your strength to the next generation, 
-</p><p class="q2">your might to everyone who is to come. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Elohim, your righteousness also reaches to the heavens. 
-</p><p class="q2">You have done great things. 
-</p><p class="q2">Elohim, who is like you? 
-</p><p class="q1">
-<span class="v">20&#160;</span>You, who have shown us many and bitter troubles, 
-</p><p class="q2">you will let me live. 
-</p><p class="q2">You will bring us up again from the depths of the earth. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Increase my honor 
-</p><p class="q2">and comfort me again. 
-</p><p class="q1">
-<span class="v">22&#160;</span>I will also praise you with the harp for your faithfulness, my Elohim. 
-</p><p class="q2">I sing praises to you with the lyre, Set-Apart One of Israel. 
-</p><p class="q1">
-<span class="v">23&#160;</span>My lips shall shout for joy! 
-</p><p class="q2">My soul, which you have redeemed, sings praises to you! 
-</p><p class="q1">
-<span class="v">24&#160;</span>My tongue will also talk about your righteousness all day long, 
-</p><p class="q2">for they are disappointed, and they are confounded, 
-</p><p class="q2">who want to harm me. 
-</p><h2 class="psalmlabel" id="72">72</h2>
-<p class="d">By Solomon. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim, give the king your justice; 
-</p><p class="q2">your righteousness to the royal son. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He will judge your people with righteousness, 
-</p><p class="q2">and your poor with justice. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The mountains shall bring prosperity to the people. 
-</p><p class="q2">The hills bring the fruit of righteousness. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He will judge the poor of the people. 
-</p><p class="q2">He will save the children of the needy, 
-</p><p class="q2">and will break the oppressor in pieces. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They shall fear you while the sun endures; 
-</p><p class="q2">and as long as the moon, throughout all generations. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He will come down like rain on the mown grass, 
-</p><p class="q2">as showers that water the earth. 
-</p><p class="q1">
-<span class="v">7&#160;</span>In his days, the righteous shall flourish, 
-</p><p class="q2">and abundance of peace, until the moon is no more. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He shall have dominion also from sea to sea, 
-</p><p class="q2">from the River to the ends of the earth. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Those who dwell in the wilderness shall bow before him. 
-</p><p class="q2">His enemies shall lick the dust. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The kings of Tarshish and of the islands will bring tribute. 
-</p><p class="q2">The kings of Sheba and Seba shall offer gifts. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yes, all kings shall fall down before him. 
-</p><p class="q2">All nations shall serve him. 
-</p><p class="q1">
-<span class="v">12&#160;</span>For he will deliver the needy when he cries; 
-</p><p class="q2">the poor, who has no helper. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He will have pity on the poor and needy. 
-</p><p class="q2">He will save the souls of the needy. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He will redeem their soul from oppression and violence. 
-</p><p class="q2">Their blood will be precious in his sight. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He will live; and Sheba’s gold will be given to him. 
-</p><p class="q2">Men will pray for him continually. 
-</p><p class="q2">They will bless him all day long. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Abundance of grain shall be throughout the land. 
-</p><p class="q2">Its fruit sways like Lebanon. 
-</p><p class="q2">Let it flourish, thriving like the grass of the field. 
-</p><p class="q1">
-<span class="v">17&#160;</span>His name endures forever. 
-</p><p class="q2">His name continues as long as the sun. 
-</p><p class="q1">Men shall be blessed by him. 
-</p><p class="q2">All nations will call him blessed. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>Praise be to Yahweh Elohim, the Elohim of Israel, 
-</p><p class="q2">who alone does marvelous deeds. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Blessed be his glorious name forever! 
-</p><p class="q2">Let the whole earth be filled with his glory! 
-</p><p class="q1">Amen and amen. 
-</p><div class="b"> &#160; </div>
-<p class="p1">
-<span class="v">20&#160;</span>This ends the prayers by David, the son of Jesse. 
+<div class="q1">
+<sup>1&#160;</sup>In you, Yahweh, I take refuge. 
+</div><div class="q2">Never let me be disappointed. 
+</div><div class="q1">
+<sup>2&#160;</sup>Deliver me in your righteousness, and rescue me. 
+</div><div class="q2">Turn your ear to me, and save me. 
+</div><div class="q1">
+<sup>3&#160;</sup>Be to me a rock of refuge to which I may always go. 
+</div><div class="q2">Give the command to save me, 
+</div><div class="q2">for you are my rock and my fortress. 
+</div><div class="q1">
+<sup>4&#160;</sup>Rescue me, my Elohim, from the hand of the wicked, 
+</div><div class="q2">from the hand of the unrighteous and cruel man. 
+</div><div class="q1">
+<sup>5&#160;</sup>For you are my hope, Lord Yahweh, 
+</div><div class="q2">my confidence from my youth. 
+</div><div class="q1">
+<sup>6&#160;</sup>I have relied on you from the womb. 
+</div><div class="q2">You are he who took me out of my mother’s womb. 
+</div><div class="q2">I will always praise you. 
+</div><div class="q1">
+<sup>7&#160;</sup>I am a marvel to many, 
+</div><div class="q2">but you are my strong refuge. 
+</div><div class="q1">
+<sup>8&#160;</sup>My mouth shall be filled with your praise, 
+</div><div class="q2">with your honor all day long. 
+</div><div class="q1">
+<sup>9&#160;</sup>Don’t reject me in my old age. 
+</div><div class="q2">Don’t forsake me when my strength fails. 
+</div><div class="q1">
+<sup>10&#160;</sup>For my enemies talk about me. 
+</div><div class="q2">Those who watch for my soul conspire together, 
+</div><div class="q2">
+<sup>11&#160;</sup>saying, “Elohim has forsaken him. 
+</div><div class="q2">Pursue and take him, for no one will rescue him.” 
+</div><div class="q1">
+<sup>12&#160;</sup>Elohim, don’t be far from me. 
+</div><div class="q2">My Elohim, hurry to help me. 
+</div><div class="q1">
+<sup>13&#160;</sup>Let my accusers be disappointed and consumed. 
+</div><div class="q2">Let them be covered with disgrace and scorn who want to harm me. 
+</div><div class="q1">
+<sup>14&#160;</sup>But I will always hope, 
+</div><div class="q2">and will add to all of your praise. 
+</div><div class="q1">
+<sup>15&#160;</sup>My mouth will tell about your righteousness, 
+</div><div class="q2">and of your salvation all day, 
+</div><div class="q2">though I don’t know its full measure. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will come with the mighty acts of the Lord Yahweh. 
+</div><div class="q2">I will make mention of your righteousness, even of yours alone. 
+</div><div class="q1">
+<sup>17&#160;</sup>Elohim, you have taught me from my youth. 
+</div><div class="q2">Until now, I have declared your wondrous works. 
+</div><div class="q1">
+<sup>18&#160;</sup>Yes, even when I am old and gray-haired, Elohim, don’t forsake me, 
+</div><div class="q2">until I have declared your strength to the next generation, 
+</div><div class="q2">your might to everyone who is to come. 
+</div><div class="q1">
+<sup>19&#160;</sup>Elohim, your righteousness also reaches to the heavens. 
+</div><div class="q2">You have done great things. 
+</div><div class="q2">Elohim, who is like you? 
+</div><div class="q1">
+<sup>20&#160;</sup>You, who have shown us many and bitter troubles, 
+</div><div class="q2">you will let me live. 
+</div><div class="q2">You will bring us up again from the depths of the earth. 
+</div><div class="q1">
+<sup>21&#160;</sup>Increase my honor 
+</div><div class="q2">and comfort me again. 
+</div><div class="q1">
+<sup>22&#160;</sup>I will also praise you with the harp for your faithfulness, my Elohim. 
+</div><div class="q2">I sing praises to you with the lyre, Set-Apart One of Israel. 
+</div><div class="q1">
+<sup>23&#160;</sup>My lips shall shout for joy! 
+</div><div class="q2">My soul, which you have redeemed, sings praises to you! 
+</div><div class="q1">
+<sup>24&#160;</sup>My tongue will also talk about your righteousness all day long, 
+</div><div class="q2">for they are disappointed, and they are confounded, 
+</div><div class="q2">who want to harm me. 
+</div><h2 class="psalmlabel" id="72">72</h2>
+<div class="d">By Solomon. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim, give the king your justice; 
+</div><div class="q2">your righteousness to the royal son. 
+</div><div class="q1">
+<sup>2&#160;</sup>He will judge your people with righteousness, 
+</div><div class="q2">and your poor with justice. 
+</div><div class="q1">
+<sup>3&#160;</sup>The mountains shall bring prosperity to the people. 
+</div><div class="q2">The hills bring the fruit of righteousness. 
+</div><div class="q1">
+<sup>4&#160;</sup>He will judge the poor of the people. 
+</div><div class="q2">He will save the children of the needy, 
+</div><div class="q2">and will break the oppressor in pieces. 
+</div><div class="q1">
+<sup>5&#160;</sup>They shall fear you while the sun endures; 
+</div><div class="q2">and as long as the moon, throughout all generations. 
+</div><div class="q1">
+<sup>6&#160;</sup>He will come down like rain on the mown grass, 
+</div><div class="q2">as showers that water the earth. 
+</div><div class="q1">
+<sup>7&#160;</sup>In his days, the righteous shall flourish, 
+</div><div class="q2">and abundance of peace, until the moon is no more. 
+</div><div class="q1">
+<sup>8&#160;</sup>He shall have dominion also from sea to sea, 
+</div><div class="q2">from the River to the ends of the earth. 
+</div><div class="q1">
+<sup>9&#160;</sup>Those who dwell in the wilderness shall bow before him. 
+</div><div class="q2">His enemies shall lick the dust. 
+</div><div class="q1">
+<sup>10&#160;</sup>The kings of Tarshish and of the islands will bring tribute. 
+</div><div class="q2">The kings of Sheba and Seba shall offer gifts. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yes, all kings shall fall down before him. 
+</div><div class="q2">All nations shall serve him. 
+</div><div class="q1">
+<sup>12&#160;</sup>For he will deliver the needy when he cries; 
+</div><div class="q2">the poor, who has no helper. 
+</div><div class="q1">
+<sup>13&#160;</sup>He will have pity on the poor and needy. 
+</div><div class="q2">He will save the souls of the needy. 
+</div><div class="q1">
+<sup>14&#160;</sup>He will redeem their soul from oppression and violence. 
+</div><div class="q2">Their blood will be precious in his sight. 
+</div><div class="q1">
+<sup>15&#160;</sup>He will live; and Sheba’s gold will be given to him. 
+</div><div class="q2">Men will pray for him continually. 
+</div><div class="q2">They will bless him all day long. 
+</div><div class="q1">
+<sup>16&#160;</sup>Abundance of grain shall be throughout the land. 
+</div><div class="q2">Its fruit sways like Lebanon. 
+</div><div class="q2">Let it flourish, thriving like the grass of the field. 
+</div><div class="q1">
+<sup>17&#160;</sup>His name endures forever. 
+</div><div class="q2">His name continues as long as the sun. 
+</div><div class="q1">Men shall be blessed by him. 
+</div><div class="q2">All nations will call him blessed. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>Praise be to Yahweh Elohim, the Elohim of Israel, 
+</div><div class="q2">who alone does marvelous deeds. 
+</div><div class="q1">
+<sup>19&#160;</sup>Blessed be his glorious name forever! 
+</div><div class="q2">Let the whole earth be filled with his glory! 
+</div><div class="q1">Amen and amen. 
+</div><div class="b"> &#160; </div>
+<div class="p1">
+<sup>20&#160;</sup>This ends the prayers by David, the son of Jesse. 
+</div><h2 class="ms1">BOOK 3</h2>
 <h2 class="psalmlabel" id="73">73</h2>
-<h2 class="ms1">BOOK 3</h2>
-</p><p class="d">A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Surely Elohim<span class="f">+ \fr 73:1 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> is good to Israel, 
-</p><p class="q2">to those who are pure in heart. 
-</p><p class="q1">
-<span class="v">2&#160;</span>But as for me, my feet were almost gone. 
-</p><p class="q2">My steps had nearly slipped. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For I was envious of the arrogant, 
-</p><p class="q2">when I saw the prosperity of the wicked. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For there are no struggles in their death, 
-</p><p class="q2">but their strength is firm. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They are free from burdens of men, 
-</p><p class="q2">neither are they plagued like other men. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Therefore pride is like a chain around their neck. 
-</p><p class="q2">Violence covers them like a garment. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Their eyes bulge with fat. 
-</p><p class="q2">Their minds pass the limits of conceit. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They scoff and speak with malice. 
-</p><p class="q2">In arrogance, they threaten oppression. 
-</p><p class="q1">
-<span class="v">9&#160;</span>They have set their mouth in the heavens. 
-</p><p class="q2">Their tongue walks through the earth. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Therefore their people return to them, 
-</p><p class="q2">and they drink up waters of abundance. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They say, “How does Elohim know? 
-</p><p class="q2">Is there knowledge in the Most High?” 
-</p><p class="q1">
-<span class="v">12&#160;</span>Behold, these are the wicked. 
-</p><p class="q2">Being always at ease, they increase in riches. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Surely I have cleansed my heart in vain, 
-</p><p class="q2">and washed my hands in innocence, 
-</p><p class="q1">
-<span class="v">14&#160;</span>For all day long I have been plagued, 
-</p><p class="q2">and punished every morning. 
-</p><p class="q1">
-<span class="v">15&#160;</span>If I had said, “I will speak thus”, 
-</p><p class="q2">behold, I would have betrayed the generation of your children. 
-</p><p class="q1">
-<span class="v">16&#160;</span>When I tried to understand this, 
-</p><p class="q2">it was too painful for me—</p><p class="q1">
-<span class="v">17&#160;</span>until I entered Elohim’s sanctuary, 
-</p><p class="q2">and considered their latter end. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Surely you set them in slippery places. 
-</p><p class="q2">You throw them down to destruction. 
-</p><p class="q1">
-<span class="v">19&#160;</span>How they are suddenly destroyed! 
-</p><p class="q2">They are completely swept away with terrors. 
-</p><p class="q1">
-<span class="v">20&#160;</span>As a dream when one wakes up, 
-</p><p class="q2">so, Lord,<span class="f">+ \fr 73:20 \ft The word translated “Lord” is “Adonai.”</span> when you awake, you will despise their fantasies. 
-</p><p class="q1">
-<span class="v">21&#160;</span>For my soul was grieved. 
-</p><p class="q2">I was embittered in my heart. 
-</p><p class="q1">
-<span class="v">22&#160;</span>I was so senseless and ignorant. 
-</p><p class="q2">I was a brute beast before you. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Nevertheless, I am continually with you. 
-</p><p class="q2">You have held my right hand. 
-</p><p class="q1">
-<span class="v">24&#160;</span>You will guide me with your counsel, 
-</p><p class="q2">and afterward receive me to glory. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Whom do I have in heaven? 
-</p><p class="q2">There is no one on earth whom I desire besides you. 
-</p><p class="q1">
-<span class="v">26&#160;</span>My flesh and my heart fails, 
-</p><p class="q2">but Elohim is the strength of my heart and my portion forever. 
-</p><p class="q1">
-<span class="v">27&#160;</span>For, behold, those who are far from you shall perish. 
-</p><p class="q2">You have destroyed all those who are unfaithful to you. 
-</p><p class="q1">
-<span class="v">28&#160;</span>But it is good for me to come close to Elohim. 
-</p><p class="q2">I have made the Lord Yahweh<span class="f">+ \fr 73:28 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> my refuge, 
-</p><p class="q2">that I may tell of all your works. 
-</p><div class="b"> &#160; </div>
+<div class="d">A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Surely Elohim is good to Israel, 
+</div><div class="q2">to those who are pure in heart. 
+</div><div class="q1">
+<sup>2&#160;</sup>But as for me, my feet were almost gone. 
+</div><div class="q2">My steps had nearly slipped. 
+</div><div class="q1">
+<sup>3&#160;</sup>For I was envious of the arrogant, 
+</div><div class="q2">when I saw the prosperity of the wicked. 
+</div><div class="q1">
+<sup>4&#160;</sup>For there are no struggles in their death, 
+</div><div class="q2">but their strength is firm. 
+</div><div class="q1">
+<sup>5&#160;</sup>They are free from burdens of men, 
+</div><div class="q2">neither are they plagued like other men. 
+</div><div class="q1">
+<sup>6&#160;</sup>Therefore pride is like a chain around their neck. 
+</div><div class="q2">Violence covers them like a garment. 
+</div><div class="q1">
+<sup>7&#160;</sup>Their eyes bulge with fat. 
+</div><div class="q2">Their minds pass the limits of conceit. 
+</div><div class="q1">
+<sup>8&#160;</sup>They scoff and speak with malice. 
+</div><div class="q2">In arrogance, they threaten oppression. 
+</div><div class="q1">
+<sup>9&#160;</sup>They have set their mouth in the heavens. 
+</div><div class="q2">Their tongue walks through the earth. 
+</div><div class="q1">
+<sup>10&#160;</sup>Therefore their people return to them, 
+</div><div class="q2">and they drink up waters of abundance. 
+</div><div class="q1">
+<sup>11&#160;</sup>They say, “How does Elohim know? 
+</div><div class="q2">Is there knowledge in the Most High?” 
+</div><div class="q1">
+<sup>12&#160;</sup>Behold, these are the wicked. 
+</div><div class="q2">Being always at ease, they increase in riches. 
+</div><div class="q1">
+<sup>13&#160;</sup>Surely I have cleansed my heart in vain, 
+</div><div class="q2">and washed my hands in innocence, 
+</div><div class="q1">
+<sup>14&#160;</sup>For all day long I have been plagued, 
+</div><div class="q2">and punished every morning. 
+</div><div class="q1">
+<sup>15&#160;</sup>If I had said, “I will speak thus”, 
+</div><div class="q2">behold, I would have betrayed the generation of your children. 
+</div><div class="q1">
+<sup>16&#160;</sup>When I tried to understand this, 
+</div><div class="q2">it was too painful for me—</div><div class="q1">
+<sup>17&#160;</sup>until I entered Elohim’s sanctuary, 
+</div><div class="q2">and considered their latter end. 
+</div><div class="q1">
+<sup>18&#160;</sup>Surely you set them in slippery places. 
+</div><div class="q2">You throw them down to destruction. 
+</div><div class="q1">
+<sup>19&#160;</sup>How they are suddenly destroyed! 
+</div><div class="q2">They are completely swept away with terrors. 
+</div><div class="q1">
+<sup>20&#160;</sup>As a dream when one wakes up, 
+</div><div class="q2">so, Lord, when you awake, you will despise their fantasies. 
+</div><div class="q1">
+<sup>21&#160;</sup>For my soul was grieved. 
+</div><div class="q2">I was embittered in my heart. 
+</div><div class="q1">
+<sup>22&#160;</sup>I was so senseless and ignorant. 
+</div><div class="q2">I was a brute beast before you. 
+</div><div class="q1">
+<sup>23&#160;</sup>Nevertheless, I am continually with you. 
+</div><div class="q2">You have held my right hand. 
+</div><div class="q1">
+<sup>24&#160;</sup>You will guide me with your counsel, 
+</div><div class="q2">and afterward receive me to glory. 
+</div><div class="q1">
+<sup>25&#160;</sup>Whom do I have in heaven? 
+</div><div class="q2">There is no one on earth whom I desire besides you. 
+</div><div class="q1">
+<sup>26&#160;</sup>My flesh and my heart fails, 
+</div><div class="q2">but Elohim is the strength of my heart and my portion forever. 
+</div><div class="q1">
+<sup>27&#160;</sup>For, behold, those who are far from you shall perish. 
+</div><div class="q2">You have destroyed all those who are unfaithful to you. 
+</div><div class="q1">
+<sup>28&#160;</sup>But it is good for me to come close to Elohim. 
+</div><div class="q2">I have made the Lord Yahweh my refuge, 
+</div><div class="q2">that I may tell of all your works. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="74">74</h2>
-<p class="d">A contemplation by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim, why have you rejected us forever? 
-</p><p class="q2">Why does your anger smolder against the sheep of your pasture? 
-</p><p class="q1">
-<span class="v">2&#160;</span>Remember your congregation, which you purchased of old, 
-</p><p class="q2">which you have redeemed to be the tribe of your inheritance: 
-</p><p class="q2">Mount Zion, in which you have lived. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Lift up your feet to the perpetual ruins, 
-</p><p class="q2">all the evil that the enemy has done in the sanctuary. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Your adversaries have roared in the middle of your assembly. 
-</p><p class="q2">They have set up their standards as signs. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They behaved like men wielding axes, 
-</p><p class="q2">cutting through a thicket of trees. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Now they break all its carved work down with hatchet and hammers. 
-</p><p class="q2">
-<span class="v">7&#160;</span>They have burned your sanctuary to the ground. 
-</p><p class="q2">They have profaned the dwelling place of your Name. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They said in their heart, “We will crush them completely.” 
-</p><p class="q2">They have burned up all the places in the land where Elohim was worshiped. 
-</p><p class="q1">
-<span class="v">9&#160;</span>We see no miraculous signs. 
-</p><p class="q2">There is no longer any prophet, 
-</p><p class="q2">neither is there among us anyone who knows how long. 
-</p><p class="q1">
-<span class="v">10&#160;</span>How long, Elohim, shall the adversary reproach? 
-</p><p class="q2">Shall the enemy blaspheme your name forever? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Why do you draw back your hand, even your right hand? 
-</p><p class="q2">Take it from your chest and consume them! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Yet Elohim is my King of old, 
-</p><p class="q2">working salvation throughout the earth. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You divided the sea by your strength. 
-</p><p class="q2">You broke the heads of the sea monsters in the waters. 
-</p><p class="q1">
-<span class="v">14&#160;</span>You broke the heads of Leviathan in pieces. 
-</p><p class="q2">You gave him as food to people and desert creatures. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You opened up spring and stream. 
-</p><p class="q2">You dried up mighty rivers. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The day is yours, the night is also yours. 
-</p><p class="q2">You have prepared the light and the sun. 
-</p><p class="q1">
-<span class="v">17&#160;</span>You have set all the boundaries of the earth. 
-</p><p class="q2">You have made summer and winter. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">18&#160;</span>Remember this, that the enemy has mocked you, Yahweh. 
-</p><p class="q2">Foolish people have blasphemed your name. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Don’t deliver the soul of your dove to wild beasts. 
-</p><p class="q2">Don’t forget the life of your poor forever. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Honor your covenant, 
-</p><p class="q2">for haunts of violence fill the dark places of the earth. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Don’t let the oppressed return ashamed. 
-</p><p class="q2">Let the poor and needy praise your name. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Arise, Elohim! Plead your own cause. 
-</p><p class="q2">Remember how the foolish man mocks you all day. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Don’t forget the voice of your adversaries. 
-</p><p class="q2">The tumult of those who rise up against you ascends continually. 
-</p><div class="b"> &#160; </div>
+<div class="d">A contemplation by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim, why have you rejected us forever? 
+</div><div class="q2">Why does your anger smolder against the sheep of your pasture? 
+</div><div class="q1">
+<sup>2&#160;</sup>Remember your congregation, which you purchased of old, 
+</div><div class="q2">which you have redeemed to be the tribe of your inheritance: 
+</div><div class="q2">Mount Zion, in which you have lived. 
+</div><div class="q1">
+<sup>3&#160;</sup>Lift up your feet to the perpetual ruins, 
+</div><div class="q2">all the evil that the enemy has done in the sanctuary. 
+</div><div class="q1">
+<sup>4&#160;</sup>Your adversaries have roared in the middle of your assembly. 
+</div><div class="q2">They have set up their standards as signs. 
+</div><div class="q1">
+<sup>5&#160;</sup>They behaved like men wielding axes, 
+</div><div class="q2">cutting through a thicket of trees. 
+</div><div class="q1">
+<sup>6&#160;</sup>Now they break all its carved work down with hatchet and hammers. 
+</div><div class="q2">
+<sup>7&#160;</sup>They have burned your sanctuary to the ground. 
+</div><div class="q2">They have profaned the dwelling place of your Name. 
+</div><div class="q1">
+<sup>8&#160;</sup>They said in their heart, “We will crush them completely.” 
+</div><div class="q2">They have burned up all the places in the land where Elohim was worshiped. 
+</div><div class="q1">
+<sup>9&#160;</sup>We see no miraculous signs. 
+</div><div class="q2">There is no longer any prophet, 
+</div><div class="q2">neither is there among us anyone who knows how long. 
+</div><div class="q1">
+<sup>10&#160;</sup>How long, Elohim, shall the adversary reproach? 
+</div><div class="q2">Shall the enemy blaspheme your name forever? 
+</div><div class="q1">
+<sup>11&#160;</sup>Why do you draw back your hand, even your right hand? 
+</div><div class="q2">Take it from your chest and consume them! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Yet Elohim is my King of old, 
+</div><div class="q2">working salvation throughout the earth. 
+</div><div class="q1">
+<sup>13&#160;</sup>You divided the sea by your strength. 
+</div><div class="q2">You broke the heads of the sea monsters in the waters. 
+</div><div class="q1">
+<sup>14&#160;</sup>You broke the heads of Leviathan in pieces. 
+</div><div class="q2">You gave him as food to people and desert creatures. 
+</div><div class="q1">
+<sup>15&#160;</sup>You opened up spring and stream. 
+</div><div class="q2">You dried up mighty rivers. 
+</div><div class="q1">
+<sup>16&#160;</sup>The day is yours, the night is also yours. 
+</div><div class="q2">You have prepared the light and the sun. 
+</div><div class="q1">
+<sup>17&#160;</sup>You have set all the boundaries of the earth. 
+</div><div class="q2">You have made summer and winter. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>18&#160;</sup>Remember this, that the enemy has mocked you, Yahweh. 
+</div><div class="q2">Foolish people have blasphemed your name. 
+</div><div class="q1">
+<sup>19&#160;</sup>Don’t deliver the soul of your dove to wild beasts. 
+</div><div class="q2">Don’t forget the life of your poor forever. 
+</div><div class="q1">
+<sup>20&#160;</sup>Honor your covenant, 
+</div><div class="q2">for haunts of violence fill the dark places of the earth. 
+</div><div class="q1">
+<sup>21&#160;</sup>Don’t let the oppressed return ashamed. 
+</div><div class="q2">Let the poor and needy praise your name. 
+</div><div class="q1">
+<sup>22&#160;</sup>Arise, Elohim! Plead your own cause. 
+</div><div class="q2">Remember how the foolish man mocks you all day. 
+</div><div class="q1">
+<sup>23&#160;</sup>Don’t forget the voice of your adversaries. 
+</div><div class="q2">The tumult of those who rise up against you ascends continually. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="75">75</h2>
-<p class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A Psalm by Asaph. A song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>We give thanks to you, Elohim. 
-</p><p class="q2">We give thanks, for your Name is near. 
-</p><p class="q2">Men tell about your wondrous works. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">2&#160;</span>When I choose the appointed time, 
-</p><p class="q2">I will judge blamelessly. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The earth and all its inhabitants quake. 
-</p><p class="q2">I firmly hold its pillars. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>I said to the arrogant, “Don’t boast!” 
-</p><p class="q2">I said to the wicked, “Don’t lift up the horn. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Don’t lift up your horn on high. 
-</p><p class="q2">Don’t speak with a stiff neck.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>For neither from the east, nor from the west, 
-</p><p class="q2">nor yet from the south, comes exaltation. 
-</p><p class="q1">
-<span class="v">7&#160;</span>But Elohim is the judge. 
-</p><p class="q2">He puts down one, and lifts up another. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For in Yahweh’s hand there is a cup, 
-</p><p class="q2">full of foaming wine mixed with spices. 
-</p><p class="q1">He pours it out. 
-</p><p class="q2">Indeed the wicked of the earth drink and drink it to its very dregs. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>But I will declare this forever: 
-</p><p class="q2">I will sing praises to the Elohim of Jacob. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I will cut off all the horns of the wicked, 
-</p><p class="q2">but the horns of the righteous shall be lifted up. 
-</p><div class="b"> &#160; </div>
+<div class="d">For the Chief Musician. To the tune of “Do Not Destroy.” A Psalm by Asaph. A song. 
+</div><div class="q1">
+<sup>1&#160;</sup>We give thanks to you, Elohim. 
+</div><div class="q2">We give thanks, for your Name is near. 
+</div><div class="q2">Men tell about your wondrous works. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>2&#160;</sup>When I choose the appointed time, 
+</div><div class="q2">I will judge blamelessly. 
+</div><div class="q1">
+<sup>3&#160;</sup>The earth and all its inhabitants quake. 
+</div><div class="q2">I firmly hold its pillars. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>I said to the arrogant, “Don’t boast!” 
+</div><div class="q2">I said to the wicked, “Don’t lift up the horn. 
+</div><div class="q1">
+<sup>5&#160;</sup>Don’t lift up your horn on high. 
+</div><div class="q2">Don’t speak with a stiff neck.” 
+</div><div class="q1">
+<sup>6&#160;</sup>For neither from the east, nor from the west, 
+</div><div class="q2">nor yet from the south, comes exaltation. 
+</div><div class="q1">
+<sup>7&#160;</sup>But Elohim is the judge. 
+</div><div class="q2">He puts down one, and lifts up another. 
+</div><div class="q1">
+<sup>8&#160;</sup>For in Yahweh’s hand there is a cup, 
+</div><div class="q2">full of foaming wine mixed with spices. 
+</div><div class="q1">He pours it out. 
+</div><div class="q2">Indeed the wicked of the earth drink and drink it to its very dregs. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>But I will declare this forever: 
+</div><div class="q2">I will sing praises to the Elohim of Jacob. 
+</div><div class="q1">
+<sup>10&#160;</sup>I will cut off all the horns of the wicked, 
+</div><div class="q2">but the horns of the righteous shall be lifted up. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="76">76</h2>
-<p class="d">For the Chief Musician. On stringed instruments. A Psalm by Asaph. A song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>In Judah, Elohim is known. 
-</p><p class="q2">His name is great in Israel. 
-</p><p class="q1">
-<span class="v">2&#160;</span>His tabernacle is also in Salem. 
-</p><p class="q2">His dwelling place in Zion. 
-</p><p class="q1">
-<span class="v">3&#160;</span>There he broke the flaming arrows of the bow, 
-</p><p class="q2">the shield, and the sword, and the weapons of war. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>Glorious are you, and excellent, 
-</p><p class="q2">more than mountains of game. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Valiant men lie plundered, 
-</p><p class="q2">they have slept their last sleep. 
-</p><p class="q2">None of the men of war can lift their hands. 
-</p><p class="q1">
-<span class="v">6&#160;</span>At your rebuke, Elohim of Jacob, 
-</p><p class="q2">both chariot and horse are cast into a dead sleep. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You, even you, are to be feared. 
-</p><p class="q2">Who can stand in your sight when you are angry? 
-</p><p class="q1">
-<span class="v">8&#160;</span>You pronounced judgment from heaven. 
-</p><p class="q2">The earth feared, and was silent, 
-</p><p class="q2">
-<span class="v">9&#160;</span>when Elohim arose to judgment, 
-</p><p class="q2">to save all the afflicted ones of the earth. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">10&#160;</span>Surely the wrath of man praises you. 
-</p><p class="q2">The survivors of your wrath are restrained. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Make vows to Yahweh your Elohim, and fulfill them! 
-</p><p class="q2">Let all of his neighbors bring presents to him who is to be feared. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He will cut off the spirit of princes. 
-</p><p class="q2">He is feared by the kings of the earth. 
-</p><div class="b"> &#160; </div>
+<div class="d">For the Chief Musician. On stringed instruments. A Psalm by Asaph. A song. 
+</div><div class="q1">
+<sup>1&#160;</sup>In Judah, Elohim is known. 
+</div><div class="q2">His name is great in Israel. 
+</div><div class="q1">
+<sup>2&#160;</sup>His tabernacle is also in Salem. 
+</div><div class="q2">His dwelling place in Zion. 
+</div><div class="q1">
+<sup>3&#160;</sup>There he broke the flaming arrows of the bow, 
+</div><div class="q2">the shield, and the sword, and the weapons of war. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>Glorious are you, and excellent, 
+</div><div class="q2">more than mountains of game. 
+</div><div class="q1">
+<sup>5&#160;</sup>Valiant men lie plundered, 
+</div><div class="q2">they have slept their last sleep. 
+</div><div class="q2">None of the men of war can lift their hands. 
+</div><div class="q1">
+<sup>6&#160;</sup>At your rebuke, Elohim of Jacob, 
+</div><div class="q2">both chariot and horse are cast into a dead sleep. 
+</div><div class="q1">
+<sup>7&#160;</sup>You, even you, are to be feared. 
+</div><div class="q2">Who can stand in your sight when you are angry? 
+</div><div class="q1">
+<sup>8&#160;</sup>You pronounced judgment from heaven. 
+</div><div class="q2">The earth feared, and was silent, 
+</div><div class="q2">
+<sup>9&#160;</sup>when Elohim arose to judgment, 
+</div><div class="q2">to save all the afflicted ones of the earth. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>10&#160;</sup>Surely the wrath of man praises you. 
+</div><div class="q2">The survivors of your wrath are restrained. 
+</div><div class="q1">
+<sup>11&#160;</sup>Make vows to Yahweh your Elohim, and fulfill them! 
+</div><div class="q2">Let all of his neighbors bring presents to him who is to be feared. 
+</div><div class="q1">
+<sup>12&#160;</sup>He will cut off the spirit of princes. 
+</div><div class="q2">He is feared by the kings of the earth. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="77">77</h2>
-<p class="d">For the Chief Musician. To Jeduthun. A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>My cry goes to Elohim! 
-</p><p class="q2">Indeed, I cry to Elohim for help, 
-</p><p class="q2">and for him to listen to me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>In the day of my trouble I sought the Lord. 
-</p><p class="q2">My hand was stretched out in the night, and didn’t get tired. 
-</p><p class="q2">My soul refused to be comforted. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I remember Elohim, and I groan. 
-</p><p class="q2">I complain, and my spirit is overwhelmed. </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>You hold my eyelids open. 
-</p><p class="q2">I am so troubled that I can’t speak. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I have considered the days of old, 
-</p><p class="q2">the years of ancient times. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I remember my song in the night. 
-</p><p class="q2">I consider in my own heart; 
-</p><p class="q2">my spirit diligently inquires: 
-</p><p class="q1">
-<span class="v">7&#160;</span>“Will the Lord reject us forever? 
-</p><p class="q2">Will he be favorable no more? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Has his loving kindness vanished forever? 
-</p><p class="q2">Does his promise fail for generations? 
-</p><p class="q1">
-<span class="v">9&#160;</span>Has Elohim forgotten to be gracious? 
-</p><p class="q2">Has he, in anger, withheld his compassion?” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">10&#160;</span>Then I thought, “I will appeal to this: 
-</p><p class="q2">the years of the right hand of the Most High.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>I will remember Yah’s deeds; 
-</p><p class="q2">for I will remember your wonders of old. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will also meditate on all your work, 
-</p><p class="q2">and consider your doings. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Your way, Elohim, is in the sanctuary. 
-</p><p class="q2">What elohim is great like Elohim? 
-</p><p class="q1">
-<span class="v">14&#160;</span>You are the Elohim who does wonders. 
-</p><p class="q2">You have made your strength known among the peoples. 
-</p><p class="q1">
-<span class="v">15&#160;</span>You have redeemed your people with your arm, 
-</p><p class="q2">the sons of Jacob and Joseph. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">16&#160;</span>The waters saw you, Elohim. 
-</p><p class="q2">The waters saw you, and they writhed. 
-</p><p class="q2">The depths also convulsed. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The clouds poured out water. 
-</p><p class="q2">The skies resounded with thunder. 
-</p><p class="q2">Your arrows also flashed around. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The voice of your thunder was in the whirlwind. 
-</p><p class="q2">The lightnings lit up the world. 
-</p><p class="q2">The earth trembled and shook. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Your way was through the sea, 
-</p><p class="q2">your paths through the great waters. 
-</p><p class="q2">Your footsteps were not known. 
-</p><p class="q1">
-<span class="v">20&#160;</span>You led your people like a flock, 
-</p><p class="q2">by the hand of Moses and Aaron. 
-</p><div class="b"> &#160; </div>
+<div class="d">For the Chief Musician. To Jeduthun. A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>My cry goes to Elohim! 
+</div><div class="q2">Indeed, I cry to Elohim for help, 
+</div><div class="q2">and for him to listen to me. 
+</div><div class="q1">
+<sup>2&#160;</sup>In the day of my trouble I sought the Lord. 
+</div><div class="q2">My hand was stretched out in the night, and didn’t get tired. 
+</div><div class="q2">My soul refused to be comforted. 
+</div><div class="q1">
+<sup>3&#160;</sup>I remember Elohim, and I groan. 
+</div><div class="q2">I complain, and my spirit is overwhelmed. </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>You hold my eyelids open. 
+</div><div class="q2">I am so troubled that I can’t speak. 
+</div><div class="q1">
+<sup>5&#160;</sup>I have considered the days of old, 
+</div><div class="q2">the years of ancient times. 
+</div><div class="q1">
+<sup>6&#160;</sup>I remember my song in the night. 
+</div><div class="q2">I consider in my own heart; 
+</div><div class="q2">my spirit diligently inquires: 
+</div><div class="q1">
+<sup>7&#160;</sup>“Will the Lord reject us forever? 
+</div><div class="q2">Will he be favorable no more? 
+</div><div class="q1">
+<sup>8&#160;</sup>Has his loving kindness vanished forever? 
+</div><div class="q2">Does his promise fail for generations? 
+</div><div class="q1">
+<sup>9&#160;</sup>Has Elohim forgotten to be gracious? 
+</div><div class="q2">Has he, in anger, withheld his compassion?” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>10&#160;</sup>Then I thought, “I will appeal to this: 
+</div><div class="q2">the years of the right hand of the Most High.” 
+</div><div class="q1">
+<sup>11&#160;</sup>I will remember Yah’s deeds; 
+</div><div class="q2">for I will remember your wonders of old. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will also meditate on all your work, 
+</div><div class="q2">and consider your doings. 
+</div><div class="q1">
+<sup>13&#160;</sup>Your way, Elohim, is in the sanctuary. 
+</div><div class="q2">What elohim is great like Elohim? 
+</div><div class="q1">
+<sup>14&#160;</sup>You are the Elohim who does wonders. 
+</div><div class="q2">You have made your strength known among the peoples. 
+</div><div class="q1">
+<sup>15&#160;</sup>You have redeemed your people with your arm, 
+</div><div class="q2">the sons of Jacob and Joseph. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>16&#160;</sup>The waters saw you, Elohim. 
+</div><div class="q2">The waters saw you, and they writhed. 
+</div><div class="q2">The depths also convulsed. 
+</div><div class="q1">
+<sup>17&#160;</sup>The clouds poured out water. 
+</div><div class="q2">The skies resounded with thunder. 
+</div><div class="q2">Your arrows also flashed around. 
+</div><div class="q1">
+<sup>18&#160;</sup>The voice of your thunder was in the whirlwind. 
+</div><div class="q2">The lightnings lit up the world. 
+</div><div class="q2">The earth trembled and shook. 
+</div><div class="q1">
+<sup>19&#160;</sup>Your way was through the sea, 
+</div><div class="q2">your paths through the great waters. 
+</div><div class="q2">Your footsteps were not known. 
+</div><div class="q1">
+<sup>20&#160;</sup>You led your people like a flock, 
+</div><div class="q2">by the hand of Moses and Aaron. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="78">78</h2>
-<p class="d">A contemplation by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear my teaching, my people. 
-</p><p class="q2">Turn your ears to the words of my mouth. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will open my mouth in a parable. 
-</p><p class="q2">I will utter dark sayings of old, 
-</p><p class="q1">
-<span class="v">3&#160;</span>which we have heard and known, 
-</p><p class="q2">and our fathers have told us. 
-</p><p class="q1">
-<span class="v">4&#160;</span>We will not hide them from their children, 
-</p><p class="q2">telling to the generation to come the praises of Yahweh, 
-</p><p class="q2">his strength, and his wondrous deeds that he has done. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For he established a covenant in Jacob, 
-</p><p class="q2">and appointed a teaching in Israel, 
-</p><p class="q2">which he commanded our fathers, 
-</p><p class="q2">that they should make them known to their children; 
-</p><p class="q1">
-<span class="v">6&#160;</span>that the generation to come might know, even the children who should be born; 
-</p><p class="q2">who should arise and tell their children, 
-</p><p class="q1">
-<span class="v">7&#160;</span>that they might set their hope in Elohim, 
-</p><p class="q2">and not forget Elohim’s deeds, 
-</p><p class="q2">but keep his commandments, 
-</p><p class="q1">
-<span class="v">8&#160;</span>and might not be as their fathers—</p><p class="q2">a stubborn and rebellious generation, 
-</p><p class="q2">a generation that didn’t make their hearts loyal, 
-</p><p class="q2">whose spirit was not steadfast with Elohim. 
-</p><p class="q1">
-<span class="v">9&#160;</span>The children of Ephraim, being armed and carrying bows, 
-</p><p class="q2">turned back in the day of battle. 
-</p><p class="q1">
-<span class="v">10&#160;</span>They didn’t keep Elohim’s covenant, 
-</p><p class="q2">and refused to walk in his law. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They forgot his doings, 
-</p><p class="q2">his wondrous deeds that he had shown them. 
-</p><p class="q1">
-<span class="v">12&#160;</span>He did marvelous things in the sight of their fathers, 
-</p><p class="q2">in the land of Egypt, in the field of Zoan. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He split the sea, and caused them to pass through. 
-</p><p class="q2">He made the waters stand as a heap. 
-</p><p class="q1">
-<span class="v">14&#160;</span>In the daytime he also led them with a cloud, 
-</p><p class="q2">and all night with a light of fire. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He split rocks in the wilderness, 
-</p><p class="q2">and gave them drink abundantly as out of the depths. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He brought streams also out of the rock, 
-</p><p class="q2">and caused waters to run down like rivers. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Yet they still went on to sin against him, 
-</p><p class="q2">to rebel against the Most High in the desert. 
-</p><p class="q1">
-<span class="v">18&#160;</span>They tempted Elohim in their heart 
-</p><p class="q2">by asking food according to their desire. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Yes, they spoke against Elohim. 
-</p><p class="q2">They said, “Can Elohim prepare a table in the wilderness? 
-</p><p class="q1">
-<span class="v">20&#160;</span>Behold, he struck the rock, so that waters gushed out, 
-</p><p class="q2">and streams overflowed. 
-</p><p class="q1">Can he give bread also? 
-</p><p class="q2">Will he provide meat for his people?” 
-</p><p class="q1">
-<span class="v">21&#160;</span>Therefore Yahweh heard, and was angry. 
-</p><p class="q2">A fire was kindled against Jacob, 
-</p><p class="q2">anger also went up against Israel, 
-</p><p class="q1">
-<span class="v">22&#160;</span>because they didn’t believe in Elohim, 
-</p><p class="q2">and didn’t trust in his salvation. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Yet he commanded the skies above, 
-</p><p class="q2">and opened the doors of heaven. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He rained down manna on them to eat, 
-</p><p class="q2">and gave them food from the sky. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Man ate the bread of angels. 
-</p><p class="q2">He sent them food to the full. 
-</p><p class="q1">
-<span class="v">26&#160;</span>He caused the east wind to blow in the sky. 
-</p><p class="q2">By his power he guided the south wind. 
-</p><p class="q1">
-<span class="v">27&#160;</span>He also rained meat on them as the dust, 
-</p><p class="q2">winged birds as the sand of the seas. 
-</p><p class="q1">
-<span class="v">28&#160;</span>He let them fall in the middle of their camp, 
-</p><p class="q2">around their habitations. 
-</p><p class="q1">
-<span class="v">29&#160;</span>So they ate, and were well filled. 
-</p><p class="q2">He gave them their own desire. 
-</p><p class="q1">
-<span class="v">30&#160;</span>They didn’t turn from their cravings. 
-</p><p class="q2">Their food was yet in their mouths, 
-</p><p class="q2">
-<span class="v">31&#160;</span>when the anger of Elohim went up against them, 
-</p><p class="q2">killed some of their strongest, 
-</p><p class="q2">and struck down the young men of Israel. 
-</p><p class="q1">
-<span class="v">32&#160;</span>For all this they still sinned, 
-</p><p class="q2">and didn’t believe in his wondrous works. 
-</p><p class="q1">
-<span class="v">33&#160;</span>Therefore he consumed their days in vanity, 
-</p><p class="q2">and their years in terror. 
-</p><p class="q1">
-<span class="v">34&#160;</span>When he killed them, then they inquired after him. 
-</p><p class="q2">They returned and sought Elohim earnestly. 
-</p><p class="q1">
-<span class="v">35&#160;</span>They remembered that Elohim was their rock, 
-</p><p class="q2">the Most High Elohim, their redeemer. 
-</p><p class="q1">
-<span class="v">36&#160;</span>But they flattered him with their mouth, 
-</p><p class="q2">and lied to him with their tongue. 
-</p><p class="q1">
-<span class="v">37&#160;</span>For their heart was not right with him, 
-</p><p class="q2">neither were they faithful in his covenant. 
-</p><p class="q1">
-<span class="v">38&#160;</span>But he, being merciful, forgave iniquity, and didn’t destroy them. 
-</p><p class="q2">Yes, many times he turned his anger away, 
-</p><p class="q2">and didn’t stir up all his wrath. 
-</p><p class="q1">
-<span class="v">39&#160;</span>He remembered that they were but flesh, 
-</p><p class="q2">a wind that passes away, and doesn’t come again. 
-</p><p class="q1">
-<span class="v">40&#160;</span>How often they rebelled against him in the wilderness, 
-</p><p class="q2">and grieved him in the desert! 
-</p><p class="q1">
-<span class="v">41&#160;</span>They turned again and tempted Elohim, 
-</p><p class="q2">and provoked the Set-Apart One of Israel. 
-</p><p class="q1">
-<span class="v">42&#160;</span>They didn’t remember his hand, 
-</p><p class="q2">nor the day when he redeemed them from the adversary; 
-</p><p class="q1">
-<span class="v">43&#160;</span>how he set his signs in Egypt, 
-</p><p class="q2">his wonders in the field of Zoan, 
-</p><p class="q1">
-<span class="v">44&#160;</span>he turned their rivers into blood, 
-</p><p class="q2">and their streams, so that they could not drink. 
-</p><p class="q1">
-<span class="v">45&#160;</span>He sent among them swarms of flies, which devoured them; 
-</p><p class="q2">and frogs, which destroyed them. 
-</p><p class="q1">
-<span class="v">46&#160;</span>He also gave their increase to the caterpillar, 
-</p><p class="q2">and their labor to the locust. 
-</p><p class="q1">
-<span class="v">47&#160;</span>He destroyed their vines with hail, 
-</p><p class="q2">their sycamore fig trees with frost. 
-</p><p class="q1">
-<span class="v">48&#160;</span>He also gave over their livestock to the hail, 
-</p><p class="q2">and their flocks to hot thunderbolts. 
-</p><p class="q1">
-<span class="v">49&#160;</span>He threw on them the fierceness of his anger, 
-</p><p class="q2">wrath, indignation, and trouble, 
-</p><p class="q2">and a band of angels of evil. 
-</p><p class="q1">
-<span class="v">50&#160;</span>He made a path for his anger. 
-</p><p class="q2">He didn’t spare their soul from death, 
-</p><p class="q2">but gave their life over to the pestilence, 
-</p><p class="q1">
-<span class="v">51&#160;</span>and struck all the firstborn in Egypt, 
-</p><p class="q2">the chief of their strength in the tents of Ham. 
-</p><p class="q1">
-<span class="v">52&#160;</span>But he led out his own people like sheep, 
-</p><p class="q2">and guided them in the wilderness like a flock. 
-</p><p class="q1">
-<span class="v">53&#160;</span>He led them safely, so that they weren’t afraid, 
-</p><p class="q2">but the sea overwhelmed their enemies. 
-</p><p class="q1">
-<span class="v">54&#160;</span>He brought them to the border of his sanctuary, 
-</p><p class="q2">to this mountain, which his right hand had taken. 
-</p><p class="q1">
-<span class="v">55&#160;</span>He also drove out the nations before them, 
-</p><p class="q2">allotted them for an inheritance by line, 
-</p><p class="q2">and made the tribes of Israel to dwell in their tents. 
-</p><p class="q1">
-<span class="v">56&#160;</span>Yet they tempted and rebelled against the Most High Elohim, 
-</p><p class="q2">and didn’t keep his testimonies, 
-</p><p class="q1">
-<span class="v">57&#160;</span>but turned back, and dealt treacherously like their fathers. 
-</p><p class="q2">They were twisted like a deceitful bow. 
-</p><p class="q1">
-<span class="v">58&#160;</span>For they provoked him to anger with their high places, 
-</p><p class="q2">and moved him to jealousy with their engraved images. 
-</p><p class="q1">
-<span class="v">59&#160;</span>When Elohim heard this, he was angry, 
-</p><p class="q2">and greatly abhorred Israel, 
-</p><p class="q1">
-<span class="v">60&#160;</span>so that he abandoned the tent of Shiloh, 
-</p><p class="q2">the tent which he placed among men, 
-</p><p class="q1">
-<span class="v">61&#160;</span>and delivered his strength into captivity, 
-</p><p class="q2">his glory into the adversary’s hand. 
-</p><p class="q1">
-<span class="v">62&#160;</span>He also gave his people over to the sword, 
-</p><p class="q2">and was angry with his inheritance. 
-</p><p class="q1">
-<span class="v">63&#160;</span>Fire devoured their young men. 
-</p><p class="q2">Their virgins had no wedding song. 
-</p><p class="q1">
-<span class="v">64&#160;</span>Their priests fell by the sword, 
-</p><p class="q2">and their widows couldn’t weep. 
-</p><p class="q1">
-<span class="v">65&#160;</span>Then the Lord awakened as one out of sleep, 
-</p><p class="q2">like a mighty man who shouts by reason of wine. 
-</p><p class="q1">
-<span class="v">66&#160;</span>He struck his adversaries backward. 
-</p><p class="q2">He put them to a perpetual reproach. 
-</p><p class="q1">
-<span class="v">67&#160;</span>Moreover he rejected the tent of Joseph, 
-</p><p class="q2">and didn’t choose the tribe of Ephraim, 
-</p><p class="q1">
-<span class="v">68&#160;</span>But chose the tribe of Judah, 
-</p><p class="q2">Mount Zion which he loved. 
-</p><p class="q1">
-<span class="v">69&#160;</span>He built his sanctuary like the heights, 
-</p><p class="q2">like the earth which he has established forever. 
-</p><p class="q1">
-<span class="v">70&#160;</span>He also chose David his servant, 
-</p><p class="q2">and took him from the sheepfolds; 
-</p><p class="q1">
-<span class="v">71&#160;</span>from following the ewes that have their young, 
-</p><p class="q2">he brought him to be the shepherd of Jacob, his people, 
-</p><p class="q2">and Israel, his inheritance. 
-</p><p class="q1">
-<span class="v">72&#160;</span>So he was their shepherd according to the integrity of his heart, 
-</p><p class="q2">and guided them by the skillfulness of his hands. 
-</p><div class="b"> &#160; </div>
+<div class="d">A contemplation by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear my teaching, my people. 
+</div><div class="q2">Turn your ears to the words of my mouth. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will open my mouth in a parable. 
+</div><div class="q2">I will utter dark sayings of old, 
+</div><div class="q1">
+<sup>3&#160;</sup>which we have heard and known, 
+</div><div class="q2">and our fathers have told us. 
+</div><div class="q1">
+<sup>4&#160;</sup>We will not hide them from their children, 
+</div><div class="q2">telling to the generation to come the praises of Yahweh, 
+</div><div class="q2">his strength, and his wondrous deeds that he has done. 
+</div><div class="q1">
+<sup>5&#160;</sup>For he established a covenant in Jacob, 
+</div><div class="q2">and appointed a teaching in Israel, 
+</div><div class="q2">which he commanded our fathers, 
+</div><div class="q2">that they should make them known to their children; 
+</div><div class="q1">
+<sup>6&#160;</sup>that the generation to come might know, even the children who should be born; 
+</div><div class="q2">who should arise and tell their children, 
+</div><div class="q1">
+<sup>7&#160;</sup>that they might set their hope in Elohim, 
+</div><div class="q2">and not forget Elohim’s deeds, 
+</div><div class="q2">but keep his commandments, 
+</div><div class="q1">
+<sup>8&#160;</sup>and might not be as their fathers—</div><div class="q2">a stubborn and rebellious generation, 
+</div><div class="q2">a generation that didn’t make their hearts loyal, 
+</div><div class="q2">whose spirit was not steadfast with Elohim. 
+</div><div class="q1">
+<sup>9&#160;</sup>The children of Ephraim, being armed and carrying bows, 
+</div><div class="q2">turned back in the day of battle. 
+</div><div class="q1">
+<sup>10&#160;</sup>They didn’t keep Elohim’s covenant, 
+</div><div class="q2">and refused to walk in his law. 
+</div><div class="q1">
+<sup>11&#160;</sup>They forgot his doings, 
+</div><div class="q2">his wondrous deeds that he had shown them. 
+</div><div class="q1">
+<sup>12&#160;</sup>He did marvelous things in the sight of their fathers, 
+</div><div class="q2">in the land of Egypt, in the field of Zoan. 
+</div><div class="q1">
+<sup>13&#160;</sup>He split the sea, and caused them to pass through. 
+</div><div class="q2">He made the waters stand as a heap. 
+</div><div class="q1">
+<sup>14&#160;</sup>In the daytime he also led them with a cloud, 
+</div><div class="q2">and all night with a light of fire. 
+</div><div class="q1">
+<sup>15&#160;</sup>He split rocks in the wilderness, 
+</div><div class="q2">and gave them drink abundantly as out of the depths. 
+</div><div class="q1">
+<sup>16&#160;</sup>He brought streams also out of the rock, 
+</div><div class="q2">and caused waters to run down like rivers. 
+</div><div class="q1">
+<sup>17&#160;</sup>Yet they still went on to sin against him, 
+</div><div class="q2">to rebel against the Most High in the desert. 
+</div><div class="q1">
+<sup>18&#160;</sup>They tempted Elohim in their heart 
+</div><div class="q2">by asking food according to their desire. 
+</div><div class="q1">
+<sup>19&#160;</sup>Yes, they spoke against Elohim. 
+</div><div class="q2">They said, “Can Elohim prepare a table in the wilderness? 
+</div><div class="q1">
+<sup>20&#160;</sup>Behold, he struck the rock, so that waters gushed out, 
+</div><div class="q2">and streams overflowed. 
+</div><div class="q1">Can he give bread also? 
+</div><div class="q2">Will he provide meat for his people?” 
+</div><div class="q1">
+<sup>21&#160;</sup>Therefore Yahweh heard, and was angry. 
+</div><div class="q2">A fire was kindled against Jacob, 
+</div><div class="q2">anger also went up against Israel, 
+</div><div class="q1">
+<sup>22&#160;</sup>because they didn’t believe in Elohim, 
+</div><div class="q2">and didn’t trust in his salvation. 
+</div><div class="q1">
+<sup>23&#160;</sup>Yet he commanded the skies above, 
+</div><div class="q2">and opened the doors of heaven. 
+</div><div class="q1">
+<sup>24&#160;</sup>He rained down manna on them to eat, 
+</div><div class="q2">and gave them food from the sky. 
+</div><div class="q1">
+<sup>25&#160;</sup>Man ate the bread of angels. 
+</div><div class="q2">He sent them food to the full. 
+</div><div class="q1">
+<sup>26&#160;</sup>He caused the east wind to blow in the sky. 
+</div><div class="q2">By his power he guided the south wind. 
+</div><div class="q1">
+<sup>27&#160;</sup>He also rained meat on them as the dust, 
+</div><div class="q2">winged birds as the sand of the seas. 
+</div><div class="q1">
+<sup>28&#160;</sup>He let them fall in the middle of their camp, 
+</div><div class="q2">around their habitations. 
+</div><div class="q1">
+<sup>29&#160;</sup>So they ate, and were well filled. 
+</div><div class="q2">He gave them their own desire. 
+</div><div class="q1">
+<sup>30&#160;</sup>They didn’t turn from their cravings. 
+</div><div class="q2">Their food was yet in their mouths, 
+</div><div class="q2">
+<sup>31&#160;</sup>when the anger of Elohim went up against them, 
+</div><div class="q2">killed some of their strongest, 
+</div><div class="q2">and struck down the young men of Israel. 
+</div><div class="q1">
+<sup>32&#160;</sup>For all this they still sinned, 
+</div><div class="q2">and didn’t believe in his wondrous works. 
+</div><div class="q1">
+<sup>33&#160;</sup>Therefore he consumed their days in vanity, 
+</div><div class="q2">and their years in terror. 
+</div><div class="q1">
+<sup>34&#160;</sup>When he killed them, then they inquired after him. 
+</div><div class="q2">They returned and sought Elohim earnestly. 
+</div><div class="q1">
+<sup>35&#160;</sup>They remembered that Elohim was their rock, 
+</div><div class="q2">the Most High Elohim, their redeemer. 
+</div><div class="q1">
+<sup>36&#160;</sup>But they flattered him with their mouth, 
+</div><div class="q2">and lied to him with their tongue. 
+</div><div class="q1">
+<sup>37&#160;</sup>For their heart was not right with him, 
+</div><div class="q2">neither were they faithful in his covenant. 
+</div><div class="q1">
+<sup>38&#160;</sup>But he, being merciful, forgave iniquity, and didn’t destroy them. 
+</div><div class="q2">Yes, many times he turned his anger away, 
+</div><div class="q2">and didn’t stir up all his wrath. 
+</div><div class="q1">
+<sup>39&#160;</sup>He remembered that they were but flesh, 
+</div><div class="q2">a wind that passes away, and doesn’t come again. 
+</div><div class="q1">
+<sup>40&#160;</sup>How often they rebelled against him in the wilderness, 
+</div><div class="q2">and grieved him in the desert! 
+</div><div class="q1">
+<sup>41&#160;</sup>They turned again and tempted Elohim, 
+</div><div class="q2">and provoked the Set-Apart One of Israel. 
+</div><div class="q1">
+<sup>42&#160;</sup>They didn’t remember his hand, 
+</div><div class="q2">nor the day when he redeemed them from the adversary; 
+</div><div class="q1">
+<sup>43&#160;</sup>how he set his signs in Egypt, 
+</div><div class="q2">his wonders in the field of Zoan, 
+</div><div class="q1">
+<sup>44&#160;</sup>he turned their rivers into blood, 
+</div><div class="q2">and their streams, so that they could not drink. 
+</div><div class="q1">
+<sup>45&#160;</sup>He sent among them swarms of flies, which devoured them; 
+</div><div class="q2">and frogs, which destroyed them. 
+</div><div class="q1">
+<sup>46&#160;</sup>He also gave their increase to the caterpillar, 
+</div><div class="q2">and their labor to the locust. 
+</div><div class="q1">
+<sup>47&#160;</sup>He destroyed their vines with hail, 
+</div><div class="q2">their sycamore fig trees with frost. 
+</div><div class="q1">
+<sup>48&#160;</sup>He also gave over their livestock to the hail, 
+</div><div class="q2">and their flocks to hot thunderbolts. 
+</div><div class="q1">
+<sup>49&#160;</sup>He threw on them the fierceness of his anger, 
+</div><div class="q2">wrath, indignation, and trouble, 
+</div><div class="q2">and a band of angels of evil. 
+</div><div class="q1">
+<sup>50&#160;</sup>He made a path for his anger. 
+</div><div class="q2">He didn’t spare their soul from death, 
+</div><div class="q2">but gave their life over to the pestilence, 
+</div><div class="q1">
+<sup>51&#160;</sup>and struck all the firstborn in Egypt, 
+</div><div class="q2">the chief of their strength in the tents of Ham. 
+</div><div class="q1">
+<sup>52&#160;</sup>But he led out his own people like sheep, 
+</div><div class="q2">and guided them in the wilderness like a flock. 
+</div><div class="q1">
+<sup>53&#160;</sup>He led them safely, so that they weren’t afraid, 
+</div><div class="q2">but the sea overwhelmed their enemies. 
+</div><div class="q1">
+<sup>54&#160;</sup>He brought them to the border of his sanctuary, 
+</div><div class="q2">to this mountain, which his right hand had taken. 
+</div><div class="q1">
+<sup>55&#160;</sup>He also drove out the nations before them, 
+</div><div class="q2">allotted them for an inheritance by line, 
+</div><div class="q2">and made the tribes of Israel to dwell in their tents. 
+</div><div class="q1">
+<sup>56&#160;</sup>Yet they tempted and rebelled against the Most High Elohim, 
+</div><div class="q2">and didn’t keep his testimonies, 
+</div><div class="q1">
+<sup>57&#160;</sup>but turned back, and dealt treacherously like their fathers. 
+</div><div class="q2">They were twisted like a deceitful bow. 
+</div><div class="q1">
+<sup>58&#160;</sup>For they provoked him to anger with their high places, 
+</div><div class="q2">and moved him to jealousy with their engraved images. 
+</div><div class="q1">
+<sup>59&#160;</sup>When Elohim heard this, he was angry, 
+</div><div class="q2">and greatly abhorred Israel, 
+</div><div class="q1">
+<sup>60&#160;</sup>so that he abandoned the tent of Shiloh, 
+</div><div class="q2">the tent which he placed among men, 
+</div><div class="q1">
+<sup>61&#160;</sup>and delivered his strength into captivity, 
+</div><div class="q2">his glory into the adversary’s hand. 
+</div><div class="q1">
+<sup>62&#160;</sup>He also gave his people over to the sword, 
+</div><div class="q2">and was angry with his inheritance. 
+</div><div class="q1">
+<sup>63&#160;</sup>Fire devoured their young men. 
+</div><div class="q2">Their virgins had no wedding song. 
+</div><div class="q1">
+<sup>64&#160;</sup>Their priests fell by the sword, 
+</div><div class="q2">and their widows couldn’t weep. 
+</div><div class="q1">
+<sup>65&#160;</sup>Then the Lord awakened as one out of sleep, 
+</div><div class="q2">like a mighty man who shouts by reason of wine. 
+</div><div class="q1">
+<sup>66&#160;</sup>He struck his adversaries backward. 
+</div><div class="q2">He put them to a perpetual reproach. 
+</div><div class="q1">
+<sup>67&#160;</sup>Moreover he rejected the tent of Joseph, 
+</div><div class="q2">and didn’t choose the tribe of Ephraim, 
+</div><div class="q1">
+<sup>68&#160;</sup>But chose the tribe of Judah, 
+</div><div class="q2">Mount Zion which he loved. 
+</div><div class="q1">
+<sup>69&#160;</sup>He built his sanctuary like the heights, 
+</div><div class="q2">like the earth which he has established forever. 
+</div><div class="q1">
+<sup>70&#160;</sup>He also chose David his servant, 
+</div><div class="q2">and took him from the sheepfolds; 
+</div><div class="q1">
+<sup>71&#160;</sup>from following the ewes that have their young, 
+</div><div class="q2">he brought him to be the shepherd of Jacob, his people, 
+</div><div class="q2">and Israel, his inheritance. 
+</div><div class="q1">
+<sup>72&#160;</sup>So he was their shepherd according to the integrity of his heart, 
+</div><div class="q2">and guided them by the skillfulness of his hands. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="79">79</h2>
-<p class="d">A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim, the nations have come into your inheritance. 
-</p><p class="q2">They have defiled your set-apart temple. 
-</p><p class="q2">They have laid Jerusalem in heaps. 
-</p><p class="q1">
-<span class="v">2&#160;</span>They have given the dead bodies of your servants to be food for the birds of the sky, 
-</p><p class="q2">the flesh of your saints to the animals of the earth. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They have shed their blood like water around Jerusalem. 
-</p><p class="q2">There was no one to bury them. 
-</p><p class="q1">
-<span class="v">4&#160;</span>We have become a reproach to our neighbors, 
-</p><p class="q2">a scoffing and derision to those who are around us. 
-</p><p class="q1">
-<span class="v">5&#160;</span>How long, Yahweh? 
-</p><p class="q2">Will you be angry forever? 
-</p><p class="q2">Will your jealousy burn like fire? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Pour out your wrath on the nations that don’t know you, 
-</p><p class="q2">on the kingdoms that don’t call on your name, 
-</p><p class="q1">
-<span class="v">7&#160;</span>for they have devoured Jacob, 
-</p><p class="q2">and destroyed his homeland. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Don’t hold the iniquities of our forefathers against us. 
-</p><p class="q2">Let your tender mercies speedily meet us, 
-</p><p class="q2">for we are in desperate need. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Help us, Elohim of our salvation, for the glory of your name. 
-</p><p class="q2">Deliver us, and forgive our sins, for your name’s sake. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Why should the nations say, “Where is their Elohim?” 
-</p><p class="q2">Let it be known among the nations, before our eyes, 
-</p><p class="q2">that vengeance for your servants’ blood is being poured out. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Let the sighing of the prisoner come before you. 
-</p><p class="q2">According to the greatness of your power, preserve those who are sentenced to death. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Pay back to our neighbors seven times into their bosom 
-</p><p class="q2">their reproach with which they have reproached you, Lord. 
-</p><p class="q1">
-<span class="v">13&#160;</span>So we, your people and sheep of your pasture, 
-</p><p class="q2">will give you thanks forever. 
-</p><p class="q2">We will praise you forever, to all generations. 
-</p><div class="b"> &#160; </div>
+<div class="d">A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim, the nations have come into your inheritance. 
+</div><div class="q2">They have defiled your set-apart temple. 
+</div><div class="q2">They have laid Jerusalem in heaps. 
+</div><div class="q1">
+<sup>2&#160;</sup>They have given the dead bodies of your servants to be food for the birds of the sky, 
+</div><div class="q2">the flesh of your saints to the animals of the earth. 
+</div><div class="q1">
+<sup>3&#160;</sup>They have shed their blood like water around Jerusalem. 
+</div><div class="q2">There was no one to bury them. 
+</div><div class="q1">
+<sup>4&#160;</sup>We have become a reproach to our neighbors, 
+</div><div class="q2">a scoffing and derision to those who are around us. 
+</div><div class="q1">
+<sup>5&#160;</sup>How long, Yahweh? 
+</div><div class="q2">Will you be angry forever? 
+</div><div class="q2">Will your jealousy burn like fire? 
+</div><div class="q1">
+<sup>6&#160;</sup>Pour out your wrath on the nations that don’t know you, 
+</div><div class="q2">on the kingdoms that don’t call on your name, 
+</div><div class="q1">
+<sup>7&#160;</sup>for they have devoured Jacob, 
+</div><div class="q2">and destroyed his homeland. 
+</div><div class="q1">
+<sup>8&#160;</sup>Don’t hold the iniquities of our forefathers against us. 
+</div><div class="q2">Let your tender mercies speedily meet us, 
+</div><div class="q2">for we are in desperate need. 
+</div><div class="q1">
+<sup>9&#160;</sup>Help us, Elohim of our salvation, for the glory of your name. 
+</div><div class="q2">Deliver us, and forgive our sins, for your name’s sake. 
+</div><div class="q1">
+<sup>10&#160;</sup>Why should the nations say, “Where is their Elohim?” 
+</div><div class="q2">Let it be known among the nations, before our eyes, 
+</div><div class="q2">that vengeance for your servants’ blood is being poured out. 
+</div><div class="q1">
+<sup>11&#160;</sup>Let the sighing of the prisoner come before you. 
+</div><div class="q2">According to the greatness of your power, preserve those who are sentenced to death. 
+</div><div class="q1">
+<sup>12&#160;</sup>Pay back to our neighbors seven times into their bosom 
+</div><div class="q2">their reproach with which they have reproached you, Lord. 
+</div><div class="q1">
+<sup>13&#160;</sup>So we, your people and sheep of your pasture, 
+</div><div class="q2">will give you thanks forever. 
+</div><div class="q2">We will praise you forever, to all generations. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="80">80</h2>
-<p class="d">For the Chief Musician. To the tune of “The Lilies of the Covenant.” A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear us, Shepherd of Israel, 
-</p><p class="q2">you who lead Joseph like a flock, 
-</p><p class="q2">you who sit above the cherubim, shine out. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Before Ephraim, Benjamin, and Manasseh, stir up your might! 
-</p><p class="q2">Come to save us! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Turn us again, Elohim. 
-</p><p class="q2">Cause your face to shine, 
-</p><p class="q2">and we will be saved. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>Yahweh Elohim of Armies, 
-</p><p class="q2">how long will you be angry against the prayer of your people? 
-</p><p class="q1">
-<span class="v">5&#160;</span>You have fed them with the bread of tears, 
-</p><p class="q2">and given them tears to drink in large measure. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You make us a source of contention to our neighbors. 
-</p><p class="q2">Our enemies laugh among themselves. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Turn us again, Elohim of Armies. 
-</p><p class="q2">Cause your face to shine, 
-</p><p class="q2">and we will be saved. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>You brought a vine out of Egypt. 
-</p><p class="q2">You drove out the nations, and planted it. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You cleared the ground for it. 
-</p><p class="q2">It took deep root, and filled the land. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The mountains were covered with its shadow. 
-</p><p class="q2">Its boughs were like Elohim’s cedars. 
-</p><p class="q1">
-<span class="v">11&#160;</span>It sent out its branches to the sea, 
-</p><p class="q2">its shoots to the River. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Why have you broken down its walls, 
-</p><p class="q2">so that all those who pass by the way pluck it? 
-</p><p class="q1">
-<span class="v">13&#160;</span>The boar out of the wood ravages it. 
-</p><p class="q2">The wild animals of the field feed on it. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Turn again, we beg you, Elohim of Armies. 
-</p><p class="q2">Look down from heaven, and see, and visit this vine, 
-</p><p class="q1">
-<span class="v">15&#160;</span>the stock which your right hand planted, 
-</p><p class="q2">the branch that you made strong for yourself. 
-</p><p class="q1">
-<span class="v">16&#160;</span>It’s burned with fire. 
-</p><p class="q2">It’s cut down. 
-</p><p class="q2">They perish at your rebuke. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let your hand be on the man of your right hand, 
-</p><p class="q2">on the son of man whom you made strong for yourself. 
-</p><p class="q1">
-<span class="v">18&#160;</span>So we will not turn away from you. 
-</p><p class="q2">Revive us, and we will call on your name. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Turn us again, Yahweh Elohim of Armies. 
-</p><p class="q2">Cause your face to shine, and we will be saved. 
-</p><h2 class="psalmlabel" id="81">81</h2>
-<p class="d">For the Chief Musician. On an instrument of Gath. By Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Sing aloud to Elohim, our strength! 
-</p><p class="q2">Make a joyful shout to the Elohim of Jacob! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Raise a song, and bring here the tambourine, 
-</p><p class="q2">the pleasant lyre with the harp. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Blow the trumpet at the New Moon, 
-</p><p class="q2">at the full moon, on our feast day. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For it is a statute for Israel, 
-</p><p class="q2">an ordinance of the Elohim of Jacob. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He appointed it in Joseph for a covenant, 
-</p><p class="q2">when he went out over the land of Egypt, 
-</p><p class="q2">I heard a language that I didn’t know. 
-</p><p class="q1">
-<span class="v">6&#160;</span>“I removed his shoulder from the burden. 
-</p><p class="q2">His hands were freed from the basket. 
-</p><p class="q1">
-<span class="v">7&#160;</span>You called in trouble, and I delivered you. 
-</p><p class="q2">I answered you in the secret place of thunder. 
-</p><p class="q2">I tested you at the waters of Meribah.” </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>“Hear, my people, and I will testify to you, 
-</p><p class="q2">Israel, if you would listen to me! 
-</p><p class="q1">
-<span class="v">9&#160;</span>There shall be no strange elohim in you, 
-</p><p class="q2">neither shall you worship any foreign elohim. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I am Yahweh, your Elohim, 
-</p><p class="q2">who brought you up out of the land of Egypt. 
-</p><p class="q2">Open your mouth wide, and I will fill it. 
-</p><p class="q1">
-<span class="v">11&#160;</span>But my people didn’t listen to my voice. 
-</p><p class="q2">Israel desired none of me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>So I let them go after the stubbornness of their hearts, 
-</p><p class="q2">that they might walk in their own counsels. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Oh that my people would listen to me, 
-</p><p class="q2">that Israel would walk in my ways! 
-</p><p class="q1">
-<span class="v">14&#160;</span>I would soon subdue their enemies, 
-</p><p class="q2">and turn my hand against their adversaries. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The haters of Yahweh would cringe before him, 
-</p><p class="q2">and their punishment would last forever. 
-</p><p class="q1">
-<span class="v">16&#160;</span>But he would have also fed them with the finest of the wheat. 
-</p><p class="q2">I will satisfy you with honey out of the rock.” 
-</p><h2 class="psalmlabel" id="82">82</h2>
-<p class="d">A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim presides in the great assembly. 
-</p><p class="q2">He judges among the elohims. 
-</p><p class="q1">
-<span class="v">2&#160;</span>“How long will you judge unjustly, 
-</p><p class="q2">and show partiality to the wicked?” </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“Defend the weak, the poor, and the fatherless. 
-</p><p class="q2">Maintain the rights of the poor and oppressed. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Rescue the weak and needy. 
-</p><p class="q2">Deliver them out of the hand of the wicked.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>They don’t know, neither do they understand. 
-</p><p class="q2">They walk back and forth in darkness. 
-</p><p class="q2">All the foundations of the earth are shaken. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I said, “You are elohims, 
-</p><p class="q2">all of you are sons of the Most High. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Nevertheless you shall die like men, 
-</p><p class="q2">and fall like one of the rulers.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>Arise, Elohim, judge the earth, 
-</p><p class="q2">for you inherit all of the nations. 
-</p><h2 class="psalmlabel" id="83">83</h2>
-<p class="d">A song. A Psalm by Asaph. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim, don’t keep silent. 
-</p><p class="q2">Don’t keep silent, 
-</p><p class="q2">and don’t be still, Elohim. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For, behold, your enemies are stirred up. 
-</p><p class="q2">Those who hate you have lifted up their heads. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They conspire with cunning against your people. 
-</p><p class="q2">They plot against your cherished ones. 
-</p><p class="q1">
-<span class="v">4&#160;</span>“Come,” they say, “let’s destroy them as a nation, 
-</p><p class="q2">that the name of Israel may be remembered no more.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>For they have conspired together with one mind. 
-</p><p class="q2">They form an alliance against you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The tents of Edom and the Ishmaelites; 
-</p><p class="q2">Moab, and the Hagrites; 
-</p><p class="q1">
-<span class="v">7&#160;</span>Gebal, Ammon, and Amalek; 
-</p><p class="q2">Philistia with the inhabitants of Tyre; 
-</p><p class="q1">
-<span class="v">8&#160;</span>Assyria also is joined with them. 
-</p><p class="q2">They have helped the children of Lot. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">9&#160;</span>Do to them as you did to Midian, 
-</p><p class="q2">as to Sisera, as to Jabin, at the river Kishon; 
-</p><p class="q1">
-<span class="v">10&#160;</span>who perished at Endor, 
-</p><p class="q2">who became as dung for the earth. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Make their nobles like Oreb and Zeeb, 
-</p><p class="q2">yes, all their princes like Zebah and Zalmunna, 
-</p><p class="q2">
-<span class="v">12&#160;</span>who said, “Let’s take possession of Elohim’s pasture lands.” 
-</p><p class="q1">
-<span class="v">13&#160;</span>My Elohim, make them like tumbleweed, 
-</p><p class="q2">like chaff before the wind. 
-</p><p class="q1">
-<span class="v">14&#160;</span>As the fire that burns the forest, 
-</p><p class="q2">as the flame that sets the mountains on fire, 
-</p><p class="q2">
-<span class="v">15&#160;</span>so pursue them with your tempest, 
-</p><p class="q2">and terrify them with your storm. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Fill their faces with confusion, 
-</p><p class="q2">that they may seek your name, Yahweh. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let them be disappointed and dismayed forever. 
-</p><p class="q2">Yes, let them be confounded and perish; 
-</p><p class="q1">
-<span class="v">18&#160;</span>that they may know that you alone, whose name is Yahweh, 
-</p><p class="q2">are the Most High over all the earth. 
-</p><h2 class="psalmlabel" id="84">84</h2>
-<p class="d">For the Chief Musician. On an instrument of Gath. A Psalm by the sons of Korah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>How lovely are your dwellings, 
-</p><p class="q2">Yahweh of Armies! 
-</p><p class="q1">
-<span class="v">2&#160;</span>My soul longs, and even faints for the courts of Yahweh. 
-</p><p class="q2">My heart and my flesh cry out for the living Elohim. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yes, the sparrow has found a home, 
-</p><p class="q2">and the swallow a nest for herself, where she may have her young, 
-</p><p class="q2">near your altars, Yahweh of Armies, my King, and my Elohim. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Blessed are those who dwell in your house. 
-</p><p class="q2">They are always praising you. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>Blessed are those whose strength is in you, 
-</p><p class="q2">who have set their hearts on a pilgrimage. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Passing through the valley of Weeping, they make it a place of springs. 
-</p><p class="q2">Yes, the autumn rain covers it with blessings. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They go from strength to strength. 
-</p><p class="q2">Every one of them appears before Elohim in Zion. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh, Elohim of Armies, hear my prayer. 
-</p><p class="q2">Listen, Elohim of Jacob. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">9&#160;</span>Behold, Elohim our shield, 
-</p><p class="q2">look at the face of your anointed. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For a day in your courts is better than a thousand. 
-</p><p class="q2">I would rather be a doorkeeper in the house of my Elohim, 
-</p><p class="q2">than to dwell in the tents of wickedness. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For Yahweh Elohim is a sun and a shield. 
-</p><p class="q2">Yahweh will give grace and glory. 
-</p><p class="q2">He withholds no good thing from those who walk blamelessly. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yahweh of Armies, 
-</p><p class="q2">blessed is the man who trusts in you. 
-</p><h2 class="psalmlabel" id="85">85</h2>
-<p class="d">For the Chief Musician. A Psalm by the sons of Korah. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, you have been favorable to your land. 
-</p><p class="q2">You have restored the fortunes of Jacob. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You have forgiven the iniquity of your people. 
-</p><p class="q2">You have covered all their sin. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">3&#160;</span>You have taken away all your wrath. 
-</p><p class="q2">You have turned from the fierceness of your anger. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Turn us, Elohim of our salvation, 
-</p><p class="q2">and cause your indignation toward us to cease. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Will you be angry with us forever? 
-</p><p class="q2">Will you draw out your anger to all generations? 
-</p><p class="q1">
-<span class="v">6&#160;</span>Won’t you revive us again, 
-</p><p class="q2">that your people may rejoice in you? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Show us your loving kindness, Yahweh. 
-</p><p class="q2">Grant us your salvation. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will hear what Elohim, Yahweh, will speak, 
-</p><p class="q2">for he will speak peace to his people, his saints; 
-</p><p class="q2">but let them not turn again to folly. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Surely his salvation is near those who fear him, 
-</p><p class="q2">that glory may dwell in our land. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Mercy and truth meet together. 
-</p><p class="q2">Righteousness and peace have kissed each other. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Truth springs out of the earth. 
-</p><p class="q2">Righteousness has looked down from heaven. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yes, Yahweh will give that which is good. 
-</p><p class="q2">Our land will yield its increase. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Righteousness goes before him, 
-</p><p class="q2">and prepares the way for his steps. 
-</p><h2 class="psalmlabel" id="86">86</h2>
-<p class="d">A Prayer by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear, Yahweh, and answer me, 
-</p><p class="q2">for I am poor and needy. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Preserve my soul, for I am elohimly. 
-</p><p class="q2">You, my Elohim, save your servant who trusts in you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Be merciful to me, Lord, 
-</p><p class="q2">for I call to you all day long. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Bring joy to the soul of your servant, 
-</p><p class="q2">for to you, Lord, do I lift up my soul. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For you, Lord, are good, and ready to forgive, 
-</p><p class="q2">abundant in loving kindness to all those who call on you. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Hear, Yahweh, my prayer. 
-</p><p class="q2">Listen to the voice of my petitions. 
-</p><p class="q1">
-<span class="v">7&#160;</span>In the day of my trouble I will call on you, 
-</p><p class="q2">for you will answer me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>There is no one like you among the elohims, Lord, 
-</p><p class="q2">nor any deeds like your deeds. 
-</p><p class="q1">
-<span class="v">9&#160;</span>All nations you have made will come and worship before you, Lord. 
-</p><p class="q2">They shall glorify your name. 
-</p><p class="q1">
-<span class="v">10&#160;</span>For you are great, and do wondrous things. 
-</p><p class="q2">You are Elohim alone. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Teach me your way, Yahweh. 
-</p><p class="q2">I will walk in your truth. 
-</p><p class="q2">Make my heart undivided to fear your name. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will praise you, Lord my Elohim, with my whole heart. 
-</p><p class="q2">I will glorify your name forever more. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For your loving kindness is great toward me. 
-</p><p class="q2">You have delivered my soul from the lowest Sheol.<span class="f">+ \fr 86:13 \ft Sheol is the place of the dead.</span> 
-</p><p class="q1">
-<span class="v">14&#160;</span>Elohim, the proud have risen up against me. 
-</p><p class="q2">A company of violent men have sought after my soul, 
-</p><p class="q2">and they don’t hold regard for you before them. 
-</p><p class="q1">
-<span class="v">15&#160;</span>But you, Lord, are a merciful and gracious Elohim, 
-</p><p class="q2">slow to anger, and abundant in loving kindness and truth. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Turn to me, and have mercy on me! 
-</p><p class="q2">Give your strength to your servant. 
-</p><p class="q2">Save the son of your servant. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Show me a sign of your goodness, 
-</p><p class="q2">that those who hate me may see it, and be shamed, 
-</p><p class="q2">because you, Yahweh, have helped me, and comforted me. 
-</p><h2 class="psalmlabel" id="87">87</h2>
-<p class="d">A Psalm by the sons of Korah; a Song. 
-</p><p class="q1">
-<span class="v">1&#160;</span>His foundation is in the set-apart mountains. 
-</p><p class="q2">
-<span class="v">2&#160;</span>Yahweh loves the gates of Zion more than all the dwellings of Jacob. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Glorious things are spoken about you, city of Elohim. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will record Rahab<span class="f">+ \fr 87:4 \ft Rahab is a reference to Egypt.</span> and Babylon among those who acknowledge me. 
-</p><p class="q2">Behold, Philistia, Tyre, and also Ethiopia: 
-</p><p class="q2">“This one was born there.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yes, of Zion it will be said, “This one and that one was born in her;” 
-</p><p class="q2">the Most High himself will establish her. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh will count, when he writes up the peoples, 
-</p><p class="q2">“This one was born there.” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">7&#160;</span>Those who sing as well as those who dance say, 
-</p><p class="q2">“All my springs are in you.” 
-</p><h2 class="psalmlabel" id="88">88</h2>
-<p class="d">A Song. A Psalm by the sons of Korah. For the Chief Musician. To the tune of “The Suffering of Affliction.” A contemplation by Heman, the Ezrahite. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, the Elohim of my salvation, 
-</p><p class="q2">I have cried day and night before you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let my prayer enter into your presence. 
-</p><p class="q2">Turn your ear to my cry. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For my soul is full of troubles. 
-</p><p class="q2">My life draws near to Sheol.<span class="f">+ \fr 88:3 \ft Sheol is the place of the dead.</span> 
-</p><p class="q1">
-<span class="v">4&#160;</span>I am counted among those who go down into the pit. 
-</p><p class="q2">I am like a man who has no help, 
-</p><p class="q2">
-<span class="v">5&#160;</span>set apart among the dead, 
-</p><p class="q2">like the slain who lie in the grave, 
-</p><p class="q2">whom you remember no more. 
-</p><p class="q2">They are cut off from your hand. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You have laid me in the lowest pit, 
-</p><p class="q2">in the darkest depths. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Your wrath lies heavily on me. 
-</p><p class="q2">You have afflicted me with all your waves. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">8&#160;</span>You have taken my friends from me. 
-</p><p class="q2">You have made me an abomination to them. 
-</p><p class="q2">I am confined, and I can’t escape. 
-</p><p class="q1">
-<span class="v">9&#160;</span>My eyes are dim from grief. 
-</p><p class="q2">I have called on you daily, Yahweh. 
-</p><p class="q2">I have spread out my hands to you. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Do you show wonders to the dead? 
-</p><p class="q2">Do the departed spirits rise up and praise you? </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">11&#160;</span>Is your loving kindness declared in the grave? 
-</p><p class="q2">Or your faithfulness in Destruction? 
-</p><p class="q1">
-<span class="v">12&#160;</span>Are your wonders made known in the dark? 
-</p><p class="q2">Or your righteousness in the land of forgetfulness? 
-</p><p class="q1">
-<span class="v">13&#160;</span>But to you, Yahweh, I have cried. 
-</p><p class="q2">In the morning, my prayer comes before you. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yahweh, why do you reject my soul? 
-</p><p class="q2">Why do you hide your face from me? 
-</p><p class="q1">
-<span class="v">15&#160;</span>I am afflicted and ready to die from my youth up. 
-</p><p class="q2">While I suffer your terrors, I am distracted. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Your fierce wrath has gone over me. 
-</p><p class="q2">Your terrors have cut me off. 
-</p><p class="q1">
-<span class="v">17&#160;</span>They came around me like water all day long. 
-</p><p class="q2">They completely engulfed me. 
-</p><p class="q1">
-<span class="v">18&#160;</span>You have put lover and friend far from me, 
-</p><p class="q2">and my friends into darkness. 
-</p><h2 class="psalmlabel" id="89">89</h2>
-<p class="d">A contemplation by Ethan, the Ezrahite. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will sing of the loving kindness of Yahweh forever. 
-</p><p class="q2">With my mouth, I will make known your faithfulness to all generations. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I indeed declare, “Love stands firm forever. 
-</p><p class="q2">You established the heavens. 
-</p><p class="q2">Your faithfulness is in them.” 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>“I have made a covenant with my chosen one, 
-</p><p class="q2">I have sworn to David, my servant, 
-</p><p class="q1">
-<span class="v">4&#160;</span>‘I will establish your offspring forever, 
-</p><p class="q2">and build up your throne to all generations.’&#160;” </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">5&#160;</span>The heavens will praise your wonders, Yahweh, 
-</p><p class="q2">your faithfulness also in the assembly of the set-apart ones. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For who in the skies can be compared to Yahweh? 
-</p><p class="q2">Who among the sons of the heavenly beings is like Yahweh, 
-</p><p class="q1">
-<span class="v">7&#160;</span>a very awesome Elohim in the council of the set-apart ones, 
-</p><p class="q2">to be feared above all those who are around him? 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh, Elohim of Armies, who is a mighty one, like you? 
-</p><p class="q2">Yah, your faithfulness is around you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You rule the pride of the sea. 
-</p><p class="q2">When its waves rise up, you calm them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You have broken Rahab in pieces, like one of the slain. 
-</p><p class="q2">You have scattered your enemies with your mighty arm. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The heavens are yours. 
-</p><p class="q2">The earth also is yours, 
-</p><p class="q2">the world and its fullness. 
-</p><p class="q2">You have founded them. 
-</p><p class="q1">
-<span class="v">12&#160;</span>You have created the north and the south. 
-</p><p class="q2">Tabor and Hermon rejoice in your name. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You have a mighty arm. 
-</p><p class="q2">Your hand is strong, and your right hand is exalted. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Righteousness and justice are the foundation of your throne. 
-</p><p class="q2">Loving kindness and truth go before your face. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Blessed are the people who learn to acclaim you. 
-</p><p class="q2">They walk in the light of your presence, Yahweh. 
-</p><p class="q1">
-<span class="v">16&#160;</span>In your name they rejoice all day. 
-</p><p class="q2">In your righteousness, they are exalted. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For you are the glory of their strength. 
-</p><p class="q2">In your favor, our horn will be exalted. 
-</p><p class="q1">
-<span class="v">18&#160;</span>For our shield belongs to Yahweh, 
-</p><p class="q2">our king to the Set-Apart One of Israel. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">19&#160;</span>Then you spoke in vision to your saints, 
-</p><p class="q2">and said, “I have given strength to the warrior. 
-</p><p class="q2">I have exalted a young man from the people. 
-</p><p class="q1">
-<span class="v">20&#160;</span>I have found David, my servant. 
-</p><p class="q2">I have anointed him with my set-apart oil, 
-</p><p class="q1">
-<span class="v">21&#160;</span>with whom my hand shall be established. 
-</p><p class="q2">My arm will also strengthen him. 
-</p><p class="q1">
-<span class="v">22&#160;</span>No enemy will tax him. 
-</p><p class="q2">No wicked man will oppress him. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I will beat down his adversaries before him, 
-</p><p class="q2">and strike those who hate him. 
-</p><p class="q1">
-<span class="v">24&#160;</span>But my faithfulness and my loving kindness will be with him. 
-</p><p class="q2">In my name, his horn will be exalted. 
-</p><p class="q1">
-<span class="v">25&#160;</span>I will set his hand also on the sea, 
-</p><p class="q2">and his right hand on the rivers. 
-</p><p class="q1">
-<span class="v">26&#160;</span>He will call to me, ‘You are my Father, 
-</p><p class="q2">my Elohim, and the rock of my salvation!’ 
-</p><p class="q1">
-<span class="v">27&#160;</span>I will also appoint him my firstborn, 
-</p><p class="q2">the highest of the kings of the earth. 
-</p><p class="q1">
-<span class="v">28&#160;</span>I will keep my loving kindness for him forever more. 
-</p><p class="q2">My covenant will stand firm with him. 
-</p><p class="q1">
-<span class="v">29&#160;</span>I will also make his offspring endure forever, 
-</p><p class="q2">and his throne as the days of heaven. 
-</p><p class="q1">
-<span class="v">30&#160;</span>If his children forsake my law, 
-</p><p class="q2">and don’t walk in my ordinances; 
-</p><p class="q1">
-<span class="v">31&#160;</span>if they break my statutes, 
-</p><p class="q2">and don’t keep my commandments; 
-</p><p class="q1">
-<span class="v">32&#160;</span>then I will punish their sin with the rod, 
-</p><p class="q2">and their iniquity with stripes. 
-</p><p class="q1">
-<span class="v">33&#160;</span>But I will not completely take my loving kindness from him, 
-</p><p class="q2">nor allow my faithfulness to fail. 
-</p><p class="q1">
-<span class="v">34&#160;</span>I will not break my covenant, 
-</p><p class="q2">nor alter what my lips have uttered. 
-</p><p class="q1">
-<span class="v">35&#160;</span>Once I have sworn by my set-apartness, 
-</p><p class="q2">I will not lie to David. 
-</p><p class="q1">
-<span class="v">36&#160;</span>His offspring will endure forever, 
-</p><p class="q2">his throne like the sun before me. 
-</p><p class="q1">
-<span class="v">37&#160;</span>It will be established forever like the moon, 
-</p><p class="q2">the faithful witness in the sky.” </p><p class="qs">Selah.</p> 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">38&#160;</span>But you have rejected and spurned. 
-</p><p class="q2">You have been angry with your anointed. 
-</p><p class="q1">
-<span class="v">39&#160;</span>You have renounced the covenant of your servant. 
-</p><p class="q2">You have defiled his crown in the dust. 
-</p><p class="q1">
-<span class="v">40&#160;</span>You have broken down all his hedges. 
-</p><p class="q2">You have brought his strongholds to ruin. 
-</p><p class="q1">
-<span class="v">41&#160;</span>All who pass by the way rob him. 
-</p><p class="q1">He has become a reproach to his neighbors. 
-</p><p class="q1">
-<span class="v">42&#160;</span>You have exalted the right hand of his adversaries. 
-</p><p class="q2">You have made all of his enemies rejoice. 
-</p><p class="q1">
-<span class="v">43&#160;</span>Yes, you turn back the edge of his sword, 
-</p><p class="q2">and haven’t supported him in battle. 
-</p><p class="q1">
-<span class="v">44&#160;</span>You have ended his splendor, 
-</p><p class="q2">and thrown his throne down to the ground. 
-</p><p class="q1">
-<span class="v">45&#160;</span>You have shortened the days of his youth. 
-</p><p class="q2">You have covered him with shame. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">46&#160;</span>How long, Yahweh? 
-</p><p class="q2">Will you hide yourself forever? 
-</p><p class="q2">Will your wrath burn like fire? 
-</p><p class="q1">
-<span class="v">47&#160;</span>Remember how short my time is, 
-</p><p class="q2">for what vanity you have created all the children of men! 
-</p><p class="q1">
-<span class="v">48&#160;</span>What man is he who shall live and not see death, 
-</p><p class="q2">who shall deliver his soul from the power of Sheol?<span class="f">+ \fr 89:48 \ft Sheol is the place of the dead.</span> </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">49&#160;</span>Lord, where are your former loving kindnesses, 
-</p><p class="q2">which you swore to David in your faithfulness? 
-</p><p class="q1">
-<span class="v">50&#160;</span>Remember, Lord, the reproach of your servants, 
-</p><p class="q2">how I bear in my heart the taunts of all the mighty peoples, 
-</p><p class="q1">
-<span class="v">51&#160;</span>With which your enemies have mocked, Yahweh, 
-</p><p class="q2">with which they have mocked the footsteps of your anointed one. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">52&#160;</span>Blessed be Yahweh forever more. 
-</p><p class="q1">Amen, and Amen. 
+<div class="d">For the Chief Musician. To the tune of “The Lilies of the Covenant.” A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear us, Shepherd of Israel, 
+</div><div class="q2">you who lead Joseph like a flock, 
+</div><div class="q2">you who sit above the cherubim, shine out. 
+</div><div class="q1">
+<sup>2&#160;</sup>Before Ephraim, Benjamin, and Manasseh, stir up your might! 
+</div><div class="q2">Come to save us! 
+</div><div class="q1">
+<sup>3&#160;</sup>Turn us again, Elohim. 
+</div><div class="q2">Cause your face to shine, 
+</div><div class="q2">and we will be saved. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>Yahweh Elohim of Armies, 
+</div><div class="q2">how long will you be angry against the prayer of your people? 
+</div><div class="q1">
+<sup>5&#160;</sup>You have fed them with the bread of tears, 
+</div><div class="q2">and given them tears to drink in large measure. 
+</div><div class="q1">
+<sup>6&#160;</sup>You make us a source of contention to our neighbors. 
+</div><div class="q2">Our enemies laugh among themselves. 
+</div><div class="q1">
+<sup>7&#160;</sup>Turn us again, Elohim of Armies. 
+</div><div class="q2">Cause your face to shine, 
+</div><div class="q2">and we will be saved. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>You brought a vine out of Egypt. 
+</div><div class="q2">You drove out the nations, and planted it. 
+</div><div class="q1">
+<sup>9&#160;</sup>You cleared the ground for it. 
+</div><div class="q2">It took deep root, and filled the land. 
+</div><div class="q1">
+<sup>10&#160;</sup>The mountains were covered with its shadow. 
+</div><div class="q2">Its boughs were like Elohim’s cedars. 
+</div><div class="q1">
+<sup>11&#160;</sup>It sent out its branches to the sea, 
+</div><div class="q2">its shoots to the River. 
+</div><div class="q1">
+<sup>12&#160;</sup>Why have you broken down its walls, 
+</div><div class="q2">so that all those who pass by the way pluck it? 
+</div><div class="q1">
+<sup>13&#160;</sup>The boar out of the wood ravages it. 
+</div><div class="q2">The wild animals of the field feed on it. 
+</div><div class="q1">
+<sup>14&#160;</sup>Turn again, we beg you, Elohim of Armies. 
+</div><div class="q2">Look down from heaven, and see, and visit this vine, 
+</div><div class="q1">
+<sup>15&#160;</sup>the stock which your right hand planted, 
+</div><div class="q2">the branch that you made strong for yourself. 
+</div><div class="q1">
+<sup>16&#160;</sup>It’s burned with fire. 
+</div><div class="q2">It’s cut down. 
+</div><div class="q2">They perish at your rebuke. 
+</div><div class="q1">
+<sup>17&#160;</sup>Let your hand be on the man of your right hand, 
+</div><div class="q2">on the son of man whom you made strong for yourself. 
+</div><div class="q1">
+<sup>18&#160;</sup>So we will not turn away from you. 
+</div><div class="q2">Revive us, and we will call on your name. 
+</div><div class="q1">
+<sup>19&#160;</sup>Turn us again, Yahweh Elohim of Armies. 
+</div><div class="q2">Cause your face to shine, and we will be saved. 
+</div><h2 class="psalmlabel" id="81">81</h2>
+<div class="d">For the Chief Musician. On an instrument of Gath. By Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Sing aloud to Elohim, our strength! 
+</div><div class="q2">Make a joyful shout to the Elohim of Jacob! 
+</div><div class="q1">
+<sup>2&#160;</sup>Raise a song, and bring here the tambourine, 
+</div><div class="q2">the pleasant lyre with the harp. 
+</div><div class="q1">
+<sup>3&#160;</sup>Blow the trumpet at the New Moon, 
+</div><div class="q2">at the full moon, on our feast day. 
+</div><div class="q1">
+<sup>4&#160;</sup>For it is a statute for Israel, 
+</div><div class="q2">an ordinance of the Elohim of Jacob. 
+</div><div class="q1">
+<sup>5&#160;</sup>He appointed it in Joseph for a covenant, 
+</div><div class="q2">when he went out over the land of Egypt, 
+</div><div class="q2">I heard a language that I didn’t know. 
+</div><div class="q1">
+<sup>6&#160;</sup>“I removed his shoulder from the burden. 
+</div><div class="q2">His hands were freed from the basket. 
+</div><div class="q1">
+<sup>7&#160;</sup>You called in trouble, and I delivered you. 
+</div><div class="q2">I answered you in the secret place of thunder. 
+</div><div class="q2">I tested you at the waters of Meribah.” </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>“Hear, my people, and I will testify to you, 
+</div><div class="q2">Israel, if you would listen to me! 
+</div><div class="q1">
+<sup>9&#160;</sup>There shall be no strange elohim in you, 
+</div><div class="q2">neither shall you worship any foreign elohim. 
+</div><div class="q1">
+<sup>10&#160;</sup>I am Yahweh, your Elohim, 
+</div><div class="q2">who brought you up out of the land of Egypt. 
+</div><div class="q2">Open your mouth wide, and I will fill it. 
+</div><div class="q1">
+<sup>11&#160;</sup>But my people didn’t listen to my voice. 
+</div><div class="q2">Israel desired none of me. 
+</div><div class="q1">
+<sup>12&#160;</sup>So I let them go after the stubbornness of their hearts, 
+</div><div class="q2">that they might walk in their own counsels. 
+</div><div class="q1">
+<sup>13&#160;</sup>Oh that my people would listen to me, 
+</div><div class="q2">that Israel would walk in my ways! 
+</div><div class="q1">
+<sup>14&#160;</sup>I would soon subdue their enemies, 
+</div><div class="q2">and turn my hand against their adversaries. 
+</div><div class="q1">
+<sup>15&#160;</sup>The haters of Yahweh would cringe before him, 
+</div><div class="q2">and their punishment would last forever. 
+</div><div class="q1">
+<sup>16&#160;</sup>But he would have also fed them with the finest of the wheat. 
+</div><div class="q2">I will satisfy you with honey out of the rock.” 
+</div><h2 class="psalmlabel" id="82">82</h2>
+<div class="d">A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim presides in the great assembly. 
+</div><div class="q2">He judges among the elohims. 
+</div><div class="q1">
+<sup>2&#160;</sup>“How long will you judge unjustly, 
+</div><div class="q2">and show partiality to the wicked?” </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“Defend the weak, the poor, and the fatherless. 
+</div><div class="q2">Maintain the rights of the poor and oppressed. 
+</div><div class="q1">
+<sup>4&#160;</sup>Rescue the weak and needy. 
+</div><div class="q2">Deliver them out of the hand of the wicked.” 
+</div><div class="q1">
+<sup>5&#160;</sup>They don’t know, neither do they understand. 
+</div><div class="q2">They walk back and forth in darkness. 
+</div><div class="q2">All the foundations of the earth are shaken. 
+</div><div class="q1">
+<sup>6&#160;</sup>I said, “You are elohims, 
+</div><div class="q2">all of you are sons of the Most High. 
+</div><div class="q1">
+<sup>7&#160;</sup>Nevertheless you shall die like men, 
+</div><div class="q2">and fall like one of the rulers.” 
+</div><div class="q1">
+<sup>8&#160;</sup>Arise, Elohim, judge the earth, 
+</div><div class="q2">for you inherit all of the nations. 
+</div><h2 class="psalmlabel" id="83">83</h2>
+<div class="d">A song. A Psalm by Asaph. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim, don’t keep silent. 
+</div><div class="q2">Don’t keep silent, 
+</div><div class="q2">and don’t be still, Elohim. 
+</div><div class="q1">
+<sup>2&#160;</sup>For, behold, your enemies are stirred up. 
+</div><div class="q2">Those who hate you have lifted up their heads. 
+</div><div class="q1">
+<sup>3&#160;</sup>They conspire with cunning against your people. 
+</div><div class="q2">They plot against your cherished ones. 
+</div><div class="q1">
+<sup>4&#160;</sup>“Come,” they say, “let’s destroy them as a nation, 
+</div><div class="q2">that the name of Israel may be remembered no more.” 
+</div><div class="q1">
+<sup>5&#160;</sup>For they have conspired together with one mind. 
+</div><div class="q2">They form an alliance against you. 
+</div><div class="q1">
+<sup>6&#160;</sup>The tents of Edom and the Ishmaelites; 
+</div><div class="q2">Moab, and the Hagrites; 
+</div><div class="q1">
+<sup>7&#160;</sup>Gebal, Ammon, and Amalek; 
+</div><div class="q2">Philistia with the inhabitants of Tyre; 
+</div><div class="q1">
+<sup>8&#160;</sup>Assyria also is joined with them. 
+</div><div class="q2">They have helped the children of Lot. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>9&#160;</sup>Do to them as you did to Midian, 
+</div><div class="q2">as to Sisera, as to Jabin, at the river Kishon; 
+</div><div class="q1">
+<sup>10&#160;</sup>who perished at Endor, 
+</div><div class="q2">who became as dung for the earth. 
+</div><div class="q1">
+<sup>11&#160;</sup>Make their nobles like Oreb and Zeeb, 
+</div><div class="q2">yes, all their princes like Zebah and Zalmunna, 
+</div><div class="q2">
+<sup>12&#160;</sup>who said, “Let’s take possession of Elohim’s pasture lands.” 
+</div><div class="q1">
+<sup>13&#160;</sup>My Elohim, make them like tumbleweed, 
+</div><div class="q2">like chaff before the wind. 
+</div><div class="q1">
+<sup>14&#160;</sup>As the fire that burns the forest, 
+</div><div class="q2">as the flame that sets the mountains on fire, 
+</div><div class="q2">
+<sup>15&#160;</sup>so pursue them with your tempest, 
+</div><div class="q2">and terrify them with your storm. 
+</div><div class="q1">
+<sup>16&#160;</sup>Fill their faces with confusion, 
+</div><div class="q2">that they may seek your name, Yahweh. 
+</div><div class="q1">
+<sup>17&#160;</sup>Let them be disappointed and dismayed forever. 
+</div><div class="q2">Yes, let them be confounded and perish; 
+</div><div class="q1">
+<sup>18&#160;</sup>that they may know that you alone, whose name is Yahweh, 
+</div><div class="q2">are the Most High over all the earth. 
+</div><h2 class="psalmlabel" id="84">84</h2>
+<div class="d">For the Chief Musician. On an instrument of Gath. A Psalm by the sons of Korah. 
+</div><div class="q1">
+<sup>1&#160;</sup>How lovely are your dwellings, 
+</div><div class="q2">Yahweh of Armies! 
+</div><div class="q1">
+<sup>2&#160;</sup>My soul longs, and even faints for the courts of Yahweh. 
+</div><div class="q2">My heart and my flesh cry out for the living Elohim. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yes, the sparrow has found a home, 
+</div><div class="q2">and the swallow a nest for herself, where she may have her young, 
+</div><div class="q2">near your altars, Yahweh of Armies, my King, and my Elohim. 
+</div><div class="q1">
+<sup>4&#160;</sup>Blessed are those who dwell in your house. 
+</div><div class="q2">They are always praising you. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>Blessed are those whose strength is in you, 
+</div><div class="q2">who have set their hearts on a pilgrimage. 
+</div><div class="q1">
+<sup>6&#160;</sup>Passing through the valley of Weeping, they make it a place of springs. 
+</div><div class="q2">Yes, the autumn rain covers it with blessings. 
+</div><div class="q1">
+<sup>7&#160;</sup>They go from strength to strength. 
+</div><div class="q2">Every one of them appears before Elohim in Zion. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh, Elohim of Armies, hear my prayer. 
+</div><div class="q2">Listen, Elohim of Jacob. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>9&#160;</sup>Behold, Elohim our shield, 
+</div><div class="q2">look at the face of your anointed. 
+</div><div class="q1">
+<sup>10&#160;</sup>For a day in your courts is better than a thousand. 
+</div><div class="q2">I would rather be a doorkeeper in the house of my Elohim, 
+</div><div class="q2">than to dwell in the tents of wickedness. 
+</div><div class="q1">
+<sup>11&#160;</sup>For Yahweh Elohim is a sun and a shield. 
+</div><div class="q2">Yahweh will give grace and glory. 
+</div><div class="q2">He withholds no good thing from those who walk blamelessly. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yahweh of Armies, 
+</div><div class="q2">blessed is the man who trusts in you. 
+</div><h2 class="psalmlabel" id="85">85</h2>
+<div class="d">For the Chief Musician. A Psalm by the sons of Korah. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, you have been favorable to your land. 
+</div><div class="q2">You have restored the fortunes of Jacob. 
+</div><div class="q1">
+<sup>2&#160;</sup>You have forgiven the iniquity of your people. 
+</div><div class="q2">You have covered all their sin. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>3&#160;</sup>You have taken away all your wrath. 
+</div><div class="q2">You have turned from the fierceness of your anger. 
+</div><div class="q1">
+<sup>4&#160;</sup>Turn us, Elohim of our salvation, 
+</div><div class="q2">and cause your indignation toward us to cease. 
+</div><div class="q1">
+<sup>5&#160;</sup>Will you be angry with us forever? 
+</div><div class="q2">Will you draw out your anger to all generations? 
+</div><div class="q1">
+<sup>6&#160;</sup>Won’t you revive us again, 
+</div><div class="q2">that your people may rejoice in you? 
+</div><div class="q1">
+<sup>7&#160;</sup>Show us your loving kindness, Yahweh. 
+</div><div class="q2">Grant us your salvation. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will hear what Elohim, Yahweh, will speak, 
+</div><div class="q2">for he will speak peace to his people, his saints; 
+</div><div class="q2">but let them not turn again to folly. 
+</div><div class="q1">
+<sup>9&#160;</sup>Surely his salvation is near those who fear him, 
+</div><div class="q2">that glory may dwell in our land. 
+</div><div class="q1">
+<sup>10&#160;</sup>Mercy and truth meet together. 
+</div><div class="q2">Righteousness and peace have kissed each other. 
+</div><div class="q1">
+<sup>11&#160;</sup>Truth springs out of the earth. 
+</div><div class="q2">Righteousness has looked down from heaven. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yes, Yahweh will give that which is good. 
+</div><div class="q2">Our land will yield its increase. 
+</div><div class="q1">
+<sup>13&#160;</sup>Righteousness goes before him, 
+</div><div class="q2">and prepares the way for his steps. 
+</div><h2 class="psalmlabel" id="86">86</h2>
+<div class="d">A Prayer by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear, Yahweh, and answer me, 
+</div><div class="q2">for I am poor and needy. 
+</div><div class="q1">
+<sup>2&#160;</sup>Preserve my soul, for I am elohimly. 
+</div><div class="q2">You, my Elohim, save your servant who trusts in you. 
+</div><div class="q1">
+<sup>3&#160;</sup>Be merciful to me, Lord, 
+</div><div class="q2">for I call to you all day long. 
+</div><div class="q1">
+<sup>4&#160;</sup>Bring joy to the soul of your servant, 
+</div><div class="q2">for to you, Lord, do I lift up my soul. 
+</div><div class="q1">
+<sup>5&#160;</sup>For you, Lord, are good, and ready to forgive, 
+</div><div class="q2">abundant in loving kindness to all those who call on you. 
+</div><div class="q1">
+<sup>6&#160;</sup>Hear, Yahweh, my prayer. 
+</div><div class="q2">Listen to the voice of my petitions. 
+</div><div class="q1">
+<sup>7&#160;</sup>In the day of my trouble I will call on you, 
+</div><div class="q2">for you will answer me. 
+</div><div class="q1">
+<sup>8&#160;</sup>There is no one like you among the elohims, Lord, 
+</div><div class="q2">nor any deeds like your deeds. 
+</div><div class="q1">
+<sup>9&#160;</sup>All nations you have made will come and worship before you, Lord. 
+</div><div class="q2">They shall glorify your name. 
+</div><div class="q1">
+<sup>10&#160;</sup>For you are great, and do wondrous things. 
+</div><div class="q2">You are Elohim alone. 
+</div><div class="q1">
+<sup>11&#160;</sup>Teach me your way, Yahweh. 
+</div><div class="q2">I will walk in your truth. 
+</div><div class="q2">Make my heart undivided to fear your name. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will praise you, Lord my Elohim, with my whole heart. 
+</div><div class="q2">I will glorify your name forever more. 
+</div><div class="q1">
+<sup>13&#160;</sup>For your loving kindness is great toward me. 
+</div><div class="q2">You have delivered my soul from the lowest Sheol. 
+</div><div class="q1">
+<sup>14&#160;</sup>Elohim, the proud have risen up against me. 
+</div><div class="q2">A company of violent men have sought after my soul, 
+</div><div class="q2">and they don’t hold regard for you before them. 
+</div><div class="q1">
+<sup>15&#160;</sup>But you, Lord, are a merciful and gracious Elohim, 
+</div><div class="q2">slow to anger, and abundant in loving kindness and truth. 
+</div><div class="q1">
+<sup>16&#160;</sup>Turn to me, and have mercy on me! 
+</div><div class="q2">Give your strength to your servant. 
+</div><div class="q2">Save the son of your servant. 
+</div><div class="q1">
+<sup>17&#160;</sup>Show me a sign of your goodness, 
+</div><div class="q2">that those who hate me may see it, and be shamed, 
+</div><div class="q2">because you, Yahweh, have helped me, and comforted me. 
+</div><h2 class="psalmlabel" id="87">87</h2>
+<div class="d">A Psalm by the sons of Korah; a Song. 
+</div><div class="q1">
+<sup>1&#160;</sup>His foundation is in the set-apart mountains. 
+</div><div class="q2">
+<sup>2&#160;</sup>Yahweh loves the gates of Zion more than all the dwellings of Jacob. 
+</div><div class="q1">
+<sup>3&#160;</sup>Glorious things are spoken about you, city of Elohim. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>I will record Rahab and Babylon among those who acknowledge me. 
+</div><div class="q2">Behold, Philistia, Tyre, and also Ethiopia: 
+</div><div class="q2">“This one was born there.” 
+</div><div class="q1">
+<sup>5&#160;</sup>Yes, of Zion it will be said, “This one and that one was born in her;” 
+</div><div class="q2">the Most High himself will establish her. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh will count, when he writes up the peoples, 
+</div><div class="q2">“This one was born there.” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>7&#160;</sup>Those who sing as well as those who dance say, 
+</div><div class="q2">“All my springs are in you.” 
+</div><h2 class="psalmlabel" id="88">88</h2>
+<div class="d">A Song. A Psalm by the sons of Korah. For the Chief Musician. To the tune of “The Suffering of Affliction.” A contemplation by Heman, the Ezrahite. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, the Elohim of my salvation, 
+</div><div class="q2">I have cried day and night before you. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let my prayer enter into your presence. 
+</div><div class="q2">Turn your ear to my cry. 
+</div><div class="q1">
+<sup>3&#160;</sup>For my soul is full of troubles. 
+</div><div class="q2">My life draws near to Sheol. 
+</div><div class="q1">
+<sup>4&#160;</sup>I am counted among those who go down into the pit. 
+</div><div class="q2">I am like a man who has no help, 
+</div><div class="q2">
+<sup>5&#160;</sup>set apart among the dead, 
+</div><div class="q2">like the slain who lie in the grave, 
+</div><div class="q2">whom you remember no more. 
+</div><div class="q2">They are cut off from your hand. 
+</div><div class="q1">
+<sup>6&#160;</sup>You have laid me in the lowest pit, 
+</div><div class="q2">in the darkest depths. 
+</div><div class="q1">
+<sup>7&#160;</sup>Your wrath lies heavily on me. 
+</div><div class="q2">You have afflicted me with all your waves. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>8&#160;</sup>You have taken my friends from me. 
+</div><div class="q2">You have made me an abomination to them. 
+</div><div class="q2">I am confined, and I can’t escape. 
+</div><div class="q1">
+<sup>9&#160;</sup>My eyes are dim from grief. 
+</div><div class="q2">I have called on you daily, Yahweh. 
+</div><div class="q2">I have spread out my hands to you. 
+</div><div class="q1">
+<sup>10&#160;</sup>Do you show wonders to the dead? 
+</div><div class="q2">Do the departed spirits rise up and praise you? </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>11&#160;</sup>Is your loving kindness declared in the grave? 
+</div><div class="q2">Or your faithfulness in Destruction? 
+</div><div class="q1">
+<sup>12&#160;</sup>Are your wonders made known in the dark? 
+</div><div class="q2">Or your righteousness in the land of forgetfulness? 
+</div><div class="q1">
+<sup>13&#160;</sup>But to you, Yahweh, I have cried. 
+</div><div class="q2">In the morning, my prayer comes before you. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yahweh, why do you reject my soul? 
+</div><div class="q2">Why do you hide your face from me? 
+</div><div class="q1">
+<sup>15&#160;</sup>I am afflicted and ready to die from my youth up. 
+</div><div class="q2">While I suffer your terrors, I am distracted. 
+</div><div class="q1">
+<sup>16&#160;</sup>Your fierce wrath has gone over me. 
+</div><div class="q2">Your terrors have cut me off. 
+</div><div class="q1">
+<sup>17&#160;</sup>They came around me like water all day long. 
+</div><div class="q2">They completely engulfed me. 
+</div><div class="q1">
+<sup>18&#160;</sup>You have put lover and friend far from me, 
+</div><div class="q2">and my friends into darkness. 
+</div><h2 class="psalmlabel" id="89">89</h2>
+<div class="d">A contemplation by Ethan, the Ezrahite. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will sing of the loving kindness of Yahweh forever. 
+</div><div class="q2">With my mouth, I will make known your faithfulness to all generations. 
+</div><div class="q1">
+<sup>2&#160;</sup>I indeed declare, “Love stands firm forever. 
+</div><div class="q2">You established the heavens. 
+</div><div class="q2">Your faithfulness is in them.” 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>“I have made a covenant with my chosen one, 
+</div><div class="q2">I have sworn to David, my servant, 
+</div><div class="q1">
+<sup>4&#160;</sup>‘I will establish your offspring forever, 
+</div><div class="q2">and build up your throne to all generations.’&#160;” </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>5&#160;</sup>The heavens will praise your wonders, Yahweh, 
+</div><div class="q2">your faithfulness also in the assembly of the set-apart ones. 
+</div><div class="q1">
+<sup>6&#160;</sup>For who in the skies can be compared to Yahweh? 
+</div><div class="q2">Who among the sons of the heavenly beings is like Yahweh, 
+</div><div class="q1">
+<sup>7&#160;</sup>a very awesome Elohim in the council of the set-apart ones, 
+</div><div class="q2">to be feared above all those who are around him? 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh, Elohim of Armies, who is a mighty one, like you? 
+</div><div class="q2">Yah, your faithfulness is around you. 
+</div><div class="q1">
+<sup>9&#160;</sup>You rule the pride of the sea. 
+</div><div class="q2">When its waves rise up, you calm them. 
+</div><div class="q1">
+<sup>10&#160;</sup>You have broken Rahab in pieces, like one of the slain. 
+</div><div class="q2">You have scattered your enemies with your mighty arm. 
+</div><div class="q1">
+<sup>11&#160;</sup>The heavens are yours. 
+</div><div class="q2">The earth also is yours, 
+</div><div class="q2">the world and its fullness. 
+</div><div class="q2">You have founded them. 
+</div><div class="q1">
+<sup>12&#160;</sup>You have created the north and the south. 
+</div><div class="q2">Tabor and Hermon rejoice in your name. 
+</div><div class="q1">
+<sup>13&#160;</sup>You have a mighty arm. 
+</div><div class="q2">Your hand is strong, and your right hand is exalted. 
+</div><div class="q1">
+<sup>14&#160;</sup>Righteousness and justice are the foundation of your throne. 
+</div><div class="q2">Loving kindness and truth go before your face. 
+</div><div class="q1">
+<sup>15&#160;</sup>Blessed are the people who learn to acclaim you. 
+</div><div class="q2">They walk in the light of your presence, Yahweh. 
+</div><div class="q1">
+<sup>16&#160;</sup>In your name they rejoice all day. 
+</div><div class="q2">In your righteousness, they are exalted. 
+</div><div class="q1">
+<sup>17&#160;</sup>For you are the glory of their strength. 
+</div><div class="q2">In your favor, our horn will be exalted. 
+</div><div class="q1">
+<sup>18&#160;</sup>For our shield belongs to Yahweh, 
+</div><div class="q2">our king to the Set-Apart One of Israel. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>19&#160;</sup>Then you spoke in vision to your saints, 
+</div><div class="q2">and said, “I have given strength to the warrior. 
+</div><div class="q2">I have exalted a young man from the people. 
+</div><div class="q1">
+<sup>20&#160;</sup>I have found David, my servant. 
+</div><div class="q2">I have anointed him with my set-apart oil, 
+</div><div class="q1">
+<sup>21&#160;</sup>with whom my hand shall be established. 
+</div><div class="q2">My arm will also strengthen him. 
+</div><div class="q1">
+<sup>22&#160;</sup>No enemy will tax him. 
+</div><div class="q2">No wicked man will oppress him. 
+</div><div class="q1">
+<sup>23&#160;</sup>I will beat down his adversaries before him, 
+</div><div class="q2">and strike those who hate him. 
+</div><div class="q1">
+<sup>24&#160;</sup>But my faithfulness and my loving kindness will be with him. 
+</div><div class="q2">In my name, his horn will be exalted. 
+</div><div class="q1">
+<sup>25&#160;</sup>I will set his hand also on the sea, 
+</div><div class="q2">and his right hand on the rivers. 
+</div><div class="q1">
+<sup>26&#160;</sup>He will call to me, ‘You are my Father, 
+</div><div class="q2">my Elohim, and the rock of my salvation!’ 
+</div><div class="q1">
+<sup>27&#160;</sup>I will also appoint him my firstborn, 
+</div><div class="q2">the highest of the kings of the earth. 
+</div><div class="q1">
+<sup>28&#160;</sup>I will keep my loving kindness for him forever more. 
+</div><div class="q2">My covenant will stand firm with him. 
+</div><div class="q1">
+<sup>29&#160;</sup>I will also make his offspring endure forever, 
+</div><div class="q2">and his throne as the days of heaven. 
+</div><div class="q1">
+<sup>30&#160;</sup>If his children forsake my law, 
+</div><div class="q2">and don’t walk in my ordinances; 
+</div><div class="q1">
+<sup>31&#160;</sup>if they break my statutes, 
+</div><div class="q2">and don’t keep my commandments; 
+</div><div class="q1">
+<sup>32&#160;</sup>then I will punish their sin with the rod, 
+</div><div class="q2">and their iniquity with stripes. 
+</div><div class="q1">
+<sup>33&#160;</sup>But I will not completely take my loving kindness from him, 
+</div><div class="q2">nor allow my faithfulness to fail. 
+</div><div class="q1">
+<sup>34&#160;</sup>I will not break my covenant, 
+</div><div class="q2">nor alter what my lips have uttered. 
+</div><div class="q1">
+<sup>35&#160;</sup>Once I have sworn by my set-apartness, 
+</div><div class="q2">I will not lie to David. 
+</div><div class="q1">
+<sup>36&#160;</sup>His offspring will endure forever, 
+</div><div class="q2">his throne like the sun before me. 
+</div><div class="q1">
+<sup>37&#160;</sup>It will be established forever like the moon, 
+</div><div class="q2">the faithful witness in the sky.” </div><div class="qs">Selah. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>38&#160;</sup>But you have rejected and spurned. 
+</div><div class="q2">You have been angry with your anointed. 
+</div><div class="q1">
+<sup>39&#160;</sup>You have renounced the covenant of your servant. 
+</div><div class="q2">You have defiled his crown in the dust. 
+</div><div class="q1">
+<sup>40&#160;</sup>You have broken down all his hedges. 
+</div><div class="q2">You have brought his strongholds to ruin. 
+</div><div class="q1">
+<sup>41&#160;</sup>All who pass by the way rob him. 
+</div><div class="q1">He has become a reproach to his neighbors. 
+</div><div class="q1">
+<sup>42&#160;</sup>You have exalted the right hand of his adversaries. 
+</div><div class="q2">You have made all of his enemies rejoice. 
+</div><div class="q1">
+<sup>43&#160;</sup>Yes, you turn back the edge of his sword, 
+</div><div class="q2">and haven’t supported him in battle. 
+</div><div class="q1">
+<sup>44&#160;</sup>You have ended his splendor, 
+</div><div class="q2">and thrown his throne down to the ground. 
+</div><div class="q1">
+<sup>45&#160;</sup>You have shortened the days of his youth. 
+</div><div class="q2">You have covered him with shame. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>46&#160;</sup>How long, Yahweh? 
+</div><div class="q2">Will you hide yourself forever? 
+</div><div class="q2">Will your wrath burn like fire? 
+</div><div class="q1">
+<sup>47&#160;</sup>Remember how short my time is, 
+</div><div class="q2">for what vanity you have created all the children of men! 
+</div><div class="q1">
+<sup>48&#160;</sup>What man is he who shall live and not see death, 
+</div><div class="q2">who shall deliver his soul from the power of Sheol? </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>49&#160;</sup>Lord, where are your former loving kindnesses, 
+</div><div class="q2">which you swore to David in your faithfulness? 
+</div><div class="q1">
+<sup>50&#160;</sup>Remember, Lord, the reproach of your servants, 
+</div><div class="q2">how I bear in my heart the taunts of all the mighty peoples, 
+</div><div class="q1">
+<sup>51&#160;</sup>With which your enemies have mocked, Yahweh, 
+</div><div class="q2">with which they have mocked the footsteps of your anointed one. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>52&#160;</sup>Blessed be Yahweh forever more. 
+</div><div class="q1">Amen, and Amen. 
+</div><h2 class="ms1">BOOK 4</h2>
 <h2 class="psalmlabel" id="90">90</h2>
-<h2 class="ms1">BOOK 4</h2>
-</p><p class="d">A Prayer by Moses, the man of Elohim.<span class="f">+ \fr 90:0 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p class="q1">
-<span class="v">1&#160;</span>Lord,<span class="f">+ \fr 90:1 \ft The word translated “Lord” is “Adonai.”</span> you have been our dwelling place for all generations. 
-</p><p class="q2">
-<span class="v">2&#160;</span>Before the mountains were born, 
-</p><p class="q2">before you had formed the earth and the world, 
-</p><p class="q2">even from everlasting to everlasting, you are Elohim. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You turn man to destruction, saying, 
-</p><p class="q2">“Return, you children of men.” 
-</p><p class="q1">
-<span class="v">4&#160;</span>For a thousand years in your sight are just like yesterday when it is past, 
-</p><p class="q2">like a watch in the night. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You sweep them away as they sleep. 
-</p><p class="q2">In the morning they sprout like new grass. 
-</p><p class="q1">
-<span class="v">6&#160;</span>In the morning it sprouts and springs up. 
-</p><p class="q2">By evening, it is withered and dry. 
-</p><p class="q1">
-<span class="v">7&#160;</span>For we are consumed in your anger. 
-</p><p class="q2">We are troubled in your wrath. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You have set our iniquities before you, 
-</p><p class="q2">our secret sins in the light of your presence. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For all our days have passed away in your wrath. 
-</p><p class="q2">We bring our years to an end as a sigh. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The days of our years are seventy, 
-</p><p class="q2">or even by reason of strength eighty years; 
-</p><p class="q2">yet their pride is but labor and sorrow, 
-</p><p class="q2">for it passes quickly, and we fly away. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Who knows the power of your anger, 
-</p><p class="q2">your wrath according to the fear that is due to you? 
-</p><p class="q1">
-<span class="v">12&#160;</span>So teach us to count our days, 
-</p><p class="q2">that we may gain a heart of wisdom. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Relent, Yahweh!<span class="f">+ \fr 90:13 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> 
-</p><p class="q2">How long? 
-</p><p class="q2">Have compassion on your servants! 
-</p><p class="q1">
-<span class="v">14&#160;</span>Satisfy us in the morning with your loving kindness, 
-</p><p class="q2">that we may rejoice and be glad all our days. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Make us glad for as many days as you have afflicted us, 
-</p><p class="q2">for as many years as we have seen evil. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Let your work appear to your servants, 
-</p><p class="q2">your glory to their children. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Let the favor of the Lord our Elohim be on us. 
-</p><p class="q2">Establish the work of our hands for us. 
-</p><p class="q2">Yes, establish the work of our hands. 
-</p><h2 class="psalmlabel" id="91">91</h2>
-<p class="q1">
-<span class="v">1&#160;</span>He who dwells in the secret place of the Most High 
-</p><p class="q2">will rest in the shadow of the Almighty. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will say of Yahweh, “He is my refuge and my fortress; 
-</p><p class="q2">my Elohim, in whom I trust.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>For he will deliver you from the snare of the fowler, 
-</p><p class="q2">and from the deadly pestilence. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He will cover you with his feathers. 
-</p><p class="q2">Under his wings you will take refuge. 
-</p><p class="q2">His faithfulness is your shield and rampart. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You shall not be afraid of the terror by night, 
-</p><p class="q2">nor of the arrow that flies by day, 
-</p><p class="q2">
-<span class="v">6&#160;</span>nor of the pestilence that walks in darkness, 
-</p><p class="q2">nor of the destruction that wastes at noonday. 
-</p><p class="q1">
-<span class="v">7&#160;</span>A thousand may fall at your side, 
-</p><p class="q2">and ten thousand at your right hand; 
-</p><p class="q2">but it will not come near you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You will only look with your eyes, 
-</p><p class="q2">and see the recompense of the wicked. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Because you have made Yahweh your refuge, 
-</p><p class="q2">and the Most High your dwelling place, 
-</p><p class="q1">
-<span class="v">10&#160;</span>no evil shall happen to you, 
-</p><p class="q2">neither shall any plague come near your dwelling. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For he will put his angels in charge of you, 
-</p><p class="q2">to guard you in all your ways. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They will bear you up in their hands, 
-</p><p class="q2">so that you won’t dash your foot against a stone. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You will tread on the lion and cobra. 
-</p><p class="q2">You will trample the young lion and the serpent underfoot. 
-</p><p class="q1">
-<span class="v">14&#160;</span>“Because he has set his love on me, therefore I will deliver him. 
-</p><p class="q2">I will set him on high, because he has known my name. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He will call on me, and I will answer him. 
-</p><p class="q2">I will be with him in trouble. 
-</p><p class="q2">I will deliver him, and honor him. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will satisfy him with long life, 
-</p><p class="q2">and show him my salvation.” 
-</p><h2 class="psalmlabel" id="92">92</h2>
-<p class="d">A Psalm. A song for the Sabbath day. 
-</p><p class="q1">
-<span class="v">1&#160;</span>It is a good thing to give thanks to Yahweh, 
-</p><p class="q2">to sing praises to your name, Most High, 
-</p><p class="q1">
-<span class="v">2&#160;</span>to proclaim your loving kindness in the morning, 
-</p><p class="q2">and your faithfulness every night, 
-</p><p class="q1">
-<span class="v">3&#160;</span>with the ten-stringed lute, with the harp, 
-</p><p class="q2">and with the melody of the lyre. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For you, Yahweh, have made me glad through your work. 
-</p><p class="q2">I will triumph in the works of your hands. 
-</p><p class="q1">
-<span class="v">5&#160;</span>How great are your works, Yahweh! 
-</p><p class="q2">Your thoughts are very deep. 
-</p><p class="q1">
-<span class="v">6&#160;</span>A senseless man doesn’t know, 
-</p><p class="q2">neither does a fool understand this: 
-</p><p class="q1">
-<span class="v">7&#160;</span>though the wicked spring up as the grass, 
-</p><p class="q2">and all the evildoers flourish, 
-</p><p class="q2">they will be destroyed forever. 
-</p><p class="q1">
-<span class="v">8&#160;</span>But you, Yahweh, are on high forever more. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For behold, your enemies, Yahweh, 
-</p><p class="q2">for behold, your enemies shall perish. 
-</p><p class="q2">All the evildoers will be scattered. 
-</p><p class="q1">
-<span class="v">10&#160;</span>But you have exalted my horn like that of the wild ox. 
-</p><p class="q2">I am anointed with fresh oil. 
-</p><p class="q1">
-<span class="v">11&#160;</span>My eye has also seen my enemies. 
-</p><p class="q2">My ears have heard of the wicked enemies who rise up against me. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The righteous shall flourish like the palm tree. 
-</p><p class="q2">He will grow like a cedar in Lebanon. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They are planted in Yahweh’s house. 
-</p><p class="q2">They will flourish in our Elohim’s courts. 
-</p><p class="q1">
-<span class="v">14&#160;</span>They will still produce fruit in old age. 
-</p><p class="q2">They will be full of sap and green, 
-</p><p class="q2">
-<span class="v">15&#160;</span>to show that Yahweh is upright. 
-</p><p class="q1">He is my rock, 
-</p><p class="q2">and there is no unrighteousness in him. 
-</p><h2 class="psalmlabel" id="93">93</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Yahweh reigns! 
-</p><p class="q2">He is clothed with majesty! 
-</p><p class="q2">Yahweh is armed with strength. 
-</p><p class="q1">The world also is established. 
-</p><p class="q2">It can’t be moved. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Your throne is established from long ago. 
-</p><p class="q2">You are from everlasting. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The floods have lifted up, Yahweh, 
-</p><p class="q2">the floods have lifted up their voice. 
-</p><p class="q2">The floods lift up their waves. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Above the voices of many waters, 
-</p><p class="q2">the mighty breakers of the sea, 
-</p><p class="q2">Yahweh on high is mighty. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Your statutes stand firm. 
-</p><p class="q2">Set-Apartness adorns your house, 
-</p><p class="q2">Yahweh, forever more. 
-</p><h2 class="psalmlabel" id="94">94</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Yahweh, you Elohim to whom vengeance belongs, 
-</p><p class="q2">you Elohim to whom vengeance belongs, shine out. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Rise up, you judge of the earth. 
-</p><p class="q2">Pay back the proud what they deserve. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh, how long will the wicked, 
-</p><p class="q2">how long will the wicked triumph? 
-</p><p class="q1">
-<span class="v">4&#160;</span>They pour out arrogant words. 
-</p><p class="q2">All the evildoers boast. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They break your people in pieces, Yahweh, 
-</p><p class="q2">and afflict your heritage. 
-</p><p class="q1">
-<span class="v">6&#160;</span>They kill the widow and the alien, 
-</p><p class="q2">and murder the fatherless. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They say, “Yah will not see, 
-</p><p class="q2">neither will Jacob’s Elohim consider.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>Consider, you senseless among the people; 
-</p><p class="q2">you fools, when will you be wise? 
-</p><p class="q1">
-<span class="v">9&#160;</span>He who implanted the ear, won’t he hear? 
-</p><p class="q2">He who formed the eye, won’t he see? 
-</p><p class="q1">
-<span class="v">10&#160;</span>He who disciplines the nations, won’t he punish? 
-</p><p class="q2">He who teaches man knows. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh knows the thoughts of man, 
-</p><p class="q2">that they are futile. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Blessed is the man whom you discipline, Yah, 
-</p><p class="q2">and teach out of your law, 
-</p><p class="q1">
-<span class="v">13&#160;</span>that you may give him rest from the days of adversity, 
-</p><p class="q2">until the pit is dug for the wicked. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For Yahweh won’t reject his people, 
-</p><p class="q2">neither will he forsake his inheritance. 
-</p><p class="q1">
-<span class="v">15&#160;</span>For judgment will return to righteousness. 
-</p><p class="q2">All the upright in heart shall follow it. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Who will rise up for me against the wicked? 
-</p><p class="q2">Who will stand up for me against the evildoers? 
-</p><p class="q1">
-<span class="v">17&#160;</span>Unless Yahweh had been my help, 
-</p><p class="q2">my soul would have soon lived in silence. 
-</p><p class="q1">
-<span class="v">18&#160;</span>When I said, “My foot is slipping!” 
-</p><p class="q2">Your loving kindness, Yahweh, held me up. 
-</p><p class="q1">
-<span class="v">19&#160;</span>In the multitude of my thoughts within me, 
-</p><p class="q2">your comforts delight my soul. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Shall the throne of wickedness have fellowship with you, 
-</p><p class="q2">which brings about mischief by statute? 
-</p><p class="q1">
-<span class="v">21&#160;</span>They gather themselves together against the soul of the righteous, 
-</p><p class="q2">and condemn the innocent blood. 
-</p><p class="q1">
-<span class="v">22&#160;</span>But Yahweh has been my high tower, 
-</p><p class="q2">my Elohim, the rock of my refuge. 
-</p><p class="q1">
-<span class="v">23&#160;</span>He has brought on them their own iniquity, 
-</p><p class="q2">and will cut them off in their own wickedness. 
-</p><p class="q2">Yahweh, our Elohim, will cut them off. 
-</p><h2 class="psalmlabel" id="95">95</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Oh come, let’s sing to Yahweh. 
-</p><p class="q2">Let’s shout aloud to the rock of our salvation! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let’s come before his presence with thanksgiving. 
-</p><p class="q2">Let’s extol him with songs! 
-</p><p class="q1">
-<span class="v">3&#160;</span>For Yahweh is a great Elohim, 
-</p><p class="q2">a great King above all elohims. 
-</p><p class="q1">
-<span class="v">4&#160;</span>In his hand are the deep places of the earth. 
-</p><p class="q2">The heights of the mountains are also his. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The sea is his, and he made it. 
-</p><p class="q2">His hands formed the dry land. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Oh come, let’s worship and bow down. 
-</p><p class="q2">Let’s kneel before Yahweh, our Maker, 
-</p><p class="q2">
-<span class="v">7&#160;</span>for he is our Elohim. 
-</p><p class="q1">We are the people of his pasture, 
-</p><p class="q2">and the sheep in his care. 
-</p><p class="q1">Today, oh that you would hear his voice! 
-</p><p class="q2">
-<span class="v">8&#160;</span>Don’t harden your heart, as at Meribah, 
-</p><p class="q2">as in the day of Massah in the wilderness, 
-</p><p class="q1">
-<span class="v">9&#160;</span>when your fathers tempted me, 
-</p><p class="q2">tested me, and saw my work. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Forty long years I was grieved with that generation, 
-</p><p class="q2">and said, “They are a people who err in their heart. 
-</p><p class="q2">They have not known my ways.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>Therefore I swore in my wrath, 
-</p><p class="q2">“They won’t enter into my rest.” 
-</p><h2 class="psalmlabel" id="96">96</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Sing to Yahweh a new song! 
-</p><p class="q2">Sing to Yahweh, all the earth. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Sing to Yahweh! 
-</p><p class="q2">Bless his name! 
-</p><p class="q2">Proclaim his salvation from day to day! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Declare his glory among the nations, 
-</p><p class="q2">his marvelous works among all the peoples. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For Yahweh is great, and greatly to be praised! 
-</p><p class="q2">He is to be feared above all elohims. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For all the elohims of the peoples are idols, 
-</p><p class="q2">but Yahweh made the heavens. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Honor and majesty are before him. 
-</p><p class="q2">Strength and beauty are in his sanctuary. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Ascribe to Yahweh, you families of nations, 
-</p><p class="q2">ascribe to Yahweh glory and strength. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Ascribe to Yahweh the glory due to his name. 
-</p><p class="q2">Bring an offering, and come into his courts. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Worship Yahweh in set-apart array. 
-</p><p class="q2">Tremble before him, all the earth. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Say among the nations, “Yahweh reigns.” 
-</p><p class="q2">The world is also established. 
-</p><p class="q2">It can’t be moved. 
-</p><p class="q2">He will judge the peoples with equity. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Let the heavens be glad, and let the earth rejoice. 
-</p><p class="q2">Let the sea roar, and its fullness! 
-</p><p class="q2">
-<span class="v">12&#160;</span>Let the field and all that is in it exult! 
-</p><p class="q2">Then all the trees of the woods shall sing for joy 
-</p><p class="q2">
-<span class="v">13&#160;</span>before Yahweh; for he comes, 
-</p><p class="q2">for he comes to judge the earth. 
-</p><p class="q1">He will judge the world with righteousness, 
-</p><p class="q2">the peoples with his truth. 
-</p><h2 class="psalmlabel" id="97">97</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Yahweh reigns! 
-</p><p class="q2">Let the earth rejoice! 
-</p><p class="q2">Let the multitude of islands be glad! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Clouds and darkness are around him. 
-</p><p class="q2">Righteousness and justice are the foundation of his throne. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A fire goes before him, 
-</p><p class="q2">and burns up his adversaries on every side. 
-</p><p class="q1">
-<span class="v">4&#160;</span>His lightning lights up the world. 
-</p><p class="q2">The earth sees, and trembles. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The mountains melt like wax at the presence of Yahweh, 
-</p><p class="q2">at the presence of the Lord of the whole earth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The heavens declare his righteousness. 
-</p><p class="q2">All the peoples have seen his glory. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Let all them be shamed who serve engraved images, 
-</p><p class="q2">who boast in their idols. 
-</p><p class="q2">Worship him, all you elohims!<span class="f">+ \fr 97:7 \ft LXX reads “angels” instead of “elohims”.</span> 
-</p><p class="q1">
-<span class="v">8&#160;</span>Zion heard and was glad. 
-</p><p class="q2">The daughters of Judah rejoiced 
-</p><p class="q2">because of your judgments, Yahweh. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For you, Yahweh, are most high above all the earth. 
-</p><p class="q2">You are exalted far above all elohims. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You who love Yahweh, hate evil! 
-</p><p class="q2">He preserves the souls of his saints. 
-</p><p class="q2">He delivers them out of the hand of the wicked. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Light is sown for the righteous, 
-</p><p class="q2">and gladness for the upright in heart. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Be glad in Yahweh, you righteous people! 
-</p><p class="q2">Give thanks to his set-apart Name. 
-</p><h2 class="psalmlabel" id="98">98</h2>
-<p class="d">A Psalm. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Sing to Yahweh a new song, 
-</p><p class="q2">for he has done marvelous things! 
-</p><p class="q2">His right hand and his set-apart arm have worked salvation for him. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh has made known his salvation. 
-</p><p class="q2">He has openly shown his righteousness in the sight of the nations. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He has remembered his loving kindness and his faithfulness toward the house of Israel. 
-</p><p class="q2">All the ends of the earth have seen the salvation of our Elohim. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Make a joyful noise to Yahweh, all the earth! 
-</p><p class="q2">Burst out and sing for joy, yes, sing praises! 
-</p><p class="q1">
-<span class="v">5&#160;</span>Sing praises to Yahweh with the harp, 
-</p><p class="q2">with the harp and the voice of melody. 
-</p><p class="q1">
-<span class="v">6&#160;</span>With trumpets and sound of the ram’s horn, 
-</p><p class="q2">make a joyful noise before the King, Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Let the sea roar with its fullness; 
-</p><p class="q2">the world, and those who dwell therein. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let the rivers clap their hands. 
-</p><p class="q2">Let the mountains sing for joy together. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Let them sing before Yahweh, 
-</p><p class="q2">for he comes to judge the earth. 
-</p><p class="q1">He will judge the world with righteousness, 
-</p><p class="q2">and the peoples with equity. 
-</p><h2 class="psalmlabel" id="99">99</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Yahweh reigns! Let the peoples tremble. 
-</p><p class="q2">He sits enthroned among the cherubim. 
-</p><p class="q2">Let the earth be moved. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh is great in Zion. 
-</p><p class="q2">He is high above all the peoples. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Let them praise your great and awesome name. 
-</p><p class="q2">He is Set-Apart! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>The King’s strength also loves justice. 
-</p><p class="q2">You establish equity. 
-</p><p class="q2">You execute justice and righteousness in Jacob. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Exalt Yahweh our Elohim. 
-</p><p class="q2">Worship at his footstool. 
-</p><p class="q2">He is Set-Apart! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Moses and Aaron were among his priests, 
-</p><p class="q2">Samuel was among those who call on his name. 
-</p><p class="q2">They called on Yahweh, and he answered them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He spoke to them in the pillar of cloud. 
-</p><p class="q2">They kept his testimonies, 
-</p><p class="q2">the statute that he gave them. 
-</p><p class="q1">
-<span class="v">8&#160;</span>You answered them, Yahweh our Elohim. 
-</p><p class="q2">You are an Elohim who forgave them, 
-</p><p class="q2">although you took vengeance for their doings. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Exalt Yahweh, our Elohim. 
-</p><p class="q2">Worship at his set-apart hill, 
-</p><p class="q2">for Yahweh, our Elohim, is set-apart! 
-</p><h2 class="psalmlabel" id="100">100</h2>
-<p class="d">A Psalm of thanksgiving. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Shout for joy to Yahweh, all you lands! 
-</p><p class="q2">
-<span class="v">2&#160;</span>Serve Yahweh with gladness. 
-</p><p class="q2">Come before his presence with singing. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Know that Yahweh, he is Elohim. 
-</p><p class="q2">It is he who has made us, and we are his. 
-</p><p class="q2">We are his people, and the sheep of his pasture. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Enter into his gates with thanksgiving, 
-</p><p class="q2">and into his courts with praise. 
-</p><p class="q2">Give thanks to him, and bless his name. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For Yahweh is good. 
-</p><p class="q2">His loving kindness endures forever, 
-</p><p class="q2">his faithfulness to all generations. 
-</p><h2 class="psalmlabel" id="101">101</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will sing of loving kindness and justice. 
-</p><p class="q2">To you, Yahweh, I will sing praises. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will be careful to live a blameless life. 
-</p><p class="q2">When will you come to me? 
-</p><p class="q2">I will walk within my house with a blameless heart. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I will set no vile thing before my eyes. 
-</p><p class="q2">I hate the deeds of faithless men. 
-</p><p class="q2">They will not cling to me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>A perverse heart will be far from me. 
-</p><p class="q2">I will have nothing to do with evil. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I will silence whoever secretly slanders his neighbor. 
-</p><p class="q2">I won’t tolerate one who is arrogant and conceited. 
-</p><p class="q1">
-<span class="v">6&#160;</span>My eyes will be on the faithful of the land, 
-</p><p class="q2">that they may dwell with me. 
-</p><p class="q1">He who walks in a perfect way, 
-</p><p class="q2">he will serve me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He who practices deceit won’t dwell within my house. 
-</p><p class="q2">He who speaks falsehood won’t be established before my eyes. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Morning by morning, I will destroy all the wicked of the land, 
-</p><p class="q2">to cut off all the workers of iniquity from Yahweh’s city. 
-</p><h2 class="psalmlabel" id="102">102</h2>
-<p class="d">A Prayer of the afflicted, when he is overwhelmed and pours out his complaint before Yahweh. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear my prayer, Yahweh! 
-</p><p class="q2">Let my cry come to you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Don’t hide your face from me in the day of my distress. 
-</p><p class="q2">Turn your ear to me. 
-</p><p class="q2">Answer me quickly in the day when I call. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For my days consume away like smoke. 
-</p><p class="q2">My bones are burned as a torch. 
-</p><p class="q1">
-<span class="v">4&#160;</span>My heart is blighted like grass, and withered, 
-</p><p class="q2">for I forget to eat my bread. 
-</p><p class="q1">
-<span class="v">5&#160;</span>By reason of the voice of my groaning, 
-</p><p class="q2">my bones stick to my skin. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I am like a pelican of the wilderness. 
-</p><p class="q2">I have become as an owl of the waste places. 
-</p><p class="q2">
-<span class="v">7&#160;</span>I watch, and have become like a sparrow that is alone on the housetop. 
-</p><p class="q1">
-<span class="v">8&#160;</span>My enemies reproach me all day. 
-</p><p class="q2">Those who are mad at me use my name as a curse. 
-</p><p class="q1">
-<span class="v">9&#160;</span>For I have eaten ashes like bread, 
-</p><p class="q2">and mixed my drink with tears, 
-</p><p class="q2">
-<span class="v">10&#160;</span>because of your indignation and your wrath; 
-</p><p class="q2">for you have taken me up and thrown me away. 
-</p><p class="q1">
-<span class="v">11&#160;</span>My days are like a long shadow. 
-</p><p class="q2">I have withered like grass. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>But you, Yahweh, will remain forever; 
-</p><p class="q2">your renown endures to all generations. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You will arise and have mercy on Zion, 
-</p><p class="q2">for it is time to have pity on her. 
-</p><p class="q2">Yes, the set time has come. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For your servants take pleasure in her stones, 
-</p><p class="q2">and have pity on her dust. 
-</p><p class="q1">
-<span class="v">15&#160;</span>So the nations will fear Yahweh’s name, 
-</p><p class="q2">all the kings of the earth your glory. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For Yahweh has built up Zion. 
-</p><p class="q2">He has appeared in his glory. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He has responded to the prayer of the destitute, 
-</p><p class="q2">and has not despised their prayer. 
-</p><p class="q1">
-<span class="v">18&#160;</span>This will be written for the generation to come. 
-</p><p class="q2">A people which will be created will praise Yah, 
-</p><p class="q1">
-<span class="v">19&#160;</span>for he has looked down from the height of his sanctuary. 
-</p><p class="q2">From heaven, Yahweh saw the earth, 
-</p><p class="q1">
-<span class="v">20&#160;</span>to hear the groans of the prisoner, 
-</p><p class="q2">to free those who are condemned to death, 
-</p><p class="q1">
-<span class="v">21&#160;</span>that men may declare Yahweh’s name in Zion, 
-</p><p class="q2">and his praise in Jerusalem, 
-</p><p class="q1">
-<span class="v">22&#160;</span>when the peoples are gathered together, 
-</p><p class="q2">the kingdoms, to serve Yahweh. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>He weakened my strength along the course. 
-</p><p class="q2">He shortened my days. 
-</p><p class="q1">
-<span class="v">24&#160;</span>I said, “My Elohim, don’t take me away in the middle of my days. 
-</p><p class="q2">Your years are throughout all generations. 
-</p><p class="q1">
-<span class="v">25&#160;</span>Of old, you laid the foundation of the earth. 
-</p><p class="q2">The heavens are the work of your hands. 
-</p><p class="q1">
-<span class="v">26&#160;</span>They will perish, but you will endure. 
-</p><p class="q2">Yes, all of them will wear out like a garment. 
-</p><p class="q2">You will change them like a cloak, and they will be changed. 
-</p><p class="q1">
-<span class="v">27&#160;</span>But you are the same. 
-</p><p class="q2">Your years will have no end. 
-</p><p class="q1">
-<span class="v">28&#160;</span>The children of your servants will continue. 
-</p><p class="q2">Their offspring will be established before you.” 
-</p><h2 class="psalmlabel" id="103">103</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Praise Yahweh, my soul! 
-</p><p class="q2">All that is within me, praise his set-apart name! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Praise Yahweh, my soul, 
-</p><p class="q2">and don’t forget all his benefits, 
-</p><p class="q1">
-<span class="v">3&#160;</span>who forgives all your sins, 
-</p><p class="q2">who heals all your diseases, 
-</p><p class="q1">
-<span class="v">4&#160;</span>who redeems your life from destruction, 
-</p><p class="q2">who crowns you with loving kindness and tender mercies, 
-</p><p class="q1">
-<span class="v">5&#160;</span>who satisfies your desire with good things, 
-</p><p class="q2">so that your youth is renewed like the eagle’s. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh executes righteous acts, 
-</p><p class="q2">and justice for all who are oppressed. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He made known his ways to Moses, 
-</p><p class="q2">his deeds to the children of Israel. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh is merciful and gracious, 
-</p><p class="q2">slow to anger, and abundant in loving kindness. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He will not always accuse; 
-</p><p class="q2">neither will he stay angry forever. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He has not dealt with us according to our sins, 
-</p><p class="q2">nor repaid us for our iniquities. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For as the heavens are high above the earth, 
-</p><p class="q2">so great is his loving kindness toward those who fear him. 
-</p><p class="q1">
-<span class="v">12&#160;</span>As far as the east is from the west, 
-</p><p class="q2">so far has he removed our transgressions from us. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Like a father has compassion on his children, 
-</p><p class="q2">so Yahweh has compassion on those who fear him. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For he knows how we are made. 
-</p><p class="q2">He remembers that we are dust. 
-</p><p class="q1">
-<span class="v">15&#160;</span>As for man, his days are like grass. 
-</p><p class="q2">As a flower of the field, so he flourishes. 
-</p><p class="q1">
-<span class="v">16&#160;</span>For the wind passes over it, and it is gone. 
-</p><p class="q2">Its place remembers it no more. 
-</p><p class="q1">
-<span class="v">17&#160;</span>But Yahweh’s loving kindness is from everlasting to everlasting with those who fear him, 
-</p><p class="q2">his righteousness to children’s children, 
-</p><p class="q1">
-<span class="v">18&#160;</span>to those who keep his covenant, 
-</p><p class="q2">to those who remember to obey his precepts. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Yahweh has established his throne in the heavens. 
-</p><p class="q2">His kingdom rules over all. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Praise Yahweh, you angels of his, 
-</p><p class="q2">who are mighty in strength, who fulfill his word, 
-</p><p class="q2">obeying the voice of his word. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Praise Yahweh, all you armies of his, 
-</p><p class="q2">you servants of his, who do his pleasure. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Praise Yahweh, all you works of his, 
-</p><p class="q2">in all places of his dominion. 
-</p><p class="q2">Praise Yahweh, my soul! 
-</p><h2 class="psalmlabel" id="104">104</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Bless Yahweh, my soul. 
-</p><p class="q2">Yahweh, my Elohim, you are very great. 
-</p><p class="q2">You are clothed with honor and majesty. 
-</p><p class="q1">
-<span class="v">2&#160;</span>He covers himself with light as with a garment. 
-</p><p class="q2">He stretches out the heavens like a curtain. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He lays the beams of his rooms in the waters. 
-</p><p class="q2">He makes the clouds his chariot. 
-</p><p class="q2">He walks on the wings of the wind. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He makes his messengers<span class="f">+ \fr 104:4 \ft or, angels</span> winds, 
-</p><p class="q2">and his servants flames of fire. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He laid the foundations of the earth, 
-</p><p class="q2">that it should not be moved forever. 
-</p><p class="q1">
-<span class="v">6&#160;</span>You covered it with the deep as with a cloak. 
-</p><p class="q2">The waters stood above the mountains. 
-</p><p class="q1">
-<span class="v">7&#160;</span>At your rebuke they fled. 
-</p><p class="q2">At the voice of your thunder they hurried away. 
-</p><p class="q1">
-<span class="v">8&#160;</span>The mountains rose, 
-</p><p class="q2">the valleys sank down, 
-</p><p class="q2">to the place which you had assigned to them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>You have set a boundary that they may not pass over, 
-</p><p class="q2">that they don’t turn again to cover the earth. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He sends springs into the valleys. 
-</p><p class="q2">They run among the mountains. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They give drink to every animal of the field. 
-</p><p class="q2">The wild donkeys quench their thirst. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The birds of the sky nest by them. 
-</p><p class="q2">They sing among the branches. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He waters the mountains from his rooms. 
-</p><p class="q2">The earth is filled with the fruit of your works. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He causes the grass to grow for the livestock, 
-</p><p class="q2">and plants for man to cultivate, 
-</p><p class="q2">that he may produce food out of the earth: 
-</p><p class="q1">
-<span class="v">15&#160;</span>wine that makes the heart of man glad, 
-</p><p class="q2">oil to make his face to shine, 
-</p><p class="q2">and bread that strengthens man’s heart. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yahweh’s trees are well watered, 
-</p><p class="q2">the cedars of Lebanon, which he has planted, 
-</p><p class="q1">
-<span class="v">17&#160;</span>where the birds make their nests. 
-</p><p class="q2">The stork makes its home in the cypress trees. 
-</p><p class="q1">
-<span class="v">18&#160;</span>The high mountains are for the wild goats. 
-</p><p class="q2">The rocks are a refuge for the rock badgers. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He appointed the moon for seasons. 
-</p><p class="q2">The sun knows when to set. 
-</p><p class="q1">
-<span class="v">20&#160;</span>You make darkness, and it is night, 
-</p><p class="q2">in which all the animals of the forest prowl. 
-</p><p class="q1">
-<span class="v">21&#160;</span>The young lions roar after their prey, 
-</p><p class="q2">and seek their food from Elohim. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The sun rises, and they steal away, 
-</p><p class="q2">and lie down in their dens. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Man goes out to his work, 
-</p><p class="q2">to his labor until the evening. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Yahweh, how many are your works! 
-</p><p class="q2">In wisdom, you have made them all. 
-</p><p class="q2">The earth is full of your riches. 
-</p><p class="q1">
-<span class="v">25&#160;</span>There is the sea, great and wide, 
-</p><p class="q2">in which are innumerable living things, 
-</p><p class="q2">both small and large animals. 
-</p><p class="q1">
-<span class="v">26&#160;</span>There the ships go, 
-</p><p class="q2">and leviathan, whom you formed to play there. 
-</p><p class="q1">
-<span class="v">27&#160;</span>These all wait for you, 
-</p><p class="q2">that you may give them their food in due season. 
-</p><p class="q1">
-<span class="v">28&#160;</span>You give to them; they gather. 
-</p><p class="q2">You open your hand; they are satisfied with good. 
-</p><p class="q1">
-<span class="v">29&#160;</span>You hide your face; they are troubled. 
-</p><p class="q2">You take away their breath; they die and return to the dust. 
-</p><p class="q1">
-<span class="v">30&#160;</span>You send out your Spirit and they are created. 
-</p><p class="q2">You renew the face of the ground. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Let Yahweh’s glory endure forever. 
-</p><p class="q2">Let Yahweh rejoice in his works. 
-</p><p class="q1">
-<span class="v">32&#160;</span>He looks at the earth, and it trembles. 
-</p><p class="q2">He touches the mountains, and they smoke. 
-</p><p class="q1">
-<span class="v">33&#160;</span>I will sing to Yahweh as long as I live. 
-</p><p class="q2">I will sing praise to my Elohim while I have any being. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Let my meditation be sweet to him. 
-</p><p class="q2">I will rejoice in Yahweh. 
-</p><p class="q1">
-<span class="v">35&#160;</span>Let sinners be consumed out of the earth. 
-</p><p class="q2">Let the wicked be no more. 
-</p><p class="q2">Bless Yahweh, my soul. 
-</p><p class="q2">Praise Yah! 
-</p><h2 class="psalmlabel" id="105">105</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Give thanks to Yahweh! Call on his name! 
-</p><p class="q2">Make his doings known among the peoples. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Sing to him, sing praises to him! 
-</p><p class="q2">Tell of all his marvelous works. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Glory in his set-apart name. 
-</p><p class="q2">Let the heart of those who seek Yahweh rejoice. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Seek Yahweh and his strength. 
-</p><p class="q2">Seek his face forever more. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Remember his marvelous works that he has done: 
-</p><p class="q2">his wonders, and the judgments of his mouth, 
-</p><p class="q1">
-<span class="v">6&#160;</span>you offspring of Abraham, his servant, 
-</p><p class="q2">you children of Jacob, his chosen ones. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He is Yahweh, our Elohim. 
-</p><p class="q2">His judgments are in all the earth. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He has remembered his covenant forever, 
-</p><p class="q2">the word which he commanded to a thousand generations, 
-</p><p class="q1">
-<span class="v">9&#160;</span>the covenant which he made with Abraham, 
-</p><p class="q2">his oath to Isaac, 
-</p><p class="q1">
-<span class="v">10&#160;</span>and confirmed it to Jacob for a statute; 
-</p><p class="q2">to Israel for an everlasting covenant, 
-</p><p class="q1">
-<span class="v">11&#160;</span>saying, “To you I will give the land of Canaan, 
-</p><p class="q2">the lot of your inheritance,” 
-</p><p class="q1">
-<span class="v">12&#160;</span>when they were but a few men in number, 
-</p><p class="q2">yes, very few, and foreigners in it. 
-</p><p class="q1">
-<span class="v">13&#160;</span>They went about from nation to nation, 
-</p><p class="q2">from one kingdom to another people. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He allowed no one to do them wrong. 
-</p><p class="q2">Yes, he reproved kings for their sakes, 
-</p><p class="q1">
-<span class="v">15&#160;</span>“Don’t touch my anointed ones! 
-</p><p class="q2">Do my prophets no harm!” 
-</p><p class="q1">
-<span class="v">16&#160;</span>He called for a famine on the land. 
-</p><p class="q2">He destroyed the food supplies. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He sent a man before them. 
-</p><p class="q2">Joseph was sold for a slave. 
-</p><p class="q1">
-<span class="v">18&#160;</span>They bruised his feet with shackles. 
-</p><p class="q2">His neck was locked in irons, 
-</p><p class="q1">
-<span class="v">19&#160;</span>until the time that his word happened, 
-</p><p class="q2">and Yahweh’s word proved him true. 
-</p><p class="q1">
-<span class="v">20&#160;</span>The king sent and freed him, 
-</p><p class="q2">even the ruler of peoples, and let him go free. 
-</p><p class="q1">
-<span class="v">21&#160;</span>He made him lord of his house, 
-</p><p class="q2">and ruler of all of his possessions, 
-</p><p class="q1">
-<span class="v">22&#160;</span>to discipline his princes at his pleasure, 
-</p><p class="q2">and to teach his elders wisdom. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Israel also came into Egypt. 
-</p><p class="q2">Jacob lived in the land of Ham. 
-</p><p class="q1">
-<span class="v">24&#160;</span>He increased his people greatly, 
-</p><p class="q2">and made them stronger than their adversaries. 
-</p><p class="q1">
-<span class="v">25&#160;</span>He turned their heart to hate his people, 
-</p><p class="q2">to conspire against his servants. 
-</p><p class="q1">
-<span class="v">26&#160;</span>He sent Moses, his servant, 
-</p><p class="q2">and Aaron, whom he had chosen. 
-</p><p class="q1">
-<span class="v">27&#160;</span>They performed miracles among them, 
-</p><p class="q2">and wonders in the land of Ham. 
-</p><p class="q1">
-<span class="v">28&#160;</span>He sent darkness, and made it dark. 
-</p><p class="q2">They didn’t rebel against his words. 
-</p><p class="q1">
-<span class="v">29&#160;</span>He turned their waters into blood, 
-</p><p class="q2">and killed their fish. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Their land swarmed with frogs, 
-</p><p class="q2">even in the rooms of their kings. 
-</p><p class="q1">
-<span class="v">31&#160;</span>He spoke, and swarms of flies came, 
-</p><p class="q2">and lice in all their borders. 
-</p><p class="q1">
-<span class="v">32&#160;</span>He gave them hail for rain, 
-</p><p class="q2">with lightning in their land. 
-</p><p class="q1">
-<span class="v">33&#160;</span>He struck their vines and also their fig trees, 
-</p><p class="q2">and shattered the trees of their country. 
-</p><p class="q1">
-<span class="v">34&#160;</span>He spoke, and the locusts came 
-</p><p class="q2">with the grasshoppers, without number. 
-</p><p class="q1">
-<span class="v">35&#160;</span>They ate up every plant in their land, 
-</p><p class="q2">and ate up the fruit of their ground. 
-</p><p class="q1">
-<span class="v">36&#160;</span>He struck also all the firstborn in their land, 
-</p><p class="q2">the first fruits of all their manhood. 
-</p><p class="q1">
-<span class="v">37&#160;</span>He brought them out with silver and gold. 
-</p><p class="q2">There was not one feeble person among his tribes. 
-</p><p class="q1">
-<span class="v">38&#160;</span>Egypt was glad when they departed, 
-</p><p class="q2">for the fear of them had fallen on them. 
-</p><p class="q1">
-<span class="v">39&#160;</span>He spread a cloud for a covering, 
-</p><p class="q2">fire to give light in the night. 
-</p><p class="q1">
-<span class="v">40&#160;</span>They asked, and he brought quails, 
-</p><p class="q2">and satisfied them with the bread of the sky. 
-</p><p class="q1">
-<span class="v">41&#160;</span>He opened the rock, and waters gushed out. 
-</p><p class="q2">They ran as a river in the dry places. 
-</p><p class="q1">
-<span class="v">42&#160;</span>For he remembered his set-apart word, 
-</p><p class="q2">and Abraham, his servant. 
-</p><p class="q1">
-<span class="v">43&#160;</span>He brought his people out with joy, 
-</p><p class="q2">his chosen with singing. 
-</p><p class="q1">
-<span class="v">44&#160;</span>He gave them the lands of the nations. 
-</p><p class="q2">They took the labor of the peoples in possession, 
-</p><p class="q1">
-<span class="v">45&#160;</span>that they might keep his statutes, 
-</p><p class="q2">and observe his laws. 
-</p><p class="q2">Praise Yah! 
-</p><h2 class="psalmlabel" id="106">106</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yahweh! 
-</p><p class="q2">Give thanks to Yahweh, for he is good, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Who can utter the mighty acts of Yahweh, 
-</p><p class="q2">or fully declare all his praise? 
-</p><p class="q1">
-<span class="v">3&#160;</span>Blessed are those who keep justice. 
-</p><p class="q2">Blessed is one who does what is right at all times. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Remember me, Yahweh, with the favor that you show to your people. 
-</p><p class="q2">Visit me with your salvation, 
-</p><p class="q1">
-<span class="v">5&#160;</span>that I may see the prosperity of your chosen, 
-</p><p class="q2">that I may rejoice in the gladness of your nation, 
-</p><p class="q2">that I may glory with your inheritance. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>We have sinned with our fathers. 
-</p><p class="q2">We have committed iniquity. 
-</p><p class="q2">We have done wickedly. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Our fathers didn’t understand your wonders in Egypt. 
-</p><p class="q2">They didn’t remember the multitude of your loving kindnesses, 
-</p><p class="q2">but were rebellious at the sea, even at the Red Sea. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Nevertheless he saved them for his name’s sake, 
-</p><p class="q2">that he might make his mighty power known. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He rebuked the Red Sea also, and it was dried up; 
-</p><p class="q2">so he led them through the depths, as through a desert. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He saved them from the hand of him who hated them, 
-</p><p class="q2">and redeemed them from the hand of the enemy. 
-</p><p class="q1">
-<span class="v">11&#160;</span>The waters covered their adversaries. 
-</p><p class="q2">There was not one of them left. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Then they believed his words. 
-</p><p class="q2">They sang his praise. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">13&#160;</span>They soon forgot his works. 
-</p><p class="q2">They didn’t wait for his counsel, 
-</p><p class="q2">
-<span class="v">14&#160;</span>but gave in to craving in the desert, 
-</p><p class="q2">and tested Elohim in the wasteland. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He gave them their request, 
-</p><p class="q2">but sent leanness into their soul. 
-</p><p class="q1">
-<span class="v">16&#160;</span>They envied Moses also in the camp, 
-</p><p class="q2">and Aaron, Yahweh’s saint. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The earth opened and swallowed up Dathan, 
-</p><p class="q2">and covered the company of Abiram. 
-</p><p class="q1">
-<span class="v">18&#160;</span>A fire was kindled in their company. 
-</p><p class="q2">The flame burned up the wicked. 
-</p><p class="q1">
-<span class="v">19&#160;</span>They made a calf in Horeb, 
-</p><p class="q2">and worshiped a molten image. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Thus they exchanged their glory 
-</p><p class="q2">for an image of a bull that eats grass. 
-</p><p class="q1">
-<span class="v">21&#160;</span>They forgot Elohim, their Savior, 
-</p><p class="q2">who had done great things in Egypt, 
-</p><p class="q2">
-<span class="v">22&#160;</span>wondrous works in the land of Ham, 
-</p><p class="q2">and awesome things by the Red Sea. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Therefore he said that he would destroy them, 
-</p><p class="q2">had Moses, his chosen, not stood before him in the breach, 
-</p><p class="q2">to turn away his wrath, so that he wouldn’t destroy them. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Yes, they despised the pleasant land. 
-</p><p class="q2">They didn’t believe his word, 
-</p><p class="q2">
-<span class="v">25&#160;</span>but murmured in their tents, 
-</p><p class="q2">and didn’t listen to Yahweh’s voice. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Therefore he swore to them 
-</p><p class="q2">that he would overthrow them in the wilderness, 
-</p><p class="q2">
-<span class="v">27&#160;</span>that he would overthrow their offspring among the nations, 
-</p><p class="q2">and scatter them in the lands. 
-</p><p class="q1">
-<span class="v">28&#160;</span>They joined themselves also to Baal Peor, 
-</p><p class="q2">and ate the sacrifices of the dead. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Thus they provoked him to anger with their deeds. 
-</p><p class="q2">The plague broke in on them. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Then Phinehas stood up and executed judgment, 
-</p><p class="q2">so the plague was stopped. 
-</p><p class="q1">
-<span class="v">31&#160;</span>That was credited to him for righteousness, 
-</p><p class="q2">for all generations to come. 
-</p><p class="q1">
-<span class="v">32&#160;</span>They angered him also at the waters of Meribah, 
-</p><p class="q2">so that Moses was troubled for their sakes; 
-</p><p class="q1">
-<span class="v">33&#160;</span>because they were rebellious against his spirit, 
-</p><p class="q2">he spoke rashly with his lips. 
-</p><p class="q1">
-<span class="v">34&#160;</span>They didn’t destroy the peoples, 
-</p><p class="q2">as Yahweh commanded them, 
-</p><p class="q2">
-<span class="v">35&#160;</span>but mixed themselves with the nations, 
-</p><p class="q2">and learned their works. 
-</p><p class="q1">
-<span class="v">36&#160;</span>They served their idols, 
-</p><p class="q2">which became a snare to them. 
-</p><p class="q1">
-<span class="v">37&#160;</span>Yes, they sacrificed their sons and their daughters to demons. 
-</p><p class="q2">
-<span class="v">38&#160;</span>They shed innocent blood, 
-</p><p class="q2">even the blood of their sons and of their daughters, 
-</p><p class="q2">whom they sacrificed to the idols of Canaan. 
-</p><p class="q2">The land was polluted with blood. 
-</p><p class="q1">
-<span class="v">39&#160;</span>Thus they were defiled with their works, 
-</p><p class="q2">and prostituted themselves in their deeds. 
-</p><p class="q1">
-<span class="v">40&#160;</span>Therefore Yahweh burned with anger against his people. 
-</p><p class="q2">He abhorred his inheritance. 
-</p><p class="q1">
-<span class="v">41&#160;</span>He gave them into the hand of the nations. 
-</p><p class="q2">Those who hated them ruled over them. 
-</p><p class="q1">
-<span class="v">42&#160;</span>Their enemies also oppressed them. 
-</p><p class="q2">They were brought into subjection under their hand. 
-</p><p class="q1">
-<span class="v">43&#160;</span>He rescued them many times, 
-</p><p class="q2">but they were rebellious in their counsel, 
-</p><p class="q2">and were brought low in their iniquity. 
-</p><p class="q1">
-<span class="v">44&#160;</span>Nevertheless he regarded their distress, 
-</p><p class="q2">when he heard their cry. 
-</p><p class="q1">
-<span class="v">45&#160;</span>He remembered for them his covenant, 
-</p><p class="q2">and repented according to the multitude of his loving kindnesses. 
-</p><p class="q1">
-<span class="v">46&#160;</span>He made them also to be pitied 
-</p><p class="q2">by all those who carried them captive. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">47&#160;</span>Save us, Yahweh, our Elohim, 
-</p><p class="q2">gather us from among the nations, 
-</p><p class="q2">to give thanks to your set-apart name, 
-</p><p class="q2">to triumph in your praise! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">48&#160;</span>Blessed be Yahweh, the Elohim of Israel, 
-</p><p class="q2">from everlasting even to everlasting! 
-</p><p class="q1">Let all the people say, “Amen.” 
-</p><p class="q2">Praise Yah! 
+<div class="d">A Prayer by Moses, the man of Elohim. 
+</div><div class="q1">
+<sup>1&#160;</sup>Lord, you have been our dwelling place for all generations. 
+</div><div class="q2">
+<sup>2&#160;</sup>Before the mountains were born, 
+</div><div class="q2">before you had formed the earth and the world, 
+</div><div class="q2">even from everlasting to everlasting, you are Elohim. 
+</div><div class="q1">
+<sup>3&#160;</sup>You turn man to destruction, saying, 
+</div><div class="q2">“Return, you children of men.” 
+</div><div class="q1">
+<sup>4&#160;</sup>For a thousand years in your sight are just like yesterday when it is past, 
+</div><div class="q2">like a watch in the night. 
+</div><div class="q1">
+<sup>5&#160;</sup>You sweep them away as they sleep. 
+</div><div class="q2">In the morning they sprout like new grass. 
+</div><div class="q1">
+<sup>6&#160;</sup>In the morning it sprouts and springs up. 
+</div><div class="q2">By evening, it is withered and dry. 
+</div><div class="q1">
+<sup>7&#160;</sup>For we are consumed in your anger. 
+</div><div class="q2">We are troubled in your wrath. 
+</div><div class="q1">
+<sup>8&#160;</sup>You have set our iniquities before you, 
+</div><div class="q2">our secret sins in the light of your presence. 
+</div><div class="q1">
+<sup>9&#160;</sup>For all our days have passed away in your wrath. 
+</div><div class="q2">We bring our years to an end as a sigh. 
+</div><div class="q1">
+<sup>10&#160;</sup>The days of our years are seventy, 
+</div><div class="q2">or even by reason of strength eighty years; 
+</div><div class="q2">yet their pride is but labor and sorrow, 
+</div><div class="q2">for it passes quickly, and we fly away. 
+</div><div class="q1">
+<sup>11&#160;</sup>Who knows the power of your anger, 
+</div><div class="q2">your wrath according to the fear that is due to you? 
+</div><div class="q1">
+<sup>12&#160;</sup>So teach us to count our days, 
+</div><div class="q2">that we may gain a heart of wisdom. 
+</div><div class="q1">
+<sup>13&#160;</sup>Relent, Yahweh! 
+</div><div class="q2">How long? 
+</div><div class="q2">Have compassion on your servants! 
+</div><div class="q1">
+<sup>14&#160;</sup>Satisfy us in the morning with your loving kindness, 
+</div><div class="q2">that we may rejoice and be glad all our days. 
+</div><div class="q1">
+<sup>15&#160;</sup>Make us glad for as many days as you have afflicted us, 
+</div><div class="q2">for as many years as we have seen evil. 
+</div><div class="q1">
+<sup>16&#160;</sup>Let your work appear to your servants, 
+</div><div class="q2">your glory to their children. 
+</div><div class="q1">
+<sup>17&#160;</sup>Let the favor of the Lord our Elohim be on us. 
+</div><div class="q2">Establish the work of our hands for us. 
+</div><div class="q2">Yes, establish the work of our hands. 
+</div><h2 class="psalmlabel" id="91">91</h2>
+<div class="q1">
+<sup>1&#160;</sup>He who dwells in the secret place of the Most High 
+</div><div class="q2">will rest in the shadow of the Almighty. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will say of Yahweh, “He is my refuge and my fortress; 
+</div><div class="q2">my Elohim, in whom I trust.” 
+</div><div class="q1">
+<sup>3&#160;</sup>For he will deliver you from the snare of the fowler, 
+</div><div class="q2">and from the deadly pestilence. 
+</div><div class="q1">
+<sup>4&#160;</sup>He will cover you with his feathers. 
+</div><div class="q2">Under his wings you will take refuge. 
+</div><div class="q2">His faithfulness is your shield and rampart. 
+</div><div class="q1">
+<sup>5&#160;</sup>You shall not be afraid of the terror by night, 
+</div><div class="q2">nor of the arrow that flies by day, 
+</div><div class="q2">
+<sup>6&#160;</sup>nor of the pestilence that walks in darkness, 
+</div><div class="q2">nor of the destruction that wastes at noonday. 
+</div><div class="q1">
+<sup>7&#160;</sup>A thousand may fall at your side, 
+</div><div class="q2">and ten thousand at your right hand; 
+</div><div class="q2">but it will not come near you. 
+</div><div class="q1">
+<sup>8&#160;</sup>You will only look with your eyes, 
+</div><div class="q2">and see the recompense of the wicked. 
+</div><div class="q1">
+<sup>9&#160;</sup>Because you have made Yahweh your refuge, 
+</div><div class="q2">and the Most High your dwelling place, 
+</div><div class="q1">
+<sup>10&#160;</sup>no evil shall happen to you, 
+</div><div class="q2">neither shall any plague come near your dwelling. 
+</div><div class="q1">
+<sup>11&#160;</sup>For he will put his angels in charge of you, 
+</div><div class="q2">to guard you in all your ways. 
+</div><div class="q1">
+<sup>12&#160;</sup>They will bear you up in their hands, 
+</div><div class="q2">so that you won’t dash your foot against a stone. 
+</div><div class="q1">
+<sup>13&#160;</sup>You will tread on the lion and cobra. 
+</div><div class="q2">You will trample the young lion and the serpent underfoot. 
+</div><div class="q1">
+<sup>14&#160;</sup>“Because he has set his love on me, therefore I will deliver him. 
+</div><div class="q2">I will set him on high, because he has known my name. 
+</div><div class="q1">
+<sup>15&#160;</sup>He will call on me, and I will answer him. 
+</div><div class="q2">I will be with him in trouble. 
+</div><div class="q2">I will deliver him, and honor him. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will satisfy him with long life, 
+</div><div class="q2">and show him my salvation.” 
+</div><h2 class="psalmlabel" id="92">92</h2>
+<div class="d">A Psalm. A song for the Sabbath day. 
+</div><div class="q1">
+<sup>1&#160;</sup>It is a good thing to give thanks to Yahweh, 
+</div><div class="q2">to sing praises to your name, Most High, 
+</div><div class="q1">
+<sup>2&#160;</sup>to proclaim your loving kindness in the morning, 
+</div><div class="q2">and your faithfulness every night, 
+</div><div class="q1">
+<sup>3&#160;</sup>with the ten-stringed lute, with the harp, 
+</div><div class="q2">and with the melody of the lyre. 
+</div><div class="q1">
+<sup>4&#160;</sup>For you, Yahweh, have made me glad through your work. 
+</div><div class="q2">I will triumph in the works of your hands. 
+</div><div class="q1">
+<sup>5&#160;</sup>How great are your works, Yahweh! 
+</div><div class="q2">Your thoughts are very deep. 
+</div><div class="q1">
+<sup>6&#160;</sup>A senseless man doesn’t know, 
+</div><div class="q2">neither does a fool understand this: 
+</div><div class="q1">
+<sup>7&#160;</sup>though the wicked spring up as the grass, 
+</div><div class="q2">and all the evildoers flourish, 
+</div><div class="q2">they will be destroyed forever. 
+</div><div class="q1">
+<sup>8&#160;</sup>But you, Yahweh, are on high forever more. 
+</div><div class="q1">
+<sup>9&#160;</sup>For behold, your enemies, Yahweh, 
+</div><div class="q2">for behold, your enemies shall perish. 
+</div><div class="q2">All the evildoers will be scattered. 
+</div><div class="q1">
+<sup>10&#160;</sup>But you have exalted my horn like that of the wild ox. 
+</div><div class="q2">I am anointed with fresh oil. 
+</div><div class="q1">
+<sup>11&#160;</sup>My eye has also seen my enemies. 
+</div><div class="q2">My ears have heard of the wicked enemies who rise up against me. 
+</div><div class="q1">
+<sup>12&#160;</sup>The righteous shall flourish like the palm tree. 
+</div><div class="q2">He will grow like a cedar in Lebanon. 
+</div><div class="q1">
+<sup>13&#160;</sup>They are planted in Yahweh’s house. 
+</div><div class="q2">They will flourish in our Elohim’s courts. 
+</div><div class="q1">
+<sup>14&#160;</sup>They will still produce fruit in old age. 
+</div><div class="q2">They will be full of sap and green, 
+</div><div class="q2">
+<sup>15&#160;</sup>to show that Yahweh is upright. 
+</div><div class="q1">He is my rock, 
+</div><div class="q2">and there is no unrighteousness in him. 
+</div><h2 class="psalmlabel" id="93">93</h2>
+<div class="q1">
+<sup>1&#160;</sup>Yahweh reigns! 
+</div><div class="q2">He is clothed with majesty! 
+</div><div class="q2">Yahweh is armed with strength. 
+</div><div class="q1">The world also is established. 
+</div><div class="q2">It can’t be moved. 
+</div><div class="q1">
+<sup>2&#160;</sup>Your throne is established from long ago. 
+</div><div class="q2">You are from everlasting. 
+</div><div class="q1">
+<sup>3&#160;</sup>The floods have lifted up, Yahweh, 
+</div><div class="q2">the floods have lifted up their voice. 
+</div><div class="q2">The floods lift up their waves. 
+</div><div class="q1">
+<sup>4&#160;</sup>Above the voices of many waters, 
+</div><div class="q2">the mighty breakers of the sea, 
+</div><div class="q2">Yahweh on high is mighty. 
+</div><div class="q1">
+<sup>5&#160;</sup>Your statutes stand firm. 
+</div><div class="q2">Set-Apartness adorns your house, 
+</div><div class="q2">Yahweh, forever more. 
+</div><h2 class="psalmlabel" id="94">94</h2>
+<div class="q1">
+<sup>1&#160;</sup>Yahweh, you Elohim to whom vengeance belongs, 
+</div><div class="q2">you Elohim to whom vengeance belongs, shine out. 
+</div><div class="q1">
+<sup>2&#160;</sup>Rise up, you judge of the earth. 
+</div><div class="q2">Pay back the proud what they deserve. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh, how long will the wicked, 
+</div><div class="q2">how long will the wicked triumph? 
+</div><div class="q1">
+<sup>4&#160;</sup>They pour out arrogant words. 
+</div><div class="q2">All the evildoers boast. 
+</div><div class="q1">
+<sup>5&#160;</sup>They break your people in pieces, Yahweh, 
+</div><div class="q2">and afflict your heritage. 
+</div><div class="q1">
+<sup>6&#160;</sup>They kill the widow and the alien, 
+</div><div class="q2">and murder the fatherless. 
+</div><div class="q1">
+<sup>7&#160;</sup>They say, “Yah will not see, 
+</div><div class="q2">neither will Jacob’s Elohim consider.” 
+</div><div class="q1">
+<sup>8&#160;</sup>Consider, you senseless among the people; 
+</div><div class="q2">you fools, when will you be wise? 
+</div><div class="q1">
+<sup>9&#160;</sup>He who implanted the ear, won’t he hear? 
+</div><div class="q2">He who formed the eye, won’t he see? 
+</div><div class="q1">
+<sup>10&#160;</sup>He who disciplines the nations, won’t he punish? 
+</div><div class="q2">He who teaches man knows. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh knows the thoughts of man, 
+</div><div class="q2">that they are futile. 
+</div><div class="q1">
+<sup>12&#160;</sup>Blessed is the man whom you discipline, Yah, 
+</div><div class="q2">and teach out of your law, 
+</div><div class="q1">
+<sup>13&#160;</sup>that you may give him rest from the days of adversity, 
+</div><div class="q2">until the pit is dug for the wicked. 
+</div><div class="q1">
+<sup>14&#160;</sup>For Yahweh won’t reject his people, 
+</div><div class="q2">neither will he forsake his inheritance. 
+</div><div class="q1">
+<sup>15&#160;</sup>For judgment will return to righteousness. 
+</div><div class="q2">All the upright in heart shall follow it. 
+</div><div class="q1">
+<sup>16&#160;</sup>Who will rise up for me against the wicked? 
+</div><div class="q2">Who will stand up for me against the evildoers? 
+</div><div class="q1">
+<sup>17&#160;</sup>Unless Yahweh had been my help, 
+</div><div class="q2">my soul would have soon lived in silence. 
+</div><div class="q1">
+<sup>18&#160;</sup>When I said, “My foot is slipping!” 
+</div><div class="q2">Your loving kindness, Yahweh, held me up. 
+</div><div class="q1">
+<sup>19&#160;</sup>In the multitude of my thoughts within me, 
+</div><div class="q2">your comforts delight my soul. 
+</div><div class="q1">
+<sup>20&#160;</sup>Shall the throne of wickedness have fellowship with you, 
+</div><div class="q2">which brings about mischief by statute? 
+</div><div class="q1">
+<sup>21&#160;</sup>They gather themselves together against the soul of the righteous, 
+</div><div class="q2">and condemn the innocent blood. 
+</div><div class="q1">
+<sup>22&#160;</sup>But Yahweh has been my high tower, 
+</div><div class="q2">my Elohim, the rock of my refuge. 
+</div><div class="q1">
+<sup>23&#160;</sup>He has brought on them their own iniquity, 
+</div><div class="q2">and will cut them off in their own wickedness. 
+</div><div class="q2">Yahweh, our Elohim, will cut them off. 
+</div><h2 class="psalmlabel" id="95">95</h2>
+<div class="q1">
+<sup>1&#160;</sup>Oh come, let’s sing to Yahweh. 
+</div><div class="q2">Let’s shout aloud to the rock of our salvation! 
+</div><div class="q1">
+<sup>2&#160;</sup>Let’s come before his presence with thanksgiving. 
+</div><div class="q2">Let’s extol him with songs! 
+</div><div class="q1">
+<sup>3&#160;</sup>For Yahweh is a great Elohim, 
+</div><div class="q2">a great King above all elohims. 
+</div><div class="q1">
+<sup>4&#160;</sup>In his hand are the deep places of the earth. 
+</div><div class="q2">The heights of the mountains are also his. 
+</div><div class="q1">
+<sup>5&#160;</sup>The sea is his, and he made it. 
+</div><div class="q2">His hands formed the dry land. 
+</div><div class="q1">
+<sup>6&#160;</sup>Oh come, let’s worship and bow down. 
+</div><div class="q2">Let’s kneel before Yahweh, our Maker, 
+</div><div class="q2">
+<sup>7&#160;</sup>for he is our Elohim. 
+</div><div class="q1">We are the people of his pasture, 
+</div><div class="q2">and the sheep in his care. 
+</div><div class="q1">Today, oh that you would hear his voice! 
+</div><div class="q2">
+<sup>8&#160;</sup>Don’t harden your heart, as at Meribah, 
+</div><div class="q2">as in the day of Massah in the wilderness, 
+</div><div class="q1">
+<sup>9&#160;</sup>when your fathers tempted me, 
+</div><div class="q2">tested me, and saw my work. 
+</div><div class="q1">
+<sup>10&#160;</sup>Forty long years I was grieved with that generation, 
+</div><div class="q2">and said, “They are a people who err in their heart. 
+</div><div class="q2">They have not known my ways.” 
+</div><div class="q1">
+<sup>11&#160;</sup>Therefore I swore in my wrath, 
+</div><div class="q2">“They won’t enter into my rest.” 
+</div><h2 class="psalmlabel" id="96">96</h2>
+<div class="q1">
+<sup>1&#160;</sup>Sing to Yahweh a new song! 
+</div><div class="q2">Sing to Yahweh, all the earth. 
+</div><div class="q1">
+<sup>2&#160;</sup>Sing to Yahweh! 
+</div><div class="q2">Bless his name! 
+</div><div class="q2">Proclaim his salvation from day to day! 
+</div><div class="q1">
+<sup>3&#160;</sup>Declare his glory among the nations, 
+</div><div class="q2">his marvelous works among all the peoples. 
+</div><div class="q1">
+<sup>4&#160;</sup>For Yahweh is great, and greatly to be praised! 
+</div><div class="q2">He is to be feared above all elohims. 
+</div><div class="q1">
+<sup>5&#160;</sup>For all the elohims of the peoples are idols, 
+</div><div class="q2">but Yahweh made the heavens. 
+</div><div class="q1">
+<sup>6&#160;</sup>Honor and majesty are before him. 
+</div><div class="q2">Strength and beauty are in his sanctuary. 
+</div><div class="q1">
+<sup>7&#160;</sup>Ascribe to Yahweh, you families of nations, 
+</div><div class="q2">ascribe to Yahweh glory and strength. 
+</div><div class="q1">
+<sup>8&#160;</sup>Ascribe to Yahweh the glory due to his name. 
+</div><div class="q2">Bring an offering, and come into his courts. 
+</div><div class="q1">
+<sup>9&#160;</sup>Worship Yahweh in set-apart array. 
+</div><div class="q2">Tremble before him, all the earth. 
+</div><div class="q1">
+<sup>10&#160;</sup>Say among the nations, “Yahweh reigns.” 
+</div><div class="q2">The world is also established. 
+</div><div class="q2">It can’t be moved. 
+</div><div class="q2">He will judge the peoples with equity. 
+</div><div class="q1">
+<sup>11&#160;</sup>Let the heavens be glad, and let the earth rejoice. 
+</div><div class="q2">Let the sea roar, and its fullness! 
+</div><div class="q2">
+<sup>12&#160;</sup>Let the field and all that is in it exult! 
+</div><div class="q2">Then all the trees of the woods shall sing for joy 
+</div><div class="q2">
+<sup>13&#160;</sup>before Yahweh; for he comes, 
+</div><div class="q2">for he comes to judge the earth. 
+</div><div class="q1">He will judge the world with righteousness, 
+</div><div class="q2">the peoples with his truth. 
+</div><h2 class="psalmlabel" id="97">97</h2>
+<div class="q1">
+<sup>1&#160;</sup>Yahweh reigns! 
+</div><div class="q2">Let the earth rejoice! 
+</div><div class="q2">Let the multitude of islands be glad! 
+</div><div class="q1">
+<sup>2&#160;</sup>Clouds and darkness are around him. 
+</div><div class="q2">Righteousness and justice are the foundation of his throne. 
+</div><div class="q1">
+<sup>3&#160;</sup>A fire goes before him, 
+</div><div class="q2">and burns up his adversaries on every side. 
+</div><div class="q1">
+<sup>4&#160;</sup>His lightning lights up the world. 
+</div><div class="q2">The earth sees, and trembles. 
+</div><div class="q1">
+<sup>5&#160;</sup>The mountains melt like wax at the presence of Yahweh, 
+</div><div class="q2">at the presence of the Lord of the whole earth. 
+</div><div class="q1">
+<sup>6&#160;</sup>The heavens declare his righteousness. 
+</div><div class="q2">All the peoples have seen his glory. 
+</div><div class="q1">
+<sup>7&#160;</sup>Let all them be shamed who serve engraved images, 
+</div><div class="q2">who boast in their idols. 
+</div><div class="q2">Worship him, all you elohims! 
+</div><div class="q1">
+<sup>8&#160;</sup>Zion heard and was glad. 
+</div><div class="q2">The daughters of Judah rejoiced 
+</div><div class="q2">because of your judgments, Yahweh. 
+</div><div class="q1">
+<sup>9&#160;</sup>For you, Yahweh, are most high above all the earth. 
+</div><div class="q2">You are exalted far above all elohims. 
+</div><div class="q1">
+<sup>10&#160;</sup>You who love Yahweh, hate evil! 
+</div><div class="q2">He preserves the souls of his saints. 
+</div><div class="q2">He delivers them out of the hand of the wicked. 
+</div><div class="q1">
+<sup>11&#160;</sup>Light is sown for the righteous, 
+</div><div class="q2">and gladness for the upright in heart. 
+</div><div class="q1">
+<sup>12&#160;</sup>Be glad in Yahweh, you righteous people! 
+</div><div class="q2">Give thanks to his set-apart Name. 
+</div><h2 class="psalmlabel" id="98">98</h2>
+<div class="d">A Psalm. 
+</div><div class="q1">
+<sup>1&#160;</sup>Sing to Yahweh a new song, 
+</div><div class="q2">for he has done marvelous things! 
+</div><div class="q2">His right hand and his set-apart arm have worked salvation for him. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh has made known his salvation. 
+</div><div class="q2">He has openly shown his righteousness in the sight of the nations. 
+</div><div class="q1">
+<sup>3&#160;</sup>He has remembered his loving kindness and his faithfulness toward the house of Israel. 
+</div><div class="q2">All the ends of the earth have seen the salvation of our Elohim. 
+</div><div class="q1">
+<sup>4&#160;</sup>Make a joyful noise to Yahweh, all the earth! 
+</div><div class="q2">Burst out and sing for joy, yes, sing praises! 
+</div><div class="q1">
+<sup>5&#160;</sup>Sing praises to Yahweh with the harp, 
+</div><div class="q2">with the harp and the voice of melody. 
+</div><div class="q1">
+<sup>6&#160;</sup>With trumpets and sound of the ram’s horn, 
+</div><div class="q2">make a joyful noise before the King, Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>Let the sea roar with its fullness; 
+</div><div class="q2">the world, and those who dwell therein. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let the rivers clap their hands. 
+</div><div class="q2">Let the mountains sing for joy together. 
+</div><div class="q1">
+<sup>9&#160;</sup>Let them sing before Yahweh, 
+</div><div class="q2">for he comes to judge the earth. 
+</div><div class="q1">He will judge the world with righteousness, 
+</div><div class="q2">and the peoples with equity. 
+</div><h2 class="psalmlabel" id="99">99</h2>
+<div class="q1">
+<sup>1&#160;</sup>Yahweh reigns! Let the peoples tremble. 
+</div><div class="q2">He sits enthroned among the cherubim. 
+</div><div class="q2">Let the earth be moved. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh is great in Zion. 
+</div><div class="q2">He is high above all the peoples. 
+</div><div class="q1">
+<sup>3&#160;</sup>Let them praise your great and awesome name. 
+</div><div class="q2">He is Set-Apart! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>The King’s strength also loves justice. 
+</div><div class="q2">You establish equity. 
+</div><div class="q2">You execute justice and righteousness in Jacob. 
+</div><div class="q1">
+<sup>5&#160;</sup>Exalt Yahweh our Elohim. 
+</div><div class="q2">Worship at his footstool. 
+</div><div class="q2">He is Set-Apart! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Moses and Aaron were among his priests, 
+</div><div class="q2">Samuel was among those who call on his name. 
+</div><div class="q2">They called on Yahweh, and he answered them. 
+</div><div class="q1">
+<sup>7&#160;</sup>He spoke to them in the pillar of cloud. 
+</div><div class="q2">They kept his testimonies, 
+</div><div class="q2">the statute that he gave them. 
+</div><div class="q1">
+<sup>8&#160;</sup>You answered them, Yahweh our Elohim. 
+</div><div class="q2">You are an Elohim who forgave them, 
+</div><div class="q2">although you took vengeance for their doings. 
+</div><div class="q1">
+<sup>9&#160;</sup>Exalt Yahweh, our Elohim. 
+</div><div class="q2">Worship at his set-apart hill, 
+</div><div class="q2">for Yahweh, our Elohim, is set-apart! 
+</div><h2 class="psalmlabel" id="100">100</h2>
+<div class="d">A Psalm of thanksgiving. 
+</div><div class="q1">
+<sup>1&#160;</sup>Shout for joy to Yahweh, all you lands! 
+</div><div class="q2">
+<sup>2&#160;</sup>Serve Yahweh with gladness. 
+</div><div class="q2">Come before his presence with singing. 
+</div><div class="q1">
+<sup>3&#160;</sup>Know that Yahweh, he is Elohim. 
+</div><div class="q2">It is he who has made us, and we are his. 
+</div><div class="q2">We are his people, and the sheep of his pasture. 
+</div><div class="q1">
+<sup>4&#160;</sup>Enter into his gates with thanksgiving, 
+</div><div class="q2">and into his courts with praise. 
+</div><div class="q2">Give thanks to him, and bless his name. 
+</div><div class="q1">
+<sup>5&#160;</sup>For Yahweh is good. 
+</div><div class="q2">His loving kindness endures forever, 
+</div><div class="q2">his faithfulness to all generations. 
+</div><h2 class="psalmlabel" id="101">101</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will sing of loving kindness and justice. 
+</div><div class="q2">To you, Yahweh, I will sing praises. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will be careful to live a blameless life. 
+</div><div class="q2">When will you come to me? 
+</div><div class="q2">I will walk within my house with a blameless heart. 
+</div><div class="q1">
+<sup>3&#160;</sup>I will set no vile thing before my eyes. 
+</div><div class="q2">I hate the deeds of faithless men. 
+</div><div class="q2">They will not cling to me. 
+</div><div class="q1">
+<sup>4&#160;</sup>A perverse heart will be far from me. 
+</div><div class="q2">I will have nothing to do with evil. 
+</div><div class="q1">
+<sup>5&#160;</sup>I will silence whoever secretly slanders his neighbor. 
+</div><div class="q2">I won’t tolerate one who is arrogant and conceited. 
+</div><div class="q1">
+<sup>6&#160;</sup>My eyes will be on the faithful of the land, 
+</div><div class="q2">that they may dwell with me. 
+</div><div class="q1">He who walks in a perfect way, 
+</div><div class="q2">he will serve me. 
+</div><div class="q1">
+<sup>7&#160;</sup>He who practices deceit won’t dwell within my house. 
+</div><div class="q2">He who speaks falsehood won’t be established before my eyes. 
+</div><div class="q1">
+<sup>8&#160;</sup>Morning by morning, I will destroy all the wicked of the land, 
+</div><div class="q2">to cut off all the workers of iniquity from Yahweh’s city. 
+</div><h2 class="psalmlabel" id="102">102</h2>
+<div class="d">A Prayer of the afflicted, when he is overwhelmed and pours out his complaint before Yahweh. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear my prayer, Yahweh! 
+</div><div class="q2">Let my cry come to you. 
+</div><div class="q1">
+<sup>2&#160;</sup>Don’t hide your face from me in the day of my distress. 
+</div><div class="q2">Turn your ear to me. 
+</div><div class="q2">Answer me quickly in the day when I call. 
+</div><div class="q1">
+<sup>3&#160;</sup>For my days consume away like smoke. 
+</div><div class="q2">My bones are burned as a torch. 
+</div><div class="q1">
+<sup>4&#160;</sup>My heart is blighted like grass, and withered, 
+</div><div class="q2">for I forget to eat my bread. 
+</div><div class="q1">
+<sup>5&#160;</sup>By reason of the voice of my groaning, 
+</div><div class="q2">my bones stick to my skin. 
+</div><div class="q1">
+<sup>6&#160;</sup>I am like a pelican of the wilderness. 
+</div><div class="q2">I have become as an owl of the waste places. 
+</div><div class="q2">
+<sup>7&#160;</sup>I watch, and have become like a sparrow that is alone on the housetop. 
+</div><div class="q1">
+<sup>8&#160;</sup>My enemies reproach me all day. 
+</div><div class="q2">Those who are mad at me use my name as a curse. 
+</div><div class="q1">
+<sup>9&#160;</sup>For I have eaten ashes like bread, 
+</div><div class="q2">and mixed my drink with tears, 
+</div><div class="q2">
+<sup>10&#160;</sup>because of your indignation and your wrath; 
+</div><div class="q2">for you have taken me up and thrown me away. 
+</div><div class="q1">
+<sup>11&#160;</sup>My days are like a long shadow. 
+</div><div class="q2">I have withered like grass. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>But you, Yahweh, will remain forever; 
+</div><div class="q2">your renown endures to all generations. 
+</div><div class="q1">
+<sup>13&#160;</sup>You will arise and have mercy on Zion, 
+</div><div class="q2">for it is time to have pity on her. 
+</div><div class="q2">Yes, the set time has come. 
+</div><div class="q1">
+<sup>14&#160;</sup>For your servants take pleasure in her stones, 
+</div><div class="q2">and have pity on her dust. 
+</div><div class="q1">
+<sup>15&#160;</sup>So the nations will fear Yahweh’s name, 
+</div><div class="q2">all the kings of the earth your glory. 
+</div><div class="q1">
+<sup>16&#160;</sup>For Yahweh has built up Zion. 
+</div><div class="q2">He has appeared in his glory. 
+</div><div class="q1">
+<sup>17&#160;</sup>He has responded to the prayer of the destitute, 
+</div><div class="q2">and has not despised their prayer. 
+</div><div class="q1">
+<sup>18&#160;</sup>This will be written for the generation to come. 
+</div><div class="q2">A people which will be created will praise Yah, 
+</div><div class="q1">
+<sup>19&#160;</sup>for he has looked down from the height of his sanctuary. 
+</div><div class="q2">From heaven, Yahweh saw the earth, 
+</div><div class="q1">
+<sup>20&#160;</sup>to hear the groans of the prisoner, 
+</div><div class="q2">to free those who are condemned to death, 
+</div><div class="q1">
+<sup>21&#160;</sup>that men may declare Yahweh’s name in Zion, 
+</div><div class="q2">and his praise in Jerusalem, 
+</div><div class="q1">
+<sup>22&#160;</sup>when the peoples are gathered together, 
+</div><div class="q2">the kingdoms, to serve Yahweh. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>He weakened my strength along the course. 
+</div><div class="q2">He shortened my days. 
+</div><div class="q1">
+<sup>24&#160;</sup>I said, “My Elohim, don’t take me away in the middle of my days. 
+</div><div class="q2">Your years are throughout all generations. 
+</div><div class="q1">
+<sup>25&#160;</sup>Of old, you laid the foundation of the earth. 
+</div><div class="q2">The heavens are the work of your hands. 
+</div><div class="q1">
+<sup>26&#160;</sup>They will perish, but you will endure. 
+</div><div class="q2">Yes, all of them will wear out like a garment. 
+</div><div class="q2">You will change them like a cloak, and they will be changed. 
+</div><div class="q1">
+<sup>27&#160;</sup>But you are the same. 
+</div><div class="q2">Your years will have no end. 
+</div><div class="q1">
+<sup>28&#160;</sup>The children of your servants will continue. 
+</div><div class="q2">Their offspring will be established before you.” 
+</div><h2 class="psalmlabel" id="103">103</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Praise Yahweh, my soul! 
+</div><div class="q2">All that is within me, praise his set-apart name! 
+</div><div class="q1">
+<sup>2&#160;</sup>Praise Yahweh, my soul, 
+</div><div class="q2">and don’t forget all his benefits, 
+</div><div class="q1">
+<sup>3&#160;</sup>who forgives all your sins, 
+</div><div class="q2">who heals all your diseases, 
+</div><div class="q1">
+<sup>4&#160;</sup>who redeems your life from destruction, 
+</div><div class="q2">who crowns you with loving kindness and tender mercies, 
+</div><div class="q1">
+<sup>5&#160;</sup>who satisfies your desire with good things, 
+</div><div class="q2">so that your youth is renewed like the eagle’s. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh executes righteous acts, 
+</div><div class="q2">and justice for all who are oppressed. 
+</div><div class="q1">
+<sup>7&#160;</sup>He made known his ways to Moses, 
+</div><div class="q2">his deeds to the children of Israel. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh is merciful and gracious, 
+</div><div class="q2">slow to anger, and abundant in loving kindness. 
+</div><div class="q1">
+<sup>9&#160;</sup>He will not always accuse; 
+</div><div class="q2">neither will he stay angry forever. 
+</div><div class="q1">
+<sup>10&#160;</sup>He has not dealt with us according to our sins, 
+</div><div class="q2">nor repaid us for our iniquities. 
+</div><div class="q1">
+<sup>11&#160;</sup>For as the heavens are high above the earth, 
+</div><div class="q2">so great is his loving kindness toward those who fear him. 
+</div><div class="q1">
+<sup>12&#160;</sup>As far as the east is from the west, 
+</div><div class="q2">so far has he removed our transgressions from us. 
+</div><div class="q1">
+<sup>13&#160;</sup>Like a father has compassion on his children, 
+</div><div class="q2">so Yahweh has compassion on those who fear him. 
+</div><div class="q1">
+<sup>14&#160;</sup>For he knows how we are made. 
+</div><div class="q2">He remembers that we are dust. 
+</div><div class="q1">
+<sup>15&#160;</sup>As for man, his days are like grass. 
+</div><div class="q2">As a flower of the field, so he flourishes. 
+</div><div class="q1">
+<sup>16&#160;</sup>For the wind passes over it, and it is gone. 
+</div><div class="q2">Its place remembers it no more. 
+</div><div class="q1">
+<sup>17&#160;</sup>But Yahweh’s loving kindness is from everlasting to everlasting with those who fear him, 
+</div><div class="q2">his righteousness to children’s children, 
+</div><div class="q1">
+<sup>18&#160;</sup>to those who keep his covenant, 
+</div><div class="q2">to those who remember to obey his precepts. 
+</div><div class="q1">
+<sup>19&#160;</sup>Yahweh has established his throne in the heavens. 
+</div><div class="q2">His kingdom rules over all. 
+</div><div class="q1">
+<sup>20&#160;</sup>Praise Yahweh, you angels of his, 
+</div><div class="q2">who are mighty in strength, who fulfill his word, 
+</div><div class="q2">obeying the voice of his word. 
+</div><div class="q1">
+<sup>21&#160;</sup>Praise Yahweh, all you armies of his, 
+</div><div class="q2">you servants of his, who do his pleasure. 
+</div><div class="q1">
+<sup>22&#160;</sup>Praise Yahweh, all you works of his, 
+</div><div class="q2">in all places of his dominion. 
+</div><div class="q2">Praise Yahweh, my soul! 
+</div><h2 class="psalmlabel" id="104">104</h2>
+<div class="q1">
+<sup>1&#160;</sup>Bless Yahweh, my soul. 
+</div><div class="q2">Yahweh, my Elohim, you are very great. 
+</div><div class="q2">You are clothed with honor and majesty. 
+</div><div class="q1">
+<sup>2&#160;</sup>He covers himself with light as with a garment. 
+</div><div class="q2">He stretches out the heavens like a curtain. 
+</div><div class="q1">
+<sup>3&#160;</sup>He lays the beams of his rooms in the waters. 
+</div><div class="q2">He makes the clouds his chariot. 
+</div><div class="q2">He walks on the wings of the wind. 
+</div><div class="q1">
+<sup>4&#160;</sup>He makes his messengers winds, 
+</div><div class="q2">and his servants flames of fire. 
+</div><div class="q1">
+<sup>5&#160;</sup>He laid the foundations of the earth, 
+</div><div class="q2">that it should not be moved forever. 
+</div><div class="q1">
+<sup>6&#160;</sup>You covered it with the deep as with a cloak. 
+</div><div class="q2">The waters stood above the mountains. 
+</div><div class="q1">
+<sup>7&#160;</sup>At your rebuke they fled. 
+</div><div class="q2">At the voice of your thunder they hurried away. 
+</div><div class="q1">
+<sup>8&#160;</sup>The mountains rose, 
+</div><div class="q2">the valleys sank down, 
+</div><div class="q2">to the place which you had assigned to them. 
+</div><div class="q1">
+<sup>9&#160;</sup>You have set a boundary that they may not pass over, 
+</div><div class="q2">that they don’t turn again to cover the earth. 
+</div><div class="q1">
+<sup>10&#160;</sup>He sends springs into the valleys. 
+</div><div class="q2">They run among the mountains. 
+</div><div class="q1">
+<sup>11&#160;</sup>They give drink to every animal of the field. 
+</div><div class="q2">The wild donkeys quench their thirst. 
+</div><div class="q1">
+<sup>12&#160;</sup>The birds of the sky nest by them. 
+</div><div class="q2">They sing among the branches. 
+</div><div class="q1">
+<sup>13&#160;</sup>He waters the mountains from his rooms. 
+</div><div class="q2">The earth is filled with the fruit of your works. 
+</div><div class="q1">
+<sup>14&#160;</sup>He causes the grass to grow for the livestock, 
+</div><div class="q2">and plants for man to cultivate, 
+</div><div class="q2">that he may produce food out of the earth: 
+</div><div class="q1">
+<sup>15&#160;</sup>wine that makes the heart of man glad, 
+</div><div class="q2">oil to make his face to shine, 
+</div><div class="q2">and bread that strengthens man’s heart. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yahweh’s trees are well watered, 
+</div><div class="q2">the cedars of Lebanon, which he has planted, 
+</div><div class="q1">
+<sup>17&#160;</sup>where the birds make their nests. 
+</div><div class="q2">The stork makes its home in the cypress trees. 
+</div><div class="q1">
+<sup>18&#160;</sup>The high mountains are for the wild goats. 
+</div><div class="q2">The rocks are a refuge for the rock badgers. 
+</div><div class="q1">
+<sup>19&#160;</sup>He appointed the moon for seasons. 
+</div><div class="q2">The sun knows when to set. 
+</div><div class="q1">
+<sup>20&#160;</sup>You make darkness, and it is night, 
+</div><div class="q2">in which all the animals of the forest prowl. 
+</div><div class="q1">
+<sup>21&#160;</sup>The young lions roar after their prey, 
+</div><div class="q2">and seek their food from Elohim. 
+</div><div class="q1">
+<sup>22&#160;</sup>The sun rises, and they steal away, 
+</div><div class="q2">and lie down in their dens. 
+</div><div class="q1">
+<sup>23&#160;</sup>Man goes out to his work, 
+</div><div class="q2">to his labor until the evening. 
+</div><div class="q1">
+<sup>24&#160;</sup>Yahweh, how many are your works! 
+</div><div class="q2">In wisdom, you have made them all. 
+</div><div class="q2">The earth is full of your riches. 
+</div><div class="q1">
+<sup>25&#160;</sup>There is the sea, great and wide, 
+</div><div class="q2">in which are innumerable living things, 
+</div><div class="q2">both small and large animals. 
+</div><div class="q1">
+<sup>26&#160;</sup>There the ships go, 
+</div><div class="q2">and leviathan, whom you formed to play there. 
+</div><div class="q1">
+<sup>27&#160;</sup>These all wait for you, 
+</div><div class="q2">that you may give them their food in due season. 
+</div><div class="q1">
+<sup>28&#160;</sup>You give to them; they gather. 
+</div><div class="q2">You open your hand; they are satisfied with good. 
+</div><div class="q1">
+<sup>29&#160;</sup>You hide your face; they are troubled. 
+</div><div class="q2">You take away their breath; they die and return to the dust. 
+</div><div class="q1">
+<sup>30&#160;</sup>You send out your Spirit and they are created. 
+</div><div class="q2">You renew the face of the ground. 
+</div><div class="q1">
+<sup>31&#160;</sup>Let Yahweh’s glory endure forever. 
+</div><div class="q2">Let Yahweh rejoice in his works. 
+</div><div class="q1">
+<sup>32&#160;</sup>He looks at the earth, and it trembles. 
+</div><div class="q2">He touches the mountains, and they smoke. 
+</div><div class="q1">
+<sup>33&#160;</sup>I will sing to Yahweh as long as I live. 
+</div><div class="q2">I will sing praise to my Elohim while I have any being. 
+</div><div class="q1">
+<sup>34&#160;</sup>Let my meditation be sweet to him. 
+</div><div class="q2">I will rejoice in Yahweh. 
+</div><div class="q1">
+<sup>35&#160;</sup>Let sinners be consumed out of the earth. 
+</div><div class="q2">Let the wicked be no more. 
+</div><div class="q2">Bless Yahweh, my soul. 
+</div><div class="q2">Praise Yah! 
+</div><h2 class="psalmlabel" id="105">105</h2>
+<div class="q1">
+<sup>1&#160;</sup>Give thanks to Yahweh! Call on his name! 
+</div><div class="q2">Make his doings known among the peoples. 
+</div><div class="q1">
+<sup>2&#160;</sup>Sing to him, sing praises to him! 
+</div><div class="q2">Tell of all his marvelous works. 
+</div><div class="q1">
+<sup>3&#160;</sup>Glory in his set-apart name. 
+</div><div class="q2">Let the heart of those who seek Yahweh rejoice. 
+</div><div class="q1">
+<sup>4&#160;</sup>Seek Yahweh and his strength. 
+</div><div class="q2">Seek his face forever more. 
+</div><div class="q1">
+<sup>5&#160;</sup>Remember his marvelous works that he has done: 
+</div><div class="q2">his wonders, and the judgments of his mouth, 
+</div><div class="q1">
+<sup>6&#160;</sup>you offspring of Abraham, his servant, 
+</div><div class="q2">you children of Jacob, his chosen ones. 
+</div><div class="q1">
+<sup>7&#160;</sup>He is Yahweh, our Elohim. 
+</div><div class="q2">His judgments are in all the earth. 
+</div><div class="q1">
+<sup>8&#160;</sup>He has remembered his covenant forever, 
+</div><div class="q2">the word which he commanded to a thousand generations, 
+</div><div class="q1">
+<sup>9&#160;</sup>the covenant which he made with Abraham, 
+</div><div class="q2">his oath to Isaac, 
+</div><div class="q1">
+<sup>10&#160;</sup>and confirmed it to Jacob for a statute; 
+</div><div class="q2">to Israel for an everlasting covenant, 
+</div><div class="q1">
+<sup>11&#160;</sup>saying, “To you I will give the land of Canaan, 
+</div><div class="q2">the lot of your inheritance,” 
+</div><div class="q1">
+<sup>12&#160;</sup>when they were but a few men in number, 
+</div><div class="q2">yes, very few, and foreigners in it. 
+</div><div class="q1">
+<sup>13&#160;</sup>They went about from nation to nation, 
+</div><div class="q2">from one kingdom to another people. 
+</div><div class="q1">
+<sup>14&#160;</sup>He allowed no one to do them wrong. 
+</div><div class="q2">Yes, he reproved kings for their sakes, 
+</div><div class="q1">
+<sup>15&#160;</sup>“Don’t touch my anointed ones! 
+</div><div class="q2">Do my prophets no harm!” 
+</div><div class="q1">
+<sup>16&#160;</sup>He called for a famine on the land. 
+</div><div class="q2">He destroyed the food supplies. 
+</div><div class="q1">
+<sup>17&#160;</sup>He sent a man before them. 
+</div><div class="q2">Joseph was sold for a slave. 
+</div><div class="q1">
+<sup>18&#160;</sup>They bruised his feet with shackles. 
+</div><div class="q2">His neck was locked in irons, 
+</div><div class="q1">
+<sup>19&#160;</sup>until the time that his word happened, 
+</div><div class="q2">and Yahweh’s word proved him true. 
+</div><div class="q1">
+<sup>20&#160;</sup>The king sent and freed him, 
+</div><div class="q2">even the ruler of peoples, and let him go free. 
+</div><div class="q1">
+<sup>21&#160;</sup>He made him lord of his house, 
+</div><div class="q2">and ruler of all of his possessions, 
+</div><div class="q1">
+<sup>22&#160;</sup>to discipline his princes at his pleasure, 
+</div><div class="q2">and to teach his elders wisdom. 
+</div><div class="q1">
+<sup>23&#160;</sup>Israel also came into Egypt. 
+</div><div class="q2">Jacob lived in the land of Ham. 
+</div><div class="q1">
+<sup>24&#160;</sup>He increased his people greatly, 
+</div><div class="q2">and made them stronger than their adversaries. 
+</div><div class="q1">
+<sup>25&#160;</sup>He turned their heart to hate his people, 
+</div><div class="q2">to conspire against his servants. 
+</div><div class="q1">
+<sup>26&#160;</sup>He sent Moses, his servant, 
+</div><div class="q2">and Aaron, whom he had chosen. 
+</div><div class="q1">
+<sup>27&#160;</sup>They performed miracles among them, 
+</div><div class="q2">and wonders in the land of Ham. 
+</div><div class="q1">
+<sup>28&#160;</sup>He sent darkness, and made it dark. 
+</div><div class="q2">They didn’t rebel against his words. 
+</div><div class="q1">
+<sup>29&#160;</sup>He turned their waters into blood, 
+</div><div class="q2">and killed their fish. 
+</div><div class="q1">
+<sup>30&#160;</sup>Their land swarmed with frogs, 
+</div><div class="q2">even in the rooms of their kings. 
+</div><div class="q1">
+<sup>31&#160;</sup>He spoke, and swarms of flies came, 
+</div><div class="q2">and lice in all their borders. 
+</div><div class="q1">
+<sup>32&#160;</sup>He gave them hail for rain, 
+</div><div class="q2">with lightning in their land. 
+</div><div class="q1">
+<sup>33&#160;</sup>He struck their vines and also their fig trees, 
+</div><div class="q2">and shattered the trees of their country. 
+</div><div class="q1">
+<sup>34&#160;</sup>He spoke, and the locusts came 
+</div><div class="q2">with the grasshoppers, without number. 
+</div><div class="q1">
+<sup>35&#160;</sup>They ate up every plant in their land, 
+</div><div class="q2">and ate up the fruit of their ground. 
+</div><div class="q1">
+<sup>36&#160;</sup>He struck also all the firstborn in their land, 
+</div><div class="q2">the first fruits of all their manhood. 
+</div><div class="q1">
+<sup>37&#160;</sup>He brought them out with silver and gold. 
+</div><div class="q2">There was not one feeble person among his tribes. 
+</div><div class="q1">
+<sup>38&#160;</sup>Egypt was glad when they departed, 
+</div><div class="q2">for the fear of them had fallen on them. 
+</div><div class="q1">
+<sup>39&#160;</sup>He spread a cloud for a covering, 
+</div><div class="q2">fire to give light in the night. 
+</div><div class="q1">
+<sup>40&#160;</sup>They asked, and he brought quails, 
+</div><div class="q2">and satisfied them with the bread of the sky. 
+</div><div class="q1">
+<sup>41&#160;</sup>He opened the rock, and waters gushed out. 
+</div><div class="q2">They ran as a river in the dry places. 
+</div><div class="q1">
+<sup>42&#160;</sup>For he remembered his set-apart word, 
+</div><div class="q2">and Abraham, his servant. 
+</div><div class="q1">
+<sup>43&#160;</sup>He brought his people out with joy, 
+</div><div class="q2">his chosen with singing. 
+</div><div class="q1">
+<sup>44&#160;</sup>He gave them the lands of the nations. 
+</div><div class="q2">They took the labor of the peoples in possession, 
+</div><div class="q1">
+<sup>45&#160;</sup>that they might keep his statutes, 
+</div><div class="q2">and observe his laws. 
+</div><div class="q2">Praise Yah! 
+</div><h2 class="psalmlabel" id="106">106</h2>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yahweh! 
+</div><div class="q2">Give thanks to Yahweh, for he is good, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>2&#160;</sup>Who can utter the mighty acts of Yahweh, 
+</div><div class="q2">or fully declare all his praise? 
+</div><div class="q1">
+<sup>3&#160;</sup>Blessed are those who keep justice. 
+</div><div class="q2">Blessed is one who does what is right at all times. 
+</div><div class="q1">
+<sup>4&#160;</sup>Remember me, Yahweh, with the favor that you show to your people. 
+</div><div class="q2">Visit me with your salvation, 
+</div><div class="q1">
+<sup>5&#160;</sup>that I may see the prosperity of your chosen, 
+</div><div class="q2">that I may rejoice in the gladness of your nation, 
+</div><div class="q2">that I may glory with your inheritance. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>We have sinned with our fathers. 
+</div><div class="q2">We have committed iniquity. 
+</div><div class="q2">We have done wickedly. 
+</div><div class="q1">
+<sup>7&#160;</sup>Our fathers didn’t understand your wonders in Egypt. 
+</div><div class="q2">They didn’t remember the multitude of your loving kindnesses, 
+</div><div class="q2">but were rebellious at the sea, even at the Red Sea. 
+</div><div class="q1">
+<sup>8&#160;</sup>Nevertheless he saved them for his name’s sake, 
+</div><div class="q2">that he might make his mighty power known. 
+</div><div class="q1">
+<sup>9&#160;</sup>He rebuked the Red Sea also, and it was dried up; 
+</div><div class="q2">so he led them through the depths, as through a desert. 
+</div><div class="q1">
+<sup>10&#160;</sup>He saved them from the hand of him who hated them, 
+</div><div class="q2">and redeemed them from the hand of the enemy. 
+</div><div class="q1">
+<sup>11&#160;</sup>The waters covered their adversaries. 
+</div><div class="q2">There was not one of them left. 
+</div><div class="q1">
+<sup>12&#160;</sup>Then they believed his words. 
+</div><div class="q2">They sang his praise. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>13&#160;</sup>They soon forgot his works. 
+</div><div class="q2">They didn’t wait for his counsel, 
+</div><div class="q2">
+<sup>14&#160;</sup>but gave in to craving in the desert, 
+</div><div class="q2">and tested Elohim in the wasteland. 
+</div><div class="q1">
+<sup>15&#160;</sup>He gave them their request, 
+</div><div class="q2">but sent leanness into their soul. 
+</div><div class="q1">
+<sup>16&#160;</sup>They envied Moses also in the camp, 
+</div><div class="q2">and Aaron, Yahweh’s saint. 
+</div><div class="q1">
+<sup>17&#160;</sup>The earth opened and swallowed up Dathan, 
+</div><div class="q2">and covered the company of Abiram. 
+</div><div class="q1">
+<sup>18&#160;</sup>A fire was kindled in their company. 
+</div><div class="q2">The flame burned up the wicked. 
+</div><div class="q1">
+<sup>19&#160;</sup>They made a calf in Horeb, 
+</div><div class="q2">and worshiped a molten image. 
+</div><div class="q1">
+<sup>20&#160;</sup>Thus they exchanged their glory 
+</div><div class="q2">for an image of a bull that eats grass. 
+</div><div class="q1">
+<sup>21&#160;</sup>They forgot Elohim, their Savior, 
+</div><div class="q2">who had done great things in Egypt, 
+</div><div class="q2">
+<sup>22&#160;</sup>wondrous works in the land of Ham, 
+</div><div class="q2">and awesome things by the Red Sea. 
+</div><div class="q1">
+<sup>23&#160;</sup>Therefore he said that he would destroy them, 
+</div><div class="q2">had Moses, his chosen, not stood before him in the breach, 
+</div><div class="q2">to turn away his wrath, so that he wouldn’t destroy them. 
+</div><div class="q1">
+<sup>24&#160;</sup>Yes, they despised the pleasant land. 
+</div><div class="q2">They didn’t believe his word, 
+</div><div class="q2">
+<sup>25&#160;</sup>but murmured in their tents, 
+</div><div class="q2">and didn’t listen to Yahweh’s voice. 
+</div><div class="q1">
+<sup>26&#160;</sup>Therefore he swore to them 
+</div><div class="q2">that he would overthrow them in the wilderness, 
+</div><div class="q2">
+<sup>27&#160;</sup>that he would overthrow their offspring among the nations, 
+</div><div class="q2">and scatter them in the lands. 
+</div><div class="q1">
+<sup>28&#160;</sup>They joined themselves also to Baal Peor, 
+</div><div class="q2">and ate the sacrifices of the dead. 
+</div><div class="q1">
+<sup>29&#160;</sup>Thus they provoked him to anger with their deeds. 
+</div><div class="q2">The plague broke in on them. 
+</div><div class="q1">
+<sup>30&#160;</sup>Then Phinehas stood up and executed judgment, 
+</div><div class="q2">so the plague was stopped. 
+</div><div class="q1">
+<sup>31&#160;</sup>That was credited to him for righteousness, 
+</div><div class="q2">for all generations to come. 
+</div><div class="q1">
+<sup>32&#160;</sup>They angered him also at the waters of Meribah, 
+</div><div class="q2">so that Moses was troubled for their sakes; 
+</div><div class="q1">
+<sup>33&#160;</sup>because they were rebellious against his spirit, 
+</div><div class="q2">he spoke rashly with his lips. 
+</div><div class="q1">
+<sup>34&#160;</sup>They didn’t destroy the peoples, 
+</div><div class="q2">as Yahweh commanded them, 
+</div><div class="q2">
+<sup>35&#160;</sup>but mixed themselves with the nations, 
+</div><div class="q2">and learned their works. 
+</div><div class="q1">
+<sup>36&#160;</sup>They served their idols, 
+</div><div class="q2">which became a snare to them. 
+</div><div class="q1">
+<sup>37&#160;</sup>Yes, they sacrificed their sons and their daughters to demons. 
+</div><div class="q2">
+<sup>38&#160;</sup>They shed innocent blood, 
+</div><div class="q2">even the blood of their sons and of their daughters, 
+</div><div class="q2">whom they sacrificed to the idols of Canaan. 
+</div><div class="q2">The land was polluted with blood. 
+</div><div class="q1">
+<sup>39&#160;</sup>Thus they were defiled with their works, 
+</div><div class="q2">and prostituted themselves in their deeds. 
+</div><div class="q1">
+<sup>40&#160;</sup>Therefore Yahweh burned with anger against his people. 
+</div><div class="q2">He abhorred his inheritance. 
+</div><div class="q1">
+<sup>41&#160;</sup>He gave them into the hand of the nations. 
+</div><div class="q2">Those who hated them ruled over them. 
+</div><div class="q1">
+<sup>42&#160;</sup>Their enemies also oppressed them. 
+</div><div class="q2">They were brought into subjection under their hand. 
+</div><div class="q1">
+<sup>43&#160;</sup>He rescued them many times, 
+</div><div class="q2">but they were rebellious in their counsel, 
+</div><div class="q2">and were brought low in their iniquity. 
+</div><div class="q1">
+<sup>44&#160;</sup>Nevertheless he regarded their distress, 
+</div><div class="q2">when he heard their cry. 
+</div><div class="q1">
+<sup>45&#160;</sup>He remembered for them his covenant, 
+</div><div class="q2">and repented according to the multitude of his loving kindnesses. 
+</div><div class="q1">
+<sup>46&#160;</sup>He made them also to be pitied 
+</div><div class="q2">by all those who carried them captive. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>47&#160;</sup>Save us, Yahweh, our Elohim, 
+</div><div class="q2">gather us from among the nations, 
+</div><div class="q2">to give thanks to your set-apart name, 
+</div><div class="q2">to triumph in your praise! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>48&#160;</sup>Blessed be Yahweh, the Elohim of Israel, 
+</div><div class="q2">from everlasting even to everlasting! 
+</div><div class="q1">Let all the people say, “Amen.” 
+</div><div class="q2">Praise Yah! 
+</div><h2 class="ms1">BOOK 5</h2>
 <h2 class="psalmlabel" id="107">107</h2>
-<h2 class="ms1">BOOK 5</h2>
-</p><p class="q1">
-<span class="v">1&#160;</span>Give thanks to Yahweh,<span class="f">+ \fr 107:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> for he is good, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let the redeemed by Yahweh say so, 
-</p><p class="q2">whom he has redeemed from the hand of the adversary, 
-</p><p class="q2">
-<span class="v">3&#160;</span>and gathered out of the lands, 
-</p><p class="q2">from the east and from the west, 
-</p><p class="q2">from the north and from the south. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>They wandered in the wilderness in a desert way. 
-</p><p class="q2">They found no city to live in. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Hungry and thirsty, 
-</p><p class="q2">their soul fainted in them. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Then they cried to Yahweh in their trouble, 
-</p><p class="q2">and he delivered them out of their distresses. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He led them also by a straight way, 
-</p><p class="q2">that they might go to a city to live in. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let them praise Yahweh for his loving kindness, 
-</p><p class="q2">for his wonderful deeds to the children of men! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>For he satisfies the longing soul. 
-</p><p class="q2">He fills the hungry soul with good. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Some sat in darkness and in the shadow of death, 
-</p><p class="q2">being bound in affliction and iron, 
-</p><p class="q2">
-<span class="v">11&#160;</span>because they rebelled against the words of Elohim,<span class="f">+ \fr 107:11 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><p class="q2">and condemned the counsel of the Most High. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Therefore he brought down their heart with labor. 
-</p><p class="q2">They fell down, and there was no one to help. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Then they cried to Yahweh in their trouble, 
-</p><p class="q2">and he saved them out of their distresses. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He brought them out of darkness and the shadow of death, 
-</p><p class="q2">and broke away their chains. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Let them praise Yahweh for his loving kindness, 
-</p><p class="q2">for his wonderful deeds to the children of men! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>For he has broken the gates of bronze, 
-</p><p class="q2">and cut through bars of iron. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">17&#160;</span>Fools are afflicted because of their disobedience, 
-</p><p class="q2">and because of their iniquities. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Their soul abhors all kinds of food. 
-</p><p class="q2">They draw near to the gates of death. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Then they cry to Yahweh in their trouble, 
-</p><p class="q2">and he saves them out of their distresses. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He sends his word, and heals them, 
-</p><p class="q2">and delivers them from their graves. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Let them praise Yahweh for his loving kindness, 
-</p><p class="q2">for his wonderful deeds to the children of men! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">22&#160;</span>Let them offer the sacrifices of thanksgiving, 
-</p><p class="q2">and declare his deeds with singing. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">23&#160;</span>Those who go down to the sea in ships, 
-</p><p class="q2">who do business in great waters, 
-</p><p class="q2">
-<span class="v">24&#160;</span>these see Yahweh’s deeds, 
-</p><p class="q2">and his wonders in the deep. 
-</p><p class="q1">
-<span class="v">25&#160;</span>For he commands, and raises the stormy wind, 
-</p><p class="q2">which lifts up its waves. 
-</p><p class="q1">
-<span class="v">26&#160;</span>They mount up to the sky; they go down again to the depths. 
-</p><p class="q2">Their soul melts away because of trouble. 
-</p><p class="q1">
-<span class="v">27&#160;</span>They reel back and forth, and stagger like a drunken man, 
-</p><p class="q2">and are at their wits’ end. 
-</p><p class="q1">
-<span class="v">28&#160;</span>Then they cry to Yahweh in their trouble, 
-</p><p class="q2">and he brings them out of their distress. 
-</p><p class="q1">
-<span class="v">29&#160;</span>He makes the storm a calm, 
-</p><p class="q2">so that its waves are still. 
-</p><p class="q1">
-<span class="v">30&#160;</span>Then they are glad because it is calm, 
-</p><p class="q2">so he brings them to their desired haven. 
-</p><p class="q1">
-<span class="v">31&#160;</span>Let them praise Yahweh for his loving kindness, 
-</p><p class="q2">for his wonderful deeds for the children of men! 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">32&#160;</span>Let them exalt him also in the assembly of the people, 
-</p><p class="q2">and praise him in the seat of the elders. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">33&#160;</span>He turns rivers into a desert, 
-</p><p class="q2">water springs into a thirsty ground, 
-</p><p class="q2">
-<span class="v">34&#160;</span>and a fruitful land into a salt waste, 
-</p><p class="q2">for the wickedness of those who dwell in it. 
-</p><p class="q1">
-<span class="v">35&#160;</span>He turns a desert into a pool of water, 
-</p><p class="q2">and a dry land into water springs. 
-</p><p class="q1">
-<span class="v">36&#160;</span>There he makes the hungry live, 
-</p><p class="q2">that they may prepare a city to live in, 
-</p><p class="q2">
-<span class="v">37&#160;</span>sow fields, plant vineyards, 
-</p><p class="q2">and reap the fruits of increase. 
-</p><p class="q1">
-<span class="v">38&#160;</span>He blesses them also, so that they are multiplied greatly. 
-</p><p class="q2">He doesn’t allow their livestock to decrease. 
-</p><p class="q1">
-<span class="v">39&#160;</span>Again, they are diminished and bowed down 
-</p><p class="q2">through oppression, trouble, and sorrow. 
-</p><p class="q1">
-<span class="v">40&#160;</span>He pours contempt on princes, 
-</p><p class="q2">and causes them to wander in a trackless waste. 
-</p><p class="q1">
-<span class="v">41&#160;</span>Yet he lifts the needy out of their affliction, 
-</p><p class="q2">and increases their families like a flock. 
-</p><p class="q1">
-<span class="v">42&#160;</span>The upright will see it, and be glad. 
-</p><p class="q2">All the wicked will shut their mouths. 
-</p><p class="q1">
-<span class="v">43&#160;</span>Whoever is wise will pay attention to these things. 
-</p><p class="q2">They will consider the loving kindnesses of Yahweh. 
-</p><h2 class="psalmlabel" id="108">108</h2>
-<p class="d">A Song. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>My heart is steadfast, Elohim. 
-</p><p class="q2">I will sing and I will make music with my soul. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Wake up, harp and lyre! 
-</p><p class="q2">I will wake up the dawn. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I will give thanks to you, Yahweh, among the nations. 
-</p><p class="q2">I will sing praises to you among the peoples. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For your loving kindness is great above the heavens. 
-</p><p class="q2">Your faithfulness reaches to the skies. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Be exalted, Elohim, above the heavens! 
-</p><p class="q2">Let your glory be over all the earth. 
-</p><p class="q1">
-<span class="v">6&#160;</span>That your beloved may be delivered, 
-</p><p class="q2">save with your right hand, and answer us. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Elohim has spoken from his sanctuary: “In triumph, 
-</p><p class="q2">I will divide Shechem, and measure out the valley of Succoth. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Gilead is mine. Manasseh is mine. 
-</p><p class="q2">Ephraim also is my helmet. 
-</p><p class="q2">Judah is my scepter. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Moab is my wash pot. 
-</p><p class="q2">I will toss my sandal on Edom. 
-</p><p class="q2">I will shout over Philistia.” 
-</p><p class="q1">
-<span class="v">10&#160;</span>Who will bring me into the fortified city? 
-</p><p class="q2">Who will lead me to Edom? 
-</p><p class="q1">
-<span class="v">11&#160;</span>Haven’t you rejected us, Elohim? 
-</p><p class="q2">You don’t go out, Elohim, with our armies. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Give us help against the enemy, 
-</p><p class="q2">for the help of man is vain. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Through Elohim, we will do valiantly, 
-</p><p class="q2">for it is he who will tread down our enemies. 
-</p><h2 class="psalmlabel" id="109">109</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Elohim of my praise, don’t remain silent, 
-</p><p class="q2">
-<span class="v">2&#160;</span>for they have opened the mouth of the wicked and the mouth of deceit against me. 
-</p><p class="q2">They have spoken to me with a lying tongue. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They have also surrounded me with words of hatred, 
-</p><p class="q2">and fought against me without a cause. 
-</p><p class="q1">
-<span class="v">4&#160;</span>In return for my love, they are my adversaries; 
-</p><p class="q2">but I am in prayer. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They have rewarded me evil for good, 
-</p><p class="q2">and hatred for my love. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Set a wicked man over him. 
-</p><p class="q2">Let an adversary stand at his right hand. 
-</p><p class="q1">
-<span class="v">7&#160;</span>When he is judged, let him come out guilty. 
-</p><p class="q2">Let his prayer be turned into sin. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Let his days be few. 
-</p><p class="q2">Let another take his office. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Let his children be fatherless, 
-</p><p class="q2">and his woman a widow. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Let his children be wandering beggars. 
-</p><p class="q2">Let them be sought from their ruins. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Let the creditor seize all that he has. 
-</p><p class="q2">Let strangers plunder the fruit of his labor. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Let there be no one to extend kindness to him, 
-</p><p class="q2">neither let there be anyone to have pity on his fatherless children. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Let his posterity be cut off. 
-</p><p class="q2">In the generation following let their name be blotted out. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Let the iniquity of his fathers be remembered by Yahweh. 
-</p><p class="q2">Don’t let the sin of his mother be blotted out. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Let them be before Yahweh continually, 
-</p><p class="q2">that he may cut off their memory from the earth; 
-</p><p class="q1">
-<span class="v">16&#160;</span>because he didn’t remember to show kindness, 
-</p><p class="q2">but persecuted the poor and needy man, 
-</p><p class="q2">the broken in heart, to kill them. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Yes, he loved cursing, and it came to him. 
-</p><p class="q2">He didn’t delight in blessing, and it was far from him. 
-</p><p class="q1">
-<span class="v">18&#160;</span>He clothed himself also with cursing as with his garment. 
-</p><p class="q2">It came into his inward parts like water, 
-</p><p class="q2">like oil into his bones. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Let it be to him as the clothing with which he covers himself, 
-</p><p class="q2">for the belt that is always around him. 
-</p><p class="q1">
-<span class="v">20&#160;</span>This is the reward of my adversaries from Yahweh, 
-</p><p class="q2">of those who speak evil against my soul. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">21&#160;</span>But deal with me, Yahweh the Lord,<span class="f">+ \fr 109:21 \ft The word translated “Lord” is “Adonai.”</span> for your name’s sake, 
-</p><p class="q2">because your loving kindness is good, deliver me; 
-</p><p class="q2">
-<span class="v">22&#160;</span>for I am poor and needy. 
-</p><p class="q2">My heart is wounded within me. 
-</p><p class="q1">
-<span class="v">23&#160;</span>I fade away like an evening shadow. 
-</p><p class="q2">I am shaken off like a locust. 
-</p><p class="q1">
-<span class="v">24&#160;</span>My knees are weak through fasting. 
-</p><p class="q2">My body is thin and lacks fat. 
-</p><p class="q1">
-<span class="v">25&#160;</span>I have also become a reproach to them. 
-</p><p class="q2">When they see me, they shake their head. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Help me, Yahweh, my Elohim. 
-</p><p class="q2">Save me according to your loving kindness; 
-</p><p class="q1">
-<span class="v">27&#160;</span>that they may know that this is your hand; 
-</p><p class="q2">that you, Yahweh, have done it. 
-</p><p class="q1">
-<span class="v">28&#160;</span>They may curse, but you bless. 
-</p><p class="q2">When they arise, they will be shamed, 
-</p><p class="q2">but your servant shall rejoice. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Let my adversaries be clothed with dishonor. 
-</p><p class="q2">Let them cover themselves with their own shame as with a robe. 
-</p><p class="q1">
-<span class="v">30&#160;</span>I will give great thanks to Yahweh with my mouth. 
-</p><p class="q2">Yes, I will praise him among the multitude. 
-</p><p class="q1">
-<span class="v">31&#160;</span>For he will stand at the right hand of the needy, 
-</p><p class="q2">to save him from those who judge his soul. 
-</p><h2 class="psalmlabel" id="110">110</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh says to my Lord, “Sit at my right hand, 
-</p><p class="q2">until I make your enemies your footstool for your feet.” 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh will send out the rod of your strength out of Zion. 
-</p><p class="q2">Rule among your enemies. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Your people offer themselves willingly in the day of your power, in set-apart array. 
-</p><p class="q2">Out of the womb of the morning, you have the dew of your youth. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh has sworn, and will not change his mind: 
-</p><p class="q2">“You are a priest forever in the order of Melchizedek.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>The Lord is at your right hand. 
-</p><p class="q2">He will crush kings in the day of his wrath. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He will judge among the nations. 
-</p><p class="q2">He will heap up dead bodies. 
-</p><p class="q2">He will crush the ruler of the whole earth. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He will drink of the brook on the way; 
-</p><p class="q2">therefore he will lift up his head. 
-</p><h2 class="psalmlabel" id="111">111</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah!<span class="f">+ \fr 111:1 \ft Psalm 111 is an acrostic poem, with each verse after the initial “Praise Yah!” starting with a letter of the alphabet (ordered from Alef to Tav).</span> 
-</p><p class="q2">I will give thanks to Yahweh with my whole heart, 
-</p><p class="q2">in the council of the upright, and in the congregation. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh’s works are great, 
-</p><p class="q2">pondered by all those who delight in them. 
-</p><p class="q1">
-<span class="v">3&#160;</span>His work is honor and majesty. 
-</p><p class="q2">His righteousness endures forever. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He has caused his wonderful works to be remembered. 
-</p><p class="q2">Yahweh is gracious and merciful. 
-</p><p class="q1">
-<span class="v">5&#160;</span>He has given food to those who fear him. 
-</p><p class="q2">He always remembers his covenant. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He has shown his people the power of his works, 
-</p><p class="q2">in giving them the heritage of the nations. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The works of his hands are truth and justice. 
-</p><p class="q2">All his precepts are sure. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They are established forever and ever. 
-</p><p class="q2">They are done in truth and uprightness. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He has sent redemption to his people. 
-</p><p class="q2">He has ordained his covenant forever. 
-</p><p class="q2">His name is set-apart and awesome! 
-</p><p class="q1">
-<span class="v">10&#160;</span>The fear of Yahweh is the beginning of wisdom. 
-</p><p class="q2">All those who do his work have a good understanding. 
-</p><p class="q1">His praise endures forever! 
-</p><h2 class="psalmlabel" id="112">112</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah!<span class="f">+ \fr 112:1 \ft Psalm 112 is an acrostic poem, with each verse after the initial “Praise Yah!” starting with a letter of the alphabet (ordered from Alef to Tav).</span> 
-</p><p class="q2">Blessed is the man who fears Yahweh, 
-</p><p class="q2">who delights greatly in his commandments. 
-</p><p class="q1">
-<span class="v">2&#160;</span>His offspring will be mighty in the land. 
-</p><p class="q2">The generation of the upright will be blessed. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Wealth and riches are in his house. 
-</p><p class="q2">His righteousness endures forever. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Light dawns in the darkness for the upright, 
-</p><p class="q2">gracious, merciful, and righteous. 
-</p><p class="q1">
-<span class="v">5&#160;</span>It is well with the man who deals graciously and lends. 
-</p><p class="q2">He will maintain his cause in judgment. 
-</p><p class="q1">
-<span class="v">6&#160;</span>For he will never be shaken. 
-</p><p class="q2">The righteous will be remembered forever. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He will not be afraid of evil news. 
-</p><p class="q2">His heart is steadfast, trusting in Yahweh. 
-</p><p class="q1">
-<span class="v">8&#160;</span>His heart is established. 
-</p><p class="q2">He will not be afraid in the end when he sees his adversaries. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He has dispersed, he has given to the poor. 
-</p><p class="q2">His righteousness endures forever. 
-</p><p class="q2">His horn will be exalted with honor. 
-</p><p class="q1">
-<span class="v">10&#160;</span>The wicked will see it, and be grieved. 
-</p><p class="q2">He shall gnash with his teeth, and melt away. 
-</p><p class="q2">The desire of the wicked will perish. 
-</p><h2 class="psalmlabel" id="113">113</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah! 
-</p><p class="q2">Praise, you servants of Yahweh, 
-</p><p class="q2">praise Yahweh’s name. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Blessed be Yahweh’s name, 
-</p><p class="q2">from this time forward and forever more. 
-</p><p class="q1">
-<span class="v">3&#160;</span>From the rising of the sun to its going down, 
-</p><p class="q2">Yahweh’s name is to be praised. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh is high above all nations, 
-</p><p class="q2">his glory above the heavens. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Who is like Yahweh, our Elohim, 
-</p><p class="q2">who has his seat on high, 
-</p><p class="q2">
-<span class="v">6&#160;</span>who stoops down to see in heaven and in the earth? 
-</p><p class="q1">
-<span class="v">7&#160;</span>He raises up the poor out of the dust, 
-</p><p class="q2">and lifts up the needy from the ash heap, 
-</p><p class="q1">
-<span class="v">8&#160;</span>that he may set him with princes, 
-</p><p class="q2">even with the princes of his people. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He settles the barren woman in her home 
-</p><p class="q2">as a joyful mother of children. 
-</p><p class="q1">Praise Yah! 
-</p><h2 class="psalmlabel" id="114">114</h2>
-<p class="q1">
-<span class="v">1&#160;</span>When Israel went out of Egypt, 
-</p><p class="q2">the house of Jacob from a people of foreign language, 
-</p><p class="q1">
-<span class="v">2&#160;</span>Judah became his sanctuary, 
-</p><p class="q2">Israel his dominion. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The sea saw it, and fled. 
-</p><p class="q2">The Jordan was driven back. 
-</p><p class="q1">
-<span class="v">4&#160;</span>The mountains skipped like rams, 
-</p><p class="q2">the little hills like lambs. 
-</p><p class="q1">
-<span class="v">5&#160;</span>What was it, you sea, that you fled? 
-</p><p class="q2">You Jordan, that you turned back? 
-</p><p class="q1">
-<span class="v">6&#160;</span>You mountains, that you skipped like rams? 
-</p><p class="q2">You little hills, like lambs? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Tremble, you earth, at the presence of the Lord, 
-</p><p class="q2">at the presence of the Elohim of Jacob, 
-</p><p class="q1">
-<span class="v">8&#160;</span>who turned the rock into a pool of water, 
-</p><p class="q2">the flint into a spring of waters. 
-</p><h2 class="psalmlabel" id="115">115</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Not to us, Yahweh, not to us, 
-</p><p class="q2">but to your name give glory, 
-</p><p class="q2">for your loving kindness, and for your truth’s sake. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Why should the nations say, 
-</p><p class="q2">“Where is their Elohim, now?” 
-</p><p class="q1">
-<span class="v">3&#160;</span>But our Elohim is in the heavens. 
-</p><p class="q2">He does whatever he pleases. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Their idols are silver and gold, 
-</p><p class="q2">the work of men’s hands. 
-</p><p class="q1">
-<span class="v">5&#160;</span>They have mouths, but they don’t speak. 
-</p><p class="q2">They have eyes, but they don’t see. 
-</p><p class="q1">
-<span class="v">6&#160;</span>They have ears, but they don’t hear. 
-</p><p class="q2">They have noses, but they don’t smell. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They have hands, but they don’t feel. 
-</p><p class="q2">They have feet, but they don’t walk, 
-</p><p class="q2">neither do they speak through their throat. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Those who make them will be like them; 
-</p><p class="q2">yes, everyone who trusts in them. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Israel, trust in Yahweh! 
-</p><p class="q2">He is their help and their shield. 
-</p><p class="q1">
-<span class="v">10&#160;</span>House of Aaron, trust in Yahweh! 
-</p><p class="q2">He is their help and their shield. 
-</p><p class="q1">
-<span class="v">11&#160;</span>You who fear Yahweh, trust in Yahweh! 
-</p><p class="q2">He is their help and their shield. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Yahweh remembers us. He will bless us. 
-</p><p class="q2">He will bless the house of Israel. 
-</p><p class="q2">He will bless the house of Aaron. 
-</p><p class="q1">
-<span class="v">13&#160;</span>He will bless those who fear Yahweh, 
-</p><p class="q2">both small and great. 
-</p><p class="q1">
-<span class="v">14&#160;</span>May Yahweh increase you more and more, 
-</p><p class="q2">you and your children. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Blessed are you by Yahweh, 
-</p><p class="q2">who made heaven and earth. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The heavens are Yahweh’s heavens, 
-</p><p class="q2">but he has given the earth to the children of men. 
-</p><p class="q1">
-<span class="v">17&#160;</span>The dead don’t praise Yah, 
-</p><p class="q2">nor any who go down into silence, 
-</p><p class="q1">
-<span class="v">18&#160;</span>but we will bless Yah, 
-</p><p class="q2">from this time forward and forever more. 
-</p><p class="q1">Praise Yah! 
-</p><h2 class="psalmlabel" id="116">116</h2>
-<p class="q1">
-<span class="v">1&#160;</span>I love Yahweh, because he listens to my voice, 
-</p><p class="q2">and my cries for mercy. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Because he has turned his ear to me, 
-</p><p class="q2">therefore I will call on him as long as I live. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The cords of death surrounded me, 
-</p><p class="q2">the pains of Sheol<span class="f">+ \fr 116:3 \ft Sheol is the place of the dead.</span> got a hold of me. 
-</p><p class="q2">I found trouble and sorrow. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Then I called on Yahweh’s name: 
-</p><p class="q2">“Yahweh, I beg you, deliver my soul.” 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh is gracious and righteous. 
-</p><p class="q2">Yes, our Elohim is merciful. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh preserves the simple. 
-</p><p class="q2">I was brought low, and he saved me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Return to your rest, my soul, 
-</p><p class="q2">for Yahweh has dealt bountifully with you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For you have delivered my soul from death, 
-</p><p class="q2">my eyes from tears, 
-</p><p class="q2">and my feet from falling. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will walk before Yahweh in the land of the living. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I believed, therefore I said, 
-</p><p class="q2">“I was greatly afflicted.” 
-</p><p class="q1">
-<span class="v">11&#160;</span>I said in my haste, 
-</p><p class="q2">“All people are liars.” 
-</p><p class="q1">
-<span class="v">12&#160;</span>What will I give to Yahweh for all his benefits toward me? 
-</p><p class="q2">
-<span class="v">13&#160;</span>I will take the cup of salvation, and call on Yahweh’s name. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will pay my vows to Yahweh, 
-</p><p class="q2">yes, in the presence of all his people. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Precious in Yahweh’s sight is the death of his saints. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Yahweh, truly I am your servant. 
-</p><p class="q2">I am your servant, the son of your servant girl. 
-</p><p class="q2">You have freed me from my chains. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will offer to you the sacrifice of thanksgiving, 
-</p><p class="q2">and will call on Yahweh’s name. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I will pay my vows to Yahweh, 
-</p><p class="q2">yes, in the presence of all his people, 
-</p><p class="q1">
-<span class="v">19&#160;</span>in the courts of Yahweh’s house, 
-</p><p class="q2">in the middle of you, Jerusalem. 
-</p><p class="q1">Praise Yah! 
-</p><h2 class="psalmlabel" id="117">117</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yahweh, all you nations! 
-</p><p class="q2">Extol him, all you peoples! 
-</p><p class="q1">
-<span class="v">2&#160;</span>For his loving kindness is great toward us. 
-</p><p class="q2">Yahweh’s faithfulness endures forever. 
-</p><p class="q1">Praise Yah! 
-</p><h2 class="psalmlabel" id="118">118</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Give thanks to Yahweh, for he is good, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let Israel now say 
-</p><p class="q2">that his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Let the house of Aaron now say 
-</p><p class="q2">that his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Now let those who fear Yahweh say 
-</p><p class="q2">that his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Out of my distress, I called on Yah. 
-</p><p class="q2">Yah answered me with freedom. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh is on my side. I will not be afraid. 
-</p><p class="q2">What can man do to me? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh is on my side among those who help me. 
-</p><p class="q2">Therefore I will look in triumph at those who hate me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>It is better to take refuge in Yahweh, 
-</p><p class="q2">than to put confidence in man. 
-</p><p class="q1">
-<span class="v">9&#160;</span>It is better to take refuge in Yahweh, 
-</p><p class="q2">than to put confidence in princes. 
-</p><p class="q1">
-<span class="v">10&#160;</span>All the nations surrounded me, 
-</p><p class="q2">but in Yahweh’s name I cut them off. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They surrounded me, yes, they surrounded me. 
-</p><p class="q2">In Yahweh’s name I indeed cut them off. 
-</p><p class="q1">
-<span class="v">12&#160;</span>They surrounded me like bees. 
-</p><p class="q2">They are quenched like the burning thorns. 
-</p><p class="q2">In Yahweh’s name I cut them off. 
-</p><p class="q1">
-<span class="v">13&#160;</span>You pushed me back hard, to make me fall, 
-</p><p class="q2">but Yahweh helped me. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yah is my strength and song. 
-</p><p class="q2">He has become my salvation. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The voice of rejoicing and salvation is in the tents of the righteous. 
-</p><p class="q2">“The right hand of Yahweh does valiantly. 
-</p><p class="q1">
-<span class="v">16&#160;</span>The right hand of Yahweh is exalted! 
-</p><p class="q2">The right hand of Yahweh does valiantly!” 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will not die, but live, 
-</p><p class="q2">and declare Yah’s works. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yah has punished me severely, 
-</p><p class="q2">but he has not given me over to death. 
-</p><p class="q1">
-<span class="v">19&#160;</span>Open to me the gates of righteousness. 
-</p><p class="q2">I will enter into them. 
-</p><p class="q2">I will give thanks to Yah. 
-</p><p class="q1">
-<span class="v">20&#160;</span>This is the gate of Yahweh; 
-</p><p class="q2">the righteous will enter into it. 
-</p><p class="q1">
-<span class="v">21&#160;</span>I will give thanks to you, for you have answered me, 
-</p><p class="q2">and have become my salvation. 
-</p><p class="q1">
-<span class="v">22&#160;</span>The stone which the builders rejected 
-</p><p class="q2">has become the cornerstone.<span class="f">+ \fr 118:22 \ft Literally, \fqa head of the corner</span> 
-</p><p class="q1">
-<span class="v">23&#160;</span>This is Yahweh’s doing. 
-</p><p class="q2">It is marvelous in our eyes. 
-</p><p class="q1">
-<span class="v">24&#160;</span>This is the day that Yahweh has made. 
-</p><p class="q2">We will rejoice and be glad in it! 
-</p><p class="q1">
-<span class="v">25&#160;</span>Save us now, we beg you, Yahweh! 
-</p><p class="q2">Yahweh, we beg you, send prosperity now. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Blessed is he who comes in Yahweh’s name! 
-</p><p class="q2">We have blessed you out of Yahweh’s house. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Yahweh is Elohim, and he has given us light. 
-</p><p class="q2">Bind the sacrifice with cords, even to the horns of the altar. 
-</p><p class="q1">
-<span class="v">28&#160;</span>You are my Elohim, and I will give thanks to you. 
-</p><p class="q2">You are my Elohim, I will exalt you. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Oh give thanks to Yahweh, for he is good, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><h2 class="psalmlabel" id="119">119</h2>
-<p class="d">ALEPH 
-</p><p class="q1">
-<span class="v">1&#160;</span>Blessed are those whose ways are blameless, 
-</p><p class="q2">who walk according to Yahweh’s law. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Blessed are those who keep his statutes, 
-</p><p class="q2">who seek him with their whole heart. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yes, they do nothing wrong. 
-</p><p class="q2">They walk in his ways. 
-</p><p class="q1">
-<span class="v">4&#160;</span>You have commanded your precepts, 
-</p><p class="q2">that we should fully obey them. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Oh that my ways were steadfast 
-</p><p class="q2">to obey your statutes! 
-</p><p class="q1">
-<span class="v">6&#160;</span>Then I wouldn’t be disappointed, 
-</p><p class="q2">when I consider all of your commandments. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I will give thanks to you with uprightness of heart, 
-</p><p class="q2">when I learn your righteous judgments. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will observe your statutes. 
-</p><p class="q2">Don’t utterly forsake me. 
-</p><p class="d">BETH 
-</p><p class="q1">
-<span class="v">9&#160;</span>How can a young man keep his way pure? 
-</p><p class="q2">By living according to your word. 
-</p><p class="q1">
-<span class="v">10&#160;</span>With my whole heart I have sought you. 
-</p><p class="q2">Don’t let me wander from your commandments. 
-</p><p class="q1">
-<span class="v">11&#160;</span>I have hidden your word in my heart, 
-</p><p class="q2">that I might not sin against you. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Blessed are you, Yahweh. 
-</p><p class="q2">Teach me your statutes. 
-</p><p class="q1">
-<span class="v">13&#160;</span>With my lips, 
-</p><p class="q2">I have declared all the ordinances of your mouth. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I have rejoiced in the way of your testimonies, 
-</p><p class="q2">as much as in all riches. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will meditate on your precepts, 
-</p><p class="q2">and consider your ways. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will delight myself in your statutes. 
-</p><p class="q2">I will not forget your word. 
-</p><p class="d">GIMEL 
-</p><p class="q1">
-<span class="v">17&#160;</span>Do good to your servant. 
-</p><p class="q2">I will live and I will obey your word. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Open my eyes, 
-</p><p class="q2">that I may see wondrous things out of your law. 
-</p><p class="q1">
-<span class="v">19&#160;</span>I am a stranger on the earth. 
-</p><p class="q2">Don’t hide your commandments from me. 
-</p><p class="q1">
-<span class="v">20&#160;</span>My soul is consumed with longing for your ordinances at all times. 
-</p><p class="q1">
-<span class="v">21&#160;</span>You have rebuked the proud who are cursed, 
-</p><p class="q2">who wander from your commandments. 
-</p><p class="q1">
-<span class="v">22&#160;</span>Take reproach and contempt away from me, 
-</p><p class="q2">for I have kept your statutes. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Though princes sit and slander me, 
-</p><p class="q2">your servant will meditate on your statutes. 
-</p><p class="q1">
-<span class="v">24&#160;</span>Indeed your statutes are my delight, 
-</p><p class="q2">and my counselors. 
-</p><p class="d">DALETH 
-</p><p class="q1">
-<span class="v">25&#160;</span>My soul is laid low in the dust. 
-</p><p class="q2">Revive me according to your word! 
-</p><p class="q1">
-<span class="v">26&#160;</span>I declared my ways, and you answered me. 
-</p><p class="q2">Teach me your statutes. 
-</p><p class="q1">
-<span class="v">27&#160;</span>Let me understand the teaching of your precepts! 
-</p><p class="q2">Then I will meditate on your wondrous works. 
-</p><p class="q1">
-<span class="v">28&#160;</span>My soul is weary with sorrow; 
-</p><p class="q2">strengthen me according to your word. 
-</p><p class="q1">
-<span class="v">29&#160;</span>Keep me from the way of deceit. 
-</p><p class="q2">Grant me your law graciously! 
-</p><p class="q1">
-<span class="v">30&#160;</span>I have chosen the way of truth. 
-</p><p class="q2">I have set your ordinances before me. 
-</p><p class="q1">
-<span class="v">31&#160;</span>I cling to your statutes, Yahweh. 
-</p><p class="q2">Don’t let me be disappointed. 
-</p><p class="q1">
-<span class="v">32&#160;</span>I run in the path of your commandments, 
-</p><p class="q2">for you have set my heart free. 
-</p><p class="d">HE 
-</p><p class="q1">
-<span class="v">33&#160;</span>Teach me, Yahweh, the way of your statutes. 
-</p><p class="q2">I will keep them to the end. 
-</p><p class="q1">
-<span class="v">34&#160;</span>Give me understanding, and I will keep your law. 
-</p><p class="q2">Yes, I will obey it with my whole heart. 
-</p><p class="q1">
-<span class="v">35&#160;</span>Direct me in the path of your commandments, 
-</p><p class="q2">for I delight in them. 
-</p><p class="q1">
-<span class="v">36&#160;</span>Turn my heart toward your statutes, 
-</p><p class="q2">not toward selfish gain. 
-</p><p class="q1">
-<span class="v">37&#160;</span>Turn my eyes away from looking at worthless things. 
-</p><p class="q2">Revive me in your ways. 
-</p><p class="q1">
-<span class="v">38&#160;</span>Fulfill your promise to your servant, 
-</p><p class="q2">that you may be feared. 
-</p><p class="q1">
-<span class="v">39&#160;</span>Take away my disgrace that I dread, 
-</p><p class="q2">for your ordinances are good. 
-</p><p class="q1">
-<span class="v">40&#160;</span>Behold, I long for your precepts! 
-</p><p class="q2">Revive me in your righteousness. 
-</p><p class="d">VAV 
-</p><p class="q1">
-<span class="v">41&#160;</span>Let your loving kindness also come to me, Yahweh, 
-</p><p class="q2">your salvation, according to your word. 
-</p><p class="q1">
-<span class="v">42&#160;</span>So I will have an answer for him who reproaches me, 
-</p><p class="q2">for I trust in your word. 
-</p><p class="q1">
-<span class="v">43&#160;</span>Don’t snatch the word of truth out of my mouth, 
-</p><p class="q2">for I put my hope in your ordinances. 
-</p><p class="q1">
-<span class="v">44&#160;</span>So I will obey your law continually, 
-</p><p class="q2">forever and ever. 
-</p><p class="q1">
-<span class="v">45&#160;</span>I will walk in liberty, 
-</p><p class="q2">for I have sought your precepts. 
-</p><p class="q1">
-<span class="v">46&#160;</span>I will also speak of your statutes before kings, 
-</p><p class="q2">and will not be disappointed. 
-</p><p class="q1">
-<span class="v">47&#160;</span>I will delight myself in your commandments, 
-</p><p class="q2">because I love them. 
-</p><p class="q1">
-<span class="v">48&#160;</span>I reach out my hands for your commandments, which I love. 
-</p><p class="q2">I will meditate on your statutes. 
-</p><p class="d">ZAYIN 
-</p><p class="q1">
-<span class="v">49&#160;</span>Remember your word to your servant, 
-</p><p class="q2">because you gave me hope. 
-</p><p class="q1">
-<span class="v">50&#160;</span>This is my comfort in my affliction, 
-</p><p class="q2">for your word has revived me. 
-</p><p class="q1">
-<span class="v">51&#160;</span>The arrogant mock me excessively, 
-</p><p class="q2">but I don’t swerve from your law. 
-</p><p class="q1">
-<span class="v">52&#160;</span>I remember your ordinances of old, Yahweh, 
-</p><p class="q2">and have comforted myself. 
-</p><p class="q1">
-<span class="v">53&#160;</span>Indignation has taken hold on me, 
-</p><p class="q2">because of the wicked who forsake your law. 
-</p><p class="q1">
-<span class="v">54&#160;</span>Your statutes have been my songs 
-</p><p class="q2">in the house where I live. 
-</p><p class="q1">
-<span class="v">55&#160;</span>I have remembered your name, Yahweh, in the night, 
-</p><p class="q2">and I obey your law. 
-</p><p class="q1">
-<span class="v">56&#160;</span>This is my way, 
-</p><p class="q2">that I keep your precepts. 
-</p><p class="d">HETH 
-</p><p class="q1">
-<span class="v">57&#160;</span>Yahweh is my portion. 
-</p><p class="q2">I promised to obey your words. 
-</p><p class="q1">
-<span class="v">58&#160;</span>I sought your favor with my whole heart. 
-</p><p class="q2">Be merciful to me according to your word. 
-</p><p class="q1">
-<span class="v">59&#160;</span>I considered my ways, 
-</p><p class="q2">and turned my steps to your statutes. 
-</p><p class="q1">
-<span class="v">60&#160;</span>I will hurry, and not delay, 
-</p><p class="q2">to obey your commandments. 
-</p><p class="q1">
-<span class="v">61&#160;</span>The ropes of the wicked bind me, 
-</p><p class="q2">but I won’t forget your law. 
-</p><p class="q1">
-<span class="v">62&#160;</span>At midnight I will rise to give thanks to you, 
-</p><p class="q2">because of your righteous ordinances. 
-</p><p class="q1">
-<span class="v">63&#160;</span>I am a friend of all those who fear you, 
-</p><p class="q2">of those who observe your precepts. 
-</p><p class="q1">
-<span class="v">64&#160;</span>The earth is full of your loving kindness, Yahweh. 
-</p><p class="q2">Teach me your statutes. 
-</p><p class="d">TETH 
-</p><p class="q1">
-<span class="v">65&#160;</span>You have treated your servant well, 
-</p><p class="q2">according to your word, Yahweh. 
-</p><p class="q1">
-<span class="v">66&#160;</span>Teach me good judgment and knowledge, 
-</p><p class="q2">for I believe in your commandments. 
-</p><p class="q1">
-<span class="v">67&#160;</span>Before I was afflicted, I went astray; 
-</p><p class="q2">but now I observe your word. 
-</p><p class="q1">
-<span class="v">68&#160;</span>You are good, and do good. 
-</p><p class="q2">Teach me your statutes. 
-</p><p class="q1">
-<span class="v">69&#160;</span>The proud have smeared a lie upon me. 
-</p><p class="q2">With my whole heart, I will keep your precepts. 
-</p><p class="q1">
-<span class="v">70&#160;</span>Their heart is as callous as the fat, 
-</p><p class="q2">but I delight in your law. 
-</p><p class="q1">
-<span class="v">71&#160;</span>It is good for me that I have been afflicted, 
-</p><p class="q2">that I may learn your statutes. 
-</p><p class="q1">
-<span class="v">72&#160;</span>The law of your mouth is better to me than thousands of pieces of gold and silver. 
-</p><p class="d">YODH 
-</p><p class="q1">
-<span class="v">73&#160;</span>Your hands have made me and formed me. 
-</p><p class="q2">Give me understanding, that I may learn your commandments. 
-</p><p class="q1">
-<span class="v">74&#160;</span>Those who fear you will see me and be glad, 
-</p><p class="q2">because I have put my hope in your word. 
-</p><p class="q1">
-<span class="v">75&#160;</span>Yahweh, I know that your judgments are righteous, 
-</p><p class="q2">that in faithfulness you have afflicted me. 
-</p><p class="q1">
-<span class="v">76&#160;</span>Please let your loving kindness be for my comfort, 
-</p><p class="q2">according to your word to your servant. 
-</p><p class="q1">
-<span class="v">77&#160;</span>Let your tender mercies come to me, that I may live; 
-</p><p class="q2">for your law is my delight. 
-</p><p class="q1">
-<span class="v">78&#160;</span>Let the proud be disappointed, for they have overthrown me wrongfully. 
-</p><p class="q2">I will meditate on your precepts. 
-</p><p class="q1">
-<span class="v">79&#160;</span>Let those who fear you turn to me. 
-</p><p class="q2">They will know your statutes. 
-</p><p class="q1">
-<span class="v">80&#160;</span>Let my heart be blameless toward your decrees, 
-</p><p class="q2">that I may not be disappointed. 
-</p><p class="d">KAPF 
-</p><p class="q1">
-<span class="v">81&#160;</span>My soul faints for your salvation. 
-</p><p class="q2">I hope in your word. 
-</p><p class="q1">
-<span class="v">82&#160;</span>My eyes fail for your word. 
-</p><p class="q2">I say, “When will you comfort me?” 
-</p><p class="q1">
-<span class="v">83&#160;</span>For I have become like a wineskin in the smoke. 
-</p><p class="q2">I don’t forget your statutes. 
-</p><p class="q1">
-<span class="v">84&#160;</span>How many are the days of your servant? 
-</p><p class="q2">When will you execute judgment on those who persecute me? 
-</p><p class="q1">
-<span class="v">85&#160;</span>The proud have dug pits for me, 
-</p><p class="q2">contrary to your law. 
-</p><p class="q1">
-<span class="v">86&#160;</span>All of your commandments are faithful. 
-</p><p class="q2">They persecute me wrongfully. 
-</p><p class="q2">Help me! 
-</p><p class="q1">
-<span class="v">87&#160;</span>They had almost wiped me from the earth, 
-</p><p class="q2">but I didn’t forsake your precepts. 
-</p><p class="q1">
-<span class="v">88&#160;</span>Preserve my life according to your loving kindness, 
-</p><p class="q2">so I will obey the statutes of your mouth. 
-</p><p class="d">LAMEDH 
-</p><p class="q1">
-<span class="v">89&#160;</span>Yahweh, your word is settled in heaven forever. 
-</p><p class="q1">
-<span class="v">90&#160;</span>Your faithfulness is to all generations. 
-</p><p class="q2">You have established the earth, and it remains. 
-</p><p class="q1">
-<span class="v">91&#160;</span>Your laws remain to this day, 
-</p><p class="q2">for all things serve you. 
-</p><p class="q1">
-<span class="v">92&#160;</span>Unless your law had been my delight, 
-</p><p class="q2">I would have perished in my affliction. 
-</p><p class="q1">
-<span class="v">93&#160;</span>I will never forget your precepts, 
-</p><p class="q2">for with them, you have revived me. 
-</p><p class="q1">
-<span class="v">94&#160;</span>I am yours. 
-</p><p class="q2">Save me, for I have sought your precepts. 
-</p><p class="q1">
-<span class="v">95&#160;</span>The wicked have waited for me, to destroy me. 
-</p><p class="q2">I will consider your statutes. 
-</p><p class="q1">
-<span class="v">96&#160;</span>I have seen a limit to all perfection, 
-</p><p class="q2">but your commands are boundless. 
-</p><p class="d">MEM 
-</p><p class="q1">
-<span class="v">97&#160;</span>How I love your law! 
-</p><p class="q2">It is my meditation all day. 
-</p><p class="q1">
-<span class="v">98&#160;</span>Your commandments make me wiser than my enemies, 
-</p><p class="q2">for your commandments are always with me. 
-</p><p class="q1">
-<span class="v">99&#160;</span>I have more understanding than all my teachers, 
-</p><p class="q2">for your testimonies are my meditation. 
-</p><p class="q1">
-<span class="v">100&#160;</span>I understand more than the aged, 
-</p><p class="q2">because I have kept your precepts. 
-</p><p class="q1">
-<span class="v">101&#160;</span>I have kept my feet from every evil way, 
-</p><p class="q2">that I might observe your word. 
-</p><p class="q1">
-<span class="v">102&#160;</span>I have not turned away from your ordinances, 
-</p><p class="q2">for you have taught me. 
-</p><p class="q1">
-<span class="v">103&#160;</span>How sweet are your promises to my taste, 
-</p><p class="q2">more than honey to my mouth! 
-</p><p class="q1">
-<span class="v">104&#160;</span>Through your precepts, I get understanding; 
-</p><p class="q2">therefore I hate every false way. 
-</p><p class="d">NUN 
-</p><p class="q1">
-<span class="v">105&#160;</span>Your word is a lamp to my feet, 
-</p><p class="q2">and a light for my path. 
-</p><p class="q1">
-<span class="v">106&#160;</span>I have sworn, and have confirmed it, 
-</p><p class="q2">that I will obey your righteous ordinances. 
-</p><p class="q1">
-<span class="v">107&#160;</span>I am afflicted very much. 
-</p><p class="q2">Revive me, Yahweh, according to your word. 
-</p><p class="q1">
-<span class="v">108&#160;</span>Accept, I beg you, the willing offerings of my mouth. 
-</p><p class="q2">Yahweh, teach me your ordinances. 
-</p><p class="q1">
-<span class="v">109&#160;</span>My soul is continually in my hand, 
-</p><p class="q2">yet I won’t forget your law. 
-</p><p class="q1">
-<span class="v">110&#160;</span>The wicked have laid a snare for me, 
-</p><p class="q2">yet I haven’t gone astray from your precepts. 
-</p><p class="q1">
-<span class="v">111&#160;</span>I have taken your testimonies as a heritage forever, 
-</p><p class="q2">for they are the joy of my heart. 
-</p><p class="q1">
-<span class="v">112&#160;</span>I have set my heart to perform your statutes forever, 
-</p><p class="q2">even to the end. 
-</p><p class="d">SAMEKH 
-</p><p class="q1">
-<span class="v">113&#160;</span>I hate double-minded men, 
-</p><p class="q2">but I love your law. 
-</p><p class="q1">
-<span class="v">114&#160;</span>You are my hiding place and my shield. 
-</p><p class="q2">I hope in your word. 
-</p><p class="q1">
-<span class="v">115&#160;</span>Depart from me, you evildoers, 
-</p><p class="q2">that I may keep the commandments of my Elohim. 
-</p><p class="q1">
-<span class="v">116&#160;</span>Uphold me according to your word, that I may live. 
-</p><p class="q2">Let me not be ashamed of my hope. 
-</p><p class="q1">
-<span class="v">117&#160;</span>Hold me up, and I will be safe, 
-</p><p class="q2">and will have respect for your statutes continually. 
-</p><p class="q1">
-<span class="v">118&#160;</span>You reject all those who stray from your statutes, 
-</p><p class="q2">for their deceit is in vain. 
-</p><p class="q1">
-<span class="v">119&#160;</span>You put away all the wicked of the earth like dross. 
-</p><p class="q2">Therefore I love your testimonies. 
-</p><p class="q1">
-<span class="v">120&#160;</span>My flesh trembles for fear of you. 
-</p><p class="q2">I am afraid of your judgments. 
-</p><p class="d">AYIN 
-</p><p class="q1">
-<span class="v">121&#160;</span>I have done what is just and righteous. 
-</p><p class="q2">Don’t leave me to my oppressors. 
-</p><p class="q1">
-<span class="v">122&#160;</span>Ensure your servant’s well-being. 
-</p><p class="q2">Don’t let the proud oppress me. 
-</p><p class="q1">
-<span class="v">123&#160;</span>My eyes fail looking for your salvation, 
-</p><p class="q2">for your righteous word. 
-</p><p class="q1">
-<span class="v">124&#160;</span>Deal with your servant according to your loving kindness. 
-</p><p class="q2">Teach me your statutes. 
-</p><p class="q1">
-<span class="v">125&#160;</span>I am your servant. Give me understanding, 
-</p><p class="q2">that I may know your testimonies. 
-</p><p class="q1">
-<span class="v">126&#160;</span>It is time to act, Yahweh, 
-</p><p class="q2">for they break your law. 
-</p><p class="q1">
-<span class="v">127&#160;</span>Therefore I love your commandments more than gold, 
-</p><p class="q2">yes, more than pure gold. 
-</p><p class="q1">
-<span class="v">128&#160;</span>Therefore I consider all of your precepts to be right. 
-</p><p class="q2">I hate every false way. 
-</p><p class="d">PE 
-</p><p class="q1">
-<span class="v">129&#160;</span>Your testimonies are wonderful, 
-</p><p class="q2">therefore my soul keeps them. 
-</p><p class="q1">
-<span class="v">130&#160;</span>The entrance of your words gives light. 
-</p><p class="q2">It gives understanding to the simple. 
-</p><p class="q1">
-<span class="v">131&#160;</span>I opened my mouth wide and panted, 
-</p><p class="q2">for I longed for your commandments. 
-</p><p class="q1">
-<span class="v">132&#160;</span>Turn to me, and have mercy on me, 
-</p><p class="q2">as you always do to those who love your name. 
-</p><p class="q1">
-<span class="v">133&#160;</span>Establish my footsteps in your word. 
-</p><p class="q2">Don’t let any iniquity have dominion over me. 
-</p><p class="q1">
-<span class="v">134&#160;</span>Redeem me from the oppression of man, 
-</p><p class="q2">so I will observe your precepts. 
-</p><p class="q1">
-<span class="v">135&#160;</span>Make your face shine on your servant. 
-</p><p class="q2">Teach me your statutes. 
-</p><p class="q1">
-<span class="v">136&#160;</span>Streams of tears run down my eyes, 
-</p><p class="q2">because they don’t observe your law. 
-</p><p class="d">TZADHE 
-</p><p class="q1">
-<span class="v">137&#160;</span>You are righteous, Yahweh. 
-</p><p class="q2">Your judgments are upright. 
-</p><p class="q1">
-<span class="v">138&#160;</span>You have commanded your statutes in righteousness. 
-</p><p class="q2">They are fully trustworthy. 
-</p><p class="q1">
-<span class="v">139&#160;</span>My zeal wears me out, 
-</p><p class="q2">because my enemies ignore your words. 
-</p><p class="q1">
-<span class="v">140&#160;</span>Your promises have been thoroughly tested, 
-</p><p class="q2">and your servant loves them. 
-</p><p class="q1">
-<span class="v">141&#160;</span>I am small and despised. 
-</p><p class="q2">I don’t forget your precepts. 
-</p><p class="q1">
-<span class="v">142&#160;</span>Your righteousness is an everlasting righteousness. 
-</p><p class="q2">Your law is truth. 
-</p><p class="q1">
-<span class="v">143&#160;</span>Trouble and anguish have taken hold of me. 
-</p><p class="q2">Your commandments are my delight. 
-</p><p class="q1">
-<span class="v">144&#160;</span>Your testimonies are righteous forever. 
-</p><p class="q2">Give me understanding, that I may live. 
-</p><p class="d">QOPH 
-</p><p class="q1">
-<span class="v">145&#160;</span>I have called with my whole heart. 
-</p><p class="q2">Answer me, Yahweh! 
-</p><p class="q2">I will keep your statutes. 
-</p><p class="q1">
-<span class="v">146&#160;</span>I have called to you. Save me! 
-</p><p class="q2">I will obey your statutes. 
-</p><p class="q1">
-<span class="v">147&#160;</span>I rise before dawn and cry for help. 
-</p><p class="q2">I put my hope in your words. 
-</p><p class="q1">
-<span class="v">148&#160;</span>My eyes stay open through the night watches, 
-</p><p class="q2">that I might meditate on your word. 
-</p><p class="q1">
-<span class="v">149&#160;</span>Hear my voice according to your loving kindness. 
-</p><p class="q2">Revive me, Yahweh, according to your ordinances. 
-</p><p class="q1">
-<span class="v">150&#160;</span>They draw near who follow after wickedness. 
-</p><p class="q2">They are far from your law. 
-</p><p class="q1">
-<span class="v">151&#160;</span>You are near, Yahweh. 
-</p><p class="q2">All your commandments are truth. 
-</p><p class="q1">
-<span class="v">152&#160;</span>Of old I have known from your testimonies, 
-</p><p class="q2">that you have founded them forever. 
-</p><p class="d">RESH 
-</p><p class="q1">
-<span class="v">153&#160;</span>Consider my affliction, and deliver me, 
-</p><p class="q2">for I don’t forget your law. 
-</p><p class="q1">
-<span class="v">154&#160;</span>Plead my cause, and redeem me! 
-</p><p class="q2">Revive me according to your promise. 
-</p><p class="q1">
-<span class="v">155&#160;</span>Salvation is far from the wicked, 
-</p><p class="q2">for they don’t seek your statutes. 
-</p><p class="q1">
-<span class="v">156&#160;</span>Great are your tender mercies, Yahweh. 
-</p><p class="q2">Revive me according to your ordinances. 
-</p><p class="q1">
-<span class="v">157&#160;</span>Many are my persecutors and my adversaries. 
-</p><p class="q2">I haven’t swerved from your testimonies. 
-</p><p class="q1">
-<span class="v">158&#160;</span>I look at the faithless with loathing, 
-</p><p class="q2">because they don’t observe your word. 
-</p><p class="q1">
-<span class="v">159&#160;</span>Consider how I love your precepts. 
-</p><p class="q2">Revive me, Yahweh, according to your loving kindness. 
-</p><p class="q1">
-<span class="v">160&#160;</span>All of your words are truth. 
-</p><p class="q2">Every one of your righteous ordinances endures forever. 
-</p><p class="d">SIN AND SHIN 
-</p><p class="q1">
-<span class="v">161&#160;</span>Princes have persecuted me without a cause, 
-</p><p class="q2">but my heart stands in awe of your words. 
-</p><p class="q1">
-<span class="v">162&#160;</span>I rejoice at your word, 
-</p><p class="q2">as one who finds great plunder. 
-</p><p class="q1">
-<span class="v">163&#160;</span>I hate and abhor falsehood. 
-</p><p class="q2">I love your law. 
-</p><p class="q1">
-<span class="v">164&#160;</span>Seven times a day, I praise you, 
-</p><p class="q2">because of your righteous ordinances. 
-</p><p class="q1">
-<span class="v">165&#160;</span>Those who love your law have great peace. 
-</p><p class="q2">Nothing causes them to stumble. 
-</p><p class="q1">
-<span class="v">166&#160;</span>I have hoped for your salvation, Yahweh. 
-</p><p class="q2">I have done your commandments. 
-</p><p class="q1">
-<span class="v">167&#160;</span>My soul has observed your testimonies. 
-</p><p class="q2">I love them exceedingly. 
-</p><p class="q1">
-<span class="v">168&#160;</span>I have obeyed your precepts and your testimonies, 
-</p><p class="q2">for all my ways are before you. 
-</p><p class="d">TAV 
-</p><p class="q1">
-<span class="v">169&#160;</span>Let my cry come before you, Yahweh. 
-</p><p class="q2">Give me understanding according to your word. 
-</p><p class="q1">
-<span class="v">170&#160;</span>Let my supplication come before you. 
-</p><p class="q2">Deliver me according to your word. 
-</p><p class="q1">
-<span class="v">171&#160;</span>Let my lips utter praise, 
-</p><p class="q2">for you teach me your statutes. 
-</p><p class="q1">
-<span class="v">172&#160;</span>Let my tongue sing of your word, 
-</p><p class="q2">for all your commandments are righteousness. 
-</p><p class="q1">
-<span class="v">173&#160;</span>Let your hand be ready to help me, 
-</p><p class="q2">for I have chosen your precepts. 
-</p><p class="q1">
-<span class="v">174&#160;</span>I have longed for your salvation, Yahweh. 
-</p><p class="q2">Your law is my delight. 
-</p><p class="q1">
-<span class="v">175&#160;</span>Let my soul live, that I may praise you. 
-</p><p class="q2">Let your ordinances help me. 
-</p><p class="q1">
-<span class="v">176&#160;</span>I have gone astray like a lost sheep. 
-</p><p class="q2">Seek your servant, for I don’t forget your commandments. 
-</p><h2 class="psalmlabel" id="120">120</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>In my distress, I cried to Yahweh. 
-</p><p class="q2">He answered me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Deliver my soul, Yahweh, from lying lips, 
-</p><p class="q2">from a deceitful tongue. 
-</p><p class="q1">
-<span class="v">3&#160;</span>What will be given to you, and what will be done more to you, 
-</p><p class="q2">you deceitful tongue? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Sharp arrows of the mighty, 
-</p><p class="q2">with coals of juniper. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Woe is me, that I live in Meshech, 
-</p><p class="q2">that I dwell among the tents of Kedar! 
-</p><p class="q1">
-<span class="v">6&#160;</span>My soul has had her dwelling too long 
-</p><p class="q2">with him who hates peace. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I am for peace, 
-</p><p class="q2">but when I speak, they are for war. 
-</p><h2 class="psalmlabel" id="121">121</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will lift up my eyes to the hills. 
-</p><p class="q2">Where does my help come from? 
-</p><p class="q1">
-<span class="v">2&#160;</span>My help comes from Yahweh, 
-</p><p class="q2">who made heaven and earth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>He will not allow your foot to be moved. 
-</p><p class="q2">He who keeps you will not slumber. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Behold, he who keeps Israel 
-</p><p class="q2">will neither slumber nor sleep. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yahweh is your keeper. 
-</p><p class="q2">Yahweh is your shade on your right hand. 
-</p><p class="q1">
-<span class="v">6&#160;</span>The sun will not harm you by day, 
-</p><p class="q2">nor the moon by night. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh will keep you from all evil. 
-</p><p class="q2">He will keep your soul. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh will keep your going out and your coming in, 
-</p><p class="q2">from this time forward, and forever more. 
-</p><h2 class="psalmlabel" id="122">122</h2>
-<p class="d">A Song of Ascents. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I was glad when they said to me, 
-</p><p class="q2">“Let’s go to Yahweh’s house!” 
-</p><p class="q1">
-<span class="v">2&#160;</span>Our feet are standing within your gates, Jerusalem! 
-</p><p class="q2">
-<span class="v">3&#160;</span>Jerusalem is built as a city that is compact together, 
-</p><p class="q1">
-<span class="v">4&#160;</span>where the tribes go up, even Yah’s tribes, 
-</p><p class="q2">according to an ordinance for Israel, 
-</p><p class="q2">to give thanks to Yahweh’s name. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For there are set thrones for judgment, 
-</p><p class="q2">the thrones of David’s house. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Pray for the peace of Jerusalem. 
-</p><p class="q2">Those who love you will prosper. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Peace be within your walls, 
-</p><p class="q2">and prosperity within your palaces. 
-</p><p class="q1">
-<span class="v">8&#160;</span>For my brothers’ and companions’ sakes, 
-</p><p class="q2">I will now say, “Peace be within you.” 
-</p><p class="q1">
-<span class="v">9&#160;</span>For the sake of the house of Yahweh our Elohim, 
-</p><p class="q2">I will seek your good. 
-</p><h2 class="psalmlabel" id="123">123</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I lift up my eyes to you, 
-</p><p class="q2">you who sit in the heavens. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Behold, as the eyes of servants look to the hand of their master, 
-</p><p class="q2">as the eyes of a maid to the hand of her mistress, 
-</p><p class="q2">so our eyes look to Yahweh, our Elohim, 
-</p><p class="q2">until he has mercy on us. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Have mercy on us, Yahweh, have mercy on us, 
-</p><p class="q2">for we have endured much contempt. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Our soul is exceedingly filled with the scoffing of those who are at ease, 
-</p><p class="q2">with the contempt of the proud. 
-</p><h2 class="psalmlabel" id="124">124</h2>
-<p class="d">A Song of Ascents. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>If it had not been Yahweh who was on our side, 
-</p><p class="q2">let Israel now say, 
-</p><p class="q1">
-<span class="v">2&#160;</span>if it had not been Yahweh who was on our side, 
-</p><p class="q2">when men rose up against us, 
-</p><p class="q1">
-<span class="v">3&#160;</span>then they would have swallowed us up alive, 
-</p><p class="q2">when their wrath was kindled against us, 
-</p><p class="q1">
-<span class="v">4&#160;</span>then the waters would have overwhelmed us, 
-</p><p class="q2">the stream would have gone over our soul. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Then the proud waters would have gone over our soul. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Blessed be Yahweh, 
-</p><p class="q2">who has not given us as a prey to their teeth. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Our soul has escaped like a bird out of the fowler’s snare. 
-</p><p class="q2">The snare is broken, and we have escaped. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Our help is in Yahweh’s name, 
-</p><p class="q2">who made heaven and earth. 
-</p><h2 class="psalmlabel" id="125">125</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Those who trust in Yahweh are as Mount Zion, 
-</p><p class="q2">which can’t be moved, but remains forever. 
-</p><p class="q1">
-<span class="v">2&#160;</span>As the mountains surround Jerusalem, 
-</p><p class="q2">so Yahweh surrounds his people from this time forward and forever more. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For the scepter of wickedness won’t remain over the allotment of the righteous, 
-</p><p class="q2">so that the righteous won’t use their hands to do evil. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Do good, Yahweh, to those who are good, 
-</p><p class="q2">to those who are upright in their hearts. 
-</p><p class="q1">
-<span class="v">5&#160;</span>But as for those who turn away to their crooked ways, 
-</p><p class="q2">Yahweh will lead them away with the workers of iniquity. 
-</p><p class="q1">Peace be on Israel. 
-</p><h2 class="psalmlabel" id="126">126</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>When Yahweh brought back those who returned to Zion, 
-</p><p class="q2">we were like those who dream. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Then our mouth was filled with laughter, 
-</p><p class="q2">and our tongue with singing. 
-</p><p class="q1">Then they said among the nations, 
-</p><p class="q2">“Yahweh has done great things for them.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh has done great things for us, 
-</p><p class="q2">and we are glad. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Restore our fortunes again, Yahweh, 
-</p><p class="q2">like the streams in the Negev. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Those who sow in tears will reap in joy. 
-</p><p class="q2">
-<span class="v">6&#160;</span>He who goes out weeping, carrying seed for sowing, 
-</p><p class="q2">will certainly come again with joy, carrying his sheaves. 
-</p><h2 class="psalmlabel" id="127">127</h2>
-<p class="d">A Song of Ascents. By Solomon. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Unless Yahweh builds the house, 
-</p><p class="q2">they who build it labor in vain. 
-</p><p class="q1">Unless Yahweh watches over the city, 
-</p><p class="q2">the watchman guards it in vain. 
-</p><p class="q1">
-<span class="v">2&#160;</span>It is vain for you to rise up early, 
-</p><p class="q2">to stay up late, 
-</p><p class="q2">eating the bread of toil, 
-</p><p class="q2">for he gives sleep to his loved ones. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Behold, children are a heritage of Yahweh. 
-</p><p class="q2">The fruit of the womb is his reward. 
-</p><p class="q1">
-<span class="v">4&#160;</span>As arrows in the hand of a mighty man, 
-</p><p class="q2">so are the children of youth. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Happy is the man who has his quiver full of them. 
-</p><p class="q2">They won’t be disappointed when they speak with their enemies in the gate. 
-</p><h2 class="psalmlabel" id="128">128</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Blessed is everyone who fears Yahweh, 
-</p><p class="q2">who walks in his ways. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For you will eat the labor of your hands. 
-</p><p class="q2">You will be happy, and it will be well with you. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Your woman will be as a fruitful vine in the innermost parts of your house, 
-</p><p class="q2">your children like olive shoots around your table. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Behold, this is how the man who fears Yahweh is blessed. 
-</p><p class="q2">
-<span class="v">5&#160;</span>May Yahweh bless you out of Zion, 
-</p><p class="q2">and may you see the good of Jerusalem all the days of your life. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yes, may you see your children’s children. 
-</p><p class="q2">Peace be upon Israel. 
-</p><h2 class="psalmlabel" id="129">129</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Many times they have afflicted me from my youth up. 
-</p><p class="q2">Let Israel now say: 
-</p><p class="q1">
-<span class="v">2&#160;</span>many times they have afflicted me from my youth up, 
-</p><p class="q2">yet they have not prevailed against me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The plowers plowed on my back. 
-</p><p class="q2">They made their furrows long. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh is righteous. 
-</p><p class="q2">He has cut apart the cords of the wicked. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let them be disappointed and turned backward, 
-</p><p class="q2">all those who hate Zion. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Let them be as the grass on the housetops, 
-</p><p class="q2">which withers before it grows up, 
-</p><p class="q1">
-<span class="v">7&#160;</span>with which the reaper doesn’t fill his hand, 
-</p><p class="q2">nor he who binds sheaves, his bosom. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Neither do those who go by say, 
-</p><p class="q2">“The blessing of Yahweh be on you. 
-</p><p class="q2">We bless you in Yahweh’s name.” 
-</p><h2 class="psalmlabel" id="130">130</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Out of the depths I have cried to you, Yahweh. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Lord, hear my voice. 
-</p><p class="q2">Let your ears be attentive to the voice of my petitions. 
-</p><p class="q1">
-<span class="v">3&#160;</span>If you, Yah, kept a record of sins, 
-</p><p class="q2">Lord, who could stand? 
-</p><p class="q1">
-<span class="v">4&#160;</span>But there is forgiveness with you, 
-</p><p class="q2">therefore you are feared. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I wait for Yahweh. 
-</p><p class="q2">My soul waits. 
-</p><p class="q2">I hope in his word. 
-</p><p class="q1">
-<span class="v">6&#160;</span>My soul longs for the Lord more than watchmen long for the morning, 
-</p><p class="q2">more than watchmen for the morning. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Israel, hope in Yahweh, 
-</p><p class="q2">for there is loving kindness with Yahweh. 
-</p><p class="q2">Abundant redemption is with him. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He will redeem Israel from all their sins. 
-</p><h2 class="psalmlabel" id="131">131</h2>
-<p class="d">A Song of Ascents. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, my heart isn’t arrogant, nor my eyes lofty; 
-</p><p class="q2">nor do I concern myself with great matters, 
-</p><p class="q2">or things too wonderful for me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Surely I have stilled and quieted my soul, 
-</p><p class="q2">like a weaned child with his mother, 
-</p><p class="q2">like a weaned child is my soul within me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Israel, hope in Yahweh, 
-</p><p class="q2">from this time forward and forever more. 
-</p><h2 class="psalmlabel" id="132">132</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, remember David and all his affliction, 
-</p><p class="q1">
-<span class="v">2&#160;</span>how he swore to Yahweh, 
-</p><p class="q2">and vowed to the Mighty One of Jacob: 
-</p><p class="q1">
-<span class="v">3&#160;</span>“Surely I will not come into the structure of my house, 
-</p><p class="q2">nor go up into my bed; 
-</p><p class="q1">
-<span class="v">4&#160;</span>I will not give sleep to my eyes, 
-</p><p class="q2">or slumber to my eyelids, 
-</p><p class="q1">
-<span class="v">5&#160;</span>until I find out a place for Yahweh, 
-</p><p class="q2">a dwelling for the Mighty One of Jacob.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>Behold, we heard of it in Ephrathah. 
-</p><p class="q2">We found it in the field of Jaar. 
-</p><p class="q1">
-<span class="v">7&#160;</span>“We will go into his dwelling place. 
-</p><p class="q2">We will worship at his footstool.” 
-</p><p class="q1">
-<span class="v">8&#160;</span>Arise, Yahweh, into your resting place, 
-</p><p class="q2">you, and the ark of your strength. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Let your priests be clothed with righteousness. 
-</p><p class="q2">Let your saints shout for joy! 
-</p><p class="q1">
-<span class="v">10&#160;</span>For your servant David’s sake, 
-</p><p class="q2">don’t turn away the face of your anointed one. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh has sworn to David in truth. 
-</p><p class="q2">He will not turn from it: 
-</p><p class="q2">“I will set the fruit of your body on your throne. 
-</p><p class="q1">
-<span class="v">12&#160;</span>If your children will keep my covenant, 
-</p><p class="q2">my testimony that I will teach them, 
-</p><p class="q2">their children also will sit on your throne forever more.” 
-</p><p class="q1">
-<span class="v">13&#160;</span>For Yahweh has chosen Zion. 
-</p><p class="q2">He has desired it for his habitation. 
-</p><p class="q1">
-<span class="v">14&#160;</span>“This is my resting place forever. 
-</p><p class="q2">I will live here, for I have desired it. 
-</p><p class="q1">
-<span class="v">15&#160;</span>I will abundantly bless her provision. 
-</p><p class="q2">I will satisfy her poor with bread. 
-</p><p class="q1">
-<span class="v">16&#160;</span>I will also clothe her priests with salvation. 
-</p><p class="q2">Her saints will shout aloud for joy. 
-</p><p class="q1">
-<span class="v">17&#160;</span>I will make the horn of David to bud there. 
-</p><p class="q2">I have ordained a lamp for my anointed. 
-</p><p class="q1">
-<span class="v">18&#160;</span>I will clothe his enemies with shame, 
-</p><p class="q2">but on himself, his crown will shine.” 
-</p><h2 class="psalmlabel" id="133">133</h2>
-<p class="d">A Song of Ascents. By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>See how good and how pleasant it is 
-</p><p class="q2">for brothers to live together in unity! 
-</p><p class="q1">
-<span class="v">2&#160;</span>It is like the precious oil on the head, 
-</p><p class="q2">that ran down on the beard, 
-</p><p class="q2">even Aaron’s beard, 
-</p><p class="q2">that came down on the edge of his robes, 
-</p><p class="q1">
-<span class="v">3&#160;</span>like the dew of Hermon, 
-</p><p class="q2">that comes down on the hills of Zion; 
-</p><p class="q2">for there Yahweh gives the blessing, 
-</p><p class="q2">even life forever more. 
-</p><h2 class="psalmlabel" id="134">134</h2>
-<p class="d">A Song of Ascents. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Look! Praise Yahweh, all you servants of Yahweh, 
-</p><p class="q2">who stand by night in Yahweh’s house! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Lift up your hands in the sanctuary. 
-</p><p class="q2">Praise Yahweh! 
-</p><p class="q1">
-<span class="v">3&#160;</span>May Yahweh bless you from Zion, 
-</p><p class="q2">even he who made heaven and earth. 
-</p><h2 class="psalmlabel" id="135">135</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah! 
-</p><p class="q2">Praise Yahweh’s name! 
-</p><p class="q2">Praise him, you servants of Yahweh, 
-</p><p class="q1">
-<span class="v">2&#160;</span>you who stand in Yahweh’s house, 
-</p><p class="q2">in the courts of our Elohim’s house. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Praise Yah, for Yahweh is good. 
-</p><p class="q2">Sing praises to his name, for that is pleasant. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For Yah has chosen Jacob for himself, 
-</p><p class="q2">Israel for his own possession. 
-</p><p class="q1">
-<span class="v">5&#160;</span>For I know that Yahweh is great, 
-</p><p class="q2">that our Lord is above all elohims. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Whatever Yahweh pleased, that he has done, 
-</p><p class="q2">in heaven and in earth, in the seas and in all deeps. 
-</p><p class="q1">
-<span class="v">7&#160;</span>He causes the clouds to rise from the ends of the earth. 
-</p><p class="q2">He makes lightnings with the rain. 
-</p><p class="q2">He brings the wind out of his treasuries. 
-</p><p class="q1">
-<span class="v">8&#160;</span>He struck the firstborn of Egypt, 
-</p><p class="q2">both of man and animal. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He sent signs and wonders into the middle of you, Egypt, 
-</p><p class="q2">on Pharaoh, and on all his servants. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He struck many nations, 
-</p><p class="q2">and killed mighty kings—</p><p class="q1">
-<span class="v">11&#160;</span>Sihon king of the Amorites, 
-</p><p class="q2">Og king of Bashan, 
-</p><p class="q2">and all the kingdoms of Canaan—</p><p class="q1">
-<span class="v">12&#160;</span>and gave their land for a heritage, 
-</p><p class="q2">a heritage to Israel, his people. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Your name, Yahweh, endures forever; 
-</p><p class="q2">your renown, Yahweh, throughout all generations. 
-</p><p class="q1">
-<span class="v">14&#160;</span>For Yahweh will judge his people 
-</p><p class="q2">and have compassion on his servants. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">15&#160;</span>The idols of the nations are silver and gold, 
-</p><p class="q2">the work of men’s hands. 
-</p><p class="q1">
-<span class="v">16&#160;</span>They have mouths, but they can’t speak. 
-</p><p class="q2">They have eyes, but they can’t see. 
-</p><p class="q1">
-<span class="v">17&#160;</span>They have ears, but they can’t hear, 
-</p><p class="q2">neither is there any breath in their mouths. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Those who make them will be like them, 
-</p><p class="q2">yes, everyone who trusts in them. 
-</p><p class="q1">
-<span class="v">19&#160;</span>House of Israel, praise Yahweh! 
-</p><p class="q2">House of Aaron, praise Yahweh! 
-</p><p class="q1">
-<span class="v">20&#160;</span>House of Levi, praise Yahweh! 
-</p><p class="q2">You who fear Yahweh, praise Yahweh! 
-</p><p class="q1">
-<span class="v">21&#160;</span>Blessed be Yahweh from Zion, 
-</p><p class="q2">who dwells in Jerusalem. 
-</p><p class="q1">Praise Yah! 
-</p><h2 class="psalmlabel" id="136">136</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Give thanks to Yahweh, for he is good, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Give thanks to the Elohim of elohims, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Give thanks to the Lord of lords, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">4&#160;</span>to him who alone does great wonders, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">5&#160;</span>to him who by understanding made the heavens, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">6&#160;</span>to him who spread out the earth above the waters, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">7&#160;</span>to him who made the great lights, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">8&#160;</span>the sun to rule by day, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">9&#160;</span>the moon and stars to rule by night, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">10&#160;</span>to him who struck down the Egyptian firstborn, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">11&#160;</span>and brought out Israel from among them, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">12&#160;</span>with a strong hand, and with an outstretched arm, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">13&#160;</span>to him who divided the Red Sea apart, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">14&#160;</span>and made Israel to pass through the middle of it, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">15&#160;</span>but overthrew Pharaoh and his army in the Red Sea, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">16&#160;</span>to him who led his people through the wilderness, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">17&#160;</span>to him who struck great kings, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">18&#160;</span>and killed mighty kings, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">19&#160;</span>Sihon king of the Amorites, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">20&#160;</span>Og king of Bashan, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">21&#160;</span>and gave their land as an inheritance, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">22&#160;</span>even a heritage to Israel his servant, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">23&#160;</span>who remembered us in our low estate, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">24&#160;</span>and has delivered us from our adversaries, 
-</p><p class="q2">for his loving kindness endures forever; 
-</p><p class="q1">
-<span class="v">25&#160;</span>who gives food to every creature, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><p class="q1">
-<span class="v">26&#160;</span>Oh give thanks to the Elohim of heaven, 
-</p><p class="q2">for his loving kindness endures forever. 
-</p><h2 class="psalmlabel" id="137">137</h2>
-<p class="q1">
-<span class="v">1&#160;</span>By the rivers of Babylon, there we sat down. 
-</p><p class="q2">Yes, we wept, when we remembered Zion. 
-</p><p class="q1">
-<span class="v">2&#160;</span>On the willows in that land, 
-</p><p class="q2">we hung up our harps. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For there, those who led us captive asked us for songs. 
-</p><p class="q2">Those who tormented us demanded songs of joy: 
-</p><p class="q2">“Sing us one of the songs of Zion!” 
-</p><p class="q1">
-<span class="v">4&#160;</span>How can we sing Yahweh’s song in a foreign land? 
-</p><p class="q1">
-<span class="v">5&#160;</span>If I forget you, Jerusalem, 
-</p><p class="q2">let my right hand forget its skill. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Let my tongue stick to the roof of my mouth if I don’t remember you, 
-</p><p class="q2">if I don’t prefer Jerusalem above my chief joy. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Remember, Yahweh, against the children of Edom in the day of Jerusalem, 
-</p><p class="q2">who said, “Raze it! 
-</p><p class="q2">Raze it even to its foundation!” 
-</p><p class="q1">
-<span class="v">8&#160;</span>Daughter of Babylon, doomed to destruction, 
-</p><p class="q2">he will be happy who repays you, 
-</p><p class="q2">as you have done to us. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Happy shall he be, 
-</p><p class="q2">who takes and dashes your little ones against the rock. 
-</p><h2 class="psalmlabel" id="138">138</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will give you thanks with my whole heart. 
-</p><p class="q2">Before the elohims,<span class="f">+ \fr 138:1 \ft The word elohim, used here, usually means “Elohim” but can also mean “elohims”, “princes”, or “angels”.</span> I will sing praises to you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will bow down toward your set-apart temple, 
-</p><p class="q2">and give thanks to your Name for your loving kindness and for your truth; 
-</p><p class="q2">for you have exalted your Name and your Word above all. 
-</p><p class="q1">
-<span class="v">3&#160;</span>In the day that I called, you answered me. 
-</p><p class="q2">You encouraged me with strength in my soul. 
-</p><p class="q1">
-<span class="v">4&#160;</span>All the kings of the earth will give you thanks, Yahweh, 
-</p><p class="q2">for they have heard the words of your mouth. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Yes, they will sing of the ways of Yahweh, 
-</p><p class="q2">for Yahweh’s glory is great! 
-</p><p class="q1">
-<span class="v">6&#160;</span>For though Yahweh is high, yet he looks after the lowly; 
-</p><p class="q2">but he knows the proud from afar. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Though I walk in the middle of trouble, you will revive me. 
-</p><p class="q2">You will stretch out your hand against the wrath of my enemies. 
-</p><p class="q2">Your right hand will save me. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh will fulfill that which concerns me. 
-</p><p class="q2">Your loving kindness, Yahweh, endures forever. 
-</p><p class="q2">Don’t forsake the works of your own hands. 
-</p><h2 class="psalmlabel" id="139">139</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, you have searched me, 
-</p><p class="q2">and you know me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>You know my sitting down and my rising up. 
-</p><p class="q2">You perceive my thoughts from afar. 
-</p><p class="q1">
-<span class="v">3&#160;</span>You search out my path and my lying down, 
-</p><p class="q2">and are acquainted with all my ways. 
-</p><p class="q1">
-<span class="v">4&#160;</span>For there is not a word on my tongue, 
-</p><p class="q2">but behold, Yahweh, you know it altogether. 
-</p><p class="q1">
-<span class="v">5&#160;</span>You hem me in behind and before. 
-</p><p class="q2">You laid your hand on me. 
-</p><p class="q1">
-<span class="v">6&#160;</span>This knowledge is beyond me. 
-</p><p class="q2">It’s lofty. 
-</p><p class="q2">I can’t attain it. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Where could I go from your Spirit? 
-</p><p class="q2">Or where could I flee from your presence? 
-</p><p class="q1">
-<span class="v">8&#160;</span>If I ascend up into heaven, you are there. 
-</p><p class="q2">If I make my bed in Sheol,<span class="f">+ \fr 139:8 \ft Sheol is the place of the dead.</span> behold, you are there! 
-</p><p class="q1">
-<span class="v">9&#160;</span>If I take the wings of the dawn, 
-</p><p class="q2">and settle in the uttermost parts of the sea, 
-</p><p class="q1">
-<span class="v">10&#160;</span>even there your hand will lead me, 
-</p><p class="q2">and your right hand will hold me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>If I say, “Surely the darkness will overwhelm me. 
-</p><p class="q2">The light around me will be night,” 
-</p><p class="q1">
-<span class="v">12&#160;</span>even the darkness doesn’t hide from you, 
-</p><p class="q2">but the night shines as the day. 
-</p><p class="q2">The darkness is like light to you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For you formed my inmost being. 
-</p><p class="q2">You knit me together in my mother’s womb. 
-</p><p class="q1">
-<span class="v">14&#160;</span>I will give thanks to you, 
-</p><p class="q2">for I am fearfully and wonderfully made. 
-</p><p class="q1">Your works are wonderful. 
-</p><p class="q2">My soul knows that very well. 
-</p><p class="q1">
-<span class="v">15&#160;</span>My frame wasn’t hidden from you, 
-</p><p class="q2">when I was made in secret, 
-</p><p class="q2">woven together in the depths of the earth. 
-</p><p class="q1">
-<span class="v">16&#160;</span>Your eyes saw my body. 
-</p><p class="q2">In your book they were all written, 
-</p><p class="q2">the days that were ordained for me, 
-</p><p class="q2">when as yet there were none of them. 
-</p><p class="q1">
-<span class="v">17&#160;</span>How precious to me are your thoughts, Elohim! 
-</p><p class="q2">How vast is their sum! 
-</p><p class="q1">
-<span class="v">18&#160;</span>If I would count them, they are more in number than the sand. 
-</p><p class="q2">When I wake up, I am still with you. 
-</p><p class="q1">
-<span class="v">19&#160;</span>If only you, Elohim, would kill the wicked. 
-</p><p class="q2">Get away from me, you bloodthirsty men! 
-</p><p class="q1">
-<span class="v">20&#160;</span>For they speak against you wickedly. 
-</p><p class="q2">Your enemies take your name in vain. 
-</p><p class="q1">
-<span class="v">21&#160;</span>Yahweh, don’t I hate those who hate you? 
-</p><p class="q2">Am I not grieved with those who rise up against you? 
-</p><p class="q1">
-<span class="v">22&#160;</span>I hate them with perfect hatred. 
-</p><p class="q2">They have become my enemies. 
-</p><p class="q1">
-<span class="v">23&#160;</span>Search me, Elohim, and know my heart. 
-</p><p class="q2">Try me, and know my thoughts. 
-</p><p class="q1">
-<span class="v">24&#160;</span>See if there is any wicked way in me, 
-</p><p class="q2">and lead me in the everlasting way. 
-</p><h2 class="psalmlabel" id="140">140</h2>
-<p class="d">For the Chief Musician. A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Deliver me, Yahweh, from evil men. 
-</p><p class="q2">Preserve me from violent men: 
-</p><p class="q1">
-<span class="v">2&#160;</span>those who devise mischief in their hearts. 
-</p><p class="q2">They continually gather themselves together for war. 
-</p><p class="q1">
-<span class="v">3&#160;</span>They have sharpened their tongues like a serpent. 
-</p><p class="q2">Viper’s poison is under their lips. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">4&#160;</span>Yahweh, keep me from the hands of the wicked. 
-</p><p class="q2">Preserve me from the violent men who have determined to trip my feet. 
-</p><p class="q1">
-<span class="v">5&#160;</span>The proud have hidden a snare for me, 
-</p><p class="q2">they have spread the cords of a net by the path. 
-</p><p class="q2">They have set traps for me. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">6&#160;</span>I said to Yahweh, “You are my Elohim.” 
-</p><p class="q2">Listen to the cry of my petitions, Yahweh. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Yahweh, the Lord, the strength of my salvation, 
-</p><p class="q2">you have covered my head in the day of battle. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh, don’t grant the desires of the wicked. 
-</p><p class="q2">Don’t let their evil plans succeed, or they will become proud. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">9&#160;</span>As for the head of those who surround me, 
-</p><p class="q2">let the mischief of their own lips cover them. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Let burning coals fall on them. 
-</p><p class="q2">Let them be thrown into the fire, 
-</p><p class="q2">into miry pits, from where they never rise. 
-</p><p class="q1">
-<span class="v">11&#160;</span>An evil speaker won’t be established in the earth. 
-</p><p class="q2">Evil will hunt the violent man to overthrow him. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I know that Yahweh will maintain the cause of the afflicted, 
-</p><p class="q2">and justice for the needy. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Surely the righteous will give thanks to your name. 
-</p><p class="q2">The upright will dwell in your presence. 
-</p><h2 class="psalmlabel" id="141">141</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Yahweh, I have called on you. 
-</p><p class="q2">Come to me quickly! 
-</p><p class="q2">Listen to my voice when I call to you. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let my prayer be set before you like incense; 
-</p><p class="q2">the lifting up of my hands like the evening sacrifice. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Set a watch, Yahweh, before my mouth. 
-</p><p class="q2">Keep the door of my lips. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Don’t incline my heart to any evil thing, 
-</p><p class="q2">to practice deeds of wickedness with men who work iniquity. 
-</p><p class="q2">Don’t let me eat of their delicacies. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let the righteous strike me, it is kindness; 
-</p><p class="q2">let him reprove me, it is like oil on the head; 
-</p><p class="q2">don’t let my head refuse it; 
-</p><p class="q2">Yet my prayer is always against evil deeds. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Their judges are thrown down by the sides of the rock. 
-</p><p class="q2">They will hear my words, for they are well spoken. 
-</p><p class="q1">
-<span class="v">7&#160;</span>“As when one plows and breaks up the earth, 
-</p><p class="q2">our bones are scattered at the mouth of Sheol.”<span class="f">+ \fr 141:7 \ft Sheol is the place of the dead.</span> 
-</p><p class="q1">
-<span class="v">8&#160;</span>For my eyes are on you, Yahweh, the Lord. 
-</p><p class="q2">I take refuge in you. 
-</p><p class="q2">Don’t leave my soul destitute. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Keep me from the snare which they have laid for me, 
-</p><p class="q2">from the traps of the workers of iniquity. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Let the wicked fall together into their own nets 
-</p><p class="q2">while I pass by. 
-</p><h2 class="psalmlabel" id="142">142</h2>
-<p class="d">A contemplation by David, when he was in the cave. A Prayer. 
-</p><p class="q1">
-<span class="v">1&#160;</span>I cry with my voice to Yahweh. 
-</p><p class="q2">With my voice, I ask Yahweh for mercy. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I pour out my complaint before him. 
-</p><p class="q2">I tell him my troubles. 
-</p><p class="q1">
-<span class="v">3&#160;</span>When my spirit was overwhelmed within me, 
-</p><p class="q2">you knew my route. 
-</p><p class="q1">On the path in which I walk, 
-</p><p class="q2">they have hidden a snare for me. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Look on my right, and see; 
-</p><p class="q2">for there is no one who is concerned for me. 
-</p><p class="q2">Refuge has fled from me. 
-</p><p class="q2">No one cares for my soul. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I cried to you, Yahweh. 
-</p><p class="q2">I said, “You are my refuge, 
-</p><p class="q2">my portion in the land of the living.” 
-</p><p class="q1">
-<span class="v">6&#160;</span>Listen to my cry, 
-</p><p class="q2">for I am in desperate need. 
-</p><p class="q1">Deliver me from my persecutors, 
-</p><p class="q2">for they are too strong for me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Bring my soul out of prison, 
-</p><p class="q2">that I may give thanks to your name. 
-</p><p class="q1">The righteous will surround me, 
-</p><p class="q2">for you will be good to me. 
-</p><h2 class="psalmlabel" id="143">143</h2>
-<p class="d">A Psalm by David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Hear my prayer, Yahweh. 
-</p><p class="q2">Listen to my petitions. 
-</p><p class="q2">In your faithfulness and righteousness, relieve me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Don’t enter into judgment with your servant, 
-</p><p class="q2">for in your sight no man living is righteous. 
-</p><p class="q1">
-<span class="v">3&#160;</span>For the enemy pursues my soul. 
-</p><p class="q2">He has struck my life down to the ground. 
-</p><p class="q2">He has made me live in dark places, as those who have been long dead. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Therefore my spirit is overwhelmed within me. 
-</p><p class="q2">My heart within me is desolate. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I remember the days of old. 
-</p><p class="q2">I meditate on all your doings. 
-</p><p class="q2">I contemplate the work of your hands. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I spread out my hands to you. 
-</p><p class="q2">My soul thirsts for you, like a parched land. </p><p class="qs">Selah.</p> 
-</p><p class="q1">
-<span class="v">7&#160;</span>Hurry to answer me, Yahweh. 
-</p><p class="q2">My spirit fails. 
-</p><p class="q1">Don’t hide your face from me, 
-</p><p class="q2">so that I don’t become like those who go down into the pit. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Cause me to hear your loving kindness in the morning, 
-</p><p class="q2">for I trust in you. 
-</p><p class="q1">Cause me to know the way in which I should walk, 
-</p><p class="q2">for I lift up my soul to you. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Deliver me, Yahweh, from my enemies. 
-</p><p class="q2">I flee to you to hide me. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Teach me to do your will, 
-</p><p class="q2">for you are my Elohim. 
-</p><p class="q1">Your Spirit is good. 
-</p><p class="q2">Lead me in the land of uprightness. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Revive me, Yahweh, for your name’s sake. 
-</p><p class="q2">In your righteousness, bring my soul out of trouble. 
-</p><p class="q1">
-<span class="v">12&#160;</span>In your loving kindness, cut off my enemies, 
-</p><p class="q2">and destroy all those who afflict my soul, 
-</p><p class="q2">for I am your servant. 
-</p><h2 class="psalmlabel" id="144">144</h2>
-<p class="d">By David. 
-</p><p class="q1">
-<span class="v">1&#160;</span>Blessed be Yahweh, my rock, 
-</p><p class="q2">who trains my hands to war, 
-</p><p class="q2">and my fingers to battle—</p><p class="q1">
-<span class="v">2&#160;</span>my loving kindness, my fortress, 
-</p><p class="q2">my high tower, my deliverer, 
-</p><p class="q2">my shield, and he in whom I take refuge, 
-</p><p class="q2">who subdues my people under me. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Yahweh, what is man, that you care for him? 
-</p><p class="q2">Or the son of man, that you think of him? 
-</p><p class="q1">
-<span class="v">4&#160;</span>Man is like a breath. 
-</p><p class="q2">His days are like a shadow that passes away. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Part your heavens, Yahweh, and come down. 
-</p><p class="q2">Touch the mountains, and they will smoke. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Throw out lightning, and scatter them. 
-</p><p class="q2">Send out your arrows, and rout them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Stretch out your hand from above, 
-</p><p class="q2">rescue me, and deliver me out of great waters, 
-</p><p class="q2">out of the hands of foreigners, 
-</p><p class="q2">
-<span class="v">8&#160;</span>whose mouths speak deceit, 
-</p><p class="q2">whose right hand is a right hand of falsehood. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will sing a new song to you, Elohim. 
-</p><p class="q2">On a ten-stringed lyre, I will sing praises to you. 
-</p><p class="q1">
-<span class="v">10&#160;</span>You are he who gives salvation to kings, 
-</p><p class="q2">who rescues David, his servant, from the deadly sword. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Rescue me, and deliver me out of the hands of foreigners, 
-</p><p class="q2">whose mouths speak deceit, 
-</p><p class="q2">whose right hand is a right hand of falsehood. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">12&#160;</span>Then our sons will be like well-nurtured plants, 
-</p><p class="q2">our daughters like pillars carved to adorn a palace. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Our barns are full, filled with all kinds of provision. 
-</p><p class="q2">Our sheep produce thousands and ten thousands in our fields. 
-</p><p class="q1">
-<span class="v">14&#160;</span>Our oxen will pull heavy loads. 
-</p><p class="q2">There is no breaking in, and no going away, 
-</p><p class="q2">and no outcry in our streets. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Happy are the people who are in such a situation. 
-</p><p class="q2">Happy are the people whose Elohim is Yahweh. 
-</p><h2 class="psalmlabel" id="145">145</h2>
-<p class="d">A praise psalm by David.<span class="f">+ \fr 145:0 \ft This is an acrostic psalm, with every verse (including the second half of verse 13) starting with a consecutive letter of the Hebrew alphabet.</span> 
-</p><p class="q1">
-<span class="v">1&#160;</span>I will exalt you, my Elohim, the King. 
-</p><p class="q2">I will praise your name forever and ever. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Every day I will praise you. 
-</p><p class="q2">I will extol your name forever and ever. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Great is Yahweh, and greatly to be praised! 
-</p><p class="q2">His greatness is unsearchable. 
-</p><p class="q1">
-<span class="v">4&#160;</span>One generation will commend your works to another, 
-</p><p class="q2">and will declare your mighty acts. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I will meditate on the glorious majesty of your honor, 
-</p><p class="q2">on your wondrous works. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Men will speak of the might of your awesome acts. 
-</p><p class="q2">I will declare your greatness. 
-</p><p class="q1">
-<span class="v">7&#160;</span>They will utter the memory of your great goodness, 
-</p><p class="q2">and will sing of your righteousness. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Yahweh is gracious, merciful, 
-</p><p class="q2">slow to anger, and of great loving kindness. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yahweh is good to all. 
-</p><p class="q2">His tender mercies are over all his works. 
-</p><p class="q1">
-<span class="v">10&#160;</span>All your works will give thanks to you, Yahweh. 
-</p><p class="q2">Your saints will extol you. 
-</p><p class="q1">
-<span class="v">11&#160;</span>They will speak of the glory of your kingdom, 
-</p><p class="q2">and talk about your power, 
-</p><p class="q1">
-<span class="v">12&#160;</span>to make known to the sons of men his mighty acts, 
-</p><p class="q2">the glory of the majesty of his kingdom. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Your kingdom is an everlasting kingdom. 
-</p><p class="q2">Your dominion endures throughout all generations. 
-</p><p class="q1">Yahweh is faithful in all his words, 
-</p><p class="q2">and loving in all his deeds.<span class="f">+ \fr 145:13 \ft Some manuscripts omit these last two lines.</span> 
-</p><p class="q1">
-<span class="v">14&#160;</span>Yahweh upholds all who fall, 
-</p><p class="q2">and raises up all those who are bowed down. 
-</p><p class="q1">
-<span class="v">15&#160;</span>The eyes of all wait for you. 
-</p><p class="q2">You give them their food in due season. 
-</p><p class="q1">
-<span class="v">16&#160;</span>You open your hand, 
-</p><p class="q2">and satisfy the desire of every living thing. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Yahweh is righteous in all his ways, 
-</p><p class="q2">and gracious in all his works. 
-</p><p class="q1">
-<span class="v">18&#160;</span>Yahweh is near to all those who call on him, 
-</p><p class="q2">to all who call on him in truth. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He will fulfill the desire of those who fear him. 
-</p><p class="q2">He also will hear their cry, and will save them. 
-</p><p class="q1">
-<span class="v">20&#160;</span>Yahweh preserves all those who love him, 
-</p><p class="q2">but he will destroy all the wicked. 
-</p><p class="q1">
-<span class="v">21&#160;</span>My mouth will speak the praise of Yahweh. 
-</p><p class="q2">Let all flesh bless his set-apart name forever and ever. 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Give thanks to Yahweh, for he is good, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let the redeemed by Yahweh say so, 
+</div><div class="q2">whom he has redeemed from the hand of the adversary, 
+</div><div class="q2">
+<sup>3&#160;</sup>and gathered out of the lands, 
+</div><div class="q2">from the east and from the west, 
+</div><div class="q2">from the north and from the south. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>They wandered in the wilderness in a desert way. 
+</div><div class="q2">They found no city to live in. 
+</div><div class="q1">
+<sup>5&#160;</sup>Hungry and thirsty, 
+</div><div class="q2">their soul fainted in them. 
+</div><div class="q1">
+<sup>6&#160;</sup>Then they cried to Yahweh in their trouble, 
+</div><div class="q2">and he delivered them out of their distresses. 
+</div><div class="q1">
+<sup>7&#160;</sup>He led them also by a straight way, 
+</div><div class="q2">that they might go to a city to live in. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let them praise Yahweh for his loving kindness, 
+</div><div class="q2">for his wonderful deeds to the children of men! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>For he satisfies the longing soul. 
+</div><div class="q2">He fills the hungry soul with good. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Some sat in darkness and in the shadow of death, 
+</div><div class="q2">being bound in affliction and iron, 
+</div><div class="q2">
+<sup>11&#160;</sup>because they rebelled against the words of Elohim, 
+</div><div class="q2">and condemned the counsel of the Most High. 
+</div><div class="q1">
+<sup>12&#160;</sup>Therefore he brought down their heart with labor. 
+</div><div class="q2">They fell down, and there was no one to help. 
+</div><div class="q1">
+<sup>13&#160;</sup>Then they cried to Yahweh in their trouble, 
+</div><div class="q2">and he saved them out of their distresses. 
+</div><div class="q1">
+<sup>14&#160;</sup>He brought them out of darkness and the shadow of death, 
+</div><div class="q2">and broke away their chains. 
+</div><div class="q1">
+<sup>15&#160;</sup>Let them praise Yahweh for his loving kindness, 
+</div><div class="q2">for his wonderful deeds to the children of men! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>For he has broken the gates of bronze, 
+</div><div class="q2">and cut through bars of iron. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>17&#160;</sup>Fools are afflicted because of their disobedience, 
+</div><div class="q2">and because of their iniquities. 
+</div><div class="q1">
+<sup>18&#160;</sup>Their soul abhors all kinds of food. 
+</div><div class="q2">They draw near to the gates of death. 
+</div><div class="q1">
+<sup>19&#160;</sup>Then they cry to Yahweh in their trouble, 
+</div><div class="q2">and he saves them out of their distresses. 
+</div><div class="q1">
+<sup>20&#160;</sup>He sends his word, and heals them, 
+</div><div class="q2">and delivers them from their graves. 
+</div><div class="q1">
+<sup>21&#160;</sup>Let them praise Yahweh for his loving kindness, 
+</div><div class="q2">for his wonderful deeds to the children of men! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>22&#160;</sup>Let them offer the sacrifices of thanksgiving, 
+</div><div class="q2">and declare his deeds with singing. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>23&#160;</sup>Those who go down to the sea in ships, 
+</div><div class="q2">who do business in great waters, 
+</div><div class="q2">
+<sup>24&#160;</sup>these see Yahweh’s deeds, 
+</div><div class="q2">and his wonders in the deep. 
+</div><div class="q1">
+<sup>25&#160;</sup>For he commands, and raises the stormy wind, 
+</div><div class="q2">which lifts up its waves. 
+</div><div class="q1">
+<sup>26&#160;</sup>They mount up to the sky; they go down again to the depths. 
+</div><div class="q2">Their soul melts away because of trouble. 
+</div><div class="q1">
+<sup>27&#160;</sup>They reel back and forth, and stagger like a drunken man, 
+</div><div class="q2">and are at their wits’ end. 
+</div><div class="q1">
+<sup>28&#160;</sup>Then they cry to Yahweh in their trouble, 
+</div><div class="q2">and he brings them out of their distress. 
+</div><div class="q1">
+<sup>29&#160;</sup>He makes the storm a calm, 
+</div><div class="q2">so that its waves are still. 
+</div><div class="q1">
+<sup>30&#160;</sup>Then they are glad because it is calm, 
+</div><div class="q2">so he brings them to their desired haven. 
+</div><div class="q1">
+<sup>31&#160;</sup>Let them praise Yahweh for his loving kindness, 
+</div><div class="q2">for his wonderful deeds for the children of men! 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>32&#160;</sup>Let them exalt him also in the assembly of the people, 
+</div><div class="q2">and praise him in the seat of the elders. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>33&#160;</sup>He turns rivers into a desert, 
+</div><div class="q2">water springs into a thirsty ground, 
+</div><div class="q2">
+<sup>34&#160;</sup>and a fruitful land into a salt waste, 
+</div><div class="q2">for the wickedness of those who dwell in it. 
+</div><div class="q1">
+<sup>35&#160;</sup>He turns a desert into a pool of water, 
+</div><div class="q2">and a dry land into water springs. 
+</div><div class="q1">
+<sup>36&#160;</sup>There he makes the hungry live, 
+</div><div class="q2">that they may prepare a city to live in, 
+</div><div class="q2">
+<sup>37&#160;</sup>sow fields, plant vineyards, 
+</div><div class="q2">and reap the fruits of increase. 
+</div><div class="q1">
+<sup>38&#160;</sup>He blesses them also, so that they are multiplied greatly. 
+</div><div class="q2">He doesn’t allow their livestock to decrease. 
+</div><div class="q1">
+<sup>39&#160;</sup>Again, they are diminished and bowed down 
+</div><div class="q2">through oppression, trouble, and sorrow. 
+</div><div class="q1">
+<sup>40&#160;</sup>He pours contempt on princes, 
+</div><div class="q2">and causes them to wander in a trackless waste. 
+</div><div class="q1">
+<sup>41&#160;</sup>Yet he lifts the needy out of their affliction, 
+</div><div class="q2">and increases their families like a flock. 
+</div><div class="q1">
+<sup>42&#160;</sup>The upright will see it, and be glad. 
+</div><div class="q2">All the wicked will shut their mouths. 
+</div><div class="q1">
+<sup>43&#160;</sup>Whoever is wise will pay attention to these things. 
+</div><div class="q2">They will consider the loving kindnesses of Yahweh. 
+</div><h2 class="psalmlabel" id="108">108</h2>
+<div class="d">A Song. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>My heart is steadfast, Elohim. 
+</div><div class="q2">I will sing and I will make music with my soul. 
+</div><div class="q1">
+<sup>2&#160;</sup>Wake up, harp and lyre! 
+</div><div class="q2">I will wake up the dawn. 
+</div><div class="q1">
+<sup>3&#160;</sup>I will give thanks to you, Yahweh, among the nations. 
+</div><div class="q2">I will sing praises to you among the peoples. 
+</div><div class="q1">
+<sup>4&#160;</sup>For your loving kindness is great above the heavens. 
+</div><div class="q2">Your faithfulness reaches to the skies. 
+</div><div class="q1">
+<sup>5&#160;</sup>Be exalted, Elohim, above the heavens! 
+</div><div class="q2">Let your glory be over all the earth. 
+</div><div class="q1">
+<sup>6&#160;</sup>That your beloved may be delivered, 
+</div><div class="q2">save with your right hand, and answer us. 
+</div><div class="q1">
+<sup>7&#160;</sup>Elohim has spoken from his sanctuary: “In triumph, 
+</div><div class="q2">I will divide Shechem, and measure out the valley of Succoth. 
+</div><div class="q1">
+<sup>8&#160;</sup>Gilead is mine. Manasseh is mine. 
+</div><div class="q2">Ephraim also is my helmet. 
+</div><div class="q2">Judah is my scepter. 
+</div><div class="q1">
+<sup>9&#160;</sup>Moab is my wash pot. 
+</div><div class="q2">I will toss my sandal on Edom. 
+</div><div class="q2">I will shout over Philistia.” 
+</div><div class="q1">
+<sup>10&#160;</sup>Who will bring me into the fortified city? 
+</div><div class="q2">Who will lead me to Edom? 
+</div><div class="q1">
+<sup>11&#160;</sup>Haven’t you rejected us, Elohim? 
+</div><div class="q2">You don’t go out, Elohim, with our armies. 
+</div><div class="q1">
+<sup>12&#160;</sup>Give us help against the enemy, 
+</div><div class="q2">for the help of man is vain. 
+</div><div class="q1">
+<sup>13&#160;</sup>Through Elohim, we will do valiantly, 
+</div><div class="q2">for it is he who will tread down our enemies. 
+</div><h2 class="psalmlabel" id="109">109</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Elohim of my praise, don’t remain silent, 
+</div><div class="q2">
+<sup>2&#160;</sup>for they have opened the mouth of the wicked and the mouth of deceit against me. 
+</div><div class="q2">They have spoken to me with a lying tongue. 
+</div><div class="q1">
+<sup>3&#160;</sup>They have also surrounded me with words of hatred, 
+</div><div class="q2">and fought against me without a cause. 
+</div><div class="q1">
+<sup>4&#160;</sup>In return for my love, they are my adversaries; 
+</div><div class="q2">but I am in prayer. 
+</div><div class="q1">
+<sup>5&#160;</sup>They have rewarded me evil for good, 
+</div><div class="q2">and hatred for my love. 
+</div><div class="q1">
+<sup>6&#160;</sup>Set a wicked man over him. 
+</div><div class="q2">Let an adversary stand at his right hand. 
+</div><div class="q1">
+<sup>7&#160;</sup>When he is judged, let him come out guilty. 
+</div><div class="q2">Let his prayer be turned into sin. 
+</div><div class="q1">
+<sup>8&#160;</sup>Let his days be few. 
+</div><div class="q2">Let another take his office. 
+</div><div class="q1">
+<sup>9&#160;</sup>Let his children be fatherless, 
+</div><div class="q2">and his woman a widow. 
+</div><div class="q1">
+<sup>10&#160;</sup>Let his children be wandering beggars. 
+</div><div class="q2">Let them be sought from their ruins. 
+</div><div class="q1">
+<sup>11&#160;</sup>Let the creditor seize all that he has. 
+</div><div class="q2">Let strangers plunder the fruit of his labor. 
+</div><div class="q1">
+<sup>12&#160;</sup>Let there be no one to extend kindness to him, 
+</div><div class="q2">neither let there be anyone to have pity on his fatherless children. 
+</div><div class="q1">
+<sup>13&#160;</sup>Let his posterity be cut off. 
+</div><div class="q2">In the generation following let their name be blotted out. 
+</div><div class="q1">
+<sup>14&#160;</sup>Let the iniquity of his fathers be remembered by Yahweh. 
+</div><div class="q2">Don’t let the sin of his mother be blotted out. 
+</div><div class="q1">
+<sup>15&#160;</sup>Let them be before Yahweh continually, 
+</div><div class="q2">that he may cut off their memory from the earth; 
+</div><div class="q1">
+<sup>16&#160;</sup>because he didn’t remember to show kindness, 
+</div><div class="q2">but persecuted the poor and needy man, 
+</div><div class="q2">the broken in heart, to kill them. 
+</div><div class="q1">
+<sup>17&#160;</sup>Yes, he loved cursing, and it came to him. 
+</div><div class="q2">He didn’t delight in blessing, and it was far from him. 
+</div><div class="q1">
+<sup>18&#160;</sup>He clothed himself also with cursing as with his garment. 
+</div><div class="q2">It came into his inward parts like water, 
+</div><div class="q2">like oil into his bones. 
+</div><div class="q1">
+<sup>19&#160;</sup>Let it be to him as the clothing with which he covers himself, 
+</div><div class="q2">for the belt that is always around him. 
+</div><div class="q1">
+<sup>20&#160;</sup>This is the reward of my adversaries from Yahweh, 
+</div><div class="q2">of those who speak evil against my soul. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>21&#160;</sup>But deal with me, Yahweh the Lord, for your name’s sake, 
+</div><div class="q2">because your loving kindness is good, deliver me; 
+</div><div class="q2">
+<sup>22&#160;</sup>for I am poor and needy. 
+</div><div class="q2">My heart is wounded within me. 
+</div><div class="q1">
+<sup>23&#160;</sup>I fade away like an evening shadow. 
+</div><div class="q2">I am shaken off like a locust. 
+</div><div class="q1">
+<sup>24&#160;</sup>My knees are weak through fasting. 
+</div><div class="q2">My body is thin and lacks fat. 
+</div><div class="q1">
+<sup>25&#160;</sup>I have also become a reproach to them. 
+</div><div class="q2">When they see me, they shake their head. 
+</div><div class="q1">
+<sup>26&#160;</sup>Help me, Yahweh, my Elohim. 
+</div><div class="q2">Save me according to your loving kindness; 
+</div><div class="q1">
+<sup>27&#160;</sup>that they may know that this is your hand; 
+</div><div class="q2">that you, Yahweh, have done it. 
+</div><div class="q1">
+<sup>28&#160;</sup>They may curse, but you bless. 
+</div><div class="q2">When they arise, they will be shamed, 
+</div><div class="q2">but your servant shall rejoice. 
+</div><div class="q1">
+<sup>29&#160;</sup>Let my adversaries be clothed with dishonor. 
+</div><div class="q2">Let them cover themselves with their own shame as with a robe. 
+</div><div class="q1">
+<sup>30&#160;</sup>I will give great thanks to Yahweh with my mouth. 
+</div><div class="q2">Yes, I will praise him among the multitude. 
+</div><div class="q1">
+<sup>31&#160;</sup>For he will stand at the right hand of the needy, 
+</div><div class="q2">to save him from those who judge his soul. 
+</div><h2 class="psalmlabel" id="110">110</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh says to my Lord, “Sit at my right hand, 
+</div><div class="q2">until I make your enemies your footstool for your feet.” 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh will send out the rod of your strength out of Zion. 
+</div><div class="q2">Rule among your enemies. 
+</div><div class="q1">
+<sup>3&#160;</sup>Your people offer themselves willingly in the day of your power, in set-apart array. 
+</div><div class="q2">Out of the womb of the morning, you have the dew of your youth. 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh has sworn, and will not change his mind: 
+</div><div class="q2">“You are a priest forever in the order of Melchizedek.” 
+</div><div class="q1">
+<sup>5&#160;</sup>The Lord is at your right hand. 
+</div><div class="q2">He will crush kings in the day of his wrath. 
+</div><div class="q1">
+<sup>6&#160;</sup>He will judge among the nations. 
+</div><div class="q2">He will heap up dead bodies. 
+</div><div class="q2">He will crush the ruler of the whole earth. 
+</div><div class="q1">
+<sup>7&#160;</sup>He will drink of the brook on the way; 
+</div><div class="q2">therefore he will lift up his head. 
+</div><h2 class="psalmlabel" id="111">111</h2>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">I will give thanks to Yahweh with my whole heart, 
+</div><div class="q2">in the council of the upright, and in the congregation. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh’s works are great, 
+</div><div class="q2">pondered by all those who delight in them. 
+</div><div class="q1">
+<sup>3&#160;</sup>His work is honor and majesty. 
+</div><div class="q2">His righteousness endures forever. 
+</div><div class="q1">
+<sup>4&#160;</sup>He has caused his wonderful works to be remembered. 
+</div><div class="q2">Yahweh is gracious and merciful. 
+</div><div class="q1">
+<sup>5&#160;</sup>He has given food to those who fear him. 
+</div><div class="q2">He always remembers his covenant. 
+</div><div class="q1">
+<sup>6&#160;</sup>He has shown his people the power of his works, 
+</div><div class="q2">in giving them the heritage of the nations. 
+</div><div class="q1">
+<sup>7&#160;</sup>The works of his hands are truth and justice. 
+</div><div class="q2">All his precepts are sure. 
+</div><div class="q1">
+<sup>8&#160;</sup>They are established forever and ever. 
+</div><div class="q2">They are done in truth and uprightness. 
+</div><div class="q1">
+<sup>9&#160;</sup>He has sent redemption to his people. 
+</div><div class="q2">He has ordained his covenant forever. 
+</div><div class="q2">His name is set-apart and awesome! 
+</div><div class="q1">
+<sup>10&#160;</sup>The fear of Yahweh is the beginning of wisdom. 
+</div><div class="q2">All those who do his work have a good understanding. 
+</div><div class="q1">His praise endures forever! 
+</div><h2 class="psalmlabel" id="112">112</h2>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">Blessed is the man who fears Yahweh, 
+</div><div class="q2">who delights greatly in his commandments. 
+</div><div class="q1">
+<sup>2&#160;</sup>His offspring will be mighty in the land. 
+</div><div class="q2">The generation of the upright will be blessed. 
+</div><div class="q1">
+<sup>3&#160;</sup>Wealth and riches are in his house. 
+</div><div class="q2">His righteousness endures forever. 
+</div><div class="q1">
+<sup>4&#160;</sup>Light dawns in the darkness for the upright, 
+</div><div class="q2">gracious, merciful, and righteous. 
+</div><div class="q1">
+<sup>5&#160;</sup>It is well with the man who deals graciously and lends. 
+</div><div class="q2">He will maintain his cause in judgment. 
+</div><div class="q1">
+<sup>6&#160;</sup>For he will never be shaken. 
+</div><div class="q2">The righteous will be remembered forever. 
+</div><div class="q1">
+<sup>7&#160;</sup>He will not be afraid of evil news. 
+</div><div class="q2">His heart is steadfast, trusting in Yahweh. 
+</div><div class="q1">
+<sup>8&#160;</sup>His heart is established. 
+</div><div class="q2">He will not be afraid in the end when he sees his adversaries. 
+</div><div class="q1">
+<sup>9&#160;</sup>He has dispersed, he has given to the poor. 
+</div><div class="q2">His righteousness endures forever. 
+</div><div class="q2">His horn will be exalted with honor. 
+</div><div class="q1">
+<sup>10&#160;</sup>The wicked will see it, and be grieved. 
+</div><div class="q2">He shall gnash with his teeth, and melt away. 
+</div><div class="q2">The desire of the wicked will perish. 
+</div><h2 class="psalmlabel" id="113">113</h2>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">Praise, you servants of Yahweh, 
+</div><div class="q2">praise Yahweh’s name. 
+</div><div class="q1">
+<sup>2&#160;</sup>Blessed be Yahweh’s name, 
+</div><div class="q2">from this time forward and forever more. 
+</div><div class="q1">
+<sup>3&#160;</sup>From the rising of the sun to its going down, 
+</div><div class="q2">Yahweh’s name is to be praised. 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh is high above all nations, 
+</div><div class="q2">his glory above the heavens. 
+</div><div class="q1">
+<sup>5&#160;</sup>Who is like Yahweh, our Elohim, 
+</div><div class="q2">who has his seat on high, 
+</div><div class="q2">
+<sup>6&#160;</sup>who stoops down to see in heaven and in the earth? 
+</div><div class="q1">
+<sup>7&#160;</sup>He raises up the poor out of the dust, 
+</div><div class="q2">and lifts up the needy from the ash heap, 
+</div><div class="q1">
+<sup>8&#160;</sup>that he may set him with princes, 
+</div><div class="q2">even with the princes of his people. 
+</div><div class="q1">
+<sup>9&#160;</sup>He settles the barren woman in her home 
+</div><div class="q2">as a joyful mother of children. 
+</div><div class="q1">Praise Yah! 
+</div><h2 class="psalmlabel" id="114">114</h2>
+<div class="q1">
+<sup>1&#160;</sup>When Israel went out of Egypt, 
+</div><div class="q2">the house of Jacob from a people of foreign language, 
+</div><div class="q1">
+<sup>2&#160;</sup>Judah became his sanctuary, 
+</div><div class="q2">Israel his dominion. 
+</div><div class="q1">
+<sup>3&#160;</sup>The sea saw it, and fled. 
+</div><div class="q2">The Jordan was driven back. 
+</div><div class="q1">
+<sup>4&#160;</sup>The mountains skipped like rams, 
+</div><div class="q2">the little hills like lambs. 
+</div><div class="q1">
+<sup>5&#160;</sup>What was it, you sea, that you fled? 
+</div><div class="q2">You Jordan, that you turned back? 
+</div><div class="q1">
+<sup>6&#160;</sup>You mountains, that you skipped like rams? 
+</div><div class="q2">You little hills, like lambs? 
+</div><div class="q1">
+<sup>7&#160;</sup>Tremble, you earth, at the presence of the Lord, 
+</div><div class="q2">at the presence of the Elohim of Jacob, 
+</div><div class="q1">
+<sup>8&#160;</sup>who turned the rock into a pool of water, 
+</div><div class="q2">the flint into a spring of waters. 
+</div><h2 class="psalmlabel" id="115">115</h2>
+<div class="q1">
+<sup>1&#160;</sup>Not to us, Yahweh, not to us, 
+</div><div class="q2">but to your name give glory, 
+</div><div class="q2">for your loving kindness, and for your truth’s sake. 
+</div><div class="q1">
+<sup>2&#160;</sup>Why should the nations say, 
+</div><div class="q2">“Where is their Elohim, now?” 
+</div><div class="q1">
+<sup>3&#160;</sup>But our Elohim is in the heavens. 
+</div><div class="q2">He does whatever he pleases. 
+</div><div class="q1">
+<sup>4&#160;</sup>Their idols are silver and gold, 
+</div><div class="q2">the work of men’s hands. 
+</div><div class="q1">
+<sup>5&#160;</sup>They have mouths, but they don’t speak. 
+</div><div class="q2">They have eyes, but they don’t see. 
+</div><div class="q1">
+<sup>6&#160;</sup>They have ears, but they don’t hear. 
+</div><div class="q2">They have noses, but they don’t smell. 
+</div><div class="q1">
+<sup>7&#160;</sup>They have hands, but they don’t feel. 
+</div><div class="q2">They have feet, but they don’t walk, 
+</div><div class="q2">neither do they speak through their throat. 
+</div><div class="q1">
+<sup>8&#160;</sup>Those who make them will be like them; 
+</div><div class="q2">yes, everyone who trusts in them. 
+</div><div class="q1">
+<sup>9&#160;</sup>Israel, trust in Yahweh! 
+</div><div class="q2">He is their help and their shield. 
+</div><div class="q1">
+<sup>10&#160;</sup>House of Aaron, trust in Yahweh! 
+</div><div class="q2">He is their help and their shield. 
+</div><div class="q1">
+<sup>11&#160;</sup>You who fear Yahweh, trust in Yahweh! 
+</div><div class="q2">He is their help and their shield. 
+</div><div class="q1">
+<sup>12&#160;</sup>Yahweh remembers us. He will bless us. 
+</div><div class="q2">He will bless the house of Israel. 
+</div><div class="q2">He will bless the house of Aaron. 
+</div><div class="q1">
+<sup>13&#160;</sup>He will bless those who fear Yahweh, 
+</div><div class="q2">both small and great. 
+</div><div class="q1">
+<sup>14&#160;</sup>May Yahweh increase you more and more, 
+</div><div class="q2">you and your children. 
+</div><div class="q1">
+<sup>15&#160;</sup>Blessed are you by Yahweh, 
+</div><div class="q2">who made heaven and earth. 
+</div><div class="q1">
+<sup>16&#160;</sup>The heavens are Yahweh’s heavens, 
+</div><div class="q2">but he has given the earth to the children of men. 
+</div><div class="q1">
+<sup>17&#160;</sup>The dead don’t praise Yah, 
+</div><div class="q2">nor any who go down into silence, 
+</div><div class="q1">
+<sup>18&#160;</sup>but we will bless Yah, 
+</div><div class="q2">from this time forward and forever more. 
+</div><div class="q1">Praise Yah! 
+</div><h2 class="psalmlabel" id="116">116</h2>
+<div class="q1">
+<sup>1&#160;</sup>I love Yahweh, because he listens to my voice, 
+</div><div class="q2">and my cries for mercy. 
+</div><div class="q1">
+<sup>2&#160;</sup>Because he has turned his ear to me, 
+</div><div class="q2">therefore I will call on him as long as I live. 
+</div><div class="q1">
+<sup>3&#160;</sup>The cords of death surrounded me, 
+</div><div class="q2">the pains of Sheol got a hold of me. 
+</div><div class="q2">I found trouble and sorrow. 
+</div><div class="q1">
+<sup>4&#160;</sup>Then I called on Yahweh’s name: 
+</div><div class="q2">“Yahweh, I beg you, deliver my soul.” 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh is gracious and righteous. 
+</div><div class="q2">Yes, our Elohim is merciful. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh preserves the simple. 
+</div><div class="q2">I was brought low, and he saved me. 
+</div><div class="q1">
+<sup>7&#160;</sup>Return to your rest, my soul, 
+</div><div class="q2">for Yahweh has dealt bountifully with you. 
+</div><div class="q1">
+<sup>8&#160;</sup>For you have delivered my soul from death, 
+</div><div class="q2">my eyes from tears, 
+</div><div class="q2">and my feet from falling. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will walk before Yahweh in the land of the living. 
+</div><div class="q1">
+<sup>10&#160;</sup>I believed, therefore I said, 
+</div><div class="q2">“I was greatly afflicted.” 
+</div><div class="q1">
+<sup>11&#160;</sup>I said in my haste, 
+</div><div class="q2">“All people are liars.” 
+</div><div class="q1">
+<sup>12&#160;</sup>What will I give to Yahweh for all his benefits toward me? 
+</div><div class="q2">
+<sup>13&#160;</sup>I will take the cup of salvation, and call on Yahweh’s name. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will pay my vows to Yahweh, 
+</div><div class="q2">yes, in the presence of all his people. 
+</div><div class="q1">
+<sup>15&#160;</sup>Precious in Yahweh’s sight is the death of his saints. 
+</div><div class="q1">
+<sup>16&#160;</sup>Yahweh, truly I am your servant. 
+</div><div class="q2">I am your servant, the son of your servant girl. 
+</div><div class="q2">You have freed me from my chains. 
+</div><div class="q1">
+<sup>17&#160;</sup>I will offer to you the sacrifice of thanksgiving, 
+</div><div class="q2">and will call on Yahweh’s name. 
+</div><div class="q1">
+<sup>18&#160;</sup>I will pay my vows to Yahweh, 
+</div><div class="q2">yes, in the presence of all his people, 
+</div><div class="q1">
+<sup>19&#160;</sup>in the courts of Yahweh’s house, 
+</div><div class="q2">in the middle of you, Jerusalem. 
+</div><div class="q1">Praise Yah! 
+</div><h2 class="psalmlabel" id="117">117</h2>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yahweh, all you nations! 
+</div><div class="q2">Extol him, all you peoples! 
+</div><div class="q1">
+<sup>2&#160;</sup>For his loving kindness is great toward us. 
+</div><div class="q2">Yahweh’s faithfulness endures forever. 
+</div><div class="q1">Praise Yah! 
+</div><h2 class="psalmlabel" id="118">118</h2>
+<div class="q1">
+<sup>1&#160;</sup>Give thanks to Yahweh, for he is good, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let Israel now say 
+</div><div class="q2">that his loving kindness endures forever. 
+</div><div class="q1">
+<sup>3&#160;</sup>Let the house of Aaron now say 
+</div><div class="q2">that his loving kindness endures forever. 
+</div><div class="q1">
+<sup>4&#160;</sup>Now let those who fear Yahweh say 
+</div><div class="q2">that his loving kindness endures forever. 
+</div><div class="q1">
+<sup>5&#160;</sup>Out of my distress, I called on Yah. 
+</div><div class="q2">Yah answered me with freedom. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh is on my side. I will not be afraid. 
+</div><div class="q2">What can man do to me? 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh is on my side among those who help me. 
+</div><div class="q2">Therefore I will look in triumph at those who hate me. 
+</div><div class="q1">
+<sup>8&#160;</sup>It is better to take refuge in Yahweh, 
+</div><div class="q2">than to put confidence in man. 
+</div><div class="q1">
+<sup>9&#160;</sup>It is better to take refuge in Yahweh, 
+</div><div class="q2">than to put confidence in princes. 
+</div><div class="q1">
+<sup>10&#160;</sup>All the nations surrounded me, 
+</div><div class="q2">but in Yahweh’s name I cut them off. 
+</div><div class="q1">
+<sup>11&#160;</sup>They surrounded me, yes, they surrounded me. 
+</div><div class="q2">In Yahweh’s name I indeed cut them off. 
+</div><div class="q1">
+<sup>12&#160;</sup>They surrounded me like bees. 
+</div><div class="q2">They are quenched like the burning thorns. 
+</div><div class="q2">In Yahweh’s name I cut them off. 
+</div><div class="q1">
+<sup>13&#160;</sup>You pushed me back hard, to make me fall, 
+</div><div class="q2">but Yahweh helped me. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yah is my strength and song. 
+</div><div class="q2">He has become my salvation. 
+</div><div class="q1">
+<sup>15&#160;</sup>The voice of rejoicing and salvation is in the tents of the righteous. 
+</div><div class="q2">“The right hand of Yahweh does valiantly. 
+</div><div class="q1">
+<sup>16&#160;</sup>The right hand of Yahweh is exalted! 
+</div><div class="q2">The right hand of Yahweh does valiantly!” 
+</div><div class="q1">
+<sup>17&#160;</sup>I will not die, but live, 
+</div><div class="q2">and declare Yah’s works. 
+</div><div class="q1">
+<sup>18&#160;</sup>Yah has punished me severely, 
+</div><div class="q2">but he has not given me over to death. 
+</div><div class="q1">
+<sup>19&#160;</sup>Open to me the gates of righteousness. 
+</div><div class="q2">I will enter into them. 
+</div><div class="q2">I will give thanks to Yah. 
+</div><div class="q1">
+<sup>20&#160;</sup>This is the gate of Yahweh; 
+</div><div class="q2">the righteous will enter into it. 
+</div><div class="q1">
+<sup>21&#160;</sup>I will give thanks to you, for you have answered me, 
+</div><div class="q2">and have become my salvation. 
+</div><div class="q1">
+<sup>22&#160;</sup>The stone which the builders rejected 
+</div><div class="q2">has become the cornerstone. 
+</div><div class="q1">
+<sup>23&#160;</sup>This is Yahweh’s doing. 
+</div><div class="q2">It is marvelous in our eyes. 
+</div><div class="q1">
+<sup>24&#160;</sup>This is the day that Yahweh has made. 
+</div><div class="q2">We will rejoice and be glad in it! 
+</div><div class="q1">
+<sup>25&#160;</sup>Save us now, we beg you, Yahweh! 
+</div><div class="q2">Yahweh, we beg you, send prosperity now. 
+</div><div class="q1">
+<sup>26&#160;</sup>Blessed is he who comes in Yahweh’s name! 
+</div><div class="q2">We have blessed you out of Yahweh’s house. 
+</div><div class="q1">
+<sup>27&#160;</sup>Yahweh is Elohim, and he has given us light. 
+</div><div class="q2">Bind the sacrifice with cords, even to the horns of the altar. 
+</div><div class="q1">
+<sup>28&#160;</sup>You are my Elohim, and I will give thanks to you. 
+</div><div class="q2">You are my Elohim, I will exalt you. 
+</div><div class="q1">
+<sup>29&#160;</sup>Oh give thanks to Yahweh, for he is good, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><h2 class="psalmlabel" id="119">119</h2>
+<div class="d">ALEPH 
+</div><div class="q1">
+<sup>1&#160;</sup>Blessed are those whose ways are blameless, 
+</div><div class="q2">who walk according to Yahweh’s law. 
+</div><div class="q1">
+<sup>2&#160;</sup>Blessed are those who keep his statutes, 
+</div><div class="q2">who seek him with their whole heart. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yes, they do nothing wrong. 
+</div><div class="q2">They walk in his ways. 
+</div><div class="q1">
+<sup>4&#160;</sup>You have commanded your precepts, 
+</div><div class="q2">that we should fully obey them. 
+</div><div class="q1">
+<sup>5&#160;</sup>Oh that my ways were steadfast 
+</div><div class="q2">to obey your statutes! 
+</div><div class="q1">
+<sup>6&#160;</sup>Then I wouldn’t be disappointed, 
+</div><div class="q2">when I consider all of your commandments. 
+</div><div class="q1">
+<sup>7&#160;</sup>I will give thanks to you with uprightness of heart, 
+</div><div class="q2">when I learn your righteous judgments. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will observe your statutes. 
+</div><div class="q2">Don’t utterly forsake me. 
+</div><div class="d">BETH 
+</div><div class="q1">
+<sup>9&#160;</sup>How can a young man keep his way pure? 
+</div><div class="q2">By living according to your word. 
+</div><div class="q1">
+<sup>10&#160;</sup>With my whole heart I have sought you. 
+</div><div class="q2">Don’t let me wander from your commandments. 
+</div><div class="q1">
+<sup>11&#160;</sup>I have hidden your word in my heart, 
+</div><div class="q2">that I might not sin against you. 
+</div><div class="q1">
+<sup>12&#160;</sup>Blessed are you, Yahweh. 
+</div><div class="q2">Teach me your statutes. 
+</div><div class="q1">
+<sup>13&#160;</sup>With my lips, 
+</div><div class="q2">I have declared all the ordinances of your mouth. 
+</div><div class="q1">
+<sup>14&#160;</sup>I have rejoiced in the way of your testimonies, 
+</div><div class="q2">as much as in all riches. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will meditate on your precepts, 
+</div><div class="q2">and consider your ways. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will delight myself in your statutes. 
+</div><div class="q2">I will not forget your word. 
+</div><div class="d">GIMEL 
+</div><div class="q1">
+<sup>17&#160;</sup>Do good to your servant. 
+</div><div class="q2">I will live and I will obey your word. 
+</div><div class="q1">
+<sup>18&#160;</sup>Open my eyes, 
+</div><div class="q2">that I may see wondrous things out of your law. 
+</div><div class="q1">
+<sup>19&#160;</sup>I am a stranger on the earth. 
+</div><div class="q2">Don’t hide your commandments from me. 
+</div><div class="q1">
+<sup>20&#160;</sup>My soul is consumed with longing for your ordinances at all times. 
+</div><div class="q1">
+<sup>21&#160;</sup>You have rebuked the proud who are cursed, 
+</div><div class="q2">who wander from your commandments. 
+</div><div class="q1">
+<sup>22&#160;</sup>Take reproach and contempt away from me, 
+</div><div class="q2">for I have kept your statutes. 
+</div><div class="q1">
+<sup>23&#160;</sup>Though princes sit and slander me, 
+</div><div class="q2">your servant will meditate on your statutes. 
+</div><div class="q1">
+<sup>24&#160;</sup>Indeed your statutes are my delight, 
+</div><div class="q2">and my counselors. 
+</div><div class="d">DALETH 
+</div><div class="q1">
+<sup>25&#160;</sup>My soul is laid low in the dust. 
+</div><div class="q2">Revive me according to your word! 
+</div><div class="q1">
+<sup>26&#160;</sup>I declared my ways, and you answered me. 
+</div><div class="q2">Teach me your statutes. 
+</div><div class="q1">
+<sup>27&#160;</sup>Let me understand the teaching of your precepts! 
+</div><div class="q2">Then I will meditate on your wondrous works. 
+</div><div class="q1">
+<sup>28&#160;</sup>My soul is weary with sorrow; 
+</div><div class="q2">strengthen me according to your word. 
+</div><div class="q1">
+<sup>29&#160;</sup>Keep me from the way of deceit. 
+</div><div class="q2">Grant me your law graciously! 
+</div><div class="q1">
+<sup>30&#160;</sup>I have chosen the way of truth. 
+</div><div class="q2">I have set your ordinances before me. 
+</div><div class="q1">
+<sup>31&#160;</sup>I cling to your statutes, Yahweh. 
+</div><div class="q2">Don’t let me be disappointed. 
+</div><div class="q1">
+<sup>32&#160;</sup>I run in the path of your commandments, 
+</div><div class="q2">for you have set my heart free. 
+</div><div class="d">HE 
+</div><div class="q1">
+<sup>33&#160;</sup>Teach me, Yahweh, the way of your statutes. 
+</div><div class="q2">I will keep them to the end. 
+</div><div class="q1">
+<sup>34&#160;</sup>Give me understanding, and I will keep your law. 
+</div><div class="q2">Yes, I will obey it with my whole heart. 
+</div><div class="q1">
+<sup>35&#160;</sup>Direct me in the path of your commandments, 
+</div><div class="q2">for I delight in them. 
+</div><div class="q1">
+<sup>36&#160;</sup>Turn my heart toward your statutes, 
+</div><div class="q2">not toward selfish gain. 
+</div><div class="q1">
+<sup>37&#160;</sup>Turn my eyes away from looking at worthless things. 
+</div><div class="q2">Revive me in your ways. 
+</div><div class="q1">
+<sup>38&#160;</sup>Fulfill your promise to your servant, 
+</div><div class="q2">that you may be feared. 
+</div><div class="q1">
+<sup>39&#160;</sup>Take away my disgrace that I dread, 
+</div><div class="q2">for your ordinances are good. 
+</div><div class="q1">
+<sup>40&#160;</sup>Behold, I long for your precepts! 
+</div><div class="q2">Revive me in your righteousness. 
+</div><div class="d">VAV 
+</div><div class="q1">
+<sup>41&#160;</sup>Let your loving kindness also come to me, Yahweh, 
+</div><div class="q2">your salvation, according to your word. 
+</div><div class="q1">
+<sup>42&#160;</sup>So I will have an answer for him who reproaches me, 
+</div><div class="q2">for I trust in your word. 
+</div><div class="q1">
+<sup>43&#160;</sup>Don’t snatch the word of truth out of my mouth, 
+</div><div class="q2">for I put my hope in your ordinances. 
+</div><div class="q1">
+<sup>44&#160;</sup>So I will obey your law continually, 
+</div><div class="q2">forever and ever. 
+</div><div class="q1">
+<sup>45&#160;</sup>I will walk in liberty, 
+</div><div class="q2">for I have sought your precepts. 
+</div><div class="q1">
+<sup>46&#160;</sup>I will also speak of your statutes before kings, 
+</div><div class="q2">and will not be disappointed. 
+</div><div class="q1">
+<sup>47&#160;</sup>I will delight myself in your commandments, 
+</div><div class="q2">because I love them. 
+</div><div class="q1">
+<sup>48&#160;</sup>I reach out my hands for your commandments, which I love. 
+</div><div class="q2">I will meditate on your statutes. 
+</div><div class="d">ZAYIN 
+</div><div class="q1">
+<sup>49&#160;</sup>Remember your word to your servant, 
+</div><div class="q2">because you gave me hope. 
+</div><div class="q1">
+<sup>50&#160;</sup>This is my comfort in my affliction, 
+</div><div class="q2">for your word has revived me. 
+</div><div class="q1">
+<sup>51&#160;</sup>The arrogant mock me excessively, 
+</div><div class="q2">but I don’t swerve from your law. 
+</div><div class="q1">
+<sup>52&#160;</sup>I remember your ordinances of old, Yahweh, 
+</div><div class="q2">and have comforted myself. 
+</div><div class="q1">
+<sup>53&#160;</sup>Indignation has taken hold on me, 
+</div><div class="q2">because of the wicked who forsake your law. 
+</div><div class="q1">
+<sup>54&#160;</sup>Your statutes have been my songs 
+</div><div class="q2">in the house where I live. 
+</div><div class="q1">
+<sup>55&#160;</sup>I have remembered your name, Yahweh, in the night, 
+</div><div class="q2">and I obey your law. 
+</div><div class="q1">
+<sup>56&#160;</sup>This is my way, 
+</div><div class="q2">that I keep your precepts. 
+</div><div class="d">HETH 
+</div><div class="q1">
+<sup>57&#160;</sup>Yahweh is my portion. 
+</div><div class="q2">I promised to obey your words. 
+</div><div class="q1">
+<sup>58&#160;</sup>I sought your favor with my whole heart. 
+</div><div class="q2">Be merciful to me according to your word. 
+</div><div class="q1">
+<sup>59&#160;</sup>I considered my ways, 
+</div><div class="q2">and turned my steps to your statutes. 
+</div><div class="q1">
+<sup>60&#160;</sup>I will hurry, and not delay, 
+</div><div class="q2">to obey your commandments. 
+</div><div class="q1">
+<sup>61&#160;</sup>The ropes of the wicked bind me, 
+</div><div class="q2">but I won’t forget your law. 
+</div><div class="q1">
+<sup>62&#160;</sup>At midnight I will rise to give thanks to you, 
+</div><div class="q2">because of your righteous ordinances. 
+</div><div class="q1">
+<sup>63&#160;</sup>I am a friend of all those who fear you, 
+</div><div class="q2">of those who observe your precepts. 
+</div><div class="q1">
+<sup>64&#160;</sup>The earth is full of your loving kindness, Yahweh. 
+</div><div class="q2">Teach me your statutes. 
+</div><div class="d">TETH 
+</div><div class="q1">
+<sup>65&#160;</sup>You have treated your servant well, 
+</div><div class="q2">according to your word, Yahweh. 
+</div><div class="q1">
+<sup>66&#160;</sup>Teach me good judgment and knowledge, 
+</div><div class="q2">for I believe in your commandments. 
+</div><div class="q1">
+<sup>67&#160;</sup>Before I was afflicted, I went astray; 
+</div><div class="q2">but now I observe your word. 
+</div><div class="q1">
+<sup>68&#160;</sup>You are good, and do good. 
+</div><div class="q2">Teach me your statutes. 
+</div><div class="q1">
+<sup>69&#160;</sup>The proud have smeared a lie upon me. 
+</div><div class="q2">With my whole heart, I will keep your precepts. 
+</div><div class="q1">
+<sup>70&#160;</sup>Their heart is as callous as the fat, 
+</div><div class="q2">but I delight in your law. 
+</div><div class="q1">
+<sup>71&#160;</sup>It is good for me that I have been afflicted, 
+</div><div class="q2">that I may learn your statutes. 
+</div><div class="q1">
+<sup>72&#160;</sup>The law of your mouth is better to me than thousands of pieces of gold and silver. 
+</div><div class="d">YODH 
+</div><div class="q1">
+<sup>73&#160;</sup>Your hands have made me and formed me. 
+</div><div class="q2">Give me understanding, that I may learn your commandments. 
+</div><div class="q1">
+<sup>74&#160;</sup>Those who fear you will see me and be glad, 
+</div><div class="q2">because I have put my hope in your word. 
+</div><div class="q1">
+<sup>75&#160;</sup>Yahweh, I know that your judgments are righteous, 
+</div><div class="q2">that in faithfulness you have afflicted me. 
+</div><div class="q1">
+<sup>76&#160;</sup>Please let your loving kindness be for my comfort, 
+</div><div class="q2">according to your word to your servant. 
+</div><div class="q1">
+<sup>77&#160;</sup>Let your tender mercies come to me, that I may live; 
+</div><div class="q2">for your law is my delight. 
+</div><div class="q1">
+<sup>78&#160;</sup>Let the proud be disappointed, for they have overthrown me wrongfully. 
+</div><div class="q2">I will meditate on your precepts. 
+</div><div class="q1">
+<sup>79&#160;</sup>Let those who fear you turn to me. 
+</div><div class="q2">They will know your statutes. 
+</div><div class="q1">
+<sup>80&#160;</sup>Let my heart be blameless toward your decrees, 
+</div><div class="q2">that I may not be disappointed. 
+</div><div class="d">KAPF 
+</div><div class="q1">
+<sup>81&#160;</sup>My soul faints for your salvation. 
+</div><div class="q2">I hope in your word. 
+</div><div class="q1">
+<sup>82&#160;</sup>My eyes fail for your word. 
+</div><div class="q2">I say, “When will you comfort me?” 
+</div><div class="q1">
+<sup>83&#160;</sup>For I have become like a wineskin in the smoke. 
+</div><div class="q2">I don’t forget your statutes. 
+</div><div class="q1">
+<sup>84&#160;</sup>How many are the days of your servant? 
+</div><div class="q2">When will you execute judgment on those who persecute me? 
+</div><div class="q1">
+<sup>85&#160;</sup>The proud have dug pits for me, 
+</div><div class="q2">contrary to your law. 
+</div><div class="q1">
+<sup>86&#160;</sup>All of your commandments are faithful. 
+</div><div class="q2">They persecute me wrongfully. 
+</div><div class="q2">Help me! 
+</div><div class="q1">
+<sup>87&#160;</sup>They had almost wiped me from the earth, 
+</div><div class="q2">but I didn’t forsake your precepts. 
+</div><div class="q1">
+<sup>88&#160;</sup>Preserve my life according to your loving kindness, 
+</div><div class="q2">so I will obey the statutes of your mouth. 
+</div><div class="d">LAMEDH 
+</div><div class="q1">
+<sup>89&#160;</sup>Yahweh, your word is settled in heaven forever. 
+</div><div class="q1">
+<sup>90&#160;</sup>Your faithfulness is to all generations. 
+</div><div class="q2">You have established the earth, and it remains. 
+</div><div class="q1">
+<sup>91&#160;</sup>Your laws remain to this day, 
+</div><div class="q2">for all things serve you. 
+</div><div class="q1">
+<sup>92&#160;</sup>Unless your law had been my delight, 
+</div><div class="q2">I would have perished in my affliction. 
+</div><div class="q1">
+<sup>93&#160;</sup>I will never forget your precepts, 
+</div><div class="q2">for with them, you have revived me. 
+</div><div class="q1">
+<sup>94&#160;</sup>I am yours. 
+</div><div class="q2">Save me, for I have sought your precepts. 
+</div><div class="q1">
+<sup>95&#160;</sup>The wicked have waited for me, to destroy me. 
+</div><div class="q2">I will consider your statutes. 
+</div><div class="q1">
+<sup>96&#160;</sup>I have seen a limit to all perfection, 
+</div><div class="q2">but your commands are boundless. 
+</div><div class="d">MEM 
+</div><div class="q1">
+<sup>97&#160;</sup>How I love your law! 
+</div><div class="q2">It is my meditation all day. 
+</div><div class="q1">
+<sup>98&#160;</sup>Your commandments make me wiser than my enemies, 
+</div><div class="q2">for your commandments are always with me. 
+</div><div class="q1">
+<sup>99&#160;</sup>I have more understanding than all my teachers, 
+</div><div class="q2">for your testimonies are my meditation. 
+</div><div class="q1">
+<sup>100&#160;</sup>I understand more than the aged, 
+</div><div class="q2">because I have kept your precepts. 
+</div><div class="q1">
+<sup>101&#160;</sup>I have kept my feet from every evil way, 
+</div><div class="q2">that I might observe your word. 
+</div><div class="q1">
+<sup>102&#160;</sup>I have not turned away from your ordinances, 
+</div><div class="q2">for you have taught me. 
+</div><div class="q1">
+<sup>103&#160;</sup>How sweet are your promises to my taste, 
+</div><div class="q2">more than honey to my mouth! 
+</div><div class="q1">
+<sup>104&#160;</sup>Through your precepts, I get understanding; 
+</div><div class="q2">therefore I hate every false way. 
+</div><div class="d">NUN 
+</div><div class="q1">
+<sup>105&#160;</sup>Your word is a lamp to my feet, 
+</div><div class="q2">and a light for my path. 
+</div><div class="q1">
+<sup>106&#160;</sup>I have sworn, and have confirmed it, 
+</div><div class="q2">that I will obey your righteous ordinances. 
+</div><div class="q1">
+<sup>107&#160;</sup>I am afflicted very much. 
+</div><div class="q2">Revive me, Yahweh, according to your word. 
+</div><div class="q1">
+<sup>108&#160;</sup>Accept, I beg you, the willing offerings of my mouth. 
+</div><div class="q2">Yahweh, teach me your ordinances. 
+</div><div class="q1">
+<sup>109&#160;</sup>My soul is continually in my hand, 
+</div><div class="q2">yet I won’t forget your law. 
+</div><div class="q1">
+<sup>110&#160;</sup>The wicked have laid a snare for me, 
+</div><div class="q2">yet I haven’t gone astray from your precepts. 
+</div><div class="q1">
+<sup>111&#160;</sup>I have taken your testimonies as a heritage forever, 
+</div><div class="q2">for they are the joy of my heart. 
+</div><div class="q1">
+<sup>112&#160;</sup>I have set my heart to perform your statutes forever, 
+</div><div class="q2">even to the end. 
+</div><div class="d">SAMEKH 
+</div><div class="q1">
+<sup>113&#160;</sup>I hate double-minded men, 
+</div><div class="q2">but I love your law. 
+</div><div class="q1">
+<sup>114&#160;</sup>You are my hiding place and my shield. 
+</div><div class="q2">I hope in your word. 
+</div><div class="q1">
+<sup>115&#160;</sup>Depart from me, you evildoers, 
+</div><div class="q2">that I may keep the commandments of my Elohim. 
+</div><div class="q1">
+<sup>116&#160;</sup>Uphold me according to your word, that I may live. 
+</div><div class="q2">Let me not be ashamed of my hope. 
+</div><div class="q1">
+<sup>117&#160;</sup>Hold me up, and I will be safe, 
+</div><div class="q2">and will have respect for your statutes continually. 
+</div><div class="q1">
+<sup>118&#160;</sup>You reject all those who stray from your statutes, 
+</div><div class="q2">for their deceit is in vain. 
+</div><div class="q1">
+<sup>119&#160;</sup>You put away all the wicked of the earth like dross. 
+</div><div class="q2">Therefore I love your testimonies. 
+</div><div class="q1">
+<sup>120&#160;</sup>My flesh trembles for fear of you. 
+</div><div class="q2">I am afraid of your judgments. 
+</div><div class="d">AYIN 
+</div><div class="q1">
+<sup>121&#160;</sup>I have done what is just and righteous. 
+</div><div class="q2">Don’t leave me to my oppressors. 
+</div><div class="q1">
+<sup>122&#160;</sup>Ensure your servant’s well-being. 
+</div><div class="q2">Don’t let the proud oppress me. 
+</div><div class="q1">
+<sup>123&#160;</sup>My eyes fail looking for your salvation, 
+</div><div class="q2">for your righteous word. 
+</div><div class="q1">
+<sup>124&#160;</sup>Deal with your servant according to your loving kindness. 
+</div><div class="q2">Teach me your statutes. 
+</div><div class="q1">
+<sup>125&#160;</sup>I am your servant. Give me understanding, 
+</div><div class="q2">that I may know your testimonies. 
+</div><div class="q1">
+<sup>126&#160;</sup>It is time to act, Yahweh, 
+</div><div class="q2">for they break your law. 
+</div><div class="q1">
+<sup>127&#160;</sup>Therefore I love your commandments more than gold, 
+</div><div class="q2">yes, more than pure gold. 
+</div><div class="q1">
+<sup>128&#160;</sup>Therefore I consider all of your precepts to be right. 
+</div><div class="q2">I hate every false way. 
+</div><div class="d">PE 
+</div><div class="q1">
+<sup>129&#160;</sup>Your testimonies are wonderful, 
+</div><div class="q2">therefore my soul keeps them. 
+</div><div class="q1">
+<sup>130&#160;</sup>The entrance of your words gives light. 
+</div><div class="q2">It gives understanding to the simple. 
+</div><div class="q1">
+<sup>131&#160;</sup>I opened my mouth wide and panted, 
+</div><div class="q2">for I longed for your commandments. 
+</div><div class="q1">
+<sup>132&#160;</sup>Turn to me, and have mercy on me, 
+</div><div class="q2">as you always do to those who love your name. 
+</div><div class="q1">
+<sup>133&#160;</sup>Establish my footsteps in your word. 
+</div><div class="q2">Don’t let any iniquity have dominion over me. 
+</div><div class="q1">
+<sup>134&#160;</sup>Redeem me from the oppression of man, 
+</div><div class="q2">so I will observe your precepts. 
+</div><div class="q1">
+<sup>135&#160;</sup>Make your face shine on your servant. 
+</div><div class="q2">Teach me your statutes. 
+</div><div class="q1">
+<sup>136&#160;</sup>Streams of tears run down my eyes, 
+</div><div class="q2">because they don’t observe your law. 
+</div><div class="d">TZADHE 
+</div><div class="q1">
+<sup>137&#160;</sup>You are righteous, Yahweh. 
+</div><div class="q2">Your judgments are upright. 
+</div><div class="q1">
+<sup>138&#160;</sup>You have commanded your statutes in righteousness. 
+</div><div class="q2">They are fully trustworthy. 
+</div><div class="q1">
+<sup>139&#160;</sup>My zeal wears me out, 
+</div><div class="q2">because my enemies ignore your words. 
+</div><div class="q1">
+<sup>140&#160;</sup>Your promises have been thoroughly tested, 
+</div><div class="q2">and your servant loves them. 
+</div><div class="q1">
+<sup>141&#160;</sup>I am small and despised. 
+</div><div class="q2">I don’t forget your precepts. 
+</div><div class="q1">
+<sup>142&#160;</sup>Your righteousness is an everlasting righteousness. 
+</div><div class="q2">Your law is truth. 
+</div><div class="q1">
+<sup>143&#160;</sup>Trouble and anguish have taken hold of me. 
+</div><div class="q2">Your commandments are my delight. 
+</div><div class="q1">
+<sup>144&#160;</sup>Your testimonies are righteous forever. 
+</div><div class="q2">Give me understanding, that I may live. 
+</div><div class="d">QOPH 
+</div><div class="q1">
+<sup>145&#160;</sup>I have called with my whole heart. 
+</div><div class="q2">Answer me, Yahweh! 
+</div><div class="q2">I will keep your statutes. 
+</div><div class="q1">
+<sup>146&#160;</sup>I have called to you. Save me! 
+</div><div class="q2">I will obey your statutes. 
+</div><div class="q1">
+<sup>147&#160;</sup>I rise before dawn and cry for help. 
+</div><div class="q2">I put my hope in your words. 
+</div><div class="q1">
+<sup>148&#160;</sup>My eyes stay open through the night watches, 
+</div><div class="q2">that I might meditate on your word. 
+</div><div class="q1">
+<sup>149&#160;</sup>Hear my voice according to your loving kindness. 
+</div><div class="q2">Revive me, Yahweh, according to your ordinances. 
+</div><div class="q1">
+<sup>150&#160;</sup>They draw near who follow after wickedness. 
+</div><div class="q2">They are far from your law. 
+</div><div class="q1">
+<sup>151&#160;</sup>You are near, Yahweh. 
+</div><div class="q2">All your commandments are truth. 
+</div><div class="q1">
+<sup>152&#160;</sup>Of old I have known from your testimonies, 
+</div><div class="q2">that you have founded them forever. 
+</div><div class="d">RESH 
+</div><div class="q1">
+<sup>153&#160;</sup>Consider my affliction, and deliver me, 
+</div><div class="q2">for I don’t forget your law. 
+</div><div class="q1">
+<sup>154&#160;</sup>Plead my cause, and redeem me! 
+</div><div class="q2">Revive me according to your promise. 
+</div><div class="q1">
+<sup>155&#160;</sup>Salvation is far from the wicked, 
+</div><div class="q2">for they don’t seek your statutes. 
+</div><div class="q1">
+<sup>156&#160;</sup>Great are your tender mercies, Yahweh. 
+</div><div class="q2">Revive me according to your ordinances. 
+</div><div class="q1">
+<sup>157&#160;</sup>Many are my persecutors and my adversaries. 
+</div><div class="q2">I haven’t swerved from your testimonies. 
+</div><div class="q1">
+<sup>158&#160;</sup>I look at the faithless with loathing, 
+</div><div class="q2">because they don’t observe your word. 
+</div><div class="q1">
+<sup>159&#160;</sup>Consider how I love your precepts. 
+</div><div class="q2">Revive me, Yahweh, according to your loving kindness. 
+</div><div class="q1">
+<sup>160&#160;</sup>All of your words are truth. 
+</div><div class="q2">Every one of your righteous ordinances endures forever. 
+</div><div class="d">SIN AND SHIN 
+</div><div class="q1">
+<sup>161&#160;</sup>Princes have persecuted me without a cause, 
+</div><div class="q2">but my heart stands in awe of your words. 
+</div><div class="q1">
+<sup>162&#160;</sup>I rejoice at your word, 
+</div><div class="q2">as one who finds great plunder. 
+</div><div class="q1">
+<sup>163&#160;</sup>I hate and abhor falsehood. 
+</div><div class="q2">I love your law. 
+</div><div class="q1">
+<sup>164&#160;</sup>Seven times a day, I praise you, 
+</div><div class="q2">because of your righteous ordinances. 
+</div><div class="q1">
+<sup>165&#160;</sup>Those who love your law have great peace. 
+</div><div class="q2">Nothing causes them to stumble. 
+</div><div class="q1">
+<sup>166&#160;</sup>I have hoped for your salvation, Yahweh. 
+</div><div class="q2">I have done your commandments. 
+</div><div class="q1">
+<sup>167&#160;</sup>My soul has observed your testimonies. 
+</div><div class="q2">I love them exceedingly. 
+</div><div class="q1">
+<sup>168&#160;</sup>I have obeyed your precepts and your testimonies, 
+</div><div class="q2">for all my ways are before you. 
+</div><div class="d">TAV 
+</div><div class="q1">
+<sup>169&#160;</sup>Let my cry come before you, Yahweh. 
+</div><div class="q2">Give me understanding according to your word. 
+</div><div class="q1">
+<sup>170&#160;</sup>Let my supplication come before you. 
+</div><div class="q2">Deliver me according to your word. 
+</div><div class="q1">
+<sup>171&#160;</sup>Let my lips utter praise, 
+</div><div class="q2">for you teach me your statutes. 
+</div><div class="q1">
+<sup>172&#160;</sup>Let my tongue sing of your word, 
+</div><div class="q2">for all your commandments are righteousness. 
+</div><div class="q1">
+<sup>173&#160;</sup>Let your hand be ready to help me, 
+</div><div class="q2">for I have chosen your precepts. 
+</div><div class="q1">
+<sup>174&#160;</sup>I have longed for your salvation, Yahweh. 
+</div><div class="q2">Your law is my delight. 
+</div><div class="q1">
+<sup>175&#160;</sup>Let my soul live, that I may praise you. 
+</div><div class="q2">Let your ordinances help me. 
+</div><div class="q1">
+<sup>176&#160;</sup>I have gone astray like a lost sheep. 
+</div><div class="q2">Seek your servant, for I don’t forget your commandments. 
+</div><h2 class="psalmlabel" id="120">120</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>In my distress, I cried to Yahweh. 
+</div><div class="q2">He answered me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Deliver my soul, Yahweh, from lying lips, 
+</div><div class="q2">from a deceitful tongue. 
+</div><div class="q1">
+<sup>3&#160;</sup>What will be given to you, and what will be done more to you, 
+</div><div class="q2">you deceitful tongue? 
+</div><div class="q1">
+<sup>4&#160;</sup>Sharp arrows of the mighty, 
+</div><div class="q2">with coals of juniper. 
+</div><div class="q1">
+<sup>5&#160;</sup>Woe is me, that I live in Meshech, 
+</div><div class="q2">that I dwell among the tents of Kedar! 
+</div><div class="q1">
+<sup>6&#160;</sup>My soul has had her dwelling too long 
+</div><div class="q2">with him who hates peace. 
+</div><div class="q1">
+<sup>7&#160;</sup>I am for peace, 
+</div><div class="q2">but when I speak, they are for war. 
+</div><h2 class="psalmlabel" id="121">121</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will lift up my eyes to the hills. 
+</div><div class="q2">Where does my help come from? 
+</div><div class="q1">
+<sup>2&#160;</sup>My help comes from Yahweh, 
+</div><div class="q2">who made heaven and earth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>He will not allow your foot to be moved. 
+</div><div class="q2">He who keeps you will not slumber. 
+</div><div class="q1">
+<sup>4&#160;</sup>Behold, he who keeps Israel 
+</div><div class="q2">will neither slumber nor sleep. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yahweh is your keeper. 
+</div><div class="q2">Yahweh is your shade on your right hand. 
+</div><div class="q1">
+<sup>6&#160;</sup>The sun will not harm you by day, 
+</div><div class="q2">nor the moon by night. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh will keep you from all evil. 
+</div><div class="q2">He will keep your soul. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh will keep your going out and your coming in, 
+</div><div class="q2">from this time forward, and forever more. 
+</div><h2 class="psalmlabel" id="122">122</h2>
+<div class="d">A Song of Ascents. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I was glad when they said to me, 
+</div><div class="q2">“Let’s go to Yahweh’s house!” 
+</div><div class="q1">
+<sup>2&#160;</sup>Our feet are standing within your gates, Jerusalem! 
+</div><div class="q2">
+<sup>3&#160;</sup>Jerusalem is built as a city that is compact together, 
+</div><div class="q1">
+<sup>4&#160;</sup>where the tribes go up, even Yah’s tribes, 
+</div><div class="q2">according to an ordinance for Israel, 
+</div><div class="q2">to give thanks to Yahweh’s name. 
+</div><div class="q1">
+<sup>5&#160;</sup>For there are set thrones for judgment, 
+</div><div class="q2">the thrones of David’s house. 
+</div><div class="q1">
+<sup>6&#160;</sup>Pray for the peace of Jerusalem. 
+</div><div class="q2">Those who love you will prosper. 
+</div><div class="q1">
+<sup>7&#160;</sup>Peace be within your walls, 
+</div><div class="q2">and prosperity within your palaces. 
+</div><div class="q1">
+<sup>8&#160;</sup>For my brothers’ and companions’ sakes, 
+</div><div class="q2">I will now say, “Peace be within you.” 
+</div><div class="q1">
+<sup>9&#160;</sup>For the sake of the house of Yahweh our Elohim, 
+</div><div class="q2">I will seek your good. 
+</div><h2 class="psalmlabel" id="123">123</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>I lift up my eyes to you, 
+</div><div class="q2">you who sit in the heavens. 
+</div><div class="q1">
+<sup>2&#160;</sup>Behold, as the eyes of servants look to the hand of their master, 
+</div><div class="q2">as the eyes of a maid to the hand of her mistress, 
+</div><div class="q2">so our eyes look to Yahweh, our Elohim, 
+</div><div class="q2">until he has mercy on us. 
+</div><div class="q1">
+<sup>3&#160;</sup>Have mercy on us, Yahweh, have mercy on us, 
+</div><div class="q2">for we have endured much contempt. 
+</div><div class="q1">
+<sup>4&#160;</sup>Our soul is exceedingly filled with the scoffing of those who are at ease, 
+</div><div class="q2">with the contempt of the proud. 
+</div><h2 class="psalmlabel" id="124">124</h2>
+<div class="d">A Song of Ascents. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>If it had not been Yahweh who was on our side, 
+</div><div class="q2">let Israel now say, 
+</div><div class="q1">
+<sup>2&#160;</sup>if it had not been Yahweh who was on our side, 
+</div><div class="q2">when men rose up against us, 
+</div><div class="q1">
+<sup>3&#160;</sup>then they would have swallowed us up alive, 
+</div><div class="q2">when their wrath was kindled against us, 
+</div><div class="q1">
+<sup>4&#160;</sup>then the waters would have overwhelmed us, 
+</div><div class="q2">the stream would have gone over our soul. 
+</div><div class="q1">
+<sup>5&#160;</sup>Then the proud waters would have gone over our soul. 
+</div><div class="q1">
+<sup>6&#160;</sup>Blessed be Yahweh, 
+</div><div class="q2">who has not given us as a prey to their teeth. 
+</div><div class="q1">
+<sup>7&#160;</sup>Our soul has escaped like a bird out of the fowler’s snare. 
+</div><div class="q2">The snare is broken, and we have escaped. 
+</div><div class="q1">
+<sup>8&#160;</sup>Our help is in Yahweh’s name, 
+</div><div class="q2">who made heaven and earth. 
+</div><h2 class="psalmlabel" id="125">125</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>Those who trust in Yahweh are as Mount Zion, 
+</div><div class="q2">which can’t be moved, but remains forever. 
+</div><div class="q1">
+<sup>2&#160;</sup>As the mountains surround Jerusalem, 
+</div><div class="q2">so Yahweh surrounds his people from this time forward and forever more. 
+</div><div class="q1">
+<sup>3&#160;</sup>For the scepter of wickedness won’t remain over the allotment of the righteous, 
+</div><div class="q2">so that the righteous won’t use their hands to do evil. 
+</div><div class="q1">
+<sup>4&#160;</sup>Do good, Yahweh, to those who are good, 
+</div><div class="q2">to those who are upright in their hearts. 
+</div><div class="q1">
+<sup>5&#160;</sup>But as for those who turn away to their crooked ways, 
+</div><div class="q2">Yahweh will lead them away with the workers of iniquity. 
+</div><div class="q1">Peace be on Israel. 
+</div><h2 class="psalmlabel" id="126">126</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>When Yahweh brought back those who returned to Zion, 
+</div><div class="q2">we were like those who dream. 
+</div><div class="q1">
+<sup>2&#160;</sup>Then our mouth was filled with laughter, 
+</div><div class="q2">and our tongue with singing. 
+</div><div class="q1">Then they said among the nations, 
+</div><div class="q2">“Yahweh has done great things for them.” 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh has done great things for us, 
+</div><div class="q2">and we are glad. 
+</div><div class="q1">
+<sup>4&#160;</sup>Restore our fortunes again, Yahweh, 
+</div><div class="q2">like the streams in the Negev. 
+</div><div class="q1">
+<sup>5&#160;</sup>Those who sow in tears will reap in joy. 
+</div><div class="q2">
+<sup>6&#160;</sup>He who goes out weeping, carrying seed for sowing, 
+</div><div class="q2">will certainly come again with joy, carrying his sheaves. 
+</div><h2 class="psalmlabel" id="127">127</h2>
+<div class="d">A Song of Ascents. By Solomon. 
+</div><div class="q1">
+<sup>1&#160;</sup>Unless Yahweh builds the house, 
+</div><div class="q2">they who build it labor in vain. 
+</div><div class="q1">Unless Yahweh watches over the city, 
+</div><div class="q2">the watchman guards it in vain. 
+</div><div class="q1">
+<sup>2&#160;</sup>It is vain for you to rise up early, 
+</div><div class="q2">to stay up late, 
+</div><div class="q2">eating the bread of toil, 
+</div><div class="q2">for he gives sleep to his loved ones. 
+</div><div class="q1">
+<sup>3&#160;</sup>Behold, children are a heritage of Yahweh. 
+</div><div class="q2">The fruit of the womb is his reward. 
+</div><div class="q1">
+<sup>4&#160;</sup>As arrows in the hand of a mighty man, 
+</div><div class="q2">so are the children of youth. 
+</div><div class="q1">
+<sup>5&#160;</sup>Happy is the man who has his quiver full of them. 
+</div><div class="q2">They won’t be disappointed when they speak with their enemies in the gate. 
+</div><h2 class="psalmlabel" id="128">128</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>Blessed is everyone who fears Yahweh, 
+</div><div class="q2">who walks in his ways. 
+</div><div class="q1">
+<sup>2&#160;</sup>For you will eat the labor of your hands. 
+</div><div class="q2">You will be happy, and it will be well with you. 
+</div><div class="q1">
+<sup>3&#160;</sup>Your woman will be as a fruitful vine in the innermost parts of your house, 
+</div><div class="q2">your children like olive shoots around your table. 
+</div><div class="q1">
+<sup>4&#160;</sup>Behold, this is how the man who fears Yahweh is blessed. 
+</div><div class="q2">
+<sup>5&#160;</sup>May Yahweh bless you out of Zion, 
+</div><div class="q2">and may you see the good of Jerusalem all the days of your life. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yes, may you see your children’s children. 
+</div><div class="q2">Peace be upon Israel. 
+</div><h2 class="psalmlabel" id="129">129</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>Many times they have afflicted me from my youth up. 
+</div><div class="q2">Let Israel now say: 
+</div><div class="q1">
+<sup>2&#160;</sup>many times they have afflicted me from my youth up, 
+</div><div class="q2">yet they have not prevailed against me. 
+</div><div class="q1">
+<sup>3&#160;</sup>The plowers plowed on my back. 
+</div><div class="q2">They made their furrows long. 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh is righteous. 
+</div><div class="q2">He has cut apart the cords of the wicked. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let them be disappointed and turned backward, 
+</div><div class="q2">all those who hate Zion. 
+</div><div class="q1">
+<sup>6&#160;</sup>Let them be as the grass on the housetops, 
+</div><div class="q2">which withers before it grows up, 
+</div><div class="q1">
+<sup>7&#160;</sup>with which the reaper doesn’t fill his hand, 
+</div><div class="q2">nor he who binds sheaves, his bosom. 
+</div><div class="q1">
+<sup>8&#160;</sup>Neither do those who go by say, 
+</div><div class="q2">“The blessing of Yahweh be on you. 
+</div><div class="q2">We bless you in Yahweh’s name.” 
+</div><h2 class="psalmlabel" id="130">130</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>Out of the depths I have cried to you, Yahweh. 
+</div><div class="q1">
+<sup>2&#160;</sup>Lord, hear my voice. 
+</div><div class="q2">Let your ears be attentive to the voice of my petitions. 
+</div><div class="q1">
+<sup>3&#160;</sup>If you, Yah, kept a record of sins, 
+</div><div class="q2">Lord, who could stand? 
+</div><div class="q1">
+<sup>4&#160;</sup>But there is forgiveness with you, 
+</div><div class="q2">therefore you are feared. 
+</div><div class="q1">
+<sup>5&#160;</sup>I wait for Yahweh. 
+</div><div class="q2">My soul waits. 
+</div><div class="q2">I hope in his word. 
+</div><div class="q1">
+<sup>6&#160;</sup>My soul longs for the Lord more than watchmen long for the morning, 
+</div><div class="q2">more than watchmen for the morning. 
+</div><div class="q1">
+<sup>7&#160;</sup>Israel, hope in Yahweh, 
+</div><div class="q2">for there is loving kindness with Yahweh. 
+</div><div class="q2">Abundant redemption is with him. 
+</div><div class="q1">
+<sup>8&#160;</sup>He will redeem Israel from all their sins. 
+</div><h2 class="psalmlabel" id="131">131</h2>
+<div class="d">A Song of Ascents. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, my heart isn’t arrogant, nor my eyes lofty; 
+</div><div class="q2">nor do I concern myself with great matters, 
+</div><div class="q2">or things too wonderful for me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Surely I have stilled and quieted my soul, 
+</div><div class="q2">like a weaned child with his mother, 
+</div><div class="q2">like a weaned child is my soul within me. 
+</div><div class="q1">
+<sup>3&#160;</sup>Israel, hope in Yahweh, 
+</div><div class="q2">from this time forward and forever more. 
+</div><h2 class="psalmlabel" id="132">132</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, remember David and all his affliction, 
+</div><div class="q1">
+<sup>2&#160;</sup>how he swore to Yahweh, 
+</div><div class="q2">and vowed to the Mighty One of Jacob: 
+</div><div class="q1">
+<sup>3&#160;</sup>“Surely I will not come into the structure of my house, 
+</div><div class="q2">nor go up into my bed; 
+</div><div class="q1">
+<sup>4&#160;</sup>I will not give sleep to my eyes, 
+</div><div class="q2">or slumber to my eyelids, 
+</div><div class="q1">
+<sup>5&#160;</sup>until I find out a place for Yahweh, 
+</div><div class="q2">a dwelling for the Mighty One of Jacob.” 
+</div><div class="q1">
+<sup>6&#160;</sup>Behold, we heard of it in Ephrathah. 
+</div><div class="q2">We found it in the field of Jaar. 
+</div><div class="q1">
+<sup>7&#160;</sup>“We will go into his dwelling place. 
+</div><div class="q2">We will worship at his footstool.” 
+</div><div class="q1">
+<sup>8&#160;</sup>Arise, Yahweh, into your resting place, 
+</div><div class="q2">you, and the ark of your strength. 
+</div><div class="q1">
+<sup>9&#160;</sup>Let your priests be clothed with righteousness. 
+</div><div class="q2">Let your saints shout for joy! 
+</div><div class="q1">
+<sup>10&#160;</sup>For your servant David’s sake, 
+</div><div class="q2">don’t turn away the face of your anointed one. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh has sworn to David in truth. 
+</div><div class="q2">He will not turn from it: 
+</div><div class="q2">“I will set the fruit of your body on your throne. 
+</div><div class="q1">
+<sup>12&#160;</sup>If your children will keep my covenant, 
+</div><div class="q2">my testimony that I will teach them, 
+</div><div class="q2">their children also will sit on your throne forever more.” 
+</div><div class="q1">
+<sup>13&#160;</sup>For Yahweh has chosen Zion. 
+</div><div class="q2">He has desired it for his habitation. 
+</div><div class="q1">
+<sup>14&#160;</sup>“This is my resting place forever. 
+</div><div class="q2">I will live here, for I have desired it. 
+</div><div class="q1">
+<sup>15&#160;</sup>I will abundantly bless her provision. 
+</div><div class="q2">I will satisfy her poor with bread. 
+</div><div class="q1">
+<sup>16&#160;</sup>I will also clothe her priests with salvation. 
+</div><div class="q2">Her saints will shout aloud for joy. 
+</div><div class="q1">
+<sup>17&#160;</sup>I will make the horn of David to bud there. 
+</div><div class="q2">I have ordained a lamp for my anointed. 
+</div><div class="q1">
+<sup>18&#160;</sup>I will clothe his enemies with shame, 
+</div><div class="q2">but on himself, his crown will shine.” 
+</div><h2 class="psalmlabel" id="133">133</h2>
+<div class="d">A Song of Ascents. By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>See how good and how pleasant it is 
+</div><div class="q2">for brothers to live together in unity! 
+</div><div class="q1">
+<sup>2&#160;</sup>It is like the precious oil on the head, 
+</div><div class="q2">that ran down on the beard, 
+</div><div class="q2">even Aaron’s beard, 
+</div><div class="q2">that came down on the edge of his robes, 
+</div><div class="q1">
+<sup>3&#160;</sup>like the dew of Hermon, 
+</div><div class="q2">that comes down on the hills of Zion; 
+</div><div class="q2">for there Yahweh gives the blessing, 
+</div><div class="q2">even life forever more. 
+</div><h2 class="psalmlabel" id="134">134</h2>
+<div class="d">A Song of Ascents. 
+</div><div class="q1">
+<sup>1&#160;</sup>Look! Praise Yahweh, all you servants of Yahweh, 
+</div><div class="q2">who stand by night in Yahweh’s house! 
+</div><div class="q1">
+<sup>2&#160;</sup>Lift up your hands in the sanctuary. 
+</div><div class="q2">Praise Yahweh! 
+</div><div class="q1">
+<sup>3&#160;</sup>May Yahweh bless you from Zion, 
+</div><div class="q2">even he who made heaven and earth. 
+</div><h2 class="psalmlabel" id="135">135</h2>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">Praise Yahweh’s name! 
+</div><div class="q2">Praise him, you servants of Yahweh, 
+</div><div class="q1">
+<sup>2&#160;</sup>you who stand in Yahweh’s house, 
+</div><div class="q2">in the courts of our Elohim’s house. 
+</div><div class="q1">
+<sup>3&#160;</sup>Praise Yah, for Yahweh is good. 
+</div><div class="q2">Sing praises to his name, for that is pleasant. 
+</div><div class="q1">
+<sup>4&#160;</sup>For Yah has chosen Jacob for himself, 
+</div><div class="q2">Israel for his own possession. 
+</div><div class="q1">
+<sup>5&#160;</sup>For I know that Yahweh is great, 
+</div><div class="q2">that our Lord is above all elohims. 
+</div><div class="q1">
+<sup>6&#160;</sup>Whatever Yahweh pleased, that he has done, 
+</div><div class="q2">in heaven and in earth, in the seas and in all deeps. 
+</div><div class="q1">
+<sup>7&#160;</sup>He causes the clouds to rise from the ends of the earth. 
+</div><div class="q2">He makes lightnings with the rain. 
+</div><div class="q2">He brings the wind out of his treasuries. 
+</div><div class="q1">
+<sup>8&#160;</sup>He struck the firstborn of Egypt, 
+</div><div class="q2">both of man and animal. 
+</div><div class="q1">
+<sup>9&#160;</sup>He sent signs and wonders into the middle of you, Egypt, 
+</div><div class="q2">on Pharaoh, and on all his servants. 
+</div><div class="q1">
+<sup>10&#160;</sup>He struck many nations, 
+</div><div class="q2">and killed mighty kings—</div><div class="q1">
+<sup>11&#160;</sup>Sihon king of the Amorites, 
+</div><div class="q2">Og king of Bashan, 
+</div><div class="q2">and all the kingdoms of Canaan—</div><div class="q1">
+<sup>12&#160;</sup>and gave their land for a heritage, 
+</div><div class="q2">a heritage to Israel, his people. 
+</div><div class="q1">
+<sup>13&#160;</sup>Your name, Yahweh, endures forever; 
+</div><div class="q2">your renown, Yahweh, throughout all generations. 
+</div><div class="q1">
+<sup>14&#160;</sup>For Yahweh will judge his people 
+</div><div class="q2">and have compassion on his servants. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>15&#160;</sup>The idols of the nations are silver and gold, 
+</div><div class="q2">the work of men’s hands. 
+</div><div class="q1">
+<sup>16&#160;</sup>They have mouths, but they can’t speak. 
+</div><div class="q2">They have eyes, but they can’t see. 
+</div><div class="q1">
+<sup>17&#160;</sup>They have ears, but they can’t hear, 
+</div><div class="q2">neither is there any breath in their mouths. 
+</div><div class="q1">
+<sup>18&#160;</sup>Those who make them will be like them, 
+</div><div class="q2">yes, everyone who trusts in them. 
+</div><div class="q1">
+<sup>19&#160;</sup>House of Israel, praise Yahweh! 
+</div><div class="q2">House of Aaron, praise Yahweh! 
+</div><div class="q1">
+<sup>20&#160;</sup>House of Levi, praise Yahweh! 
+</div><div class="q2">You who fear Yahweh, praise Yahweh! 
+</div><div class="q1">
+<sup>21&#160;</sup>Blessed be Yahweh from Zion, 
+</div><div class="q2">who dwells in Jerusalem. 
+</div><div class="q1">Praise Yah! 
+</div><h2 class="psalmlabel" id="136">136</h2>
+<div class="q1">
+<sup>1&#160;</sup>Give thanks to Yahweh, for he is good, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>2&#160;</sup>Give thanks to the Elohim of elohims, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>3&#160;</sup>Give thanks to the Lord of lords, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>4&#160;</sup>to him who alone does great wonders, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>5&#160;</sup>to him who by understanding made the heavens, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>6&#160;</sup>to him who spread out the earth above the waters, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>7&#160;</sup>to him who made the great lights, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>8&#160;</sup>the sun to rule by day, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>9&#160;</sup>the moon and stars to rule by night, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>10&#160;</sup>to him who struck down the Egyptian firstborn, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>11&#160;</sup>and brought out Israel from among them, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>12&#160;</sup>with a strong hand, and with an outstretched arm, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>13&#160;</sup>to him who divided the Red Sea apart, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>14&#160;</sup>and made Israel to pass through the middle of it, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>15&#160;</sup>but overthrew Pharaoh and his army in the Red Sea, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>16&#160;</sup>to him who led his people through the wilderness, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>17&#160;</sup>to him who struck great kings, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>18&#160;</sup>and killed mighty kings, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>19&#160;</sup>Sihon king of the Amorites, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>20&#160;</sup>Og king of Bashan, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>21&#160;</sup>and gave their land as an inheritance, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>22&#160;</sup>even a heritage to Israel his servant, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>23&#160;</sup>who remembered us in our low estate, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>24&#160;</sup>and has delivered us from our adversaries, 
+</div><div class="q2">for his loving kindness endures forever; 
+</div><div class="q1">
+<sup>25&#160;</sup>who gives food to every creature, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><div class="q1">
+<sup>26&#160;</sup>Oh give thanks to the Elohim of heaven, 
+</div><div class="q2">for his loving kindness endures forever. 
+</div><h2 class="psalmlabel" id="137">137</h2>
+<div class="q1">
+<sup>1&#160;</sup>By the rivers of Babylon, there we sat down. 
+</div><div class="q2">Yes, we wept, when we remembered Zion. 
+</div><div class="q1">
+<sup>2&#160;</sup>On the willows in that land, 
+</div><div class="q2">we hung up our harps. 
+</div><div class="q1">
+<sup>3&#160;</sup>For there, those who led us captive asked us for songs. 
+</div><div class="q2">Those who tormented us demanded songs of joy: 
+</div><div class="q2">“Sing us one of the songs of Zion!” 
+</div><div class="q1">
+<sup>4&#160;</sup>How can we sing Yahweh’s song in a foreign land? 
+</div><div class="q1">
+<sup>5&#160;</sup>If I forget you, Jerusalem, 
+</div><div class="q2">let my right hand forget its skill. 
+</div><div class="q1">
+<sup>6&#160;</sup>Let my tongue stick to the roof of my mouth if I don’t remember you, 
+</div><div class="q2">if I don’t prefer Jerusalem above my chief joy. 
+</div><div class="q1">
+<sup>7&#160;</sup>Remember, Yahweh, against the children of Edom in the day of Jerusalem, 
+</div><div class="q2">who said, “Raze it! 
+</div><div class="q2">Raze it even to its foundation!” 
+</div><div class="q1">
+<sup>8&#160;</sup>Daughter of Babylon, doomed to destruction, 
+</div><div class="q2">he will be happy who repays you, 
+</div><div class="q2">as you have done to us. 
+</div><div class="q1">
+<sup>9&#160;</sup>Happy shall he be, 
+</div><div class="q2">who takes and dashes your little ones against the rock. 
+</div><h2 class="psalmlabel" id="138">138</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will give you thanks with my whole heart. 
+</div><div class="q2">Before the elohims, I will sing praises to you. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will bow down toward your set-apart temple, 
+</div><div class="q2">and give thanks to your Name for your loving kindness and for your truth; 
+</div><div class="q2">for you have exalted your Name and your Word above all. 
+</div><div class="q1">
+<sup>3&#160;</sup>In the day that I called, you answered me. 
+</div><div class="q2">You encouraged me with strength in my soul. 
+</div><div class="q1">
+<sup>4&#160;</sup>All the kings of the earth will give you thanks, Yahweh, 
+</div><div class="q2">for they have heard the words of your mouth. 
+</div><div class="q1">
+<sup>5&#160;</sup>Yes, they will sing of the ways of Yahweh, 
+</div><div class="q2">for Yahweh’s glory is great! 
+</div><div class="q1">
+<sup>6&#160;</sup>For though Yahweh is high, yet he looks after the lowly; 
+</div><div class="q2">but he knows the proud from afar. 
+</div><div class="q1">
+<sup>7&#160;</sup>Though I walk in the middle of trouble, you will revive me. 
+</div><div class="q2">You will stretch out your hand against the wrath of my enemies. 
+</div><div class="q2">Your right hand will save me. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh will fulfill that which concerns me. 
+</div><div class="q2">Your loving kindness, Yahweh, endures forever. 
+</div><div class="q2">Don’t forsake the works of your own hands. 
+</div><h2 class="psalmlabel" id="139">139</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, you have searched me, 
+</div><div class="q2">and you know me. 
+</div><div class="q1">
+<sup>2&#160;</sup>You know my sitting down and my rising up. 
+</div><div class="q2">You perceive my thoughts from afar. 
+</div><div class="q1">
+<sup>3&#160;</sup>You search out my path and my lying down, 
+</div><div class="q2">and are acquainted with all my ways. 
+</div><div class="q1">
+<sup>4&#160;</sup>For there is not a word on my tongue, 
+</div><div class="q2">but behold, Yahweh, you know it altogether. 
+</div><div class="q1">
+<sup>5&#160;</sup>You hem me in behind and before. 
+</div><div class="q2">You laid your hand on me. 
+</div><div class="q1">
+<sup>6&#160;</sup>This knowledge is beyond me. 
+</div><div class="q2">It’s lofty. 
+</div><div class="q2">I can’t attain it. 
+</div><div class="q1">
+<sup>7&#160;</sup>Where could I go from your Spirit? 
+</div><div class="q2">Or where could I flee from your presence? 
+</div><div class="q1">
+<sup>8&#160;</sup>If I ascend up into heaven, you are there. 
+</div><div class="q2">If I make my bed in Sheol, behold, you are there! 
+</div><div class="q1">
+<sup>9&#160;</sup>If I take the wings of the dawn, 
+</div><div class="q2">and settle in the uttermost parts of the sea, 
+</div><div class="q1">
+<sup>10&#160;</sup>even there your hand will lead me, 
+</div><div class="q2">and your right hand will hold me. 
+</div><div class="q1">
+<sup>11&#160;</sup>If I say, “Surely the darkness will overwhelm me. 
+</div><div class="q2">The light around me will be night,” 
+</div><div class="q1">
+<sup>12&#160;</sup>even the darkness doesn’t hide from you, 
+</div><div class="q2">but the night shines as the day. 
+</div><div class="q2">The darkness is like light to you. 
+</div><div class="q1">
+<sup>13&#160;</sup>For you formed my inmost being. 
+</div><div class="q2">You knit me together in my mother’s womb. 
+</div><div class="q1">
+<sup>14&#160;</sup>I will give thanks to you, 
+</div><div class="q2">for I am fearfully and wonderfully made. 
+</div><div class="q1">Your works are wonderful. 
+</div><div class="q2">My soul knows that very well. 
+</div><div class="q1">
+<sup>15&#160;</sup>My frame wasn’t hidden from you, 
+</div><div class="q2">when I was made in secret, 
+</div><div class="q2">woven together in the depths of the earth. 
+</div><div class="q1">
+<sup>16&#160;</sup>Your eyes saw my body. 
+</div><div class="q2">In your book they were all written, 
+</div><div class="q2">the days that were ordained for me, 
+</div><div class="q2">when as yet there were none of them. 
+</div><div class="q1">
+<sup>17&#160;</sup>How precious to me are your thoughts, Elohim! 
+</div><div class="q2">How vast is their sum! 
+</div><div class="q1">
+<sup>18&#160;</sup>If I would count them, they are more in number than the sand. 
+</div><div class="q2">When I wake up, I am still with you. 
+</div><div class="q1">
+<sup>19&#160;</sup>If only you, Elohim, would kill the wicked. 
+</div><div class="q2">Get away from me, you bloodthirsty men! 
+</div><div class="q1">
+<sup>20&#160;</sup>For they speak against you wickedly. 
+</div><div class="q2">Your enemies take your name in vain. 
+</div><div class="q1">
+<sup>21&#160;</sup>Yahweh, don’t I hate those who hate you? 
+</div><div class="q2">Am I not grieved with those who rise up against you? 
+</div><div class="q1">
+<sup>22&#160;</sup>I hate them with perfect hatred. 
+</div><div class="q2">They have become my enemies. 
+</div><div class="q1">
+<sup>23&#160;</sup>Search me, Elohim, and know my heart. 
+</div><div class="q2">Try me, and know my thoughts. 
+</div><div class="q1">
+<sup>24&#160;</sup>See if there is any wicked way in me, 
+</div><div class="q2">and lead me in the everlasting way. 
+</div><h2 class="psalmlabel" id="140">140</h2>
+<div class="d">For the Chief Musician. A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Deliver me, Yahweh, from evil men. 
+</div><div class="q2">Preserve me from violent men: 
+</div><div class="q1">
+<sup>2&#160;</sup>those who devise mischief in their hearts. 
+</div><div class="q2">They continually gather themselves together for war. 
+</div><div class="q1">
+<sup>3&#160;</sup>They have sharpened their tongues like a serpent. 
+</div><div class="q2">Viper’s poison is under their lips. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>4&#160;</sup>Yahweh, keep me from the hands of the wicked. 
+</div><div class="q2">Preserve me from the violent men who have determined to trip my feet. 
+</div><div class="q1">
+<sup>5&#160;</sup>The proud have hidden a snare for me, 
+</div><div class="q2">they have spread the cords of a net by the path. 
+</div><div class="q2">They have set traps for me. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>6&#160;</sup>I said to Yahweh, “You are my Elohim.” 
+</div><div class="q2">Listen to the cry of my petitions, Yahweh. 
+</div><div class="q1">
+<sup>7&#160;</sup>Yahweh, the Lord, the strength of my salvation, 
+</div><div class="q2">you have covered my head in the day of battle. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh, don’t grant the desires of the wicked. 
+</div><div class="q2">Don’t let their evil plans succeed, or they will become proud. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>9&#160;</sup>As for the head of those who surround me, 
+</div><div class="q2">let the mischief of their own lips cover them. 
+</div><div class="q1">
+<sup>10&#160;</sup>Let burning coals fall on them. 
+</div><div class="q2">Let them be thrown into the fire, 
+</div><div class="q2">into miry pits, from where they never rise. 
+</div><div class="q1">
+<sup>11&#160;</sup>An evil speaker won’t be established in the earth. 
+</div><div class="q2">Evil will hunt the violent man to overthrow him. 
+</div><div class="q1">
+<sup>12&#160;</sup>I know that Yahweh will maintain the cause of the afflicted, 
+</div><div class="q2">and justice for the needy. 
+</div><div class="q1">
+<sup>13&#160;</sup>Surely the righteous will give thanks to your name. 
+</div><div class="q2">The upright will dwell in your presence. 
+</div><h2 class="psalmlabel" id="141">141</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Yahweh, I have called on you. 
+</div><div class="q2">Come to me quickly! 
+</div><div class="q2">Listen to my voice when I call to you. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let my prayer be set before you like incense; 
+</div><div class="q2">the lifting up of my hands like the evening sacrifice. 
+</div><div class="q1">
+<sup>3&#160;</sup>Set a watch, Yahweh, before my mouth. 
+</div><div class="q2">Keep the door of my lips. 
+</div><div class="q1">
+<sup>4&#160;</sup>Don’t incline my heart to any evil thing, 
+</div><div class="q2">to practice deeds of wickedness with men who work iniquity. 
+</div><div class="q2">Don’t let me eat of their delicacies. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let the righteous strike me, it is kindness; 
+</div><div class="q2">let him reprove me, it is like oil on the head; 
+</div><div class="q2">don’t let my head refuse it; 
+</div><div class="q2">Yet my prayer is always against evil deeds. 
+</div><div class="q1">
+<sup>6&#160;</sup>Their judges are thrown down by the sides of the rock. 
+</div><div class="q2">They will hear my words, for they are well spoken. 
+</div><div class="q1">
+<sup>7&#160;</sup>“As when one plows and breaks up the earth, 
+</div><div class="q2">our bones are scattered at the mouth of Sheol.” 
+</div><div class="q1">
+<sup>8&#160;</sup>For my eyes are on you, Yahweh, the Lord. 
+</div><div class="q2">I take refuge in you. 
+</div><div class="q2">Don’t leave my soul destitute. 
+</div><div class="q1">
+<sup>9&#160;</sup>Keep me from the snare which they have laid for me, 
+</div><div class="q2">from the traps of the workers of iniquity. 
+</div><div class="q1">
+<sup>10&#160;</sup>Let the wicked fall together into their own nets 
+</div><div class="q2">while I pass by. 
+</div><h2 class="psalmlabel" id="142">142</h2>
+<div class="d">A contemplation by David, when he was in the cave. A Prayer. 
+</div><div class="q1">
+<sup>1&#160;</sup>I cry with my voice to Yahweh. 
+</div><div class="q2">With my voice, I ask Yahweh for mercy. 
+</div><div class="q1">
+<sup>2&#160;</sup>I pour out my complaint before him. 
+</div><div class="q2">I tell him my troubles. 
+</div><div class="q1">
+<sup>3&#160;</sup>When my spirit was overwhelmed within me, 
+</div><div class="q2">you knew my route. 
+</div><div class="q1">On the path in which I walk, 
+</div><div class="q2">they have hidden a snare for me. 
+</div><div class="q1">
+<sup>4&#160;</sup>Look on my right, and see; 
+</div><div class="q2">for there is no one who is concerned for me. 
+</div><div class="q2">Refuge has fled from me. 
+</div><div class="q2">No one cares for my soul. 
+</div><div class="q1">
+<sup>5&#160;</sup>I cried to you, Yahweh. 
+</div><div class="q2">I said, “You are my refuge, 
+</div><div class="q2">my portion in the land of the living.” 
+</div><div class="q1">
+<sup>6&#160;</sup>Listen to my cry, 
+</div><div class="q2">for I am in desperate need. 
+</div><div class="q1">Deliver me from my persecutors, 
+</div><div class="q2">for they are too strong for me. 
+</div><div class="q1">
+<sup>7&#160;</sup>Bring my soul out of prison, 
+</div><div class="q2">that I may give thanks to your name. 
+</div><div class="q1">The righteous will surround me, 
+</div><div class="q2">for you will be good to me. 
+</div><h2 class="psalmlabel" id="143">143</h2>
+<div class="d">A Psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Hear my prayer, Yahweh. 
+</div><div class="q2">Listen to my petitions. 
+</div><div class="q2">In your faithfulness and righteousness, relieve me. 
+</div><div class="q1">
+<sup>2&#160;</sup>Don’t enter into judgment with your servant, 
+</div><div class="q2">for in your sight no man living is righteous. 
+</div><div class="q1">
+<sup>3&#160;</sup>For the enemy pursues my soul. 
+</div><div class="q2">He has struck my life down to the ground. 
+</div><div class="q2">He has made me live in dark places, as those who have been long dead. 
+</div><div class="q1">
+<sup>4&#160;</sup>Therefore my spirit is overwhelmed within me. 
+</div><div class="q2">My heart within me is desolate. 
+</div><div class="q1">
+<sup>5&#160;</sup>I remember the days of old. 
+</div><div class="q2">I meditate on all your doings. 
+</div><div class="q2">I contemplate the work of your hands. 
+</div><div class="q1">
+<sup>6&#160;</sup>I spread out my hands to you. 
+</div><div class="q2">My soul thirsts for you, like a parched land. </div><div class="qs">Selah. 
+</div><div class="q1">
+<sup>7&#160;</sup>Hurry to answer me, Yahweh. 
+</div><div class="q2">My spirit fails. 
+</div><div class="q1">Don’t hide your face from me, 
+</div><div class="q2">so that I don’t become like those who go down into the pit. 
+</div><div class="q1">
+<sup>8&#160;</sup>Cause me to hear your loving kindness in the morning, 
+</div><div class="q2">for I trust in you. 
+</div><div class="q1">Cause me to know the way in which I should walk, 
+</div><div class="q2">for I lift up my soul to you. 
+</div><div class="q1">
+<sup>9&#160;</sup>Deliver me, Yahweh, from my enemies. 
+</div><div class="q2">I flee to you to hide me. 
+</div><div class="q1">
+<sup>10&#160;</sup>Teach me to do your will, 
+</div><div class="q2">for you are my Elohim. 
+</div><div class="q1">Your Spirit is good. 
+</div><div class="q2">Lead me in the land of uprightness. 
+</div><div class="q1">
+<sup>11&#160;</sup>Revive me, Yahweh, for your name’s sake. 
+</div><div class="q2">In your righteousness, bring my soul out of trouble. 
+</div><div class="q1">
+<sup>12&#160;</sup>In your loving kindness, cut off my enemies, 
+</div><div class="q2">and destroy all those who afflict my soul, 
+</div><div class="q2">for I am your servant. 
+</div><h2 class="psalmlabel" id="144">144</h2>
+<div class="d">By David. 
+</div><div class="q1">
+<sup>1&#160;</sup>Blessed be Yahweh, my rock, 
+</div><div class="q2">who trains my hands to war, 
+</div><div class="q2">and my fingers to battle—</div><div class="q1">
+<sup>2&#160;</sup>my loving kindness, my fortress, 
+</div><div class="q2">my high tower, my deliverer, 
+</div><div class="q2">my shield, and he in whom I take refuge, 
+</div><div class="q2">who subdues my people under me. 
+</div><div class="q1">
+<sup>3&#160;</sup>Yahweh, what is man, that you care for him? 
+</div><div class="q2">Or the son of man, that you think of him? 
+</div><div class="q1">
+<sup>4&#160;</sup>Man is like a breath. 
+</div><div class="q2">His days are like a shadow that passes away. 
+</div><div class="q1">
+<sup>5&#160;</sup>Part your heavens, Yahweh, and come down. 
+</div><div class="q2">Touch the mountains, and they will smoke. 
+</div><div class="q1">
+<sup>6&#160;</sup>Throw out lightning, and scatter them. 
+</div><div class="q2">Send out your arrows, and rout them. 
+</div><div class="q1">
+<sup>7&#160;</sup>Stretch out your hand from above, 
+</div><div class="q2">rescue me, and deliver me out of great waters, 
+</div><div class="q2">out of the hands of foreigners, 
+</div><div class="q2">
+<sup>8&#160;</sup>whose mouths speak deceit, 
+</div><div class="q2">whose right hand is a right hand of falsehood. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will sing a new song to you, Elohim. 
+</div><div class="q2">On a ten-stringed lyre, I will sing praises to you. 
+</div><div class="q1">
+<sup>10&#160;</sup>You are he who gives salvation to kings, 
+</div><div class="q2">who rescues David, his servant, from the deadly sword. 
+</div><div class="q1">
+<sup>11&#160;</sup>Rescue me, and deliver me out of the hands of foreigners, 
+</div><div class="q2">whose mouths speak deceit, 
+</div><div class="q2">whose right hand is a right hand of falsehood. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>12&#160;</sup>Then our sons will be like well-nurtured plants, 
+</div><div class="q2">our daughters like pillars carved to adorn a palace. 
+</div><div class="q1">
+<sup>13&#160;</sup>Our barns are full, filled with all kinds of provision. 
+</div><div class="q2">Our sheep produce thousands and ten thousands in our fields. 
+</div><div class="q1">
+<sup>14&#160;</sup>Our oxen will pull heavy loads. 
+</div><div class="q2">There is no breaking in, and no going away, 
+</div><div class="q2">and no outcry in our streets. 
+</div><div class="q1">
+<sup>15&#160;</sup>Happy are the people who are in such a situation. 
+</div><div class="q2">Happy are the people whose Elohim is Yahweh. 
+</div><h2 class="psalmlabel" id="145">145</h2>
+<div class="d">A praise psalm by David. 
+</div><div class="q1">
+<sup>1&#160;</sup>I will exalt you, my Elohim, the King. 
+</div><div class="q2">I will praise your name forever and ever. 
+</div><div class="q1">
+<sup>2&#160;</sup>Every day I will praise you. 
+</div><div class="q2">I will extol your name forever and ever. 
+</div><div class="q1">
+<sup>3&#160;</sup>Great is Yahweh, and greatly to be praised! 
+</div><div class="q2">His greatness is unsearchable. 
+</div><div class="q1">
+<sup>4&#160;</sup>One generation will commend your works to another, 
+</div><div class="q2">and will declare your mighty acts. 
+</div><div class="q1">
+<sup>5&#160;</sup>I will meditate on the glorious majesty of your honor, 
+</div><div class="q2">on your wondrous works. 
+</div><div class="q1">
+<sup>6&#160;</sup>Men will speak of the might of your awesome acts. 
+</div><div class="q2">I will declare your greatness. 
+</div><div class="q1">
+<sup>7&#160;</sup>They will utter the memory of your great goodness, 
+</div><div class="q2">and will sing of your righteousness. 
+</div><div class="q1">
+<sup>8&#160;</sup>Yahweh is gracious, merciful, 
+</div><div class="q2">slow to anger, and of great loving kindness. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yahweh is good to all. 
+</div><div class="q2">His tender mercies are over all his works. 
+</div><div class="q1">
+<sup>10&#160;</sup>All your works will give thanks to you, Yahweh. 
+</div><div class="q2">Your saints will extol you. 
+</div><div class="q1">
+<sup>11&#160;</sup>They will speak of the glory of your kingdom, 
+</div><div class="q2">and talk about your power, 
+</div><div class="q1">
+<sup>12&#160;</sup>to make known to the sons of men his mighty acts, 
+</div><div class="q2">the glory of the majesty of his kingdom. 
+</div><div class="q1">
+<sup>13&#160;</sup>Your kingdom is an everlasting kingdom. 
+</div><div class="q2">Your dominion endures throughout all generations. 
+</div><div class="q1">Yahweh is faithful in all his words, 
+</div><div class="q2">and loving in all his deeds. 
+</div><div class="q1">
+<sup>14&#160;</sup>Yahweh upholds all who fall, 
+</div><div class="q2">and raises up all those who are bowed down. 
+</div><div class="q1">
+<sup>15&#160;</sup>The eyes of all wait for you. 
+</div><div class="q2">You give them their food in due season. 
+</div><div class="q1">
+<sup>16&#160;</sup>You open your hand, 
+</div><div class="q2">and satisfy the desire of every living thing. 
+</div><div class="q1">
+<sup>17&#160;</sup>Yahweh is righteous in all his ways, 
+</div><div class="q2">and gracious in all his works. 
+</div><div class="q1">
+<sup>18&#160;</sup>Yahweh is near to all those who call on him, 
+</div><div class="q2">to all who call on him in truth. 
+</div><div class="q1">
+<sup>19&#160;</sup>He will fulfill the desire of those who fear him. 
+</div><div class="q2">He also will hear their cry, and will save them. 
+</div><div class="q1">
+<sup>20&#160;</sup>Yahweh preserves all those who love him, 
+</div><div class="q2">but he will destroy all the wicked. 
+</div><div class="q1">
+<sup>21&#160;</sup>My mouth will speak the praise of Yahweh. 
+</div><div class="q2">Let all flesh bless his set-apart name forever and ever. 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="146">146</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah! 
-</p><p class="q2">Praise Yahweh, my soul. 
-</p><p class="q1">
-<span class="v">2&#160;</span>While I live, I will praise Yahweh. 
-</p><p class="q2">I will sing praises to my Elohim as long as I exist. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Don’t put your trust in princes, 
-</p><p class="q2">in a son of man in whom there is no help. 
-</p><p class="q1">
-<span class="v">4&#160;</span>His spirit departs, and he returns to the earth. 
-</p><p class="q2">In that very day, his thoughts perish. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Happy is he who has the Elohim of Jacob for his help, 
-</p><p class="q2">whose hope is in Yahweh, his Elohim, 
-</p><p class="q1">
-<span class="v">6&#160;</span>who made heaven and earth, 
-</p><p class="q2">the sea, and all that is in them; 
-</p><p class="q2">who keeps truth forever; 
-</p><p class="q1">
-<span class="v">7&#160;</span>who executes justice for the oppressed; 
-</p><p class="q2">who gives food to the hungry. 
-</p><p class="q1">Yahweh frees the prisoners. 
-</p><p class="q2">
-<span class="v">8&#160;</span>Yahweh opens the eyes of the blind. 
-</p><p class="q2">Yahweh raises up those who are bowed down. 
-</p><p class="q2">Yahweh loves the righteous. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Yahweh preserves the foreigners. 
-</p><p class="q2">He upholds the fatherless and widow, 
-</p><p class="q2">but he turns the way of the wicked upside down. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Yahweh will reign forever; 
-</p><p class="q2">your Elohim, O Zion, to all generations. 
-</p><p class="q1">Praise Yah! 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">Praise Yahweh, my soul. 
+</div><div class="q1">
+<sup>2&#160;</sup>While I live, I will praise Yahweh. 
+</div><div class="q2">I will sing praises to my Elohim as long as I exist. 
+</div><div class="q1">
+<sup>3&#160;</sup>Don’t put your trust in princes, 
+</div><div class="q2">in a son of man in whom there is no help. 
+</div><div class="q1">
+<sup>4&#160;</sup>His spirit departs, and he returns to the earth. 
+</div><div class="q2">In that very day, his thoughts perish. 
+</div><div class="q1">
+<sup>5&#160;</sup>Happy is he who has the Elohim of Jacob for his help, 
+</div><div class="q2">whose hope is in Yahweh, his Elohim, 
+</div><div class="q1">
+<sup>6&#160;</sup>who made heaven and earth, 
+</div><div class="q2">the sea, and all that is in them; 
+</div><div class="q2">who keeps truth forever; 
+</div><div class="q1">
+<sup>7&#160;</sup>who executes justice for the oppressed; 
+</div><div class="q2">who gives food to the hungry. 
+</div><div class="q1">Yahweh frees the prisoners. 
+</div><div class="q2">
+<sup>8&#160;</sup>Yahweh opens the eyes of the blind. 
+</div><div class="q2">Yahweh raises up those who are bowed down. 
+</div><div class="q2">Yahweh loves the righteous. 
+</div><div class="q1">
+<sup>9&#160;</sup>Yahweh preserves the foreigners. 
+</div><div class="q2">He upholds the fatherless and widow, 
+</div><div class="q2">but he turns the way of the wicked upside down. 
+</div><div class="q1">
+<sup>10&#160;</sup>Yahweh will reign forever; 
+</div><div class="q2">your Elohim, O Zion, to all generations. 
+</div><div class="q1">Praise Yah! 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="147">147</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah, 
-</p><p class="q2">for it is good to sing praises to our Elohim; 
-</p><p class="q2">for it is pleasant and fitting to praise him. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Yahweh builds up Jerusalem. 
-</p><p class="q2">He gathers together the outcasts of Israel. 
-</p><p class="q1">
-<span class="v">3&#160;</span>He heals the broken in heart, 
-</p><p class="q2">and binds up their wounds. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He counts the number of the stars. 
-</p><p class="q2">He calls them all by their names. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Great is our Lord, and mighty in power. 
-</p><p class="q2">His understanding is infinite. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Yahweh upholds the humble. 
-</p><p class="q2">He brings the wicked down to the ground. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Sing to Yahweh with thanksgiving. 
-</p><p class="q2">Sing praises on the harp to our Elohim, 
-</p><p class="q1">
-<span class="v">8&#160;</span>who covers the sky with clouds, 
-</p><p class="q2">who prepares rain for the earth, 
-</p><p class="q2">who makes grass grow on the mountains. 
-</p><p class="q1">
-<span class="v">9&#160;</span>He provides food for the livestock, 
-</p><p class="q2">and for the young ravens when they call. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He doesn’t delight in the strength of the horse. 
-</p><p class="q2">He takes no pleasure in the legs of a man. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Yahweh takes pleasure in those who fear him, 
-</p><p class="q2">in those who hope in his loving kindness. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Praise Yahweh, Jerusalem! 
-</p><p class="q2">Praise your Elohim, Zion! 
-</p><p class="q1">
-<span class="v">13&#160;</span>For he has strengthened the bars of your gates. 
-</p><p class="q2">He has blessed your children within you. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He makes peace in your borders. 
-</p><p class="q2">He fills you with the finest of the wheat. 
-</p><p class="q1">
-<span class="v">15&#160;</span>He sends out his commandment to the earth. 
-</p><p class="q2">His word runs very swiftly. 
-</p><p class="q1">
-<span class="v">16&#160;</span>He gives snow like wool, 
-</p><p class="q2">and scatters frost like ashes. 
-</p><p class="q1">
-<span class="v">17&#160;</span>He hurls down his hail like pebbles. 
-</p><p class="q2">Who can stand before his cold? 
-</p><p class="q1">
-<span class="v">18&#160;</span>He sends out his word, and melts them. 
-</p><p class="q2">He causes his wind to blow, and the waters flow. 
-</p><p class="q1">
-<span class="v">19&#160;</span>He shows his word to Jacob, 
-</p><p class="q2">his statutes and his ordinances to Israel. 
-</p><p class="q1">
-<span class="v">20&#160;</span>He has not done this for just any nation. 
-</p><p class="q2">They don’t know his ordinances. 
-</p><p class="q1">Praise Yah! 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah, 
+</div><div class="q2">for it is good to sing praises to our Elohim; 
+</div><div class="q2">for it is pleasant and fitting to praise him. 
+</div><div class="q1">
+<sup>2&#160;</sup>Yahweh builds up Jerusalem. 
+</div><div class="q2">He gathers together the outcasts of Israel. 
+</div><div class="q1">
+<sup>3&#160;</sup>He heals the broken in heart, 
+</div><div class="q2">and binds up their wounds. 
+</div><div class="q1">
+<sup>4&#160;</sup>He counts the number of the stars. 
+</div><div class="q2">He calls them all by their names. 
+</div><div class="q1">
+<sup>5&#160;</sup>Great is our Lord, and mighty in power. 
+</div><div class="q2">His understanding is infinite. 
+</div><div class="q1">
+<sup>6&#160;</sup>Yahweh upholds the humble. 
+</div><div class="q2">He brings the wicked down to the ground. 
+</div><div class="q1">
+<sup>7&#160;</sup>Sing to Yahweh with thanksgiving. 
+</div><div class="q2">Sing praises on the harp to our Elohim, 
+</div><div class="q1">
+<sup>8&#160;</sup>who covers the sky with clouds, 
+</div><div class="q2">who prepares rain for the earth, 
+</div><div class="q2">who makes grass grow on the mountains. 
+</div><div class="q1">
+<sup>9&#160;</sup>He provides food for the livestock, 
+</div><div class="q2">and for the young ravens when they call. 
+</div><div class="q1">
+<sup>10&#160;</sup>He doesn’t delight in the strength of the horse. 
+</div><div class="q2">He takes no pleasure in the legs of a man. 
+</div><div class="q1">
+<sup>11&#160;</sup>Yahweh takes pleasure in those who fear him, 
+</div><div class="q2">in those who hope in his loving kindness. 
+</div><div class="q1">
+<sup>12&#160;</sup>Praise Yahweh, Jerusalem! 
+</div><div class="q2">Praise your Elohim, Zion! 
+</div><div class="q1">
+<sup>13&#160;</sup>For he has strengthened the bars of your gates. 
+</div><div class="q2">He has blessed your children within you. 
+</div><div class="q1">
+<sup>14&#160;</sup>He makes peace in your borders. 
+</div><div class="q2">He fills you with the finest of the wheat. 
+</div><div class="q1">
+<sup>15&#160;</sup>He sends out his commandment to the earth. 
+</div><div class="q2">His word runs very swiftly. 
+</div><div class="q1">
+<sup>16&#160;</sup>He gives snow like wool, 
+</div><div class="q2">and scatters frost like ashes. 
+</div><div class="q1">
+<sup>17&#160;</sup>He hurls down his hail like pebbles. 
+</div><div class="q2">Who can stand before his cold? 
+</div><div class="q1">
+<sup>18&#160;</sup>He sends out his word, and melts them. 
+</div><div class="q2">He causes his wind to blow, and the waters flow. 
+</div><div class="q1">
+<sup>19&#160;</sup>He shows his word to Jacob, 
+</div><div class="q2">his statutes and his ordinances to Israel. 
+</div><div class="q1">
+<sup>20&#160;</sup>He has not done this for just any nation. 
+</div><div class="q2">They don’t know his ordinances. 
+</div><div class="q1">Praise Yah! 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="148">148</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah! 
-</p><p class="q2">Praise Yahweh from the heavens! 
-</p><p class="q2">Praise him in the heights! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Praise him, all his angels! 
-</p><p class="q2">Praise him, all his army! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Praise him, sun and moon! 
-</p><p class="q2">Praise him, all you shining stars! 
-</p><p class="q1">
-<span class="v">4&#160;</span>Praise him, you heavens of heavens, 
-</p><p class="q2">you waters that are above the heavens. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let them praise Yahweh’s name, 
-</p><p class="q2">for he commanded, and they were created. 
-</p><p class="q1">
-<span class="v">6&#160;</span>He has also established them forever and ever. 
-</p><p class="q2">He has made a decree which will not pass away. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Praise Yahweh from the earth, 
-</p><p class="q2">you great sea creatures, and all depths, 
-</p><p class="q1">
-<span class="v">8&#160;</span>lightning and hail, snow and clouds, 
-</p><p class="q2">stormy wind, fulfilling his word, 
-</p><p class="q1">
-<span class="v">9&#160;</span>mountains and all hills, 
-</p><p class="q2">fruit trees and all cedars, 
-</p><p class="q1">
-<span class="v">10&#160;</span>wild animals and all livestock, 
-</p><p class="q2">small creatures and flying birds, 
-</p><p class="q1">
-<span class="v">11&#160;</span>kings of the earth and all peoples, 
-</p><p class="q2">princes and all judges of the earth, 
-</p><p class="q1">
-<span class="v">12&#160;</span>both young men and maidens, 
-</p><p class="q2">old men and children. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Let them praise Yahweh’s name, 
-</p><p class="q2">for his name alone is exalted. 
-</p><p class="q2">His glory is above the earth and the heavens. 
-</p><p class="q1">
-<span class="v">14&#160;</span>He has lifted up the horn of his people, 
-</p><p class="q2">the praise of all his saints, 
-</p><p class="q2">even of the children of Israel, a people near to him. 
-</p><p class="q1">Praise Yah! 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">Praise Yahweh from the heavens! 
+</div><div class="q2">Praise him in the heights! 
+</div><div class="q1">
+<sup>2&#160;</sup>Praise him, all his angels! 
+</div><div class="q2">Praise him, all his army! 
+</div><div class="q1">
+<sup>3&#160;</sup>Praise him, sun and moon! 
+</div><div class="q2">Praise him, all you shining stars! 
+</div><div class="q1">
+<sup>4&#160;</sup>Praise him, you heavens of heavens, 
+</div><div class="q2">you waters that are above the heavens. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let them praise Yahweh’s name, 
+</div><div class="q2">for he commanded, and they were created. 
+</div><div class="q1">
+<sup>6&#160;</sup>He has also established them forever and ever. 
+</div><div class="q2">He has made a decree which will not pass away. 
+</div><div class="q1">
+<sup>7&#160;</sup>Praise Yahweh from the earth, 
+</div><div class="q2">you great sea creatures, and all depths, 
+</div><div class="q1">
+<sup>8&#160;</sup>lightning and hail, snow and clouds, 
+</div><div class="q2">stormy wind, fulfilling his word, 
+</div><div class="q1">
+<sup>9&#160;</sup>mountains and all hills, 
+</div><div class="q2">fruit trees and all cedars, 
+</div><div class="q1">
+<sup>10&#160;</sup>wild animals and all livestock, 
+</div><div class="q2">small creatures and flying birds, 
+</div><div class="q1">
+<sup>11&#160;</sup>kings of the earth and all peoples, 
+</div><div class="q2">princes and all judges of the earth, 
+</div><div class="q1">
+<sup>12&#160;</sup>both young men and maidens, 
+</div><div class="q2">old men and children. 
+</div><div class="q1">
+<sup>13&#160;</sup>Let them praise Yahweh’s name, 
+</div><div class="q2">for his name alone is exalted. 
+</div><div class="q2">His glory is above the earth and the heavens. 
+</div><div class="q1">
+<sup>14&#160;</sup>He has lifted up the horn of his people, 
+</div><div class="q2">the praise of all his saints, 
+</div><div class="q2">even of the children of Israel, a people near to him. 
+</div><div class="q1">Praise Yah! 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="149">149</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yahweh! 
-</p><p class="q2">Sing to Yahweh a new song, 
-</p><p class="q2">his praise in the assembly of the saints. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let Israel rejoice in him who made them. 
-</p><p class="q2">Let the children of Zion be joyful in their King. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Let them praise his name in the dance! 
-</p><p class="q2">Let them sing praises to him with tambourine and harp! 
-</p><p class="q1">
-<span class="v">4&#160;</span>For Yahweh takes pleasure in his people. 
-</p><p class="q2">He crowns the humble with salvation. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Let the saints rejoice in honor. 
-</p><p class="q2">Let them sing for joy on their beds. 
-</p><p class="q1">
-<span class="v">6&#160;</span>May the high praises of Elohim be in their mouths, 
-</p><p class="q2">and a two-edged sword in their hand, 
-</p><p class="q1">
-<span class="v">7&#160;</span>to execute vengeance on the nations, 
-</p><p class="q2">and punishments on the peoples; 
-</p><p class="q1">
-<span class="v">8&#160;</span>to bind their kings with chains, 
-</p><p class="q2">and their nobles with fetters of iron; 
-</p><p class="q1">
-<span class="v">9&#160;</span>to execute on them the written judgment. 
-</p><p class="q2">All his saints have this honor. 
-</p><p class="q1">Praise Yah! 
-</p><div class="b"> &#160; </div>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yahweh! 
+</div><div class="q2">Sing to Yahweh a new song, 
+</div><div class="q2">his praise in the assembly of the saints. 
+</div><div class="q1">
+<sup>2&#160;</sup>Let Israel rejoice in him who made them. 
+</div><div class="q2">Let the children of Zion be joyful in their King. 
+</div><div class="q1">
+<sup>3&#160;</sup>Let them praise his name in the dance! 
+</div><div class="q2">Let them sing praises to him with tambourine and harp! 
+</div><div class="q1">
+<sup>4&#160;</sup>For Yahweh takes pleasure in his people. 
+</div><div class="q2">He crowns the humble with salvation. 
+</div><div class="q1">
+<sup>5&#160;</sup>Let the saints rejoice in honor. 
+</div><div class="q2">Let them sing for joy on their beds. 
+</div><div class="q1">
+<sup>6&#160;</sup>May the high praises of Elohim be in their mouths, 
+</div><div class="q2">and a two-edged sword in their hand, 
+</div><div class="q1">
+<sup>7&#160;</sup>to execute vengeance on the nations, 
+</div><div class="q2">and punishments on the peoples; 
+</div><div class="q1">
+<sup>8&#160;</sup>to bind their kings with chains, 
+</div><div class="q2">and their nobles with fetters of iron; 
+</div><div class="q1">
+<sup>9&#160;</sup>to execute on them the written judgment. 
+</div><div class="q2">All his saints have this honor. 
+</div><div class="q1">Praise Yah! 
+</div><div class="b"> &#160; </div>
 <h2 class="psalmlabel" id="150">150</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Praise Yah! 
-</p><p class="q2">Praise Elohim in his sanctuary! 
-</p><p class="q2">Praise him in his heavens for his acts of power! 
-</p><p class="q1">
-<span class="v">2&#160;</span>Praise him for his mighty acts! 
-</p><p class="q2">Praise him according to his excellent greatness! 
-</p><p class="q1">
-<span class="v">3&#160;</span>Praise him with the sounding of the trumpet! 
-</p><p class="q2">Praise him with harp and lyre! 
-</p><p class="q1">
-<span class="v">4&#160;</span>Praise him with tambourine and dancing! 
-</p><p class="q2">Praise him with stringed instruments and flute! 
-</p><p class="q1">
-<span class="v">5&#160;</span>Praise him with loud cymbals! 
-</p><p class="q2">Praise him with resounding cymbals! 
-</p><p class="q1">
-<span class="v">6&#160;</span>Let everything that has breath praise Yah! 
-</p><p class="q2">Praise Yah! </div><script src="../main.js"></script></body></html>
+<div class="q1">
+<sup>1&#160;</sup>Praise Yah! 
+</div><div class="q2">Praise Elohim in his sanctuary! 
+</div><div class="q2">Praise him in his heavens for his acts of power! 
+</div><div class="q1">
+<sup>2&#160;</sup>Praise him for his mighty acts! 
+</div><div class="q2">Praise him according to his excellent greatness! 
+</div><div class="q1">
+<sup>3&#160;</sup>Praise him with the sounding of the trumpet! 
+</div><div class="q2">Praise him with harp and lyre! 
+</div><div class="q1">
+<sup>4&#160;</sup>Praise him with tambourine and dancing! 
+</div><div class="q2">Praise him with stringed instruments and flute! 
+</div><div class="q1">
+<sup>5&#160;</sup>Praise him with loud cymbals! 
+</div><div class="q2">Praise him with resounding cymbals! 
+</div><div class="q1">
+<sup>6&#160;</sup>Let everything that has breath praise Yah! 
+</div><div class="q2">Praise Yah! </div></div><script src="../main.js"></script></body></html>

--- a/book/revelation.html
+++ b/book/revelation.html
@@ -3,6 +3,47 @@
 <head>
 <title>Revelation</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,595 +53,618 @@
 <div class="main">
 <!-- REV World English Scripture (WES) -->
 <h1 class="booklabel">Revelation</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>This is the Revelation of Yahushua Christ,<span class="f">+ \fr 1:1 \ft “Christ” means “Anointed One”.</span> which Elohim gave him to show to his servants the things which must happen soon, which he sent and made known by his angel<span class="f">+ \fr 1:1 \ft or, messenger (here and wherever angel is mentioned)</span> to his servant, John, 
-<span class="v">2&#160;</span>who testified to Elohim’s word and of the testimony of Yahushua Christ, about everything that he saw. 
-</p><p>
-<span class="v">3&#160;</span>Blessed is he who reads and those who hear the words of the prophecy, and keep the things that are written in it, for the time is near. 
-</p><p>
-<span class="v">4&#160;</span>John, to the seven assemblies that are in Asia: Grace to you and peace from Elohim, who is and who was and who is to come; and from the seven Spirits who are before his throne; 
-<span class="v">5&#160;</span>and from Yahushua Christ, the faithful witness, the firstborn of the dead, and the ruler of the kings of the earth. To him who loves us, and washed us from our sins by his blood—<span class="v">6&#160;</span>and he made us to be a Kingdom, priests<span class="x">+ \xo 1:6 \xt Exodus 19:6; Isaiah 61:6 </span> to his Elohim and Father—to him be the glory and the dominion forever and ever. Amen. 
-</p><p>
-<span class="v">7&#160;</span>Behold,<span class="f">+ \fr 1:7 \ft “Behold”, from “ἰδοὺ”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> he is coming with the clouds, and every eye will see him, including those who pierced him. All the tribes of the earth will mourn over him. Even so, Amen. 
-</p><p>
-<span class="v">8&#160;</span><span class="wj">“I am the Alpha and the Omega,</span><span class="f">+ \fr 1:8 \ft TR adds “the Beginning and the End”</span><span class="wj">”</span> says the Lord Elohim,<span class="f">+ \fr 1:8 \ft TR omits “Elohim”</span> <span class="wj">“who is and who was and who is to come, the Almighty.”</span> 
-</p><p>
-<span class="v">9&#160;</span>I John, your brother and partner with you in the oppression, Kingdom, and perseverance in Christ Yahushua, was on the isle that is called Patmos because of Elohim’s Word and the testimony of Yahushua Christ. 
-<span class="v">10&#160;</span>I was in the Spirit on the Lord’s day, and I heard behind me a loud voice, like a trumpet 
-<span class="v">11&#160;</span>saying,<span class="f">+ \fr 1:11 \ft TR adds “I am the Alpha and the Omega, the First and the Last.”</span> <span class="wj">“What you see, write in a book and send to the seven assemblies:</span><span class="f">+ \fr 1:11 \ft TR adds “which are in Asia”</span> <span class="wj">to Ephesus, Smyrna, Pergamum, Thyatira, Sardis, Philadelphia, and to Laodicea.”</span> 
-</p><p>
-<span class="v">12&#160;</span>I turned to see the voice that spoke with me. Having turned, I saw seven golden lamp stands. 
-<span class="v">13&#160;</span>And among the lamp stands was one like a son of man,<span class="x">+ \xo 1:13 \xt Daniel 7:13 </span> clothed with a robe reaching down to his feet, and with a golden sash around his chest. 
-<span class="v">14&#160;</span>His head and his hair were white as white wool, like snow. His eyes were like a flame of fire. 
-<span class="v">15&#160;</span>His feet were like burnished brass, as if it had been refined in a furnace. His voice was like the voice of many waters. 
-<span class="v">16&#160;</span>He had seven stars in his right hand. Out of his mouth proceeded a sharp two-edged sword. His face was like the sun shining at its brightest. 
-<span class="v">17&#160;</span>When I saw him, I fell at his feet like a dead man. 
-</p><p>He laid his right hand on me, saying, <span class="wj">“Don’t be afraid. I am the first and the last, </span> 
-<span class="v">18&#160;</span><span class="wj">and the Living one. I was dead, and behold, I am alive forever and ever. Amen. I have the keys of Death and of Hades.</span><span class="f">+ \fr 1:18 \ft or, Hell</span> 
-<span class="v">19&#160;</span><span class="wj">Write therefore the things which you have seen, and the things which are, and the things which will happen hereafter. </span> 
-<span class="v">20&#160;</span><span class="wj">The mystery of the seven stars which you saw in my right hand, and the seven golden lamp stands is this: The seven stars are the angels</span><span class="f">+ \fr 1:20 \ft or, messengers (here and wherever angels are mentioned)</span> <span class="wj">of the seven assemblies. The seven lamp stands are seven assemblies.</span> 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“To the angel of the assembly in Ephesus write:</span> 
-</p><p><span class="wj">“He who holds the seven stars in his right hand, he who walks among the seven golden lamp stands says these things:</span> 
-</p><p>
-<span class="v">2&#160;</span><span class="wj">“I know your works, and your toil and perseverance, and that you can’t tolerate evil men, and have tested those who call themselves apostles, and they are not, and found them false. </span> 
-<span class="v">3&#160;</span><span class="wj">You have perseverance and have endured for my name’s sake, and have </span><span class="f">+ \fr 2:3 \ft TR adds “have labored and”</span> <span class="wj">not grown weary. </span> 
-<span class="v">4&#160;</span><span class="wj">But I have this against you, that you left your first love. </span> 
-<span class="v">5&#160;</span><span class="wj">Remember therefore from where you have fallen, and repent and do the first works; or else I am coming to you swiftly, and will move your lamp stand out of its place, unless you repent. </span> 
-<span class="v">6&#160;</span><span class="wj">But this you have, that you hate the works of the Nicolaitans, which I also hate. </span> 
-<span class="v">7&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes I will give to eat from the tree of life, which is in the Paradise of my Elohim.</span> 
-</p><p>
-<span class="v">8&#160;</span><span class="wj">“To the angel of the assembly in Smyrna write:</span> 
-</p><p><span class="wj">“The first and the last, who was dead, and has come to life says these things:</span> 
-</p><p>
-<span class="v">9&#160;</span><span class="wj">“I know your works, oppression, and your poverty (but you are rich), and the blasphemy of those who say they are Jews, and they are not, but are a synagogue of Satan. </span> 
-<span class="v">10&#160;</span><span class="wj">Don’t be afraid of the things which you are about to suffer. Behold, the devil is about to throw some of you into prison, that you may be tested; and you will have oppression for ten days. Be faithful to death, and I will give you the crown of life. </span> 
-<span class="v">11&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies. He who overcomes won’t be harmed by the second death.</span> 
-</p><p>
-<span class="v">12&#160;</span><span class="wj">“To the angel of the assembly in Pergamum write:</span> 
-</p><p><span class="wj">“He who has the sharp two-edged sword says these things:</span> 
-</p><p>
-<span class="v">13&#160;</span><span class="wj">“I know your works and where you dwell, where Satan’s throne is. You hold firmly to my name, and didn’t deny my faith in the days of Antipas my witness, my faithful one, who was killed among you, where Satan dwells. </span> 
-<span class="v">14&#160;</span><span class="wj">But I have a few things against you, because you have there some who hold the teaching of Balaam, who taught Balak to throw a stumbling block before the children of Israel, to eat things sacrificed to idols, and to commit sexual immorality. </span> 
-<span class="v">15&#160;</span><span class="wj">So also you likewise have some who hold to the teaching of the Nicolaitans.</span><span class="f">+ \fr 2:15 \ft TR reads “which I hate” instead of “likewise”</span> 
-<span class="v">16&#160;</span><span class="wj">Repent therefore, or else I am coming to you quickly and I will make war against them with the sword of my mouth. </span> 
-<span class="v">17&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes, to him I will give of the hidden manna, </span><span class="f">+ \fr 2:17 \ft Manna is supernatural food, named after the Hebrew for “What is it?”. See Exodus 11:7-9.</span> <span class="wj">and I will give him a white stone, and on the stone a new name written which no one knows but he who receives it.</span> 
-</p><p>
-<span class="v">18&#160;</span><span class="wj">“To the angel of the assembly in Thyatira write:</span> 
-</p><p><span class="wj">“The Son of Elohim, who has his eyes like a flame of fire, and his feet are like burnished brass, says these things:</span> 
-</p><p>
-<span class="v">19&#160;</span><span class="wj">“I know your works, your love, faith, service, patient endurance, and that your last works are more than the first. </span> 
-<span class="v">20&#160;</span><span class="wj">But I have this against you, that you tolerate your</span><span class="f">+ \fr 2:20 \ft TR, NU read “that” instead of “your”</span> <span class="wj">woman Jezebel, who calls herself a prophetess. She teaches and seduces my servants to commit sexual immorality and to eat things sacrificed to idols. </span> 
-<span class="v">21&#160;</span><span class="wj">I gave her time to repent, but she refuses to repent of her sexual immorality. </span> 
-<span class="v">22&#160;</span><span class="wj">Behold, I will throw her and those who commit adultery with her into a bed of great oppression, unless they repent of her works. </span> 
-<span class="v">23&#160;</span><span class="wj">I will kill her children with Death, and all the assemblies will know that I am he who searches the minds and hearts. I will give to each one of you according to your deeds. </span> 
-<span class="v">24&#160;</span><span class="wj">But to you I say, to the rest who are in Thyatira—as many as don’t have this teaching, who don’t know what some call ‘the deep things of Satan’—to you I say, I am not putting any other burden on you. </span> 
-<span class="v">25&#160;</span><span class="wj">Nevertheless, hold that which you have firmly until I come. </span> 
-<span class="v">26&#160;</span><span class="wj">He who overcomes, and he who keeps my works to the end, to him I will give authority over the nations. </span> 
-<span class="v">27&#160;</span><span class="wj">He will rule them with a rod of iron, shattering them like clay pots,</span><span class="x">+ \xo 2:27 \xt Psalm 2:9</span> <span class="wj">as I also have received of my Father; </span> 
-<span class="v">28&#160;</span><span class="wj">and I will give him the morning star. </span> 
-<span class="v">29&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.</span> 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span><span class="wj">“And to the angel of the assembly in Sardis write:</span> 
-</p><p><span class="wj">“He who has the seven Spirits of Elohim and the seven stars says these things:</span> 
-</p><p><span class="wj">“I know your works, that you have a reputation of being alive, but you are dead. </span> 
-<span class="v">2&#160;</span><span class="wj">Wake up and strengthen the things that remain, which you were about to throw away,</span><span class="f">+ \fr 3:2 \ft NU & TR read “which were about to die” instead of “which you were about to throw away”.</span> <span class="wj">for I have found no works of yours perfected before my Elohim. </span> 
-<span class="v">3&#160;</span><span class="wj">Remember therefore how you have received and heard. Keep it and repent. If therefore you won’t watch, I will come as a thief, and you won’t know what hour I will come upon you. </span> 
-<span class="v">4&#160;</span><span class="wj">Nevertheless you have a few names in Sardis that didn’t defile their garments. They will walk with me in white, for they are worthy. </span> 
-<span class="v">5&#160;</span><span class="wj">He who overcomes will be arrayed in white garments, and I will in no way blot his name out of the book of life, and I will confess his name before my Father, and before his angels. </span> 
-<span class="v">6&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.</span> 
-</p><p>
-<span class="v">7&#160;</span><span class="wj">“To the angel of the assembly in Philadelphia write:</span> 
-</p><p><span class="wj">“He who is set-apart, he who is true, he who has the key of David, he who opens and no one can shut, and who shuts and no one opens, says these things: </span> 
-</p><p>
-<span class="v">8&#160;</span><span class="wj">“I know your works (behold, I have set before you an open door, which no one can shut), that you have a little power, and kept my word, and didn’t deny my name. </span> 
-<span class="v">9&#160;</span><span class="wj">Behold, I make some of the synagogue of Satan, of those who say they are Jews, and they are not, but lie—behold, I will make them to come and worship before your feet, and to know that I have loved you. </span> 
-<span class="v">10&#160;</span><span class="wj">Because you kept my command to endure, I also will keep you from the hour of testing which is to come on the whole world, to test those who dwell on the earth. </span> 
-<span class="v">11&#160;</span><span class="wj">I am coming quickly! Hold firmly that which you have, so that no one takes your crown. </span> 
-<span class="v">12&#160;</span><span class="wj">He who overcomes, I will make him a pillar in the temple of my Elohim, and he will go out from there no more. I will write on him the name of my Elohim and the name of the city of my Elohim, the new Jerusalem, which comes down out of heaven from my Elohim, and my own new name. </span> 
-<span class="v">13&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.</span> 
-</p><p>
-<span class="v">14&#160;</span><span class="wj">“To the angel of the assembly in Laodicea write:</span> 
-</p><p><span class="wj">“The Amen, the Faithful and True Witness, the Beginning</span><span class="f">+ \fr 3:14 \ft or, Source, or Head</span> <span class="wj">of Elohim’s creation, says these things:</span> 
-</p><p>
-<span class="v">15&#160;</span><span class="wj">“I know your works, that you are neither cold nor hot. I wish you were cold or hot. </span> 
-<span class="v">16&#160;</span><span class="wj">So, because you are lukewarm, and neither hot nor cold, I will vomit you out of my mouth. </span> 
-<span class="v">17&#160;</span><span class="wj">Because you say, ‘I am rich, and have gotten riches, and have need of nothing,’ and don’t know that you are the wretched one, miserable, poor, blind, and naked; </span> 
-<span class="v">18&#160;</span><span class="wj">I counsel you to buy from me gold refined by fire, that you may become rich; and white garments, that you may clothe yourself, and that the shame of your nakedness may not be revealed; and eye salve to anoint your eyes, that you may see. </span> 
-<span class="v">19&#160;</span><span class="wj">As many as I love, I reprove and chasten. Be zealous therefore, and repent. </span> 
-<span class="v">20&#160;</span><span class="wj">Behold, I stand at the door and knock. If anyone hears my voice and opens the door, then I will come in to him and will dine with him, and he with me. </span> 
-<span class="v">21&#160;</span><span class="wj">He who overcomes, I will give to him to sit down with me on my throne, as I also overcame and sat down with my Father on his throne. </span> 
-<span class="v">22&#160;</span><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.”</span> 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>After these things I looked and saw a door opened in heaven; and the first voice that I heard, like a trumpet speaking with me, was one saying, “Come up here, and I will show you the things which must happen after this.” 
-</p><p>
-<span class="v">2&#160;</span>Immediately I was in the Spirit. Behold, there was a throne set in heaven, and one sitting on the throne 
-<span class="v">3&#160;</span>that looked like a jasper stone and a sardius. There was a rainbow around the throne, like an emerald to look at. 
-<span class="v">4&#160;</span>Around the throne were twenty-four thrones. On the thrones were twenty-four elders sitting, dressed in white garments, with crowns of gold on their heads. 
-<span class="v">5&#160;</span>Out of the throne proceed lightnings, sounds, and thunders. There were seven lamps of fire burning before his throne, which are the seven Spirits of Elohim. 
-<span class="v">6&#160;</span>Before the throne was something like a sea of glass, similar to crystal. In the middle of the throne, and around the throne were four living creatures full of eyes before and behind. 
-<span class="v">7&#160;</span>The first creature was like a lion, the second creature like a calf, the third creature had a face like a man, and the fourth was like a flying eagle. 
-<span class="v">8&#160;</span>The four living creatures, each one of them having six wings, are full of eyes around and within. They have no rest day and night, saying, “Set-Apart, set-apart, set-apart<span class="f">+ \fr 4:8 \ft Hodges/Farstad MT reads “set-apart” 9 times instead of 3.</span> is the Lord Elohim, the Almighty, who was and who is and who is to come!” 
-</p><p>
-<span class="v">9&#160;</span>When the living creatures give glory, honor, and thanks to him who sits on the throne, to him who lives forever and ever, 
-<span class="v">10&#160;</span>the twenty-four elders fall down before him who sits on the throne and worship him who lives forever and ever, and throw their crowns before the throne, saying, 
-<span class="v">11&#160;</span>“Worthy are you, our Lord and Elohim, the Set-Apart One,<span class="f">+ \fr 4:11 \ft TR omits “and Elohim, the Set-Apart One,”</span> to receive the glory, the honor, and the power, for you created all things, and because of your desire they existed and were created!” 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>I saw, in the right hand of him who sat on the throne, a book written inside and outside, sealed shut with seven seals. 
-<span class="v">2&#160;</span>I saw a mighty angel proclaiming with a loud voice, “Who is worthy to open the book, and to break its seals?” 
-<span class="v">3&#160;</span>No one in heaven above, or on the earth, or under the earth, was able to open the book or to look in it. 
-<span class="v">4&#160;</span>Then I wept much, because no one was found worthy to open the book or to look in it. 
-<span class="v">5&#160;</span>One of the elders said to me, “Don’t weep. Behold, the Lion who is of the tribe of Judah, the Root of David, has overcome: he who opens the book and its seven seals.” 
-</p><p>
-<span class="v">6&#160;</span>I saw in the middle of the throne and of the four living creatures, and in the middle of the elders, a Lamb standing, as though it had been slain, having seven horns and seven eyes, which are the seven Spirits of Elohim, sent out into all the earth. 
-<span class="v">7&#160;</span>Then he came, and he took it out of the right hand of him who sat on the throne. 
-<span class="v">8&#160;</span>Now when he had taken the book, the four living creatures and the twenty-four elders fell down before the Lamb, each one having a harp, and golden bowls full of incense, which are the prayers of the saints. 
-<span class="v">9&#160;</span>They sang a new song, saying, 
-</p><p class="q1">“You are worthy to take the book 
-</p><p class="q2">and to open its seals, 
-</p><p class="q1">for you were killed, 
-</p><p class="q2">and bought us for Elohim with your blood 
-</p><p class="q2">out of every tribe, language, people, and nation, 
-</p><p class="q1">
-<span class="v">10&#160;</span>and made us kings and priests to our Elohim; 
-</p><p class="q2">and we will reign on the earth.” 
-</p><p>
-<span class="v">11&#160;</span>I looked, and I heard something like a voice of many angels around the throne, the living creatures, and the elders. The number of them was ten thousands of ten thousands, and thousands of thousands, 
-<span class="v">12&#160;</span>saying with a loud voice, “Worthy is the Lamb who has been killed to receive the power, wealth, wisdom, strength, honor, glory, and blessing!” 
-</p><p>
-<span class="v">13&#160;</span>I heard every created thing which is in heaven, on the earth, under the earth, on the sea, and everything in them, saying, “To him who sits on the throne and to the Lamb be the blessing, the honor, the glory, and the dominion, forever and ever! Amen!”<span class="f">+ \fr 5:13 \ft TR omits “Amen!”</span> 
-</p><p>
-<span class="v">14&#160;</span>The four living creatures said, “Amen!” Then the<span class="f">+ \fr 5:14 \ft TR adds “twenty-four”</span> elders fell down and worshiped.<span class="f">+ \fr 5:14 \ft TR adds “the one living forever and ever”</span> 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>I saw that the Lamb opened one of the seven seals, and I heard one of the four living creatures saying, as with a voice of thunder, “Come and see!” 
-<span class="v">2&#160;</span>Then a white horse appeared, and he who sat on it had a bow. A crown was given to him, and he came out conquering, and to conquer. 
-</p><p>
-<span class="v">3&#160;</span>When he opened the second seal, I heard the second living creature saying, “Come!” 
-<span class="v">4&#160;</span>Another came out, a red horse. To him who sat on it was given power to take peace from the earth, and that they should kill one another. There was given to him a great sword. 
-</p><p>
-<span class="v">5&#160;</span>When he opened the third seal, I heard the third living creature saying, “Come and see!” And behold, a black horse, and he who sat on it had a balance in his hand. 
-<span class="v">6&#160;</span>I heard a voice in the middle of the four living creatures saying, “A choenix<span class="f">+ \fr 6:6 \ft A choenix is a dry volume measure that is a little more than a liter (a little more than a quart).</span> of wheat for a denarius, and three choenix of barley for a denarius! Don’t damage the oil and the wine!” 
-</p><p>
-<span class="v">7&#160;</span>When he opened the fourth seal, I heard the fourth living creature saying, “Come and see!” 
-<span class="v">8&#160;</span>And behold, a pale horse, and the name of he who sat on it was Death. Hades<span class="f">+ \fr 6:8 \ft or, Hell</span> followed with him. Authority over one fourth of the earth, to kill with the sword, with famine, with death, and by the wild animals of the earth was given to him. 
-</p><p>
-<span class="v">9&#160;</span>When he opened the fifth seal, I saw underneath the altar the souls of those who had been killed for the Word of Elohim, and for the testimony of the Lamb which they had. 
-<span class="v">10&#160;</span>They cried with a loud voice, saying, “How long, Master, the set-apart and true, until you judge and avenge our blood on those who dwell on the earth?” 
-<span class="v">11&#160;</span>A long white robe was given to each of them. They were told that they should rest yet for a while, until their fellow servants and their brothers,<span class="f">+ \fr 6:11 \ft The word for “brothers” here and where context allows may also be correctly translated “brothers and sisters” or “siblings.”</span> who would also be killed even as they were, should complete their course. 
-</p><p>
-<span class="v">12&#160;</span>I saw when he opened the sixth seal, and there was a great earthquake. The sun became black as sackcloth made of hair, and the whole moon became as blood. 
-<span class="v">13&#160;</span>The stars of the sky fell to the earth, like a fig tree dropping its unripe figs when it is shaken by a great wind. 
-<span class="v">14&#160;</span>The sky was removed like a scroll when it is rolled up. Every mountain and island was moved out of its place. 
-<span class="v">15&#160;</span>The kings of the earth, the princes, the commanding officers, the rich, the strong, and every slave and free person, hid themselves in the caves and in the rocks of the mountains. 
-<span class="v">16&#160;</span>They told the mountains and the rocks, “Fall on us, and hide us from the face of him who sits on the throne, and from the wrath of the Lamb, 
-<span class="v">17&#160;</span>for the great day of his wrath has come, and who is able to stand?” 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>After this, I saw four angels standing at the four corners of the earth, holding the four winds of the earth, so that no wind would blow on the earth, or on the sea, or on any tree. 
-<span class="v">2&#160;</span>I saw another angel ascend from the sunrise, having the seal of the living Elohim. He cried with a loud voice to the four angels to whom it was given to harm the earth and the sea, 
-<span class="v">3&#160;</span>saying, “Don’t harm the earth, the sea, or the trees, until we have sealed the bondservants of our Elohim on their foreheads!” 
-<span class="v">4&#160;</span>I heard the number of those who were sealed, one hundred forty-four thousand, sealed out of every tribe of the children of Israel: 
-</p><p class="q1">
-<span class="v">5&#160;</span>of the tribe of Judah twelve thousand were sealed, 
-</p><p class="q1">of the tribe of Reuben twelve thousand, 
-</p><p class="q1">of the tribe of Gad twelve thousand, 
-</p><p class="q1">
-<span class="v">6&#160;</span>of the tribe of Asher twelve thousand, 
-</p><p class="q1">of the tribe of Naphtali twelve thousand, 
-</p><p class="q1">of the tribe of Manasseh twelve thousand, 
-</p><p class="q1">
-<span class="v">7&#160;</span>of the tribe of Simeon twelve thousand, 
-</p><p class="q1">of the tribe of Levi twelve thousand, 
-</p><p class="q1">of the tribe of Issachar twelve thousand, 
-</p><p class="q1">
-<span class="v">8&#160;</span>of the tribe of Zebulun twelve thousand, 
-</p><p class="q1">of the tribe of Joseph twelve thousand, and 
-</p><p class="q1">of the tribe of Benjamin twelve thousand were sealed. 
-</p><p>
-<span class="v">9&#160;</span>After these things I looked, and behold, a great multitude which no man could count, out of every nation and of all tribes, peoples, and languages, standing before the throne and before the Lamb, dressed in white robes, with palm branches in their hands. 
-<span class="v">10&#160;</span>They cried with a loud voice, saying, “Salvation be to our Elohim, who sits on the throne, and to the Lamb!” 
-</p><p>
-<span class="v">11&#160;</span>All the angels were standing around the throne, the elders, and the four living creatures; and they fell on their faces before his throne, and worshiped Elohim, 
-<span class="v">12&#160;</span>saying, “Amen! Blessing, glory, wisdom, thanksgiving, honor, power, and might, be to our Elohim forever and ever! Amen.” 
-</p><p>
-<span class="v">13&#160;</span>One of the elders answered, saying to me, “These who are arrayed in the white robes, who are they, and where did they come from?” 
-</p><p>
-<span class="v">14&#160;</span>I told him, “My lord, you know.” 
-</p><p>He said to me, “These are those who came out of the great suffering.<span class="f">+ \fr 7:14 \ft or, oppression</span> They washed their robes and made them white in the Lamb’s blood. 
-<span class="v">15&#160;</span>Therefore they are before the throne of Elohim, and they serve him day and night in his temple. He who sits on the throne will spread his tabernacle over them. 
-<span class="v">16&#160;</span>They will never be hungry or thirsty any more. The sun won’t beat on them, nor any heat; 
-<span class="v">17&#160;</span>for the Lamb who is in the middle of the throne shepherds them and leads them to springs of life-giving waters. And Elohim will wipe away every tear from their eyes.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>When he opened the seventh seal, there was silence in heaven for about half an hour. 
-<span class="v">2&#160;</span>I saw the seven angels who stand before Elohim, and seven trumpets were given to them. 
-</p><p>
-<span class="v">3&#160;</span>Another angel came and stood over the altar, having a golden censer. Much incense was given to him, that he should add it to the prayers of all the saints on the golden altar which was before the throne. 
-<span class="v">4&#160;</span>The smoke of the incense, with the prayers of the saints, went up before Elohim out of the angel’s hand. 
-<span class="v">5&#160;</span>The angel took the censer, and he filled it with the fire of the altar, then threw it on the earth. Thunders, sounds, lightnings, and an earthquake followed. 
-</p><p>
-<span class="v">6&#160;</span>The seven angels who had the seven trumpets prepared themselves to sound. 
-</p><p>
-<span class="v">7&#160;</span>The first sounded, and there followed hail and fire, mixed with blood, and they were thrown to the earth. One third of the earth was burned up,<span class="f">+ \fr 8:7 \ft TR omits “One third of the earth was burned up”</span> and one third of the trees were burned up, and all green grass was burned up. 
-</p><p>
-<span class="v">8&#160;</span>The second angel sounded, and something like a great burning mountain was thrown into the sea. One third of the sea became blood, 
-<span class="v">9&#160;</span>and one third of the living creatures which were in the sea died. One third of the ships were destroyed. 
-</p><p>
-<span class="v">10&#160;</span>The third angel sounded, and a great star fell from the sky, burning like a torch, and it fell on one third of the rivers, and on the springs of water. 
-<span class="v">11&#160;</span>The name of the star is “Wormwood.” One third of the waters became wormwood. Many people died from the waters, because they were made bitter. 
-</p><p>
-<span class="v">12&#160;</span>The fourth angel sounded, and one third of the sun was struck, and one third of the moon, and one third of the stars, so that one third of them would be darkened; and the day wouldn’t shine for one third of it, and the night in the same way. 
-<span class="v">13&#160;</span>I saw, and I heard an eagle,<span class="f">+ \fr 8:13 \ft TR reads “angel” instead of “eagle” </span> flying in mid heaven, saying with a loud voice, “Woe! Woe! Woe to those who dwell on the earth, because of the other blasts of the trumpets of the three angels, who are yet to sound!” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>The fifth angel sounded, and I saw a star from the sky which had fallen to the earth. The key to the pit of the abyss was given to him. 
-<span class="v">2&#160;</span>He opened the pit of the abyss, and smoke went up out of the pit, like the smoke from a<span class="f">+ \fr 9:2 \ft TR adds “great”</span> burning furnace. The sun and the air were darkened because of the smoke from the pit. 
-<span class="v">3&#160;</span>Then out of the smoke came locusts on the earth, and power was given to them, as the scorpions of the earth have power. 
-<span class="v">4&#160;</span>They were told that they should not hurt the grass of the earth, neither any green thing, neither any tree, but only those people who don’t have Elohim’s seal on their foreheads. 
-<span class="v">5&#160;</span>They were given power, not to kill them, but to torment them for five months. Their torment was like the torment of a scorpion when it strikes a person. 
-<span class="v">6&#160;</span>In those days people will seek death, and will in no way find it. They will desire to die, and death will flee from them. 
-</p><p>
-<span class="v">7&#160;</span>The shapes of the locusts were like horses prepared for war. On their heads were something like golden crowns, and their faces were like people’s faces. 
-<span class="v">8&#160;</span>They had hair like women’s hair, and their teeth were like those of lions. 
-<span class="v">9&#160;</span>They had breastplates like breastplates of iron. The sound of their wings was like the sound of many chariots and horses rushing to war. 
-<span class="v">10&#160;</span>They have tails like those of scorpions, with stingers. In their tails they have power to harm men for five months. 
-<span class="v">11&#160;</span>They have over them as king the angel of the abyss. His name in Hebrew is “Abaddon”,<span class="f">+ \fr 9:11 \ft “Abaddon” is a Hebrew word that means “ruin”, “destruction”, or “the place of destruction”</span> but in Greek, he has the name “Apollyon”.<span class="f">+ \fr 9:11 \ft “Apollyon” means “Destroyer”.</span> 
-</p><p>
-<span class="v">12&#160;</span>The first woe is past. Behold, there are still two woes coming after this. 
-</p><p>
-<span class="v">13&#160;</span>The sixth angel sounded. I heard a voice from the horns of the golden altar which is before Elohim, 
-<span class="v">14&#160;</span>saying to the sixth angel who had the trumpet, “Free the four angels who are bound at the great river Euphrates!” 
-</p><p>
-<span class="v">15&#160;</span>The four angels were freed who had been prepared for that hour and day and month and year, so that they might kill one third of mankind. 
-<span class="v">16&#160;</span>The number of the armies of the horsemen was two hundred million.<span class="f">+ \fr 9:16 \ft literally, “ten thousands of ten thousands”</span> I heard the number of them. 
-<span class="v">17&#160;</span>Thus I saw the horses in the vision and those who sat on them, having breastplates of fiery red, hyacinth blue, and sulfur yellow; and the horses’ heads resembled lions’ heads. Out of their mouths proceed fire, smoke, and sulfur. 
-<span class="v">18&#160;</span>By these three plagues, one third of mankind was killed: by the fire, the smoke, and the sulfur, which proceeded out of their mouths. 
-<span class="v">19&#160;</span>For the power of the horses is in their mouths and in their tails. For their tails are like serpents, and have heads; and with them they harm. 
-</p><p>
-<span class="v">20&#160;</span>The rest of mankind, who were not killed with these plagues, didn’t repent of the works of their hands, that they wouldn’t worship demons, and the idols of gold, and of silver, and of brass, and of stone, and of wood, which can’t see, hear, or walk. 
-<span class="v">21&#160;</span>They didn’t repent of their murders, their sorceries,<span class="f">+ \fr 9:21 \ft The word for “sorceries” (pharmakeia) also implies the use of potions, poisons, and drugs</span> their sexual immorality, or their thefts. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p>
-<span class="v">1&#160;</span>I saw a mighty angel coming down out of the sky, clothed with a cloud. A rainbow was on his head. His face was like the sun, and his feet like pillars of fire. 
-<span class="v">2&#160;</span>He had in his hand a little open book. He set his right foot on the sea, and his left on the land. 
-<span class="v">3&#160;</span>He cried with a loud voice, as a lion roars. When he cried, the seven thunders uttered their voices. 
-<span class="v">4&#160;</span>When the seven thunders sounded, I was about to write; but I heard a voice from the sky saying, “Seal up the things which the seven thunders said, and don’t write them.” 
-</p><p>
-<span class="v">5&#160;</span>The angel whom I saw standing on the sea and on the land lifted up his right hand to the sky 
-<span class="v">6&#160;</span>and swore by him who lives forever and ever, who created heaven and the things that are in it, the earth and the things that are in it, and the sea and the things that are in it, that there will no longer be delay, 
-<span class="v">7&#160;</span>but in the days of the voice of the seventh angel, when he is about to sound, then the mystery of Elohim is finished, as he declared to his servants the prophets. 
-</p><p>
-<span class="v">8&#160;</span>The voice which I heard from heaven, again speaking with me, said, “Go, take the book which is open in the hand of the angel who stands on the sea and on the land.” 
-</p><p>
-<span class="v">9&#160;</span>I went to the angel, telling him to give me the little book. 
-</p><p>He said to me, “Take it and eat it. It will make your stomach bitter, but in your mouth it will be as sweet as honey.” 
-</p><p>
-<span class="v">10&#160;</span>I took the little book out of the angel’s hand, and ate it. It was as sweet as honey in my mouth. When I had eaten it, my stomach was made bitter. 
-<span class="v">11&#160;</span>They<span class="f">+ \fr 10:11 \ft TR reads “He” instead of “They”</span> told me, “You must prophesy again over many peoples, nations, languages, and kings.” 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p>
-<span class="v">1&#160;</span>A reed like a rod was given to me. Someone said, “Rise and measure Elohim’s temple, and the altar, and those who worship in it. 
-<span class="v">2&#160;</span>Leave out the court which is outside of the temple, and don’t measure it, for it has been given to the nations. They will tread the set-apart city under foot for forty-two months. 
-<span class="v">3&#160;</span>I will give power to my two witnesses, and they will prophesy one thousand two hundred sixty days, clothed in sackcloth.” 
-</p><p>
-<span class="v">4&#160;</span>These are the two olive trees and the two lamp stands, standing before the Lord of the earth. 
-<span class="v">5&#160;</span>If anyone desires to harm them, fire proceeds out of their mouth and devours their enemies. If anyone desires to harm them, he must be killed in this way. 
-<span class="v">6&#160;</span>These have the power to shut up the sky, that it may not rain during the days of their prophecy. They have power over the waters, to turn them into blood, and to strike the earth with every plague, as often as they desire. 
-</p><p>
-<span class="v">7&#160;</span>When they have finished their testimony, the beast that comes up out of the abyss will make war with them, and overcome them, and kill them. 
-<span class="v">8&#160;</span>Their dead bodies will be in the street of the great city, which spiritually is called Sodom and Egypt, where also their Lord was crucified. 
-<span class="v">9&#160;</span>From among the peoples, tribes, languages, and nations, people will look at their dead bodies for three and a half days, and will not allow their dead bodies to be laid in a tomb. 
-<span class="v">10&#160;</span>Those who dwell on the earth will rejoice over them, and they will be glad. They will give gifts to one another, because these two prophets tormented those who dwell on the earth. 
-</p><p>
-<span class="v">11&#160;</span>After the three and a half days, the breath of life from Elohim entered into them, and they stood on their feet. Great fear fell on those who saw them. 
-<span class="v">12&#160;</span>I heard a loud voice from heaven saying to them, “Come up here!” They went up into heaven in a cloud, and their enemies saw them. 
-<span class="v">13&#160;</span>In that day there was a great earthquake, and a tenth of the city fell. Seven thousand people were killed in the earthquake, and the rest were terrified and gave glory to the Elohim of heaven. 
-</p><p>
-<span class="v">14&#160;</span>The second woe is past. Behold, the third woe comes quickly. 
-</p><p>
-<span class="v">15&#160;</span>The seventh angel sounded, and great voices in heaven followed, saying, “The kingdom of the world has become the Kingdom of our Lord and of his Christ. He will reign forever and ever!” 
-</p><p>
-<span class="v">16&#160;</span>The twenty-four elders, who sit on their thrones before Elohim’s throne, fell on their faces and worshiped Elohim, 
-<span class="v">17&#160;</span>saying: “We give you thanks, Lord Elohim, the Almighty, the one who is and who was,<span class="f">+ \fr 11:17 \ft TR adds “and who is coming”</span> because you have taken your great power and reigned. 
-<span class="v">18&#160;</span>The nations were angry, and your wrath came, as did the time for the dead to be judged, and to give your bondservants the prophets, their reward, as well as to the saints and those who fear your name, to the small and the great, and to destroy those who destroy the earth.” 
-</p><p>
-<span class="v">19&#160;</span>Elohim’s temple that is in heaven was opened, and the ark of the Lord’s covenant was seen in his temple. Lightnings, sounds, thunders, an earthquake, and great hail followed. 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>A great sign was seen in heaven: a woman clothed with the sun, and the moon under her feet, and on her head a crown of twelve stars. 
-<span class="v">2&#160;</span>She was with child. She cried out in pain, laboring to give birth. 
-</p><p>
-<span class="v">3&#160;</span>Another sign was seen in heaven. Behold, a great red dragon, having seven heads and ten horns, and on his heads seven crowns. 
-<span class="v">4&#160;</span>His tail drew one third of the stars of the sky, and threw them to the earth. The dragon stood before the woman who was about to give birth, so that when she gave birth he might devour her child. 
-<span class="v">5&#160;</span>She gave birth to a son, a male child, who is to rule all the nations with a rod of iron. Her child was caught up to Elohim and to his throne. 
-<span class="v">6&#160;</span>The woman fled into the wilderness, where she has a place prepared by Elohim, that there they may nourish her one thousand two hundred sixty days. 
-</p><p>
-<span class="v">7&#160;</span>There was war in the sky. Michael and his angels made war on the dragon. The dragon and his angels made war. 
-<span class="v">8&#160;</span>They didn’t prevail. No place was found for them any more in heaven. 
-<span class="v">9&#160;</span>The great dragon was thrown down, the old serpent, he who is called the devil and Satan, the deceiver of the whole world. He was thrown down to the earth, and his angels were thrown down with him. 
-</p><p>
-<span class="v">10&#160;</span>I heard a loud voice in heaven, saying, “Now the salvation, the power, and the Kingdom of our Elohim, and the authority of his Christ has come; for the accuser of our brothers has been thrown down, who accuses them before our Elohim day and night. 
-<span class="v">11&#160;</span>They overcame him because of the Lamb’s blood, and because of the word of their testimony. They didn’t love their life, even to death. 
-<span class="v">12&#160;</span>Therefore rejoice, heavens, and you who dwell in them. Woe to the earth and to the sea, because the devil has gone down to you, having great wrath, knowing that he has but a short time.” 
-</p><p>
-<span class="v">13&#160;</span>When the dragon saw that he was thrown down to the earth, he persecuted the woman who gave birth to the male child. 
-<span class="v">14&#160;</span>Two wings of the great eagle were given to the woman, that she might fly into the wilderness to her place, so that she might be nourished for a time, times, and half a time, from the face of the serpent. 
-<span class="v">15&#160;</span>The serpent spewed water out of his mouth after the woman like a river, that he might cause her to be carried away by the stream. 
-<span class="v">16&#160;</span>The earth helped the woman, and the earth opened its mouth and swallowed up the river which the dragon spewed out of his mouth. 
-<span class="v">17&#160;</span>The dragon grew angry with the woman, and went away to make war with the rest of her offspring,<span class="f">+ \fr 12:17 \ft or, seed</span> who keep Elohim’s commandments and hold Yahushua’s testimony. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>Then I stood<span class="f">+ \fr 13:1 \ft NU reads \fqa he stood</span> on the sand of the sea. I saw a beast coming up out of the sea, having ten horns and seven heads. On his horns were ten crowns, and on his heads, blasphemous names. 
-<span class="v">2&#160;</span>The beast which I saw was like a leopard, and his feet were like those of a bear, and his mouth like the mouth of a lion. The dragon gave him his power, his throne, and great authority. 
-<span class="v">3&#160;</span>One of his heads looked like it had been wounded fatally. His fatal wound was healed, and the whole earth marveled at the beast. 
-<span class="v">4&#160;</span>They worshiped the dragon because he gave his authority to the beast; and they worshiped the beast, saying, “Who is like the beast? Who is able to make war with him?” 
-</p><p>
-<span class="v">5&#160;</span>A mouth speaking great things and blasphemy was given to him. Authority to make war for forty-two months was given to him. 
-<span class="v">6&#160;</span>He opened his mouth for blasphemy against Elohim, to blaspheme his name, his dwelling, and those who dwell in heaven. 
-<span class="v">7&#160;</span>It was given to him to make war with the saints and to overcome them. Authority over every tribe, people, language, and nation was given to him. 
-<span class="v">8&#160;</span>All who dwell on the earth will worship him, everyone whose name has not been written from the foundation of the world in the book of life of the Lamb who has been killed. 
-<span class="v">9&#160;</span>If anyone has an ear, let him hear. 
-<span class="v">10&#160;</span>If anyone is to go into captivity, he will go into captivity. If anyone is to be killed with the sword, he must be killed.<span class="f">+ \fr 13:10 \ft TR reads “If anyone leads into captivity, into captivity he goes. If anyone will kill with the sword, he must be killed with a sword.” instead of “If anyone is to go into captivity, he will go into captivity. If anyone is to be killed with the sword, he must be killed.” </span> Here is the endurance and the faith of the saints. 
-</p><p>
-<span class="v">11&#160;</span>I saw another beast coming up out of the earth. He had two horns like a lamb and it spoke like a dragon. 
-<span class="v">12&#160;</span>He exercises all the authority of the first beast in his presence. He makes the earth and those who dwell in it to worship the first beast, whose fatal wound was healed. 
-<span class="v">13&#160;</span>He performs great signs, even making fire come down out of the sky to the earth in the sight of people. 
-<span class="v">14&#160;</span>He deceives my own<span class="f">+ \fr 13:14 \ft NU omits “my own”</span> people who dwell on the earth because of the signs he was granted to do in front of the beast, saying to those who dwell on the earth that they should make an image to the beast who had the sword wound and lived. 
-<span class="v">15&#160;</span>It was given to him to give breath to the image of the beast, that the image of the beast should both speak, and cause as many as wouldn’t worship the image of the beast to be killed. 
-<span class="v">16&#160;</span>He causes all, the small and the great, the rich and the poor, and the free and the slave, to be given marks on their right hands or on their foreheads; 
-<span class="v">17&#160;</span>and that no one would be able to buy or to sell unless he has that mark, which is the name of the beast or the number of his name. 
-<span class="v">18&#160;</span>Here is wisdom. He who has understanding, let him calculate the number of the beast, for it is the number of a man. His number is six hundred sixty-six. 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>I saw, and behold, the Lamb standing on Mount Zion, and with him a number, one hundred forty-four thousand, having his name and the name of his Father written on their foreheads. 
-<span class="v">2&#160;</span>I heard a sound from heaven like the sound of many waters and like the sound of a great thunder. The sound which I heard was like that of harpists playing on their harps. 
-<span class="v">3&#160;</span>They sing a new song before the throne and before the four living creatures and the elders. No one could learn the song except the one hundred forty-four thousand, those who had been redeemed out of the earth. 
-<span class="v">4&#160;</span>These are those who were not defiled with women, for they are virgins. These are those who follow the Lamb wherever he goes. These were redeemed by Yahushua from among men, the first fruits to Elohim and to the Lamb. 
-<span class="v">5&#160;</span>In their mouth was found no lie, for they are blameless.<span class="f">+ \fr 14:5 \ft TR adds “before the throne of Elohim”</span> 
-</p><p>
-<span class="v">6&#160;</span>I saw an angel flying in mid heaven, having an eternal Good News to proclaim to those who dwell on the earth—to every nation, tribe, language, and people. 
-<span class="v">7&#160;</span>He said with a loud voice, “Fear the Lord, and give him glory, for the hour of his judgment has come. Worship him who made the heaven, the earth, the sea, and the springs of waters!” 
-</p><p>
-<span class="v">8&#160;</span>Another, a second angel, followed, saying, “Babylon the great has fallen, which has made all the nations to drink of the wine of the wrath of her sexual immorality.” 
-</p><p>
-<span class="v">9&#160;</span>Another angel, a third, followed them, saying with a great voice, “If anyone worships the beast and his image, and receives a mark on his forehead or on his hand, 
-<span class="v">10&#160;</span>he also will drink of the wine of the wrath of Elohim, which is prepared unmixed in the cup of his anger. He will be tormented with fire and sulfur in the presence of the set-apart angels and in the presence of the Lamb. 
-<span class="v">11&#160;</span>The smoke of their torment goes up forever and ever. They have no rest day and night, those who worship the beast and his image, and whoever receives the mark of his name. 
-</p><p>
-<span class="v">12&#160;</span>Here is the perseverance of the saints, those who keep the commandments of Elohim and the faith of Yahushua.” 
-</p><p>
-<span class="v">13&#160;</span>I heard a voice from heaven saying, “Write, ‘Blessed are the dead who die in the Lord from now on.’&#160;” 
-</p><p>“Yes,” says the Spirit, “that they may rest from their labors, for their works follow with them.” 
-</p><p>
-<span class="v">14&#160;</span>I looked, and saw a white cloud, and on the cloud one sitting like a son of man,<span class="x">+ \xo 14:14 \xt Daniel 7:13</span> having on his head a golden crown, and in his hand a sharp sickle. 
-<span class="v">15&#160;</span>Another angel came out of the temple, crying with a loud voice to him who sat on the cloud, “Send your sickle and reap, for the hour to reap has come; for the harvest of the earth is ripe!” 
-<span class="v">16&#160;</span>He who sat on the cloud thrust his sickle on the earth, and the earth was reaped. 
-</p><p>
-<span class="v">17&#160;</span>Another angel came out of the temple which is in heaven. He also had a sharp sickle. 
-<span class="v">18&#160;</span>Another angel came out from the altar, he who has power over fire, and he called with a great voice to him who had the sharp sickle, saying, “Send your sharp sickle and gather the clusters of the vine of the earth, for the earth’s grapes are fully ripe!” 
-<span class="v">19&#160;</span>The angel thrust his sickle into the earth, and gathered the vintage of the earth and threw it into the great wine press of the wrath of Elohim. 
-<span class="v">20&#160;</span>The wine press was trodden outside of the city, and blood came out of the wine press, up to the bridles of the horses, as far as one thousand six hundred stadia.<span class="f">+ \fr 14:20 \ft 1600 stadia = 296 kilometers or 184 miles</span> 
-</p><h2 class="chapterlabel" id="15">15</h2>
-<p>
-<span class="v">1&#160;</span>I saw another great and marvelous sign in the sky: seven angels having the seven last plagues, for in them Elohim’s wrath is finished. 
-</p><p>
-<span class="v">2&#160;</span>I saw something like a sea of glass mixed with fire, and those who overcame the beast, his image,<span class="f">+ \fr 15:2 \ft TR adds “his mark,”</span> and the number of his name, standing on the sea of glass, having harps of Elohim. 
-<span class="v">3&#160;</span>They sang the song of Moses, the servant of Elohim, and the song of the Lamb, saying, 
-</p><p class="q1">“Great and marvelous are your works, Lord Elohim, the Almighty! 
-</p><p class="q2">Righteous and true are your ways, you King of the nations. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Who wouldn’t fear you, Lord, 
-</p><p class="q2">and glorify your name? 
-</p><p class="q1">For you only are set-apart. 
-</p><p class="q2">For all the nations will come and worship before you. 
-</p><p class="q2">For your righteous acts have been revealed.” 
-</p><p>
-<span class="v">5&#160;</span>After these things I looked, and the temple of the tabernacle of the testimony in heaven was opened. 
-<span class="v">6&#160;</span>The seven angels who had the seven plagues came out, clothed with pure, bright linen, and wearing golden sashes around their chests. 
-</p><p>
-<span class="v">7&#160;</span>One of the four living creatures gave to the seven angels seven golden bowls full of the wrath of Elohim, who lives forever and ever. 
-<span class="v">8&#160;</span>The temple was filled with smoke from the glory of Elohim and from his power. No one was able to enter into the temple until the seven plagues of the seven angels would be finished. 
-</p><h2 class="chapterlabel" id="16">16</h2>
-<p>
-<span class="v">1&#160;</span>I heard a loud voice out of the temple, saying to the seven angels, “Go and pour out the seven bowls of the wrath of Elohim on the earth!” 
-</p><p>
-<span class="v">2&#160;</span>The first went, and poured out his bowl into the earth, and it became a harmful and painful sore on the people who had the mark of the beast, and who worshiped his image. 
-</p><p>
-<span class="v">3&#160;</span>The second angel poured out his bowl into the sea, and it became blood as of a dead man. Every living thing in the sea died. 
-</p><p>
-<span class="v">4&#160;</span>The third poured out his bowl into the rivers and springs of water, and they became blood. 
-<span class="v">5&#160;</span>I heard the angel of the waters saying, “You are righteous, who are and who were, O Set-Apart One, because you have judged these things. 
-<span class="v">6&#160;</span>For they poured out the blood of saints and prophets, and you have given them blood to drink. They deserve this.” 
-</p><p>
-<span class="v">7&#160;</span>I heard the altar saying, “Yes, Lord Elohim, the Almighty, true and righteous are your judgments.” 
-</p><p>
-<span class="v">8&#160;</span>The fourth poured out his bowl on the sun, and it was given to him to scorch men with fire. 
-<span class="v">9&#160;</span>People were scorched with great heat, and people blasphemed the name of Elohim who has the power over these plagues. They didn’t repent and give him glory. 
-</p><p>
-<span class="v">10&#160;</span>The fifth poured out his bowl on the throne of the beast, and his kingdom was darkened. They gnawed their tongues because of the pain, 
-<span class="v">11&#160;</span>and they blasphemed the Elohim of heaven because of their pains and their sores. They still didn’t repent of their works. 
-</p><p>
-<span class="v">12&#160;</span>The sixth poured out his bowl on the great river, the Euphrates. Its water was dried up, that the way might be prepared for the kings that come from the sunrise.<span class="f">+ \fr 16:12 \ft or, east</span> 
-<span class="v">13&#160;</span>I saw coming out of the mouth of the dragon, and out of the mouth of the beast, and out of the mouth of the false prophet, three unclean spirits, something like frogs; 
-<span class="v">14&#160;</span>for they are spirits of demons, performing signs, which go out to the kings of the whole inhabited earth, to gather them together for the war of that great day of Elohim the Almighty. 
-</p><p>
-<span class="v">15&#160;</span><span class="wj">“Behold, I come like a thief. Blessed is he who watches, and keeps his clothes, so that he doesn’t walk naked, and they see his shame.” </span> 
-<span class="v">16&#160;</span>He gathered them together into the place which is called in Hebrew, “Harmagedon”. 
-</p><p>
-<span class="v">17&#160;</span>The seventh poured out his bowl into the air. A loud voice came out of the temple of heaven, from the throne, saying, “It is done!” 
-<span class="v">18&#160;</span>There were lightnings, sounds, and thunders; and there was a great earthquake such as has not happened since there were men on the earth—so great an earthquake and so mighty. 
-<span class="v">19&#160;</span>The great city was divided into three parts, and the cities of the nations fell. Babylon the great was remembered in the sight of Elohim, to give to her the cup of the wine of the fierceness of his wrath. 
-<span class="v">20&#160;</span>Every island fled away, and the mountains were not found. 
-<span class="v">21&#160;</span>Great hailstones, about the weight of a talent,<span class="f">+ \fr 16:21 \ft A talent is about 30 kilograms or 66 pounds.</span> came down out of the sky on people. People blasphemed Elohim because of the plague of the hail, for this plague was exceedingly severe. 
-</p><h2 class="chapterlabel" id="17">17</h2>
-<p>
-<span class="v">1&#160;</span>One of the seven angels who had the seven bowls came and spoke with me, saying, “Come here. I will show you the judgment of the great prostitute who sits on many waters, 
-<span class="v">2&#160;</span>with whom the kings of the earth committed sexual immorality. Those who dwell in the earth were made drunken with the wine of her sexual immorality.” 
-<span class="v">3&#160;</span>He carried me away in the Spirit into a wilderness. I saw a woman sitting on a scarlet-colored beast, full of blasphemous names, having seven heads and ten horns. 
-<span class="v">4&#160;</span>The woman was dressed in purple and scarlet, and decked with gold and precious stones and pearls, having in her hand a golden cup full of abominations and the impurities of the sexual immorality of the earth. 
-<span class="v">5&#160;</span>And on her forehead a name was written, “MYSTERY, BABYLON THE GREAT, THE MOTHER OF THE PROSTITUTES AND OF THE ABOMINATIONS OF THE EARTH.” 
-<span class="v">6&#160;</span>I saw the woman drunken with the blood of the saints and with the blood of the martyrs of Yahushua. When I saw her, I wondered with great amazement. 
-</p><p>
-<span class="v">7&#160;</span>The angel said to me, “Why do you wonder? I will tell you the mystery of the woman and of the beast that carries her, which has the seven heads and the ten horns. 
-<span class="v">8&#160;</span>The beast that you saw was, and is not; and is about to come up out of the abyss and to go into destruction. Those who dwell on the earth and whose names have not been written in the book of life from the foundation of the world will marvel when they see that the beast was, and is not, and shall be present.<span class="f">+ \fr 17:8 \ft TR reads “yet is” instead of “shall be present”</span> 
-</p><p>
-<span class="v">9&#160;</span>Here is the mind that has wisdom. The seven heads are seven mountains on which the woman sits. 
-<span class="v">10&#160;</span>They are seven kings. Five have fallen, the one is, and the other has not yet come. When he comes, he must continue a little while. 
-<span class="v">11&#160;</span>The beast that was, and is not, is himself also an eighth, and is of the seven; and he goes to destruction. 
-<span class="v">12&#160;</span>The ten horns that you saw are ten kings who have received no kingdom as yet, but they receive authority as kings with the beast for one hour. 
-<span class="v">13&#160;</span>These have one mind, and they give their power and authority to the beast. 
-<span class="v">14&#160;</span>These will war against the Lamb, and the Lamb will overcome them, for he is Lord of lords and King of kings; and those who are with him are called, chosen, and faithful.” 
-<span class="v">15&#160;</span>He said to me, “The waters which you saw, where the prostitute sits, are peoples, multitudes, nations, and languages. 
-<span class="v">16&#160;</span>The ten horns which you saw, they and the beast will hate the prostitute, will make her desolate, will strip her naked, will eat her flesh, and will burn her utterly with fire. 
-<span class="v">17&#160;</span>For Elohim has put in their hearts to do what he has in mind, to be of one mind, and to give their kingdom to the beast, until the words of Elohim should be accomplished. 
-<span class="v">18&#160;</span>The woman whom you saw is the great city which reigns over the kings of the earth.” 
-</p><h2 class="chapterlabel" id="18">18</h2>
-<p>
-<span class="v">1&#160;</span>After these things, I saw another angel coming down out of the sky, having great authority. The earth was illuminated with his glory. 
-<span class="v">2&#160;</span>He cried with a mighty voice, saying, “Fallen, fallen is Babylon the great, and she has become a habitation of demons, a prison of every unclean spirit, and a prison of every unclean and hated bird! 
-<span class="v">3&#160;</span>For all the nations have drunk of the wine of the wrath of her sexual immorality, the kings of the earth committed sexual immorality with her, and the merchants of the earth grew rich from the abundance of her luxury.” 
-</p><p>
-<span class="v">4&#160;</span>I heard another voice from heaven, saying, “Come out of her, my people, that you have no participation in her sins, and that you don’t receive of her plagues, 
-<span class="v">5&#160;</span>for her sins have reached to the sky, and Elohim has remembered her iniquities. 
-<span class="v">6&#160;</span>Return to her just as she returned, and repay her double as she did, and according to her works. In the cup which she mixed, mix to her double. 
-<span class="v">7&#160;</span>However much she glorified herself and grew wanton, so much give her of torment and mourning. For she says in her heart, ‘I sit a queen, and am no widow, and will in no way see mourning.’ 
-<span class="v">8&#160;</span>Therefore in one day her plagues will come: death, mourning, and famine; and she will be utterly burned with fire, for the Lord Elohim who has judged her is strong. 
-</p><p>
-<span class="v">9&#160;</span>The kings of the earth who committed sexual immorality and lived wantonly with her will weep and wail over her, when they look at the smoke of her burning, 
-<span class="v">10&#160;</span>standing far away for the fear of her torment, saying, ‘Woe, woe, the great city, Babylon, the strong city! For your judgment has come in one hour.’ 
-<span class="v">11&#160;</span>The merchants of the earth weep and mourn over her, for no one buys their merchandise any more: 
-<span class="v">12&#160;</span>merchandise of gold, silver, precious stones, pearls, fine linen, purple, silk, scarlet, all expensive wood, every vessel of ivory, every vessel made of most precious wood, and of brass, and iron, and marble; 
-<span class="v">13&#160;</span>and cinnamon, incense, perfume, frankincense, wine, olive oil, fine flour, wheat, sheep, horses, chariots, and people’s bodies and souls. 
-<span class="v">14&#160;</span>The fruits which your soul lusted after have been lost to you. All things that were dainty and sumptuous have perished from you, and you will find them no more at all. 
-<span class="v">15&#160;</span>The merchants of these things, who were made rich by her, will stand far away for the fear of her torment, weeping and mourning, 
-<span class="v">16&#160;</span>saying, ‘Woe, woe, the great city, she who was dressed in fine linen, purple, and scarlet, and decked with gold and precious stones and pearls! 
-<span class="v">17&#160;</span>For in an hour such great riches are made desolate.’ Every ship master, and everyone who sails anywhere, and mariners, and as many as gain their living by sea, stood far away, 
-<span class="v">18&#160;</span>and cried out as they looked at the smoke of her burning, saying, ‘What is like the great city?’ 
-<span class="v">19&#160;</span>They cast dust on their heads, and cried, weeping and mourning, saying, ‘Woe, woe, the great city, in which all who had their ships in the sea were made rich by reason of her great wealth!’ For she is made desolate in one hour. 
-</p><p>
-<span class="v">20&#160;</span>“Rejoice over her, O heaven, you saints, apostles, and prophets, for Elohim has judged your judgment on her.” 
-</p><p>
-<span class="v">21&#160;</span>A mighty angel took up a stone like a great millstone and cast it into the sea, saying, “Thus with violence will Babylon, the great city, be thrown down, and will be found no more at all. 
-<span class="v">22&#160;</span>The voice of harpists, minstrels, flute players, and trumpeters will be heard no more at all in you. No craftsman of whatever craft will be found any more at all in you. The sound of a mill will be heard no more at all in you. 
-<span class="v">23&#160;</span>The light of a lamp will shine no more at all in you. The voice of the bridegroom and of the bride will be heard no more at all in you, for your merchants were the princes of the earth; for with your sorcery all the nations were deceived. 
-<span class="v">24&#160;</span>In her was found the blood of prophets and of saints, and of all who have been slain on the earth.” 
-</p><h2 class="chapterlabel" id="19">19</h2>
-<p>
-<span class="v">1&#160;</span>After these things I heard something like a loud voice of a great multitude in heaven, saying, “Hallelujah! Salvation, power, and glory belong to our Elohim; 
-<span class="v">2&#160;</span>for his judgments are true and righteous. For he has judged the great prostitute who corrupted the earth with her sexual immorality, and he has avenged the blood of his servants at her hand.” 
-</p><p>
-<span class="v">3&#160;</span>A second said, “Hallelujah! Her smoke goes up forever and ever.” 
-<span class="v">4&#160;</span>The twenty-four elders and the four living creatures fell down and worshiped Elohim who sits on the throne, saying, “Amen! Hallelujah!” 
-</p><p>
-<span class="v">5&#160;</span>A voice came from the throne, saying, “Give praise to our Elohim, all you his servants, you who fear him, the small and the great!” 
-</p><p>
-<span class="v">6&#160;</span>I heard something like the voice of a great multitude, and like the voice of many waters, and like the voice of mighty thunders, saying, “Hallelujah! For the Lord our Elohim, the Almighty, reigns! 
-<span class="v">7&#160;</span>Let’s rejoice and be exceedingly glad, and let’s give the glory to him. For the wedding of the Lamb has come, and his woman has made herself ready.” 
-<span class="v">8&#160;</span>It was given to her that she would array herself in bright, pure, fine linen, for the fine linen is the righteous acts of the saints. 
-</p><p>
-<span class="v">9&#160;</span>He said to me, “Write, ‘Blessed are those who are invited to the wedding supper of the Lamb.’&#160;” He said to me, “These are true words of Elohim.” 
-</p><p>
-<span class="v">10&#160;</span>I fell down before his feet to worship him. He said to me, “Look! Don’t do it! I am a fellow bondservant with you and with your brothers who hold the testimony of Yahushua. Worship Elohim, for the testimony of Yahushua is the Spirit of Prophecy.” 
-</p><p>
-<span class="v">11&#160;</span>I saw the heaven opened, and behold, a white horse, and he who sat on it is called Faithful and True. In righteousness he judges and makes war. 
-<span class="v">12&#160;</span>His eyes are a flame of fire, and on his head are many crowns. He has names written and a name written which no one knows but he himself. 
-<span class="v">13&#160;</span>He is clothed in a garment sprinkled with blood. His name is called “The Word of Elohim.” 
-<span class="v">14&#160;</span>The armies which are in heaven, clothed in white, pure, fine linen, followed him on white horses. 
-<span class="v">15&#160;</span>Out of his mouth proceeds a sharp, double-edged sword that with it he should strike the nations. He will rule them with an iron rod.<span class="x">+ \xo 19:15 \xt Psalm 2:9 </span> He treads the wine press of the fierceness of the wrath of Elohim, the Almighty. 
-<span class="v">16&#160;</span>He has on his garment and on his thigh a name written, “KING OF KINGS AND LORD OF LORDS.” 
-</p><p>
-<span class="v">17&#160;</span>I saw an angel standing in the sun. He cried with a loud voice, saying to all the birds that fly in the sky, “Come! Be gathered together to the great supper of Elohim,<span class="f">+ \fr 19:17 \ft TR reads “supper of the great Elohim” instead of “great supper of Elohim”</span> 
-<span class="v">18&#160;</span>that you may eat the flesh of kings, the flesh of captains, the flesh of mighty men, and the flesh of horses and of those who sit on them, and the flesh of all men, both free and slave, small and great.” 
-<span class="v">19&#160;</span>I saw the beast, the kings of the earth, and their armies, gathered together to make war against him who sat on the horse and against his army. 
-<span class="v">20&#160;</span>The beast was taken, and with him the false prophet who worked the signs in his sight, with which he deceived those who had received the mark of the beast and those who worshiped his image. These two were thrown alive into the lake of fire that burns with sulfur. 
-<span class="v">21&#160;</span>The rest were killed with the sword of him who sat on the horse, the sword which came out of his mouth. So all the birds were filled with their flesh. 
-</p><h2 class="chapterlabel" id="20">20</h2>
-<p>
-<span class="v">1&#160;</span>I saw an angel coming down out of heaven, having the key of the abyss and a great chain in his hand. 
-<span class="v">2&#160;</span>He seized the dragon, the old serpent, who is the devil and Satan, who deceives the whole inhabited earth,<span class="f">+ \fr 20:2 \ft TR and NU omit “who deceives the whole inhabited earth”.</span> and bound him for a thousand years, 
-<span class="v">3&#160;</span>and cast him into the abyss, and shut it and sealed it over him, that he should deceive the nations no more until the thousand years were finished. After this, he must be freed for a short time. 
-</p><p>
-<span class="v">4&#160;</span>I saw thrones, and they sat on them, and judgment was given to them. I saw the souls of those who had been beheaded for the testimony of Yahushua and for the word of Elohim, and such as didn’t worship the beast nor his image, and didn’t receive the mark on their forehead and on their hand. They lived and reigned with Christ for a thousand years. 
-<span class="v">5&#160;</span>The rest of the dead didn’t live until the thousand years were finished. This is the first resurrection. 
-<span class="v">6&#160;</span>Blessed and set-apart is he who has part in the first resurrection. Over these, the second death has no power, but they will be priests of Elohim and of Christ, and will reign with him one thousand years. 
-</p><p>
-<span class="v">7&#160;</span>And after the thousand years, Satan will be released from his prison 
-<span class="v">8&#160;</span>and he will come out to deceive the nations which are in the four corners of the earth, Gog and Magog, to gather them together to the war, whose number is as the sand of the sea. 
-<span class="v">9&#160;</span>They went up over the width of the earth and surrounded the camp of the saints and the beloved city. Fire came down out of heaven from Elohim and devoured them. 
-<span class="v">10&#160;</span>The devil who deceived them was thrown into the lake of fire and sulfur, where the beast and the false prophet are also. They will be tormented day and night forever and ever. 
-</p><p>
-<span class="v">11&#160;</span>I saw a great white throne and him who sat on it, from whose face the earth and the heaven fled away. There was found no place for them. 
-<span class="v">12&#160;</span>I saw the dead, the great and the small, standing before the throne, and they opened books. Another book was opened, which is the book of life. The dead were judged out of the things which were written in the books, according to their works. 
-<span class="v">13&#160;</span>The sea gave up the dead who were in it. Death and Hades<span class="f">+ \fr 20:13 \ft or, Hell </span> gave up the dead who were in them. They were judged, each one according to his works. 
-<span class="v">14&#160;</span>Death and Hades<span class="f">+ \fr 20:14 \ft or, Hell</span> were thrown into the lake of fire. This is the second death, the lake of fire. 
-<span class="v">15&#160;</span>If anyone was not found written in the book of life, he was cast into the lake of fire. 
-</p><h2 class="chapterlabel" id="21">21</h2>
-<p>
-<span class="v">1&#160;</span>I saw a new heaven and a new earth, for the first heaven and the first earth have passed away, and the sea is no more. 
-<span class="v">2&#160;</span>I saw the set-apart city, New Jerusalem, coming down out of heaven from Elohim, prepared like a bride adorned for her man. 
-<span class="v">3&#160;</span>I heard a loud voice out of heaven saying, “Behold, Elohim’s dwelling is with people; and he will dwell with them, and they will be his people, and Elohim himself will be with them as their Elohim. 
-<span class="v">4&#160;</span>He will wipe away every tear from their eyes. Death will be no more; neither will there be mourning, nor crying, nor pain any more. The first things have passed away.” 
-</p><p>
-<span class="v">5&#160;</span>He who sits on the throne said, <span class="wj">“Behold, I am making all things new.”</span> He said, <span class="wj">“Write, for these words of Elohim are faithful and true.” </span> 
-<span class="v">6&#160;</span>He said to me, <span class="wj">“I am the Alpha and the Omega, the Beginning and the End. I will give freely to him who is thirsty from the spring of the water of life. </span> 
-<span class="v">7&#160;</span><span class="wj">He who overcomes, I will give him these things. I will be his Elohim, and he will be my son. </span> 
-<span class="v">8&#160;</span><span class="wj">But for the cowardly, unbelieving, sinners,</span><span class="f">+ \fr 21:8 \ft TR and NU omit “sinners”</span> <span class="wj">abominable, murderers, sexually immoral, sorcerers,</span><span class="f">+ \fr 21:8 \ft The word for “sorcerers” here also includes users of potions and drugs.</span> <span class="wj">idolaters, and all liars, their part is in the lake that burns with fire and sulfur, which is the second death.”</span> 
-</p><p>
-<span class="v">9&#160;</span>One of the seven angels who had the seven bowls which were loaded with the seven last plagues came, and he spoke with me, saying, “Come here. I will show you the bride, the Lamb’s woman.” 
-<span class="v">10&#160;</span>He carried me away in the Spirit to a great and high mountain, and showed me the set-apart city, Jerusalem, coming down out of heaven from Elohim, 
-<span class="v">11&#160;</span>having the glory of Elohim. Her light was like a most precious stone, like a jasper stone, clear as crystal; 
-<span class="v">12&#160;</span>having a great and high wall with twelve gates, and at the gates twelve angels, and names written on them, which are the names of the twelve tribes of the children of Israel. 
-<span class="v">13&#160;</span>On the east were three gates, and on the north three gates, and on the south three gates, and on the west three gates. 
-<span class="v">14&#160;</span>The wall of the city had twelve foundations, and on them twelve names of the twelve Apostles of the Lamb. 
-</p><p>
-<span class="v">15&#160;</span>He who spoke with me had for a measure a golden reed to measure the city, its gates, and its walls. 
-<span class="v">16&#160;</span>The city is square. Its length is as great as its width. He measured the city with the reed: twelve thousand twelve stadia.<span class="f">+ \fr 21:16 \ft 12,012 stadia = 2,221 kilometers or 1,380 miles. TR reads 12,000 stadia instead of 12,012 stadia.</span> Its length, width, and height are equal. 
-<span class="v">17&#160;</span>Its wall is one hundred forty-four cubits,<span class="f">+ \fr 21:17 \ft 144 cubits is about 65.8 meters or 216 feet</span> by the measure of a man, that is, of an angel. 
-<span class="v">18&#160;</span>The construction of its wall was jasper. The city was pure gold, like pure glass. 
-<span class="v">19&#160;</span>The foundations of the city’s wall were adorned with all kinds of precious stones. The first foundation was jasper, the second sapphire;<span class="f">+ \fr 21:19 \ft or, lapis lazuli</span> the third chalcedony, the fourth emerald, 
-<span class="v">20&#160;</span>the fifth sardonyx, the sixth sardius, the seventh chrysolite, the eighth beryl, the ninth topaz, the tenth chrysoprase, the eleventh jacinth, and the twelfth amethyst. 
-<span class="v">21&#160;</span>The twelve gates were twelve pearls. Each one of the gates was made of one pearl. The street of the city was pure gold, like transparent glass. 
-</p><p>
-<span class="v">22&#160;</span>I saw no temple in it, for the Lord Elohim the Almighty and the Lamb are its temple. 
-<span class="v">23&#160;</span>The city has no need for the sun or moon to shine, for the very glory of Elohim illuminated it and its lamp is the Lamb. 
-<span class="v">24&#160;</span>The nations will walk in its light. The kings of the earth bring the glory and honor of the nations into it. 
-<span class="v">25&#160;</span>Its gates will in no way be shut by day (for there will be no night there), 
-<span class="v">26&#160;</span>and they shall bring the glory and the honor of the nations into it so that they may enter. 
-<span class="v">27&#160;</span>There will in no way enter into it anything profane, or one who causes an abomination or a lie, but only those who are written in the Lamb’s book of life. 
-</p><h2 class="chapterlabel" id="22">22</h2>
-<p>
-<span class="v">1&#160;</span>He showed me a<span class="f">+ \fr 22:1 \ft TR adds “pure”</span> river of water of life, clear as crystal, proceeding out of the throne of Elohim and of the Lamb, 
-<span class="v">2&#160;</span>in the middle of its street. On this side of the river and on that was the tree of life, bearing twelve kinds of fruits, yielding its fruit every month. The leaves of the tree were for the healing of the nations. 
-<span class="v">3&#160;</span>There will be no curse any more. The throne of Elohim and of the Lamb will be in it, and his servants will serve him. 
-<span class="v">4&#160;</span>They will see his face, and his name will be on their foreheads. 
-<span class="v">5&#160;</span>There will be no night, and they need no lamp light or sun light; for the Lord Elohim will illuminate them. They will reign forever and ever. 
-</p><p>
-<span class="v">6&#160;</span>He said to me, “These words are faithful and true. The Lord Elohim of the spirits of the prophets sent his angel to show to his bondservants the things which must happen soon.” 
-</p><p>
-<span class="v">7&#160;</span><span class="wj">“Behold, I am coming soon! Blessed is he who keeps the words of the prophecy of this book.”</span> 
-</p><p>
-<span class="v">8&#160;</span>Now I, John, am the one who heard and saw these things. When I heard and saw, I fell down to worship before the feet of the angel who had shown me these things. 
-<span class="v">9&#160;</span>He said to me, “You must not do that! I am a fellow bondservant with you and with your brothers, the prophets, and with those who keep the words of this book. Worship Elohim.” 
-<span class="v">10&#160;</span>He said to me, “Don’t seal up the words of the prophecy of this book, for the time is at hand. 
-<span class="v">11&#160;</span>He who acts unjustly, let him act unjustly still. He who is filthy, let him be filthy still. He who is righteous, let him do righteousness still. He who is set-apart, let him be set-apart still.” 
-</p><p>
-<span class="v">12&#160;</span><span class="wj">“Behold, I am coming soon! My reward is with me, to repay to each man according to his work. </span> 
-<span class="v">13&#160;</span><span class="wj">I am the Alpha and the Omega, the First and the Last, the Beginning and the End. </span> 
-<span class="v">14&#160;</span><span class="wj">Blessed are those who do his commandments,</span><span class="f">+ \fr 22:14 \ft NU reads “wash their robes” instead of “do his commandments”.</span> <span class="wj">that they may have the right to the tree of life, and may enter in by the gates into the city. </span> 
-<span class="v">15&#160;</span><span class="wj">Outside are the dogs, the sorcerers, the sexually immoral, the murderers, the idolaters, and everyone who loves and practices falsehood. </span> 
-<span class="v">16&#160;</span><span class="wj">I, Yahushua, have sent my angel to testify these things to you for the assemblies. I am the root and the offspring of David, the Bright and Morning Star.”</span> 
-</p><p>
-<span class="v">17&#160;</span>The Spirit and the bride say, “Come!” He who hears, let him say, “Come!” He who is thirsty, let him come. He who desires, let him take the water of life freely. 
-</p><p>
-<span class="v">18&#160;</span>I testify to everyone who hears the words of the prophecy of this book: if anyone adds to them, Elohim will add to him the plagues which are written in this book. 
-<span class="v">19&#160;</span>If anyone takes away from the words of the book of this prophecy, Elohim will take away his part from the tree<span class="f">+ \fr 22:19 \ft TR reads “Book” instead of “tree”</span> of life, and out of the set-apart city, which are written in this book. 
-<span class="v">20&#160;</span>He who testifies these things says, <span class="wj">“Yes, I am coming soon.” </span> 
-</p><p>Amen! Yes, come, Lord Yahushua! 
-</p><p>
-<span class="v">21&#160;</span>The grace of the Lord Yahushua Christ be with all the saints. Amen. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+<a href="#15">15</a>
+<a href="#16">16</a>
+<a href="#17">17</a>
+<a href="#18">18</a>
+<a href="#19">19</a>
+<a href="#20">20</a>
+<a href="#21">21</a>
+<a href="#22">22</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>This is the Revelation of Yahushua Christ, to his servant, John, 
+<sup>2&#160;</sup>who testified to Elohim’s word and of the testimony of Yahushua Christ, about everything that he saw. 
+</div><div class="p">
+<sup>3&#160;</sup>Blessed is he who reads and those who hear the words of the prophecy, and keep the things that are written in it, for the time is near. 
+</div><div class="p">
+<sup>4&#160;</sup>John, to the seven assemblies that are in Asia: Grace to you and peace from Elohim, who is and who was and who is to come; and from the seven Spirits who are before his throne; 
+<sup>5&#160;</sup>and from Yahushua Christ, the faithful witness, the firstborn of the dead, and the ruler of the kings of the earth. To him who loves us, and washed us from our sins by his blood—<sup>6&#160;</sup>and he made us to be a Kingdom, priests to his Elohim and Father—to him be the glory and the dominion forever and ever. Amen. 
+</div><div class="p">
+<sup>7&#160;</sup>Behold, he is coming with the clouds, and every eye will see him, including those who pierced him. All the tribes of the earth will mourn over him. Even so, Amen. 
+</div><div class="p">
+<sup>8&#160;</sup><span class="wj">“I am the Alpha and the Omega,</span> <span class="wj">“who is and who was and who is to come, the Almighty.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>I John, your brother and partner with you in the oppression, Kingdom, and perseverance in Christ Yahushua, was on the isle that is called Patmos because of Elohim’s Word and the testimony of Yahushua Christ. 
+<sup>10&#160;</sup>I was in the Spirit on the Lord’s day, and I heard behind me a loud voice, like a trumpet 
+<sup>11&#160;</sup>saying, <span class="wj">to Ephesus, Smyrna, Pergamum, Thyatira, Sardis, Philadelphia, and to Laodicea.”</span> 
+</div><div class="p">
+<sup>12&#160;</sup>I turned to see the voice that spoke with me. Having turned, I saw seven golden lamp stands. 
+<sup>13&#160;</sup>And among the lamp stands was one like a son of man, clothed with a robe reaching down to his feet, and with a golden sash around his chest. 
+<sup>14&#160;</sup>His head and his hair were white as white wool, like snow. His eyes were like a flame of fire. 
+<sup>15&#160;</sup>His feet were like burnished brass, as if it had been refined in a furnace. His voice was like the voice of many waters. 
+<sup>16&#160;</sup>He had seven stars in his right hand. Out of his mouth proceeded a sharp two-edged sword. His face was like the sun shining at its brightest. 
+<sup>17&#160;</sup>When I saw him, I fell at his feet like a dead man. 
+</div><div class="p">He laid his right hand on me, saying, <span class="wj">“Don’t be afraid. I am the first and the last, </span> 
+<sup>18&#160;</sup><span class="wj">and the Living one. I was dead, and behold, I am alive forever and ever. Amen. I have the keys of Death and of Hades.</span> 
+<sup>19&#160;</sup><span class="wj">Write therefore the things which you have seen, and the things which are, and the things which will happen hereafter. </span> 
+<sup>20&#160;</sup><span class="wj">The mystery of the seven stars which you saw in my right hand, and the seven golden lamp stands is this: The seven stars are the angels</span> <span class="wj">of the seven assemblies. The seven lamp stands are seven assemblies.</span> 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“To the angel of the assembly in Ephesus write:</span> 
+</div><div class="p"><span class="wj">“He who holds the seven stars in his right hand, he who walks among the seven golden lamp stands says these things:</span> 
+</div><div class="p">
+<sup>2&#160;</sup><span class="wj">“I know your works, and your toil and perseverance, and that you can’t tolerate evil men, and have tested those who call themselves apostles, and they are not, and found them false. </span> 
+<sup>3&#160;</sup><span class="wj">You have perseverance and have endured for my name’s sake, and have </span> <span class="wj">not grown weary. </span> 
+<sup>4&#160;</sup><span class="wj">But I have this against you, that you left your first love. </span> 
+<sup>5&#160;</sup><span class="wj">Remember therefore from where you have fallen, and repent and do the first works; or else I am coming to you swiftly, and will move your lamp stand out of its place, unless you repent. </span> 
+<sup>6&#160;</sup><span class="wj">But this you have, that you hate the works of the Nicolaitans, which I also hate. </span> 
+<sup>7&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes I will give to eat from the tree of life, which is in the Paradise of my Elohim.</span> 
+</div><div class="p">
+<sup>8&#160;</sup><span class="wj">“To the angel of the assembly in Smyrna write:</span> 
+</div><div class="p"><span class="wj">“The first and the last, who was dead, and has come to life says these things:</span> 
+</div><div class="p">
+<sup>9&#160;</sup><span class="wj">“I know your works, oppression, and your poverty (but you are rich), and the blasphemy of those who say they are Jews, and they are not, but are a synagogue of Satan. </span> 
+<sup>10&#160;</sup><span class="wj">Don’t be afraid of the things which you are about to suffer. Behold, the devil is about to throw some of you into prison, that you may be tested; and you will have oppression for ten days. Be faithful to death, and I will give you the crown of life. </span> 
+<sup>11&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies. He who overcomes won’t be harmed by the second death.</span> 
+</div><div class="p">
+<sup>12&#160;</sup><span class="wj">“To the angel of the assembly in Pergamum write:</span> 
+</div><div class="p"><span class="wj">“He who has the sharp two-edged sword says these things:</span> 
+</div><div class="p">
+<sup>13&#160;</sup><span class="wj">“I know your works and where you dwell, where Satan’s throne is. You hold firmly to my name, and didn’t deny my faith in the days of Antipas my witness, my faithful one, who was killed among you, where Satan dwells. </span> 
+<sup>14&#160;</sup><span class="wj">But I have a few things against you, because you have there some who hold the teaching of Balaam, who taught Balak to throw a stumbling block before the children of Israel, to eat things sacrificed to idols, and to commit sexual immorality. </span> 
+<sup>15&#160;</sup><span class="wj">So also you likewise have some who hold to the teaching of the Nicolaitans.</span> 
+<sup>16&#160;</sup><span class="wj">Repent therefore, or else I am coming to you quickly and I will make war against them with the sword of my mouth. </span> 
+<sup>17&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies. To him who overcomes, to him I will give of the hidden manna, </span> <span class="wj">and I will give him a white stone, and on the stone a new name written which no one knows but he who receives it.</span> 
+</div><div class="p">
+<sup>18&#160;</sup><span class="wj">“To the angel of the assembly in Thyatira write:</span> 
+</div><div class="p"><span class="wj">“The Son of Elohim, who has his eyes like a flame of fire, and his feet are like burnished brass, says these things:</span> 
+</div><div class="p">
+<sup>19&#160;</sup><span class="wj">“I know your works, your love, faith, service, patient endurance, and that your last works are more than the first. </span> 
+<sup>20&#160;</sup><span class="wj">But I have this against you, that you tolerate your</span> <span class="wj">woman Jezebel, who calls herself a prophetess. She teaches and seduces my servants to commit sexual immorality and to eat things sacrificed to idols. </span> 
+<sup>21&#160;</sup><span class="wj">I gave her time to repent, but she refuses to repent of her sexual immorality. </span> 
+<sup>22&#160;</sup><span class="wj">Behold, I will throw her and those who commit adultery with her into a bed of great oppression, unless they repent of her works. </span> 
+<sup>23&#160;</sup><span class="wj">I will kill her children with Death, and all the assemblies will know that I am he who searches the minds and hearts. I will give to each one of you according to your deeds. </span> 
+<sup>24&#160;</sup><span class="wj">But to you I say, to the rest who are in Thyatira—as many as don’t have this teaching, who don’t know what some call ‘the deep things of Satan’—to you I say, I am not putting any other burden on you. </span> 
+<sup>25&#160;</sup><span class="wj">Nevertheless, hold that which you have firmly until I come. </span> 
+<sup>26&#160;</sup><span class="wj">He who overcomes, and he who keeps my works to the end, to him I will give authority over the nations. </span> 
+<sup>27&#160;</sup><span class="wj">He will rule them with a rod of iron, shattering them like clay pots,</span> <span class="wj">as I also have received of my Father; </span> 
+<sup>28&#160;</sup><span class="wj">and I will give him the morning star. </span> 
+<sup>29&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.</span> 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup><span class="wj">“And to the angel of the assembly in Sardis write:</span> 
+</div><div class="p"><span class="wj">“He who has the seven Spirits of Elohim and the seven stars says these things:</span> 
+</div><div class="p"><span class="wj">“I know your works, that you have a reputation of being alive, but you are dead. </span> 
+<sup>2&#160;</sup><span class="wj">Wake up and strengthen the things that remain, which you were about to throw away,</span> <span class="wj">for I have found no works of yours perfected before my Elohim. </span> 
+<sup>3&#160;</sup><span class="wj">Remember therefore how you have received and heard. Keep it and repent. If therefore you won’t watch, I will come as a thief, and you won’t know what hour I will come upon you. </span> 
+<sup>4&#160;</sup><span class="wj">Nevertheless you have a few names in Sardis that didn’t defile their garments. They will walk with me in white, for they are worthy. </span> 
+<sup>5&#160;</sup><span class="wj">He who overcomes will be arrayed in white garments, and I will in no way blot his name out of the book of life, and I will confess his name before my Father, and before his angels. </span> 
+<sup>6&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.</span> 
+</div><div class="p">
+<sup>7&#160;</sup><span class="wj">“To the angel of the assembly in Philadelphia write:</span> 
+</div><div class="p"><span class="wj">“He who is set-apart, he who is true, he who has the key of David, he who opens and no one can shut, and who shuts and no one opens, says these things: </span> 
+</div><div class="p">
+<sup>8&#160;</sup><span class="wj">“I know your works (behold, I have set before you an open door, which no one can shut), that you have a little power, and kept my word, and didn’t deny my name. </span> 
+<sup>9&#160;</sup><span class="wj">Behold, I make some of the synagogue of Satan, of those who say they are Jews, and they are not, but lie—behold, I will make them to come and worship before your feet, and to know that I have loved you. </span> 
+<sup>10&#160;</sup><span class="wj">Because you kept my command to endure, I also will keep you from the hour of testing which is to come on the whole world, to test those who dwell on the earth. </span> 
+<sup>11&#160;</sup><span class="wj">I am coming quickly! Hold firmly that which you have, so that no one takes your crown. </span> 
+<sup>12&#160;</sup><span class="wj">He who overcomes, I will make him a pillar in the temple of my Elohim, and he will go out from there no more. I will write on him the name of my Elohim and the name of the city of my Elohim, the new Jerusalem, which comes down out of heaven from my Elohim, and my own new name. </span> 
+<sup>13&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.</span> 
+</div><div class="p">
+<sup>14&#160;</sup><span class="wj">“To the angel of the assembly in Laodicea write:</span> 
+</div><div class="p"><span class="wj">“The Amen, the Faithful and True Witness, the Beginning</span> <span class="wj">of Elohim’s creation, says these things:</span> 
+</div><div class="p">
+<sup>15&#160;</sup><span class="wj">“I know your works, that you are neither cold nor hot. I wish you were cold or hot. </span> 
+<sup>16&#160;</sup><span class="wj">So, because you are lukewarm, and neither hot nor cold, I will vomit you out of my mouth. </span> 
+<sup>17&#160;</sup><span class="wj">Because you say, ‘I am rich, and have gotten riches, and have need of nothing,’ and don’t know that you are the wretched one, miserable, poor, blind, and naked; </span> 
+<sup>18&#160;</sup><span class="wj">I counsel you to buy from me gold refined by fire, that you may become rich; and white garments, that you may clothe yourself, and that the shame of your nakedness may not be revealed; and eye salve to anoint your eyes, that you may see. </span> 
+<sup>19&#160;</sup><span class="wj">As many as I love, I reprove and chasten. Be zealous therefore, and repent. </span> 
+<sup>20&#160;</sup><span class="wj">Behold, I stand at the door and knock. If anyone hears my voice and opens the door, then I will come in to him and will dine with him, and he with me. </span> 
+<sup>21&#160;</sup><span class="wj">He who overcomes, I will give to him to sit down with me on my throne, as I also overcame and sat down with my Father on his throne. </span> 
+<sup>22&#160;</sup><span class="wj">He who has an ear, let him hear what the Spirit says to the assemblies.”</span> 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things I looked and saw a door opened in heaven; and the first voice that I heard, like a trumpet speaking with me, was one saying, “Come up here, and I will show you the things which must happen after this.” 
+</div><div class="p">
+<sup>2&#160;</sup>Immediately I was in the Spirit. Behold, there was a throne set in heaven, and one sitting on the throne 
+<sup>3&#160;</sup>that looked like a jasper stone and a sardius. There was a rainbow around the throne, like an emerald to look at. 
+<sup>4&#160;</sup>Around the throne were twenty-four thrones. On the thrones were twenty-four elders sitting, dressed in white garments, with crowns of gold on their heads. 
+<sup>5&#160;</sup>Out of the throne proceed lightnings, sounds, and thunders. There were seven lamps of fire burning before his throne, which are the seven Spirits of Elohim. 
+<sup>6&#160;</sup>Before the throne was something like a sea of glass, similar to crystal. In the middle of the throne, and around the throne were four living creatures full of eyes before and behind. 
+<sup>7&#160;</sup>The first creature was like a lion, the second creature like a calf, the third creature had a face like a man, and the fourth was like a flying eagle. 
+<sup>8&#160;</sup>The four living creatures, each one of them having six wings, are full of eyes around and within. They have no rest day and night, saying, “Set-Apart, set-apart, set-apart is the Lord Elohim, the Almighty, who was and who is and who is to come!” 
+</div><div class="p">
+<sup>9&#160;</sup>When the living creatures give glory, honor, and thanks to him who sits on the throne, to him who lives forever and ever, 
+<sup>10&#160;</sup>the twenty-four elders fall down before him who sits on the throne and worship him who lives forever and ever, and throw their crowns before the throne, saying, 
+<sup>11&#160;</sup>“Worthy are you, our Lord and Elohim, the Set-Apart One, to receive the glory, the honor, and the power, for you created all things, and because of your desire they existed and were created!” 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw, in the right hand of him who sat on the throne, a book written inside and outside, sealed shut with seven seals. 
+<sup>2&#160;</sup>I saw a mighty angel proclaiming with a loud voice, “Who is worthy to open the book, and to break its seals?” 
+<sup>3&#160;</sup>No one in heaven above, or on the earth, or under the earth, was able to open the book or to look in it. 
+<sup>4&#160;</sup>Then I wept much, because no one was found worthy to open the book or to look in it. 
+<sup>5&#160;</sup>One of the elders said to me, “Don’t weep. Behold, the Lion who is of the tribe of Judah, the Root of David, has overcome: he who opens the book and its seven seals.” 
+</div><div class="p">
+<sup>6&#160;</sup>I saw in the middle of the throne and of the four living creatures, and in the middle of the elders, a Lamb standing, as though it had been slain, having seven horns and seven eyes, which are the seven Spirits of Elohim, sent out into all the earth. 
+<sup>7&#160;</sup>Then he came, and he took it out of the right hand of him who sat on the throne. 
+<sup>8&#160;</sup>Now when he had taken the book, the four living creatures and the twenty-four elders fell down before the Lamb, each one having a harp, and golden bowls full of incense, which are the prayers of the saints. 
+<sup>9&#160;</sup>They sang a new song, saying, 
+</div><div class="q1">“You are worthy to take the book 
+</div><div class="q2">and to open its seals, 
+</div><div class="q1">for you were killed, 
+</div><div class="q2">and bought us for Elohim with your blood 
+</div><div class="q2">out of every tribe, language, people, and nation, 
+</div><div class="q1">
+<sup>10&#160;</sup>and made us kings and priests to our Elohim; 
+</div><div class="q2">and we will reign on the earth.” 
+</div><div class="p">
+<sup>11&#160;</sup>I looked, and I heard something like a voice of many angels around the throne, the living creatures, and the elders. The number of them was ten thousands of ten thousands, and thousands of thousands, 
+<sup>12&#160;</sup>saying with a loud voice, “Worthy is the Lamb who has been killed to receive the power, wealth, wisdom, strength, honor, glory, and blessing!” 
+</div><div class="p">
+<sup>13&#160;</sup>I heard every created thing which is in heaven, on the earth, under the earth, on the sea, and everything in them, saying, “To him who sits on the throne and to the Lamb be the blessing, the honor, the glory, and the dominion, forever and ever! Amen!” 
+</div><div class="p">
+<sup>14&#160;</sup>The four living creatures said, “Amen!” Then the 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw that the Lamb opened one of the seven seals, and I heard one of the four living creatures saying, as with a voice of thunder, “Come and see!” 
+<sup>2&#160;</sup>Then a white horse appeared, and he who sat on it had a bow. A crown was given to him, and he came out conquering, and to conquer. 
+</div><div class="p">
+<sup>3&#160;</sup>When he opened the second seal, I heard the second living creature saying, “Come!” 
+<sup>4&#160;</sup>Another came out, a red horse. To him who sat on it was given power to take peace from the earth, and that they should kill one another. There was given to him a great sword. 
+</div><div class="p">
+<sup>5&#160;</sup>When he opened the third seal, I heard the third living creature saying, “Come and see!” And behold, a black horse, and he who sat on it had a balance in his hand. 
+<sup>6&#160;</sup>I heard a voice in the middle of the four living creatures saying, “A choenix of wheat for a denarius, and three choenix of barley for a denarius! Don’t damage the oil and the wine!” 
+</div><div class="p">
+<sup>7&#160;</sup>When he opened the fourth seal, I heard the fourth living creature saying, “Come and see!” 
+<sup>8&#160;</sup>And behold, a pale horse, and the name of he who sat on it was Death. Hades followed with him. Authority over one fourth of the earth, to kill with the sword, with famine, with death, and by the wild animals of the earth was given to him. 
+</div><div class="p">
+<sup>9&#160;</sup>When he opened the fifth seal, I saw underneath the altar the souls of those who had been killed for the Word of Elohim, and for the testimony of the Lamb which they had. 
+<sup>10&#160;</sup>They cried with a loud voice, saying, “How long, Master, the set-apart and true, until you judge and avenge our blood on those who dwell on the earth?” 
+<sup>11&#160;</sup>A long white robe was given to each of them. They were told that they should rest yet for a while, until their fellow servants and their brothers, who would also be killed even as they were, should complete their course. 
+</div><div class="p">
+<sup>12&#160;</sup>I saw when he opened the sixth seal, and there was a great earthquake. The sun became black as sackcloth made of hair, and the whole moon became as blood. 
+<sup>13&#160;</sup>The stars of the sky fell to the earth, like a fig tree dropping its unripe figs when it is shaken by a great wind. 
+<sup>14&#160;</sup>The sky was removed like a scroll when it is rolled up. Every mountain and island was moved out of its place. 
+<sup>15&#160;</sup>The kings of the earth, the princes, the commanding officers, the rich, the strong, and every slave and free person, hid themselves in the caves and in the rocks of the mountains. 
+<sup>16&#160;</sup>They told the mountains and the rocks, “Fall on us, and hide us from the face of him who sits on the throne, and from the wrath of the Lamb, 
+<sup>17&#160;</sup>for the great day of his wrath has come, and who is able to stand?” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>After this, I saw four angels standing at the four corners of the earth, holding the four winds of the earth, so that no wind would blow on the earth, or on the sea, or on any tree. 
+<sup>2&#160;</sup>I saw another angel ascend from the sunrise, having the seal of the living Elohim. He cried with a loud voice to the four angels to whom it was given to harm the earth and the sea, 
+<sup>3&#160;</sup>saying, “Don’t harm the earth, the sea, or the trees, until we have sealed the bondservants of our Elohim on their foreheads!” 
+<sup>4&#160;</sup>I heard the number of those who were sealed, one hundred forty-four thousand, sealed out of every tribe of the children of Israel: 
+</div><div class="q1">
+<sup>5&#160;</sup>of the tribe of Judah twelve thousand were sealed, 
+</div><div class="q1">of the tribe of Reuben twelve thousand, 
+</div><div class="q1">of the tribe of Gad twelve thousand, 
+</div><div class="q1">
+<sup>6&#160;</sup>of the tribe of Asher twelve thousand, 
+</div><div class="q1">of the tribe of Naphtali twelve thousand, 
+</div><div class="q1">of the tribe of Manasseh twelve thousand, 
+</div><div class="q1">
+<sup>7&#160;</sup>of the tribe of Simeon twelve thousand, 
+</div><div class="q1">of the tribe of Levi twelve thousand, 
+</div><div class="q1">of the tribe of Issachar twelve thousand, 
+</div><div class="q1">
+<sup>8&#160;</sup>of the tribe of Zebulun twelve thousand, 
+</div><div class="q1">of the tribe of Joseph twelve thousand, and 
+</div><div class="q1">of the tribe of Benjamin twelve thousand were sealed. 
+</div><div class="p">
+<sup>9&#160;</sup>After these things I looked, and behold, a great multitude which no man could count, out of every nation and of all tribes, peoples, and languages, standing before the throne and before the Lamb, dressed in white robes, with palm branches in their hands. 
+<sup>10&#160;</sup>They cried with a loud voice, saying, “Salvation be to our Elohim, who sits on the throne, and to the Lamb!” 
+</div><div class="p">
+<sup>11&#160;</sup>All the angels were standing around the throne, the elders, and the four living creatures; and they fell on their faces before his throne, and worshiped Elohim, 
+<sup>12&#160;</sup>saying, “Amen! Blessing, glory, wisdom, thanksgiving, honor, power, and might, be to our Elohim forever and ever! Amen.” 
+</div><div class="p">
+<sup>13&#160;</sup>One of the elders answered, saying to me, “These who are arrayed in the white robes, who are they, and where did they come from?” 
+</div><div class="p">
+<sup>14&#160;</sup>I told him, “My lord, you know.” 
+</div><div class="p">He said to me, “These are those who came out of the great suffering. They washed their robes and made them white in the Lamb’s blood. 
+<sup>15&#160;</sup>Therefore they are before the throne of Elohim, and they serve him day and night in his temple. He who sits on the throne will spread his tabernacle over them. 
+<sup>16&#160;</sup>They will never be hungry or thirsty any more. The sun won’t beat on them, nor any heat; 
+<sup>17&#160;</sup>for the Lamb who is in the middle of the throne shepherds them and leads them to springs of life-giving waters. And Elohim will wipe away every tear from their eyes.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>When he opened the seventh seal, there was silence in heaven for about half an hour. 
+<sup>2&#160;</sup>I saw the seven angels who stand before Elohim, and seven trumpets were given to them. 
+</div><div class="p">
+<sup>3&#160;</sup>Another angel came and stood over the altar, having a golden censer. Much incense was given to him, that he should add it to the prayers of all the saints on the golden altar which was before the throne. 
+<sup>4&#160;</sup>The smoke of the incense, with the prayers of the saints, went up before Elohim out of the angel’s hand. 
+<sup>5&#160;</sup>The angel took the censer, and he filled it with the fire of the altar, then threw it on the earth. Thunders, sounds, lightnings, and an earthquake followed. 
+</div><div class="p">
+<sup>6&#160;</sup>The seven angels who had the seven trumpets prepared themselves to sound. 
+</div><div class="p">
+<sup>7&#160;</sup>The first sounded, and there followed hail and fire, mixed with blood, and they were thrown to the earth. One third of the earth was burned up, and one third of the trees were burned up, and all green grass was burned up. 
+</div><div class="p">
+<sup>8&#160;</sup>The second angel sounded, and something like a great burning mountain was thrown into the sea. One third of the sea became blood, 
+<sup>9&#160;</sup>and one third of the living creatures which were in the sea died. One third of the ships were destroyed. 
+</div><div class="p">
+<sup>10&#160;</sup>The third angel sounded, and a great star fell from the sky, burning like a torch, and it fell on one third of the rivers, and on the springs of water. 
+<sup>11&#160;</sup>The name of the star is “Wormwood.” One third of the waters became wormwood. Many people died from the waters, because they were made bitter. 
+</div><div class="p">
+<sup>12&#160;</sup>The fourth angel sounded, and one third of the sun was struck, and one third of the moon, and one third of the stars, so that one third of them would be darkened; and the day wouldn’t shine for one third of it, and the night in the same way. 
+<sup>13&#160;</sup>I saw, and I heard an eagle, flying in mid heaven, saying with a loud voice, “Woe! Woe! Woe to those who dwell on the earth, because of the other blasts of the trumpets of the three angels, who are yet to sound!” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>The fifth angel sounded, and I saw a star from the sky which had fallen to the earth. The key to the pit of the abyss was given to him. 
+<sup>2&#160;</sup>He opened the pit of the abyss, and smoke went up out of the pit, like the smoke from a burning furnace. The sun and the air were darkened because of the smoke from the pit. 
+<sup>3&#160;</sup>Then out of the smoke came locusts on the earth, and power was given to them, as the scorpions of the earth have power. 
+<sup>4&#160;</sup>They were told that they should not hurt the grass of the earth, neither any green thing, neither any tree, but only those people who don’t have Elohim’s seal on their foreheads. 
+<sup>5&#160;</sup>They were given power, not to kill them, but to torment them for five months. Their torment was like the torment of a scorpion when it strikes a person. 
+<sup>6&#160;</sup>In those days people will seek death, and will in no way find it. They will desire to die, and death will flee from them. 
+</div><div class="p">
+<sup>7&#160;</sup>The shapes of the locusts were like horses prepared for war. On their heads were something like golden crowns, and their faces were like people’s faces. 
+<sup>8&#160;</sup>They had hair like women’s hair, and their teeth were like those of lions. 
+<sup>9&#160;</sup>They had breastplates like breastplates of iron. The sound of their wings was like the sound of many chariots and horses rushing to war. 
+<sup>10&#160;</sup>They have tails like those of scorpions, with stingers. In their tails they have power to harm men for five months. 
+<sup>11&#160;</sup>They have over them as king the angel of the abyss. His name in Hebrew is “Abaddon”, 
+</div><div class="p">
+<sup>12&#160;</sup>The first woe is past. Behold, there are still two woes coming after this. 
+</div><div class="p">
+<sup>13&#160;</sup>The sixth angel sounded. I heard a voice from the horns of the golden altar which is before Elohim, 
+<sup>14&#160;</sup>saying to the sixth angel who had the trumpet, “Free the four angels who are bound at the great river Euphrates!” 
+</div><div class="p">
+<sup>15&#160;</sup>The four angels were freed who had been prepared for that hour and day and month and year, so that they might kill one third of mankind. 
+<sup>16&#160;</sup>The number of the armies of the horsemen was two hundred million. I heard the number of them. 
+<sup>17&#160;</sup>Thus I saw the horses in the vision and those who sat on them, having breastplates of fiery red, hyacinth blue, and sulfur yellow; and the horses’ heads resembled lions’ heads. Out of their mouths proceed fire, smoke, and sulfur. 
+<sup>18&#160;</sup>By these three plagues, one third of mankind was killed: by the fire, the smoke, and the sulfur, which proceeded out of their mouths. 
+<sup>19&#160;</sup>For the power of the horses is in their mouths and in their tails. For their tails are like serpents, and have heads; and with them they harm. 
+</div><div class="p">
+<sup>20&#160;</sup>The rest of mankind, who were not killed with these plagues, didn’t repent of the works of their hands, that they wouldn’t worship demons, and the idols of gold, and of silver, and of brass, and of stone, and of wood, which can’t see, hear, or walk. 
+<sup>21&#160;</sup>They didn’t repent of their murders, their sorceries, their sexual immorality, or their thefts. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw a mighty angel coming down out of the sky, clothed with a cloud. A rainbow was on his head. His face was like the sun, and his feet like pillars of fire. 
+<sup>2&#160;</sup>He had in his hand a little open book. He set his right foot on the sea, and his left on the land. 
+<sup>3&#160;</sup>He cried with a loud voice, as a lion roars. When he cried, the seven thunders uttered their voices. 
+<sup>4&#160;</sup>When the seven thunders sounded, I was about to write; but I heard a voice from the sky saying, “Seal up the things which the seven thunders said, and don’t write them.” 
+</div><div class="p">
+<sup>5&#160;</sup>The angel whom I saw standing on the sea and on the land lifted up his right hand to the sky 
+<sup>6&#160;</sup>and swore by him who lives forever and ever, who created heaven and the things that are in it, the earth and the things that are in it, and the sea and the things that are in it, that there will no longer be delay, 
+<sup>7&#160;</sup>but in the days of the voice of the seventh angel, when he is about to sound, then the mystery of Elohim is finished, as he declared to his servants the prophets. 
+</div><div class="p">
+<sup>8&#160;</sup>The voice which I heard from heaven, again speaking with me, said, “Go, take the book which is open in the hand of the angel who stands on the sea and on the land.” 
+</div><div class="p">
+<sup>9&#160;</sup>I went to the angel, telling him to give me the little book. 
+</div><div class="p">He said to me, “Take it and eat it. It will make your stomach bitter, but in your mouth it will be as sweet as honey.” 
+</div><div class="p">
+<sup>10&#160;</sup>I took the little book out of the angel’s hand, and ate it. It was as sweet as honey in my mouth. When I had eaten it, my stomach was made bitter. 
+<sup>11&#160;</sup>They told me, “You must prophesy again over many peoples, nations, languages, and kings.” 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="p">
+<sup>1&#160;</sup>A reed like a rod was given to me. Someone said, “Rise and measure Elohim’s temple, and the altar, and those who worship in it. 
+<sup>2&#160;</sup>Leave out the court which is outside of the temple, and don’t measure it, for it has been given to the nations. They will tread the set-apart city under foot for forty-two months. 
+<sup>3&#160;</sup>I will give power to my two witnesses, and they will prophesy one thousand two hundred sixty days, clothed in sackcloth.” 
+</div><div class="p">
+<sup>4&#160;</sup>These are the two olive trees and the two lamp stands, standing before the Lord of the earth. 
+<sup>5&#160;</sup>If anyone desires to harm them, fire proceeds out of their mouth and devours their enemies. If anyone desires to harm them, he must be killed in this way. 
+<sup>6&#160;</sup>These have the power to shut up the sky, that it may not rain during the days of their prophecy. They have power over the waters, to turn them into blood, and to strike the earth with every plague, as often as they desire. 
+</div><div class="p">
+<sup>7&#160;</sup>When they have finished their testimony, the beast that comes up out of the abyss will make war with them, and overcome them, and kill them. 
+<sup>8&#160;</sup>Their dead bodies will be in the street of the great city, which spiritually is called Sodom and Egypt, where also their Lord was crucified. 
+<sup>9&#160;</sup>From among the peoples, tribes, languages, and nations, people will look at their dead bodies for three and a half days, and will not allow their dead bodies to be laid in a tomb. 
+<sup>10&#160;</sup>Those who dwell on the earth will rejoice over them, and they will be glad. They will give gifts to one another, because these two prophets tormented those who dwell on the earth. 
+</div><div class="p">
+<sup>11&#160;</sup>After the three and a half days, the breath of life from Elohim entered into them, and they stood on their feet. Great fear fell on those who saw them. 
+<sup>12&#160;</sup>I heard a loud voice from heaven saying to them, “Come up here!” They went up into heaven in a cloud, and their enemies saw them. 
+<sup>13&#160;</sup>In that day there was a great earthquake, and a tenth of the city fell. Seven thousand people were killed in the earthquake, and the rest were terrified and gave glory to the Elohim of heaven. 
+</div><div class="p">
+<sup>14&#160;</sup>The second woe is past. Behold, the third woe comes quickly. 
+</div><div class="p">
+<sup>15&#160;</sup>The seventh angel sounded, and great voices in heaven followed, saying, “The kingdom of the world has become the Kingdom of our Lord and of his Christ. He will reign forever and ever!” 
+</div><div class="p">
+<sup>16&#160;</sup>The twenty-four elders, who sit on their thrones before Elohim’s throne, fell on their faces and worshiped Elohim, 
+<sup>17&#160;</sup>saying: “We give you thanks, Lord Elohim, the Almighty, the one who is and who was, because you have taken your great power and reigned. 
+<sup>18&#160;</sup>The nations were angry, and your wrath came, as did the time for the dead to be judged, and to give your bondservants the prophets, their reward, as well as to the saints and those who fear your name, to the small and the great, and to destroy those who destroy the earth.” 
+</div><div class="p">
+<sup>19&#160;</sup>Elohim’s temple that is in heaven was opened, and the ark of the Lord’s covenant was seen in his temple. Lightnings, sounds, thunders, an earthquake, and great hail followed. 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>A great sign was seen in heaven: a woman clothed with the sun, and the moon under her feet, and on her head a crown of twelve stars. 
+<sup>2&#160;</sup>She was with child. She cried out in pain, laboring to give birth. 
+</div><div class="p">
+<sup>3&#160;</sup>Another sign was seen in heaven. Behold, a great red dragon, having seven heads and ten horns, and on his heads seven crowns. 
+<sup>4&#160;</sup>His tail drew one third of the stars of the sky, and threw them to the earth. The dragon stood before the woman who was about to give birth, so that when she gave birth he might devour her child. 
+<sup>5&#160;</sup>She gave birth to a son, a male child, who is to rule all the nations with a rod of iron. Her child was caught up to Elohim and to his throne. 
+<sup>6&#160;</sup>The woman fled into the wilderness, where she has a place prepared by Elohim, that there they may nourish her one thousand two hundred sixty days. 
+</div><div class="p">
+<sup>7&#160;</sup>There was war in the sky. Michael and his angels made war on the dragon. The dragon and his angels made war. 
+<sup>8&#160;</sup>They didn’t prevail. No place was found for them any more in heaven. 
+<sup>9&#160;</sup>The great dragon was thrown down, the old serpent, he who is called the devil and Satan, the deceiver of the whole world. He was thrown down to the earth, and his angels were thrown down with him. 
+</div><div class="p">
+<sup>10&#160;</sup>I heard a loud voice in heaven, saying, “Now the salvation, the power, and the Kingdom of our Elohim, and the authority of his Christ has come; for the accuser of our brothers has been thrown down, who accuses them before our Elohim day and night. 
+<sup>11&#160;</sup>They overcame him because of the Lamb’s blood, and because of the word of their testimony. They didn’t love their life, even to death. 
+<sup>12&#160;</sup>Therefore rejoice, heavens, and you who dwell in them. Woe to the earth and to the sea, because the devil has gone down to you, having great wrath, knowing that he has but a short time.” 
+</div><div class="p">
+<sup>13&#160;</sup>When the dragon saw that he was thrown down to the earth, he persecuted the woman who gave birth to the male child. 
+<sup>14&#160;</sup>Two wings of the great eagle were given to the woman, that she might fly into the wilderness to her place, so that she might be nourished for a time, times, and half a time, from the face of the serpent. 
+<sup>15&#160;</sup>The serpent spewed water out of his mouth after the woman like a river, that he might cause her to be carried away by the stream. 
+<sup>16&#160;</sup>The earth helped the woman, and the earth opened its mouth and swallowed up the river which the dragon spewed out of his mouth. 
+<sup>17&#160;</sup>The dragon grew angry with the woman, and went away to make war with the rest of her offspring, who keep Elohim’s commandments and hold Yahushua’s testimony. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>Then I stood on the sand of the sea. I saw a beast coming up out of the sea, having ten horns and seven heads. On his horns were ten crowns, and on his heads, blasphemous names. 
+<sup>2&#160;</sup>The beast which I saw was like a leopard, and his feet were like those of a bear, and his mouth like the mouth of a lion. The dragon gave him his power, his throne, and great authority. 
+<sup>3&#160;</sup>One of his heads looked like it had been wounded fatally. His fatal wound was healed, and the whole earth marveled at the beast. 
+<sup>4&#160;</sup>They worshiped the dragon because he gave his authority to the beast; and they worshiped the beast, saying, “Who is like the beast? Who is able to make war with him?” 
+</div><div class="p">
+<sup>5&#160;</sup>A mouth speaking great things and blasphemy was given to him. Authority to make war for forty-two months was given to him. 
+<sup>6&#160;</sup>He opened his mouth for blasphemy against Elohim, to blaspheme his name, his dwelling, and those who dwell in heaven. 
+<sup>7&#160;</sup>It was given to him to make war with the saints and to overcome them. Authority over every tribe, people, language, and nation was given to him. 
+<sup>8&#160;</sup>All who dwell on the earth will worship him, everyone whose name has not been written from the foundation of the world in the book of life of the Lamb who has been killed. 
+<sup>9&#160;</sup>If anyone has an ear, let him hear. 
+<sup>10&#160;</sup>If anyone is to go into captivity, he will go into captivity. If anyone is to be killed with the sword, he must be killed. Here is the endurance and the faith of the saints. 
+</div><div class="p">
+<sup>11&#160;</sup>I saw another beast coming up out of the earth. He had two horns like a lamb and it spoke like a dragon. 
+<sup>12&#160;</sup>He exercises all the authority of the first beast in his presence. He makes the earth and those who dwell in it to worship the first beast, whose fatal wound was healed. 
+<sup>13&#160;</sup>He performs great signs, even making fire come down out of the sky to the earth in the sight of people. 
+<sup>14&#160;</sup>He deceives my own people who dwell on the earth because of the signs he was granted to do in front of the beast, saying to those who dwell on the earth that they should make an image to the beast who had the sword wound and lived. 
+<sup>15&#160;</sup>It was given to him to give breath to the image of the beast, that the image of the beast should both speak, and cause as many as wouldn’t worship the image of the beast to be killed. 
+<sup>16&#160;</sup>He causes all, the small and the great, the rich and the poor, and the free and the slave, to be given marks on their right hands or on their foreheads; 
+<sup>17&#160;</sup>and that no one would be able to buy or to sell unless he has that mark, which is the name of the beast or the number of his name. 
+<sup>18&#160;</sup>Here is wisdom. He who has understanding, let him calculate the number of the beast, for it is the number of a man. His number is six hundred sixty-six. 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw, and behold, the Lamb standing on Mount Zion, and with him a number, one hundred forty-four thousand, having his name and the name of his Father written on their foreheads. 
+<sup>2&#160;</sup>I heard a sound from heaven like the sound of many waters and like the sound of a great thunder. The sound which I heard was like that of harpists playing on their harps. 
+<sup>3&#160;</sup>They sing a new song before the throne and before the four living creatures and the elders. No one could learn the song except the one hundred forty-four thousand, those who had been redeemed out of the earth. 
+<sup>4&#160;</sup>These are those who were not defiled with women, for they are virgins. These are those who follow the Lamb wherever he goes. These were redeemed by Yahushua from among men, the first fruits to Elohim and to the Lamb. 
+<sup>5&#160;</sup>In their mouth was found no lie, for they are blameless. 
+</div><div class="p">
+<sup>6&#160;</sup>I saw an angel flying in mid heaven, having an eternal Good News to proclaim to those who dwell on the earth—to every nation, tribe, language, and people. 
+<sup>7&#160;</sup>He said with a loud voice, “Fear the Lord, and give him glory, for the hour of his judgment has come. Worship him who made the heaven, the earth, the sea, and the springs of waters!” 
+</div><div class="p">
+<sup>8&#160;</sup>Another, a second angel, followed, saying, “Babylon the great has fallen, which has made all the nations to drink of the wine of the wrath of her sexual immorality.” 
+</div><div class="p">
+<sup>9&#160;</sup>Another angel, a third, followed them, saying with a great voice, “If anyone worships the beast and his image, and receives a mark on his forehead or on his hand, 
+<sup>10&#160;</sup>he also will drink of the wine of the wrath of Elohim, which is prepared unmixed in the cup of his anger. He will be tormented with fire and sulfur in the presence of the set-apart angels and in the presence of the Lamb. 
+<sup>11&#160;</sup>The smoke of their torment goes up forever and ever. They have no rest day and night, those who worship the beast and his image, and whoever receives the mark of his name. 
+</div><div class="p">
+<sup>12&#160;</sup>Here is the perseverance of the saints, those who keep the commandments of Elohim and the faith of Yahushua.” 
+</div><div class="p">
+<sup>13&#160;</sup>I heard a voice from heaven saying, “Write, ‘Blessed are the dead who die in the Lord from now on.’&#160;” 
+</div><div class="p">“Yes,” says the Spirit, “that they may rest from their labors, for their works follow with them.” 
+</div><div class="p">
+<sup>14&#160;</sup>I looked, and saw a white cloud, and on the cloud one sitting like a son of man, having on his head a golden crown, and in his hand a sharp sickle. 
+<sup>15&#160;</sup>Another angel came out of the temple, crying with a loud voice to him who sat on the cloud, “Send your sickle and reap, for the hour to reap has come; for the harvest of the earth is ripe!” 
+<sup>16&#160;</sup>He who sat on the cloud thrust his sickle on the earth, and the earth was reaped. 
+</div><div class="p">
+<sup>17&#160;</sup>Another angel came out of the temple which is in heaven. He also had a sharp sickle. 
+<sup>18&#160;</sup>Another angel came out from the altar, he who has power over fire, and he called with a great voice to him who had the sharp sickle, saying, “Send your sharp sickle and gather the clusters of the vine of the earth, for the earth’s grapes are fully ripe!” 
+<sup>19&#160;</sup>The angel thrust his sickle into the earth, and gathered the vintage of the earth and threw it into the great wine press of the wrath of Elohim. 
+<sup>20&#160;</sup>The wine press was trodden outside of the city, and blood came out of the wine press, up to the bridles of the horses, as far as one thousand six hundred stadia. 
+</div><h2 class="chapterlabel" id="15">15</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw another great and marvelous sign in the sky: seven angels having the seven last plagues, for in them Elohim’s wrath is finished. 
+</div><div class="p">
+<sup>2&#160;</sup>I saw something like a sea of glass mixed with fire, and those who overcame the beast, his image, and the number of his name, standing on the sea of glass, having harps of Elohim. 
+<sup>3&#160;</sup>They sang the song of Moses, the servant of Elohim, and the song of the Lamb, saying, 
+</div><div class="q1">“Great and marvelous are your works, Lord Elohim, the Almighty! 
+</div><div class="q2">Righteous and true are your ways, you King of the nations. 
+</div><div class="q1">
+<sup>4&#160;</sup>Who wouldn’t fear you, Lord, 
+</div><div class="q2">and glorify your name? 
+</div><div class="q1">For you only are set-apart. 
+</div><div class="q2">For all the nations will come and worship before you. 
+</div><div class="q2">For your righteous acts have been revealed.” 
+</div><div class="p">
+<sup>5&#160;</sup>After these things I looked, and the temple of the tabernacle of the testimony in heaven was opened. 
+<sup>6&#160;</sup>The seven angels who had the seven plagues came out, clothed with pure, bright linen, and wearing golden sashes around their chests. 
+</div><div class="p">
+<sup>7&#160;</sup>One of the four living creatures gave to the seven angels seven golden bowls full of the wrath of Elohim, who lives forever and ever. 
+<sup>8&#160;</sup>The temple was filled with smoke from the glory of Elohim and from his power. No one was able to enter into the temple until the seven plagues of the seven angels would be finished. 
+</div><h2 class="chapterlabel" id="16">16</h2>
+<div class="p">
+<sup>1&#160;</sup>I heard a loud voice out of the temple, saying to the seven angels, “Go and pour out the seven bowls of the wrath of Elohim on the earth!” 
+</div><div class="p">
+<sup>2&#160;</sup>The first went, and poured out his bowl into the earth, and it became a harmful and painful sore on the people who had the mark of the beast, and who worshiped his image. 
+</div><div class="p">
+<sup>3&#160;</sup>The second angel poured out his bowl into the sea, and it became blood as of a dead man. Every living thing in the sea died. 
+</div><div class="p">
+<sup>4&#160;</sup>The third poured out his bowl into the rivers and springs of water, and they became blood. 
+<sup>5&#160;</sup>I heard the angel of the waters saying, “You are righteous, who are and who were, O Set-Apart One, because you have judged these things. 
+<sup>6&#160;</sup>For they poured out the blood of saints and prophets, and you have given them blood to drink. They deserve this.” 
+</div><div class="p">
+<sup>7&#160;</sup>I heard the altar saying, “Yes, Lord Elohim, the Almighty, true and righteous are your judgments.” 
+</div><div class="p">
+<sup>8&#160;</sup>The fourth poured out his bowl on the sun, and it was given to him to scorch men with fire. 
+<sup>9&#160;</sup>People were scorched with great heat, and people blasphemed the name of Elohim who has the power over these plagues. They didn’t repent and give him glory. 
+</div><div class="p">
+<sup>10&#160;</sup>The fifth poured out his bowl on the throne of the beast, and his kingdom was darkened. They gnawed their tongues because of the pain, 
+<sup>11&#160;</sup>and they blasphemed the Elohim of heaven because of their pains and their sores. They still didn’t repent of their works. 
+</div><div class="p">
+<sup>12&#160;</sup>The sixth poured out his bowl on the great river, the Euphrates. Its water was dried up, that the way might be prepared for the kings that come from the sunrise. 
+<sup>13&#160;</sup>I saw coming out of the mouth of the dragon, and out of the mouth of the beast, and out of the mouth of the false prophet, three unclean spirits, something like frogs; 
+<sup>14&#160;</sup>for they are spirits of demons, performing signs, which go out to the kings of the whole inhabited earth, to gather them together for the war of that great day of Elohim the Almighty. 
+</div><div class="p">
+<sup>15&#160;</sup><span class="wj">“Behold, I come like a thief. Blessed is he who watches, and keeps his clothes, so that he doesn’t walk naked, and they see his shame.” </span> 
+<sup>16&#160;</sup>He gathered them together into the place which is called in Hebrew, “Harmagedon”. 
+</div><div class="p">
+<sup>17&#160;</sup>The seventh poured out his bowl into the air. A loud voice came out of the temple of heaven, from the throne, saying, “It is done!” 
+<sup>18&#160;</sup>There were lightnings, sounds, and thunders; and there was a great earthquake such as has not happened since there were men on the earth—so great an earthquake and so mighty. 
+<sup>19&#160;</sup>The great city was divided into three parts, and the cities of the nations fell. Babylon the great was remembered in the sight of Elohim, to give to her the cup of the wine of the fierceness of his wrath. 
+<sup>20&#160;</sup>Every island fled away, and the mountains were not found. 
+<sup>21&#160;</sup>Great hailstones, about the weight of a talent, came down out of the sky on people. People blasphemed Elohim because of the plague of the hail, for this plague was exceedingly severe. 
+</div><h2 class="chapterlabel" id="17">17</h2>
+<div class="p">
+<sup>1&#160;</sup>One of the seven angels who had the seven bowls came and spoke with me, saying, “Come here. I will show you the judgment of the great prostitute who sits on many waters, 
+<sup>2&#160;</sup>with whom the kings of the earth committed sexual immorality. Those who dwell in the earth were made drunken with the wine of her sexual immorality.” 
+<sup>3&#160;</sup>He carried me away in the Spirit into a wilderness. I saw a woman sitting on a scarlet-colored beast, full of blasphemous names, having seven heads and ten horns. 
+<sup>4&#160;</sup>The woman was dressed in purple and scarlet, and decked with gold and precious stones and pearls, having in her hand a golden cup full of abominations and the impurities of the sexual immorality of the earth. 
+<sup>5&#160;</sup>And on her forehead a name was written, “MYSTERY, BABYLON THE GREAT, THE MOTHER OF THE PROSTITUTES AND OF THE ABOMINATIONS OF THE EARTH.” 
+<sup>6&#160;</sup>I saw the woman drunken with the blood of the saints and with the blood of the martyrs of Yahushua. When I saw her, I wondered with great amazement. 
+</div><div class="p">
+<sup>7&#160;</sup>The angel said to me, “Why do you wonder? I will tell you the mystery of the woman and of the beast that carries her, which has the seven heads and the ten horns. 
+<sup>8&#160;</sup>The beast that you saw was, and is not; and is about to come up out of the abyss and to go into destruction. Those who dwell on the earth and whose names have not been written in the book of life from the foundation of the world will marvel when they see that the beast was, and is not, and shall be present. 
+</div><div class="p">
+<sup>9&#160;</sup>Here is the mind that has wisdom. The seven heads are seven mountains on which the woman sits. 
+<sup>10&#160;</sup>They are seven kings. Five have fallen, the one is, and the other has not yet come. When he comes, he must continue a little while. 
+<sup>11&#160;</sup>The beast that was, and is not, is himself also an eighth, and is of the seven; and he goes to destruction. 
+<sup>12&#160;</sup>The ten horns that you saw are ten kings who have received no kingdom as yet, but they receive authority as kings with the beast for one hour. 
+<sup>13&#160;</sup>These have one mind, and they give their power and authority to the beast. 
+<sup>14&#160;</sup>These will war against the Lamb, and the Lamb will overcome them, for he is Lord of lords and King of kings; and those who are with him are called, chosen, and faithful.” 
+<sup>15&#160;</sup>He said to me, “The waters which you saw, where the prostitute sits, are peoples, multitudes, nations, and languages. 
+<sup>16&#160;</sup>The ten horns which you saw, they and the beast will hate the prostitute, will make her desolate, will strip her naked, will eat her flesh, and will burn her utterly with fire. 
+<sup>17&#160;</sup>For Elohim has put in their hearts to do what he has in mind, to be of one mind, and to give their kingdom to the beast, until the words of Elohim should be accomplished. 
+<sup>18&#160;</sup>The woman whom you saw is the great city which reigns over the kings of the earth.” 
+</div><h2 class="chapterlabel" id="18">18</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things, I saw another angel coming down out of the sky, having great authority. The earth was illuminated with his glory. 
+<sup>2&#160;</sup>He cried with a mighty voice, saying, “Fallen, fallen is Babylon the great, and she has become a habitation of demons, a prison of every unclean spirit, and a prison of every unclean and hated bird! 
+<sup>3&#160;</sup>For all the nations have drunk of the wine of the wrath of her sexual immorality, the kings of the earth committed sexual immorality with her, and the merchants of the earth grew rich from the abundance of her luxury.” 
+</div><div class="p">
+<sup>4&#160;</sup>I heard another voice from heaven, saying, “Come out of her, my people, that you have no participation in her sins, and that you don’t receive of her plagues, 
+<sup>5&#160;</sup>for her sins have reached to the sky, and Elohim has remembered her iniquities. 
+<sup>6&#160;</sup>Return to her just as she returned, and repay her double as she did, and according to her works. In the cup which she mixed, mix to her double. 
+<sup>7&#160;</sup>However much she glorified herself and grew wanton, so much give her of torment and mourning. For she says in her heart, ‘I sit a queen, and am no widow, and will in no way see mourning.’ 
+<sup>8&#160;</sup>Therefore in one day her plagues will come: death, mourning, and famine; and she will be utterly burned with fire, for the Lord Elohim who has judged her is strong. 
+</div><div class="p">
+<sup>9&#160;</sup>The kings of the earth who committed sexual immorality and lived wantonly with her will weep and wail over her, when they look at the smoke of her burning, 
+<sup>10&#160;</sup>standing far away for the fear of her torment, saying, ‘Woe, woe, the great city, Babylon, the strong city! For your judgment has come in one hour.’ 
+<sup>11&#160;</sup>The merchants of the earth weep and mourn over her, for no one buys their merchandise any more: 
+<sup>12&#160;</sup>merchandise of gold, silver, precious stones, pearls, fine linen, purple, silk, scarlet, all expensive wood, every vessel of ivory, every vessel made of most precious wood, and of brass, and iron, and marble; 
+<sup>13&#160;</sup>and cinnamon, incense, perfume, frankincense, wine, olive oil, fine flour, wheat, sheep, horses, chariots, and people’s bodies and souls. 
+<sup>14&#160;</sup>The fruits which your soul lusted after have been lost to you. All things that were dainty and sumptuous have perished from you, and you will find them no more at all. 
+<sup>15&#160;</sup>The merchants of these things, who were made rich by her, will stand far away for the fear of her torment, weeping and mourning, 
+<sup>16&#160;</sup>saying, ‘Woe, woe, the great city, she who was dressed in fine linen, purple, and scarlet, and decked with gold and precious stones and pearls! 
+<sup>17&#160;</sup>For in an hour such great riches are made desolate.’ Every ship master, and everyone who sails anywhere, and mariners, and as many as gain their living by sea, stood far away, 
+<sup>18&#160;</sup>and cried out as they looked at the smoke of her burning, saying, ‘What is like the great city?’ 
+<sup>19&#160;</sup>They cast dust on their heads, and cried, weeping and mourning, saying, ‘Woe, woe, the great city, in which all who had their ships in the sea were made rich by reason of her great wealth!’ For she is made desolate in one hour. 
+</div><div class="p">
+<sup>20&#160;</sup>“Rejoice over her, O heaven, you saints, apostles, and prophets, for Elohim has judged your judgment on her.” 
+</div><div class="p">
+<sup>21&#160;</sup>A mighty angel took up a stone like a great millstone and cast it into the sea, saying, “Thus with violence will Babylon, the great city, be thrown down, and will be found no more at all. 
+<sup>22&#160;</sup>The voice of harpists, minstrels, flute players, and trumpeters will be heard no more at all in you. No craftsman of whatever craft will be found any more at all in you. The sound of a mill will be heard no more at all in you. 
+<sup>23&#160;</sup>The light of a lamp will shine no more at all in you. The voice of the bridegroom and of the bride will be heard no more at all in you, for your merchants were the princes of the earth; for with your sorcery all the nations were deceived. 
+<sup>24&#160;</sup>In her was found the blood of prophets and of saints, and of all who have been slain on the earth.” 
+</div><h2 class="chapterlabel" id="19">19</h2>
+<div class="p">
+<sup>1&#160;</sup>After these things I heard something like a loud voice of a great multitude in heaven, saying, “Hallelujah! Salvation, power, and glory belong to our Elohim; 
+<sup>2&#160;</sup>for his judgments are true and righteous. For he has judged the great prostitute who corrupted the earth with her sexual immorality, and he has avenged the blood of his servants at her hand.” 
+</div><div class="p">
+<sup>3&#160;</sup>A second said, “Hallelujah! Her smoke goes up forever and ever.” 
+<sup>4&#160;</sup>The twenty-four elders and the four living creatures fell down and worshiped Elohim who sits on the throne, saying, “Amen! Hallelujah!” 
+</div><div class="p">
+<sup>5&#160;</sup>A voice came from the throne, saying, “Give praise to our Elohim, all you his servants, you who fear him, the small and the great!” 
+</div><div class="p">
+<sup>6&#160;</sup>I heard something like the voice of a great multitude, and like the voice of many waters, and like the voice of mighty thunders, saying, “Hallelujah! For the Lord our Elohim, the Almighty, reigns! 
+<sup>7&#160;</sup>Let’s rejoice and be exceedingly glad, and let’s give the glory to him. For the wedding of the Lamb has come, and his woman has made herself ready.” 
+<sup>8&#160;</sup>It was given to her that she would array herself in bright, pure, fine linen, for the fine linen is the righteous acts of the saints. 
+</div><div class="p">
+<sup>9&#160;</sup>He said to me, “Write, ‘Blessed are those who are invited to the wedding supper of the Lamb.’&#160;” He said to me, “These are true words of Elohim.” 
+</div><div class="p">
+<sup>10&#160;</sup>I fell down before his feet to worship him. He said to me, “Look! Don’t do it! I am a fellow bondservant with you and with your brothers who hold the testimony of Yahushua. Worship Elohim, for the testimony of Yahushua is the Spirit of Prophecy.” 
+</div><div class="p">
+<sup>11&#160;</sup>I saw the heaven opened, and behold, a white horse, and he who sat on it is called Faithful and True. In righteousness he judges and makes war. 
+<sup>12&#160;</sup>His eyes are a flame of fire, and on his head are many crowns. He has names written and a name written which no one knows but he himself. 
+<sup>13&#160;</sup>He is clothed in a garment sprinkled with blood. His name is called “The Word of Elohim.” 
+<sup>14&#160;</sup>The armies which are in heaven, clothed in white, pure, fine linen, followed him on white horses. 
+<sup>15&#160;</sup>Out of his mouth proceeds a sharp, double-edged sword that with it he should strike the nations. He will rule them with an iron rod. He treads the wine press of the fierceness of the wrath of Elohim, the Almighty. 
+<sup>16&#160;</sup>He has on his garment and on his thigh a name written, “KING OF KINGS AND LORD OF LORDS.” 
+</div><div class="p">
+<sup>17&#160;</sup>I saw an angel standing in the sun. He cried with a loud voice, saying to all the birds that fly in the sky, “Come! Be gathered together to the great supper of Elohim, 
+<sup>18&#160;</sup>that you may eat the flesh of kings, the flesh of captains, the flesh of mighty men, and the flesh of horses and of those who sit on them, and the flesh of all men, both free and slave, small and great.” 
+<sup>19&#160;</sup>I saw the beast, the kings of the earth, and their armies, gathered together to make war against him who sat on the horse and against his army. 
+<sup>20&#160;</sup>The beast was taken, and with him the false prophet who worked the signs in his sight, with which he deceived those who had received the mark of the beast and those who worshiped his image. These two were thrown alive into the lake of fire that burns with sulfur. 
+<sup>21&#160;</sup>The rest were killed with the sword of him who sat on the horse, the sword which came out of his mouth. So all the birds were filled with their flesh. 
+</div><h2 class="chapterlabel" id="20">20</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw an angel coming down out of heaven, having the key of the abyss and a great chain in his hand. 
+<sup>2&#160;</sup>He seized the dragon, the old serpent, who is the devil and Satan, who deceives the whole inhabited earth, and bound him for a thousand years, 
+<sup>3&#160;</sup>and cast him into the abyss, and shut it and sealed it over him, that he should deceive the nations no more until the thousand years were finished. After this, he must be freed for a short time. 
+</div><div class="p">
+<sup>4&#160;</sup>I saw thrones, and they sat on them, and judgment was given to them. I saw the souls of those who had been beheaded for the testimony of Yahushua and for the word of Elohim, and such as didn’t worship the beast nor his image, and didn’t receive the mark on their forehead and on their hand. They lived and reigned with Christ for a thousand years. 
+<sup>5&#160;</sup>The rest of the dead didn’t live until the thousand years were finished. This is the first resurrection. 
+<sup>6&#160;</sup>Blessed and set-apart is he who has part in the first resurrection. Over these, the second death has no power, but they will be priests of Elohim and of Christ, and will reign with him one thousand years. 
+</div><div class="p">
+<sup>7&#160;</sup>And after the thousand years, Satan will be released from his prison 
+<sup>8&#160;</sup>and he will come out to deceive the nations which are in the four corners of the earth, Gog and Magog, to gather them together to the war, whose number is as the sand of the sea. 
+<sup>9&#160;</sup>They went up over the width of the earth and surrounded the camp of the saints and the beloved city. Fire came down out of heaven from Elohim and devoured them. 
+<sup>10&#160;</sup>The devil who deceived them was thrown into the lake of fire and sulfur, where the beast and the false prophet are also. They will be tormented day and night forever and ever. 
+</div><div class="p">
+<sup>11&#160;</sup>I saw a great white throne and him who sat on it, from whose face the earth and the heaven fled away. There was found no place for them. 
+<sup>12&#160;</sup>I saw the dead, the great and the small, standing before the throne, and they opened books. Another book was opened, which is the book of life. The dead were judged out of the things which were written in the books, according to their works. 
+<sup>13&#160;</sup>The sea gave up the dead who were in it. Death and Hades gave up the dead who were in them. They were judged, each one according to his works. 
+<sup>14&#160;</sup>Death and Hades were thrown into the lake of fire. This is the second death, the lake of fire. 
+<sup>15&#160;</sup>If anyone was not found written in the book of life, he was cast into the lake of fire. 
+</div><h2 class="chapterlabel" id="21">21</h2>
+<div class="p">
+<sup>1&#160;</sup>I saw a new heaven and a new earth, for the first heaven and the first earth have passed away, and the sea is no more. 
+<sup>2&#160;</sup>I saw the set-apart city, New Jerusalem, coming down out of heaven from Elohim, prepared like a bride adorned for her man. 
+<sup>3&#160;</sup>I heard a loud voice out of heaven saying, “Behold, Elohim’s dwelling is with people; and he will dwell with them, and they will be his people, and Elohim himself will be with them as their Elohim. 
+<sup>4&#160;</sup>He will wipe away every tear from their eyes. Death will be no more; neither will there be mourning, nor crying, nor pain any more. The first things have passed away.” 
+</div><div class="p">
+<sup>5&#160;</sup>He who sits on the throne said, <span class="wj">“Behold, I am making all things new.”</span> He said, <span class="wj">“Write, for these words of Elohim are faithful and true.” </span> 
+<sup>6&#160;</sup>He said to me, <span class="wj">“I am the Alpha and the Omega, the Beginning and the End. I will give freely to him who is thirsty from the spring of the water of life. </span> 
+<sup>7&#160;</sup><span class="wj">He who overcomes, I will give him these things. I will be his Elohim, and he will be my son. </span> 
+<sup>8&#160;</sup><span class="wj">But for the cowardly, unbelieving, sinners,</span> <span class="wj">idolaters, and all liars, their part is in the lake that burns with fire and sulfur, which is the second death.”</span> 
+</div><div class="p">
+<sup>9&#160;</sup>One of the seven angels who had the seven bowls which were loaded with the seven last plagues came, and he spoke with me, saying, “Come here. I will show you the bride, the Lamb’s woman.” 
+<sup>10&#160;</sup>He carried me away in the Spirit to a great and high mountain, and showed me the set-apart city, Jerusalem, coming down out of heaven from Elohim, 
+<sup>11&#160;</sup>having the glory of Elohim. Her light was like a most precious stone, like a jasper stone, clear as crystal; 
+<sup>12&#160;</sup>having a great and high wall with twelve gates, and at the gates twelve angels, and names written on them, which are the names of the twelve tribes of the children of Israel. 
+<sup>13&#160;</sup>On the east were three gates, and on the north three gates, and on the south three gates, and on the west three gates. 
+<sup>14&#160;</sup>The wall of the city had twelve foundations, and on them twelve names of the twelve Apostles of the Lamb. 
+</div><div class="p">
+<sup>15&#160;</sup>He who spoke with me had for a measure a golden reed to measure the city, its gates, and its walls. 
+<sup>16&#160;</sup>The city is square. Its length is as great as its width. He measured the city with the reed: twelve thousand twelve stadia. Its length, width, and height are equal. 
+<sup>17&#160;</sup>Its wall is one hundred forty-four cubits, by the measure of a man, that is, of an angel. 
+<sup>18&#160;</sup>The construction of its wall was jasper. The city was pure gold, like pure glass. 
+<sup>19&#160;</sup>The foundations of the city’s wall were adorned with all kinds of precious stones. The first foundation was jasper, the second sapphire; the third chalcedony, the fourth emerald, 
+<sup>20&#160;</sup>the fifth sardonyx, the sixth sardius, the seventh chrysolite, the eighth beryl, the ninth topaz, the tenth chrysoprase, the eleventh jacinth, and the twelfth amethyst. 
+<sup>21&#160;</sup>The twelve gates were twelve pearls. Each one of the gates was made of one pearl. The street of the city was pure gold, like transparent glass. 
+</div><div class="p">
+<sup>22&#160;</sup>I saw no temple in it, for the Lord Elohim the Almighty and the Lamb are its temple. 
+<sup>23&#160;</sup>The city has no need for the sun or moon to shine, for the very glory of Elohim illuminated it and its lamp is the Lamb. 
+<sup>24&#160;</sup>The nations will walk in its light. The kings of the earth bring the glory and honor of the nations into it. 
+<sup>25&#160;</sup>Its gates will in no way be shut by day (for there will be no night there), 
+<sup>26&#160;</sup>and they shall bring the glory and the honor of the nations into it so that they may enter. 
+<sup>27&#160;</sup>There will in no way enter into it anything profane, or one who causes an abomination or a lie, but only those who are written in the Lamb’s book of life. 
+</div><h2 class="chapterlabel" id="22">22</h2>
+<div class="p">
+<sup>1&#160;</sup>He showed me a river of water of life, clear as crystal, proceeding out of the throne of Elohim and of the Lamb, 
+<sup>2&#160;</sup>in the middle of its street. On this side of the river and on that was the tree of life, bearing twelve kinds of fruits, yielding its fruit every month. The leaves of the tree were for the healing of the nations. 
+<sup>3&#160;</sup>There will be no curse any more. The throne of Elohim and of the Lamb will be in it, and his servants will serve him. 
+<sup>4&#160;</sup>They will see his face, and his name will be on their foreheads. 
+<sup>5&#160;</sup>There will be no night, and they need no lamp light or sun light; for the Lord Elohim will illuminate them. They will reign forever and ever. 
+</div><div class="p">
+<sup>6&#160;</sup>He said to me, “These words are faithful and true. The Lord Elohim of the spirits of the prophets sent his angel to show to his bondservants the things which must happen soon.” 
+</div><div class="p">
+<sup>7&#160;</sup><span class="wj">“Behold, I am coming soon! Blessed is he who keeps the words of the prophecy of this book.”</span> 
+</div><div class="p">
+<sup>8&#160;</sup>Now I, John, am the one who heard and saw these things. When I heard and saw, I fell down to worship before the feet of the angel who had shown me these things. 
+<sup>9&#160;</sup>He said to me, “You must not do that! I am a fellow bondservant with you and with your brothers, the prophets, and with those who keep the words of this book. Worship Elohim.” 
+<sup>10&#160;</sup>He said to me, “Don’t seal up the words of the prophecy of this book, for the time is at hand. 
+<sup>11&#160;</sup>He who acts unjustly, let him act unjustly still. He who is filthy, let him be filthy still. He who is righteous, let him do righteousness still. He who is set-apart, let him be set-apart still.” 
+</div><div class="p">
+<sup>12&#160;</sup><span class="wj">“Behold, I am coming soon! My reward is with me, to repay to each man according to his work. </span> 
+<sup>13&#160;</sup><span class="wj">I am the Alpha and the Omega, the First and the Last, the Beginning and the End. </span> 
+<sup>14&#160;</sup><span class="wj">Blessed are those who do his commandments,</span> <span class="wj">that they may have the right to the tree of life, and may enter in by the gates into the city. </span> 
+<sup>15&#160;</sup><span class="wj">Outside are the dogs, the sorcerers, the sexually immoral, the murderers, the idolaters, and everyone who loves and practices falsehood. </span> 
+<sup>16&#160;</sup><span class="wj">I, Yahushua, have sent my angel to testify these things to you for the assemblies. I am the root and the offspring of David, the Bright and Morning Star.”</span> 
+</div><div class="p">
+<sup>17&#160;</sup>The Spirit and the bride say, “Come!” He who hears, let him say, “Come!” He who is thirsty, let him come. He who desires, let him take the water of life freely. 
+</div><div class="p">
+<sup>18&#160;</sup>I testify to everyone who hears the words of the prophecy of this book: if anyone adds to them, Elohim will add to him the plagues which are written in this book. 
+<sup>19&#160;</sup>If anyone takes away from the words of the book of this prophecy, Elohim will take away his part from the tree of life, and out of the set-apart city, which are written in this book. 
+<sup>20&#160;</sup>He who testifies these things says, <span class="wj">“Yes, I am coming soon.” </span> 
+</div><div class="p">Amen! Yes, come, Lord Yahushua! 
+</div><div class="p">
+<sup>21&#160;</sup>The grace of the Lord Yahushua Christ be with all the saints. Amen. </div></div><script src="../main.js"></script></body></html>

--- a/book/ruth.html
+++ b/book/ruth.html
@@ -3,6 +3,47 @@
 <head>
 <title>Ruth</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,134 +53,139 @@
 <div class="main">
 <!-- RUT World English Scripture (WES) -->
 <h1 class="booklabel">Ruth</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>In the days when the judges judged, there was a famine in the land. A certain man of Bethlehem Judah went to live in the country of Moab with his woman and his two sons. 
-<span class="v">2&#160;</span>The name of the man was Elimelech, and the name of his woman Naomi. The names of his two sons were Mahlon and Chilion, Ephrathites of Bethlehem Judah. They came into the country of Moab and lived there. 
-<span class="v">3&#160;</span>Elimelech, Naomi’s man, died; and she was left with her two sons. 
-<span class="v">4&#160;</span>They took for themselves women of the women of Moab. The name of the one was Orpah, and the name of the other was Ruth. They lived there about ten years. 
-<span class="v">5&#160;</span>Mahlon and Chilion both died, and the woman was bereaved of her two children and of her man. 
-<span class="v">6&#160;</span>Then she arose with her daughters-in-law, that she might return from the country of Moab; for she had heard in the country of Moab how Yahweh<span class="f">+ \fr 1:6 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> had visited his people in giving them bread. 
-<span class="v">7&#160;</span>She went out of the place where she was, and her two daughters-in-law with her. They went on the way to return to the land of Judah. 
-<span class="v">8&#160;</span>Naomi said to her two daughters-in-law, “Go, return each of you to her mother’s house. May Yahweh deal kindly with you, as you have dealt with the dead and with me. 
-<span class="v">9&#160;</span>May Yahweh grant you that you may find rest, each of you in the house of her man.” 
-</p><p>Then she kissed them, and they lifted up their voices, and wept. 
-<span class="v">10&#160;</span>They said to her, “No, but we will return with you to your people.” 
-</p><p>
-<span class="v">11&#160;</span>Naomi said, “Go back, my daughters. Why do you want to go with me? Do I still have sons in my womb, that they may be your men? 
-<span class="v">12&#160;</span>Go back, my daughters, go your way; for I am too old to have a man. If I should say, ‘I have hope,’ if I should even have a man tonight, and should also bear sons, 
-<span class="v">13&#160;</span>would you then wait until they were grown? Would you then refrain from having men? No, my daughters, for it grieves me seriously for your sakes, for Yahweh’s hand has gone out against me.” 
-</p><p>
-<span class="v">14&#160;</span>They lifted up their voices and wept again; then Orpah kissed her mother-in-law, but Ruth stayed with her. 
-<span class="v">15&#160;</span>She said, “Behold,<span class="f">+ \fr 1:15 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> your sister-in-law has gone back to her people and to her elohim. Follow your sister-in-law.” 
-</p><p>
-<span class="v">16&#160;</span>Ruth said, “Don’t urge me to leave you, and to return from following you, for where you go, I will go; and where you stay, I will stay. Your people will be my people, and your Elohim<span class="f">+ \fr 1:16 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> my Elohim. 
-<span class="v">17&#160;</span>Where you die, I will die, and there I will be buried. May Yahweh do so to me, and more also, if anything but death parts you and me.” 
-</p><p>
-<span class="v">18&#160;</span>When Naomi saw that she was determined to go with her, she stopped urging her. 
-</p><p>
-<span class="v">19&#160;</span>So they both went until they came to Bethlehem. When they had come to Bethlehem, all the city was excited about them, and they asked, “Is this Naomi?” 
-</p><p>
-<span class="v">20&#160;</span>She said to them, “Don’t call me Naomi.<span class="f">+ \fr 1:20 \ft “Naomi” means “pleasant”.</span> Call me Mara,<span class="f">+ \fr 1:20 \ft “Mara” means “bitter”.</span> for the Almighty has dealt very bitterly with me. 
-<span class="v">21&#160;</span>I went out full, and Yahweh has brought me home again empty. Why do you call me Naomi, since Yahweh has testified against me, and the Almighty has afflicted me?” 
-<span class="v">22&#160;</span>So Naomi returned, and Ruth the Moabitess, her daughter-in-law, with her, who returned out of the country of Moab. They came to Bethlehem in the beginning of barley harvest. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Naomi had a relative of her man’s, a mighty man of wealth, of the family of Elimelech, and his name was Boaz. 
-<span class="v">2&#160;</span>Ruth the Moabitess said to Naomi, “Let me now go to the field, and glean among the ears of grain after him in whose sight I find favor.” 
-</p><p>She said to her, “Go, my daughter.” 
-<span class="v">3&#160;</span>She went, and came and gleaned in the field after the reapers; and she happened to come to the portion of the field belonging to Boaz, who was of the family of Elimelech. 
-</p><p>
-<span class="v">4&#160;</span>Behold, Boaz came from Bethlehem, and said to the reapers, “May Yahweh be with you.” 
-</p><p>They answered him, “May Yahweh bless you.” 
-</p><p>
-<span class="v">5&#160;</span>Then Boaz said to his servant who was set over the reapers, “Whose young lady is this?” 
-</p><p>
-<span class="v">6&#160;</span>The servant who was set over the reapers answered, “It is the Moabite lady who came back with Naomi out of the country of Moab. 
-<span class="v">7&#160;</span>She said, ‘Please let me glean and gather after the reapers among the sheaves.’ So she came, and has continued even from the morning until now, except that she rested a little in the house.” 
-</p><p>
-<span class="v">8&#160;</span>Then Boaz said to Ruth, “Listen, my daughter. Don’t go to glean in another field, and don’t go from here, but stay here close to my maidens. 
-<span class="v">9&#160;</span>Let your eyes be on the field that they reap, and go after them. Haven’t I commanded the young men not to touch you? When you are thirsty, go to the vessels, and drink from that which the young men have drawn.” 
-</p><p>
-<span class="v">10&#160;</span>Then she fell on her face and bowed herself to the ground, and said to him, “Why have I found favor in your sight, that you should take knowledge of me, since I am a foreigner?” 
-</p><p>
-<span class="v">11&#160;</span>Boaz answered her, “I have been told all about what you have done for your mother-in-law since the death of your man, and how you have left your father, your mother, and the land of your birth, and have come to a people that you didn’t know before. 
-<span class="v">12&#160;</span>May Yahweh repay your work, and a full reward be given to you from Yahweh, the Elohim of Israel, under whose wings you have come to take refuge.” 
-</p><p>
-<span class="v">13&#160;</span>Then she said, “Let me find favor in your sight, my lord, because you have comforted me, and because you have spoken kindly to your servant, though I am not as one of your servants.” 
-</p><p>
-<span class="v">14&#160;</span>At meal time Boaz said to her, “Come here, and eat some bread, and dip your morsel in the vinegar.” 
-</p><p>She sat beside the reapers, and they passed her parched grain. She ate, was satisfied, and left some of it. 
-<span class="v">15&#160;</span>When she had risen up to glean, Boaz commanded his young men, saying, “Let her glean even among the sheaves, and don’t reproach her. 
-<span class="v">16&#160;</span>Also pull out some for her from the bundles, and leave it. Let her glean, and don’t rebuke her.” 
-</p><p>
-<span class="v">17&#160;</span>So she gleaned in the field until evening; and she beat out that which she had gleaned, and it was about an ephah<span class="f">+ \fr 2:17 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> of barley. 
-<span class="v">18&#160;</span>She took it up, and went into the city. Then her mother-in-law saw what she had gleaned; and she brought out and gave to her that which she had left after she had enough. 
-</p><p>
-<span class="v">19&#160;</span>Her mother-in-law said to her, “Where have you gleaned today? Where have you worked? Blessed be he who noticed you.” 
-</p><p>She told her mother-in-law with whom she had worked, “The man’s name with whom I worked today is Boaz.” 
-<span class="v">20&#160;</span>Naomi said to her daughter-in-law, “May he be blessed by Yahweh, who has not abandoned his kindness to the living and to the dead.” Naomi said to her, “The man is a close relative to us, one of our near kinsmen.” 
-</p><p>
-<span class="v">21&#160;</span>Ruth the Moabitess said, “Yes, he said to me, ‘You shall stay close to my young men until they have finished all my harvest.’&#160;” 
-</p><p>
-<span class="v">22&#160;</span>Naomi said to Ruth her daughter-in-law, “It is good, my daughter, that you go out with his maidens, and that they not meet you in any other field.” 
-<span class="v">23&#160;</span>So she stayed close to the maidens of Boaz, to glean to the end of barley harvest and of wheat harvest; and she lived with her mother-in-law. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Naomi her mother-in-law said to her, “My daughter, shall I not seek rest for you, that it may be well with you? 
-<span class="v">2&#160;</span>Now isn’t Boaz our kinsman, with whose maidens you were? Behold, he will be winnowing barley tonight on the threshing floor. 
-<span class="v">3&#160;</span>Therefore wash yourself, anoint yourself, get dressed, and go down to the threshing floor; but don’t make yourself known to the man until he has finished eating and drinking. 
-<span class="v">4&#160;</span>It shall be, when he lies down, that you shall note the place where he is lying. Then you shall go in, uncover his feet, and lie down. Then he will tell you what to do.” 
-</p><p>
-<span class="v">5&#160;</span>She said to her, “All that you say, I will do.” 
-<span class="v">6&#160;</span>She went down to the threshing floor, and did everything that her mother-in-law told her. 
-<span class="v">7&#160;</span>When Boaz had eaten and drunk, and his heart was merry, he went to lie down at the end of the heap of grain. She came softly, uncovered his feet, and lay down. 
-<span class="v">8&#160;</span>At midnight, the man was startled and turned himself; and behold, a woman lay at his feet. 
-<span class="v">9&#160;</span>He said, “Who are you?” 
-</p><p>She answered, “I am Ruth your servant. Therefore spread the corner of your garment over your servant; for you are a near kinsman.” 
-</p><p>
-<span class="v">10&#160;</span>He said, “You are blessed by Yahweh, my daughter. You have shown more kindness in the latter end than at the beginning, because you didn’t follow young men, whether poor or rich. 
-<span class="v">11&#160;</span>Now, my daughter, don’t be afraid. I will do to you all that you say; for all the city of my people knows that you are a worthy woman. 
-<span class="v">12&#160;</span>Now it is true that I am a near kinsman. However, there is a kinsman nearer than I. 
-<span class="v">13&#160;</span>Stay this night, and in the morning, if he will perform for you the part of a kinsman, good. Let him do the kinsman’s duty. But if he will not do the duty of a kinsman for you, then I will do the duty of a kinsman for you, as Yahweh lives. Lie down until the morning.” 
-</p><p>
-<span class="v">14&#160;</span>She lay at his feet until the morning, then she rose up before one could discern another. For he said, “Let it not be known that the woman came to the threshing floor.” 
-<span class="v">15&#160;</span>He said, “Bring the mantle that is on you, and hold it.” She held it; and he measured six measures of barley, and laid it on her; then he went into the city. 
-</p><p>
-<span class="v">16&#160;</span>When she came to her mother-in-law, she said, “How did it go, my daughter?” 
-</p><p>She told her all that the man had done for her. 
-<span class="v">17&#160;</span>She said, “He gave me these six measures of barley; for he said, ‘Don’t go empty to your mother-in-law.’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>Then she said, “Wait, my daughter, until you know what will happen; for the man will not rest until he has settled this today.” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>Now Boaz went up to the gate and sat down there. Behold, the near kinsman of whom Boaz spoke came by. Boaz said to him, “Come over here, friend, and sit down!” He came over, and sat down. 
-<span class="v">2&#160;</span>Boaz took ten men of the elders of the city, and said, “Sit down here,” and they sat down. 
-<span class="v">3&#160;</span>He said to the near kinsman, “Naomi, who has come back out of the country of Moab, is selling the parcel of land, which was our brother Elimelech’s. 
-<span class="v">4&#160;</span>I thought I should tell you, saying, ‘Buy it before those who sit here, and before the elders of my people.’ If you will redeem it, redeem it; but if you will not redeem it, then tell me, that I may know. For there is no one to redeem it besides you; and I am after you.” 
-</p><p>He said, “I will redeem it.” 
-</p><p>
-<span class="v">5&#160;</span>Then Boaz said, “On the day you buy the field from the hand of Naomi, you must buy it also from Ruth the Moabitess, the woman of the dead, to raise up the name of the dead on his inheritance.” 
-</p><p>
-<span class="v">6&#160;</span>The near kinsman said, “I can’t redeem it for myself, lest I endanger my own inheritance. Take my right of redemption for yourself; for I can’t redeem it.” 
-</p><p>
-<span class="v">7&#160;</span>Now this was the custom in former time in Israel concerning redeeming and concerning exchanging, to confirm all things: a man took off his sandal, and gave it to his neighbor; and this was the way of formalizing transactions in Israel. 
-<span class="v">8&#160;</span>So the near kinsman said to Boaz, “Buy it for yourself,” then he took off his sandal. 
-</p><p>
-<span class="v">9&#160;</span>Boaz said to the elders and to all the people, “You are witnesses today, that I have bought all that was Elimelech’s, and all that was Chilion’s and Mahlon’s, from the hand of Naomi. 
-<span class="v">10&#160;</span>Moreover, Ruth the Moabitess, the woman of Mahlon, I have purchased to be my woman, to raise up the name of the dead on his inheritance, that the name of the dead may not be cut off from among his brothers and from the gate of his place. You are witnesses today.” 
-</p><p>
-<span class="v">11&#160;</span>All the people who were in the gate, and the elders, said, “We are witnesses. May Yahweh make the woman who has come into your house like Rachel and like Leah, which both built the house of Israel; and treat you worthily in Ephrathah, and be famous in Bethlehem. 
-<span class="v">12&#160;</span>Let your house be like the house of Perez, whom Tamar bore to Judah, of the offspring<span class="f">+ \fr 4:12 \ft or, seed</span> which Yahweh will give you by this young woman.” 
-</p><p>
-<span class="v">13&#160;</span>So Boaz took Ruth and she became his woman; and he went in to her, and Yahweh enabled her to conceive, and she bore a son. 
-<span class="v">14&#160;</span>The women said to Naomi, “Blessed be Yahweh, who has not left you today without a near kinsman. Let his name be famous in Israel. 
-<span class="v">15&#160;</span>He shall be to you a restorer of life and sustain you in your old age; for your daughter-in-law, who loves you, who is better to you than seven sons, has given birth to him.” 
-<span class="v">16&#160;</span>Naomi took the child, laid him in her bosom, and became nurse to him. 
-<span class="v">17&#160;</span>The women, her neighbors, gave him a name, saying, “A son is born to Naomi”. They named him Obed. He is the father of Jesse, the father of David. 
-</p><p>
-<span class="v">18&#160;</span>Now this is the history of the generations of Perez: Perez brought forth Hezron, 
-<span class="v">19&#160;</span>and Hezron brought forth Ram, and Ram brought forth Amminadab, 
-<span class="v">20&#160;</span>and Amminadab brought forth Nahshon, and Nahshon brought forth Salmon, 
-<span class="v">21&#160;</span>and Salmon brought forth Boaz, and Boaz brought forth Obed, 
-<span class="v">22&#160;</span>and Obed brought forth Jesse, and Jesse brought forth David. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>In the days when the judges judged, there was a famine in the land. A certain man of Bethlehem Judah went to live in the country of Moab with his woman and his two sons. 
+<sup>2&#160;</sup>The name of the man was Elimelech, and the name of his woman Naomi. The names of his two sons were Mahlon and Chilion, Ephrathites of Bethlehem Judah. They came into the country of Moab and lived there. 
+<sup>3&#160;</sup>Elimelech, Naomi’s man, died; and she was left with her two sons. 
+<sup>4&#160;</sup>They took for themselves women of the women of Moab. The name of the one was Orpah, and the name of the other was Ruth. They lived there about ten years. 
+<sup>5&#160;</sup>Mahlon and Chilion both died, and the woman was bereaved of her two children and of her man. 
+<sup>6&#160;</sup>Then she arose with her daughters-in-law, that she might return from the country of Moab; for she had heard in the country of Moab how Yahweh had visited his people in giving them bread. 
+<sup>7&#160;</sup>She went out of the place where she was, and her two daughters-in-law with her. They went on the way to return to the land of Judah. 
+<sup>8&#160;</sup>Naomi said to her two daughters-in-law, “Go, return each of you to her mother’s house. May Yahweh deal kindly with you, as you have dealt with the dead and with me. 
+<sup>9&#160;</sup>May Yahweh grant you that you may find rest, each of you in the house of her man.” 
+</div><div class="p">Then she kissed them, and they lifted up their voices, and wept. 
+<sup>10&#160;</sup>They said to her, “No, but we will return with you to your people.” 
+</div><div class="p">
+<sup>11&#160;</sup>Naomi said, “Go back, my daughters. Why do you want to go with me? Do I still have sons in my womb, that they may be your men? 
+<sup>12&#160;</sup>Go back, my daughters, go your way; for I am too old to have a man. If I should say, ‘I have hope,’ if I should even have a man tonight, and should also bear sons, 
+<sup>13&#160;</sup>would you then wait until they were grown? Would you then refrain from having men? No, my daughters, for it grieves me seriously for your sakes, for Yahweh’s hand has gone out against me.” 
+</div><div class="p">
+<sup>14&#160;</sup>They lifted up their voices and wept again; then Orpah kissed her mother-in-law, but Ruth stayed with her. 
+<sup>15&#160;</sup>She said, “Behold, your sister-in-law has gone back to her people and to her elohim. Follow your sister-in-law.” 
+</div><div class="p">
+<sup>16&#160;</sup>Ruth said, “Don’t urge me to leave you, and to return from following you, for where you go, I will go; and where you stay, I will stay. Your people will be my people, and your Elohim my Elohim. 
+<sup>17&#160;</sup>Where you die, I will die, and there I will be buried. May Yahweh do so to me, and more also, if anything but death parts you and me.” 
+</div><div class="p">
+<sup>18&#160;</sup>When Naomi saw that she was determined to go with her, she stopped urging her. 
+</div><div class="p">
+<sup>19&#160;</sup>So they both went until they came to Bethlehem. When they had come to Bethlehem, all the city was excited about them, and they asked, “Is this Naomi?” 
+</div><div class="p">
+<sup>20&#160;</sup>She said to them, “Don’t call me Naomi. for the Almighty has dealt very bitterly with me. 
+<sup>21&#160;</sup>I went out full, and Yahweh has brought me home again empty. Why do you call me Naomi, since Yahweh has testified against me, and the Almighty has afflicted me?” 
+<sup>22&#160;</sup>So Naomi returned, and Ruth the Moabitess, her daughter-in-law, with her, who returned out of the country of Moab. They came to Bethlehem in the beginning of barley harvest. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Naomi had a relative of her man’s, a mighty man of wealth, of the family of Elimelech, and his name was Boaz. 
+<sup>2&#160;</sup>Ruth the Moabitess said to Naomi, “Let me now go to the field, and glean among the ears of grain after him in whose sight I find favor.” 
+</div><div class="p">She said to her, “Go, my daughter.” 
+<sup>3&#160;</sup>She went, and came and gleaned in the field after the reapers; and she happened to come to the portion of the field belonging to Boaz, who was of the family of Elimelech. 
+</div><div class="p">
+<sup>4&#160;</sup>Behold, Boaz came from Bethlehem, and said to the reapers, “May Yahweh be with you.” 
+</div><div class="p">They answered him, “May Yahweh bless you.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then Boaz said to his servant who was set over the reapers, “Whose young lady is this?” 
+</div><div class="p">
+<sup>6&#160;</sup>The servant who was set over the reapers answered, “It is the Moabite lady who came back with Naomi out of the country of Moab. 
+<sup>7&#160;</sup>She said, ‘Please let me glean and gather after the reapers among the sheaves.’ So she came, and has continued even from the morning until now, except that she rested a little in the house.” 
+</div><div class="p">
+<sup>8&#160;</sup>Then Boaz said to Ruth, “Listen, my daughter. Don’t go to glean in another field, and don’t go from here, but stay here close to my maidens. 
+<sup>9&#160;</sup>Let your eyes be on the field that they reap, and go after them. Haven’t I commanded the young men not to touch you? When you are thirsty, go to the vessels, and drink from that which the young men have drawn.” 
+</div><div class="p">
+<sup>10&#160;</sup>Then she fell on her face and bowed herself to the ground, and said to him, “Why have I found favor in your sight, that you should take knowledge of me, since I am a foreigner?” 
+</div><div class="p">
+<sup>11&#160;</sup>Boaz answered her, “I have been told all about what you have done for your mother-in-law since the death of your man, and how you have left your father, your mother, and the land of your birth, and have come to a people that you didn’t know before. 
+<sup>12&#160;</sup>May Yahweh repay your work, and a full reward be given to you from Yahweh, the Elohim of Israel, under whose wings you have come to take refuge.” 
+</div><div class="p">
+<sup>13&#160;</sup>Then she said, “Let me find favor in your sight, my lord, because you have comforted me, and because you have spoken kindly to your servant, though I am not as one of your servants.” 
+</div><div class="p">
+<sup>14&#160;</sup>At meal time Boaz said to her, “Come here, and eat some bread, and dip your morsel in the vinegar.” 
+</div><div class="p">She sat beside the reapers, and they passed her parched grain. She ate, was satisfied, and left some of it. 
+<sup>15&#160;</sup>When she had risen up to glean, Boaz commanded his young men, saying, “Let her glean even among the sheaves, and don’t reproach her. 
+<sup>16&#160;</sup>Also pull out some for her from the bundles, and leave it. Let her glean, and don’t rebuke her.” 
+</div><div class="p">
+<sup>17&#160;</sup>So she gleaned in the field until evening; and she beat out that which she had gleaned, and it was about an ephah of barley. 
+<sup>18&#160;</sup>She took it up, and went into the city. Then her mother-in-law saw what she had gleaned; and she brought out and gave to her that which she had left after she had enough. 
+</div><div class="p">
+<sup>19&#160;</sup>Her mother-in-law said to her, “Where have you gleaned today? Where have you worked? Blessed be he who noticed you.” 
+</div><div class="p">She told her mother-in-law with whom she had worked, “The man’s name with whom I worked today is Boaz.” 
+<sup>20&#160;</sup>Naomi said to her daughter-in-law, “May he be blessed by Yahweh, who has not abandoned his kindness to the living and to the dead.” Naomi said to her, “The man is a close relative to us, one of our near kinsmen.” 
+</div><div class="p">
+<sup>21&#160;</sup>Ruth the Moabitess said, “Yes, he said to me, ‘You shall stay close to my young men until they have finished all my harvest.’&#160;” 
+</div><div class="p">
+<sup>22&#160;</sup>Naomi said to Ruth her daughter-in-law, “It is good, my daughter, that you go out with his maidens, and that they not meet you in any other field.” 
+<sup>23&#160;</sup>So she stayed close to the maidens of Boaz, to glean to the end of barley harvest and of wheat harvest; and she lived with her mother-in-law. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Naomi her mother-in-law said to her, “My daughter, shall I not seek rest for you, that it may be well with you? 
+<sup>2&#160;</sup>Now isn’t Boaz our kinsman, with whose maidens you were? Behold, he will be winnowing barley tonight on the threshing floor. 
+<sup>3&#160;</sup>Therefore wash yourself, anoint yourself, get dressed, and go down to the threshing floor; but don’t make yourself known to the man until he has finished eating and drinking. 
+<sup>4&#160;</sup>It shall be, when he lies down, that you shall note the place where he is lying. Then you shall go in, uncover his feet, and lie down. Then he will tell you what to do.” 
+</div><div class="p">
+<sup>5&#160;</sup>She said to her, “All that you say, I will do.” 
+<sup>6&#160;</sup>She went down to the threshing floor, and did everything that her mother-in-law told her. 
+<sup>7&#160;</sup>When Boaz had eaten and drunk, and his heart was merry, he went to lie down at the end of the heap of grain. She came softly, uncovered his feet, and lay down. 
+<sup>8&#160;</sup>At midnight, the man was startled and turned himself; and behold, a woman lay at his feet. 
+<sup>9&#160;</sup>He said, “Who are you?” 
+</div><div class="p">She answered, “I am Ruth your servant. Therefore spread the corner of your garment over your servant; for you are a near kinsman.” 
+</div><div class="p">
+<sup>10&#160;</sup>He said, “You are blessed by Yahweh, my daughter. You have shown more kindness in the latter end than at the beginning, because you didn’t follow young men, whether poor or rich. 
+<sup>11&#160;</sup>Now, my daughter, don’t be afraid. I will do to you all that you say; for all the city of my people knows that you are a worthy woman. 
+<sup>12&#160;</sup>Now it is true that I am a near kinsman. However, there is a kinsman nearer than I. 
+<sup>13&#160;</sup>Stay this night, and in the morning, if he will perform for you the part of a kinsman, good. Let him do the kinsman’s duty. But if he will not do the duty of a kinsman for you, then I will do the duty of a kinsman for you, as Yahweh lives. Lie down until the morning.” 
+</div><div class="p">
+<sup>14&#160;</sup>She lay at his feet until the morning, then she rose up before one could discern another. For he said, “Let it not be known that the woman came to the threshing floor.” 
+<sup>15&#160;</sup>He said, “Bring the mantle that is on you, and hold it.” She held it; and he measured six measures of barley, and laid it on her; then he went into the city. 
+</div><div class="p">
+<sup>16&#160;</sup>When she came to her mother-in-law, she said, “How did it go, my daughter?” 
+</div><div class="p">She told her all that the man had done for her. 
+<sup>17&#160;</sup>She said, “He gave me these six measures of barley; for he said, ‘Don’t go empty to your mother-in-law.’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>Then she said, “Wait, my daughter, until you know what will happen; for the man will not rest until he has settled this today.” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>Now Boaz went up to the gate and sat down there. Behold, the near kinsman of whom Boaz spoke came by. Boaz said to him, “Come over here, friend, and sit down!” He came over, and sat down. 
+<sup>2&#160;</sup>Boaz took ten men of the elders of the city, and said, “Sit down here,” and they sat down. 
+<sup>3&#160;</sup>He said to the near kinsman, “Naomi, who has come back out of the country of Moab, is selling the parcel of land, which was our brother Elimelech’s. 
+<sup>4&#160;</sup>I thought I should tell you, saying, ‘Buy it before those who sit here, and before the elders of my people.’ If you will redeem it, redeem it; but if you will not redeem it, then tell me, that I may know. For there is no one to redeem it besides you; and I am after you.” 
+</div><div class="p">He said, “I will redeem it.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then Boaz said, “On the day you buy the field from the hand of Naomi, you must buy it also from Ruth the Moabitess, the woman of the dead, to raise up the name of the dead on his inheritance.” 
+</div><div class="p">
+<sup>6&#160;</sup>The near kinsman said, “I can’t redeem it for myself, lest I endanger my own inheritance. Take my right of redemption for yourself; for I can’t redeem it.” 
+</div><div class="p">
+<sup>7&#160;</sup>Now this was the custom in former time in Israel concerning redeeming and concerning exchanging, to confirm all things: a man took off his sandal, and gave it to his neighbor; and this was the way of formalizing transactions in Israel. 
+<sup>8&#160;</sup>So the near kinsman said to Boaz, “Buy it for yourself,” then he took off his sandal. 
+</div><div class="p">
+<sup>9&#160;</sup>Boaz said to the elders and to all the people, “You are witnesses today, that I have bought all that was Elimelech’s, and all that was Chilion’s and Mahlon’s, from the hand of Naomi. 
+<sup>10&#160;</sup>Moreover, Ruth the Moabitess, the woman of Mahlon, I have purchased to be my woman, to raise up the name of the dead on his inheritance, that the name of the dead may not be cut off from among his brothers and from the gate of his place. You are witnesses today.” 
+</div><div class="p">
+<sup>11&#160;</sup>All the people who were in the gate, and the elders, said, “We are witnesses. May Yahweh make the woman who has come into your house like Rachel and like Leah, which both built the house of Israel; and treat you worthily in Ephrathah, and be famous in Bethlehem. 
+<sup>12&#160;</sup>Let your house be like the house of Perez, whom Tamar bore to Judah, of the offspring which Yahweh will give you by this young woman.” 
+</div><div class="p">
+<sup>13&#160;</sup>So Boaz took Ruth and she became his woman; and he went in to her, and Yahweh enabled her to conceive, and she bore a son. 
+<sup>14&#160;</sup>The women said to Naomi, “Blessed be Yahweh, who has not left you today without a near kinsman. Let his name be famous in Israel. 
+<sup>15&#160;</sup>He shall be to you a restorer of life and sustain you in your old age; for your daughter-in-law, who loves you, who is better to you than seven sons, has given birth to him.” 
+<sup>16&#160;</sup>Naomi took the child, laid him in her bosom, and became nurse to him. 
+<sup>17&#160;</sup>The women, her neighbors, gave him a name, saying, “A son is born to Naomi”. They named him Obed. He is the father of Jesse, the father of David. 
+</div><div class="p">
+<sup>18&#160;</sup>Now this is the history of the generations of Perez: Perez brought forth Hezron, 
+<sup>19&#160;</sup>and Hezron brought forth Ram, and Ram brought forth Amminadab, 
+<sup>20&#160;</sup>and Amminadab brought forth Nahshon, and Nahshon brought forth Salmon, 
+<sup>21&#160;</sup>and Salmon brought forth Boaz, and Boaz brought forth Obed, 
+<sup>22&#160;</sup>and Obed brought forth Jesse, and Jesse brought forth David. </div></div><script src="../main.js"></script></body></html>

--- a/book/songofsongs.html
+++ b/book/songofsongs.html
@@ -3,6 +3,47 @@
 <head>
 <title>Song of Songs</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,545 +53,554 @@
 <div class="main">
 <!-- SNG World English Scripture (WES) -->
 <h1 class="booklabel">Song of Songs</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>The Song of songs, which is Solomon’s. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">2&#160;</span>Let him kiss me with the kisses of his mouth; 
-</p><p class="q2">for your love is better than wine. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Your oils have a pleasing fragrance. 
-</p><p class="q2">Your name is oil poured out, 
-</p><p class="q2">therefore the virgins love you. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Take me away with you. 
-</p><p class="q2">Let’s hurry. 
-</p><p class="q2">The king has brought me into his rooms. 
-</p><p class="sp">Friends 
-</p><p class="q1">We will be glad and rejoice in you. 
-</p><p class="q2">We will praise your love more than wine! 
-</p><p class="sp">Beloved 
-</p><p class="q1">They are right to love you. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I am dark, but lovely, 
-</p><p class="q2">you daughters of Jerusalem, 
-</p><p class="q2">like Kedar’s tents, 
-</p><p class="q2">like Solomon’s curtains. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Don’t stare at me because I am dark, 
-</p><p class="q2">because the sun has scorched me. 
-</p><p class="q1">My mother’s sons were angry with me. 
-</p><p class="q2">They made me keeper of the vineyards. 
-</p><p class="q2">I haven’t kept my own vineyard. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Tell me, you whom my soul loves, 
-</p><p class="q2">where you graze your flock, 
-</p><p class="q2">where you rest them at noon; 
-</p><p class="q2">for why should I be as one who is veiled 
-</p><p class="q2">beside the flocks of your companions? 
-</p><p class="sp">Lover 
-</p><p class="q1">
-<span class="v">8&#160;</span>If you don’t know, most beautiful among women, 
-</p><p class="q2">follow the tracks of the sheep. 
-</p><p class="q2">Graze your young goats beside the shepherds’ tents. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>I have compared you, my love, 
-</p><p class="q2">to a steed in Pharaoh’s chariots. 
-</p><p class="q1">
-<span class="v">10&#160;</span>Your cheeks are beautiful with earrings, 
-</p><p class="q2">your neck with strings of jewels. 
-</p><p class="sp">Friends 
-</p><p class="q1">
-<span class="v">11&#160;</span>We will make you earrings of gold, 
-</p><p class="q2">with studs of silver. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">12&#160;</span>While the king sat at his table, 
-</p><p class="q2">my perfume spread its fragrance. 
-</p><p class="q1">
-<span class="v">13&#160;</span>My beloved is to me a sachet of myrrh, 
-</p><p class="q2">that lies between my breasts. 
-</p><p class="q1">
-<span class="v">14&#160;</span>My beloved is to me a cluster of henna blossoms 
-</p><p class="q2">from the vineyards of En Gedi. 
-</p><p class="sp">Lover 
-</p><p class="q1">
-<span class="v">15&#160;</span>Behold,<span class="f">+ \fr 1:15 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> you are beautiful, my love. 
-</p><p class="q2">Behold, you are beautiful. 
-</p><p class="q2">Your eyes are like doves. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">16&#160;</span>Behold, you are beautiful, my beloved, yes, pleasant; 
-</p><p class="q2">and our couch is verdant. 
-</p><p class="sp">Lover 
-</p><p class="q1">
-<span class="v">17&#160;</span>The beams of our house are cedars. 
-</p><p class="q2">Our rafters are firs. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">1&#160;</span>I am a rose of Sharon, 
-</p><p class="q2">a lily of the valleys. 
-</p><p class="sp">Lover 
-</p><p class="q1">
-<span class="v">2&#160;</span>As a lily among thorns, 
-</p><p class="q2">so is my love among the daughters. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">3&#160;</span>As the apple tree among the trees of the wood, 
-</p><p class="q2">so is my beloved among the sons. 
-</p><p class="q1">I sat down under his shadow with great delight, 
-</p><p class="q2">his fruit was sweet to my taste. 
-</p><p class="q1">
-<span class="v">4&#160;</span>He brought me to the banquet hall. 
-</p><p class="q2">His banner over me is love. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Strengthen me with raisins, 
-</p><p class="q2">refresh me with apples; 
-</p><p class="q2">for I am faint with love. 
-</p><p class="q1">
-<span class="v">6&#160;</span>His left hand is under my head. 
-</p><p class="q2">His right hand embraces me. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I adjure you, daughters of Jerusalem, 
-</p><p class="q2">by the roes, or by the hinds of the field, 
-</p><p class="q2">that you not stir up, nor awaken love, 
-</p><p class="q2">until it so desires. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>The voice of my beloved! 
-</p><p class="q2">Behold, he comes, 
-</p><p class="q2">leaping on the mountains, 
-</p><p class="q2">skipping on the hills. 
-</p><p class="q1">
-<span class="v">9&#160;</span>My beloved is like a roe or a young deer. 
-</p><p class="q2">Behold, he stands behind our wall! 
-</p><p class="q1">He looks in at the windows. 
-</p><p class="q2">He glances through the lattice. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>My beloved spoke, and said to me, 
-</p><p class="q2">“Rise up, my love, my beautiful one, and come away. 
-</p><p class="q1">
-<span class="v">11&#160;</span>For behold, the winter is past. 
-</p><p class="q2">The rain is over and gone. 
-</p><p class="q1">
-<span class="v">12&#160;</span>The flowers appear on the earth. 
-</p><p class="q2">The time of the singing has come, 
-</p><p class="q2">and the voice of the turtledove is heard in our land. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The fig tree ripens her green figs. 
-</p><p class="q2">The vines are in blossom. 
-</p><p class="q2">They give out their fragrance. 
-</p><p class="q1">Arise, my love, my beautiful one, 
-</p><p class="q2">and come away.” 
-</p><p class="sp">Lover 
-</p><p class="q1">
-<span class="v">14&#160;</span>My dove in the clefts of the rock, 
-</p><p class="q2">in the hiding places of the mountainside, 
-</p><p class="q2">let me see your face. 
-</p><p class="q2">Let me hear your voice; 
-</p><p class="q2">for your voice is sweet and your face is lovely. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Catch for us the foxes, 
-</p><p class="q2">the little foxes that plunder the vineyards; 
-</p><p class="q2">for our vineyards are in blossom. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">16&#160;</span>My beloved is mine, and I am his. 
-</p><p class="q2">He browses among the lilies. 
-</p><p class="q1">
-<span class="v">17&#160;</span>Until the day is cool, and the shadows flee away, 
-</p><p class="q2">turn, my beloved, 
-</p><p class="q2">and be like a roe or a young deer on the mountains of Bether. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>By night on my bed, 
-</p><p class="q2">I sought him whom my soul loves. 
-</p><p class="q2">I sought him, but I didn’t find him. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I will get up now, and go about the city; 
-</p><p class="q2">in the streets and in the squares I will seek him whom my soul loves. 
-</p><p class="q2">I sought him, but I didn’t find him. 
-</p><p class="q1">
-<span class="v">3&#160;</span>The watchmen who go about the city found me; 
-</p><p class="q2">“Have you seen him whom my soul loves?” 
-</p><p class="q1">
-<span class="v">4&#160;</span>I had scarcely passed from them, 
-</p><p class="q2">when I found him whom my soul loves. 
-</p><p class="q1">I held him, and would not let him go, 
-</p><p class="q2">until I had brought him into my mother’s house, 
-</p><p class="q2">into the room of her who conceived me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>I adjure you, daughters of Jerusalem, 
-</p><p class="q2">by the roes, or by the hinds of the field, 
-</p><p class="q2">that you not stir up nor awaken love, 
-</p><p class="q2">until it so desires. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Who is this who comes up from the wilderness like pillars of smoke, 
-</p><p class="q2">perfumed with myrrh and frankincense, 
-</p><p class="q2">with all spices of the merchant? 
-</p><p class="q1">
-<span class="v">7&#160;</span>Behold, it is Solomon’s carriage! 
-</p><p class="q2">Sixty mighty men are around it, 
-</p><p class="q2">of the mighty men of Israel. 
-</p><p class="q1">
-<span class="v">8&#160;</span>They all handle the sword, and are expert in war. 
-</p><p class="q2">Every man has his sword on his thigh, 
-</p><p class="q2">because of fear in the night. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>King Solomon made himself a carriage 
-</p><p class="q2">of the wood of Lebanon. 
-</p><p class="q1">
-<span class="v">10&#160;</span>He made its pillars of silver, 
-</p><p class="q2">its bottom of gold, its seat of purple, 
-</p><p class="q2">the middle of it being paved with love, 
-</p><p class="q2">from the daughters of Jerusalem. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Go out, you daughters of Zion, and see King Solomon, 
-</p><p class="q2">with the crown with which his mother has crowned him, 
-</p><p class="q2">in the day of his weddings, 
-</p><p class="q2">in the day of the gladness of his heart. 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p class="sp">Lover 
-</p><p>
-<span class="v">1&#160;</span>Behold, you are beautiful, my love. 
-</p><p class="q2">Behold, you are beautiful. 
-</p><p class="q1">Your eyes are like doves behind your veil. 
-</p><p class="q2">Your hair is as a flock of goats, 
-</p><p class="q2">that descend from Mount Gilead. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Your teeth are like a newly shorn flock, 
-</p><p class="q2">which have come up from the washing, 
-</p><p class="q2">where every one of them has twins. 
-</p><p class="q2">None is bereaved among them. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Your lips are like scarlet thread. 
-</p><p class="q2">Your mouth is lovely. 
-</p><p class="q2">Your temples are like a piece of a pomegranate behind your veil. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Your neck is like David’s tower built for an armory, 
-</p><p class="q2">on which a thousand shields hang, 
-</p><p class="q2">all the shields of the mighty men. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Your two breasts are like two fawns 
-</p><p class="q2">that are twins of a roe, 
-</p><p class="q2">which feed among the lilies. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Until the day is cool, and the shadows flee away, 
-</p><p class="q2">I will go to the mountain of myrrh, 
-</p><p class="q2">to the hill of frankincense. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>You are all beautiful, my love. 
-</p><p class="q2">There is no spot in you. 
-</p><p class="q1">
-<span class="v">8&#160;</span>Come with me from Lebanon, my bride, 
-</p><p class="q2">with me from Lebanon. 
-</p><p class="q2">Look from the top of Amana, 
-</p><p class="q2">from the top of Senir and Hermon, 
-</p><p class="q2">from the lions’ dens, 
-</p><p class="q2">from the mountains of the leopards. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>You have ravished my heart, my sister, my bride. 
-</p><p class="q2">You have ravished my heart with one of your eyes, 
-</p><p class="q2">with one chain of your neck. 
-</p><p class="q1">
-<span class="v">10&#160;</span>How beautiful is your love, my sister, my bride! 
-</p><p class="q2">How much better is your love than wine, 
-</p><p class="q2">the fragrance of your perfumes than all kinds of spices! 
-</p><p class="q1">
-<span class="v">11&#160;</span>Your lips, my bride, drip like the honeycomb. 
-</p><p class="q2">Honey and milk are under your tongue. 
-</p><p class="q2">The smell of your garments is like the smell of Lebanon. 
-</p><p class="q1">
-<span class="v">12&#160;</span>My sister, my bride, is a locked up garden; 
-</p><p class="q2">a locked up spring, 
-</p><p class="q2">a sealed fountain. 
-</p><p class="q1">
-<span class="v">13&#160;</span>Your shoots are an orchard of pomegranates, with precious fruits, 
-</p><p class="q2">henna with spikenard plants, 
-</p><p class="q2">
-<span class="v">14&#160;</span>spikenard and saffron, 
-</p><p class="q2">calamus and cinnamon, with every kind of incense tree; 
-</p><p class="q2">myrrh and aloes, with all the best spices, 
-</p><p class="q2">
-<span class="v">15&#160;</span>a fountain of gardens, 
-</p><p class="q2">a well of living waters, 
-</p><p class="q2">flowing streams from Lebanon. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">16&#160;</span>Awake, north wind, and come, you south! 
-</p><p class="q2">Blow on my garden, that its spices may flow out. 
-</p><p class="q1">Let my beloved come into his garden, 
-</p><p class="q2">and taste his precious fruits. 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p class="sp">Lover 
-</p><p class="q1">
-<span class="v">1&#160;</span>I have come into my garden, my sister, my bride. 
-</p><p class="q2">I have gathered my myrrh with my spice; 
-</p><p class="q2">I have eaten my honeycomb with my honey; 
-</p><p class="q2">I have drunk my wine with my milk. 
-</p><p class="sp">Friends 
-</p><p class="q1">Eat, friends! 
-</p><p class="q2">Drink, yes, drink abundantly, beloved. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">2&#160;</span>I was asleep, but my heart was awake. 
-</p><p class="q2">It is the voice of my beloved who knocks: 
-</p><p class="q2">“Open to me, my sister, my love, my dove, my undefiled; 
-</p><p class="q2">for my head is filled with dew, 
-</p><p class="q2">and my hair with the dampness of the night.” 
-</p><p class="q1">
-<span class="v">3&#160;</span>I have taken off my robe. Indeed, must I put it on? 
-</p><p class="q2">I have washed my feet. Indeed, must I soil them? 
-</p><p class="q1">
-<span class="v">4&#160;</span>My beloved thrust his hand in through the latch opening. 
-</p><p class="q2">My heart pounded for him. 
-</p><p class="q1">
-<span class="v">5&#160;</span>I rose up to open for my beloved. 
-</p><p class="q2">My hands dripped with myrrh, 
-</p><p class="q2">my fingers with liquid myrrh, 
-</p><p class="q2">on the handles of the lock. 
-</p><p class="q1">
-<span class="v">6&#160;</span>I opened to my beloved; 
-</p><p class="q2">but my beloved left, and had gone away. 
-</p><p class="q1">My heart went out when he spoke. 
-</p><p class="q2">I looked for him, but I didn’t find him. 
-</p><p class="q2">I called him, but he didn’t answer. 
-</p><p class="q1">
-<span class="v">7&#160;</span>The watchmen who go about the city found me. 
-</p><p class="q2">They beat me. 
-</p><p class="q2">They bruised me. 
-</p><p class="q2">The keepers of the walls took my cloak away from me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>I adjure you, daughters of Jerusalem, 
-</p><p class="q2">If you find my beloved, 
-</p><p class="q2">that you tell him that I am faint with love. 
-</p><p class="sp">Friends 
-</p><p class="q1">
-<span class="v">9&#160;</span>How is your beloved better than another beloved, 
-</p><p class="q2">you fairest among women? 
-</p><p class="q1">How is your beloved better than another beloved, 
-</p><p class="q1">that you do so adjure us? 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">10&#160;</span>My beloved is white and ruddy. 
-</p><p class="q2">The best among ten thousand. 
-</p><p class="q1">
-<span class="v">11&#160;</span>His head is like the purest gold. 
-</p><p class="q2">His hair is bushy, black as a raven. 
-</p><p class="q1">
-<span class="v">12&#160;</span>His eyes are like doves beside the water brooks, 
-</p><p class="q2">washed with milk, mounted like jewels. 
-</p><p class="q1">
-<span class="v">13&#160;</span>His cheeks are like a bed of spices with towers of perfumes. 
-</p><p class="q2">His lips are like lilies, dropping liquid myrrh. 
-</p><p class="q1">
-<span class="v">14&#160;</span>His hands are like rings of gold set with beryl. 
-</p><p class="q2">His body is like ivory work overlaid with sapphires. 
-</p><p class="q1">
-<span class="v">15&#160;</span>His legs are like pillars of marble set on sockets of fine gold. 
-</p><p class="q2">His appearance is like Lebanon, excellent as the cedars. 
-</p><p class="q1">
-<span class="v">16&#160;</span>His mouth is sweetness; 
-</p><p class="q2">yes, he is altogether lovely. 
-</p><p class="q1">This is my beloved, and this is my friend, 
-</p><p class="q2">daughters of Jerusalem. 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p class="sp">Friends 
-</p><p class="q1">
-<span class="v">1&#160;</span>Where has your beloved gone, you fairest among women? 
-</p><p class="q2">Where has your beloved turned, that we may seek him with you? 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">2&#160;</span>My beloved has gone down to his garden, 
-</p><p class="q2">to the beds of spices, 
-</p><p class="q2">to pasture his flock in the gardens, and to gather lilies. 
-</p><p class="q1">
-<span class="v">3&#160;</span>I am my beloved’s, and my beloved is mine. 
-</p><p class="q2">He browses among the lilies. 
-</p><div class="b"> &#160; </div>
-<p class="sp">Lover 
-</p><p class="q1">
-<span class="v">4&#160;</span>You are beautiful, my love, as Tirzah, 
-</p><p class="q2">lovely as Jerusalem, 
-</p><p class="q2">awesome as an army with banners. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Turn away your eyes from me, 
-</p><p class="q2">for they have overcome me. 
-</p><p class="q1">Your hair is like a flock of goats, 
-</p><p class="q2">that lie along the side of Gilead. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Your teeth are like a flock of ewes, 
-</p><p class="q2">which have come up from the washing, 
-</p><p class="q2">of which every one has twins; 
-</p><p class="q2">not one is bereaved among them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Your temples are like a piece of a pomegranate behind your veil. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">8&#160;</span>There are sixty queens, eighty concubines, 
-</p><p class="q2">and virgins without number. 
-</p><p class="q1">
-<span class="v">9&#160;</span>My dove, my perfect one, is unique. 
-</p><p class="q2">She is her mother’s only daughter. 
-</p><p class="q2">She is the favorite one of her who bore her. 
-</p><p class="q1">The daughters saw her, and called her blessed. 
-</p><p class="q2">The queens and the concubines saw her, and they praised her. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">10&#160;</span>Who is she who looks out as the morning, 
-</p><p class="q2">beautiful as the moon, 
-</p><p class="q2">clear as the sun, 
-</p><p class="q2">and awesome as an army with banners? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>I went down into the nut tree grove, 
-</p><p class="q2">to see the green plants of the valley, 
-</p><p class="q2">to see whether the vine budded, 
-</p><p class="q2">and the pomegranates were in flower. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Without realizing it, 
-</p><p class="q2">my desire set me with my royal people’s chariots. 
-</p><p class="sp">Friends 
-</p><p class="q1">
-<span class="v">13&#160;</span>Return, return, Shulammite! 
-</p><p class="q2">Return, return, that we may gaze at you. 
-</p><p class="sp">Lover 
-</p><p class="q1">Why do you desire to gaze at the Shulammite, 
-</p><p class="q2">as at the dance of Mahanaim? 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>How beautiful are your feet in sandals, prince’s daughter! 
-</p><p class="q2">Your rounded thighs are like jewels, 
-</p><p class="q2">the work of the hands of a skillful workman. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Your body is like a round goblet, 
-</p><p class="q2">no mixed wine is wanting. 
-</p><p class="q1">Your waist is like a heap of wheat, 
-</p><p class="q2">set about with lilies. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Your two breasts are like two fawns, 
-</p><p class="q2">that are twins of a roe. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Your neck is like an ivory tower. 
-</p><p class="q2">Your eyes are like the pools in Heshbon by the gate of Bathrabbim. 
-</p><p class="q2">Your nose is like the tower of Lebanon which looks toward Damascus. 
-</p><p class="q1">
-<span class="v">5&#160;</span>Your head on you is like Carmel. 
-</p><p class="q2">The hair of your head like purple. 
-</p><p class="q2">The king is held captive in its tresses. 
-</p><p class="q1">
-<span class="v">6&#160;</span>How beautiful and how pleasant you are, 
-</p><p class="q2">love, for delights! 
-</p><p class="q1">
-<span class="v">7&#160;</span>This, your stature, is like a palm tree, 
-</p><p class="q2">your breasts like its fruit. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I said, “I will climb up into the palm tree. 
-</p><p class="q2">I will take hold of its fruit.” 
-</p><p class="q1">Let your breasts be like clusters of the vine, 
-</p><p class="q2">the smell of your breath like apples. 
-</p><p class="q1">
-<span class="v">9&#160;</span>Your mouth is like the best wine, 
-</p><p class="q2">that goes down smoothly for my beloved, 
-</p><p class="q2">gliding through the lips of those who are asleep. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">10&#160;</span>I am my beloved’s. 
-</p><p class="q2">His desire is toward me. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Come, my beloved! Let’s go out into the field. 
-</p><p class="q2">Let’s lodge in the villages. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Let’s go early up to the vineyards. 
-</p><p class="q2">Let’s see whether the vine has budded, 
-</p><p class="q2">its blossom is open, 
-</p><p class="q2">and the pomegranates are in flower. 
-</p><p class="q2">There I will give you my love. 
-</p><p class="q1">
-<span class="v">13&#160;</span>The mandrakes produce fragrance. 
-</p><p class="q2">At our doors are all kinds of precious fruits, new and old, 
-</p><p class="q2">which I have stored up for you, my beloved. 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>Oh that you were like my brother, 
-</p><p class="q2">who nursed from the breasts of my mother! 
-</p><p class="q1">If I found you outside, I would kiss you; 
-</p><p class="q2">yes, and no one would despise me. 
-</p><p class="q1">
-<span class="v">2&#160;</span>I would lead you, bringing you into the house of my mother, 
-</p><p class="q2">who would instruct me. 
-</p><p class="q1">I would have you drink spiced wine, 
-</p><p class="q2">of the juice of my pomegranate. 
-</p><p class="q1">
-<span class="v">3&#160;</span>His left hand would be under my head. 
-</p><p class="q2">His right hand would embrace me. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">4&#160;</span>I adjure you, daughters of Jerusalem, 
-</p><p class="q2">that you not stir up, nor awaken love, 
-</p><p class="q2">until it so desires. 
-</p><p class="sp">Friends 
-</p><p class="q1">
-<span class="v">5&#160;</span>Who is this who comes up from the wilderness, 
-</p><p class="q2">leaning on her beloved? 
-</p><div class="b"> &#160; </div>
-<p class="sp">Beloved 
-</p><p class="q1">Under the apple tree I awakened you. 
-</p><p class="q2">There your mother conceived you. 
-</p><p class="q2">There she was in labor and bore you. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>Set me as a seal on your heart, 
-</p><p class="q2">as a seal on your arm; 
-</p><p class="q2">for love is strong as death. 
-</p><p class="q2">Jealousy is as cruel as Sheol.<span class="f">+ \fr 8:6 \ft Sheol is the place of the dead. </span> 
-</p><p class="q2">Its flashes are flashes of fire, 
-</p><p class="q2">a very flame of Yah.<span class="f">+ \fr 8:6 \ft “Yah” is a short form of “Yahweh”, which is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> 
-</p><p class="q1">
-<span class="v">7&#160;</span>Many waters can’t quench love, 
-</p><p class="q2">neither can floods drown it. 
-</p><p class="q1">If a man would give all the wealth of his house for love, 
-</p><p class="q2">he would be utterly scorned. 
-</p><p class="sp">Brothers 
-</p><p class="q1">
-<span class="v">8&#160;</span>We have a little sister. 
-</p><p class="q2">She has no breasts. 
-</p><p class="q1">What shall we do for our sister 
-</p><p class="q2">in the day when she is to be spoken for? 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>If she is a wall, 
-</p><p class="q2">we will build on her a turret of silver. 
-</p><p class="q1">If she is a door, 
-</p><p class="q2">we will enclose her with boards of cedar. 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">10&#160;</span>I am a wall, and my breasts like towers, 
-</p><p class="q2">then I was in his eyes like one who found peace. 
-</p><p class="q1">
-<span class="v">11&#160;</span>Solomon had a vineyard at Baal Hamon. 
-</p><p class="q2">He leased out the vineyard to keepers. 
-</p><p class="q2">Each was to bring a thousand shekels<span class="f">+ \fr 8:11 \ft A shekel is about 10 grams or about 0.35 ounces, so 1000 shekels is about 10 kilograms or about 22 pounds.</span> of silver for its fruit. 
-</p><p class="q1">
-<span class="v">12&#160;</span>My own vineyard is before me. 
-</p><p class="q2">The thousand are for you, Solomon, 
-</p><p class="q2">two hundred for those who tend its fruit. 
-</p><p class="sp">Lover 
-</p><p class="q1">
-<span class="v">13&#160;</span>You who dwell in the gardens, with friends in attendance, 
-</p><p class="q2">let me hear your voice! 
-</p><p class="sp">Beloved 
-</p><p class="q1">
-<span class="v">14&#160;</span>Come away, my beloved! 
-</p><p class="q2">Be like a gazelle or a young stag on the mountains of spices! </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>The Song of songs, which is Solomon’s. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>2&#160;</sup>Let him kiss me with the kisses of his mouth; 
+</div><div class="q2">for your love is better than wine. 
+</div><div class="q1">
+<sup>3&#160;</sup>Your oils have a pleasing fragrance. 
+</div><div class="q2">Your name is oil poured out, 
+</div><div class="q2">therefore the virgins love you. 
+</div><div class="q1">
+<sup>4&#160;</sup>Take me away with you. 
+</div><div class="q2">Let’s hurry. 
+</div><div class="q2">The king has brought me into his rooms. 
+</div><div class="sp">Friends 
+</div><div class="q1">We will be glad and rejoice in you. 
+</div><div class="q2">We will praise your love more than wine! 
+</div><div class="sp">Beloved 
+</div><div class="q1">They are right to love you. 
+</div><div class="q1">
+<sup>5&#160;</sup>I am dark, but lovely, 
+</div><div class="q2">you daughters of Jerusalem, 
+</div><div class="q2">like Kedar’s tents, 
+</div><div class="q2">like Solomon’s curtains. 
+</div><div class="q1">
+<sup>6&#160;</sup>Don’t stare at me because I am dark, 
+</div><div class="q2">because the sun has scorched me. 
+</div><div class="q1">My mother’s sons were angry with me. 
+</div><div class="q2">They made me keeper of the vineyards. 
+</div><div class="q2">I haven’t kept my own vineyard. 
+</div><div class="q1">
+<sup>7&#160;</sup>Tell me, you whom my soul loves, 
+</div><div class="q2">where you graze your flock, 
+</div><div class="q2">where you rest them at noon; 
+</div><div class="q2">for why should I be as one who is veiled 
+</div><div class="q2">beside the flocks of your companions? 
+</div><div class="sp">Lover 
+</div><div class="q1">
+<sup>8&#160;</sup>If you don’t know, most beautiful among women, 
+</div><div class="q2">follow the tracks of the sheep. 
+</div><div class="q2">Graze your young goats beside the shepherds’ tents. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>I have compared you, my love, 
+</div><div class="q2">to a steed in Pharaoh’s chariots. 
+</div><div class="q1">
+<sup>10&#160;</sup>Your cheeks are beautiful with earrings, 
+</div><div class="q2">your neck with strings of jewels. 
+</div><div class="sp">Friends 
+</div><div class="q1">
+<sup>11&#160;</sup>We will make you earrings of gold, 
+</div><div class="q2">with studs of silver. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>12&#160;</sup>While the king sat at his table, 
+</div><div class="q2">my perfume spread its fragrance. 
+</div><div class="q1">
+<sup>13&#160;</sup>My beloved is to me a sachet of myrrh, 
+</div><div class="q2">that lies between my breasts. 
+</div><div class="q1">
+<sup>14&#160;</sup>My beloved is to me a cluster of henna blossoms 
+</div><div class="q2">from the vineyards of En Gedi. 
+</div><div class="sp">Lover 
+</div><div class="q1">
+<sup>15&#160;</sup>Behold, you are beautiful, my love. 
+</div><div class="q2">Behold, you are beautiful. 
+</div><div class="q2">Your eyes are like doves. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>16&#160;</sup>Behold, you are beautiful, my beloved, yes, pleasant; 
+</div><div class="q2">and our couch is verdant. 
+</div><div class="sp">Lover 
+</div><div class="q1">
+<sup>17&#160;</sup>The beams of our house are cedars. 
+</div><div class="q2">Our rafters are firs. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="sp">Beloved 
+</div><div class="q1">
+<sup>1&#160;</sup>I am a rose of Sharon, 
+</div><div class="q2">a lily of the valleys. 
+</div><div class="sp">Lover 
+</div><div class="q1">
+<sup>2&#160;</sup>As a lily among thorns, 
+</div><div class="q2">so is my love among the daughters. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>3&#160;</sup>As the apple tree among the trees of the wood, 
+</div><div class="q2">so is my beloved among the sons. 
+</div><div class="q1">I sat down under his shadow with great delight, 
+</div><div class="q2">his fruit was sweet to my taste. 
+</div><div class="q1">
+<sup>4&#160;</sup>He brought me to the banquet hall. 
+</div><div class="q2">His banner over me is love. 
+</div><div class="q1">
+<sup>5&#160;</sup>Strengthen me with raisins, 
+</div><div class="q2">refresh me with apples; 
+</div><div class="q2">for I am faint with love. 
+</div><div class="q1">
+<sup>6&#160;</sup>His left hand is under my head. 
+</div><div class="q2">His right hand embraces me. 
+</div><div class="q1">
+<sup>7&#160;</sup>I adjure you, daughters of Jerusalem, 
+</div><div class="q2">by the roes, or by the hinds of the field, 
+</div><div class="q2">that you not stir up, nor awaken love, 
+</div><div class="q2">until it so desires. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>The voice of my beloved! 
+</div><div class="q2">Behold, he comes, 
+</div><div class="q2">leaping on the mountains, 
+</div><div class="q2">skipping on the hills. 
+</div><div class="q1">
+<sup>9&#160;</sup>My beloved is like a roe or a young deer. 
+</div><div class="q2">Behold, he stands behind our wall! 
+</div><div class="q1">He looks in at the windows. 
+</div><div class="q2">He glances through the lattice. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>My beloved spoke, and said to me, 
+</div><div class="q2">“Rise up, my love, my beautiful one, and come away. 
+</div><div class="q1">
+<sup>11&#160;</sup>For behold, the winter is past. 
+</div><div class="q2">The rain is over and gone. 
+</div><div class="q1">
+<sup>12&#160;</sup>The flowers appear on the earth. 
+</div><div class="q2">The time of the singing has come, 
+</div><div class="q2">and the voice of the turtledove is heard in our land. 
+</div><div class="q1">
+<sup>13&#160;</sup>The fig tree ripens her green figs. 
+</div><div class="q2">The vines are in blossom. 
+</div><div class="q2">They give out their fragrance. 
+</div><div class="q1">Arise, my love, my beautiful one, 
+</div><div class="q2">and come away.” 
+</div><div class="sp">Lover 
+</div><div class="q1">
+<sup>14&#160;</sup>My dove in the clefts of the rock, 
+</div><div class="q2">in the hiding places of the mountainside, 
+</div><div class="q2">let me see your face. 
+</div><div class="q2">Let me hear your voice; 
+</div><div class="q2">for your voice is sweet and your face is lovely. 
+</div><div class="q1">
+<sup>15&#160;</sup>Catch for us the foxes, 
+</div><div class="q2">the little foxes that plunder the vineyards; 
+</div><div class="q2">for our vineyards are in blossom. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>16&#160;</sup>My beloved is mine, and I am his. 
+</div><div class="q2">He browses among the lilies. 
+</div><div class="q1">
+<sup>17&#160;</sup>Until the day is cool, and the shadows flee away, 
+</div><div class="q2">turn, my beloved, 
+</div><div class="q2">and be like a roe or a young deer on the mountains of Bether. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>By night on my bed, 
+</div><div class="q2">I sought him whom my soul loves. 
+</div><div class="q2">I sought him, but I didn’t find him. 
+</div><div class="q1">
+<sup>2&#160;</sup>I will get up now, and go about the city; 
+</div><div class="q2">in the streets and in the squares I will seek him whom my soul loves. 
+</div><div class="q2">I sought him, but I didn’t find him. 
+</div><div class="q1">
+<sup>3&#160;</sup>The watchmen who go about the city found me; 
+</div><div class="q2">“Have you seen him whom my soul loves?” 
+</div><div class="q1">
+<sup>4&#160;</sup>I had scarcely passed from them, 
+</div><div class="q2">when I found him whom my soul loves. 
+</div><div class="q1">I held him, and would not let him go, 
+</div><div class="q2">until I had brought him into my mother’s house, 
+</div><div class="q2">into the room of her who conceived me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>I adjure you, daughters of Jerusalem, 
+</div><div class="q2">by the roes, or by the hinds of the field, 
+</div><div class="q2">that you not stir up nor awaken love, 
+</div><div class="q2">until it so desires. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Who is this who comes up from the wilderness like pillars of smoke, 
+</div><div class="q2">perfumed with myrrh and frankincense, 
+</div><div class="q2">with all spices of the merchant? 
+</div><div class="q1">
+<sup>7&#160;</sup>Behold, it is Solomon’s carriage! 
+</div><div class="q2">Sixty mighty men are around it, 
+</div><div class="q2">of the mighty men of Israel. 
+</div><div class="q1">
+<sup>8&#160;</sup>They all handle the sword, and are expert in war. 
+</div><div class="q2">Every man has his sword on his thigh, 
+</div><div class="q2">because of fear in the night. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>King Solomon made himself a carriage 
+</div><div class="q2">of the wood of Lebanon. 
+</div><div class="q1">
+<sup>10&#160;</sup>He made its pillars of silver, 
+</div><div class="q2">its bottom of gold, its seat of purple, 
+</div><div class="q2">the middle of it being paved with love, 
+</div><div class="q2">from the daughters of Jerusalem. 
+</div><div class="q1">
+<sup>11&#160;</sup>Go out, you daughters of Zion, and see King Solomon, 
+</div><div class="q2">with the crown with which his mother has crowned him, 
+</div><div class="q2">in the day of his weddings, 
+</div><div class="q2">in the day of the gladness of his heart. 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="sp">Lover 
+</div><div class="p">
+<sup>1&#160;</sup>Behold, you are beautiful, my love. 
+</div><div class="q2">Behold, you are beautiful. 
+</div><div class="q1">Your eyes are like doves behind your veil. 
+</div><div class="q2">Your hair is as a flock of goats, 
+</div><div class="q2">that descend from Mount Gilead. 
+</div><div class="q1">
+<sup>2&#160;</sup>Your teeth are like a newly shorn flock, 
+</div><div class="q2">which have come up from the washing, 
+</div><div class="q2">where every one of them has twins. 
+</div><div class="q2">None is bereaved among them. 
+</div><div class="q1">
+<sup>3&#160;</sup>Your lips are like scarlet thread. 
+</div><div class="q2">Your mouth is lovely. 
+</div><div class="q2">Your temples are like a piece of a pomegranate behind your veil. 
+</div><div class="q1">
+<sup>4&#160;</sup>Your neck is like David’s tower built for an armory, 
+</div><div class="q2">on which a thousand shields hang, 
+</div><div class="q2">all the shields of the mighty men. 
+</div><div class="q1">
+<sup>5&#160;</sup>Your two breasts are like two fawns 
+</div><div class="q2">that are twins of a roe, 
+</div><div class="q2">which feed among the lilies. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Until the day is cool, and the shadows flee away, 
+</div><div class="q2">I will go to the mountain of myrrh, 
+</div><div class="q2">to the hill of frankincense. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>You are all beautiful, my love. 
+</div><div class="q2">There is no spot in you. 
+</div><div class="q1">
+<sup>8&#160;</sup>Come with me from Lebanon, my bride, 
+</div><div class="q2">with me from Lebanon. 
+</div><div class="q2">Look from the top of Amana, 
+</div><div class="q2">from the top of Senir and Hermon, 
+</div><div class="q2">from the lions’ dens, 
+</div><div class="q2">from the mountains of the leopards. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>You have ravished my heart, my sister, my bride. 
+</div><div class="q2">You have ravished my heart with one of your eyes, 
+</div><div class="q2">with one chain of your neck. 
+</div><div class="q1">
+<sup>10&#160;</sup>How beautiful is your love, my sister, my bride! 
+</div><div class="q2">How much better is your love than wine, 
+</div><div class="q2">the fragrance of your perfumes than all kinds of spices! 
+</div><div class="q1">
+<sup>11&#160;</sup>Your lips, my bride, drip like the honeycomb. 
+</div><div class="q2">Honey and milk are under your tongue. 
+</div><div class="q2">The smell of your garments is like the smell of Lebanon. 
+</div><div class="q1">
+<sup>12&#160;</sup>My sister, my bride, is a locked up garden; 
+</div><div class="q2">a locked up spring, 
+</div><div class="q2">a sealed fountain. 
+</div><div class="q1">
+<sup>13&#160;</sup>Your shoots are an orchard of pomegranates, with precious fruits, 
+</div><div class="q2">henna with spikenard plants, 
+</div><div class="q2">
+<sup>14&#160;</sup>spikenard and saffron, 
+</div><div class="q2">calamus and cinnamon, with every kind of incense tree; 
+</div><div class="q2">myrrh and aloes, with all the best spices, 
+</div><div class="q2">
+<sup>15&#160;</sup>a fountain of gardens, 
+</div><div class="q2">a well of living waters, 
+</div><div class="q2">flowing streams from Lebanon. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>16&#160;</sup>Awake, north wind, and come, you south! 
+</div><div class="q2">Blow on my garden, that its spices may flow out. 
+</div><div class="q1">Let my beloved come into his garden, 
+</div><div class="q2">and taste his precious fruits. 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="sp">Lover 
+</div><div class="q1">
+<sup>1&#160;</sup>I have come into my garden, my sister, my bride. 
+</div><div class="q2">I have gathered my myrrh with my spice; 
+</div><div class="q2">I have eaten my honeycomb with my honey; 
+</div><div class="q2">I have drunk my wine with my milk. 
+</div><div class="sp">Friends 
+</div><div class="q1">Eat, friends! 
+</div><div class="q2">Drink, yes, drink abundantly, beloved. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>2&#160;</sup>I was asleep, but my heart was awake. 
+</div><div class="q2">It is the voice of my beloved who knocks: 
+</div><div class="q2">“Open to me, my sister, my love, my dove, my undefiled; 
+</div><div class="q2">for my head is filled with dew, 
+</div><div class="q2">and my hair with the dampness of the night.” 
+</div><div class="q1">
+<sup>3&#160;</sup>I have taken off my robe. Indeed, must I put it on? 
+</div><div class="q2">I have washed my feet. Indeed, must I soil them? 
+</div><div class="q1">
+<sup>4&#160;</sup>My beloved thrust his hand in through the latch opening. 
+</div><div class="q2">My heart pounded for him. 
+</div><div class="q1">
+<sup>5&#160;</sup>I rose up to open for my beloved. 
+</div><div class="q2">My hands dripped with myrrh, 
+</div><div class="q2">my fingers with liquid myrrh, 
+</div><div class="q2">on the handles of the lock. 
+</div><div class="q1">
+<sup>6&#160;</sup>I opened to my beloved; 
+</div><div class="q2">but my beloved left, and had gone away. 
+</div><div class="q1">My heart went out when he spoke. 
+</div><div class="q2">I looked for him, but I didn’t find him. 
+</div><div class="q2">I called him, but he didn’t answer. 
+</div><div class="q1">
+<sup>7&#160;</sup>The watchmen who go about the city found me. 
+</div><div class="q2">They beat me. 
+</div><div class="q2">They bruised me. 
+</div><div class="q2">The keepers of the walls took my cloak away from me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>I adjure you, daughters of Jerusalem, 
+</div><div class="q2">If you find my beloved, 
+</div><div class="q2">that you tell him that I am faint with love. 
+</div><div class="sp">Friends 
+</div><div class="q1">
+<sup>9&#160;</sup>How is your beloved better than another beloved, 
+</div><div class="q2">you fairest among women? 
+</div><div class="q1">How is your beloved better than another beloved, 
+</div><div class="q1">that you do so adjure us? 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>10&#160;</sup>My beloved is white and ruddy. 
+</div><div class="q2">The best among ten thousand. 
+</div><div class="q1">
+<sup>11&#160;</sup>His head is like the purest gold. 
+</div><div class="q2">His hair is bushy, black as a raven. 
+</div><div class="q1">
+<sup>12&#160;</sup>His eyes are like doves beside the water brooks, 
+</div><div class="q2">washed with milk, mounted like jewels. 
+</div><div class="q1">
+<sup>13&#160;</sup>His cheeks are like a bed of spices with towers of perfumes. 
+</div><div class="q2">His lips are like lilies, dropping liquid myrrh. 
+</div><div class="q1">
+<sup>14&#160;</sup>His hands are like rings of gold set with beryl. 
+</div><div class="q2">His body is like ivory work overlaid with sapphires. 
+</div><div class="q1">
+<sup>15&#160;</sup>His legs are like pillars of marble set on sockets of fine gold. 
+</div><div class="q2">His appearance is like Lebanon, excellent as the cedars. 
+</div><div class="q1">
+<sup>16&#160;</sup>His mouth is sweetness; 
+</div><div class="q2">yes, he is altogether lovely. 
+</div><div class="q1">This is my beloved, and this is my friend, 
+</div><div class="q2">daughters of Jerusalem. 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="sp">Friends 
+</div><div class="q1">
+<sup>1&#160;</sup>Where has your beloved gone, you fairest among women? 
+</div><div class="q2">Where has your beloved turned, that we may seek him with you? 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>2&#160;</sup>My beloved has gone down to his garden, 
+</div><div class="q2">to the beds of spices, 
+</div><div class="q2">to pasture his flock in the gardens, and to gather lilies. 
+</div><div class="q1">
+<sup>3&#160;</sup>I am my beloved’s, and my beloved is mine. 
+</div><div class="q2">He browses among the lilies. 
+</div><div class="b"> &#160; </div>
+<div class="sp">Lover 
+</div><div class="q1">
+<sup>4&#160;</sup>You are beautiful, my love, as Tirzah, 
+</div><div class="q2">lovely as Jerusalem, 
+</div><div class="q2">awesome as an army with banners. 
+</div><div class="q1">
+<sup>5&#160;</sup>Turn away your eyes from me, 
+</div><div class="q2">for they have overcome me. 
+</div><div class="q1">Your hair is like a flock of goats, 
+</div><div class="q2">that lie along the side of Gilead. 
+</div><div class="q1">
+<sup>6&#160;</sup>Your teeth are like a flock of ewes, 
+</div><div class="q2">which have come up from the washing, 
+</div><div class="q2">of which every one has twins; 
+</div><div class="q2">not one is bereaved among them. 
+</div><div class="q1">
+<sup>7&#160;</sup>Your temples are like a piece of a pomegranate behind your veil. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>8&#160;</sup>There are sixty queens, eighty concubines, 
+</div><div class="q2">and virgins without number. 
+</div><div class="q1">
+<sup>9&#160;</sup>My dove, my perfect one, is unique. 
+</div><div class="q2">She is her mother’s only daughter. 
+</div><div class="q2">She is the favorite one of her who bore her. 
+</div><div class="q1">The daughters saw her, and called her blessed. 
+</div><div class="q2">The queens and the concubines saw her, and they praised her. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>10&#160;</sup>Who is she who looks out as the morning, 
+</div><div class="q2">beautiful as the moon, 
+</div><div class="q2">clear as the sun, 
+</div><div class="q2">and awesome as an army with banners? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>I went down into the nut tree grove, 
+</div><div class="q2">to see the green plants of the valley, 
+</div><div class="q2">to see whether the vine budded, 
+</div><div class="q2">and the pomegranates were in flower. 
+</div><div class="q1">
+<sup>12&#160;</sup>Without realizing it, 
+</div><div class="q2">my desire set me with my royal people’s chariots. 
+</div><div class="sp">Friends 
+</div><div class="q1">
+<sup>13&#160;</sup>Return, return, Shulammite! 
+</div><div class="q2">Return, return, that we may gaze at you. 
+</div><div class="sp">Lover 
+</div><div class="q1">Why do you desire to gaze at the Shulammite, 
+</div><div class="q2">as at the dance of Mahanaim? 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>How beautiful are your feet in sandals, prince’s daughter! 
+</div><div class="q2">Your rounded thighs are like jewels, 
+</div><div class="q2">the work of the hands of a skillful workman. 
+</div><div class="q1">
+<sup>2&#160;</sup>Your body is like a round goblet, 
+</div><div class="q2">no mixed wine is wanting. 
+</div><div class="q1">Your waist is like a heap of wheat, 
+</div><div class="q2">set about with lilies. 
+</div><div class="q1">
+<sup>3&#160;</sup>Your two breasts are like two fawns, 
+</div><div class="q2">that are twins of a roe. 
+</div><div class="q1">
+<sup>4&#160;</sup>Your neck is like an ivory tower. 
+</div><div class="q2">Your eyes are like the pools in Heshbon by the gate of Bathrabbim. 
+</div><div class="q2">Your nose is like the tower of Lebanon which looks toward Damascus. 
+</div><div class="q1">
+<sup>5&#160;</sup>Your head on you is like Carmel. 
+</div><div class="q2">The hair of your head like purple. 
+</div><div class="q2">The king is held captive in its tresses. 
+</div><div class="q1">
+<sup>6&#160;</sup>How beautiful and how pleasant you are, 
+</div><div class="q2">love, for delights! 
+</div><div class="q1">
+<sup>7&#160;</sup>This, your stature, is like a palm tree, 
+</div><div class="q2">your breasts like its fruit. 
+</div><div class="q1">
+<sup>8&#160;</sup>I said, “I will climb up into the palm tree. 
+</div><div class="q2">I will take hold of its fruit.” 
+</div><div class="q1">Let your breasts be like clusters of the vine, 
+</div><div class="q2">the smell of your breath like apples. 
+</div><div class="q1">
+<sup>9&#160;</sup>Your mouth is like the best wine, 
+</div><div class="q2">that goes down smoothly for my beloved, 
+</div><div class="q2">gliding through the lips of those who are asleep. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>10&#160;</sup>I am my beloved’s. 
+</div><div class="q2">His desire is toward me. 
+</div><div class="q1">
+<sup>11&#160;</sup>Come, my beloved! Let’s go out into the field. 
+</div><div class="q2">Let’s lodge in the villages. 
+</div><div class="q1">
+<sup>12&#160;</sup>Let’s go early up to the vineyards. 
+</div><div class="q2">Let’s see whether the vine has budded, 
+</div><div class="q2">its blossom is open, 
+</div><div class="q2">and the pomegranates are in flower. 
+</div><div class="q2">There I will give you my love. 
+</div><div class="q1">
+<sup>13&#160;</sup>The mandrakes produce fragrance. 
+</div><div class="q2">At our doors are all kinds of precious fruits, new and old, 
+</div><div class="q2">which I have stored up for you, my beloved. 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>Oh that you were like my brother, 
+</div><div class="q2">who nursed from the breasts of my mother! 
+</div><div class="q1">If I found you outside, I would kiss you; 
+</div><div class="q2">yes, and no one would despise me. 
+</div><div class="q1">
+<sup>2&#160;</sup>I would lead you, bringing you into the house of my mother, 
+</div><div class="q2">who would instruct me. 
+</div><div class="q1">I would have you drink spiced wine, 
+</div><div class="q2">of the juice of my pomegranate. 
+</div><div class="q1">
+<sup>3&#160;</sup>His left hand would be under my head. 
+</div><div class="q2">His right hand would embrace me. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>4&#160;</sup>I adjure you, daughters of Jerusalem, 
+</div><div class="q2">that you not stir up, nor awaken love, 
+</div><div class="q2">until it so desires. 
+</div><div class="sp">Friends 
+</div><div class="q1">
+<sup>5&#160;</sup>Who is this who comes up from the wilderness, 
+</div><div class="q2">leaning on her beloved? 
+</div><div class="b"> &#160; </div>
+<div class="sp">Beloved 
+</div><div class="q1">Under the apple tree I awakened you. 
+</div><div class="q2">There your mother conceived you. 
+</div><div class="q2">There she was in labor and bore you. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>Set me as a seal on your heart, 
+</div><div class="q2">as a seal on your arm; 
+</div><div class="q2">for love is strong as death. 
+</div><div class="q2">Jealousy is as cruel as Sheol. 
+</div><div class="q2">Its flashes are flashes of fire, 
+</div><div class="q2">a very flame of Yah. 
+</div><div class="q1">
+<sup>7&#160;</sup>Many waters can’t quench love, 
+</div><div class="q2">neither can floods drown it. 
+</div><div class="q1">If a man would give all the wealth of his house for love, 
+</div><div class="q2">he would be utterly scorned. 
+</div><div class="sp">Brothers 
+</div><div class="q1">
+<sup>8&#160;</sup>We have a little sister. 
+</div><div class="q2">She has no breasts. 
+</div><div class="q1">What shall we do for our sister 
+</div><div class="q2">in the day when she is to be spoken for? 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>If she is a wall, 
+</div><div class="q2">we will build on her a turret of silver. 
+</div><div class="q1">If she is a door, 
+</div><div class="q2">we will enclose her with boards of cedar. 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>10&#160;</sup>I am a wall, and my breasts like towers, 
+</div><div class="q2">then I was in his eyes like one who found peace. 
+</div><div class="q1">
+<sup>11&#160;</sup>Solomon had a vineyard at Baal Hamon. 
+</div><div class="q2">He leased out the vineyard to keepers. 
+</div><div class="q2">Each was to bring a thousand shekels of silver for its fruit. 
+</div><div class="q1">
+<sup>12&#160;</sup>My own vineyard is before me. 
+</div><div class="q2">The thousand are for you, Solomon, 
+</div><div class="q2">two hundred for those who tend its fruit. 
+</div><div class="sp">Lover 
+</div><div class="q1">
+<sup>13&#160;</sup>You who dwell in the gardens, with friends in attendance, 
+</div><div class="q2">let me hear your voice! 
+</div><div class="sp">Beloved 
+</div><div class="q1">
+<sup>14&#160;</sup>Come away, my beloved! 
+</div><div class="q2">Be like a gazelle or a young stag on the mountains of spices! </div></div><script src="../main.js"></script></body></html>

--- a/book/zechariah.html
+++ b/book/zechariah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Zechariah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,447 +53,462 @@
 <div class="main">
 <!-- ZEC World English Scripture (WES) -->
 <h1 class="booklabel">Zechariah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>In the eighth month, in the second year of Darius, Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
-<span class="v">2&#160;</span>“Yahweh was very displeased with your fathers. 
-<span class="v">3&#160;</span>Therefore tell them, Yahweh of Armies says: ‘Return to me,’ says Yahweh of Armies, ‘and I will return to you,’ says Yahweh of Armies. 
-<span class="v">4&#160;</span>Don’t you be like your fathers, to whom the former prophets proclaimed, saying: Yahweh of Armies says, ‘Return now from your evil ways and from your evil doings;’ but they didn’t hear nor listen to me, says Yahweh. 
-<span class="v">5&#160;</span>Your fathers, where are they? And the prophets, do they live forever? 
-<span class="v">6&#160;</span>But my words and my decrees, which I commanded my servants the prophets, didn’t they overtake your fathers? 
-</p><p>“Then they repented and said, ‘Just as Yahweh of Armies determined to do to us, according to our ways and according to our practices, so he has dealt with us.’&#160;” 
-</p><p>
-<span class="v">7&#160;</span>On the twenty-fourth day of the eleventh month, which is the month Shebat, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
-<span class="v">8&#160;</span>“I had a vision in the night, and behold,<span class="f">+ \fr 1:8 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> a man riding on a red horse, and he stood among the myrtle trees that were in a ravine; and behind him there were red, brown, and white horses. 
-<span class="v">9&#160;</span>Then I asked, ‘My lord, what are these?’&#160;” 
-</p><p>The angel who talked with me said to me, “I will show you what these are.” 
-</p><p>
-<span class="v">10&#160;</span>The man who stood among the myrtle trees answered, “They are the ones Yahweh has sent to go back and forth through the earth.” 
-</p><p>
-<span class="v">11&#160;</span>They reported to Yahweh’s angel who stood among the myrtle trees, and said, “We have walked back and forth through the earth, and behold, all the earth is at rest and in peace.” 
-</p><p>
-<span class="v">12&#160;</span>Then Yahweh’s angel replied, “O Yahweh of Armies, how long will you not have mercy on Jerusalem and on the cities of Judah, against which you have had indignation these seventy years?” 
-</p><p>
-<span class="v">13&#160;</span>Yahweh answered the angel who talked with me with kind and comforting words. 
-<span class="v">14&#160;</span>So the angel who talked with me said to me, “Proclaim, saying, ‘Yahweh of Armies says: “I am jealous for Jerusalem and for Zion with a great jealousy. 
-<span class="v">15&#160;</span>I am very angry with the nations that are at ease; for I was but a little displeased, but they added to the calamity.” 
-<span class="v">16&#160;</span>Therefore Yahweh says: “I have returned to Jerusalem with mercy. My house shall be built in it,” says Yahweh of Armies, “and a line shall be stretched out over Jerusalem.”&#160;’ 
-</p><p>
-<span class="v">17&#160;</span>“Proclaim further, saying, ‘Yahweh of Armies says: “My cities will again overflow with prosperity, and Yahweh will again comfort Zion, and will again choose Jerusalem.”&#160;’&#160;” 
-</p><p>
-<span class="v">18&#160;</span>I lifted up my eyes and saw, and behold, four horns. 
-<span class="v">19&#160;</span>I asked the angel who talked with me, “What are these?” 
-</p><p>He answered me, “These are the horns which have scattered Judah, Israel, and Jerusalem.” 
-</p><p>
-<span class="v">20&#160;</span>Yahweh showed me four craftsmen. 
-<span class="v">21&#160;</span>Then I asked, “What are these coming to do?” 
-</p><p>He said, “These are the horns which scattered Judah, so that no man lifted up his head; but these have come to terrify them, to cast down the horns of the nations that lifted up their horn against the land of Judah to scatter it.” 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>I lifted up my eyes, and saw, and behold, a man with a measuring line in his hand. 
-<span class="v">2&#160;</span>Then I asked, “Where are you going?” 
-</p><p>He said to me, “To measure Jerusalem, to see what is its width and what is its length.” 
-</p><p>
-<span class="v">3&#160;</span>Behold, the angel who talked with me went out, and another angel went out to meet him, 
-<span class="v">4&#160;</span>and said to him, “Run, speak to this young man, saying, ‘Jerusalem will be inhabited as villages without walls, because of the multitude of men and livestock in it. 
-<span class="v">5&#160;</span>For I,’ says Yahweh, ‘will be to her a wall of fire around it, and I will be the glory in the middle of her. 
-</p><p>
-<span class="v">6&#160;</span>Come! Come! Flee from the land of the north,’ says Yahweh; ‘for I have spread you abroad as the four winds of the sky,’ says Yahweh. 
-<span class="v">7&#160;</span>‘Come, Zion! Escape, you who dwell with the daughter of Babylon.’ 
-<span class="v">8&#160;</span>For Yahweh of Armies says: ‘For honor he has sent me to the nations which plundered you; for he who touches you touches the apple of his eye. 
-<span class="v">9&#160;</span>For, behold, I will shake my hand over them, and they will be a plunder to those who served them; and you will know that Yahweh of Armies has sent me. 
-<span class="v">10&#160;</span>Sing and rejoice, daughter of Zion! For behold, I come and I will dwell within you,’ says Yahweh. 
-<span class="v">11&#160;</span>Many nations shall join themselves to Yahweh in that day, and shall be my people; and I will dwell among you, and you shall know that Yahweh of Armies has sent me to you. 
-<span class="v">12&#160;</span>Yahweh will inherit Judah as his portion in the set-apart land, and will again choose Jerusalem. 
-<span class="v">13&#160;</span>Be silent, all flesh, before Yahweh; for he has roused himself from his set-apart habitation!” 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>He showed me Joshua the high priest standing before Yahweh’s angel, and Satan standing at his right hand to be his adversary. 
-<span class="v">2&#160;</span>Yahweh said to Satan, “Yahweh rebuke you, Satan! Yes, Yahweh who has chosen Jerusalem rebuke you! Isn’t this a burning stick plucked out of the fire?” 
-</p><p>
-<span class="v">3&#160;</span>Now Joshua was clothed with filthy garments, and was standing before the angel. 
-<span class="v">4&#160;</span>He answered and spoke to those who stood before him, saying, “Take the filthy garments off him.” To him he said, “Behold, I have caused your iniquity to pass from you, and I will clothe you with rich clothing.” 
-</p><p>
-<span class="v">5&#160;</span>I said, “Let them set a clean turban on his head.” 
-</p><p>So they set a clean turban on his head, and clothed him; and Yahweh’s angel was standing by. 
-</p><p>
-<span class="v">6&#160;</span>Yahweh’s angel solemnly assured Joshua, saying, 
-<span class="v">7&#160;</span>“Yahweh of Armies says: ‘If you will walk in my ways, and if you will follow my instructions, then you also shall judge my house, and shall also keep my courts, and I will give you a place of access among these who stand by. 
-<span class="v">8&#160;</span>Hear now, Joshua the high priest, you and your fellows who sit before you, for they are men who are a sign; for, behold, I will bring out my servant, the Branch. 
-<span class="v">9&#160;</span>For, behold, the stone that I have set before Joshua: on one stone are seven eyes; behold, I will engrave its inscription,’ says Yahweh of Armies, ‘and I will remove the iniquity of that land in one day. 
-<span class="v">10&#160;</span>In that day,’ says Yahweh of Armies, ‘you will invite every man his neighbor under the vine and under the fig tree.’&#160;” 
-</p><h2 class="chapterlabel" id="4">4</h2>
-<p>
-<span class="v">1&#160;</span>The angel who talked with me came again and wakened me, as a man who is wakened out of his sleep. 
-<span class="v">2&#160;</span>He said to me, “What do you see?” 
-</p><p>I said, “I have seen, and behold, a lamp stand all of gold, with its bowl on the top of it, and its seven lamps on it; there are seven pipes to each of the lamps which are on the top of it; 
-<span class="v">3&#160;</span>and two olive trees by it, one on the right side of the bowl, and the other on the left side of it.” 
-</p><p>
-<span class="v">4&#160;</span>I answered and spoke to the angel who talked with me, saying, “What are these, my lord?” 
-</p><p>
-<span class="v">5&#160;</span>Then the angel who talked with me answered me, “Don’t you know what these are?” 
-</p><p>I said, “No, my lord.” 
-</p><p>
-<span class="v">6&#160;</span>Then he answered and spoke to me, saying, “This is Yahweh’s word to Zerubbabel, saying, ‘Not by might, nor by power, but by my Spirit,’ says Yahweh of Armies. 
-<span class="v">7&#160;</span>Who are you, great mountain? Before Zerubbabel you are a plain; and he will bring out the capstone with shouts of ‘Grace, grace, to it!’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>Moreover Yahweh’s word came to me, saying, 
-<span class="v">9&#160;</span>“The hands of Zerubbabel have laid the foundation of this house. His hands shall also finish it; and you will know that Yahweh of Armies has sent me to you. 
-<span class="v">10&#160;</span>Indeed, who despises the day of small things? For these seven shall rejoice, and shall see the plumb line in the hand of Zerubbabel. These are Yahweh’s eyes, which run back and forth through the whole earth.” 
-</p><p>
-<span class="v">11&#160;</span>Then I asked him, “What are these two olive trees on the right side of the lamp stand and on the left side of it?” 
-</p><p>
-<span class="v">12&#160;</span>I asked him the second time, “What are these two olive branches, which are beside the two golden spouts that pour the golden oil out of themselves?” 
-</p><p>
-<span class="v">13&#160;</span>He answered me, “Don’t you know what these are?” 
-</p><p>I said, “No, my lord.” 
-</p><p>
-<span class="v">14&#160;</span>Then he said, “These are the two anointed ones who stand by the Lord<span class="f">+ \fr 4:14 \ft The word translated “Lord” is “Adonai.”</span> of the whole earth.” 
-</p><h2 class="chapterlabel" id="5">5</h2>
-<p>
-<span class="v">1&#160;</span>Then again I lifted up my eyes and saw, and behold, a flying scroll. 
-<span class="v">2&#160;</span>He said to me, “What do you see?” 
-</p><p>I answered, “I see a flying scroll; its length is twenty cubits,<span class="f">+ \fr 5:2 \ft A cubit is the length from the tip of the middle finger to the elbow on a man’s arm, or about 18 inches or 46 centimeters.</span> and its width ten cubits.” 
-</p><p>
-<span class="v">3&#160;</span>Then he said to me, “This is the curse that goes out over the surface of the whole land, for everyone who steals shall be cut off according to it on the one side; and everyone who swears falsely shall be cut off according to it on the other side. 
-<span class="v">4&#160;</span>I will cause it to go out,” says Yahweh of Armies, “and it will enter into the house of the thief, and into the house of him who swears falsely by my name; and it will remain in the middle of his house, and will destroy it with its timber and its stones.” 
-</p><p>
-<span class="v">5&#160;</span>Then the angel who talked with me came forward and said to me, “Lift up now your eyes and see what this is that is appearing.” 
-</p><p>
-<span class="v">6&#160;</span>I said, “What is it?” 
-</p><p>He said, “This is the ephah<span class="f">+ \fr 5:6 \ft An ephah is a measure of volume of about 22 liters, 5.8 U. S. gallons, or about 2/3 of a bushel. </span> basket that is appearing.” He said moreover, “This is their appearance in all the land—<span class="v">7&#160;</span>and behold, a lead cover weighing one talent<span class="f">+ \fr 5:7 \ft A talent is about 30 kilograms or 66 pounds.</span> was lifted up—and there was a woman sitting in the middle of the ephah<span class="f">+ \fr 5:7 \ft 1 ephah is about 22 liters or about 2/3 of a bushel</span> basket.” 
-<span class="v">8&#160;</span>He said, “This is Wickedness;” and he threw her down into the middle of the ephah basket; and he threw the lead weight on its mouth. 
-</p><p>
-<span class="v">9&#160;</span>Then I lifted up my eyes and saw, and behold, there were two women; and the wind was in their wings. Now they had wings like the wings of a stork, and they lifted up the ephah basket between earth and the sky. 
-<span class="v">10&#160;</span>Then I said to the angel who talked with me, “Where are these carrying the ephah basket?” 
-</p><p>
-<span class="v">11&#160;</span>He said to me, “To build her a house in the land of Shinar. When it is prepared, she will be set there in her own place.” 
-</p><h2 class="chapterlabel" id="6">6</h2>
-<p>
-<span class="v">1&#160;</span>Again I lifted up my eyes, and saw, and behold, four chariots came out from between two mountains; and the mountains were mountains of bronze. 
-<span class="v">2&#160;</span>In the first chariot were red horses. In the second chariot were black horses. 
-<span class="v">3&#160;</span>In the third chariot were white horses. In the fourth chariot were dappled horses, all of them powerful. 
-<span class="v">4&#160;</span>Then I asked the angel who talked with me, “What are these, my lord?” 
-</p><p>
-<span class="v">5&#160;</span>The angel answered me, “These are the four winds of the sky, which go out from standing before the Lord of all the earth. 
-<span class="v">6&#160;</span>The one with the black horses goes out toward the north country; and the white went out after them; and the dappled went out toward the south country.” 
-<span class="v">7&#160;</span>The strong went out, and sought to go that they might walk back and forth through the earth. He said, “Go around and through the earth!” So they walked back and forth through the earth. 
-</p><p>
-<span class="v">8&#160;</span>Then he called to me, and spoke to me, saying, “Behold, those who go toward the north country have quieted my spirit in the north country.” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh’s word came to me, saying, 
-<span class="v">10&#160;</span>“Take of them of the captivity, even of Heldai, of Tobijah, and of Jedaiah; and come the same day, and go into the house of Josiah the son of Zephaniah, where they have come from Babylon. 
-<span class="v">11&#160;</span>Yes, take silver and gold, and make crowns, and set them on the head of Joshua the son of Jehozadak, the high priest; 
-<span class="v">12&#160;</span>and speak to him, saying, ‘Yahweh of Armies says, “Behold, the man whose name is the Branch! He will grow up out of his place; and he will build Yahweh’s temple. 
-<span class="v">13&#160;</span>He will build Yahweh’s temple. He will bear the glory, and will sit and rule on his throne. He will be a priest on his throne. The counsel of peace will be between them both. 
-<span class="v">14&#160;</span>The crowns shall be to Helem, to Tobijah, to Jedaiah, and to Hen the son of Zephaniah, for a memorial in Yahweh’s temple. 
-</p><p>
-<span class="v">15&#160;</span>Those who are far off shall come and build in Yahweh’s temple; and you shall know that Yahweh of Armies has sent me to you. This will happen, if you will diligently obey Yahweh your Elohim’s voice.”&#160;’&#160;”<span class="f">+ \fr 6:15 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> 
-</p><h2 class="chapterlabel" id="7">7</h2>
-<p>
-<span class="v">1&#160;</span>In the fourth year of King Darius, Yahweh’s word came to Zechariah in the fourth day of the ninth month, the month of Chislev. 
-<span class="v">2&#160;</span>The people of Bethel sent Sharezer and Regem Melech and their men to entreat Yahweh’s favor, 
-<span class="v">3&#160;</span>and to speak to the priests of the house of Yahweh of Armies and to the prophets, saying, “Should I weep in the fifth month, separating myself, as I have done these so many years?” 
-</p><p>
-<span class="v">4&#160;</span>Then the word of Yahweh of Armies came to me, saying, 
-<span class="v">5&#160;</span>“Speak to all the people of the land and to the priests, saying, ‘When you fasted and mourned in the fifth and in the seventh month for these seventy years, did you at all fast to me, really to me? 
-<span class="v">6&#160;</span>When you eat and when you drink, don’t you eat for yourselves and drink for yourselves? 
-<span class="v">7&#160;</span>Aren’t these the words which Yahweh proclaimed by the former prophets when Jerusalem was inhabited and in prosperity, and its cities around her, and the South and the lowland were inhabited?’&#160;” 
-</p><p>
-<span class="v">8&#160;</span>Yahweh’s word came to Zechariah, saying, 
-<span class="v">9&#160;</span>“Thus has Yahweh of Armies spoken, saying, ‘Execute true judgment, and show kindness and compassion every man to his brother. 
-<span class="v">10&#160;</span>Don’t oppress the widow, the fatherless, the foreigner, nor the poor; and let none of you devise evil against his brother in your heart.’ 
-<span class="v">11&#160;</span>But they refused to listen, and turned their backs, and stopped their ears, that they might not hear. 
-<span class="v">12&#160;</span>Yes, they made their hearts as hard as flint, lest they might hear the law and the words which Yahweh of Armies had sent by his Spirit by the former prophets. Therefore great wrath came from Yahweh of Armies. 
-<span class="v">13&#160;</span>It has come to pass that, as he called and they refused to listen, so they will call and I will not listen,” said Yahweh of Armies; 
-<span class="v">14&#160;</span>“but I will scatter them with a whirlwind among all the nations which they have not known. Thus the land was desolate after them, so that no man passed through nor returned; for they made the pleasant land desolate.” 
-</p><h2 class="chapterlabel" id="8">8</h2>
-<p>
-<span class="v">1&#160;</span>The word of Yahweh of Armies came to me. 
-<span class="v">2&#160;</span>Yahweh of Armies says: “I am jealous for Zion with great jealousy, and I am jealous for her with great wrath.” 
-</p><p>
-<span class="v">3&#160;</span>Yahweh says: “I have returned to Zion, and will dwell in the middle of Jerusalem. Jerusalem shall be called ‘The City of Truth;’ and the mountain of Yahweh of Armies, ‘The Set-Apart Mountain.’&#160;” 
-</p><p>
-<span class="v">4&#160;</span>Yahweh of Armies says: “Old men and old women will again dwell in the streets of Jerusalem, every man with his staff in his hand because of their old age. 
-<span class="v">5&#160;</span>The streets of the city will be full of boys and girls playing in its streets.” 
-</p><p>
-<span class="v">6&#160;</span>Yahweh of Armies says: “If it is marvelous in the eyes of the remnant of this people in those days, should it also be marvelous in my eyes?” says Yahweh of Armies. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh of Armies says: “Behold, I will save my people from the east country and from the west country. 
-<span class="v">8&#160;</span>I will bring them, and they will dwell within Jerusalem. They will be my people, and I will be their Elohim, in truth and in righteousness.” 
-</p><p>
-<span class="v">9&#160;</span>Yahweh of Armies says: “Let your hands be strong, you who hear in these days these words from the mouth of the prophets who were in the day that the foundation of the house of Yahweh of Armies was laid, even the temple, that it might be built. 
-<span class="v">10&#160;</span>For before those days there was no wages for man nor any wages for an animal, neither was there any peace to him who went out or came in, because of the adversary. For I set all men everyone against his neighbor. 
-<span class="v">11&#160;</span>But now I will not be to the remnant of this people as in the former days,” says Yahweh of Armies. 
-<span class="v">12&#160;</span>“For the seed of peace and the vine will yield its fruit, and the ground will give its increase, and the heavens will give their dew. I will cause the remnant of this people to inherit all these things. 
-<span class="v">13&#160;</span>It shall come to pass that, as you were a curse among the nations, house of Judah and house of Israel, so I will save you, and you shall be a blessing. Don’t be afraid. Let your hands be strong.” 
-</p><p>
-<span class="v">14&#160;</span>For Yahweh of Armies says: “As I thought to do evil to you when your fathers provoked me to wrath,” says Yahweh of Armies, “and I didn’t repent, 
-<span class="v">15&#160;</span>so again I have thought in these days to do good to Jerusalem and to the house of Judah. Don’t be afraid. 
-<span class="v">16&#160;</span>These are the things that you shall do: speak every man the truth with his neighbor. Execute the judgment of truth and peace in your gates, 
-<span class="v">17&#160;</span>and let none of you devise evil in your hearts against his neighbor, and love no false oath; for all these are things that I hate,” says Yahweh. 
-</p><p>
-<span class="v">18&#160;</span>The word of Yahweh of Armies came to me. 
-<span class="v">19&#160;</span>Yahweh of Armies says: “The fasts of the fourth, fifth, seventh, and tenth months shall be for the house of Judah joy, gladness, and cheerful feasts. Therefore love truth and peace.” 
-</p><p>
-<span class="v">20&#160;</span>Yahweh of Armies says: “Many peoples and the inhabitants of many cities will yet come. 
-<span class="v">21&#160;</span>The inhabitants of one will go to another, saying, ‘Let’s go speedily to entreat the favor of Yahweh, and to seek Yahweh of Armies. I will go also.’ 
-<span class="v">22&#160;</span>Yes, many peoples and strong nations will come to seek Yahweh of Armies in Jerusalem and to entreat the favor of Yahweh.” 
-<span class="v">23&#160;</span>Yahweh of Armies says: “In those days, ten men out of all the languages of the nations will take hold of the skirt of him who is a Jew, saying, ‘We will go with you, for we have heard that Elohim is with you.’&#160;” 
-</p><h2 class="chapterlabel" id="9">9</h2>
-<p>
-<span class="v">1&#160;</span>A revelation. 
-</p><p class="q1">Yahweh’s word is against the land of Hadrach, 
-</p><p class="q2">and will rest upon Damascus—</p><p class="q1">for the eye of man 
-</p><p class="q2">and of all the tribes of Israel is toward Yahweh—</p><p class="q1">
-<span class="v">2&#160;</span>and Hamath, also, which borders on it, 
-</p><p class="q2">Tyre and Sidon, because they are very wise. 
-</p><p class="q1">
-<span class="v">3&#160;</span>Tyre built herself a stronghold, 
-</p><p class="q2">and heaped up silver like the dust, 
-</p><p class="q2">and fine gold like the mire of the streets. 
-</p><p class="q1">
-<span class="v">4&#160;</span>Behold, the Lord will dispossess her, 
-</p><p class="q2">and he will strike her power in the sea; 
-</p><p class="q2">and she will be devoured with fire. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">5&#160;</span>Ashkelon will see it, and fear; 
-</p><p class="q2">Gaza also, and will writhe in agony; 
-</p><p class="q2">as will Ekron, for her expectation will be disappointed; 
-</p><p class="q2">and the king will perish from Gaza, 
-</p><p class="q2">and Ashkelon will not be inhabited. 
-</p><p class="q1">
-<span class="v">6&#160;</span>Foreigners will dwell in Ashdod, 
-</p><p class="q2">and I will cut off the pride of the Philistines. 
-</p><p class="q1">
-<span class="v">7&#160;</span>I will take away his blood out of his mouth, 
-</p><p class="q2">and his abominations from between his teeth; 
-</p><p class="q1">and he also will be a remnant for our Elohim; 
-</p><p class="q2">and he will be as a chieftain in Judah, 
-</p><p class="q2">and Ekron as a Jebusite. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will encamp around my house against the army, 
-</p><p class="q2">that no one pass through or return; 
-</p><p class="q2">and no oppressor will pass through them any more: 
-</p><p class="q2">for now I have seen with my eyes. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">9&#160;</span>Rejoice greatly, daughter of Zion! 
-</p><p class="q2">Shout, daughter of Jerusalem! 
-</p><p class="q1">Behold, your King comes to you! 
-</p><p class="q2">He is righteous, and having salvation; 
-</p><p class="q2">lowly, and riding on a donkey, 
-</p><p class="q2">even on a colt, the foal of a donkey. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I will cut off the chariot from Ephraim 
-</p><p class="q2">and the horse from Jerusalem. 
-</p><p class="q1">The battle bow will be cut off; 
-</p><p class="q2">and he will speak peace to the nations. 
-</p><p class="q1">His dominion will be from sea to sea, 
-</p><p class="q2">and from the River to the ends of the earth. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">11&#160;</span>As for you also, 
-</p><p class="q2">because of the blood of your covenant, 
-</p><p class="q2">I have set free your prisoners from the pit in which is no water. 
-</p><p class="q1">
-<span class="v">12&#160;</span>Turn to the stronghold, you prisoners of hope! 
-</p><p class="q2">Even today I declare that I will restore double to you. 
-</p><p class="q1">
-<span class="v">13&#160;</span>For indeed I bend Judah as a bow for me. 
-</p><p class="q2">I have loaded the bow with Ephraim. 
-</p><p class="q1">I will stir up your sons, Zion, 
-</p><p class="q2">against your sons, Greece, 
-</p><p class="q2">and will make you like the sword of a mighty man. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">14&#160;</span>Yahweh will be seen over them. 
-</p><p class="q2">His arrow will flash like lightning. 
-</p><p class="q1">The Lord Yahweh will blow the trumpet, 
-</p><p class="q2">and will go with whirlwinds of the south. 
-</p><p class="q1">
-<span class="v">15&#160;</span>Yahweh of Armies will defend them. 
-</p><p class="q2">They will destroy and overcome with sling stones. 
-</p><p class="q1">They will drink, and roar as through wine. 
-</p><p class="q2">They will be filled like bowls, 
-</p><p class="q2">like the corners of the altar. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">16&#160;</span>Yahweh their Elohim will save them in that day as the flock of his people; 
-</p><p class="q2">for they are like the jewels of a crown, 
-</p><p class="q2">lifted on high over his land. 
-</p><p class="q1">
-<span class="v">17&#160;</span>For how great is his goodness, 
-</p><p class="q2">and how great is his beauty! 
-</p><p class="q1">Grain will make the young men flourish, 
-</p><p class="q2">and new wine the virgins. 
-</p><h2 class="chapterlabel" id="10">10</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Ask of Yahweh rain in the spring time, 
-</p><p class="q2">Yahweh who makes storm clouds, 
-</p><p class="q2">and he gives rain showers to everyone for the plants in the field. 
-</p><p class="q1">
-<span class="v">2&#160;</span>For the teraphim<span class="f">+ \fr 10:2 \ft teraphim were household idols that may have been associated with inheritance rights to the household property.</span> have spoken vanity, 
-</p><p class="q2">and the diviners have seen a lie; 
-</p><p class="q2">and they have told false dreams. 
-</p><p class="q1">They comfort in vain. 
-</p><p class="q2">Therefore they go their way like sheep. 
-</p><p class="q2">They are oppressed, because there is no shepherd. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">3&#160;</span>My anger is kindled against the shepherds, 
-</p><p class="q2">and I will punish the male goats, 
-</p><p class="q2">for Yahweh of Armies has visited his flock, the house of Judah, 
-</p><p class="q2">and will make them as his majestic horse in the battle. 
-</p><p class="q1">
-<span class="v">4&#160;</span>From him will come the cornerstone, 
-</p><p class="q2">from him the tent peg, 
-</p><p class="q2">from him the battle bow, 
-</p><p class="q2">from him every ruler together. 
-</p><p class="q2">
-<span class="v">5&#160;</span>They will be as mighty men, 
-</p><p class="q2">treading down muddy streets in the battle. 
-</p><p class="q1">They will fight, because Yahweh is with them. 
-</p><p class="q2">The riders on horses will be confounded. 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">6&#160;</span>“I will strengthen the house of Judah, 
-</p><p class="q2">and I will save the house of Joseph. 
-</p><p class="q1">I will bring them back, 
-</p><p class="q2">for I have mercy on them. 
-</p><p class="q1">They will be as though I had not cast them off, 
-</p><p class="q2">for I am Yahweh their Elohim, and I will hear them. 
-</p><p class="q1">
-<span class="v">7&#160;</span>Ephraim will be like a mighty man, 
-</p><p class="q2">and their heart will rejoice as through wine. 
-</p><p class="q1">Yes, their children will see it and rejoice. 
-</p><p class="q2">Their heart will be glad in Yahweh. 
-</p><p class="q1">
-<span class="v">8&#160;</span>I will signal for them and gather them, 
-</p><p class="q2">for I have redeemed them. 
-</p><p class="q2">They will increase as they were before. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will sow them among the peoples. 
-</p><p class="q2">They will remember me in far countries. 
-</p><p class="q2">They will live with their children and will return. 
-</p><p class="q1">
-<span class="v">10&#160;</span>I will bring them again also out of the land of Egypt, 
-</p><p class="q2">and gather them out of Assyria. 
-</p><p class="q1">I will bring them into the land of Gilead and Lebanon; 
-</p><p class="q2">and there won’t be room enough for them. 
-</p><p class="q1">
-<span class="v">11&#160;</span>He will pass through the sea of affliction, 
-</p><p class="q2">and will strike the waves in the sea, 
-</p><p class="q2">and all the depths of the Nile will dry up; 
-</p><p class="q2">and the pride of Assyria will be brought down, 
-</p><p class="q2">and the scepter of Egypt will depart. 
-</p><p class="q1">
-<span class="v">12&#160;</span>I will strengthen them in Yahweh. 
-</p><p class="q2">They will walk up and down in his name,” says Yahweh. 
-</p><h2 class="chapterlabel" id="11">11</h2>
-<p class="q1">
-<span class="v">1&#160;</span>Open your doors, Lebanon, 
-</p><p class="q2">that the fire may devour your cedars. 
-</p><p class="q1">
-<span class="v">2&#160;</span>Wail, cypress tree, for the cedar has fallen, 
-</p><p class="q2">because the stately ones are destroyed. 
-</p><p class="q1">Wail, you oaks of Bashan, 
-</p><p class="q2">for the strong forest has come down. 
-</p><p class="q1">
-<span class="v">3&#160;</span>A voice of the wailing of the shepherds! 
-</p><p class="q2">For their glory is destroyed—a voice of the roaring of young lions! 
-</p><p class="q2">For the pride of the Jordan is ruined. 
-</p><p>
-<span class="v">4&#160;</span>Yahweh my Elohim says: “Feed the flock of slaughter. 
-<span class="v">5&#160;</span>Their buyers slaughter them and go unpunished. Those who sell them say, ‘Blessed be Yahweh, for I am rich;’ and their own shepherds don’t pity them. 
-<span class="v">6&#160;</span>For I will no more pity the inhabitants of the land,” says Yahweh; “but, behold, I will deliver every one of the men into his neighbor’s hand and into the hand of his king. They will strike the land, and out of their hand I will not deliver them.” 
-</p><p>
-<span class="v">7&#160;</span>So I fed the flock to be slaughtered, especially the oppressed of the flock. I took for myself two staffs. The one I called “Favor” and the other I called “Union”, and I fed the flock. 
-<span class="v">8&#160;</span>I cut off the three shepherds in one month; for my soul was weary of them, and their soul also loathed me. 
-<span class="v">9&#160;</span>Then I said, “I will not feed you. That which dies, let it die; and that which is to be cut off, let it be cut off; and let those who are left eat each other’s flesh.” 
-<span class="v">10&#160;</span>I took my staff Favor and cut it apart, that I might break my covenant that I had made with all the peoples. 
-<span class="v">11&#160;</span>It was broken in that day; and thus the poor of the flock that listened to me knew that it was Yahweh’s word. 
-<span class="v">12&#160;</span>I said to them, “If you think it best, give me my wages; and if not, keep them.” So they weighed for my wages thirty pieces of silver. 
-<span class="v">13&#160;</span>Yahweh said to me, “Throw it to the potter—the handsome price that I was valued at by them!” I took the thirty pieces of silver and threw them to the potter in Yahweh’s house. 
-<span class="v">14&#160;</span>Then I cut apart my other staff, Union, that I might break the brotherhood between Judah and Israel. 
-</p><p>
-<span class="v">15&#160;</span>Yahweh said to me, “Take for yourself yet again the equipment of a foolish shepherd. 
-<span class="v">16&#160;</span>For, behold, I will raise up a shepherd in the land who will not visit those who are cut off, neither will seek those who are scattered, nor heal that which is broken, nor feed that which is sound; but he will eat the meat of the fat sheep, and will tear their hoofs in pieces. 
-<span class="v">17&#160;</span>Woe to the worthless shepherd who leaves the flock! The sword will strike his arm and his right eye. His arm will be completely withered, and his right eye will be totally blinded!” 
-</p><h2 class="chapterlabel" id="12">12</h2>
-<p>
-<span class="v">1&#160;</span>A revelation of Yahweh’s word concerning Israel: Yahweh, who stretches out the heavens and lays the foundation of the earth, and forms the spirit of man within him says: 
-<span class="v">2&#160;</span>“Behold, I will make Jerusalem a cup of reeling to all the surrounding peoples, and it will also be on Judah in the siege against Jerusalem. 
-<span class="v">3&#160;</span>It will happen in that day that I will make Jerusalem a burdensome stone for all the peoples. All who burden themselves with it will be severely wounded, and all the nations of the earth will be gathered together against it. 
-<span class="v">4&#160;</span>In that day,” says Yahweh, “I will strike every horse with terror and his rider with madness. I will open my eyes on the house of Judah, and will strike every horse of the peoples with blindness. 
-<span class="v">5&#160;</span>The chieftains of Judah will say in their heart, ‘The inhabitants of Jerusalem are my strength in Yahweh of Armies their Elohim.’ 
-</p><p>
-<span class="v">6&#160;</span>In that day I will make the chieftains of Judah like a pan of fire among wood, and like a flaming torch among sheaves. They will devour all the surrounding peoples on the right hand and on the left; and Jerusalem will yet again dwell in their own place, even in Jerusalem. 
-</p><p>
-<span class="v">7&#160;</span>Yahweh also will save the tents of Judah first, that the glory of David’s house and the glory of the inhabitants of Jerusalem not be magnified above Judah. 
-<span class="v">8&#160;</span>In that day Yahweh will defend the inhabitants of Jerusalem. He who is feeble among them at that day will be like David, and David’s house will be like Elohim, like Yahweh’s angel before them. 
-<span class="v">9&#160;</span>It will happen in that day, that I will seek to destroy all the nations that come against Jerusalem. 
-</p><p>
-<span class="v">10&#160;</span>I will pour on David’s house and on the inhabitants of Jerusalem the spirit of grace and of supplication. They will look to me<span class="f">+ \fr 12:10 \ft After “me”, the Hebrew has the two letters “Aleph Tav” (the first and last letters of the Hebrew alphabet), not as a word, but as a grammatical marker.</span> whom they have pierced; and they shall mourn for him as one mourns for his only son, and will grieve bitterly for him as one grieves for his firstborn. 
-<span class="v">11&#160;</span>In that day there will be a great mourning in Jerusalem, like the mourning of Hadadrimmon in the valley of Megiddo. 
-<span class="v">12&#160;</span>The land will mourn, every family apart; the family of David’s house apart, and their women apart; the family of the house of Nathan apart, and their women apart; 
-<span class="v">13&#160;</span>the family of the house of Levi apart, and their women apart; the family of the Shimeites apart, and their women apart; 
-<span class="v">14&#160;</span>all the families who remain, every family apart, and their women apart. 
-</p><h2 class="chapterlabel" id="13">13</h2>
-<p>
-<span class="v">1&#160;</span>“In that day there will be a fountain opened to David’s house and to the inhabitants of Jerusalem, for sin and for uncleanness. 
-</p><p>
-<span class="v">2&#160;</span>It will come to pass in that day, says Yahweh of Armies, that I will cut off the names of the idols out of the land, and they will be remembered no more. I will also cause the prophets and the spirit of impurity to pass out of the land. 
-<span class="v">3&#160;</span>It will happen that when anyone still prophesies, then his father and his mother who bore him will tell him, ‘You must die, because you speak lies in Yahweh’s name;’ and his father and his mother who bore him will stab him when he prophesies. 
-<span class="v">4&#160;</span>It will happen in that day that the prophets will each be ashamed of his vision when he prophesies; they won’t wear a hairy mantle to deceive, 
-<span class="v">5&#160;</span>but he will say, ‘I am no prophet, I am a tiller of the ground; for I have been made a bondservant from my youth.’ 
-<span class="v">6&#160;</span>One will say to him, ‘What are these wounds between your arms?’ Then he will answer, ‘Those with which I was wounded in the house of my friends.’ 
-</p><div class="b"> &#160; </div>
-<p class="q1">
-<span class="v">7&#160;</span>“Awake, sword, against my shepherd, 
-</p><p class="q2">and against the man who is close to me,” says Yahweh of Armies. 
-</p><p class="q1">“Strike the shepherd, and the sheep will be scattered; 
-</p><p class="q2">and I will turn my hand against the little ones. 
-</p><p class="q1">
-<span class="v">8&#160;</span>It shall happen that in all the land,” says Yahweh, 
-</p><p class="q2">“two parts in it will be cut off and die; 
-</p><p class="q2">but the third will be left in it. 
-</p><p class="q1">
-<span class="v">9&#160;</span>I will bring the third part into the fire, 
-</p><p class="q2">and will refine them as silver is refined, 
-</p><p class="q2">and will test them like gold is tested. 
-</p><p class="q1">They will call on my name, and I will hear them. 
-</p><p class="q2">I will say, ‘It is my people;’ 
-</p><p class="q2">and they will say, ‘Yahweh is my Elohim.’&#160;” 
-</p><h2 class="chapterlabel" id="14">14</h2>
-<p>
-<span class="v">1&#160;</span>Behold, a day of Yahweh comes, when your plunder will be divided within you. 
-<span class="v">2&#160;</span>For I will gather all nations against Jerusalem to battle; and the city will be taken, the houses rifled, and the women ravished. Half of the city will go out into captivity, and the rest of the people will not be cut off from the city. 
-<span class="v">3&#160;</span>Then Yahweh will go out and fight against those nations, as when he fought in the day of battle. 
-<span class="v">4&#160;</span>His feet will stand in that day on the Mount of Olives, which is before Jerusalem on the east; and the Mount of Olives will be split in two from east to west, making a very great valley. Half of the mountain will move toward the north, and half of it toward the south. 
-<span class="v">5&#160;</span>You shall flee by the valley of my mountains, for the valley of the mountains shall reach to Azel. Yes, you shall flee, just like you fled from before the earthquake in the days of Uzziah king of Judah. Yahweh my Elohim will come, and all the set-apart ones with you.<span class="f">+ \fr 14:5 \ft Septuagint reads “him” instead of “you”.</span> 
-</p><p>
-<span class="v">6&#160;</span>It will happen in that day that there will not be light, cold, or frost. 
-<span class="v">7&#160;</span>It will be a unique day which is known to Yahweh—not day, and not night; but it will come to pass that at evening time there will be light. 
-</p><p>
-<span class="v">8&#160;</span>It will happen in that day that living waters will go out from Jerusalem, half of them toward the eastern sea, and half of them toward the western sea. It will be so in summer and in winter. 
-</p><p>
-<span class="v">9&#160;</span>Yahweh will be King over all the earth. In that day Yahweh will be one, and his name one. 
-</p><p>
-<span class="v">10&#160;</span>All the land will be made like the Arabah, from Geba to Rimmon south of Jerusalem; and she will be lifted up and will dwell in her place, from Benjamin’s gate to the place of the first gate, to the corner gate, and from the tower of Hananel to the king’s wine presses. 
-<span class="v">11&#160;</span>Men will dwell therein, and there will be no more curse; but Jerusalem will dwell safely. 
-</p><p>
-<span class="v">12&#160;</span>This will be the plague with which Yahweh will strike all the peoples who have fought against Jerusalem: their flesh will consume away while they stand on their feet, and their eyes will consume away in their sockets, and their tongue will consume away in their mouth. 
-<span class="v">13&#160;</span>It will happen in that day that a great panic from Yahweh will be among them; and they will each seize the hand of his neighbor, and his hand will rise up against the hand of his neighbor. 
-<span class="v">14&#160;</span>Judah also will fight at Jerusalem; and the wealth of all the surrounding nations will be gathered together: gold, silver, and clothing, in great abundance. 
-</p><p>
-<span class="v">15&#160;</span>A plague like this will fall on the horse, on the mule, on the camel, on the donkey, and on all the animals that will be in those camps. 
-</p><p>
-<span class="v">16&#160;</span>It will happen that everyone who is left of all the nations that came against Jerusalem will go up from year to year to worship the King, Yahweh of Armies, and to keep the feast of booths. 
-<span class="v">17&#160;</span>It will be that whoever of all the families of the earth doesn’t go up to Jerusalem to worship the King, Yahweh of Armies, on them there will be no rain. 
-<span class="v">18&#160;</span>If the family of Egypt doesn’t go up and doesn’t come, neither will it rain on them. This will be the plague with which Yahweh will strike the nations that don’t go up to keep the feast of booths. 
-<span class="v">19&#160;</span>This will be the punishment of Egypt and the punishment of all the nations that don’t go up to keep the feast of booths. 
-</p><p>
-<span class="v">20&#160;</span>In that day there will be inscribed on the bells of the horses, “SET-APART TO YAHWEH”; and the pots in Yahweh’s house will be like the bowls before the altar. 
-<span class="v">21&#160;</span>Yes, every pot in Jerusalem and in Judah will be set-apart to Yahweh of Armies; and all those who sacrifice will come and take of them, and cook in them. In that day there will no longer be a Canaanite<span class="f">+ \fr 14:21 \ft or, merchant</span> in the house of Yahweh of Armies. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+<a href="#4">4</a>
+<a href="#5">5</a>
+<a href="#6">6</a>
+<a href="#7">7</a>
+<a href="#8">8</a>
+<a href="#9">9</a>
+<a href="#10">10</a>
+<a href="#11">11</a>
+<a href="#12">12</a>
+<a href="#13">13</a>
+<a href="#14">14</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>In the eighth month, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
+<sup>2&#160;</sup>“Yahweh was very displeased with your fathers. 
+<sup>3&#160;</sup>Therefore tell them, Yahweh of Armies says: ‘Return to me,’ says Yahweh of Armies, ‘and I will return to you,’ says Yahweh of Armies. 
+<sup>4&#160;</sup>Don’t you be like your fathers, to whom the former prophets proclaimed, saying: Yahweh of Armies says, ‘Return now from your evil ways and from your evil doings;’ but they didn’t hear nor listen to me, says Yahweh. 
+<sup>5&#160;</sup>Your fathers, where are they? And the prophets, do they live forever? 
+<sup>6&#160;</sup>But my words and my decrees, which I commanded my servants the prophets, didn’t they overtake your fathers? 
+</div><div class="p">“Then they repented and said, ‘Just as Yahweh of Armies determined to do to us, according to our ways and according to our practices, so he has dealt with us.’&#160;” 
+</div><div class="p">
+<sup>7&#160;</sup>On the twenty-fourth day of the eleventh month, which is the month Shebat, in the second year of Darius, Yahweh’s word came to the prophet Zechariah the son of Berechiah, the son of Iddo, saying, 
+<sup>8&#160;</sup>“I had a vision in the night, and behold, a man riding on a red horse, and he stood among the myrtle trees that were in a ravine; and behind him there were red, brown, and white horses. 
+<sup>9&#160;</sup>Then I asked, ‘My lord, what are these?’&#160;” 
+</div><div class="p">The angel who talked with me said to me, “I will show you what these are.” 
+</div><div class="p">
+<sup>10&#160;</sup>The man who stood among the myrtle trees answered, “They are the ones Yahweh has sent to go back and forth through the earth.” 
+</div><div class="p">
+<sup>11&#160;</sup>They reported to Yahweh’s angel who stood among the myrtle trees, and said, “We have walked back and forth through the earth, and behold, all the earth is at rest and in peace.” 
+</div><div class="p">
+<sup>12&#160;</sup>Then Yahweh’s angel replied, “O Yahweh of Armies, how long will you not have mercy on Jerusalem and on the cities of Judah, against which you have had indignation these seventy years?” 
+</div><div class="p">
+<sup>13&#160;</sup>Yahweh answered the angel who talked with me with kind and comforting words. 
+<sup>14&#160;</sup>So the angel who talked with me said to me, “Proclaim, saying, ‘Yahweh of Armies says: “I am jealous for Jerusalem and for Zion with a great jealousy. 
+<sup>15&#160;</sup>I am very angry with the nations that are at ease; for I was but a little displeased, but they added to the calamity.” 
+<sup>16&#160;</sup>Therefore Yahweh says: “I have returned to Jerusalem with mercy. My house shall be built in it,” says Yahweh of Armies, “and a line shall be stretched out over Jerusalem.”&#160;’ 
+</div><div class="p">
+<sup>17&#160;</sup>“Proclaim further, saying, ‘Yahweh of Armies says: “My cities will again overflow with prosperity, and Yahweh will again comfort Zion, and will again choose Jerusalem.”&#160;’&#160;” 
+</div><div class="p">
+<sup>18&#160;</sup>I lifted up my eyes and saw, and behold, four horns. 
+<sup>19&#160;</sup>I asked the angel who talked with me, “What are these?” 
+</div><div class="p">He answered me, “These are the horns which have scattered Judah, Israel, and Jerusalem.” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh showed me four craftsmen. 
+<sup>21&#160;</sup>Then I asked, “What are these coming to do?” 
+</div><div class="p">He said, “These are the horns which scattered Judah, so that no man lifted up his head; but these have come to terrify them, to cast down the horns of the nations that lifted up their horn against the land of Judah to scatter it.” 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>I lifted up my eyes, and saw, and behold, a man with a measuring line in his hand. 
+<sup>2&#160;</sup>Then I asked, “Where are you going?” 
+</div><div class="p">He said to me, “To measure Jerusalem, to see what is its width and what is its length.” 
+</div><div class="p">
+<sup>3&#160;</sup>Behold, the angel who talked with me went out, and another angel went out to meet him, 
+<sup>4&#160;</sup>and said to him, “Run, speak to this young man, saying, ‘Jerusalem will be inhabited as villages without walls, because of the multitude of men and livestock in it. 
+<sup>5&#160;</sup>For I,’ says Yahweh, ‘will be to her a wall of fire around it, and I will be the glory in the middle of her. 
+</div><div class="p">
+<sup>6&#160;</sup>Come! Come! Flee from the land of the north,’ says Yahweh; ‘for I have spread you abroad as the four winds of the sky,’ says Yahweh. 
+<sup>7&#160;</sup>‘Come, Zion! Escape, you who dwell with the daughter of Babylon.’ 
+<sup>8&#160;</sup>For Yahweh of Armies says: ‘For honor he has sent me to the nations which plundered you; for he who touches you touches the apple of his eye. 
+<sup>9&#160;</sup>For, behold, I will shake my hand over them, and they will be a plunder to those who served them; and you will know that Yahweh of Armies has sent me. 
+<sup>10&#160;</sup>Sing and rejoice, daughter of Zion! For behold, I come and I will dwell within you,’ says Yahweh. 
+<sup>11&#160;</sup>Many nations shall join themselves to Yahweh in that day, and shall be my people; and I will dwell among you, and you shall know that Yahweh of Armies has sent me to you. 
+<sup>12&#160;</sup>Yahweh will inherit Judah as his portion in the set-apart land, and will again choose Jerusalem. 
+<sup>13&#160;</sup>Be silent, all flesh, before Yahweh; for he has roused himself from his set-apart habitation!” 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>He showed me Joshua the high priest standing before Yahweh’s angel, and Satan standing at his right hand to be his adversary. 
+<sup>2&#160;</sup>Yahweh said to Satan, “Yahweh rebuke you, Satan! Yes, Yahweh who has chosen Jerusalem rebuke you! Isn’t this a burning stick plucked out of the fire?” 
+</div><div class="p">
+<sup>3&#160;</sup>Now Joshua was clothed with filthy garments, and was standing before the angel. 
+<sup>4&#160;</sup>He answered and spoke to those who stood before him, saying, “Take the filthy garments off him.” To him he said, “Behold, I have caused your iniquity to pass from you, and I will clothe you with rich clothing.” 
+</div><div class="p">
+<sup>5&#160;</sup>I said, “Let them set a clean turban on his head.” 
+</div><div class="p">So they set a clean turban on his head, and clothed him; and Yahweh’s angel was standing by. 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh’s angel solemnly assured Joshua, saying, 
+<sup>7&#160;</sup>“Yahweh of Armies says: ‘If you will walk in my ways, and if you will follow my instructions, then you also shall judge my house, and shall also keep my courts, and I will give you a place of access among these who stand by. 
+<sup>8&#160;</sup>Hear now, Joshua the high priest, you and your fellows who sit before you, for they are men who are a sign; for, behold, I will bring out my servant, the Branch. 
+<sup>9&#160;</sup>For, behold, the stone that I have set before Joshua: on one stone are seven eyes; behold, I will engrave its inscription,’ says Yahweh of Armies, ‘and I will remove the iniquity of that land in one day. 
+<sup>10&#160;</sup>In that day,’ says Yahweh of Armies, ‘you will invite every man his neighbor under the vine and under the fig tree.’&#160;” 
+</div><h2 class="chapterlabel" id="4">4</h2>
+<div class="p">
+<sup>1&#160;</sup>The angel who talked with me came again and wakened me, as a man who is wakened out of his sleep. 
+<sup>2&#160;</sup>He said to me, “What do you see?” 
+</div><div class="p">I said, “I have seen, and behold, a lamp stand all of gold, with its bowl on the top of it, and its seven lamps on it; there are seven pipes to each of the lamps which are on the top of it; 
+<sup>3&#160;</sup>and two olive trees by it, one on the right side of the bowl, and the other on the left side of it.” 
+</div><div class="p">
+<sup>4&#160;</sup>I answered and spoke to the angel who talked with me, saying, “What are these, my lord?” 
+</div><div class="p">
+<sup>5&#160;</sup>Then the angel who talked with me answered me, “Don’t you know what these are?” 
+</div><div class="p">I said, “No, my lord.” 
+</div><div class="p">
+<sup>6&#160;</sup>Then he answered and spoke to me, saying, “This is Yahweh’s word to Zerubbabel, saying, ‘Not by might, nor by power, but by my Spirit,’ says Yahweh of Armies. 
+<sup>7&#160;</sup>Who are you, great mountain? Before Zerubbabel you are a plain; and he will bring out the capstone with shouts of ‘Grace, grace, to it!’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>Moreover Yahweh’s word came to me, saying, 
+<sup>9&#160;</sup>“The hands of Zerubbabel have laid the foundation of this house. His hands shall also finish it; and you will know that Yahweh of Armies has sent me to you. 
+<sup>10&#160;</sup>Indeed, who despises the day of small things? For these seven shall rejoice, and shall see the plumb line in the hand of Zerubbabel. These are Yahweh’s eyes, which run back and forth through the whole earth.” 
+</div><div class="p">
+<sup>11&#160;</sup>Then I asked him, “What are these two olive trees on the right side of the lamp stand and on the left side of it?” 
+</div><div class="p">
+<sup>12&#160;</sup>I asked him the second time, “What are these two olive branches, which are beside the two golden spouts that pour the golden oil out of themselves?” 
+</div><div class="p">
+<sup>13&#160;</sup>He answered me, “Don’t you know what these are?” 
+</div><div class="p">I said, “No, my lord.” 
+</div><div class="p">
+<sup>14&#160;</sup>Then he said, “These are the two anointed ones who stand by the Lord of the whole earth.” 
+</div><h2 class="chapterlabel" id="5">5</h2>
+<div class="p">
+<sup>1&#160;</sup>Then again I lifted up my eyes and saw, and behold, a flying scroll. 
+<sup>2&#160;</sup>He said to me, “What do you see?” 
+</div><div class="p">I answered, “I see a flying scroll; its length is twenty cubits, and its width ten cubits.” 
+</div><div class="p">
+<sup>3&#160;</sup>Then he said to me, “This is the curse that goes out over the surface of the whole land, for everyone who steals shall be cut off according to it on the one side; and everyone who swears falsely shall be cut off according to it on the other side. 
+<sup>4&#160;</sup>I will cause it to go out,” says Yahweh of Armies, “and it will enter into the house of the thief, and into the house of him who swears falsely by my name; and it will remain in the middle of his house, and will destroy it with its timber and its stones.” 
+</div><div class="p">
+<sup>5&#160;</sup>Then the angel who talked with me came forward and said to me, “Lift up now your eyes and see what this is that is appearing.” 
+</div><div class="p">
+<sup>6&#160;</sup>I said, “What is it?” 
+</div><div class="p">He said, “This is the ephah basket.” 
+<sup>8&#160;</sup>He said, “This is Wickedness;” and he threw her down into the middle of the ephah basket; and he threw the lead weight on its mouth. 
+</div><div class="p">
+<sup>9&#160;</sup>Then I lifted up my eyes and saw, and behold, there were two women; and the wind was in their wings. Now they had wings like the wings of a stork, and they lifted up the ephah basket between earth and the sky. 
+<sup>10&#160;</sup>Then I said to the angel who talked with me, “Where are these carrying the ephah basket?” 
+</div><div class="p">
+<sup>11&#160;</sup>He said to me, “To build her a house in the land of Shinar. When it is prepared, she will be set there in her own place.” 
+</div><h2 class="chapterlabel" id="6">6</h2>
+<div class="p">
+<sup>1&#160;</sup>Again I lifted up my eyes, and saw, and behold, four chariots came out from between two mountains; and the mountains were mountains of bronze. 
+<sup>2&#160;</sup>In the first chariot were red horses. In the second chariot were black horses. 
+<sup>3&#160;</sup>In the third chariot were white horses. In the fourth chariot were dappled horses, all of them powerful. 
+<sup>4&#160;</sup>Then I asked the angel who talked with me, “What are these, my lord?” 
+</div><div class="p">
+<sup>5&#160;</sup>The angel answered me, “These are the four winds of the sky, which go out from standing before the Lord of all the earth. 
+<sup>6&#160;</sup>The one with the black horses goes out toward the north country; and the white went out after them; and the dappled went out toward the south country.” 
+<sup>7&#160;</sup>The strong went out, and sought to go that they might walk back and forth through the earth. He said, “Go around and through the earth!” So they walked back and forth through the earth. 
+</div><div class="p">
+<sup>8&#160;</sup>Then he called to me, and spoke to me, saying, “Behold, those who go toward the north country have quieted my spirit in the north country.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh’s word came to me, saying, 
+<sup>10&#160;</sup>“Take of them of the captivity, even of Heldai, of Tobijah, and of Jedaiah; and come the same day, and go into the house of Josiah the son of Zephaniah, where they have come from Babylon. 
+<sup>11&#160;</sup>Yes, take silver and gold, and make crowns, and set them on the head of Joshua the son of Jehozadak, the high priest; 
+<sup>12&#160;</sup>and speak to him, saying, ‘Yahweh of Armies says, “Behold, the man whose name is the Branch! He will grow up out of his place; and he will build Yahweh’s temple. 
+<sup>13&#160;</sup>He will build Yahweh’s temple. He will bear the glory, and will sit and rule on his throne. He will be a priest on his throne. The counsel of peace will be between them both. 
+<sup>14&#160;</sup>The crowns shall be to Helem, to Tobijah, to Jedaiah, and to Hen the son of Zephaniah, for a memorial in Yahweh’s temple. 
+</div><div class="p">
+<sup>15&#160;</sup>Those who are far off shall come and build in Yahweh’s temple; and you shall know that Yahweh of Armies has sent me to you. This will happen, if you will diligently obey Yahweh your Elohim’s voice.”&#160;’&#160;” 
+</div><h2 class="chapterlabel" id="7">7</h2>
+<div class="p">
+<sup>1&#160;</sup>In the fourth year of King Darius, Yahweh’s word came to Zechariah in the fourth day of the ninth month, the month of Chislev. 
+<sup>2&#160;</sup>The people of Bethel sent Sharezer and Regem Melech and their men to entreat Yahweh’s favor, 
+<sup>3&#160;</sup>and to speak to the priests of the house of Yahweh of Armies and to the prophets, saying, “Should I weep in the fifth month, separating myself, as I have done these so many years?” 
+</div><div class="p">
+<sup>4&#160;</sup>Then the word of Yahweh of Armies came to me, saying, 
+<sup>5&#160;</sup>“Speak to all the people of the land and to the priests, saying, ‘When you fasted and mourned in the fifth and in the seventh month for these seventy years, did you at all fast to me, really to me? 
+<sup>6&#160;</sup>When you eat and when you drink, don’t you eat for yourselves and drink for yourselves? 
+<sup>7&#160;</sup>Aren’t these the words which Yahweh proclaimed by the former prophets when Jerusalem was inhabited and in prosperity, and its cities around her, and the South and the lowland were inhabited?’&#160;” 
+</div><div class="p">
+<sup>8&#160;</sup>Yahweh’s word came to Zechariah, saying, 
+<sup>9&#160;</sup>“Thus has Yahweh of Armies spoken, saying, ‘Execute true judgment, and show kindness and compassion every man to his brother. 
+<sup>10&#160;</sup>Don’t oppress the widow, the fatherless, the foreigner, nor the poor; and let none of you devise evil against his brother in your heart.’ 
+<sup>11&#160;</sup>But they refused to listen, and turned their backs, and stopped their ears, that they might not hear. 
+<sup>12&#160;</sup>Yes, they made their hearts as hard as flint, lest they might hear the law and the words which Yahweh of Armies had sent by his Spirit by the former prophets. Therefore great wrath came from Yahweh of Armies. 
+<sup>13&#160;</sup>It has come to pass that, as he called and they refused to listen, so they will call and I will not listen,” said Yahweh of Armies; 
+<sup>14&#160;</sup>“but I will scatter them with a whirlwind among all the nations which they have not known. Thus the land was desolate after them, so that no man passed through nor returned; for they made the pleasant land desolate.” 
+</div><h2 class="chapterlabel" id="8">8</h2>
+<div class="p">
+<sup>1&#160;</sup>The word of Yahweh of Armies came to me. 
+<sup>2&#160;</sup>Yahweh of Armies says: “I am jealous for Zion with great jealousy, and I am jealous for her with great wrath.” 
+</div><div class="p">
+<sup>3&#160;</sup>Yahweh says: “I have returned to Zion, and will dwell in the middle of Jerusalem. Jerusalem shall be called ‘The City of Truth;’ and the mountain of Yahweh of Armies, ‘The Set-Apart Mountain.’&#160;” 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh of Armies says: “Old men and old women will again dwell in the streets of Jerusalem, every man with his staff in his hand because of their old age. 
+<sup>5&#160;</sup>The streets of the city will be full of boys and girls playing in its streets.” 
+</div><div class="p">
+<sup>6&#160;</sup>Yahweh of Armies says: “If it is marvelous in the eyes of the remnant of this people in those days, should it also be marvelous in my eyes?” says Yahweh of Armies. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh of Armies says: “Behold, I will save my people from the east country and from the west country. 
+<sup>8&#160;</sup>I will bring them, and they will dwell within Jerusalem. They will be my people, and I will be their Elohim, in truth and in righteousness.” 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh of Armies says: “Let your hands be strong, you who hear in these days these words from the mouth of the prophets who were in the day that the foundation of the house of Yahweh of Armies was laid, even the temple, that it might be built. 
+<sup>10&#160;</sup>For before those days there was no wages for man nor any wages for an animal, neither was there any peace to him who went out or came in, because of the adversary. For I set all men everyone against his neighbor. 
+<sup>11&#160;</sup>But now I will not be to the remnant of this people as in the former days,” says Yahweh of Armies. 
+<sup>12&#160;</sup>“For the seed of peace and the vine will yield its fruit, and the ground will give its increase, and the heavens will give their dew. I will cause the remnant of this people to inherit all these things. 
+<sup>13&#160;</sup>It shall come to pass that, as you were a curse among the nations, house of Judah and house of Israel, so I will save you, and you shall be a blessing. Don’t be afraid. Let your hands be strong.” 
+</div><div class="p">
+<sup>14&#160;</sup>For Yahweh of Armies says: “As I thought to do evil to you when your fathers provoked me to wrath,” says Yahweh of Armies, “and I didn’t repent, 
+<sup>15&#160;</sup>so again I have thought in these days to do good to Jerusalem and to the house of Judah. Don’t be afraid. 
+<sup>16&#160;</sup>These are the things that you shall do: speak every man the truth with his neighbor. Execute the judgment of truth and peace in your gates, 
+<sup>17&#160;</sup>and let none of you devise evil in your hearts against his neighbor, and love no false oath; for all these are things that I hate,” says Yahweh. 
+</div><div class="p">
+<sup>18&#160;</sup>The word of Yahweh of Armies came to me. 
+<sup>19&#160;</sup>Yahweh of Armies says: “The fasts of the fourth, fifth, seventh, and tenth months shall be for the house of Judah joy, gladness, and cheerful feasts. Therefore love truth and peace.” 
+</div><div class="p">
+<sup>20&#160;</sup>Yahweh of Armies says: “Many peoples and the inhabitants of many cities will yet come. 
+<sup>21&#160;</sup>The inhabitants of one will go to another, saying, ‘Let’s go speedily to entreat the favor of Yahweh, and to seek Yahweh of Armies. I will go also.’ 
+<sup>22&#160;</sup>Yes, many peoples and strong nations will come to seek Yahweh of Armies in Jerusalem and to entreat the favor of Yahweh.” 
+<sup>23&#160;</sup>Yahweh of Armies says: “In those days, ten men out of all the languages of the nations will take hold of the skirt of him who is a Jew, saying, ‘We will go with you, for we have heard that Elohim is with you.’&#160;” 
+</div><h2 class="chapterlabel" id="9">9</h2>
+<div class="p">
+<sup>1&#160;</sup>A revelation. 
+</div><div class="q1">Yahweh’s word is against the land of Hadrach, 
+</div><div class="q2">and will rest upon Damascus—</div><div class="q1">for the eye of man 
+</div><div class="q2">and of all the tribes of Israel is toward Yahweh—</div><div class="q1">
+<sup>2&#160;</sup>and Hamath, also, which borders on it, 
+</div><div class="q2">Tyre and Sidon, because they are very wise. 
+</div><div class="q1">
+<sup>3&#160;</sup>Tyre built herself a stronghold, 
+</div><div class="q2">and heaped up silver like the dust, 
+</div><div class="q2">and fine gold like the mire of the streets. 
+</div><div class="q1">
+<sup>4&#160;</sup>Behold, the Lord will dispossess her, 
+</div><div class="q2">and he will strike her power in the sea; 
+</div><div class="q2">and she will be devoured with fire. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>5&#160;</sup>Ashkelon will see it, and fear; 
+</div><div class="q2">Gaza also, and will writhe in agony; 
+</div><div class="q2">as will Ekron, for her expectation will be disappointed; 
+</div><div class="q2">and the king will perish from Gaza, 
+</div><div class="q2">and Ashkelon will not be inhabited. 
+</div><div class="q1">
+<sup>6&#160;</sup>Foreigners will dwell in Ashdod, 
+</div><div class="q2">and I will cut off the pride of the Philistines. 
+</div><div class="q1">
+<sup>7&#160;</sup>I will take away his blood out of his mouth, 
+</div><div class="q2">and his abominations from between his teeth; 
+</div><div class="q1">and he also will be a remnant for our Elohim; 
+</div><div class="q2">and he will be as a chieftain in Judah, 
+</div><div class="q2">and Ekron as a Jebusite. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will encamp around my house against the army, 
+</div><div class="q2">that no one pass through or return; 
+</div><div class="q2">and no oppressor will pass through them any more: 
+</div><div class="q2">for now I have seen with my eyes. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>9&#160;</sup>Rejoice greatly, daughter of Zion! 
+</div><div class="q2">Shout, daughter of Jerusalem! 
+</div><div class="q1">Behold, your King comes to you! 
+</div><div class="q2">He is righteous, and having salvation; 
+</div><div class="q2">lowly, and riding on a donkey, 
+</div><div class="q2">even on a colt, the foal of a donkey. 
+</div><div class="q1">
+<sup>10&#160;</sup>I will cut off the chariot from Ephraim 
+</div><div class="q2">and the horse from Jerusalem. 
+</div><div class="q1">The battle bow will be cut off; 
+</div><div class="q2">and he will speak peace to the nations. 
+</div><div class="q1">His dominion will be from sea to sea, 
+</div><div class="q2">and from the River to the ends of the earth. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>11&#160;</sup>As for you also, 
+</div><div class="q2">because of the blood of your covenant, 
+</div><div class="q2">I have set free your prisoners from the pit in which is no water. 
+</div><div class="q1">
+<sup>12&#160;</sup>Turn to the stronghold, you prisoners of hope! 
+</div><div class="q2">Even today I declare that I will restore double to you. 
+</div><div class="q1">
+<sup>13&#160;</sup>For indeed I bend Judah as a bow for me. 
+</div><div class="q2">I have loaded the bow with Ephraim. 
+</div><div class="q1">I will stir up your sons, Zion, 
+</div><div class="q2">against your sons, Greece, 
+</div><div class="q2">and will make you like the sword of a mighty man. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>14&#160;</sup>Yahweh will be seen over them. 
+</div><div class="q2">His arrow will flash like lightning. 
+</div><div class="q1">The Lord Yahweh will blow the trumpet, 
+</div><div class="q2">and will go with whirlwinds of the south. 
+</div><div class="q1">
+<sup>15&#160;</sup>Yahweh of Armies will defend them. 
+</div><div class="q2">They will destroy and overcome with sling stones. 
+</div><div class="q1">They will drink, and roar as through wine. 
+</div><div class="q2">They will be filled like bowls, 
+</div><div class="q2">like the corners of the altar. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>16&#160;</sup>Yahweh their Elohim will save them in that day as the flock of his people; 
+</div><div class="q2">for they are like the jewels of a crown, 
+</div><div class="q2">lifted on high over his land. 
+</div><div class="q1">
+<sup>17&#160;</sup>For how great is his goodness, 
+</div><div class="q2">and how great is his beauty! 
+</div><div class="q1">Grain will make the young men flourish, 
+</div><div class="q2">and new wine the virgins. 
+</div><h2 class="chapterlabel" id="10">10</h2>
+<div class="q1">
+<sup>1&#160;</sup>Ask of Yahweh rain in the spring time, 
+</div><div class="q2">Yahweh who makes storm clouds, 
+</div><div class="q2">and he gives rain showers to everyone for the plants in the field. 
+</div><div class="q1">
+<sup>2&#160;</sup>For the teraphim have spoken vanity, 
+</div><div class="q2">and the diviners have seen a lie; 
+</div><div class="q2">and they have told false dreams. 
+</div><div class="q1">They comfort in vain. 
+</div><div class="q2">Therefore they go their way like sheep. 
+</div><div class="q2">They are oppressed, because there is no shepherd. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>3&#160;</sup>My anger is kindled against the shepherds, 
+</div><div class="q2">and I will punish the male goats, 
+</div><div class="q2">for Yahweh of Armies has visited his flock, the house of Judah, 
+</div><div class="q2">and will make them as his majestic horse in the battle. 
+</div><div class="q1">
+<sup>4&#160;</sup>From him will come the cornerstone, 
+</div><div class="q2">from him the tent peg, 
+</div><div class="q2">from him the battle bow, 
+</div><div class="q2">from him every ruler together. 
+</div><div class="q2">
+<sup>5&#160;</sup>They will be as mighty men, 
+</div><div class="q2">treading down muddy streets in the battle. 
+</div><div class="q1">They will fight, because Yahweh is with them. 
+</div><div class="q2">The riders on horses will be confounded. 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>6&#160;</sup>“I will strengthen the house of Judah, 
+</div><div class="q2">and I will save the house of Joseph. 
+</div><div class="q1">I will bring them back, 
+</div><div class="q2">for I have mercy on them. 
+</div><div class="q1">They will be as though I had not cast them off, 
+</div><div class="q2">for I am Yahweh their Elohim, and I will hear them. 
+</div><div class="q1">
+<sup>7&#160;</sup>Ephraim will be like a mighty man, 
+</div><div class="q2">and their heart will rejoice as through wine. 
+</div><div class="q1">Yes, their children will see it and rejoice. 
+</div><div class="q2">Their heart will be glad in Yahweh. 
+</div><div class="q1">
+<sup>8&#160;</sup>I will signal for them and gather them, 
+</div><div class="q2">for I have redeemed them. 
+</div><div class="q2">They will increase as they were before. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will sow them among the peoples. 
+</div><div class="q2">They will remember me in far countries. 
+</div><div class="q2">They will live with their children and will return. 
+</div><div class="q1">
+<sup>10&#160;</sup>I will bring them again also out of the land of Egypt, 
+</div><div class="q2">and gather them out of Assyria. 
+</div><div class="q1">I will bring them into the land of Gilead and Lebanon; 
+</div><div class="q2">and there won’t be room enough for them. 
+</div><div class="q1">
+<sup>11&#160;</sup>He will pass through the sea of affliction, 
+</div><div class="q2">and will strike the waves in the sea, 
+</div><div class="q2">and all the depths of the Nile will dry up; 
+</div><div class="q2">and the pride of Assyria will be brought down, 
+</div><div class="q2">and the scepter of Egypt will depart. 
+</div><div class="q1">
+<sup>12&#160;</sup>I will strengthen them in Yahweh. 
+</div><div class="q2">They will walk up and down in his name,” says Yahweh. 
+</div><h2 class="chapterlabel" id="11">11</h2>
+<div class="q1">
+<sup>1&#160;</sup>Open your doors, Lebanon, 
+</div><div class="q2">that the fire may devour your cedars. 
+</div><div class="q1">
+<sup>2&#160;</sup>Wail, cypress tree, for the cedar has fallen, 
+</div><div class="q2">because the stately ones are destroyed. 
+</div><div class="q1">Wail, you oaks of Bashan, 
+</div><div class="q2">for the strong forest has come down. 
+</div><div class="q1">
+<sup>3&#160;</sup>A voice of the wailing of the shepherds! 
+</div><div class="q2">For their glory is destroyed—a voice of the roaring of young lions! 
+</div><div class="q2">For the pride of the Jordan is ruined. 
+</div><div class="p">
+<sup>4&#160;</sup>Yahweh my Elohim says: “Feed the flock of slaughter. 
+<sup>5&#160;</sup>Their buyers slaughter them and go unpunished. Those who sell them say, ‘Blessed be Yahweh, for I am rich;’ and their own shepherds don’t pity them. 
+<sup>6&#160;</sup>For I will no more pity the inhabitants of the land,” says Yahweh; “but, behold, I will deliver every one of the men into his neighbor’s hand and into the hand of his king. They will strike the land, and out of their hand I will not deliver them.” 
+</div><div class="p">
+<sup>7&#160;</sup>So I fed the flock to be slaughtered, especially the oppressed of the flock. I took for myself two staffs. The one I called “Favor” and the other I called “Union”, and I fed the flock. 
+<sup>8&#160;</sup>I cut off the three shepherds in one month; for my soul was weary of them, and their soul also loathed me. 
+<sup>9&#160;</sup>Then I said, “I will not feed you. That which dies, let it die; and that which is to be cut off, let it be cut off; and let those who are left eat each other’s flesh.” 
+<sup>10&#160;</sup>I took my staff Favor and cut it apart, that I might break my covenant that I had made with all the peoples. 
+<sup>11&#160;</sup>It was broken in that day; and thus the poor of the flock that listened to me knew that it was Yahweh’s word. 
+<sup>12&#160;</sup>I said to them, “If you think it best, give me my wages; and if not, keep them.” So they weighed for my wages thirty pieces of silver. 
+<sup>13&#160;</sup>Yahweh said to me, “Throw it to the potter—the handsome price that I was valued at by them!” I took the thirty pieces of silver and threw them to the potter in Yahweh’s house. 
+<sup>14&#160;</sup>Then I cut apart my other staff, Union, that I might break the brotherhood between Judah and Israel. 
+</div><div class="p">
+<sup>15&#160;</sup>Yahweh said to me, “Take for yourself yet again the equipment of a foolish shepherd. 
+<sup>16&#160;</sup>For, behold, I will raise up a shepherd in the land who will not visit those who are cut off, neither will seek those who are scattered, nor heal that which is broken, nor feed that which is sound; but he will eat the meat of the fat sheep, and will tear their hoofs in pieces. 
+<sup>17&#160;</sup>Woe to the worthless shepherd who leaves the flock! The sword will strike his arm and his right eye. His arm will be completely withered, and his right eye will be totally blinded!” 
+</div><h2 class="chapterlabel" id="12">12</h2>
+<div class="p">
+<sup>1&#160;</sup>A revelation of Yahweh’s word concerning Israel: Yahweh, who stretches out the heavens and lays the foundation of the earth, and forms the spirit of man within him says: 
+<sup>2&#160;</sup>“Behold, I will make Jerusalem a cup of reeling to all the surrounding peoples, and it will also be on Judah in the siege against Jerusalem. 
+<sup>3&#160;</sup>It will happen in that day that I will make Jerusalem a burdensome stone for all the peoples. All who burden themselves with it will be severely wounded, and all the nations of the earth will be gathered together against it. 
+<sup>4&#160;</sup>In that day,” says Yahweh, “I will strike every horse with terror and his rider with madness. I will open my eyes on the house of Judah, and will strike every horse of the peoples with blindness. 
+<sup>5&#160;</sup>The chieftains of Judah will say in their heart, ‘The inhabitants of Jerusalem are my strength in Yahweh of Armies their Elohim.’ 
+</div><div class="p">
+<sup>6&#160;</sup>In that day I will make the chieftains of Judah like a pan of fire among wood, and like a flaming torch among sheaves. They will devour all the surrounding peoples on the right hand and on the left; and Jerusalem will yet again dwell in their own place, even in Jerusalem. 
+</div><div class="p">
+<sup>7&#160;</sup>Yahweh also will save the tents of Judah first, that the glory of David’s house and the glory of the inhabitants of Jerusalem not be magnified above Judah. 
+<sup>8&#160;</sup>In that day Yahweh will defend the inhabitants of Jerusalem. He who is feeble among them at that day will be like David, and David’s house will be like Elohim, like Yahweh’s angel before them. 
+<sup>9&#160;</sup>It will happen in that day, that I will seek to destroy all the nations that come against Jerusalem. 
+</div><div class="p">
+<sup>10&#160;</sup>I will pour on David’s house and on the inhabitants of Jerusalem the spirit of grace and of supplication. They will look to me whom they have pierced; and they shall mourn for him as one mourns for his only son, and will grieve bitterly for him as one grieves for his firstborn. 
+<sup>11&#160;</sup>In that day there will be a great mourning in Jerusalem, like the mourning of Hadadrimmon in the valley of Megiddo. 
+<sup>12&#160;</sup>The land will mourn, every family apart; the family of David’s house apart, and their women apart; the family of the house of Nathan apart, and their women apart; 
+<sup>13&#160;</sup>the family of the house of Levi apart, and their women apart; the family of the Shimeites apart, and their women apart; 
+<sup>14&#160;</sup>all the families who remain, every family apart, and their women apart. 
+</div><h2 class="chapterlabel" id="13">13</h2>
+<div class="p">
+<sup>1&#160;</sup>“In that day there will be a fountain opened to David’s house and to the inhabitants of Jerusalem, for sin and for uncleanness. 
+</div><div class="p">
+<sup>2&#160;</sup>It will come to pass in that day, says Yahweh of Armies, that I will cut off the names of the idols out of the land, and they will be remembered no more. I will also cause the prophets and the spirit of impurity to pass out of the land. 
+<sup>3&#160;</sup>It will happen that when anyone still prophesies, then his father and his mother who bore him will tell him, ‘You must die, because you speak lies in Yahweh’s name;’ and his father and his mother who bore him will stab him when he prophesies. 
+<sup>4&#160;</sup>It will happen in that day that the prophets will each be ashamed of his vision when he prophesies; they won’t wear a hairy mantle to deceive, 
+<sup>5&#160;</sup>but he will say, ‘I am no prophet, I am a tiller of the ground; for I have been made a bondservant from my youth.’ 
+<sup>6&#160;</sup>One will say to him, ‘What are these wounds between your arms?’ Then he will answer, ‘Those with which I was wounded in the house of my friends.’ 
+</div><div class="b"> &#160; </div>
+<div class="q1">
+<sup>7&#160;</sup>“Awake, sword, against my shepherd, 
+</div><div class="q2">and against the man who is close to me,” says Yahweh of Armies. 
+</div><div class="q1">“Strike the shepherd, and the sheep will be scattered; 
+</div><div class="q2">and I will turn my hand against the little ones. 
+</div><div class="q1">
+<sup>8&#160;</sup>It shall happen that in all the land,” says Yahweh, 
+</div><div class="q2">“two parts in it will be cut off and die; 
+</div><div class="q2">but the third will be left in it. 
+</div><div class="q1">
+<sup>9&#160;</sup>I will bring the third part into the fire, 
+</div><div class="q2">and will refine them as silver is refined, 
+</div><div class="q2">and will test them like gold is tested. 
+</div><div class="q1">They will call on my name, and I will hear them. 
+</div><div class="q2">I will say, ‘It is my people;’ 
+</div><div class="q2">and they will say, ‘Yahweh is my Elohim.’&#160;” 
+</div><h2 class="chapterlabel" id="14">14</h2>
+<div class="p">
+<sup>1&#160;</sup>Behold, a day of Yahweh comes, when your plunder will be divided within you. 
+<sup>2&#160;</sup>For I will gather all nations against Jerusalem to battle; and the city will be taken, the houses rifled, and the women ravished. Half of the city will go out into captivity, and the rest of the people will not be cut off from the city. 
+<sup>3&#160;</sup>Then Yahweh will go out and fight against those nations, as when he fought in the day of battle. 
+<sup>4&#160;</sup>His feet will stand in that day on the Mount of Olives, which is before Jerusalem on the east; and the Mount of Olives will be split in two from east to west, making a very great valley. Half of the mountain will move toward the north, and half of it toward the south. 
+<sup>5&#160;</sup>You shall flee by the valley of my mountains, for the valley of the mountains shall reach to Azel. Yes, you shall flee, just like you fled from before the earthquake in the days of Uzziah king of Judah. Yahweh my Elohim will come, and all the set-apart ones with you. 
+</div><div class="p">
+<sup>6&#160;</sup>It will happen in that day that there will not be light, cold, or frost. 
+<sup>7&#160;</sup>It will be a unique day which is known to Yahweh—not day, and not night; but it will come to pass that at evening time there will be light. 
+</div><div class="p">
+<sup>8&#160;</sup>It will happen in that day that living waters will go out from Jerusalem, half of them toward the eastern sea, and half of them toward the western sea. It will be so in summer and in winter. 
+</div><div class="p">
+<sup>9&#160;</sup>Yahweh will be King over all the earth. In that day Yahweh will be one, and his name one. 
+</div><div class="p">
+<sup>10&#160;</sup>All the land will be made like the Arabah, from Geba to Rimmon south of Jerusalem; and she will be lifted up and will dwell in her place, from Benjamin’s gate to the place of the first gate, to the corner gate, and from the tower of Hananel to the king’s wine presses. 
+<sup>11&#160;</sup>Men will dwell therein, and there will be no more curse; but Jerusalem will dwell safely. 
+</div><div class="p">
+<sup>12&#160;</sup>This will be the plague with which Yahweh will strike all the peoples who have fought against Jerusalem: their flesh will consume away while they stand on their feet, and their eyes will consume away in their sockets, and their tongue will consume away in their mouth. 
+<sup>13&#160;</sup>It will happen in that day that a great panic from Yahweh will be among them; and they will each seize the hand of his neighbor, and his hand will rise up against the hand of his neighbor. 
+<sup>14&#160;</sup>Judah also will fight at Jerusalem; and the wealth of all the surrounding nations will be gathered together: gold, silver, and clothing, in great abundance. 
+</div><div class="p">
+<sup>15&#160;</sup>A plague like this will fall on the horse, on the mule, on the camel, on the donkey, and on all the animals that will be in those camps. 
+</div><div class="p">
+<sup>16&#160;</sup>It will happen that everyone who is left of all the nations that came against Jerusalem will go up from year to year to worship the King, Yahweh of Armies, and to keep the feast of booths. 
+<sup>17&#160;</sup>It will be that whoever of all the families of the earth doesn’t go up to Jerusalem to worship the King, Yahweh of Armies, on them there will be no rain. 
+<sup>18&#160;</sup>If the family of Egypt doesn’t go up and doesn’t come, neither will it rain on them. This will be the plague with which Yahweh will strike the nations that don’t go up to keep the feast of booths. 
+<sup>19&#160;</sup>This will be the punishment of Egypt and the punishment of all the nations that don’t go up to keep the feast of booths. 
+</div><div class="p">
+<sup>20&#160;</sup>In that day there will be inscribed on the bells of the horses, “SET-APART TO YAHWEH”; and the pots in Yahweh’s house will be like the bowls before the altar. 
+<sup>21&#160;</sup>Yes, every pot in Jerusalem and in Judah will be set-apart to Yahweh of Armies; and all those who sacrifice will come and take of them, and cook in them. In that day there will no longer be a Canaanite in the house of Yahweh of Armies. </div></div><script src="../main.js"></script></body></html>

--- a/book/zephaniah.html
+++ b/book/zephaniah.html
@@ -3,6 +3,47 @@
 <head>
 <title>Zephaniah</title>
 <meta charset="utf-8" />
+<style>
+sup {
+ display: none;
+}
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
+ text-indent: 2em;
+}
+.p1 {
+ text-indent: 0;
+}
+.d {
+ text-indent: 0;
+}
+.li1 {
+ display: list-item;
+ list-style-type: none;
+}
+.sp {
+ margin-top: 0.5em;
+ font-style: italic;
+}
+.pi1 {
+ margin-left: 2em;
+}
+html[dir=ltr] .q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+html[dir=ltr] .q2 {
+ text-indent: -1em;
+ margin-left: 2em;
+}
+.q1 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+.q2 {
+ text-indent: -2em;
+ margin-left: 2em;
+}
+</style>
 <link rel="stylesheet" type="text/css" href="../style.css" />
 <link rel="shortcut icon" type="image/png" href="../book.png" />
 <meta name="viewport" content="user-scalable=yes, initial-scale=1, minimum-scale=1, width=device-width" />
@@ -12,73 +53,77 @@
 <div class="main">
 <!-- ZEP World English Scripture (WES) -->
 <h1 class="booklabel">Zephaniah</h1>
-<h2 class="chapterlabel" id="1">1</h2>
-<p class="p1">
-<span class="v">1&#160;</span>Yahweh’s<span class="f">+ \fr 1:1 \ft “Yahweh” is Elohim’s proper Name, sometimes rendered “LORD” (all caps) in other translations.</span> word which came to Zephaniah, the son of Cushi, the son of Gedaliah, the son of Amariah, the son of Hezekiah, in the days of Josiah, the son of Amon, king of Judah. 
-</p><p>
-<span class="v">2&#160;</span>I will utterly sweep away everything from the surface of the earth, says Yahweh. 
-<span class="v">3&#160;</span>I will sweep away man and animal. I will sweep away the birds of the sky, the fish of the sea, and the heaps of rubble with the wicked. I will cut off man from the surface of the earth, says Yahweh. 
-<span class="v">4&#160;</span>I will stretch out my hand against Judah and against all the inhabitants of Jerusalem. I will cut off the remnant of Baal from this place—the name of the idolatrous and pagan priests, 
-<span class="v">5&#160;</span>those who worship the army of the sky on the housetops, those who worship and swear by Yahweh and also swear by Malcam, 
-<span class="v">6&#160;</span>those who have turned back from following Yahweh, and those who haven’t sought Yahweh nor inquired after him. 
-</p><p>
-<span class="v">7&#160;</span>Be silent at the presence of the Lord<span class="f">+ \fr 1:7 \ft The word translated “Lord” is “Adonai.”</span> Yahweh, for the day of Yahweh is at hand. For Yahweh has prepared a sacrifice. He has consecrated his guests. 
-<span class="v">8&#160;</span>It will happen in the day of Yahweh’s sacrifice that I will punish the princes, the king’s sons, and all those who are clothed with foreign clothing. 
-<span class="v">9&#160;</span>In that day, I will punish all those who leap over the threshold, who fill their master’s house with violence and deceit. 
-</p><p>
-<span class="v">10&#160;</span>In that day, says Yahweh, there will be the noise of a cry from the fish gate, a wailing from the second quarter, and a great crashing from the hills. 
-<span class="v">11&#160;</span>Wail, you inhabitants of Maktesh, for all the people of Canaan are undone! All those who were loaded with silver are cut off. 
-<span class="v">12&#160;</span>It will happen at that time, that I will search Jerusalem with lamps, and I will punish the men who are settled on their dregs, who say in their heart, “Yahweh will not do good, neither will he do evil.” 
-<span class="v">13&#160;</span>Their wealth will become a plunder, and their houses a desolation. Yes, they will build houses, but won’t inhabit them. They will plant vineyards, but won’t drink their wine. 
-</p><p>
-<span class="v">14&#160;</span>The great day of Yahweh is near. It is near and hurries greatly, the voice of the day of Yahweh. The mighty man cries there bitterly. 
-<span class="v">15&#160;</span>That day is a day of wrath, a day of distress and anguish, a day of trouble and ruin, a day of darkness and gloom, a day of clouds and blackness, 
-<span class="v">16&#160;</span>a day of the trumpet and alarm against the fortified cities and against the high battlements. 
-<span class="v">17&#160;</span>I will bring such distress on men that they will walk like blind men because they have sinned against Yahweh. Their blood will be poured out like dust and their flesh like dung. 
-<span class="v">18&#160;</span>Neither their silver nor their gold will be able to deliver them in the day of Yahweh’s wrath, but the whole land will be devoured by the fire of his jealousy; for he will make an end, yes, a terrible end, of all those who dwell in the land. 
-</p><h2 class="chapterlabel" id="2">2</h2>
-<p>
-<span class="v">1&#160;</span>Gather yourselves together, yes, gather together, you nation that has no shame, 
-<span class="v">2&#160;</span>before the appointed time when the day passes as the chaff, before the fierce anger of Yahweh comes on you, before the day of Yahweh’s anger comes on you. 
-<span class="v">3&#160;</span>Seek Yahweh, all you humble of the land, who have kept his ordinances. Seek righteousness. Seek humility. It may be that you will be hidden in the day of Yahweh’s anger. 
-<span class="v">4&#160;</span>For Gaza will be forsaken, and Ashkelon a desolation. They will drive out Ashdod at noonday, and Ekron will be rooted up. 
-<span class="v">5&#160;</span>Woe to the inhabitants of the sea coast, the nation of the Cherethites! Yahweh’s word is against you, Canaan, the land of the Philistines. I will destroy you until there is no inhabitant. 
-<span class="v">6&#160;</span>The sea coast will be pastures, with cottages for shepherds and folds for flocks. 
-<span class="v">7&#160;</span>The coast will be for the remnant of the house of Judah. They will find pasture. In the houses of Ashkelon, they will lie down in the evening, for Yahweh, their Elohim,<span class="f">+ \fr 2:7 \ft The Hebrew word rendered “Elohim” is “אֱלֹהִ֑ים” (Elohim).</span> will visit them and restore them. 
-<span class="v">8&#160;</span>I have heard the reproach of Moab and the insults of the children of Ammon, with which they have reproached my people and magnified themselves against their border. 
-<span class="v">9&#160;</span>Therefore, as I live, says Yahweh of Armies, the Elohim of Israel, surely Moab will be as Sodom, and the children of Ammon as Gomorrah, a possession of nettles and salt pits, and a perpetual desolation. The remnant of my people will plunder them, and the survivors of my nation will inherit them. 
-<span class="v">10&#160;</span>This they will have for their pride, because they have reproached and magnified themselves against the people of Yahweh of Armies. 
-<span class="v">11&#160;</span>Yahweh will be awesome to them, for he will famish all the elohims of the land. Men will worship him, everyone from his place, even all the shores of the nations. 
-</p><p>
-<span class="v">12&#160;</span>You Cushites also, you will be killed by my sword. 
-</p><p>
-<span class="v">13&#160;</span>He will stretch out his hand against the north, destroy Assyria, and will make Nineveh a desolation, as dry as the wilderness. 
-<span class="v">14&#160;</span>Herds will lie down in the middle of her, all kinds of animals. Both the pelican and the porcupine will lodge in its capitals. Their calls will echo through the windows. Desolation will be in the thresholds, for he has laid bare the cedar beams. 
-<span class="v">15&#160;</span>This is the joyous city that lived carelessly, that said in her heart, “I am, and there is no one besides me.” How she has become a desolation, a place for animals to lie down in! Everyone who passes by her will hiss and shake their fists. 
-</p><h2 class="chapterlabel" id="3">3</h2>
-<p>
-<span class="v">1&#160;</span>Woe to her who is rebellious and polluted, the oppressing city! 
-<span class="v">2&#160;</span>She didn’t obey the voice. She didn’t receive correction. She didn’t trust in Yahweh. She didn’t draw near to her Elohim. 
-</p><p>
-<span class="v">3&#160;</span>Her princes within her are roaring lions. Her judges are evening wolves. They leave nothing until the next day. 
-<span class="v">4&#160;</span>Her prophets are arrogant and treacherous people. Her priests have profaned the sanctuary. They have done violence to the law. 
-<span class="v">5&#160;</span>Yahweh, within her, is righteous. He will do no wrong. Every morning he brings his justice to light. He doesn’t fail, but the unjust know no shame. 
-</p><p>
-<span class="v">6&#160;</span>I have cut off nations. Their battlements are desolate. I have made their streets waste, so that no one passes by. Their cities are destroyed, so that there is no man, so that there is no inhabitant. 
-<span class="v">7&#160;</span>I said, “Just fear me. Receive correction,” so that her dwelling won’t be cut off, according to all that I have appointed concerning her. But they rose early and corrupted all their doings. 
-</p><p>
-<span class="v">8&#160;</span>“Therefore wait for me”, says Yahweh, “until the day that I rise up to the prey, for my determination is to gather the nations, that I may assemble the kingdoms to pour on them my indignation, even all my fierce anger, for all the earth will be devoured with the fire of my jealousy. 
-</p><p>
-<span class="v">9&#160;</span>For then I will purify the lips of the peoples, that they may all call on Yahweh’s name, to serve him shoulder to shoulder. 
-<span class="v">10&#160;</span>From beyond the rivers of Cush, my worshipers, even the daughter of my dispersed people, will bring my offering. 
-<span class="v">11&#160;</span>In that day you will not be disappointed for all your doings in which you have transgressed against me; for then I will take away out from among you your proudly exulting ones, and you will no more be arrogant in my set-apart mountain. 
-<span class="v">12&#160;</span>But I will leave among you an afflicted and poor people, and they will take refuge in Yahweh’s name. 
-<span class="v">13&#160;</span>The remnant of Israel will not do iniquity nor speak lies, neither will a deceitful tongue be found in their mouth, for they will feed and lie down, and no one will make them afraid.” 
-</p><p>
-<span class="v">14&#160;</span>Sing, daughter of Zion! Shout, Israel! Be glad and rejoice with all your heart, daughter of Jerusalem. 
-<span class="v">15&#160;</span>Yahweh has taken away your judgments. He has thrown out your enemy. The King of Israel, Yahweh, is among you. You will not be afraid of evil any more. 
-<span class="v">16&#160;</span>In that day, it will be said to Jerusalem, “Don’t be afraid, Zion. Don’t let your hands be weak.” 
-<span class="v">17&#160;</span>Yahweh, your Elohim, is among you, a mighty one who will save. He will rejoice over you with joy. He will calm you in his love. He will rejoice over you with singing. 
-<span class="v">18&#160;</span>I will remove those who grieve about the appointed feasts from you. They are a burden and a reproach to you. 
-<span class="v">19&#160;</span>Behold,<span class="f">+ \fr 3:19 \ft “Behold”, from “הִנֵּה”, means look at, take notice, observe, see, or gaze at. It is often used as an interjection.</span> at that time I will deal with all those who afflict you; and I will save those who are lame and gather those who were driven away. I will give them praise and honor, whose shame has been in all the earth. 
-<span class="v">20&#160;</span>At that time I will bring you in, and at that time I will gather you; for I will give you honor and praise among all the peoples of the earth when I restore your fortunes before your eyes, says Yahweh. </div><script src="../main.js"></script></body></html>
+<div class="chapterlabel nav chapnav">
+<a href="#1">1</a>
+<a href="#2">2</a>
+<a href="#3">3</a>
+</div><h2 class="chapterlabel" id="1">1</h2>
+<div class="p1">
+<sup>1&#160;</sup>Yahweh’s word which came to Zephaniah, the son of Cushi, the son of Gedaliah, the son of Amariah, the son of Hezekiah, in the days of Josiah, the son of Amon, king of Judah. 
+</div><div class="p">
+<sup>2&#160;</sup>I will utterly sweep away everything from the surface of the earth, says Yahweh. 
+<sup>3&#160;</sup>I will sweep away man and animal. I will sweep away the birds of the sky, the fish of the sea, and the heaps of rubble with the wicked. I will cut off man from the surface of the earth, says Yahweh. 
+<sup>4&#160;</sup>I will stretch out my hand against Judah and against all the inhabitants of Jerusalem. I will cut off the remnant of Baal from this place—the name of the idolatrous and pagan priests, 
+<sup>5&#160;</sup>those who worship the army of the sky on the housetops, those who worship and swear by Yahweh and also swear by Malcam, 
+<sup>6&#160;</sup>those who have turned back from following Yahweh, and those who haven’t sought Yahweh nor inquired after him. 
+</div><div class="p">
+<sup>7&#160;</sup>Be silent at the presence of the Lord Yahweh, for the day of Yahweh is at hand. For Yahweh has prepared a sacrifice. He has consecrated his guests. 
+<sup>8&#160;</sup>It will happen in the day of Yahweh’s sacrifice that I will punish the princes, the king’s sons, and all those who are clothed with foreign clothing. 
+<sup>9&#160;</sup>In that day, I will punish all those who leap over the threshold, who fill their master’s house with violence and deceit. 
+</div><div class="p">
+<sup>10&#160;</sup>In that day, says Yahweh, there will be the noise of a cry from the fish gate, a wailing from the second quarter, and a great crashing from the hills. 
+<sup>11&#160;</sup>Wail, you inhabitants of Maktesh, for all the people of Canaan are undone! All those who were loaded with silver are cut off. 
+<sup>12&#160;</sup>It will happen at that time, that I will search Jerusalem with lamps, and I will punish the men who are settled on their dregs, who say in their heart, “Yahweh will not do good, neither will he do evil.” 
+<sup>13&#160;</sup>Their wealth will become a plunder, and their houses a desolation. Yes, they will build houses, but won’t inhabit them. They will plant vineyards, but won’t drink their wine. 
+</div><div class="p">
+<sup>14&#160;</sup>The great day of Yahweh is near. It is near and hurries greatly, the voice of the day of Yahweh. The mighty man cries there bitterly. 
+<sup>15&#160;</sup>That day is a day of wrath, a day of distress and anguish, a day of trouble and ruin, a day of darkness and gloom, a day of clouds and blackness, 
+<sup>16&#160;</sup>a day of the trumpet and alarm against the fortified cities and against the high battlements. 
+<sup>17&#160;</sup>I will bring such distress on men that they will walk like blind men because they have sinned against Yahweh. Their blood will be poured out like dust and their flesh like dung. 
+<sup>18&#160;</sup>Neither their silver nor their gold will be able to deliver them in the day of Yahweh’s wrath, but the whole land will be devoured by the fire of his jealousy; for he will make an end, yes, a terrible end, of all those who dwell in the land. 
+</div><h2 class="chapterlabel" id="2">2</h2>
+<div class="p">
+<sup>1&#160;</sup>Gather yourselves together, yes, gather together, you nation that has no shame, 
+<sup>2&#160;</sup>before the appointed time when the day passes as the chaff, before the fierce anger of Yahweh comes on you, before the day of Yahweh’s anger comes on you. 
+<sup>3&#160;</sup>Seek Yahweh, all you humble of the land, who have kept his ordinances. Seek righteousness. Seek humility. It may be that you will be hidden in the day of Yahweh’s anger. 
+<sup>4&#160;</sup>For Gaza will be forsaken, and Ashkelon a desolation. They will drive out Ashdod at noonday, and Ekron will be rooted up. 
+<sup>5&#160;</sup>Woe to the inhabitants of the sea coast, the nation of the Cherethites! Yahweh’s word is against you, Canaan, the land of the Philistines. I will destroy you until there is no inhabitant. 
+<sup>6&#160;</sup>The sea coast will be pastures, with cottages for shepherds and folds for flocks. 
+<sup>7&#160;</sup>The coast will be for the remnant of the house of Judah. They will find pasture. In the houses of Ashkelon, they will lie down in the evening, for Yahweh, their Elohim, will visit them and restore them. 
+<sup>8&#160;</sup>I have heard the reproach of Moab and the insults of the children of Ammon, with which they have reproached my people and magnified themselves against their border. 
+<sup>9&#160;</sup>Therefore, as I live, says Yahweh of Armies, the Elohim of Israel, surely Moab will be as Sodom, and the children of Ammon as Gomorrah, a possession of nettles and salt pits, and a perpetual desolation. The remnant of my people will plunder them, and the survivors of my nation will inherit them. 
+<sup>10&#160;</sup>This they will have for their pride, because they have reproached and magnified themselves against the people of Yahweh of Armies. 
+<sup>11&#160;</sup>Yahweh will be awesome to them, for he will famish all the elohims of the land. Men will worship him, everyone from his place, even all the shores of the nations. 
+</div><div class="p">
+<sup>12&#160;</sup>You Cushites also, you will be killed by my sword. 
+</div><div class="p">
+<sup>13&#160;</sup>He will stretch out his hand against the north, destroy Assyria, and will make Nineveh a desolation, as dry as the wilderness. 
+<sup>14&#160;</sup>Herds will lie down in the middle of her, all kinds of animals. Both the pelican and the porcupine will lodge in its capitals. Their calls will echo through the windows. Desolation will be in the thresholds, for he has laid bare the cedar beams. 
+<sup>15&#160;</sup>This is the joyous city that lived carelessly, that said in her heart, “I am, and there is no one besides me.” How she has become a desolation, a place for animals to lie down in! Everyone who passes by her will hiss and shake their fists. 
+</div><h2 class="chapterlabel" id="3">3</h2>
+<div class="p">
+<sup>1&#160;</sup>Woe to her who is rebellious and polluted, the oppressing city! 
+<sup>2&#160;</sup>She didn’t obey the voice. She didn’t receive correction. She didn’t trust in Yahweh. She didn’t draw near to her Elohim. 
+</div><div class="p">
+<sup>3&#160;</sup>Her princes within her are roaring lions. Her judges are evening wolves. They leave nothing until the next day. 
+<sup>4&#160;</sup>Her prophets are arrogant and treacherous people. Her priests have profaned the sanctuary. They have done violence to the law. 
+<sup>5&#160;</sup>Yahweh, within her, is righteous. He will do no wrong. Every morning he brings his justice to light. He doesn’t fail, but the unjust know no shame. 
+</div><div class="p">
+<sup>6&#160;</sup>I have cut off nations. Their battlements are desolate. I have made their streets waste, so that no one passes by. Their cities are destroyed, so that there is no man, so that there is no inhabitant. 
+<sup>7&#160;</sup>I said, “Just fear me. Receive correction,” so that her dwelling won’t be cut off, according to all that I have appointed concerning her. But they rose early and corrupted all their doings. 
+</div><div class="p">
+<sup>8&#160;</sup>“Therefore wait for me”, says Yahweh, “until the day that I rise up to the prey, for my determination is to gather the nations, that I may assemble the kingdoms to pour on them my indignation, even all my fierce anger, for all the earth will be devoured with the fire of my jealousy. 
+</div><div class="p">
+<sup>9&#160;</sup>For then I will purify the lips of the peoples, that they may all call on Yahweh’s name, to serve him shoulder to shoulder. 
+<sup>10&#160;</sup>From beyond the rivers of Cush, my worshipers, even the daughter of my dispersed people, will bring my offering. 
+<sup>11&#160;</sup>In that day you will not be disappointed for all your doings in which you have transgressed against me; for then I will take away out from among you your proudly exulting ones, and you will no more be arrogant in my set-apart mountain. 
+<sup>12&#160;</sup>But I will leave among you an afflicted and poor people, and they will take refuge in Yahweh’s name. 
+<sup>13&#160;</sup>The remnant of Israel will not do iniquity nor speak lies, neither will a deceitful tongue be found in their mouth, for they will feed and lie down, and no one will make them afraid.” 
+</div><div class="p">
+<sup>14&#160;</sup>Sing, daughter of Zion! Shout, Israel! Be glad and rejoice with all your heart, daughter of Jerusalem. 
+<sup>15&#160;</sup>Yahweh has taken away your judgments. He has thrown out your enemy. The King of Israel, Yahweh, is among you. You will not be afraid of evil any more. 
+<sup>16&#160;</sup>In that day, it will be said to Jerusalem, “Don’t be afraid, Zion. Don’t let your hands be weak.” 
+<sup>17&#160;</sup>Yahweh, your Elohim, is among you, a mighty one who will save. He will rejoice over you with joy. He will calm you in his love. He will rejoice over you with singing. 
+<sup>18&#160;</sup>I will remove those who grieve about the appointed feasts from you. They are a burden and a reproach to you. 
+<sup>19&#160;</sup>Behold, at that time I will deal with all those who afflict you; and I will save those who are lame and gather those who were driven away. I will give them praise and honor, whose shame has been in all the earth. 
+<sup>20&#160;</sup>At that time I will bring you in, and at that time I will gather you; for I will give you honor and praise among all the peoples of the earth when I restore your fortunes before your eyes, says Yahweh. </div></div><script src="../main.js"></script></body></html>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 <h2 class="torah">Teaching</h2>
 
 <div class="booklist torah">
-  <ul class="vnav torah">
+  <ul class="nav booknav torah">
     <li><a class="torah" href="book/genesis.html">Genesis</a></li>
     <li><a class="torah" href="book/exodus.html">Exodus</a></li>
     <li><a class="torah" href="book/leviticus.html">Leviticus</a></li>
@@ -33,7 +33,7 @@
 <h2 class="neviim">Prophets</h2>
 
 <div class="booklist neviim">
-  <ul class="vnav neviim">
+  <ul class="nav booknav neviim">
     <li><a class="neviim" href="book/joshua.html">Joshua</a></li>
     <li><a class="neviim" href="book/judges.html">Judges</a></li>
     <li><a class="neviim" href="book/1samuel.html">1 Samuel</a></li>
@@ -72,7 +72,7 @@ and its preface notes that josephus also considered daniel a prophet.
 <h2 class="ketuvim1">Writings</h2>
 
 <div class="booklist ketuvim1">
-  <ul class="vnav ketuvim1">
+  <ul class="nav booknav ketuvim1">
     <li><a class="ketuvim1" href="book/psalms.html">Psalms</a></li>
     <li><a class="ketuvim1" href="book/job.html">Job</a></li>
 
@@ -104,7 +104,7 @@ yahweh. so job is being included as well.
 <h2 class="messiah">Messiah</h2>
 
 <div class="booklist messiah">
-  <ul class="vnav messiah">
+  <ul class="nav booknav messiah">
     <li><a class="messiah" href="book/matthew.html">Matthew</a></li>
     <li><a class="messiah" href="book/john.html">John</a></li>
     <li><a class="messiah" href="book/revelation.html">Revelation</a></li>
@@ -132,7 +132,7 @@ to him, even if he is a brother of james.. i am uncertain.
 <h2 class="letters">Letters</h2>
 
 <div class="booklist letters">
-  <ul class="vnav letters">
+  <ul class="nav booknav letters">
     <li><a class="letters" href="book/james.html">James</a></li>
     <li><a class="letters" href="book/1john.html">1 John</a></li>
     <li><a class="letters" href="book/2john.html">2 John</a></li>

--- a/main.js
+++ b/main.js
@@ -3,8 +3,12 @@
 
 
 const html = document.querySelector("html");
+//const a = document.querySelector("a");
+//const div = document.querySelector("div");
+//const p = document.querySelector("p");
+//const h1 = document.querySelector("h1");
 const chap = document.getElementsByClassName("chapterlabel");
-const vers = document.getElementsByClassName("v");
+const vers = document.getElementsByTagName("sup");
 
 function toggleChap() {
   if (chap[0].style.display !== "block") {
@@ -29,7 +33,11 @@ function toggleVers() {
     }
   }
 }
-html.addEventListener("click", () => {
+
+
+
+
+function mainToggle(event) {
 
   // tap/click feedback for testing
   /*
@@ -39,6 +47,11 @@ html.addEventListener("click", () => {
     html.style.backgroundColor = "";
   }
   */
+
+  // avoid toggle if clicking chapter link (an <a> tag)
+  if (event.target.localName === "a") {
+    return;
+  }
 
   // catch psalms
   if (chap.length === 0) {
@@ -58,6 +71,21 @@ html.addEventListener("click", () => {
       toggleVers();
     }
   }
+}
 
-});
+/*
+let flip = false;
+function testa(event) {
+  if (flip === false) {
+    console.log(event);
+    console.log(event.target.localName);
+    alert("testa");
+    flip = true;
+  }
+}
+html.addEventListener("click", testa);
+*/
+
+
+html.addEventListener("click", mainToggle);
 

--- a/style.css
+++ b/style.css
@@ -34,11 +34,11 @@ html, body {
 
 h1, h2 {
   text-align: center;
+}
 /*
   background-color: tan;
   padding: 0.5em;
 */
-}
 
 
 /*
@@ -114,7 +114,7 @@ div.booklist {
 }
 
 
-ul.vnav {
+ul.nav {
   padding-left: 0;
   list-style-type: none;
   text-align: center;
@@ -126,19 +126,85 @@ li {
 }
 */
 
-.vnav a {
+.booknav a {
   display: block;
+}
+.nav a {
   background-color: #0080ff;
   padding: 0.4em;
   margin: 0.08em;
+}
+.chapnav a {
+  /* switch this to inline-block to get links */
+  display: none;
 /*
+  display: inline-block;
+*/
+  min-width: 32px;
+  text-align: center;
+/*
+  min-height: 32px;
+  background-color: #777777;
+  margin-left: 0.3em;
+  margin-right: 0.3em;
+  margin-top: 0.3em;
+  margin-bottom: 0.3em;
+  padding: 0.4em;
+  vertical-align: middle;
+  margin-top: 5em;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 2em;
 */
 }
+.chapnav {
+  text-align: center;
+}
 
-.vnav a:visited {color: #ffffff;}
-.vnav a:link {color: #ffffff;}
-.vnav a:hover {color: #ffffff;
+
+.nav a:visited {color: #ffffff;}
+.nav a:link {color: #ffffff;}
+.nav a:hover {color: #ffffff;
   background-color: #777777 !important;}
+
+
+
+
+
+
+
+/*
+ul.cnav {
+  padding-left: 0;
+  list-style-type: none;
+  text-align: center;
+}
+*/
+
+/*
+li {
+  background-color: #b85;
+}
+*/
+
+/*
+.cnav a {
+  display: inline-block;
+  background-color: #0080ff;
+  padding: 0.4em;
+  margin: 0.08em;
+}
+
+.cnav a:visited {color: #ffffff;}
+.cnav a:link {color: #ffffff;}
+.cnav a:hover {color: #ffffff;
+  background-color: #777777 !important;}
+*/
+
+
+
+
+
 
 
 
@@ -147,14 +213,14 @@ li {
 /* -------------------------------------------------------------------------- */
 /* scripture */
 
-p {
+.p, .p1, .q1, .q2, .qs, .sp, .m, .mi, .pi1, .li1, .d, .nb {
   line-height: 1.3em;
   text-indent: 2em;
   text-align: justify;
+/*
   display: block;
   margin-top: 0;
   margin-bottom: 0;
-/*
   background-color: #ffc;
   font-size: 1em;
   margin-top: 0.5em;
@@ -191,7 +257,10 @@ p {
 }
 
 /* li: ezra 8, 10, neh7. an indented list */
-.li1 {display: list-item; list-style-type: none; text-indent: 2em;}
+.li1 {
+  display: list-item;
+  list-style-type: none;
+}
 
 /* various, especially Joshua 12. basically a non-indented list? */
 /*
@@ -207,7 +276,9 @@ p {
 }
 
 /* hab and psalms. selah on right */
-.qs {text-align: right;}
+.qs {
+  text-align: right;
+}
 
 /* sp: song of song, for titles lover, beloved, friends */
 .sp {
@@ -224,11 +295,11 @@ there may be doctrine issues with red lettering
 /* pi: only dan, ezr, jer. double-indented. awkward in dan 4 */
 .pi1 {
   margin-left: 2em;
+}
 /*
   text-indent: 2em;
   margin: .5em 0 0 2em;
 */
-}
 
 
 /* psalms, songofsol, daniel 4, etc. */
@@ -250,11 +321,21 @@ html[dir=ltr] .q2 {
   margin-left: 2em;
 }
 
-
+/* psalms books (major sections) only */
+.ms1 {
+  margin-top: 2em;
+}
 
 
 /* verse numbers */
-.v {white-space:nowrap;vertical-align:super;font-size:.6em;line-height:0}
+sup {
+  white-space: nowrap;
+  font-size: .6em;
+  line-height: 0;
+}
+/*
+  vertical-align: super;
+*/
 
 
 
@@ -290,7 +371,9 @@ html[dir=ltr] .q2 {
 .chapterlabel,
 
 /* no verse numbers */
-.v {
+/* this is now already disabled in the html head
+*/
+sup {
   display: none;
 }
 
@@ -299,7 +382,9 @@ html[dir=ltr] .q2 {
 .indextitle,
 
 /* no psalm book titles */
+/*
 .ms1,
+*/
 
 /* no full size line breaks */
 /*


### PR DESCRIPTION
this patch includes 3 development updates:

```
usfm1
  made chapter links, but left them disabled for site for now (usable in pure html)

usfm2
  use <sup> tag for verse numbers instead of <span>
  using <sup>, remove class="v", save a lot of space
  verse numbers off by default via internal css
  remove footnotes in html
  remove cross-references in html

usfm3
  move psalm book label to above chapter label
  add essential css to html
  replace p tags with div tags, to not paste new lines
  fix missing final closing tag
  make psalm book sections visible
```

psalm books are now visible, especially because psalm 72 makes more sense with book section context.