### PR TITLE
Translate h2530 as desire not covet

### DIFF
--- a/book/deuteronomy.html
+++ b/book/deuteronomy.html
@@ -319,7 +319,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>20&#160;</sup>“You shall not give false testimony against your neighbor. 
 </div><div class="p">
-<sup>21&#160;</sup>“You shall not covet your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
+<sup>21&#160;</sup>“You shall not desire your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
 </div><div class="p">
 <sup>22&#160;</sup>Yahweh spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
 <sup>23&#160;</sup>When you heard the voice out of the middle of the darkness, while the mountain was burning with fire, you came near to me, even all the heads of your tribes, and your elders; 
@@ -392,7 +392,7 @@ html[dir=ltr] .q2 {
 <sup>22&#160;</sup>Yahweh your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
 <sup>23&#160;</sup>But Yahweh your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
 <sup>24&#160;</sup>He will deliver their kings into your hand, and you shall make their name perish from under the sky. No one will be able to stand before you until you have destroyed them. 
-<sup>25&#160;</sup>You shall burn the engraved images of their elohims with fire. You shall not covet the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
+<sup>25&#160;</sup>You shall burn the engraved images of their elohims with fire. You shall not desire the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
 <sup>26&#160;</sup>You shall not bring an abomination into your house and become a devoted thing like it. You shall utterly detest it. You shall utterly abhor it; for it is a devoted thing. 
 </div><h2 class="chapterlabel" id="8">8</h2>
 <div class="p">

--- a/book/exodus.html
+++ b/book/exodus.html
@@ -871,7 +871,7 @@ html[dir=ltr] .q2 {
 </div><div class="p">
 <sup>16&#160;</sup>“You shall not give false testimony against your neighbor. 
 </div><div class="p">
-<sup>17&#160;</sup>“You shall not covet your neighbor’s house. You shall not covet your neighbor’s woman, nor his male servant, nor his female servant, nor his ox, nor his donkey, nor anything that is your neighbor’s.” 
+<sup>17&#160;</sup>“You shall not desire your neighbor’s house. You shall not desire your neighbor’s woman, nor his male servant, nor his female servant, nor his ox, nor his donkey, nor anything that is your neighbor’s.” 
 </div><div class="p">
 <sup>18&#160;</sup>All the people perceived the thunderings, the lightnings, the sound of the trumpet, and the mountain smoking. When the people saw it, they trembled, and stayed at a distance. 
 <sup>19&#160;</sup>They said to Moses, “Speak with us yourself, and we will listen; but don’t let Elohim speak with us, lest we die.” 

--- a/book/isaiah.html
+++ b/book/isaiah.html
@@ -3724,7 +3724,7 @@ html[dir=ltr] .q2 {
 </div><div class="q2">for the spirit would faint before me, 
 </div><div class="q2">and the souls whom I have made. 
 </div><div class="q1">
-<sup>17&#160;</sup>I was angry because of the iniquity of his covetousness and struck him. 
+<sup>17&#160;</sup>I was angry because of the iniquity of his desire and struck him. 
 </div><div class="q2">I hid myself and was angry; 
 </div><div class="q2">and he went on backsliding in the way of his heart. 
 </div><div class="q1">

--- a/book/james.html
+++ b/book/james.html
@@ -151,7 +151,7 @@ html[dir=ltr] .q2 {
 </div><h2 class="chapterlabel" id="4">4</h2>
 <div class="p">
 <sup>1&#160;</sup>Where do wars and fightings among you come from? Don’t they come from your pleasures that war in your members? 
-<sup>2&#160;</sup>You lust, and don’t have. You murder and covet, and can’t obtain. You fight and make war. You don’t have, because you don’t ask. 
+<sup>2&#160;</sup>You lust, and don’t have. You murder and desire, and can’t obtain. You fight and make war. You don’t have, because you don’t ask. 
 <sup>3&#160;</sup>You ask, and don’t receive, because you ask with wrong motives, so that you may spend it on your pleasures. 
 <sup>4&#160;</sup>You adulterers and adulteresses, don’t you know that friendship with the world is hostility toward Elohim? Whoever therefore wants to be a friend of the world makes himself an enemy of Elohim. 
 <sup>5&#160;</sup>Or do you think that the Scripture says in vain, “The Spirit who lives in us yearns jealously”? 

--- a/book/jeremiah.html
+++ b/book/jeremiah.html
@@ -450,7 +450,7 @@ html[dir=ltr] .q2 {
 </div><div class="q2">their fields and their women together; 
 </div><div class="q1">for I will stretch out my hand on the inhabitants of the land, says Yahweh.” 
 </div><div class="q1">
-<sup>13&#160;</sup>“For from their least even to their greatest, everyone is given to covetousness. 
+<sup>13&#160;</sup>“For from their least even to their greatest, everyone is given to desire. 
 </div><div class="q2">From the prophet even to the priest, everyone deals falsely. 
 </div><div class="q1">
 <sup>14&#160;</sup>They have healed also the hurt of my people superficially, 
@@ -555,7 +555,7 @@ html[dir=ltr] .q2 {
 </div><div class="q1">
 <sup>10&#160;</sup>Therefore I will give their women to others 
 </div><div class="q2">and their fields to those who will possess them. 
-</div><div class="q1">For everyone from the least even to the greatest is given to covetousness; 
+</div><div class="q1">For everyone from the least even to the greatest is given to desire; 
 </div><div class="q2">from the prophet even to the priest everyone deals falsely. 
 </div><div class="q1">
 <sup>11&#160;</sup>They have healed the hurt of the daughter of my people slightly, saying, 
@@ -1621,7 +1621,7 @@ html[dir=ltr] .q2 {
 </div><div class="q1">Wasn’t this to know me?” 
 </div><div class="q2">says Yahweh. 
 </div><div class="q1">
-<sup>17&#160;</sup>But your eyes and your heart are only for your covetousness, 
+<sup>17&#160;</sup>But your eyes and your heart are only for your desire, 
 </div><div class="q2">for shedding innocent blood, 
 </div><div class="q2">for oppression, and for doing violence.” 
 </div><div class="m">
@@ -3622,7 +3622,7 @@ html[dir=ltr] .q2 {
 </div><div class="q2">that which he spoke concerning the inhabitants of Babylon. 
 </div><div class="q1">
 <sup>13&#160;</sup>You who dwell on many waters, abundant in treasures, 
-</div><div class="q2">your end has come, the measure of your covetousness. 
+</div><div class="q2">your end has come, the measure of your desire. 
 </div><div class="q1">
 <sup>14&#160;</sup>Yahweh of Armies has sworn by himself, saying, 
 </div><div class="q2">‘Surely I will fill you with men, 

--- a/book/joshua.html
+++ b/book/joshua.html
@@ -276,7 +276,7 @@ html[dir=ltr] .q2 {
 <sup>19&#160;</sup>Joshua said to Achan, “My son, please give glory to Yahweh, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
 </div><div class="p">
 <sup>20&#160;</sup>Achan answered Joshua, and said, “I have truly sinned against Yahweh, the Elohim of Israel, and this is what I have done. 
-<sup>21&#160;</sup>When I saw among the plunder a beautiful Babylonian robe, two hundred shekels of silver, and a wedge of gold weighing fifty shekels, then I coveted them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
+<sup>21&#160;</sup>When I saw among the plunder a beautiful Babylonian robe, two hundred shekels of silver, and a wedge of gold weighing fifty shekels, then I desired them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
 </div><div class="p">
 <sup>22&#160;</sup>So Joshua sent messengers, and they ran to the tent. Behold, it was hidden in his tent, with the silver under it. 
 <sup>23&#160;</sup>They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahweh. 

--- a/book/micah.html
+++ b/book/micah.html
@@ -140,7 +140,7 @@ html[dir=ltr] .q2 {
 </div><div class="q1">When the morning is light, they practice it, 
 </div><div class="q2">because it is in the power of their hand. 
 </div><div class="q1">
-<sup>2&#160;</sup>They covet fields and seize them, 
+<sup>2&#160;</sup>They desire fields and seize them, 
 </div><div class="q2">and houses, then take them away. 
 </div><div class="q1">They oppress a man and his house, 
 </div><div class="q2">even a man and his heritage. 

--- a/book/proverbs.html
+++ b/book/proverbs.html
@@ -1967,7 +1967,7 @@ html[dir=ltr] .q2 {
 <sup>25&#160;</sup>The desire of the sluggard kills him, 
 </div><div class="q2">for his hands refuse to labor. 
 </div><div class="q1">
-<sup>26&#160;</sup>There are those who covet greedily all day long; 
+<sup>26&#160;</sup>There are those who desire greedily all day long; 
 </div><div class="q2">but the righteous give and don’t withhold. 
 </div><div class="q1">
 <sup>27&#160;</sup>The sacrifice of the wicked is an abomination—</div><div class="q2">how much more, when he brings it with a wicked mind! 

--- a/setup.sh
+++ b/setup.sh
@@ -1936,6 +1936,14 @@ printf .
 
 
 
+# ----------------------------------------------------------
+# covet to desire
+sed -i 's/covetousness/desire/g' *.usfm
+sed -i 's/coveted/desired/g' *.usfm
+sed -i 's/covet/desire/g' *.usfm
+
+
+
 # ------------------------------------------------------------------------------
 # CONVERT USFM TO HTML
 # only usfm markers used in the web version are considered
@@ -2014,6 +2022,8 @@ done
 # clean up temporary file
 rm top-tempfile.html
 
+printf .
+
 # customize book title
 for f in *.html; do
 h=$(grep '\\h ' $f | cut -c 4- | xargs)
@@ -2066,6 +2076,7 @@ sed -i 's/\\c \([0-9]\+\)/<h2 class="chapterlabel" id="\1">\1<\/h2>/' *.html
 # no chapters
 #sed -i '/\\c /d' *.html
 
+printf .
 
 
 # ------------------------------------------------------------------------------
@@ -2077,6 +2088,8 @@ sed -i '/booklabel/a <div class="chapterlabel nav chapnav">' *.html
 # after chapnav, close the div
 # this will be done later by the "close divs" section
 #sed -i '/chapnav/a <\/div>' *.html
+
+printf .
 
 # add chapter links according to number of chapters
 for f in *.html; do
@@ -2092,6 +2105,8 @@ sed -i "/chapnav/a <a href=\"#$n\">$n</a>" $f
 ((n--))
 done
 done
+
+printf .
 
 # rename for psalms
 sed -i 's/chapterlabel/psalmlabel/' psalms.html
@@ -2109,7 +2124,7 @@ sed -i "/chapnav/a <a href=\"#$n\">$n</a>" psalms.html
 ((n--))
 done
 
-
+printf .
 
 
 
@@ -2142,6 +2157,7 @@ sed -i '0,/<div class="p">/{s/<div class="p">/<div class="p1">/}' *.html
 # will need to remove the first "</div>"
 # \qs* makes close
 
+printf .
 
 
 # ------------------------------------------------------------------------------
@@ -2170,6 +2186,8 @@ sed -i 's/\\qs/<div class="qs">/g' *.html
 #sed -i 's/\\qs //g' *.html
 #sed -i 's/\\qs//g' *.html
 #sed -i 's/\\qs\*//g' *.html
+
+printf .
 
 # convert speaker, for song of songs
 sed -i 's/\\sp /<div class="sp">/g' *.html
@@ -2214,6 +2232,7 @@ sed -i 's/\\d/<div class="d">/g' *.html
 sed -i 's/\\nb /<div class="nb">/g' *.html
 sed -i 's/\\nb/<div class="nb">/g' *.html
 
+printf .
 
 
 # ------------------------------------------------------------------------------
@@ -2232,6 +2251,7 @@ sed -i '0,/<\/div>/{s/<\/div>//}' *.html
 #sed -i 's/<\/div><\/body>/<\/p><\/div><\/body>/' *.html
 #sed -i 's/<\/div><\/body>/<\/div><\/div><\/body>/' *.html
 
+printf .
 
 
 # ------------------------------------------------------------------------------

--- a/usfm/deuteronomy.usfm
+++ b/usfm/deuteronomy.usfm
@@ -232,7 +232,7 @@
 \p
 \v 20 “You shall not give false testimony against your neighbor. 
 \p
-\v 21 “You shall not covet your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
+\v 21 “You shall not desire your neighbor’s woman. Neither shall you desire your neighbor’s house, his field, or his male servant, or his female servant, his ox, or his donkey, or anything that is your neighbor’s.” 
 \p
 \v 22 Yahweh spoke these words to all your assembly on the mountain out of the middle of the fire, of the cloud, and of the thick darkness, with a great voice. He added no more. He wrote them on two stone tablets, and gave them to me. 
 \v 23 When you heard the voice out of the middle of the darkness, while the mountain was burning with fire, you came near to me, even all the heads of your tribes, and your elders; 
@@ -305,7 +305,7 @@
 \v 22 Yahweh your Elohim will cast out those nations before you little by little. You may not consume them at once, lest the animals of the field increase on you. 
 \v 23 But Yahweh your Elohim will deliver them up before you, and will confuse them with a great confusion, until they are destroyed. 
 \v 24 He will deliver their kings into your hand, and you shall make their name perish from under the sky. No one will be able to stand before you until you have destroyed them. 
-\v 25 You shall burn the engraved images of their elohims with fire. You shall not covet the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
+\v 25 You shall burn the engraved images of their elohims with fire. You shall not desire the silver or the gold that is on them, nor take it for yourself, lest you be snared in it; for it is an abomination to Yahweh your Elohim. 
 \v 26 You shall not bring an abomination into your house and become a devoted thing like it. You shall utterly detest it. You shall utterly abhor it; for it is a devoted thing. 
 \c 8
 \p

--- a/usfm/exodus.usfm
+++ b/usfm/exodus.usfm
@@ -778,7 +778,7 @@
 \p
 \v 16 “You shall not give false testimony against your neighbor. 
 \p
-\v 17 “You shall not covet your neighbor’s house. You shall not covet your neighbor’s woman, nor his male servant, nor his female servant, nor his ox, nor his donkey, nor anything that is your neighbor’s.” 
+\v 17 “You shall not desire your neighbor’s house. You shall not desire your neighbor’s woman, nor his male servant, nor his female servant, nor his ox, nor his donkey, nor anything that is your neighbor’s.” 
 \p
 \v 18 All the people perceived the thunderings, the lightnings, the sound of the trumpet, and the mountain smoking. When the people saw it, they trembled, and stayed at a distance. 
 \v 19 They said to Moses, “Speak with us yourself, and we will listen; but don’t let Elohim speak with us, lest we die.” 

--- a/usfm/isaiah.usfm
+++ b/usfm/isaiah.usfm
@@ -3605,7 +3605,7 @@
 \q2 for the spirit would faint before me, 
 \q2 and the souls whom I have made. 
 \q1
-\v 17 I was angry because of the iniquity of his covetousness and struck him. 
+\v 17 I was angry because of the iniquity of his desire and struck him. 
 \q2 I hid myself and was angry; 
 \q2 and he went on backsliding in the way of his heart. 
 \q1

--- a/usfm/james.usfm
+++ b/usfm/james.usfm
@@ -93,7 +93,7 @@
 \c 4
 \p
 \v 1 Where do wars and fightings among you come from? Don’t they come from your pleasures that war in your members? 
-\v 2 You lust, and don’t have. You murder and covet, and can’t obtain. You fight and make war. You don’t have, because you don’t ask. 
+\v 2 You lust, and don’t have. You murder and desire, and can’t obtain. You fight and make war. You don’t have, because you don’t ask. 
 \v 3 You ask, and don’t receive, because you ask with wrong motives, so that you may spend it on your pleasures. 
 \v 4 You adulterers and adulteresses, don’t you know that friendship with the world is hostility toward Elohim? Whoever therefore wants to be a friend of the world makes himself an enemy of Elohim. 
 \v 5 Or do you think that the Scripture says in vain, “The Spirit who lives in us yearns jealously”? 

--- a/usfm/jeremiah.usfm
+++ b/usfm/jeremiah.usfm
@@ -345,7 +345,7 @@
 \q2 their fields and their women together; 
 \q1 for I will stretch out my hand on the inhabitants of the land, says Yahweh.” 
 \q1
-\v 13 “For from their least even to their greatest, everyone is given to covetousness. 
+\v 13 “For from their least even to their greatest, everyone is given to desire. 
 \q2 From the prophet even to the priest, everyone deals falsely. 
 \q1
 \v 14 They have healed also the hurt of my people superficially, 
@@ -450,7 +450,7 @@
 \q1
 \v 10 Therefore I will give their women to others 
 \q2 and their fields to those who will possess them. 
-\q1 For everyone from the least even to the greatest is given to covetousness; 
+\q1 For everyone from the least even to the greatest is given to desire; 
 \q2 from the prophet even to the priest everyone deals falsely. 
 \q1
 \v 11 They have healed the hurt of the daughter of my people slightly, saying, 
@@ -1516,7 +1516,7 @@
 \q1 Wasn’t this to know me?” 
 \q2 says Yahweh. 
 \q1
-\v 17 But your eyes and your heart are only for your covetousness, 
+\v 17 But your eyes and your heart are only for your desire, 
 \q2 for shedding innocent blood, 
 \q2 for oppression, and for doing violence.” 
 \m
@@ -3517,7 +3517,7 @@
 \q2 that which he spoke concerning the inhabitants of Babylon. 
 \q1
 \v 13 You who dwell on many waters, abundant in treasures, 
-\q2 your end has come, the measure of your covetousness. 
+\q2 your end has come, the measure of your desire. 
 \q1
 \v 14 Yahweh of Armies has sworn by himself, saying, 
 \q2 ‘Surely I will fill you with men, 

--- a/usfm/joshua.usfm
+++ b/usfm/joshua.usfm
@@ -199,7 +199,7 @@
 \v 19 Joshua said to Achan, “My son, please give glory to Yahweh, the Elohim of Israel, and make confession to him. Tell me now what you have done! Don’t hide it from me!” 
 \p
 \v 20 Achan answered Joshua, and said, “I have truly sinned against Yahweh, the Elohim of Israel, and this is what I have done. 
-\v 21 When I saw among the plunder a beautiful Babylonian robe, two hundred shekels\f + \fr 7:21 \ft A shekel is about 10 grams or about 0.35 ounces.\f* of silver, and a wedge of gold weighing fifty shekels, then I coveted them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
+\v 21 When I saw among the plunder a beautiful Babylonian robe, two hundred shekels\f + \fr 7:21 \ft A shekel is about 10 grams or about 0.35 ounces.\f* of silver, and a wedge of gold weighing fifty shekels, then I desired them and took them. Behold, they are hidden in the ground in the middle of my tent, with the silver under it.” 
 \p
 \v 22 So Joshua sent messengers, and they ran to the tent. Behold, it was hidden in his tent, with the silver under it. 
 \v 23 They took them from the middle of the tent, and brought them to Joshua and to all the children of Israel. They laid them down before Yahweh. 

--- a/usfm/micah.usfm
+++ b/usfm/micah.usfm
@@ -80,7 +80,7 @@
 \q1 When the morning is light, they practice it, 
 \q2 because it is in the power of their hand. 
 \q1
-\v 2 They covet fields and seize them, 
+\v 2 They desire fields and seize them, 
 \q2 and houses, then take them away. 
 \q1 They oppress a man and his house, 
 \q2 even a man and his heritage. 

--- a/usfm/proverbs.usfm
+++ b/usfm/proverbs.usfm
@@ -1883,7 +1883,7 @@
 \v 25 The desire of the sluggard kills him, 
 \q2 for his hands refuse to labor. 
 \q1
-\v 26 There are those who covet greedily all day long; 
+\v 26 There are those who desire greedily all day long; 
 \q2 but the righteous give and don’t withhold. 
 \q1
 \v 27 The sacrifice of the wicked is an abomination—\q2 how much more, when he brings it with a wicked mind! 


### PR DESCRIPTION
the word covet is archaic. it also implies more than the hebrew by being only used in the pejorative sense, while the same root is translated desire in other cases, which means it includes doctrinal commentary.
this update changes covet to desire in 13 instances to improve the translation by being more literal, transparent, and modern.