### PR TITLE
Fix 3 instances of married

### DIFF
--- a/book/deuteronomy.html
+++ b/book/deuteronomy.html
@@ -745,7 +745,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>5&#160;</sup>The officers shall speak to the people, saying, “What man is there who has built a new house, and has not dedicated it? Let him go and return to his house, lest he die in the battle, and another man dedicate it. 
 <sup>6&#160;</sup>What man is there who has planted a vineyard, and has not used its fruit? Let him go and return to his house, lest he die in the battle, and another man use its fruit. 
-<sup>7&#160;</sup>What man is there who has pledged to be married to a woman, and has not taken her? Let him go and return to his house, lest he die in the battle, and another man take her.” 
+<sup>7&#160;</sup>What man is there who has requested and been granted a woman, and has not taken her? Let him go and return to his house, lest he die in the battle, and another man take her.” 
 <sup>8&#160;</sup>The officers shall speak further to the people, and they shall say, “What man is there who is fearful and faint-hearted? Let him go and return to his house, lest his brother’s heart melt as his heart.” 
 <sup>9&#160;</sup>It shall be, when the officers have finished speaking to the people, that they shall appoint captains of armies at the head of the people. 
 </div><div class="p">
@@ -821,7 +821,7 @@ html[dir=ltr] .q2 {
 <sup>21&#160;</sup>then they shall bring out the young lady to the door of her father’s house, and the men of her city shall stone her to death with stones, because she has done folly in Israel, to play the prostitute in her father’s house. So you shall remove the evil from among you. 
 </div><div class="p">
 <sup>22&#160;</sup>If a man is found lying with a woman owned by an owner, then they shall both die, the man who lay with the woman and the woman. So you shall remove the evil from Israel. 
-<sup>23&#160;</sup>If there is a young lady who is a virgin pledged to be married to a man, and a man finds her in the city, and lies with her, 
+<sup>23&#160;</sup>If there is a young lady who is a virgin, who was requested and granted to a man, and a man finds her in the city, and lies with her, 
 <sup>24&#160;</sup>then you shall bring them both out to the gate of that city, and you shall stone them to death with stones; the lady, because she didn’t cry, being in the city; and the man, because he has humbled his neighbor’s woman. So you shall remove the evil from among you. 
 <sup>25&#160;</sup>But if the man finds the lady, who was requested and granted, in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
 <sup>26&#160;</sup>but to the lady you shall do nothing. There is in the lady no sin worthy of death; for as when a man rises against his neighbor and kills him, even so is this matter; 

--- a/book/genesis.html
+++ b/book/genesis.html
@@ -529,7 +529,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>27&#160;</sup>Now this is the history of the generations of Terah. Terah brought forth Abram, Nahor, and Haran. Haran brought forth Lot. 
 <sup>28&#160;</sup>Haran died in the land of his birth, in Ur of the Chaldees, while his father Terah was still alive. 
-<sup>29&#160;</sup>Abram and Nahor married women. The name of Abram’s woman was Sarai, and the name of Nahor’s woman was Milcah, the daughter of Haran, who was also the father of Iscah. 
+<sup>29&#160;</sup>Abram and Nahor took women. The name of Abram’s woman was Sarai, and the name of Nahor’s woman was Milcah, the daughter of Haran, who was also the father of Iscah. 
 <sup>30&#160;</sup>Sarai was barren. She had no child. 
 <sup>31&#160;</sup>Terah took Abram his son, Lot the son of Haran, his son’s son, and Sarai his daughter-in-law, his son Abram’s woman. They went from Ur of the Chaldees, to go into the land of Canaan. They came to Haran and lived there. 
 <sup>32&#160;</sup>The days of Terah were two hundred five years. Terah died in Haran. 

--- a/setup.sh
+++ b/setup.sh
@@ -1157,10 +1157,10 @@ sed -i 's/Caleb married Ephrath/Caleb took to himself Ephrath/' 1chronicles.usfm
 sed -i 's/for he married Ahab’s daughter/for he took to himself Ahab’s daughter/' 2kings.usfm
 
 # deu 20:7
-sed -i 's/who has pledged to be married to a woman/who has requested and been granted a woman/' deuteronomy.usfm
+sed -i 's/who has pledged to be married to a wife/who has requested and been granted a wife/' deuteronomy.usfm
 
 # deu 22:23
-sed -i 's/virgin pledged to be married to a man/virgin, who was requested and granted to a man/' deuteronomy.usfm
+sed -i 's/virgin pledged to be married to a husband/virgin, who was requested and granted to a husband/' deuteronomy.usfm
 
 # deu 22:25
 sed -i 's/lady who is pledged to be married in the field/lady, who was requested and granted, in the field/' deuteronomy.usfm
@@ -1196,7 +1196,7 @@ sed -i 's/married/taken/' ezra.usfm
 
 
 # gen 11:29
-sed -i 's/Abram and Nahor married women/Abram and Nahor took women/' genesis.usfm
+sed -i 's/Abram and Nahor married wives/Abram and Nahor took wives/' genesis.usfm
 
 # isa 62:4 footnote
 sed -i 's/Beulah means “married”/Beulah means “owned”/' isaiah.usfm

--- a/usfm/deuteronomy.usfm
+++ b/usfm/deuteronomy.usfm
@@ -658,7 +658,7 @@
 \p
 \v 5 The officers shall speak to the people, saying, “What man is there who has built a new house, and has not dedicated it? Let him go and return to his house, lest he die in the battle, and another man dedicate it. 
 \v 6 What man is there who has planted a vineyard, and has not used its fruit? Let him go and return to his house, lest he die in the battle, and another man use its fruit. 
-\v 7 What man is there who has pledged to be married to a woman, and has not taken her? Let him go and return to his house, lest he die in the battle, and another man take her.” 
+\v 7 What man is there who has requested and been granted a woman, and has not taken her? Let him go and return to his house, lest he die in the battle, and another man take her.” 
 \v 8 The officers shall speak further to the people, and they shall say, “What man is there who is fearful and faint-hearted? Let him go and return to his house, lest his brother’s heart melt as his heart.” 
 \v 9 It shall be, when the officers have finished speaking to the people, that they shall appoint captains of armies at the head of the people. 
 \p
@@ -734,7 +734,7 @@
 \v 21 then they shall bring out the young lady to the door of her father’s house, and the men of her city shall stone her to death with stones, because she has done folly in Israel, to play the prostitute in her father’s house. So you shall remove the evil from among you. 
 \p
 \v 22 If a man is found lying with a woman owned by an owner, then they shall both die, the man who lay with the woman and the woman. So you shall remove the evil from Israel. 
-\v 23 If there is a young lady who is a virgin pledged to be married to a man, and a man finds her in the city, and lies with her, 
+\v 23 If there is a young lady who is a virgin, who was requested and granted to a man, and a man finds her in the city, and lies with her, 
 \v 24 then you shall bring them both out to the gate of that city, and you shall stone them to death with stones; the lady, because she didn’t cry, being in the city; and the man, because he has humbled his neighbor’s woman. So you shall remove the evil from among you. 
 \v 25 But if the man finds the lady, who was requested and granted, in the field, and the man forces her and lies with her, then only the man who lay with her shall die; 
 \v 26 but to the lady you shall do nothing. There is in the lady no sin worthy of death; for as when a man rises against his neighbor and kills him, even so is this matter; 

--- a/usfm/genesis.usfm
+++ b/usfm/genesis.usfm
@@ -426,7 +426,7 @@
 \p
 \v 27 Now this is the history of the generations of Terah. Terah brought forth Abram, Nahor, and Haran. Haran brought forth Lot. 
 \v 28 Haran died in the land of his birth, in Ur of the Chaldees, while his father Terah was still alive. 
-\v 29 Abram and Nahor married women. The name of Abram’s woman was Sarai, and the name of Nahor’s woman was Milcah, the daughter of Haran, who was also the father of Iscah. 
+\v 29 Abram and Nahor took women. The name of Abram’s woman was Sarai, and the name of Nahor’s woman was Milcah, the daughter of Haran, who was also the father of Iscah. 
 \v 30 Sarai was barren. She had no child. 
 \v 31 Terah took Abram his son, Lot the son of Haran, his son’s son, and Sarai his daughter-in-law, his son Abram’s woman. They went from Ur of the Chaldees, to go into the land of Canaan. They came to Haran and lived there. 
 \v 32 The days of Terah were two hundred five years. Terah died in Haran. 


### PR DESCRIPTION
3 instances of married weren't getting changed because, i.e., they expected the term woman before wife was changed to woman.
so, to solve, i just changed the search string to have the term wife. so now it finds the phrase, changes the term married, then later changes wife to woman.
one instance is based on the word husband instead of the word wife.