### PR TITLE
Restore meaning behind "marry"

### DIFF
--- a/book/1chronicles.html
+++ b/book/1chronicles.html
@@ -171,7 +171,7 @@ html[dir=ltr] .q2 {
 <sup>17&#160;</sup>Abigail bore Amasa; and the father of Amasa was Jether the Ishmaelite. 
 </div><div class="p">
 <sup>18&#160;</sup>Caleb the son of Hezron brought forth children by Azubah his woman, and by Jerioth; and these were her sons: Jesher, Shobab, and Ardon. 
-<sup>19&#160;</sup>Azubah died, and Caleb married Ephrath, who bore him Hur. 
+<sup>19&#160;</sup>Azubah died, and Caleb took to himself Ephrath, who bore him Hur. 
 <sup>20&#160;</sup>Hur brought forth Uri, and Uri brought forth Bezalel. 
 </div><div class="p">
 <sup>21&#160;</sup>Afterward Hezron went in to the daughter of Machir the father of Gilead, whom he took as woman when he was sixty years old; and she bore him Segub. 

--- a/book/1kings.html
+++ b/book/1kings.html
@@ -225,7 +225,7 @@ html[dir=ltr] .q2 {
 <sup>46&#160;</sup>So the king commanded Benaiah the son of Jehoiada; and he went out, and fell on him, so that he died. The kingdom was established in the hand of Solomon. 
 </div><h2 class="chapterlabel" id="3">3</h2>
 <div class="p">
-<sup>1&#160;</sup>Solomon made a marriage alliance with Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
+<sup>1&#160;</sup>Solomon made himself a relative of Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
 <sup>2&#160;</sup>However, the people sacrificed in the high places, because there was not yet a house built for Yahweh’s name. 
 <sup>3&#160;</sup>Solomon loved Yahweh, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
 <sup>4&#160;</sup>The king went to Gibeon to sacrifice there, for that was the great high place. Solomon offered a thousand burnt offerings on that altar. 

--- a/book/2kings.html
+++ b/book/2kings.html
@@ -457,7 +457,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>16&#160;</sup>In the fifth year of Joram the son of Ahab king of Israel, Jehoshaphat being king of Judah then, Jehoram the son of Jehoshaphat king of Judah began to reign. 
 <sup>17&#160;</sup>He was thirty-two years old when he began to reign. He reigned eight years in Jerusalem. 
-<sup>18&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he married Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
+<sup>18&#160;</sup>He walked in the way of the kings of Israel, as did Ahab’s house, for he took to himself Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
 <sup>19&#160;</sup>However, Yahweh would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
 </div><div class="p">
 <sup>20&#160;</sup>In his days Edom revolted from under the hand of Judah, and made a king over themselves. 

--- a/book/2samuel.html
+++ b/book/2samuel.html
@@ -214,7 +214,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>Abner sent messengers to David on his behalf, saying, “Whose is the land?” and saying, “Make your alliance with me, and behold, my hand will be with you to bring all Israel around to you.” 
 </div><div class="p">
 <sup>13&#160;</sup>David said, “Good. I will make a treaty with you, but one thing I require of you. That is, you will not see my face unless you first bring Michal, Saul’s daughter, when you come to see my face.” 
-<sup>14&#160;</sup>David sent messengers to Ishbosheth, Saul’s son, saying, “Deliver me my woman Michal, whom I was given to marry for one hundred foreskins of the Philistines.” 
+<sup>14&#160;</sup>David sent messengers to Ishbosheth, Saul’s son, saying, “Deliver me my woman Michal, whom I requested and was granted to me for one hundred foreskins of the Philistines.” 
 </div><div class="p">
 <sup>15&#160;</sup>Ishbosheth sent and took her from her man, Paltiel the son of Laish. 
 <sup>16&#160;</sup>Her man went with her, weeping as he went, and followed her to Bahurim. Then Abner said to him, “Go! Return!” and he returned. 

--- a/book/deuteronomy.html
+++ b/book/deuteronomy.html
@@ -370,7 +370,7 @@ html[dir=ltr] .q2 {
 <div class="p">
 <sup>1&#160;</sup>When Yahweh your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
 <sup>2&#160;</sup>and when Yahweh your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
-<sup>3&#160;</sup>You shall not make marriages with them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
+<sup>3&#160;</sup>You shall not make yourself a relative of them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
 <sup>4&#160;</sup>For that would turn away your sons from following me, that they may serve other elohims. So Yahweh’s anger would be kindled against you, and he would destroy you quickly. 
 <sup>5&#160;</sup>But you shall deal with them like this: you shall break down their altars, dash their pillars in pieces, cut down their Asherah poles, and burn their engraved images with fire. 
 <sup>6&#160;</sup>For you are a set-apart people to Yahweh your Elohim. Yahweh your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
@@ -823,10 +823,10 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>If a man is found lying with a woman owned by an owner, then they shall both die, the man who lay with the woman and the woman. So you shall remove the evil from Israel. 
 <sup>23&#160;</sup>If there is a young lady who is a virgin pledged to be married to a man, and a man finds her in the city, and lies with her, 
 <sup>24&#160;</sup>then you shall bring them both out to the gate of that city, and you shall stone them to death with stones; the lady, because she didn’t cry, being in the city; and the man, because he has humbled his neighbor’s woman. So you shall remove the evil from among you. 
-<sup>25&#160;</sup>But if the man finds the lady who is pledged to be married in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
+<sup>25&#160;</sup>But if the man finds the lady, who was requested and granted, in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
 <sup>26&#160;</sup>but to the lady you shall do nothing. There is in the lady no sin worthy of death; for as when a man rises against his neighbor and kills him, even so is this matter; 
-<sup>27&#160;</sup>for he found her in the field, the pledged to be married lady cried, and there was no one to save her. 
-<sup>28&#160;</sup>If a man finds a lady who is a virgin, who is not pledged to be married, grabs her and lies with her, and they are found, 
+<sup>27&#160;</sup>for he found her in the field, the lady who was requested and granted cried, and there was no one to save her. 
+<sup>28&#160;</sup>If a man finds a lady who is a virgin, who was not requested and granted, grabs her and lies with her, and they are found, 
 <sup>29&#160;</sup>then the man who lay with her shall give to the lady’s father fifty shekels of silver. She shall be his woman, because he has humbled her. He may not put her away all his days. 
 <sup>30&#160;</sup>A man shall not take his father’s woman, and shall not uncover his father’s skirt. 
 </div><h2 class="chapterlabel" id="23">23</h2>
@@ -902,7 +902,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>4&#160;</sup>You shall not muzzle the ox when he treads out the grain. 
 </div><div class="p">
-<sup>5&#160;</sup>If brothers dwell together, and one of them dies and has no son, the woman of the dead shall not be married outside to a stranger. Her brother-in-law shall go in to her, and take her as his woman, and perform the duty of a brother-in-law to her. 
+<sup>5&#160;</sup>If brothers dwell together, and one of them dies and has no son, the woman of the dead shall not go outside to a man who is a stranger. Her brother-in-law shall go in to her, and take her as his woman, and perform the duty of a brother-in-law to her. 
 <sup>6&#160;</sup>It shall be that the firstborn whom she bears shall succeed in the name of his brother who is dead, that his name not be blotted out of Israel. 
 </div><div class="p">
 <sup>7&#160;</sup>If the man doesn’t want to take his brother’s woman, then his brother’s woman shall go up to the gate to the elders, and say, “My brother-in-law refuses to raise up to his brother a name in Israel. He will not perform the duty of a brother-in-law to me.” 

--- a/book/exodus.html
+++ b/book/exodus.html
@@ -895,9 +895,9 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>then his master shall bring him to Elohim, and shall bring him to the door or to the doorpost, and his master shall bore his ear through with an awl, and he shall serve him forever. 
 </div><div class="p">
 <sup>7&#160;</sup>“If a man sells his daughter to be a female servant, she shall not go out as the male servants do. 
-<sup>8&#160;</sup>If she doesn’t please her master, who has married her to himself, then he shall let her be redeemed. He shall have no right to sell her to a foreign people, since he has dealt deceitfully with her. 
-<sup>9&#160;</sup>If he marries her to his son, he shall deal with her as a daughter. 
-<sup>10&#160;</sup>If he takes another woman to himself, he shall not diminish her food, her clothing, and her marital rights. 
+<sup>8&#160;</sup>If she is dysfunctional in the eyes of her master, who didn’t join together with her, then he shall let her be redeemed. He shall have no right to sell her to a foreign people, since he has dealt deceitfully with her. 
+<sup>9&#160;</sup>If he joins her to his son, he shall deal with her as a daughter. 
+<sup>10&#160;</sup>If he takes another woman to himself, he shall not diminish her food, her clothing, and her shelter. 
 <sup>11&#160;</sup>If he doesn’t do these three things for her, she may go free without paying any money. 
 </div><div class="p">
 <sup>12&#160;</sup>“One who strikes a man so that he dies shall surely be put to death, 
@@ -958,7 +958,7 @@ html[dir=ltr] .q2 {
 <sup>14&#160;</sup>“If a man borrows anything of his neighbor’s, and it is injured, or dies, its owner not being with it, he shall surely make restitution. 
 <sup>15&#160;</sup>If its owner is with it, he shall not make it good. If it is a leased thing, it came for its lease. 
 </div><div class="p">
-<sup>16&#160;</sup>“If a man entices a virgin who isn’t pledged to be married, and lies with her, he shall surely pay a dowry for her to be his woman. 
+<sup>16&#160;</sup>“If a man entices a virgin who wasn’t requested and granted, and lies with her, he shall surely pay a dowry for her to be his woman. 
 <sup>17&#160;</sup>If her father utterly refuses to give her to him, he shall pay money according to the dowry of virgins. 
 </div><div class="p">
 <sup>18&#160;</sup>“You shall not allow a sorceress to live. 

--- a/book/ezra.html
+++ b/book/ezra.html
@@ -398,7 +398,7 @@ html[dir=ltr] .q2 {
 </div><h2 class="chapterlabel" id="10">10</h2>
 <div class="p">
 <sup>1&#160;</sup>Now while Ezra prayed and made confession, weeping and casting himself down before Elohim’s house, there was gathered together to him out of Israel a very great assembly of men and women and children; for the people wept very bitterly. 
-<sup>2&#160;</sup>Shecaniah the son of Jehiel, one of the sons of Elam, answered Ezra, “We have trespassed against our Elohim, and have married foreign women of the peoples of the land. Yet now there is hope for Israel concerning this thing. 
+<sup>2&#160;</sup>Shecaniah the son of Jehiel, one of the sons of Elam, answered Ezra, “We have trespassed against our Elohim, and have taken foreign women of the peoples of the land. Yet now there is hope for Israel concerning this thing. 
 <sup>3&#160;</sup>Now therefore let’s make a covenant with our Elohim to put away all the women and those who are born of them, according to the counsel of my lord and of those who tremble at the commandment of our Elohim. Let it be done according to the law. 
 <sup>4&#160;</sup>Arise, for the matter belongs to you and we are with you. Be courageous, and do it.” 
 </div><div class="p">
@@ -409,19 +409,19 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>9&#160;</sup>Then all the men of Judah and Benjamin gathered themselves together to Jerusalem within the three days. It was the ninth month, on the twentieth day of the month; and all the people sat in the wide place in front of Elohim’s house, trembling because of this matter, and because of the great rain. 
 </div><div class="p">
-<sup>10&#160;</sup>Ezra the priest stood up and said to them, “You have trespassed, and have married foreign women, increasing the guilt of Israel. 
+<sup>10&#160;</sup>Ezra the priest stood up and said to them, “You have trespassed, and have taken foreign women, increasing the guilt of Israel. 
 <sup>11&#160;</sup>Now therefore make confession to Yahweh, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
 </div><div class="p">
 <sup>12&#160;</sup>Then all the assembly answered with a loud voice, “We must do as you have said concerning us. 
 <sup>13&#160;</sup>But the people are many, and it is a time of much rain, and we are not able to stand outside. This is not a work of one day or two, for we have greatly transgressed in this matter. 
-<sup>14&#160;</sup>Now let our princes be appointed for all the assembly, and let all those who are in our cities who have married foreign women come at appointed times, and with them the elders of every city and its judges, until the fierce wrath of our Elohim is turned from us, until this matter is resolved.” 
+<sup>14&#160;</sup>Now let our princes be appointed for all the assembly, and let all those who are in our cities who have taken foreign women come at appointed times, and with them the elders of every city and its judges, until the fierce wrath of our Elohim is turned from us, until this matter is resolved.” 
 </div><div class="p">
 <sup>15&#160;</sup>Only Jonathan the son of Asahel and Jahzeiah the son of Tikvah stood up against this; and Meshullam and Shabbethai the Levite helped them. 
 </div><div class="p">
 <sup>16&#160;</sup>The children of the captivity did so. Ezra the priest, with certain heads of fathers’ households, after their fathers’ houses, and all of them by their names, were set apart; and they sat down in the first day of the tenth month to examine the matter. 
-<sup>17&#160;</sup>They finished with all the men who had married foreign women by the first day of the first month. 
+<sup>17&#160;</sup>They finished with all the men who had taken foreign women by the first day of the first month. 
 </div><div class="p">
-<sup>18&#160;</sup>Among the sons of the priests there were found who had married foreign women: 
+<sup>18&#160;</sup>Among the sons of the priests there were found who had taken foreign women: 
 </div><div class="li1">of the sons of Jeshua, the son of Jozadak, and his brothers: Maaseiah, Eliezer, Jarib, and Gedaliah. 
 <sup>19&#160;</sup>They gave their hand that they would put away their women; and being guilty, they offered a ram of the flock for their guilt. 
 </div><div class="li1">

--- a/book/genesis.html
+++ b/book/genesis.html
@@ -780,7 +780,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>The men said to Lot, “Do you have anybody else here? Sons-in-law, your sons, your daughters, and whomever you have in the city, bring them out of the place: 
 <sup>13&#160;</sup>for we will destroy this place, because the outcry against them has grown so great before Yahweh that Yahweh has sent us to destroy it.” 
 </div><div class="p">
-<sup>14&#160;</sup>Lot went out, and spoke to his sons-in-law, who were pledged to marry his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
+<sup>14&#160;</sup>Lot went out, and spoke to his sons-in-law, who took his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
 </div><div class="p">But he seemed to his sons-in-law to be joking. 
 <sup>15&#160;</sup>When the morning came, then the angels hurried Lot, saying, “Get up! Take your woman and your two daughters who are here, lest you be consumed in the iniquity of the city.” 
 <sup>16&#160;</sup>But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahweh being merciful to him; and they took him out, and set him outside of the city. 
@@ -1535,7 +1535,7 @@ html[dir=ltr] .q2 {
 <sup>6&#160;</sup>Hamor the father of Shechem went out to Jacob to talk with him. 
 <sup>7&#160;</sup>The sons of Jacob came in from the field when they heard it. The men were grieved, and they were very angry, because he had done folly in Israel in lying with Jacob’s daughter, a thing that ought not to be done. 
 <sup>8&#160;</sup>Hamor talked with them, saying, “The soul of my son, Shechem, longs for your daughter. Please give her to him as a woman. 
-<sup>9&#160;</sup>Make marriages with us. Give your daughters to us, and take our daughters for yourselves. 
+<sup>9&#160;</sup>Make yourselves relatives of us. Give your daughters to us, and take our daughters for yourselves. 
 <sup>10&#160;</sup>You shall dwell with us, and the land will be before you. Live and trade in it, and get possessions in it.” 
 </div><div class="p">
 <sup>11&#160;</sup>Shechem said to her father and to her brothers, “Let me find favor in your eyes, and whatever you will tell me I will give. 

--- a/book/joshua.html
+++ b/book/joshua.html
@@ -905,7 +905,7 @@ html[dir=ltr] .q2 {
 <sup>10&#160;</sup>One man of you shall chase a thousand; for it is Yahweh your Elohim who fights for you, as he spoke to you. 
 <sup>11&#160;</sup>Take good heed therefore to yourselves, that you love Yahweh your Elohim. 
 </div><div class="p">
-<sup>12&#160;</sup>“But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and make marriages with them, and go in to them, and they to you; 
+<sup>12&#160;</sup>“But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and you make yourselves relatives of them, and go in to them, and they to you; 
 <sup>13&#160;</sup>know for a certainty that Yahweh your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahweh your Elohim has given you. 
 </div><div class="p">
 <sup>14&#160;</sup>“Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahweh your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 

--- a/book/leviticus.html
+++ b/book/leviticus.html
@@ -827,7 +827,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">“&#160;‘You shall not sow your field with two kinds of seed; 
 </div><div class="p">“&#160;‘Don’t wear a garment made of two kinds of material. 
 </div><div class="p">
-<sup>20&#160;</sup>“&#160;‘If a man lies carnally with a woman who is a slave girl, pledged to be married to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
+<sup>20&#160;</sup>“&#160;‘If a man lies carnally with a woman who is a slave girl, pierced to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
 <sup>21&#160;</sup>He shall bring his trespass offering to Yahweh, to the door of the Tent of Meeting, even a ram for a trespass offering. 
 <sup>22&#160;</sup>The priest shall make atonement for him with the ram of the trespass offering before Yahweh for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
 </div><div class="p">
@@ -912,7 +912,7 @@ html[dir=ltr] .q2 {
 <sup>5&#160;</sup>“&#160;‘They shall not shave their heads or shave off the corners of their beards or make any cuttings in their flesh. 
 <sup>6&#160;</sup>They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahweh made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
 </div><div class="p">
-<sup>7&#160;</sup>“&#160;‘They shall not marry a woman who is a prostitute, or profane. A priest shall not marry a woman divorced from her man; for he is set-apart to his Elohim. 
+<sup>7&#160;</sup>“&#160;‘They shall not marry a woman who is a whore, or pierced. A priest shall not take a woman divorced from her man; for he is set-apart to his Elohim. 
 <sup>8&#160;</sup>Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahweh, who sanctify you, am set-apart. 
 </div><div class="p">
 <sup>9&#160;</sup>“&#160;‘The daughter of any priest, if she profanes herself by playing the prostitute, she profanes her father. She shall be burned with fire. 
@@ -922,7 +922,7 @@ html[dir=ltr] .q2 {
 <sup>12&#160;</sup>He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahweh. 
 </div><div class="p">
 <sup>13&#160;</sup>“&#160;‘He shall take a woman in her virginity. 
-<sup>14&#160;</sup>He shall not marry a widow, or one divorced, or a woman who has been defiled, or a prostitute. He shall take a virgin of his own people as a woman. 
+<sup>14&#160;</sup>He shall not take a widow, or one divorced, or a woman who has been pierced, or a whore. He shall take a virgin of his own people as a woman. 
 <sup>15&#160;</sup>He shall not profane his offspring among his people, for I am Yahweh who sanctifies him.’&#160;” 
 </div><div class="p">
 <sup>16&#160;</sup>Yahweh spoke to Moses, saying, 
@@ -951,7 +951,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>10&#160;</sup>“&#160;‘No stranger shall eat of the set-apart thing: a foreigner living with the priests, or a hired servant, shall not eat of the set-apart thing. 
 <sup>11&#160;</sup>But if a priest buys a slave, purchased by his money, he shall eat of it; and those who are born in his house shall eat of his bread. 
-<sup>12&#160;</sup>If a priest’s daughter is married to an outsider, she shall not eat of the heave offering of the set-apart things. 
+<sup>12&#160;</sup>If a priest’s daughter becomes the woman of a man who is an outsider, she shall not eat of the heave offering of the set-apart things. 
 <sup>13&#160;</sup>But if a priest’s daughter is a widow, or divorced, and has no child, and has returned to her father’s house as in her youth, she may eat of her father’s bread; but no stranger shall eat any of it. 
 </div><div class="p">
 <sup>14&#160;</sup>“&#160;‘If a man eats something set-apart unwittingly, then he shall add the fifth part of its value to it, and shall give the set-apart thing to the priest. 

--- a/book/matthew.html
+++ b/book/matthew.html
@@ -278,7 +278,7 @@ html[dir=ltr] .q2 {
 <sup>30&#160;</sup><span class="wj">If your right hand causes you to stumble, cut it off, and throw it away from you. For it is more profitable for you that one of your members should perish, than for your whole body to be cast into Gehenna.</span> 
 </div><div class="p">
 <sup>31&#160;</sup><span class="wj">“It was also said, ‘Whoever shall put away his woman, let him give her a writing of divorce,’</span> 
-<sup>32&#160;</sup><span class="wj">but I tell you that whoever puts away his woman, except for the cause of sexual immorality, makes her an adulteress; and whoever marries her when she is put away commits adultery.</span> 
+<sup>32&#160;</sup><span class="wj">but I tell you that whoever puts away his woman, except for the cause of sexual immorality, makes her an adulteress; and whoever takes her when she is put away commits adultery.</span> 
 </div><div class="p">
 <sup>33&#160;</sup><span class="wj">“Again you have heard that it was said to the ancient ones, ‘You shall not make false vows by my name, but shall perform to the Lord your vows,’</span> 
 <sup>34&#160;</sup><span class="wj">but I tell you, don’t swear falsely at all: neither by heaven, for it is the throne of Elohim; </span> 
@@ -1020,9 +1020,9 @@ html[dir=ltr] .q2 {
 <sup>7&#160;</sup>They asked him, “Why then did Moses command us to give her a certificate of divorce and divorce her?” 
 </div><div class="p">
 <sup>8&#160;</sup>He said to them, <span class="wj">“Moses, because of the hardness of your hearts, allowed you to put away your women, but from the beginning it has not been so. </span> 
-<sup>9&#160;</sup><span class="wj">I tell you that whoever puts away his woman, except for sexual immorality, and marries another, commits adultery; and he who marries her when she is put away commits adultery.”</span> 
+<sup>9&#160;</sup><span class="wj">I tell you that whoever puts away his woman, except for sexual immorality, and takes another, commits adultery; and he who takes her when she is put away commits adultery.”</span> 
 </div><div class="p">
-<sup>10&#160;</sup>His disciples said to him, “If this is the case of the man with his woman, it is not expedient to marry.” 
+<sup>10&#160;</sup>His disciples said to him, “If this is the case of the man with his woman, it is not expedient to take her.” 
 </div><div class="p">
 <sup>11&#160;</sup>But he said to them, <span class="wj">“Not all men can receive this saying, but those to whom it is given. </span> 
 <sup>12&#160;</sup><span class="wj">For there are eunuchs who were born that way from their mother’s womb, and there are eunuchs who were made eunuchs by men; and there are eunuchs who made themselves eunuchs for the Kingdom of Heaven’s sake. He who is able to receive it, let him receive it.”</span> 
@@ -1223,13 +1223,13 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>23&#160;</sup>On that day Sadducees (those who say that there is no resurrection) came to him. They asked him, 
 <sup>24&#160;</sup>saying, “Teacher, Moses said, ‘If a man dies, having no children, his brother shall marry his woman and raise up offspring for his brother.’ 
-<sup>25&#160;</sup>Now there were with us seven brothers. The first married and died, and having no offspring left his woman to his brother. 
+<sup>25&#160;</sup>Now there were with us seven brothers. The first took a woman and died, and having no offspring left his woman to his brother. 
 <sup>26&#160;</sup>In the same way, the second also, and the third, to the seventh. 
 <sup>27&#160;</sup>After them all, the woman died. 
 <sup>28&#160;</sup>In the resurrection therefore, whose woman will she be of the seven? For they all had her.” 
 </div><div class="p">
 <sup>29&#160;</sup>But Yahushua answered them, <span class="wj">“You are mistaken, not knowing the Scriptures, nor the power of Elohim. </span> 
-<sup>30&#160;</sup><span class="wj">For in the resurrection they neither marry nor are given in marriage, but are like Elohim’s angels in heaven. </span> 
+<sup>30&#160;</sup><span class="wj">For in the resurrection they neither take nor are taken, but are like Elohim’s angels in heaven. </span> 
 <sup>31&#160;</sup><span class="wj">But concerning the resurrection of the dead, haven’t you read that which was spoken to you by Elohim, saying, </span> 
 <sup>32&#160;</sup><span class="wj">‘I am the Elohim of Abraham, and the Elohim of Isaac, and the Elohim of Jacob’?</span> <span class="wj">Elohim is not the Elohim of the dead, but of the living.”</span> 
 </div><div class="p">
@@ -1355,7 +1355,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>36&#160;</sup><span class="wj">“But no one knows of that day and hour, not even the angels of heaven,</span> <span class="wj">but my Father only.</span> 
 <sup>37&#160;</sup><span class="wj">As the days of Noah were, so will the coming of the Son of Man be. </span> 
-<sup>38&#160;</sup><span class="wj">For as in those days which were before the flood they were eating and drinking, marrying and giving in marriage, until the day that Noah entered into the ship, </span> 
+<sup>38&#160;</sup><span class="wj">For as in those days which were before the flood they were eating, drinking, being fruitful, and multiplying until the day that Noah entered into the ship, </span> 
 <sup>39&#160;</sup><span class="wj">and they didn’t know until the flood came and took them all away, so will the coming of the Son of Man be. </span> 
 <sup>40&#160;</sup><span class="wj">Then two men will be in the field: one will be taken and one will be left. </span> 
 <sup>41&#160;</sup><span class="wj">Two women will be grinding at the mill: one will be taken and one will be left. </span> 

--- a/book/nehemiah.html
+++ b/book/nehemiah.html
@@ -623,7 +623,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>Then I testified against them, and said to them, “Why do you stay around the wall? If you do so again, I will lay hands on you.” From that time on, they didn’t come on the Sabbath. 
 <sup>22&#160;</sup>I commanded the Levites that they should purify themselves, and that they should come and keep the gates, to sanctify the Sabbath day. Remember me for this also, my Elohim, and spare me according to the greatness of your loving kindness. 
 </div><div class="p">
-<sup>23&#160;</sup>In those days I also saw the Jews who had married women of Ashdod, of Ammon, and of Moab; 
+<sup>23&#160;</sup>In those days I also saw the Jews who had taken women of Ashdod, of Ammon, and of Moab; 
 <sup>24&#160;</sup>and their children spoke half in the speech of Ashdod, and could not speak in the Jews’ language, but according to the language of each people. 
 <sup>25&#160;</sup>I contended with them, cursed them, struck certain of them, plucked off their hair, and made them swear by Elohim, “You shall not give your daughters to their sons, nor take their daughters for your sons, or for yourselves. 
 <sup>26&#160;</sup>Didn’t Solomon king of Israel sin by these things? Yet among many nations there was no king like him, and he was loved by his Elohim, and Elohim made him king over all Israel. Nevertheless foreign women caused even him to sin. 

--- a/book/numbers.html
+++ b/book/numbers.html
@@ -815,7 +815,7 @@ html[dir=ltr] .q2 {
 <sup>35&#160;</sup>From Kibroth Hattaavah the people traveled to Hazeroth; and they stayed at Hazeroth. 
 </div><h2 class="chapterlabel" id="12">12</h2>
 <div class="p">
-<sup>1&#160;</sup>Miriam and Aaron spoke against Moses because of the Cushite woman whom he had married; for he had married a Cushite woman. 
+<sup>1&#160;</sup>Miriam and Aaron spoke against Moses because of the Cushite woman whom he had taken; for he had taken a Cushite woman. 
 <sup>2&#160;</sup>They said, “Has Yahweh indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahweh heard it. 
 </div><div class="p">
 <sup>3&#160;</sup>Now the man Moses was very humble, more than all the men who were on the surface of the earth. 
@@ -2005,17 +2005,17 @@ html[dir=ltr] .q2 {
 <div class="p">
 <sup>1&#160;</sup>The heads of the fathers’ households of the family of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near and spoke before Moses and before the princes, the heads of the fathers’ households of the children of Israel. 
 <sup>2&#160;</sup>They said, “Yahweh commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahweh to give the inheritance of Zelophehad our brother to his daughters. 
-<sup>3&#160;</sup>If they are married to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
+<sup>3&#160;</sup>If they are women to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
 <sup>4&#160;</sup>When the jubilee of the children of Israel comes, then their inheritance will be added to the inheritance of the tribe to which they shall belong. So their inheritance will be taken away from the inheritance of the tribe of our fathers.” 
 </div><div class="p">
 <sup>5&#160;</sup>Moses commanded the children of Israel according to Yahweh’s word, saying, “The tribe of the sons of Joseph speak what is right. 
-<sup>6&#160;</sup>This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be married to whom they think best, only they shall marry into the family of the tribe of their father. 
+<sup>6&#160;</sup>This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be women to whom they think best, only they shall be women into the family of the tribe of their father. 
 <sup>7&#160;</sup>So shall no inheritance of the children of Israel move from tribe to tribe; for the children of Israel shall all keep the inheritance of the tribe of his fathers. 
 <sup>8&#160;</sup>Every daughter who possesses an inheritance in any tribe of the children of Israel shall be woman to one of the family of the tribe of her father, that the children of Israel may each possess the inheritance of his fathers. 
 <sup>9&#160;</sup>So shall no inheritance move from one tribe to another tribe; for the tribes of the children of Israel shall each keep his own inheritance.’&#160;” 
 </div><div class="p">
 <sup>10&#160;</sup>The daughters of Zelophehad did as Yahweh commanded Moses: 
-<sup>11&#160;</sup>for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were married to their father’s brothers’ sons. 
-<sup>12&#160;</sup>They were married into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
+<sup>11&#160;</sup>for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were women to their father’s brothers’ sons. 
+<sup>12&#160;</sup>They were women into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
 </div><div class="p">
 <sup>13&#160;</sup>These are the commandments and the ordinances which Yahweh commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. </div></div><script src="../main.js"></script></body></html>

--- a/book/proverbs.html
+++ b/book/proverbs.html
@@ -2838,7 +2838,7 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>For a servant when he is king, 
 </div><div class="q2">a fool when he is filled with food, 
 </div><div class="q2">
-<sup>23&#160;</sup>for an unloved woman when she is married, 
+<sup>23&#160;</sup>for an unloved woman when she becomes owned, 
 </div><div class="q2">and a servant who is heir to her mistress. 
 </div><div class="b"> &#160; </div>
 <div class="q1">

--- a/setup.sh
+++ b/setup.sh
@@ -1130,24 +1130,197 @@ sed -i 's/treacherously departs from her husband/treacherously departs from her 
 # ------------------------------------------------------------------------------
 # marry vs take
 # TO DO: review all occurrences and implement
-# marry is a modern word
+# marry is a modern word which obscures the meaning
 
-# marry
+# OVERVIEW
+
+# marr: 48 lines (50 instances?)
+#   27  married
+#   10  marry
+#    6  marriage & marriages
+#    4  marries
+#    2  marrow (will not be changed, obviously)
+#    1  marred (will not be changed, obviously)
+
+# marital: 1 line
+
+
+# CHANGES
+
+# married: 27 lines
+# marital: 1 line (exo 21:10)
+
+# 1ch 2:19
+sed -i 's/Caleb married Ephrath/Caleb took to himself Ephrath/' 1chronicles.usfm
+
+# 2ki 8:18
+sed -i 's/for he married Ahab’s daughter/for he took to himself Ahab’s daughter/' 2kings.usfm
+
+# deu 20:7
+sed -i 's/who has pledged to be married to a woman/who has requested and been granted a woman/' deuteronomy.usfm
+
+# deu 22:23
+sed -i 's/virgin pledged to be married to a man/virgin, who was requested and granted to a man/' deuteronomy.usfm
+
+# deu 22:25
+sed -i 's/lady who is pledged to be married in the field/lady, who was requested and granted, in the field/' deuteronomy.usfm
+
+# deu 22:27
+sed -i 's/the pledged to be married lady cried/the lady who was requested and granted cried/' deuteronomy.usfm
+
+# deu 22:28
+sed -i 's/virgin, who is not pledged to be married, grabs/virgin, who was not requested and granted, grabs/' deuteronomy.usfm
+
+# deu 25:5
+sed -i 's/not be married outside to a stranger/not go outside to a man who is a stranger/' deuteronomy.usfm
+
+# exo 21:8
+sed -i 's/If she doesn’t please her master, who has married her to himself, then/If she is dysfunctional in the eyes of her master, who didn’t join together with her, then/' exodus.usfm
+
+# exo 21:9
+sed -i 's/If he marries her to his son/If he joins her to his son/' exodus.usfm
+
+# exo 21:10
+sed -i 's/her clothing, and her marital rights/her clothing, and her shelter/' exodus.usfm
+
+# exo 22:16
+sed -i 's/virgin who isn’t pledged to be married, and lies/virgin who wasn’t requested and granted, and lies/' exodus.usfm
+
+
+# ezra 10:2
+# ezra 10:10
+# ezra 10:14
+# ezra 10:17
+# ezra 10:18
+sed -i 's/married/taken/' ezra.usfm
+
+
+# gen 11:29
+sed -i 's/Abram and Nahor married women/Abram and Nahor took women/' genesis.usfm
+
+# isa 62:4 footnote
+sed -i 's/Beulah means “married”/Beulah means “owned”/' isaiah.usfm
+
+# lev 19:20
+sed -i 's/slave girl, pledged to be married to another man/slave girl, pierced to another man/' leviticus.usfm
+
+# lev 22:12
+sed -i 's/daughter is married to an outsider/daughter becomes the woman of a man who is an outsider/' leviticus.usfm
+
+# matthew 22:25
+sed -i 's/The first married and died/The first took a woman and died/' matthew.usfm
+
+# nehemiah 13:23
+sed -i 's/married/taken/' nehemiah.usfm
+
+# numbers 12:1
+sed -i 's/woman whom he had married; for he had married a Cushite/woman whom he had taken; for he had taken a Cushite/' numbers.usfm
+
+# numbers 36:3
+sed -i 's/they are married to any of the sons/they are women to any of the sons/' numbers.usfm
+
+# numbers 36:6
+sed -i 's/them be married to whom/them be women to whom/' numbers.usfm
+
+# numbers 36:11
+sed -i 's/Zelophehad, were married to their/Zelophehad, were women to their/' numbers.usfm
+
+# numbers 36:12
+sed -i 's/They were married into/They were women into/' numbers.usfm
+
+# proverbs 30:23
+sed -i 's/unloved woman when she is married/unloved woman when she becomes owned/' proverbs.usfm
+
+
+
+# marry: 10 lines
+
+# 2sa 3:14
+sed -i 's/whom I was given to marry for one/whom I requested and was granted to me for one/' 2samuel.usfm
 
 # gen 19:14
-#sed -i 's/who were pledged to marry his daughters/who took his daughters/' genesis.usfm
+sed -i 's/who were pledged to marry his daughters/who took his daughters/' genesis.usfm
+
+# NOTE: changing "profane" or "defiled" to pierced
+# it would probably be good to find all instances of the root word and
+# change each of them. also: prostitute to whore.
+# lev 21:7
+sed -i 's/who is a prostitute, or profane\. A priest shall not marry a woman divorced/who is a whore, or pierced\. A priest shall not take a woman divorced/' leviticus.usfm
+
+# lev 21:14
+sed -i 's/shall not marry a widow, or one divorced, or a woman who has been defiled, or a prostitute/shall not take a widow, or one divorced, or a woman who has been pierced, or a whore/' leviticus.usfm
+
+# mat 19:10
+sed -i 's/it is not expedient to marry/it is not expedient to take her/' matthew.usfm
+
+# mat 22:24
+sed -i 's/his brother shall marry his woman/his brother shall take his woman/' matthew.usfm
+
+# mat 22:30
+sed -i 's/they neither marry nor are given in marriage/they neither take nor are taken/' matthew.usfm
+
+# mat 24:38
+sed -i 's/they were eating and drinking, marrying and giving in marriage, until/they were eating, drinking, being fruitful, and multiplying until/' matthew.usfm
+
+# neh 13:27
+sed -i 's/against our Elohim in marrying foreign women/against our Elohim in dwelling with foreign women/' nehemiah.usfm
+
+# num 36:6
+sed -i 's/only they shall marry into the family/only they shall be women into the family/' numbers.usfm
 
 
 
-# marriage
+
+# marriage / marriages
 
 # 1ki 3:1
-#sed -i 's/Solomon made a marriage alliance with Pharaoh/Solomon made himself son in law of Pharaoh/' 1kings.usfm
+sed -i 's/Solomon made a marriage alliance with Pharaoh/Solomon made himself a relative of Pharaoh/' 1kings.usfm
+
+# deu 7:3
+sed -i 's/You shall not make marriages with them/You shall not make yourself a relative of them/' deuteronomy.usfm
+
+# gen 34:9
+sed -i 's/Make marriages with us/Make yourselves relatives of us/' genesis.usfm
+
+# jos 23:12
+sed -i 's/and make marriages with them/and you make yourselves relatives of them/' joshua.usfm
+
+
+# marries
+
+# deu 24:1
+sed -i 's/When a man takes a woman and marries her/When a man takes a woman and owns her/' deuteronomy.usfm
+
+# mat 5:32
+sed -i 's/and whoever marries her when she is put away commits adultery/and whoever takes her when she is put away commits adultery/' matthew.usfm
+
+# mat 19:9
+sed -i 's/and marries another, commits adultery; and he who marries her/and takes another, commits adultery; and he who takes her/' matthew.usfm
 
 
 
 
+# --- unbalanced:
+# one or more changes were made that change the following term:
+# profane -> pierced
+# however, other instances appear in the text and are not changed
+# therefore resulting in an imbalance of translation.
+# this imbalance is outside the scope of this update, but
+# it should probably be addressed in a future update.
+# note: even though it may currently be a bit imbalanced, it is the goal
+# of this project to make improvements whenever they can be made,
+# so it is deemed better to have updated one or more than none.
 
+# another term to reconsider:
+# defiled -> unclean
+
+
+
+
+# other terms to reconsider:
+# wedding & weddings: 17 lines
+# wedlock: 1 line
+# bride: 34 lines
 
 
 
@@ -1448,7 +1621,7 @@ sed -i 's/Moses, because of the hardness of your hearts, allowed you to divorce 
 # "divorces" -> "puts away"
 # "divorced" -> "put away"
 # matthew 19:9
-sed -i 's/I tell you that whoever divorces his wife, except for sexual immorality, and marries another, commits adultery; and he who marries her when she is divorced commits adultery/I tell you that whoever puts away his wife, except for sexual immorality, and marries another, commits adultery; and he who marries her when she is put away commits adultery/' matthew.usfm
+sed -i 's/I tell you that whoever divorces his wife, except for sexual immorality, and takes another, commits adultery; and he who takes her when she is divorced commits adultery/I tell you that whoever puts away his wife, except for sexual immorality, and takes another, commits adultery; and he who takes her when she is put away commits adultery/' matthew.usfm
 
 
 

--- a/usfm/1chronicles.usfm
+++ b/usfm/1chronicles.usfm
@@ -89,7 +89,7 @@
 \v 17 Abigail bore Amasa; and the father of Amasa was Jether the Ishmaelite. 
 \p
 \v 18 Caleb the son of Hezron brought forth children by Azubah his woman, and by Jerioth; and these were her sons: Jesher, Shobab, and Ardon. 
-\v 19 Azubah died, and Caleb married Ephrath, who bore him Hur. 
+\v 19 Azubah died, and Caleb took to himself Ephrath, who bore him Hur. 
 \v 20 Hur brought forth Uri, and Uri brought forth Bezalel. 
 \p
 \v 21 Afterward Hezron went in to the daughter of Machir the father of Gilead, whom he took as woman when he was sixty years old; and she bore him Segub. 

--- a/usfm/1kings.usfm
+++ b/usfm/1kings.usfm
@@ -150,7 +150,7 @@
 \v 46 So the king commanded Benaiah the son of Jehoiada; and he went out, and fell on him, so that he died. The kingdom was established in the hand of Solomon. 
 \c 3
 \p
-\v 1 Solomon made a marriage alliance with Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
+\v 1 Solomon made himself a relative of Pharaoh king of Egypt. He took Pharaoh’s daughter and brought her into David’s city until he had finished building his own house, Yahweh’s house, and the wall around Jerusalem. 
 \v 2 However, the people sacrificed in the high places, because there was not yet a house built for Yahweh’s name. 
 \v 3 Solomon loved Yahweh, walking in the statutes of David his father, except that he sacrificed and burned incense in the high places. 
 \v 4 The king went to Gibeon to sacrifice there, for that was the great high place. Solomon offered a thousand burnt offerings on that altar. 

--- a/usfm/2kings.usfm
+++ b/usfm/2kings.usfm
@@ -379,7 +379,7 @@
 \p
 \v 16 In the fifth year of Joram the son of Ahab king of Israel, Jehoshaphat being king of Judah then, Jehoram the son of Jehoshaphat king of Judah began to reign. 
 \v 17 He was thirty-two years old when he began to reign. He reigned eight years in Jerusalem. 
-\v 18 He walked in the way of the kings of Israel, as did Ahab’s house, for he married Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
+\v 18 He walked in the way of the kings of Israel, as did Ahab’s house, for he took to himself Ahab’s daughter. He did that which was evil in Yahweh’s sight. 
 \v 19 However, Yahweh would not destroy Judah, for David his servant’s sake, as he promised him to give to him a lamp for his children always. 
 \p
 \v 20 In his days Edom revolted from under the hand of Judah, and made a king over themselves. 

--- a/usfm/2samuel.usfm
+++ b/usfm/2samuel.usfm
@@ -137,7 +137,7 @@
 \v 12 Abner sent messengers to David on his behalf, saying, “Whose is the land?” and saying, “Make your alliance with me, and behold, my hand will be with you to bring all Israel around to you.” 
 \p
 \v 13 David said, “Good. I will make a treaty with you, but one thing I require of you. That is, you will not see my face unless you first bring Michal, Saul’s daughter, when you come to see my face.” 
-\v 14 David sent messengers to Ishbosheth, Saul’s son, saying, “Deliver me my woman Michal, whom I was given to marry for one hundred foreskins of the Philistines.” 
+\v 14 David sent messengers to Ishbosheth, Saul’s son, saying, “Deliver me my woman Michal, whom I requested and was granted to me for one hundred foreskins of the Philistines.” 
 \p
 \v 15 Ishbosheth sent and took her from her man, Paltiel the son of Laish. 
 \v 16 Her man went with her, weeping as he went, and followed her to Bahurim. Then Abner said to him, “Go! Return!” and he returned. 

--- a/usfm/deuteronomy.usfm
+++ b/usfm/deuteronomy.usfm
@@ -283,7 +283,7 @@
 \p
 \v 1 When Yahweh your Elohim brings you into the land where you go to possess it, and casts out many nations before you—the Hittite, the Girgashite, the Amorite, the Canaanite, the Perizzite, the Hivite, and the Jebusite—seven nations greater and mightier than you; 
 \v 2 and when Yahweh your Elohim delivers them up before you, and you strike them, then you shall utterly destroy them. You shall make no covenant with them, nor show mercy to them. 
-\v 3 You shall not make marriages with them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
+\v 3 You shall not make yourself a relative of them. You shall not give your daughter to his son, nor shall you take his daughter for your son. 
 \v 4 For that would turn away your sons from following me, that they may serve other elohims. So Yahweh’s anger would be kindled against you, and he would destroy you quickly. 
 \v 5 But you shall deal with them like this: you shall break down their altars, dash their pillars in pieces, cut down their Asherah poles, and burn their engraved images with fire. 
 \v 6 For you are a set-apart people to Yahweh your Elohim. Yahweh your Elohim has chosen you to be a people for his own possession, above all peoples who are on the face of the earth. 
@@ -736,10 +736,10 @@
 \v 22 If a man is found lying with a woman owned by an owner, then they shall both die, the man who lay with the woman and the woman. So you shall remove the evil from Israel. 
 \v 23 If there is a young lady who is a virgin pledged to be married to a man, and a man finds her in the city, and lies with her, 
 \v 24 then you shall bring them both out to the gate of that city, and you shall stone them to death with stones; the lady, because she didn’t cry, being in the city; and the man, because he has humbled his neighbor’s woman. So you shall remove the evil from among you. 
-\v 25 But if the man finds the lady who is pledged to be married in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
+\v 25 But if the man finds the lady, who was requested and granted, in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
 \v 26 but to the lady you shall do nothing. There is in the lady no sin worthy of death; for as when a man rises against his neighbor and kills him, even so is this matter; 
-\v 27 for he found her in the field, the pledged to be married lady cried, and there was no one to save her. 
-\v 28 If a man finds a lady who is a virgin, who is not pledged to be married, grabs her and lies with her, and they are found, 
+\v 27 for he found her in the field, the lady who was requested and granted cried, and there was no one to save her. 
+\v 28 If a man finds a lady who is a virgin, who was not requested and granted, grabs her and lies with her, and they are found, 
 \v 29 then the man who lay with her shall give to the lady’s father fifty shekels\f + \fr 22:29 \ft A shekel is about 10 grams or about 0.35 ounces.\f* of silver. She shall be his woman, because he has humbled her. He may not put her away all his days. 
 \v 30 A man shall not take his father’s woman, and shall not uncover his father’s skirt. 
 \c 23
@@ -815,7 +815,7 @@
 \p
 \v 4 You shall not muzzle the ox when he treads out the grain. 
 \p
-\v 5 If brothers dwell together, and one of them dies and has no son, the woman of the dead shall not be married outside to a stranger. Her brother-in-law shall go in to her, and take her as his woman, and perform the duty of a brother-in-law to her. 
+\v 5 If brothers dwell together, and one of them dies and has no son, the woman of the dead shall not go outside to a man who is a stranger. Her brother-in-law shall go in to her, and take her as his woman, and perform the duty of a brother-in-law to her. 
 \v 6 It shall be that the firstborn whom she bears shall succeed in the name of his brother who is dead, that his name not be blotted out of Israel. 
 \p
 \v 7 If the man doesn’t want to take his brother’s woman, then his brother’s woman shall go up to the gate to the elders, and say, “My brother-in-law refuses to raise up to his brother a name in Israel. He will not perform the duty of a brother-in-law to me.” 

--- a/usfm/exodus.usfm
+++ b/usfm/exodus.usfm
@@ -802,9 +802,9 @@
 \v 6 then his master shall bring him to Elohim, and shall bring him to the door or to the doorpost, and his master shall bore his ear through with an awl, and he shall serve him forever. 
 \p
 \v 7 “If a man sells his daughter to be a female servant, she shall not go out as the male servants do. 
-\v 8 If she doesn’t please her master, who has married her to himself, then he shall let her be redeemed. He shall have no right to sell her to a foreign people, since he has dealt deceitfully with her. 
-\v 9 If he marries her to his son, he shall deal with her as a daughter. 
-\v 10 If he takes another woman to himself, he shall not diminish her food, her clothing, and her marital rights. 
+\v 8 If she is dysfunctional in the eyes of her master, who didn’t join together with her, then he shall let her be redeemed. He shall have no right to sell her to a foreign people, since he has dealt deceitfully with her. 
+\v 9 If he joins her to his son, he shall deal with her as a daughter. 
+\v 10 If he takes another woman to himself, he shall not diminish her food, her clothing, and her shelter. 
 \v 11 If he doesn’t do these three things for her, she may go free without paying any money. 
 \p
 \v 12 “One who strikes a man so that he dies shall surely be put to death, 
@@ -865,7 +865,7 @@
 \v 14 “If a man borrows anything of his neighbor’s, and it is injured, or dies, its owner not being with it, he shall surely make restitution. 
 \v 15 If its owner is with it, he shall not make it good. If it is a leased thing, it came for its lease. 
 \p
-\v 16 “If a man entices a virgin who isn’t pledged to be married, and lies with her, he shall surely pay a dowry for her to be his woman. 
+\v 16 “If a man entices a virgin who wasn’t requested and granted, and lies with her, he shall surely pay a dowry for her to be his woman. 
 \v 17 If her father utterly refuses to give her to him, he shall pay money according to the dowry of virgins. 
 \p
 \v 18 “You shall not allow a sorceress to live. 

--- a/usfm/ezra.usfm
+++ b/usfm/ezra.usfm
@@ -335,7 +335,7 @@
 \c 10
 \p
 \v 1 Now while Ezra prayed and made confession, weeping and casting himself down before Elohim’s house, there was gathered together to him out of Israel a very great assembly of men and women and children; for the people wept very bitterly. 
-\v 2 Shecaniah the son of Jehiel, one of the sons of Elam, answered Ezra, “We have trespassed against our Elohim, and have married foreign women of the peoples of the land. Yet now there is hope for Israel concerning this thing. 
+\v 2 Shecaniah the son of Jehiel, one of the sons of Elam, answered Ezra, “We have trespassed against our Elohim, and have taken foreign women of the peoples of the land. Yet now there is hope for Israel concerning this thing. 
 \v 3 Now therefore let’s make a covenant with our Elohim to put away all the women and those who are born of them, according to the counsel of my lord and of those who tremble at the commandment of our Elohim. Let it be done according to the law. 
 \v 4 Arise, for the matter belongs to you and we are with you. Be courageous, and do it.” 
 \p
@@ -346,19 +346,19 @@
 \p
 \v 9 Then all the men of Judah and Benjamin gathered themselves together to Jerusalem within the three days. It was the ninth month, on the twentieth day of the month; and all the people sat in the wide place in front of Elohim’s house, trembling because of this matter, and because of the great rain. 
 \p
-\v 10 Ezra the priest stood up and said to them, “You have trespassed, and have married foreign women, increasing the guilt of Israel. 
+\v 10 Ezra the priest stood up and said to them, “You have trespassed, and have taken foreign women, increasing the guilt of Israel. 
 \v 11 Now therefore make confession to Yahweh, the Elohim of your fathers and do his pleasure. Separate yourselves from the peoples of the land and from the foreign women.” 
 \p
 \v 12 Then all the assembly answered with a loud voice, “We must do as you have said concerning us. 
 \v 13 But the people are many, and it is a time of much rain, and we are not able to stand outside. This is not a work of one day or two, for we have greatly transgressed in this matter. 
-\v 14 Now let our princes be appointed for all the assembly, and let all those who are in our cities who have married foreign women come at appointed times, and with them the elders of every city and its judges, until the fierce wrath of our Elohim is turned from us, until this matter is resolved.” 
+\v 14 Now let our princes be appointed for all the assembly, and let all those who are in our cities who have taken foreign women come at appointed times, and with them the elders of every city and its judges, until the fierce wrath of our Elohim is turned from us, until this matter is resolved.” 
 \p
 \v 15 Only Jonathan the son of Asahel and Jahzeiah the son of Tikvah stood up against this; and Meshullam and Shabbethai the Levite helped them. 
 \p
 \v 16 The children of the captivity did so. Ezra the priest, with certain heads of fathers’ households, after their fathers’ houses, and all of them by their names, were set apart; and they sat down in the first day of the tenth month to examine the matter. 
-\v 17 They finished with all the men who had married foreign women by the first day of the first month. 
+\v 17 They finished with all the men who had taken foreign women by the first day of the first month. 
 \p
-\v 18 Among the sons of the priests there were found who had married foreign women: 
+\v 18 Among the sons of the priests there were found who had taken foreign women: 
 \li1 of the sons of Jeshua, the son of Jozadak, and his brothers: Maaseiah, Eliezer, Jarib, and Gedaliah. 
 \v 19 They gave their hand that they would put away their women; and being guilty, they offered a ram of the flock for their guilt. 
 \li1

--- a/usfm/genesis.usfm
+++ b/usfm/genesis.usfm
@@ -677,7 +677,7 @@
 \v 12 The men said to Lot, “Do you have anybody else here? Sons-in-law, your sons, your daughters, and whomever you have in the city, bring them out of the place: 
 \v 13 for we will destroy this place, because the outcry against them has grown so great before Yahweh that Yahweh has sent us to destroy it.” 
 \p
-\v 14 Lot went out, and spoke to his sons-in-law, who were pledged to marry his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
+\v 14 Lot went out, and spoke to his sons-in-law, who took his daughters, and said, “Get up! Get out of this place, for Yahweh will destroy the city!” 
 \p But he seemed to his sons-in-law to be joking. 
 \v 15 When the morning came, then the angels hurried Lot, saying, “Get up! Take your woman and your two daughters who are here, lest you be consumed in the iniquity of the city.” 
 \v 16 But he lingered; and the men grabbed his hand, his woman’s hand, and his two daughters’ hands, Yahweh being merciful to him; and they took him out, and set him outside of the city. 
@@ -1432,7 +1432,7 @@
 \v 6 Hamor the father of Shechem went out to Jacob to talk with him. 
 \v 7 The sons of Jacob came in from the field when they heard it. The men were grieved, and they were very angry, because he had done folly in Israel in lying with Jacob’s daughter, a thing that ought not to be done. 
 \v 8 Hamor talked with them, saying, “The soul of my son, Shechem, longs for your daughter. Please give her to him as a woman. 
-\v 9 Make marriages with us. Give your daughters to us, and take our daughters for yourselves. 
+\v 9 Make yourselves relatives of us. Give your daughters to us, and take our daughters for yourselves. 
 \v 10 You shall dwell with us, and the land will be before you. Live and trade in it, and get possessions in it.” 
 \p
 \v 11 Shechem said to her father and to her brothers, “Let me find favor in your eyes, and whatever you will tell me I will give. 

--- a/usfm/isaiah.usfm
+++ b/usfm/isaiah.usfm
@@ -4001,7 +4001,7 @@
 \v 4 You will not be called Forsaken any more, 
 \q2 nor will your land be called Desolate any more; 
 \q1 but you will be called Hephzibah,\f + \fr 62:4 \ft Hephzibah means “I delight in her”.\f* 
-\q2 and your land Beulah;\f + \fr 62:4 \ft Beulah means “married”\f* 
+\q2 and your land Beulah;\f + \fr 62:4 \ft Beulah means “owned”\f* 
 \q1 for Yahweh delights in you, 
 \q2 and your land will be owned. 
 \q1

--- a/usfm/joshua.usfm
+++ b/usfm/joshua.usfm
@@ -828,7 +828,7 @@
 \v 10 One man of you shall chase a thousand; for it is Yahweh your Elohim who fights for you, as he spoke to you. 
 \v 11 Take good heed therefore to yourselves, that you love Yahweh your Elohim. 
 \p
-\v 12 “But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and make marriages with them, and go in to them, and they to you; 
+\v 12 “But if you do at all go back, and hold fast to the remnant of these nations, even these who remain among you, and you make yourselves relatives of them, and go in to them, and they to you; 
 \v 13 know for a certainty that Yahweh your Elohim will no longer drive these nations from out of your sight; but they shall be a snare and a trap to you, a scourge in your sides, and thorns in your eyes, until you perish from off this good land which Yahweh your Elohim has given you. 
 \p
 \v 14 “Behold, today I am going the way of all the earth. You know in all your hearts and in all your souls that not one thing has failed of all the good things which Yahweh your Elohim spoke concerning you. All have happened to you. Not one thing has failed of it. 

--- a/usfm/leviticus.usfm
+++ b/usfm/leviticus.usfm
@@ -747,7 +747,7 @@
 \p “ ‘You shall not sow your field with two kinds of seed; 
 \p “ ‘Don’t wear a garment made of two kinds of material. 
 \p
-\v 20 “ ‘If a man lies carnally with a woman who is a slave girl, pledged to be married to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
+\v 20 “ ‘If a man lies carnally with a woman who is a slave girl, pierced to another man, and not ransomed or given her freedom; they shall be punished. They shall not be put to death, because she was not free. 
 \v 21 He shall bring his trespass offering to Yahweh, to the door of the Tent of Meeting, even a ram for a trespass offering. 
 \v 22 The priest shall make atonement for him with the ram of the trespass offering before Yahweh for his sin which he has committed; and the sin which he has committed shall be forgiven him. 
 \p
@@ -832,7 +832,7 @@
 \v 5 “ ‘They shall not shave their heads or shave off the corners of their beards or make any cuttings in their flesh. 
 \v 6 They shall be set-apart to their Elohim, and not profane the name of their Elohim, for they offer the offerings of Yahweh made by fire, the bread of their Elohim. Therefore they shall be set-apart. 
 \p
-\v 7 “ ‘They shall not marry a woman who is a prostitute, or profane. A priest shall not marry a woman divorced from her man; for he is set-apart to his Elohim. 
+\v 7 “ ‘They shall not marry a woman who is a whore, or pierced. A priest shall not take a woman divorced from her man; for he is set-apart to his Elohim. 
 \v 8 Therefore you shall sanctify him, for he offers the bread of your Elohim. He shall be set-apart to you, for I Yahweh, who sanctify you, am set-apart. 
 \p
 \v 9 “ ‘The daughter of any priest, if she profanes herself by playing the prostitute, she profanes her father. She shall be burned with fire. 
@@ -842,7 +842,7 @@
 \v 12 He shall not go out of the sanctuary, nor profane the sanctuary of his Elohim; for the crown of the anointing oil of his Elohim is upon him. I am Yahweh. 
 \p
 \v 13 “ ‘He shall take a woman in her virginity. 
-\v 14 He shall not marry a widow, or one divorced, or a woman who has been defiled, or a prostitute. He shall take a virgin of his own people as a woman. 
+\v 14 He shall not take a widow, or one divorced, or a woman who has been pierced, or a whore. He shall take a virgin of his own people as a woman. 
 \v 15 He shall not profane his offspring among his people, for I am Yahweh who sanctifies him.’ ” 
 \p
 \v 16 Yahweh spoke to Moses, saying, 
@@ -871,7 +871,7 @@
 \p
 \v 10 “ ‘No stranger shall eat of the set-apart thing: a foreigner living with the priests, or a hired servant, shall not eat of the set-apart thing. 
 \v 11 But if a priest buys a slave, purchased by his money, he shall eat of it; and those who are born in his house shall eat of his bread. 
-\v 12 If a priest’s daughter is married to an outsider, she shall not eat of the heave offering of the set-apart things. 
+\v 12 If a priest’s daughter becomes the woman of a man who is an outsider, she shall not eat of the heave offering of the set-apart things. 
 \v 13 But if a priest’s daughter is a widow, or divorced, and has no child, and has returned to her father’s house as in her youth, she may eat of her father’s bread; but no stranger shall eat any of it. 
 \p
 \v 14 “ ‘If a man eats something set-apart unwittingly, then he shall add the fifth part of its value to it, and shall give the set-apart thing to the priest. 

--- a/usfm/matthew.usfm
+++ b/usfm/matthew.usfm
@@ -197,7 +197,7 @@
 \v 30 \wj If your right hand causes you to stumble, cut it off, and throw it away from you. For it is more profitable for you that one of your members should perish, than for your whole body to be cast into Gehenna.\wj*\f + \fr 5:30 \ft or, Hell\f* 
 \p
 \v 31 \wj “It was also said, ‘Whoever shall put away his woman, let him give her a writing of divorce,’\wj*\x + \xo 5:31 \xt Deuteronomy 24:1\x* 
-\v 32 \wj but I tell you that whoever puts away his woman, except for the cause of sexual immorality, makes her an adulteress; and whoever marries her when she is put away commits adultery.\wj* 
+\v 32 \wj but I tell you that whoever puts away his woman, except for the cause of sexual immorality, makes her an adulteress; and whoever takes her when she is put away commits adultery.\wj* 
 \p
 \v 33 \wj “Again you have heard that it was said to the ancient ones, ‘You shall not make false vows by my name, but shall perform to the Lord your vows,’\wj*\x + \xo 5:33 \xt Numbers 30:2; Deuteronomy 23:21; Ecclesiastes 5:4\x* 
 \v 34 \wj but I tell you, don’t swear falsely at all: neither by heaven, for it is the throne of Elohim; \wj* 
@@ -939,9 +939,9 @@
 \v 7 They asked him, “Why then did Moses command us to give her a certificate of divorce and divorce her?” 
 \p
 \v 8 He said to them, \wj “Moses, because of the hardness of your hearts, allowed you to put away your women, but from the beginning it has not been so. \wj* 
-\v 9 \wj I tell you that whoever puts away his woman, except for sexual immorality, and marries another, commits adultery; and he who marries her when she is put away commits adultery.”\wj* 
+\v 9 \wj I tell you that whoever puts away his woman, except for sexual immorality, and takes another, commits adultery; and he who takes her when she is put away commits adultery.”\wj* 
 \p
-\v 10 His disciples said to him, “If this is the case of the man with his woman, it is not expedient to marry.” 
+\v 10 His disciples said to him, “If this is the case of the man with his woman, it is not expedient to take her.” 
 \p
 \v 11 But he said to them, \wj “Not all men can receive this saying, but those to whom it is given. \wj* 
 \v 12 \wj For there are eunuchs who were born that way from their mother’s womb, and there are eunuchs who were made eunuchs by men; and there are eunuchs who made themselves eunuchs for the Kingdom of Heaven’s sake. He who is able to receive it, let him receive it.”\wj* 
@@ -1142,13 +1142,13 @@
 \p
 \v 23 On that day Sadducees (those who say that there is no resurrection) came to him. They asked him, 
 \v 24 saying, “Teacher, Moses said, ‘If a man dies, having no children, his brother shall marry his woman and raise up offspring\f + \fr 22:24 \ft or, seed\f* for his brother.’ 
-\v 25 Now there were with us seven brothers. The first married and died, and having no offspring left his woman to his brother. 
+\v 25 Now there were with us seven brothers. The first took a woman and died, and having no offspring left his woman to his brother. 
 \v 26 In the same way, the second also, and the third, to the seventh. 
 \v 27 After them all, the woman died. 
 \v 28 In the resurrection therefore, whose woman will she be of the seven? For they all had her.” 
 \p
 \v 29 But Yahushua answered them, \wj “You are mistaken, not knowing the Scriptures, nor the power of Elohim. \wj* 
-\v 30 \wj For in the resurrection they neither marry nor are given in marriage, but are like Elohim’s angels in heaven. \wj* 
+\v 30 \wj For in the resurrection they neither take nor are taken, but are like Elohim’s angels in heaven. \wj* 
 \v 31 \wj But concerning the resurrection of the dead, haven’t you read that which was spoken to you by Elohim, saying, \wj* 
 \v 32 \wj ‘I am the Elohim of Abraham, and the Elohim of Isaac, and the Elohim of Jacob’?\wj*\x + \xo 22:32 \xt Exodus 3:6\x* \wj Elohim is not the Elohim of the dead, but of the living.”\wj* 
 \p
@@ -1274,7 +1274,7 @@
 \p
 \v 36 \wj “But no one knows of that day and hour, not even the angels of heaven,\wj*\f + \fr 24:36 \ft NU adds “nor the son”\f* \wj but my Father only.\wj* 
 \v 37 \wj As the days of Noah were, so will the coming of the Son of Man be. \wj* 
-\v 38 \wj For as in those days which were before the flood they were eating and drinking, marrying and giving in marriage, until the day that Noah entered into the ship, \wj* 
+\v 38 \wj For as in those days which were before the flood they were eating, drinking, being fruitful, and multiplying until the day that Noah entered into the ship, \wj* 
 \v 39 \wj and they didn’t know until the flood came and took them all away, so will the coming of the Son of Man be. \wj* 
 \v 40 \wj Then two men will be in the field: one will be taken and one will be left. \wj* 
 \v 41 \wj Two women will be grinding at the mill: one will be taken and one will be left. \wj* 

--- a/usfm/nehemiah.usfm
+++ b/usfm/nehemiah.usfm
@@ -557,7 +557,7 @@
 \v 21 Then I testified against them, and said to them, “Why do you stay around the wall? If you do so again, I will lay hands on you.” From that time on, they didn’t come on the Sabbath. 
 \v 22 I commanded the Levites that they should purify themselves, and that they should come and keep the gates, to sanctify the Sabbath day. Remember me for this also, my Elohim, and spare me according to the greatness of your loving kindness. 
 \p
-\v 23 In those days I also saw the Jews who had married women of Ashdod, of Ammon, and of Moab; 
+\v 23 In those days I also saw the Jews who had taken women of Ashdod, of Ammon, and of Moab; 
 \v 24 and their children spoke half in the speech of Ashdod, and could not speak in the Jews’ language, but according to the language of each people. 
 \v 25 I contended with them, cursed them, struck certain of them, plucked off their hair, and made them swear by Elohim, “You shall not give your daughters to their sons, nor take their daughters for your sons, or for yourselves. 
 \v 26 Didn’t Solomon king of Israel sin by these things? Yet among many nations there was no king like him, and he was loved by his Elohim, and Elohim made him king over all Israel. Nevertheless foreign women caused even him to sin. 

--- a/usfm/numbers.usfm
+++ b/usfm/numbers.usfm
@@ -726,7 +726,7 @@
 \v 35 From Kibroth Hattaavah the people traveled to Hazeroth; and they stayed at Hazeroth. 
 \c 12
 \p
-\v 1 Miriam and Aaron spoke against Moses because of the Cushite woman whom he had married; for he had married a Cushite woman. 
+\v 1 Miriam and Aaron spoke against Moses because of the Cushite woman whom he had taken; for he had taken a Cushite woman. 
 \v 2 They said, “Has Yahweh indeed spoken only with Moses? Hasn’t he spoken also with us?” And Yahweh heard it. 
 \p
 \v 3 Now the man Moses was very humble, more than all the men who were on the surface of the earth. 
@@ -1916,17 +1916,17 @@
 \p
 \v 1 The heads of the fathers’ households of the family of the children of Gilead, the son of Machir, the son of Manasseh, of the families of the sons of Joseph, came near and spoke before Moses and before the princes, the heads of the fathers’ households of the children of Israel. 
 \v 2 They said, “Yahweh commanded my lord to give the land for inheritance by lot to the children of Israel. My lord was commanded by Yahweh to give the inheritance of Zelophehad our brother to his daughters. 
-\v 3 If they are married to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
+\v 3 If they are women to any of the sons of the other tribes of the children of Israel, then their inheritance will be taken away from the inheritance of our fathers, and will be added to the inheritance of the tribe to which they shall belong. So it will be taken away from the lot of our inheritance. 
 \v 4 When the jubilee of the children of Israel comes, then their inheritance will be added to the inheritance of the tribe to which they shall belong. So their inheritance will be taken away from the inheritance of the tribe of our fathers.” 
 \p
 \v 5 Moses commanded the children of Israel according to Yahweh’s word, saying, “The tribe of the sons of Joseph speak what is right. 
-\v 6 This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be married to whom they think best, only they shall marry into the family of the tribe of their father. 
+\v 6 This is the thing which Yahweh commands concerning the daughters of Zelophehad, saying, ‘Let them be women to whom they think best, only they shall be women into the family of the tribe of their father. 
 \v 7 So shall no inheritance of the children of Israel move from tribe to tribe; for the children of Israel shall all keep the inheritance of the tribe of his fathers. 
 \v 8 Every daughter who possesses an inheritance in any tribe of the children of Israel shall be woman to one of the family of the tribe of her father, that the children of Israel may each possess the inheritance of his fathers. 
 \v 9 So shall no inheritance move from one tribe to another tribe; for the tribes of the children of Israel shall each keep his own inheritance.’ ” 
 \p
 \v 10 The daughters of Zelophehad did as Yahweh commanded Moses: 
-\v 11 for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were married to their father’s brothers’ sons. 
-\v 12 They were married into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
+\v 11 for Mahlah, Tirzah, Hoglah, Milcah, and Noah, the daughters of Zelophehad, were women to their father’s brothers’ sons. 
+\v 12 They were women into the families of the sons of Manasseh the son of Joseph. Their inheritance remained in the tribe of the family of their father. 
 \p
 \v 13 These are the commandments and the ordinances which Yahweh commanded by Moses to the children of Israel in the plains of Moab by the Jordan at Jericho. 

--- a/usfm/proverbs.usfm
+++ b/usfm/proverbs.usfm
@@ -2754,7 +2754,7 @@
 \v 22 For a servant when he is king, 
 \q2 a fool when he is filled with food, 
 \q2
-\v 23 for an unloved woman when she is married, 
+\v 23 for an unloved woman when she becomes owned, 
 \q2 and a servant who is heir to her mistress. 
 \b
 \q1


### PR DESCRIPTION
mat 5:32 and 19:8-9 are difficult again in light of hebrew matthew but i did not attempt to deal with that, i just restore terms of "marry" to "take".

see notes in setup.sh

this only deals with marry, marriage, married, marries, marital...
not wed, or bride, or bridegroom.

several meanings are uncovered: take, become relative of, requested and granted, pierced, etc.